### PR TITLE
chore: bump x402 package

### DIFF
--- a/python/x402/README.md
+++ b/python/x402/README.md
@@ -26,7 +26,7 @@ from x402.fastapi.middleware import require_payment
 
 app = FastAPI()
 app.middleware("http")(
-    require_payment(amount="0.01", pay_to_address="0x209693Bc6afc0C5328bA36FaF03C514EF312287C")
+    require_payment(price="0.01", pay_to_address="0x209693Bc6afc0C5328bA36FaF03C514EF312287C")
 )
 
 @app.get("/")
@@ -38,7 +38,7 @@ To protect specific routes:
 
 ```py
 app.middleware("http")(
-    require_payment(amount="0.01",
+    require_payment(price="0.01",
     pay_to_address="0x209693Bc6afc0C5328bA36FaF03C514EF312287C"),
     path="/foo"  # <-- this can also be a list ex: ["/foo", "/bar"]
 )

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "x402"
-version = "0.1.1"
+version = "0.1.2"
 description = "x402: An internet native payments protocol"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
bump `x402` PyPi package from `0.1.1` to `0.1.2`