### PR TITLE
feat: updated README to spec, and code to match README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 ```typescript
 app.use(
+  '/your-endpoint',
   // How much you want to charge, and where you want the funds to land
-  paymentMiddleware("$0.10", "0x209693Bc6afc0C5328bA36FaF03C514EF312287C")
+  paymentMiddleware('$0.10', '0x209693Bc6afc0C5328bA36FaF03C514EF312287C')
 );
 // Thats it! See examples/typescript/servers/express.ts for a complete example. Instruction below for running on base-sepolia.
 ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 
 ```typescript
 app.use(
-  "/your-endpoint",
   // How much you want to charge, and where you want the funds to land
   paymentMiddleware("$0.10", "0x209693Bc6afc0C5328bA36FaF03C514EF312287C")
 );
-// Thats it! See example/resource.ts for a complete example. Instruction below for running on base-sepolia.
+// Thats it! See examples/typescript/servers/express.ts for a complete example. Instruction below for running on base-sepolia.
 ```
 
 ## Terms:
@@ -32,7 +31,7 @@ The `x402` protocol is a chain agnostic standard for payments on top of HTTP, le
 
 It specifies:
 
-1. A schema for how servers can respond to clients to facilitate payment for a resource (`PaymentDetails`)
+1. A schema for how servers can respond to clients to facilitate payment for a resource (`PaymentRequirements`)
 2. A standard header `X-PAYMENT` that is set by clients paying for resources
 3. A standard schema and encoding method for data in the `X-PAYMENT` header
 4. A recommended flow for how payments should be verified and settled by a resource server
@@ -50,19 +49,19 @@ the payment details accepted for a resource.
 
 2. `Resource server` responds with a `402 Payment Required` status and a `Payment Required Response` JSON object in the response body.
 
-3. `Client` selects one of the `paymentDetails` returned by the `accepts` field of the server response and creates a `Payment Payload` based on the `scheme` of the `paymentDetails` they have selected.
+3. `Client` selects one of the `paymentRequirements` returned by the server response and creates a `Payment Payload` based on the `scheme` of the `paymentRequirements` they have selected.
 
 4. `Client` sends the HTTP request with the `X-PAYMENT` header containing the `Payment Payload` to the resource server
 
-5. `Resource server` verifies the `Payment Payload` is valid either via local verification or by POSTing the `Payment Payload` and `Payment Details` to the `/verify` endpoint of a `facilitator server`.
+5. `Resource server` verifies the `Payment Payload` is valid either via local verification or by POSTing the `Payment Payload` and `Payment Requirements` to the `/verify` endpoint of a `facilitator server`.
 
-6. `Facilitator server` performs verification of the object based on the `scheme` and `networkId` of the `Payment Payload` and returns a `Verification Response`
+6. `Facilitator server` performs verification of the object based on the `scheme` and `network` of the `Payment Payload` and returns a `Verification Response`
 
 7. If the `Verification Response` is valid, the resource server performs the work to fulfill the request. If the `Verification Response` is invalid, the resource server returns a `402 Payment Required` status and a `Payment Required Response` JSON object in the response body.
 
-8. `Resource server` either settles the payment by interacting with a blockchain directly, or by POSTing the `Payment Payload` and `Payment Details` to the `/settle` endpoint of a `facilitator server`.
+8. `Resource server` either settles the payment by interacting with a blockchain directly, or by POSTing the `Payment Payload` and `Payment PaymentRequirements` to the `/settle` endpoint of a `facilitator server`.
 
-9. `Facilitator server` submits the payment to the blockchain based on the `scheme` and `networkId` of the `Payment Payload`.
+9. `Facilitator server` submits the payment to the blockchain based on the `scheme` and `network` of the `Payment Payload`.
 
 10. `Facilitator server` waits for the payment to be confirmed on the blockchain.
 
@@ -80,22 +79,22 @@ the payment details accepted for a resource.
   // Version of the x402 payment protocol
   x402Version: int,
 
-  // List of payment details that the resource server accepts. A resource server may accept on multiple chains.
-  accepts: [paymentDetails]
+  // List of payment requirements that the resource server accepts. A resource server may accept on multiple chains, or in multiple currencies.
+  accepts: [paymentRequirements]
 
   // Message from the resource server to the client to communicate errors in processing payment
   error: string
 }
 
-// paymentDetails
+// paymentRequirements
 {
   // Scheme of the payment protocol to use
   scheme: string;
 
   // Network of the blockchain to send payment on
-  networkId: string;
+  network: string;
 
-  // Maximum amount required to pay for the resource as usdc dollars x 10**6
+  // Maximum amount required to pay for the resource in atomic units of the asset
   maxAmountRequired: uint256 as string;
 
   // URL of resource to pay for
@@ -111,15 +110,16 @@ the payment details accepted for a resource.
   outputSchema?: object | null;
 
   // Address to pay value to
-  payToAddress: string;
+  payTo: string;
 
   // Maximum time in seconds for the resource server to respond
   maxTimeoutSeconds: number;
 
-  // Address of the USDC contract
-  usdcAddress: string;
+  // Address of the EIP-3009 compliant ERC20 contract
+  asset: string;
 
   // Extra information about the payment details specific to the scheme
+  // For `exact` scheme on a EVM network, expects extra to contain the records `name` and `version` pertaining to asset
   extra: object | null;
 }
 
@@ -131,14 +131,11 @@ the payment details accepted for a resource.
   // scheme is the scheme value of the accepted `paymentDetails` the client is using to pay
   scheme: string;
 
-  // networkId is the network id of the accepted `paymentDetails` the client is using to pay
-  networkId: string;
+  // network is the network id of the accepted `paymentRequirements` the client is using to pay
+  network: string;
 
   // payload is scheme dependent
   payload: <scheme dependent>;
-
-  // resource the client is paying for
-  resource: string;
 }
 ```
 
@@ -151,6 +148,7 @@ A `facilitator server` is a 3rd party service that can be used by a `resource se
 POST /verify
 Request body JSON:
 {
+  x402Version: number;
   paymentHeader: string;
   paymentDetails: paymentDetails;
 }
@@ -165,6 +163,7 @@ Response:
 POST /settle
 Request body JSON:
 {
+  x402Version: number;
   paymentHeader: string;
   paymentDetails: paymentDetails;
 }
@@ -184,18 +183,6 @@ Response:
   networkId: string | null;
 }
 
-// Get supported payment schemes and networks
-GET /supported
-Response:
-{
-  kinds: [
-    {
-      "scheme": string,
-      "networkId": string,
-    }
-  ]
-}
-
 ```
 
 ### Schemes
