### PR TITLE
Update README.md

### DIFF
--- a/examples/typescript/fullstack/next/README.md
+++ b/examples/typescript/fullstack/next/README.md
@@ -10,10 +10,10 @@ This is a Next.js application that demonstrates how to use the `x402-next` middl
 
 ## Setup
 
-1. Copy `.env.local` to `.env` and add your Ethereum address to receive payments:
+1. Copy `.env-local` to `.env` and add your Ethereum address to receive payments:
 
 ```bash
-cp .env.local .env
+cp .env-local .env
 ```
 
 2. Install and build all packages from the typescript examples root:


### PR DESCRIPTION
# Fix: Correct env filename in Next.js example README

## Description

This PR fixes a typo in the Next.js example setup instructions where `.env.local` should be `.env-local` to match the actual filename present in the repository.

## Changes Made

- Fixed typo in `examples/typescript/fullstack/next/README.md` (line 13)
  - Changed `.env.local` to `.env-local` in setup instructions

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

### TypeScript Tests
- ✅ Ran `pnpm test` from `/typescript` directory - All 185 tests passed
- ✅ Ran `pnpm format` from `/typescript` directory - All formatting checks passed
- ✅ Ran `pnpm lint` from `/typescript` directory - All linting checks passed
- ✅ Ran `pnpm format && pnpm lint` from `/examples/typescript` directory - All checks passed

### Manual Verification
- ✅ Verified that `.env-local` file exists in the repository
- ✅ Confirmed that the setup instructions now correctly reference the existing file
- ✅ Tested that the corrected instructions work as expected


## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits