### PR TITLE
chore: added a PR draft template to guide OS contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+Thanks for contributing to x402!
+Please fill out the information below to help reviewers understand your changes.
+
+Note: We require commit signing.
+See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
+-->
+
+## Description
+
+<!--
+Please provide a clear and concise description of what the changes are, and why they are needed.
+Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
+-->
+
+## Tests
+
+<!--
+Please describe the tests you've performed to verify your changes.
+Include relevant code samples, unit test cases, or screenshots if applicable.
+
+For TypeScript: Run `pnpm test` from the `/typescript` directory
+For Go: Run `go test ./...` from the `/go` directory
+-->
+
+## Checklist
+
+- [ ] I have formatted and linted my code
+- [ ] All new and existing tests pass
+- [ ] My commits are signed (required for merge) 
+
+<!--
+For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
+For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
+--> 


### PR DESCRIPTION
I'm seeing a common trend with OS contributors that is creating friction.
1. They do not know about our Lint/Format/Test github actions until we approve the workflows to run.
2. They do not know we required signed commits until we tell them

Contributors deserve to know this info upfront when creating their PR, in order to reduce friction on the back-and-forths