@@ -209,34 +196,30 @@ For example `exact`, the first scheme shipping as part of the protocol, would ha
 
 See `specs/schemes` for more details on schemes, and see `specs/schemes/exact/scheme_exact_evm.md` to see the first proposed scheme for exact payment on EVM chains.
 
-### Schemes vs NetworkIds
+### Schemes vs Networks
 
 Because a scheme is a logical way of moving money, the way a scheme is implemented can be different for different blockchains. (ex: the way you need to implement `exact` on Ethereum is very different than the way you need to implement `exact` on Solana)
 
-Clients and facilitator must explicitly support different `(scheme, networkId)` pairs in order to be able to create proper payloads and verify / settle payments.
+Clients and facilitator must explicitly support different `(scheme, network)` pairs in order to be able to create proper payloads and verify / settle payments.
 
 ## Running example
 
-`cd example`
+1. In three separate terminals, navigate to the following directories:
+   - `examples/typescript/facilitator`
+   - `examples/typescript/servers/express`
+   - `examples/typescript/clients/axios`
 
-1. create `.env` `cp ../packages/typescript/x402/.env.example .env` and follow instruction in the file to create wallets
+2. In each terminal:
+   - Copy the environment file: `cp .env-local .env`
+   - Fill in the required values in the `.env` file
+   - Run `pnpm dev`
 
-2. `npm install` to install dependencies
-
-3. in 3 separate terminals, run `npm run facilitator`, `npm run resource`, then finally `npm run client`. You should see things happen across all 3 terminals, and get a joke at the end in the client terminal.
+3. You should see activity across all three terminals, and the client terminal will display a weather report.
 
 ## Running tests
 
-`cd packages/typescript`
+1. Navigate to the typescript directory: `cd packages/typescript`
+2. Install dependencies: `pnpm install`
+3. Run the unit tests: `pnpm test`
 
-1. `npm install` to install dependencies
-2. Create `.env` with funded keys as above
-3. `npm run test` to run tests
-
-## TODO
-
-- have tests run on an anvil fork
-
-## 📝 License
-
-The `x402` protocol is licensed under the [Apache-2.0](LICENSE.md) license.
+This will run the unit tests for the x402 packages.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ```typescript
 app.use(
-  '/your-endpoint',
+  "/your-endpoint",
   // How much you want to charge, and where you want the funds to land
-  paymentMiddleware('$0.10', '0x209693Bc6afc0C5328bA36FaF03C514EF312287C')
+  paymentMiddleware("$0.10", "0x209693Bc6afc0C5328bA36FaF03C514EF312287C")
 );
 // Thats it! See examples/typescript/servers/express.ts for a complete example. Instruction below for running on base-sepolia.
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ the payment details accepted for a resource.
   // Version of the x402 payment protocol
   x402Version: number;
 
-  // scheme is the scheme value of the accepted `paymentDetails` the client is using to pay
+  // scheme is the scheme value of the accepted `paymentRequirements` the client is using to pay
   scheme: string;
 
   // network is the network id of the accepted `paymentRequirements` the client is using to pay
@@ -150,7 +150,7 @@ Request body JSON:
 {
   x402Version: number;
   paymentHeader: string;
-  paymentDetails: paymentDetails;
+  paymentRequirements: paymentRequirements;
 }
 
 Response:
@@ -165,7 +165,7 @@ Request body JSON:
 {
   x402Version: number;
   paymentHeader: string;
-  paymentDetails: paymentDetails;
+  paymentRequirements: paymentRequirements;
 }
 
 Response:

--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ Response:
   networkId: string | null;
 }
 
+// Get supported payment schemes and networks
+GET /supported
+Response:
+{
+  kinds: [
+    {
+      "scheme": string,
+      "network": string,
+    }
+  ]
+}
+
 ```
 
 ### Schemes

--- a/examples/typescript/facilitator/index.ts
+++ b/examples/typescript/facilitator/index.ts
@@ -73,6 +73,18 @@ app.get("/settle", (req, res) => {
   });
 });
 
