### PR TITLE
Remove unreachable else

### DIFF
--- a/python/x402/src/x402/common.py
+++ b/python/x402/src/x402/common.py
@@ -81,9 +81,6 @@ def process_price_to_atomic_amount(
             },
         )
 
-    else:
-        raise ValueError(f"Invalid price type: {type(price)}")
-
 
 def get_usdc_address(chain_id: int | str) -> str:
     """Get the USDC contract address for a given chain ID"""


### PR DESCRIPTION
The function exhaustively handles all possible types that Price can be:
- isinstance(price, (str, int)) catches all str and int values (the Money type)
- isinstance(price, TokenAmount) catches all TokenAmount instances

Since the Price type union only contains str, int, and TokenAmount, there are no other possible types that could reach the else clause.