### PR TITLE
feat: add Go standard library middleware

### DIFF
--- a/go/pkg/gin/middleware.go
+++ b/go/pkg/gin/middleware.go
@@ -11,9 +11,8 @@ import (
 
 	"github.com/coinbase/x402/go/pkg/facilitatorclient"
 	"github.com/coinbase/x402/go/pkg/types"
+	"github.com/coinbase/x402/go/pkg/x402"
 )
-
-const x402Version = 1
 
 // PaymentMiddlewareOptions is the options for the PaymentMiddleware.
 type PaymentMiddlewareOptions struct {
@@ -151,7 +150,7 @@ func PaymentMiddleware(amount *big.Float, address string, opts ...Options) gin.H
 			fmt.Println("failed to set USDC info:", err)
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
 				"error":       err.Error(),
-				"x402Version": x402Version,
+				"x402Version": x402.CurrentVersion,
 			})
 			return
 		}
@@ -172,11 +171,11 @@ func PaymentMiddleware(amount *big.Float, address string, opts ...Options) gin.H
 			c.AbortWithStatusJSON(http.StatusPaymentRequired, gin.H{
 				"error":       "X-PAYMENT header is required",
 				"accepts":     []*types.PaymentRequirements{paymentRequirements},
-				"x402Version": x402Version,
+				"x402Version": x402.CurrentVersion,
 			})
 			return
 		}
-		paymentPayload.X402Version = x402Version
+		paymentPayload.X402Version = x402.CurrentVersion
 
 		// Verify payment
 		response, err := facilitatorClient.Verify(paymentPayload, paymentRequirements)
@@ -184,7 +183,7 @@ func PaymentMiddleware(amount *big.Float, address string, opts ...Options) gin.H
 			fmt.Println("failed to verify", err)
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
 				"error":       err.Error(),
-				"x402Version": x402Version,
+				"x402Version": x402.CurrentVersion,
 			})
 			return
 		}
@@ -194,7 +193,7 @@ func PaymentMiddleware(amount *big.Float, address string, opts ...Options) gin.H
 			c.AbortWithStatusJSON(http.StatusPaymentRequired, gin.H{
 				"error":       response.InvalidReason,
 				"accepts":     []*types.PaymentRequirements{paymentRequirements},
-				"x402Version": x402Version,
+				"x402Version": x402.CurrentVersion,
 			})
 			return
 		}
@@ -226,7 +225,7 @@ func PaymentMiddleware(amount *big.Float, address string, opts ...Options) gin.H
 			c.AbortWithStatusJSON(http.StatusPaymentRequired, gin.H{
 				"error":       err.Error(),
 				"accepts":     []*types.PaymentRequirements{paymentRequirements},
-				"x402Version": x402Version,
+				"x402Version": x402.CurrentVersion,
 			})
 			return
 		}
@@ -238,7 +237,7 @@ func PaymentMiddleware(amount *big.Float, address string, opts ...Options) gin.H
 			c.Writer = writer.ResponseWriter
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
 				"error":       err.Error(),
-				"x402Version": x402Version,
+				"x402Version": x402.CurrentVersion,
 			})
 			return
 		}

