### PR TITLE
feat: exporting core x402 utilities

### DIFF
--- a/python/x402/src/x402/__init__.py
+++ b/python/x402/src/x402/__init__.py
@@ -1,2 +1,42 @@
-def hello() -> str:
-    return "Hello from x402!"
+# Core utilities used by middleware and clients
+from .common import process_price_to_atomic_amount, x402_VERSION
+
+# Core types used by middleware and clients
+from .types import (
+    PaymentRequirements,
+    x402PaymentRequiredResponse,
+    PaymentPayload,
+    Price,
+    Money,
+    TokenAmount,
+    TokenAsset,
+    EIP712Domain,
+    UnsupportedSchemeException,
+)
+
+# Core functions used by clients
+from .exact import sign_payment_header
+
+# Core utilities used by middleware
+from .encoding import safe_base64_decode
+from .path import path_is_match
+
+__all__ = [
+    # Core utilities
+    "process_price_to_atomic_amount",
+    "x402_VERSION",
+    "safe_base64_decode",
+    "path_is_match",
+    # Core types
+    "PaymentRequirements",
+    "x402PaymentRequiredResponse",
+    "PaymentPayload",
+    "Price",
+    "Money",
+    "TokenAmount",
+    "TokenAsset",
+    "EIP712Domain",
+    "UnsupportedSchemeException",
+    # Core functions
+    "sign_payment_header",
+]


### PR DESCRIPTION
## Description

In working on a Python integration, I realized that none of the core x402 utility functions were being exported. We were only exporting the clients/middleware but not the core product.

This PR updates the core x402 export to export all utility functions that middeware or clients rely on. It does not export the clients nor middleware themselves, as they already export independently.

## Checklist

- [ ] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 