### PR TITLE
fix(bug): fix types export in package.json

### DIFF
--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -3,7 +3,7 @@
   "version": "0.6.5",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/cjs/index.d.ts",
   "scripts": {
     "start": "tsx --env-file=.env index.ts",
     "build": "tsup",


### PR DESCRIPTION
The published x402 lib does not contain a `index.d.ts` referenced in `package.json` leading to Typescript errors.

e.g.: 
<img width="211" height="141" alt="image" src="https://github.com/user-attachments/assets/7e7a4188-0fbd-4ae8-9f81-b0b37011c6cb" />

```
Could not find a declaration file for module 'x402'. '/Users/dylanfiedler/Documents/ario/ar-io/ar-io-node/node_modules/x402/dist/esm/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/x402` if it exists or add a new declaration (.d.ts) file containing `declare module 'x402';`ts(7016)
```

This PR updates it to use esm types by default.

<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 