### PR TITLE
chore: Release x402 0.1.2 NPM Package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "base402",
+  "name": "x402",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -10884,7 +10884,7 @@
       }
     },
     "packages/typescript/x402": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.13.8",

--- a/packages/typescript/x402/package.json
+++ b/packages/typescript/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "dist/index.js",
   "scripts": {
     "start": "tsx --env-file=.env index.ts",


### PR DESCRIPTION
- version bump to cut new npm package `x402 0.1.2`
