### PR TITLE
fix: exports to match cjs build structure

### DIFF
--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/x402",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -48,7 +48,7 @@
         "default": "./dist/esm/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/index.d.cts",
+        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
     }

--- a/typescript/packages/x402-axios/package.json
+++ b/typescript/packages/x402-axios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-axios",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -50,7 +50,7 @@
         "default": "./dist/esm/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/index.d.cts",
+        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
     }

--- a/typescript/packages/x402-express/package.json
+++ b/typescript/packages/x402-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-express",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -51,7 +51,7 @@
         "default": "./dist/esm/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/index.d.cts",
+        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
     }

--- a/typescript/packages/x402-fetch/package.json
+++ b/typescript/packages/x402-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-fetch",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -49,7 +49,7 @@
         "default": "./dist/esm/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/index.d.cts",
+        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
     }

--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-hono",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -50,7 +50,7 @@
         "default": "./dist/esm/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/index.d.cts",
+        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
     }

--- a/typescript/packages/x402-next/package.json
+++ b/typescript/packages/x402-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-next",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -52,7 +52,7 @@
       },
       "require": {
         "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.js"
+        "default": "./dist/cjs/index.cjs"
       }
     }
   },

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -50,8 +50,8 @@
         "default": "./dist/esm/shared/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/shared/index.d.cts",
-        "default": "./dist/cjs/shared/index.cjs"
+        "types": "./dist/cjs/shared/index.d.ts",
+        "default": "./dist/cjs/shared/index.js"
       }
     },
     "./shared/evm": {
@@ -60,8 +60,8 @@
         "default": "./dist/esm/shared/evm/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/shared/evm/index.d.cts",
-        "default": "./dist/cjs/shared/evm/index.cjs"
+        "types": "./dist/cjs/shared/evm/index.d.ts",
+        "default": "./dist/cjs/shared/evm/index.js"
       }
     },
     "./schemes": {
@@ -70,8 +70,8 @@
         "default": "./dist/esm/schemes/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/schemes/index.d.cts",
-        "default": "./dist/cjs/schemes/index.cjs"
+        "types": "./dist/cjs/schemes/index.d.ts",
+        "default": "./dist/cjs/schemes/index.js"
       }
     },
     "./client": {
@@ -80,8 +80,8 @@
         "default": "./dist/esm/client/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/client/index.d.cts",
-        "default": "./dist/cjs/client/index.cjs"
+        "types": "./dist/cjs/client/index.d.ts",
+        "default": "./dist/cjs/client/index.js"
       }
     },
     "./verify": {
@@ -90,8 +90,8 @@
         "default": "./dist/esm/verify/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/verify/index.d.cts",
-        "default": "./dist/cjs/verify/index.cjs"
+        "types": "./dist/cjs/verify/index.d.ts",
+        "default": "./dist/cjs/verify/index.js"
       }
     },
     "./facilitator": {
@@ -100,8 +100,8 @@
         "default": "./dist/esm/facilitator/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/facilitator/index.d.cts",
-        "default": "./dist/cjs/facilitator/index.cjs"
+        "types": "./dist/cjs/facilitator/index.d.ts",
+        "default": "./dist/cjs/facilitator/index.js"
       }
     },
     "./types": {
@@ -110,8 +110,8 @@
         "default": "./dist/esm/types/index.mjs"
       },
       "require": {
-        "types": "./dist/cjs/types/index.d.cts",
-        "default": "./dist/cjs/types/index.cjs"
+        "types": "./dist/cjs/types/index.d.ts",
+        "default": "./dist/cjs/types/index.js"
       }
     }
   },


### PR DESCRIPTION
The exports were not properly lined up with the build structure for cjs.

For reference, this is how the cjs builds should be for all the cjs-first packages (everything but `x402-next`). The types is a `.d.ts` file while the code is a `.js` file. Meanwhile, on the esm side, we correctly were saying the types were `.d.mts` and the core code was `.mjs`
![Screenshot 2025-05-06 at 11 13 54 AM](https://github.com/user-attachments/assets/b7237dcb-ab52-42a5-9d78-ec294131d7e3)
![Screenshot 2025-05-06 at 11 14 12 AM](https://github.com/user-attachments/assets/d6e8620d-9be2-42ea-ab32-d4194e84d3b4)
![Screenshot 2025-05-06 at 11 15 28 AM](https://github.com/user-attachments/assets/be4b393a-7d96-444d-a8da-09d9e36e52d3)

The exception is `next`, whose esm first, declared by the `type: module` in its package.json. In this case, the cjs type is `.d.cts` with the code as `.cjs`, and it's the esm side who gets the simplified `.d.ts`/`.js` extensions.
![Screenshot 2025-05-06 at 11 15 53 AM](https://github.com/user-attachments/assets/1136ae11-6d6d-4d3f-aace-eaccee7134c6)



