### PR TITLE
feat: improved selectPaymentRequirements default function

### DIFF
--- a/typescript/packages/x402-axios/src/index.test.ts
+++ b/typescript/packages/x402-axios/src/index.test.ts
@@ -84,7 +84,7 @@ describe("withPaymentInterceptor()", () => {
     // Mock payment requirements selector
     const { selectPaymentRequirements } = await import("x402/client");
     (selectPaymentRequirements as ReturnType<typeof vi.fn>).mockImplementation(
-      requirements => requirements[0],
+      (requirements, _) => requirements[0],
     );
 
     // Set up the interceptor
@@ -114,7 +114,7 @@ describe("withPaymentInterceptor()", () => {
     const { createPaymentHeader, selectPaymentRequirements } = await import("x402/client");
     (createPaymentHeader as ReturnType<typeof vi.fn>).mockResolvedValue(paymentHeader);
     (selectPaymentRequirements as ReturnType<typeof vi.fn>).mockImplementation(
-      requirements => requirements[0],
+      (requirements, _) => requirements[0],
     );
     (mockAxiosClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
 
@@ -126,7 +126,7 @@ describe("withPaymentInterceptor()", () => {
     const result = await interceptor(error);
 
     expect(result).toBe(successResponse);
-    expect(selectPaymentRequirements).toHaveBeenCalledWith(validPaymentRequirements);
+    expect(selectPaymentRequirements).toHaveBeenCalledWith(validPaymentRequirements, undefined);
     expect(createPaymentHeader).toHaveBeenCalledWith(
       mockWalletClient,
       1,

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance, AxiosError } from "axios";
-import { PaymentRequirements, PaymentRequirementsSchema } from "x402/types";
+import { ChainIdToNetwork, PaymentRequirements, PaymentRequirementsSchema } from "x402/types";
 import { evm } from "x402/types";
 import {
   createPaymentHeader,
@@ -60,7 +60,10 @@ export function withPaymentInterceptor(
         };
         const parsed = accepts.map(x => PaymentRequirementsSchema.parse(x));
 
-        const selectedPaymentRequirements = paymentRequirementsSelector(parsed);
+        const selectedPaymentRequirements = paymentRequirementsSelector(
+          parsed,
+          ChainIdToNetwork[walletClient.chain?.id],
+        );
         const paymentHeader = await createPaymentHeader(
           walletClient,
           x402Version,

--- a/typescript/packages/x402-fetch/src/index.test.ts
+++ b/typescript/packages/x402-fetch/src/index.test.ts
@@ -48,7 +48,7 @@ describe("fetchWithPayment()", () => {
     // Mock payment requirements selector
     const { selectPaymentRequirements } = await import("x402/client");
     (selectPaymentRequirements as ReturnType<typeof vi.fn>).mockImplementation(
-      requirements => requirements[0],
+      (requirements, _) => requirements[0],
     );
 
     wrappedFetch = wrapFetchWithPayment(mockFetch, mockWalletClient);
@@ -71,7 +71,7 @@ describe("fetchWithPayment()", () => {
     const { createPaymentHeader, selectPaymentRequirements } = await import("x402/client");
     (createPaymentHeader as ReturnType<typeof vi.fn>).mockResolvedValue(paymentHeader);
     (selectPaymentRequirements as ReturnType<typeof vi.fn>).mockImplementation(
-      requirements => requirements[0],
+      (requirements, _) => requirements[0],
     );
     mockFetch
       .mockResolvedValueOnce(
@@ -85,7 +85,7 @@ describe("fetchWithPayment()", () => {
     } as RequestInitWithRetry);
 
     expect(result).toBe(successResponse);
-    expect(selectPaymentRequirements).toHaveBeenCalledWith(validPaymentRequirements);
+    expect(selectPaymentRequirements).toHaveBeenCalledWith(validPaymentRequirements, undefined);
     expect(createPaymentHeader).toHaveBeenCalledWith(
       mockWalletClient,
       1,

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -1,4 +1,4 @@
-import { PaymentRequirementsSchema } from "x402/types";
+import { ChainIdToNetwork, PaymentRequirementsSchema } from "x402/types";
 import { evm } from "x402/types";
 import {
   createPaymentHeader,
@@ -56,7 +56,10 @@ export function wrapFetchWithPayment(
     };
     const parsedPaymentRequirements = accepts.map(x => PaymentRequirementsSchema.parse(x));
 
-    const selectedPaymentRequirements = paymentRequirementsSelector(parsedPaymentRequirements);
+    const selectedPaymentRequirements = paymentRequirementsSelector(
+      parsedPaymentRequirements,
+      ChainIdToNetwork[walletClient.chain?.id],
+    );
 
     if (BigInt(selectedPaymentRequirements.maxAmountRequired) > maxValue) {
       throw new Error("Payment amount exceeds maximum allowed");

--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -24,7 +24,10 @@ export function getPaywallHtml({
   paymentRequirements,
   currentUrl,
 }: PaywallOptions): string {
-  const selectedPaymentRequirements = selectPaymentRequirements(paymentRequirements);
+  const selectedPaymentRequirements = selectPaymentRequirements(
+    paymentRequirements,
+    testnet ? "base-sepolia" : "base",
+  );
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -477,8 +480,9 @@ export function getPaywallHtml({
         });
 
         if (balance === 0n) {
-          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${testnet ? "Base Sepolia" : "Base"
-    }.\`;
+          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${
+            testnet ? "Base Sepolia" : "Base"
+          }.\`;
           return;
         }
 

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -8,3 +8,7 @@ export const EvmNetworkToChainId = new Map<Network, number>([
   ["base-sepolia", 84532],
   ["base", 8453],
 ]);
+
+export const ChainIdToNetwork = Object.fromEntries(
+  SupportedEVMNetworks.map(network => [EvmNetworkToChainId.get(network), network]),
+) as Record<number, Network>;


### PR DESCRIPTION
Improved `selectPaymentRequirements` to take in an optional network ID.

Updated paywall case to derive the network ID based on whether its a testnet or not, while the client tools use the wallet to determine network id.

Updated unit tests