### PR TITLE
#515 scheme_exact_evm.md needs to specify encoding rules

### DIFF
--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -11,7 +11,22 @@ The `payload` field of the `X-PAYMENT` header must contain the following fields:
 - `signature`: The signature of the `EIP-3009` `transferWithAuthorization` operation.
 - `authorization`: parameters required to reconstruct the messaged signed for the `transferWithAuthorization` operation.
 
-Example:
+### Encoding Rules
+
+Each field must be encoded as follows:
+
+| Field | Type | Encoding | Notes |
+|--------|------|-----------|-------|
+| `from` | Address | Hexadecimal (EIP-55 checksummed) | Must include the `"0x"` prefix. |
+| `to` | Address | Hexadecimal (EIP-55 checksummed) | Must include the `"0x"` prefix. |
+| `value` | Integer | Decimal string | No leading zeros. |
+| `validAfter` | Integer (UNIX timestamp) | Decimal string | No leading zeros. |
+| `validBefore` | Integer (UNIX timestamp) | Decimal string | No leading zeros. |
+| `nonce` | Bytes32 | Hexadecimal string | Must include the `"0x"` or `"0X"` prefix. |
+
+### Example
+
+
 
 ```json
 {

--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -17,12 +17,13 @@ Each field must be encoded as follows:
 
 | Field | Type | Encoding | Notes |
 |--------|------|-----------|-------|
-| `from` | Address | Hexadecimal (EIP-55 checksummed) | Must include the `"0x"`or `"0X"` prefix. |
-| `to` | Address | Hexadecimal (EIP-55 checksummed) | Must include the `"0x"` or `"0X"` prefix. |
-| `value` | Integer | Decimal string | No leading zeros. |
-| `validAfter` | Integer (UNIX timestamp) | Decimal string | No leading zeros. |
-| `validBefore` | Integer (UNIX timestamp) | Decimal string | No leading zeros. |
-| `nonce` | Bytes32 | Hexadecimal string | Must include the `"0x"` or `"0X"` prefix. |
+| `signature` | 65-byte EIP-712 Signature | Hex string | Must include `"0x"`or `"0X"` prefix. |
+| `from` | 20-byte Eth Address | Hex string (EIP-55 checksummed) | Must include `"0x"`or `"0X"` prefix. |
+| `to` | 120-bit Eth Address | Hex string (EIP-55 checksummed) | Must include `"0x"` or `"0X"` prefix. |
+| `value` |32-byte integer | Hex string, if starts with `"0x"` or `"0X"`. Decimal otherwise. | May omit leading zeros. |
+| `validAfter` | 32-byte integer (UNIX timestamp) | Hex string if starts with `"0x"` or `"0X"`. Decimal otherwise. | May omit leading zeros. |
+| `validBefore` | 32-byte integer (UNIX timestamp) | Hex string if starts with `"0x"` or `"0X"`. Decimal otherwise. | May omit leading zeros. |
+| `nonce` | 32-byte integer |Hex string if starts with `"0x"` or `"0X"`. Decimal otherwise.  | May omit leading zeros. |
 
 ### Example
 

--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -17,8 +17,8 @@ Each field must be encoded as follows:
 
 | Field | Type | Encoding | Notes |
 |--------|------|-----------|-------|
-| `from` | Address | Hexadecimal (EIP-55 checksummed) | Must include the `"0x"` prefix. |
-| `to` | Address | Hexadecimal (EIP-55 checksummed) | Must include the `"0x"` prefix. |
+| `from` | Address | Hexadecimal (EIP-55 checksummed) | Must include the `"0x"`or `"0X"` prefix. |
+| `to` | Address | Hexadecimal (EIP-55 checksummed) | Must include the `"0x"` or `"0X"` prefix. |
 | `value` | Integer | Decimal string | No leading zeros. |
 | `validAfter` | Integer (UNIX timestamp) | Decimal string | No leading zeros. |
 | `validBefore` | Integer (UNIX timestamp) | Decimal string | No leading zeros. |


### PR DESCRIPTION
Title
Specify encoding rules for hex vs decimal in `PaymentPayload`

Description
This PR updates **scheme_exact_evm.md** to clearly define the acceptable encoding formats for fields in `PaymentPayload`.

Specifically:
- `signature`, `to` and `from` are now explicitly defined as **hex-encoded** fields.
- `nonce`, `value`, `validFrom`, and `validTo` are defined as **hex-encoded** or **decimal-encoded** fields, depending on the prefix.

It is also specified, that leading zeroes may omitted for `nonce`, `value`, `validFrom`, and `validTo`.

This clarification ensures consistent interpretation of payloads across implementations and avoids ambiguity when encoding or decoding payment data.

Tests
- Verified consistency of `PaymentPayload` encoding with existing documentation examples.
- Manually reviewed all affected references in `scheme_exact_evm.md` for accuracy and clarity.
- Confirmed that example payloads follow the specified encoding rules.

Checklist
- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)