### PR TITLE
feat: expanded support from USDC to any eip-3009 asset

### DIFF
--- a/examples/python/servers/fastapi/.env-local
+++ b/examples/python/servers/fastapi/.env-local
@@ -1,2 +1,1 @@
-NETWORK=base-sepolia
 ADDRESS=

--- a/examples/python/servers/fastapi/README.md
+++ b/examples/python/servers/fastapi/README.md
@@ -35,7 +35,7 @@ To add more paid endpoints, follow this pattern:
 # First, configure the payment middleware with your routes
 app.middleware("http")(
     require_payment(
-        amount="$0.10",
+        price="$0.10",
         pay_to_address=ADDRESS,
         path="/your-endpoint",
         network_id=NETWORK,

--- a/examples/python/servers/fastapi/main.py
+++ b/examples/python/servers/fastapi/main.py
@@ -1,17 +1,15 @@
 import os
-from typing import Dict, Any
+from typing import Any, Dict
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
-
+from fastapi import FastAPI
 from x402.fastapi.middleware import require_payment
+from x402.types import EIP712Domain, TokenAmount, TokenAsset
 
 # Load environment variables
 load_dotenv()
 
 # Get configuration from environment
-NETWORK = os.getenv("NETWORK", "base-sepolia")
 ADDRESS = os.getenv("ADDRESS")
 
 if not ADDRESS:
@@ -22,20 +20,27 @@ app = FastAPI()
 # Apply payment middleware to specific routes
 app.middleware("http")(
     require_payment(
-        amount="$0.001",
-        pay_to_address=ADDRESS,
         path="/weather",
-        network_id=NETWORK,
+        price="$0.001",
+        pay_to_address=ADDRESS,
+        network_id="base-sepolia",
     )
 )
 
 # Apply payment middleware to premium routes
 app.middleware("http")(
     require_payment(
-        amount="$0.01",
-        pay_to_address=ADDRESS,
         path="/premium/*",
-        network_id=NETWORK,
+        price=TokenAmount(
+            amount="10000",
+            asset=TokenAsset(
+                address="0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+                decimals=6,
+                eip712=EIP712Domain(name="USDC", version="2"),
+            ),
+        ),
+        pay_to_address=ADDRESS,
+        network_id="base-sepolia",
     )
 )
 

--- a/examples/python/servers/mainnet/main.py
+++ b/examples/python/servers/mainnet/main.py
@@ -1,10 +1,10 @@
 import os
-from typing import Dict, Any
+from typing import Any, Dict
 
+from cdp.x402 import create_facilitator_config
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from x402.fastapi.middleware import require_payment
-from cdp.x402 import create_facilitator_config
 
 # Load environment variables
 load_dotenv()
@@ -25,7 +25,7 @@ facilitator_config = create_facilitator_config(CDP_API_KEY_ID, CDP_API_KEY_SECRE
 # Apply payment middleware to specific routes
 app.middleware("http")(
     require_payment(
-        amount="$0.001",
+        price="$0.001",
         pay_to_address=ADDRESS,
         path="/weather",
         network_id=NETWORK,
@@ -36,7 +36,7 @@ app.middleware("http")(
 # Apply payment middleware to premium routes
 app.middleware("http")(
     require_payment(
-        amount="$0.01",
+        price="$0.01",
         pay_to_address=ADDRESS,
         path="/premium/*",
         network_id=NETWORK,

--- a/python/x402/README.md
+++ b/python/x402/README.md
@@ -151,7 +151,7 @@ async def foo(req: request: Request):
     if payment_header == "":
         payment_required.error = "X-PAYMENT header not set"
         return JSONResponse(
-            content=payment_required.model_dump(),
+            content=payment_required.model_dump(by_alias=True),
             status_code=402,
         )
     
@@ -161,7 +161,7 @@ async def foo(req: request: Request):
     if not verify_response.is_valid:
         payment_required.error = "Invalid payment"
         return JSONResponse(
-            content=payment_required.model_dump(),
+            content=payment_required.model_dump(by_alias=True),
             status_code=402,
         )
 
@@ -173,7 +173,7 @@ async def foo(req: request: Request):
     else:
         payment_required.error = "Settle failed: " + settle_response.error
         return JSONResponse(
-            content=payment_required.model_dump(),
+            content=payment_required.model_dump(by_alias=True),
             status_code=402,
         )
 ```

--- a/python/x402/src/x402/common.py
+++ b/python/x402/src/x402/common.py
@@ -1,5 +1,12 @@
 from decimal import Decimal
-from x402.chains import get_chain_id, get_token_decimals
+
+from x402.chains import (
+    get_chain_id,
+    get_token_decimals,
+    get_token_name,
+    get_token_version,
+)
+from x402.types import Price, TokenAmount
 
 
 def parse_money(amount: str | int, address: str, network_id: str) -> int:
@@ -18,6 +25,77 @@ def parse_money(amount: str | int, address: str, network_id: str) -> int:
         amount = amount * Decimal(10**decimals)
         return int(amount)
     return amount
+
+
+def process_price_to_atomic_amount(
+    price: Price, network_id: str
+) -> tuple[str, str, dict[str, str]]:
+    """Process a Price into atomic amount, asset address, and EIP-712 domain info
+
+    Args:
+        price: Either Money (USD string/int) or TokenAmount
+        network_id: Network identifier
+
+    Returns:
+        Tuple of (max_amount_required, asset_address, eip712_domain)
+
+    Raises:
+        ValueError: If price format is invalid
+    """
+    if isinstance(price, (str, int)):
+        # Money type - convert USD to USDC atomic units
+        try:
+            if isinstance(price, str) and price.startswith("$"):
+                price = price[1:]
+            amount = Decimal(str(price))
+
+            # Get USDC address for the network
+            chain_id = get_chain_id(network_id)
+            asset_address = get_usdc_address(chain_id)
+            decimals = get_token_decimals(chain_id, asset_address)
+
+            # Convert to atomic units
+            atomic_amount = int(amount * Decimal(10**decimals))
+
+            # Get EIP-712 domain info
+            eip712_domain = {
+                "name": get_token_name(chain_id, asset_address),
+                "version": get_token_version(chain_id, asset_address),
+            }
+
+            return str(atomic_amount), asset_address, eip712_domain
+
+        except (ValueError, KeyError) as e:
+            raise ValueError(f"Invalid price format: {price}. Error: {e}")
+
+    elif isinstance(price, TokenAmount):
+        # TokenAmount type - already in atomic units with asset info
+        return (
+            price.amount,
+            price.asset.address,
+            {
+                "name": price.asset.eip712.name,
+                "version": price.asset.eip712.version,
+            },
+        )
+
+    else:
+        raise ValueError(f"Invalid price type: {type(price)}")
+
+
+def get_usdc_address(chain_id: int | str) -> str:
+    """Get the USDC contract address for a given chain ID"""
+    if isinstance(chain_id, str):
+        chain_id = int(chain_id)
+    if chain_id == 84532:  # Base Sepolia testnet
+        return "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+    elif chain_id == 8453:  # Base mainnet
+        return "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+    elif chain_id == 43113:  # Avalanche Fuji testnet
+        return "0x5425890298aed601595a70AB815c96711a31Bc65"
+    elif chain_id == 43114:  # Avalanche mainnet
+        return "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"
+    raise ValueError(f"Unsupported chain ID: {chain_id}")
 
 
 x402_VERSION = 1

--- a/python/x402/src/x402/facilitator.py
+++ b/python/x402/src/x402/facilitator.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Dict, TypedDict
+from typing import Callable, Optional, TypedDict
 import httpx
 from x402.types import (
     PaymentPayload,

--- a/python/x402/src/x402/types.py
+++ b/python/x402/src/x402/types.py
@@ -1,9 +1,52 @@
 from __future__ import annotations
 
+from typing import Any, Optional, Union
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
-from typing import Optional, Any
+
 from x402.networks import SupportedNetworks
+
+
+class TokenAmount(BaseModel):
+    """Represents an amount of tokens in atomic units with asset information"""
+
+    amount: str
+    asset: TokenAsset
+
+    @field_validator("amount")
+    def validate_amount(cls, v):
+        try:
+            int(v)
+        except ValueError:
+            raise ValueError("amount must be an integer encoded as a string")
+        return v
+
+
+class TokenAsset(BaseModel):
+    """Represents token asset information including EIP-712 domain data"""
+
+    address: str
+    decimals: int
+    eip712: EIP712Domain
+
+    @field_validator("decimals")
+    def validate_decimals(cls, v):
+        if v < 0 or v > 255:
+            raise ValueError("decimals must be between 0 and 255")
+        return v
+
+
+class EIP712Domain(BaseModel):
+    """EIP-712 domain information for token signing"""
+
+    name: str
+    version: str
+
+
+# Price can be either Money (USD string) or TokenAmount
+Money = Union[str, int]  # e.g., "$0.01", 0.01, "0.001"
+Price = Union[Money, TokenAmount]
 
 
 class PaymentRequirements(BaseModel):

--- a/python/x402/tests/clients/test_httpx.py
+++ b/python/x402/tests/clients/test_httpx.py
@@ -86,7 +86,7 @@ async def test_on_response_payment_flow(hooks, payment_requirements):
     # Create initial 402 response
     response = Response(402)
     response.request = Request("GET", "https://example.com")
-    response._content = json.dumps(payment_response.model_dump()).encode()
+    response._content = json.dumps(payment_response.model_dump(by_alias=True)).encode()
 
     # Mock the retry response with payment response header
     payment_result = {
@@ -150,7 +150,7 @@ async def test_on_response_payment_error(hooks, payment_requirements):
     # Create initial 402 response
     response = Response(402)
     response.request = Request("GET", "https://example.com")
-    response._content = json.dumps(payment_response.model_dump()).encode()
+    response._content = json.dumps(payment_response.model_dump(by_alias=True)).encode()
 
     # Test payment error handling
     with pytest.raises(PaymentError):

--- a/python/x402/tests/clients/test_requests.py
+++ b/python/x402/tests/clients/test_requests.py
@@ -140,7 +140,9 @@ def test_adapter_payment_flow(adapter, payment_requirements):
     # Create initial 402 response
     initial_response = Response()
     initial_response.status_code = 402
-    initial_response._content = json.dumps(payment_response.model_dump()).encode()
+    initial_response._content = json.dumps(
+        payment_response.model_dump(by_alias=True)
+    ).encode()
 
     # Mock the retry response with payment response header
     payment_result = {
@@ -216,7 +218,9 @@ def test_adapter_payment_error(adapter, payment_requirements):
     # Create initial 402 response
     initial_response = Response()
     initial_response.status_code = 402
-    initial_response._content = json.dumps(payment_response.model_dump()).encode()
+    initial_response._content = json.dumps(
+        payment_response.model_dump(by_alias=True)
+    ).encode()
 
     # Create a prepared request
     request = PreparedRequest()

--- a/python/x402/tests/fastapi_tests/test_middleware.py
+++ b/python/x402/tests/fastapi_tests/test_middleware.py
@@ -12,7 +12,7 @@ def test_middleware_invalid_payment():
     app_with_middleware.get("/test")(test_endpoint)
     app_with_middleware.middleware("http")(
         require_payment(
-            amount="$1.00",
+            price="$1.00",
             pay_to_address="0x1111111111111111111111111111111111111111",
             network_id="base-sepolia",
             description="Test payment",
@@ -34,7 +34,7 @@ def test_app_middleware_path_matching():
 
     app_with_middleware.middleware("http")(
         require_payment(
-            amount="$1.00",
+            price="$1.00",
             pay_to_address="0x1111111111111111111111111111111111111111",
             path="/test",
             network_id="base-sepolia",
@@ -62,7 +62,7 @@ def test_middleware_path_list_matching():
 
     app_with_middleware.middleware("http")(
         require_payment(
-            amount="$1.00",
+            price="$1.00",
             pay_to_address="0x1111111111111111111111111111111111111111",
             path=["/test1", "/test2"],
             network_id="base-sepolia",

--- a/python/x402/tests/test_types.py
+++ b/python/x402/tests/test_types.py
@@ -37,7 +37,7 @@ def test_payment_requirements_serde():
         "asset": "0x0000000000000000000000000000000000000000",
         "extra": None,
     }
-    assert original.model_dump() == expected
+    assert original.model_dump(by_alias=True) == expected
     assert PaymentRequirements(**expected) == original
 
 
@@ -58,8 +58,12 @@ def test_x402_payment_required_response_serde():
     original = x402PaymentRequiredResponse(
         x402_version=1, accepts=[payment_req], error=""
     )
-    expected = {"x402Version": 1, "accepts": [payment_req.model_dump()], "error": ""}
-    assert original.model_dump() == expected
+    expected = {
+        "x402Version": 1,
+        "accepts": [payment_req.model_dump(by_alias=True)],
+        "error": "",
+    }
+    assert original.model_dump(by_alias=True) == expected
     assert x402PaymentRequiredResponse(**expected) == original
 
 
@@ -80,7 +84,7 @@ def test_eip3009_authorization_serde():
         "validBefore": "1000",
         "nonce": "0x789",
     }
-    assert original.model_dump() == expected
+    assert original.model_dump(by_alias=True) == expected
     assert EIP3009Authorization(**expected) == original
 
 
@@ -94,15 +98,15 @@ def test_exact_payment_payload_serde():
         nonce="0x789",
     )
     original = ExactPaymentPayload(signature="0x123", authorization=auth)
-    expected = {"signature": "0x123", "authorization": auth.model_dump()}
-    assert original.model_dump() == expected
+    expected = {"signature": "0x123", "authorization": auth.model_dump(by_alias=True)}
+    assert original.model_dump(by_alias=True) == expected
     assert ExactPaymentPayload(**expected) == original
 
 
 def test_verify_response_serde():
     original = VerifyResponse(is_valid=True, invalid_reason=None, payer="0x123")
     expected = {"isValid": True, "invalidReason": None, "payer": "0x123"}
-    assert original.model_dump() == expected
+    assert original.model_dump(by_alias=True) == expected
     assert VerifyResponse(**expected) == original
 
 
@@ -121,7 +125,7 @@ def test_settle_response_serde():
         "network": "base",
         "payer": "0x123",
     }
-    assert original.model_dump() == expected
+    assert original.model_dump(by_alias=True) == expected
     assert SettleResponse(**expected) == original
 
 
@@ -145,14 +149,14 @@ def test_payment_payload_serde():
         "x402Version": 1,
         "scheme": "exact",
         "network": "base",
-        "payload": payload.model_dump(),
+        "payload": payload.model_dump(by_alias=True),
     }
-    assert original.model_dump() == expected
+    assert original.model_dump(by_alias=True) == expected
     assert PaymentPayload(**expected) == original
 
 
 def test_x402_headers_serde():
     original = X402Headers(x_payment="test-payment")
     expected = {"x_payment": "test-payment"}
-    assert original.model_dump() == expected
+    assert original.model_dump(by_alias=True) == expected
     assert X402Headers(**expected) == original


### PR DESCRIPTION
## Description

In Python, the FastAPI's `require_payment` was taking `amount` (in USD $ terms) and `asset` as two arguments, where letting asset default would enforce USDC for whatever network was select.

This was not flexible enough. First, despite `asset` seeming flexible, it required looking up that asset against a local mapping, meaning only assets in the SDK's internal mapping could be used. The only accepted assets were USDC on various supported chains. We want to be flexible, and we also don't want every coin to independently make a PR to try and get their coin added to the SDK mapping.

Essentially, the interface made it seem like we were flexible, but in reality we only supported USDC, and we were gating what new assets could be added.

This PR addresses this by replacing `amount` and `asset` with `price`, where Price is a union of either `Money` ($'s, inferring USDC) or `TokenAmount`. Essentially, if you want USDC and to make your declarations in $'s, you can say `price='$0.01'`, e.g.:
```python
app.middleware("http")(
    require_payment(
        path="/weather",
        price="$0.001",
        pay_to_address=ADDRESS,
        network_id="base-sepolia",
    )
)
```

However, it you want to outright declare a specific EIP-3009 token amount, you can also define price as a TokenAmount, e.g.:
```python
app.middleware("http")(
    require_payment(
        path="/premium/*",
        price=TokenAmount(
            amount="10000",
            asset=TokenAsset(
                address="0x036CbD53842c5426634e7929541eC2318f3dCF7e",
                decimals=6,
                eip712=EIP712Domain(name="USDC", version="2"),
            ),
        ),
        pay_to_address=ADDRESS,
        network_id="base-sepolia",
    )
)
```

## Tests

1. Updated unit tests accordingly

```
❯ uv run pytest                  
============================================= test session starts ==============================================
platform darwin -- Python 3.10.16, pytest-8.4.0, pluggy-1.6.0
rootdir: /Users/carsonroscoe/Documents/Github/Coinbase/x402/python/x402
configfile: pyproject.toml
plugins: anyio-4.9.0, asyncio-1.0.0
asyncio: mode=auto, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 50 items                                                                                             

tests/clients/test_base.py .......                                                                       [ 14%]
tests/clients/test_httpx.py .........                                                                    [ 32%]
tests/clients/test_requests.py ..........                                                                [ 52%]
tests/fastapi_tests/test_middleware.py ......                                                            [ 64%]
tests/test_common.py .                                                                                   [ 66%]
tests/test_encoding.py ...                                                                               [ 72%]
tests/test_exact.py ......                                                                               [ 84%]
tests/test_types.py ........                                                                             [100%]

============================================== 50 passed in 0.57s ==============================================
```

2. Updated the fastapi example to test both definitions of price.

![Screenshot 2025-06-19 at 10 47 01 AM](https://github.com/user-attachments/assets/0c092969-3dae-4dae-94eb-388d5efb4a3c)
![Screenshot 2025-06-19 at 10 46 24 AM](https://github.com/user-attachments/assets/e2d60efe-381d-4220-994e-5796eb437cad)
![Screenshot 2025-06-19 at 10 46 19 AM](https://github.com/user-attachments/assets/61f580c2-2ad2-478d-837c-c0219631c651)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 