### PR TITLE
[Chore] [Docs] Improve formatting of `json` blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The following outlines the flow of a payment using the `x402` protocol. Note tha
 
 **Payment Required Response**
 
-```json
+```json5
 {
   // Version of the x402 payment protocol
   x402Version: int,
@@ -115,7 +115,7 @@ The following outlines the flow of a payment using the `x402` protocol. Note tha
 
 **paymentRequirements**
 
-```json
+```json5
 {
   // Scheme of the payment protocol to use
   scheme: string;
@@ -155,7 +155,7 @@ The following outlines the flow of a payment using the `x402` protocol. Note tha
 
 **`Payment Payload`** (included as the `X-PAYMENT` header in base64 encoded json)
 
-```json
+```json5
 {
   // Version of the x402 payment protocol
   x402Version: number;
@@ -178,7 +178,7 @@ A `facilitator server` is a 3rd party service that can be used by a `resource se
 **POST /verify**. Verify a payment with a supported scheme and network:
 
 - Request body JSON:
-  ```json
+  ```json5
   {
     x402Version: number;
     paymentHeader: string;
@@ -186,7 +186,7 @@ A `facilitator server` is a 3rd party service that can be used by a `resource se
   }
   ```
 - Response:
-  ```json
+  ```json5
   {
     isValid: boolean;
     invalidReason: string | null;
@@ -197,7 +197,7 @@ A `facilitator server` is a 3rd party service that can be used by a `resource se
 
 - Request body JSON:
 
-  ```json
+  ```json5
   {
     x402Version: number;
     paymentHeader: string;
@@ -207,7 +207,7 @@ A `facilitator server` is a 3rd party service that can be used by a `resource se
 
 - Response:
 
-  ```json
+  ```json5
   {
     // Whether the payment was successful
     success: boolean;
@@ -226,7 +226,7 @@ A `facilitator server` is a 3rd party service that can be used by a `resource se
 **GET /supported**. Get supported payment schemes and networks:
 
 - Response:
-  ```json
+  ```json5
   {
     kinds: [
       {


### PR DESCRIPTION
Based on [this gist](https://gist.github.com/DamianEdwards/31d2457737304ca73556), I suggest improving the rendering of `json` code blocks in `README.md` file to better support comment highlighting.