### PR TITLE
Create example/README.md / add example/keygen.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,15 +215,9 @@ Because a scheme is a logical way of moving money, the way a scheme is implement
 
 Clients and facilitator must explicitly support different `(scheme, networkId)` pairs in order to be able to create proper payloads and verify / settle payments.
 
-## Running example
+## Running the example
 
-`cd example`
-
-1. create `.env` `cp ../packages/typescript/x402/.env.example .env` and follow instruction in the file to create wallets
-
-2. `npm install` to install dependencies
-
-3. in 3 separate terminals, run `npm run facilitator`, `npm run resource`, then finally `npm run client`. You should see things happen across all 3 terminals, and get a joke at the end in the client terminal.
+See [example/README.md](example/README.md)
 
 ## Running tests
 

--- a/example/README.md
+++ b/example/README.md
@@ -23,7 +23,7 @@ npm run keygen
 ## Fund the wallets
 The client requires USDC and the facilitator requires ETH, both on the Base Sepolia network.
 
-If you don't already have some, you can get each of these with a free developer account from the [Coinbase Developer Platform Faucet](https://portal.cdp.coinbase.com/products/faucet). (requires a free account)
+If you don't already have some, you can get each of these with a free developer account from the [Coinbase Developer Platform Faucet](https://portal.cdp.coinbase.com/products/faucet).
 
 The Base Sepolia explorer can be found at https://sepolia.basescan.org - check to make sure your accounts have the necessary funds.
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,45 @@
+# x409 Example
+
+## Setup
+Build in the root and install required packages in the `example/` directory.
+```
+npm run build
+cd example/
+npm install
+```
+
+Make a copy of the example `.env` file.
+```
+cp ../packages/typescript/x402/.env.example .env
+```
+
+Edit `.env` adding the private key and public address of three acounts.
+
+You can run `keygen` to generate new random accounts.
+```
+npm run keygen
+```
+
+## Fund the wallets
+The client requires USDC and the facilitator requires ETH, both on the Base Sepolia network.
+
+If you don't already have some, you can get each of these with a free developer account from the [Coinbase Developer Platform Faucet](https://portal.cdp.coinbase.com/products/faucet). (requires a free account)
+
+The Base Sepolia explorer can be found at https://sepolia.basescan.org - check to make sure your accounts have the necessary funds.
+
+## Run
+* In two other terminal windows, run
+  ```
+  npm run facilitator
+  ```
+  and
+  ```
+  npm run resource
+  ```
+* Run the client
+  ```
+  npm run client
+  ```
+If all goes well, your client will make a request to `/joke`, get a 402 response and then pay $0.01 USDC to get a random joke returned.
+
+You will notice the USDC balance going down by $0.01 each request you make.

--- a/example/keygen.ts
+++ b/example/keygen.ts
@@ -1,0 +1,38 @@
+import { generatePrivateKey, privateKeyToAccount, type Address, type PrivateKeyAccount } from 'viem/accounts';
+
+/**
+ * Interface representing a generated wallet
+ */
+interface Wallet {
+  privateKey: `0x${string}`;
+  address: Address;
+}
+
+/**
+ * Generates a random Ethereum wallet using viem
+ * @returns {Wallet} An object containing the wallet information
+ */
+function generateWallet(): Wallet {
+  const privateKey = generatePrivateKey();
+  const account: PrivateKeyAccount = privateKeyToAccount(privateKey);
+
+  return {
+    privateKey,
+    address: account.address
+  };
+}
+
+function main(): void {
+  try {	
+    const wallet: Wallet = generateWallet();
+
+    console.log(wallet);
+
+  }
+  catch (error) {
+    console.error('Error generating wallet:', (error as Error).message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -43,16 +43,18 @@
       }
     },
     "../packages/typescript/x402": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.13.8",
         "axios": "^1.7.9",
+        "express": "^4.18.2",
         "hono": "^4.7.1",
         "viem": "^2.23.1",
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@types/express": "^4.17.21",
         "@types/node": "^22.13.4",
         "prettier": "3.5.2",
         "tsx": "^4.19.2",

--- a/example/package.json
+++ b/example/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "keygen": "tsx keygen.ts",
     "facilitator": "tsx --env-file=.env facilitator.ts",
     "resource": "tsx resource.ts",
     "client": "tsx --env-file=.env client.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
         "packages/typescript/x402",
         "site"
       ],
+      "dependencies": {
+        "typescript": "^5.8.3"
+      },
       "devDependencies": {
         "turbo": "^2.4.4"
       }
