### PR TITLE
fix: missing env vars in next config

### DIFF
--- a/typescript/site/next.config.ts
+++ b/typescript/site/next.config.ts
@@ -4,6 +4,8 @@ const nextConfig: NextConfig = {
   env: {
     RESOURCE_WALLET_ADDRESS: process.env.RESOURCE_WALLET_ADDRESS,
     NEXT_PUBLIC_FACILITATOR_URL: process.env.NEXT_PUBLIC_FACILITATOR_URL,
+    PRIVATE_KEY: process.env.PRIVATE_KEY,
+    NETWORK: process.env.NETWORK,
   },
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
fix: missing env vars in next config