### PR TITLE
feat: middlewares take custom error strings as optional param

### DIFF
--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -101,7 +101,6 @@ export function paymentMiddleware(
       outputSchema,
       customPaywallHtml,
       resource,
-      errorMessages,
     } = config;
 
     const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
@@ -184,7 +183,7 @@ export function paymentMiddleware(
       }
       res.status(402).json({
         x402Version,
-        error: errorMessages?.paymentRequired || "X-PAYMENT header is required",
+        error: "X-PAYMENT header is required",
         accepts: toJsonSafe(paymentRequirements),
       });
       return;
@@ -197,7 +196,7 @@ export function paymentMiddleware(
     } catch (error) {
       res.status(402).json({
         x402Version,
-        error: errorMessages?.invalidPayment || error || "Invalid or malformed payment header",
+        error: error || "Invalid or malformed payment header",
         accepts: toJsonSafe(paymentRequirements),
       });
       return;
@@ -210,8 +209,7 @@ export function paymentMiddleware(
     if (!selectedPaymentRequirements) {
       res.status(402).json({
         x402Version,
-        error:
-          errorMessages?.noMatchingRequirements || "Unable to find matching payment requirements",
+        error: "Unable to find matching payment requirements",
         accepts: toJsonSafe(paymentRequirements),
       });
       return;
@@ -222,7 +220,7 @@ export function paymentMiddleware(
       if (!response.isValid) {
         res.status(402).json({
           x402Version,
-          error: errorMessages?.verificationFailed || response.invalidReason,
+          error: response.invalidReason,
           accepts: toJsonSafe(paymentRequirements),
           payer: response.payer,
         });
@@ -231,7 +229,7 @@ export function paymentMiddleware(
     } catch (error) {
       res.status(402).json({
         x402Version,
-        error: errorMessages?.verificationFailed || error,
+        error,
         accepts: toJsonSafe(paymentRequirements),
       });
       return;
@@ -273,7 +271,7 @@ export function paymentMiddleware(
       if (!res.headersSent) {
         res.status(402).json({
           x402Version,
-          error: errorMessages?.settlementFailed || error,
+          error,
           accepts: toJsonSafe(paymentRequirements),
         });
         return;

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -115,18 +115,18 @@ export function paymentMiddleware(
 
     const input = inputSchema
       ? ({
-        type: "http",
-        method: req.method.toUpperCase(),
-        ...inputSchema,
-      } as RequestStructure)
+          type: "http",
+          method: req.method.toUpperCase(),
+          ...inputSchema,
+        } as RequestStructure)
       : undefined;
 
     const requestStructure =
       input || outputSchema
         ? {
-          input,
-          output: outputSchema,
-        }
+            input,
+            output: outputSchema,
+          }
         : undefined;
 
     const paymentRequirements: PaymentRequirements[] = [

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -97,6 +97,7 @@ export function paymentMiddleware(
       outputSchema,
       customPaywallHtml,
       resource,
+      errorMessages,
     } = config;
 
     const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
@@ -109,18 +110,18 @@ export function paymentMiddleware(
 
     const input = inputSchema
       ? ({
-          type: "http",
-          method,
-          ...inputSchema,
-        } as RequestStructure)
+        type: "http",
+        method,
+        ...inputSchema,
+      } as RequestStructure)
       : undefined;
 
     const requestStructure =
       input || outputSchema
         ? {
-            input,
-            output: outputSchema,
-          }
+          input,
+          output: outputSchema,
+        }
         : undefined;
 
     const paymentRequirements: PaymentRequirements[] = [
@@ -178,7 +179,7 @@ export function paymentMiddleware(
       }
       return c.json(
         {
-          error: "X-PAYMENT header is required",
+          error: errorMessages?.paymentRequired || "X-PAYMENT header is required",
           accepts: paymentRequirements,
           x402Version,
         },

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -195,10 +195,7 @@ export function paymentMiddleware(
     } catch (error) {
       return c.json(
         {
-          error:
-            errorMessages?.invalidPayment || error instanceof Error
-              ? error
-              : new Error("Invalid or malformed payment header"),
+          error: errorMessages?.invalidPayment || (error instanceof Error ? error : new Error("Invalid or malformed payment header")),
           accepts: paymentRequirements,
           x402Version,
         },
@@ -227,7 +224,7 @@ export function paymentMiddleware(
     if (!verification.isValid) {
       return c.json(
         {
-          error: errorMessages?.verificationFailed || new Error(verification.invalidReason),
+          error: errorMessages?.verificationFailed || verification.invalidReason,
           accepts: paymentRequirements,
           payer: verification.payer,
           x402Version,
@@ -260,10 +257,7 @@ export function paymentMiddleware(
     } catch (error) {
       res = c.json(
         {
-          error:
-            errorMessages?.settlementFailed || error instanceof Error
-              ? error
-              : new Error("Failed to settle payment"),
+          error: errorMessages?.settlementFailed || (error instanceof Error ? error : new Error("Failed to settle payment")),
           accepts: paymentRequirements,
           x402Version,
         },

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -110,18 +110,18 @@ export function paymentMiddleware(
 
     const input = inputSchema
       ? ({
-        type: "http",
-        method,
-        ...inputSchema,
-      } as RequestStructure)
+          type: "http",
+          method,
+          ...inputSchema,
+        } as RequestStructure)
       : undefined;
 
     const requestStructure =
       input || outputSchema
         ? {
-          input,
-          output: outputSchema,
-        }
+            input,
+            output: outputSchema,
+          }
         : undefined;
 
     const paymentRequirements: PaymentRequirements[] = [
@@ -195,7 +195,10 @@ export function paymentMiddleware(
     } catch (error) {
       return c.json(
         {
-          error: error instanceof Error ? error : new Error("Invalid or malformed payment header"),
+          error:
+            errorMessages?.invalidPayment || error instanceof Error
+              ? error
+              : new Error("Invalid or malformed payment header"),
           accepts: paymentRequirements,
           x402Version,
         },
@@ -210,7 +213,8 @@ export function paymentMiddleware(
     if (!selectedPaymentRequirements) {
       return c.json(
         {
-          error: "Unable to find matching payment requirements",
+          error:
+            errorMessages?.noMatchingRequirements || "Unable to find matching payment requirements",
           accepts: toJsonSafe(paymentRequirements),
           x402Version,
         },
@@ -223,7 +227,7 @@ export function paymentMiddleware(
     if (!verification.isValid) {
       return c.json(
         {
-          error: new Error(verification.invalidReason),
+          error: errorMessages?.verificationFailed || new Error(verification.invalidReason),
           accepts: paymentRequirements,
           payer: verification.payer,
           x402Version,
@@ -256,7 +260,10 @@ export function paymentMiddleware(
     } catch (error) {
       res = c.json(
         {
-          error: error instanceof Error ? error : new Error("Failed to settle payment"),
+          error:
+            errorMessages?.settlementFailed || error instanceof Error
+              ? error
+              : new Error("Failed to settle payment"),
           accepts: paymentRequirements,
           x402Version,
         },

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -195,7 +195,9 @@ export function paymentMiddleware(
     } catch (error) {
       return c.json(
         {
-          error: errorMessages?.invalidPayment || (error instanceof Error ? error : new Error("Invalid or malformed payment header")),
+          error:
+            errorMessages?.invalidPayment ||
+            (error instanceof Error ? error : new Error("Invalid or malformed payment header")),
           accepts: paymentRequirements,
           x402Version,
         },
@@ -257,7 +259,9 @@ export function paymentMiddleware(
     } catch (error) {
       res = c.json(
         {
-          error: errorMessages?.settlementFailed || (error instanceof Error ? error : new Error("Failed to settle payment")),
+          error:
+            errorMessages?.settlementFailed ||
+            (error instanceof Error ? error : new Error("Failed to settle payment")),
           accepts: paymentRequirements,
           x402Version,
         },

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -119,6 +119,7 @@ export function paymentMiddleware(
       outputSchema,
       customPaywallHtml,
       resource,
+      errorMessages,
     } = config;
 
     const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
@@ -132,18 +133,18 @@ export function paymentMiddleware(
 
     const input = inputSchema
       ? ({
-          type: "http",
-          method,
-          ...inputSchema,
-        } as RequestStructure)
+        type: "http",
+        method,
+        ...inputSchema,
+      } as RequestStructure)
       : undefined;
 
     const requestStructure =
       input || outputSchema
         ? {
-            input,
-            output: outputSchema,
-          }
+          input,
+          output: outputSchema,
+        }
         : undefined;
 
     const paymentRequirements: PaymentRequirements[] = [
@@ -206,7 +207,7 @@ export function paymentMiddleware(
       return new NextResponse(
         JSON.stringify({
           x402Version,
-          error: "X-PAYMENT header is required",
+          error: errorMessages?.paymentRequired || "X-PAYMENT header is required",
           accepts: paymentRequirements,
         }),
         { status: 402, headers: { "Content-Type": "application/json" } },

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -223,8 +223,7 @@ export function paymentMiddleware(
       return new NextResponse(
         JSON.stringify({
           x402Version,
-          error:
-            errorMessages?.invalidPayment || error instanceof Error ? error : "Invalid payment",
+          error: errorMessages?.invalidPayment || (error instanceof Error ? error : "Invalid payment"),
           accepts: paymentRequirements,
         }),
         { status: 402, headers: { "Content-Type": "application/json" } },
@@ -290,9 +289,7 @@ export function paymentMiddleware(
       return new NextResponse(
         JSON.stringify({
           x402Version,
-          error:
-            errorMessages?.settlementFailed ||
-            (error instanceof Error ? error.message : "Settlement failed"),
+          error: errorMessages?.settlementFailed || (error instanceof Error ? error : "Settlement failed"),
           accepts: paymentRequirements,
         }),
         { status: 402, headers: { "Content-Type": "application/json" } },

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -133,18 +133,18 @@ export function paymentMiddleware(
 
     const input = inputSchema
       ? ({
-        type: "http",
-        method,
-        ...inputSchema,
-      } as RequestStructure)
+          type: "http",
+          method,
+          ...inputSchema,
+        } as RequestStructure)
       : undefined;
 
     const requestStructure =
       input || outputSchema
         ? {
-          input,
-          output: outputSchema,
-        }
+            input,
+            output: outputSchema,
+          }
         : undefined;
 
     const paymentRequirements: PaymentRequirements[] = [
@@ -223,7 +223,8 @@ export function paymentMiddleware(
       return new NextResponse(
         JSON.stringify({
           x402Version,
-          error: error instanceof Error ? error : "Invalid payment",
+          error:
+            errorMessages?.invalidPayment || error instanceof Error ? error : "Invalid payment",
           accepts: paymentRequirements,
         }),
         { status: 402, headers: { "Content-Type": "application/json" } },
@@ -238,7 +239,8 @@ export function paymentMiddleware(
       return new NextResponse(
         JSON.stringify({
           x402Version,
-          error: "Unable to find matching payment requirements",
+          error:
+            errorMessages?.noMatchingRequirements || "Unable to find matching payment requirements",
           accepts: toJsonSafe(paymentRequirements),
         }),
         { status: 402, headers: { "Content-Type": "application/json" } },
@@ -251,7 +253,7 @@ export function paymentMiddleware(
       return new NextResponse(
         JSON.stringify({
           x402Version,
-          error: verification.invalidReason,
+          error: errorMessages?.verificationFailed || verification.invalidReason,
           accepts: paymentRequirements,
           payer: verification.payer,
         }),
@@ -288,7 +290,9 @@ export function paymentMiddleware(
       return new NextResponse(
         JSON.stringify({
           x402Version,
-          error: error instanceof Error ? error : "Settlement failed",
+          error:
+            errorMessages?.settlementFailed ||
+            (error instanceof Error ? error.message : "Settlement failed"),
           accepts: paymentRequirements,
         }),
         { status: 402, headers: { "Content-Type": "application/json" } },

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -223,7 +223,8 @@ export function paymentMiddleware(
       return new NextResponse(
         JSON.stringify({
           x402Version,
-          error: errorMessages?.invalidPayment || (error instanceof Error ? error : "Invalid payment"),
+          error:
+            errorMessages?.invalidPayment || (error instanceof Error ? error : "Invalid payment"),
           accepts: paymentRequirements,
         }),
         { status: 402, headers: { "Content-Type": "application/json" } },
@@ -289,7 +290,9 @@ export function paymentMiddleware(
       return new NextResponse(
         JSON.stringify({
           x402Version,
-          error: errorMessages?.settlementFailed || (error instanceof Error ? error : "Settlement failed"),
+          error:
+            errorMessages?.settlementFailed ||
+            (error instanceof Error ? error : "Settlement failed"),
           accepts: paymentRequirements,
         }),
         { status: 402, headers: { "Content-Type": "application/json" } },

--- a/typescript/packages/x402/src/types/shared/middleware.ts
+++ b/typescript/packages/x402/src/types/shared/middleware.ts
@@ -26,6 +26,13 @@ export type PaymentMiddlewareConfig = {
   outputSchema?: object;
   customPaywallHtml?: string;
   resource?: Resource;
+  errorMessages?: {
+    paymentRequired?: string;
+    invalidPayment?: string;
+    noMatchingRequirements?: string;
+    verificationFailed?: string;
+    settlementFailed?: string;
+  };
 };
 
 export interface ERC20TokenAmount {


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

Fixes #217 

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

Adds an extra option for payment middlewares so that custom error messages can be passed in.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

Tests passing - I can add a test to validate the error messages if you want but doesn't seem critical.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) 

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 