### PR TITLE
fix: resource server middleware docstrings were updated

### DIFF
--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -23,44 +23,42 @@ import { useFacilitator } from "x402/verify";
 /**
  * Creates a payment middleware factory for Express
  *
- * @param payTo - The Ethereum address to receive payments
+ * @param payTo - The address to receive payments
  * @param routes - Configuration for protected routes and their payment requirements
  * @param facilitator - Optional configuration for the payment facilitator service
  * @returns An Express middleware handler
  *
  * @example
  * ```typescript
- * // Full configuration with specific routes
- * const middleware = paymentMiddleware({
- *   facilitator: {
+ * // Simple configuration - All endpoints are protected by $0.01 of USDC on base-sepolia
+ * app.use(paymentMiddleware(
+ *   '0x123...', // payTo address
+ *   {
+ *     price: '$0.01', // USDC amount in dollars
+ *     network: 'base-sepolia'
+ *   },
+ *   // Optional facilitator configuration. Defaults to x402.org/facilitator for testnet usage
+ * ));
+ *
+ * // Advanced configuration - Endpoint-specific payment requirements & custom facilitator
+ * app.use(paymentMiddleware('0x123...', // payTo: The address to receive payments*    {
+ *   {
+ *     '/weather/*': {
+ *       price: '$0.001', // USDC amount in dollars
+ *       network: 'base',
+ *       config: {
+ *         description: 'Access to weather data'
+ *       }
+ *     }
+ *   },
+ *   {
  *     url: 'https://facilitator.example.com',
  *     createAuthHeaders: async () => ({
  *       verify: { "Authorization": "Bearer token" },
  *       settle: { "Authorization": "Bearer token" }
  *     })
- *   },
- *   payTo: '0x123...',
- *   routes: {
- *     '/weather/*': {
- *       price: '$0.001', // USDC amount in dollars
- *       config: {
- *         description: 'Access to weather data'
- *       }
- *     }
  *   }
- * });
- *
- * // Simple configuration with a single price for all routes
- * const middleware = paymentMiddleware({
- *   facilitator: {
- *     url: 'https://facilitator.example.com'
- *   },
- *   payTo: '0x123...',
- *   routes: {
- *     price: '$0.01',
- *     network: 'base'
- *   }
- * });
+ * ));
  * ```
  */
 export function paymentMiddleware(

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -21,29 +21,34 @@ import {
 import { useFacilitator } from "x402/verify";
 
 /**
- * Enables APIs to be paid for using the x402 payment protocol.
+ * Creates a payment middleware factory for Hono
  *
- * This middleware:
- * 1. Validates payment headers and requirements
- * 2. Serves a paywall page for browser requests
- * 3. Returns JSON payment requirements for API requests
- * 4. Verifies and settles payments
- * 5. Sets appropriate response headers
- *
- * @param payTo - Address to receive payments
- * @param routes - Route configuration for payment amounts
- * @param facilitator - Configuration for the payment facilitator service
- *
- * @returns A function that creates a Hono middleware handler for a specific payment amount
+ * @param payTo - The address to receive payments
+ * @param routes - Configuration for protected routes and their payment requirements
+ * @param facilitator - Optional configuration for the payment facilitator service
+ * @returns A Hono middleware handler
  *
  * @example
  * ```typescript
- * const middleware = paymentMiddleware(
- *   '0x123...',
+ * // Simple configuration - All endpoints are protected by $0.01 of USDC on base-sepolia
+ * app.use(paymentMiddleware(
+ *   '0x123...', // payTo address
  *   {
- *     '/premium/*': {
- *       price: '$0.01',
- *       network: 'base'
+ *     price: '$0.01', // USDC amount in dollars
+ *     network: 'base-sepolia'
+ *   },
+ *   // Optional facilitator configuration. Defaults to x402.org/facilitator for testnet usage
+ * ));
+ *
+ * // Advanced configuration - Endpoint-specific payment requirements & custom facilitator
+ * app.use(paymentMiddleware('0x123...', // payTo: The address to receive payments
+ *   {
+ *     '/weather/*': {
+ *       price: '$0.001', // USDC amount in dollars
+ *       network: 'base',
+ *       config: {
+ *         description: 'Access to weather data'
+ *       }
  *     }
  *   },
  *   {
@@ -53,9 +58,7 @@ import { useFacilitator } from "x402/verify";
  *       settle: { "Authorization": "Bearer token" }
  *     })
  *   }
- * );
- *
- * app.use('/premium', middleware);
+ * ));
  * ```
  */
 export function paymentMiddleware(

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -21,20 +21,31 @@ import {
 import { useFacilitator } from "x402/verify";
 
 /**
- * Creates a Next.js middleware handler for x402 payments
+ * Creates a payment middleware factory for Next.js
  *
- * @param payTo - Address to receive payments
- * @param routes - Route configuration for payment amounts
- * @param facilitator - Configuration for the payment facilitator service
+ * @param payTo - The address to receive payments
+ * @param routes - Configuration for protected routes and their payment requirements
+ * @param facilitator - Optional configuration for the payment facilitator service
  * @returns A Next.js middleware handler
  *
  * @example
  * ```typescript
+ * // Simple configuration - All endpoints are protected by $0.01 of USDC on base-sepolia
  * export const middleware = paymentMiddleware(
- *   process.env.RESOURCE_WALLET_ADDRESS,
+ *   '0x123...', // payTo address
+ *   {
+ *     price: '$0.01', // USDC amount in dollars
+ *     network: 'base-sepolia'
+ *   },
+ *   // Optional facilitator configuration. Defaults to x402.org/facilitator for testnet usage
+ * );
+ *
+ * // Advanced configuration - Endpoint-specific payment requirements & custom facilitator
+ * export const middleware = paymentMiddleware(
+ *   '0x123...', // payTo: The address to receive payments
  *   {
  *     '/protected/*': {
- *       price: '$0.01',
+ *       price: '$0.001', // USDC amount in dollars
  *       network: 'base',
  *       config: {
  *         description: 'Access to protected content'
@@ -56,7 +67,7 @@ import { useFacilitator } from "x402/verify";
  *     }
  *   },
  *   {
- *     url: process.env.NEXT_PUBLIC_FACILITATOR_URL,
+ *     url: 'https://facilitator.example.com',
  *     createAuthHeaders: async () => ({
  *       verify: { "Authorization": "Bearer token" },
  *       settle: { "Authorization": "Bearer token" }


### PR DESCRIPTION
I noticed the docstrings were outdated. Specifically, the middleware docstrings were for the old arguments, back when it was one large object.