### PR TITLE
feat: updated go package to spec

### DIFF
--- a/go/pkg/facilitatorclient/facilitatorclient.go
+++ b/go/pkg/facilitatorclient/facilitatorclient.go
@@ -32,7 +32,6 @@ func NewFacilitatorClient(url string) *FacilitatorClient {
 // Verify sends a payment verification request to the facilitator
 func (c *FacilitatorClient) Verify(payload *types.PaymentPayload, requirements *types.PaymentRequirements) (*types.VerifyResponse, error) {
 	reqBody := map[string]any{
-		"x402Version":         1,
 		"paymentPayload":      payload,
 		"paymentRequirements": requirements,
 	}
@@ -69,7 +68,6 @@ func (c *FacilitatorClient) Verify(payload *types.PaymentPayload, requirements *
 // Settle sends a payment settlement request to the facilitator
 func (c *FacilitatorClient) Settle(payload *types.PaymentPayload, requirements *types.PaymentRequirements) (*types.SettleResponse, error) {
 	reqBody := map[string]any{
-		"x402Version":         1,
 		"paymentPayload":      payload,
 		"paymentRequirements": requirements,
 	}

--- a/go/pkg/types/types.go
+++ b/go/pkg/types/types.go
@@ -48,16 +48,18 @@ type ExactEvmPayloadAuthorization struct {
 
 // VerifyResponse represents the response from the verify endpoint
 type VerifyResponse struct {
-	IsValid       bool   `json:"isValid"`
-	InvalidReason string `json:"invalidReason"`
+	IsValid       bool    `json:"isValid"`
+	InvalidReason *string `json:"invalidReason,omitempty"`
+	Payer         *string `json:"payer,omitempty"`
 }
 
 // SettleResponse represents the response from the settle endpoint
 type SettleResponse struct {
-	Success     bool   `json:"success"`
-	ErrorReason string `json:"errorReason"`
-	Transaction string `json:"transaction"`
-	Network     string `json:"network"`
+	Success     bool    `json:"success"`
+	ErrorReason *string `json:"errorReason,omitempty"`
+	Transaction string  `json:"transaction"`
+	Network     string  `json:"network"`
+	Payer       *string `json:"payer,omitempty"`
 }
 
 func (s *SettleResponse) EncodeToBase64String() (string, error) {
@@ -80,6 +82,9 @@ func DecodePaymentPayloadFromBase64(encoded string) (*PaymentPayload, error) {
 	if err := json.Unmarshal(decodedBytes, &payload); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal payment payload: %w", err)
 	}
+
+	// Set the x402Version after decoding, matching the TypeScript behavior
+	payload.X402Version = 1
 
 	return &payload, nil
 }


### PR DESCRIPTION
The `go` packages' middleware was behind the spec in a couple of areas. This PR brings it up to speed.
1. The `x402Version` sent to the facilitator to verify must come from the server, not the client, otherwise the client has the ability to switch versions on the server.
2. Missing `payer` property of facilitator responses
3. `invalid reason` was not-optional in the facilitator responses

## Tests

### Manual
![Screenshot 2025-05-05 at 2 55 24 PM](https://github.com/user-attachments/assets/6583795c-95dc-4d56-9180-0831bbb1834b)

### Unit

```
❯ go test -v
=== RUN   TestPaymentMiddleware_NoPaymentHeader
Payment middleware checking request: /protected
--- PASS: TestPaymentMiddleware_NoPaymentHeader (0.00s)
=== RUN   TestPaymentMiddleware_WebBrowserRequest
Payment middleware checking request: /protected
--- PASS: TestPaymentMiddleware_WebBrowserRequest (0.00s)
=== RUN   TestPaymentMiddleware_ValidPayment
Payment middleware checking request: /protected
Payment verified, proceeding
--- PASS: TestPaymentMiddleware_ValidPayment (0.00s)
=== RUN   TestPaymentMiddleware_VerificationFails
Payment middleware checking request: /protected
Invalid payment:  0x14000202280
--- PASS: TestPaymentMiddleware_VerificationFails (0.00s)
=== RUN   TestPaymentMiddleware_VerificationServerError
Payment middleware checking request: /protected
failed to verify failed to verify payment: 500 Internal Server Error
--- PASS: TestPaymentMiddleware_VerificationServerError (0.00s)
=== RUN   TestPaymentMiddleware_SettlementFails
Payment middleware checking request: /protected
Payment verified, proceeding
--- PASS: TestPaymentMiddleware_SettlementFails (0.00s)
=== RUN   TestPaymentMiddleware_SettlementServerError
Payment middleware checking request: /protected
Payment verified, proceeding
Settlement failed: failed to settle payment: 500 Internal Server Error
--- PASS: TestPaymentMiddleware_SettlementServerError (0.00s)
=== RUN   TestPaymentMiddleware_Options
=== RUN   TestPaymentMiddleware_Options/with_custom_description
Payment middleware checking request: /protected
Payment verified, proceeding
=== RUN   TestPaymentMiddleware_Options/with_custom_paywall_HTML
Payment middleware checking request: /protected
Payment verified, proceeding
--- PASS: TestPaymentMiddleware_Options (0.00s)
    --- PASS: TestPaymentMiddleware_Options/with_custom_description (0.00s)
    --- PASS: TestPaymentMiddleware_Options/with_custom_paywall_HTML (0.00s)
=== RUN   TestPaymentMiddleware_NetworkSelection
=== RUN   TestPaymentMiddleware_NetworkSelection/base-sepolia
Payment middleware checking request: /protected
=== RUN   TestPaymentMiddleware_NetworkSelection/base
Payment middleware checking request: /protected
--- PASS: TestPaymentMiddleware_NetworkSelection (0.00s)
    --- PASS: TestPaymentMiddleware_NetworkSelection/base-sepolia (0.00s)
    --- PASS: TestPaymentMiddleware_NetworkSelection/base (0.00s)
PASS
ok      github.com/coinbase/x402/go/pkg/gin     0.409s
```
