### PR TITLE
fix: Fix python CI workflow

### DIFF
--- a/.github/workflows/check_python.yml
+++ b/.github/workflows/check_python.yml
@@ -14,7 +14,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          cache-dependency-glob: "python/x402/uv.lock"
 
       - name: Set up Python
         run: uv python install
@@ -37,7 +37,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          cache-dependency-glob: "uv.lock"
+          cache-dependency-glob: "python/x402/uv.lock"
 
       - name: Lint
         run: uvx ruff check

--- a/.github/workflows/check_python.yml
+++ b/.github/workflows/check_python.yml
@@ -23,7 +23,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run Tests
-        run: pytest
+        run: uv run python -m pytest
 
   lint-python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

test-python job failing due to incorrect pytest invocation and cache warnings from mismatched dependency glob path.

Solution:
- Use `uv run python -m pytest` instead of bare `pytest`
- Fix cache-dependency-glob to point to correct `python/x402/uv.lock` path

All tests pass, no more cache warnings.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 