### PR TITLE
feat: README for express and express example

### DIFF
--- a/typescript/examples/servers/express/README.md
+++ b/typescript/examples/servers/express/README.md
@@ -1,0 +1,116 @@
+# x402-express Example Server
+
+This is an example Express.js server that demonstrates how to use the `x402-express` middleware to implement paywall functionality in your API endpoints.
+
+## Prerequisites
+
+- Node.js (v18 or higher)
+- A valid x402 facilitator URL (you can run the example facilitator at `examples/facilitator`)
+- A valid Ethereum address for receiving payments
+
+## Setup
+
+1. First, start the local facilitator server:
+```bash
+cd examples/facilitator
+npm install
+npm dev
+```
+The facilitator will run on http://localhost:3002
+
+2. In a new terminal, install and start the example server:
+```bash
+cd examples/servers/express
+npm install
+npm dev
+```
+The server will run on http://localhost:3001
+
+3. Create a `.env` file in the root directory with the following variables:
+```env
+FACILITATOR_URL=http://localhost:3002
+ADDRESS=0xYourEthereumAddress
+NETWORK=base # or 'base-sepolia' for testnet
+PORT=3001
+```
+
+## Testing the Server
+
+You can test the server using one of the example clients:
+
+### Using the Fetch Client
+```bash
+cd examples/clients/fetch
+npm install
+npm dev
+```
+
+### Using the Axios Client
+```bash
+cd examples/clients/axios
+npm install
+npm dev
+```
+
+These clients will demonstrate how to:
+1. Make an initial request to get payment requirements
+2. Process the payment requirements
+3. Make a second request with the payment token
+
+## Example Endpoint
+
+The server includes a single example endpoint at `/weather` that requires a payment of $0.001 to access. The endpoint returns a simple weather report.
+
+## Response Format
+
+### Payment Required (402)
+```json
+{
+  "error": "X-PAYMENT header is required",
+  "paymentRequirements": {
+    "scheme": "exact",
+    "network": "base",
+    "maxAmountRequired": "1000",
+    "resource": "http://localhost:3001/weather",
+    "description": "",
+    "mimeType": "",
+    "payTo": "0xYourAddress",
+    "maxTimeoutSeconds": 60,
+    "asset": "0x...",
+    "outputSchema": null,
+    "extra": null
+  }
+}
+```
+
+### Successful Response
+```ts
+// Body
+{
+  "report": {
+    "weather": "sunny",
+    "temperature": 70
+  }
+}
+// Headers
+{
+  "X-PAYMENT-RESPONSE": "..." // Encoded response object
+}
+```
+
+## Extending the Example
+
+To add more paid endpoints, follow the pattern in the example:
+
+```typescript
+app.get(
+  "/your-endpoint",
+  paymentMiddleware("$0.10", {
+    description: "Description of your endpoint",
+    resource: `http://localhost:${port}/your-endpoint`,
+  }),
+  (req, res) => {
+    // Your endpoint logic here
+  }
+);
+```

--- a/typescript/examples/servers/express/README.md
+++ b/typescript/examples/servers/express/README.md
@@ -30,7 +30,7 @@ The server will run on http://localhost:3001
 ```env
 FACILITATOR_URL=http://localhost:3002
 ADDRESS=0xYourEthereumAddress
