### PR TITLE
chore: version typescript packages

### DIFF
--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/x402",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/coinbase-x402/src/index.ts
+++ b/typescript/packages/coinbase-x402/src/index.ts
@@ -5,7 +5,7 @@ import { CreateHeaders } from "x402/verify";
 const COINBASE_FACILITATOR_BASE_URL = "https://api.cdp.coinbase.com";
 const COINBASE_FACILITATOR_V2_ROUTE = "/platform/v2/x402";
 
-const X402_SDK_VERSION = "0.5.0";
+const X402_SDK_VERSION = "0.5.1";
 const CDP_SDK_VERSION = "1.29.0";
 
 /**

--- a/typescript/packages/x402-axios/package.json
+++ b/typescript/packages/x402-axios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-axios",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-express/package.json
+++ b/typescript/packages/x402-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-express",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-fetch/package.json
+++ b/typescript/packages/x402-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-fetch",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-hono",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-next/package.json
+++ b/typescript/packages/x402-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-next",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Release 0.5.1 with Sei network support and Sei's USDC #268 