### PR TITLE
depps: in python updated x402's pydantic depp to >=2.10.3

### DIFF
--- a/e2e/clients/httpx/uv.lock
+++ b/e2e/clients/httpx/uv.lock
@@ -1834,7 +1834,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },

--- a/e2e/clients/requests/uv.lock
+++ b/e2e/clients/requests/uv.lock
@@ -1834,7 +1834,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },

--- a/e2e/servers/fastapi/uv.lock
+++ b/e2e/servers/fastapi/uv.lock
@@ -2090,7 +2090,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },

--- a/e2e/servers/flask/uv.lock
+++ b/e2e/servers/flask/uv.lock
@@ -2137,7 +2137,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },

--- a/examples/python/clients/httpx/uv.lock
+++ b/examples/python/clients/httpx/uv.lock
@@ -1794,7 +1794,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },

--- a/examples/python/clients/requests/uv.lock
+++ b/examples/python/clients/requests/uv.lock
@@ -1794,7 +1794,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },

--- a/examples/python/servers/fastapi/uv.lock
+++ b/examples/python/servers/fastapi/uv.lock
@@ -1794,7 +1794,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },

--- a/examples/python/servers/flask/uv.lock
+++ b/examples/python/servers/flask/uv.lock
@@ -1841,7 +1841,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },

--- a/examples/python/servers/mainnet/uv.lock
+++ b/examples/python/servers/mainnet/uv.lock
@@ -2050,7 +2050,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },

--- a/examples/python/sync.py
+++ b/examples/python/sync.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def run_uv_sync(project_dir: Path):
+    """Run uv sync in the given directory if it contains a pyproject.toml file."""
+    if (project_dir / "pyproject.toml").exists():
+        print(f"Running uv sync in {project_dir}")
+        subprocess.run(["uv", "sync"], cwd=project_dir, check=True)
+
+
+def main():
+    # Get the examples/python directory
+    examples_dir = Path(__file__).parent.absolute()
+
+    # Process servers directory
+    servers_dir = examples_dir / "servers"
+    for server_dir in servers_dir.iterdir():
+        if server_dir.is_dir():
+            run_uv_sync(server_dir)
+
+    # Process clients directory
+    clients_dir = examples_dir / "clients"
+    for client_dir in clients_dir.iterdir():
+        if client_dir.is_dir():
+            run_uv_sync(client_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "eth-typing>=4.0.0",
     "eth-utils>=3.0.0",
     "fastapi[standard]>=0.115.12",
-    "pydantic>=2.10.3,<=2.10.4",
+    "pydantic>=2.10.3",
     "pydantic-settings>=2.2.1",
     "python-dotenv>=1.0.1",
     "web3>=6.0.0",

--- a/python/x402/uv.lock
+++ b/python/x402/uv.lock
@@ -1922,7 +1922,7 @@ requires-dist = [
     { name = "eth-typing", specifier = ">=4.0.0" },
     { name = "eth-utils", specifier = ">=3.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.12" },
-    { name = "pydantic", specifier = ">=2.10.3,<=2.10.4" },
+    { name = "pydantic", specifier = ">=2.10.3" },
     { name = "pydantic-settings", specifier = ">=2.2.1" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "web3", specifier = ">=6.0.0" },


### PR DESCRIPTION
## Description

* Updated `pydantic` dependency range from `pydantic>=2.10.3,<=2.10.4` to `pydantic>=2.10.3`
* Added `sync.py` which can be run via `cd examples/python && ./sync.py` in the CLI. This will sync all examples and update all lock files

## Tests

Continues to pass all e2e and unit tests

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 