### PR TITLE
fix: package dir in gha

### DIFF
--- a/.github/workflows/publish_pypi_x402.yml
+++ b/.github/workflows/publish_pypi_x402.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
-          packages-dir: dist/
+          packages-dir: python/x402/dist/
           password: ${{ secrets.PYPI_X402_TOKEN }}


### PR DESCRIPTION
Declares the full path to dist, rather than the relative based on working path.

This aligns with how AgentKit uses it [here](https://github.com/coinbase/agentkit/blob/main/.github/workflows/publish_pypi_coinbase_agentkit.yml#L48)