### PR TITLE
release: bump package versions

### DIFF
--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/x402",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/coinbase-x402/src/index.ts
+++ b/typescript/packages/coinbase-x402/src/index.ts
@@ -5,7 +5,7 @@ import { CreateHeaders } from "x402/verify";
 const COINBASE_FACILITATOR_BASE_URL = "https://api.cdp.coinbase.com";
 const COINBASE_FACILITATOR_V2_ROUTE = "/platform/v2/x402";
 
-const X402_VERSION = "0.3.5";
+const X402_VERSION = "0.3.6";
 const SDK_VERSION = "1.1.1";
 
 /**

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Bumping `x402` package in preparation for release.
Bumping `@coinbase/x402` package alongside it, to keep metrics tracking in sync