@@ -3767,17 +3770,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
-      "integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
+      "version": "8.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.1.tgz",
+      "integrity": "sha512-ba0rr4Wfvg23vERs3eB+P3lfj2E+2g3lhWcCVukUuhtcdUx5lSIFZlGFEBHKr+3zizDa/TvZTptdNHVZWAkSBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.25.0",
-        "@typescript-eslint/type-utils": "8.25.0",
-        "@typescript-eslint/utils": "8.25.0",
-        "@typescript-eslint/visitor-keys": "8.25.0",
+        "@typescript-eslint/scope-manager": "8.29.1",
+        "@typescript-eslint/type-utils": "8.29.1",
+        "@typescript-eslint/utils": "8.29.1",
+        "@typescript-eslint/visitor-keys": "8.29.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3793,20 +3796,20 @@
       "peerDependencies": {
         "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
-      "integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
+      "version": "8.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.1.tgz",
+      "integrity": "sha512-zczrHVEqEaTwh12gWBIJWj8nx+ayDcCJs06yoNMY0kwjMWDM6+kppljY+BxWI06d2Ja+h4+WdufDcwMnnMEWmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.25.0",
-        "@typescript-eslint/types": "8.25.0",
-        "@typescript-eslint/typescript-estree": "8.25.0",
-        "@typescript-eslint/visitor-keys": "8.25.0",
+        "@typescript-eslint/scope-manager": "8.29.1",
+        "@typescript-eslint/types": "8.29.1",
+        "@typescript-eslint/typescript-estree": "8.29.1",
+        "@typescript-eslint/visitor-keys": "8.29.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3818,18 +3821,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
-      "integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+      "version": "8.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.1.tgz",
+      "integrity": "sha512-2nggXGX5F3YrsGN08pw4XpMLO1Rgtnn4AzTegC2MDesv6q3QaTU5yU7IbS1tf1IwCR0Hv/1EFygLn9ms6LIpDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.25.0",
-        "@typescript-eslint/visitor-keys": "8.25.0"
+        "@typescript-eslint/types": "8.29.1",
+        "@typescript-eslint/visitor-keys": "8.29.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3840,14 +3843,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
-      "integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
+      "version": "8.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.1.tgz",
+      "integrity": "sha512-DkDUSDwZVCYN71xA4wzySqqcZsHKic53A4BLqmrWFFpOpNSoxX233lwGu/2135ymTCR04PoKiEEEvN1gFYg4Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.25.0",
-        "@typescript-eslint/utils": "8.25.0",
+        "@typescript-eslint/typescript-estree": "8.29.1",
+        "@typescript-eslint/utils": "8.29.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.1"
       },
@@ -3860,13 +3863,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
-      "integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+      "version": "8.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.1.tgz",
+      "integrity": "sha512-VT7T1PuJF1hpYC3AGm2rCgJBjHL3nc+A/bhOp9sGMKfi5v0WufsX/sHCFBfNTx2F+zA6qBc/PD0/kLRLjdt8mQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3878,14 +3881,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
-      "integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+      "version": "8.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.1.tgz",
+      "integrity": "sha512-l1enRoSaUkQxOQnbi0KPUtqeZkSiFlqrx9/3ns2rEDhGKfTa+88RmXqedC1zmVTOWrLc2e6DEJrTA51C9iLH5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.25.0",
-        "@typescript-eslint/visitor-keys": "8.25.0",
+        "@typescript-eslint/types": "8.29.1",
+        "@typescript-eslint/visitor-keys": "8.29.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3901,7 +3904,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -3961,16 +3964,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
-      "integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+      "version": "8.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.1.tgz",
+      "integrity": "sha512-QAkFEbytSaB8wnmB+DflhUPz6CLbFWE2SnSCrRMEa+KnXIzDYbpsn++1HGvnfAsUY44doDXmvRkO5shlM/3UfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.25.0",
-        "@typescript-eslint/types": "8.25.0",
-        "@typescript-eslint/typescript-estree": "8.25.0"
+        "@typescript-eslint/scope-manager": "8.29.1",
+        "@typescript-eslint/types": "8.29.1",
+        "@typescript-eslint/typescript-estree": "8.29.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3981,17 +3984,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
-      "integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+      "version": "8.29.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.1.tgz",
+      "integrity": "sha512-RGLh5CRaUEf02viP5c1Vh1cMGffQscyHe7HPAzGpfmfflFg1wUz2rYxd+OZqwpeypYvZ8UxSxuIpF++fmOzEcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.25.0",
+        "@typescript-eslint/types": "8.29.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -10204,10 +10207,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "devOptional": true,
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   "packageManager": "npm@10.9.2",
   "license": "Apache-2.0",
   "author": "Coinbase Inc.",
-  "repository": "https://github.com/coinbase/x402"
+  "repository": "https://github.com/coinbase/x402",
+  "dependencies": {
+    "typescript": "^5.8.3"
+  }
 }


### PR DESCRIPTION
This attempts to streamline getting the example running.

* Remove example instructions from `/README.md`
* Add `/example/README.md`
* Add `/example/keygen.ts` (CLI utility to generate random accounts) releasing the requirement to have `cast` installed
* Add `typescript` dependancy so `npm run` builds ts -> js
* Direct people to the Coinbase Developer Platform Faucet for Sepolia ETH / USDC