### PR TITLE
feat: expand error messages

### DIFF
--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -58,7 +58,7 @@ export async function verify<
   if (payload.scheme !== SCHEME || paymentRequirements.scheme !== SCHEME) {
     return {
       isValid: false,
-      invalidReason: `Incompatible payload scheme. payload: ${payload.scheme}, paymentRequirements: ${paymentRequirements.scheme}, supported: ${SCHEME}`,
+      invalidReason: `invalid_scheme`,
       payer: payload.payload.authorization.from,
     };
   }
@@ -106,7 +106,7 @@ export async function verify<
   if (!recoveredAddress) {
     return {
       isValid: false,
-      invalidReason: "invalid_scheme", //"Invalid permit signature",
+      invalidReason: "invalid_exact_evm_payload_signature", //"Invalid permit signature",
       payer: payload.payload.authorization.from,
     };
   }
@@ -115,7 +115,7 @@ export async function verify<
   if (getAddress(payload.payload.authorization.to) !== getAddress(paymentRequirements.payTo)) {
     return {
       isValid: false,
-      invalidReason: "invalid_scheme",
+      invalidReason: "invalid_exact_evm_payload_signature_address",
       payer: payload.payload.authorization.from,
     };
   }
@@ -127,7 +127,7 @@ export async function verify<
   ) {
     return {
       isValid: false,
-      invalidReason: "invalid_scheme", //"Deadline on permit isn't far enough in the future",
+      invalidReason: "invalid_exact_evm_payload_authorization_valid_before", //"Deadline on permit isn't far enough in the future",
       payer: payload.payload.authorization.from,
     };
   }
@@ -135,7 +135,7 @@ export async function verify<
   if (BigInt(payload.payload.authorization.validAfter) > BigInt(Math.floor(Date.now() / 1000))) {
     return {
       isValid: false,
-      invalidReason: "invalid_scheme", //"Deadline on permit is in the future",
+      invalidReason: "invalid_exact_evm_payload_authorization_valid_after", //"Deadline on permit is in the future",
       payer: payload.payload.authorization.from,
     };
   }
@@ -156,7 +156,7 @@ export async function verify<
   if (BigInt(payload.payload.authorization.value) < BigInt(paymentRequirements.maxAmountRequired)) {
     return {
       isValid: false,
-      invalidReason: "invalid_scheme", //"Value in payload is not enough to cover paymentRequirements.maxAmountRequired",
+      invalidReason: "invalid_exact_evm_payload_authorization_value", //"Value in payload is not enough to cover paymentRequirements.maxAmountRequired",
       payer: payload.payload.authorization.from,
     };
   }
@@ -191,7 +191,7 @@ export async function settle<transport extends Transport, chain extends Chain>(
       success: false,
       network: paymentPayload.network,
       transaction: "",
-      errorReason: "invalid_scheme", //`Payment is no longer valid: ${valid.invalidReason}`,
+      errorReason: valid.invalidReason ?? "invalid_scheme", //`Payment is no longer valid: ${valid.invalidReason}`,
       payer: paymentPayload.payload.authorization.from,
     };
   }
