### PR TITLE
fix: remove account from data to sign

### DIFF
--- a/typescript/packages/x402/src/schemes/exact/evm/sign.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/sign.ts
@@ -33,10 +33,8 @@ export async function signAuthorization<transport extends Transport, chain exten
   const chainId = getNetworkId(network);
   const name = extra?.name;
   const version = extra?.version;
-  const account = isSignerWallet(walletClient) ? walletClient.account : walletClient;
 
   const data = {
-    account,
     types: authorizationTypes,
     domain: {
       name,


### PR DESCRIPTION
## Description

`account` was added as a field to `data` during signAuthorization. This was simply wrong, as `account` is not part of the typed data spec. Viem signers hold your hand, and trim out fields which are out of spec, as well as add fields that are required by spec (such as EIP712Types to types). However, if a Viem-interfaced compatible signer, such as `cdp-sdk`, does not trim out the extra fields, it will cause issues.

## Tests

Re-affirmed this did not break anything by re-running the express/hono/next servers against axios/fetch/paywall clients and ensured that, in the Viem-signer case, it still works

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 