### PR TITLE
Add optional `paymentId` to PaymentRequirements and PaymentPayload schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .env
 node_modules/
 dist/

--- a/typescript/packages/x402/src/schemes/exact/evm/client.test.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/client.test.ts
@@ -26,6 +26,7 @@ describe("preparePaymentHeader", () => {
     description: "Test resource",
     mimeType: "application/json",
     payTo: "0x1234567890123456789012345678901234567890",
+    paymentId: "payment-id-1234567890",
     maxTimeoutSeconds: 300,
     asset: "0x1234567890123456789012345678901234567890",
   };
@@ -51,6 +52,7 @@ describe("preparePaymentHeader", () => {
       x402Version: 1,
       scheme: "exact",
       network: "base-sepolia",
+      paymentId: "payment-id-1234567890",
       payload: {
         signature: undefined,
         authorization: {
@@ -105,6 +107,7 @@ describe("signPaymentHeader", () => {
     description: "Test resource",
     mimeType: "application/json",
     payTo: "0x1234567890123456789012345678901234567890",
+    paymentId: "payment-id-1234567890",
     maxTimeoutSeconds: 300,
     asset: "0x1234567890123456789012345678901234567890",
   };
@@ -113,6 +116,7 @@ describe("signPaymentHeader", () => {
     x402Version: 1,
     scheme: "exact",
     network: "base-sepolia",
+    paymentId: "payment-id-1234567890",
     payload: {
       signature: undefined,
       authorization: {
@@ -189,6 +193,7 @@ describe("createPaymentHeader", () => {
     description: "Test resource",
     mimeType: "application/json",
     payTo: "0x1234567890123456789012345678901234567890",
+    paymentId: "payment-id-1234567890",
     maxTimeoutSeconds: 300,
     asset: "0x1234567890123456789012345678901234567890",
   };
@@ -197,6 +202,7 @@ describe("createPaymentHeader", () => {
     x402Version: 1,
     scheme: "exact",
     network: "base-sepolia",
+    paymentId: "payment-id-1234567890",
     payload: {
       signature:
         "0x1234567890123456789012345678901234567890123456789012345678901234" as `0x${string}`,

--- a/typescript/packages/x402/src/schemes/exact/evm/client.test.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/client.test.ts
@@ -26,7 +26,7 @@ describe("preparePaymentHeader", () => {
     description: "Test resource",
     mimeType: "application/json",
     payTo: "0x1234567890123456789012345678901234567890",
-``    maxTimeoutSeconds: 300,
+    maxTimeoutSeconds: 300,
     asset: "0x1234567890123456789012345678901234567890",
   };
 

--- a/typescript/packages/x402/src/schemes/exact/evm/client.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/client.ts
@@ -30,6 +30,7 @@ export function preparePaymentHeader(
     x402Version,
     scheme: paymentRequirements.scheme,
     network: paymentRequirements.network,
+    paymentId: paymentRequirements.paymentId,
     payload: {
       signature: undefined,
       authorization: {

--- a/typescript/packages/x402/src/schemes/exact/evm/client.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/client.ts
@@ -26,11 +26,17 @@ export function preparePaymentHeader(
     Math.floor(Date.now() / 1000 + paymentRequirements.maxTimeoutSeconds),
   ).toString();
 
+  const optionalData: { paymentId?: string } = {};
+
+  if (paymentRequirements.paymentId) {
+    optionalData.paymentId = paymentRequirements.paymentId;
+  }
+
   return {
     x402Version,
     scheme: paymentRequirements.scheme,
     network: paymentRequirements.network,
-    paymentId: paymentRequirements.paymentId,
+    ...optionalData,
     payload: {
       signature: undefined,
       authorization: {

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -42,6 +42,7 @@ export const PaymentRequirementsSchema = z.object({
   outputSchema: z.record(z.any()).optional(),
   payTo: z.string().regex(MixedAddressRegex),
   maxTimeoutSeconds: z.number().int(),
+  paymentId: z.string(),
   asset: z.string().regex(MixedAddressRegex),
   extra: z.record(z.any()).optional(),
 });
@@ -69,6 +70,7 @@ export const PaymentPayloadSchema = z.object({
   x402Version: z.number().refine(val => x402Versions.includes(val as 1)),
   scheme: z.enum(schemes),
   network: NetworkSchema,
+  paymentId: z.string(),
   payload: ExactEvmPayloadSchema,
 });
 export type PaymentPayload = z.infer<typeof PaymentPayloadSchema>;

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -42,7 +42,7 @@ export const PaymentRequirementsSchema = z.object({
   outputSchema: z.record(z.any()).optional(),
   payTo: z.string().regex(MixedAddressRegex),
   maxTimeoutSeconds: z.number().int(),
-  paymentId: z.string(),
+  paymentId: z.string().optional(),
   asset: z.string().regex(MixedAddressRegex),
   extra: z.record(z.any()).optional(),
 });
@@ -70,7 +70,7 @@ export const PaymentPayloadSchema = z.object({
   x402Version: z.number().refine(val => x402Versions.includes(val as 1)),
   scheme: z.enum(schemes),
   network: NetworkSchema,
-  paymentId: z.string(),
+  paymentId: z.string().optional(),
   payload: ExactEvmPayloadSchema,
 });
 export type PaymentPayload = z.infer<typeof PaymentPayloadSchema>;

--- a/typescript/packages/x402/src/verify/useFacilitator.test.ts
+++ b/typescript/packages/x402/src/verify/useFacilitator.test.ts
@@ -7,6 +7,7 @@ describe("useFacilitator", () => {
     x402Version: 1,
     scheme: "exact",
     network: "base-sepolia",
+    paymentId: "payment-id-1234567890",
     payload: {
       signature: "0x1234567890123456789012345678901234567890123456789012345678901234",
       authorization: {
@@ -28,6 +29,7 @@ describe("useFacilitator", () => {
     description: "Test resource",
     mimeType: "application/json",
     payTo: "0x1234567890123456789012345678901234567890",
+    paymentId: "payment-id-1234567890",
     maxTimeoutSeconds: 300,
     asset: "0x1234567890123456789012345678901234567890",
   };

--- a/typescript/packages/x402/src/verify/useFacilitator.test.ts
+++ b/typescript/packages/x402/src/verify/useFacilitator.test.ts
@@ -7,7 +7,6 @@ describe("useFacilitator", () => {
     x402Version: 1,
     scheme: "exact",
     network: "base-sepolia",
-    paymentId: "payment-id-1234567890",
     payload: {
       signature: "0x1234567890123456789012345678901234567890123456789012345678901234",
       authorization: {
@@ -29,7 +28,6 @@ describe("useFacilitator", () => {
     description: "Test resource",
     mimeType: "application/json",
     payTo: "0x1234567890123456789012345678901234567890",
-    paymentId: "payment-id-1234567890",
     maxTimeoutSeconds: 300,
     asset: "0x1234567890123456789012345678901234567890",
   };


### PR DESCRIPTION
## Description

Add support for including the optional `paymentId` that can be provided by the implementor property inside the PaymentRequirements payload, as well as including it in the signed PaymentPayload that is sent for verification.

This can help with issues like https://github.com/coinbase/x402/issues/188 

This should be inline with what is proposed in the [x402 Whitepaper](https://www.x402.org/x402-whitepaper.pdf) where `paymentId` is part of the response and authorization payload.
<img width="654" height="538" alt="image" src="https://github.com/user-attachments/assets/fc064660-e389-4597-bb77-fbafbafbe139" />

This change is backwards compatible and doesn't introduce breaking changes for older implementations.

### Considerations & Questions

- Whether building the `optionalData` structure is the right path for including `paymentId` and for future additions (or if that is even needed)?
- Can `paymentId` always be included in the payload to promote it's usage and stay `undefined`?
- Would it be better to include the `paymentId` property and then just omit all undefined properties at the root of the payload?
- I'm not sure if the future use case would be that the x402 library generates the unique paymentId and if it is desirable to allow for implementation to override this to their own?

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

I've added tests that check if the `paymentId` is included in the unsigned and signed response when provided and that it is omitted if not provided (so that for older versions it doesn't change the payload).

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Future Additions

If a solution like this is acceptable, I would work on propagating this change across other language SDKs. 

## Checklist

- [X] I have formatted and linted my code
- [X] All new and existing tests pass
- [X] My commits are signed (required for merge) 