### PR TITLE
feat: typescript initial unit tests

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "build": "turbo run build",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "turbo run test"
   },
   "keywords": [],
   "author": "",

--- a/typescript/packages/x402-axios/src/index.test.ts
+++ b/typescript/packages/x402-axios/src/index.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { withPaymentInterceptor } from './index'
+import { AxiosError, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig, AxiosHeaders } from 'axios'
+import { evm, PaymentRequirements } from 'x402/types'
+
+// Mock the createPaymentHeader function
+vi.mock('x402/client', () => ({
+  createPaymentHeader: vi.fn() as any
+}))
+
+describe('withPaymentInterceptor()', () => {
+  let mockAxiosClient: AxiosInstance
+  let mockWalletClient: typeof evm.SignerWallet
+  let interceptor: (error: AxiosError) => Promise<any>
+  const validPaymentRequirements: PaymentRequirements = {
+    scheme: 'exact',
+    network: 'base-sepolia',
+    maxAmountRequired: '1000000', // 1 USDC in base units
+    resource: 'https://api.example.com/resource',
+    description: 'Test payment',
+    mimeType: 'application/json',
+    payTo: '0x1234567890123456789012345678901234567890',
+    maxTimeoutSeconds: 300,
+    asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e' // USDC on base-sepolia
+  }
+
+  const createErrorConfig = (isRetry = false): InternalAxiosRequestConfig => ({
+    headers: new AxiosHeaders(),
+    url: 'https://api.example.com',
+    method: 'GET',
+    ...(isRetry ? { __is402Retry: true } : {})
+  } as InternalAxiosRequestConfig)
+
+  const createAxiosError = (status: number, config?: InternalAxiosRequestConfig, data?: any): AxiosError => {
+    const error = new AxiosError('Error', 'ERROR', config, {}, {
+      status,
+      statusText: status === 402 ? 'Payment Required' : 'Not Found',
+      data,
+      headers: {},
+      config: config || createErrorConfig()
+    })
+    return error
+  }
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.resetAllMocks()
+
+    // Mock axios client
+    mockAxiosClient = {
+      interceptors: {
+        response: {
+          use: vi.fn()
+        }
+      },
+      request: vi.fn()
+    } as unknown as AxiosInstance
+
+    // Mock wallet client
+    mockWalletClient = {
+      signMessage: vi.fn()
+    } as unknown as typeof evm.SignerWallet
+
+    // Set up the interceptor
+    withPaymentInterceptor(mockAxiosClient, mockWalletClient)
+    interceptor = (mockAxiosClient.interceptors.response.use as any).mock.calls[0][1]
+  })
+
+  it('should return the axios client instance', () => {
+    const result = withPaymentInterceptor(mockAxiosClient, mockWalletClient)
+    expect(result).toBe(mockAxiosClient)
+  })
+
+  it('should set up response interceptor', () => {
+    expect(mockAxiosClient.interceptors.response.use).toHaveBeenCalled()
+  })
+
+  it('should not handle non-402 errors', async () => {
+    const error = createAxiosError(404)
+    await expect(interceptor(error)).rejects.toBe(error)
+  })
+
+  it('should handle 402 errors and retry with payment header', async () => {
+    const paymentHeader = 'payment-header-value'
+    const successResponse = { data: 'success' } as AxiosResponse
+
+    const { createPaymentHeader } = await import('x402/client')
+      ; (createPaymentHeader as any).mockResolvedValue(paymentHeader)
+      ; (mockAxiosClient.request as any).mockResolvedValue(successResponse)
+
+    const error = createAxiosError(402, createErrorConfig(), { paymentRequirements: validPaymentRequirements })
+
+    const result = await interceptor(error)
+
+    expect(result).toBe(successResponse)
+    expect(createPaymentHeader).toHaveBeenCalledWith(mockWalletClient, validPaymentRequirements)
+    expect(mockAxiosClient.request).toHaveBeenCalledWith({
+      ...error.config,
+      headers: new AxiosHeaders({
+        'X-PAYMENT': paymentHeader,
+        'Access-Control-Expose-Headers': 'X-PAYMENT-RESPONSE'
+      }),
+      __is402Retry: true
+    })
+  })
+
+  it('should not retry if already retried', async () => {
+    const error = createAxiosError(402, createErrorConfig(true), { paymentRequirements: validPaymentRequirements })
+    await expect(interceptor(error)).rejects.toBe(error)
+  })
+
+  it('should reject if missing request config', async () => {
+    const error = createAxiosError(402, undefined, { paymentRequirements: validPaymentRequirements })
+    await expect(interceptor(error)).rejects.toThrow('Missing axios request configuration')
+  })
+
+  it('should reject if payment header creation fails', async () => {
+    const paymentError = new Error('Payment failed')
+    const { createPaymentHeader } = await import('x402/client')
+      ; (createPaymentHeader as any).mockRejectedValue(paymentError)
+
+    const error = createAxiosError(402, createErrorConfig(), { paymentRequirements: validPaymentRequirements })
+    await expect(interceptor(error)).rejects.toBe(paymentError)
+  })
+})

