### PR TITLE
feat: Add x402-browser-fetch

### DIFF
--- a/typescript/packages/x402-browser-fetch/.prettierignore
+++ b/typescript/packages/x402-browser-fetch/.prettierignore
@@ -1,0 +1,8 @@
+docs/
+dist/
+node_modules/
+coverage/
+.github/
+src/client
+**/**/*.json
+*.md

--- a/typescript/packages/x402-browser-fetch/.prettierrc
+++ b/typescript/packages/x402-browser-fetch/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/typescript/packages/x402-browser-fetch/README.md
+++ b/typescript/packages/x402-browser-fetch/README.md
@@ -1,0 +1,94 @@
+# x402-fetch
+
+A utility package that extends the native `fetch` API to automatically handle 402 Payment Required responses using the x402 payment protocol. This package enables seamless integration of payment functionality into your applications when making HTTP requests.
+
+## Installation
+
+```bash
+npm install x402-fetch
+```
+
+## Quick Start
+
+```typescript
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { wrapFetchWithPayment } from "x402-fetch";
+import { baseSepolia } from "viem/chains";
+
+// Create a wallet client
+const account = privateKeyToAccount("0xYourPrivateKey");
+const client = createWalletClient({
+  account,
+  transport: http(),
+  chain: baseSepolia,
+});
+
+// Wrap the fetch function with payment handling
+const fetchWithPay = wrapFetchWithPayment(fetch, client);
+
+// Make a request that may require payment
+const response = await fetchWithPay("https://api.example.com/paid-endpoint", {
+  method: "GET",
+});
+
+const data = await response.json();
+```
+
+## API
+
+### `wrapFetchWithPayment(fetch, walletClient, maxValue?, paymentRequirementsSelector?)`
+
+Wraps the native fetch API to handle 402 Payment Required responses automatically.
+
+#### Parameters
+
+- `fetch`: The fetch function to wrap (typically `globalThis.fetch`)
+- `walletClient`: The wallet client used to sign payment messages (must implement the x402 wallet interface)
+- `maxValue`: Optional maximum allowed payment amount in base units (defaults to 0.1 USDC)
+- `paymentRequirementsSelector`: Optional function to select payment requirements from the response (defaults to `selectPaymentRequirements`)
+
+#### Returns
+
+A wrapped fetch function that automatically handles 402 responses by:
+1. Making the initial request
+2. If a 402 response is received, parsing the payment requirements
+3. Verifying the payment amount is within the allowed maximum
+4. Creating a payment header using the provided wallet client
+5. Retrying the request with the payment header
+
+## Example
+
+```typescript
+import { config } from "dotenv";
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { wrapFetchWithPayment } from "x402-fetch";
+import { baseSepolia } from "viem/chains";
+
+config();
+
+const { PRIVATE_KEY, API_URL } = process.env;
+
+const account = privateKeyToAccount(PRIVATE_KEY as `0x${string}`);
+const client = createWalletClient({
+  account,
+  transport: http(),
+  chain: baseSepolia,
+});
+
+const fetchWithPay = wrapFetchWithPayment(fetch, client);
+
+// Make a request to a paid API endpoint
+fetchWithPay(API_URL, {
+  method: "GET",
+})
+  .then(async response => {
+    const data = await response.json();
+    console.log(data);
+  })
+  .catch(error => {
+    console.error(error);
+  });
+```
+

--- a/typescript/packages/x402-browser-fetch/eslint.config.js
+++ b/typescript/packages/x402-browser-fetch/eslint.config.js
@@ -1,0 +1,76 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        RequestInfo: "readonly",
+        RequestInit: "readonly",
+        Response: "readonly",
+        Headers: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+];

