### PR TITLE
feat: add arbitrum-one and arbitrum-sepolia support in python sdk

### DIFF
--- a/python/x402/src/x402/chains.py
+++ b/python/x402/src/x402/chains.py
@@ -3,6 +3,8 @@ NETWORK_TO_ID = {
     "base": "8453",
     "avalanche-fuji": "43113",
     "avalanche": "43114",
+    "arbitrum-one": "42161",
+    "arbitrum-sepolia": "421614",
 }
 
 
@@ -53,6 +55,24 @@ KNOWN_TOKENS = {
             "human_name": "usdc",
             "address": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
             "name": "USDC",
+            "decimals": 6,
+            "version": "2",
+        }
+    ],
+    "42161": [
+        {
+            "human_name": "usdc",
+            "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+            "name": "USD Coin",
+            "decimals": 6,
+            "version": "2",
+        }
+    ],
+    "421614": [
+        {
+            "human_name": "usdc",
+            "address": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+            "name": "USD Coin",
             "decimals": 6,
             "version": "2",
         }

--- a/python/x402/src/x402/networks.py
+++ b/python/x402/src/x402/networks.py
@@ -1,11 +1,20 @@
 from typing import Literal
 
 
-SupportedNetworks = Literal["base", "base-sepolia", "avalanche-fuji", "avalanche"]
+SupportedNetworks = Literal[
+    "base",
+    "base-sepolia",
+    "avalanche-fuji",
+    "avalanche",
+    "arbitrum-one",
+    "arbitrum-sepolia",
+]
 
 EVM_NETWORK_TO_CHAIN_ID = {
     "base-sepolia": 84532,
     "base": 8453,
     "avalanche-fuji": 43113,
     "avalanche": 43114,
+    "arbitrum-one": 42161,
+    "arbitrum-sepolia": 421614,
 }


### PR DESCRIPTION
## Description

- Add Arbitrum-one and Arbitrum Sepolia support in python sdk
- Add chain data for Arbitrum-one and Arbitrum Sepolia
- Add USDC token data on Arbitrum-one and Arbitrum Sepolia

## Tests

Passed pytest

## Checklist
All checked.

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
