### PR TITLE
chore: bump package versions

### DIFF
--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         specifier: ^2.23.1
         version: 2.27.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -143,7 +143,7 @@ importers:
         specifier: ^2.23.1
         version: 2.27.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -204,7 +204,7 @@ importers:
         specifier: ^2.23.1
         version: 2.27.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -265,7 +265,7 @@ importers:
         specifier: ^2.23.1
         version: 2.27.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -326,7 +326,7 @@ importers:
         specifier: ^2.23.1
         version: 2.27.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -387,7 +387,7 @@ importers:
         specifier: ^2.23.1
         version: 2.27.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2

--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/x402",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "viem": "^2.23.1",
-    "x402": "workspace:*",
+    "x402": "workspace:^",
     "zod": "^3.24.2"
   },
   "exports": {

--- a/typescript/packages/x402-axios/package.json
+++ b/typescript/packages/x402-axios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-axios",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "dependencies": {
     "axios": "^1.7.9",
     "viem": "^2.23.1",
-    "x402": "workspace:*",
+    "x402": "workspace:^",
     "zod": "^3.24.2"
   },
   "exports": {

--- a/typescript/packages/x402-express/package.json
+++ b/typescript/packages/x402-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-express",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -41,7 +41,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "viem": "^2.23.1",
-    "x402": "workspace:*",
+    "x402": "workspace:^",
     "zod": "^3.24.2"
   },
   "exports": {

--- a/typescript/packages/x402-fetch/package.json
+++ b/typescript/packages/x402-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-fetch",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "dependencies": {
     "viem": "^2.23.1",
     "zod": "^3.24.2",
-    "x402": "workspace:*"
+    "x402": "workspace:^"
   },
   "exports": {
     ".": {

--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-hono",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -40,7 +40,7 @@
   "dependencies": {
     "hono": "^4.7.1",
     "viem": "^2.23.1",
-    "x402": "workspace:*",
+    "x402": "workspace:^",
     "zod": "^3.24.2"
   },
   "exports": {

--- a/typescript/packages/x402-next/package.json
+++ b/typescript/packages/x402-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-next",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "viem": "^2.23.1",
-    "x402": "workspace:*",
+    "x402": "workspace:^",
     "next": "^15.2.4",
     "zod": "^3.24.2"
   },

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402/src/version.ts
+++ b/typescript/packages/x402/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.3.1";
+export const version = "0.3.2";

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         specifier: ^2.23.1
         version: 2.26.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -143,7 +143,7 @@ importers:
         specifier: ^2.23.1
         version: 2.26.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -204,7 +204,7 @@ importers:
         specifier: ^2.23.1
         version: 2.26.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -265,7 +265,7 @@ importers:
         specifier: ^2.23.1
         version: 2.26.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -326,7 +326,7 @@ importers:
         specifier: ^2.23.1
         version: 2.26.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2
@@ -387,7 +387,7 @@ importers:
         specifier: ^2.23.1
         version: 2.26.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       x402:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../x402
       zod:
         specifier: ^3.24.2


### PR DESCRIPTION
Bumped package versions in preparation for release.

Note: The dependent packages had their association updated from `workspace:*` to `workspace:^`. 

This was done because `workspace:*` creates a direct mapping during publication, where if `x402` was version `0.3.3`, the depending packages would expect `0.3.3` exactly. This forces all packages to bump whenever x402 bumps.

`workspace:^`, on the otherhand, would map it to `^0.3.3`. Since we are major version 0, the behavior is that depending packages effectively gets the dependency `>=0.3.3, <0.4.0`. This allows `x402` to have patches without re-publishing the dependent packages. Only when `x402` bumps to a new minor version would we need to bump all other packages moving forward.

[See here for context in pnpm docs](https://pnpm.io/workspaces#publishing-workspace-packages)