### PR TITLE
chore: version typescript package

### DIFF
--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/x402",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/coinbase-x402/src/index.ts
+++ b/typescript/packages/coinbase-x402/src/index.ts
@@ -5,7 +5,7 @@ import { CreateHeaders } from "x402/verify";
 const COINBASE_FACILITATOR_BASE_URL = "https://api.cdp.coinbase.com";
 const COINBASE_FACILITATOR_V2_ROUTE = "/platform/v2/x402";
 
-const X402_SDK_VERSION = "0.6.0";
+const X402_SDK_VERSION = "0.6.1";
 const CDP_SDK_VERSION = "1.29.0";
 
 /**


### PR DESCRIPTION
Releasing `@coinbase/x402` v0.6.2 to release #370, enabling discovery access without auth headers