### PR TITLE
feat: add peaq EVM support (chainId 3338) with native USDC (EIP-3009)

### DIFF
--- a/typescript/packages/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/x402/src/types/shared/evm/config.ts
@@ -40,6 +40,10 @@ export const config: Record<string, ChainConfig> = {
     usdcAddress: "0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392",
     usdcName: "USDC",
   },
+  "3338": {
+    usdcAddress: "0xbbA60da06c2c5424f03f7434542280FCAd453d10",
+    usdcName: "USDC",
+  },
 };
 
 export type ChainConfig = {

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -10,24 +10,9 @@ import type {
   PublicClient,
   LocalAccount,
 } from "viem";
-import { baseSepolia, avalancheFuji, base, sei, seiTestnet, defineChain } from "viem/chains";
+import { baseSepolia, avalancheFuji, base, sei, seiTestnet, peaq } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 import { Hex } from "viem";
-
-// peaq chain via defineChain if not available in viem by default
-export const peaq = defineChain({
-  id: 3338,
-  name: "peaq",
-  network: "peaq",
-  nativeCurrency: { name: "peaq", symbol: "PEAQ", decimals: 18 },
-  rpcUrls: {
-    default: { http: ["https://quicknode1.peaq.xyz"] },
-    public: { http: ["https://quicknode1.peaq.xyz"] },
-  },
-  blockExplorers: {
-    default: { name: "peaqscan", url: "https://peaqscan.xyz" },
-  },
-});
 
 // Create a public client for reading data
 export type SignerWallet<

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -67,22 +67,115 @@ export function createSigner(network: string, privateKey: Hex): SignerWallet<Cha
   }).extend(publicActions);
 }
 
-// Back-compat helpers (deprecated)
+/**
+ * Creates a public client configured for the Base Sepolia testnet
+ *
+ * @deprecated Use `createConnectedClient("base-sepolia")` instead
+ * @returns A public client instance connected to Base Sepolia
+ */
 export function createClientSepolia(): ConnectedClient<Transport, typeof baseSepolia, undefined> {
-  return createConnectedClient("base-sepolia") as ConnectedClient<Transport, typeof baseSepolia, undefined>;
+  return createConnectedClient("base-sepolia") as ConnectedClient<
+    Transport,
+    typeof baseSepolia,
+    undefined
+  >;
 }
