### PR TITLE
feat: add Arbitrum One and Arbitrum Sepolia EVM support

### DIFF
--- a/typescript/packages/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/x402/src/types/shared/evm/config.ts
@@ -21,8 +21,15 @@ export const config: Record<string, ChainConfig> = {
     usdcAddress: "0xcdf79194c6c285077a58da47641d4dbe51f63542",
     usdcName: "Bridged USDC",
   },
+  "42161": {
+    usdcAddress: "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+    usdcName: "USDC",
+  },
+  "421614": {
+    usdcAddress: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+    usdcName: "USDC",
+  },
 };
-
 export type ChainConfig = {
   usdcAddress: Address;
   usdcName: string;

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -93,11 +93,7 @@ export function createSignerAvalancheFuji(privateKey: Hex): SignerWallet<typeof 
  *
  * @returns A public client instance connected to Arbitrum One
  */
-export function createClientArbitrumOne(): ConnectedClient<
-  Transport,
-  typeof arbitrum,
-  undefined
-> {
+export function createClientArbitrumOne(): ConnectedClient<Transport, typeof arbitrum, undefined> {
   return createPublicClient({
     chain: arbitrum,
     transport: http(),

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -9,7 +9,7 @@ import type {
   WalletActions,
   PublicClient,
 } from "viem";
-import { baseSepolia, avalancheFuji } from "viem/chains";
+import { baseSepolia, avalancheFuji, arbitrum, arbitrumSepolia } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 import { Hex } from "viem";
 
@@ -83,6 +83,66 @@ export function createSignerSepolia(privateKey: Hex): SignerWallet<typeof baseSe
 export function createSignerAvalancheFuji(privateKey: Hex): SignerWallet<typeof avalancheFuji> {
   return createWalletClient({
     chain: avalancheFuji,
+    transport: http(),
+    account: privateKeyToAccount(privateKey),
+  }).extend(publicActions);
+}
+
+/**
+ * Creates a public client configured for the Arbitrum One mainnet
+ *
+ * @returns A public client instance connected to Arbitrum One
+ */
+export function createClientArbitrumOne(): ConnectedClient<
+  Transport,
+  typeof arbitrum,
+  undefined
+> {
+  return createPublicClient({
+    chain: arbitrum,
+    transport: http(),
+  }).extend(publicActions);
+}
+
+/**
+ * Creates a public client configured for the Arbitrum Sepolia testnet
+ *
+ * @returns A public client instance connected to Arbitrum Sepolia
+ */
+export function createClientArbitrumSepolia(): ConnectedClient<
+  Transport,
+  typeof arbitrumSepolia,
+  undefined
+> {
+  return createPublicClient({
+    chain: arbitrumSepolia,
+    transport: http(),
+  }).extend(publicActions);
+}
+
+/**
+ * Creates a wallet client configured for the Arbitrum One mainnet with a private key
+ *
+ * @param privateKey - The private key to use for signing transactions
+ * @returns A wallet client instance connected to Arbitrum One with the provided private key
+ */
+export function createSignerArbitrumOne(privateKey: Hex): SignerWallet<typeof arbitrum> {
+  return createWalletClient({
+    chain: arbitrum,
+    transport: http(),
+    account: privateKeyToAccount(privateKey),
+  }).extend(publicActions);
+}
+
+/**
+ * Creates a wallet client configured for the Arbitrum Sepolia testnet with a private key
+ *
+ * @param privateKey - The private key to use for signing transactions
+ * @returns A wallet client instance connected to Arbitrum Sepolia with the provided private key
+ */
+export function createSignerArbitrumSepolia(privateKey: Hex): SignerWallet<typeof arbitrumSepolia> {
+  return createWalletClient({
+    chain: arbitrumSepolia,
     transport: http(),
     account: privateKeyToAccount(privateKey),
   }).extend(publicActions);

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -1,12 +1,7 @@
+import { iotex } from "viem/chains";
 import { z } from "zod";
+export const NetworkSchema = z.enum(["base-sepolia", "base", "avalanche-fuji", "avalanche", "arbitrum-sepolia", "arbitrum-one", "iotex"]);
 
-export const NetworkSchema = z.enum([
-  "base-sepolia",
-  "base",
-  "avalanche-fuji",
-  "avalanche",
-  "iotex",
-]);
 export type Network = z.infer<typeof NetworkSchema>;
 
 export const SupportedEVMNetworks: Network[] = [
@@ -15,6 +10,9 @@ export const SupportedEVMNetworks: Network[] = [
   "avalanche-fuji",
   "avalanche",
   "iotex",
+  "arbitrum-sepolia",
+  "arbitrum-one",
+
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
   ["base-sepolia", 84532],
@@ -22,6 +20,8 @@ export const EvmNetworkToChainId = new Map<Network, number>([
   ["avalanche-fuji", 43113],
   ["avalanche", 43114],
   ["iotex", 4689],
+  ["arbitrum-sepolia", 421614],
+  ["arbitrum-one", 42161],
 ]);
 
 export const ChainIdToNetwork = Object.fromEntries(

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -1,7 +1,15 @@
 import { iotex } from "viem/chains";
 import { z } from "zod";
-export const NetworkSchema = z.enum(["base-sepolia", "base", "avalanche-fuji", "avalanche", "arbitrum-sepolia", "arbitrum-one", "iotex"]);
 
+export const NetworkSchema = z.enum([
+  "base-sepolia",
+  "base",
+  "avalanche-fuji",
+  "avalanche",
+  "iotex",
+  "arbitrum-sepolia",
+  "arbitrum-one",
+]);
 export type Network = z.infer<typeof NetworkSchema>;
 
 export const SupportedEVMNetworks: Network[] = [


### PR DESCRIPTION
Following the pattern established in PR #157 for Avalanche support:

- Add Arbitrum One (chainId: 42161) and Arbitrum Sepolia (chainId: 421614)
- Configure USDC contract addresses:
  * Arbitrum One: 0xaf88d065e77c8cc2239327c5edb3a432268e5831 (Native USDC)
  * Arbitrum Sepolia: 0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d (Native USDC)
- Add client/signer functions: createClientArbitrumOne, createSignerArbitrumOne, etc.
- Update network mappings and supported networks list

This enables x402 payments on Arbitrum networks using the existing EIP-3009 exact scheme with lower gas costs and faster settlement times.