### PR TITLE
feat: expanding gha scopes to lint/format/check locks

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -20,3 +20,22 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm run format:check
+
+  check-format-examples-typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: ./examples/typescript
+      - name: Ensure formatting
+        working-directory: ./examples/typescript
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run format:check

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: ./typescript
         run: |
           pnpm install --frozen-lockfile
-          pnpm run format:check
+          pnpm format:check
 
   check-format-examples-typescript:
     runs-on: ubuntu-latest
@@ -38,4 +38,4 @@ jobs:
         working-directory: ./examples/typescript
         run: |
           pnpm install --frozen-lockfile
-          pnpm run format:check
+          pnpm format:check

--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: ./typescript
         run: |
           pnpm install --frozen-lockfile
-          pnpm run lint
+          pnpm lint:check
 
   check-lint-examples-typescript:
     runs-on: ubuntu-latest
@@ -38,4 +38,4 @@ jobs:
         working-directory: ./examples/typescript
         run: |
           pnpm install --frozen-lockfile
-          pnpm run lint
+          pnpm lint:check

--- a/.github/workflows/check_lint.yml
+++ b/.github/workflows/check_lint.yml
@@ -20,3 +20,22 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm run lint
+
+  check-lint-examples-typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: ./examples/typescript
+      - name: Ensure Linting
+        working-directory: ./examples/typescript
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run lint

--- a/.github/workflows/check_package_lock.yml
+++ b/.github/workflows/check_package_lock.yml
@@ -27,3 +27,29 @@ jobs:
             git diff pnpm-lock.yaml
             exit 1
           fi
+
+  check-package-lock-examples-typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: ./examples/typescript
+
+      - name: Check if pnpm-lock.yaml changed
+        working-directory: ./examples/typescript
+        run: |
+          pnpm install
+          if [ -n "$(git diff pnpm-lock.yaml)" ]; then
+            echo "Error: pnpm-lock.yaml was modified after running pnpm install. Please commit the updated pnpm-lock.yaml file."
+            git diff pnpm-lock.yaml
+            exit 1
+          fi

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "build": "turbo run build",
     "lint": "turbo run lint",
-    "format": "turbo run format"
+    "lint:check": "turbo run lint:check",
+    "format": "turbo run format",
+    "format:check": "turbo run format:check"
   },
   "keywords": [],
   "author": "",

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -18,61 +18,6 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
-  ../../typescript/packages/coinbase-x402:
-    dependencies:
-      viem:
-        specifier: ^2.23.1
-        version: 2.27.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
-      x402:
-        specifier: workspace:*
-        version: link:../x402
-      zod:
-        specifier: ^3.24.2
-        version: 3.24.3
-    devDependencies:
-      '@eslint/js':
-        specifier: ^9.24.0
-        version: 9.24.0
-      '@types/node':
-        specifier: ^22.13.4
-        version: 22.14.1
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.29.1
-        version: 8.30.1(@typescript-eslint/parser@8.30.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3)
-      '@typescript-eslint/parser':
-        specifier: ^8.29.1
-        version: 8.30.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3)
-      eslint:
-        specifier: ^9.24.0
-        version: 9.24.0(jiti@1.21.7)
-      eslint-plugin-import:
-        specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.30.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@9.24.0(jiti@1.21.7))
-      eslint-plugin-jsdoc:
-        specifier: ^50.6.9
-        version: 50.6.9(eslint@9.24.0(jiti@1.21.7))
-      eslint-plugin-prettier:
-        specifier: ^5.2.6
-        version: 5.2.6(eslint@9.24.0(jiti@1.21.7))(prettier@3.5.2)
-      prettier:
-        specifier: 3.5.2
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.19.3
-      typescript:
-        specifier: ^5.7.3
-        version: 5.8.3
-      vite:
-        specifier: ^6.2.6
-        version: 6.3.2(@types/node@22.14.1)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1)
-      vite-tsconfig-paths:
-        specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@6.3.2(@types/node@22.14.1)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1))
-      vitest:
-        specifier: ^3.0.5
-        version: 3.1.1(@types/node@22.14.1)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1)
-
   ../../typescript/packages/x402:
     dependencies:
       '@coinbase/cdp-sdk':

--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -477,8 +477,9 @@ export function getPaywallHtml({
         });
 
         if (balance === 0n) {
-          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${testnet ? "Base Sepolia" : "Base"
-    }.\`;
+          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${
+            testnet ? "Base Sepolia" : "Base"
+          }.\`;
           return;
         }
 


### PR DESCRIPTION
Right now, the lint, format and package-lock GHA's only run in `/typescript` and not `/examples/typescript`.

This PR addresses that