### PR TITLE
feat: Add "get more USDC" button to hono and express middleware & paywalls

### DIFF
--- a/examples/typescript/fullstack/mainnet/app/api/x402/session-token/route.ts
+++ b/examples/typescript/fullstack/mainnet/app/api/x402/session-token/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "x402-next";

--- a/examples/typescript/fullstack/mainnet/middleware.ts
+++ b/examples/typescript/fullstack/mainnet/middleware.ts
@@ -19,6 +19,7 @@ export const middleware = paymentMiddleware(
   {
     appName: "Mainnet x402 Demo",
     appLogo: "/x402-icon-blue.png",
+    sessionTokenEndpoint: "/api/x402/session-token",
   },
 );
 

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
 
   ../../typescript/packages/x402-express:
     dependencies:
+      '@coinbase/cdp-sdk':
+        specifier: ^1.22.0
+        version: 1.22.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       express:
         specifier: ^4.18.2
         version: 4.21.2
@@ -352,6 +355,9 @@ importers:
 
   ../../typescript/packages/x402-hono:
     dependencies:
+      '@coinbase/cdp-sdk':
+        specifier: ^1.22.0
+        version: 1.22.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       hono:
         specifier: ^4.7.1
         version: 4.7.7

--- a/typescript/packages/x402-express/README.md
+++ b/typescript/packages/x402-express/README.md
@@ -98,5 +98,102 @@ type PaywallConfig = {
   cdpClientKey?: string;              // Your CDP Client API Key
   appName?: string;                   // Name displayed in the paywall wallet selection modal
   appLogo?: string;                   // Logo for the paywall wallet selection modal
+  sessionTokenEndpoint?: string;      // API endpoint for Coinbase Onramp session authentication
 };
 ```
+
+## Optional: Coinbase Onramp Integration
+
+**Note**: Onramp integration is completely optional. Your x402 paywall will work perfectly without it. This feature is for users who want to provide an easy way for their customers to fund their wallets directly from the paywall.
+
+When configured, a "Get more USDC" button will appear in your paywall, allowing users to purchase USDC directly through Coinbase Onramp.
+
+### Quick Setup
+
+#### 1. Create the Session Token Route
+
+Add a session token endpoint to your Express app:
+
+```typescript
+import express from "express";
+import { POST } from "x402-express/session-token";
+
+const app = express();
+
+// Add the session token endpoint
+app.post("/api/x402/session-token", POST);
+```
+
+#### 2. Configure Your Middleware
+
+Add `sessionTokenEndpoint` to your middleware configuration. This tells the paywall where to find your session token API:
+
+```typescript
+app.use(paymentMiddleware(
+  payTo,
+  routes,
+  facilitator,
+  {
+    sessionTokenEndpoint: "/api/x402/session-token",
+    cdpClientKey: "your-cdp-client-key",
+  }
+));
+```
+
+**Important**: The `sessionTokenEndpoint` must match the route you created above. You can use any path you prefer - just make sure both the route and configuration use the same path. Without this configuration, the "Get more USDC" button will be hidden.
+
+#### 3. Get CDP API Keys
+
+1. Go to [CDP Portal](https://portal.cdp.coinbase.com/)
+2. Navigate to your project's **[API Keys](https://portal.cdp.coinbase.com/projects/api-keys)**
+3. Click **Create API key**
+4. Download and securely store your API key
+
+#### 4. Enable Onramp Secure Initialization in CDP Portal
+
+1. Go to [CDP Portal](https://portal.cdp.coinbase.com/)
+2. Navigate to **Payments → [Onramp & Offramp](https://portal.cdp.coinbase.com/products/onramp)**
+3. Toggle **"Enforce secure initialization"** to **Enabled**
+
+#### 5. Set Environment Variables
+
+Add your CDP API keys to your environment:
+
+```bash
+# .env
+CDP_API_KEY_ID=your_secret_api_key_id_here
+CDP_API_KEY_SECRET=your_secret_api_key_secret_here
+```
+
+### How Onramp Works
+
+Once set up, your x402 paywall will automatically show a "Get more USDC" button when users need to fund their wallets. 
+
+1. **Generates session token**: Your backend securely creates a session token using CDP's API
+2. **Opens secure onramp**: User is redirected to Coinbase Onramp with the session token
+3. **No exposed data**: Wallet addresses and app IDs are never exposed in URLs
+
+### Troubleshooting Onramp
+
+#### Common Issues
+
+1. **"Missing CDP API credentials"**
+    - Ensure `CDP_API_KEY_ID` and `CDP_API_KEY_SECRET` are set
+    - Verify you're using **Secret API Keys**, not Client API Keys
+
+2. **"Failed to generate session token"**
+    - Check your CDP Secret API key has proper permissions
+    - Verify your project has Onramp enabled
+
+3. **API route not found**
+    - Ensure you've added the session token route: `app.post("/your-path", POST)`
+    - Check that your route path matches your `sessionTokenEndpoint` configuration
+    - Verify the import: `import { POST } from "x402-express/session-token"`
+    - Example: If you configured `sessionTokenEndpoint: "/api/custom/onramp"`, add `app.post("/api/custom/onramp", POST)`
+
+
+## Resources
+
+- [x402 Protocol](https://x402.org)
+- [CDP Documentation](https://docs.cdp.coinbase.com)
+- [CDP Discord](https://discord.com/invite/cdp)

--- a/typescript/packages/x402-express/package.json
+++ b/typescript/packages/x402-express/package.json
@@ -39,6 +39,7 @@
     "vitest": "^3.0.5"
   },
   "dependencies": {
+    "@coinbase/cdp-sdk": "^1.22.0",
     "express": "^4.18.2",
     "viem": "^2.21.26",
     "x402": "workspace:^",

--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -378,4 +378,116 @@ describe("paymentMiddleware()", () => {
     expect(mockSettle).not.toHaveBeenCalled();
     expect(mockRes.statusCode).toBe(500);
   });
+
+  describe("session token integration", () => {
+    it("should pass sessionTokenEndpoint to paywall HTML when configured", async () => {
+      const paywallConfig = {
+        cdpClientKey: "test-client-key",
+        appName: "Test App",
+        appLogo: "/test-logo.png",
+        sessionTokenEndpoint: "/api/x402/session-token",
+      };
+
+      const middlewareWithPaywall = paymentMiddleware(
+        payTo,
+        routesConfig,
+        facilitatorConfig,
+        paywallConfig,
+      );
+
+      mockReq.headers = {
+        accept: "text/html",
+        "user-agent": "Mozilla/5.0",
+      };
+
+      await middlewareWithPaywall(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(getPaywallHtml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cdpClientKey: "test-client-key",
+          appName: "Test App",
+          appLogo: "/test-logo.png",
+          sessionTokenEndpoint: "/api/x402/session-token",
+        }),
+      );
+    });
+
+    it("should not pass sessionTokenEndpoint when not configured", async () => {
+      const paywallConfig = {
+        cdpClientKey: "test-client-key",
+        appName: "Test App",
+      };
+
+      const middlewareWithPaywall = paymentMiddleware(
+        payTo,
+        routesConfig,
+        facilitatorConfig,
+        paywallConfig,
+      );
+
+      mockReq.headers = {
+        accept: "text/html",
+        "user-agent": "Mozilla/5.0",
+      };
+
+      await middlewareWithPaywall(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(getPaywallHtml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cdpClientKey: "test-client-key",
+          appName: "Test App",
+          sessionTokenEndpoint: undefined,
+        }),
+      );
+    });
+
+    it("should pass sessionTokenEndpoint even when other paywall config is minimal", async () => {
+      const paywallConfig = {
+        sessionTokenEndpoint: "/custom/session-token",
+      };
+
+      const middlewareWithPaywall = paymentMiddleware(
+        payTo,
+        routesConfig,
+        facilitatorConfig,
+        paywallConfig,
+      );
+
+      mockReq.headers = {
+        accept: "text/html",
+        "user-agent": "Mozilla/5.0",
+      };
+
+      await middlewareWithPaywall(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(getPaywallHtml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionTokenEndpoint: "/custom/session-token",
+          cdpClientKey: undefined,
+          appName: undefined,
+          appLogo: undefined,
+        }),
+      );
+    });
+
+    it("should work without any paywall config", async () => {
+      const middlewareWithoutPaywall = paymentMiddleware(payTo, routesConfig, facilitatorConfig);
+
+      mockReq.headers = {
+        accept: "text/html",
+        "user-agent": "Mozilla/5.0",
+      };
+
+      await middlewareWithoutPaywall(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(getPaywallHtml).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionTokenEndpoint: undefined,
+          cdpClientKey: undefined,
+          appName: undefined,
+          appLogo: undefined,
+        }),
+      );
+    });
+  });
 });

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -151,6 +151,7 @@ export function paymentMiddleware(
             cdpClientKey: paywall?.cdpClientKey,
             appName: paywall?.appName,
             appLogo: paywall?.appLogo,
+            sessionTokenEndpoint: paywall?.sessionTokenEndpoint,
           });
         res.status(402).send(html);
         return;

--- a/typescript/packages/x402-express/src/session-token.test.ts
+++ b/typescript/packages/x402-express/src/session-token.test.ts
@@ -1,0 +1,292 @@
+import { Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { generateJwt } from "@coinbase/cdp-sdk/auth";
+import { POST } from "./session-token";
+
+// Mock the CDP SDK
+vi.mock("@coinbase/cdp-sdk/auth", () => ({
+  generateJwt: vi.fn(),
+}));
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe("session-token POST handler", () => {
+  let mockReq: Partial<Request>;
+  let mockRes: Partial<Response>;
+  let mockEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Mock environment variables
+    mockEnv = {
+      CDP_API_KEY_ID: "test-key-id",
+      CDP_API_KEY_SECRET: "test-key-secret",
+    };
+    vi.stubGlobal("process", {
+      env: mockEnv,
+    });
+
+    // Set up Express request and response mocks
+    mockReq = {
+      body: {},
+    } as Request;
+
+    mockRes = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("successful token generation", () => {
+    it("should generate session token successfully", async () => {
+      const mockJwt = "mock-jwt-token";
+      const mockSessionToken = {
+        token: "session-token-123",
+        expires_at: "2024-01-01T00:00:00Z",
+      };
+
+      mockReq.body = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(generateJwt).mockResolvedValue(mockJwt);
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockSessionToken),
+      } as unknown as globalThis.Response);
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(generateJwt).toHaveBeenCalledWith({
+        apiKeyId: "test-key-id",
+        apiKeySecret: "test-key-secret",
+        requestMethod: "POST",
+        requestHost: "api.developer.coinbase.com",
+        requestPath: "/onramp/v1/token",
+      });
+
+      expect(fetch).toHaveBeenCalledWith("https://api.developer.coinbase.com/onramp/v1/token", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${mockJwt}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          addresses: [
+            {
+              address: "0x1234567890123456789012345678901234567890",
+              blockchains: ["base"],
+            },
+          ],
+        }),
+      });
+
+      expect(mockRes.json).toHaveBeenCalledWith(mockSessionToken);
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("environment variable validation", () => {
+    it("should return 500 when CDP_API_KEY_ID is missing", async () => {
+      mockEnv.CDP_API_KEY_ID = undefined;
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "Server configuration error: Missing CDP API credentials",
+      });
+    });
+
+    it("should return 500 when CDP_API_KEY_SECRET is missing", async () => {
+      mockEnv.CDP_API_KEY_SECRET = undefined;
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "Server configuration error: Missing CDP API credentials",
+      });
+    });
+
+    it("should return 500 when both API keys are missing", async () => {
+      mockEnv.CDP_API_KEY_ID = undefined;
+      mockEnv.CDP_API_KEY_SECRET = undefined;
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "Server configuration error: Missing CDP API credentials",
+      });
+    });
+  });
+
+  describe("request body validation", () => {
+    it("should return 400 when addresses is missing", async () => {
+      mockReq.body = {};
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "addresses is required and must be a non-empty array",
+      });
+    });
+
+    it("should return 400 when addresses is null", async () => {
+      mockReq.body = { addresses: null };
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "addresses is required and must be a non-empty array",
+      });
+    });
+
+    it("should return 400 when addresses is not an array", async () => {
+      mockReq.body = { addresses: "not-an-array" };
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "addresses is required and must be a non-empty array",
+      });
+    });
+
+    it("should return 400 when addresses is empty array", async () => {
+      mockReq.body = { addresses: [] };
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "addresses is required and must be a non-empty array",
+      });
+    });
+  });
+
+  describe("JWT generation errors", () => {
+    it("should return 500 when JWT generation fails", async () => {
+      mockReq.body = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(generateJwt).mockRejectedValue(new Error("JWT generation failed"));
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "Internal server error",
+      });
+    });
+  });
+
+  describe("CDP API errors", () => {
+    it("should return 400 when CDP API returns 400", async () => {
+      mockReq.body = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve("Bad Request"),
+      } as unknown as globalThis.Response);
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "Failed to generate session token",
+      });
+    });
+
+    it("should return 401 when CDP API returns 401", async () => {
+      mockReq.body = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve("Unauthorized"),
+      } as unknown as globalThis.Response);
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "Failed to generate session token",
+      });
+    });
+
+    it("should return 500 when CDP API returns 500", async () => {
+      mockReq.body = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Internal Server Error"),
+      } as unknown as globalThis.Response);
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "Failed to generate session token",
+      });
+    });
+  });
+
+  describe("network errors", () => {
+    it("should return 500 when fetch fails", async () => {
+      mockReq.body = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockRejectedValue(new Error("Network error"));
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "Internal server error",
+      });
+    });
+
+    it("should return 500 when response.json() fails", async () => {
+      mockReq.body = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(new Error("JSON parsing error")),
+      } as unknown as globalThis.Response);
+
+      await POST(mockReq as Request, mockRes as Response);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: "Internal server error",
+      });
+    });
+  });
+});

--- a/typescript/packages/x402-express/src/session-token.ts
+++ b/typescript/packages/x402-express/src/session-token.ts
@@ -1,0 +1,87 @@
+import { generateJwt } from "@coinbase/cdp-sdk/auth";
+import type { Request, Response } from "express";
+
+/**
+ * Generate a session token for Coinbase Onramp and Offramp using Secure Init
+ *
+ * This endpoint creates a server-side session token that can be used
+ * instead of passing appId and addresses directly in onramp/offramp URLs.
+ *
+ * Setup:
+ * 1. Set CDP_API_KEY_ID and CDP_API_KEY_SECRET environment variables
+ * 2. Add this to your Express app: app.post("/api/x402/session-token", POST);
+ *
+ * @param req - The Express Request containing the session token request
+ * @param res - The Express Response object
+ * @returns Promise<void> - The response containing the session token or error
+ */
+export async function POST(req: Request, res: Response) {
+  try {
+    // Get CDP API credentials from environment variables
+    const apiKeyId = process.env.CDP_API_KEY_ID;
+    const apiKeySecret = process.env.CDP_API_KEY_SECRET;
+
+    if (!apiKeyId || !apiKeySecret) {
+      console.error("Missing CDP API credentials");
+      return res.status(500).json({
+        error: "Server configuration error: Missing CDP API credentials",
+      });
+    }
+
+    // Parse request body
+    const body = req.body as {
+      addresses?: Array<{ address: string; blockchains?: string[] }>;
+      assets?: string[];
+    };
+    const { addresses, assets } = body;
+
+    if (!addresses || !Array.isArray(addresses) || addresses.length === 0) {
+      return res.status(400).json({
+        error: "addresses is required and must be a non-empty array",
+      });
+    }
+
+    // Generate JWT for authentication
+    const jwt = await generateJwt({
+      apiKeyId,
+      apiKeySecret,
+      requestMethod: "POST",
+      requestHost: "api.developer.coinbase.com",
+      requestPath: "/onramp/v1/token",
+    });
+
+    // Create session token request payload
+    const tokenRequestPayload = {
+      addresses: addresses.map((addr: { address: string; blockchains?: string[] }) => ({
+        address: addr.address,
+        blockchains: addr.blockchains || ["base"],
+      })),
+      ...(assets && { assets }),
+    };
+
+    // Call Coinbase API to generate session token
+    const response = await fetch("https://api.developer.coinbase.com/onramp/v1/token", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(tokenRequestPayload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("Failed to generate session token:", response.status, errorText);
+      return res.status(response.status).json({
+        error: "Failed to generate session token",
+      });
+    }
+
+    const data = await response.json();
+
+    return res.json(data);
+  } catch (error) {
+    console.error("Error generating session token:", error);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+}

--- a/typescript/packages/x402-hono/README.md
+++ b/typescript/packages/x402-hono/README.md
@@ -100,5 +100,101 @@ type PaywallConfig = {
   cdpClientKey?: string;              // Your CDP Client API Key
   appName?: string;                   // Name displayed in the paywall wallet selection modal
   appLogo?: string;                   // Logo for the paywall wallet selection modal
+  sessionTokenEndpoint?: string;      // API endpoint for Coinbase Onramp session authentication
 };
 ```
