### PR TITLE
fix: route matching regex

### DIFF
--- a/typescript/packages/x402/src/shared/middleware.test.ts
+++ b/typescript/packages/x402/src/shared/middleware.test.ts
@@ -218,14 +218,44 @@ describe("findMatchingRoute", () => {
     expect(result).toBeUndefined();
   });
 
-  it("should fail to match when path has extra slashes", () => {
-    const result = findMatchingRoute(routePatterns, "//api/test", "GET");
-    expect(result).toBeUndefined();
+  it("should normalize paths with multiple consecutive slashes", () => {
+    const result = findMatchingRoute(routePatterns, "//api///test", "GET");
+    expect(result).toEqual(routePatterns[0]);
   });
 
-  it("should fail to match when path has trailing slash", () => {
+  it("should match paths with trailing slashes", () => {
     const result = findMatchingRoute(routePatterns, "/api/test/", "GET");
-    expect(result).toBeUndefined();
+    expect(result).toEqual(routePatterns[0]);
+  });
+
+  it("should match paths with multiple trailing slashes", () => {
+    const result = findMatchingRoute(routePatterns, "/api/test///", "GET");
+    expect(result).toEqual(routePatterns[0]);
+  });
+
+  it("should match paths with trailing backslash", () => {
+    const result = findMatchingRoute(routePatterns, "/api/test\\", "GET");
+    expect(result).toEqual(routePatterns[0]);
+  });
+
+  it("should match paths with multiple trailing backslashes", () => {
+    const result = findMatchingRoute(routePatterns, "/api/test\\\\", "GET");
+    expect(result).toEqual(routePatterns[0]);
+  });
+
+  it("should match paths with multiple consecutive slashes", () => {
+    const result = findMatchingRoute(routePatterns, "/api///test", "GET");
+    expect(result).toEqual(routePatterns[0]);
+  });
+
+  it("should match paths with query parameters", () => {
+    const result = findMatchingRoute(routePatterns, "/api/test?foo=bar", "GET");
+    expect(result).toEqual(routePatterns[0]);
+  });
+
+  it("should match paths with hash fragments", () => {
+    const result = findMatchingRoute(routePatterns, "/api/test#section", "GET");
+    expect(result).toEqual(routePatterns[0]);
   });
 });
 


### PR DESCRIPTION
Fixes a bug report regarding bypassing the middleware. This can be accomplished by requesting with an addition backslash in the URL. This demonstrates that our regex path matching in general needs to be tightened up.

## Tests

### Unit Tests

The unit tests have been updated to handle a much broader case of pattern matching.

### Manual Tests

You can bypass the x402.org/protected paywall via the following:

`curl -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" "https://www.x402.org/protected\\" `

This curls with an added backslash. On browsers, default curl configs or PostMan, the backslash is automatically removed. However, you can force curl or other tools to add it, which was breaking the regex matching and bypassing paywall.

This PR attempts to fix this. From local testing with the same command, I can run it on the localhost site and get the x402 errors that I should. However, we can't be certain until we test a Vercel deploy