### PR TITLE
fix(coinbase-x402): add missing tsup dependency for build process

### DIFF
--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       prettier:
         specifier: 3.5.2
         version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.4.0(jiti@1.21.7)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       tsx:
         specifier: ^4.19.2
         version: 4.19.3

--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -30,11 +30,12 @@
     "eslint-plugin-jsdoc": "^50.6.9",
     "eslint-plugin-prettier": "^5.2.6",
     "prettier": "3.5.2",
+    "tsup": "^8.4.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
+    "vite": "^6.2.6",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.5",
-    "vite": "^6.2.6"
+    "vitest": "^3.0.5"
   },
   "dependencies": {
     "viem": "^2.23.1",

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       prettier:
         specifier: 3.5.2
         version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.4.0(jiti@1.21.7)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       tsx:
         specifier: ^4.19.2
         version: 4.19.3


### PR DESCRIPTION
This PR fixes a build failure issue in the coinbase-x402 package. The package uses tsup for its build script but was missing the dependency in its package.json file.

Ran into this issue while setting up the examples, `pnpm build` would fail as it couldn't build this package. Fixed after adding this.