### PR TITLE
fix: Share core payment logic via PaymentMiddleware, and fix bugs in Hono/Express middlewares

### DIFF
--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -238,13 +238,10 @@ importers:
         version: 4.21.2
       viem:
         specifier: ^2.21.26
-        version: 2.28.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
+        version: 2.28.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
       x402:
         specifier: workspace:^
         version: link:../x402
-      zod:
-        specifier: ^3.24.2
-        version: 3.24.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.24.0
@@ -359,17 +356,14 @@ importers:
         specifier: ^1.22.0
         version: 1.22.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       hono:
-        specifier: ^4.7.1
-        version: 4.7.7
+        specifier: ^4.8.4
+        version: 4.8.5
       viem:
         specifier: ^2.21.26
-        version: 2.28.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.3)
+        version: 2.28.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
       x402:
         specifier: workspace:^
         version: link:../x402
-      zod:
-        specifier: ^3.24.2
-        version: 3.24.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.24.0
@@ -5501,6 +5495,10 @@ packages:
 
   hono@4.7.7:
     resolution: {integrity: sha512-2PCpQRbN87Crty8/L/7akZN3UyZIAopSoRxCwRbJgUuV1+MHNFHzYFxZTg4v/03cXUm+jce/qa2VSBZpKBm3Qw==}
+    engines: {node: '>=16.9.0'}
+
+  hono@4.8.5:
+    resolution: {integrity: sha512-Up2cQbtNz1s111qpnnECdTGqSIUIhZJMLikdKkshebQSEBcoUKq6XJayLGqSZWidiH0zfHRCJqFu062Mz5UuRA==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -16103,6 +16101,8 @@ snapshots:
       minimalistic-crypto-utils: 1.0.1
 
   hono@4.7.7: {}
+
+  hono@4.8.5: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:

--- a/typescript/packages/x402-express/package.json
+++ b/typescript/packages/x402-express/package.json
@@ -38,12 +38,13 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
   },