@@ -217,7 +217,7 @@ export async function settle<transport extends Transport, chain extends Chain>(
   if (receipt.status !== "success") {
     return {
       success: false,
-      errorReason: "invalid_scheme", //`Transaction failed`,
+      errorReason: "invalid_transaction_state", //`Transaction failed`,
       transaction: tx,
       network: paymentPayload.network,
       payer: paymentPayload.payload.authorization.from,

--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -58,7 +58,7 @@ export async function verify<
   if (payload.scheme !== SCHEME || paymentRequirements.scheme !== SCHEME) {
     return {
       isValid: false,
-      invalidReason: `invalid_scheme`,
+      invalidReason: `unsupported_scheme`,
       payer: payload.payload.authorization.from,
     };
   }
@@ -115,7 +115,7 @@ export async function verify<
   if (getAddress(payload.payload.authorization.to) !== getAddress(paymentRequirements.payTo)) {
     return {
       isValid: false,
-      invalidReason: "invalid_exact_evm_payload_signature_address",
+      invalidReason: "invalid_exact_evm_payload_recipient_mismatch",
       payer: payload.payload.authorization.from,
     };
   }

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -11,7 +11,6 @@ export const schemes = ["exact"] as const;
 export const x402Versions = [1] as const;
 export const ErrorReasons = [
   "insufficient_funds",
-  "invalid_exact_evm_payload_authorization_typed_data_message",
   "invalid_exact_evm_payload_authorization_valid_after",
   "invalid_exact_evm_payload_authorization_valid_before",
   "invalid_exact_evm_payload_authorization_value",

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -9,7 +9,22 @@ const EvmSignatureRegex = /^0x[0-9a-fA-F]{130}$/;
 // Enums
 export const schemes = ["exact"] as const;
 export const x402Versions = [1] as const;
-export const ErrorReasons = ["insufficient_funds", "invalid_scheme", "invalid_network"] as const;
+export const ErrorReasons = [
+  "insufficient_funds",
+  "invalid_exact_evm_payload_authorization_typed_data_message",
+  "invalid_exact_evm_payload_authorization_valid_after",
+  "invalid_exact_evm_payload_authorization_valid_before",
+  "invalid_exact_evm_payload_authorization_value",
+  "invalid_exact_evm_payload_signature",
+  "invalid_exact_evm_payload_signature_address",
+  "invalid_network",
+  "invalid_payload",
+  "invalid_payment_requirements",
+  "invalid_scheme",
+  "invalid_x402_version",
+  "invalid_transaction_state",
+] as const;
+
 // Refiners
 const isInteger = (value: string) => Number.isInteger(Number(value)) && Number(value) >= 0;
 const hasMaxLength = (maxLength: number) => (value: string) => value.length <= maxLength;

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -15,13 +15,16 @@ export const ErrorReasons = [
   "invalid_exact_evm_payload_authorization_valid_before",
   "invalid_exact_evm_payload_authorization_value",
   "invalid_exact_evm_payload_signature",
-  "invalid_exact_evm_payload_signature_address",
+  "invalid_exact_evm_payload_recipient_mismatch",
   "invalid_network",
   "invalid_payload",
   "invalid_payment_requirements",
   "invalid_scheme",
+  "unsupported_scheme",
   "invalid_x402_version",
   "invalid_transaction_state",
+  "unexpected_verify_error",
+  "unexpected_settle_error",
 ] as const;
 
 // Refiners

--- a/typescript/site/app/facilitator/settle/route.ts
+++ b/typescript/site/app/facilitator/settle/route.ts
@@ -25,28 +25,36 @@ export async function POST(req: Request) {
 
   const body: SettleRequest = await req.json();
 
-  let paymentPayload: PaymentPayload
+  let paymentPayload: PaymentPayload;
   try {
     paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
   } catch (error) {
-    return Response.json({
-      success: false,
-      errorReason: "invalid_payload",
-      transaction: "",
-      network: paymentPayload.network,
-    } as SettleResponse, { status: 400 });
+    console.error("Invalid payment payload:", error);
+    return Response.json(
+      {
+        success: false,
+        errorReason: "invalid_payload",
+        transaction: "",
+        network: body.paymentPayload?.network || "",
+      } as SettleResponse,
+      { status: 400 },
+    );
   }
 
   let paymentRequirements: PaymentRequirements;
   try {
     paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);
   } catch (error) {
-    return Response.json({
-      success: false,
-      errorReason: "invalid_payment_requirements",
-      transaction: "",
-      network: paymentPayload.network,
-    } as SettleResponse, { status: 400 });
+    console.error("Invalid payment requirements:", error);
+    return Response.json(
+      {
+        success: false,
+        errorReason: "invalid_payment_requirements",
+        transaction: "",
+        network: paymentPayload.network,
+      } as SettleResponse,
+      { status: 400 },
+    );
   }
 
   const response = await settle(wallet, paymentPayload, paymentRequirements);

--- a/typescript/site/app/facilitator/settle/route.ts
+++ b/typescript/site/app/facilitator/settle/route.ts
@@ -5,6 +5,7 @@ import {
   PaymentPayloadSchema,
   PaymentRequirements,
   PaymentRequirementsSchema,
+  SettleResponse,
   evm,
 } from "x402/types";
 
@@ -24,11 +25,31 @@ export async function POST(req: Request) {
 
   const body: SettleRequest = await req.json();
 
-  const paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
-  const paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);
+  let paymentPayload: PaymentPayload
+  try {
+    paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
+  } catch (error) {
+    return Response.json({
+      success: false,
+      errorReason: "invalid_payload",
+      transaction: "",
+      network: paymentPayload.network,
+    } as SettleResponse, { status: 400 });
+  }
+
+  let paymentRequirements: PaymentRequirements;
+  try {
+    paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);
+  } catch (error) {
+    return Response.json({
+      success: false,
+      errorReason: "invalid_payment_requirements",
+      transaction: "",
+      network: paymentPayload.network,
+    } as SettleResponse, { status: 400 });
+  }
 
   const response = await settle(wallet, paymentPayload, paymentRequirements);
-
   return Response.json(response);
 }
 

--- a/typescript/site/app/facilitator/settle/route.ts
+++ b/typescript/site/app/facilitator/settle/route.ts
@@ -57,8 +57,21 @@ export async function POST(req: Request) {
     );
   }
 
-  const response = await settle(wallet, paymentPayload, paymentRequirements);
-  return Response.json(response);
+  try {
+    const response = await settle(wallet, paymentPayload, paymentRequirements);
+    return Response.json(response);
+  } catch (error) {
+    console.error("Error settling payment:", error);
+    return Response.json(
+      {
+        success: false,
+        errorReason: "unexpected_settle_error",
+        transaction: "",
+        network: paymentPayload.network,
+      } as SettleResponse,
+      { status: 500 },
+    );
+  }
 }
 
 /**

--- a/typescript/site/app/facilitator/verify/route.ts
+++ b/typescript/site/app/facilitator/verify/route.ts
@@ -28,24 +28,32 @@ export async function POST(req: Request) {
   try {
     paymentPayload = PaymentPayloadSchema.parse(body.paymentPayload);
   } catch (error) {
-    return Response.json({
-      success: false,
-      errorReason: "invalid_payload",
-      transaction: "",
-      network: paymentPayload.network,
-    } as SettleResponse, { status: 400 });
+    console.error("Invalid payment payload:", error);
+    return Response.json(
+      {
+        success: false,
+        errorReason: "invalid_payload",
+        transaction: "",
+        network: body.paymentPayload?.network || "",
+      } as SettleResponse,
+      { status: 400 },
+    );
   }
 
   let paymentRequirements: PaymentRequirements;
   try {
     paymentRequirements = PaymentRequirementsSchema.parse(body.paymentRequirements);
   } catch (error) {
-    return Response.json({
-      success: false,
-      errorReason: "invalid_payment_requirements",
-      transaction: "",
-      network: paymentPayload.network,
-    } as SettleResponse, { status: 400 });
+    console.error("Invalid payment requirements:", error);
+    return Response.json(
+      {
+        success: false,
+        errorReason: "invalid_payment_requirements",
+        transaction: "",
+        network: paymentPayload.network,
+      } as SettleResponse,
+      { status: 400 },
+    );
   }
 
   const valid = await verify(client, paymentPayload, paymentRequirements);

--- a/typescript/site/app/facilitator/verify/route.ts
+++ b/typescript/site/app/facilitator/verify/route.ts
@@ -54,9 +54,20 @@ export async function POST(req: Request) {
     );
   }
 
-  const valid = await verify(client, paymentPayload, paymentRequirements);
-
-  return Response.json(valid);
+  try {
+    const valid = await verify(client, paymentPayload, paymentRequirements);
+    return Response.json(valid);
+  } catch (error) {
+    console.error("Error verifying payment:", error);
+    return Response.json(
+      {
+        isValid: false,
+        invalidReason: "unexpected_verify_error",
+        payer: paymentPayload.payload.authorization.from,
+      } as VerifyResponse,
+      { status: 500 },
+    );
+  }
 }
 
 /**

--- a/typescript/site/app/facilitator/verify/route.ts
+++ b/typescript/site/app/facilitator/verify/route.ts
@@ -3,7 +3,7 @@ import {
   PaymentPayloadSchema,
   PaymentRequirements,
   PaymentRequirementsSchema,
-  SettleResponse,
+  VerifyResponse,
   evm,
 } from "x402/types";
 import { verify } from "x402/facilitator";
@@ -31,11 +31,10 @@ export async function POST(req: Request) {
     console.error("Invalid payment payload:", error);
     return Response.json(
       {
-        success: false,
-        errorReason: "invalid_payload",
-        transaction: "",
-        network: body.paymentPayload?.network || "",
-      } as SettleResponse,
+        isValid: false,
+        invalidReason: "invalid_payload",
+        payer: body.paymentPayload?.payload?.authorization?.from ?? "",
+      } as VerifyResponse,
       { status: 400 },
     );
   }
@@ -47,11 +46,10 @@ export async function POST(req: Request) {
     console.error("Invalid payment requirements:", error);
     return Response.json(
       {
-        success: false,
-        errorReason: "invalid_payment_requirements",
-        transaction: "",
-        network: paymentPayload.network,
-      } as SettleResponse,
+        isValid: false,
+        invalidReason: "invalid_payment_requirements",
+        payer: paymentPayload.payload.authorization.from,
+      } as VerifyResponse,
       { status: 400 },
     );
   }


### PR DESCRIPTION
## Description

Our typescript offering (and therefore, the testnet facilitator), was too strict in the error messages. It lead to `invalid_scheme` being the most frequent error messages builders would face.

This PR expands it to align more closely with the Coinbase hosted facilitator's error message handling. This keeps the two sets of error messages users can face in-sync between the dev and prod environments, while expanding it to have a lot more nuance in what users will see.

## Tests

1. Manually ran the express/axios examples and confirmed that positive cases are not impacted
2. Manually ran the advanced/axios examples, and intentionally added lines in the advanced server example to break things, such as making the received payment requirements invalid, messing with the validAfter/validBefore, etc. All intentional error cases were returning the correct values.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 
