### PR TITLE
Remove unnecessary dependency from package.json

### DIFF
--- a/examples/typescript/clients/fetch/package.json
+++ b/examples/typescript/clients/fetch/package.json
@@ -10,7 +10,6 @@
     "lint:check": "eslint . --ext .ts"
   },
   "dependencies": {
-    "axios": "^1.7.9",
     "dotenv": "^16.4.7",
     "viem": "^2.23.1",
     "x402-fetch": "workspace:*"


### PR DESCRIPTION
The vanilla fetch client doesn't require the axios dependency.