### PR TITLE
fix: display amount in middleware paywall

### DIFF
--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from "x402/shared";
 import {
   FacilitatorConfig,
+  moneySchema,
   PaymentPayload,
   PaymentRequirements,
   Resource,
@@ -127,10 +128,17 @@ export function paymentMiddleware(
 
     if (!payment) {
       if (isWebBrowser) {
-        const displayAmount =
-          typeof price === "string" || typeof price === "number"
-            ? Number(price)
-            : Number(price.amount) / 10 ** price.asset.decimals;
+        let displayAmount: number;
+        if (typeof price === "string" || typeof price === "number") {
+          const parsed = moneySchema.safeParse(price);
+          if (parsed.success) {
+            displayAmount = parsed.data;
+          } else {
+            displayAmount = Number.NaN;
+          }
+        } else {
+          displayAmount = Number(price.amount) / 10 ** price.asset.decimals;
+        }
 
         const html =
           customPaywallHtml ||

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from "x402/shared";
 import {
   FacilitatorConfig,
+  moneySchema,
   PaymentPayload,
   PaymentRequirements,
   Resource,
@@ -108,10 +109,18 @@ export function paymentMiddleware(
 
     if (!payment) {
       if (isWebBrowser) {
-        const displayAmount =
-          typeof price === "string" || typeof price === "number"
-            ? Number(price)
-            : Number(price.amount) / 10 ** price.asset.decimals;
+        let displayAmount: number;
+        if (typeof price === "string" || typeof price === "number") {
+          const parsed = moneySchema.safeParse(price);
+          if (parsed.success) {
+            displayAmount = parsed.data;
+          } else {
+            displayAmount = Number.NaN;
+          }
+        } else {
+          displayAmount = Number(price.amount) / 10 ** price.asset.decimals;
+        }
+
         const html =
           customPaywallHtml ??
           getPaywallHtml({


### PR DESCRIPTION
Fixed a bug where the displayAmount for express and hono middleware was mishandling the conversion for the displayAmount to be displayed by the paywall html