### PR TITLE
feat: improved e2e cli devx

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,338 +1,88 @@
-# X402 End-to-End Test Suite
+# E2E Tests
 
-This directory contains a comprehensive end-to-end test suite for the X402 payment protocol, testing client-server-facilitator communication across multiple languages and frameworks.
-
-## Overview
-
-The test suite validates the complete X402 payment flow:
-```
-Client → Server → Facilitator → Server → Facilitator → Server → Client
-```
-
-It supports multiple languages (TypeScript, Python, Go) and frameworks (Express, FastAPI, Flask, Gin, Next.js) to ensure protocol compatibility across the entire ecosystem.
-
-## Architecture
-
-### Test Discovery
-- **Dynamic Discovery**: Automatically discovers servers and clients by scanning subfolders
-- **Configuration Files**: Each implementation has a `test.config.json` defining its capabilities
-- **Environment Variables**: Supports dynamic configuration via `.env` files
-
-### Proxy System
-- **Language-Agnostic**: Uses CLI commands to run implementations
-- **Structured Output**: All implementations output JSON results for consistent parsing
-- **Process Management**: Handles startup, health checks, and graceful shutdown
-
-### Test Scenarios
-The suite tests all combinations of:
-- **Clients**: TypeScript (axios, fetch), Python (httpx, requests)
-- **Servers**: TypeScript (express, hono, next), Python (fastapi, flask), Go (gin)
-- **Facilitators**: CDP facilitator enabled/disabled
-- **Networks**: base-sepolia, base mainnet
-
-## Installation
-
-### Prerequisites
-- Node.js 18+ and pnpm
-- Python 3.10+ and uv
-- Go 1.23+
-
-### Setup
-
-1. **Install TypeScript dependencies** (from the `e2e` directory):
-   ```bash
-   pnpm install
-   ```
-
-2. **Install Python dependencies** (run in each Python implementation directory):
-   ```bash
-   # For Python clients
-   cd clients/httpx && uv sync
-   cd ../requests && uv sync
-   
-   # For Python servers  
-   cd ../../servers/fastapi && uv sync
-   cd ../flask && uv sync
-   ```
-
-3. **Install Go dependencies** (run in the Go server directory):
-   ```bash
-   cd servers/gin && go mod tidy
-   ```
-
-## Running Tests
-
-### Quick Start
-```bash
-pnpm test
-```
-
-This will:
-1. Discover all available servers and clients
-2. Run all test scenarios (client × server × facilitator × network combinations)
-3. Display results with pass/fail status
-
-### Test Filters
-
-You can filter test scenarios using command-line arguments:
-
-```bash
-# Run specific test combinations
-pnpm test -- --client=httpx                  # Test only httpx client with all servers
-pnpm test -- --server=express                # Test only express server with all clients
-pnpm test -- --language=python               # Test only Python clients with Python servers
-pnpm test -- --network=base-sepolia          # Test only base-sepolia network
-pnpm test -- --prod=true                     # Test only production scenarios (CDP on base/base-sepolia)
-pnpm test -- --prod=false                    # Test only testnet scenarios (no CDP, base-sepolia only)
-
-# Combine filters with verbose logging
-pnpm test -- --client=httpx --server=express -v  # Test specific combination with detailed logs
-pnpm test -- --language=typescript --network=base -v --log-file=test.log  # Log to file
-
-# Combine filters
-pnpm test -- --client=httpx --server=express # Test specific client-server combination
-pnpm test -- --language=typescript --network=base # Test TypeScript implementations on base
-pnpm test -- --network=base --prod=true      # Test only production scenarios on base
-
-### Available Filters
-
-- `--language=<name>`: Filter by programming language
-  - Available languages: typescript, python, go
-  - Filters both clients and servers to match the specified language
-  - Default: Run all languages
-
-- `--client=<name>`: Filter by client implementation
-  - Available clients: httpx, axios, fetch, requests
-  - Default: Run all clients
-
-- `--server=<name>`: Filter by server implementation
-  - Available servers: express, fastapi, flask, gin, hono, next
-  - Default: Run all servers
-
-- `--network=<name>`: Filter by network
-  - Available networks: base, base-sepolia
-  - Default: Run all networks
-
-- `--prod=<true|false>`: Filter by production vs testnet scenarios
-  - `true`: Only run production scenarios (CDP facilitator on base/base-sepolia)
-  - `false`: Only run testnet scenarios (no CDP facilitator, base-sepolia only)
-  - Default: Run all scenarios
-
-### Verbose Logging
-
-- `-v, --verbose`: Enable detailed logging for all tests
-  - Shows detailed test execution steps
-  - Displays configuration details
-  - Shows full error information
-  - Default: Basic pass/fail logging only
-
-- `--log-file=<path>`: Save verbose output to a file
-  - Useful for debugging test failures
-  - Captures all verbose output
-  - Example: `--log-file=test.log`
-
-### Test Matrix
-
-The test suite runs a combination of:
-- Clients: HTTP clients in different languages (httpx, axios, fetch, requests)
-- Servers: HTTP servers in different languages (express, fastapi, flask, gin, hono, next)
-- Networks: Supported networks (base, base-sepolia)
-- Scenarios:
-  - Production: CDP facilitator on base and base-sepolia
-  - Testnet: No CDP facilitator on base-sepolia
-
-### Test Output
-```
-🚀 Starting X402 E2E Test Suite
-===============================
-📋 Configuration:
-   Server Address: 0x122F8Fcaf2152420445Aa424E1D8C0306935B5c9
-   Server Port: 4021
-
-🔍 Test Discovery Summary
-========================
-📡 Servers found: 6
-   - express (typescript) - 1 x402 endpoints
-   - fastapi (python) - 1 x402 endpoints
-   - flask (python) - 1 x402 endpoints
-   - gin (go) - 1 x402 endpoints
-   - hono (typescript) - 1 x402 endpoints
-   - next (typescript) - 1 x402 endpoints
-📱 Clients found: 4
-   - axios (typescript)
-   - fetch (typescript)
-   - httpx (python)
-   - requests (python)
-🔧 Facilitator/Network combos: 3
-📊 Test scenarios: 72
-
-📊 Test Summary
-==============
-✅ Passed: 72
-❌ Failed: 0
-📈 Total: 72
-```
-
-## Implementation Structure
-
-### Servers
-Each server implements the standard protocol:
-- `GET /protected` - Protected endpoint requiring payment
-- `GET /health` - Health check endpoint  
-- `POST /close` - Graceful shutdown endpoint
-
-**Supported Servers:**
-- `servers/express/` - TypeScript Express server
-- `servers/fastapi/` - Python FastAPI server
-- `servers/flask/` - Python Flask server
-- `servers/gin/` - Go Gin server
-- `servers/hono/` - TypeScript Hono server
-- `servers/next/` - TypeScript Next.js server
-
-### Clients
-Each client makes requests to protected endpoints and handles payment responses.
-
-**Supported Clients:**
-- `clients/axios/` - TypeScript axios client
-- `clients/fetch/` - TypeScript fetch client
-- `clients/httpx/` - Python httpx client
-- `clients/requests/` - Python requests client
-
-### Configuration Files
-
-#### test.config.json
-```json
-{
-  "name": "server-name",
-  "type": "server",
-  "language": "typescript|python|go",
-  "description": "Description of the implementation",
-  "endpoints": [
-    {
-      "path": "/protected",
-      "method": "GET",
-      "description": "Protected endpoint requiring payment",
-      "requiresPayment": true
-    }
-  ],
-  "environment": {
-    "required": ["ADDRESS"],
-    "optional": ["PORT", "USE_CDP_FACILITATOR", "NETWORK"]
-  }
-}
-```
-
-#### run.sh
-Each implementation has a `run.sh` script that starts the process:
-```bash
-#!/bin/bash
-# For TypeScript
-pnpm dev
-
-# For Python  
-uv run python main.py
-
-# For Go
-go run main.go
-```
+End-to-end test suite for validating client-server-facilitator communication across languages and frameworks.
 
 ## Environment Variables
 
-### Required
-- `ADDRESS` - Server wallet address for receiving payments
+Required:
+- `ADDRESS`: Server wallet address
+- `PRIVATE_KEY`: Client private key (when running single client)
 
-### Optional
-- `PORT` - Server port (default: 4021)
-- `USE_CDP_FACILITATOR` - Enable CDP facilitator (default: false)
-- `NETWORK` - Network to use (default: base-sepolia)
-- `CDP_API_KEY_ID` - CDP API key ID (required if USE_CDP_FACILITATOR=true)
-- `CDP_API_KEY_SECRET` - CDP API key secret (required if USE_CDP_FACILITATOR=true)
+## Quick Start
 
-### Client-Specific
-- `PRIVATE_KEY` - Client private key for signing payments
-- `RESOURCE_SERVER_URL` - Server URL to connect to
-- `ENDPOINT_PATH` - Endpoint path to request
-
-## Adding New Implementations
-
-### 1. Create Implementation Directory
-```
-e2e/
-├── servers/
-│   └── your-server/
-│       ├── main.py (or index.ts, main.go)
-│       ├── run.sh
-│       ├── test.config.json
-│       └── pyproject.toml (for Python)
-└── clients/
-    └── your-client/
-        ├── main.py (or index.ts)
-        ├── run.sh
-        ├── test.config.json
-        └── pyproject.toml (for Python)
-```
-
-### 2. Implement Protocol
-- **Servers**: Implement `/protected`, `/health`, `/close` endpoints
-- **Clients**: Output JSON results with success/error status
-- **Environment**: Use standard environment variables
-
-### 3. Create Configuration
-- Add `test.config.json` with proper metadata
-- Create `run.sh` script for process startup
-- Install dependencies (uv sync, go mod tidy, etc.)
-
-### 4. Test
-Run `pnpm test` to verify your implementation works with the test suite.
-
-## Troubleshooting
-
-### Common Issues
-
-**Python Import Errors**
-- Ensure `uv sync` was run in the implementation directory
-- Check that `x402` is properly referenced in `pyproject.toml`
-
-**Go Module Errors**
-- Run `go mod tidy` in the Go implementation directory
-- Verify the `replace` directive in `go.mod` points to the correct x402 path
-
-**Next.js Build Errors**
-- The Next.js server uses development mode for faster startup
-- Check that all dependencies are installed with `pnpm install`
-
-**Health Check Failures**
-- Verify the server is listening on the correct port
-- Check that the `/health` endpoint returns the expected JSON format
-- Ensure the server outputs "Server listening on port X" for the proxy to detect
-
-### Debugging
-
-**Manual Testing**
 ```bash
