### PR TITLE
ci: fix YAML syntax in `check_format` workflow

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         with:
-        run_install: false
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: "20"


### PR DESCRIPTION
Fixes a YAML parsing error in the `check_format` GitHub Actions workflow by correctly indenting `run_install`.
Reference: https://github.com/coinbase/x402/actions/runs/15235143521/workflow