+
+## Optional: Coinbase Onramp Integration
+
+**Note**: Onramp integration is completely optional. Your x402 paywall will work perfectly without it. This feature is for users who want to provide an easy way for their customers to fund their wallets directly from the paywall.
+
+When configured, a "Get more USDC" button will appear in your paywall, allowing users to purchase USDC directly through Coinbase Onramp.
+
+### Quick Setup
+
+#### 1. Create the Session Token Route
+
+Add a session token endpoint to your Hono app:
+
+```typescript
+import { Hono } from "hono";
+import { POST } from "x402-hono/session-token";
+
+const app = new Hono();
+
+// Add the session token endpoint
+app.post("/api/x402/session-token", POST);
+```
+
+#### 2. Configure Your Middleware
+
+Add `sessionTokenEndpoint` to your middleware configuration. This tells the paywall where to find your session token API:
+
+```typescript
+app.use(paymentMiddleware(
+  payTo,
+  routes,
+  facilitator,
+  {
+    sessionTokenEndpoint: "path/to/session-token-route",
+  }
+));
+```
+
+**Important**: The `sessionTokenEndpoint` must match the route you created above. You can use any path you prefer - just make sure both the route and configuration use the same path. Without this configuration, the "Get more USDC" button will be hidden.
+
+#### 3. Get CDP API Keys
+
+1. Go to [CDP Portal](https://portal.cdp.coinbase.com/)
+2. Navigate to your project's **[API Keys](https://portal.cdp.coinbase.com/projects/api-keys)**
+3. Click **Create API key**
+4. Download and securely store your API key
+
+#### 4. Enable Onramp Secure Initialization in CDP Portal
+
+1. Go to [CDP Portal](https://portal.cdp.coinbase.com/)
+2. Navigate to **Payments → [Onramp & Offramp](https://portal.cdp.coinbase.com/products/onramp)**
+3. Toggle **"Enforce secure initialization"** to **Enabled**
+
+#### 5. Set Environment Variables
+
+Add your CDP API keys to your environment:
+
+```bash
+# .env
+CDP_API_KEY_ID=your_secret_api_key_id_here
+CDP_API_KEY_SECRET=your_secret_api_key_secret_here
+```
+
+### How Onramp Works
+
+Once set up, your x402 paywall will automatically show a "Get more USDC" button when users need to fund their wallets. 
+
+1. **Generates session token**: Your backend securely creates a session token using CDP's API
+2. **Opens secure onramp**: User is redirected to Coinbase Onramp with the session token
+3. **No exposed data**: Wallet addresses and app IDs are never exposed in URLs
+
+### Troubleshooting Onramp
+
+#### Common Issues
+
+1. **"Missing CDP API credentials"**
+    - Ensure `CDP_API_KEY_ID` and `CDP_API_KEY_SECRET` are set
+    - Verify you're using **Secret API Keys**, not Client API Keys
+
+2. **"Failed to generate session token"**
+    - Check your CDP Secret API key has proper permissions
+    - Verify your project has Onramp enabled
+
+3. **API route not found**
+    - Ensure you've added the session token route: `app.post("/your-path", POST)`
+    - Check that your route path matches your `sessionTokenEndpoint` configuration
+    - Verify the import: `import { POST } from "x402-hono/session-token"`
+    - Example: If you configured `sessionTokenEndpoint: "/api/custom/onramp"`, add `app.post("/api/custom/onramp", POST)`
+
+
+## Resources
+
+- [x402 Protocol](https://x402.org)
+- [CDP Documentation](https://docs.cdp.coinbase.com)
+- [CDP Discord](https://discord.com/invite/cdp)

--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -38,6 +38,7 @@
     "vite": "^6.2.6"
   },
   "dependencies": {
+    "@coinbase/cdp-sdk": "^1.22.0",
     "hono": "^4.7.1",
     "viem": "^2.21.26",
     "x402": "workspace:^",

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -146,6 +146,7 @@ export function paymentMiddleware(
             cdpClientKey: paywall?.cdpClientKey,
             appName: paywall?.appName,
             appLogo: paywall?.appLogo,
+            sessionTokenEndpoint: paywall?.sessionTokenEndpoint,
           });
         return c.html(html, 402);
       }

--- a/typescript/packages/x402-hono/src/session-token.test.ts
+++ b/typescript/packages/x402-hono/src/session-token.test.ts
@@ -1,0 +1,306 @@
+import { Context } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { generateJwt } from "@coinbase/cdp-sdk/auth";
+import { POST } from "./session-token";
+
+// Mock the CDP SDK
+vi.mock("@coinbase/cdp-sdk/auth", () => ({
+  generateJwt: vi.fn(),
+}));
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe("session-token POST handler", () => {
+  let mockContext: Context;
+  let mockEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Mock environment variables
+    mockEnv = {
+      CDP_API_KEY_ID: "test-key-id",
+      CDP_API_KEY_SECRET: "test-key-secret",
+    };
+    vi.stubGlobal("process", {
+      env: mockEnv,
+    });
+
+    // Set up Hono context mock
+    mockContext = {
+      req: {
+        json: vi.fn(),
+      },
+      json: vi.fn(),
+    } as unknown as Context;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("successful token generation", () => {
+    it("should generate session token successfully", async () => {
+      const mockJwt = "mock-jwt-token";
+      const mockSessionToken = {
+        token: "session-token-123",
+        expires_at: "2024-01-01T00:00:00Z",
+      };
+
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockContext.req.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue(mockJwt);
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockSessionToken),
+      } as unknown as globalThis.Response);
+
+      await POST(mockContext);
+
+      expect(generateJwt).toHaveBeenCalledWith({
+        apiKeyId: "test-key-id",
+        apiKeySecret: "test-key-secret",
+        requestMethod: "POST",
+        requestHost: "api.developer.coinbase.com",
+        requestPath: "/onramp/v1/token",
+      });
+
+      expect(fetch).toHaveBeenCalledWith("https://api.developer.coinbase.com/onramp/v1/token", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${mockJwt}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          addresses: [
+            {
+              address: "0x1234567890123456789012345678901234567890",
+              blockchains: ["base"],
+            },
+          ],
+        }),
+      });
+
+      expect(mockContext.json).toHaveBeenCalledWith(mockSessionToken);
+    });
+  });
+
+  describe("environment variable validation", () => {
+    it("should return 500 when CDP_API_KEY_ID is missing", async () => {
+      mockEnv.CDP_API_KEY_ID = undefined;
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Server configuration error: Missing CDP API credentials" },
+        { status: 500 },
+      );
+    });
+
+    it("should return 500 when CDP_API_KEY_SECRET is missing", async () => {
+      mockEnv.CDP_API_KEY_SECRET = undefined;
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Server configuration error: Missing CDP API credentials" },
+        { status: 500 },
+      );
+    });
+
+    it("should return 500 when both API keys are missing", async () => {
+      mockEnv.CDP_API_KEY_ID = undefined;
+      mockEnv.CDP_API_KEY_SECRET = undefined;
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Server configuration error: Missing CDP API credentials" },
+        { status: 500 },
+      );
+    });
+  });
+
+  describe("request body validation", () => {
+    it("should return 400 when addresses is missing", async () => {
+      vi.mocked(mockContext.req.json).mockResolvedValue({});
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "addresses is required and must be a non-empty array" },
+        { status: 400 },
+      );
+    });
+
+    it("should return 400 when addresses is null", async () => {
+      vi.mocked(mockContext.req.json).mockResolvedValue({ addresses: null });
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "addresses is required and must be a non-empty array" },
+        { status: 400 },
+      );
+    });
+
+    it("should return 400 when addresses is not an array", async () => {
+      vi.mocked(mockContext.req.json).mockResolvedValue({ addresses: "not-an-array" });
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "addresses is required and must be a non-empty array" },
+        { status: 400 },
+      );
+    });
+
+    it("should return 400 when addresses is empty array", async () => {
+      vi.mocked(mockContext.req.json).mockResolvedValue({ addresses: [] });
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "addresses is required and must be a non-empty array" },
+        { status: 400 },
+      );
+    });
+  });
+
+  describe("JWT generation errors", () => {
+    it("should return 500 when JWT generation fails", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockContext.req.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockRejectedValue(new Error("JWT generation failed"));
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
+    });
+  });
+
+  describe("CDP API errors", () => {
+    it("should return 400 when CDP API returns 400", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockContext.req.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve("Bad Request"),
+      } as unknown as globalThis.Response);
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Failed to generate session token" },
+        { status: 400 },
+      );
+    });
+
+    it("should return 401 when CDP API returns 401", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockContext.req.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve("Unauthorized"),
+      } as unknown as globalThis.Response);
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Failed to generate session token" },
+        { status: 401 },
+      );
+    });
+
+    it("should return 500 when CDP API returns 500", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockContext.req.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Internal Server Error"),
+      } as unknown as globalThis.Response);
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Failed to generate session token" },
+        { status: 500 },
+      );
+    });
+  });
+
+  describe("network errors", () => {
+    it("should return 500 when fetch fails", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockContext.req.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockRejectedValue(new Error("Network error"));
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
+    });
+
+    it("should return 500 when response.json() fails", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockContext.req.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(new Error("JSON parsing error")),
+      } as unknown as globalThis.Response);
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
+    });
+
+    it("should return 500 when request body parsing fails", async () => {
+      vi.mocked(mockContext.req.json).mockRejectedValue(new Error("JSON parsing error"));
+
+      await POST(mockContext);
+
+      expect(mockContext.json).toHaveBeenCalledWith(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
+    });
+  });
+});