-# Test a server manually
-cd servers/express
-ADDRESS=0x123... PORT=4021 pnpm dev
+# Full suite
+pnpm test                     # Run all tests
 
-# Test a client manually  
-cd clients/axios
-PRIVATE_KEY=0xabc... RESOURCE_SERVER_URL=http://localhost:4021 ENDPOINT_PATH=/protected pnpm dev
+# Development mode (recommended)
+pnpm test -d                  # Test on testnet
+pnpm test -d -v               # Test with verbose logging
+
+# Language filters
+pnpm test -d -ts              # Test TypeScript implementations
+pnpm test -d -py              # Test Python implementations
+pnpm test -d -go              # Test Go implementations
 ```
 
-**Verbose Logging**
-- Check the proxy output in test results for detailed error messages
-- Run implementations manually to see full logs
-- Verify environment variables are set correctly
+## Filtering Tests
 
-## Contributing
+### Implementation Filters
+```bash
+--client=<name>               # Test specific client
+--server=<name>              # Test specific server
 
-When adding new implementations:
-1. Follow the existing patterns and file structure
-2. Ensure all required endpoints are implemented
-3. Test with multiple facilitator/network combinations
-4. Update this README if adding new languages or frameworks
-5. Keep implementations minimal and focused on protocol compliance
+# Available implementations
+Clients: httpx, axios, fetch, requests
+Servers: express, fastapi, flask, gin, hono, next
 
