### PR TITLE
fix: preserve Headers object during 402 retry in x402-fetch

### DIFF
--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -81,13 +81,14 @@ export function wrapFetchWithPayment(
       throw new Error("Payment already attempted");
     }
 
+    // retain headers from initial call
+    const headers = new Headers(init.headers);
+    headers.set("X-PAYMENT", paymentHeader);
+    headers.set("Access-Control-Expose-Headers", "X-PAYMENT-RESPONSE");
+
     const newInit = {
       ...init,
-      headers: {
-        ...(init.headers || {}),
-        "X-PAYMENT": paymentHeader,
-        "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
-      },
+      headers,
       __is402Retry: true,
     };
 


### PR DESCRIPTION
## Summary
- Fixed Headers object preservation during 402 retry in `x402-fetch`
- Replaced spread operator with Headers constructor to properly handle all HeadersInit types
- Added test coverage for Headers object preservation

## Problem
The retry logic in `wrapFetchWithPayment` used the spread operator on `init.headers`, which doesn't work correctly with Headers objects. The spread operator does not iterate through the actual header entries, causing headers to be lost during retry.

### Example of the issue:
```javascript
// Original headers
const headers = new Headers({
  'Accept': 'application/json, text/event-stream',
  'Content-Type': 'application/json'
});

// Spread operator fails - results in empty objects
{ ...headers } 
```

## Solution
Use the Headers constructor which properly handles all HeadersInit types:
- **Headers objects**: `new Headers(headersObj)` clones all entries
- **Plain objects**: `new Headers({ 'Accept': 'application/json' })` works as expected  
- **Arrays**: `new Headers([['Accept', 'application/json']])` converts correctly

## Impact
This fix ensures headers are preserved during retry.
