### PR TITLE
fix: e2e express non-prod facilitator

### DIFF
--- a/e2e/servers/express/index.ts
+++ b/e2e/servers/express/index.ts
@@ -41,7 +41,7 @@ app.use(
         network: svmNetwork,
       },
     },
-    useCdpFacilitator ? facilitator : { url: "http://localhost:3000/facilitator" }
+    useCdpFacilitator ? facilitator : undefined
   ),
 );
 


### PR DESCRIPTION
Removed testing code where I was pointing the express server to the localhost facilitator for the default case when testing Solana support with updated site