--- a/typescript/packages/x402-browser-fetch/package.json
+++ b/typescript/packages/x402-browser-fetch/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "x402-browser-fetch",
+  "version": "0.1.0",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "start": "tsx --env-file=.env index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "build": "tsup",
+    "watch": "tsc --watch",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "keywords": [],
+  "license": "Apache-2.0",
+  "author": "Coinbase Inc.",
+  "repository": "https://github.com/coinbase/x402",
+  "description": "x402 Payment Protocol",
+  "devDependencies": {
+    "@types/node": "^22.13.4",
+    "@eslint/js": "^9.24.0",
+    "eslint": "^9.24.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint-plugin-import": "^2.31.0",
+    "prettier": "3.5.2",
+    "tsup": "^8.4.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.0.5",
+    "vite": "^6.2.6"
+  },
+  "dependencies": {
+    "viem": "^2.23.1",
+    "x402": "workspace:^"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/typescript/packages/x402-browser-fetch/src/index.test.ts
+++ b/typescript/packages/x402-browser-fetch/src/index.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { wrapBrowserFetchWithPayment } from "./index";
+import type { PaymentRequirements } from "x402/types";
+
+// Mock the x402 imports
+vi.mock("x402/shared", () => ({
+  safeBase64Encode: vi.fn((data: string) => btoa(data)),
+}));
+
+vi.mock("../../x402/src/schemes/exact/evm/sign", () => ({
+  createNonce: vi.fn(() => "0x1234567890123456789012345678901234567890123456789012345678901234"),
+}));
+
+vi.mock("../../x402/src/types/shared/evm", () => ({
+  authorizationTypes: {
+    TransferWithAuthorization: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "validAfter", type: "uint256" },
+      { name: "validBefore", type: "uint256" },
+      { name: "nonce", type: "bytes32" },
+    ],
+  },
+}));
+
+vi.mock("../../x402/src/shared/network", () => ({
+  getNetworkId: vi.fn((network: string) => {
+    const networkMap: Record<string, number> = {
+      "base-sepolia": 84532,
+      base: 8453,
+    };
+    return networkMap[network];
+  }),
+}));
+
+vi.mock("../../x402/src/types/shared/evm/config", () => ({
+  config: {
+    "84532": {
+      usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      usdcName: "USDC",
+    },
+    "8453": {
+      usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      usdcName: "USDC",
+    },
+  },
+}));
+
+describe("wrapBrowserFetchWithPayment", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let mockSignTypedData: ReturnType<typeof vi.fn>;
+  let wrappedFetch: ReturnType<typeof wrapBrowserFetchWithPayment>;
+  const testAccount = "0xabcdef1234567890123456789012345678901234" as const;
+  const validPaymentRequirements: PaymentRequirements[] = [
+    {
+      scheme: "exact",
+      network: "base-sepolia",
+      maxAmountRequired: "100000", // 0.1 USDC in base units
+      resource: "https://api.example.com/resource",
+      description: "Test payment",
+      mimeType: "application/json",
+      payTo: "0x1234567890123456789012345678901234567890" as `0x${string}`,
+      maxTimeoutSeconds: 300,
+      asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as `0x${string}`, // USDC on base-sepolia
+    },
+  ];
+
+  const createResponse = (status: number, data?: unknown): Response => {
+    const response = new Response(JSON.stringify(data), {
+      status,
+      statusText: status === 402 ? "Payment Required" : status === 200 ? "OK" : "Error",
+      headers: new Headers({ "Content-Type": "application/json" }),
+    });
+    return response;
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Mock global fetch
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+
+    // Mock sign function
+    mockSignTypedData = vi
+      .fn()
+      .mockResolvedValue(
+        "0x1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234",
+      ) as ReturnType<typeof vi.fn>;
+
+    wrappedFetch = wrapBrowserFetchWithPayment(testAccount, mockSignTypedData);
+  });
+
+  it("should return the original response for non-402 status codes", async () => {
+    const successResponse = createResponse(200, { data: "success" });
+    mockFetch.mockResolvedValue(successResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(successResponse);
+    expect(mockFetch).toHaveBeenCalledWith("https://api.example.com", undefined);
+    expect(mockSignTypedData).not.toHaveBeenCalled();
+  });
+
+  it("should handle 402 errors and retry with payment header", async () => {
+    const successResponse = createResponse(200, { data: "success" });
+
+    mockFetch
+      .mockResolvedValueOnce(
+        createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+      )
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await wrappedFetch("https://api.example.com", {
+      method: "GET",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(result).toBe(successResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Check that signTypedData was called with correct parameters
+    expect(mockSignTypedData).toHaveBeenCalledWith({
+      types: {
+        TransferWithAuthorization: [
+          { name: "from", type: "address" },
+          { name: "to", type: "address" },
+          { name: "value", type: "uint256" },
+          { name: "validAfter", type: "uint256" },
+          { name: "validBefore", type: "uint256" },
+          { name: "nonce", type: "bytes32" },
+        ],
+      },
+      primaryType: "TransferWithAuthorization",
+      domain: {
+        name: "USDC",
+        version: "2",
+        chainId: 84532,
+        verifyingContract: validPaymentRequirements[0].asset,
+      },
+      message: expect.objectContaining({
+        from: testAccount,
+        to: validPaymentRequirements[0].payTo,
+        value: validPaymentRequirements[0].maxAmountRequired,
+        validAfter: expect.any(String),
+        validBefore: expect.any(String),
+        nonce: expect.any(String),
+      }),
+    });
+
+    // Check that the second call includes the payment header
+    expect(mockFetch).toHaveBeenLastCalledWith("https://api.example.com", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-PAYMENT": expect.any(String),
+        "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
+      },
+    });
+  });
+
+  it("should throw error when no payment options are available", async () => {
+    mockFetch.mockResolvedValue(createResponse(402, { accepts: [], x402Version: 1 }));
+
+    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
+      "No payment options available",
+    );
+  });
+
+  it("should throw error when payment requirements are undefined", async () => {
+    mockFetch.mockResolvedValue(createResponse(402, { accepts: [null], x402Version: 1 }));
+
+    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
+      "Payment requirements undefined",
+    );
+  });
+
+  it("should reject if payment amount exceeds maximum", async () => {
+    const expensivePaymentRequirements = [
+      {
+        ...validPaymentRequirements[0],
+        maxAmountRequired: "200000", // 0.2 USDC, which exceeds our default max of 0.1 USDC
+      },
+    ];
+
+    mockFetch.mockResolvedValue(
+      createResponse(402, { accepts: expensivePaymentRequirements, x402Version: 1 }),
+    );
+
+    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
+      "Payment amount (200000) exceeds maximum allowed (100000)",
+    );
+  });
+
+  it("should handle custom maximum payment amount", async () => {
+    const customMaxAmount = BigInt(50000); // 0.05 USDC
+    const customWrappedFetch = wrapBrowserFetchWithPayment(
+      testAccount,
+      mockSignTypedData,
+      customMaxAmount,
+    );
+
+    mockFetch.mockResolvedValue(
+      createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+    );
+
+    await expect(customWrappedFetch("https://api.example.com")).rejects.toThrow(
+      "Payment amount (100000) exceeds maximum allowed (50000)",
+    );
+  });
+
+  it("should handle signing errors", async () => {
+    const signingError = new Error("User rejected signing");
+    (mockSignTypedData as ReturnType<typeof vi.fn>).mockRejectedValue(signingError);
+
+    mockFetch.mockResolvedValue(
+      createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+    );
+
+    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow("User rejected signing");
+  });
+
+  it("should handle payment failure responses", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+      )
+      .mockResolvedValueOnce(createResponse(402, { error: "Insufficient balance" }));
+
+    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
+      "Payment failed: Insufficient balance",
+    );
+  });
+
+  it("should handle payment failure without error message", async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+      )
+      .mockResolvedValueOnce(createResponse(402, {}));
+
+    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
+      "Payment failed: Unknown error",
+    );
+  });
+
+  it("should handle insufficient balance errors", async () => {
+    const insufficientError = new Error("insufficient funds");
+    (mockSignTypedData as ReturnType<typeof vi.fn>).mockRejectedValue(insufficientError);
+
+    mockFetch.mockResolvedValue(
+      createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+    );
+
+    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
+      "Insufficient USDC balance to make payment",
+    );
+  });
+
+  it("should handle unknown errors gracefully", async () => {
+    (mockSignTypedData as ReturnType<typeof vi.fn>).mockRejectedValue("String error");
+
+    mockFetch.mockResolvedValue(
+      createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+    );
+
+    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
+      "Failed to process payment",
+    );
+  });
+
+  it("should work with different networks", async () => {
+    const basePaymentRequirements: PaymentRequirements[] = [
+      {
+        ...validPaymentRequirements[0],
+        network: "base",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`,
+      },
+    ];
+
+    const successResponse = createResponse(200, { data: "success" });
+
+    mockFetch
+      .mockResolvedValueOnce(
+        createResponse(402, { accepts: basePaymentRequirements, x402Version: 1 }),
+      )
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(successResponse);
+    expect(mockSignTypedData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: expect.objectContaining({
+          chainId: 8453, // Base mainnet
+          verifyingContract: basePaymentRequirements[0].asset,
+        }),
+      }),
+    );
+  });
+});

--- a/typescript/packages/x402-browser-fetch/src/index.ts
+++ b/typescript/packages/x402-browser-fetch/src/index.ts
@@ -1,0 +1,191 @@
+// typescript/packages/x402-browser-fetch/src/index.ts
+import { safeBase64Encode } from "x402/shared";
+import type { PaymentRequirements, PaymentPayload } from "x402/types";
+import { createNonce } from "../../x402/src/schemes/exact/evm/sign";
+import { authorizationTypes } from "../../x402/src/types/shared/evm";
+import { getNetworkId } from "../../x402/src/shared/network";
+import { config } from "../../x402/src/types/shared/evm/config";
+import type { TypedData, TypedDataDomain } from "viem";
+
+/**
+ * EIP-712 typed data structure for signing.
+ */
+export interface EIP712SignableData {
+  types: TypedData;
+  primaryType: string;
+  domain?: TypedDataDomain;
+  message: Record<string, unknown>;
+}
+/**
+ *
+ * Function type for signing EIP-712 typed data.
+ *
+ * @param typedData - The EIP-712 typed data to sign
+ * @returns Promise that resolves to the signature as a hex string
+ */
+export type SignTypedDataFunction<T extends EIP712SignableData = EIP712SignableData> = (
+  typedData: T,
+) => Promise<`0x${string}`>;
+
+/**
+ * Response structure for HTTP 402 Payment Required responses.
+ */
+interface X402Response {
+  error?: string;
+  accepts: PaymentRequirements[];
+  x402Version: number;
+}
+
+/**
+ * Signs a payment authorization using EIP-712 typed data signing.
+ *
+ * @param account - The Ethereum account address making the payment
+ * @param signTypedData - Function to sign the EIP-712 typed data
+ * @param paymentRequirements - The payment requirements from the server
+ * @returns Promise that resolves to a signed payment payload
+ * @throws Error if the network is unsupported
+ */
+async function signPaymentAuthorization(
+  account: `0x${string}`,
+  signTypedData: SignTypedDataFunction,
+  paymentRequirements: PaymentRequirements,
+): Promise<PaymentPayload> {
+  const chainId = getNetworkId(paymentRequirements.network);
+  const chainConfig = config[chainId.toString()];
+
+  if (!chainConfig) {
+    throw new Error(`Unsupported network: ${paymentRequirements.network}`);
+  }
+
+  const nonce = createNonce();
+  const currentTime = Math.floor(Date.now() / 1000);
+  const validAfter = (currentTime - 600).toString(); // 10 minutes before
+  const validBefore = (currentTime + paymentRequirements.maxTimeoutSeconds).toString();
+
+  const authorization = {
+    from: account,
+    to: paymentRequirements.payTo,
+    value: paymentRequirements.maxAmountRequired,
+    validAfter,
+    validBefore,
+    nonce,
+  };
+
+  const typedData = {
+    types: authorizationTypes,
+    primaryType: "TransferWithAuthorization" as const,
+    domain: {
+      name: paymentRequirements.extra?.name || chainConfig.usdcName,
+      version: paymentRequirements.extra?.version || "2",
+      chainId,
+      verifyingContract: paymentRequirements.asset as `0x${string}`,
+    },
+    message: authorization,
+  };
+
+  const signature = await signTypedData(typedData);
+
+  return {
+    x402Version: 1,
+    scheme: "exact",
+    network: paymentRequirements.network,
+    payload: {
+      signature,
+      authorization,
+    },
+  };
+}
+
+/**
+ * Wraps the browser's fetch function to automatically handle HTTP 402 Payment Required responses.
+ * When a 402 response is received, it will attempt to make a payment and retry the request.
+ *
+ * @param account - The Ethereum account address to use for payments
+ * @param signTypedData - Function to sign EIP-712 typed data for payment authorization
+ * @param maxPaymentAmount - Maximum amount willing to pay (default: 100000 = 0.1 USDC in base units)
+ * @returns A fetch function that handles payments automatically
+ * @throws Error if payment fails, amount exceeds maximum, or insufficient balance
+ */
+export function wrapBrowserFetchWithPayment(
+  account: `0x${string}`,
+  signTypedData: SignTypedDataFunction,
+  maxPaymentAmount: bigint = BigInt(100000), // 0.1 USDC in base units
+) {
+  return async function fetchWithPayment(url: string, init?: RequestInit): Promise<Response> {
+    // Make initial request
+    const response = await fetch(url, init);
+
+    // If not 402, return original response
+    if (response.status !== 402) {
+      return response;
+    }
+
+    // Parse 402 response
+    const x402Response = (await response.json()) as X402Response;
+
+    if (!x402Response.accepts || x402Response.accepts.length === 0) {
+      throw new Error("No payment options available");
+    }
+
+    // Select first available payment requirement
+    const paymentRequirements = x402Response.accepts[0];
+
+    if (!paymentRequirements) {
+      throw new Error("Payment requirements undefined");
+    }
+
+    // Check if payment amount is within allowed limit
+    if (BigInt(paymentRequirements.maxAmountRequired) > maxPaymentAmount) {
+      throw new Error(
+        `Payment amount (${paymentRequirements.maxAmountRequired}) exceeds maximum allowed (${maxPaymentAmount})`,
+      );
+    }
+
+    try {
+      // Create signed payment
+      const signedPayment = await signPaymentAuthorization(
+        account,
+        signTypedData,
+        paymentRequirements,
+      );
+
+      // Encode payment header using existing utility
+      const paymentHeader = safeBase64Encode(JSON.stringify(signedPayment));
+
+      // Retry request with payment header
+      const retryInit = {
+        ...init,
+        headers: {
+          ...(init?.headers || {}),
+          "X-PAYMENT": paymentHeader,
+          "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
+        },
+      };
+
+      const retryResponse = await fetch(url, retryInit);
+
+      if (retryResponse.status === 402) {
+        // Payment failed, try to get error details
+        const errorResponse = (await retryResponse.json()) as {
+          error?: string;
+        };
+        throw new Error(`Payment failed: ${errorResponse.error || "Unknown error"}`);
+      }
+
+      return retryResponse;
+    } catch (error) {
+      if (error instanceof Error) {
+        // Handle common payment errors
+        if (error.message.includes("insufficient")) {
+          throw new Error("Insufficient USDC balance to make payment");
+        }
+        throw error;
+      }
+      throw new Error("Failed to process payment");
+    }
+  };
+}
+
+// Export commonly needed utilities for browser environments
+export { safeBase64Encode } from "x402/shared";
+export type { PaymentRequirements, PaymentPayload } from "x402/types";

--- a/typescript/packages/x402-browser-fetch/tsconfig.json
+++ b/typescript/packages/x402-browser-fetch/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
+    "lib": ["DOM"]
+  },
+  "include": ["src"]
+}

--- a/typescript/packages/x402-browser-fetch/tsup.config.ts
+++ b/typescript/packages/x402-browser-fetch/tsup.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "tsup";
+
+const baseConfig = {
+  entry: {
+    index: "src/index.ts",
+  },
+  dts: {
+    resolve: true,
+  },
+  sourcemap: true,
+  target: "node16",
+};
+
+export default defineConfig([
+  {
+    ...baseConfig,
+    format: "esm",
+    outDir: "dist/esm",
+    clean: true,
+  },
+  {
+    ...baseConfig,
+    format: "cjs",
+    outDir: "dist/cjs",
+    clean: false,
+  },
+]);

--- a/typescript/packages/x402-browser-fetch/vitest.config.ts
+++ b/typescript/packages/x402-browser-fetch/vitest.config.ts
@@ -1,0 +1,10 @@
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig(({ mode }) => ({
+  test: {
+    env: loadEnv(mode, process.cwd(), ""),
+  },
+  plugins: [tsconfigPaths({ projects: ["."] })],
+}));

--- a/typescript/packages/x402-fetch/src/index.test.ts
+++ b/typescript/packages/x402-fetch/src/index.test.ts
@@ -1,11 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { wrapFetchWithPayment } from "./index";
-import { evm, PaymentRequirements } from "x402/types";
+import type { evm, PaymentRequirements } from "x402/types";
 
 vi.mock("x402/client", () => ({
   createPaymentHeader: vi.fn(),
   selectPaymentRequirements: vi.fn(),
 }));
+
+// Mock browser APIs
+Object.defineProperty(globalThis, "fetch", {
+  value: vi.fn(),
+  writable: true,
+});
 
 type RequestInitWithRetry = RequestInit & { __is402Retry?: boolean };
 
@@ -30,8 +36,8 @@ describe("fetchWithPayment()", () => {
   const createResponse = (status: number, data?: unknown): Response => {
     const response = new Response(JSON.stringify(data), {
       status,
-      statusText: status === 402 ? "Payment Required" : "Not Found",
-      headers: new Headers(),
+      statusText: status === 402 ? "Payment Required" : status === 200 ? "OK" : "Not Found",
+      headers: new Headers({ "Content-Type": "application/json" }),
     });
     return response;
   };
@@ -54,116 +60,362 @@ describe("fetchWithPayment()", () => {
     wrappedFetch = wrapFetchWithPayment(mockFetch, mockWalletClient);
   });
 
-  it("should return the original response for non-402 status codes", async () => {
-    const successResponse = createResponse(200, { data: "success" });
-    mockFetch.mockResolvedValue(successResponse);
+  describe("Custom fetch wrapper", () => {
+    it("should return the original response for non-402 status codes", async () => {
+      const successResponse = createResponse(200, { data: "success" });
+      mockFetch.mockResolvedValue(successResponse);
 
-    const result = await wrappedFetch("https://api.example.com");
+      const result = await wrappedFetch("https://api.example.com");
 
-    expect(result).toBe(successResponse);
-    expect(mockFetch).toHaveBeenCalledWith("https://api.example.com", undefined);
-  });
-
-  it("should handle 402 errors and retry with payment header", async () => {
-    const paymentHeader = "payment-header-value";
-    const successResponse = createResponse(200, { data: "success" });
-
-    const { createPaymentHeader, selectPaymentRequirements } = await import("x402/client");
-    (createPaymentHeader as ReturnType<typeof vi.fn>).mockResolvedValue(paymentHeader);
-    (selectPaymentRequirements as ReturnType<typeof vi.fn>).mockImplementation(
-      (requirements, _) => requirements[0],
-    );
-    mockFetch
-      .mockResolvedValueOnce(
-        createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
-      )
-      .mockResolvedValueOnce(successResponse);
-
-    const result = await wrappedFetch("https://api.example.com", {
-      method: "GET",
-      headers: { "Content-Type": "application/json" },
-    } as RequestInitWithRetry);
-
-    expect(result).toBe(successResponse);
-    expect(selectPaymentRequirements).toHaveBeenCalledWith(
-      validPaymentRequirements,
-      undefined,
-      "exact",
-    );
-    expect(createPaymentHeader).toHaveBeenCalledWith(
-      mockWalletClient,
-      1,
-      validPaymentRequirements[0],
-    );
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch).toHaveBeenLastCalledWith("https://api.example.com", {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "X-PAYMENT": paymentHeader,
-        "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
-      },
-      __is402Retry: true,
-    } as RequestInitWithRetry);
-  });
-
-  it("should not retry if already retried", async () => {
-    const errorResponse = createResponse(402, {
-      accepts: validPaymentRequirements,
-      x402Version: 1,
+      expect(result).toBe(successResponse);
+      expect(mockFetch).toHaveBeenCalledWith("https://api.example.com", undefined);
     });
-    mockFetch.mockResolvedValue(errorResponse);
 
-    await expect(
-      wrappedFetch("https://api.example.com", {
-        __is402Retry: true,
-      } as RequestInitWithRetry),
-    ).rejects.toThrow("Payment already attempted");
-  });
+    it("should handle 402 errors and retry with payment header", async () => {
+      const paymentHeader = "payment-header-value";
+      const successResponse = createResponse(200, { data: "success" });
 
-  it("should reject if missing request config", async () => {
-    const errorResponse = createResponse(402, {
-      accepts: validPaymentRequirements,
-      x402Version: 1,
-    });
-    mockFetch.mockResolvedValue(errorResponse);
+      const { createPaymentHeader, selectPaymentRequirements } = await import("x402/client");
+      (createPaymentHeader as ReturnType<typeof vi.fn>).mockResolvedValue(paymentHeader);
+      (selectPaymentRequirements as ReturnType<typeof vi.fn>).mockImplementation(
+        (requirements, _) => requirements[0],
+      );
+      mockFetch
+        .mockResolvedValueOnce(
+          createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+        )
+        .mockResolvedValueOnce(successResponse);
 
-    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
-      "Missing fetch request configuration",
-    );
-  });
+      const result = await wrappedFetch("https://api.example.com", {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      } as RequestInitWithRetry);
 
-  it("should reject if payment amount exceeds maximum", async () => {
-    const errorResponse = createResponse(402, {
-      accepts: [
-        {
-          ...validPaymentRequirements[0],
-          maxAmountRequired: "200000", // 0.2 USDC, which exceeds our default max of 0.1 USDC
+      expect(result).toBe(successResponse);
+      expect(selectPaymentRequirements).toHaveBeenCalledWith(
+        validPaymentRequirements,
+        undefined,
+        "exact",
+      );
+      expect(createPaymentHeader).toHaveBeenCalledWith(
+        mockWalletClient,
+        1,
+        validPaymentRequirements[0],
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenLastCalledWith("https://api.example.com", {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          "X-PAYMENT": paymentHeader,
+          "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
         },
-      ],
-      x402Version: 1,
+        __is402Retry: true,
+      } as RequestInitWithRetry);
     });
-    mockFetch.mockResolvedValue(errorResponse);
 
-    await expect(
-      wrappedFetch("https://api.example.com", {
-        method: "GET",
-      } as RequestInitWithRetry),
-    ).rejects.toThrow("Payment amount exceeds maximum allowed");
+    it("should not retry if already retried", async () => {
+      const errorResponse = createResponse(402, {
+        accepts: validPaymentRequirements,
+        x402Version: 1,
+      });
+      mockFetch.mockResolvedValue(errorResponse);
+
+      await expect(
+        wrappedFetch("https://api.example.com", {
+          __is402Retry: true,
+        } as RequestInitWithRetry),
+      ).rejects.toThrow("Payment already attempted");
+    });
+
+    it("should reject if missing request config", async () => {
+      const errorResponse = createResponse(402, {
+        accepts: validPaymentRequirements,
+        x402Version: 1,
+      });
+      mockFetch.mockResolvedValue(errorResponse);
+
+      await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
+        "Missing fetch request configuration",
+      );
+    });
+
+    it("should reject if payment amount exceeds maximum", async () => {
+      const errorResponse = createResponse(402, {
+        accepts: [
+          {
+            ...validPaymentRequirements[0],
+            maxAmountRequired: "200000", // 0.2 USDC, which exceeds our default max of 0.1 USDC
+          },
+        ],
+        x402Version: 1,
+      });
+      mockFetch.mockResolvedValue(errorResponse);
+
+      await expect(
+        wrappedFetch("https://api.example.com", {
+          method: "GET",
+        } as RequestInitWithRetry),
+      ).rejects.toThrow("Payment amount exceeds maximum allowed");
+    });
+
+    it("should reject if payment header creation fails", async () => {
+      const paymentError = new Error("Payment failed");
+      const { createPaymentHeader } = await import("x402/client");
+      (createPaymentHeader as ReturnType<typeof vi.fn>).mockRejectedValue(paymentError);
+      mockFetch.mockResolvedValue(
+        createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+      );
+
+      await expect(
+        wrappedFetch("https://api.example.com", {
+          method: "GET",
+        } as RequestInitWithRetry),
+      ).rejects.toBe(paymentError);
+    });
   });
 
-  it("should reject if payment header creation fails", async () => {
-    const paymentError = new Error("Payment failed");
-    const { createPaymentHeader } = await import("x402/client");
-    (createPaymentHeader as ReturnType<typeof vi.fn>).mockRejectedValue(paymentError);
-    mockFetch.mockResolvedValue(
-      createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
-    );
+  describe("Browser fetch integration", () => {
+    let originalFetch: typeof globalThis.fetch;
+    let browserWrappedFetch: ReturnType<typeof wrapFetchWithPayment>;
 
-    await expect(
-      wrappedFetch("https://api.example.com", {
+    beforeEach(() => {
+      // Store original fetch and set up mock
+      originalFetch = globalThis.fetch;
+      const mockBrowserFetch = vi.fn();
+      globalThis.fetch = mockBrowserFetch;
+
+      browserWrappedFetch = wrapFetchWithPayment(globalThis.fetch, mockWalletClient);
+    });
+
+    afterEach(() => {
+      // Restore original fetch
+      globalThis.fetch = originalFetch;
+    });
+
+    it("should work with browser's native fetch", async () => {
+      const successResponse = createResponse(200, { data: "browser success" });
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+      const result = await browserWrappedFetch("https://api.example.com/browser");
+
+      expect(result).toBe(successResponse);
+      expect(globalThis.fetch).toHaveBeenCalledWith("https://api.example.com/browser", undefined);
+    });
+
+    it("should handle browser fetch with 402 payment flow", async () => {
+      const paymentHeader = "browser-payment-header";
+      const successResponse = createResponse(200, { data: "paid content" });
+
+      const { createPaymentHeader } = await import("x402/client");
+      (createPaymentHeader as ReturnType<typeof vi.fn>).mockResolvedValue(paymentHeader);
+
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(
+          createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+        )
+        .mockResolvedValueOnce(successResponse);
+
+      const result = await browserWrappedFetch("https://api.example.com/paid", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ test: "data" }),
+      });
+
+      expect(result).toBe(successResponse);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+
+      // Verify first call (initial request)
+      expect(globalThis.fetch).toHaveBeenNthCalledWith(1, "https://api.example.com/paid", {
+        method: "POST",
+        headers: { Authorization: "Bearer token" },
+        body: JSON.stringify({ test: "data" }),
+      });
+
+      // Verify second call (with payment header)
+      expect(globalThis.fetch).toHaveBeenNthCalledWith(2, "https://api.example.com/paid", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer token",
+          "X-PAYMENT": paymentHeader,
+          "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
+        },
+        body: JSON.stringify({ test: "data" }),
+        __is402Retry: true,
+      });
+    });
+
+    it("should handle browser fetch with different request methods", async () => {
+      const testCases = [
+        { method: "GET", hasBody: false },
+        { method: "POST", hasBody: true },
+        { method: "PUT", hasBody: true },
+        { method: "DELETE", hasBody: false },
+        { method: "PATCH", hasBody: true },
+      ];
+
+      for (const testCase of testCases) {
+        vi.clearAllMocks();
+
+        const successResponse = createResponse(200, { method: testCase.method });
+        (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+        const requestInit: RequestInit = {
+          method: testCase.method,
+          headers: { "Content-Type": "application/json" },
+          ...(testCase.hasBody && { body: JSON.stringify({ data: "test" }) }),
+        };
+
+        const result = await browserWrappedFetch(
+          `https://api.example.com/${testCase.method.toLowerCase()}`,
+          requestInit,
+        );
+
+        expect(result).toBe(successResponse);
+        expect(globalThis.fetch).toHaveBeenCalledWith(
+          `https://api.example.com/${testCase.method.toLowerCase()}`,
+          requestInit,
+        );
+      }
+    });
+
+    it("should preserve request headers and body in browser fetch retry", async () => {
+      const paymentHeader = "browser-retry-payment";
+      const successResponse = createResponse(200, { data: "retry success" });
+      const requestBody = JSON.stringify({ important: "data" });
+
+      const { createPaymentHeader } = await import("x402/client");
+      (createPaymentHeader as ReturnType<typeof vi.fn>).mockResolvedValue(paymentHeader);
+
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce(
+          createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+        )
+        .mockResolvedValueOnce(successResponse);
+
+      const result = await browserWrappedFetch("https://api.example.com/preserve", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer secret-token",
+          "X-Custom-Header": "custom-value",
+        },
+        body: requestBody,
+      });
+
+      expect(result).toBe(successResponse);
+
+      // Verify the retry call preserves all original headers plus payment header
+      expect(globalThis.fetch).toHaveBeenLastCalledWith("https://api.example.com/preserve", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer secret-token",
+          "X-Custom-Header": "custom-value",
+          "X-PAYMENT": paymentHeader,
+          "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
+        },
+        body: requestBody,
+        __is402Retry: true,
+      });
+    });
+
+    it("should handle browser fetch network errors", async () => {
+      const networkError = new Error("Failed to fetch");
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(networkError);
+
+      await expect(browserWrappedFetch("https://api.example.com/network-error")).rejects.toThrow(
+        "Failed to fetch",
+      );
+    });
+
+    it("should handle browser fetch with AbortController", async () => {
+      const controller = new AbortController();
+      const successResponse = createResponse(200, { data: "abortable" });
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(successResponse);
+
+      // Test that signal is passed through
+      const result = await browserWrappedFetch("https://api.example.com/abort", {
+        signal: controller.signal,
+      });
+
+      expect(result).toBe(successResponse);
+      expect(globalThis.fetch).toHaveBeenCalledWith("https://api.example.com/abort", {
+        signal: controller.signal,
+      });
+    });
+
+    it("should handle browser fetch timeout scenarios", async () => {
+      const paymentHeader = "timeout-payment";
+      const { createPaymentHeader } = await import("x402/client");
+      (createPaymentHeader as ReturnType<typeof vi.fn>).mockResolvedValue(paymentHeader);
+
+      // Mock a slow initial request that returns 402, then fast payment response
+      (globalThis.fetch as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce(
+          () =>
+            new Promise(resolve =>
+              setTimeout(
+                () =>
+                  resolve(
+                    createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+                  ),
+                100,
+              ),
+            ),
+        )
+        .mockResolvedValueOnce(createResponse(200, { data: "eventually successful" }));
+
+      const result = await browserWrappedFetch("https://api.example.com/slow", {
         method: "GET",
-      } as RequestInitWithRetry),
-    ).rejects.toBe(paymentError);
+      });
+
+      expect(result.status).toBe(200);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Error handling with browser fetch", () => {
+    let browserWrappedFetch: ReturnType<typeof wrapFetchWithPayment>;
+
+    beforeEach(() => {
+      const mockBrowserFetch = vi.fn();
+      globalThis.fetch = mockBrowserFetch;
+      browserWrappedFetch = wrapFetchWithPayment(globalThis.fetch, mockWalletClient);
+    });
+
+    it("should handle malformed 402 responses in browser", async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        new Response("Invalid JSON", { status: 402 }),
+      );
+
+      await expect(browserWrappedFetch("https://api.example.com/malformed")).rejects.toThrow();
+    });
+
+    it("should handle missing payment requirements in browser", async () => {
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        createResponse(402, { x402Version: 1 }),
+      );
+
+      await expect(
+        browserWrappedFetch("https://api.example.com/missing-accepts"),
+      ).rejects.toThrow();
+    });
+
+    it("should propagate wallet errors in browser context", async () => {
+      const walletError = new Error("Wallet connection failed");
+      mockWalletClient.signMessage = vi.fn().mockRejectedValue(walletError);
+
+      const { createPaymentHeader } = await import("x402/client");
+      (createPaymentHeader as ReturnType<typeof vi.fn>).mockRejectedValue(walletError);
+
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        createResponse(402, { accepts: validPaymentRequirements, x402Version: 1 }),
+      );
+
+      await expect(
+        browserWrappedFetch("https://api.example.com/wallet-error", { method: "GET" }),
+      ).rejects.toThrow("Wallet connection failed");
+    });
   });
 });

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -2,10 +2,17 @@ import { ChainIdToNetwork, PaymentRequirementsSchema } from "x402/types";
 import { evm } from "x402/types";
 import {
   createPaymentHeader,
-  PaymentRequirementsSelector,
+  type PaymentRequirementsSelector,
   selectPaymentRequirements,
 } from "x402/client";
