### PR TITLE
feat: add error descriptions

### DIFF
--- a/typescript/packages/x402/src/facilitator/facilitator.ts
+++ b/typescript/packages/x402/src/facilitator/facilitator.ts
@@ -13,6 +13,7 @@ import {
   SettleResponse,
   VerifyResponse,
   ExactEvmPayload,
+  createVerifyResponse,
 } from "../types/verify";
 import { Chain, Transport, Account } from "viem";
 import { TransactionSigner } from "@solana/kit";
@@ -60,13 +61,16 @@ export async function verify<
   }
 
   // unsupported scheme
-  return {
-    isValid: false,
+  return createVerifyResponse({
     invalidReason: "invalid_scheme",
     payer: SupportedEVMNetworks.includes(paymentRequirements.network)
       ? (payload.payload as ExactEvmPayload).authorization.from
       : "",
-  };
+    context: {
+      value: paymentRequirements.scheme,
+      expected: `[${SupportedEVMNetworks.join(", ")}] or [${SupportedSVMNetworks.join(", ")}]`,
+    },
+  });
 }
 
 /**

--- a/typescript/packages/x402/src/schemes/exact/svm/facilitator/settle.test.ts
+++ b/typescript/packages/x402/src/schemes/exact/svm/facilitator/settle.test.ts
@@ -115,7 +115,7 @@ describe("SVM Settle", () => {
       const mockVerifyResponse = {
         isValid: true,
         invalidReason: undefined,
-      };
+      } as const;
       vi.mocked(verify).mockResolvedValue(mockVerifyResponse);
       vi.mocked(decodeTransactionFromPayload).mockReturnValue(mockSignedTransaction);
       vi.mocked(getRpcClient).mockReturnValue(mockRpcClient);
@@ -163,8 +163,9 @@ describe("SVM Settle", () => {
       // Arrange
       const mockVerifyResponse = {
         isValid: false,
-        invalidReason: "invalid_exact_svm_payload_transaction_simulation_failed" as const,
-      };
+        invalidReason: "invalid_exact_svm_payload_transaction_simulation_failed",
+        invalidDescription: "",
+      } as const;
       vi.mocked(verify).mockResolvedValue(mockVerifyResponse);
 
       // Act
@@ -185,7 +186,7 @@ describe("SVM Settle", () => {
       const mockVerifyResponse = {
         isValid: true,
         invalidReason: undefined,
-      };
+      } as const;
       vi.mocked(verify).mockResolvedValue(mockVerifyResponse);
       vi.mocked(decodeTransactionFromPayload).mockReturnValue(mockSignedTransaction);
       vi.mocked(getTokenPayerFromTransaction).mockReturnValue(payerAddress);
@@ -430,7 +431,7 @@ describe("SVM Settle", () => {
       const mockVerifyResponse = {
         isValid: true,
         invalidReason: undefined,
-      };
+      } as const;
       vi.mocked(verify).mockResolvedValue(mockVerifyResponse);
       vi.mocked(decodeTransactionFromPayload).mockReturnValue(mockSignedTransaction);
       vi.mocked(getRpcClient).mockReturnValue(mockRpcClient);
@@ -469,7 +470,7 @@ describe("SVM Settle", () => {
       const mockVerifyResponse = {
         isValid: true,
         invalidReason: undefined,
-      };
+      } as const;
       vi.mocked(verify).mockResolvedValue(mockVerifyResponse);
       vi.mocked(decodeTransactionFromPayload).mockReturnValue(mockSignedTransaction);
       vi.mocked(getRpcClient).mockReturnValue(mockRpcClient);
@@ -505,7 +506,7 @@ describe("SVM Settle", () => {
       const mockVerifyResponse = {
         isValid: true,
         invalidReason: undefined,
-      };
+      } as const;
       vi.mocked(verify).mockResolvedValue(mockVerifyResponse);
       vi.mocked(decodeTransactionFromPayload).mockReturnValue(mockSignedTransaction);
       vi.mocked(getRpcClient).mockReturnValue(mockRpcClient);

--- a/typescript/packages/x402/src/schemes/exact/svm/facilitator/verify.test.ts
+++ b/typescript/packages/x402/src/schemes/exact/svm/facilitator/verify.test.ts
@@ -543,16 +543,6 @@ describe("verify", () => {
       expect(result.invalidReason).toBe("unsupported_scheme");
     });
 
-    it("should return isValid: false if transaction decoding fails", async () => {
-      const error = new Error("invalid_exact_svm_payload_transaction");
-      vi.mocked(SvmShared.decodeTransactionFromPayload).mockImplementation(() => {
-        throw error;
-      });
-      const result = await verify(mockSigner, mockPayload, mockRequirements);
-      expect(result.isValid).toBe(false);
-      expect(result.invalidReason).toBe("invalid_exact_svm_payload_transaction");
-    });
-
     it("should return isValid: false if instruction validation fails", async () => {
       vi.mocked(decompileTransactionMessage).mockReturnValue({
         instructions: [mockTransferInstruction, mockTransferInstruction],

--- a/typescript/packages/x402/src/types/verify/index.ts
+++ b/typescript/packages/x402/src/types/verify/index.ts
@@ -1,2 +1,3 @@
 export * from "./x402Specs";
 export * from "./facilitator";
+export * from "./reason";

--- a/typescript/packages/x402/src/types/verify/reason.ts
+++ b/typescript/packages/x402/src/types/verify/reason.ts
@@ -1,0 +1,440 @@
+import { ErrorReasons, VerifyResponse } from "..";
+
+type ErrorCode = (typeof ErrorReasons)[number];
+
+/**
+ *
+ * @param input
+ */
+
+/**
+ * Error subtype that encapsulates verification failures and the generated verification response.
+ * It stores the original `VerifyInput` along with the derived `VerifyResponse` for inspection.
+ */
+export class VerifyError extends Error {
+  public readonly input: VerifyInput;
+  public readonly response: VerifyResponse;
+
+  /**
+   * Builds a `VerifyError` populated with the provided verification input and the processed response.
+   *
+   * @param input - Verification payload, includes invalidReason and context if needed
+   */
+  constructor(input: VerifyInput) {
+    super(input.invalidReason);
+    this.input = input;
+    this.response = createVerifyResponse(input);
+    this.name = "VerifyError";
+  }
+}
+
+/**
+ * Produces a `VerifyResponse` describing the verification failure based on the invalidReason
+ * The response includes a human-readable `invalidDescription` based on the `invalidReason`.
+ *
+ * @param input - Verification payload whose `invalidReason` and optional context dictate the response details.
+ * @returns A `VerifyResponse` with included error metadata.
+ */
+export function createVerifyResponse(input: VerifyInput): VerifyResponse {
+  const { payer, invalidReason } = input;
+
+  switch (invalidReason) {
+    case "insufficient_funds": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Available balance of ${context.available} ${context.unit} is less than the required ${context.cost} ${context.unit}.`,
+      };
+    }
+    case "invalid_exact_evm_payload_authorization_valid_after": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Authorization is not valid until ${context.expected}, received at ${context.value}.`,
+      };
+    }
+    case "invalid_exact_evm_payload_authorization_valid_before": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Authorization expired on ${context.expected}, received at ${context.value}.`,
+      };
+    }
+    case "invalid_exact_evm_payload_authorization_value": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Authorization covers ${context.available} ${context.unit}, but ${context.cost} ${context.unit} is required.`,
+      };
+    }
+    case "invalid_exact_evm_payload_signature": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Permit Signature ${context.signature} is invalid.`,
+      };
+    }
+    case "invalid_exact_evm_payload_recipient_mismatch": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Recipient ${context.value} does not match expected recipient ${context.expected}.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Submitted transaction does not match the expected serialized value: ${context.transaction}.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_amount_mismatch": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Transaction amount of ${context.value} differs from the required ${context.expected}.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_create_ata_instruction":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription:
+          "Transaction is missing the required create associated token account instruction.",
+      };
+    case "invalid_exact_svm_payload_transaction_create_ata_instruction_incorrect_payee": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Create ATA instruction targets ${context.value}, but expected payee is ${context.expected}.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_create_ata_instruction_incorrect_asset": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Create ATA instruction references asset ${context.value}, but expected asset is ${context.expected}.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_instructions":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: "Instruction set does not match the required exact sequence.",
+      };
+    case "invalid_exact_svm_payload_transaction_instructions_length": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Instruction list contains ${context.value} entries; expected exactly ${context.expected}.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_instructions_compute_limit_instruction":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: "Compute limit instruction is missing from the transaction.",
+      };
+    case "invalid_exact_svm_payload_transaction_instructions_compute_price_instruction":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: "Compute price instruction is missing from the transaction.",
+      };
+    case "invalid_exact_svm_payload_transaction_instructions_compute_price_instruction_too_high": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Compute price of ${context.value} exceeds allowed maximum ${context.expected}.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_instruction_not_spl_token_transfer_checked":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription:
+          "Transfer instruction is not an SPL Token transfer checked instruction.",
+      };
+    case "invalid_exact_svm_payload_transaction_instruction_not_token_2022_transfer_checked":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription:
+          "Transfer instruction is not a Token 2022 transfer checked instruction.",
+      };
+    case "invalid_exact_svm_payload_transaction_fee_payer_included_in_instruction_accounts":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: "Fee payer must not appear within the instruction account list.",
+      };
+    case "invalid_exact_svm_payload_transaction_fee_payer_transferring_funds": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Fee payer ${context.feePayer} should not be the same as the signer ${context.signer}`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_not_a_transfer_instruction": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Instruction ${context.value} is not a supported transfer instruction ${context.expected}.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_receiver_ata_not_found": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Receiver associated token account ${context.receiver} could not be located.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_sender_ata_not_found": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Sender associated token account ${context.sender} could not be located.`,
+      };
+    }
+    case "invalid_exact_svm_payload_transaction_simulation_failed":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: "Preflight simulation failed for the submitted transaction.",
+      };
+    case "invalid_exact_svm_payload_transaction_transfer_to_incorrect_ata": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Transfer targets ${context.value}, but the expected associated token account is ${context.expected}.`,
+      };
+    }
+    case "invalid_network": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Could not find requested referenced network ${context.network}.`,
+      };
+    }
+    case "invalid_payload": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Payload value ${context.value} does not match the expected format ${context.expected}.`,
+      };
+    }
+    case "invalid_payment_requirements": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Payment requirements value ${context.value} differs from expected ${context.expected}.`,
+      };
+    }
+    case "invalid_scheme": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Scheme ${context.value} is invalid; expected ${context.expected}.`,
+      };
+    }
+    case "invalid_payment": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Payment amount ${context.cost} ${context.unit} is incompatible with the authorized ${context.available} ${context.unit}.`,
+      };
+    }
+    case "payment_expired":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: "Payment authorization has expired.",
+      };
+    case "invalid_transaction_state": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Transaction is in an invalid state: ${context.error}.`,
+      };
+    }
+    case "invalid_x402_version": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `x402 version ${context.value} is not supported; expected version ${context.expected}.`,
+      };
+    }
+    case "settle_exact_svm_block_height_exceeded": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Current block height ${context.blockHeight} exceeds the allowed settlement window.`,
+      };
+    }
+    case "settle_exact_svm_transaction_confirmation_timed_out":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: "Transaction confirmation timed out before settlement completed.",
+      };
+    case "unsupported_scheme": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Scheme ${context.value} is unsupported; expected scheme ${context.expected}.`,
+      };
+    }
+    case "unexpected_settle_error": {
+      const { context } = input;
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: `Unexpected error occurred during settlement: ${context.error}.`,
+      };
+    }
+    case "unexpected_verify_error":
+      return {
+        payer,
+        isValid: false,
+        invalidReason,
+        invalidDescription: "An unexpected error occurred during verification.",
+      };
+  }
+}
+
+type VerifyInput = { payer?: string } & ErrorWithContext;
+type ErrorWithContext = {
+  [K in ErrorCode]: ErrorCodeContext[K] extends undefined
+    ? { invalidReason: K }
+    : { invalidReason: K; context: ErrorCodeContext[K] };
+}[ErrorCode];
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+type ValidateErrorCodeContext<T extends Record<ErrorCode, any>> = T;
+type ErrorCodeContext = ValidateErrorCodeContext<{
+  insufficient_funds: FundMismatch;
+  invalid_exact_evm_payload_authorization_valid_after: ExpectedBigInt;
+  invalid_exact_evm_payload_authorization_valid_before: ExpectedBigInt;
+  invalid_exact_evm_payload_authorization_value: FundMismatch;
+  invalid_exact_evm_payload_signature: { signature: string };
+  invalid_exact_evm_payload_recipient_mismatch: ExpectedString;
+  invalid_exact_svm_payload_transaction: { transaction: string };
+  invalid_exact_svm_payload_transaction_amount_mismatch: ExpectedBigInt;
+  invalid_exact_svm_payload_transaction_create_ata_instruction: undefined;
+  invalid_exact_svm_payload_transaction_create_ata_instruction_incorrect_payee: ExpectedString;
+  invalid_exact_svm_payload_transaction_create_ata_instruction_incorrect_asset: ExpectedString;
+  invalid_exact_svm_payload_transaction_instructions: undefined;
+  invalid_exact_svm_payload_transaction_instructions_length: ExpectedString;
+  invalid_exact_svm_payload_transaction_instructions_compute_limit_instruction: undefined;
+  invalid_exact_svm_payload_transaction_instructions_compute_price_instruction: undefined;
+  invalid_exact_svm_payload_transaction_instructions_compute_price_instruction_too_high: ExpectedBigInt;
+  invalid_exact_svm_payload_transaction_instruction_not_spl_token_transfer_checked: undefined;
+  invalid_exact_svm_payload_transaction_instruction_not_token_2022_transfer_checked: undefined;
+  invalid_exact_svm_payload_transaction_fee_payer_included_in_instruction_accounts: undefined;
+  invalid_exact_svm_payload_transaction_fee_payer_transferring_funds: {
+    feePayer: string;
+    signer: string;
+  };
+  invalid_exact_svm_payload_transaction_not_a_transfer_instruction: ExpectedString;
+  invalid_exact_svm_payload_transaction_receiver_ata_not_found: { receiver: string };
+  invalid_exact_svm_payload_transaction_sender_ata_not_found: { sender: string };
+  invalid_exact_svm_payload_transaction_simulation_failed: undefined;
+  invalid_exact_svm_payload_transaction_transfer_to_incorrect_ata: ExpectedString;
+  invalid_network: { network: string };
+  invalid_payload: ExpectedString;
+  invalid_payment_requirements: ExpectedString;
+  invalid_scheme: ExpectedString;
+  invalid_payment: FundMismatch;
+  payment_expired: undefined;
+  invalid_transaction_state: { error: string };
+  invalid_x402_version: ExpectedNumber;
+  settle_exact_svm_block_height_exceeded: { blockHeight: number };
+  settle_exact_svm_transaction_confirmation_timed_out: undefined;
+  unsupported_scheme: ExpectedString;
+  unexpected_settle_error: { error: string };
+  unexpected_verify_error: undefined;
+}>;
+
+type FundMismatch = {
+  available: bigint;
+  cost: bigint;
+  unit: string;
+};
+
+type ExpectedString = {
+  value: string;
+  expected: string;
+};
+
+type ExpectedNumber = {
+  value: number;
+  expected: number;
+};
+
+type ExpectedBigInt = {
+  value: bigint;
+  expected: bigint;
+};

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -190,11 +190,19 @@ export const VerifyRequestSchema = z.object({
 export type VerifyRequest = z.infer<typeof VerifyRequestSchema>;
 
 // x402VerifyResponse
-export const VerifyResponseSchema = z.object({
-  isValid: z.boolean(),
-  invalidReason: z.enum(ErrorReasons).optional(),
-  payer: EvmOrSvmAddress.optional(),
-});
+export const VerifyResponseSchema = z.union([
+  z.object({
+    isValid: z.literal(true),
+    invalidReason: z.undefined(),
+    payer: EvmOrSvmAddress.optional(),
+  }),
+  z.object({
+    isValid: z.literal(false),
+    invalidReason: z.enum(ErrorReasons),
+    invalidDescription: z.string(),
+    payer: EvmOrSvmAddress.optional(),
+  }),
+]);
 export type VerifyResponse = z.infer<typeof VerifyResponseSchema>;
 
 // x402SettleResponse


### PR DESCRIPTION
## Description

This PR is for #213 

The main change is that the VerifyResponse schema has been updated to a discriminated union, and now contains `invalidDescription`.

```ts
export const VerifyResponseSchema = z.union([
  z.object({
    isValid: z.literal(true),
    invalidReason: z.undefined(),
    payer: EvmOrSvmAddress.optional(),
  }),
  z.object({
    isValid: z.literal(false),
    invalidReason: z.enum(ErrorReasons),
    invalidDescription: z.string(),
    payer: EvmOrSvmAddress.optional(),
  }),
]);
```

When you want to return a `VerifyResponse` you can use the new helper function `createVerifyResponse`, and pass in additional context as necessary so that the message will be as descriptive as possible. For example:

```ts
  const required = BigInt(paymentRequirements.maxAmountRequired);
  if (balance < required) {
    return createVerifyResponse({
      invalidReason: "insufficient_funds", //"Client does not have enough funds",
      context: { available: balance, cost: required, unit: name },
      payer: exactEvmPayload.authorization.from,
    });
  }
```

`createVerifyResponse` is completely typesafe, and will give type hints about what context keys and types are required for the particular error code that is being created. All the error codes have tight requirements on explicitly defining what context is needed, or explicitly undefined. This allows every response to be well defined, and give as much information to the user as possible.

## Tests

All tests pass. I needed to modify a few to add expected response `{} as const` because `VerifyResponse` now is a discriminated union, with `isValid` literal `true` or `false` and will have different fields/keys depending on it.

There was one test that did not pass an I removed it. It looked like it was directly testing an injected `Error`, but now errors can be thrown with context with new `VerifyError`, and will be more type-safe because we aren't relying on the `message: string` to infer what type was thrown.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
