### PR TITLE
add optional paymentRequirements field to PaymentPayloadSchema

### DIFF
--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -108,6 +108,7 @@ export const PaymentPayloadSchema = z.object({
   scheme: z.enum(schemes),
   network: NetworkSchema,
   payload: z.union([ExactEvmPayloadSchema, ExactSvmPayloadSchema]),
+  paymentRequirements: PaymentRequirementsSchema.optional(),
 });
 export type PaymentPayload = z.infer<typeof PaymentPayloadSchema>;
 export type UnsignedPaymentPayload = Omit<PaymentPayload, "payload"> & {


### PR DESCRIPTION
Fixes the issue where clients lose `paymentRequirements` information when creating `PaymentPayload` by adding an optional `paymentRequirements` field to the schema.

## Problem

Currently, `PaymentPayloadSchema` does not include a field for `paymentRequirements`. This causes the original payment requirements to be lost when clients create payments, forcing facilitators to maintain separate state to track requirements or lose access to critical information like `extra` fields.

## Solution

Add an optional `paymentRequirements` field to `PaymentPayloadSchema`:

```diff
export const PaymentPayloadSchema = z.object({
  x402Version: z.number().refine(val => x402Versions.includes(val as 1)),
  scheme: z.enum(schemes),
  network: NetworkSchema,
  payload: z.union([ExactEvmPayloadSchema, ExactSvmPayloadSchema]),
+  paymentRequirements: PaymentRequirementsSchema.optional(), // Allow client to send back original requirements
});
```

fix #577 