+app.get("/supported", (req, res) => {
+  res.json({
+    kinds: [
+      {
+        x402Version: 1,
+        scheme: "exact",
+        network: "base-sepolia",
+      },
+    ],
+  });
+});
+
 app.post("/settle", async (req, res) => {
   try {
     const signer = createSignerSepolia(PRIVATE_KEY as `0x${string}`);

--- a/examples/typescript/facilitator/index.ts
+++ b/examples/typescript/facilitator/index.ts
@@ -28,13 +28,13 @@ const port = parseInt(PORT);
 app.use(express.json());
 
 type VerifyRequest = {
-  payload: PaymentPayload;
-  details: PaymentRequirements;
+  paymentPayload: PaymentPayload;
+  paymentRequirements: PaymentRequirements;
 };
 
 type SettleRequest = {
-  payload: PaymentPayload;
-  details: PaymentRequirements;
+  paymentPayload: PaymentPayload;
+  paymentRequirements: PaymentRequirements;
 };
 
 const client = createClientSepolia();
@@ -44,8 +44,8 @@ app.get("/verify", (req, res) => {
     endpoint: "/verify",
     description: "POST to verify x402 payments",
     body: {
-      payload: "string",
-      details: "PaymentRequirements",
+      paymentPayload: "PaymentPayload",
+      paymentRequirements: "PaymentRequirements",
     },
   });
 });
@@ -53,8 +53,8 @@ app.get("/verify", (req, res) => {
 app.post("/verify", async (req, res) => {
   try {
     const body: VerifyRequest = req.body;
-    const paymentRequirements = PaymentRequirementsSchema.parse(body.details);
-    const paymentPayload = PaymentPayloadSchema.parse(body.payload);
+    const paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);
+    const paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
     const valid = await verify(client, paymentPayload, paymentRequirements);
     res.json(valid);
   } catch {
@@ -67,8 +67,8 @@ app.get("/settle", (req, res) => {
     endpoint: "/settle",
     description: "POST to settle x402 payments",
     body: {
-      payload: "string",
-      details: "PaymentRequirements",
+      paymentPayload: "PaymentPayload",
+      paymentRequirements: "PaymentRequirements",
     },
   });
 });
@@ -89,8 +89,8 @@ app.post("/settle", async (req, res) => {
   try {
     const signer = createSignerSepolia(PRIVATE_KEY as `0x${string}`);
     const body: SettleRequest = req.body;
-    const paymentRequirements = PaymentRequirementsSchema.parse(body.details);
-    const paymentPayload = PaymentPayloadSchema.parse(body.payload);
+    const paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);
+    const paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
     const response = await settle(signer, paymentPayload, paymentRequirements);
     res.json(response);
   } catch {

--- a/site/app/facilitator/settle/route.ts
+++ b/site/app/facilitator/settle/route.ts
@@ -9,8 +9,8 @@ import {
 } from "x402/types";
 
 type SettleRequest = {
-  payload: PaymentPayload;
-  details: PaymentRequirements;
+  paymentPayload: PaymentPayload;
+  paymentRequirements: PaymentRequirements;
 };
 
 /**
@@ -24,8 +24,8 @@ export async function POST(req: Request) {
 
   const body: SettleRequest = await req.json();
 
-  const paymentPayload = PaymentPayloadSchema.parse(body.payload);
-  const paymentRequirements = PaymentRequirementsSchema.parse(body.details);
+  const paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
+  const paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);
 
   const response = await settle(wallet, paymentPayload, paymentRequirements);
 
@@ -42,8 +42,8 @@ export async function GET() {
     endpoint: "/settle",
     description: "POST to settle x402 payments",
     body: {
-      payload: "PaymentPayload",
-      details: "PaymentRequirements",
+      paymentPayload: "PaymentPayload",
+      paymentRequirements: "PaymentRequirements",
     },
   });
 }

--- a/site/app/facilitator/supported/route.ts
+++ b/site/app/facilitator/supported/route.ts
@@ -1,0 +1,25 @@
+import { SupportedPaymentKindsResponse } from "x402/types";
+
+/**
+ * Returns the supported payment kinds for the x402 protocol
+ *
+ * @returns A JSON response containing the list of supported payment kinds
+ */
+export async function GET() {
+  const response: SupportedPaymentKindsResponse = {
+    kinds: [
+      {
+        x402Version: 1,
+        scheme: "exact",
+        network: "base",
+      },
+      {
+        x402Version: 1,
+        scheme: "exact",
+        network: "base-sepolia",
+      },
+    ],
+  };
+
+  return Response.json(response);
+}

--- a/site/app/facilitator/supported/route.ts
+++ b/site/app/facilitator/supported/route.ts
@@ -11,11 +11,6 @@ export async function GET() {
       {
         x402Version: 1,
         scheme: "exact",
-        network: "base",
-      },
-      {
-        x402Version: 1,
-        scheme: "exact",
         network: "base-sepolia",
       },
     ],

--- a/site/app/facilitator/verify/route.ts
+++ b/site/app/facilitator/verify/route.ts
@@ -8,8 +8,8 @@ import {
 import { verify } from "x402/facilitator";
 
 type VerifyRequest = {
-  payload: PaymentPayload;
-  details: PaymentRequirements;
+  paymentPayload: PaymentPayload;
+  paymentRequirements: PaymentRequirements;
 };
 
 const client = evm.createClientSepolia();
@@ -23,8 +23,8 @@ const client = evm.createClientSepolia();
 export async function POST(req: Request) {
   const body: VerifyRequest = await req.json();
 
-  const paymentPayload = PaymentPayloadSchema.parse(body.payload);
-  const paymentRequirements = PaymentRequirementsSchema.parse(body.details);
+  const paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
+  const paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);
 
   // @ts-expect-error - Type instantiation is excessively deep
   const valid = await verify(client, paymentPayload, paymentRequirements);
@@ -42,8 +42,8 @@ export async function GET() {
     endpoint: "/verify",
     description: "POST to verify x402 payments",
     body: {
-      payload: "PaymentPayload",
-      details: "PaymentRequirements",
+      paymentPayload: "PaymentPayload",
+      paymentRequirements: "PaymentRequirements",
     },
   });
 }

--- a/specs/scheme_impl_template.md
+++ b/specs/scheme_impl_template.md
@@ -6,7 +6,7 @@ Summarize the purpose and behavior of your scheme here. Include example use case
 
 ## `X-Payment` header payload
 
-Document how to construct the `X-Payment` header payload for your scheme, based on `paymentDetails` returned in a `402` response.
+Document how to construct the `X-Payment` header payload for your scheme, based on `paymentRequirements` returned in a `402` response.
 
 ## Verification
 

--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The `exact` scheme on EVM chains uses `EIP-3009` to authorize a transfer of a specific amount of `usdc` from the payer to the resource server. The approach results in the facilitator having no ability to direct funds anywhere but the address specified by the resource server in paymentDetails.
+The `exact` scheme on EVM chains uses `EIP-3009` to authorize a transfer of a specific amount of an `ERC20 token` from the payer to the resource server. The approach results in the facilitator having no ability to direct funds anywhere but the address specified by the resource server in paymentDetails.
 
 ## `X-Payment` header payload
 
@@ -15,15 +15,15 @@ Example:
 
 ```
 {
-  "signature": "0x2d6a7588d6acca505cbf0d9a4a227e0c52c6c34008c8e8986a1283259764173608a2ce6496642e377d6da8dbbf5836e9bd15092f9ecab05ded3d6293af148b571c",
-  "authorization": {
-    "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-    "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-    "value": 10000n,
-    "validAfter": 1740672089n,
-    "validBefore": 1740672154n,
-    "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480",
-    "version": "2"
+  'signature': '0x2d6a7588d6acca505cbf0d9a4a227e0c52c6c34008c8e8986a1283259764173608a2ce6496642e377d6da8dbbf5836e9bd15092f9ecab05ded3d6293af148b571c',
+  'authorization': {
+    'from': '0x857b06519E91e3A54538791bDbb0E22373e36b66',
+    'to': '0x209693Bc6afc0C5328bA36FaF03C514EF312287C',
+    'value': '10000',
+    'validAfter': '1740672089',
+    'validBefore': '1740672154',
+    'nonce': '0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480',
+    'version': '2'
   }
 }
 
@@ -41,14 +41,13 @@ Full `X-PAYMENT` header:
     authorization: {
       from: '0x857b06519E91e3A54538791bDbb0E22373e36b66',
       to: '0x209693Bc6afc0C5328bA36FaF03C514EF312287C',
-      value: 10000n,
-      validAfter: 1740672089n,
-      validBefore: 1740672154n,
+      value: '10000',
+      validAfter: '1740672089',
+      validBefore: '1740672154',
       nonce: '0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480',
       version: '2'
     }
-  },
-  resource: 'http://localhost:4021/joke'
+  }
 }
 ```
 
@@ -57,16 +56,16 @@ Full `X-PAYMENT` header:
 Steps to verify a payment for the `exact` scheme:
 
 1. Verify the signature is valid
-2. Verify the `client` has enough `usdc` to cover `paymentDetails.maxAmountRequired`
-3. Verify the value in the `payload.authorization` is enough to cover `paymentDetails.maxAmountRequired`
+2. Verify the `client` has enough of the `asset` (ERC20 token) to cover `paymentRequirements.maxAmountRequired`
+3. Verify the value in the `payload.authorization` is enough to cover `paymentRequirements.maxAmountRequired`
 4. Verify the authorization parameters are within the valid time range
 5. Verify nonce is not used
-6. Verify the authorization parameters are for the correct `usdc` contract for the agreed upon chain
+6. Verify the authorization parameters are for the agreed upon ERC20 contract and chain
 7. Simulate the `transferWithAuthorization` to ensure the transaction would succeed
 
 ## Settlement
 
-Settlement is performed via the facilitator calling the `transferWithAuthorization` function on the `usdc` contract with the `payload.signature` and `payload.authorization` parameters from the `X-PAYMENT` header.
+Settlement is performed via the facilitator calling the `transferWithAuthorization` function on the `EIP-3009` compliant contract with the `payload.signature` and `payload.authorization` parameters from the `X-PAYMENT` header.
 
 ## Appendix
 

--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -15,15 +15,15 @@ Example:
 
 ```
 {
-  'signature': '0x2d6a7588d6acca505cbf0d9a4a227e0c52c6c34008c8e8986a1283259764173608a2ce6496642e377d6da8dbbf5836e9bd15092f9ecab05ded3d6293af148b571c',
-  'authorization': {
-    'from': '0x857b06519E91e3A54538791bDbb0E22373e36b66',
-    'to': '0x209693Bc6afc0C5328bA36FaF03C514EF312287C',
-    'value': '10000',
-    'validAfter': '1740672089',
-    'validBefore': '1740672154',
-    'nonce': '0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480',
-    'version': '2'
+  "signature": "0x2d6a7588d6acca505cbf0d9a4a227e0c52c6c34008c8e8986a1283259764173608a2ce6496642e377d6da8dbbf5836e9bd15092f9ecab05ded3d6293af148b571c",
+  "authorization": {
+    "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+    "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+    "value": "10000",
+    "validAfter": "1740672089",
+    "validBefore": "1740672154",
+    "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480",
+    "version": "2"
   }
 }
 
@@ -34,18 +34,18 @@ Full `X-PAYMENT` header:
 ```
 {
   x402Version: 1,
-  scheme: 'exact',
-  networkId: '84532',
+  scheme: "exact",
+  networkId: "84532",
   payload: {
-    signature: '0x2d6a7588d6acca505cbf0d9a4a227e0c52c6c34008c8e8986a1283259764173608a2ce6496642e377d6da8dbbf5836e9bd15092f9ecab05ded3d6293af148b571c',
+    signature: "0x2d6a7588d6acca505cbf0d9a4a227e0c52c6c34008c8e8986a1283259764173608a2ce6496642e377d6da8dbbf5836e9bd15092f9ecab05ded3d6293af148b571c",
     authorization: {
-      from: '0x857b06519E91e3A54538791bDbb0E22373e36b66',
-      to: '0x209693Bc6afc0C5328bA36FaF03C514EF312287C',
-      value: '10000',
-      validAfter: '1740672089',
-      validBefore: '1740672154',
-      nonce: '0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480',
-      version: '2'
+      from: "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      to: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      value: "10000",
+      validAfter: "1740672089",
+      validBefore: "1740672154",
+      nonce: "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480",
+      version: "2"
     }
   }
 }

--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The `exact` scheme on EVM chains uses `EIP-3009` to authorize a transfer of a specific amount of an `ERC20 token` from the payer to the resource server. The approach results in the facilitator having no ability to direct funds anywhere but the address specified by the resource server in paymentDetails.
+The `exact` scheme on EVM chains uses `EIP-3009` to authorize a transfer of a specific amount of an `ERC20 token` from the payer to the resource server. The approach results in the facilitator having no ability to direct funds anywhere but the address specified by the resource server in paymentRequirements.
 
 ## `X-Payment` header payload
 

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -54,13 +54,18 @@ export function withPaymentInterceptor(
           return Promise.reject(error);
         }
 
-        const { paymentRequirements } = error.response.data as {
-          paymentRequirements: PaymentRequirements[];
+        const { x402Version, accepts } = error.response.data as {
+          x402Version: number;
+          accepts: PaymentRequirements[];
         };
-        const parsed = paymentRequirements.map(x => PaymentRequirementsSchema.parse(x));
+        const parsed = accepts.map(x => PaymentRequirementsSchema.parse(x));
 
         const selectedPaymentRequirements = paymentRequirementsSelector(parsed);
-        const paymentHeader = await createPaymentHeader(walletClient, selectedPaymentRequirements);
+        const paymentHeader = await createPaymentHeader(
+          walletClient,
+          x402Version,
+          selectedPaymentRequirements,
+        );
 
         (originalConfig as { __is402Retry?: boolean }).__is402Retry = true;
 

--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -127,7 +127,8 @@ describe("configurePaymentMiddleware()", () => {
     expect(mockRes.json).toHaveBeenCalledWith(
       expect.objectContaining({
         error: "X-PAYMENT header is required",
-        paymentRequirements: expect.any(Object),
+        accepts: expect.any(Array),
+        x402Version: 1,
       }),
     );
   });
@@ -181,8 +182,26 @@ describe("configurePaymentMiddleware()", () => {
     expect(mockRes.status).toHaveBeenCalledWith(402);
     expect(mockRes.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        error: expect.any(Error),
-        paymentRequirements: expect.any(Object),
+        error: new Error("Invalid payment"),
+        accepts: [
+          expect.objectContaining({
+            scheme: "exact",
+            network: "base-sepolia",
+            maxAmountRequired: "1000000",
+            resource: "https://api.example.com/resource",
+            description: "Test payment",
+            mimeType: "application/json",
+            payTo: "0x1234567890123456789012345678901234567890",
+            maxTimeoutSeconds: 300,
+            asset: undefined,
+            outputSchema: { type: "object" },
+            extra: {
+              name: "USDC",
+              version: "2",
+            },
+          }),
+        ],
+        x402Version: 1,
       }),
     );
   });
@@ -230,7 +249,25 @@ describe("configurePaymentMiddleware()", () => {
     expect(mockRes.json).toHaveBeenCalledWith(
       expect.objectContaining({
         error: expect.any(Error),
-        paymentRequirements: expect.any(Object),
+        accepts: [
+          expect.objectContaining({
+            scheme: "exact",
+            network: "base-sepolia",
+            maxAmountRequired: "1000000",
+            resource: "https://api.example.com/resource",
+            description: "Test payment",
+            mimeType: "application/json",
+            payTo: "0x1234567890123456789012345678901234567890",
+            maxTimeoutSeconds: 300,
+            asset: undefined,
+            outputSchema: { type: "object" },
+            extra: {
+              name: "USDC",
+              version: "2",
+            },
+          }),
+        ],
+        x402Version: 1,
       }),
     );
   });

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -147,7 +147,13 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
       }
 
       try {
-        const response = await verify(decodedPayment, selectedPaymentRequirements);
+        const response = await verify(
+          {
+            ...decodedPayment,
+            x402Version,
+          },
+          selectedPaymentRequirements,
+        );
         if (!response.isValid) {
           return res.status(402).json({
             x402Version,
@@ -183,7 +189,13 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
       await next();
 
       try {
-        const settleResponse = await settle(decodedPayment, selectedPaymentRequirements);
+        const settleResponse = await settle(
+          {
+            ...decodedPayment,
+            x402Version,
+          },
+          selectedPaymentRequirements,
+        );
         const responseHeader = settleResponseHeader(settleResponse);
         res.setHeader("X-PAYMENT-RESPONSE", responseHeader);
       } catch (error) {

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -50,10 +50,11 @@ export function wrapFetchWithPayment(
       return response;
     }
 
-    const { paymentRequirements } = (await response.json()) as { paymentRequirements: unknown[] };
-    const parsedPaymentRequirements = paymentRequirements.map(x =>
-      PaymentRequirementsSchema.parse(x),
-    );
+    const { x402Version, accepts } = (await response.json()) as {
+      x402Version: number;
+      accepts: unknown[];
+    };
+    const parsedPaymentRequirements = accepts.map(x => PaymentRequirementsSchema.parse(x));
 
     const selectedPaymentRequirements = paymentRequirementsSelector(parsedPaymentRequirements);
 
@@ -61,7 +62,11 @@ export function wrapFetchWithPayment(
       throw new Error("Payment amount exceeds maximum allowed");
     }
 
-    const paymentHeader = await createPaymentHeader(walletClient, selectedPaymentRequirements);
+    const paymentHeader = await createPaymentHeader(
+      walletClient,
+      x402Version,
+      selectedPaymentRequirements,
+    );
 
     if (!init) {
       throw new Error("Missing fetch request configuration");

--- a/typescript/packages/x402-hono/src/index.test.ts
+++ b/typescript/packages/x402-hono/src/index.test.ts
@@ -115,7 +115,25 @@ describe("configurePaymentMiddleware()", () => {
     expect(mockContext.json).toHaveBeenCalledWith(
       {
         error: "X-PAYMENT header is required",
-        paymentRequirements: expect.any(Object),
+        accepts: [
+          expect.objectContaining({
+            scheme: "exact",
+            network: "base-sepolia",
+            maxAmountRequired: "1000000",
+            resource: "https://api.example.com/resource",
+            description: "Test payment",
+            mimeType: "application/json",
+            payTo: "0x1234567890123456789012345678901234567890",
+            maxTimeoutSeconds: 300,
+            asset: undefined,
+            outputSchema: { type: "object" },
+            extra: {
+              name: "USDC",
+              version: "2",
+            },
+          }),
+        ],
+        x402Version: 1,
       },
       402,
     );
@@ -169,7 +187,25 @@ describe("configurePaymentMiddleware()", () => {
     expect(mockContext.json).toHaveBeenCalledWith(
       {
         error: expect.any(Error),
-        paymentRequirements: expect.any(Object),
+        accepts: [
+          expect.objectContaining({
+            scheme: "exact",
+            network: "base-sepolia",
+            maxAmountRequired: "1000000",
+            resource: "https://api.example.com/resource",
+            description: "Test payment",
+            mimeType: "application/json",
+            payTo: "0x1234567890123456789012345678901234567890",
+            maxTimeoutSeconds: 300,
+            asset: undefined,
+            outputSchema: { type: "object" },
+            extra: {
+              name: "USDC",
+              version: "2",
+            },
+          }),
+        ],
+        x402Version: 1,
       },
       402,
     );
@@ -217,7 +253,25 @@ describe("configurePaymentMiddleware()", () => {
     expect(mockContext.json).toHaveBeenCalledWith(
       {
         error: expect.any(Error),
-        paymentRequirements: expect.any(Object),
+        accepts: [
+          expect.objectContaining({
+            scheme: "exact",
+            network: "base-sepolia",
+            maxAmountRequired: "1000000",
+            resource: "https://api.example.com/resource",
+            description: "Test payment",
+            mimeType: "application/json",
+            payTo: "0x1234567890123456789012345678901234567890",
+            maxTimeoutSeconds: 300,
+            asset: undefined,
+            outputSchema: { type: "object" },
+            extra: {
+              name: "USDC",
+              version: "2",
+            },
+          }),
+        ],
+        x402Version: 1,
       },
       402,
     );

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -158,7 +158,13 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
         );
       }
 
-      const response = await verify(decodedPayment, selectedPaymentRequirements);
+      const response = await verify(
+        {
+          ...decodedPayment,
+          x402Version,
+        },
+        selectedPaymentRequirements,
+      );
       if (!response.isValid) {
         return c.json(
           {
@@ -174,7 +180,13 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
       await next();
 
       try {
-        const settleResponse = await settle(decodedPayment, selectedPaymentRequirements);
+        const settleResponse = await settle(
+          {
+            ...decodedPayment,
+            x402Version,
+          },
+          selectedPaymentRequirements,
+        );
         const responseHeader = settleResponseHeader(settleResponse);
 
         c.header("X-PAYMENT-RESPONSE", responseHeader);

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -49,6 +49,7 @@ import { useFacilitator } from "x402/verify";
 export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
   const { facilitatorUrl, address, network, createAuthHeaders } = globalConfig;
   const { verify, settle } = useFacilitator(facilitatorUrl, createAuthHeaders);
+  const x402Version = 1;
 
   return function paymentMiddleware(
     amount: Money,
@@ -122,7 +123,8 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
         return c.json(
           {
             error: "X-PAYMENT header is required",
-            paymentRequirements: toJsonSafe(paymentRequirements),
+            accepts: toJsonSafe(paymentRequirements),
+            x402Version: 1,
           },
           402,
         );
@@ -134,8 +136,9 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
       } catch (error) {
         return c.json(
           {
+            x402Version,
             error: error || "Invalid or malformed payment header",
-            paymentRequirements: toJsonSafe(paymentRequirements),
+            accepts: toJsonSafe(paymentRequirements),
           },
           402,
         );
@@ -147,8 +150,9 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
       if (!selectedPaymentRequirements) {
         return c.json(
           {
+            x402Version,
             error: "Unable to find matching payment requirements",
-            paymentRequirements: toJsonSafe(paymentRequirements),
+            accepts: toJsonSafe(paymentRequirements),
           },
           402,
         );
@@ -158,8 +162,9 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
       if (!response.isValid) {
         return c.json(
           {
+            x402Version,
             error: response.invalidReason,
-            paymentRequirements: toJsonSafe(paymentRequirements),
+            accepts: toJsonSafe(paymentRequirements),
             payerAddress: response.payerAddress,
           },
           402,
@@ -176,8 +181,9 @@ export function configurePaymentMiddleware(globalConfig: GlobalConfig) {
       } catch (error) {
         c.res = c.json(
           {
+            x402Version,
             error: error || "Failed to settle payment",
-            paymentRequirements: toJsonSafe(paymentRequirements),
+            accepts: toJsonSafe(paymentRequirements),
           },
           402,
         );

--- a/typescript/packages/x402-next/src/index.test.ts
+++ b/typescript/packages/x402-next/src/index.test.ts
@@ -153,7 +153,10 @@ describe("createPaymentMiddleware()", () => {
 
     expect(mockDecodePayment).toHaveBeenCalledWith(validPayment);
     expect(mockVerify).toHaveBeenCalledWith(
-      decodedPayment,
+      {
+        ...decodedPayment,
+        x402Version: 1,
+      },
       expect.objectContaining({
         scheme: "exact",
         network: "base-sepolia",
@@ -218,7 +221,10 @@ describe("createPaymentMiddleware()", () => {
     const response = await middleware(mockRequest);
 
     expect(mockSettle).toHaveBeenCalledWith(
-      decodedPayment,
+      {
+        ...decodedPayment,
+        x402Version: 1,
+      },
       expect.objectContaining({
         scheme: "exact",
         network: "base-sepolia",

--- a/typescript/packages/x402-next/src/index.test.ts
+++ b/typescript/packages/x402-next/src/index.test.ts
@@ -110,22 +110,14 @@ describe("createPaymentMiddleware()", () => {
     const response = await middleware(mockRequest);
 
     expect(response.status).toBe(402);
-    const json = await response.json();
-    expect(json).toEqual({
-      error: "X-PAYMENT header is required",
-      paymentRequirements: expect.arrayContaining([
-        expect.objectContaining({
-          scheme: "exact",
-          network: "base-sepolia",
-          maxAmountRequired: "1000000000000000000", // 1.0 * 10^18
-          asset: "0xCustomAssetAddress",
-          extra: {
-            name: "Custom Token",
-            version: "1.0",
-          },
-        }),
-      ]),
-    });
+    const json = (await response.json()) as {
+      accepts: Array<{ maxAmountRequired: string }>;
+    };
+    expect(json.accepts[0]).toEqual(
+      expect.objectContaining({
+        maxAmountRequired: "1000000000000000000",
+      }),
+    );
   });
 
   it("should return HTML paywall for browser requests", async () => {
@@ -194,13 +186,14 @@ describe("createPaymentMiddleware()", () => {
     const json = await response.json();
     expect(json).toEqual({
       error: "insufficient_funds",
-      paymentRequirements: expect.arrayContaining([
+      accepts: expect.arrayContaining([
         expect.objectContaining({
           scheme: "exact",
           network: "base-sepolia",
           asset: "0xCustomAssetAddress",
         }),
       ]),
+      x402Version: 1,
     });
   });
 
@@ -255,13 +248,14 @@ describe("createPaymentMiddleware()", () => {
     const json = await response.json();
     expect(json).toEqual({
       error: expect.any(Object),
-      paymentRequirements: expect.arrayContaining([
+      accepts: expect.arrayContaining([
         expect.objectContaining({
           scheme: "exact",
           network: "base-sepolia",
           asset: "0xCustomAssetAddress",
         }),
       ]),
+      x402Version: 1,
     });
   });
 
@@ -302,9 +296,9 @@ describe("createPaymentMiddleware()", () => {
 
     expect(response.status).toBe(402);
     const json = (await response.json()) as {
-      paymentRequirements: Array<{ maxAmountRequired: string }>;
+      accepts: Array<{ maxAmountRequired: string }>;
     };
-    expect(json.paymentRequirements[0]).toEqual(
+    expect(json.accepts[0]).toEqual(
       expect.objectContaining({
         maxAmountRequired: "1000000",
       }),

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -63,6 +63,7 @@ export interface NextPaymentConfig extends GlobalConfig {
 export function createPaymentMiddleware(globalConfig: NextPaymentConfig) {
   const { facilitatorUrl, address, network, routes, createAuthHeaders } = globalConfig;
   const { verify, settle } = useFacilitator(facilitatorUrl, createAuthHeaders);
+  const x402Version = 1;
 
   // Pre-compile route patterns to regex
   const routePatterns = Object.entries(routes).map(([pattern, config]) => ({
@@ -152,8 +153,9 @@ export function createPaymentMiddleware(globalConfig: NextPaymentConfig) {
 
       return NextResponse.json(
         {
+          x402Version,
           error: "X-PAYMENT header is required",
-          paymentRequirements: toJsonSafe(paymentRequirements),
+          accepts: toJsonSafe(paymentRequirements),
         },
         { status: 402 },
       );
@@ -165,8 +167,9 @@ export function createPaymentMiddleware(globalConfig: NextPaymentConfig) {
     } catch (error) {
       return NextResponse.json(
         {
+          x402Version,
           error: error || "Invalid or malformed payment header",
-          paymentRequirements: toJsonSafe(paymentRequirements),
+          accepts: toJsonSafe(paymentRequirements),
         },
         { status: 402 },
       );
@@ -178,8 +181,9 @@ export function createPaymentMiddleware(globalConfig: NextPaymentConfig) {
     if (!selectedPaymentRequirements) {
       return NextResponse.json(
         {
+          x402Version,
           error: "Unable to find matching payment requirements",
-          paymentRequirements: toJsonSafe(paymentRequirements),
+          accepts: toJsonSafe(paymentRequirements),
         },
         { status: 402 },
       );
@@ -190,8 +194,9 @@ export function createPaymentMiddleware(globalConfig: NextPaymentConfig) {
       if (!response.isValid) {
         return NextResponse.json(
           {
+            x402Version,
             error: response.invalidReason,
-            paymentRequirements: toJsonSafe(paymentRequirements),
+            accepts: toJsonSafe(paymentRequirements),
             payerAddress: response.payerAddress,
           },
           { status: 402 },
@@ -200,8 +205,9 @@ export function createPaymentMiddleware(globalConfig: NextPaymentConfig) {
     } catch (error) {
       return NextResponse.json(
         {
+          x402Version,
           error,
-          paymentRequirements: toJsonSafe(paymentRequirements),
+          accepts: toJsonSafe(paymentRequirements),
         },
         { status: 402 },
       );
@@ -217,8 +223,9 @@ export function createPaymentMiddleware(globalConfig: NextPaymentConfig) {
     } catch (error) {
       return NextResponse.json(
         {
+          x402Version,
           error,
-          paymentRequirements: toJsonSafe(paymentRequirements),
+          accepts: toJsonSafe(paymentRequirements),
         },
         { status: 402 },
       );

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -190,7 +190,13 @@ export function createPaymentMiddleware(globalConfig: NextPaymentConfig) {
     }
 
     try {
-      const response = await verify(decodedPayment, selectedPaymentRequirements);
+      const response = await verify(
+        {
+          ...decodedPayment,
+          x402Version,
+        },
+        selectedPaymentRequirements,
+      );
       if (!response.isValid) {
         return NextResponse.json(
           {
@@ -217,7 +223,13 @@ export function createPaymentMiddleware(globalConfig: NextPaymentConfig) {
     const response = NextResponse.next();
 
     try {
-      const settleResponse = await settle(decodedPayment, selectedPaymentRequirements);
+      const settleResponse = await settle(
+        {
+          ...decodedPayment,
+          x402Version,
+        },
+        selectedPaymentRequirements,
+      );
       const responseHeader = settleResponseHeader(settleResponse);
       response.headers.set("X-PAYMENT-RESPONSE", responseHeader);
     } catch (error) {

--- a/typescript/packages/x402/src/client/createPaymentHeader.ts
+++ b/typescript/packages/x402/src/client/createPaymentHeader.ts
@@ -7,18 +7,20 @@ import { PaymentRequirements } from "../types/verify";
  * Creates a payment header based on the provided client and payment requirements.
  * 
  * @param client - The signer wallet instance used to create the payment header
+ * @param x402Version - The version of the X402 protocol to use
  * @param paymentRequirements - The payment requirements containing scheme and network information
  * @returns A promise that resolves to the created payment header string
  */
 export async function createPaymentHeader(
   client: SignerWallet,
+  x402Version: number,
   paymentRequirements: PaymentRequirements,
 ): Promise<string> {
   if (
     paymentRequirements.scheme === "exact" &&
     SupportedEVMNetworks.includes(paymentRequirements.network)
   ) {
-    return await createPaymentHeaderExactEVM(client, paymentRequirements);
+    return await createPaymentHeaderExactEVM(client, x402Version, paymentRequirements);
   }
 
   throw new Error("Unsupported scheme");

--- a/typescript/packages/x402/src/client/preparePaymentHeader.ts
+++ b/typescript/packages/x402/src/client/preparePaymentHeader.ts
@@ -7,18 +7,20 @@ import { PaymentRequirements, UnsignedPaymentPayload } from "../types/verify";
  * Prepares a payment header with the given sender address and payment requirements.
  * 
  * @param from - The sender's address from which the payment will be made
+ * @param x402Version - The version of the X402 protocol to use
  * @param paymentRequirements - The payment requirements containing scheme and network information
  * @returns An unsigned payment payload that can be used to create a payment header
  */
 export function preparePaymentHeader(
   from: Address,
+  x402Version: number,
   paymentRequirements: PaymentRequirements,
 ): UnsignedPaymentPayload {
   if (
     paymentRequirements.scheme === "exact" &&
     SupportedEVMNetworks.includes(paymentRequirements.network)
   ) {
-    return preparePaymentHeaderExactEVM(from, paymentRequirements);
+    return preparePaymentHeaderExactEVM(from, x402Version, paymentRequirements);
   }
 
   throw new Error("Unsupported scheme");

--- a/typescript/packages/x402/src/schemes/exact/evm/client.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/client.ts
@@ -8,11 +8,13 @@ import { encodePayment } from "./utils/paymentUtils";
  * Prepares an unsigned payment header with the given sender address and payment requirements.
  *
  * @param from - The sender's address from which the payment will be made
+ * @param x402Version - The version of the X402 protocol to use
  * @param paymentRequirements - The payment requirements containing scheme and network information
  * @returns An unsigned payment payload containing authorization details
  */
 export function preparePaymentHeader(
   from: Address,
+  x402Version: number,
   paymentRequirements: PaymentRequirements,
 ): UnsignedPaymentPayload {
   const nonce = createNonce();
@@ -25,7 +27,7 @@ export function preparePaymentHeader(
   ).toString();
 
   return {
-    x402Version: 1,
+    x402Version,
     scheme: paymentRequirements.scheme,
     network: paymentRequirements.network,
     payload: {
@@ -74,15 +76,17 @@ export async function signPaymentHeader<transport extends Transport, chain exten
  * Creates a complete payment payload by preparing and signing a payment header.
  *
  * @param client - The signer wallet instance used to create and sign the payment
+ * @param x402Version - The version of the X402 protocol to use
  * @param paymentRequirements - The payment requirements containing scheme and network information
  * @returns A promise that resolves to the complete signed payment payload
  */
 export async function createPayment<transport extends Transport, chain extends Chain>(
   client: SignerWallet<chain, transport>,
+  x402Version: number,
   paymentRequirements: PaymentRequirements,
 ): Promise<PaymentPayload> {
   const from = client!.account!.address;
-  const unsignedPaymentHeader = preparePaymentHeader(from, paymentRequirements);
+  const unsignedPaymentHeader = preparePaymentHeader(from, x402Version, paymentRequirements);
   return signPaymentHeader(client, paymentRequirements, unsignedPaymentHeader);
 }
 
@@ -90,13 +94,15 @@ export async function createPayment<transport extends Transport, chain extends C
  * Creates and encodes a payment header for the given client and payment requirements.
  *
  * @param client - The signer wallet instance used to create the payment header
+ * @param x402Version - The version of the X402 protocol to use
  * @param paymentRequirements - The payment requirements containing scheme and network information
  * @returns A promise that resolves to the encoded payment header string
  */
 export async function createPaymentHeader(
   client: SignerWallet,
+  x402Version: number,
   paymentRequirements: PaymentRequirements,
 ): Promise<string> {
-  const payment = await createPayment(client, paymentRequirements);
+  const payment = await createPayment(client, x402Version, paymentRequirements);
   return encodePayment(payment);
 }

--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -165,22 +165,22 @@ export async function verify<
  * The facilitator wallet submits the transaction but does not need to hold or transfer any tokens itself.
  *
  * @param wallet - The facilitator wallet that will submit the transaction
- * @param payload - The signed payment payload containing the transfer parameters and signature
+ * @param paymentPayload - The signed payment payload containing the transfer parameters and signature
  * @param paymentRequirements - The original payment details that were used to create the payload
  * @returns A PaymentExecutionResponse containing the transaction status and hash
  */
 export async function settle<transport extends Transport, chain extends Chain>(
   wallet: SignerWallet<chain, transport>,
-  payload: PaymentPayload,
+  paymentPayload: PaymentPayload,
   paymentRequirements: PaymentRequirements,
 ): Promise<SettleResponse> {
   // re-verify to ensure the payment is still valid
-  const valid = await verify(wallet, payload, paymentRequirements);
+  const valid = await verify(wallet, paymentPayload, paymentRequirements);
 
   if (!valid.isValid) {
     return {
       success: false,
-      network: payload.network,
+      network: paymentPayload.network,
       transaction: "",
       errorReason: "invalid_scheme", //`Payment is no longer valid: ${valid.invalidReason}`,
     };
@@ -191,13 +191,13 @@ export async function settle<transport extends Transport, chain extends Chain>(
     abi,
     functionName: "transferWithAuthorization" as const,
     args: [
-      payload.payload.authorization.from as Address,
-      payload.payload.authorization.to as Address,
-      BigInt(payload.payload.authorization.value),
-      BigInt(payload.payload.authorization.validAfter),
-      BigInt(payload.payload.authorization.validBefore),
-      payload.payload.authorization.nonce as Hex,
-      payload.payload.signature as Hex,
+      paymentPayload.payload.authorization.from as Address,
+      paymentPayload.payload.authorization.to as Address,
+      BigInt(paymentPayload.payload.authorization.value),
+      BigInt(paymentPayload.payload.authorization.validAfter),
+      BigInt(paymentPayload.payload.authorization.validBefore),
+      paymentPayload.payload.authorization.nonce as Hex,
+      paymentPayload.payload.signature as Hex,
     ],
     chain: wallet.chain as Chain,
   });
@@ -209,13 +209,13 @@ export async function settle<transport extends Transport, chain extends Chain>(
       success: false,
       errorReason: "invalid_scheme", //`Transaction failed`,
       transaction: tx,
-      network: payload.network,
+      network: paymentPayload.network,
     };
   }
 
   return {
     success: true,
     transaction: tx,
-    network: payload.network,
+    network: paymentPayload.network,
   };
 }

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -75,3 +75,17 @@ export const SettleResponseSchema = z.object({
   network: NetworkSchema,
 });
 export type SettleResponse = z.infer<typeof SettleResponseSchema>;
+
+// x402SupportedPaymentKind
+export const SupportedPaymentKindSchema = z.object({
+  x402Version: z.number().refine(val => x402Versions.includes(val as 1)),
+  scheme: z.enum(schemes),
+  network: NetworkSchema,
+});
+export type SupportedPaymentKind = z.infer<typeof SupportedPaymentKindSchema>;
+
+// x402SupportedPaymentKindsResponse
+export const SupportedPaymentKindsResponseSchema = z.object({
+  kinds: z.array(SupportedPaymentKindSchema),
+});
+export type SupportedPaymentKindsResponse = z.infer<typeof SupportedPaymentKindsResponseSchema>;


### PR DESCRIPTION
1. Updated root README to spec, and the documents in `/specs`
2. Noticed and confirmed  our resource server responses in the middleware were not up to spec, so I updated those to match the README.
a) Server Response was `{ error, paymentRequirements }` and I changed it to `{ x402Version, error, accepts }`
b) Updated clients `createPaymentHeader` to take the x402Version header it receives from the server response and pass it through when making payment
3. `/supported` and its dependent types were not defined. Added the types to `x402Specs.ts`, and implementations to `site` and `examples/typescript/facilitator` to match the README

**Note**:
The "1 line of code" portion has not been updated. I will update this section in the PR that addresses the middleware devx once it's locked down and we know the exact interface. I will try to get the default behavior to as few characters as I can for this flashy display