### PR TITLE
fix: add proper `Content-Type` header to facilitator requests

### DIFF
--- a/typescript/packages/x402/src/verify/useFacilitator.test.ts
+++ b/typescript/packages/x402/src/verify/useFacilitator.test.ts
@@ -48,7 +48,7 @@ describe("useFacilitator", () => {
 
       expect(fetch).toHaveBeenCalledWith("https://x402.org/facilitator/verify", {
         method: "POST",
-        headers: undefined,
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           x402Version: mockPaymentPayload.x402Version,
           paymentPayload: mockPaymentPayload,
@@ -64,7 +64,7 @@ describe("useFacilitator", () => {
 
       expect(fetch).toHaveBeenCalledWith(`${customUrl}/verify`, {
         method: "POST",
-        headers: undefined,
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           x402Version: mockPaymentPayload.x402Version,
           paymentPayload: mockPaymentPayload,
@@ -87,7 +87,7 @@ describe("useFacilitator", () => {
       expect(fetch).toHaveBeenCalledWith(
         "https://x402.org/facilitator/verify",
         expect.objectContaining({
-          headers: mockHeaders.verify,
+          headers: { "Content-Type": "application/json", ...mockHeaders.verify },
         }),
       );
     });
@@ -113,7 +113,7 @@ describe("useFacilitator", () => {
 
       expect(fetch).toHaveBeenCalledWith("https://x402.org/facilitator/settle", {
         method: "POST",
-        headers: undefined,
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           x402Version: mockPaymentPayload.x402Version,
           paymentPayload: mockPaymentPayload,
@@ -129,7 +129,7 @@ describe("useFacilitator", () => {
 
       expect(fetch).toHaveBeenCalledWith(`${customUrl}/settle`, {
         method: "POST",
-        headers: undefined,
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           x402Version: mockPaymentPayload.x402Version,
           paymentPayload: mockPaymentPayload,
@@ -152,7 +152,7 @@ describe("useFacilitator", () => {
       expect(fetch).toHaveBeenCalledWith(
         "https://x402.org/facilitator/settle",
         expect.objectContaining({
-          headers: mockHeaders.settle,
+          headers: { "Content-Type": "application/json", ...mockHeaders.settle },
         }),
       );
     });

--- a/typescript/packages/x402/src/verify/useFacilitator.ts
+++ b/typescript/packages/x402/src/verify/useFacilitator.ts
@@ -38,9 +38,7 @@ export function useFacilitator(facilitator?: FacilitatorConfig) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        ...(facilitator?.createAuthHeaders
-          ? (await facilitator.createAuthHeaders()).verify
-          : {}),
+        ...(facilitator?.createAuthHeaders ? (await facilitator.createAuthHeaders()).verify : {}),
       },
       body: JSON.stringify({
         x402Version: payload.x402Version,
@@ -73,9 +71,7 @@ export function useFacilitator(facilitator?: FacilitatorConfig) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        ...(facilitator?.createAuthHeaders
-          ? (await facilitator.createAuthHeaders()).settle
-          : {}),
+        ...(facilitator?.createAuthHeaders ? (await facilitator.createAuthHeaders()).settle : {}),
       },
       body: JSON.stringify({
         x402Version: payload.x402Version,

--- a/typescript/packages/x402/src/verify/useFacilitator.ts
+++ b/typescript/packages/x402/src/verify/useFacilitator.ts
@@ -36,9 +36,12 @@ export function useFacilitator(facilitator?: FacilitatorConfig) {
 
     const res = await fetch(`${url}/verify`, {
       method: "POST",
-      headers: facilitator?.createAuthHeaders
-        ? (await facilitator.createAuthHeaders()).verify
-        : undefined,
+      headers: {
+        "Content-Type": "application/json",
+        ...(facilitator?.createAuthHeaders
+          ? (await facilitator.createAuthHeaders()).verify
+          : {}),
+      },
       body: JSON.stringify({
         x402Version: payload.x402Version,
         paymentPayload: toJsonSafe(payload),
@@ -68,9 +71,12 @@ export function useFacilitator(facilitator?: FacilitatorConfig) {
 
     const res = await fetch(`${url}/settle`, {
       method: "POST",
-      headers: facilitator?.createAuthHeaders
-        ? (await facilitator.createAuthHeaders()).settle
-        : undefined,
+      headers: {
+        "Content-Type": "application/json",
+        ...(facilitator?.createAuthHeaders
+          ? (await facilitator.createAuthHeaders()).settle
+          : {}),
+      },
       body: JSON.stringify({
         x402Version: payload.x402Version,
         paymentPayload: toJsonSafe(payload),


### PR DESCRIPTION
When the `@coinbase/x402` package is used with the `useFacilitator` hook from the core `x402` package, requests to the `/verify` and `/settle` endpoints consistently fail with a `400 Bad Request`. This issue is specific to the JavaScript implementation, as the Golang implementation [adds the proper `Content-Type` header explicitly.](https://github.com/coinbase/x402/blob/main/go/pkg/facilitatorclient/facilitatorclient.go#L54) 

This PR adds that same header to `useFacilitator.ts`, as while the default test facilitator might tolerate the missing header, the maninet one does not.

Fixes #200 