### PR TITLE
feat: increased validAfter to be 60 seconds ago

### DIFF
--- a/typescript/packages/x402/src/schemes/exact/evm/client.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/client.ts
@@ -20,7 +20,7 @@ export function preparePaymentHeader(
   const nonce = createNonce();
 
   const validAfter = BigInt(
-    Math.floor(Date.now() / 1000) - 5, // 1 block (2s) before to account for block timestamping
+    Math.floor(Date.now() / 1000) - 60, // 60 seconds before
   ).toString();
   const validBefore = BigInt(
     Math.floor(Date.now() / 1000 + paymentRequirements.maxTimeoutSeconds),

--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -480,8 +480,9 @@ export function getPaywallHtml({
         });
 
         if (balance === 0n) {
-          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${testnet ? "Base Sepolia" : "Base"
-    }.\`;
+          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${
+            testnet ? "Base Sepolia" : "Base"
+          }.\`;
           return;
         }
 

--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -333,7 +333,7 @@ export function getPaywallHtml({
     const from = client.account.address;
 
     const validAfter = BigInt(
-      Math.floor(Date.now() / 1000) - 5 // 1 block (2s) before to account for block timestamping
+      Math.floor(Date.now() / 1000) - 60 // 60 seconds before
     );
     const validBefore = BigInt(
       Math.floor(Date.now() / 1000 + window.x402.paymentRequirements.maxTimeoutSeconds)
@@ -480,9 +480,8 @@ export function getPaywallHtml({
         });
 
         if (balance === 0n) {
-          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${
-            testnet ? "Base Sepolia" : "Base"
-          }.\`;
+          statusDiv.textContent = \`Your USDC balance is 0. Please make sure you have USDC tokens on ${testnet ? "Base Sepolia" : "Base"
+    }.\`;
           return;
         }
 


### PR DESCRIPTION
Updated the `validAfter` logic in `preparePaymentHeader` to go back 60 seconds, rather than the 5 that was hardcoded.

This is to attempt to fix an issue users ran into for a brief period today where, despite `validAfter` being slightly in the past, the EIP-3009 `transferWithAuthorization` was throwing a `not yet valid` error, signifying that the timestamp being checked on-chain was before the `validAfter` timestamp.