### PR TITLE
feat: Expanded client side signing to be either a WalletSigner or a viem Account

### DIFF
--- a/examples/typescript/agent/index.ts
+++ b/examples/typescript/agent/index.ts
@@ -1,30 +1,25 @@
-import { http, publicActions, createWalletClient } from "viem";
-import { baseSepolia } from "viem/chains";
-import { privateKeyToAccount } from "viem/accounts";
-import { Hex } from "viem";
 import Anthropic from "@anthropic-ai/sdk";
-import { wrapFetchWithPayment } from "x402-fetch";
 import { config } from "dotenv";
+import { Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { wrapFetchWithPayment } from "x402-fetch";
 
 config();
 
-const { RESOURCE_SERVER_URL, PRIVATE_KEY } = process.env;
+const privateKey = process.env.PRIVATE_KEY as Hex;
+const baseURL = process.env.RESOURCE_SERVER_URL as string;
 
-if (!RESOURCE_SERVER_URL || !PRIVATE_KEY) {
+if (!baseURL || !privateKey) {
   console.error("Missing required environment variables");
   process.exit(1);
 }
 
-const wallet = createWalletClient({
-  chain: baseSepolia,
-  transport: http(),
-  account: privateKeyToAccount(PRIVATE_KEY as Hex),
-}).extend(publicActions);
+const account = privateKeyToAccount(privateKey);
 
 const anthropic = new Anthropic({
-  baseURL: RESOURCE_SERVER_URL,
+  baseURL,
   apiKey: "not needed",
-  fetch: wrapFetchWithPayment(fetch, wallet),
+  fetch: wrapFetchWithPayment(fetch, account),
 });
 
 const msg = await anthropic.messages.create({

--- a/examples/typescript/clients/axios/index.ts
+++ b/examples/typescript/clients/axios/index.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { config } from "dotenv";
 import { Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { withPaymentInterceptor } from "x402-axios";
+import { withPaymentInterceptor, decodeXPaymentResponse } from "x402-axios";
 
 config();
 
@@ -27,8 +27,10 @@ const api = withPaymentInterceptor(
 api
   .get(endpointPath)
   .then(response => {
-    console.log(response.headers);
     console.log(response.data);
+
+    const paymentResponse = decodeXPaymentResponse(response.headers["x-payment-response"]);
+    console.log(paymentResponse);
   })
   .catch(error => {
     console.error(error.response?.data?.error);

--- a/examples/typescript/clients/axios/index.ts
+++ b/examples/typescript/clients/axios/index.ts
@@ -1,9 +1,7 @@
+import axios from "axios";
 import { config } from "dotenv";
-import { createWalletClient, http, publicActions } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { withPaymentInterceptor } from "x402-axios";
-import axios from "axios";
-import { baseSepolia } from "viem/chains";
 
 config();
 
@@ -15,17 +13,12 @@ if (!RESOURCE_SERVER_URL || !PRIVATE_KEY || !ENDPOINT_PATH) {
 }
 
 const account = privateKeyToAccount(PRIVATE_KEY as `0x${string}`);
-const client = createWalletClient({
-  account,
-  transport: http(),
-  chain: baseSepolia,
-}).extend(publicActions);
 
 const api = withPaymentInterceptor(
   axios.create({
     baseURL: `${RESOURCE_SERVER_URL}`,
   }),
-  client,
+  account,
 );
 
 api

--- a/examples/typescript/clients/axios/index.ts
+++ b/examples/typescript/clients/axios/index.ts
@@ -1,28 +1,31 @@
 import axios from "axios";
 import { config } from "dotenv";
+import { Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { withPaymentInterceptor } from "x402-axios";
 
 config();
 
-const { RESOURCE_SERVER_URL, PRIVATE_KEY, ENDPOINT_PATH } = process.env;
+const privateKey = process.env.PRIVATE_KEY as Hex;
+const baseURL = process.env.RESOURCE_SERVER_URL as string; // e.g. https://example.com
+const endpointPath = process.env.ENDPOINT_PATH as string; // e.g. /weather
 
-if (!RESOURCE_SERVER_URL || !PRIVATE_KEY || !ENDPOINT_PATH) {
+if (!baseURL || !privateKey || !endpointPath) {
   console.error("Missing required environment variables");
   process.exit(1);
 }
 
-const account = privateKeyToAccount(PRIVATE_KEY as `0x${string}`);
+const account = privateKeyToAccount(privateKey);
 
 const api = withPaymentInterceptor(
   axios.create({
-    baseURL: `${RESOURCE_SERVER_URL}`,
+    baseURL,
   }),
   account,
 );
 
 api
-  .get(`${ENDPOINT_PATH}`)
+  .get(endpointPath)
   .then(response => {
     console.log(response.headers);
     console.log(response.data);

--- a/examples/typescript/clients/fetch/index.ts
+++ b/examples/typescript/clients/fetch/index.ts
@@ -1,28 +1,25 @@
 import { config } from "dotenv";
-import { createWalletClient, http, publicActions } from "viem";
+import { Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { wrapFetchWithPayment } from "x402-fetch";
-import { baseSepolia } from "viem/chains";
 
 config();
 
-const { RESOURCE_SERVER_URL, PRIVATE_KEY, ENDPOINT_PATH } = process.env;
+const privateKey = process.env.PRIVATE_KEY as Hex;
+const baseURL = process.env.RESOURCE_SERVER_URL as string; // e.g. https://example.com
+const endpointPath = process.env.ENDPOINT_PATH as string; // e.g. /weather
+const url = `${baseURL}${endpointPath}`; // e.g. https://example.com/weather
 
-if (!RESOURCE_SERVER_URL || !PRIVATE_KEY || !ENDPOINT_PATH) {
+if (!baseURL || !privateKey || !endpointPath) {
   console.error("Missing required environment variables");
   process.exit(1);
 }
 
-const account = privateKeyToAccount(PRIVATE_KEY as `0x${string}`);
-const client = createWalletClient({
-  account,
-  transport: http(),
-  chain: baseSepolia,
-}).extend(publicActions);
+const account = privateKeyToAccount(privateKey);
 
-const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+const fetchWithPayment = wrapFetchWithPayment(fetch, account);
 
-fetchWithPayment(`${RESOURCE_SERVER_URL}${ENDPOINT_PATH}`, {
+fetchWithPayment(url, {
   method: "GET",
 })
   .then(async response => {

--- a/examples/typescript/clients/fetch/index.ts
+++ b/examples/typescript/clients/fetch/index.ts
@@ -1,7 +1,7 @@
 import { config } from "dotenv";
 import { Hex } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { wrapFetchWithPayment } from "x402-fetch";
+import { decodeXPaymentResponse, wrapFetchWithPayment } from "x402-fetch";
 
 config();
 
@@ -25,6 +25,9 @@ fetchWithPayment(url, {
   .then(async response => {
     const body = await response.json();
     console.log(body);
+
+    const paymentResponse = decodeXPaymentResponse(response.headers.get("x-payment-response")!);
+    console.log(paymentResponse);
   })
   .catch(error => {
     console.error(error.response?.data?.error);

--- a/typescript/packages/x402-axios/src/index.test.ts
+++ b/typescript/packages/x402-axios/src/index.test.ts
@@ -126,7 +126,11 @@ describe("withPaymentInterceptor()", () => {
     const result = await interceptor(error);
 
     expect(result).toBe(successResponse);
-    expect(selectPaymentRequirements).toHaveBeenCalledWith(validPaymentRequirements, undefined);
+    expect(selectPaymentRequirements).toHaveBeenCalledWith(
+      validPaymentRequirements,
+      undefined,
+      "exact",
+    );
     expect(createPaymentHeader).toHaveBeenCalledWith(
       mockWalletClient,
       1,

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -70,6 +70,7 @@ export function withPaymentInterceptor(
         const selectedPaymentRequirements = paymentRequirementsSelector(
           parsed,
           chainId ? ChainIdToNetwork[chainId] : undefined,
+          "exact",
         );
         const paymentHeader = await createPaymentHeader(
           walletClient,

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -6,6 +6,7 @@ import {
   PaymentRequirementsSelector,
   selectPaymentRequirements,
 } from "x402/client";
+import { Account } from "viem";
 
 /**
  * Enables the payment of APIs using the x402 payment protocol.
@@ -34,7 +35,7 @@ import {
  */
 export function withPaymentInterceptor(
   axiosClient: AxiosInstance,
-  walletClient: typeof evm.SignerWallet,
+  walletClient: typeof evm.SignerWallet | Account,
   paymentRequirementsSelector: PaymentRequirementsSelector = selectPaymentRequirements,
 ) {
   axiosClient.interceptors.response.use(
@@ -60,9 +61,15 @@ export function withPaymentInterceptor(
         };
         const parsed = accepts.map(x => PaymentRequirementsSchema.parse(x));
 
+        const chainId = evm.isSignerWallet(walletClient)
+          ? walletClient.chain?.id
+          : evm.isAccount(walletClient)
+            ? walletClient.client?.chain?.id
+            : undefined;
+
         const selectedPaymentRequirements = paymentRequirementsSelector(
           parsed,
-          ChainIdToNetwork[walletClient.chain?.id],
+          chainId ? ChainIdToNetwork[chainId] : undefined,
         );
         const paymentHeader = await createPaymentHeader(
           walletClient,

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -93,3 +93,5 @@ export function withPaymentInterceptor(
 
   return axiosClient;
 }
+
+export { decodeXPaymentResponse } from "x402/shared";

--- a/typescript/packages/x402-fetch/src/index.test.ts
+++ b/typescript/packages/x402-fetch/src/index.test.ts
@@ -85,7 +85,11 @@ describe("fetchWithPayment()", () => {
     } as RequestInitWithRetry);
 
     expect(result).toBe(successResponse);
-    expect(selectPaymentRequirements).toHaveBeenCalledWith(validPaymentRequirements, undefined);
+    expect(selectPaymentRequirements).toHaveBeenCalledWith(
+      validPaymentRequirements,
+      undefined,
+      "exact",
+    );
     expect(createPaymentHeader).toHaveBeenCalledWith(
       mockWalletClient,
       1,

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -5,6 +5,7 @@ import {
   PaymentRequirementsSelector,
   selectPaymentRequirements,
 } from "x402/client";
+import { Account } from "viem";
 
 /**
  * Enables the payment of APIs using the x402 payment protocol.
@@ -39,7 +40,7 @@ import {
  */
 export function wrapFetchWithPayment(
   fetch: typeof globalThis.fetch,
-  walletClient: typeof evm.SignerWallet,
+  walletClient: typeof evm.SignerWallet | Account,
   maxValue: bigint = BigInt(0.1 * 10 ** 6), // Default to 0.10 USDC
   paymentRequirementsSelector: PaymentRequirementsSelector = selectPaymentRequirements,
 ) {
@@ -56,9 +57,14 @@ export function wrapFetchWithPayment(
     };
     const parsedPaymentRequirements = accepts.map(x => PaymentRequirementsSchema.parse(x));
 
+    const chainId = evm.isSignerWallet(walletClient)
+      ? walletClient.chain?.id
+      : evm.isAccount(walletClient)
+        ? walletClient.client?.chain?.id
+        : undefined;
     const selectedPaymentRequirements = paymentRequirementsSelector(
       parsedPaymentRequirements,
-      ChainIdToNetwork[walletClient.chain?.id],
+      chainId ? ChainIdToNetwork[chainId] : undefined,
     );
 
     if (BigInt(selectedPaymentRequirements.maxAmountRequired) > maxValue) {

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -65,6 +65,7 @@ export function wrapFetchWithPayment(
     const selectedPaymentRequirements = paymentRequirementsSelector(
       parsedPaymentRequirements,
       chainId ? ChainIdToNetwork[chainId] : undefined,
+      "exact",
     );
 
     if (BigInt(selectedPaymentRequirements.maxAmountRequired) > maxValue) {

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -100,3 +100,5 @@ export function wrapFetchWithPayment(
     return secondResponse;
   };
 }
+
+export { decodeXPaymentResponse } from "x402/shared";

--- a/typescript/packages/x402/src/client/selectPaymentRequirements.ts
+++ b/typescript/packages/x402/src/client/selectPaymentRequirements.ts
@@ -9,22 +9,48 @@ import { getNetworkId } from "../shared/network";
  * 
  * @param paymentRequirements - The payment requirements to select from.
  * @param network - The network to check against. If not provided, the network will not be checked.
+ * @param scheme - The scheme to check against. If not provided, the scheme will not be checked.
  * @returns The payment requirement that is the most appropriate for the user.
  */
-export function selectPaymentRequirements(paymentRequirements: PaymentRequirements[], network?: Network): PaymentRequirements {
-  const usdcPaymentRequirement = paymentRequirements.find(requirement => {
-    const isExpectedScheme = requirement.scheme === "exact";
-    const isExpectedAsset = requirement.asset === getUsdcAddressForChain(getNetworkId(requirement.network));
-    // If the chain is not resolveable, we skip the check. Otherwise, we check if our connected chain is the expected chain.
-    const isExpectedChain = !network || network == requirement.network;
-
-    return isExpectedScheme && isExpectedAsset && isExpectedChain;
+export function selectPaymentRequirements(paymentRequirements: PaymentRequirements[], network?: Network, scheme?: "exact"): PaymentRequirements {
+  // Sort `base` payment requirements to the front of the list. This is to ensure that base is preferred if available.
+  paymentRequirements.sort((a, b) => {
+    if (a.network === "base" && b.network !== "base") {
+      return -1;
+    }
+    if (a.network !== "base" && b.network === "base") {
+      return 1;
+    }
+    return 0;
   });
 
-  if (usdcPaymentRequirement) {
-    return usdcPaymentRequirement;
+  // Filter down to the scheme/network if provided
+  const broadlyAcceptedPaymentRequirements = paymentRequirements.filter(requirement => {
+    // If the scheme is not provided, we accept any scheme.
+    const isExpectedScheme = !scheme || requirement.scheme === scheme;
+    // If the chain is not provided, we accept any chain.
+    const isExpectedChain = !network || network == requirement.network;
+
+    return isExpectedScheme && isExpectedChain;
+  });
+
+  // Filter down to USDC requirements
+  const usdcRequirements = broadlyAcceptedPaymentRequirements.filter(requirement => {
+    // If the address is a USDC address, we return it.
+    return requirement.asset === getUsdcAddressForChain(getNetworkId(requirement.network));
+  });
+
+  // Prioritize USDC requirements if available
+  if (usdcRequirements.length > 0) {
+    return usdcRequirements[0];
   }
 
+  // If no USDC requirements are found, return the first broadly accepted requirement.
+  if (broadlyAcceptedPaymentRequirements.length > 0) {
+    return broadlyAcceptedPaymentRequirements[0];
+  }
+
+  // If no matching requirements are found, return the first requirement.
   return paymentRequirements[0];
 }
 
@@ -33,6 +59,7 @@ export function selectPaymentRequirements(paymentRequirements: PaymentRequiremen
  * 
  * @param paymentRequirements - The payment requirements to select from.
  * @param network - The network to check against. If not provided, the network will not be checked.
+ * @param scheme - The scheme to check against. If not provided, the scheme will not be checked.
  * @returns The payment requirement that is the most appropriate for the user.
  */
-export type PaymentRequirementsSelector = (paymentRequirements: PaymentRequirements[], network?: Network) => PaymentRequirements;
+export type PaymentRequirementsSelector = (paymentRequirements: PaymentRequirements[], network?: Network, scheme?: "exact") => PaymentRequirements;

--- a/typescript/packages/x402/src/schemes/exact/evm/client.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/client.ts
@@ -1,5 +1,5 @@
-import { Address, Chain, Transport } from "viem";
-import { SignerWallet } from "../../../types/shared/evm";
+import { Account, Address, Chain, Transport } from "viem";
+import { isSignerWallet, SignerWallet } from "../../../types/shared/evm";
 import { PaymentPayload, PaymentRequirements, UnsignedPaymentPayload } from "../../../types/verify";
 import { createNonce, signAuthorization } from "./sign";
 import { encodePayment } from "./utils/paymentUtils";
@@ -53,7 +53,7 @@ export function preparePaymentHeader(
  * @returns A promise that resolves to the signed payment payload
  */
 export async function signPaymentHeader<transport extends Transport, chain extends Chain>(
-  client: SignerWallet<chain, transport>,
+  client: SignerWallet<chain, transport> | Account,
   paymentRequirements: PaymentRequirements,
   unsignedPaymentHeader: UnsignedPaymentPayload,
 ): Promise<PaymentPayload> {
@@ -81,11 +81,11 @@ export async function signPaymentHeader<transport extends Transport, chain exten
  * @returns A promise that resolves to the complete signed payment payload
  */
 export async function createPayment<transport extends Transport, chain extends Chain>(
-  client: SignerWallet<chain, transport>,
+  client: SignerWallet<chain, transport> | Account,
   x402Version: number,
   paymentRequirements: PaymentRequirements,
 ): Promise<PaymentPayload> {
-  const from = client!.account!.address;
+  const from = isSignerWallet(client) ? client.account!.address : client.address;
   const unsignedPaymentHeader = preparePaymentHeader(from, x402Version, paymentRequirements);
   return signPaymentHeader(client, paymentRequirements, unsignedPaymentHeader);
 }
@@ -99,7 +99,7 @@ export async function createPayment<transport extends Transport, chain extends C
  * @returns A promise that resolves to the encoded payment header string
  */
 export async function createPaymentHeader(
-  client: SignerWallet,
+  client: SignerWallet | Account,
   x402Version: number,
   paymentRequirements: PaymentRequirements,
 ): Promise<string> {

--- a/typescript/packages/x402/src/schemes/exact/evm/sign.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/sign.ts
@@ -1,9 +1,8 @@
-import { Address, Chain, Hex, toHex, Transport } from "viem";
-import { getNetworkId } from "../../../shared";
-import { getVersion } from "../../../shared/evm";
-import { authorizationTypes, config, SignerWallet } from "../../../types/shared/evm";
-import { ExactEvmPayloadAuthorization, PaymentRequirements } from "../../../types/verify";
 import { getRandomValues } from "crypto";
+import { Account, Address, Chain, Hex, toHex, Transport } from "viem";
+import { getNetworkId } from "../../../shared";
+import { authorizationTypes, isAccount, isSignerWallet, SignerWallet } from "../../../types/shared/evm";
+import { ExactEvmPayloadAuthorization, PaymentRequirements } from "../../../types/verify";
 
 /**
  * Signs an EIP-3009 authorization for USDC transfer
@@ -23,16 +22,17 @@ import { getRandomValues } from "crypto";
  * @returns The signature for the authorization
  */
 export async function signAuthorization<transport extends Transport, chain extends Chain>(
-  walletClient: SignerWallet<chain, transport>,
+  walletClient: SignerWallet<chain, transport> | Account,
   { from, to, value, validAfter, validBefore, nonce }: ExactEvmPayloadAuthorization,
   { asset, network, extra }: PaymentRequirements,
 ): Promise<{ signature: Hex }> {
   const chainId = getNetworkId(network);
-  const name = extra?.name ?? config[chainId].usdcName;
-  const version = extra?.version ?? (await getVersion(walletClient));
+  const name = extra?.name;
+  const version = extra?.version;
+  const account = isSignerWallet(walletClient) ? walletClient.account : walletClient;
 
   const data = {
-    account: walletClient.account!,
+    account,
     types: authorizationTypes,
     domain: {
       name,
@@ -51,11 +51,21 @@ export async function signAuthorization<transport extends Transport, chain exten
     },
   };
 
-  const signature = await walletClient.signTypedData(data);
-
-  return {
-    signature,
-  };
+  if (isSignerWallet(walletClient)) {
+    const signature = await walletClient.signTypedData(data);
+    return {
+      signature,
+    };
+  }
+  else if (isAccount(walletClient) && walletClient.signTypedData) {
+    const signature = await walletClient.signTypedData(data);
+    return {
+      signature,
+    };
+  }
+  else {
+    throw new Error("Invalid wallet client provided does not support signTypedData");
+  }
 }
 
 /**

--- a/typescript/packages/x402/src/schemes/exact/evm/sign.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/sign.ts
@@ -1,7 +1,12 @@
 import { getRandomValues } from "crypto";
 import { Account, Address, Chain, Hex, toHex, Transport } from "viem";
 import { getNetworkId } from "../../../shared";
-import { authorizationTypes, isAccount, isSignerWallet, SignerWallet } from "../../../types/shared/evm";
+import {
+  authorizationTypes,
+  isAccount,
+  isSignerWallet,
+  SignerWallet,
+} from "../../../types/shared/evm";
 import { ExactEvmPayloadAuthorization, PaymentRequirements } from "../../../types/verify";
 
 /**
@@ -56,14 +61,12 @@ export async function signAuthorization<transport extends Transport, chain exten
     return {
       signature,
     };
-  }
-  else if (isAccount(walletClient) && walletClient.signTypedData) {
+  } else if (isAccount(walletClient) && walletClient.signTypedData) {
     const signature = await walletClient.signTypedData(data);
     return {
       signature,
     };
-  }
-  else {
+  } else {
     throw new Error("Invalid wallet client provided does not support signTypedData");
   }
 }

--- a/typescript/packages/x402/src/shared/middleware.ts
+++ b/typescript/packages/x402/src/shared/middleware.ts
@@ -1,3 +1,4 @@
+import { Address, Hex } from "viem";
 import {
   moneySchema,
   Network,
@@ -9,6 +10,7 @@ import {
   PaymentPayload,
 } from "../types";
 import { RoutesConfig } from "../types";
+import { safeBase64Decode } from "./base64";
 import { getUsdcAddressForChain } from "./evm";
 import { getNetworkId } from "./network";
 
@@ -148,4 +150,20 @@ export function findMatchingPaymentRequirements(
   return paymentRequirements.find(
     value => value.scheme === payment.scheme && value.network === payment.network,
   );
+}
+
+/**
+ * Decodes the X-PAYMENT-RESPONSE header
+ *
+ * @param header - The X-PAYMENT-RESPONSE header to decode
+ * @returns The decoded payment response
+ */
+export function decodeXPaymentResponse(header: string) {
+  const decoded = safeBase64Decode(header);
+  return JSON.parse(decoded) as {
+    success: boolean;
+    transaction: Hex;
+    network: Network;
+    payer: Address;
+  };
 }

--- a/typescript/packages/x402/src/shared/paywall.ts
+++ b/typescript/packages/x402/src/shared/paywall.ts
@@ -27,6 +27,7 @@ export function getPaywallHtml({
   const selectedPaymentRequirements = selectPaymentRequirements(
     paymentRequirements,
     testnet ? "base-sepolia" : "base",
+    "exact",
   );
   return `<!DOCTYPE html>
 <html lang="en">

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -67,8 +67,10 @@ export function createSignerSepolia(privateKey: Hex): SignerWallet<typeof baseSe
 export function isSignerWallet<
   TChain extends Chain = Chain,
   TTransport extends Transport = Transport,
-  TAccount extends Account = Account
->(wallet: SignerWallet<TChain, TTransport, TAccount> | Account): wallet is SignerWallet<TChain, TTransport, TAccount> {
+  TAccount extends Account = Account,
+>(
+  wallet: SignerWallet<TChain, TTransport, TAccount> | Account,
+): wallet is SignerWallet<TChain, TTransport, TAccount> {
   return "chain" in wallet && "transport" in wallet;
 }
 

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -57,3 +57,27 @@ export function createSignerSepolia(privateKey: Hex): SignerWallet<typeof baseSe
     account: privateKeyToAccount(privateKey),
   }).extend(publicActions);
 }
+
+/**
+ * Checks if a wallet is a signer wallet
+ *
+ * @param wallet - The wallet to check
+ * @returns True if the wallet is a signer wallet, false otherwise
+ */
+export function isSignerWallet<
+  TChain extends Chain = Chain,
+  TTransport extends Transport = Transport,
+  TAccount extends Account = Account
+>(wallet: SignerWallet<TChain, TTransport, TAccount> | Account): wallet is SignerWallet<TChain, TTransport, TAccount> {
+  return "chain" in wallet && "transport" in wallet;
+}
+
+/**
+ * Checks if a wallet is an account
+ *
+ * @param wallet - The wallet to check
+ * @returns True if the wallet is an account, false otherwise
+ */
+export function isAccount(wallet: SignerWallet | Account): wallet is Account {
+  return "address" in wallet && "type" in wallet;
+}


### PR DESCRIPTION
1. Broaden the scope of the signers allowed to be passed in. Previously, it was just a Viem client wallet, however now we have added Viem accounts as well. This enables Viem-compatible signers to be immediately supported, such as the Cdp server wallets
2. Update all client examples to use the Viem account to simplify the examples
3. Update environment variable handling in the examples to be more readeable and feel less verbose
4. Rewrite selectPaymentRequirements for improved behavior and readability
5. Added `decodeXPaymentResponse` in `x402`, which is re-exported in `x402-axios` and `x402-fetch`, and used in the `axios` and `fetch` examples. This is to showcase validating client-side that the transaction went through. Without this function, they need to otherwise import `x402` directly, so this conveniently allows them to do it without needing to add another direct dependency