### PR TITLE
feat: middleware spec update

### DIFF
--- a/packages/typescript/x402/src/axios/index.ts
+++ b/packages/typescript/x402/src/axios/index.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance, AxiosError } from "axios";
-import { PaymentRequirementsSchema } from "../types";
+import { PaymentRequirements, PaymentRequirementsSchema } from "../types";
 import { evm } from "../shared";
 import { createPaymentHeader } from "../client";
 
@@ -15,10 +15,13 @@ export function withPaymentInterceptor(
       }
 
       try {
-        const { paymentRequirements } = error.response.data as any;
-        const parsed = PaymentRequirementsSchema.parse(paymentRequirements);
+        const { paymentRequirements } = error.response.data as { paymentRequirements: PaymentRequirements[] };
+        const parsedPaymentRequirements = paymentRequirements.map(x => PaymentRequirementsSchema.parse(x));
 
-        const paymentHeader = await createPaymentHeader(walletClient, parsed);
+        // TODO: Improve selection between multiple payment requirements
+        const selectedPaymentRequirements = parsedPaymentRequirements[0];
+
+        const paymentHeader = await createPaymentHeader(walletClient, selectedPaymentRequirements);
 
         const originalConfig = error.config;
         if (!originalConfig || !originalConfig.headers) {

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -192,4 +192,4 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
   };
 }
 
-export { Resource, Network, GlobalConfig, PaymentMiddlewareConfig, Money } from "x402/types";
+export type { Resource, Network, GlobalConfig, PaymentMiddlewareConfig, Money } from "x402/types";

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -68,19 +68,21 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
       // Use req.originalUrl as the resource if none is provided
       // TODO: req.originalUrl is not always correct, and can just be the route, i.e. `/route`. Need to consider a better fallback.
       const resourceUrl: Resource = resource || (req.originalUrl as Resource);
-      const paymentRequirements: PaymentRequirements[] = [{
-        scheme: "exact",
-        network,
-        maxAmountRequired: maxAmountRequired.toString(),
-        resource: resourceUrl,
-        description: description ?? "",
-        mimeType: mimeType ?? "",
-        payTo: address,
-        maxTimeoutSeconds: maxTimeoutSeconds ?? 60,
-        asset: getUsdcAddressForChain(getNetworkId(network)),
-        outputSchema: outputSchema ?? undefined,
-        extra: undefined,
-      }];
+      const paymentRequirements: PaymentRequirements[] = [
+        {
+          scheme: "exact",
+          network,
+          maxAmountRequired: maxAmountRequired.toString(),
+          resource: resourceUrl,
+          description: description ?? "",
+          mimeType: mimeType ?? "",
+          payTo: address,
+          maxTimeoutSeconds: maxTimeoutSeconds ?? 60,
+          asset: getUsdcAddressForChain(getNetworkId(network)),
+          outputSchema: outputSchema ?? undefined,
+          extra: undefined,
+        },
+      ];
 
       const payment = req.header("X-PAYMENT");
       const userAgent = req.header("User-Agent") || "";
@@ -117,7 +119,9 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
         });
       }
 
