### PR TITLE
chore: Use GHA Environment to Publish NPM

### DIFF
--- a/.github/workflows/publish_npm_x402.yml
+++ b/.github/workflows/publish_npm_x402.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   publish-npm-x402:
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
- Configure `publish_npm_x402.yml` GHA to use `npm` GH environment.