### PR TITLE
added missing dev dependency

### DIFF
--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       prettier:
         specifier: 3.5.2
         version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.4.0(jiti@1.21.7)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       tsx:
         specifier: ^4.19.2
         version: 4.19.3

--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -34,7 +34,8 @@
     "typescript": "^5.7.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5",
-    "vite": "^6.2.6"
+    "vite": "^6.2.6",
+    "tsup": "^8.4.0"
   },
   "dependencies": {
     "viem": "^2.23.1",


### PR DESCRIPTION
"tsup" was missing in "coinbase-x402" package, causing "pnpm build" to fail when calling from "examples/typescript" as per the README.