### PR TITLE
fix: resourceUrl in example client

### DIFF
--- a/example/client.ts
+++ b/example/client.ts
@@ -15,7 +15,7 @@ const wallet = createWalletClient({
   account: privateKeyToAccount(process.env.PRIVATE_KEY as Hex),
 }).extend(publicActions);
 
-const resourceUrl = "https://x402.org/protected";
+const resourceUrl = "http://localhost:4021/joke";
 
 let axiosInstance = axios.create({});
 axiosInstance = withPaymentInterceptor(axiosInstance, wallet);


### PR DESCRIPTION
Right now if following the directions in the `Readme` for the example you'll interact with the hosted version of the facilitator and resource code vs the local version. This change makes it so that the example code hits the local instances and behaves as expected.

Edit - Closes #26 