### PR TITLE
Adding Scroll and Scroll Sepolia Network Support

### DIFF
--- a/typescript/packages/x402/src/shared/middleware.test.ts
+++ b/typescript/packages/x402/src/shared/middleware.test.ts
@@ -344,6 +344,32 @@ describe("getDefaultAsset", () => {
     });
   });
 
+  it("should return Scroll USDC asset details", () => {
+    const result = getDefaultAsset("scroll");
+
+    expect(result).toEqual({
+      address: "0x06efdbff2a14a7c8e15944d1f4a48f9f95f663a4",
+      decimals: 6,
+      eip712: {
+        name: "Bridged USDC",
+        version: "2",
+      },
+    });
+  });
+
+  it("should return Scroll Sepolia USDC Test Tokenasset details", () => {
+    const result = getDefaultAsset("scroll-sepolia");
+
+    expect(result).toEqual({
+      address: "0xB1933d0330F117e137cd00852A3c8E6f7254C566",
+      decimals: 6,
+      eip712: {
+        name: "USDC Test Token",
+        version: "2",
+      },
+    });
+  });
+
   it("should handle unknown networks", () => {
     expect(() => getDefaultAsset("unknown" as Network)).toThrow("Unsupported network: unknown");
   });

--- a/typescript/packages/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/x402/src/types/shared/evm/config.ts
@@ -40,6 +40,14 @@ export const config: Record<string, ChainConfig> = {
     usdcAddress: "0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392",
     usdcName: "USDC",
   },
+  "534352": {
+    usdcAddress: "0x06efdbff2a14a7c8e15944d1f4a48f9f95f663a4",
+    usdcName: "Bridged USDC",
+  },
+  "534351": {
+    usdcAddress: "0xB1933d0330F117e137cd00852A3c8E6f7254C566",
+    usdcName: "USDC Test Token",
+  },
 };
 
 export type ChainConfig = {

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -10,7 +10,7 @@ import type {
   PublicClient,
   LocalAccount,
 } from "viem";
-import { baseSepolia, avalancheFuji, base, sei, seiTestnet } from "viem/chains";
+import { baseSepolia, avalancheFuji, base, sei, seiTestnet, scroll, scrollSepolia } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 import { Hex } from "viem";
 
@@ -187,6 +187,10 @@ function getChainFromNetwork(network: string | undefined): Chain {
       return sei;
     case "sei-testnet":
       return seiTestnet;
+    case "scroll":
+      return scroll;
+    case "scroll-sepolia":
+      return scrollSepolia;
     default:
       throw new Error(`Unsupported network: ${network}`);
   }

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -10,6 +10,8 @@ export const NetworkSchema = z.enum([
   "solana",
   "sei",
   "sei-testnet",
+  "scroll",
+  "scroll-sepolia",
 ]);
 export type Network = z.infer<typeof NetworkSchema>;
 
@@ -22,6 +24,8 @@ export const SupportedEVMNetworks: Network[] = [
   "iotex",
   "sei",
   "sei-testnet",
+  "scroll",
+  "scroll-sepolia",
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
   ["base-sepolia", 84532],
@@ -31,6 +35,8 @@ export const EvmNetworkToChainId = new Map<Network, number>([
   ["iotex", 4689],
   ["sei", 1329],
   ["sei-testnet", 1328],
+  ["scroll", 534352],
+  ["scroll-sepolia", 534351],
 ]);
 
 // svm

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -52,6 +52,7 @@ export const ErrorReasons = [
   "unsupported_scheme",
   "unexpected_settle_error",
   "unexpected_verify_error",
+  "smart_contract_wallet_not_supported_on_scroll",
 ] as const;
 
 // Refiners


### PR DESCRIPTION
## Description

Introduces support for Scroll and Scroll Sepolia networks, including their USDC asset details and chain IDs. 
Implements a temporary workaround for Scroll mainnet's USDC contract by converting signatures to v, r, s format and restricting smart contract wallet usage. Updates tests, network schemas, and error reasons to reflect these changes.

Creating a new clean repo to ease the tracking. I have closed the old PR #350 


Related: [Issue 343](https://github.com/coinbase/x402/issues/343) 
## Tests

Run `pnpm test` on `/typescript`
Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`

## Checklist

- [ x ] I have formatted and linted my code
- [ x ] All new and existing tests pass
- [ x ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits