### PR TITLE
Transport-Agnostic x402

### DIFF
--- a/specs/transport_template.md
+++ b/specs/transport_template.md
@@ -1,0 +1,42 @@
+# Transport: `<name>`
+
+## Summary
+
+Describe the purpose and characteristics of this transport layer. Include example use cases and key advantages.
+
+## Payment Required Signaling
+
+Define how the server indicates that payment is required for resource access:
+
+- **Mechanism**: How payment requirements are communicated (e.g., status codes, error messages)
+- **Data Format**: Where and how the `PaymentRequirementsResponse` schema is included
+- **Examples**: Complete examples of payment required responses using the `PaymentRequirementsResponse` schema
+
+## Payment Payload Transmission
+
+Define how clients send payment data to servers:
+
+- **Mechanism**: How payment data is transmitted (e.g., headers, request body, metadata)
+- **Data Format**: Encoding and structure requirements for the `PaymentPayload` schema
+- **Examples**: Complete examples of requests with `PaymentPayload` data
+
+## Settlement Response Delivery
+
+Define how servers communicate payment settlement results:
+
+- **Mechanism**: How settlement data is returned to clients
+- **Data Format**: Structure and encoding of the `SettlementResponse` schema
+- **Examples**: Complete examples of successful and failed `SettlementResponse` data
+
+## Error Handling
+
+Define transport-specific error handling:
+
+- **Error Types**: How different x402 error conditions map to transport-specific mechanisms
+- **Error Format**: Structure of error responses (may include `PaymentRequirementsResponse` for payment-related errors)
+- **Examples**: Error response examples showing both technical errors and payment requirement errors
+
+## References
+
+- [Core x402 Specification](../x402-specification.md) - Contains all schema definitions (`PaymentRequirementsResponse`, `PaymentPayload`, `SettlementResponse`, etc.)
+- Relevant transport protocol documentation

