### PR TITLE
chore: version typescript packages

### DIFF
--- a/typescript/packages/x402-express/package.json
+++ b/typescript/packages/x402-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-express",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-hono",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-next/package.json
+++ b/typescript/packages/x402-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-next",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Release #320 for fix in `x402`, and bump `x402-express`, `x402-hono` and `x402-next` packages that rely on it