--- a/typescript/packages/x402-axios/src/index.test.ts
+++ b/typescript/packages/x402-axios/src/index.test.ts
@@ -84,9 +84,9 @@ describe('withPaymentInterceptor()', () => {
     const paymentHeader = 'payment-header-value'
     const successResponse = { data: 'success' } as AxiosResponse
 
-    const { createPaymentHeader } = await import('x402/client')
-      ; (createPaymentHeader as any).mockResolvedValue(paymentHeader)
-      ; (mockAxiosClient.request as any).mockResolvedValue(successResponse)
+    const { createPaymentHeader } = await import('x402/client');
+    (createPaymentHeader as any).mockResolvedValue(paymentHeader);
+    (mockAxiosClient.request as any).mockResolvedValue(successResponse);
 
     const error = createAxiosError(402, createErrorConfig(), { paymentRequirements: validPaymentRequirements })
 
@@ -115,9 +115,9 @@ describe('withPaymentInterceptor()', () => {
   })
 
   it('should reject if payment header creation fails', async () => {
-    const paymentError = new Error('Payment failed')
-    const { createPaymentHeader } = await import('x402/client')
-      ; (createPaymentHeader as any).mockRejectedValue(paymentError)
+    const paymentError = new Error('Payment failed');
+    const { createPaymentHeader } = await import('x402/client');
+    (createPaymentHeader as any).mockRejectedValue(paymentError);
 
     const error = createAxiosError(402, createErrorConfig(), { paymentRequirements: validPaymentRequirements })
     await expect(interceptor(error)).rejects.toBe(paymentError)

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -4,7 +4,7 @@ import { evm } from "x402/types";
 import { createPaymentHeader } from "x402/client";
 
 /**
- * Adds a payment interceptor to an Axios instance to automatically handle 402 Payment Required responses.
+ * Enables the payment of APIs using the x402 payment protocol.
  * 
  * When a request receives a 402 response:
  * 1. Extracts payment requirements from the response

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -3,6 +3,31 @@ import { PaymentRequirementsSchema } from "x402/types";
 import { evm } from "x402/types";
 import { createPaymentHeader } from "x402/client";
 
+/**
+ * Adds a payment interceptor to an Axios instance to automatically handle 402 Payment Required responses.
+ * 
+ * When a request receives a 402 response:
+ * 1. Extracts payment requirements from the response
+ * 2. Creates a payment header using the provided wallet client
+ * 3. Retries the original request with the payment header
+ * 4. Exposes the X-PAYMENT-RESPONSE header in the final response
+ * 
+ * @param axiosClient - The Axios instance to add the interceptor to
+ * @param walletClient - A wallet client that can sign transactions and create payment headers
+ * 
+ * @returns The modified Axios instance with the payment interceptor
+ * 
+ * @example
+ * ```typescript
+ * const client = withPaymentInterceptor(
+ *   axios.create(),
+ *   signer
+ * );
+ * 
+ * // The client will automatically handle 402 responses
+ * const response = await client.get('https://api.example.com/premium-content');
+ * ```
+ */
 export function withPaymentInterceptor(
   axiosClient: AxiosInstance,
   walletClient: typeof evm.SignerWallet,

--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -69,24 +69,24 @@ describe('configurePaymentMiddleware()', () => {
     // Setup facilitator mocks
     mockVerify = vi.fn() as any
     mockSettle = vi.fn() as any
-      ; (useFacilitator as any).mockReturnValue({
-        verify: mockVerify,
-        settle: mockSettle
-      })
+    (useFacilitator as any).mockReturnValue({
+      verify: mockVerify,
+      settle: mockSettle
+    });
 
-      // Setup paywall HTML mock
-      ; (getPaywallHtml as any).mockReturnValue('<html>Paywall</html>')
+    // Setup paywall HTML mock
+    (getPaywallHtml as any).mockReturnValue('<html>Paywall</html>');
 
     // Create middleware
     middleware = configurePaymentMiddleware(globalConfig)(1.0, middlewareConfig)
   })
 
   it('should return 402 with payment requirements when no payment header is present', async () => {
-    ; (mockReq.header as any).mockReturnValue(undefined)
-      ; (mockReq.header as any).mockImplementation((name: string) => {
-        if (name === 'Accept') return 'application/json'
-        return undefined
-      })
+    (mockReq.header as any).mockReturnValue(undefined);
+    (mockReq.header as any).mockImplementation((name: string) => {
+      if (name === 'Accept') return 'application/json'
+      return undefined
+    });
 
     await middleware(mockReq as Request, mockRes as Response, mockNext)
 
@@ -100,11 +100,11 @@ describe('configurePaymentMiddleware()', () => {
   })
 
   it('should return HTML paywall for browser requests', async () => {
-    ; (mockReq.header as any).mockImplementation((name: string) => {
+    (mockReq.header as any).mockImplementation((name: string) => {
       if (name === 'Accept') return 'text/html'
       if (name === 'User-Agent') return 'Mozilla/5.0'
       return undefined
-    })
+    });
 
     await middleware(mockReq as Request, mockRes as Response, mockNext)
 
@@ -113,13 +113,13 @@ describe('configurePaymentMiddleware()', () => {
   })
 
   it('should verify payment and proceed if valid', async () => {
-    const validPayment = 'valid-payment-header'
-      ; (mockReq.header as any).mockImplementation((name: string) => {
-        if (name === 'X-PAYMENT') return validPayment
-        return undefined
-      })
+    const validPayment = 'valid-payment-header';
+    (mockReq.header as any).mockImplementation((name: string) => {
+      if (name === 'X-PAYMENT') return validPayment
+      return undefined
+    });
 
-      ; (mockVerify as any).mockResolvedValue({ isValid: true })
+    (mockVerify as any).mockResolvedValue({ isValid: true });
 
     await middleware(mockReq as Request, mockRes as Response, mockNext)
 
@@ -128,16 +128,16 @@ describe('configurePaymentMiddleware()', () => {
   })
 
   it('should return 402 if payment verification fails', async () => {
-    const invalidPayment = 'invalid-payment-header'
-      ; (mockReq.header as any).mockImplementation((name: string) => {
-        if (name === 'X-PAYMENT') return invalidPayment
-        return undefined
-      })
+    const invalidPayment = 'invalid-payment-header';
+    (mockReq.header as any).mockImplementation((name: string) => {
+      if (name === 'X-PAYMENT') return invalidPayment
+      return undefined
+    });
 
-      ; (mockVerify as any).mockResolvedValue({
-        isValid: false,
-        invalidReason: 'insufficient_funds'
-      })
+    (mockVerify as any).mockResolvedValue({
+      isValid: false,
+      invalidReason: 'insufficient_funds'
+    });
 
     await middleware(mockReq as Request, mockRes as Response, mockNext)
 
@@ -151,24 +151,24 @@ describe('configurePaymentMiddleware()', () => {
   })
 
   it('should handle settlement after response', async () => {
-    const validPayment = 'valid-payment-header'
-      ; (mockReq.header as any).mockImplementation((name: string) => {
-        if (name === 'X-PAYMENT') return validPayment
-        return undefined
-      })
+    const validPayment = 'valid-payment-header';
+    (mockReq.header as any).mockImplementation((name: string) => {
+      if (name === 'X-PAYMENT') return validPayment
+      return undefined
+    });
 
-      ; (mockVerify as any).mockResolvedValue({ isValid: true })
-      ; (mockSettle as any).mockResolvedValue({
-        success: true,
-        transaction: '0x123',
-        network: 'base-sepolia'
-      })
+    (mockVerify as any).mockResolvedValue({ isValid: true });
+    (mockSettle as any).mockResolvedValue({
+      success: true,
+      transaction: '0x123',
+      network: 'base-sepolia'
+    });
 
     // Mock response.end to capture arguments
-    const endArgs: any[] = []
-      ; (mockRes.end as any).mockImplementation((...args: any[]) => {
-        endArgs.push(args)
-      })
+    const endArgs: any[] = [];
+    (mockRes.end as any).mockImplementation((...args: any[]) => {
+      endArgs.push(args)
+    });
 
     await middleware(mockReq as Request, mockRes as Response, mockNext)
 
@@ -180,14 +180,14 @@ describe('configurePaymentMiddleware()', () => {
   })
 
   it('should handle settlement failure before response is sent', async () => {
-    const validPayment = 'valid-payment-header'
-      ; (mockReq.header as any).mockImplementation((name: string) => {
-        if (name === 'X-PAYMENT') return validPayment
-        return undefined
-      })
+    const validPayment = 'valid-payment-header';
+    (mockReq.header as any).mockImplementation((name: string) => {
+      if (name === 'X-PAYMENT') return validPayment
+      return undefined
+    });
 
-      ; (mockVerify as any).mockResolvedValue({ isValid: true })
-      ; (mockSettle as any).mockRejectedValue(new Error('Settlement failed'))
+    (mockVerify as any).mockResolvedValue({ isValid: true });
+    (mockSettle as any).mockRejectedValue(new Error('Settlement failed'));
 
     await middleware(mockReq as Request, mockRes as Response, mockNext)
 
@@ -201,21 +201,21 @@ describe('configurePaymentMiddleware()', () => {
   })
 
   it('should handle settlement failure after response is sent', async () => {
-    const validPayment = 'valid-payment-header'
-      ; (mockReq.header as any).mockImplementation((name: string) => {
-        if (name === 'X-PAYMENT') return validPayment
-        return undefined
-      })
+    const validPayment = 'valid-payment-header';
+    (mockReq.header as any).mockImplementation((name: string) => {
+      if (name === 'X-PAYMENT') return validPayment
+      return undefined
+    });
 
-      ; (mockVerify as any).mockResolvedValue({ isValid: true })
-      ; (mockSettle as any).mockRejectedValue(new Error('Settlement failed'))
-    mockRes.headersSent = true
+    (mockVerify as any).mockResolvedValue({ isValid: true });
+    (mockSettle as any).mockRejectedValue(new Error('Settlement failed'));
+    mockRes.headersSent = true;
 
     // Mock response.end to capture arguments
-    const endArgs: any[] = []
-      ; (mockRes.end as any).mockImplementation((...args: any[]) => {
-        endArgs.push(args)
-      })
+    const endArgs: any[] = [];
+    (mockRes.end as any).mockImplementation((...args: any[]) => {
+      endArgs.push(args)
+    });
 
     await middleware(mockReq as Request, mockRes as Response, mockNext)
 

--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -1,0 +1,226 @@
+import { NextFunction, Request, Response } from 'express'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getPaywallHtml } from 'x402/shared'
+import { GlobalConfig, PaymentMiddlewareConfig } from 'x402/types'
+import { useFacilitator } from 'x402/verify'
+import { configurePaymentMiddleware } from './index'
+
+// Mock dependencies
+vi.mock('x402/verify', () => ({
+  useFacilitator: vi.fn()
+}))
+
+vi.mock('x402/shared', () => ({
+  getPaywallHtml: vi.fn(),
+  getNetworkId: vi.fn().mockReturnValue('base-sepolia'),
+  toJsonSafe: vi.fn(x => x)
+}))
+
+vi.mock('x402/shared/evm', () => ({
+  getUsdcAddressForChain: vi.fn().mockReturnValue('0x036CbD53842c5426634e7929541eC2318f3dCF7e')
+}))
+
+describe('configurePaymentMiddleware()', () => {
+  let mockReq: Partial<Request>
+  let mockRes: Partial<Response>
+  let mockNext: NextFunction
+  let middleware: ReturnType<ReturnType<(typeof configurePaymentMiddleware)>>
+  let mockVerify: ReturnType<typeof useFacilitator>['verify']
+  let mockSettle: ReturnType<typeof useFacilitator>['settle']
+
+  const globalConfig: GlobalConfig = {
+    facilitatorUrl: 'https://facilitator.example.com',
+    address: '0x1234567890123456789012345678901234567890',
+    network: 'base-sepolia'
+  }
+
+  const middlewareConfig: PaymentMiddlewareConfig = {
+    description: 'Test payment',
+    mimeType: 'application/json',
+    maxTimeoutSeconds: 300,
+    outputSchema: { type: 'object' },
+    resource: 'https://api.example.com/resource'
+  }
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.resetAllMocks()
+
+    // Setup request mock
+    mockReq = {
+      originalUrl: '/test',
+      header: vi.fn(),
+      headers: {}
+    }
+
+    // Setup response mock
+    mockRes = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+      setHeader: vi.fn(),
+      end: vi.fn(),
+      headersSent: false
+    }
+
+    // Setup next function mock
+    mockNext = vi.fn()
+
+    // Setup facilitator mocks
+    mockVerify = vi.fn() as any
+    mockSettle = vi.fn() as any
+      ; (useFacilitator as any).mockReturnValue({
+        verify: mockVerify,
+        settle: mockSettle
+      })
+
+      // Setup paywall HTML mock
+      ; (getPaywallHtml as any).mockReturnValue('<html>Paywall</html>')
+
+    // Create middleware
+    middleware = configurePaymentMiddleware(globalConfig)(1.0, middlewareConfig)
+  })
+
+  it('should return 402 with payment requirements when no payment header is present', async () => {
+    ; (mockReq.header as any).mockReturnValue(undefined)
+      ; (mockReq.header as any).mockImplementation((name: string) => {
+        if (name === 'Accept') return 'application/json'
+        return undefined
+      })
+
+    await middleware(mockReq as Request, mockRes as Response, mockNext)
+
+    expect(mockRes.status).toHaveBeenCalledWith(402)
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: 'X-PAYMENT header is required',
+        paymentRequirements: expect.any(Object)
+      })
+    )
+  })
+
+  it('should return HTML paywall for browser requests', async () => {
+    ; (mockReq.header as any).mockImplementation((name: string) => {
+      if (name === 'Accept') return 'text/html'
+      if (name === 'User-Agent') return 'Mozilla/5.0'
+      return undefined
+    })
+
+    await middleware(mockReq as Request, mockRes as Response, mockNext)
+
+    expect(mockRes.status).toHaveBeenCalledWith(402)
+    expect(mockRes.send).toHaveBeenCalledWith('<html>Paywall</html>')
+  })
+
+  it('should verify payment and proceed if valid', async () => {
+    const validPayment = 'valid-payment-header'
+      ; (mockReq.header as any).mockImplementation((name: string) => {
+        if (name === 'X-PAYMENT') return validPayment
+        return undefined
+      })
+
+      ; (mockVerify as any).mockResolvedValue({ isValid: true })
+
+    await middleware(mockReq as Request, mockRes as Response, mockNext)
+
+    expect(mockVerify).toHaveBeenCalledWith(validPayment, expect.any(Object))
+    expect(mockNext).toHaveBeenCalled()
+  })
+
+  it('should return 402 if payment verification fails', async () => {
+    const invalidPayment = 'invalid-payment-header'
+      ; (mockReq.header as any).mockImplementation((name: string) => {
+        if (name === 'X-PAYMENT') return invalidPayment
+        return undefined
+      })
+
+      ; (mockVerify as any).mockResolvedValue({
+        isValid: false,
+        invalidReason: 'insufficient_funds'
+      })
+
+    await middleware(mockReq as Request, mockRes as Response, mockNext)
+
+    expect(mockRes.status).toHaveBeenCalledWith(402)
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: 'insufficient_funds',
+        paymentRequirements: expect.any(Object)
+      })
+    )
+  })
+
+  it('should handle settlement after response', async () => {
+    const validPayment = 'valid-payment-header'
+      ; (mockReq.header as any).mockImplementation((name: string) => {
+        if (name === 'X-PAYMENT') return validPayment
+        return undefined
+      })
+
+      ; (mockVerify as any).mockResolvedValue({ isValid: true })
+      ; (mockSettle as any).mockResolvedValue({
+        success: true,
+        transaction: '0x123',
+        network: 'base-sepolia'
+      })
+
+    // Mock response.end to capture arguments
+    const endArgs: any[] = []
+      ; (mockRes.end as any).mockImplementation((...args: any[]) => {
+        endArgs.push(args)
+      })
+
+    await middleware(mockReq as Request, mockRes as Response, mockNext)
+
+    expect(mockSettle).toHaveBeenCalledWith(validPayment, expect.any(Object))
+    expect(mockRes.setHeader).toHaveBeenCalledWith(
+      'X-PAYMENT-RESPONSE',
+      expect.any(String)
+    )
+  })
+
+  it('should handle settlement failure before response is sent', async () => {
+    const validPayment = 'valid-payment-header'
+      ; (mockReq.header as any).mockImplementation((name: string) => {
+        if (name === 'X-PAYMENT') return validPayment
+        return undefined
+      })
+
+      ; (mockVerify as any).mockResolvedValue({ isValid: true })
+      ; (mockSettle as any).mockRejectedValue(new Error('Settlement failed'))
+
+    await middleware(mockReq as Request, mockRes as Response, mockNext)
+
+    expect(mockRes.status).toHaveBeenCalledWith(402)
+    expect(mockRes.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.any(Error),
+        paymentRequirements: expect.any(Object)
+      })
+    )
+  })
+
+  it('should handle settlement failure after response is sent', async () => {
+    const validPayment = 'valid-payment-header'
+      ; (mockReq.header as any).mockImplementation((name: string) => {
+        if (name === 'X-PAYMENT') return validPayment
+        return undefined
+      })
+
+      ; (mockVerify as any).mockResolvedValue({ isValid: true })
+      ; (mockSettle as any).mockRejectedValue(new Error('Settlement failed'))
+    mockRes.headersSent = true
+
+    // Mock response.end to capture arguments
+    const endArgs: any[] = []
+      ; (mockRes.end as any).mockImplementation((...args: any[]) => {
+        endArgs.push(args)
+      })
+
+    await middleware(mockReq as Request, mockRes as Response, mockNext)
+
+    expect(mockSettle).toHaveBeenCalledWith(validPayment, expect.any(Object))
+    // Should not try to send another response since headers are already sent
+    expect(mockRes.status).not.toHaveBeenCalledWith(402)
+  })
+})

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -5,7 +5,7 @@ import { getUsdcAddressForChain } from "x402/shared/evm";
 import { Money, Resource, GlobalConfig, PaymentMiddlewareConfig, moneySchema, PaymentRequirements, settleResponseHeader } from "x402/types"
 
 /**
- * Configures an Express middleware for handling 402 Payment Required responses.
+ * Enables APIs to be paid for using the x402 payment protocol.
  * 
  * This middleware:
  * 1. Validates payment headers and requirements

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -4,6 +4,38 @@ import { getNetworkId, getPaywallHtml, toJsonSafe } from "x402/shared";
 import { getUsdcAddressForChain } from "x402/shared/evm";
 import { Money, Resource, GlobalConfig, PaymentMiddlewareConfig, moneySchema, PaymentRequirements, settleResponseHeader } from "x402/types"
 
+/**
+ * Configures an Express middleware for handling 402 Payment Required responses.
+ * 
+ * This middleware:
+ * 1. Validates payment headers and requirements
+ * 2. Serves a paywall page for browser requests
+ * 3. Returns JSON payment requirements for API requests
+ * 4. Verifies and settles payments
+ * 5. Sets appropriate response headers
+ * 6. Handles response streaming by intercepting the end() method
+ * 
+ * @param globalConfig - Global configuration for the payment middleware
+ * @param globalConfig.facilitatorUrl - URL of the payment facilitator service
+ * @param globalConfig.address - Address to receive payments
+ * @param globalConfig.network - Network identifier (e.g. 'base-sepolia')
+ * 
+ * @returns A function that creates an Express middleware handler for a specific payment amount
+ * 
+ * @example
+ * ```typescript
+ * const middleware = configurePaymentMiddleware({
+ *   facilitatorUrl: 'https://facilitator.example.com',
+ *   address: '0x123...',
+ *   network: 'base-sepolia'
+ * })(1.0, {
+ *   description: 'Access to premium content',
+ *   mimeType: 'application/json'
+ * });
+ * 
+ * app.use('/premium', middleware);
+ * ```
+ */
 export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
   const { facilitatorUrl, address, network } = globalConfig;
   const { settle, verify } = useFacilitator(facilitatorUrl);

--- a/typescript/turbo.json
+++ b/typescript/turbo.json
@@ -8,6 +8,15 @@
       "outputs": [
         "dist/**"
       ]
+    },
+    "test": {
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+      ]
     }
   }
 }


### PR DESCRIPTION
* Adds `test` command to turbo root
* Adds unit tests for `x402-axios` package
* Adds unit tests for `x402-express` package

Will fast follow with:
- [x]  Adding unit tests to `x402-fetch` pr
- [x]  Adding unit tests to `x402-hono` pr
- [ ] Plan scope of `402` tests & ticket it up for next sprint
- [ ] PR for adding github action for running tests

# Tests

### x402-axios

```
 ✓ src/index.test.ts (7 tests) 5ms
   ✓ withPaymentInterceptor() > should return the axios client instance 1ms
   ✓ withPaymentInterceptor() > should set up response interceptor 0ms
   ✓ withPaymentInterceptor() > should not handle non-402 errors 0ms
   ✓ withPaymentInterceptor() > should handle 402 errors and retry with payment header 2ms
   ✓ withPaymentInterceptor() > should not retry if already retried 0ms
   ✓ withPaymentInterceptor() > should reject if missing request config 0ms
   ✓ withPaymentInterceptor() > should reject if payment header creation fails 0ms
```

### x402-express

```
 ✓ src/index.test.ts (7 tests) 5ms
   ✓ configurePaymentMiddleware() > should return 402 with payment requirements when no payment header is present 3ms
   ✓ configurePaymentMiddleware() > should return HTML paywall for browser requests 0ms
   ✓ configurePaymentMiddleware() > should verify payment and proceed if valid 0ms
   ✓ configurePaymentMiddleware() > should return 402 if payment verification fails 0ms
   ✓ configurePaymentMiddleware() > should handle settlement after response 0ms
   ✓ configurePaymentMiddleware() > should handle settlement failure before response is sent 0ms
   ✓ configurePaymentMiddleware() > should handle settlement failure after response is sent 0ms
```