-import { Account } from "viem";
+import type { Account } from "viem";
+import { safeBase64Encode } from "x402/shared";
+import type { PaymentRequirements, PaymentPayload } from "x402/types";
+import { createNonce } from "../../x402/src/schemes/exact/evm/sign";
+import { authorizationTypes } from "../../x402/src/types/shared/evm";
+import { getNetworkId } from "../../x402/src/shared/network";
+import { config } from "../../x402/src/types/shared/evm/config";
+import type { TypedData, TypedDataDomain } from "viem";
 
 /**
  * Enables the payment of APIs using the x402 payment protocol.
@@ -101,4 +108,185 @@ export function wrapFetchWithPayment(
   };
 }
 
+/**
+ * EIP-712 typed data structure for signing.
+ */
+export interface EIP712SignableData {
+  types: TypedData;
+  primaryType: string;
+  domain?: TypedDataDomain;
+  message: Record<string, unknown>;
+}
+/**
+ *
+ * Function type for signing EIP-712 typed data.
+ *
+ * @param typedData - The EIP-712 typed data to sign
+ * @returns Promise that resolves to the signature as a hex string
+ */
+export type SignTypedDataFunction<T extends EIP712SignableData = EIP712SignableData> = (
+  typedData: T,
+) => Promise<`0x${string}`>;
+
+/**
+ * Response structure for HTTP 402 Payment Required responses.
+ */
+interface X402Response {
+  error?: string;
+  accepts: PaymentRequirements[];
+  x402Version: number;
+}
+
+/**
+ * Signs a payment authorization using EIP-712 typed data signing.
+ *
+ * @param account - The Ethereum account address making the payment
+ * @param signTypedData - Function to sign the EIP-712 typed data
+ * @param paymentRequirements - The payment requirements from the server
+ * @returns Promise that resolves to a signed payment payload
+ * @throws Error if the network is unsupported
+ */
+async function signPaymentAuthorization(
+  account: `0x${string}`,
+  signTypedData: SignTypedDataFunction,
+  paymentRequirements: PaymentRequirements,
+): Promise<PaymentPayload> {
+  const chainId = getNetworkId(paymentRequirements.network);
+  const chainConfig = config[chainId.toString()];
+
+  if (!chainConfig) {
+    throw new Error(`Unsupported network: ${paymentRequirements.network}`);
+  }
+
+  const nonce = createNonce();
+  const currentTime = Math.floor(Date.now() / 1000);
+  const validAfter = (currentTime - 600).toString(); // 10 minutes before
+  const validBefore = (currentTime + paymentRequirements.maxTimeoutSeconds).toString();
+
+  const authorization = {
+    from: account,
+    to: paymentRequirements.payTo,
+    value: paymentRequirements.maxAmountRequired,
+    validAfter,
+    validBefore,
+    nonce,
+  };
+
+  const typedData = {
+    types: authorizationTypes,
+    primaryType: "TransferWithAuthorization" as const,
+    domain: {
+      name: paymentRequirements.extra?.name || chainConfig.usdcName,
+      version: paymentRequirements.extra?.version || "2",
+      chainId,
+      verifyingContract: paymentRequirements.asset as `0x${string}`,
+    },
+    message: authorization,
+  };
+
+  const signature = await signTypedData(typedData);
+
+  return {
+    x402Version: 1,
+    scheme: "exact",
+    network: paymentRequirements.network,
+    payload: {
+      signature,
+      authorization,
+    },
+  };
+}
+
+/**
+ * Wraps the browser's fetch function to automatically handle HTTP 402 Payment Required responses.
+ * When a 402 response is received, it will attempt to make a payment and retry the request.
+ *
+ * @param account - The Ethereum account address to use for payments
+ * @param signTypedData - Function to sign EIP-712 typed data for payment authorization
+ * @param maxPaymentAmount - Maximum amount willing to pay (default: 100000 = 0.1 USDC in base units)
+ * @returns A fetch function that handles payments automatically
+ * @throws Error if payment fails, amount exceeds maximum, or insufficient balance
+ */
+export function wrapBrowserFetchWithPayment(
+  account: `0x${string}`,
+  signTypedData: SignTypedDataFunction,
+  maxPaymentAmount: bigint = BigInt(100000), // 0.1 USDC in base units
+) {
+  return async function fetchWithPayment(url: string, init?: RequestInit): Promise<Response> {
+    // Make initial request
+    const response = await fetch(url, init);
+
+    // If not 402, return original response
+    if (response.status !== 402) {
+      return response;
+    }
+
+    // Parse 402 response
+    const x402Response = (await response.json()) as X402Response;
+
+    if (!x402Response.accepts || x402Response.accepts.length === 0) {
+      throw new Error("No payment options available");
+    }
+
+    // Select first available payment requirement
+    const paymentRequirements = x402Response.accepts[0];
+
+    if (!paymentRequirements) {
+      throw new Error("Payment requirements undefined");
+    }
+
+    // Check if payment amount is within allowed limit
+    if (BigInt(paymentRequirements.maxAmountRequired) > maxPaymentAmount) {
+      throw new Error(
+        `Payment amount (${paymentRequirements.maxAmountRequired}) exceeds maximum allowed (${maxPaymentAmount})`,
+      );
+    }
+
+    try {
+      // Create signed payment
+      const signedPayment = await signPaymentAuthorization(
+        account,
+        signTypedData,
+        paymentRequirements,
+      );
+
+      // Encode payment header using existing utility
+      const paymentHeader = safeBase64Encode(JSON.stringify(signedPayment));
+
+      // Retry request with payment header
+      const retryInit = {
+        ...init,
+        headers: {
+          ...(init?.headers || {}),
+          "X-PAYMENT": paymentHeader,
+          "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
+        },
+      };
+
+      const retryResponse = await fetch(url, retryInit);
+
+      if (retryResponse.status === 402) {
+        // Payment failed, try to get error details
+        const errorResponse = (await retryResponse.json()) as {
+          error?: string;
+        };
+        throw new Error(`Payment failed: ${errorResponse.error || "Unknown error"}`);
+      }
+
+      return retryResponse;
+    } catch (error) {
+      if (error instanceof Error) {
+        // Handle common payment errors
+        if (error.message.includes("insufficient")) {
+          throw new Error("Insufficient USDC balance to make payment");
+        }
+        throw error;
+      }
+      throw new Error("Failed to process payment");
+    }
+  };
+}
+
+export { safeBase64Encode } from "x402/shared";
+export type { PaymentRequirements, PaymentPayload } from "x402/types";
 export { decodeXPaymentResponse } from "x402/shared";

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -117,7 +117,7 @@ importers:
         version: 9.24.0(jiti@1.21.7)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.24.0(jiti@1.21.7))
