### PR TITLE
chore: GHA to Publish x402 NPM Package

### DIFF
--- a/.github/workflows/publish_npm_x402.yml
+++ b/.github/workflows/publish_npm_x402.yml
@@ -1,0 +1,26 @@
+name: Publish x402 to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-npm-x402:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+      - name: Install, build and publish x402
+        working-directory: ./packages/typescript/x402
+        run: |
+          npm ci
+          npm run build
+          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Adds a Github Action to Publish the x402 MVP package
- Uses NPM_TOKEN GHA Secret as the publication token