### PR TITLE
Fix Wrong Facilitator Test Link

### DIFF
--- a/examples/typescript/facilitator/README.md
+++ b/examples/typescript/facilitator/README.md
@@ -4,7 +4,7 @@ This is an example implementation of an x402 facilitator service that handles pa
 
 For production use, we recommend using:
 
-- Testnet: https://x402.org/facilitator
+- Testnet: https://www.x402.org/protected
 - Production: https://api.cdp.coinbase.com/platform/v2/x402
 
 ## Overview


### PR DESCRIPTION
While trying out the Facilitator example, i discovered the attached testnet link for facilitator on x402 page is wrong/changed, got the official new one from the page and add it


### Old Link
https://x402.org/facilitator

### New Link
https://x402.org/protected