--- a/typescript/packages/x402-hono/src/session-token.ts
+++ b/typescript/packages/x402-hono/src/session-token.ts
@@ -1,0 +1,89 @@
+import { generateJwt } from "@coinbase/cdp-sdk/auth";
+import type { Context } from "hono";
+
+/**
+ * Generate a session token for Coinbase Onramp and Offramp using Secure Init
+ *
+ * This endpoint creates a server-side session token that can be used
+ * instead of passing appId and addresses directly in onramp/offramp URLs.
+ *
+ * Setup:
+ * 1. Set CDP_API_KEY_ID and CDP_API_KEY_SECRET environment variables
+ * 2. Add this to your Hono app: app.post("/api/x402/session-token", POST);
+ *
+ * @param c - The Hono Context containing the session token request
+ * @returns Promise<Response> - The response containing the session token or error
+ */
+export async function POST(c: Context) {
+  try {
+    // Get CDP API credentials from environment variables
+    const apiKeyId = process.env.CDP_API_KEY_ID;
+    const apiKeySecret = process.env.CDP_API_KEY_SECRET;
+
+    if (!apiKeyId || !apiKeySecret) {
+      console.error("Missing CDP API credentials");
+      return c.json(
+        { error: "Server configuration error: Missing CDP API credentials" },
+        { status: 500 },
+      );
+    }
+
+    // Parse request body
+    const body = (await c.req.json()) as {
+      addresses?: Array<{ address: string; blockchains?: string[] }>;
+      assets?: string[];
+    };
+    const { addresses, assets } = body;
+
+    if (!addresses || !Array.isArray(addresses) || addresses.length === 0) {
+      return c.json(
+        { error: "addresses is required and must be a non-empty array" },
+        { status: 400 },
+      );
+    }
+
+    // Generate JWT for authentication
+    const jwt = await generateJwt({
+      apiKeyId,
+      apiKeySecret,
+      requestMethod: "POST",
+      requestHost: "api.developer.coinbase.com",
+      requestPath: "/onramp/v1/token",
+    });
+
+    // Create session token request payload
+    const tokenRequestPayload = {
+      addresses: addresses.map((addr: { address: string; blockchains?: string[] }) => ({
+        address: addr.address,
+        blockchains: addr.blockchains || ["base"],
+      })),
+      ...(assets && { assets }),
+    };
+
+    // Call Coinbase API to generate session token
+    const response = await fetch("https://api.developer.coinbase.com/onramp/v1/token", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(tokenRequestPayload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("Failed to generate session token:", response.status, errorText);
+      return c.json(
+        { error: "Failed to generate session token" },
+        { status: response.status as 400 | 401 | 500 },
+      );
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+
+    return c.json(data);
+  } catch (error) {
+    console.error("Error generating session token:", error);
+    return c.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/typescript/packages/x402-next/src/api/session-token.test.ts
+++ b/typescript/packages/x402-next/src/api/session-token.test.ts
@@ -1,0 +1,319 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { generateJwt } from "@coinbase/cdp-sdk/auth";
+import { POST } from "./session-token";
+
+// Mock the CDP SDK
+vi.mock("@coinbase/cdp-sdk/auth", () => ({
+  generateJwt: vi.fn(),
+}));
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe("session-token POST handler", () => {
+  let mockRequest: NextRequest;
+  let mockEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    // Mock environment variables
+    mockEnv = {
+      CDP_API_KEY_ID: "test-key-id",
+      CDP_API_KEY_SECRET: "test-key-secret",
+    };
+    vi.stubGlobal("process", {
+      env: mockEnv,
+    });
+
+    // Set up NextRequest mock
+    mockRequest = {
+      json: vi.fn(),
+    } as unknown as NextRequest;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("successful token generation", () => {
+    it("should generate session token successfully", async () => {
+      const mockJwt = "mock-jwt-token";
+      const mockSessionToken = {
+        token: "session-token-123",
+        expires_at: "2024-01-01T00:00:00Z",
+      };
+
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockRequest.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue(mockJwt);
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockSessionToken),
+      } as unknown as globalThis.Response);
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(generateJwt).toHaveBeenCalledWith({
+        apiKeyId: "test-key-id",
+        apiKeySecret: "test-key-secret",
+        requestMethod: "POST",
+        requestHost: "api.developer.coinbase.com",
+        requestPath: "/onramp/v1/token",
+      });
+
+      expect(fetch).toHaveBeenCalledWith("https://api.developer.coinbase.com/onramp/v1/token", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${mockJwt}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          addresses: [
+            {
+              address: "0x1234567890123456789012345678901234567890",
+              blockchains: ["base"],
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(responseData).toEqual(mockSessionToken);
+    });
+  });
+
+  describe("environment variable validation", () => {
+    it("should return 500 when CDP_API_KEY_ID is missing", async () => {
+      mockEnv.CDP_API_KEY_ID = undefined;
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseData).toEqual({
+        error: "Server configuration error: Missing CDP API credentials",
+      });
+    });
+
+    it("should return 500 when CDP_API_KEY_SECRET is missing", async () => {
+      mockEnv.CDP_API_KEY_SECRET = undefined;
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseData).toEqual({
+        error: "Server configuration error: Missing CDP API credentials",
+      });
+    });
+
+    it("should return 500 when both API keys are missing", async () => {
+      mockEnv.CDP_API_KEY_ID = undefined;
+      mockEnv.CDP_API_KEY_SECRET = undefined;
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseData).toEqual({
+        error: "Server configuration error: Missing CDP API credentials",
+      });
+    });
+  });
+
+  describe("request body validation", () => {
+    it("should return 400 when addresses is missing", async () => {
+      vi.mocked(mockRequest.json).mockResolvedValue({});
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(responseData).toEqual({
+        error: "addresses is required and must be a non-empty array",
+      });
+    });
+
+    it("should return 400 when addresses is null", async () => {
+      vi.mocked(mockRequest.json).mockResolvedValue({ addresses: null });
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(responseData).toEqual({
+        error: "addresses is required and must be a non-empty array",
+      });
+    });
+
+    it("should return 400 when addresses is not an array", async () => {
+      vi.mocked(mockRequest.json).mockResolvedValue({ addresses: "not-an-array" });
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(responseData).toEqual({
+        error: "addresses is required and must be a non-empty array",
+      });
+    });
+
+    it("should return 400 when addresses is empty array", async () => {
+      vi.mocked(mockRequest.json).mockResolvedValue({ addresses: [] });
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(responseData).toEqual({
+        error: "addresses is required and must be a non-empty array",
+      });
+    });
+  });
+
+  describe("JWT generation errors", () => {
+    it("should return 500 when JWT generation fails", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockRequest.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockRejectedValue(new Error("JWT generation failed"));
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseData).toEqual({
+        error: "Internal server error",
+      });
+    });
+  });
+
+  describe("CDP API errors", () => {
+    it("should return 400 when CDP API returns 400", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockRequest.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve("Bad Request"),
+      } as unknown as globalThis.Response);
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(responseData).toEqual({
+        error: "Failed to generate session token",
+      });
+    });
+
+    it("should return 401 when CDP API returns 401", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockRequest.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve("Unauthorized"),
+      } as unknown as globalThis.Response);
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(responseData).toEqual({
+        error: "Failed to generate session token",
+      });
+    });
+
+    it("should return 500 when CDP API returns 500", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockRequest.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Internal Server Error"),
+      } as unknown as globalThis.Response);
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseData).toEqual({
+        error: "Failed to generate session token",
+      });
+    });
+  });
+
+  describe("network errors", () => {
+    it("should return 500 when fetch fails", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockRequest.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockRejectedValue(new Error("Network error"));
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseData).toEqual({
+        error: "Internal server error",
+      });
+    });
+
+    it("should return 500 when response.json() fails", async () => {
+      const mockRequestBody = {
+        addresses: [{ address: "0x1234567890123456789012345678901234567890" }],
+      };
+
+      vi.mocked(mockRequest.json).mockResolvedValue(mockRequestBody);
+      vi.mocked(generateJwt).mockResolvedValue("mock-jwt");
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(new Error("JSON parsing error")),
+      } as unknown as globalThis.Response);
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseData).toEqual({
+        error: "Internal server error",
+      });
+    });
+
+    it("should return 500 when request body parsing fails", async () => {
+      vi.mocked(mockRequest.json).mockRejectedValue(new Error("JSON parsing error"));
+
+      const response = await POST(mockRequest);
+      const responseData = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(responseData).toEqual({
+        error: "Internal server error",
+      });
+    });
+  });
+});

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
 
   packages/x402-express:
     dependencies:
