### PR TITLE
skip: building paywall on package build

### DIFF
--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "start": "tsx --env-file=.env index.ts",
-    "build": "npm run build:paywall && tsup",
+    "build": "tsup",
     "build:paywall": "tsx src/paywall/build.ts",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
Paywall generation generates a different paywall each time. Even if you remove the timestamp and make the code physically the same, the underlying file gets rewritten, becoming a unchecked file in Git. This [breaks NPM publication](https://github.com/coinbase/x402/actions/runs/15055526233/job/42320527372), as we expect a clean git state when publishing.

This PR addresses this by not regenerating it on package build. Instead, developers working on their own paywall update are expected to call `build:paywall` independently while building.