### PR TITLE
Fix error serialization in payment middleware responses

### DIFF
--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -270,7 +270,7 @@ describe("paymentMiddleware()", () => {
     expect(mockRes.status).toHaveBeenCalledWith(402);
     expect(mockRes.json).toHaveBeenCalledWith({
       x402Version: 1,
-      error: new Error("Invalid payment"),
+      error: "Invalid payment",
       accepts: [
         {
           scheme: "exact",
@@ -303,7 +303,7 @@ describe("paymentMiddleware()", () => {
     expect(mockRes.status).toHaveBeenCalledWith(402);
     expect(mockRes.json).toHaveBeenCalledWith({
       x402Version: 1,
-      error: new Error("Unexpected error"),
+      error: "Unexpected error",
       accepts: [
         {
           scheme: "exact",
@@ -363,7 +363,7 @@ describe("paymentMiddleware()", () => {
     expect(mockRes.status).toHaveBeenCalledWith(402);
     expect(mockRes.json).toHaveBeenCalledWith({
       x402Version: 1,
-      error: new Error("Settlement failed"),
+      error: "Settlement failed",
       accepts: [
         {
           scheme: "exact",

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -245,7 +245,7 @@ export function paymentMiddleware(
       console.error(error);
       res.status(402).json({
         x402Version,
-        error: error || "Invalid or malformed payment header",
+        error: error instanceof Error ? error.message : "Invalid or malformed payment header",
         accepts: toJsonSafe(paymentRequirements),
       });
       return;
@@ -279,7 +279,7 @@ export function paymentMiddleware(
       console.error(error);
       res.status(402).json({
         x402Version,
-        error,
+        error: error instanceof Error ? error.message : "Payment verification failed",
         accepts: toJsonSafe(paymentRequirements),
       });
       return;
@@ -375,7 +375,7 @@ export function paymentMiddleware(
         bufferedCalls = [];
         res.status(402).json({
           x402Version,
-          error,
+          error: error instanceof Error ? error.message : "Payment settlement failed",
           accepts: toJsonSafe(paymentRequirements),
         });
         return;

--- a/typescript/packages/x402-hono/src/index.test.ts
+++ b/typescript/packages/x402-hono/src/index.test.ts
@@ -878,7 +878,7 @@ describe("paymentMiddleware()", () => {
     expect(mockContext.json).toHaveBeenCalledWith(
       {
         x402Version: 1,
-        error: new Error("Invalid payment"),
+        error: "Invalid payment",
         accepts: [
           {
             scheme: "exact",
@@ -1065,7 +1065,7 @@ describe("paymentMiddleware()", () => {
     expect(mockContext.json).toHaveBeenCalledWith(
       {
         x402Version: 1,
-        error: new Error("Settlement failed"),
+        error: "Settlement failed",
         accepts: [
           {
             scheme: "exact",

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -259,7 +259,7 @@ export function paymentMiddleware(
         {
           error:
             errorMessages?.invalidPayment ||
-            (error instanceof Error ? error : new Error("Invalid or malformed payment header")),
+            (error instanceof Error ? error.message : "Invalid or malformed payment header"),
           accepts: paymentRequirements,
           x402Version,
         },
@@ -337,7 +337,7 @@ export function paymentMiddleware(
         {
           error:
             errorMessages?.settlementFailed ||
-            (error instanceof Error ? error : new Error("Failed to settle payment")),
+            (error instanceof Error ? error.message : "Failed to settle payment"),
           accepts: paymentRequirements,
           x402Version,
         },


### PR DESCRIPTION
## Summary

Fixes a bug where Error objects were being serialized to JSON in payment middleware error responses, resulting in empty objects `{}` instead of meaningful error messages.

## Problem

When JavaScript Error objects are passed to `JSON.stringify()`, they serialize to empty objects:
```javascript
JSON.stringify({error: new Error('test')}) // {"error":{}}
```

This affected all error responses in the x402 payment middleware across Express, Next.js, and Hono implementations. Clients would receive responses like:
```json
{"x402Version": 1, "error": {}, "accepts": [...]}
```

Making debugging impossible.

## Solution

Changed error handling in catch blocks to extract the error message:
```typescript
// Before
error: error instanceof Error ? error : "Fallback message"

// After  
error: error instanceof Error ? error.message : "Fallback message"
```

## Changes

- **x402-express** (`src/index.ts`): Fixed 3 catch blocks at lines 248, 282, 335
- **x402-next** (`src/index.ts`): Fixed 2 catch blocks at lines 275, 343
- **x402-hono** (`src/index.ts`): Fixed 2 catch blocks at lines 248, 312
- Updated all test files to expect string error messages instead of Error objects

## Testing

All tests pass:
- x402-express: 30 tests passed
- x402-next: 35 tests passed
- x402-hono: 36 tests passed

Clients now receive proper error messages:
```json
{"x402Version": 1, "error": "Invalid payment", "accepts": [...]}
```