### PR TITLE
Improved facilitator error handling in middleware packages

### DIFF
--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -304,7 +304,7 @@ describe("paymentMiddleware()", () => {
     expect(mockRes.status).toHaveBeenCalledWith(402);
     expect(mockRes.json).toHaveBeenCalledWith({
       x402Version: 1,
-      error: new Error("Settlement failed"),
+      error: "Settlement failed",
       accepts: [
         {
           scheme: "exact",

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -193,9 +193,19 @@ export function paymentMiddleware(
         return;
       }
     } catch (error) {
+      let errorMessage = "Verification failed";
+
+      if (error) {
+        if (typeof error === "string" && error.trim() !== "") {
+          errorMessage = error;
+        } else if (typeof error === "object" && Object.keys(error).length > 0) {
+          errorMessage = JSON.stringify(error);
+        }
+      }
+
       res.status(402).json({
         x402Version,
-        error,
+        error: errorMessage,
         accepts: toJsonSafe(paymentRequirements),
       });
       return;
@@ -224,11 +234,21 @@ export function paymentMiddleware(
       const responseHeader = settleResponseHeader(settleResponse);
       res.setHeader("X-PAYMENT-RESPONSE", responseHeader);
     } catch (error) {
+      let errorMessage = "Settlement failed";
+
+      if (error) {
+        if (typeof error === "string" && error.trim() !== "") {
+          errorMessage = error;
+        } else if (typeof error === "object" && Object.keys(error).length > 0) {
+          errorMessage = JSON.stringify(error);
+        }
+      }
+
       // If settlement fails and the response hasn't been sent yet, return an error
       if (!res.headersSent) {
         res.status(402).json({
           x402Version,
-          error,
+          error: errorMessage,
           accepts: toJsonSafe(paymentRequirements),
         });
         return;

--- a/typescript/packages/x402-next/src/index.test.ts
+++ b/typescript/packages/x402-next/src/index.test.ts
@@ -532,7 +532,7 @@ describe("paymentMiddleware()", () => {
     const json = await response.json();
     expect(json).toEqual({
       x402Version: 1,
-      error: expect.any(Object),
+      error: "Settlement failed",
       accepts: [
         {
           scheme: "exact",

--- a/typescript/packages/x402/src/schemes/exact/evm/client.test.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/client.test.ts
@@ -57,7 +57,7 @@ describe("preparePaymentHeader", () => {
           from: mockFromAddress,
           to: mockPaymentRequirements.payTo,
           value: mockPaymentRequirements.maxAmountRequired,
-          validAfter: (currentTime - 60).toString(),
+          validAfter: (currentTime - 600).toString(),
           validBefore: (currentTime + mockPaymentRequirements.maxTimeoutSeconds).toString(),
           nonce: expect.any(String),
         },
@@ -79,7 +79,7 @@ describe("preparePaymentHeader", () => {
     const currentTime = Math.floor(Date.now() / 1000);
     const validAfter = parseInt(result.payload.authorization.validAfter);
 
-    expect(validAfter).toBe(currentTime - 60);
+    expect(validAfter).toBe(currentTime - 600);
   });
 
   it("should calculate validBefore as current time plus maxTimeoutSeconds", () => {

--- a/typescript/packages/x402/src/schemes/exact/evm/client.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/client.ts
@@ -20,7 +20,7 @@ export function preparePaymentHeader(
   const nonce = createNonce();
 
   const validAfter = BigInt(
-    Math.floor(Date.now() / 1000) - 60, // 60 seconds before
+    Math.floor(Date.now() / 1000) - 600, // 10 minutes before
   ).toString();
   const validBefore = BigInt(
     Math.floor(Date.now() / 1000 + paymentRequirements.maxTimeoutSeconds),


### PR DESCRIPTION
## Description

Some users were experiencing `transferWithAuthorization` fails on settlement because transactions were failing with `authorization is not yet valid` errors. We were hoping that putting `validAfter` 60 seconds into the past was sufficient, but these errors show that we can reasonably assume more than 60 seconds of variance can be expected between a resources servers clock and the clock of the node which processes any given transaction. This PR bumps this timeframe to 10 minutes.