-NETWORK=base # or 'base-sepolia' for testnet
+NETWORK=base # or "base-sepolia" for testnet
 PORT=3001
 ```
 

--- a/typescript/examples/servers/express/index.ts
+++ b/typescript/examples/servers/express/index.ts
@@ -1,7 +1,6 @@
 import { config } from "dotenv";
 import express from "express";
-import { configurePaymentMiddleware } from "x402-express";
-import { Network, Resource } from "x402/types";
+import { configurePaymentMiddleware, Resource, Network } from "x402-express";
 
 config();
 

--- a/typescript/examples/servers/express/package.json
+++ b/typescript/examples/servers/express/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "dotenv": "^16.4.7",
     "express": "^4.18.2",
-    "x402": "workspace:*",
     "x402-express": "workspace:*"
   },
   "devDependencies": {

--- a/typescript/packages/x402-express/README.md
+++ b/typescript/packages/x402-express/README.md
@@ -1,0 +1,80 @@
+# x402-express
+
+Express middleware integration for the x402 Payment Protocol. This package allows you to easily add paywall functionality to your Express.js applications using the x402 protocol.
+
+## Installation
+
+```bash
+npm install x402 x402-express
+```
+
+## Quick Start
+
+```typescript
+import express from 'express';
+import { configurePaymentMiddleware, Network } from 'x402-express';
+
+const app = express();
+
+// Configure the payment middleware
+const paymentMiddleware = configurePaymentMiddleware({
+  facilitatorUrl: 'https://your-facilitator-url.com',
+  address: '0xYourAddress',
+  network: 'base' as Network, // or 'base-sepolia' for testnet
+});
+
+// Apply the middleware to a route
+app.get('/protected-route', 
+  paymentMiddleware("$0.10", {
+    description: "Access to premium content",
+    resource: "https://your-api.com/protected-route"
+  }),
+  (req, res) => {
+    res.json({ message: "This content is behind a paywall" });
+  }
+);
+
+app.listen(3000);
+```
+
+## Configuration
+
+The `configurePaymentMiddleware` function accepts a global configuration object with the following properties:
+
+```typescript
+interface GlobalConfig {
+  facilitatorUrl: string;  // URL of the x402 facilitator service
+  address: `0x${string}`;  // Your receiving address
+  network: Network;        // 'base' or 'base-sepolia'
+}
+```
+
+## Middleware Options
+
+When applying the middleware to a route, you can specify the following options:
+
+```typescript
+interface PaymentMiddlewareConfig {
+  description?: string;               // Description of the payment
+  mimeType?: string;                  // MIME type of the resource
+  maxTimeoutSeconds?: number;         // Maximum time for payment (default: 60)
+  outputSchema?: Record<string, any>; // JSON schema for the response
+  customPaywallHtml?: string;         // Custom HTML for the paywall
+  resource?: string;                  // Resource URL (defaults to request URL)
+}
+```
+
+## Features
+
+- Payment verification and settlement
+- Automatic paywall generation for web browsers
+- Payment receipt in response header
+- Customizable paywall HTML
+
+## Error Handling
+
+The middleware will return:
+- 402 status code when payment is required
+- 402 status code when payment verification fails
+- 402 status code when settlement fails
+

--- a/typescript/packages/x402-express/README.md
+++ b/typescript/packages/x402-express/README.md
@@ -11,20 +11,20 @@ npm install x402 x402-express
 ## Quick Start
 
 ```typescript
-import express from 'express';
-import { configurePaymentMiddleware, Network } from 'x402-express';
+import express from "express";
+import { configurePaymentMiddleware, Network } from "x402-express";
 
 const app = express();
 
 // Configure the payment middleware
 const paymentMiddleware = configurePaymentMiddleware({
-  facilitatorUrl: 'https://your-facilitator-url.com',
-  address: '0xYourAddress',
-  network: 'base' as Network, // or 'base-sepolia' for testnet
+  facilitatorUrl: "https://your-facilitator-url.com",
+  address: "0xYourAddress",
+  network: "base" as Network, // or "base-sepolia" for testnet
 });
 
 // Apply the middleware to a route
-app.get('/protected-route', 
+app.get("/protected-route", 
   paymentMiddleware("$0.10", {
     description: "Access to premium content",
     resource: "https://your-api.com/protected-route"
@@ -45,7 +45,7 @@ The `configurePaymentMiddleware` function accepts a global configuration object 
 interface GlobalConfig {
   facilitatorUrl: string;  // URL of the x402 facilitator service
   address: `0x${string}`;  // Your receiving address
-  network: Network;        // 'base' or 'base-sepolia'
+  network: Network;        // "base" or "base-sepolia"
 }
 ```
 

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -159,3 +159,5 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
     };
   };
 }
+
+export { Resource, Network, GlobalConfig, PaymentMiddlewareConfig, Money } from "x402/types";

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.21.2
-      x402:
-        specifier: workspace:*
-        version: link:../../../packages/x402
       x402-express:
         specifier: workspace:*
         version: link:../../../packages/x402-express


### PR DESCRIPTION
This PR adds a readme to the `x402-express` npm module, and the `examples/servers/express` example.

This also makes one tweak so that `x402-express` exports the types needed to define the config objects (i.e. re-exports `Network`). This allows clients to not install `x402` alongside it just to `as Network` when defining config objects.