### PR TITLE
docs: Update examples

### DIFF
--- a/examples/typescript/servers/advanced/.env-local
+++ b/examples/typescript/servers/advanced/.env-local
@@ -1,3 +1,7 @@
 FACILITATOR_URL=https://x402.org/facilitator
 NETWORK=base-sepolia
 ADDRESS=
+
+# required if using the Base mainnet facilitator
+CDP_API_KEY_ID="Coinbase Developer Platform Key"
+CDP_API_KEY_SECRET="Coinbase Developer Platform Key Secret"

--- a/examples/typescript/servers/advanced/README.md
+++ b/examples/typescript/servers/advanced/README.md
@@ -12,6 +12,8 @@ This is an advanced example of an Express.js server that demonstrates how to imp
 - Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
 - pnpm v10 (install via [pnpm.io/installation](https://pnpm.io/installation))
 - A valid Ethereum address for receiving payments
+- Coinbase Developer Platform API Key & Secret (if accepting payments on Base mainnet)
+  -- Get them here [https://portal.cdp.coinbase.com/projects](https://portal.cdp.coinbase.com/projects)
 
 ## Setup
 

--- a/examples/typescript/servers/advanced/index.ts
+++ b/examples/typescript/servers/advanced/index.ts
@@ -130,6 +130,7 @@ app.get("/delayed-settlement", async (req, res) => {
   const paymentRequirements = [
     createExactPaymentRequirements(
       "$0.001",
+      // network: "base" // uncomment for Base mainnet
       "base-sepolia",
       resource,
       "Access to weather data (async)",
@@ -175,6 +176,7 @@ app.get("/dynamic-price", async (req, res) => {
   const paymentRequirements = [
     createExactPaymentRequirements(
       price, // Expect dynamic pricing
+      // network: "base" // uncomment for Base mainnet
       "base-sepolia",
       resource,
       "Access to weather data",
@@ -228,6 +230,7 @@ app.get("/multiple-payment-requirements", async (req, res) => {
           },
         },
       },
+      // network: "base" // uncomment for Base mainnet
       "base-sepolia",
       resource,
     ),

--- a/examples/typescript/servers/express/.env-local
+++ b/examples/typescript/servers/express/.env-local
@@ -1,3 +1,7 @@
 FACILITATOR_URL=https://x402.org/facilitator
 NETWORK=base-sepolia
 ADDRESS=
+
+# required if using the Base mainnet facilitator
+CDP_API_KEY_ID="Coinbase Developer Platform Key"
+CDP_API_KEY_SECRET="Coinbase Developer Platform Key Secret"

--- a/examples/typescript/servers/express/README.md
+++ b/examples/typescript/servers/express/README.md
@@ -7,6 +7,8 @@ This is an example Express.js server that demonstrates how to use the `x402-expr
 - Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
 - pnpm v10 (install via [pnpm.io/installation](https://pnpm.io/installation))
 - A valid Ethereum address for receiving payments
+- Coinbase Developer Platform API Key & Secret (if accepting payments on Base mainnet)
+  -- Get them here [https://portal.cdp.coinbase.com/projects](https://portal.cdp.coinbase.com/projects)
 
 ## Setup
 

--- a/examples/typescript/servers/express/index.ts
+++ b/examples/typescript/servers/express/index.ts
@@ -20,6 +20,7 @@ app.use(
       "GET /weather": {
         // USDC amount in dollars
         price: "$0.001",
+        // network: "base" // uncomment for Base mainnet
         network: "base-sepolia",
       },
       "/premium/*": {
@@ -35,6 +36,7 @@ app.use(
             },
           },
         },
+        // network: "base" // uncomment for Base mainnet
         network: "base-sepolia",
       },
     },

--- a/examples/typescript/servers/hono/.env-local
+++ b/examples/typescript/servers/hono/.env-local
@@ -1,3 +1,7 @@
 FACILITATOR_URL=https://x402.org/facilitator
 NETWORK=base-sepolia
 ADDRESS=
+
+# required if using the Base mainnet facilitator
+CDP_API_KEY_ID="Coinbase Developer Platform Key"
+CDP_API_KEY_SECRET="Coinbase Developer Platform Key Secret"

--- a/examples/typescript/servers/hono/README.md
+++ b/examples/typescript/servers/hono/README.md
@@ -7,6 +7,8 @@ This is an example Hono server that demonstrates how to use the `x402-hono` midd
 - Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
 - pnpm v10 (install via [pnpm.io/installation](https://pnpm.io/installation))
 - A valid Ethereum address for receiving payments
+- Coinbase Developer Platform API Key & Secret (if accepting payments on Base mainnet)
+-- get them here [https://portal.cdp.coinbase.com/projects](https://portal.cdp.coinbase.com/projects)
 
 ## Setup
 


### PR DESCRIPTION
Update examples to mention that Coinbase Developer Platform API keys are necessary if using the Base Mainnet facilitator.

I see that it exists in the "mainnet" example, but when I started I just jumped into the express example and I spent about 30 minutes before I figured out what was wrong.