### PR TITLE
Support timeout option for facilitator http client

### DIFF
--- a/go/pkg/facilitatorclient/facilitatorclient.go
+++ b/go/pkg/facilitatorclient/facilitatorclient.go
@@ -27,9 +27,14 @@ func NewFacilitatorClient(config *types.FacilitatorConfig) *FacilitatorClient {
 		}
 	}
 
+	httpCli := &http.Client{}
+	if config.Timeout != nil {
+		httpCli.Timeout = config.Timeout()
+	}
+
 	return &FacilitatorClient{
 		URL:               config.URL,
-		HTTPClient:        http.DefaultClient,
+		HTTPClient:        httpCli,
 		CreateAuthHeaders: config.CreateAuthHeaders,
 	}
 }

--- a/go/pkg/types/types.go
+++ b/go/pkg/types/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // PaymentRequirements represents the payment requirements for a resource
@@ -113,5 +114,6 @@ func (p *PaymentRequirements) SetUSDCInfo(isTestnet bool) error {
 // FacilitatorConfig represents configuration for the facilitator service
 type FacilitatorConfig struct {
 	URL               string
+	Timeout           func() time.Duration
 	CreateAuthHeaders func() (map[string]map[string]string, error)
 }


### PR DESCRIPTION
Hi, I added support for a timeout option to the facilitator HTTP client. The changes involved:

- Updating `facilitatorclient.go` to implement the timeout feature.
- Modifying `facilitatorclient_test.go` to add tests for the new timeout functionality.

These changes can allow users of the facilitator HTTP client to specify a timeout duration for requests, improving robustness by preventing indefinite waits and making the client more configurable for different use cases, thank you.