+        version: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@9.24.0(jiti@1.21.7))
       eslint-plugin-jsdoc:
         specifier: ^50.6.9
         version: 50.6.9(eslint@9.24.0(jiti@1.21.7))
@@ -160,6 +160,61 @@ importers:
       zod:
         specifier: ^3.24.2
         version: 3.24.2
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.24.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.14.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.29.1(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.24.0(jiti@1.21.7)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@9.24.0(jiti@1.21.7))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.6.9(eslint@9.24.0(jiti@1.21.7))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.2.6(eslint@9.24.0(jiti@1.21.7))(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.4.0(jiti@1.21.7)(postcss@8.5.3)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.19.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      vite:
+        specifier: ^6.2.6
+        version: 6.2.6(@types/node@22.14.0)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.3)(vite@6.2.6(@types/node@22.14.0)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1))
+      vitest:
+        specifier: ^3.0.5
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.14.0)(jiti@1.21.7)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(tsx@4.19.3)(yaml@2.7.1)
+
+  packages/x402-browser-fetch:
+    dependencies:
+      viem:
+        specifier: ^2.23.1
+        version: 2.26.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      x402:
+        specifier: workspace:^
+        version: link:../x402
     devDependencies:
       '@eslint/js':
         specifier: ^9.24.0
@@ -9097,16 +9152,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.24.0(jiti@1.21.7)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3)
-      eslint: 9.24.0(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@9.24.0(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -9119,35 +9164,6 @@ snapshots:
       eslint: 9.24.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@9.24.0(jiti@1.21.7))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.24.0(jiti@1.21.7)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.24.0(jiti@1.21.7)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.24.0(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11131,7 +11147,7 @@ snapshots:
 
   tsx@4.19.3:
     dependencies:
-      esbuild: 0.25.2
+      esbuild: 0.25.4
       get-tsconfig: 4.10.0
     optionalDependencies:
       fsevents: 2.3.3


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

This commit includes a new package for x402/typescript called `x402-browser-fetch`. The existing `x402-fetch` package is not browser/client compatible due to how the account and signing data function is passed. `x402-browser-fetch` accepts a `SignTypedDataFunction` parameter which allows for any kind of wallet or account implementation to be used with x402 server requests

Here is an example implementation and use of the `wrapBrowserFetchWithPayment()` function

```typescript
  const makeRequest = useCallback(async () => {
    if (!account || !window.ethereum) {
      console.log("Connect wallet");
      return;
    }
    // Create Viem wallet client
    const walletClient = createWalletClient({
      account: account,
      chain: baseSepolia,
      transport: custom(window.ethereum),
    });

    // Create signTypedData function for x402
    const signTypedData: SignTypedDataFunction = async (typedData) => {
      return await walletClient.signTypedData({
        account: account,
        ...typedData,
      });
    };

    // Create x402 fetch function
    const fetchWithPayment = wrapBrowserFetchWithPayment(
      account,
      signTypedData,
      BigInt(100000), // Max 0.1 USDC
    );

    setStatus("Making request...");
    setApiResponse("");

    try {
      const response = await fetchWithPayment(apiUrl, {
        method: "POST",
        headers: { "Content-Type": "application/json" },
        body: JSON.stringify({
          model: "llama3.2",
          messages: [
            {
              role: "user",
              content: "Write a one-sentence bedtime story about a unicorn.",
            },
          ],
        }),
      });

      const text = await response.text();
      setApiResponse(`Status: ${response.status}\n\n${text}`);
      setStatus("Success");
```
## Tests

Built unit test for new package under `typescript/packages/x402-browser-fetch/src/index.test.ts`, all unit tests passing for `typescript` directory.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 