### PR TITLE
fix: use configured EIP-712 domain name for USDC instead of hardcoded ternary

### DIFF
--- a/typescript/packages/x402/src/client/selectPaymentRequirements.ts
+++ b/typescript/packages/x402/src/client/selectPaymentRequirements.ts
@@ -1,12 +1,12 @@
 import { Network, PaymentRequirements } from "../types";
-import { getUsdcAddressForChain } from "../shared/evm";
+import { getUsdcChainConfigForChain } from "../shared/evm";
 import { getNetworkId } from "../shared/network";
 
 /**
  * Default selector for payment requirements.
  * Default behavior is to select the first payment requirement that has a USDC asset.
  * If no USDC payment requirement is found, the first payment requirement is selected.
- * 
+ *
  * @param paymentRequirements - The payment requirements to select from.
  * @param network - The network to check against. If not provided, the network will not be checked.
  * @param scheme - The scheme to check against. If not provided, the scheme will not be checked.
@@ -37,7 +37,7 @@ export function selectPaymentRequirements(paymentRequirements: PaymentRequiremen
   // Filter down to USDC requirements
   const usdcRequirements = broadlyAcceptedPaymentRequirements.filter(requirement => {
     // If the address is a USDC address, we return it.
-    return requirement.asset === getUsdcAddressForChain(getNetworkId(requirement.network));
+    return requirement.asset === getUsdcChainConfigForChain(getNetworkId(requirement.network))?.usdcAddress;
   });
 
   // Prioritize USDC requirements if available
@@ -56,7 +56,7 @@ export function selectPaymentRequirements(paymentRequirements: PaymentRequiremen
 
 /**
  * Selector for payment requirements.
- * 
+ *
  * @param paymentRequirements - The payment requirements to select from.
  * @param network - The network to check against. If not provided, the network will not be checked.
  * @param scheme - The scheme to check against. If not provided, the scheme will not be checked.

--- a/typescript/packages/x402/src/shared/middleware.ts
+++ b/typescript/packages/x402/src/shared/middleware.ts
@@ -91,13 +91,14 @@ export function findMatchingRoute(
 export function getDefaultAsset(network: Network) {
   const chainId = getNetworkId(network);
   const usdc = getUsdcChainConfigForChain(chainId);
-  const address = usdc?.usdcAddress || "0x";
-  const name = usdc?.usdcName || "USDC";
+  if (!usdc) {
+    throw new Error(`Unable to get default asset on ${network}`);
+  }
   return {
-    address: address,
+    address: usdc.usdcAddress,
     decimals: 6,
     eip712: {
-      name: name,
+      name: usdc.usdcName,
       version: "2",
     },
   };

--- a/typescript/packages/x402/src/shared/middleware.ts
+++ b/typescript/packages/x402/src/shared/middleware.ts
@@ -11,7 +11,7 @@ import {
 } from "../types";
 import { RoutesConfig } from "../types";
 import { safeBase64Decode } from "./base64";
-import { getUsdcAddressForChain } from "./evm";
+import { getUsdcChainConfigForChain } from "./evm";
 import { getNetworkId } from "./network";
 
 /**
@@ -89,11 +89,15 @@ export function findMatchingRoute(
  * @returns The default asset
  */
 export function getDefaultAsset(network: Network) {
+  const chainId = getNetworkId(network);
+  const usdc = getUsdcChainConfigForChain(chainId);
+  const address = usdc?.usdcAddress || "0x";
+  const name = usdc?.usdcName || "USDC";
   return {
-    address: getUsdcAddressForChain(getNetworkId(network)),
+    address: address,
     decimals: 6,
     eip712: {
-      name: network === "base" ? "USD Coin" : network === "iotex" ? "Bridged USDC" : "USDC",
+      name: name,
       version: "2",
     },
   };

--- a/typescript/packages/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/x402/src/types/shared/evm/config.ts
@@ -15,7 +15,7 @@ export const config: Record<string, ChainConfig> = {
   },
   "43114": {
     usdcAddress: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
-    usdcName: "USDC",
+    usdcName: "USD Coin",
   },
   "4689": {
     usdcAddress: "0xcdf79194c6c285077a58da47641d4dbe51f63542",


### PR DESCRIPTION
## Description

This PR ensures the correct EIP-712 domain name is used for USDC by retrieving it from the per-chain config (usdcName), instead of relying on a brittle ternary expression.

Key improvements:
- Replaces the hardcoded logic for EIP-712 name with a config-driven value from getUsdcChainConfigForChain.
- Introduces and uses getUsdcChainConfigForChain across:
  - selectPaymentRequirements.ts
  - middleware.ts
  - getUSDCBalance
- Marks getUsdcAddressForChain as deprecated (but keeps it for backward compatibility).

Oh, and it sets correct eip712 domain name for USDC on Avalanche C-Chain mainnet.

### Why it matters

Using the correct domain name is critical for EIP-712 signature validation. This change prevents potential signature mismatch issues caused by inconsistencies across chains (e.g. “USD Coin” vs “Bridged USDC”).

## Tests

Usual `pnpm format` and `pnpm test` passed.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)