### PR TITLE
feat: add peaq EVM support (3338) – minimal additive change

### DIFF
--- a/typescript/packages/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/x402/src/types/shared/evm/config.ts
@@ -40,6 +40,10 @@ export const config: Record<string, ChainConfig> = {
     usdcAddress: "0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392",
     usdcName: "USDC",
   },
+  "3338": {
+    usdcAddress: "0xbbA60da06c2c5424f03f7434542280FCAd453d10",
+    usdcName: "USDC",
+  },
 };
 
 export type ChainConfig = {

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -10,7 +10,7 @@ import type {
   PublicClient,
   LocalAccount,
 } from "viem";
-import { baseSepolia, avalancheFuji, base, sei, seiTestnet } from "viem/chains";
+import { baseSepolia, avalancheFuji, base, sei, seiTestnet, peaq } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 import { Hex } from "viem";
 
@@ -52,6 +52,22 @@ export function createConnectedClient(
 }
 
 /**
+ * Creates a wallet client configured for the specified chain with a private key
+ *
+ * @param network - The network to connect to
+ * @param privateKey - The private key to use for signing transactions
+ * @returns A wallet client instance connected to the specified chain with the provided private key
+ */
+export function createSigner(network: string, privateKey: Hex): SignerWallet<Chain> {
+  const chain = getChainFromNetwork(network);
+  return createWalletClient({
+    chain,
+    transport: http(),
+    account: privateKeyToAccount(privateKey),
+  }).extend(publicActions);
+}
+
+/**
  * Creates a public client configured for the Base Sepolia testnet
  *
  * @deprecated Use `createConnectedClient("base-sepolia")` instead
@@ -81,22 +97,6 @@ export function createClientAvalancheFuji(): ConnectedClient<
     typeof avalancheFuji,
     undefined
   >;
-}
-
-/**
- * Creates a wallet client configured for the specified chain with a private key
- *
- * @param network - The network to connect to
- * @param privateKey - The private key to use for signing transactions
- * @returns A wallet client instance connected to the specified chain with the provided private key
- */
-export function createSigner(network: string, privateKey: Hex): SignerWallet<Chain> {
-  const chain = getChainFromNetwork(network);
-  return createWalletClient({
-    chain,
-    transport: http(),
-    account: privateKeyToAccount(privateKey),
-  }).extend(publicActions);
 }
 
 /**
@@ -187,6 +187,8 @@ function getChainFromNetwork(network: string | undefined): Chain {
       return sei;
     case "sei-testnet":
       return seiTestnet;
+    case "peaq":
+      return peaq;
     default:
       throw new Error(`Unsupported network: ${network}`);
   }

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -10,6 +10,7 @@ export const NetworkSchema = z.enum([
   "solana",
   "sei",
   "sei-testnet",
+  "peaq",
 ]);
 export type Network = z.infer<typeof NetworkSchema>;
 
@@ -22,6 +23,7 @@ export const SupportedEVMNetworks: Network[] = [
   "iotex",
   "sei",
   "sei-testnet",
+  "peaq",
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
   ["base-sepolia", 84532],
@@ -31,6 +33,7 @@ export const EvmNetworkToChainId = new Map<Network, number>([
   ["iotex", 4689],
   ["sei", 1329],
   ["sei-testnet", 1328],
+  ["peaq", 3338],
 ]);
 
 // svm


### PR DESCRIPTION
Following the established pattern in [#204](https://github.com/coinbase/x402/pull/204) and [#157](https://github.com/coinbase/x402/pull/157):

- Add `peaq` to EVM networks with `chainId: 3338`
- Configure USDC (EIP-3009) on peaq: `0xbbA60da06c2c5424f03f7434542280FCAd453d10`
- Import `peaq` directly from `viem/chains` and extend switch in wallet helpers

Single commit, no unrelated diffs.
