### PR TITLE
fix: add session-token subpath export to x402-hono

### DIFF
--- a/typescript/packages/x402-hono/package.json
+++ b/typescript/packages/x402-hono/package.json
@@ -55,6 +55,16 @@
         "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       }
+    },
+    "./session-token": {
+      "import": {
+        "types": "./dist/esm/session-token.d.mts",
+        "default": "./dist/esm/session-token.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/session-token.d.ts",
+        "default": "./dist/cjs/session-token.js"
+      }
     }
   },
   "files": [

--- a/typescript/packages/x402-hono/tsup.config.ts
+++ b/typescript/packages/x402-hono/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup";
 const baseConfig = {
   entry: {
     index: "src/index.ts",
+    "session-token": "src/session-token.ts",
   },
   dts: {
     resolve: true,


### PR DESCRIPTION
Enable import from 'x402-hono/session-token' by adding:
- session-token entry point in tsup.config.ts
- ./session-token export path in package.json

This fixes the broken import path documented in the README.

## Description

This PR adds support for importing the `POST` session token handler from `x402-hono/session-token` as documented in the README. Previously, the README showed an import path (`import { POST } from "x402-hono/session-token"`) that was not actually exported from the package, causing confusion and requiring users to manually copy the implementation.

## Tests

`pnpm test` from the `/typescript` directory


## Checklist

- [x ] I have formatted and linted my code
- [ x] All new and existing tests pass
- [ x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
