### PR TITLE
feat: shared middleware function to build payment requirements

### DIFF
--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -116,6 +116,7 @@ export function paymentMiddleware(
       mimeType,
       maxTimeoutSeconds,
       inputSchema,
+      // TODO: Rename outputSchema to requestStructure
       outputSchema,
       discoverable,
       getSupportedKinds: supported,

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -1,17 +1,16 @@
 import type { Context } from "hono";
-import { Address, getAddress } from "viem";
+import { Address } from "viem";
 import { Address as SolanaAddress } from "@solana/kit";
 import { exact } from "x402/schemes";
 import {
   computeRoutePatterns,
   findMatchingPaymentRequirements,
   findMatchingRoute,
-  processPriceToAtomicAmount,
   toJsonSafe,
+  buildPaymentRequirements,
 } from "x402/shared";
 import { getPaywallHtml } from "x402/paywall";
 import {
-  ERC20TokenAmount,
   FacilitatorConfig,
   moneySchema,
   PaymentPayload,
@@ -20,8 +19,6 @@ import {
   RoutesConfig,
   settleResponseHeader,
   PaywallConfig,
-  SupportedEVMNetworks,
-  SupportedSVMNetworks,
 } from "x402/types";
 import { useFacilitator } from "x402/verify";
 
@@ -104,6 +101,7 @@ export function paymentMiddleware(
       discoverable,
     } = config;
 
+<<<<<<< HEAD
     const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
     if ("error" in atomicAmountForAsset) {
       throw new Error(atomicAmountForAsset.error);
@@ -201,6 +199,26 @@ export function paymentMiddleware(
     } else {
       throw new Error(`Unsupported network: ${network}`);
     }
+=======
+    const resourceUrl: Resource = resource || (c.req.url as Resource);
+    const paymentRequirements: PaymentRequirements[] = await buildPaymentRequirements({
+      price,
+      network,
+      method,
+      resourceUrl,
+      payTo,
+      description,
+      mimeType,
+      maxTimeoutSeconds,
+      inputSchema,
+      outputSchema,
+      discoverable,
+      getSupportedKinds: supported,
+      defaultEvmTimeoutSeconds: 300,
+      defaultSvmTimeoutSeconds: 60,
+      defaultMimeType: "application/json",
+    });
+>>>>>>> 2875a3f (feat: shared middleware function to build payment requirements)
 
     const payment = c.req.header("X-PAYMENT");
     const userAgent = c.req.header("User-Agent") || "";

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -2,8 +2,29 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { Address } from "viem";
 import type { Address as SolanaAddress } from "@solana/kit";
+<<<<<<< HEAD
 import { computeRoutePatterns, findMatchingRoute } from "x402/shared";
 import { FacilitatorConfig, Resource, RoutesConfig, RouteConfig, PaywallConfig } from "x402/types";
+=======
+import { exact } from "x402/schemes";
+import {
+  computeRoutePatterns,
+  findMatchingPaymentRequirements,
+  findMatchingRoute,
+  toJsonSafe,
+  buildPaymentRequirements,
+} from "x402/shared";
+import { getPaywallHtml } from "x402/paywall";
+import {
+  FacilitatorConfig,
+  moneySchema,
+  PaymentPayload,
+  PaymentRequirements,
+  Resource,
+  RoutesConfig,
+  PaywallConfig,
+} from "x402/types";
+>>>>>>> 2875a3f (feat: shared middleware function to build payment requirements)
 import { useFacilitator } from "x402/verify";
 
 import { POST } from "./api/session-token";
@@ -100,6 +121,7 @@ export function paymentMiddleware(
     }
 
     const { price, network, config = {} } = matchingRoute.config;
+<<<<<<< HEAD
     const { customPaywallHtml, resource, errorMessages } = config;
 
     const resourceUrl =
@@ -115,6 +137,48 @@ export function paymentMiddleware(
       method,
       supported,
     );
+=======
+    const {
+      description,
+      mimeType,
+      maxTimeoutSeconds,
+      inputSchema,
+      outputSchema,
+      customPaywallHtml,
+      resource,
+      errorMessages,
+      discoverable,
+    } = config;
+
+    const resourceUrl =
+      resource || (`${request.nextUrl.protocol}//${request.nextUrl.host}${pathname}` as Resource);
+    let paymentRequirements: PaymentRequirements[];
+    try {
+      paymentRequirements = await buildPaymentRequirements({
+        price,
+        network,
+        method,
+        resourceUrl,
+        payTo,
+        description,
+        mimeType,
+        maxTimeoutSeconds,
+        inputSchema,
+        outputSchema,
+        discoverable,
+        getSupportedKinds: supported,
+        defaultEvmTimeoutSeconds: 300,
+        defaultSvmTimeoutSeconds: 60,
+        defaultMimeType: "application/json",
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (typeof msg === "string" && msg.startsWith("Unsupported network:")) {
+        throw e instanceof Error ? e : new Error(msg);
+      }
+      return new NextResponse(msg, { status: 500 });
+    }
+>>>>>>> 2875a3f (feat: shared middleware function to build payment requirements)
 
     // Check for payment header
     const paymentHeader = request.headers.get("X-PAYMENT");

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -2,29 +2,8 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { Address } from "viem";
 import type { Address as SolanaAddress } from "@solana/kit";
-<<<<<<< HEAD
 import { computeRoutePatterns, findMatchingRoute } from "x402/shared";
 import { FacilitatorConfig, Resource, RoutesConfig, RouteConfig, PaywallConfig } from "x402/types";
-=======
-import { exact } from "x402/schemes";
-import {
-  computeRoutePatterns,
-  findMatchingPaymentRequirements,
-  findMatchingRoute,
-  toJsonSafe,
-  buildPaymentRequirements,
-} from "x402/shared";
-import { getPaywallHtml } from "x402/paywall";
-import {
-  FacilitatorConfig,
-  moneySchema,
-  PaymentPayload,
-  PaymentRequirements,
-  Resource,
-  RoutesConfig,
-  PaywallConfig,
-} from "x402/types";
->>>>>>> 2875a3f (feat: shared middleware function to build payment requirements)
 import { useFacilitator } from "x402/verify";
 
 import { POST } from "./api/session-token";
@@ -121,7 +100,6 @@ export function paymentMiddleware(
     }
 
     const { price, network, config = {} } = matchingRoute.config;
-<<<<<<< HEAD
     const { customPaywallHtml, resource, errorMessages } = config;
 
     const resourceUrl =
@@ -137,48 +115,6 @@ export function paymentMiddleware(
       method,
       supported,
     );
-=======
-    const {
-      description,
-      mimeType,
-      maxTimeoutSeconds,
-      inputSchema,
-      outputSchema,
-      customPaywallHtml,
-      resource,
-      errorMessages,
-      discoverable,
-    } = config;
-
-    const resourceUrl =
-      resource || (`${request.nextUrl.protocol}//${request.nextUrl.host}${pathname}` as Resource);
-    let paymentRequirements: PaymentRequirements[];
-    try {
-      paymentRequirements = await buildPaymentRequirements({
-        price,
-        network,
-        method,
-        resourceUrl,
-        payTo,
-        description,
-        mimeType,
-        maxTimeoutSeconds,
-        inputSchema,
-        outputSchema,
-        discoverable,
-        getSupportedKinds: supported,
-        defaultEvmTimeoutSeconds: 300,
-        defaultSvmTimeoutSeconds: 60,
-        defaultMimeType: "application/json",
-      });
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      if (typeof msg === "string" && msg.startsWith("Unsupported network:")) {
-        throw e instanceof Error ? e : new Error(msg);
-      }
-      return new NextResponse(msg, { status: 500 });
-    }
->>>>>>> 2875a3f (feat: shared middleware function to build payment requirements)
 
     // Check for payment header
     const paymentHeader = request.headers.get("X-PAYMENT");

--- a/typescript/packages/x402/src/shared/middleware.ts
+++ b/typescript/packages/x402/src/shared/middleware.ts
@@ -265,9 +265,6 @@ export async function buildPaymentRequirements(params: {
     outputSchema,
     discoverable,
     getSupportedKinds,
-    defaultEvmTimeoutSeconds = 60,
-    defaultSvmTimeoutSeconds = 60,
-    defaultMimeType = "",
   } = params;
 
   const atomicAmountForAsset = processPriceToAtomicAmount(price, network);
@@ -276,6 +273,13 @@ export async function buildPaymentRequirements(params: {
   }
 
   const { maxAmountRequired, asset } = atomicAmountForAsset;
+
+  const isEvmNetwork = SupportedEVMNetworks.includes(network);
+  const networkDefaultTimeout = isEvmNetwork ? 300 : 60;
+  const finalTimeout =
+    typeof maxTimeoutSeconds === "number" ? maxTimeoutSeconds : networkDefaultTimeout;
+  const finalMimeType =
+    typeof mimeType === "string" ? mimeType : isEvmNetwork ? "application/json" : "";
 
   // EVM networks
   if (SupportedEVMNetworks.includes(network)) {
@@ -286,9 +290,9 @@ export async function buildPaymentRequirements(params: {
         maxAmountRequired,
         resource: resourceUrl,
         description: description ?? "",
-        mimeType: mimeType ?? defaultMimeType,
+        mimeType: finalMimeType,
         payTo: getAddress(payTo),
-        maxTimeoutSeconds: maxTimeoutSeconds ?? defaultEvmTimeoutSeconds,
+        maxTimeoutSeconds: finalTimeout,
         asset: getAddress((asset as ERC20TokenAmount["asset"]).address),
         outputSchema: {
           input: {
@@ -333,9 +337,9 @@ export async function buildPaymentRequirements(params: {
         maxAmountRequired,
         resource: resourceUrl,
         description: description ?? "",
-        mimeType: mimeType ?? defaultMimeType,
+        mimeType: finalMimeType,
         payTo: payTo,
-        maxTimeoutSeconds: maxTimeoutSeconds ?? defaultSvmTimeoutSeconds,
+        maxTimeoutSeconds: finalTimeout,
         asset: (asset as { address: string }).address,
         outputSchema: {
           input: {

--- a/typescript/site/eslint.config.js
+++ b/typescript/site/eslint.config.js
@@ -7,7 +7,7 @@ import importPlugin from "eslint-plugin-import";
 
 export default [
   {
-    ignores: ["dist/**", "node_modules/**", ".next/**"],
+    ignores: ["dist/**", "node_modules/**", ".next/**", "next-env.d.ts"],
   },
   {
     files: ["**/*.ts"],


### PR DESCRIPTION
## Description
let’s have a single builder to construct `PaymentRequirements`, as mentioned in commit 26f132bf. 
besides, this will simplify maintenance and prevent implementation drifts

## Tests
```bash
cd typescript && \
pnpm build && \
pnpm lint:check && \
pnpm --filter x402 exec vitest run src/shared/middleware.test.ts --reporter=verbose
```

## Checklist
- [x] formatted and linted code
- [x] all new and existing tests pass
- [x] signed commits  