+  "peerDependencies": {
+    "express": "^4.18.2",
+    "viem": "^2.21.26"
+  },
   "dependencies": {
     "@coinbase/cdp-sdk": "^1.22.0",
-    "express": "^4.18.2",
-    "viem": "^2.21.26",
-    "x402": "workspace:^",
-    "zod": "^3.24.2"
+    "x402": "workspace:^"
   },
   "exports": {
     ".": {

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -1,25 +1,36 @@
-import { NextFunction, Request, Response } from "express";
-import { Address, getAddress } from "viem";
+import type { NextFunction, Request, Response } from "express";
+import type { Address } from "viem";
+import type { FacilitatorConfig, PaywallConfig, RoutesConfig } from "x402/types";
 import { exact } from "x402/schemes";
-import {
-  computeRoutePatterns,
-  findMatchingPaymentRequirements,
-  findMatchingRoute,
-  getPaywallHtml,
-  processPriceToAtomicAmount,
-  toJsonSafe,
-} from "x402/shared";
-import {
-  FacilitatorConfig,
-  moneySchema,
-  PaymentPayload,
-  PaymentRequirements,
-  PaywallConfig,
-  Resource,
-  RoutesConfig,
-  settleResponseHeader,
-} from "x402/types";
+import { getPaywallHtml, toJsonSafe } from "x402/shared";
+import { moneySchema, settleResponseHeader } from "x402/types";
 import { useFacilitator } from "x402/verify";
+import { PaymentMiddleware, X402Error } from "x402/middleware";
+
+type EndArgs =
+  | [cb?: () => void]
+  | [chunk: unknown, cb?: () => void]
+  | [chunk: unknown, encoding: BufferEncoding, cb?: () => void];
+
+/**
+ * Creates a deferred promise with exposed `resolve` and `reject` functions.
+ *
+ * Useful for integrating with callback-style APIs or pausing execution until
+ * an external event (like `res.end`) occurs.
+ *
+ * @returns An object containing the promise, and its associated `resolve` and `reject` functions.
+ */
+function defer<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
 
 /**
  * Creates a payment middleware factory for Express
@@ -28,6 +39,7 @@ import { useFacilitator } from "x402/verify";
  * @param routes - Configuration for protected routes and their payment requirements
  * @param facilitator - Optional configuration for the payment facilitator service
  * @param paywall - Optional configuration for the default paywall
+ * @param useFacilitatorFn - Optional useFacilitator function, used in dev/testing mode
  * @returns An Express middleware handler
  *
  * @example
@@ -73,60 +85,50 @@ export function paymentMiddleware(
   routes: RoutesConfig,
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
+  useFacilitatorFn: typeof useFacilitator = useFacilitator,
 ) {
-  const { verify, settle } = useFacilitator(facilitator);
-  const x402Version = 1;
-
-  // Pre-compile route patterns to regex and extract verbs
-  const routePatterns = computeRoutePatterns(routes);
+  const middlewares = PaymentMiddleware.forRoutes<Request>(
+    payTo,
+    routes,
+    function paymentFromRequest(req) {
+      const paymentHeader = req.header("X-PAYMENT");
+      if (!paymentHeader) {
+        return undefined;
+      }
+      return exact.evm.decodePayment(paymentHeader);
+    },
+    function canRenderPaywall(req) {
+      const userAgent = req.header("User-Agent") || "";
+      const acceptHeader = req.header("Accept") || "";
+      return acceptHeader.includes("text/html") && userAgent.includes("Mozilla");
+    },
+    facilitator,
+    paywall,
+    useFacilitatorFn,
+  );
 
   return async function paymentMiddleware(
     req: Request,
     res: Response,
     next: NextFunction,
   ): Promise<void> {
-    const matchingRoute = findMatchingRoute(routePatterns, req.path, req.method.toUpperCase());
-
-    if (!matchingRoute) {
+    // Determine whether the current request matches any protected route.
+    // If it doesn't, skip payment logic and proceed as usual.
+    const x402Middleware = middlewares.match(req.path, req.method.toUpperCase());
+    if (!x402Middleware) {
       return next();
     }
 
-    const { price, network, config = {} } = matchingRoute.config;
-    const { description, mimeType, maxTimeoutSeconds, outputSchema, customPaywallHtml, resource } =
-      config;
+    const originalEnd = res.end.bind(res);
+    const deferred = defer<EndArgs>();
 
-    const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
-    if ("error" in atomicAmountForAsset) {
-      throw new Error(atomicAmountForAsset.error);
-    }
-    const { maxAmountRequired, asset } = atomicAmountForAsset;
-
-    const resourceUrl: Resource =
-      resource || (`${req.protocol}://${req.headers.host}${req.path}` as Resource);
-
-    const paymentRequirements: PaymentRequirements[] = [
-      {
-        scheme: "exact",
-        network,
-        maxAmountRequired,
-        resource: resourceUrl,
-        description: description ?? "",
-        mimeType: mimeType ?? "",
-        payTo: getAddress(payTo),
-        maxTimeoutSeconds: maxTimeoutSeconds ?? 60,
-        asset: getAddress(asset.address),
-        outputSchema: outputSchema ?? undefined,
-        extra: asset.eip712,
-      },
-    ];
-
-    const payment = req.header("X-PAYMENT");
-    const userAgent = req.header("User-Agent") || "";
-    const acceptHeader = req.header("Accept") || "";
-    const isWebBrowser = acceptHeader.includes("text/html") && userAgent.includes("Mozilla");
-
-    if (!payment) {
-      if (isWebBrowser) {
+    try {
+      const paymentRequirements = x402Middleware.paymentRequirements(req);
+      const payment = await x402Middleware.acquirePayment(req, paymentRequirements);
+      if (!payment) {
+        const price = x402Middleware.config.price;
+        const network = x402Middleware.config.network;
+        const customPaywallHtml = x402Middleware.config.config?.customPaywallHtml;
         let displayAmount: number;
         if (typeof price === "string" || typeof price === "number") {
           const parsed = moneySchema.safeParse(price);
@@ -156,106 +158,46 @@ export function paymentMiddleware(
         res.status(402).send(html);
         return;
       }
-      res.status(402).json({
-        x402Version,
-        error: "X-PAYMENT header is required",
-        accepts: toJsonSafe(paymentRequirements),
-      });
-      return;
-    }
 
-    let decodedPayment: PaymentPayload;
-    try {
-      decodedPayment = exact.evm.decodePayment(payment);
-      decodedPayment.x402Version = x402Version;
-    } catch (error) {
-      res.status(402).json({
-        x402Version,
-        error: error || "Invalid or malformed payment header",
-        accepts: toJsonSafe(paymentRequirements),
-      });
-      return;
-    }
+      // Monkey-patch `res.end` to capture when the response is finalized.
+      // This allows us to defer settlement logic until after the underlying response is available.
+      res.end = function (...args: EndArgs) {
+        deferred.resolve(args);
+        return res;
+      };
 
-    const selectedPaymentRequirements = findMatchingPaymentRequirements(
-      paymentRequirements,
-      decodedPayment,
-    );
-    if (!selectedPaymentRequirements) {
-      res.status(402).json({
-        x402Version,
-        error: "Unable to find matching payment requirements",
-        accepts: toJsonSafe(paymentRequirements),
-      });
-      return;
-    }
+      // Proceed to the next middleware or route handler.
+      next();
+      // Wait for the response to finish before attempting payment settlement.
+      await deferred.promise;
 
-    try {
-      const response = await verify(decodedPayment, selectedPaymentRequirements);
-      if (!response.isValid) {
-        res.status(402).json({
-          x402Version,
-          error: response.invalidReason,
-          accepts: toJsonSafe(paymentRequirements),
-          payer: response.payer,
-        });
+      // If the response from the protected route is >= 400, do not settle payment
+      if (res.statusCode >= 400) {
+        // We turn res.end back to the original fn in the `finally` clause below.
         return;
       }
-    } catch (error) {
-      res.status(402).json({
-        x402Version,
-        error,
-        accepts: toJsonSafe(paymentRequirements),
-      });
-      return;
-    }
 
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    type EndArgs =
-      | [cb?: () => void]
-      | [chunk: any, cb?: () => void]
-      | [chunk: any, encoding: BufferEncoding, cb?: () => void];
-    /* eslint-enable @typescript-eslint/no-explicit-any */
-
-    const originalEnd = res.end.bind(res);
-    let endArgs: EndArgs | null = null;
-
-    res.end = function (...args: EndArgs) {
-      endArgs = args;
-      return res; // maintain correct return type
-    };
-
-    // Proceed to the next middleware or route handler
-    await next();
-
-    // If the response from the protected route is >= 400, do not settle payment
-    if (res.statusCode >= 400) {
-      res.end = originalEnd;
-      if (endArgs) {
-        originalEnd(...(endArgs as Parameters<typeof res.end>));
-      }
-      return;
-    }
-
-    try {
-      const settleResponse = await settle(decodedPayment, selectedPaymentRequirements);
-      const responseHeader = settleResponseHeader(settleResponse);
+      const settlement = await payment.settle();
+      const responseHeader = settleResponseHeader(settlement);
       res.setHeader("X-PAYMENT-RESPONSE", responseHeader);
-    } catch (error) {
-      // If settlement fails and the response hasn't been sent yet, return an error
-      if (!res.headersSent) {
-        res.status(402).json({
-          x402Version,
-          error,
-          accepts: toJsonSafe(paymentRequirements),
-        });
-        return;
+    } catch (e) {
+      // Return a structured 402 error response if the failure is a known x402 error
+      // and the headers haven't yet been sent.
+      if (e instanceof X402Error) {
+        if (!res.headersSent) {
+          res.status(402).json(e.toJSON());
+          return;
+        }
+      } else {
+        throw e;
       }
     } finally {
+      // Ensure the original `res.end` is restored to avoid side effects.
+      // Then call it with the originally captured arguments to finalize the response.
       res.end = originalEnd;
-      if (endArgs) {
+      deferred.promise.then(endArgs => {
         originalEnd(...(endArgs as Parameters<typeof res.end>));
-      }
+      });
     }
   };
 }

--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -33,16 +33,17 @@
     "tsup": "^8.4.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
+    "vite": "^6.2.6",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.5",
-    "vite": "^6.2.6"
+    "vitest": "^3.0.5"
+  },
+  "peerDependencies": {
+    "hono": "^4.8.4",
+    "viem": "^2.21.26"
   },
   "dependencies": {
     "@coinbase/cdp-sdk": "^1.22.0",
-    "hono": "^4.7.1",
-    "viem": "^2.21.26",
-    "x402": "workspace:^",
-    "zod": "^3.24.2"
+    "x402": "workspace:^"
   },
   "exports": {
     ".": {

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -1,25 +1,11 @@
 import type { Context } from "hono";
-import { Address, getAddress } from "viem";
+import type { Address } from "viem";
+import type { FacilitatorConfig, RoutesConfig, PaywallConfig } from "x402/types";
 import { exact } from "x402/schemes";
-import {
-  computeRoutePatterns,
-  findMatchingPaymentRequirements,
-  findMatchingRoute,
-  getPaywallHtml,
-  processPriceToAtomicAmount,
-  toJsonSafe,
-} from "x402/shared";
-import {
-  FacilitatorConfig,
-  moneySchema,
-  PaymentPayload,
-  PaymentRequirements,
-  Resource,
-  RoutesConfig,
-  settleResponseHeader,
-  PaywallConfig,
-} from "x402/types";
+import { getPaywallHtml, toJsonSafe } from "x402/shared";
+import { moneySchema, settleResponseHeader } from "x402/types";
 import { useFacilitator } from "x402/verify";
+import { PaymentMiddleware, X402Error } from "x402/middleware";
 
 /**
  * Creates a payment middleware factory for Hono
@@ -28,6 +14,7 @@ import { useFacilitator } from "x402/verify";
  * @param routes - Configuration for protected routes and their payment requirements
  * @param facilitator - Optional configuration for the payment facilitator service
  * @param paywall - Optional configuration for the default paywall
+ * @param useFacilitatorFn - Optional useFacilitator function, used in dev/testing mode
  * @returns A Hono middleware handler
  *
  * @example
@@ -73,54 +60,41 @@ export function paymentMiddleware(
   routes: RoutesConfig,
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
+  useFacilitatorFn: typeof useFacilitator = useFacilitator,
 ) {
-  const { verify, settle } = useFacilitator(facilitator);
-  const x402Version = 1;
-
-  // Pre-compile route patterns to regex and extract verbs
-  const routePatterns = computeRoutePatterns(routes);
+  const middlewares = PaymentMiddleware.forRoutes<Context>(
+    payTo,
+    routes,
+    function paymentFromRequest(ctx) {
+      const paymentHeader = ctx.req.header("X-Payment");
+      if (!paymentHeader) {
+        return undefined;
+      }
+      return exact.evm.decodePayment(paymentHeader);
+    },
+    function canRenderPaywall(ctx) {
+      const userAgent = ctx.req.header("User-Agent") || "";
+      const acceptHeader = ctx.req.header("Accept") || "";
+      return acceptHeader.includes("text/html") && userAgent.includes("Mozilla");
+    },
+    facilitator,
+    paywall,
+    useFacilitatorFn,
+  );
 
   return async function paymentMiddleware(c: Context, next: () => Promise<void>) {
-    const matchingRoute = findMatchingRoute(routePatterns, c.req.path, c.req.method.toUpperCase());
-    if (!matchingRoute) {
+    const x402Middleware = middlewares.match(c.req.path, c.req.method.toUpperCase());
+    if (!x402Middleware) {
       return next();
     }
 
-    const { price, network } = matchingRoute.config;
-    const { description, mimeType, maxTimeoutSeconds, outputSchema, customPaywallHtml, resource } =
-      matchingRoute.config.config || {};
-
-    const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
-    if ("error" in atomicAmountForAsset) {
-      throw new Error(atomicAmountForAsset.error);
-    }
-    const { maxAmountRequired, asset } = atomicAmountForAsset;
-
-    const resourceUrl: Resource = resource || (c.req.url as Resource);
-
-    const paymentRequirements: PaymentRequirements[] = [
-      {
-        scheme: "exact",
-        network,
-        maxAmountRequired,
-        resource: resourceUrl,
-        description: description ?? "",
-        mimeType: mimeType ?? "application/json",
-        payTo: getAddress(payTo),
-        maxTimeoutSeconds: maxTimeoutSeconds ?? 300,
-        asset: getAddress(asset.address),
-        outputSchema,
-        extra: asset.eip712,
-      },
-    ];
-
-    const payment = c.req.header("X-PAYMENT");
-    const userAgent = c.req.header("User-Agent") || "";
-    const acceptHeader = c.req.header("Accept") || "";
-    const isWebBrowser = acceptHeader.includes("text/html") && userAgent.includes("Mozilla");
-
-    if (!payment) {
-      if (isWebBrowser) {
+    try {
+      const paymentRequirements = x402Middleware.paymentRequirements(c);
+      const payment = await x402Middleware.acquirePayment(c, paymentRequirements);
+      if (!payment) {
+        const price = x402Middleware.config.price;
+        const network = x402Middleware.config.network;
+        const customPaywallHtml = x402Middleware.config.config?.customPaywallHtml;
         let displayAmount: number;
         if (typeof price === "string" || typeof price === "number") {
           const parsed = moneySchema.safeParse(price);
@@ -150,94 +124,31 @@ export function paymentMiddleware(
           });
         return c.html(html, 402);
       }
-      return c.json(
-        {
-          error: "X-PAYMENT header is required",
-          accepts: paymentRequirements,
-          x402Version,
-        },
-        402,
-      );
-    }
+      // Proceed with request
+      await next();
 
-    // Verify payment
-    let decodedPayment: PaymentPayload;
-    try {
-      decodedPayment = exact.evm.decodePayment(payment);
-      decodedPayment.x402Version = x402Version;
-    } catch (error) {
-      return c.json(
-        {
-          error: error instanceof Error ? error : new Error("Invalid or malformed payment header"),
-          accepts: paymentRequirements,
-          x402Version,
-        },
-        402,
-      );
-    }
+      const res = c.res;
 
-    const selectedPaymentRequirements = findMatchingPaymentRequirements(
-      paymentRequirements,
-      decodedPayment,
-    );
-    if (!selectedPaymentRequirements) {
-      return c.json(
-        {
-          error: "Unable to find matching payment requirements",
-          accepts: toJsonSafe(paymentRequirements),
-          x402Version,
-        },
-        402,
-      );
-    }
-
-    const verification = await verify(decodedPayment, selectedPaymentRequirements);
-
-    if (!verification.isValid) {
-      return c.json(
-        {
-          error: new Error(verification.invalidReason),
-          accepts: paymentRequirements,
-          payer: verification.payer,
-          x402Version,
-        },
-        402,
-      );
-    }
-
-    // Proceed with request
-    await next();
-
-    let res = c.res;
-
-    // If the response from the protected route is >= 400, do not settle payment
-    if (res.status >= 400) {
-      return;
-    }
-
-    c.res = undefined;
-
-    // Settle payment before processing the request, as Hono middleware does not allow us to set headers after the response has been sent
-    try {
-      const settlement = await settle(decodedPayment, selectedPaymentRequirements);
-      if (settlement.success) {
-        const responseHeader = settleResponseHeader(settlement);
-        res.headers.set("X-PAYMENT-RESPONSE", responseHeader);
-      } else {
-        throw new Error(settlement.errorReason);
+      // If the response from the protected route is >= 400, do not settle payment
+      if (res.status >= 400) {
+        return;
       }
-    } catch (error) {
-      res = c.json(
-        {
-          error: error instanceof Error ? error : new Error("Failed to settle payment"),
-          accepts: paymentRequirements,
-          x402Version,
-        },
-        402,
-      );
-    }
 
-    c.res = res;
+      const settlement = await payment.settle();
+      const responseHeader = settleResponseHeader(settlement);
+      res.headers.set("X-PAYMENT-RESPONSE", responseHeader);
+    } catch (e) {
+      if (e instanceof X402Error) {
+        const headers = new Headers(c.res.headers);
+        headers.set("Content-Type", "application/json");
+        c.res = new Response(JSON.stringify(e), {
+          headers: headers,
+          status: 402,
+        });
+      } else {
+        throw e;
+      }
+    }
   };
 }
 

--- a/typescript/packages/x402-next/README.md
+++ b/typescript/packages/x402-next/README.md
@@ -36,6 +36,51 @@ export const config = {
 };
 ```
 
+## Protect Individual Route Handlers
+
+Use `withPayment()` to protect a single `GET`, `POST`, or other HTTP method in a file-based route (e.g., `app/api/*/route.ts`).
+
+This is ideal when:
+- You’re not using a global middleware
+- You want fine-grained control over payment requirements
+- You only want to apply payments to certain methods or endpoints
+
+**Example: Protect an API route:**
+
+```typescript
+// app/api/premium/route.ts
+import { withPayment } from "x402-next";
+
+export const GET = withPayment(
+    async (req) => {
+        return new Response("Welcome to the premium zone");
+    }, 
+    {
+        price: "$0.01", 
+        network: "base-sepolia", 
+        payTo: "0xYourAddress", 
+        config: {
+            description: "Premium content",
+        },
+    }
+);
+```
+
+### Parameters
+
+```typescript
+function withPayment(
+    handler: (req: NextRequest) => Promise<Response>,
+    config: RouteConfig & {
+        payTo: string;
+        facilitator?: FacilitatorConfig;
+        paywall?: PaywallConfig;
+    }
+): (req: NextRequest) => Promise<Response>
+```
+
+You can use the same price, network, and facilitator options as with paymentMiddleware.
+
 ## Configuration
 
 The `paymentMiddleware` function accepts three parameters:

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -1,28 +1,51 @@
 import type { NextRequest } from "next/server";
+import type { Address } from "viem";
+import type { FacilitatorConfig, RoutesConfig, PaywallConfig, RouteConfig } from "x402/types";
 import { NextResponse } from "next/server";
-import { Address, getAddress } from "viem";
 import { exact } from "x402/schemes";
-import {
-  computeRoutePatterns,
-  findMatchingPaymentRequirements,
-  findMatchingRoute,
-  getPaywallHtml,
-  processPriceToAtomicAmount,
-  toJsonSafe,
-} from "x402/shared";
-import {
-  FacilitatorConfig,
-  moneySchema,
-  PaymentPayload,
-  PaymentRequirements,
-  Resource,
-  RoutesConfig,
-  PaywallConfig,
-} from "x402/types";
+import { getPaywallHtml, toJsonSafe } from "x402/shared";
+import { moneySchema, settleResponseHeader } from "x402/types";
 import { useFacilitator } from "x402/verify";
-import { safeBase64Encode } from "x402/shared";
+import { PaymentMiddleware, X402Error } from "x402/middleware";
+import { PaymentPayload, Resource } from "x402/types";
 
 import { POST } from "./api/session-token";
+
+/**
+ * Extracts and decodes a PaymentPayload from the X-PAYMENT header of a Next.js request.
+ *
+ * @param req - The incoming Next.js request.
+ * @returns The decoded PaymentPayload if present, or undefined.
+ */
+function paymentFromRequest(req: NextRequest): PaymentPayload | undefined {
+  const paymentHeader = req.headers.get("X-PAYMENT");
+  if (!paymentHeader) {
+    return undefined;
+  }
+  return exact.evm.decodePayment(paymentHeader);
+}
+
+/**
+ * Derives the x402 resource identifier from the request URL.
+ *
+ * @param req - The incoming Next.js request.
+ * @returns A resource string formatted as an absolute URL for use in payment requirements.
+ */
+function resourceFromRequest(req: NextRequest): Resource {
+  return `${req.nextUrl.protocol}//${req.nextUrl.host}${req.nextUrl.pathname}` as Resource;
+}
+
+/**
+ * Determines whether the request likely came from a browser capable of rendering a visual paywall.
+ *
+ * @param req - The incoming Next.js request.
+ * @returns True if the request accepts HTML and comes from a browser (e.g., contains "Mozilla" in User-Agent).
+ */
+function canRenderPaywall(req: NextRequest): boolean {
+  const userAgent = req.headers.get("User-Agent") || "";
+  const acceptHeader = req.headers.get("Accept") || "";
+  return acceptHeader.includes("text/html") && userAgent.includes("Mozilla");
+}
 
 /**
  * Creates a payment middleware factory for Next.js
@@ -31,6 +54,7 @@ import { POST } from "./api/session-token";
  * @param routes - Configuration for protected routes and their payment requirements
  * @param facilitator - Optional configuration for the payment facilitator service
  * @param paywall - Optional configuration for the default paywall
+ * @param useFacilitatorFn - Optional useFacilitator function, used in dev/testing mode
  * @returns A Next.js middleware handler
  *
  * @example
@@ -91,184 +115,191 @@ export function paymentMiddleware(
   routes: RoutesConfig,
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
+  useFacilitatorFn: typeof useFacilitator = useFacilitator,
 ) {
-  const { verify, settle } = useFacilitator(facilitator);
-  const x402Version = 1;
-
-  // Pre-compile route patterns to regex and extract verbs
-  const routePatterns = computeRoutePatterns(routes);
+  const middlewares = PaymentMiddleware.forRoutes<NextRequest>(
+    payTo,
+    routes,
+    paymentFromRequest,
+    canRenderPaywall,
+    facilitator,
+    paywall,
+    useFacilitatorFn,
+  );
 
   return async function middleware(request: NextRequest) {
     const pathname = request.nextUrl.pathname;
     const method = request.method.toUpperCase();
 
     // Find matching route configuration
-    const matchingRoute = findMatchingRoute(routePatterns, pathname, method);
-
-    if (!matchingRoute) {
+    const x402Middleware = middlewares.match(pathname, method);
+    if (!x402Middleware) {
       return NextResponse.next();
     }
-
-    const { price, network, config = {} } = matchingRoute.config;
-    const { description, mimeType, maxTimeoutSeconds, outputSchema, customPaywallHtml, resource } =
-      config;
-
-    const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
-    if ("error" in atomicAmountForAsset) {
-      return new NextResponse(atomicAmountForAsset.error, { status: 500 });
-    }
-    const { maxAmountRequired, asset } = atomicAmountForAsset;
-
-    const resourceUrl =
-      resource || (`${request.nextUrl.protocol}//${request.nextUrl.host}${pathname}` as Resource);
-    const paymentRequirements: PaymentRequirements[] = [
-      {
-        scheme: "exact",
-        network,
-        maxAmountRequired,
-        resource: resourceUrl,
-        description: description ?? "",
-        mimeType: mimeType ?? "application/json",
-        payTo: getAddress(payTo),
-        maxTimeoutSeconds: maxTimeoutSeconds ?? 300,
-        asset: getAddress(asset.address),
-        outputSchema,
-        extra: asset.eip712,
-      },
-    ];
-
-    // Check for payment header
-    const paymentHeader = request.headers.get("X-PAYMENT");
-    if (!paymentHeader) {
-      const accept = request.headers.get("Accept");
-      if (accept?.includes("text/html")) {
-        const userAgent = request.headers.get("User-Agent");
-        if (userAgent?.includes("Mozilla")) {
-          let displayAmount: number;
-          if (typeof price === "string" || typeof price === "number") {
-            const parsed = moneySchema.safeParse(price);
-            if (parsed.success) {
-              displayAmount = parsed.data;
-            } else {
-              displayAmount = Number.NaN;
-            }
+    try {
+      const paymentRequirements = x402Middleware.paymentRequirements(request);
+      const payment = await x402Middleware.acquirePayment(request, paymentRequirements);
+      if (!payment) {
+        const price = x402Middleware.config.price;
+        const network = x402Middleware.config.network;
+        const customPaywallHtml = x402Middleware.config.config?.customPaywallHtml;
+        let displayAmount: number;
+        if (typeof price === "string" || typeof price === "number") {
+          const parsed = moneySchema.safeParse(price);
+          if (parsed.success) {
+            displayAmount = parsed.data;
           } else {
-            displayAmount = Number(price.amount) / 10 ** price.asset.decimals;
+            displayAmount = Number.NaN;
           }
-
-          const html =
-            customPaywallHtml ??
-            getPaywallHtml({
-              amount: displayAmount,
-              paymentRequirements: toJsonSafe(paymentRequirements) as Parameters<
-                typeof getPaywallHtml
-              >[0]["paymentRequirements"],
-              currentUrl: request.url,
-              testnet: network === "base-sepolia",
-              cdpClientKey: paywall?.cdpClientKey,
-              appLogo: paywall?.appLogo,
-              appName: paywall?.appName,
-              sessionTokenEndpoint: paywall?.sessionTokenEndpoint,
-            });
-          return new NextResponse(html, {
-            status: 402,
-            headers: { "Content-Type": "text/html" },
-          });
+        } else {
+          displayAmount = Number(price.amount) / 10 ** price.asset.decimals;
         }
+
+        const html =
+          customPaywallHtml ??
+          getPaywallHtml({
+            amount: displayAmount,
+            paymentRequirements: toJsonSafe(paymentRequirements) as Parameters<
+              typeof getPaywallHtml
+            >[0]["paymentRequirements"],
+            currentUrl: request.url,
+            testnet: network === "base-sepolia",
+            cdpClientKey: paywall?.cdpClientKey,
+            appLogo: paywall?.appLogo,
+            appName: paywall?.appName,
+            sessionTokenEndpoint: paywall?.sessionTokenEndpoint,});
+        return new NextResponse(html, {
+          status: 402,
+          headers: { "Content-Type": "text/html" },
+        });
       }
 
-      return new NextResponse(
-        JSON.stringify({
-          x402Version,
-          error: "X-PAYMENT header is required",
-          accepts: paymentRequirements,
-        }),
-        { status: 402, headers: { "Content-Type": "application/json" } },
-      );
-    }
-
-    // Verify payment
-    let decodedPayment: PaymentPayload;
-    try {
-      decodedPayment = exact.evm.decodePayment(paymentHeader);
-      decodedPayment.x402Version = x402Version;
-    } catch (error) {
-      return new NextResponse(
-        JSON.stringify({
-          x402Version,
-          error: error instanceof Error ? error : "Invalid payment",
-          accepts: paymentRequirements,
-        }),
-        { status: 402, headers: { "Content-Type": "application/json" } },
-      );
-    }
-
-    const selectedPaymentRequirements = findMatchingPaymentRequirements(
-      paymentRequirements,
-      decodedPayment,
-    );
-    if (!selectedPaymentRequirements) {
-      return new NextResponse(
-        JSON.stringify({
-          x402Version,
-          error: "Unable to find matching payment requirements",
-          accepts: toJsonSafe(paymentRequirements),
-        }),
-        { status: 402, headers: { "Content-Type": "application/json" } },
-      );
-    }
-
-    const verification = await verify(decodedPayment, selectedPaymentRequirements);
-
-    if (!verification.isValid) {
-      return new NextResponse(
-        JSON.stringify({
-          x402Version,
-          error: verification.invalidReason,
-          accepts: paymentRequirements,
-          payer: verification.payer,
-        }),
-        { status: 402, headers: { "Content-Type": "application/json" } },
-      );
-    }
-
-    // Proceed with request
-    const response = await NextResponse.next();
-
-    // if the response from the protected route is >= 400, do not settle the payment
-    if (response.status >= 400) {
+      // Proceed with request
+      const response = NextResponse.next();
+      // TODO `NextResponse.next` returns a fresh instance of NextResponse used to continue routing and modify headers.
+      // There is no point to wait for it. We use it just to modify headers.
+      const settlement = await payment.settle();
+      const responseHeader = settleResponseHeader(settlement);
+      response.headers.set("X-PAYMENT-RESPONSE", responseHeader);
       return response;
-    }
-
-    // Settle payment after response
-    try {
-      const settlement = await settle(decodedPayment, selectedPaymentRequirements);
-
-      if (settlement.success) {
-        response.headers.set(
-          "X-PAYMENT-RESPONSE",
-          safeBase64Encode(
-            JSON.stringify({
-              success: true,
-              transaction: settlement.transaction,
-              network: settlement.network,
-              payer: settlement.payer,
-            }),
-          ),
-        );
+    } catch (e) {
+      if (e instanceof X402Error) {
+        return new NextResponse(JSON.stringify(e), {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 402,
+        });
+      } else {
+        throw e;
       }
-    } catch (error) {
-      return new NextResponse(
-        JSON.stringify({
-          x402Version,
-          error: error instanceof Error ? error : "Settlement failed",
-          accepts: paymentRequirements,
-        }),
-        { status: 402, headers: { "Content-Type": "application/json" } },
-      );
     }
+  };
+}
 
-    return response;
+/**
+ * Wraps an individual route handler with x402 payment enforcement in Next.js.
+ *
+ * This is useful for applying payments to dynamic or API routes like `/api/secure-data`.
+ * If the request contains a valid payment, the handler is executed and the payment is settled.
+ * Otherwise, the client receives a 402 response (either HTML or JSON).
+ *
+ * @param handler - A Next.js-compatible async route handler function.
+ * @param config - Route-specific configuration for price, network, payee, and optional paywall/facilitator.
+ * @returns A wrapped Next.js handler that enforces x402 payment requirements before executing the route logic.
+ *
+ * @example
+ * ```ts
+ * export const GET = withPayment(
+ *   async (req) => {
+ *     return new Response("Hello, world!");
+ *   },
+ *   {
+ *     price: "$0.01",
+ *     network: "base",
+ *     payTo: "0xRecipientAddress"
+ *   }
+ * );
+ * ```
+ */
+export function withPayment(
+  handler: (req: NextRequest) => Promise<Response>,
+  config: RouteConfig & {
+    payTo: string;
+    facilitator?: FacilitatorConfig;
+    paywall?: PaywallConfig;
+  },
+) {
+  const x402Middleware = new PaymentMiddleware<NextRequest>({
+    payTo: config.payTo,
+    network: config.network,
+    price: config.price,
+    config: config.config,
+    facilitator: config.facilitator,
+    paywall: config.paywall,
+    paymentFromRequest,
+    canRenderPaywall,
+    resourceFromRequest,
+  });
+  const paywall = config.paywall;
+
+  return async function middleware(request: NextRequest) {
+    try {
+      const paymentRequirements = x402Middleware.paymentRequirements(request);
+      const payment = await x402Middleware.acquirePayment(request, paymentRequirements);
+      if (!payment) {
+        const price = x402Middleware.config.price;
+        const network = x402Middleware.config.network;
+        const customPaywallHtml = x402Middleware.config.config?.customPaywallHtml;
+        let displayAmount: number;
+        if (typeof price === "string" || typeof price === "number") {
+          const parsed = moneySchema.safeParse(price);
+          if (parsed.success) {
+            displayAmount = parsed.data;
+          } else {
+            displayAmount = Number.NaN;
+          }
+        } else {
+          displayAmount = Number(price.amount) / 10 ** price.asset.decimals;
+        }
+
+        const html =
+          customPaywallHtml ??
+          getPaywallHtml({
+            amount: displayAmount,
+            paymentRequirements: toJsonSafe(paymentRequirements) as Parameters<
+              typeof getPaywallHtml
+            >[0]["paymentRequirements"],
+            currentUrl: request.url,
+            testnet: network === "base-sepolia",
+            cdpClientKey: paywall?.cdpClientKey,
+            appLogo: paywall?.appLogo,
+            appName: paywall?.appName,
+          });
+        return new NextResponse(html, {
+          status: 402,
+          headers: { "Content-Type": "text/html" },
+        });
+      }
+
+      // Proceed with request
+      const response = await handler(request);
+      const settlement = await payment.settle();
+      const responseHeader = settleResponseHeader(settlement);
+      response.headers.set("X-PAYMENT-RESPONSE", responseHeader);
+      return response;
+    } catch (e) {
+      if (e instanceof X402Error) {
+        return new NextResponse(JSON.stringify(e), {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 402,
+        });
+      } else {
+        throw e;
+      }
+    }
   };
 }
 

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -44,7 +44,6 @@
     "tsup": "^8.4.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
-    "viem": "^2.21.26",
     "vite": "^6.2.6",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
@@ -123,6 +122,16 @@
       "require": {
         "types": "./dist/cjs/types/index.d.ts",
         "default": "./dist/cjs/types/index.js"
+      }
+    },
+    "./middleware": {
+      "import": {
+        "types": "./dist/esm/middleware/index.d.mts",
+        "default": "./dist/esm/middleware/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/middleware/index.d.ts",
+        "default": "./dist/cjs/middleware/index.js"
       }
     }
   },