--- a/go/pkg/stdlib/middleware.go
+++ b/go/pkg/stdlib/middleware.go
@@ -1,0 +1,255 @@
+package stdlib
+
+import (
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strings"
+
+	"github.com/coinbase/x402/go/pkg/facilitatorclient"
+	"github.com/coinbase/x402/go/pkg/types"
+	"github.com/coinbase/x402/go/pkg/x402"
+)
+
+// PaymentMiddlewareOptions is the options for the PaymentMiddleware.
+type PaymentMiddlewareOptions struct {
+	Description       string
+	MimeType          string
+	MaxTimeoutSeconds int
+	OutputSchema      *json.RawMessage
+	FacilitatorConfig *types.FacilitatorConfig
+	Testnet           bool
+	CustomPaywallHTML string
+	Resource          string
+	ResourceRootURL   string
+	Network           string
+	Asset             string
+}
+
+// Options is the type for the options for the PaymentMiddleware.
+type Options func(*PaymentMiddlewareOptions)
+
+// WithDescription is an option for the PaymentMiddleware to set the description.
+func WithDescription(description string) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.Description = description
+	}
+}
+
+// WithMimeType is an option for the PaymentMiddleware to set the mime type.
+func WithMimeType(mimeType string) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.MimeType = mimeType
+	}
+}
+
+// WithMaxDeadlineSeconds is an option for the PaymentMiddleware to set the max timeout seconds.
+func WithMaxTimeoutSeconds(maxTimeoutSeconds int) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.MaxTimeoutSeconds = maxTimeoutSeconds
+	}
+}
+
+// WithOutputSchema is an option for the PaymentMiddleware to set the output schema.
+func WithOutputSchema(outputSchema *json.RawMessage) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.OutputSchema = outputSchema
+	}
+}
+
+// WithFacilitatorConfig is an option for the PaymentMiddleware to set the facilitator config.
+func WithFacilitatorConfig(config *types.FacilitatorConfig) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.FacilitatorConfig = config
+	}
+}
+
+// WithTestnet is an option for the PaymentMiddleware to set the testnet flag.
+func WithTestnet(testnet bool) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.Testnet = testnet
+	}
+}
+
+// WithCustomPaywallHTML is an option for the PaymentMiddleware to set the custom paywall HTML.
+func WithCustomPaywallHTML(customPaywallHTML string) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.CustomPaywallHTML = customPaywallHTML
+	}
+}
+
+// WithResource is an option for the PaymentMiddleware to set the resource.
+func WithResource(resource string) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.Resource = resource
+	}
+}
+
+// WithResourceRootURL is an option for the PaymentMiddleware to set the resource root URL.
+func WithResourceRootURL(resourceRootURL string) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.ResourceRootURL = resourceRootURL
+	}
+}
+
+// WithNetwork is an option for the PaymentMiddleware to set the network (chain).
+func WithNetwork(network string) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.Network = network
+	}
+}
+
+// WithAsset is an option for the PaymentMiddleware to set the asset address.
+func WithAsset(asset string) Options {
+	return func(options *PaymentMiddlewareOptions) {
+		options.Asset = asset
+	}
+}
+
+const (
+	usdcAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" // USDC on Base
+
+	usdcBaseSepolia = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+)
+
+// PaymentMiddleware is the Go standard library middleware for the resource server using the x402payment protocol.
+// Amount: the decimal denominated amount to charge (ex: 0.01 for 1 cent)
+func PaymentMiddleware(amount *big.Float, address string, opts ...Options) func(http.Handler) http.Handler {
+	options := &PaymentMiddlewareOptions{
+		FacilitatorConfig: &types.FacilitatorConfig{
+			URL: facilitatorclient.DefaultFacilitatorURL,
+		},
+		MaxTimeoutSeconds: 60,
+		Testnet:           false,  // Default to mainnet
+		Network:           "base", // Default to Base chain
+		Asset:             usdcAddress,
+	}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var (
+				network              = options.Network
+				asset                = options.Asset
+				facilitatorClient    = facilitatorclient.NewFacilitatorClient(options.FacilitatorConfig)
+				maxAmountRequired, _ = new(big.Float).Mul(amount, big.NewFloat(1e6)).Int(nil)
+			)
+
+			// Override defaults for testnet if explicitly set and no custom network/asset provided
+			if options.Testnet && options.Network == "base" && options.Asset == usdcAddress {
+				network = "base-sepolia"
+				asset = usdcBaseSepolia
+			}
+
+			userAgent := r.Header.Get("User-Agent")
+			acceptHeader := r.Header.Get("Accept")
+			isWebBrowser := strings.Contains(acceptHeader, "text/html") && strings.Contains(userAgent, "Mozilla")
+			var resource string
+			if options.Resource == "" {
+				resource = options.ResourceRootURL + r.URL.Path
+			} else {
+				resource = options.Resource
+			}
+
+			paymentRequirements := &types.PaymentRequirements{
+				Scheme:            "exact",
+				Network:           network,
+				MaxAmountRequired: maxAmountRequired.String(),
+				Resource:          resource,
+				Description:       options.Description,
+				MimeType:          options.MimeType,
+				PayTo:             address,
+				MaxTimeoutSeconds: options.MaxTimeoutSeconds,
+				Asset:             asset,
+				OutputSchema:      options.OutputSchema,
+				Extra:             nil,
+			}
+
+			if err := paymentRequirements.SetUSDCInfo(options.Testnet && asset == usdcBaseSepolia); err != nil {
+				writeErrorResponse(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+
+			payment := r.Header.Get("X-PAYMENT")
+			paymentPayload, err := types.DecodePaymentPayloadFromBase64(payment)
+			if err != nil {
+				if isWebBrowser {
+					html := options.CustomPaywallHTML
+					if html == "" {
+						html = getPaywallHtml(options)
+					}
+					http.Error(w, html, http.StatusPaymentRequired)
+					return
+				}
+
+				writePaymentRequiredResponse(w, "X-PAYMENT header is required", paymentRequirements)
+				return
+			}
+			paymentPayload.X402Version = x402.CurrentVersion
+
+			// Verify payment
+			response, err := facilitatorClient.Verify(paymentPayload, paymentRequirements)
+			if err != nil {
+				writeErrorResponse(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+
+			if !response.IsValid {
+				reason := "invalid reason"
+				if response.InvalidReason != nil {
+					reason = *response.InvalidReason
+				}
+
+				writePaymentRequiredResponse(w, reason, paymentRequirements)
+				return
+			}
+
+			// Settle payment
+			settleResponse, err := facilitatorClient.Settle(paymentPayload, paymentRequirements)
+			if err != nil {
+				writePaymentRequiredResponse(w, err.Error(), paymentRequirements)
+				return
+			}
+
+			settleResponseHeader, err := settleResponse.EncodeToBase64String()
+			if err != nil {
+				writeErrorResponse(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+
+			w.Header().Set("X-PAYMENT-RESPONSE", settleResponseHeader)
+
+			// Proceed to the next handler
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// writeErrorResponse writes an error response with the given status code and message.
+func writeErrorResponse(w http.ResponseWriter, statusCode int, errorMsg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error":       errorMsg,
+		"x402Version": x402.CurrentVersion,
+	})
+}
+
+// writePaymentRequiredResponse writes a payment required response with the given error message and payment requirements.
+func writePaymentRequiredResponse(w http.ResponseWriter, errorMsg string, requirements *types.PaymentRequirements) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusPaymentRequired)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error":       errorMsg,
+		"accepts":     []*types.PaymentRequirements{requirements},
+		"x402Version": x402.CurrentVersion,
+	})
+}
+
+// getPaywallHtml is the default paywall HTML for the PaymentMiddleware.
+func getPaywallHtml(_ *PaymentMiddlewareOptions) string {
+	return "<html><body>Payment Required</body></html>"
+}

--- a/go/pkg/stdlib/middleware_test.go
+++ b/go/pkg/stdlib/middleware_test.go
@@ -1,0 +1,361 @@
+package stdlib_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	x402payment "github.com/coinbase/x402/go/pkg/stdlib"
+	"github.com/coinbase/x402/go/pkg/types"
+)
+
+// TestServerConfig configures how the test facilitator server responds.
+type TestServerConfig struct {
+	PaymentPayload *types.PaymentPayload
+
+	// Verification response
+	VerifySuccess bool
+	InvalidReason *string
+
+	// Settlement response
+	SettleSuccess     bool
+	SettleErrorReason *string
+	Transaction       string
+	Network           string
+	Payer             *string
+
+	// Server behavior
+	VerifyStatusCode int
+	SettleStatusCode int
+}
+
+// NewTestConfig returns a default test configuration with successful responses.
+func NewTestConfig() TestServerConfig {
+	invalidReason := "Invalid payment"
+	settleErrorReason := "Settlement failed"
+	payer := "0xvalidPayer"
+
+	return TestServerConfig{
+		PaymentPayload: &types.PaymentPayload{
+			X402Version: 1,
+			Scheme:      "exact",
+			Network:     "base-sepolia",
+			Payload: &types.ExactEvmPayload{
+				Signature: "0xvalidSignature",
+				Authorization: &types.ExactEvmPayloadAuthorization{
+					From:        "0xvalidFrom",
+					To:          "0xvalidTo",
+					Value:       "1000000",
+					ValidAfter:  "1745323800",
+					ValidBefore: "1745323985",
+					Nonce:       "0xvalidNonce",
+				},
+			},
+		},
+		VerifySuccess:     true,
+		InvalidReason:     &invalidReason,
+		SettleSuccess:     true,
+		SettleErrorReason: &settleErrorReason,
+		Transaction:       "0xtesthash",
+		Network:           "base-sepolia",
+		Payer:             &payer,
+		VerifyStatusCode:  http.StatusOK,
+		SettleStatusCode:  http.StatusOK,
+	}
+}
+
+// setupTest creates a test environment with configurable facilitator server.
+func setupTest(t *testing.T, amount *big.Float, address string, config TestServerConfig, opts ...x402payment.Options) (*http.ServeMux, *httptest.ResponseRecorder, *http.Request) {
+	t.Helper()
+
+	// Create a test facilitator server
+	facilitatorServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/verify":
+			w.WriteHeader(config.VerifyStatusCode)
+			json.NewEncoder(w).Encode(types.VerifyResponse{
+				IsValid:       config.VerifySuccess,
+				InvalidReason: config.InvalidReason,
+				Payer:         config.Payer,
+			})
+		case "/settle":
+			w.WriteHeader(config.SettleStatusCode)
+			json.NewEncoder(w).Encode(types.SettleResponse{
+				Success:     config.SettleSuccess,
+				ErrorReason: config.SettleErrorReason,
+				Transaction: config.Transaction,
+				Network:     config.Network,
+				Payer:       config.Payer,
+			})
+		}
+	}))
+	t.Cleanup(func() { facilitatorServer.Close() })
+
+	// Create a new ServeMux
+	mux := http.NewServeMux()
+
+	// Apply the PaymentMiddleware and register the handler
+	allOpts := append([]x402payment.Options{x402payment.WithFacilitatorConfig(&types.FacilitatorConfig{
+		URL: facilitatorServer.URL,
+	})}, opts...)
+	middleware := x402payment.PaymentMiddleware(amount, address, allOpts...)
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	}))
+
+	mux.Handle("/protected", handler)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/protected", nil)
+
+	return mux, w, req
+}
+
+func TestPaymentMiddleware_NoPaymentHeader(t *testing.T) {
+	mux, w, req := setupTest(t, big.NewFloat(1.0), "0xTestAddress", NewTestConfig())
+
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPaymentRequired, w.Code)
+
+	var response map[string]any
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Contains(t, response, "error")
+	assert.Contains(t, response, "accepts")
+}
+
+func TestPaymentMiddleware_WebBrowserRequest(t *testing.T) {
+	mux, w, req := setupTest(t, big.NewFloat(1.0), "0xTestAddress", NewTestConfig())
+
+	req.Header.Set("Accept", "text/html")
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPaymentRequired, w.Code)
+	assert.Contains(t, w.Body.String(), "<html>")
+	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+}
+
+func TestPaymentMiddleware_ValidPayment(t *testing.T) {
+	config := NewTestConfig()
+
+	mux, w, req := setupTest(t, big.NewFloat(1.0), "0xTestAddress", config)
+
+	paymentPayloadJson, err := json.Marshal(config.PaymentPayload)
+	assert.NoError(t, err, "marshaling payment payload should not fail")
+
+	paymentPayloadBase64 := base64.StdEncoding.EncodeToString(paymentPayloadJson)
+	req.Header.Set("X-PAYMENT", paymentPayloadBase64)
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "success")
+	assert.NotEmpty(t, w.Header().Get("X-PAYMENT-RESPONSE"))
+
+	responseStr := w.Header().Get("X-PAYMENT-RESPONSE")
+	responseBytes, err := base64.StdEncoding.DecodeString(responseStr)
+	assert.NoError(t, err)
+
+	var settleResponse types.SettleResponse
+	err = json.Unmarshal(responseBytes, &settleResponse)
+	assert.NoError(t, err)
+	assert.True(t, settleResponse.Success)
+	assert.Equal(t, "0xtesthash", settleResponse.Transaction)
+}
+
+func TestPaymentMiddleware_VerificationFails(t *testing.T) {
+	config := NewTestConfig()
+	config.VerifySuccess = false
+	config.PaymentPayload.Payload.Signature = "0xInvalidSignature"
+
+	mux, w, req := setupTest(t, big.NewFloat(1.0), "0xTestAddress", config)
+
+	paymentPayloadJson, err := json.Marshal(config.PaymentPayload)
+	assert.NoError(t, err, "marshaling payment payload should not fail")
+
+	paymentPayloadBase64 := base64.StdEncoding.EncodeToString(paymentPayloadJson)
+	req.Header.Set("X-PAYMENT", paymentPayloadBase64)
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPaymentRequired, w.Code)
+
+	var response map[string]any
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Contains(t, response, "error")
+	assert.Contains(t, response, "accepts")
+	assert.Equal(t, *config.InvalidReason, response["error"])
+}
+
+func TestPaymentMiddleware_VerificationServerError(t *testing.T) {
+	config := NewTestConfig()
+	config.VerifyStatusCode = http.StatusInternalServerError
+
+	mux, w, req := setupTest(t, big.NewFloat(1.0), "0xTestAddress", config)
+
+	paymentPayloadJson, err := json.Marshal(config.PaymentPayload)
+	assert.NoError(t, err, "marshaling payment payload should not fail")
+
+	paymentPayloadBase64 := base64.StdEncoding.EncodeToString(paymentPayloadJson)
+	req.Header.Set("X-PAYMENT", paymentPayloadBase64)
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	var response map[string]any
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Contains(t, response, "error")
+}
+
+func TestPaymentMiddleware_SettlementFails(t *testing.T) {
+	config := NewTestConfig()
+	config.SettleSuccess = false
+
+	mux, w, req := setupTest(t, big.NewFloat(1.0), "0xTestAddress", config)
+
+	paymentPayloadJson, err := json.Marshal(config.PaymentPayload)
+	assert.NoError(t, err, "marshaling payment payload should not fail")
+
+	paymentPayloadBase64 := base64.StdEncoding.EncodeToString(paymentPayloadJson)
+	req.Header.Set("X-PAYMENT", paymentPayloadBase64)
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "success")
+
+	assert.NotEmpty(t, w.Header().Get("X-PAYMENT-RESPONSE"))
+
+	responseStr := w.Header().Get("X-PAYMENT-RESPONSE")
+	responseBytes, err := base64.StdEncoding.DecodeString(responseStr)
+	assert.NoError(t, err)
+
+	var settleResponse types.SettleResponse
+	err = json.Unmarshal(responseBytes, &settleResponse)
+	assert.NoError(t, err)
+	assert.False(t, settleResponse.Success)
+}
+
+func TestPaymentMiddleware_SettlementServerError(t *testing.T) {
+	config := NewTestConfig()
+	config.SettleStatusCode = http.StatusInternalServerError
+
+	mux, w, req := setupTest(t, big.NewFloat(1.0), "0xTestAddress", config)
+
+	paymentPayloadJson, err := json.Marshal(config.PaymentPayload)
+	assert.NoError(t, err, "marshaling payment payload should not fail")
+
+	paymentPayloadBase64 := base64.StdEncoding.EncodeToString(paymentPayloadJson)
+	req.Header.Set("X-PAYMENT", paymentPayloadBase64)
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusPaymentRequired, w.Code)
+	assert.Contains(t, w.Body.String(), `failed to settle payment: 500 Internal Server Error`)
+
+	assert.Empty(t, w.Header().Get("X-PAYMENT-RESPONSE"))
+}
+
+func TestPaymentMiddleware_Options(t *testing.T) {
+	testCases := []struct {
+		name    string
+		opts    []x402payment.Options
+		amount  *big.Float
+		address string
+	}{
+		{
+			name: "with custom description",
+			opts: []x402payment.Options{
+				x402payment.WithDescription("Test Description"),
+				x402payment.WithMimeType("application/json"),
+				x402payment.WithMaxTimeoutSeconds(120),
+				x402payment.WithTestnet(true),
+			},
+			amount:  big.NewFloat(1.0),
+			address: "0xTestAddress",
+		},
+		{
+			name: "with custom paywall HTML",
+			opts: []x402payment.Options{
+				x402payment.WithCustomPaywallHTML("<html><body>Custom Paywall</body></html>"),
+				x402payment.WithResource("test-resource"),
+			},
+			amount:  big.NewFloat(2.0),
+			address: "0xTestAddress2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := NewTestConfig()
+
+			mux, w, req := setupTest(t, tc.amount, tc.address, config, tc.opts...)
+
+			paymentPayloadJson, err := json.Marshal(config.PaymentPayload)
+			assert.NoError(t, err, "marshaling payment payload should not fail")
+
+			paymentPayloadBase64 := base64.StdEncoding.EncodeToString(paymentPayloadJson)
+			req.Header.Set("X-PAYMENT", paymentPayloadBase64)
+			mux.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, w.Body.String(), "success")
+			assert.NotEmpty(t, w.Header().Get("X-PAYMENT-RESPONSE"))
+		})
+	}
+}
+
+func TestPaymentMiddleware_NetworkSelection(t *testing.T) {
+	testCases := []struct {
+		name    string
+		testnet bool
+	}{
+		{
+			name:    "base-sepolia",
+			testnet: true,
+		},
+		{
+			name:    "base",
+			testnet: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, w, req := setupTest(
+				t,
+				big.NewFloat(1.0),
+				"0xTestAddress",
+				NewTestConfig(),
+				x402payment.WithTestnet(tc.testnet),
+			)
+
+			mux.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusPaymentRequired, w.Code)
+
+			var response map[string]any
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err)
+
+			requirementsSlice, ok := response["accepts"].([]any)
+			assert.True(t, ok)
+
+			requirements, ok := requirementsSlice[0].(map[string]any)
+			assert.True(t, ok)
+
+			expectedNetwork := "base"
+			if tc.testnet {
+				expectedNetwork = "base-sepolia"
+			}
+
+			assert.Equal(t, expectedNetwork, requirements["network"])
+		})
+	}
+}

--- a/go/pkg/types/types.go
+++ b/go/pkg/types/types.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/coinbase/x402/go/pkg/x402"
 )
 
 // PaymentRequirements represents the payment requirements for a resource
@@ -85,7 +87,7 @@ func DecodePaymentPayloadFromBase64(encoded string) (*PaymentPayload, error) {
 	}
 
 	// Set the x402Version after decoding, matching the TypeScript behavior
-	payload.X402Version = 1
+	payload.X402Version = x402.CurrentVersion
 
 	return &payload, nil
 }

--- a/go/pkg/x402/x402.go
+++ b/go/pkg/x402/x402.go
@@ -1,0 +1,3 @@
+package x402
+
+const CurrentVersion = 1


### PR DESCRIPTION
Following the Gin example we can add a middleware for the standard library (which is also useful for other libraries like gorilla/mux). 