-## License
+# Examples
+pnpm test -d -ts --client=axios     # Test TypeScript axios client
+pnpm test -d -py --server=fastapi   # Test Python FastAPI server
+```
 
-This test suite is part of the X402 project and follows the same license terms.
+### Language Flags (can combine)
+```bash
+-ts, --typescript              # TypeScript implementations
+-py, --python                  # Python implementations
+-go, --go                      # Go implementations
+
+# Examples
+pnpm test -ts -py             # Test TypeScript and Python together
+pnpm test -py -go             # Test Python and Go together
+```
+
+### Environment Filters
+```bash
+--network=<name>              # base or base-sepolia
+--prod=<true|false>          # true=CDP facilitator, false=no CDP
+
+# Examples
+pnpm test --prod=true        # Test production scenarios
+pnpm test --network=base     # Test on base network
+```
+
+### Common Workflows
+
+```bash
+# Local Development
+pnpm test -d -ts                     # TypeScript development
+pnpm test -d -py                     # Python development
+pnpm test -d -ts --server=next       # Next.js middleware development
+pnpm test -d -py --client=httpx      # Python httpx client development
+
+# Cross-Language Testing
+pnpm test -ts -py                    # Test TypeScript/Python compatibility
+pnpm test -d -py -go                 # Test Python/Go on testnet
+
+# Production Testing
+pnpm test --prod=true -ts            # Test TypeScript in production
+pnpm test --network=base -py         # Test Python on base network
+```
+
+### Environment Options
+
+```bash
+-d, --dev                  # Development mode (testnet, no CDP)
+-v, --verbose              # Detailed logging
+--log-file=<path>          # Save output to file
+```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -72,6 +72,75 @@ This will:
 2. Run all test scenarios (client × server × facilitator × network combinations)
 3. Display results with pass/fail status
 
+### Test Filters
+
+You can filter test scenarios using command-line arguments:
+
+```bash
+# Run specific test combinations
+pnpm test -- --client=httpx                  # Test only httpx client with all servers
+pnpm test -- --server=express                # Test only express server with all clients
+pnpm test -- --language=python               # Test only Python clients with Python servers
+pnpm test -- --network=base-sepolia          # Test only base-sepolia network
+pnpm test -- --prod=true                     # Test only production scenarios (CDP on base/base-sepolia)
+pnpm test -- --prod=false                    # Test only testnet scenarios (no CDP, base-sepolia only)
+
+# Combine filters with verbose logging
+pnpm test -- --client=httpx --server=express -v  # Test specific combination with detailed logs
+pnpm test -- --language=typescript --network=base -v --log-file=test.log  # Log to file
+
+# Combine filters
+pnpm test -- --client=httpx --server=express # Test specific client-server combination
+pnpm test -- --language=typescript --network=base # Test TypeScript implementations on base
+pnpm test -- --network=base --prod=true      # Test only production scenarios on base
+
+### Available Filters
+
+- `--language=<name>`: Filter by programming language
+  - Available languages: typescript, python, go
+  - Filters both clients and servers to match the specified language
+  - Default: Run all languages
+
+- `--client=<name>`: Filter by client implementation
+  - Available clients: httpx, axios, fetch, requests
+  - Default: Run all clients
+
+- `--server=<name>`: Filter by server implementation
+  - Available servers: express, fastapi, flask, gin, hono, next
+  - Default: Run all servers
+
+- `--network=<name>`: Filter by network
+  - Available networks: base, base-sepolia
+  - Default: Run all networks
+
+- `--prod=<true|false>`: Filter by production vs testnet scenarios
+  - `true`: Only run production scenarios (CDP facilitator on base/base-sepolia)
+  - `false`: Only run testnet scenarios (no CDP facilitator, base-sepolia only)
+  - Default: Run all scenarios
+
+### Verbose Logging
+
+- `-v, --verbose`: Enable detailed logging for all tests
+  - Shows detailed test execution steps
+  - Displays configuration details
+  - Shows full error information
+  - Default: Basic pass/fail logging only
+
+- `--log-file=<path>`: Save verbose output to a file
+  - Useful for debugging test failures
+  - Captures all verbose output
+  - Example: `--log-file=test.log`
+
+### Test Matrix
+
+The test suite runs a combination of:
+- Clients: HTTP clients in different languages (httpx, axios, fetch, requests)
+- Servers: HTTP servers in different languages (express, fastapi, flask, gin, hono, next)
+- Networks: Supported networks (base, base-sepolia)
+- Scenarios:
+  - Production: CDP facilitator on base and base-sepolia
+  - Testnet: No CDP facilitator on base-sepolia
+
 ### Test Output
 ```
 🚀 Starting X402 E2E Test Suite

--- a/e2e/src/clients/generic-client.ts
+++ b/e2e/src/clients/generic-client.ts
@@ -1,5 +1,5 @@
-import { BaseProxy, RunConfig, ProcessResult } from '../proxy-base';
-import { ClientProxy, ClientConfig, ClientResult } from '../types';
+import { BaseProxy, RunConfig } from '../proxy-base';
+import { ClientConfig, ClientProxy } from '../types';
 
 export interface ClientCallResult {
   success: boolean;
@@ -16,10 +16,9 @@ export class GenericClientProxy extends BaseProxy implements ClientProxy {
     super(directory, '');
   }
 
-  async call(config: ClientConfig, verbose: boolean = false): Promise<ClientCallResult> {
+  async call(config: ClientConfig): Promise<ClientCallResult> {
     try {
       const runConfig: RunConfig = {
-        verbose,
         env: {
           PRIVATE_KEY: config.privateKey,
           RESOURCE_SERVER_URL: config.serverUrl,

--- a/e2e/src/discovery.ts
+++ b/e2e/src/discovery.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { GenericServerProxy } from './servers/generic-server';
 import { GenericClientProxy } from './clients/generic-client';
+import { log, verboseLog, errorLog } from './logger';
 import {
   TestConfig,
   DiscoveredServer,
@@ -58,7 +59,7 @@ export class TestDiscovery {
             });
           }
         } catch (error) {
-          console.warn(`Failed to load config for server ${serverName}:`, error);
+          errorLog(`Failed to load config for server ${serverName}: ${error}`);
         }
       }
     }
@@ -67,8 +68,8 @@ export class TestDiscovery {
   }
 
   /**
- * Discover all clients in the clients directory
- */
+   * Discover all clients in the clients directory
+   */
   discoverClients(): DiscoveredClient[] {
     const clientsDir = join(this.baseDir, 'clients');
     if (!existsSync(clientsDir)) {
@@ -98,7 +99,7 @@ export class TestDiscovery {
             });
           }
         } catch (error) {
-          console.warn(`Failed to load config for client ${clientName}:`, error);
+          errorLog(`Failed to load config for client ${clientName}: ${error}`);
         }
       }
     }
@@ -140,28 +141,28 @@ export class TestDiscovery {
   }
 
   /**
- * Print discovery summary
- */
-  printDiscoverySummary(logFn: (message: string) => void = console.log): void {
+   * Print discovery summary
+   */
+  printDiscoverySummary(): void {
     const servers = this.discoverServers();
     const clients = this.discoverClients();
     const scenarios = this.generateTestScenarios();
 
-    logFn('🔍 Test Discovery Summary');
-    logFn('========================');
-    logFn(`📡 Servers found: ${servers.length}`);
+    log('🔍 Test Discovery Summary');
+    log('========================');
+    log(`📡 Servers found: ${servers.length}`);
     servers.forEach(server => {
       const paidEndpoints = server.config.endpoints?.filter(e => e.requiresPayment).length || 0;
-      logFn(`   - ${server.name} (${server.config.language}) - ${paidEndpoints} x402 endpoints`);
+      log(`   - ${server.name} (${server.config.language}) - ${paidEndpoints} x402 endpoints`);
     });
 
-    logFn(`📱 Clients found: ${clients.length}`);
+    log(`📱 Clients found: ${clients.length}`);
     clients.forEach(client => {
-      logFn(`   - ${client.name} (${client.config.language})`);
+      log(`   - ${client.name} (${client.config.language})`);
     });
 
-    logFn(`🔧 Facilitator/Network combos: ${this.getFacilitatorNetworkCombos().length}`);
-    logFn(`📊 Test scenarios: ${scenarios.length}`);
-    logFn('');
+    log(`🔧 Facilitator/Network combos: ${this.getFacilitatorNetworkCombos().length}`);
+    log(`📊 Test scenarios: ${scenarios.length}`);
+    log('');
   }
 } 

--- a/e2e/src/logger.ts
+++ b/e2e/src/logger.ts
@@ -1,0 +1,106 @@
+import { WriteStream, createWriteStream } from 'fs';
+
+interface LoggerConfig {
+  logFile?: string;
+  verbose?: boolean;
+}
+
+class Logger {
+  private logStream: WriteStream | null = null;
+  private isVerbose: boolean = false;
+
+  constructor(config: LoggerConfig) {
+    this.isVerbose = config.verbose || false;
+
+    if (config.logFile) {
+      try {
+        this.logStream = createWriteStream(config.logFile);
+        this.log(`🚀 X402 E2E Test Suite - Log started at ${new Date().toISOString()}`);
+        this.log(`📝 Logging output to: ${config.logFile}`);
+      } catch (error) {
+        console.error(`Failed to create log file ${config.logFile}:`, error);
+        process.exit(1);
+      }
+    }
+  }
+
+  log(message: string, toFile: boolean = true): void {
+    console.log(message);
+    if (this.logStream && toFile) {
+      this.logStream.write(message + '\n');
+    }
+  }
+
+  verboseLog(message: string, toFile: boolean = true): void {
+    if (this.isVerbose) {
+      this.log(message, toFile);
+    }
+  }
+
+  errorLog(message: string, toFile: boolean = true): void {
+    console.error(message);
+    if (this.logStream && toFile) {
+      this.logStream.write(`ERROR: ${message}\n`);
+    }
+  }
+
+  close(): void {
+    if (this.logStream) {
+      this.logStream.end();
+      this.logStream = null;
+    }
+  }
+}
+
+// Single global logger instance
+let globalLogger: Logger | null = null;
+
+/**
+ * Configure and initialize the global logger
+ */
+export function config(options: LoggerConfig): void {
+  if (globalLogger) {
+    globalLogger.close();
+  }
+  globalLogger = new Logger(options);
+}
+
+/**
+ * Log a normal message that will always be shown
+ */
+export function log(message: string, toFile: boolean = true): void {
+  if (!globalLogger) {
+    globalLogger = new Logger({});
+  }
+  globalLogger.log(message, toFile);
+}
+
+/**
+ * Log a verbose message that will only be shown if verbose mode is enabled
+ */
+export function verboseLog(message: string, toFile: boolean = true): void {
+  if (!globalLogger) {
+    globalLogger = new Logger({});
+  }
+  globalLogger.verboseLog(message, toFile);
+}
+
+/**
+ * Log an error message
+ */
+export function errorLog(message: string, toFile: boolean = true): void {
+  if (!globalLogger) {
+    globalLogger = new Logger({});
+  }
+  globalLogger.errorLog(message, toFile);
+}
+
+/**
+ * Close the logger and its file streams
+ */
+export function close(): void {
+  if (globalLogger) {
+    globalLogger.close();
+    globalLogger = null;
+  }
+} 

--- a/e2e/src/servers/generic-server.ts
+++ b/e2e/src/servers/generic-server.ts
@@ -1,5 +1,6 @@
 import { BaseProxy, RunConfig } from '../proxy-base';
 import { ServerProxy, ServerConfig } from '../types';
+import { verboseLog, errorLog } from '../logger';
 
 export interface ProtectedResponse {
   message: string;
@@ -59,16 +60,15 @@ export class GenericServerProxy extends BaseProxy implements ServerProxy {
       }
     } catch (error) {
       // Fallback to defaults if config loading fails
-      console.warn(`Failed to load endpoints from config for ${this.directory}, using defaults`);
+      errorLog(`Failed to load endpoints from config for ${this.directory}, using defaults`);
     }
   }
 
-  async start(config: ServerConfig, verbose: boolean = false): Promise<void> {
+  async start(config: ServerConfig): Promise<void> {
     this.port = config.port;
 
     const runConfig: RunConfig = {
       port: config.port,
-      verbose,
       env: {
         USE_CDP_FACILITATOR: config.useCdpFacilitator.toString(),
         CDP_API_KEY_ID: process.env.CDP_API_KEY_ID || '',
@@ -171,10 +171,10 @@ export class GenericServerProxy extends BaseProxy implements ServerProxy {
           // Wait a bit for graceful shutdown
           await new Promise(resolve => setTimeout(resolve, 2000));
         } else {
-          console.log('Graceful shutdown failed, using force kill');
+          verboseLog('Graceful shutdown failed, using force kill');
         }
       } catch (error) {
-        console.log('Graceful shutdown failed, using force kill');
+        verboseLog('Graceful shutdown failed, using force kill');
       }
     }
 

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -146,7 +146,7 @@ async function runTest() {
     console.log('  pnpm test -py -go                 # Test Python and Go implementations');
     console.log('  pnpm test -ts --client=axios      # Test TypeScript axios client');
     console.log('  pnpm test -d -py                  # Dev mode, Python implementations only');
-    console.log('  pnpm test --network=base --prod=true');
+    console.log('  pnpm test --network=base --prod=true # Base mainnet only');
     console.log('');
     return;
   }


### PR DESCRIPTION
## Description

My goal was to make it easier to have peace-of-mind when making changes to x402.

Once this is in, it should be quick and easy to verify that any implementation changes continue to work.

For example, if I made a change to Python x402 implementation, I can run `pnpm test -d -py` to test just the Python clients & server in a development environment (x402.org/facilitator + base-sepolia).

If I see that it's failing, throw on `-v` to get more logs. If you see a specific server or client is failing, add `--server=fastapi` or `client=axios` to pin a specific server or client.

The intention is to make running e2e tests as efficient as running unit tests for the 99% scenario

```shell
❯ pnpm test --help

Usage: npm test [options]

Options:
Environment:
  -d, --dev                  Development mode (base-sepolia, no CDP)
  -v, --verbose              Enable verbose logging
  -ts, --typescript          Include TypeScript implementations
  -py, --python              Include Python implementations
  -go, --go                  Include Go implementations

Filters:
  --log-file=<path>          Save verbose output to file
  --client=<name>            Filter by client name (e.g., httpx, axios)
  --server=<name>            Filter by server name (e.g., express, fastapi)
  --network=<name>           Filter by network (base, base-sepolia)
  --prod=<true|false>        Filter by production vs testnet scenarios
  --language=<name>          Filter by language (e.g., typescript, python, go)
  -h, --help                 Show this help message

Examples:
  pnpm test                         # Run all tests
  pnpm test -d                      # Run tests in development mode
  pnpm test -py -go                 # Test Python and Go implementations
  pnpm test -ts --client=axios      # Test TypeScript axios client
  pnpm test -d -py                  # Dev mode, Python implementations only
  pnpm test --network=base --prod=true

```

The README is very concise and where you should read more about its usage. My goal was to make rapid testing easier when working on the core frameworks

## Tests

Ran many series of e2e tests

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 