### PR TITLE
feat: early thoughts

### DIFF
--- a/examples/typescript/servers/express/index.ts
+++ b/examples/typescript/servers/express/index.ts
@@ -22,6 +22,14 @@ app.use(
         price: "$0.001",
         // network: "base" // uncomment for Base mainnet
         network: "base-sepolia",
+        config: {
+          inputSchema: {
+            queryParams: {
+              city: "string",
+              country: "string",
+            }
+          },
+        }
       },
       "/premium/*": {
         // Define atomic amounts in any EIP-3009 token

--- a/python/x402/src/x402/fastapi/middleware.py
+++ b/python/x402/src/x402/fastapi/middleware.py
@@ -23,6 +23,7 @@ from x402.types import (
     x402PaymentRequiredResponse,
     PaywallConfig,
     SupportedNetworks,
+    HTTPInputSchema,
 )
 
 logger = logging.getLogger(__name__)
@@ -36,7 +37,8 @@ def require_payment(
     description: str = "",
     mime_type: str = "",
     max_deadline_seconds: int = 60,
-    output_schema: Any = None,
+    input_schema: Optional[HTTPInputSchema] = None,
+    output_schema: Optional[Any] = None,
     facilitator_config: Optional[FacilitatorConfig] = None,
     network: str = "base-sepolia",
     resource: Optional[str] = None,
@@ -54,7 +56,8 @@ def require_payment(
         description (str, optional): Description of what is being purchased. Defaults to "".
         mime_type (str, optional): MIME type of the resource. Defaults to "".
         max_deadline_seconds (int, optional): Maximum time allowed for payment. Defaults to 60.
-        output_schema (Any, optional): JSON schema for the response. Defaults to None.
+        input_schema (Optional[HTTPInputSchema], optional): Schema for the request structure. Defaults to None.
+        output_schema (Optional[Any], optional): Schema for the response. Defaults to None.
         facilitator_config (Optional[Dict[str, Any]], optional): Configuration for the payment facilitator.
             If not provided, defaults to the public x402.org facilitator.
         network (str, optional): Ethereum network ID. Defaults to "base-sepolia" (Base Sepolia testnet).
@@ -91,8 +94,19 @@ def require_payment(
         # Get resource URL if not explicitly provided
         resource_url = resource or str(request.url)
 
-        # Ensure output_schema and extra are objects, not null
-        output_schema_obj = {} if output_schema is None else output_schema
+        # Create input structure if input_schema is provided
+        input_structure = None
+        if input_schema:
+            input_structure = {
+                "spec": "http",
+                "method": request.method.upper(),
+                **input_schema.model_dump(),
+            }
+
+        # Create request structure if either input or output is provided
+        request_structure = None
+        if input_structure or output_schema:
+            request_structure = {"input": input_structure, "output": output_schema}
 
         # Construct payment details
         payment_requirements = [
@@ -106,7 +120,8 @@ def require_payment(
                 mime_type=mime_type,
                 pay_to=pay_to_address,
                 max_timeout_seconds=max_deadline_seconds,
-                output_schema=output_schema_obj,
+                # TODO: Rename output_schema to request_structure
+                output_schema=request_structure,
                 extra=eip712_domain,
             )
         ]

--- a/python/x402/src/x402/flask/middleware.py
+++ b/python/x402/src/x402/flask/middleware.py
@@ -10,6 +10,7 @@ from x402.types import (
     x402PaymentRequiredResponse,
     PaywallConfig,
     SupportedNetworks,
+    HTTPInputSchema,
 )
 from x402.common import (
     process_price_to_atomic_amount,
@@ -63,7 +64,8 @@ class PaymentMiddleware:
         description: str = "",
         mime_type: str = "",
         max_deadline_seconds: int = 60,
-        output_schema: Any = None,
+        input_schema: Optional[HTTPInputSchema] = None,
+        output_schema: Optional[Any] = None,
         facilitator_config: Optional[FacilitatorConfig] = None,
         network: str = "base-sepolia",
         resource: Optional[str] = None,
@@ -80,7 +82,8 @@ class PaymentMiddleware:
             description (str, optional): Description of the resource
             mime_type (str, optional): MIME type of the resource
             max_deadline_seconds (int, optional): Max time for payment
-            output_schema (Any, optional): JSON schema for response
+            input_schema (Optional[HTTPInputSchema], optional): Schema for the request structure. Defaults to None.
+            output_schema (Optional[Any], optional): Schema for the response. Defaults to None.
             facilitator_config (dict, optional): Facilitator config
             network (str, optional): Network ID
             resource (str, optional): Resource URL
@@ -94,6 +97,7 @@ class PaymentMiddleware:
             "description": description,
             "mime_type": mime_type,
             "max_deadline_seconds": max_deadline_seconds,
+            "input_schema": input_schema,
             "output_schema": output_schema,
             "facilitator_config": facilitator_config,
             "network": network,
@@ -147,10 +151,22 @@ class PaymentMiddleware:
                 # Get resource URL if not explicitly provided
                 resource_url = config["resource"] or request.url
 
-                # Ensure output_schema and extra are objects, not null
-                output_schema_obj = (
-                    {} if config["output_schema"] is None else config["output_schema"]
-                )
+                # Create input structure if input_schema is provided
+                input_structure = None
+                if config["input_schema"]:
+                    input_structure = {
+                        "spec": "http",
+                        "method": request.method.upper(),
+                        **config["input_schema"].model_dump(),
+                    }
+
+                # Create request structure if either input or output is provided
+                request_structure = None
+                if input_structure or config["output_schema"]:
+                    request_structure = {
+                        "input": input_structure,
+                        "output": config["output_schema"],
+                    }
 
                 # Construct payment details
                 payment_requirements = [
@@ -164,7 +180,8 @@ class PaymentMiddleware:
                         mime_type=config["mime_type"],
                         pay_to=config["pay_to_address"],
                         max_timeout_seconds=config["max_deadline_seconds"],
-                        output_schema=output_schema_obj,
+                        # TODO: Rename output_schema to request_structure
+                        output_schema=request_structure,
                         extra=eip712_domain,
                     )
                 ]

--- a/python/x402/src/x402/types.py
+++ b/python/x402/src/x402/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from enum import Enum
+from typing import Any, Optional, Union, Dict, Literal
 from typing_extensions import (
     TypedDict,
 )  # use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12
@@ -9,6 +10,45 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.alias_generators import to_camel
 
 from x402.networks import SupportedNetworks
+
+
+# Add HTTP request structure types
+class HTTPVerbs(str, Enum):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+    DELETE = "DELETE"
+    PATCH = "PATCH"
+    OPTIONS = "OPTIONS"
+    HEAD = "HEAD"
+
+
+class HTTPInputSchema(BaseModel):
+    """Schema for HTTP request input, excluding spec and method which are handled by the middleware"""
+
+    query_params: Optional[Dict[str, str]] = None
+    body_type: Optional[
+        Literal["json", "form-data", "multipart-form-data", "text", "binary"]
+    ] = None
+    body_fields: Optional[Dict[str, Any]] = None
+    header_fields: Optional[Dict[str, Any]] = None
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        from_attributes=True,
+    )
+
+
+class HTTPRequestStructure(HTTPInputSchema):
+    """Complete HTTP request structure including spec and method"""
+
+    spec: Literal["http"]
+    method: HTTPVerbs
+
+
+# For now we only support HTTP, but could add MCP and OpenAPI later
+RequestStructure = HTTPRequestStructure
 
 
 class TokenAmount(BaseModel):

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -15,6 +15,7 @@ import {
   PaymentPayload,
   PaymentRequirements,
   PaywallConfig,
+  RequestStructure,
   Resource,
   RoutesConfig,
   settleResponseHeader,
@@ -92,8 +93,15 @@ export function paymentMiddleware(
     }
 
     const { price, network, config = {} } = matchingRoute.config;
-    const { description, mimeType, maxTimeoutSeconds, outputSchema, customPaywallHtml, resource } =
-      config;
+    const {
+      description,
+      mimeType,
+      maxTimeoutSeconds,
+      inputSchema,
+      outputSchema,
+      customPaywallHtml,
+      resource,
+    } = config;
 
     const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
     if ("error" in atomicAmountForAsset) {
@@ -103,6 +111,22 @@ export function paymentMiddleware(
 
     const resourceUrl: Resource =
       resource || (`${req.protocol}://${req.headers.host}${req.path}` as Resource);
+
+    const input = inputSchema
+      ? ({
+          spec: "http",
+          method: req.method.toUpperCase(),
+          ...inputSchema,
+        } as RequestStructure)
+      : undefined;
+
+    const requestStructure =
+      input || outputSchema
+        ? {
+            input,
+            output: outputSchema,
+          }
+        : undefined;
 
     const paymentRequirements: PaymentRequirements[] = [
       {
@@ -115,7 +139,8 @@ export function paymentMiddleware(
         payTo: getAddress(payTo),
         maxTimeoutSeconds: maxTimeoutSeconds ?? 60,
         asset: getAddress(asset.address),
-        outputSchema: outputSchema ?? undefined,
+        // TODO: Rename outputSchema to requestStructure
+        outputSchema: requestStructure,
         extra: asset.eip712,
       },
     ];

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -18,6 +18,7 @@ import {
   RoutesConfig,
   settleResponseHeader,
   PaywallConfig,
+  RequestStructure,
 } from "x402/types";
 import { useFacilitator } from "x402/verify";
 
@@ -81,14 +82,22 @@ export function paymentMiddleware(
   const routePatterns = computeRoutePatterns(routes);
 
   return async function paymentMiddleware(c: Context, next: () => Promise<void>) {
-    const matchingRoute = findMatchingRoute(routePatterns, c.req.path, c.req.method.toUpperCase());
+    const method = c.req.method.toUpperCase();
+    const matchingRoute = findMatchingRoute(routePatterns, c.req.path, method);
     if (!matchingRoute) {
       return next();
     }
 
-    const { price, network } = matchingRoute.config;
-    const { description, mimeType, maxTimeoutSeconds, outputSchema, customPaywallHtml, resource } =
-      matchingRoute.config.config || {};
+    const { price, network, config = {} } = matchingRoute.config;
+    const {
+      description,
+      mimeType,
+      maxTimeoutSeconds,
+      inputSchema,
+      outputSchema,
+      customPaywallHtml,
+      resource,
+    } = config;
 
     const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
     if ("error" in atomicAmountForAsset) {
@@ -97,6 +106,22 @@ export function paymentMiddleware(
     const { maxAmountRequired, asset } = atomicAmountForAsset;
 
     const resourceUrl: Resource = resource || (c.req.url as Resource);
+
+    const input = inputSchema
+      ? ({
+          spec: "http",
+          method,
+          ...inputSchema,
+        } as RequestStructure)
+      : undefined;
+
+    const requestStructure =
+      input || outputSchema
+        ? {
+            input,
+            output: outputSchema,
+          }
+        : undefined;
 
     const paymentRequirements: PaymentRequirements[] = [
       {
@@ -109,7 +134,8 @@ export function paymentMiddleware(
         payTo: getAddress(payTo),
         maxTimeoutSeconds: maxTimeoutSeconds ?? 300,
         asset: getAddress(asset.address),
-        outputSchema,
+        // TODO: Rename outputSchema to requestStructure
+        outputSchema: requestStructure,
         extra: asset.eip712,
       },
     ];

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -18,6 +18,7 @@ import {
   Resource,
   RoutesConfig,
   PaywallConfig,
+  RequestStructure,
 } from "x402/types";
 import { useFacilitator } from "x402/verify";
 import { safeBase64Encode } from "x402/shared";
@@ -110,8 +111,15 @@ export function paymentMiddleware(
     }
 
     const { price, network, config = {} } = matchingRoute.config;
-    const { description, mimeType, maxTimeoutSeconds, outputSchema, customPaywallHtml, resource } =
-      config;
+    const {
+      description,
+      mimeType,
+      maxTimeoutSeconds,
+      inputSchema,
+      outputSchema,
+      customPaywallHtml,
+      resource,
+    } = config;
 
     const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
     if ("error" in atomicAmountForAsset) {
@@ -121,6 +129,23 @@ export function paymentMiddleware(
 
     const resourceUrl =
       resource || (`${request.nextUrl.protocol}//${request.nextUrl.host}${pathname}` as Resource);
+
+    const input = inputSchema
+      ? ({
+          spec: "http",
+          method,
+          ...inputSchema,
+        } as RequestStructure)
+      : undefined;
+
+    const requestStructure =
+      input || outputSchema
+        ? {
+            input,
+            output: outputSchema,
+          }
+        : undefined;
+
     const paymentRequirements: PaymentRequirements[] = [
       {
         scheme: "exact",
@@ -132,7 +157,8 @@ export function paymentMiddleware(
         payTo: getAddress(payTo),
         maxTimeoutSeconds: maxTimeoutSeconds ?? 300,
         asset: getAddress(asset.address),
-        outputSchema,
+        // TODO: Rename outputSchema to requestStructure
+        outputSchema: requestStructure,
         extra: asset.eip712,
       },
     ];

--- a/typescript/packages/x402/src/types/shared/middleware.ts
+++ b/typescript/packages/x402/src/types/shared/middleware.ts
@@ -4,6 +4,7 @@ import { Network } from "./network";
 import { Resource } from "./resource";
 import { LocalAccount } from "viem";
 import { SignerWallet } from "./evm";
+import { HTTPRequestStructure } from "..";
 
 export type FacilitatorConfig = {
   url: Resource;
@@ -21,6 +22,7 @@ export type PaymentMiddlewareConfig = {
   description?: string;
   mimeType?: string;
   maxTimeoutSeconds?: number;
+  inputSchema?: Omit<HTTPRequestStructure, "spec" | "method">;
   outputSchema?: object;
   customPaywallHtml?: string;
   resource?: Resource;

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -76,6 +76,70 @@ export type UnsignedPaymentPayload = Omit<PaymentPayload, "payload"> & {
   payload: Omit<ExactEvmPayload, "signature"> & { signature: undefined };
 };
 
+// x402RequestStructure
+const HTTPVerbsSchema = z.enum(["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"]);
+export type HTTPVerbs = z.infer<typeof HTTPVerbsSchema>;
+
+export const HTTPRequestStructureSchema = z.object({
+  spec: z.literal("http"),
+  method: HTTPVerbsSchema,
+  queryParams: z.record(z.string(), z.string()).optional(),
+  bodyType: z.enum(["json", "form-data", "multipart-form-data", "text", "binary"]).optional(),
+  bodyFields: z.record(z.string(), z.any()).optional(),
+  headerFields: z.record(z.string(), z.any()).optional(),
+});
+
+// export const MCPRequestStructureSchema = z.object({
+//   spec: z.literal("mcp"),
+//   sessionIsPayed: z.boolean(),
+//   payedAction: z.object({
+//     kind: z.enum(["prompts", "resources", "tools"]),
+//     name: z.string(),
+//   }).optional(),
+// });
+
+// export const OpenAPIRequestStructureSchema = z.object({
+//   spec: z.literal("openapi"),
+//   openApiUrl: z.string().url(),
+//   path: z.string(),
+// });
+
+export const RequestStructureSchema = z.discriminatedUnion("spec", [
+  HTTPRequestStructureSchema,
+  // MCPRequestStructureSchema,
+  // OpenAPIRequestStructureSchema,
+]);
+
+export type HTTPRequestStructure = z.infer<typeof HTTPRequestStructureSchema>;
+// export type MCPRequestStructure = z.infer<typeof MCPRequestStructureSchema>;
+// export type OpenAPIRequestStructure = z.infer<typeof OpenAPIRequestStructureSchema>;
+export type RequestStructure = z.infer<typeof RequestStructureSchema>;
+
+// x402BazaarItem
+export const BazaarItemSchema = z.object({
+  resource: z.string(),
+  type: z.enum(["http"]),
+  x402Version: z.number().refine(val => x402Versions.includes(val as 1)),
+  accepts: z.array(PaymentRequirementsSchema),
+  lastUpdated: z.number().positive(),
+  metadata: z.record(z.any()).optional(),
+});
+export type BazaarItem = z.infer<typeof BazaarItemSchema>;
+
+// x402SettleRequest
+export const SettleRequestSchema = z.object({
+  paymentPayload: PaymentPayloadSchema,
+  paymentRequirements: PaymentRequirementsSchema,
+});
+export type SettleRequest = z.infer<typeof SettleRequestSchema>;
+
+// x402VerifyRequest
+export const VerifyRequestSchema = z.object({
+  paymentPayload: PaymentPayloadSchema,
+  paymentRequirements: PaymentRequirementsSchema,
+});
+export type VerifyRequest = z.infer<typeof VerifyRequestSchema>;
+
 // x402VerifyResponse
 export const VerifyResponseSchema = z.object({
   isValid: z.boolean(),
@@ -93,6 +157,28 @@ export const SettleResponseSchema = z.object({
   network: NetworkSchema,
 });
 export type SettleResponse = z.infer<typeof SettleResponseSchema>;
+
+// x402DiscoverListRequest
+export const DiscoverListRequestSchema = z.object({
+  type: z.string().optional(),
+  resource: z.string().optional(),
+  pageSize: z.number().optional(),
+  pageToken: z.string().optional(),
+});
+export type DiscoverListRequest = z.infer<typeof DiscoverListRequestSchema>;
+
+// x402DiscoveryListResponse aka x402BazaarResponse
+export const DiscoveryListResponseSchema = z.object({
+  x402Version: z.number().refine(val => x402Versions.includes(val as 1)),
+  items: z.array(BazaarItemSchema),
+  numItems: z.number(),
+  pagination: z.object({
+    pageSize: z.number(),
+    pageToken: z.string(),
+    nextPageToken: z.string().optional(),
+  }),
+});
+export type DiscoveryListResponse = z.infer<typeof DiscoveryListResponseSchema>;
 
 // x402SupportedPaymentKind
 export const SupportedPaymentKindSchema = z.object({

--- a/typescript/site/app/facilitator/discover/list/route.ts
+++ b/typescript/site/app/facilitator/discover/list/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  DiscoverListRequest,
+  DiscoveryListResponse,
+  DiscoveryListResponseSchema,
+} from "x402/types";
+
+/**
+ * This route is used to discover the available services on the facilitator.
+ * It returns a list of services that are available on the facilitator.
+ *
+ * @param request - The request object
+ * @returns A list of services that are available on the facilitator
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // TODO: Implement actual discovery logic
+
+    // Parse query parameters
+    const { searchParams } = new URL(request.url);
+    const { resource, pageSize, pageToken } = Object.fromEntries(
+      searchParams.entries(),
+    ) as DiscoverListRequest;
+
+    // TODO: Search by type, resource, fetching page size and page token
+
+    // For now, return mock data
+    const mockDiscoveryListResponse: DiscoveryListResponse = {
+      x402Version: 1,
+      items: [
+        {
+          type: "http",
+          resource,
+          x402Version: 1,
+          lastUpdated: Date.now(),
+          accepts: [
+            {
+              scheme: "exact",
+              network: "base",
+              maxAmountRequired: "1000000000000000000", // 1 ETH in wei
+              resource: "https://api.example.com/ai/completion",
+              description: "AI text completion service",
+              outputSchema: {
+                input: {
+                  spec: "http",
+                  method: "POST",
+                  bodyType: "json",
+                  bodyFields: {
+                    prompt: "string",
+                    maxTokens: "number",
+                  },
+                  headerFields: {
+                    "Content-Type": "application/json",
+                  },
+                },
+              },
+              mimeType: "application/json",
+              payTo: "0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6",
+              maxTimeoutSeconds: 300,
+              asset: "0x0000000000000000000000000000000000000000", // ETH
+            },
+          ],
+          metadata: {
+            categories: ["ai", "text-generation"],
+            successRate7d: 98.5,
+            avgLatencyMs: 1200,
+            totalRequests: 15420,
+          },
+        },
+        {
+          type: "http",
+          resource,
+          x402Version: 1,
+          lastUpdated: Date.now(),
+          accepts: [
+            {
+              scheme: "exact",
+              network: "base",
+              maxAmountRequired: "500000000000000000", // 0.5 ETH in wei
+              resource: "https://api.example.com/image/generate",
+              description: "AI image generation service",
+              outputSchema: {
+                input: {
+                  spec: "http",
+                  method: "POST",
+                  bodyType: "json",
+                  bodyFields: {
+                    prompt: "string",
+                    width: "number",
+                    height: "number",
+                  },
+                },
+              },
+              mimeType: "application/json",
+              payTo: "0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6",
+              maxTimeoutSeconds: 600,
+              asset: "0x0000000000000000000000000000000000000000", // ETH
+            },
+          ],
+          metadata: {
+            categories: ["ai", "image-generation"],
+            successRate7d: 95.2,
+            avgLatencyMs: 4500,
+            totalRequests: 8230,
+          },
+        },
+      ],
+      numItems: 2,
+      pagination: {
+        pageSize,
+        pageToken,
+        nextPageToken: undefined, // Latest token
+      },
+    };
+
+    // Validate response with schema
+    const validatedResponse = DiscoveryListResponseSchema.parse(mockDiscoveryListResponse);
+
+    return NextResponse.json(validatedResponse);
+  } catch (error) {
+    console.error("Error in discover/list:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Description

Early `/discovery/list` thoughts and how it integrates with the facilitator in a backwards-compatible way.

1. At the server level when using the middleware, have route config (endpoint grouping configuration) provide the request data that is important to them
// We do this, instead of have the middleware read these values upright, to minimize any invasiveness while also ensuring builders have the most control over how agents use their endpoints
2. At the middleware level, combine the server-provided HTTP request structure with the verb in question to create a valid request structure
3. At the `useFacilitator` level, have `RequestStructure` be a optional 3rd argument to the `/settle` call
4. (In the backend) store this request structure (or find the existing record for it), and track any metadata we need, i.e. related to success rate

Thoughts:
* If we require this optional argument in /verify, we can pre-create the entry before the settle attempt, and store a timestamp. Then, on settle, we can deduce the latency and success rates

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) 

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 