### PR TITLE
docs: Update Go README with `FacilitatorConfig` example

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -23,12 +23,16 @@ import (
 func main() {
 	r := gin.Default()
 
+	facilitatorConfig := &types.FacilitatorConfig{
+		URL: "http://localhost:3000",
+	}
+
 	r.GET(
 		"/joke",
 		x402gin.PaymentMiddleware(
 			big.NewFloat(0.0001),
 			"0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-			x402gin.WithFacilitatorURL("https://x402.org/facilitator"),
+			x402gin.WithFacilitatorConfig(facilitatorConfig),
 			x402gin.WithResource("http://localhost:4021/joke"),
 		),
 		func(c *gin.Context) {


### PR DESCRIPTION
## Summary
Updates the Go README example to use the newer `FacilitatorConfig` struct instead of the deprecated `WithFacilitatorURL` approach.

## Changes
- Updated example code in `go/README.md` to demonstrate `FacilitatorConfig` usage

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change