### PR TITLE
fix: coinbase-x402 release gha

### DIFF
--- a/.github/workflows/publish_npm_coinbase_x402.yml
+++ b/.github/workflows/publish_npm_coinbase_x402.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: ./typescript
         run: |
           pnpm install --frozen-lockfile
-          pnpm -r --filter=x402 --filter=coinbase-x402 run build
+          pnpm -r --filter=x402 --filter=@coinbase/x402 run build
       
       - name: Publish coinbase-x402 package
         working-directory: ./typescript/packages/coinbase-x402

--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/x402",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
* Fixed the coinbase x402 release gha, which was not building, as it was filtering down based on folder name, when it should have based on package name
* Bumped patch to 0.3.1

![Screenshot 2025-05-06 at 9 53 18 AM](https://github.com/user-attachments/assets/50923624-b81c-4de3-b3d9-dae641f8f002)
