### PR TITLE
feat: do not settle payment if protected endpoint fails

### DIFF
--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -361,17 +361,17 @@ describe("paymentMiddleware()", () => {
       network: "base-sepolia",
     });
 
-    // Simulate downstream handler setting status 404
+    // Simulate downstream handler setting status 500
     (mockRes.status as ReturnType<typeof vi.fn>).mockImplementation(function (this: any, code: number) {
       this.statusCode = code;
       return this;
     });
-    mockRes.statusCode = 404;
+    mockRes.statusCode = 500;
 
-    // next() does nothing, but we want to simulate a 404 response
+    // next() does nothing, but we want to simulate a 500 response
     await middleware(mockReq as Request, mockRes as Response, mockNext);
 
     expect(mockSettle).not.toHaveBeenCalled();
-    expect(mockRes.statusCode).toBe(404);
+    expect(mockRes.statusCode).toBe(500);
   });
 });

--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -362,7 +362,10 @@ describe("paymentMiddleware()", () => {
     });
 
     // Simulate downstream handler setting status 500
-    (mockRes.status as ReturnType<typeof vi.fn>).mockImplementation(function (this: any, code: number) {
+    (mockRes.status as ReturnType<typeof vi.fn>).mockImplementation(function (
+      this: Response,
+      code: number,
+    ) {
       this.statusCode = code;
       return this;
     });

--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -368,9 +368,10 @@ describe("paymentMiddleware()", () => {
     });
     mockRes.statusCode = 500;
 
-    // next() does nothing, but we want to simulate a 500 response
+    // call the middleware
     await middleware(mockReq as Request, mockRes as Response, mockNext);
 
+    // make assertions
     expect(mockSettle).not.toHaveBeenCalled();
     expect(mockRes.statusCode).toBe(500);
   });

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -219,6 +219,15 @@ export function paymentMiddleware(
     // Proceed to the next middleware or route handler
     await next();
 
+    // If the response from the protected route is >= 400, do not settle payment
+    if (res.statusCode >= 400) {
+      res.end = originalEnd;
+      if (endArgs) {
+        originalEnd(...(endArgs as Parameters<typeof res.end>));
+      }
+      return;
+    }
+
     try {
       const settleResponse = await settle(decodedPayment, selectedPaymentRequirements);
       const responseHeader = settleResponseHeader(settleResponse);

--- a/typescript/packages/x402-hono/src/index.test.ts
+++ b/typescript/packages/x402-hono/src/index.test.ts
@@ -373,7 +373,7 @@ describe("paymentMiddleware()", () => {
     });
 
     // Simulate downstream handler setting status 500
-    Object.defineProperty(mockContext.res, 'status', { value: 500, writable: true });
+    Object.defineProperty(mockContext.res, "status", { value: 500, writable: true });
 
     await middleware(mockContext, mockNext);
 

--- a/typescript/packages/x402-hono/src/index.test.ts
+++ b/typescript/packages/x402-hono/src/index.test.ts
@@ -372,7 +372,7 @@ describe("paymentMiddleware()", () => {
       network: "base-sepolia",
     });
 
-    // Simulate downstream handler setting status 404
+    // Simulate downstream handler setting status 500
     Object.defineProperty(mockContext.res, 'status', { value: 500, writable: true });
 
     await middleware(mockContext, mockNext);

--- a/typescript/packages/x402-hono/src/index.test.ts
+++ b/typescript/packages/x402-hono/src/index.test.ts
@@ -359,4 +359,25 @@ describe("paymentMiddleware()", () => {
       402,
     );
   });
+
+  it("should not settle payment if protected route returns status >= 400", async () => {
+    (mockContext.req.header as ReturnType<typeof vi.fn>).mockImplementation((name: string) => {
+      if (name === "X-PAYMENT") return encodedValidPayment;
+      return undefined;
+    });
+    (mockVerify as ReturnType<typeof vi.fn>).mockResolvedValue({ isValid: true });
+    (mockSettle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      transaction: "0x123",
+      network: "base-sepolia",
+    });
+
+    // Simulate downstream handler setting status 404
+    Object.defineProperty(mockContext.res, 'status', { value: 500, writable: true });
+
+    await middleware(mockContext, mockNext);
+
+    expect(mockSettle).not.toHaveBeenCalled();
+    expect(mockContext.res.status).toBe(500);
+  });
 });

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -197,6 +197,12 @@ export function paymentMiddleware(
     await next();
 
     let res = c.res;
+
+    // If the response from the protected route is >= 400, do not settle payment
+    if (res.status >= 400) {
+      return;
+    }
+
     c.res = undefined;
 
     // Settle payment before processing the request, as Hono middleware does not allow us to set headers after the response has been sent

--- a/typescript/packages/x402-next/src/index.test.ts
+++ b/typescript/packages/x402-next/src/index.test.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { exact } from "x402/schemes";
 import { findMatchingRoute, getPaywallHtml, findMatchingPaymentRequirements } from "x402/shared";
@@ -678,9 +678,8 @@ describe("paymentMiddleware()", () => {
     });
 
     // Mock NextResponse.next to return a 500 response
-    const originalNext = (await import("next/server")).NextResponse.next;
-    const mockNext = vi.spyOn(require("next/server").NextResponse, "next").mockImplementation(() => {
-      return new Response("Internal server error", { status: 500 });
+    const mockNext = vi.spyOn(NextResponse, "next").mockImplementation(() => {
+      return new NextResponse("Internal server error", { status: 500 });
     });
 
     const response = await middleware(request);

--- a/typescript/packages/x402-next/src/index.test.ts
+++ b/typescript/packages/x402-next/src/index.test.ts
@@ -677,16 +677,16 @@ describe("paymentMiddleware()", () => {
       network: "base-sepolia",
     });
 
-    // Mock NextResponse.next to return a 404 response
+    // Mock NextResponse.next to return a 500 response
     const originalNext = (await import("next/server")).NextResponse.next;
     const mockNext = vi.spyOn(require("next/server").NextResponse, "next").mockImplementation(() => {
-      return new Response("Not found", { status: 404 });
+      return new Response("Internal server error", { status: 500 });
     });
 
     const response = await middleware(request);
     console.log(response);
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(500);
     expect(mockSettle).not.toHaveBeenCalled();
 
     // Restore original NextResponse.next

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -220,6 +220,11 @@ export function paymentMiddleware(
     // Proceed with request
     const response = await NextResponse.next();
 
+    // if the response from the protected route is >= 400, do not settle the payment
+    if (response.status >= 400) {
+      return response;
+    }
+
     // Settle payment after response
     try {
       const settlement = await settle(decodedPayment, selectedPaymentRequirements);


### PR DESCRIPTION
feat: do not settle payment if protected endpoint fails -- this makes it less likely that a customer will ask for a refund

Added a check in the paymentMiddleware to prevent payment settlement if the response from the protected route returns a status code of 400 or higher.

Tests were created to verify this behavior, ensuring that payments are not settled when the response indicates an error.