+      '@coinbase/cdp-sdk':
+        specifier: ^1.22.0
+        version: 1.22.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       express:
         specifier: ^4.18.2
         version: 4.21.2
@@ -352,6 +355,9 @@ importers:
 
   packages/x402-hono:
     dependencies:
+      '@coinbase/cdp-sdk':
+        specifier: ^1.22.0
+        version: 1.22.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       hono:
         specifier: ^4.7.1
         version: 4.8.2


### PR DESCRIPTION
This PR adds **optional** Coinbase Onramp integration to the x402 Express and Hono middleware packages, allowing users to purchase USDC directly from the paywall when they need to fund their wallets.

- Updated both Express and Hono middleware to pass `sessionTokenEndpoint` configuration to the paywall
- Added support for the new `sessionTokenEndpoint` option in `PaywallConfig` for each pkg
- Added onramp integration guides to both Express and Hono READMEs
- Included setup instructions, CDP Portal configuration, and troubleshooting
- Updated `fullstack/mainnet` example to demonstrate the onramp integration

###  **Dependencies**
- Added `@coinbase/cdp-sdk` ^1.22.0 to both packages for JWT generation and CDP API integration

## Breaking Changes

**None** - This is a purely additive feature that doesn't affect existing functionality.

## Tests

- Unit tests (also added them for x402-next)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 