### PR TITLE
feat: add protocol family declaration support to e2e tests

### DIFF
--- a/e2e/clients/axios/test.config.json
+++ b/e2e/clients/axios/test.config.json
@@ -2,6 +2,7 @@
   "name": "axios",
   "type": "client",
   "language": "typescript",
+  "protocolFamilies": ["evm"],
   "environment": {
     "required": [
       "PRIVATE_KEY",

--- a/e2e/clients/fetch/test.config.json
+++ b/e2e/clients/fetch/test.config.json
@@ -2,6 +2,7 @@
   "name": "fetch",
   "type": "client",
   "language": "typescript",
+  "protocolFamilies": ["evm"],
   "environment": {
     "required": [
       "PRIVATE_KEY",

--- a/e2e/clients/httpx/test.config.json
+++ b/e2e/clients/httpx/test.config.json
@@ -2,6 +2,7 @@
   "name": "httpx",
   "type": "client",
   "language": "python",
+  "protocolFamilies": ["evm"],
   "description": "Python httpx client with x402 payment hooks",
   "environment": {
     "required": [

--- a/e2e/clients/requests/test.config.json
+++ b/e2e/clients/requests/test.config.json
@@ -2,6 +2,7 @@
   "name": "requests",
   "type": "client",
   "language": "python",
+  "protocolFamilies": ["evm"],
   "description": "Python requests client with x402 HTTP adapter",
   "environment": {
     "required": [

--- a/e2e/clients/text-client-protocol.txt
+++ b/e2e/clients/text-client-protocol.txt
@@ -6,6 +6,39 @@
 3. Must exit with code 0 for success, 1 for failure
 4. Must output JSON result as the last line of stdout
 
+## Protocol Family Support
+Clients must declare which protocol families they support in their test.config.json:
+- **EVM**: Ethereum Virtual Machine compatible networks (Base, Ethereum, etc.)
+- **SVM**: Solana Virtual Machine compatible networks (Solana, etc.)
+
+Example configuration:
+```json
+{
+  "name": "my-client",
+  "type": "client",
+  "language": "typescript",
+  "protocolFamilies": ["evm"],
+  "environment": {
+    "required": ["PRIVATE_KEY", "RESOURCE_SERVER_URL", "ENDPOINT_PATH"],
+    "optional": []
+  }
+}
+```
+
+Multi-protocol client example:
+```json
+{
+  "name": "universal-client",
+  "type": "client", 
+  "language": "typescript",
+  "protocolFamilies": ["evm", "svm"],
+  "environment": {
+    "required": ["PRIVATE_KEY", "RESOURCE_SERVER_URL", "ENDPOINT_PATH"],
+    "optional": []
+  }
+}
+```
+
 ## Environment Variables / CLI Arguments
 The following parameters must be configurable:
 - `PRIVATE_KEY`: Private key for signing requests

--- a/e2e/servers/express/test.config.json
+++ b/e2e/servers/express/test.config.json
@@ -7,13 +7,15 @@
       "path": "/protected",
       "method": "GET",
       "description": "Protected endpoint requiring payment",
-      "requiresPayment": true
+      "requiresPayment": true,
+      "protocolFamily": "evm"
     },
     {
       "path": "/protected-2",
       "method": "GET",
       "description": "Protected endpoint requiring ERC20 payment",
-      "requiresPayment": true
+      "requiresPayment": true,
+      "protocolFamily": "evm"
     },
     {
       "path": "/health",

--- a/e2e/servers/fastapi/test.config.json
+++ b/e2e/servers/fastapi/test.config.json
@@ -8,13 +8,15 @@
       "path": "/protected",
       "method": "GET",
       "description": "Protected endpoint requiring payment",
-      "requiresPayment": true
+      "requiresPayment": true,
+      "protocolFamily": "evm"
     },
     {
       "path": "/protected-2",
       "method": "GET",
       "description": "Protected endpoint requiring ERC20 payment",
-      "requiresPayment": true
+      "requiresPayment": true,
+      "protocolFamily": "evm"
     },
     {
       "path": "/health",

--- a/e2e/servers/flask/test.config.json
+++ b/e2e/servers/flask/test.config.json
@@ -8,7 +8,8 @@
       "path": "/protected",
       "method": "GET",
       "description": "Protected endpoint requiring payment",
-      "requiresPayment": true
+      "requiresPayment": true,
+      "protocolFamily": "evm"
     },
     {
       "path": "/health",

--- a/e2e/servers/gin/test.config.json
+++ b/e2e/servers/gin/test.config.json
@@ -8,7 +8,8 @@
       "path": "/protected",
       "method": "GET",
       "description": "Protected endpoint requiring payment",
-      "requiresPayment": true
+      "requiresPayment": true,
+      "protocolFamily": "evm"
     },
     {
       "path": "/health",

--- a/e2e/servers/hono/test.config.json
+++ b/e2e/servers/hono/test.config.json
@@ -7,7 +7,8 @@
       "path": "/protected",
       "method": "GET",
       "description": "Protected endpoint requiring payment",
-      "requiresPayment": true
+      "requiresPayment": true,
+      "protocolFamily": "evm"
     },
     {
       "path": "/health",

--- a/e2e/servers/next/test.config.json
+++ b/e2e/servers/next/test.config.json
@@ -7,7 +7,8 @@
       "path": "/api/protected",
       "method": "GET",
       "description": "Protected API endpoint requiring payment",
-      "requiresPayment": true
+      "requiresPayment": true,
+      "protocolFamily": "evm"
     },
     {
       "path": "/api/health",

--- a/e2e/servers/text-server-protocol.txt
+++ b/e2e/servers/text-server-protocol.txt
@@ -5,6 +5,60 @@
 2. Must output specific logs
 3. Must error code 0 or 1, with a JSON response payload
 
+## Protocol Family Support
+Servers must declare which protocol family each payment endpoint requires in their test.config.json:
+- **EVM**: Ethereum Virtual Machine compatible networks (Base, Ethereum, etc.)
+- **SVM**: Solana Virtual Machine compatible networks (Solana, etc.)
+
+Example configuration:
+```json
+{
+  "name": "my-server",
+  "type": "server",
+  "language": "typescript",
+  "endpoints": [
+    {
+      "path": "/protected",
+      "method": "GET",
+      "description": "Protected endpoint requiring EVM payment",
+      "requiresPayment": true,
+      "protocolFamily": "evm"
+    },
+    {
+      "path": "/health",
+      "method": "GET",
+      "description": "Health check endpoint",
+      "health": true
+    }
+  ]
+}
+```
+
+Multi-protocol server example:
+```json
+{
+  "name": "universal-server",
+  "type": "server",
+  "language": "typescript", 
+  "endpoints": [
+    {
+      "path": "/evm-protected",
+      "method": "GET",
+      "description": "Protected endpoint requiring EVM payment",
+      "requiresPayment": true,
+      "protocolFamily": "evm"
+    },
+    {
+      "path": "/svm-protected", 
+      "method": "GET",
+      "description": "Protected endpoint requiring SVM payment",
+      "requiresPayment": true,
+      "protocolFamily": "svm"
+    }
+  ]
+}
+```
+
 ## Environment Variables / CLI Arguments
 The following parameters must be configurable:
 - `USE_CDP_FACILITATOR`: Flag to switch facilitators from default

--- a/e2e/src/types.ts
+++ b/e2e/src/types.ts
@@ -1,3 +1,5 @@
+export type ProtocolFamily = 'evm' | 'svm';
+
 export interface ClientResult {
   success: boolean;
   data?: any;
@@ -37,6 +39,8 @@ export interface TestEndpoint {
   method: string;
   description: string;
   requiresPayment?: boolean;
+  protocolFamily?: ProtocolFamily;
+  networks?: string[];
   health?: boolean;
   close?: boolean;
 }
@@ -45,6 +49,7 @@ export interface TestConfig {
   name: string;
   type: 'server' | 'client';
   language: string;
+  protocolFamilies?: ProtocolFamily[];
   endpoints?: TestEndpoint[];
   supportedMethods?: string[];
   capabilities?: {
@@ -75,6 +80,7 @@ export interface TestScenario {
   client: DiscoveredClient;
   server: DiscoveredServer;
   endpoint: TestEndpoint;
+  protocolFamily: ProtocolFamily;
   facilitatorNetworkCombo: {
     useCdpFacilitator: boolean;
     network: string;

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -5,7 +5,6 @@ import {
   PaymentRequirementsSchema,
   Signer,
   MultiNetworkSigner,
-  isEvmSignerWallet,
   isMultiNetworkSigner,
   isSvmSignerWallet,
   Network,

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -72,8 +72,8 @@ export function withPaymentInterceptor(
 
         const network = isMultiNetworkSigner(walletClient)
           ? undefined
-          : isEvmSignerWallet(walletClient as Signer)
-            ? ChainIdToNetwork[(walletClient as unknown as typeof evm.EvmSigner).chain?.id]
+          : evm.isSignerWallet(walletClient as typeof evm.EvmSigner)
+            ? ChainIdToNetwork[(walletClient as typeof evm.EvmSigner).chain?.id]
             : isSvmSignerWallet(walletClient as Signer)
               ? (["solana", "solana-devnet"] as Network[])
               : undefined;

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -2,7 +2,6 @@ import {
   ChainIdToNetwork,
   PaymentRequirementsSchema,
   Signer,
-  isEvmSignerWallet,
   evm,
   MultiNetworkSigner,
   isMultiNetworkSigner,

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -67,8 +67,8 @@ export function wrapFetchWithPayment(
 
     const network = isMultiNetworkSigner(walletClient)
       ? undefined
-      : isEvmSignerWallet(walletClient)
-        ? ChainIdToNetwork[(walletClient as unknown as typeof evm.EvmSigner).chain?.id]
+      : evm.isSignerWallet(walletClient as typeof evm.EvmSigner)
+        ? ChainIdToNetwork[(walletClient as typeof evm.EvmSigner).chain?.id]
         : isSvmSignerWallet(walletClient)
           ? (["solana", "solana-devnet"] as Network[])
           : undefined;

--- a/typescript/packages/x402/src/client/createPaymentHeader.ts
+++ b/typescript/packages/x402/src/client/createPaymentHeader.ts
@@ -21,11 +21,11 @@ export async function createPaymentHeader(
     // evm
     if (SupportedEVMNetworks.includes(paymentRequirements.network)) {
       const evmClient = isMultiNetworkSigner(client) ? client.evm : client;
-      
+
       if (!isEvmSignerWallet(evmClient)) {
         throw new Error("Invalid evm wallet client provided");
       }
-      
+
       return await createPaymentHeaderExactEVM(
         evmClient,
         x402Version,
@@ -35,11 +35,10 @@ export async function createPaymentHeader(
     // svm
     if (SupportedSVMNetworks.includes(paymentRequirements.network)) {
       const svmClient = isMultiNetworkSigner(client) ? client.svm : client;
-      
       if (!isSvmSignerWallet(svmClient)) {
         throw new Error("Invalid svm wallet client provided");
       }
-      
+
       return await createPaymentHeaderExactSVM(
         svmClient,
         x402Version,

--- a/typescript/packages/x402/src/client/signPaymentHeader.ts
+++ b/typescript/packages/x402/src/client/signPaymentHeader.ts
@@ -25,7 +25,6 @@ export async function signPaymentHeader(
     if (!isEvmSignerWallet(evmClient)) {
       throw new Error("Invalid evm wallet client provided");
     }
-    
     const signedPaymentHeader = await signPaymentHeaderExactEVM(evmClient, paymentRequirements, unsignedPaymentHeader);
     return encodePayment(signedPaymentHeader);
   }

--- a/typescript/packages/x402/src/types/shared/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/wallet.ts
@@ -53,7 +53,7 @@ export function createSigner(network: string, privateKey: Hex | string): Promise
  * @returns True if the wallet is an EVM signer wallet, false otherwise.
  */
 export function isEvmSignerWallet(wallet: Signer): wallet is evm.EvmSigner {
-  return evm.isSignerWallet(wallet as evm.EvmSigner);
+  return evm.isSignerWallet(wallet as evm.EvmSigner) || evm.isAccount(wallet as evm.EvmSigner);
 }
 
 /**


### PR DESCRIPTION
1. Updates the e2e testing structure to support specifying protocol families supported. Clients declare many protocol families they support, while servers specify one protocol family per endpoint used in testing. These are taken into consideration when pairing up client+server+server-endpoint+facilitator combinations for testing.
2. Hotfix regression we saw with the EVM e2e tests, where the Solana PR mishandled the fact that there are two types of supported Viem signing wallets (Viem signers and Viem accounts) for EVM

### Tests

Ran unit tests and confirmed they pass