### PR TITLE
fix: middleware url to paywall

### DIFF
--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -143,7 +143,7 @@ export function paymentMiddleware(
             paymentRequirements: toJsonSafe(paymentRequirements) as Parameters<
               typeof getPaywallHtml
             >[0]["paymentRequirements"],
-            currentUrl: req.path,
+            currentUrl: req.originalUrl,
             testnet: network === "base-sepolia",
           });
         res.status(402).send(html);

--- a/typescript/packages/x402-hono/src/index.test.ts
+++ b/typescript/packages/x402-hono/src/index.test.ts
@@ -132,7 +132,7 @@ describe("paymentMiddleware()", () => {
 
     mockContext = {
       req: {
-        url: "/weather",
+        url: "http://localhost:3000/weather",
         path: "/weather",
         method: "GET",
         header: vi.fn(),

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -121,7 +121,7 @@ export function paymentMiddleware(
           displayAmount = Number(price.amount) / 10 ** price.asset.decimals;
         }
 
-        const currentUrl = new URL(c.req.url).pathname + new URL(c.req.url).search
+        const currentUrl = new URL(c.req.url).pathname + new URL(c.req.url).search;
         const html =
           customPaywallHtml ??
           getPaywallHtml({

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -121,6 +121,7 @@ export function paymentMiddleware(
           displayAmount = Number(price.amount) / 10 ** price.asset.decimals;
         }
 
+        const currentUrl = new URL(c.req.url).pathname + new URL(c.req.url).search
         const html =
           customPaywallHtml ??
           getPaywallHtml({
@@ -128,7 +129,7 @@ export function paymentMiddleware(
             paymentRequirements: toJsonSafe(paymentRequirements) as Parameters<
               typeof getPaywallHtml
             >[0]["paymentRequirements"],
-            currentUrl: c.req.path,
+            currentUrl,
             testnet: network === "base-sepolia",
           });
         return c.html(html, 402);


### PR DESCRIPTION
Addresses issue #150.

Bug was confirmed in `x402-express` and `x402-hono`. `x402-next` does not have this bug.

The issue was the parsed path was being passed in as the current URL to the paywall.

## Tests

I tested by having the endpoints capture and return the query params. I was able to show that `x402-express` and `x402-hono`'s responses did not have the query information, but `x402-next` did.

#### Fixed express

<img width="630" alt="Screenshot 2025-05-09 at 6 36 28 PM" src="https://github.com/user-attachments/assets/1b7fc6c9-74ed-48a1-b0f3-eaf96f534109" />

#### Fixed hono

<img width="642" alt="Screenshot 2025-05-09 at 6 43 45 PM" src="https://github.com/user-attachments/assets/ebdaffa0-85e2-4824-952e-35741af15a99" />