--- a/specs/transports/a2a.md
+++ b/specs/transports/a2a.md
@@ -1,0 +1,288 @@
+# Transport: A2A (Agent-to-Agent Protocol)
+
+## Summary
+
+The A2A transport implements x402 payment flows over the Agent-to-Agent protocol using JSON-RPC messages and task-based state management. This enables AI agents to monetize their services through on-chain cryptocurrency payments within the A2A framework, leveraging the protocol's task lifecycle and metadata system for payment coordination.
+
+## Payment Required Signaling
+
+The server agent indicates payment is required using A2A's task state `input-required` with payment metadata.
+
+**Mechanism**: Task with `state: "input-required"` and `x402.payment.status: "payment-required"` in message metadata  
+**Data Format**: `PaymentRequirementsResponse` schema in `x402.payment.required` metadata field
+
+**Example:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-001",
+  "result": {
+    "kind": "task",
+    "id": "task-123",
+    "status": {
+      "state": "input-required",
+      "message": {
+        "kind": "message",
+        "role": "agent",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Payment is required to generate the image."
+          }
+        ],
+        "metadata": {
+          "x402.payment.status": "payment-required",
+          "x402.payment.required": {
+            "x402Version": 1,
+            "error": "Payment required to access this resource",
+            "accepts": [
+              {
+                "scheme": "exact",
+                "network": "base",
+                "resource": "https://api.example.com/generate-image",
+                "description": "Generate an image",
+                "mimeType": "application/json",
+                "outputSchema": {},
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913",
+                "payTo": "0xServerWalletAddressHere",
+                "maxAmountRequired": "48240000",
+                "maxTimeoutSeconds": 600,
+                "extra": {
+                  "name": "USD Coin",
+                  "version": 2
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Payment Payload Transmission
+
+Clients send payment data using the A2A message metadata with task correlation.
+
+**Mechanism**: Message with `x402.payment.payload` metadata field and `taskId` for correlation  
+**Data Format**: `PaymentPayload` schema in `x402.payment.payload` metadata field
+
+**Example:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "message/send",
+  "id": "req-003",
+  "params": {
+    "message": {
+      "taskId": "task-123",
+      "role": "user",
+      "parts": [
+        { "kind": "text", "text": "Here is the payment authorization." }
+      ],
+      "metadata": {
+        "x402.payment.status": "payment-submitted",
+        "x402.payment.payload": {
+          "x402Version": 1,
+          "scheme": "exact",
+          "network": "base",
+          "payload": {
+            "signature": "0x2d6a7588d6acca505cbf0d9a4a227e0c52c6c34008c8e8986a1283259764173608a2ce6496642e377d6da8dbbf5836e9bd15092f9ecab05ded3d6293af148b571c",
+            "authorization": {
+              "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+              "to": "0xServerWalletAddressHere",
+              "value": "48240000",
+              "validAfter": "1740672089",
+              "validBefore": "1740672154",
+              "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Settlement Response Delivery
+
+Servers communicate payment settlement results using task status updates with settlement metadata.
+
+**Mechanism**: Task status update with `x402.payment.receipts` metadata field  
+**Data Format**: Array of `SettlementResponse` schemas in `x402.payment.receipts` metadata field
+
+**Example (Successful Settlement):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-003",
+  "result": {
+    "kind": "task",
+    "id": "task-123",
+    "status": {
+      "state": "completed",
+      "message": {
+        "kind": "message",
+        "role": "agent",
+        "parts": [
+          { "kind": "text", "text": "Payment successful. Your image is ready." }
+        ],
+        "metadata": {
+          "x402.payment.status": "payment-completed",
+          "x402.payment.receipts": [
+            {
+              "success": true,
+              "transaction": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+              "network": "base",
+              "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+            }
+          ]
+        }
+      }
+    },
+    "artifacts": [
+      {
+        "kind": "image",
+        "name": "generated-image.png",
+        "mimeType": "image/png",
+        "data": "base64-encoded-image-data"
+      }
+    ]
+  }
+}
+```
+
+**Example (Payment Failure):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "req-003",
+  "result": {
+    "kind": "task",
+    "id": "task-123",
+    "status": {
+      "state": "failed",
+      "message": {
+        "kind": "message",
+        "role": "agent",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Payment verification failed: The signature has expired."
+          }
+        ],
+        "metadata": {
+          "x402.payment.status": "payment-failed",
+          "x402.payment.error": "EXPIRED_PAYMENT",
+          "x402.payment.receipts": [
+            {
+              "success": false,
+              "errorReason": "Payment authorization was submitted after its 'validBefore' timestamp.",
+              "network": "base",
+              "transaction": ""
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+## Payment Status Lifecycle
+
+The A2A transport uses a detailed payment status progression tracked in the `x402.payment.status` metadata field:
+
+| Status              | Description                               | Task State                   |
+| ------------------- | ----------------------------------------- | ---------------------------- |
+| `payment-required`  | Payment requirements sent to client       | `input-required`             |
+| `payment-rejected`  | Client rejected payment requirements      | `failed` or `input-required` |
+| `payment-submitted` | Payment payload received by server        | `input-required` → `working` |
+| `payment-verified`  | Payment payload verified by server        | `working`                    |
+| `payment-completed` | Payment settled on-chain successfully     | `working` → `completed`      |
+| `payment-failed`    | Payment verification or settlement failed | `failed`                     |
+
+## Error Handling
+
+A2A transport maps x402 errors to task states and metadata:
+
+| x402 Error       | Task State       | Payment Status      | Description                                     |
+| ---------------- | ---------------- | ------------------- | ----------------------------------------------- |
+| Payment Required | `input-required` | `payment-required`  | Payment needed to access resource               |
+| Payment Rejected | `failed`         | `payment-rejected`  | Client declined payment requirements            |
+| Invalid Payment  | `failed`         | `payment-failed`    | Malformed payment payload or requirements       |
+| Payment Failed   | `failed`         | `payment-failed`    | Payment verification or settlement failed       |
+| Server Error     | `failed`         | `payment-failed`    | Internal server error during payment processing |
+| Success          | `completed`      | `payment-completed` | Payment verified and settled successfully       |
+
+**Error Response Format:**
+
+Task state transitions to `failed` with detailed error information in metadata:
+
+```json
+{
+  "kind": "task",
+  "id": "task-123",
+  "status": {
+    "state": "failed",
+    "message": {
+      "kind": "message",
+      "role": "agent",
+      "parts": [
+        {
+          "kind": "text",
+          "text": "Payment verification failed: insufficient funds"
+        }
+      ],
+      "metadata": {
+        "x402.payment.status": "payment-failed",
+        "x402.payment.error": "INSUFFICIENT_FUNDS",
+        "x402.payment.receipts": [
+          {
+            "success": false,
+            "errorReason": "The client's wallet has insufficient funds to cover the payment.",
+            "network": "base",
+            "transaction": ""
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Extension Declaration and Activation
+
+Agents supporting x402 payments must declare the extension in their AgentCard:
+
+```json
+{
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://github.com/google-a2a/a2a-x402/v0.1",
+        "description": "Supports payments using the x402 protocol for on-chain settlement.",
+        "required": true
+      }
+    ]
+  }
+}
+```
+
+Clients must activate the extension using the `X-A2A-Extensions` HTTP header:
+
+```http
+X-A2A-Extensions: https://github.com/google-a2a/a2a-x402/v0.1
+```
+
+## References
+
+- [Core x402 Specification](../x402-specification.md)
+- [A2A Protocol Specification](https://a2a-protocol.org/latest/specification)
+- [A2A Extensions Documentation](https://github.com/a2aproject/A2A/blob/main/docs/topics/extensions.md)
+- [A2A x402 Extension Specification](https://github.com/google-agentic-commerce/a2a-x402/blob/main/spec/v0.1/spec.md)

--- a/specs/transports/http.md
+++ b/specs/transports/http.md
@@ -1,0 +1,160 @@
+# Transport: HTTP
+
+## Summary
+
+The HTTP transport implements x402 payment flows over standard HTTP/HTTPS protocols. This is the original transport for x402 and leverages existing HTTP status codes and headers for payment required signaling and payment payload transmission.
+
+## Payment Required Signaling
+
+The server indicates payment is required using the HTTP 402 "Payment Required" status code.
+
+**Mechanism**: HTTP 402 status code with JSON response body
+**Data Format**: `PaymentRequirementsResponse` schema in response body
+
+**Example:**
+
+```http
+HTTP/1.1 402 Payment Required
+Content-Type: application/json
+
+{
+  "x402Version": 1,
+  "error": "Payment required to access this resource",
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "base-sepolia",
+      "maxAmountRequired": "10000",
+      "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "resource": "https://api.example.com/premium-data",
+      "description": "Access to premium market data",
+      "mimeType": "application/json",
+      "outputSchema": null,
+      "maxTimeoutSeconds": 60,
+      "extra": {
+        "name": "USDC",
+        "version": "2"
+      }
+    }
+  ]
+}
+```
+
+## Payment Payload Transmission
+
+Clients send payment data using the `X-PAYMENT` HTTP header.
+
+**Mechanism**: `X-PAYMENT` header containing base64-encoded JSON
+**Data Format**: Base64-encoded `PaymentPayload` schema
+
+**Example:**
+
+```http
+POST /premium-data HTTP/1.1
+Host: api.example.com
+X-PAYMENT: eyJ4NDAyVmVyc2lvbiI6MSwic2NoZW1lIjoiZXhhY3QiLCJuZXR3b3JrIjoiYmFzZS1zZXBvbGlhIiwicGF5bG9hZCI6eyJzaWduYXR1cmUiOiIweDJkNmE3NTg4ZDZhY2NhNTA1Y2JmMGQ5YTRhMjI3ZTBjNTJjNmMzNDAwOGM4ZTg5ODZhMTI4MzI1OTc2NDE3MzYwOGEyY2U2NDk2NjQyZTM3N2Q2ZGE4ZGJiZjU4MzZlOWJkMTUwOTJmOWVjYWIwNWRlZDNkNjI5M2FmMTQ4YjU3MWMiLCJhdXRob3JpemF0aW9uIjp7ImZyb20iOiIweDg1N2IwNjUxOUU5MWUzQTU0NTM4NzkxYkRiYjBFMjIzNzNlMzZiNjYiLCJ0byI6IjB4MjA5NjkzQmM2YWZjMEM1MzI4YkEzNkZhRjAzQzUxNEVGMzEyMjg3QyIsInZhbHVlIjoiMTAwMDAiLCJ2YWxpZEFmdGVyIjoiMTc0MDY3MjA4OSIsInZhbGlkQmVmb3JlIjoiMTc0MDY3MjE1NCIsIm5vbmNlIjoiMHhmMzc0NjYxM2MyZDkyMGI1ZmRhYmMwODU2ZjJhZWIyZDRmODhlZTYwMzdiOGNjNWQwNGE3MWE0NDYyZjEzNDgwIn19fQ==
+Content-Type: application/json
+
+{
+  "query": "latest market data"
+}
+```
+
+The base64 payload decodes to:
+
+```json
+{
+  "x402Version": 1,
+  "scheme": "exact",
+  "network": "base-sepolia",
+  "payload": {
+    "signature": "0x2d6a7588d6acca505cbf0d9a4a227e0c52c6c34008c8e8986a1283259764173608a2ce6496642e377d6da8dbbf5836e9bd15092f9ecab05ded3d6293af148b571c",
+    "authorization": {
+      "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "value": "10000",
+      "validAfter": "1740672089",
+      "validBefore": "1740672154",
+      "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+    }
+  }
+}
+```
+
+## Settlement Response Delivery
+
+Servers communicate payment settlement results using the `X-PAYMENT-RESPONSE` header.
+
+**Mechanism**: `X-PAYMENT-RESPONSE` header containing base64-encoded JSON
+**Data Format**: Base64-encoded `SettlementResponse` schema
+
+**Example (Success):**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-PAYMENT-RESPONSE: eyJzdWNjZXNzIjp0cnVlLCJ0cmFuc2FjdGlvbiI6IjB4MTIzNDU2Nzg5MGFiY2RlZjEyMzQ1Njc4OTBhYmNkZWYxMjM0NTY3ODkwYWJjZGVmMTIzNDU2Nzg5MGFiY2RlZiIsIm5ldHdvcmsiOiJiYXNlLXNlcG9saWEiLCJwYXllciI6IjB4ODU3YjA2NTE5RTkxZTNBNTQ1Mzg3OTFiRGJiMEUyMjM3M2UzNmI2NiJ9
+
+{
+  "data": "premium market data response",
+  "timestamp": "2024-01-15T10:30:00Z"
+}
+```
+
+The base64 response header decodes to:
+
+```json
+{
+  "success": true,
+  "transaction": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  "network": "base-sepolia",
+  "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+}
+```
+
+**Example (Failure):**
+
+```http
+HTTP/1.1 402 Payment Required
+Content-Type: application/json
+X-PAYMENT-RESPONSE: eyJzdWNjZXNzIjpmYWxzZSwiZXJyb3JSZWFzb24iOiJpbnN1ZmZpY2llbnRfZnVuZHMiLCJ0cmFuc2FjdGlvbiI6IiIsIm5ldHdvcmsiOiJiYXNlLXNlcG9saWEiLCJwYXllciI6IjB4ODU3YjA2NTE5RTkxZTNBNTQ1Mzg3OTFiRGJiMEUyMjM3M2UzNmI2NiJ9
+
+{
+  "x402Version": 1,
+  "error": "Payment failed: insufficient funds",
+  "accepts": [...]
+}
+```
+
+## Error Handling
+
+HTTP transport maps x402 errors to standard HTTP status codes:
+
+| x402 Error       | HTTP Status | Description                                     |
+| ---------------- | ----------- | ----------------------------------------------- |
+| Payment Required | 402         | Payment needed to access resource               |
+| Invalid Payment  | 400         | Malformed payment payload or requirements       |
+| Payment Failed   | 402         | Payment verification or settlement failed       |
+| Server Error     | 500         | Internal server error during payment processing |
+| Success          | 200         | Payment verified and settled successfully       |
+
+**Error Response Format:**
+
+```json
+{
+  "x402Version": 1,
+  "error": "Human-readable error message",
+  "accepts": [
+    /* payment requirements */
+  ]
+}
+```
+
+## References
+
+- [Core x402 Specification](../x402-specification.md)
+- [HTTP/1.1 Specification (RFC 7231)](https://tools.ietf.org/html/rfc7231)
+- [HTTP 402 Status Code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402)
+- [Express.js x402 Integration](../../examples/typescript/servers/express.ts)
+- [Fetch API x402 Client](../../examples/typescript/clients/fetch.ts)

--- a/specs/transports/mcp.md
+++ b/specs/transports/mcp.md
@@ -1,0 +1,215 @@
+# Transport: MCP (Model Context Protocol)
+
+## Summary
+
+The MCP transport implements x402 payment flows over the Model Context Protocol using JSON-RPC messages. This enables AI agents and MCP clients to seamlessly pay for tools and resources independent of the underlying MCP transport.
+
+The flow described below can be used for any MCP request/response cycle: tool calls, resources or client/server initialization.
+
+## Payment Required Signaling
+
+The server indicates payment is required using JSON-RPC's native error format with a 402 status code.
+
+**Mechanism**: JSON-RPC error response with `code: 402` and `PaymentRequirementsResponse` in `error.data`
+**Data Format**: `PaymentRequirementsResponse` schema in `error.data` field
+
+**Example:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": 402,
+    "message": "Payment required",
+    "data": {
+      "x402Version": 1,
+      "error": "Payment required to access this resource",
+      "accepts": [
+        {
+          "scheme": "exact",
+          "network": "base-sepolia",
+          "maxAmountRequired": "10000",
+          "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+          "resource": "mcp://tool/financial_analysis",
+          "description": "Advanced financial analysis tool",
+          "mimeType": "application/json",
+          "outputSchema": null,
+          "maxTimeoutSeconds": 60,
+          "extra": {
+            "name": "USDC",
+            "version": "2"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Payment Payload Transmission
+
+Clients send payment data using the MCP `_meta` field with key `x402/payment`.
+
+**Mechanism**: `_meta["x402/payment"]` field in request parameters
+**Data Format**: `PaymentPayload` schema in metadata field
+
+**Example (Tool Call with Payment):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "financial_analysis",
+    "arguments": {
+      "ticker": "AAPL",
+      "analysis_type": "deep"
+    },
+    "_meta": {
+      "x402/payment": {
+        "x402Version": 1,
+        "scheme": "exact",
+        "network": "base-sepolia",
+        "payload": {
+          "signature": "0x2d6a7588d6acca505cbf0d9a4a227e0c52c6c34008c8e8986a1283259764173608a2ce6496642e377d6da8dbbf5836e9bd15092f9ecab05ded3d6293af148b571c",
+          "authorization": {
+            "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+            "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+            "value": "10000",
+            "validAfter": "1740672089",
+            "validBefore": "1740672154",
+            "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Settlement Response Delivery
+
+Servers communicate payment settlement results using the `_meta["x402/payment-response"]` field.
+
+**Mechanism**: `_meta["x402/payment-response"]` field in response result
+**Data Format**: `SettlementResponse` schema in metadata field
+
+**Example (Successful Tool Response):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Financial analysis for AAPL: Strong fundamentals with positive outlook..."
+      }
+    ],
+    "_meta": {
+      "x402/payment-response": {
+        "success": true,
+        "transaction": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        "network": "base-sepolia",
+        "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+      }
+    }
+  }
+}
+```
+
+**Example (Payment Failure):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": 402,
+    "message": "Payment settlement failed: insufficient funds",
+    "data": {
+      "x402Version": 1,
+      "error": "Payment settlement failed: insufficient funds",
+      "accepts": [
+        /* original payment requirements */
+      ],
+      "x402/payment-response": {
+        "success": false,
+        "errorReason": "insufficient_funds",
+        "transaction": "",
+        "network": "base-sepolia",
+        "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+      }
+    }
+  }
+}
+```
+
+## Error Handling
+
+MCP transport maps x402 errors to appropriate JSON-RPC mechanisms:
+
+| x402 Error       | JSON-RPC Response | Code   | Description                                                    |
+| ---------------- | ----------------- | ------ | -------------------------------------------------------------- |
+| Payment Required | Error Response    | 402    | Payment required with `PaymentRequirementsResponse` in `data` |
+| Payment Failed   | Error Response    | 402    | Payment settlement failed with failure details in `data`      |
+| Invalid Payment  | Error Response    | -32602 | Malformed payment payload or invalid parameters                |
+| Server Error     | Error Response    | -32603 | Internal server error during payment processing                |
+| Parse Error      | Error Response    | -32700 | Invalid JSON in payment payload                                |
+| Method Error     | Error Response    | -32601 | Unsupported x402 method or capability                          |
+
+### Payment-Related Errors (402)
+
+Payment-related errors use JSON-RPC's native error format with code 402 and structured data:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": 402,
+    "message": "Payment required to access this resource",
+    "data": {
+      "x402Version": 1,
+      "error": "Payment required to access this resource",
+      "accepts": [
+        /* PaymentRequirements array */
+      ]
+    }
+  }
+}
+```
+
+### Protocol Errors (Technical Issues)
+
+Technical errors use standard JSON-RPC error responses:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32602,
+    "message": "Invalid parameters: malformed payment payload in _meta['x402/payment']"
+  }
+}
+```
+
+**Common Protocol Error Examples:**
+
+- **Parse Error (-32700)**: Invalid JSON in `_meta["x402/payment"]` field
+- **Invalid Params (-32602)**: Missing required payment fields or invalid payment schema
+- **Internal Error (-32603)**: Payment processor unavailable or blockchain network error
+- **Method Not Found (-32601)**: Server doesn't support x402 payments for the requested method
+
+## References
+
+- [Core x402 Specification](../x402-specification.md)
+- [MCP Specification](https://modelcontextprotocol.io/specification/)
+- [MCP \_meta Field Documentation](https://modelcontextprotocol.io/specification/2025-06-18/basic#meta)
+- [x402-mcp](https://github.com/ethanniser/x402-mcp)
+- [agents/x402-mcp](https://github.com/cloudflare/agents/blob/main/packages/agents/src/mcp/x402.ts)


### PR DESCRIPTION
# Transport-Agnostic x402

closes #376

## Summary

This PR refactors the x402 specification to be transport-agnostic, enabling the protocol to work seamlessly across different transport layers including HTTP, MCP (Model Context Protocol), A2A (Agent to Agent), and future protocols (such as XMTP). The core payment schemas and flows remain unchanged, but the specification now separates transport-specific implementation details from the core protocol definition.

## Key Changes

### 1. **Transport-Agnostic Core Specification**

- Updated `specs/x402-specification.md` to focus on JSON schemas and payment flows rather than HTTP-specific mechanisms
- Replaced HTTP-specific terminology (402 status codes, X-PAYMENT headers) with transport-neutral concepts
- Maintained full backward compatibility for existing HTTP implementations

### 2. **New Transport Specifications**

- **`http.md`**: Complete HTTP transport specification (existing functionality)
- **`mcp.md`**: MCP transport specification using JSON-RPC error codes and `_meta` fields
- **`a2a.md`**: Agent-to-Agent protocol transport specification using task states and metadata
- **`transport_template.md`**: Template for future transport implementations

### 3. **Enhanced Protocol Flexibility**

- Core protocol now defines standard response types that map to transport-specific mechanisms
- Payment payload and settlement response schemas remain identical across transports
- Facilitator APIs remain HTTP-based

## Motivation

### Growing Demand for Multi-Transport Support

The x402 protocol has seen significant community adoption beyond HTTP, particularly in AI agent environments:

1. **Model Context Protocol (MCP) Integration**: Multiple community implementations exist:

   - [Vercel's x402-mcp](https://github.com/ethanniser/x402-mcp) - Uses MCP metadata fields
   - [Cloudflare's agents/x402](https://github.com/cloudflare/agents/blob/main/packages/agents/src/mcp/x402.ts) - Uses MCP metadata fields
   - [MCPay](https://mcpay.tech) - x402 payment layer for MCP servers
   - [MonetizedMCP](https://github.com/MonetizedMCP/typescript-sdk) - Tool-based payment approach
   - [Civic Team x402-mcp](https://github.com/civicteam/x402-mcp) - HTTP-over-MCP implementation

2. **Agent-to-Agent (A2A) Protocol Integration**: The emerging A2A protocol standard includes:

   - [Google's A2A x402 Extension](https://github.com/google-agentic-commerce/a2a-x402) - Official x402 extension specification

3. **AI Agent Use Cases**: AI agents benefit from transport-agnostic payments as they work across:
   - HTTP APIs for web services
   - MCP tools for structured interactions
   - A2A protocol for agent-to-agent commerce
   - Custom protocols for specialized services

### Technical Benefits

1. **Protocol Clarity**: Separating core schemas from transport details makes the protocol easier to understand and implement
2. **Implementation Flexibility**: Developers can choose the appropriate transport for their use case
3. **Future-Proofing**: New transports can be added without modifying the core specification
4. **Ecosystem Growth**: Lower barriers to entry for new transport integrations

## Implementation Details

### Core Protocol Changes

The specification now defines transport-neutral concepts:

- **Payment Required Response** → Generic payment requirements signaling
- **Payment Payload Transmission** → Transport-specific payload delivery
- **Settlement Response Delivery** → Transport-specific settlement communication

### HTTP Transport (Existing Functionality)

All existing HTTP-based implementations continue to work without changes:

- HTTP 402 status codes for payment requirements
- `X-PAYMENT` headers for payment data
- `X-PAYMENT-RESPONSE` headers for settlement results

### MCP Transport (New to this repo)

Enables native x402 integration in AI environments:

- `isError: true` with `_meta["x402/payment-required"]` for payment requirements signaling
- `_meta["x402/payment"]` for payment payload transmission
- `_meta["x402/payment-response"]` for settlement response delivery

### A2A Transport (New to this repo)

Enables native x402 integration in agent-to-agent commerce:

- Task `state: "input-required"` with `x402.payment.status: "payment-required"` for payment requirements
- Message metadata `x402.payment.payload` for payment payload transmission with task correlation
- Task status updates with `x402.payment.receipts` for settlement response delivery

### Facilitator Compatibility

Facilitator APIs remain HTTP-based

---

Of course this is very much up for discussion- please chime in!
Also not opposed to ripping a2a out of this PR if that is a blocker since it seems like a2a has its own concept of "extensions"