### PR TITLE
release: bump npm packages to 0.3.0

### DIFF
--- a/typescript/packages/x402-axios/package.json
+++ b/typescript/packages/x402-axios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-axios",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-express/package.json
+++ b/typescript/packages/x402-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-express",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-fetch/package.json
+++ b/typescript/packages/x402-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-fetch",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-hono",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-next/package.json
+++ b/typescript/packages/x402-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-next",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Bumps all packages to 0.3.0. This excludes `@coinbase/x402`, we need to land #91 first and then we can bump that package