### PR TITLE
debug: testing a paywall tweak and adding prints

### DIFF
--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -364,10 +364,8 @@ export function getPaywallHtml({
           validAfter,
           validBefore,
           nonce,
-          version,
         },
       },
-      resource: window.x402.paymentRequirements.resource,
     };
   }
 
@@ -479,9 +477,8 @@ export function getPaywallHtml({
         });
 
         if (balance === 0n) {
-          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${
-            testnet ? "Base Sepolia" : "Base"
-          }.\`;
+          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${testnet ? "Base Sepolia" : "Base"
+    }.\`;
           return;
         }
 

--- a/typescript/site/app/facilitator/settle/route.ts
+++ b/typescript/site/app/facilitator/settle/route.ts
@@ -23,6 +23,7 @@ export async function POST(req: Request) {
   const wallet = evm.createSignerSepolia(process.env.PRIVATE_KEY as Hex);
 
   const body: SettleRequest = await req.json();
+  console.info("Settle body", body);
 
   const paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
   const paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);

--- a/typescript/site/app/facilitator/verify/route.ts
+++ b/typescript/site/app/facilitator/verify/route.ts
@@ -22,6 +22,7 @@ const client = evm.createClientSepolia();
  */
 export async function POST(req: Request) {
   const body: VerifyRequest = await req.json();
+  console.info("Validate body", body);
 
   const paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
   const paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);


### PR DESCRIPTION
Testing `x402.org`, ran into a internal 500 after the merges.

1. The payload sent from the paywall page was not up to spec. It sent the payload header as `{"x402Version":1,"scheme":"exact","network":"base-sepolia","payload":{"signature":"0x2bbcc9b32773c3a750e446ebc77697552bd1411ede3f14fec11768c771a5488b1ecf9110add1d13662fe6e3272d6d86c8dd0f72410c54a241bffc2628f812c241b","authorization":{"from":"0xF918379448f25AAA867C1cdef86331a05A955Cf2","to":"0x209693Bc6afc0C5328bA36FaF03C514EF312287C","value":"10000","validAfter":"1745601445","validBefore":"1745601750","nonce":"0x616385b7303c68f9d084d5d739d68f934c884a028f4ad6dd08ab126244d94784","version":"2"}},"resource":"https://www.x402.org/protected"}`, which while not incompatible with the current spec, it does add two extra fields - `version` and `resource`.
2. Added prints to the body of the verify and settle endpoints. This is because, all I can see in the internal 500 logs, is the verify route was called, and it was a `Zod` parse error trying to validate the payload.

Will remove the prints in a fast-follow once we verify its fixed.