--- a/typescript/packages/x402/src/middleware/index.ts
+++ b/typescript/packages/x402/src/middleware/index.ts
@@ -1,0 +1,1 @@
+export * from "./middleware.js";

--- a/typescript/packages/x402/src/middleware/middleware.test.ts
+++ b/typescript/packages/x402/src/middleware/middleware.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi } from "vitest";
+import type { PaymentPayload, PaymentRequirements, Resource, SettleResponse } from "../types";
+import {
+  AcquiredPayment,
+  PaymentMiddleware,
+  PaymentMiddlewareConfigError,
+  X402Error,
+} from "./middleware";
+
+const CONFIG = {
+  price: "$0.01",
+  network: "base",
+  payTo: "0xBAc675C310721717Cd4A37F6cbeA1F081b1C2a07",
+  paymentFromRequest: () => undefined,
+} as const;
+
+describe("PaymentMiddleware", () => {
+  describe("constructor", () => {
+    it("throws if neither config.resource nor resourceFromRequest is provided", () => {
+      expect(() => new PaymentMiddleware(CONFIG)).toThrowError(PaymentMiddlewareConfigError);
+    });
+    it("throws if price is invalid", () => {
+      const config = {
+        ...CONFIG,
+        price: "💩", // intentionally invalid
+        config: {
+          resource: "https://example.com/resource.json" as Resource,
+        },
+      } as const;
+      expect(() => new PaymentMiddleware(config)).toThrowError(PaymentMiddlewareConfigError);
+    });
+    it("throws if processPriceToAtomicAmount returns an error", () => {
+      const config = {
+        ...CONFIG,
+        config: {
+          resource: "https://example.com/resource.json" as Resource,
+        },
+        processPriceToAtomicAmountFn: () => {
+          return { error: "Oops" };
+        },
+      } as const;
+      expect(() => new PaymentMiddleware(config)).toThrowError(PaymentMiddlewareConfigError);
+    });
+    it("builds internal payment requirements correctly from config", () => {
+      const config = {
+        price: "$0.12345",
+        network: "base",
+        payTo: "0xBAc675C310721717Cd4A37F6cbeA1F081b1C2a07",
+        config: {
+          resource: "https://example.com/protected/resource",
+          description: "Access to premium content",
+          mimeType: "application/json",
+          maxTimeoutSeconds: 600,
+        },
+        paymentFromRequest: () => undefined,
+      } as const;
+
+      const middleware = new PaymentMiddleware(config);
+
+      const requirements = middleware.paymentRequirements({});
+      expect(requirements).toHaveLength(1);
+
+      const req = requirements[0];
+
+      expect(req.resource).toEqual("https://example.com/protected/resource");
+      expect(req.description).toEqual("Access to premium content");
+      expect(req.mimeType).toEqual("application/json");
+      expect(req.maxTimeoutSeconds).toEqual(600);
+      expect(req.outputSchema).toEqual(undefined);
+      expect(req.asset.toLowerCase()).toEqual("0x833589fcd6edb6e08f4c7c32d4f71b54bda02913");
+      expect(req.payTo.toLowerCase()).toEqual("0xbac675c310721717cd4a37f6cbea1f081b1c2a07");
+      expect(req.maxAmountRequired).toEqual("123450");
+      expect(req.scheme).toBe("exact");
+      expect(req.network).toBe("base");
+    });
+    it("accepts resourceFromRequest function and uses it", () => {
+      type FauxRequest = { path: string };
+      const resourceFromRequest = vi.fn((req: FauxRequest) => `/dynamic/${req.path}` as Resource);
+      const config = {
+        ...CONFIG,
+        resourceFromRequest,
+      } as const;
+      const middleware = new PaymentMiddleware(config);
+
+      const fakeRequest = { path: "user/42" };
+      const requirements = middleware.paymentRequirements(fakeRequest);
+
+      expect(requirements).toHaveLength(1);
+      expect(requirements[0].resource).toEqual("/dynamic/user/42");
+      expect(resourceFromRequest).toHaveBeenCalledWith(fakeRequest);
+    });
+  });
+
+  describe("paymentRequirements", () => {
+    it("returns payment requirements using static resource", () => {
+      const config = {
+        ...CONFIG,
+        config: {
+          resource: "https://static.example/resource" as Resource,
+          description: "static",
+          mimeType: "application/json",
+        },
+      } as const;
+      const middleware = new PaymentMiddleware(config);
+      const requirements = middleware.paymentRequirements({});
+
+      expect(requirements).toHaveLength(1);
+      expect(requirements[0].resource).toEqual("https://static.example/resource");
+      expect(requirements[0].description).toEqual("static");
+      expect(requirements[0].mimeType).toEqual("application/json");
+    });
+    it("returns payment requirements using dynamic resourceFromRequest", () => {
+      const resourceFromRequest = vi.fn(
+        (req: { slug: string }) => `/dynamic/${req.slug}` as Resource,
+      );
+      const config = {
+        ...CONFIG,
+        resourceFromRequest,
+      } as const;
+      const middleware = new PaymentMiddleware<{ slug: string }>(config);
+      const fakeRequest = { slug: "abc123" };
+      const requirements = middleware.paymentRequirements(fakeRequest);
+
+      expect(requirements).toHaveLength(1);
+      expect(requirements[0].resource).toEqual("/dynamic/abc123");
+    });
+    it("includes correct network, asset, payTo, and maxAmountRequired", () => {
+      const config = {
+        price: "$0.01",
+        network: "base",
+        payTo: "0xBAc675C310721717Cd4A37F6cbeA1F081b1C2a07",
+        config: {
+          resource: "res://test",
+        },
+        paymentFromRequest: () => undefined,
+      } as const;
+
+      const middleware = new PaymentMiddleware(config);
+      const req = middleware.paymentRequirements({})[0];
+
+      expect(req.network).toBe("base");
+      expect(req.maxAmountRequired).toBe("10000");
+      expect(req.payTo.toLowerCase()).toBe("0xbac675c310721717cd4a37f6cbea1f081b1c2a07");
+      expect(req.asset.toLowerCase()).toBe("0x833589fcd6edb6e08f4c7c32d4f71b54bda02913");
+    });
+  });
+
+  describe("acquirePayment", () => {
+    it("returns AcquiredPayment on valid payment and verification", async () => {
+      const validPayload = { foo: "bar" };
+      const matchingRequirements = [
+        { resource: "res://test" },
+      ] as unknown as Array<PaymentRequirements>;
+
+      const middleware = new PaymentMiddleware({
+        ...CONFIG,
+        config: {
+          resource: "res://test",
+        },
+        paymentFromRequest: () => validPayload as unknown as PaymentPayload,
+        verifyFn: vi.fn(() => Promise.resolve({ isValid: true, payer: "0xabc" })),
+      });
+
+      const result = await middleware.acquirePayment({}, matchingRequirements);
+      expect(result).toBeDefined();
+      expect(result?.payload).toBe(validPayload);
+    });
+    it("returns undefined if no payment and canRenderPaywall returns true", async () => {
+      const middleware = new PaymentMiddleware({
+        ...CONFIG,
+        config: {
+          resource: "res://test",
+        },
+        canRenderPaywall: () => true,
+        paymentFromRequest: () => undefined,
+      });
+
+      const result = await middleware.acquirePayment({}, []);
+      expect(result).toBeUndefined();
+    });
+    it("throws X402Error if no payment and canRenderPaywall returns false", async () => {
+      const middleware = new PaymentMiddleware({
+        ...CONFIG,
+        config: {
+          resource: "res://test",
+        },
+        canRenderPaywall: () => false,
+        paymentFromRequest: () => undefined,
+      });
+
+      try {
+        await middleware.acquirePayment({}, []);
+        expect.unreachable();
+      } catch (e) {
+        expect(e).instanceOf(X402Error);
+        expect(String(e)).toContain("X-PAYMENT header is required");
+      }
+    });
+    it("throws X402Error if no matching payment requirements", async () => {
+      const middleware = new PaymentMiddleware({
+        ...CONFIG,
+        config: {
+          resource: "res://test",
+        },
+        paymentFromRequest: () => ({ foo: "bar" }) as unknown as PaymentPayload,
+      });
+
+      try {
+        await middleware.acquirePayment({}, []);
+        expect.unreachable();
+      } catch (e) {
+        expect(e).instanceOf(X402Error);
+        expect(String(e)).toContain("Unable to find matching payment requirements");
+      }
+    });
+    it("throws X402Error if facilitator.verify returns isValid: false", async () => {
+      const middleware = new PaymentMiddleware({
+        ...CONFIG,
+        config: {
+          resource: "res://test",
+        },
+        paymentFromRequest: () => ({ foo: "bar" }) as unknown as PaymentPayload,
+        verifyFn: vi.fn(() =>
+          Promise.resolve({
+            isValid: false,
+            invalidReason: "invalid_exact_evm_payload_authorization_valid_before",
+            payer: "0xdef",
+          } as const),
+        ),
+      });
+
+      try {
+        await middleware.acquirePayment({}, [
+          { resource: "res://test" } as unknown as PaymentRequirements,
+        ]);
+        expect.unreachable();
+      } catch (e) {
+        expect(e).instanceOf(X402Error);
+        expect(String(e)).toContain("invalid_exact_evm_payload_authorization_valid_before");
+      }
+    });
+  });
+});
+
+describe("AcquiredPayment", () => {
+  it("settle resolves with settlement on success", async () => {
+    const settleMock = vi.fn(async () => {
+      return {
+        success: true,
+        transaction: "0x123",
+        network: "base",
+        payer: "0xabc",
+      } satisfies SettleResponse;
+    });
+
+    const payment = new AcquiredPayment(
+      { foo: "bar" } as unknown as PaymentPayload,
+      { resource: "res://test" } as unknown as PaymentRequirements,
+      [{ resource: "res://test" } as unknown as PaymentRequirements],
+      settleMock,
+    );
+
+    const result = await payment.settle();
+    expect(result).toEqual({
+      success: true,
+      transaction: "0x123",
+      network: "base",
+      payer: "0xabc",
+    });
+    expect(settleMock).toHaveBeenCalled();
+  });
+  it("settle throws X402Error on settlement failure", async () => {
+    const settleMock = vi.fn(async () => {
+      return {
+        success: false,
+        errorReason: "insufficient_funds",
+        network: "base",
+        payer: "0xabc",
+        transaction: "0x123",
+      } satisfies SettleResponse;
+    });
+
+    const payment = new AcquiredPayment(
+      { foo: "bar" } as unknown as PaymentPayload,
+      { resource: "res://test" } as unknown as PaymentRequirements,
+      [{ resource: "res://test" } as unknown as PaymentRequirements],
+      settleMock,
+    );
+
+    await expect(payment.settle()).rejects.toThrow(X402Error);
+    await expect(payment.settle()).rejects.toThrow("Settlement failed: insufficient_funds");
+  });
+});
+
+describe("X402Error", () => {
+  it("toJSON returns correct structure with x402Version, error, accepts, and payer", () => {
+    const error = new X402Error(
+      "some error occurred",
+      [{ resource: "res://abc" } as unknown as PaymentRequirements],
+      "0xabc123",
+    );
+
+    const json = error.toJSON();
+
+    expect(json).toEqual({
+      x402Version: 1,
+      error: "some error occurred",
+      accepts: [{ resource: "res://abc" }],
+      payer: "0xabc123",
+    });
+  });
+});
+
+describe("PaymentMiddlewareConfigError", () => {
+  it("sets message and inherits from Error", async () => {
+    const err = new PaymentMiddlewareConfigError("something went wrong");
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("something went wrong");
+    expect(err.name).toBe("PaymentMiddlewareConfigError");
+  });
+});

