### PR TITLE
fix: cjs imports

### DIFF
--- a/typescript/packages/x402-axios/package.json
+++ b/typescript/packages/x402-axios/package.json
@@ -42,12 +42,16 @@
     "x402": "workspace:*",
     "zod": "^3.24.2"
   },
-  "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      }
     }
   },
   "files": [

--- a/typescript/packages/x402-express/package.json
+++ b/typescript/packages/x402-express/package.json
@@ -43,12 +43,16 @@
     "x402": "workspace:*",
     "zod": "^3.24.2"
   },
-  "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      }
     }
   },
   "files": [

--- a/typescript/packages/x402-fetch/package.json
+++ b/typescript/packages/x402-fetch/package.json
@@ -41,12 +41,16 @@
     "zod": "^3.24.2",
     "x402": "workspace:*"
   },
-  "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      }
     }
   },
   "files": [

--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -42,12 +42,16 @@
     "x402": "workspace:*",
     "zod": "^3.24.2"
   },
-  "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      }
     }
   },
   "files": [

--- a/typescript/packages/x402-next/package.json
+++ b/typescript/packages/x402-next/package.json
@@ -45,9 +45,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.js"
+      }
     }
   },
   "files": [

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -40,42 +40,76 @@
     "viem": "^2.23.1",
     "zod": "^3.24.2"
   },
-  "type": "module",
   "exports": {
     "./shared": {
-      "types": "./dist/esm/shared/index.d.ts",
-      "import": "./dist/esm/shared/index.js",
-      "require": "./dist/cjs/shared/index.js"
+      "import": {
+        "types": "./dist/esm/shared/index.d.mts",
+        "default": "./dist/esm/shared/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/shared/index.d.cts",
+        "default": "./dist/cjs/shared/index.cjs"
+      }
     },
     "./shared/evm": {
-      "types": "./dist/esm/shared/evm/index.d.ts",
-      "import": "./dist/esm/shared/evm/index.js",
-      "require": "./dist/cjs/shared/evm/index.js"
+      "import": {
+        "types": "./dist/esm/shared/evm/index.d.mts",
+        "default": "./dist/esm/shared/evm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/shared/evm/index.d.cts",
+        "default": "./dist/cjs/shared/evm/index.cjs"
+      }
     },
     "./schemes": {
-      "types": "./dist/esm/schemes/index.d.ts",
-      "import": "./dist/esm/schemes/index.js",
-      "require": "./dist/cjs/schemes/index.js"
+      "import": {
+        "types": "./dist/esm/schemes/index.d.mts",
+        "default": "./dist/esm/schemes/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/schemes/index.d.cts",
+        "default": "./dist/cjs/schemes/index.cjs"
+      }
     },
     "./client": {
-      "types": "./dist/esm/client/index.d.ts",
-      "import": "./dist/esm/client/index.js",
-      "require": "./dist/cjs/client/index.js"
+      "import": {
+        "types": "./dist/esm/client/index.d.mts",
+        "default": "./dist/esm/client/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/client/index.d.cts",
+        "default": "./dist/cjs/client/index.cjs"
+      }
     },
     "./verify": {
-      "types": "./dist/esm/verify/index.d.ts",
-      "import": "./dist/esm/verify/index.js",
-      "require": "./dist/cjs/verify/index.js"
+      "import": {
+        "types": "./dist/esm/verify/index.d.mts",
+        "default": "./dist/esm/verify/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/verify/index.d.cts",
+        "default": "./dist/cjs/verify/index.cjs"
+      }
     },
     "./facilitator": {
-      "types": "./dist/esm/facilitator/index.d.ts",
-      "import": "./dist/esm/facilitator/index.js",
-      "require": "./dist/cjs/facilitator/index.js"
+      "import": {
+        "types": "./dist/esm/facilitator/index.d.mts",
+        "default": "./dist/esm/facilitator/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/facilitator/index.d.cts",
+        "default": "./dist/cjs/facilitator/index.cjs"
+      }
     },
     "./types": {
-      "types": "./dist/esm/types/index.d.ts",
-      "import": "./dist/esm/types/index.js",
-      "require": "./dist/cjs/types/index.js"
+      "import": {
+        "types": "./dist/esm/types/index.d.mts",
+        "default": "./dist/esm/types/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/types/index.d.cts",
+        "default": "./dist/cjs/types/index.cjs"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
Despite properly building `cjs` builds, our packages were using `type: module`, which signals to the importing package that the code is modern esm js and to use the `esm` builds. Essentially, `type:module` was making the importing package skip the selection for itself, forcing it into the `esm` path.

This tweak though changes the builds. i.e., by removing `type: module`, the building process no longer assumes `esm`, and now must specify it. The file extentions of the built for often changed from `.ts` to `.mts`, which is correct and more closely aligns with how the cjs side was compiling the code as `.cjs`.

Therefore, the exports were updated to handle this.

NOTE: You may notice that `x402-next` is the exception, and did not get this full refactor. This is because `next` is special, in that we can assume the environment users are running in. Next is a `esm`-first framework, and thus keeping `x402-next` as `type: module` is appropriate. Next CAN be run with CJS, which is why we did not outright delete the cjs builds. However, builders in Next opt-in to that, so it's best to focus on `esm` for Next

### Tests

You can easily test by removing `type: module` from the `/examples`. This flips it from being a ESM module to a CJS module. I removed and re-added it to all the tests (beyond Next, who will continue to assume esm), and confirmed that after these changes, both sides worked.

I then re-created Lincolns experiment of having a folder with just `package.json` and `index.ts` using `tsx index.ts` to run, to ensure its truly CJS with no tsconfig in sight. Before these changes, that failed to resolve the module. After these changes, this test worked as expected.