### PR TITLE
feat: cleanup middlewares

### DIFF
--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -3,6 +3,7 @@ import { Address } from "viem";
 import { exact } from "x402/schemes";
 import {
   computeRoutePatterns,
+  findMatchingPaymentRequirements,
   findMatchingRoute,
   getPaywallHtml,
   processPriceToAtomicAmount,
@@ -155,6 +156,7 @@ export function paymentMiddleware(
     let decodedPayment: PaymentPayload;
     try {
       decodedPayment = exact.evm.decodePayment(payment);
+      decodedPayment.x402Version = x402Version;
     } catch (error) {
       res.status(402).json({
         x402Version,
@@ -164,8 +166,9 @@ export function paymentMiddleware(
       return;
     }
 
-    const selectedPaymentRequirements = paymentRequirements.find(
-      value => value.scheme === decodedPayment.scheme && value.network === decodedPayment.network,
+    const selectedPaymentRequirements = findMatchingPaymentRequirements(
+      paymentRequirements,
+      decodedPayment,
     );
     if (!selectedPaymentRequirements) {
       res.status(402).json({

--- a/typescript/packages/x402/src/shared/middleware.ts
+++ b/typescript/packages/x402/src/shared/middleware.ts
@@ -1,4 +1,13 @@
-import { moneySchema, Network, Price, RouteConfig, RoutePattern, ERC20TokenAmount } from "../types";
+import {
+  moneySchema,
+  Network,
+  Price,
+  RouteConfig,
+  RoutePattern,
+  ERC20TokenAmount,
+  PaymentRequirements,
+  PaymentPayload,
+} from "../types";
 import { RoutesConfig } from "../types";
 import { getUsdcAddressForChain } from "./evm";
 import { getNetworkId } from "./network";
@@ -123,4 +132,20 @@ export function processPriceToAtomicAmount(
     maxAmountRequired,
     asset,
   };
+}
+
+/**
+ * Finds the matching payment requirements for the given payment
+ *
+ * @param paymentRequirements - The payment requirements to search through
+ * @param payment - The payment to match against
+ * @returns The matching payment requirements or undefined if no match is found
+ */
+export function findMatchingPaymentRequirements(
+  paymentRequirements: PaymentRequirements[],
+  payment: PaymentPayload,
+) {
+  return paymentRequirements.find(
+    value => value.scheme === payment.scheme && value.network === payment.network,
+  );
 }


### PR DESCRIPTION
Each middleware is similar to each other. The intention of this PR was to review them for duplicate code that should be isolated to reusable business logic. I did a pass of this last week, and it seems I caught most of it.

However, this exercise did show me bugs where `x402-next` and `x402-hono` were not selecting which payment requirement users were paying for, and instead assumed the first in the list.

So this PR adds a minor refactor to the overlapping code logic, and also addresses that issue.