--- a/typescript/packages/x402/src/middleware/middleware.test.ts
+++ b/typescript/packages/x402/src/middleware/middleware.test.ts
@@ -1,24 +1,38 @@
 import { describe, it, expect, vi } from "vitest";
-import type { PaymentPayload, PaymentRequirements, Resource, SettleResponse } from "../types";
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+  Resource,
+  RouteConfig,
+  SettleResponse,
+} from "../types";
 import {
-  AcquiredPayment,
+  VerifiedPayment,
   PaymentMiddleware,
   PaymentMiddlewareConfigError,
   X402Error,
+  routeConfigToPaymentOptions,
+  renderPaywallHtml,
 } from "./middleware";
+import { getPaywallHtml, safeBase64Encode } from "../shared";
 
 const CONFIG = {
   price: "$0.01",
   network: "base",
   payTo: "0xBAc675C310721717Cd4A37F6cbeA1F081b1C2a07",
-  paymentFromRequest: () => undefined,
+  getHeader: () => undefined,
 } as const;
+
+vi.mock("../shared", async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getPaywallHtml: vi.fn().mockReturnValue(`<html>paywall</html>`),
+  };
+});
 
 describe("PaymentMiddleware", () => {
   describe("constructor", () => {
-    it("throws if neither config.resource nor resourceFromRequest is provided", () => {
-      expect(() => new PaymentMiddleware(CONFIG)).toThrowError(PaymentMiddlewareConfigError);
-    });
     it("throws if price is invalid", () => {
       const config = {
         ...CONFIG,
@@ -52,12 +66,12 @@ describe("PaymentMiddleware", () => {
           mimeType: "application/json",
           maxTimeoutSeconds: 600,
         },
-        paymentFromRequest: () => undefined,
+        getHeader: () => undefined,
       } as const;
 
       const middleware = new PaymentMiddleware(config);
 
-      const requirements = middleware.paymentRequirements({});
+      const requirements = middleware.paymentRequirements("https://example.com/protected/treasure");
       expect(requirements).toHaveLength(1);
 
       const req = requirements[0];
@@ -73,22 +87,6 @@ describe("PaymentMiddleware", () => {
       expect(req.scheme).toBe("exact");
       expect(req.network).toBe("base");
     });
-    it("accepts resourceFromRequest function and uses it", () => {
-      type FauxRequest = { path: string };
-      const resourceFromRequest = vi.fn((req: FauxRequest) => `/dynamic/${req.path}` as Resource);
-      const config = {
-        ...CONFIG,
-        resourceFromRequest,
-      } as const;
-      const middleware = new PaymentMiddleware(config);
-
-      const fakeRequest = { path: "user/42" };
-      const requirements = middleware.paymentRequirements(fakeRequest);
-
-      expect(requirements).toHaveLength(1);
-      expect(requirements[0].resource).toEqual("/dynamic/user/42");
-      expect(resourceFromRequest).toHaveBeenCalledWith(fakeRequest);
-    });
   });
 
   describe("paymentRequirements", () => {
@@ -96,34 +94,19 @@ describe("PaymentMiddleware", () => {
       const config = {
         ...CONFIG,
         config: {
-          resource: "https://static.example/resource" as Resource,
           description: "static",
           mimeType: "application/json",
         },
       } as const;
       const middleware = new PaymentMiddleware(config);
-      const requirements = middleware.paymentRequirements({});
+      const requirements = middleware.paymentRequirements("https://static.example/resource");
 
       expect(requirements).toHaveLength(1);
       expect(requirements[0].resource).toEqual("https://static.example/resource");
       expect(requirements[0].description).toEqual("static");
       expect(requirements[0].mimeType).toEqual("application/json");
     });
-    it("returns payment requirements using dynamic resourceFromRequest", () => {
-      const resourceFromRequest = vi.fn(
-        (req: { slug: string }) => `/dynamic/${req.slug}` as Resource,
-      );
-      const config = {
-        ...CONFIG,
-        resourceFromRequest,
-      } as const;
-      const middleware = new PaymentMiddleware<{ slug: string }>(config);
-      const fakeRequest = { slug: "abc123" };
-      const requirements = middleware.paymentRequirements(fakeRequest);
 
-      expect(requirements).toHaveLength(1);
-      expect(requirements[0].resource).toEqual("/dynamic/abc123");
-    });
     it("includes correct network, asset, payTo, and maxAmountRequired", () => {
       const config = {
         price: "$0.01",
@@ -132,11 +115,11 @@ describe("PaymentMiddleware", () => {
         config: {
           resource: "res://test",
         },
-        paymentFromRequest: () => undefined,
+        getHeader: () => undefined,
       } as const;
 
       const middleware = new PaymentMiddleware(config);
-      const req = middleware.paymentRequirements({})[0];
+      const req = middleware.paymentRequirements("https://example.com/protected/resource")[0];
 
       expect(req.network).toBe("base");
       expect(req.maxAmountRequired).toBe("10000");
@@ -145,25 +128,50 @@ describe("PaymentMiddleware", () => {
     });
   });
 
-  describe("acquirePayment", () => {
-    it("returns AcquiredPayment on valid payment and verification", async () => {
-      const validPayload = { foo: "bar" };
-      const matchingRequirements = [
-        { resource: "res://test" },
-      ] as unknown as Array<PaymentRequirements>;
+  describe("verifyPayment", () => {
+    const PAYMENT_PAYLOAD: PaymentPayload = {
+      scheme: "exact",
+      x402Version: 1,
+      network: "base",
+      payload: {
+        authorization: {
+          from: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+          to: "0xBAc675C310721717Cd4A37F6cbeA1F081b1C2a07",
+          value: "1000",
+          validAfter: "1671234567",
+          validBefore: "1671234567",
+          nonce: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+        signature: "0xdeadbeaf",
+      },
+    };
+    const PAYMENT_PAYLOAD_B64 = safeBase64Encode(JSON.stringify(PAYMENT_PAYLOAD));
+    const MATCHING_REQUIREMENTS = [
+      { scheme: "exact", resource: "res://test", network: "base" },
+    ] as unknown as Array<PaymentRequirements>;
 
+    it("returns VerifiedPayment on valid payment and verification", async () => {
       const middleware = new PaymentMiddleware({
         ...CONFIG,
         config: {
           resource: "res://test",
         },
-        paymentFromRequest: () => validPayload as unknown as PaymentPayload,
-        verifyFn: vi.fn(() => Promise.resolve({ isValid: true, payer: "0xabc" })),
+        getHeader: (_req, name) => {
+          if (name === "x-payment") {
+            return PAYMENT_PAYLOAD_B64;
+          }
+        },
+        useFacilitatorFn: () => {
+          return {
+            settle: vi.fn(),
+            verify: vi.fn(() => Promise.resolve({ isValid: true, payer: "0xabc" })),
+          };
+        },
       });
 
-      const result = await middleware.acquirePayment({}, matchingRequirements);
+      const result = await middleware.verifyPayment({}, MATCHING_REQUIREMENTS);
       expect(result).toBeDefined();
-      expect(result?.payload).toBe(validPayload);
+      expect(result?.payload).toEqual(PAYMENT_PAYLOAD);
     });
     it("returns undefined if no payment and canRenderPaywall returns true", async () => {
       const middleware = new PaymentMiddleware({
@@ -171,12 +179,94 @@ describe("PaymentMiddleware", () => {
         config: {
           resource: "res://test",
         },
-        canRenderPaywall: () => true,
-        paymentFromRequest: () => undefined,
+        getHeader: () => undefined,
+        useFacilitatorFn: () => {
+          return {
+            settle: vi.fn(),
+            verify: vi.fn(() => Promise.resolve({ isValid: true, payer: "0xabc" })),
+          };
+        },
       });
+      middleware.canRenderPaywall = () => true;
 
-      const result = await middleware.acquirePayment({}, []);
+      const result = await middleware.verifyPayment({}, []);
       expect(result).toBeUndefined();
+    });
+    it("returns undefined if no payment and headers indicate it is a browser", async () => {
+      const middleware = new PaymentMiddleware({
+        ...CONFIG,
+        config: {
+          resource: "res://test",
+        },
+        getHeader: (_req, name) => {
+          switch (name) {
+            case "x-payment":
+              return undefined;
+            case "user-agent":
+              return "Mozilla";
+            case "accept":
+              return "text/html";
+          }
+        },
+        useFacilitatorFn: () => {
+          return {
+            settle: vi.fn(),
+            verify: vi.fn(() => Promise.resolve({ isValid: true, payer: "0xabc" })),
+          };
+        },
+      });
+      expect(middleware.canRenderPaywall({})).toEqual(true);
+
+      const result = await middleware.verifyPayment({}, []);
+      expect(result).toBeUndefined();
+    });
+    it("returns undefined if no payment and headers indicate it is a browser via an Array", async () => {
+      const middleware = new PaymentMiddleware({
+        ...CONFIG,
+        config: {
+          resource: "res://test",
+        },
+        getHeader: (_req, name) => {
+          switch (name) {
+            case "x-payment":
+              return undefined;
+            case "user-agent":
+              return ["Mozilla", "Opera"];
+            case "accept":
+              return ["text/html", "application/json"];
+          }
+        },
+        useFacilitatorFn: () => {
+          return {
+            settle: vi.fn(),
+            verify: vi.fn(() => Promise.resolve({ isValid: true, payer: "0xabc" })),
+          };
+        },
+      });
+      expect(middleware.canRenderPaywall({})).toEqual(true);
+
+      const result = await middleware.verifyPayment({}, []);
+      expect(result).toBeUndefined();
+    });
+    it("throws X402Error if invalid payment", async () => {
+      const middleware = new PaymentMiddleware({
+        ...CONFIG,
+        config: {
+          resource: "res://test",
+        },
+        getHeader: (_req, name) => {
+          if (name === "x-payment") {
+            return safeBase64Encode(JSON.stringify({ "not-a-payment": true }));
+          }
+        },
+        useFacilitatorFn: () => {
+          return {
+            settle: vi.fn(),
+            verify: vi.fn(() => Promise.resolve({ isValid: true, payer: "0xabc" })),
+          };
+        },
+      });
+      await expect(middleware.verifyPayment({}, [])).rejects.toThrow(X402Error);
     });
     it("throws X402Error if no payment and canRenderPaywall returns false", async () => {
       const middleware = new PaymentMiddleware({
@@ -184,12 +274,20 @@ describe("PaymentMiddleware", () => {
         config: {
           resource: "res://test",
         },
-        canRenderPaywall: () => false,
-        paymentFromRequest: () => undefined,
+        getHeader: () => {
+          return undefined;
+        },
+        useFacilitatorFn: () => {
+          return {
+            settle: vi.fn(),
+            verify: vi.fn(() => Promise.resolve({ isValid: true, payer: "0xabc" })),
+          };
+        },
       });
+      expect(middleware.canRenderPaywall({})).toEqual(false);
 
       try {
-        await middleware.acquirePayment({}, []);
+        await middleware.verifyPayment({}, []);
         expect.unreachable();
       } catch (e) {
         expect(e).instanceOf(X402Error);
@@ -202,11 +300,21 @@ describe("PaymentMiddleware", () => {
         config: {
           resource: "res://test",
         },
-        paymentFromRequest: () => ({ foo: "bar" }) as unknown as PaymentPayload,
+        getHeader: (_req, name) => {
+          if (name === "x-payment") {
+            return PAYMENT_PAYLOAD_B64;
+          }
+        },
+        useFacilitatorFn: () => {
+          return {
+            settle: vi.fn(),
+            verify: vi.fn(() => Promise.resolve({ isValid: true, payer: "0xabc" })),
+          };
+        },
       });
 
       try {
-        await middleware.acquirePayment({}, []);
+        await middleware.verifyPayment({}, []);
         expect.unreachable();
       } catch (e) {
         expect(e).instanceOf(X402Error);
@@ -219,30 +327,69 @@ describe("PaymentMiddleware", () => {
         config: {
           resource: "res://test",
         },
-        paymentFromRequest: () => ({ foo: "bar" }) as unknown as PaymentPayload,
-        verifyFn: vi.fn(() =>
-          Promise.resolve({
-            isValid: false,
-            invalidReason: "invalid_exact_evm_payload_authorization_valid_before",
-            payer: "0xdef",
-          } as const),
-        ),
+        getHeader: (_req, name) => {
+          if (name === "x-payment") {
+            return PAYMENT_PAYLOAD_B64;
+          }
+        },
+        useFacilitatorFn: () => {
+          return {
+            settle: vi.fn(),
+            verify: vi.fn(() =>
+              Promise.resolve({
+                isValid: false,
+                invalidReason: "invalid_exact_evm_payload_authorization_valid_before",
+                payer: "0xdef",
+              } as const),
+            ),
+          };
+        },
       });
 
       try {
-        await middleware.acquirePayment({}, [
-          { resource: "res://test" } as unknown as PaymentRequirements,
-        ]);
+        await middleware.verifyPayment({}, MATCHING_REQUIREMENTS);
         expect.unreachable();
       } catch (e) {
         expect(e).instanceOf(X402Error);
         expect(String(e)).toContain("invalid_exact_evm_payload_authorization_valid_before");
       }
     });
+    it("throws X402Error if facilitator.verify returns isValid: false with no invalidReason", async () => {
+      const middleware = new PaymentMiddleware({
+        ...CONFIG,
+        config: {
+          resource: "res://test",
+        },
+        getHeader: (_req, name) => {
+          if (name === "x-payment") {
+            return PAYMENT_PAYLOAD_B64;
+          }
+        },
+        useFacilitatorFn: () => {
+          return {
+            settle: vi.fn(),
+            verify: vi.fn(() =>
+              Promise.resolve({
+                isValid: false,
+                payer: "0xdef",
+              } as const),
+            ),
+          };
+        },
+      });
+
+      try {
+        await middleware.verifyPayment({}, MATCHING_REQUIREMENTS);
+        expect.unreachable();
+      } catch (e) {
+        expect(e).instanceOf(X402Error);
+        expect(String(e)).toContain("Payment verification failed");
+      }
+    });
   });
 });
 
-describe("AcquiredPayment", () => {
+describe("VerifiedPayment", () => {
   it("settle resolves with settlement on success", async () => {
     const settleMock = vi.fn(async () => {
       return {
@@ -253,7 +400,7 @@ describe("AcquiredPayment", () => {
       } satisfies SettleResponse;
     });
 
-    const payment = new AcquiredPayment(
+    const payment = new VerifiedPayment(
       { foo: "bar" } as unknown as PaymentPayload,
       { resource: "res://test" } as unknown as PaymentRequirements,
       [{ resource: "res://test" } as unknown as PaymentRequirements],
@@ -280,7 +427,7 @@ describe("AcquiredPayment", () => {
       } satisfies SettleResponse;
     });
 
-    const payment = new AcquiredPayment(
+    const payment = new VerifiedPayment(
       { foo: "bar" } as unknown as PaymentPayload,
       { resource: "res://test" } as unknown as PaymentRequirements,
       [{ resource: "res://test" } as unknown as PaymentRequirements],
@@ -289,6 +436,21 @@ describe("AcquiredPayment", () => {
 
     await expect(payment.settle()).rejects.toThrow(X402Error);
     await expect(payment.settle()).rejects.toThrow("Settlement failed: insufficient_funds");
+  });
+  it("settle throws X402Error on settlement error", async () => {
+    const settleMock = vi.fn(async () => {
+      throw new Error(`Oops`);
+    });
+
+    const payment = new VerifiedPayment(
+      { foo: "bar" } as unknown as PaymentPayload,
+      { resource: "res://test" } as unknown as PaymentRequirements,
+      [{ resource: "res://test" } as unknown as PaymentRequirements],
+      settleMock,
+    );
+
+    await expect(payment.settle()).rejects.toThrow(X402Error);
+    await expect(payment.settle()).rejects.toThrow("Oops");
   });
 });
 
@@ -318,5 +480,108 @@ describe("PaymentMiddlewareConfigError", () => {
     expect(err).toBeInstanceOf(Error);
     expect(err.message).toBe("something went wrong");
     expect(err.name).toBe("PaymentMiddlewareConfigError");
+  });
+});
+
+describe("routeConfigToPaymentOptions", () => {
+  it("returns the same array if prices is provided and is non-empty", () => {
+    const routeConfig = {
+      prices: [{ price: "$0.01", network: "base" }],
+    } satisfies RouteConfig;
+    const result = routeConfigToPaymentOptions(routeConfig);
+    expect(result).toEqual([{ price: "$0.01", network: "base" }]);
+  });
+  it("return a single-element array with the legacy format", () => {
+    const routeConfig = {
+      price: "$0.01",
+      network: "base",
+    } satisfies RouteConfig;
+    const result = routeConfigToPaymentOptions(routeConfig);
+    expect(result).toEqual([{ price: "$0.01", network: "base" }]);
+  });
+  it("throw PaymentMiddlewareConfigError if no prices, price, or network", () => {
+    expect(() => routeConfigToPaymentOptions({})).toThrow(PaymentMiddlewareConfigError);
+  });
+});
+
+describe("MiddlewareRoutesMap", () => {
+  it("finds a correct route", () => {
+    const map = PaymentMiddleware.forRoutes({
+      routes: {
+        "/foo": {
+          price: "0.01",
+        },
+      },
+      ...CONFIG,
+    });
+    const result = map.match("/foo", "GET");
+    expect(result).toBeInstanceOf(PaymentMiddleware);
+  });
+  it("returns undefined if no match", () => {
+    const map = PaymentMiddleware.forRoutes({
+      routes: {
+        "/foo": {
+          price: "0.01",
+        },
+      },
+      ...CONFIG,
+    });
+    const result = map.match("/foo/blah", "GET");
+    expect(result).toBeUndefined();
+  });
+  it("correctly maps multiple routes", () => {
+    const map = PaymentMiddleware.forRoutes({
+      routes: {
+        "/a": {
+          price: "0.01",
+        },
+        "/b": { prices: [{ price: "0.01", network: "base" }] },
+      },
+      ...CONFIG,
+    });
+    expect(map.match("/a", "GET")).toBeInstanceOf(PaymentMiddleware);
+    expect(map.match("/b", "POST")).toBeInstanceOf(PaymentMiddleware);
+  });
+});
+
+describe("renderPaywallHtml", () => {
+  it("renders default HTML when no customPaywallHtml is set", () => {
+    const x402 = new PaymentMiddleware({
+      ...CONFIG,
+      config: {
+        resource: "res://test",
+      },
+      paywall: {
+        cdpClientKey: "test-client-key",
+        appName: "Test App",
+        appLogo: "/test-logo.png",
+        sessionTokenEndpoint: "/api/x402/session-token",
+      },
+      getHeader: () => undefined,
+    });
+
+    const html = renderPaywallHtml(x402, x402.paymentRequirements("res://test"), "/test");
+    expect(html).toMatch(/<html/i); // crude check that HTML was returned
+    expect(getPaywallHtml).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpClientKey: "test-client-key",
+        appName: "Test App",
+        appLogo: "/test-logo.png",
+        sessionTokenEndpoint: "/api/x402/session-token",
+      }),
+    );
+  });
+  it("renders customPaywallHtml when configured", () => {
+    const x402 = new PaymentMiddleware({
+      ...CONFIG,
+      config: {
+        resource: "res://test",
+        customPaywallHtml: "<h1>Custom</h1>",
+      },
+      getHeader: () => undefined,
+    });
+
+    const html = renderPaywallHtml(x402, x402.paymentRequirements("res://test"), "/test");
+    expect(html).toEqual("<h1>Custom</h1>");
   });
 });

--- a/typescript/packages/x402/src/middleware/middleware.ts
+++ b/typescript/packages/x402/src/middleware/middleware.ts
@@ -1,0 +1,425 @@
+import type {
+  FacilitatorConfig,
+  Network,
+  PaymentPayload,
+  PaymentRequirements,
+  PaywallConfig,
+  Resource,
+  RouteConfig,
+  RoutePattern,
+  RoutesConfig,
+} from "../types";
+import { useFacilitator } from "../verify";
+import {
+  computeRoutePatterns,
+  findMatchingPaymentRequirements,
+  findMatchingRoute,
+  processPriceToAtomicAmount,
+  toJsonSafe,
+} from "../shared";
+import { type Address, getAddress } from "viem";
+
+export type { PaymentMiddlewareConfig, Settlement };
+export {
+  PaymentMiddlewareConfigError,
+  X402Error,
+  AcquiredPayment,
+  PaymentMiddleware,
+  MiddlewareRoutesMap,
+};
+
+const X402_VERSION = 1;
+
+/**
+ * Configuration options for the PaymentMiddleware.
+ *
+ * @template TRequest - The request type, typically a framework-specific request object.
+ */
+type PaymentMiddlewareConfig<TRequest> = RouteConfig & {
+  /** The address to receive payments. */
+  payTo: string;
+  /** Optional facilitator configuration. */
+  facilitator?: FacilitatorConfig;
+  /** Optional metadata for rendering a paywall. */
+  paywall?: PaywallConfig;
+  /** Function to derive the resource identifier from a request. Either `resource` or this `resourceFromRequest` should be configured. */
+  resourceFromRequest?: (request: TRequest) => Resource;
+  /** Determines whether a paywall can be rendered for the given request if no payment header is present */
+  canRenderPaywall?: (request: TRequest) => boolean;
+  /** Extracts and decodes the payment payload from the request. */
+  paymentFromRequest: (request: TRequest) => PaymentPayload | undefined;
+
+  /** Pass a custom ` processPriceToAtomicAmount ` function for testing purposes */
+  processPriceToAtomicAmountFn?: typeof processPriceToAtomicAmount;
+  /** Pass a custom `facilitator.verify` function for testing purposes */
+  verifyFn?: ReturnType<typeof useFacilitator>["verify"];
+  /** Pass a custom `facilitator.settle` function for testing purposes */
+  settleFn?: ReturnType<typeof useFacilitator>["settle"];
+};
+
+/**
+ * Thrown when the middleware is misconfigured or encounters an invalid setup.
+ */
+class PaymentMiddlewareConfigError extends Error {
+  readonly name = "PaymentMiddlewareConfigError";
+  readonly message: string;
+  /**
+   * Constructor.
+   *
+   * @param message - Description of the configuration issue.
+   */
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+  }
+}
+
+/**
+ * Error thrown during the x402 payment flow.
+ * Can be serialized and returned to clients in a 402 response.
+ */
+class X402Error extends Error {
+  readonly name = "X402Error";
+  readonly x402Version = X402_VERSION;
+  readonly error: Error | string;
+  readonly accepts: Array<PaymentRequirements>;
+  readonly payer?: string;
+
+  /**
+   * Constructor.
+   *
+   * @param error - An Error instance or a string describing the issue.
+   * @param accepts - List of acceptable payment requirements.
+   * @param payer - Optional address of the payer, if known.
+   */
+  constructor(error: Error | string, accepts: Array<PaymentRequirements>, payer?: string) {
+    super(String(error));
+    this.error = error;
+    this.accepts = accepts;
+    this.payer = payer;
+  }
+
+  /**
+   * Converts the error into a JSON-serializable object for HTTP responses.
+   *
+   * @returns An object representing the error in x402 JSON format.
+   */
+  toJSON() {
+    return {
+      x402Version: this.x402Version,
+      error:
+        typeof this.error === "object" && "message" in this.error
+          ? this.error.message
+          : String(this.error),
+      accepts: toJsonSafe(this.accepts),
+      payer: this.payer,
+    };
+  }
+}
+
+/**
+ * The result of a successful x402 settlement.
+ *
+ * Note: Ideally, this should be part of useFacilitator typing.
+ */
+type Settlement = {
+  /** Indicates settlement was successful. */
+  success: true;
+  /** Transaction hash of the on-chain transfer. */
+  transaction: string;
+  /** The network where the payment was settled. */
+  network: Network;
+  /** Address of the payer. */
+  payer: string;
+};
+
+/**
+ * Represents a verified payment that can be settled after serving a response.
+ */
+class AcquiredPayment {
+  readonly payload: PaymentPayload;
+  readonly selected: PaymentRequirements;
+  readonly requirements: Array<PaymentRequirements>;
+  readonly #settle: ReturnType<typeof useFacilitator>["settle"];
+
+  /**
+   * Creates a wrapper for a verified payment, allowing it to be settled later.
+   *
+   * @param payload - The decoded x402 payment payload.
+   * @param selected - The matching payment requirements for the payload.
+   * @param requirements - Full list of acceptable payment requirements.
+   * @param settle - Settlement function returned from the facilitator.
+   */
+  constructor(
+    payload: PaymentPayload,
+    selected: PaymentRequirements,
+    requirements: Array<PaymentRequirements>,
+    settle: ReturnType<typeof useFacilitator>["settle"],
+  ) {
+    this.payload = payload;
+    this.selected = selected;
+    this.requirements = requirements;
+    this.#settle = settle;
+  }
+
+  /**
+   * Attempts to settle the payment on-chain.
+   *
+   * @throws {X402Error} If settlement fails.
+   * @returns A promise resolving to a settlement object.
+   */
+  async settle(): Promise<Settlement> {
+    let settlement;
+    try {
+      settlement = await this.#settle(this.payload, this.selected);
+    } catch (e) {
+      throw new X402Error(e as Error, this.requirements);
+    }
+    if (settlement.success) {
+      return {
+        success: true,
+        transaction: settlement.transaction,
+        network: settlement.network,
+        payer: settlement.payer!,
+      };
+    } else {
+      throw new X402Error(
+        `Settlement failed: ${settlement.errorReason}`,
+        this.requirements,
+        settlement.payer,
+      );
+    }
+  }
+}
+
+/**
+ * A specialized `Map` that associates route patterns with `PaymentMiddleware` instances,
+ * and provides convenient route matching logic.
+ *
+ * This is the internal structure returned by `PaymentMiddleware.forRoutes()` and is used
+ * by framework adapters to dynamically resolve middleware based on request path and method.
+ *
+ * @template TRequest - The request type used by the `PaymentMiddleware` (e.g., Express `Request`, Hono `Context`, etc).
+ *
+ * @example
+ * const routesMap = PaymentMiddleware.forRoutes(reqHandlerConfig);
+ * const middleware = routesMap.match("/weather", "GET");
+ * if (middleware) {
+ *   const requirements = middleware.paymentRequirements(request);
+ *   ...
+ * }
+ */
+class MiddlewareRoutesMap<TRequest> extends Map<RoutePattern, PaymentMiddleware<TRequest>> {
+  readonly #routePatterns: RoutePattern[];
+
+  /**
+   * Constructs a `MiddlewareRoutesMap` from a list of route pattern and middleware pairs.
+   *
+   * This class extends `Map` and retains the list of route patterns to enable
+   * efficient route matching via the `.match()` method.
+   *
+   * @param entries - An optional iterable of `[RoutePattern, PaymentMiddleware]` pairs
+   *                  used to initialize the map.
+   */
+  constructor(entries?: readonly (readonly [RoutePattern, PaymentMiddleware<TRequest>])[] | null) {
+    super(entries);
+    this.#routePatterns = Array.from(this.keys());
+  }
+
+  /**
+   * Attempts to find a matching middleware based on the request path and method.
+   *
+   * @param path - The URL path of the incoming request (e.g., `/weather/today`).
+   * @param method - The HTTP method of the request (e.g., `GET`, `POST`).
+   * @returns The corresponding `PaymentMiddleware` instance, or `undefined` if no match is found.
+   */
+  match(path: string, method: string): PaymentMiddleware<TRequest> | undefined {
+    const route = findMatchingRoute(this.#routePatterns, path, method);
+    if (!route) {
+      return undefined;
+    }
+    return this.get(route);
+  }
+}
+
+/**
+ * Core logic for handling x402-based payment validation and settlement.
+ *
+ * This class is framework-agnostic and should be paired with specific adapters
+ * (e.g., Next.js, Express, Hono) for HTTP request/response integration.
+ *
+ * @template TRequest - The type of the incoming request object.
+ */
+class PaymentMiddleware<TRequest> {
+  readonly config: RouteConfig;
+
+  readonly #facilitator: ReturnType<typeof useFacilitator>;
+  readonly #paymentReq: Omit<PaymentRequirements, "resource">;
+
+  readonly #resource: Resource | Required<PaymentMiddlewareConfig<TRequest>>["resourceFromRequest"];
+  readonly #paymentFromRequest: PaymentMiddlewareConfig<TRequest>["paymentFromRequest"];
+  readonly #canRenderPaywall?: (request: TRequest) => boolean;
+
+  /**
+   * Constructs the middleware using the provided configuration.
+   *
+   * @param config - Configuration including price, payTo, network, and request extractors.
+   * @throws {PaymentMiddlewareConfigError} If required config is missing or invalid.
+   */
+  constructor(config: PaymentMiddlewareConfig<TRequest>) {
+    let facilitator = useFacilitator(config.facilitator);
+    if (config.verifyFn) {
+      facilitator.verify = config.verifyFn;
+    }
+    if (config.settleFn) {
+      facilitator.settle = config.settleFn;
+    }
+    this.#facilitator = facilitator;
+    this.#paymentFromRequest = config.paymentFromRequest;
+    this.#canRenderPaywall = config.canRenderPaywall;
+
+    this.config = {
+      price: config.price,
+      network: config.network,
+      config: config.config,
+    };
+
+    const resource = config.config?.resource || config.resourceFromRequest;
+    if (!resource) {
+      throw new PaymentMiddlewareConfigError(
+        "Either config.resource or resourceFromRequest must be provided",
+      );
+    }
+    this.#resource = resource;
+    const processPriceToAtomicAmountFn =
+      config.processPriceToAtomicAmountFn || processPriceToAtomicAmount;
+    const atomicAmountForAsset = processPriceToAtomicAmountFn(config.price, config.network);
+    if ("error" in atomicAmountForAsset) {
+      throw new PaymentMiddlewareConfigError(atomicAmountForAsset.error);
+    }
+    this.#paymentReq = {
+      scheme: "exact",
+      network: config.network,
+      maxAmountRequired: atomicAmountForAsset.maxAmountRequired,
+      description: config.config?.description ?? "",
+      mimeType: config.config?.mimeType ?? "application/json",
+      payTo: getAddress(config.payTo),
+      maxTimeoutSeconds: config.config?.maxTimeoutSeconds ?? 300,
+      asset: getAddress(atomicAmountForAsset.asset.address),
+      outputSchema: config.config?.outputSchema,
+      extra: atomicAmountForAsset.asset.eip712,
+    };
+  }
+
+  /**
+   * Constructs a mapping of route patterns to `PaymentMiddleware` instances for a given set of x402-protected routes.
+   *
+   * This is typically used inside framework-specific adapters (e.g., Express, Hono, Next.js middleware) to build
+   * the per-route middleware logic needed to enforce payments.
+   *
+   * @template TRequest - The request type (e.g., Express `Request`, Hono `Context`, etc).
+   * @param payTo - The address to receive payments.
+   * @param routes - A mapping of route patterns to their associated payment configurations.
+   * @param paymentFromRequest - A function to extract the x402 payment payload from a request.
+   * @param canRenderPaywall - A function that determines if an HTML paywall should be rendered for a given request.
+   * @param facilitator - Optional facilitator configuration (e.g. custom verify/settle endpoints).
+   * @param paywall - Optional metadata for customizing the HTML paywall UI.
+   * @param useFacilitatorFn - Internal injection point for `useFacilitator`, primarily used for testing.
+   * @returns A `Map` associating route patterns with corresponding `PaymentMiddleware` instances.
+   */
+  static forRoutes<TRequest>(
+    payTo: Address,
+    routes: RoutesConfig,
+    paymentFromRequest: PaymentMiddlewareConfig<TRequest>["paymentFromRequest"],
+    canRenderPaywall: PaymentMiddlewareConfig<TRequest>["canRenderPaywall"],
+    facilitator?: FacilitatorConfig,
+    paywall?: PaywallConfig,
+    useFacilitatorFn: typeof useFacilitator = useFacilitator,
+  ): MiddlewareRoutesMap<TRequest> {
+    const { verify, settle } = useFacilitatorFn(facilitator);
+    const routePatterns = computeRoutePatterns(routes);
+    return new MiddlewareRoutesMap<TRequest>(
+      routePatterns.map(routePattern => {
+        return [
+          routePattern,
+          new PaymentMiddleware<TRequest>({
+            payTo: payTo,
+            facilitator: facilitator,
+            paywall: paywall,
+            price: routePattern.config.price,
+            network: routePattern.config.network,
+            config: routePattern.config.config,
+            verifyFn: verify,
+            settleFn: settle,
+            paymentFromRequest,
+            canRenderPaywall,
+          }),
+        ] as const;
+      }),
+    );
+  }
+
+  /**
+   * Builds the full list of payment requirements for a given request.
+   *
+   * @param request - The incoming request.
+   * @returns An array of acceptable payment requirement objects.
+   */
+  paymentRequirements(request: TRequest): Array<PaymentRequirements> {
+    let resource: Resource;
+    if (typeof this.#resource === "function") {
+      resource = this.#resource(request);
+    } else {
+      resource = this.#resource;
+    }
+    const paymentRequirement = Object.assign({}, this.#paymentReq, {
+      resource: resource,
+    });
+    return [paymentRequirement];
+  }
+
+  /**
+   * Attempts to acquire and verify a payment for the request.
+   *
+   * @param request - The incoming HTTP request.
+   * @param paymentRequirements - Requirements this route expects.
+   * @returns An AcquiredPayment object on success, or undefined if paywall should be shown.
+   * @throws {X402Error} If payment is missing or invalid.
+   */
+  async acquirePayment(
+    request: TRequest,
+    paymentRequirements: Array<PaymentRequirements>,
+  ): Promise<AcquiredPayment | undefined> {
+    let paymentPayload: PaymentPayload | undefined;
+    try {
+      paymentPayload = this.#paymentFromRequest(request);
+    } catch (error) {
+      throw new X402Error(error as Error, paymentRequirements);
+    }
+    if (!paymentPayload) {
+      if (this.#canRenderPaywall?.(request)) {
+        return undefined;
+      } else {
+        throw new X402Error("X-PAYMENT header is required", paymentRequirements);
+      }
+    }
+    const selected = findMatchingPaymentRequirements(paymentRequirements, paymentPayload);
+    if (!selected) {
+      throw new X402Error("Unable to find matching payment requirements", paymentRequirements);
+    }
+    const verification = await this.#facilitator.verify(paymentPayload, selected);
+    if (!verification.isValid) {
+      throw new X402Error(
+        verification.invalidReason ?? "Payment verification failed",
+        paymentRequirements,
+        verification.payer,
+      );
+    }
+    return new AcquiredPayment(
+      paymentPayload,
+      selected,
+      paymentRequirements,
+      this.#facilitator.settle.bind(this.#facilitator),
+    );
+  }
+}

--- a/typescript/packages/x402/src/types/shared/middleware.ts
+++ b/typescript/packages/x402/src/types/shared/middleware.ts
@@ -40,9 +40,15 @@ export interface ERC20TokenAmount {
 
 export type Price = Money | ERC20TokenAmount;
 
-export interface RouteConfig {
+export interface PaymentOption {
   price: Price;
   network: Network;
+}
+
+export interface RouteConfig {
+  price?: Price;
+  network?: Network;
+  prices?: Array<PaymentOption>;
   config?: PaymentMiddlewareConfig;
 }
 

--- a/typescript/packages/x402/tsup.config.ts
+++ b/typescript/packages/x402/tsup.config.ts
@@ -10,6 +10,7 @@ const baseConfig = {
     "verify/index": "src/verify/index.ts",
     "facilitator/index": "src/facilitator/index.ts",
     "types/index": "src/types/index.ts",
+    "middleware/index": "src/middleware/index.ts",
   },
   dts: {
     resolve: true,

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -242,9 +242,6 @@ importers:
       x402:
         specifier: workspace:^
         version: link:../x402
-      zod:
-        specifier: ^3.24.2
-        version: 3.25.67
     devDependencies:
       '@eslint/js':
         specifier: ^9.24.0
@@ -359,17 +356,14 @@ importers:
         specifier: ^1.22.0
         version: 1.22.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       hono:
-        specifier: ^4.7.1
-        version: 4.8.2
+        specifier: ^4.8.4
+        version: 4.8.4
       viem:
         specifier: ^2.21.26
         version: 2.31.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.67)
       x402:
         specifier: workspace:^
         version: link:../x402
-      zod:
-        specifier: ^3.24.2
-        version: 3.25.67
     devDependencies:
       '@eslint/js':
         specifier: ^9.24.0
@@ -3681,6 +3675,10 @@ packages:
 
   hono@4.8.2:
     resolution: {integrity: sha512-hM+1RIn9PK1I6SiTNS6/y7O1mvg88awYLFEuEtoiMtRyT3SD2iu9pSFgbBXT3b1Ua4IwzvSTLvwO0SEhDxCi4w==}
+    engines: {node: '>=16.9.0'}
+
+  hono@4.8.4:
+    resolution: {integrity: sha512-KOIBp1+iUs0HrKztM4EHiB2UtzZDTBihDtOF5K6+WaJjCPeaW4Q92R8j63jOhvJI5+tZSMuKD9REVEXXY9illg==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -9954,6 +9952,8 @@ snapshots:
       function-bind: 1.1.2
 
   hono@4.8.2: {}
+
+  hono@4.8.4: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:


### PR DESCRIPTION
## Description

This PR introduces a major internal and API refactor of the x402 middleware libraries across Hono, Express, and Next.js:
- Extracts core verification/settlement logic into a shared `PaymentMiddleware` class.
- Refactors existing middleware implementations to use the shared class.
- Fixes long-standing settlement timing bug in Express middleware.
- Fixes response rewriting bug in Hono middleware.
- Cleans up package dependencies to properly declare `peerDependencies`.
- Adds a higher-level `withPayment()` helper for paygating individual handlers on Next.js.

### Motivation

While building a small Next.js app with a protected GET route, I discovered a fundamental flaw: Next.js middleware cannot observe handler completion. This led to premature settlement, even if the handler failed.

To solve this in a non-middleware context (e.g., an API handler), I prototyped a wrapper that performs payment verification before executing the handler, and settlement after it completes. This became `withPayment`.

However, I ran into code duplication and tight coupling to web frameworks, which wouldn’t scale to future transports (e.g., XMTP) and currently leads to weird subtle bugs (see changes to the tests for Next middleware). So I extracted shared logic into a framework-agnostic `PaymentMiddleware` class and refactored the existing Hono and Express middlewares around it.

### New Features

**`withPayment()` API**

Ergonomic helper for wrapping individual handlers with payment verification + settlement:

```typescript
import { withPayment } from "x402-next";

export const GET = withPayment(
    async (req) => {
        return new Response("Welcome to the premium zone");
    }, 
    {
        price: "$0.01", 
        network: "base-sepolia", 
        payTo: "0xYourAddress", 
        config: {
            description: "Premium content",
        },
    }
);
```

This is especially useful in environments where full middleware support is limited (e.g. Next.js API routes).

**`PaymentMiddleware` core abstraction**

A shared, transport-agnostic class that implements:
- Payment requirement selection
- Verification (via facilitator /verify)
- Settlement (via /settle)
- transport-specific hooks to accept payments, determine if human paywall should be rendered, determine resource URL

Used internally now by Express, Hono, Next middleware, and can be reused for future transports (e.g., XMTP).

The separation of responsibilities is now clearer:
- `PaymentMiddleware` handles payment logic,
- Middleware wrappers (Express, Hono, etc.) handle actual request/response mechanics.

### Bug Fixes

**Hono**
- Before: On settlement failure, we attempted to return `c.json(...)` after the response had already been sent. That just does not work.
- After: We now properly replace `c.res` with a new `Response`, which is the correct way to override a response in Hono.

**Express**
- Before: Middleware awaited `next()`, which does not actually wait for handler completion in Express.
- After: We now monkey-patch res.end to detect when the response is available, and only then proceed to settle the payment.

**Package Dependencies**
- Before: Middleware packages incorrectly listed viem, hono, and express as hard dependencies, even when only types were used.
- After: These have been moved to peerDependencies as appropriate.

### Known Limitations
- ❗ Next.js `middleware.ts` limitation remains. Because of framework constraints, there’s still no way to wait for the page handler to finish before settling the payment. If the middleware is used directly (not via `withPayment`), payments may be settled even if the handler fails.

## Tests

Got through the usual `pnpm run test` routine. Added tests to `PaymentMiddleware`.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 