-export function createClientAvalancheFuji(): ConnectedClient<Transport, typeof avalancheFuji, undefined> {
-  return createConnectedClient("avalanche-fuji") as ConnectedClient<Transport, typeof avalancheFuji, undefined>;
+
+/**
+ * Creates a public client configured for the Avalanche Fuji testnet
+ *
+ * @deprecated Use `createConnectedClient("avalanche-fuji")` instead
+ * @returns A public client instance connected to Avalanche Fuji
+ */
+export function createClientAvalancheFuji(): ConnectedClient<
+  Transport,
+  typeof avalancheFuji,
+  undefined
+> {
+  return createConnectedClient("avalanche-fuji") as ConnectedClient<
+    Transport,
+    typeof avalancheFuji,
+    undefined
+  >;
 }
+
+/**
+ * Creates a wallet client configured for the Base Sepolia testnet with a private key
+ *
+ * @deprecated Use `createSigner("base-sepolia", privateKey)` instead
+ * @param privateKey - The private key to use for signing transactions
+ * @returns A wallet client instance connected to Base Sepolia with the provided private key
+ */
 export function createSignerSepolia(privateKey: Hex): SignerWallet<typeof baseSepolia> {
   return createSigner("base-sepolia", privateKey) as SignerWallet<typeof baseSepolia>;
 }
+
+/**
+ * Creates a wallet client configured for the Avalanche Fuji testnet with a private key
+ *
+ * @deprecated Use `createSigner("avalanche-fuji", privateKey)` instead
+ * @param privateKey - The private key to use for signing transactions
+ * @returns A wallet client instance connected to Avalanche Fuji with the provided private key
+ */
 export function createSignerAvalancheFuji(privateKey: Hex): SignerWallet<typeof avalancheFuji> {
   return createSigner("avalanche-fuji", privateKey) as SignerWallet<typeof avalancheFuji>;
 }
 
-export function getChainFromNetwork(network: string | undefined): Chain {
-  if (!network) throw new Error("NETWORK environment variable is not set");
+/**
+ * Checks if a wallet is a signer wallet
+ *
+ * @param wallet - The wallet to check
+ * @returns True if the wallet is a signer wallet, false otherwise
+ */
+export function isSignerWallet<
+  TChain extends Chain = Chain,
+  TTransport extends Transport = Transport,
+  TAccount extends Account = Account,
+>(
+  wallet: SignerWallet<TChain, TTransport, TAccount> | LocalAccount,
+): wallet is SignerWallet<TChain, TTransport, TAccount> {
+  return (
+    typeof wallet === "object" && wallet !== null && "chain" in wallet && "transport" in wallet
+  );
+}
+
+/**
+ * Checks if a wallet is an account
+ *
+ * @param wallet - The wallet to check
+ * @returns True if the wallet is an account, false otherwise
+ */
+export function isAccount<
+  TChain extends Chain = Chain,
+  TTransport extends Transport = Transport,
+  TAccount extends Account = Account,
+>(wallet: SignerWallet<TChain, TTransport, TAccount> | LocalAccount): wallet is LocalAccount {
+  const w = wallet as LocalAccount;
+  return (
+    typeof wallet === "object" &&
+    wallet !== null &&
+    typeof w.address === "string" &&
+    typeof w.type === "string" &&
+    // Check for essential signing capabilities
+    typeof w.sign === "function" &&
+    typeof w.signMessage === "function" &&
+    typeof w.signTypedData === "function" &&
+    // Check for transaction signing (required by LocalAccount)
+    typeof w.signTransaction === "function"
+  );
+}
+
+/**
+ * Maps network strings to Chain objects
+ *
+ * @param network - The network string to convert to a Chain object
+ * @returns The corresponding Chain object
+ */
+function getChainFromNetwork(network: string | undefined): Chain {
+  if (!network) {
+    throw new Error("NETWORK environment variable is not set");
+  }
+
   switch (network) {
     case "base":
       return base;

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -10,6 +10,7 @@ export const NetworkSchema = z.enum([
   "solana",
   "sei",
   "sei-testnet",
+  "peaq",
 ]);
 export type Network = z.infer<typeof NetworkSchema>;
 
@@ -22,6 +23,7 @@ export const SupportedEVMNetworks: Network[] = [
   "iotex",
   "sei",
   "sei-testnet",
+  "peaq",
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
   ["base-sepolia", 84532],
@@ -31,6 +33,7 @@ export const EvmNetworkToChainId = new Map<Network, number>([
   ["iotex", 4689],
   ["sei", 1329],
   ["sei-testnet", 1328],
+  ["peaq", 3338],
 ]);
 
 // svm


### PR DESCRIPTION
This PR adds peaq mainnet support following the pattern used for Avalanche and Arbitrum additions.

Summary:
- Add `peaq` to EVM networks and map to `chainId: 3338`
- Configure USDC for peaq (checksummed): `0xbbA60da06c2c5424f03f7434542280FCAd453d10`
- Provide wallet helpers by defining a `peaq` chain via `defineChain` with RPC (`https://quicknode1.peaq.xyz`) and explorer (`https://peaqscan.xyz`)
- Keep existing network helpers intact

Why:
- peaq hosts a USDC (LayerZero OFT) contract that supports EIP-3009 (`transferWithAuthorization`), which is required by x402 exact EVM scheme.

References:
- Arbitrum support example (structure mirrored): https://github.com/coinbase/x402/pull/204/commits/3c074e80cc209e6d7d41505e04604fb5ba7f8d5a
- EIP-3009 settle path in x402: `typescript/packages/x402/src/schemes/exact/evm/facilitator.ts`
- USDC ABI with EIP-3009 in-repo: `typescript/packages/x402/src/types/shared/evm/erc20PermitABI.ts`
- Explorer: https://peaqscan.xyz/

Notes:
- If `viem/chains` adds peaq later, the `defineChain` block can be replaced with the official import.
- We tested end-to-end sign → settle on peaq using the EIP‑3009 flow and confirmed success tx hash (example): `0x1fb33d54f0397d5634d7df0a6774ab2386ffd3fb0970ef46908f257ce129869a`.

Happy to add examples or make naming tweaks (e.g., network key `"peaq"`).