### PR TITLE
chore: Update examples docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@ For Go: Run `go test ./...` from the `/go` directory
 
 - [ ] I have formatted and linted my code
 - [ ] All new and existing tests pass
-- [ ] My commits are signed (required for merge) 
+- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
 
 <!--
 For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Merging contributions is at the discretion of the CDP Engineering team, based on
 
 If you update the core x402 Typescript package, you'll need to rebuild the paywall via `pnpm build:paywall` and commit the resulting generated files as part of your PR.
 
+You will also need to sign all of your commits for any contributions to be merged.
+
 ## Middleware and language libraries
 
 Language libraries should implement best practices of the language they target, have tests, linting, and follow best practices for x402 client development.

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,0 +1,79 @@
+# X402 Python Examples
+
+This directory contains a collection of Python examples demonstrating how to use the X402 protocol in various contexts. These examples use the Python `x402` package and standard Python web frameworks/HTTP clients.
+
+## Setup
+
+Before running any examples, ensure you have:
+
+- Python 3.10+
+- `uv` package manager installed (see `https://github.com/astral-sh/uv`)
+
+Then install dependencies for the examples you want to run. You can either:
+
+```bash
+# Option A: sync each example individually (recommended by each example README)
+cd <example-dir>
+uv sync
+
+# Option B: run the helper script to sync all examples
+cd examples/python
+uv run python sync.py
+```
+
+## Example Structure
+
+The examples are organized into several categories:
+
+### Clients
+
+Examples of different client implementations for interacting with x402-protected services:
+
+- `clients/httpx/` - Two approaches with httpx: a pre-configured `x402HttpxClient` and an extensible `event_hooks` integration.
+- `clients/requests/` - Two approaches with requests: a simple `x402_requests` session and an extensible HTTP adapter.
+
+### Discovery
+
+- `discovery/` - Uses the facilitator to list available x402-protected resources (Bazaar) with CDP credentials.
+
+### Fullstack
+
+- `fullstack/fastapi/` - FastAPI application with x402 middleware protecting routes. Includes simple UI assets.
+- `fullstack/flask/` - Flask application with x402 middleware protecting routes. Includes simple UI assets.
+
+### Servers
+
+Examples of different server implementations:
+
+- `servers/fastapi/` - FastAPI server using x402 middleware to protect endpoints.
+- `servers/flask/` - Flask server using x402 middleware to protect endpoints.
+- `servers/advanced/` - FastAPI server without middleware: delayed settlement, dynamic pricing, multiple requirements.
+- `servers/mainnet/` - Server example for accepting real USDC on Base mainnet using the Coinbase hosted facilitator.
+
+## Running Examples
+
+Each example directory contains its own README with specific instructions. In general:
+
+```bash
+cd <example-dir>
+cp .env-local .env   # then fill in required values
+uv sync
+uv run python main.py
+```
+
+Some client examples also provide an `extensible.py` variant that demonstrates lower-level integrations.
+
+## Development
+
+This workspace uses:
+
+- `uv` for Python environment and dependency management
+- Python 3.10+ and standard tooling
+
+The examples are independent projects; install dependencies per example before running.
+
+## A note on private keys
+
+The examples in this folder commonly use private keys to sign messages. **Never put a private key with mainnet funds in a `.env` file**. This can result in keys getting checked into codebases and being drained.
+
+Use a development wallet funded on testnets (e.g., Base Sepolia USDC/ETH). You can fund a dev wallet via the testnet [CDP Faucet](https://portal.cdp.coinbase.com/products/faucet).

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -20,26 +20,46 @@ The examples are organized into several categories:
 
 Examples of different client implementations for interacting with X402 services:
 
-- `agent/` - Example using an Anthropic agent implementation using `x402-fetch`
-- `axios/` - Example using the Axios interceptor from `x402-axios`
-- `fetch/` - Example using the fetch wrapper from `x402-fetch`
-- `mcp/` - Example using MCP (Model Context Protocol) as a client using `x402-axios`
-- `vrfnft/` - Example using [Chainlink](docs.chain.link) to mint a randomized NFT (See them on [Opensea](https://testnets.opensea.io/collection/vrfnft-1)) which uses `x402-axios`.
+- `clients/axios/` - Axios client with x402 payment interceptor from `x402-axios`.
+- `clients/fetch/` - Client using the `x402-fetch` wrapper around the native fetch API.
+- `clients/cdp-sdk/` - Client that uses CDP Server Wallets as the signer with `x402-axios`.
+- `clients/chainlink-vrf-nft/` - Example using [Chainlink](docs.chain.link) to mint a randomized NFT (see them on [Opensea](https://testnets.opensea.io/collection/vrfnft-1)). Demonstrates verify/settle flow with `x402-axios`.
+
+### Agents
+
+- `agent/` - Anthropic agent that pays via a Go proxy using `x402-fetch`.
+- `dynamic_agent/` - Agent that discovers tools dynamically and pays per-request using x402.
+
+### Discovery
+
+- `discovery/` - Uses the facilitator to list available x402-protected resources (Bazaar).
+
+### MCP
+
+- `mcp/` - MCP server that makes paid API requests via `x402-axios` (Claude Desktop compatible).
+- `mcp-embedded-wallet/` - Electron-based MCP server with an embedded wallet that signs requests via IPC.
 
 ### Facilitator
 
-- `facilitator/` - Example implementation of an X402 payment facilitator
+- `facilitator/` - Example implementation of an x402 payment facilitator exposing `/verify` and `/settle`.
 
 ### Fullstack
 
-- `next/` - Example Next.js application demonstrating full-stack X402 integration using `x402-next`
+- `fullstack/next/` - Next.js app demonstrating route protection with `x402-next` middleware.
+- `fullstack/mainnet/` - Next.js app configured for Base mainnet using the Coinbase hosted facilitator.
+- `fullstack/next-advanced/` - [WIP] Deep Next.js integration using a paywall + session cookie after verify/settle.
+- `fullstack/browser-wallet-example/` - Browser wallet template: Hono server + React client with session and one-time payments.
+- `fullstack/farcaster-miniapp/` - Farcaster Mini App template with x402-protected APIs using [MiniKit](https://www.base.org/build/mini-apps).
+- `fullstack/auth_based_pricing/` - SIWE + JWT with conditional pricing ($0.01 with JWT vs $0.10 without) using x402.
 
 ### Servers
 
 Examples of different server implementations:
 
-- `express/` - Example using Express.js with `x402-express`
-- `hono/` - Example using Hono framework with `x402-hono`
+- `servers/express/` - Express.js server using `x402-express` middleware.
+- `servers/hono/` - Hono server using `x402-hono` middleware.
+- `servers/advanced/` - Express server without middleware: delayed settlement, dynamic pricing, multiple requirements.
+- `servers/mainnet/` - Server example for accepting real USDC on Base mainnet using the Coinbase hosted facilitator.
 
 ## Running Examples
 

--- a/examples/typescript/mcp-embedded-wallet/README.md
+++ b/examples/typescript/mcp-embedded-wallet/README.md
@@ -29,7 +29,7 @@ Add as an MCP server for Claude, in `claude_desktop_config.json` (`cmd + ,` -> D
       "args": [
         "--silent",
         "-C",
-        "/Users/erik/dev/electron/examples/electron",  <- full path on your machine
+        "<absolute path to this repo>/examples/typescript/mcp-embedded-wallet",
         "run",
         "mcp"
       ],
@@ -40,6 +40,8 @@ Add as an MCP server for Claude, in `claude_desktop_config.json` (`cmd + ,` -> D
 ```
 
 Then restart Claude.
+
+Note that Claude will run an instance of the MCP server on startup, so you don't need to have it running in the background. You will need to rebuild the assets and restart Claude in order to see changes.
 
 ## How does this work?
 
@@ -90,7 +92,7 @@ contextBridge.exposeInMainWorld("electron", {
 
 If you want bi-dreictional communication you need something like `ipcRenderer.send("sign-message-response", signature);`
 
-2. implement the callback in `src/ipc.ts`, then register it in `src/main.tsx`. the function in `ipc.ts` can
+2. implement the callback in `src/ipc.ts`, then register it in `src/main.tsx`. The function in `ipc.ts` can
    be a full TS async function, but it is executed outside to context of the react render tree (using zustand stores for state syncing to react is recommended)
 
 ```typescript
@@ -108,7 +110,7 @@ We now have everything we need on the renderer side.
 
 3. Set up call from electron
 
-Call from electrong live in `operations` in `electron.ts` just for convinience.
+Call from electron live in `operations` in `electron.ts` just for convinience.
 You might add something like this
 
 ```typescript

--- a/examples/typescript/mcp/README.md
+++ b/examples/typescript/mcp/README.md
@@ -34,7 +34,7 @@ cp .env-local .env
       "args": [
         "--silent",
         "-C",
-        "<absolute path to this repo>/examples/typescript/clients/mcp",
+        "<absolute path to this repo>/examples/typescript/mcp",
         "dev"
       ],
       "env": {


### PR DESCRIPTION
## Description

Update example documentation.

Adds a top-level README for the examples/python dir, and updates the examples/typescript README to account for all the examples we've added recently.