-      const selectedPaymentRequirements = paymentRequirements.find((value) => value.scheme === decodedPayment.scheme && value.network === decodedPayment.network);
+      const selectedPaymentRequirements = paymentRequirements.find(
+        value => value.scheme === decodedPayment.scheme && value.network === decodedPayment.network,
+      );
       if (!selectedPaymentRequirements) {
         return res.status(402).json({
           error: "Unable to find matching payment requirements",

--- a/typescript/packages/x402-fetch/src/index.test.ts
+++ b/typescript/packages/x402-fetch/src/index.test.ts
@@ -12,17 +12,19 @@ describe("fetchWithPayment()", () => {
   let mockFetch: ReturnType<typeof vi.fn>;
   let mockWalletClient: typeof evm.SignerWallet;
   let wrappedFetch: ReturnType<typeof fetchWithPayment>;
-  const validPaymentRequirements: PaymentRequirements = {
-    scheme: "exact",
-    network: "base-sepolia",
-    maxAmountRequired: "100000", // 0.1 USDC in base units
-    resource: "https://api.example.com/resource",
-    description: "Test payment",
-    mimeType: "application/json",
-    payTo: "0x1234567890123456789012345678901234567890",
-    maxTimeoutSeconds: 300,
-    asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e", // USDC on base-sepolia
-  };
+  const validPaymentRequirements: PaymentRequirements[] = [
+    {
+      scheme: "exact",
+      network: "base-sepolia",
+      maxAmountRequired: "100000", // 0.1 USDC in base units
+      resource: "https://api.example.com/resource",
+      description: "Test payment",
+      mimeType: "application/json",
+      payTo: "0x1234567890123456789012345678901234567890",
+      maxTimeoutSeconds: 300,
+      asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e", // USDC on base-sepolia
+    },
+  ];
 
   const createResponse = (status: number, data?: unknown): Response => {
     const response = new Response(JSON.stringify(data), {
@@ -71,7 +73,7 @@ describe("fetchWithPayment()", () => {
     } as RequestInitWithRetry);
 
     expect(result).toBe(successResponse);
-    expect(createPaymentHeader).toHaveBeenCalledWith(mockWalletClient, validPaymentRequirements);
+    expect(createPaymentHeader).toHaveBeenCalledWith(mockWalletClient, validPaymentRequirements[0]);
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(mockFetch).toHaveBeenLastCalledWith("https://api.example.com", {
       method: "GET",
@@ -106,10 +108,12 @@ describe("fetchWithPayment()", () => {
 
   it("should reject if payment amount exceeds maximum", async () => {
     const errorResponse = createResponse(402, {
-      paymentRequirements: {
-        ...validPaymentRequirements,
-        maxAmountRequired: "200000", // 0.2 USDC, which exceeds our default max of 0.1 USDC
-      },
+      paymentRequirements: [
+        {
+          ...validPaymentRequirements[0],
+          maxAmountRequired: "200000", // 0.2 USDC, which exceeds our default max of 0.1 USDC
+        },
+      ],
     });
     mockFetch.mockResolvedValue(errorResponse);
 

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -45,7 +45,9 @@ export function fetchWithPayment(
     }
 
     const { paymentRequirements } = (await response.json()) as { paymentRequirements: unknown[] };
-    const parsedPaymentRequirements = paymentRequirements.map(x => PaymentRequirementsSchema.parse(x));
+    const parsedPaymentRequirements = paymentRequirements.map(x =>
+      PaymentRequirementsSchema.parse(x),
+    );
 
     // TODO: Improve selection between multiple payment requirements
     const selectedPaymentRequirements = parsedPaymentRequirements[0];

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -44,13 +44,17 @@ export function fetchWithPayment(
       return response;
     }
 
-    const { paymentRequirements } = (await response.json()) as { paymentRequirements: unknown };
-    const parsed = PaymentRequirementsSchema.parse(paymentRequirements);
-    if (BigInt(parsed.maxAmountRequired) > maxValue) {
+    const { paymentRequirements } = (await response.json()) as { paymentRequirements: unknown[] };
+    const parsedPaymentRequirements = paymentRequirements.map(x => PaymentRequirementsSchema.parse(x));
+
+    // TODO: Improve selection between multiple payment requirements
+    const selectedPaymentRequirements = parsedPaymentRequirements[0];
+
+    if (BigInt(selectedPaymentRequirements.maxAmountRequired) > maxValue) {
       throw new Error("Payment amount exceeds maximum allowed");
     }
 
-    const paymentHeader = await createPaymentHeader(walletClient, parsed);
+    const paymentHeader = await createPaymentHeader(walletClient, selectedPaymentRequirements);
 
     if (!init) {
       throw new Error("Missing fetch request configuration");

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -67,19 +67,21 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
 
     return async (c, next) => {
       let resourceUrl = resource || (c.req.url as Resource);
-      const paymentRequirements: PaymentRequirements[] = [{
-        scheme: "exact",
-        network,
-        maxAmountRequired: maxAmountRequired.toString(),
-        resource: resourceUrl,
-        description: description ?? "",
-        mimeType: mimeType ?? "",
-        payTo: address,
-        maxTimeoutSeconds: maxTimeoutSeconds ?? 60,
-        asset: getUsdcAddressForChain(getNetworkId(network)),
-        outputSchema: outputSchema || undefined,
-        extra: undefined,
-      }];
+      const paymentRequirements: PaymentRequirements[] = [
+        {
+          scheme: "exact",
+          network,
+          maxAmountRequired: maxAmountRequired.toString(),
+          resource: resourceUrl,
+          description: description ?? "",
+          mimeType: mimeType ?? "",
+          payTo: address,
+          maxTimeoutSeconds: maxTimeoutSeconds ?? 60,
+          asset: getUsdcAddressForChain(getNetworkId(network)),
+          outputSchema: outputSchema || undefined,
+          extra: undefined,
+        },
+      ];
 
       const payment = c.req.header("X-PAYMENT");
       const userAgent = c.req.header("User-Agent") || "";
@@ -126,7 +128,9 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
         );
       }
 
-      const selectedPaymentRequirements = paymentRequirements.find((value) => value.scheme === decodedPayment.scheme && value.network === decodedPayment.network);
+      const selectedPaymentRequirements = paymentRequirements.find(
+        value => value.scheme === decodedPayment.scheme && value.network === decodedPayment.network,
+      );
       if (!selectedPaymentRequirements) {
         return c.json(
           {

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -53,6 +53,11 @@
       "import": "./dist/esm/shared/evm/index.js",
       "require": "./dist/cjs/shared/evm/index.js"
     },
+    "./schemes": {
+      "types": "./dist/esm/schemes/index.d.ts",
+      "import": "./dist/esm/schemes/index.js",
+      "require": "./dist/cjs/schemes/index.js"
+    },
     "./client": {
       "types": "./dist/esm/client/index.d.ts",
       "import": "./dist/esm/client/index.js",

--- a/typescript/packages/x402/src/client/index.ts
+++ b/typescript/packages/x402/src/client/index.ts
@@ -1,3 +1,4 @@
 export * from "./createPaymentHeader";
 export * from "./preparePaymentHeader";
+export * from "./selectPaymentRequirements";
 export * from "./signPaymentHeader";

--- a/typescript/packages/x402/src/client/selectPaymentRequirements.ts
+++ b/typescript/packages/x402/src/client/selectPaymentRequirements.ts
@@ -1,0 +1,27 @@
+import { PaymentRequirements } from "../types";
+import { getUsdcAddressForChain } from "../shared/evm";
+import { getNetworkId } from "../shared/network";
+
+/**
+ * Default selector for payment requirements.
+ * Default behavior is to select the first payment requirement that has a USDC asset.
+ * If no USDC payment requirement is found, the first payment requirement is selected.
+ * 
+ * @param paymentRequirements - The payment requirements to select from.
+ * @returns The payment requirement that is the most appropriate for the user.
+ */
+export function selectPaymentRequirements(paymentRequirements: PaymentRequirements[]): PaymentRequirements {
+  const usdcPaymentRequirement = paymentRequirements.find(requirement => requirement.scheme === "exact" && requirement.asset === getUsdcAddressForChain(getNetworkId(requirement.network)));
+  if (usdcPaymentRequirement) {
+    return usdcPaymentRequirement;
+  }
+  return paymentRequirements[0];
+}
+
+/**
+ * Selector for payment requirements.
+ * 
+ * @param paymentRequirements - The payment requirements to select from.
+ * @returns The payment requirement that is the most appropriate for the user.
+ */
+export type PaymentRequirementsSelector = (paymentRequirements: PaymentRequirements[]) => PaymentRequirements;

--- a/typescript/packages/x402/src/facilitator/facilitator.ts
+++ b/typescript/packages/x402/src/facilitator/facilitator.ts
@@ -1,7 +1,12 @@
-import { verify as verifyExact, settle as settleExact, decodePayment } from "../schemes/exact/evm";
+import { verify as verifyExact, settle as settleExact } from "../schemes/exact/evm";
 import { SupportedEVMNetworks } from "../types/shared";
 import { ConnectedClient, SignerWallet } from "../types/shared/evm";
-import { PaymentRequirements, SettleResponse, VerifyResponse } from "../types/verify";
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from "../types/verify";
 import { Chain, Transport, Account } from "viem";
 
 /**
@@ -19,15 +24,14 @@ export async function verify<
   account extends Account | undefined,
 >(
   client: ConnectedClient<transport, chain, account>,
-  payload: string,
+  payload: PaymentPayload,
   paymentRequirements: PaymentRequirements,
 ): Promise<VerifyResponse> {
   if (
     paymentRequirements.scheme == "exact" &&
     SupportedEVMNetworks.includes(paymentRequirements.network)
   ) {
-    const payment = decodePayment(payload);
-    const valid = await verifyExact(client, payment, paymentRequirements);
+    const valid = await verifyExact(client, payload, paymentRequirements);
     return valid;
   }
   return {
@@ -47,16 +51,14 @@ export async function verify<
  */
 export async function settle<transport extends Transport, chain extends Chain>(
   client: SignerWallet<chain, transport>,
-  payload: string,
+  payload: PaymentPayload,
   paymentRequirements: PaymentRequirements,
 ): Promise<SettleResponse> {
-  const payment = decodePayment(payload);
-
   if (
     paymentRequirements.scheme == "exact" &&
     SupportedEVMNetworks.includes(paymentRequirements.network)
   ) {
-    return settleExact(client, payment, paymentRequirements);
+    return settleExact(client, payload, paymentRequirements);
   }
 
   return {

--- a/typescript/packages/x402/src/schemes/exact/evm/sign.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/sign.ts
@@ -19,24 +19,25 @@ import { getRandomValues } from "crypto";
  * @param paymentRequirements - The payment requirements containing asset and network information
  * @param paymentRequirements.asset - The address of the USDC contract
  * @param paymentRequirements.network - The network where the USDC contract exists
+ * @param paymentRequirements.extra - The extra information containing the name and version of the ERC20 contract
  * @returns The signature for the authorization
  */
 export async function signAuthorization<transport extends Transport, chain extends Chain>(
   walletClient: SignerWallet<chain, transport>,
   { from, to, value, validAfter, validBefore, nonce }: ExactEvmPayloadAuthorization,
-  { asset, network }: PaymentRequirements,
+  { asset, network, extra }: PaymentRequirements,
 ): Promise<{ signature: Hex }> {
   const chainId = getNetworkId(network);
-  const usdcName = config[chainId].usdcName;
-  const version = await getVersion(walletClient);
+  const name = extra?.name ?? config[chainId].usdcName;
+  const version = extra?.version ?? (await getVersion(walletClient));
 
   const data = {
     account: walletClient.account!,
     types: authorizationTypes,
     domain: {
-      name: usdcName,
-      version: version,
-      chainId: chainId,
+      name,
+      version,
+      chainId,
       verifyingContract: asset as Address,
     },
     primaryType: "TransferWithAuthorization" as const,

--- a/typescript/packages/x402/src/shared/evm/erc20.ts
+++ b/typescript/packages/x402/src/shared/evm/erc20.ts
@@ -1,0 +1,29 @@
+import { Account, Address, Chain, Transport } from "viem";
+import { usdcABI as erc20PermitABI } from "../../types/shared/evm/erc20PermitABI";
+import { ConnectedClient } from "../../types/shared/evm/wallet";
+
+/**
+ * Gets the USDC balance for a specific address
+ *
+ * @param client - The Viem client instance connected to the blockchain
+ * @param erc20Address - The address of the ERC20 contract
+ * @param address - The address to check the USDC balance for
+ * @returns A promise that resolves to the USDC balance as a bigint
+ */
+export async function getERC20Balance<
+  transport extends Transport,
+  chain extends Chain,
+  account extends Account | undefined = undefined,
+>(
+  client: ConnectedClient<transport, chain, account>,
+  erc20Address: Address,
+  address: Address,
+): Promise<bigint> {
+  const balance = await client.readContract({
+    address: erc20Address,
+    abi: erc20PermitABI,
+    functionName: "balanceOf",
+    args: [address],
+  });
+  return balance as bigint;
+}

--- a/typescript/packages/x402/src/shared/evm/index.ts
+++ b/typescript/packages/x402/src/shared/evm/index.ts
@@ -1,1 +1,2 @@
 export * from "./usdc";
+export * from "./erc20";

--- a/typescript/packages/x402/src/shared/json.ts
+++ b/typescript/packages/x402/src/shared/json.ts
@@ -17,7 +17,7 @@ export function toJsonSafe<T extends object>(data: T): object {
    * @returns The converted value with bigints as strings
    */
   function convert(value: unknown): unknown {
-    if (value !== null && typeof value === "object") {
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
       return Object.fromEntries(Object.entries(value).map(([key, val]) => [key, convert(val)]));
     }
 

--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -288,18 +288,18 @@ export function getPaywallHtml({
 
   window.x402.utils.signAuthorization = async (walletClient, authorizationParameters, paymentRequirements, publicClient) => {
     const chainId = getNetworkId(paymentRequirements.network);
-    const usdcName = window.x402.config.chainConfig[chainId].usdcName;
-    const usdcAddress = window.x402.config.chainConfig[chainId].usdcAddress;
-    const version = await window.x402.utils.getVersion(publicClient, usdcAddress);
+    const name = paymentRequirements.extra?.name ?? window.x402.config.chainConfig[chainId].usdcName;
+    const erc20Address = paymentRequirements.asset;
+    const version = paymentRequirements.extra?.version ?? await window.x402.utils.getVersion(publicClient, erc20Address);
     const { from, to, value, validAfter, validBefore, nonce } = authorizationParameters;
     const data = {
       account: walletClient.account,
       types: authorizationTypes,
       domain: {
-        name: usdcName,
-        version: version,
-        chainId: chainId,
-        verifyingContract: usdcAddress,
+        name,
+        version,
+        chainId,
+        verifyingContract: erc20Address,
       },
       primaryType: "TransferWithAuthorization",
       message: {

--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -1,3 +1,4 @@
+import { selectPaymentRequirements } from "../client";
 import { PaymentRequirements } from "../types/verify";
 
 interface PaywallOptions {
@@ -157,7 +158,7 @@ export function getPaywallHtml({
   try {
     // Initialize x402 namespace
     window.x402 = {
-      paymentRequirements: ${JSON.stringify(paymentRequirements[0])},
+      paymentRequirements: ${JSON.stringify(selectPaymentRequirements(paymentRequirements))},
       isTestnet: ${testnet},
       currentUrl: "${currentUrl}",
       state: {

--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -2,7 +2,7 @@ import { PaymentRequirements } from "../types/verify";
 
 interface PaywallOptions {
   amount: number;
-  paymentRequirements: PaymentRequirements;
+  paymentRequirements: PaymentRequirements[];
   currentUrl: string;
   testnet: boolean;
 }
@@ -157,7 +157,7 @@ export function getPaywallHtml({
   try {
     // Initialize x402 namespace
     window.x402 = {
-      paymentRequirements: ${JSON.stringify(paymentRequirements)},
+      paymentRequirements: ${JSON.stringify(paymentRequirements[0])},
       isTestnet: ${testnet},
       currentUrl: "${currentUrl}",
       state: {
@@ -525,7 +525,7 @@ window.addEventListener('load', initializeApp);
   <div class="container">
     <div class="header">
       <h1 class="title">Payment Required</h1>
-      <p class="subtitle">${paymentRequirements.description}. To access this content, please pay $${amount} ${testnet ? "Base Sepolia" : "Base"} USDC.</p>
+      <p class="subtitle">${paymentRequirements[0].description}. To access this content, please pay $${amount} ${testnet ? "Base Sepolia" : "Base"} USDC.</p>
       <p class="instructions">Need Base Sepolia USDC? <a href="https://faucet.circle.com/" target="_blank" rel="noopener noreferrer">Get some here.</a></p>
     </div>
 

--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -24,6 +24,7 @@ export function getPaywallHtml({
   paymentRequirements,
   currentUrl,
 }: PaywallOptions): string {
+  const selectedPaymentRequirements = selectPaymentRequirements(paymentRequirements);
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -158,7 +159,7 @@ export function getPaywallHtml({
   try {
     // Initialize x402 namespace
     window.x402 = {
-      paymentRequirements: ${JSON.stringify(selectPaymentRequirements(paymentRequirements))},
+      paymentRequirements: ${JSON.stringify(selectedPaymentRequirements)},
       isTestnet: ${testnet},
       currentUrl: "${currentUrl}",
       state: {
@@ -526,7 +527,7 @@ window.addEventListener('load', initializeApp);
   <div class="container">
     <div class="header">
       <h1 class="title">Payment Required</h1>
-      <p class="subtitle">${paymentRequirements[0].description}. To access this content, please pay $${amount} ${testnet ? "Base Sepolia" : "Base"} USDC.</p>
+      <p class="subtitle">${selectedPaymentRequirements.description}. To access this content, please pay $${amount} ${testnet ? "Base Sepolia" : "Base"} USDC.</p>
       <p class="instructions">Need Base Sepolia USDC? <a href="https://faucet.circle.com/" target="_blank" rel="noopener noreferrer">Get some here.</a></p>
     </div>
 

--- a/typescript/packages/x402/src/types/shared/middleware.ts
+++ b/typescript/packages/x402/src/types/shared/middleware.ts
@@ -15,4 +15,12 @@ export type PaymentMiddlewareConfig = {
   outputSchema?: object;
   customPaywallHtml?: string;
   resource?: Resource;
+  asset?: {
+    address: string;
+    decimals: number;
+    eip712: {
+      name: string;
+      version: string;
+    };
+  };
 };

--- a/typescript/packages/x402/src/verify/useFacilitator.ts
+++ b/typescript/packages/x402/src/verify/useFacilitator.ts
@@ -1,4 +1,9 @@
-import { PaymentRequirements, SettleResponse, VerifyResponse } from "../types/verify";
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from "../types/verify";
 import axios from "axios";
 import { toJsonSafe } from "../shared";
 
@@ -17,11 +22,11 @@ export function useFacilitator(url: string = "https://x402.org/facilitator") {
    * @returns A promise that resolves to the verification response
    */
   async function verify(
-    payload: string,
+    payload: PaymentPayload,
     paymentRequirements: PaymentRequirements,
   ): Promise<VerifyResponse> {
     const res = await axios.post(`${url}/verify`, {
-      payload: payload,
+      payload: toJsonSafe(payload),
       details: toJsonSafe(paymentRequirements),
     });
 
@@ -40,11 +45,11 @@ export function useFacilitator(url: string = "https://x402.org/facilitator") {
    * @returns A promise that resolves to the settlement response
    */
   async function settle(
-    payload: string,
+    payload: PaymentPayload,
     paymentRequirements: PaymentRequirements,
   ): Promise<SettleResponse> {
     const res = await axios.post(`${url}/settle`, {
-      payload: payload,
+      payload: toJsonSafe(payload),
       details: toJsonSafe(paymentRequirements),
     });
 

--- a/typescript/packages/x402/tsup.config.ts
+++ b/typescript/packages/x402/tsup.config.ts
@@ -5,6 +5,7 @@ const baseConfig = {
     index: "src/index.ts",
     "shared/index": "src/shared/index.ts",
     "shared/evm/index": "src/shared/evm/index.ts",
+    "schemes/index": "src/schemes/index.ts",
     "client/index": "src/client/index.ts",
     "verify/index": "src/verify/index.ts",
     "facilitator/index": "src/facilitator/index.ts",


### PR DESCRIPTION
- [x] The x402 packages' verify/settle helpers have been updated to take a decoded object
- [x] The x402 middleware packages have been updated to decode the payment requirements from the user and pass them along to the facilitator
- [x] The x402 middleware packages have been updated to respond with an array of PaymentRequirements when giving a x402 error. Clients are expected to pick from the array.
- [x] The x402 axios interceptor and fetch wrapper packages have been updated to handle an array of payment requirements
- [x] Clients packages offer a selector to pick which payment requirements. If none is explicitly given, it defaults to our selector, which selects USDC by default
- [x] The default HTML paywall has been updated to expect an array of PaymentRequirements, and uses our default selector
- [x] The `extra` field should be used to request asset-related metadata required for the domain separator. If this is not set, USDC is defaulted

## Tests

### Axios + Express + Facilitator with the above changes
![Screenshot 2025-04-16 at 2 45 02 PM](https://github.com/user-attachments/assets/3674378c-3992-415c-b109-7c77204ffedf)

### Fetch + Hono + Facilitator with the above changes
![Screenshot 2025-04-16 at 2 45 46 PM](https://github.com/user-attachments/assets/cafb51f4-3406-499d-8ed6-2b745e984d43)

### TODO Tests
Once Next + Site refactor updated to include these changes, they will test the paywall addition
