### PR TITLE
feat: added legacy route support to hosted test facilitator

### DIFF
--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       x402:
         specifier: workspace:*
         version: link:../packages/x402
+      x402-legacy:
+        specifier: npm:x402@0.1.2
+        version: x402@0.1.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       x402-next:
         specifier: workspace:*
         version: link:../packages/x402-next
@@ -1212,6 +1215,12 @@ packages:
     resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
     peerDependencies:
       react: '>= 16 || ^19.0.0-rc'
+
+  '@hono/node-server@1.14.1':
+    resolution: {integrity: sha512-vmbuM+HPinjWzPe7FFPWMMQMsbKE9gDPhaH0FFdqbGpkT5lp++tcWDTxwBl5EgS5y6JVgIaCdjeHRfQ4XRBRjQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -4210,6 +4219,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  x402@0.1.2:
+    resolution: {integrity: sha512-TiQHNS/ygLxZzEwNDYpUS6Tu0Kquf13KENcgSQEPd5cgrEvBF3+hUZ8hZnbJL7a9oCORkRCb6TSIFz6V/XcgHw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -5117,6 +5129,10 @@ snapshots:
   '@heroicons/react@2.2.0(react@19.1.0)':
     dependencies:
       react: 19.1.0
+
+  '@hono/node-server@1.14.1(hono@4.7.6)':
+    dependencies:
+      hono: 4.7.6
 
   '@humanfs/core@0.19.1': {}
 
@@ -8405,6 +8421,21 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
+
+  x402@0.1.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10):
+    dependencies:
+      '@hono/node-server': 1.14.1(hono@4.7.6)
+      axios: 1.8.4
+      express: 4.21.2
+      hono: 4.7.6
+      viem: 2.26.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      zod: 3.24.2
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - typescript
+      - utf-8-validate
 
   yallist@3.1.1: {}
 

--- a/typescript/site/app/legacy/facilitator/settle/route.ts
+++ b/typescript/site/app/legacy/facilitator/settle/route.ts
@@ -1,0 +1,57 @@
+import { paymentDetailsSchema, PaymentDetails } from "x402-legacy/types";
+import { settle } from "x402-legacy/facilitator";
+import { evm } from "x402-legacy/shared";
+import { Hex } from "viem";
+
+/**
+ * Request body for the legacy settle endpoint
+ */
+type SettleRequest = {
+  payload: string;
+  details: PaymentDetails;
+};
+
+const wallet = evm.wallet.createSignerSepolia(process.env.PRIVATE_KEY as Hex);
+
+/**
+ * Settles a payment request using the legacy x402 protocol. This endpoint processes
+ * the payment and returns the settlement result.
+ *
+ * ## X-Payment Header Payload
+ * The payload should be a base64 encoded JSON string containing:
+ * - `x402Version`: Protocol version number
+ * - `scheme`: Payment scheme identifier
+ * - `network`: Network identifier
+ * - `payload`: Scheme-specific payment data
+ *
+ * @deprecated Legacy endpoint for x402@0.1.2. This endpoint is maintained for backward compatibility only.
+ * @param req - The incoming request containing the payment payload and details
+ * @returns A response containing the settlement result
+ */
+export async function POST(req: Request) {
+  const body: SettleRequest = await req.json();
+
+  const paymentDetails = paymentDetailsSchema.parse(body.details);
+
+  const response = await settle(wallet, body.payload, paymentDetails);
+
+  return Response.json(response);
+}
+
+/**
+ * Returns documentation about the legacy settle endpoint, including request format
+ * and expected response structure.
+ *
+ * @deprecated Legacy endpoint for x402@0.1.2. This endpoint is maintained for backward compatibility only.
+ * @returns A response containing endpoint documentation
+ */
+export async function GET() {
+  return Response.json({
+    endpoint: "/settle",
+    description: "POST to settle x402 payments (legacy v0.1.2)",
+    body: {
+      payload: "string",
+      details: "PaymentDetails",
+    },
+  });
+}

--- a/typescript/site/app/legacy/facilitator/settle/route.ts
+++ b/typescript/site/app/legacy/facilitator/settle/route.ts
@@ -11,8 +11,6 @@ type SettleRequest = {
   details: PaymentDetails;
 };
 
-const wallet = evm.wallet.createSignerSepolia(process.env.PRIVATE_KEY as Hex);
-
 /**
  * Settles a payment request using the legacy x402 protocol. This endpoint processes
  * the payment and returns the settlement result.
@@ -30,6 +28,7 @@ const wallet = evm.wallet.createSignerSepolia(process.env.PRIVATE_KEY as Hex);
  */
 export async function POST(req: Request) {
   const body: SettleRequest = await req.json();
+  const wallet = evm.wallet.createSignerSepolia(process.env.PRIVATE_KEY as Hex);
 
   const paymentDetails = paymentDetailsSchema.parse(body.details);
 

--- a/typescript/site/app/legacy/facilitator/verify/route.ts
+++ b/typescript/site/app/legacy/facilitator/verify/route.ts
@@ -1,0 +1,56 @@
+import { paymentDetailsSchema, PaymentDetails } from "x402-legacy/types";
+import { verify } from "x402-legacy/facilitator";
+import { evm } from "x402-legacy/shared";
+
+/**
+ * Request body for the legacy verify endpoint
+ */
+type VerifyRequest = {
+  payload: string;
+  details: PaymentDetails;
+};
+
+const client = evm.wallet.createClientSepolia();
+
+/**
+ * Verifies a payment request using the legacy x402 protocol. This endpoint checks if a payment header
+ * is valid for the given payment details.
+ *
+ * ## X-Payment Header Payload
+ * The payload should be a base64 encoded JSON string containing:
+ * - `x402Version`: Protocol version number
+ * - `scheme`: Payment scheme identifier
+ * - `network`: Network identifier
+ * - `payload`: Scheme-specific payment data
+ *
+ * @deprecated Legacy endpoint for x402@0.1.2. This endpoint is maintained for backward compatibility only.
+ * @param req - The incoming request containing the payment payload and details
+ * @returns A response indicating whether the payment is valid
+ */
+export async function POST(req: Request) {
+  const body: VerifyRequest = await req.json();
+
+  const paymentDetails = paymentDetailsSchema.parse(body.details);
+
+  const valid = await verify(client, body.payload, paymentDetails);
+
+  return Response.json(valid);
+}
+
+/**
+ * Returns documentation about the legacy verify endpoint, including request format
+ * and expected response structure.
+ *
+ * @deprecated Legacy endpoint for x402@0.1.2. This endpoint is maintained for backward compatibility only.
+ * @returns A response containing endpoint documentation
+ */
+export async function GET() {
+  return Response.json({
+    endpoint: "/verify",
+    description: "POST to verify x402 payments (legacy v0.1.2)",
+    body: {
+      payload: "string",
+      details: "PaymentDetails",
+    },
+  });
+}

--- a/typescript/site/app/legacy/facilitator/verify/route.ts
+++ b/typescript/site/app/legacy/facilitator/verify/route.ts
@@ -10,8 +10,6 @@ type VerifyRequest = {
   details: PaymentDetails;
 };
 
-const client = evm.wallet.createClientSepolia();
-
 /**
  * Verifies a payment request using the legacy x402 protocol. This endpoint checks if a payment header
  * is valid for the given payment details.
@@ -29,9 +27,11 @@ const client = evm.wallet.createClientSepolia();
  */
 export async function POST(req: Request) {
   const body: VerifyRequest = await req.json();
+  const client = evm.wallet.createClientSepolia();
 
   const paymentDetails = paymentDetailsSchema.parse(body.details);
 
+  // @ts-expect-error infinite instantiation
   const valid = await verify(client, body.payload, paymentDetails);
 
   return Response.json(valid);

--- a/typescript/site/app/legacy/facilitator/verify/route.ts
+++ b/typescript/site/app/legacy/facilitator/verify/route.ts
@@ -31,7 +31,6 @@ export async function POST(req: Request) {
 
   const paymentDetails = paymentDetailsSchema.parse(body.details);
 
-  // @ts-expect-error infinite instantiation
   const valid = await verify(client, body.payload, paymentDetails);
 
   return Response.json(valid);

--- a/typescript/site/middleware.ts
+++ b/typescript/site/middleware.ts
@@ -3,7 +3,11 @@ import { createPaymentMiddleware, Network, Resource } from "x402-next";
 
 const address = process.env.RESOURCE_WALLET_ADDRESS as Address;
 const network = process.env.NETWORK as Network;
-const facilitatorUrl = (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}/facilitator` : process.env.NEXT_PUBLIC_FACILITATOR_URL) as Resource;
+const facilitatorUrl = (
+  process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}/facilitator`
+    : process.env.NEXT_PUBLIC_FACILITATOR_URL
+) as Resource;
 
 export const middleware = createPaymentMiddleware({
   facilitatorUrl,

--- a/typescript/site/package.json
+++ b/typescript/site/package.json
@@ -20,6 +20,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "viem": "^2.26.2",
+    "x402-legacy": "npm:x402@0.1.2",
     "x402": "workspace:*",
     "x402-next": "workspace:*"
   },


### PR DESCRIPTION
1. Copy-paste of `facilitator/verify` and `facilitator/settle` from main, put into a `legacy` subfolder
2. Swap out `x402` dependency with `x402-legacy`
3. Define `x402-legacy` as pinned `x402@0.1.2` npm package
4. Moved `client` creation out of global scope and into handlers. It was running into issues trying to load the .env vars during build time.