### PR TITLE
release: bump package versions

### DIFF
--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/x402",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/coinbase-x402/src/index.ts
+++ b/typescript/packages/coinbase-x402/src/index.ts
@@ -5,7 +5,7 @@ import { CreateHeaders } from "x402/verify";
 const COINBASE_FACILITATOR_BASE_URL = "https://api.cdp.coinbase.com";
 const COINBASE_FACILITATOR_V2_ROUTE = "/platform/v2/x402";
 
-const X402_VERSION = "0.3.3";
+const X402_VERSION = "0.3.4";
 const SDK_VERSION = "1.1.1";
 
 /**

--- a/typescript/packages/x402-express/package.json
+++ b/typescript/packages/x402-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-express",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-hono",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-next/package.json
+++ b/typescript/packages/x402-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-next",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Bumping packages in anticipation for release.

`x402` from `0.3.3` to `0.3.4`
`x402-express` from `0.3.3` to `0.3.4`
`x402-hono` from `0.3.3` to `0.3.4`
`x402-next` from `0.3.3` to `0.3.4`
`@coinbase/x402` from `0.3.4` to `0.3.5`

`x402-axios` and `x402-fetch` had no changes since last release. They also have a `^` dependency on `x402` and therefore do not need a bump in order to install the latest version post release. They will not be getting a release.