### PR TITLE
Add SKALE Base Sepolia to x402 Typescript

### DIFF
--- a/typescript/packages/x402/src/types/shared/custom-chains/eip155-324705682.ts
+++ b/typescript/packages/x402/src/types/shared/custom-chains/eip155-324705682.ts
@@ -1,0 +1,25 @@
+import { type Chain } from "viem";
+
+// This chain isactive and is waiting for addition to https://github.com/ethereum-lists/chains
+// before it can be added to wevm/viem/chains.
+export const skaleBaseSepolia = {
+	id: 324705682,
+	name: "SKALE Base Sepolia",
+	nativeCurrency: {
+		name: "Credits",
+		symbol: "CREDITS",
+		decimals: 18
+	},
+	rpcUrls: {
+		default: {
+			http: ["https://base-sepolia-testnet.skalenodes.com/v1/jubilant-horrible-ancha"],
+		}
+	},
+	blockExplorers: {
+		default: {
+			name: "Blockscout",
+			url: "https://base-sepolia-testnet-explorer.skalenodes.com",
+			apiUrl: "https://base-sepolia-testnet-explorer.skalenodes.com/api",
+		}
+	},
+} satisfies Chain;

--- a/typescript/packages/x402/src/types/shared/custom-chains/eip155-324705682.ts
+++ b/typescript/packages/x402/src/types/shared/custom-chains/eip155-324705682.ts
@@ -3,23 +3,23 @@ import { type Chain } from "viem";
 // This chain isactive and is waiting for addition to https://github.com/ethereum-lists/chains
 // before it can be added to wevm/viem/chains.
 export const skaleBaseSepolia = {
-	id: 324705682,
-	name: "SKALE Base Sepolia",
-	nativeCurrency: {
-		name: "Credits",
-		symbol: "CREDITS",
-		decimals: 18
-	},
-	rpcUrls: {
-		default: {
-			http: ["https://base-sepolia-testnet.skalenodes.com/v1/jubilant-horrible-ancha"],
-		}
-	},
-	blockExplorers: {
-		default: {
-			name: "Blockscout",
-			url: "https://base-sepolia-testnet-explorer.skalenodes.com",
-			apiUrl: "https://base-sepolia-testnet-explorer.skalenodes.com/api",
-		}
-	},
+  id: 324705682,
+  name: "SKALE Base Sepolia",
+  nativeCurrency: {
+    name: "Credits",
+    symbol: "CREDITS",
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ["https://base-sepolia-testnet.skalenodes.com/v1/jubilant-horrible-ancha"],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: "Blockscout",
+      url: "https://base-sepolia-testnet-explorer.skalenodes.com",
+      apiUrl: "https://base-sepolia-testnet-explorer.skalenodes.com/api",
+    },
+  },
 } satisfies Chain;

--- a/typescript/packages/x402/src/types/shared/custom-chains/index.ts
+++ b/typescript/packages/x402/src/types/shared/custom-chains/index.ts
@@ -1,0 +1,1 @@
+export { skaleBaseSepolia } from "./eip155-324705682";

--- a/typescript/packages/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/x402/src/types/shared/evm/config.ts
@@ -2,71 +2,75 @@ import { Address } from "viem";
 import { Address as SolanaAddress } from "@solana/kit";
 
 export const config: Record<string, ChainConfig> = {
-  "84532": {
-    usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-    usdcName: "USDC",
-  },
-  "8453": {
-    usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-    usdcName: "USD Coin",
-  },
-  "43113": {
-    usdcAddress: "0x5425890298aed601595a70AB815c96711a31Bc65",
-    usdcName: "USD Coin",
-  },
-  "43114": {
-    usdcAddress: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
-    usdcName: "USD Coin",
-  },
-  "4689": {
-    usdcAddress: "0xcdf79194c6c285077a58da47641d4dbe51f63542",
-    usdcName: "Bridged USDC",
-  },
-  // solana devnet
-  "103": {
-    usdcAddress: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU" as SolanaAddress,
-    usdcName: "USDC",
-  },
-  // solana mainnet
-  "101": {
-    usdcAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" as SolanaAddress,
-    usdcName: "USDC",
-  },
-  "1328": {
-    usdcAddress: "0x4fcf1784b31630811181f670aea7a7bef803eaed",
-    usdcName: "USDC",
-  },
-  "1329": {
-    usdcAddress: "0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392",
-    usdcName: "USDC",
-  },
-  "137": {
-    usdcAddress: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
-    usdcName: "USD Coin",
-  },
-  "80002": {
-    usdcAddress: "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
-    usdcName: "USDC",
-  },
-  "3338": {
-    usdcAddress: "0xbbA60da06c2c5424f03f7434542280FCAd453d10",
-    usdcName: "USDC",
-  },
-  "2741": {
-    usdcAddress: "0x84a71ccd554cc1b02749b35d22f684cc8ec987e1",
-    usdcName: "Bridged USDC",
-  },
-  "11124": {
-    usdcAddress: "0xe4C7fBB0a626ed208021ccabA6Be1566905E2dFc",
-    usdcName: "Bridged USDC",
-  },
-  "1514": {
-    usdcAddress: "0xF1815bd50389c46847f0Bda824eC8da914045D14",
-    usdcName: "Bridged USDC",
-  },
+	"84532": {
+		usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+		usdcName: "USDC",
+	},
+	"8453": {
+		usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+		usdcName: "USD Coin",
+	},
+	"43113": {
+		usdcAddress: "0x5425890298aed601595a70AB815c96711a31Bc65",
+		usdcName: "USD Coin",
+	},
+	"43114": {
+		usdcAddress: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+		usdcName: "USD Coin",
+	},
+	"4689": {
+		usdcAddress: "0xcdf79194c6c285077a58da47641d4dbe51f63542",
+		usdcName: "Bridged USDC",
+	},
+	// solana devnet
+	"103": {
+		usdcAddress: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU" as SolanaAddress,
+		usdcName: "USDC",
+	},
+	// solana mainnet
+	"101": {
+		usdcAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" as SolanaAddress,
+		usdcName: "USDC",
+	},
+	"1328": {
+		usdcAddress: "0x4fcf1784b31630811181f670aea7a7bef803eaed",
+		usdcName: "USDC",
+	},
+	"1329": {
+		usdcAddress: "0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392",
+		usdcName: "USDC",
+	},
+	"137": {
+		usdcAddress: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+		usdcName: "USD Coin",
+	},
+	"80002": {
+		usdcAddress: "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
+		usdcName: "USDC",
+	},
+	"3338": {
+		usdcAddress: "0xbbA60da06c2c5424f03f7434542280FCAd453d10",
+		usdcName: "USDC",
+	},
+	"2741": {
+		usdcAddress: "0x84a71ccd554cc1b02749b35d22f684cc8ec987e1",
+		usdcName: "Bridged USDC",
+	},
+	"11124": {
+		usdcAddress: "0xe4C7fBB0a626ed208021ccabA6Be1566905E2dFc",
+		usdcName: "Bridged USDC",
+	},
+	"1514": {
+		usdcAddress: "0xF1815bd50389c46847f0Bda824eC8da914045D14",
+		usdcName: "Bridged USDC",
+	},
+	"324705682": {
+		usdcAddress: "0x2e08028E3C4c2356572E096d8EF835cD5C6030bD",
+		usdcName: "Bridged USDC (SKALE Bridge)"
+	}
 };
 
 export type ChainConfig = {
-  usdcAddress: Address | SolanaAddress;
-  usdcName: string;
+	usdcAddress: Address | SolanaAddress;
+	usdcName: string;
 };

--- a/typescript/packages/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/x402/src/types/shared/evm/config.ts
@@ -2,75 +2,75 @@ import { Address } from "viem";
 import { Address as SolanaAddress } from "@solana/kit";
 
 export const config: Record<string, ChainConfig> = {
-	"84532": {
-		usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
-		usdcName: "USDC",
-	},
-	"8453": {
-		usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-		usdcName: "USD Coin",
-	},
-	"43113": {
-		usdcAddress: "0x5425890298aed601595a70AB815c96711a31Bc65",
-		usdcName: "USD Coin",
-	},
-	"43114": {
-		usdcAddress: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
-		usdcName: "USD Coin",
-	},
-	"4689": {
-		usdcAddress: "0xcdf79194c6c285077a58da47641d4dbe51f63542",
-		usdcName: "Bridged USDC",
-	},
-	// solana devnet
-	"103": {
-		usdcAddress: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU" as SolanaAddress,
-		usdcName: "USDC",
-	},
-	// solana mainnet
-	"101": {
-		usdcAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" as SolanaAddress,
-		usdcName: "USDC",
-	},
-	"1328": {
-		usdcAddress: "0x4fcf1784b31630811181f670aea7a7bef803eaed",
-		usdcName: "USDC",
-	},
-	"1329": {
-		usdcAddress: "0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392",
-		usdcName: "USDC",
-	},
-	"137": {
-		usdcAddress: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
-		usdcName: "USD Coin",
-	},
-	"80002": {
-		usdcAddress: "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
-		usdcName: "USDC",
-	},
-	"3338": {
-		usdcAddress: "0xbbA60da06c2c5424f03f7434542280FCAd453d10",
-		usdcName: "USDC",
-	},
-	"2741": {
-		usdcAddress: "0x84a71ccd554cc1b02749b35d22f684cc8ec987e1",
-		usdcName: "Bridged USDC",
-	},
-	"11124": {
-		usdcAddress: "0xe4C7fBB0a626ed208021ccabA6Be1566905E2dFc",
-		usdcName: "Bridged USDC",
-	},
-	"1514": {
-		usdcAddress: "0xF1815bd50389c46847f0Bda824eC8da914045D14",
-		usdcName: "Bridged USDC",
-	},
-	"324705682": {
-		usdcAddress: "0x2e08028E3C4c2356572E096d8EF835cD5C6030bD",
-		usdcName: "Bridged USDC (SKALE Bridge)"
-	}
+  "84532": {
+    usdcAddress: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    usdcName: "USDC",
+  },
+  "8453": {
+    usdcAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    usdcName: "USD Coin",
+  },
+  "43113": {
+    usdcAddress: "0x5425890298aed601595a70AB815c96711a31Bc65",
+    usdcName: "USD Coin",
+  },
+  "43114": {
+    usdcAddress: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+    usdcName: "USD Coin",
+  },
+  "4689": {
+    usdcAddress: "0xcdf79194c6c285077a58da47641d4dbe51f63542",
+    usdcName: "Bridged USDC",
+  },
+  // solana devnet
+  "103": {
+    usdcAddress: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU" as SolanaAddress,
+    usdcName: "USDC",
+  },
+  // solana mainnet
+  "101": {
+    usdcAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" as SolanaAddress,
+    usdcName: "USDC",
+  },
+  "1328": {
+    usdcAddress: "0x4fcf1784b31630811181f670aea7a7bef803eaed",
+    usdcName: "USDC",
+  },
+  "1329": {
+    usdcAddress: "0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392",
+    usdcName: "USDC",
+  },
+  "137": {
+    usdcAddress: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+    usdcName: "USD Coin",
+  },
+  "80002": {
+    usdcAddress: "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
+    usdcName: "USDC",
+  },
+  "3338": {
+    usdcAddress: "0xbbA60da06c2c5424f03f7434542280FCAd453d10",
+    usdcName: "USDC",
+  },
+  "2741": {
+    usdcAddress: "0x84a71ccd554cc1b02749b35d22f684cc8ec987e1",
+    usdcName: "Bridged USDC",
+  },
+  "11124": {
+    usdcAddress: "0xe4C7fBB0a626ed208021ccabA6Be1566905E2dFc",
+    usdcName: "Bridged USDC",
+  },
+  "1514": {
+    usdcAddress: "0xF1815bd50389c46847f0Bda824eC8da914045D14",
+    usdcName: "Bridged USDC",
+  },
+  "324705682": {
+    usdcAddress: "0x2e08028E3C4c2356572E096d8EF835cD5C6030bD",
+    usdcName: "Bridged USDC (SKALE Bridge)",
+  },
 };
 
 export type ChainConfig = {
-	usdcAddress: Address | SolanaAddress;
-	usdcName: string;
+  usdcAddress: Address | SolanaAddress;
+  usdcName: string;
 };

--- a/typescript/packages/x402/src/types/shared/evm/wallet.test.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { base, baseSepolia, avalancheFuji, abstract } from "viem/chains";
+import { skaleBaseSepolia } from "../custom-chains";
 import { privateKeyToAccount } from "viem/accounts";
 import { createConnectedClient, createSigner } from "./wallet";
 
@@ -8,198 +9,215 @@ const mockExtend = vi.fn();
 const mockEip712WalletActionsFn = vi.fn();
 
 vi.mock("viem", async () => {
-  const actual = await vi.importActual("viem");
-  return {
-    ...actual,
-    createPublicClient: vi.fn().mockImplementation(({ chain, transport }) => ({
-      chain,
-      transport,
-      extend: vi.fn().mockReturnValue({
-        chain,
-        transport,
-        getBlockNumber: vi.fn(),
-        getBalance: vi.fn(),
-      }),
-    })),
-    createWalletClient: vi.fn().mockImplementation(({ chain, transport, account }) => {
-      const client = {
-        chain,
-        transport,
-        account,
-        sendTransaction: vi.fn(),
-        signMessage: vi.fn(),
-      };
-      return {
-        ...client,
-        extend: mockExtend.mockReturnValue({
-          ...client,
-          extend: mockExtend.mockReturnValue(client),
-        }),
-      };
-    }),
-    http: vi.fn().mockReturnValue("mock-transport"),
-    publicActions: vi.fn(),
-  };
+	const actual = await vi.importActual("viem");
+	return {
+		...actual,
+		createPublicClient: vi.fn().mockImplementation(({ chain, transport }) => ({
+			chain,
+			transport,
+			extend: vi.fn().mockReturnValue({
+				chain,
+				transport,
+				getBlockNumber: vi.fn(),
+				getBalance: vi.fn(),
+			}),
+		})),
+		createWalletClient: vi.fn().mockImplementation(({ chain, transport, account }) => {
+			const client = {
+				chain,
+				transport,
+				account,
+				sendTransaction: vi.fn(),
+				signMessage: vi.fn(),
+			};
+			return {
+				...client,
+				extend: mockExtend.mockReturnValue({
+					...client,
+					extend: mockExtend.mockReturnValue(client),
+				}),
+			};
+		}),
+		http: vi.fn().mockReturnValue("mock-transport"),
+		publicActions: vi.fn(),
+	};
 });
 
 vi.mock("viem/zksync", () => ({
-  eip712WalletActions: () => {
-    mockEip712WalletActionsFn();
-    return vi.fn();
-  },
+	eip712WalletActions: () => {
+		mockEip712WalletActionsFn();
+		return vi.fn();
+	},
 }));
 
 vi.mock("viem/accounts", () => ({
-  privateKeyToAccount: vi.fn().mockImplementation(privateKey => ({
-    address: "0x1234567890123456789012345678901234567890",
-    privateKey,
-    type: "local",
-    source: "privateKey",
-    sign: vi.fn(),
-    signMessage: vi.fn(),
-    signTransaction: vi.fn(),
-    signTypedData: vi.fn(),
-  })),
+	privateKeyToAccount: vi.fn().mockImplementation(privateKey => ({
+		address: "0x1234567890123456789012345678901234567890",
+		privateKey,
+		type: "local",
+		source: "privateKey",
+		sign: vi.fn(),
+		signMessage: vi.fn(),
+		signTransaction: vi.fn(),
+		signTypedData: vi.fn(),
+	})),
 }));
 
 describe("createConnectedClient", () => {
-  it("should create a public client for base network", () => {
-    const client = createConnectedClient("base");
+	it("should create a public client for base network", () => {
+		const client = createConnectedClient("base");
 
-    expect(client.chain).toEqual(base);
-    expect(client.transport).toBe("mock-transport");
-  });
+		expect(client.chain).toEqual(base);
+		expect(client.transport).toBe("mock-transport");
+	});
 
-  it("should create a public client for base-sepolia network", () => {
-    const client = createConnectedClient("base-sepolia");
+	it("should create a public client for base-sepolia network", () => {
+		const client = createConnectedClient("base-sepolia");
 
-    expect(client.chain).toEqual(baseSepolia);
-    expect(client.transport).toBe("mock-transport");
-  });
+		expect(client.chain).toEqual(baseSepolia);
+		expect(client.transport).toBe("mock-transport");
+	});
 
-  it("should create a public client for avalanche-fuji network", () => {
-    const client = createConnectedClient("avalanche-fuji");
+	it("should create a public client for avalanche-fuji network", () => {
+		const client = createConnectedClient("avalanche-fuji");
 
-    expect(client.chain).toEqual(avalancheFuji);
-    expect(client.transport).toBe("mock-transport");
-  });
+		expect(client.chain).toEqual(avalancheFuji);
+		expect(client.transport).toBe("mock-transport");
+	});
 
-  it("should throw an error for unsupported network", () => {
-    expect(() => createConnectedClient("unsupported-network")).toThrow(
-      "Unsupported network: unsupported-network",
-    );
-  });
+	it("should create a public client for skale-base-sepolia network", () => {
+		const client = createConnectedClient("skale-base-sepolia");
 
-  it("should throw an error for empty network", () => {
-    expect(() => createConnectedClient("")).toThrow("NETWORK environment variable is not set");
-  });
+		expect(client.chain).toEqual(skaleBaseSepolia);
+		expect(client.transport).toBe("mock-transport");
+	});
 
-  it("should throw an error for undefined network", () => {
-    expect(() => createConnectedClient(undefined as unknown as string)).toThrow(
-      "NETWORK environment variable is not set",
-    );
-  });
+	it("should throw an error for unsupported network", () => {
+		expect(() => createConnectedClient("unsupported-network")).toThrow(
+			"Unsupported network: unsupported-network",
+		);
+	});
+
+	it("should throw an error for empty network", () => {
+		expect(() => createConnectedClient("")).toThrow("NETWORK environment variable is not set");
+	});
+
+	it("should throw an error for undefined network", () => {
+		expect(() => createConnectedClient(undefined as unknown as string)).toThrow(
+			"NETWORK environment variable is not set",
+		);
+	});
 });
 
 describe("createSigner", () => {
-  const mockPrivateKey =
-    "0x1234567890123456789012345678901234567890123456789012345678901234" as const;
+	const mockPrivateKey =
+		"0x1234567890123456789012345678901234567890123456789012345678901234" as const;
 
-  it("should create a wallet client for base network with private key", () => {
-    const signer = createSigner("base", mockPrivateKey);
+	it("should create a wallet client for base network with private key", () => {
+		const signer = createSigner("base", mockPrivateKey);
 
-    expect(signer.chain).toEqual(base);
-    expect(signer.transport).toBe("mock-transport");
-    expect(signer.account).toBeDefined();
-    expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
-    expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
-  });
+		expect(signer.chain).toEqual(base);
+		expect(signer.transport).toBe("mock-transport");
+		expect(signer.account).toBeDefined();
+		expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
+		expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
+	});
 
-  it("should create a wallet client for base-sepolia network with private key", () => {
-    const signer = createSigner("base-sepolia", mockPrivateKey);
+	it("should create a wallet client for base-sepolia network with private key", () => {
+		const signer = createSigner("base-sepolia", mockPrivateKey);
 
-    expect(signer.chain).toEqual(baseSepolia);
-    expect(signer.transport).toBe("mock-transport");
-    expect(signer.account).toBeDefined();
-    expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
-    expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
-  });
+		expect(signer.chain).toEqual(baseSepolia);
+		expect(signer.transport).toBe("mock-transport");
+		expect(signer.account).toBeDefined();
+		expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
+		expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
+	});
 
-  it("should create a wallet client for avalanche-fuji network with private key", () => {
-    const signer = createSigner("avalanche-fuji", mockPrivateKey);
+	it("should create a wallet client for avalanche-fuji network with private key", () => {
+		const signer = createSigner("avalanche-fuji", mockPrivateKey);
 
-    expect(signer.chain).toEqual(avalancheFuji);
-    expect(signer.transport).toBe("mock-transport");
-    expect(signer.account).toBeDefined();
-    expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
-    expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
-  });
+		expect(signer.chain).toEqual(avalancheFuji);
+		expect(signer.transport).toBe("mock-transport");
+		expect(signer.account).toBeDefined();
+		expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
+		expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
+	});
 
-  it("should throw an error for unsupported network", () => {
-    expect(() => createSigner("unsupported-network", mockPrivateKey)).toThrow(
-      "Unsupported network: unsupported-network",
-    );
-  });
+	it("should create a wallet client for skale-base-sepolia network with private key", () => {
+		const signer = createSigner("skale-base-sepolia", mockPrivateKey);
 
-  it("should throw an error for empty network", () => {
-    expect(() => createSigner("", mockPrivateKey)).toThrow(
-      "NETWORK environment variable is not set",
-    );
-  });
+		expect(signer.chain).toEqual(skaleBaseSepolia);
+		expect(signer.transport).toBe("mock-transport");
+		expect(signer.account).toBeDefined();
+		expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
+		expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
+	});
 
-  it("should throw an error for undefined network", () => {
-    expect(() => createSigner(undefined as unknown as string, mockPrivateKey)).toThrow(
-      "NETWORK environment variable is not set",
-    );
-  });
+	it("should throw an error for unsupported network", () => {
+		expect(() => createSigner("unsupported-network", mockPrivateKey)).toThrow(
+			"Unsupported network: unsupported-network",
+		);
+	});
 
-  it("should handle different private key formats", () => {
-    const differentPrivateKey =
-      "0xabcdef1234567890123456789012345678901234567890123456789012345678" as const;
-    const signer = createSigner("base", differentPrivateKey);
+	it("should throw an error for empty network", () => {
+		expect(() => createSigner("", mockPrivateKey)).toThrow(
+			"NETWORK environment variable is not set",
+		);
+	});
 
-    expect(privateKeyToAccount).toHaveBeenCalledWith(differentPrivateKey);
-    expect(signer.account).toBeDefined();
-  });
+	it("should throw an error for undefined network", () => {
+		expect(() => createSigner(undefined as unknown as string, mockPrivateKey)).toThrow(
+			"NETWORK environment variable is not set",
+		);
+	});
 
-  it("should create unique signers for the same network with different private keys", () => {
-    const privateKey1 =
-      "0x1111111111111111111111111111111111111111111111111111111111111111" as const;
-    const privateKey2 =
-      "0x2222222222222222222222222222222222222222222222222222222222222222" as const;
+	it("should handle different private key formats", () => {
+		const differentPrivateKey =
+			"0xabcdef1234567890123456789012345678901234567890123456789012345678" as const;
+		const signer = createSigner("base", differentPrivateKey);
 
-    const signer1 = createSigner("base", privateKey1);
-    const signer2 = createSigner("base", privateKey2);
+		expect(privateKeyToAccount).toHaveBeenCalledWith(differentPrivateKey);
+		expect(signer.account).toBeDefined();
+	});
 
-    expect(signer1.account).toBeDefined();
-    expect(signer2.account).toBeDefined();
-    expect(privateKeyToAccount).toHaveBeenCalledWith(privateKey1);
-    expect(privateKeyToAccount).toHaveBeenCalledWith(privateKey2);
-  });
+	it("should create unique signers for the same network with different private keys", () => {
+		const privateKey1 =
+			"0x1111111111111111111111111111111111111111111111111111111111111111" as const;
+		const privateKey2 =
+			"0x2222222222222222222222222222222222222222222222222222222222222222" as const;
 
-  it("should extend wallet client with eip712WalletActions for ZK stack chains", () => {
-    mockExtend.mockClear();
-    mockEip712WalletActionsFn.mockClear();
+		const signer1 = createSigner("base", privateKey1);
+		const signer2 = createSigner("base", privateKey2);
 
-    const signer = createSigner("abstract", mockPrivateKey);
+		expect(signer1.account).toBeDefined();
+		expect(signer2.account).toBeDefined();
+		expect(privateKeyToAccount).toHaveBeenCalledWith(privateKey1);
+		expect(privateKeyToAccount).toHaveBeenCalledWith(privateKey2);
+	});
 
-    // Should call eip712WalletActions for ZK Stack chains
-    expect(mockEip712WalletActionsFn).toHaveBeenCalledTimes(1);
-    expect(mockExtend).toHaveBeenCalledTimes(2);
-    expect(signer.chain).toEqual(abstract);
-    expect(signer.account).toBeDefined();
-  });
+	it("should extend wallet client with eip712WalletActions for ZK stack chains", () => {
+		mockExtend.mockClear();
+		mockEip712WalletActionsFn.mockClear();
 
-  it("should NOT extend with eip712WalletActions for non ZK stack chains", () => {
-    mockExtend.mockClear();
-    mockEip712WalletActionsFn.mockClear();
+		const signer = createSigner("abstract", mockPrivateKey);
 
-    const signer = createSigner("base", mockPrivateKey);
+		// Should call eip712WalletActions for ZK Stack chains
+		expect(mockEip712WalletActionsFn).toHaveBeenCalledTimes(1);
+		expect(mockExtend).toHaveBeenCalledTimes(2);
+		expect(signer.chain).toEqual(abstract);
+		expect(signer.account).toBeDefined();
+	});
 
-    // Should only call extend once for publicActions on non-ZK Stack chains
-    expect(mockEip712WalletActionsFn).toHaveBeenCalledTimes(0);
-    expect(mockExtend).toHaveBeenCalledTimes(1);
-    expect(signer.chain).toEqual(base);
-    expect(signer.account).toBeDefined();
-  });
+	it("should NOT extend with eip712WalletActions for non ZK stack chains", () => {
+		mockExtend.mockClear();
+		mockEip712WalletActionsFn.mockClear();
+
+		const signer = createSigner("base", mockPrivateKey);
+
+		// Should only call extend once for publicActions on non-ZK Stack chains
+		expect(mockEip712WalletActionsFn).toHaveBeenCalledTimes(0);
+		expect(mockExtend).toHaveBeenCalledTimes(1);
+		expect(signer.chain).toEqual(base);
+		expect(signer.account).toBeDefined();
+	});
 });

--- a/typescript/packages/x402/src/types/shared/evm/wallet.test.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.test.ts
@@ -9,215 +9,215 @@ const mockExtend = vi.fn();
 const mockEip712WalletActionsFn = vi.fn();
 
 vi.mock("viem", async () => {
-	const actual = await vi.importActual("viem");
-	return {
-		...actual,
-		createPublicClient: vi.fn().mockImplementation(({ chain, transport }) => ({
-			chain,
-			transport,
-			extend: vi.fn().mockReturnValue({
-				chain,
-				transport,
-				getBlockNumber: vi.fn(),
-				getBalance: vi.fn(),
-			}),
-		})),
-		createWalletClient: vi.fn().mockImplementation(({ chain, transport, account }) => {
-			const client = {
-				chain,
-				transport,
-				account,
-				sendTransaction: vi.fn(),
-				signMessage: vi.fn(),
-			};
-			return {
-				...client,
-				extend: mockExtend.mockReturnValue({
-					...client,
-					extend: mockExtend.mockReturnValue(client),
-				}),
-			};
-		}),
-		http: vi.fn().mockReturnValue("mock-transport"),
-		publicActions: vi.fn(),
-	};
+  const actual = await vi.importActual("viem");
+  return {
+    ...actual,
+    createPublicClient: vi.fn().mockImplementation(({ chain, transport }) => ({
+      chain,
+      transport,
+      extend: vi.fn().mockReturnValue({
+        chain,
+        transport,
+        getBlockNumber: vi.fn(),
+        getBalance: vi.fn(),
+      }),
+    })),
+    createWalletClient: vi.fn().mockImplementation(({ chain, transport, account }) => {
+      const client = {
+        chain,
+        transport,
+        account,
+        sendTransaction: vi.fn(),
+        signMessage: vi.fn(),
+      };
+      return {
+        ...client,
+        extend: mockExtend.mockReturnValue({
+          ...client,
+          extend: mockExtend.mockReturnValue(client),
+        }),
+      };
+    }),
+    http: vi.fn().mockReturnValue("mock-transport"),
+    publicActions: vi.fn(),
+  };
 });
 
 vi.mock("viem/zksync", () => ({
-	eip712WalletActions: () => {
-		mockEip712WalletActionsFn();
-		return vi.fn();
-	},
+  eip712WalletActions: () => {
+    mockEip712WalletActionsFn();
+    return vi.fn();
+  },
 }));
 
 vi.mock("viem/accounts", () => ({
-	privateKeyToAccount: vi.fn().mockImplementation(privateKey => ({
-		address: "0x1234567890123456789012345678901234567890",
-		privateKey,
-		type: "local",
-		source: "privateKey",
-		sign: vi.fn(),
-		signMessage: vi.fn(),
-		signTransaction: vi.fn(),
-		signTypedData: vi.fn(),
-	})),
+  privateKeyToAccount: vi.fn().mockImplementation(privateKey => ({
+    address: "0x1234567890123456789012345678901234567890",
+    privateKey,
+    type: "local",
+    source: "privateKey",
+    sign: vi.fn(),
+    signMessage: vi.fn(),
+    signTransaction: vi.fn(),
+    signTypedData: vi.fn(),
+  })),
 }));
 
 describe("createConnectedClient", () => {
-	it("should create a public client for base network", () => {
-		const client = createConnectedClient("base");
+  it("should create a public client for base network", () => {
+    const client = createConnectedClient("base");
 
-		expect(client.chain).toEqual(base);
-		expect(client.transport).toBe("mock-transport");
-	});
+    expect(client.chain).toEqual(base);
+    expect(client.transport).toBe("mock-transport");
+  });
 
-	it("should create a public client for base-sepolia network", () => {
-		const client = createConnectedClient("base-sepolia");
+  it("should create a public client for base-sepolia network", () => {
+    const client = createConnectedClient("base-sepolia");
 
-		expect(client.chain).toEqual(baseSepolia);
-		expect(client.transport).toBe("mock-transport");
-	});
+    expect(client.chain).toEqual(baseSepolia);
+    expect(client.transport).toBe("mock-transport");
+  });
 
-	it("should create a public client for avalanche-fuji network", () => {
-		const client = createConnectedClient("avalanche-fuji");
+  it("should create a public client for avalanche-fuji network", () => {
+    const client = createConnectedClient("avalanche-fuji");
 
-		expect(client.chain).toEqual(avalancheFuji);
-		expect(client.transport).toBe("mock-transport");
-	});
+    expect(client.chain).toEqual(avalancheFuji);
+    expect(client.transport).toBe("mock-transport");
+  });
 
-	it("should create a public client for skale-base-sepolia network", () => {
-		const client = createConnectedClient("skale-base-sepolia");
+  it("should create a public client for skale-base-sepolia network", () => {
+    const client = createConnectedClient("skale-base-sepolia");
 
-		expect(client.chain).toEqual(skaleBaseSepolia);
-		expect(client.transport).toBe("mock-transport");
-	});
+    expect(client.chain).toEqual(skaleBaseSepolia);
+    expect(client.transport).toBe("mock-transport");
+  });
 
-	it("should throw an error for unsupported network", () => {
-		expect(() => createConnectedClient("unsupported-network")).toThrow(
-			"Unsupported network: unsupported-network",
-		);
-	});
+  it("should throw an error for unsupported network", () => {
+    expect(() => createConnectedClient("unsupported-network")).toThrow(
+      "Unsupported network: unsupported-network",
+    );
+  });
 
-	it("should throw an error for empty network", () => {
-		expect(() => createConnectedClient("")).toThrow("NETWORK environment variable is not set");
-	});
+  it("should throw an error for empty network", () => {
+    expect(() => createConnectedClient("")).toThrow("NETWORK environment variable is not set");
+  });
 
-	it("should throw an error for undefined network", () => {
-		expect(() => createConnectedClient(undefined as unknown as string)).toThrow(
-			"NETWORK environment variable is not set",
-		);
-	});
+  it("should throw an error for undefined network", () => {
+    expect(() => createConnectedClient(undefined as unknown as string)).toThrow(
+      "NETWORK environment variable is not set",
+    );
+  });
 });
 
 describe("createSigner", () => {
-	const mockPrivateKey =
-		"0x1234567890123456789012345678901234567890123456789012345678901234" as const;
+  const mockPrivateKey =
+    "0x1234567890123456789012345678901234567890123456789012345678901234" as const;
 
-	it("should create a wallet client for base network with private key", () => {
-		const signer = createSigner("base", mockPrivateKey);
+  it("should create a wallet client for base network with private key", () => {
+    const signer = createSigner("base", mockPrivateKey);
 
-		expect(signer.chain).toEqual(base);
-		expect(signer.transport).toBe("mock-transport");
-		expect(signer.account).toBeDefined();
-		expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
-		expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
-	});
+    expect(signer.chain).toEqual(base);
+    expect(signer.transport).toBe("mock-transport");
+    expect(signer.account).toBeDefined();
+    expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
+    expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
+  });
 
-	it("should create a wallet client for base-sepolia network with private key", () => {
-		const signer = createSigner("base-sepolia", mockPrivateKey);
+  it("should create a wallet client for base-sepolia network with private key", () => {
+    const signer = createSigner("base-sepolia", mockPrivateKey);
 
-		expect(signer.chain).toEqual(baseSepolia);
-		expect(signer.transport).toBe("mock-transport");
-		expect(signer.account).toBeDefined();
-		expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
-		expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
-	});
+    expect(signer.chain).toEqual(baseSepolia);
+    expect(signer.transport).toBe("mock-transport");
+    expect(signer.account).toBeDefined();
+    expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
+    expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
+  });
 
-	it("should create a wallet client for avalanche-fuji network with private key", () => {
-		const signer = createSigner("avalanche-fuji", mockPrivateKey);
+  it("should create a wallet client for avalanche-fuji network with private key", () => {
+    const signer = createSigner("avalanche-fuji", mockPrivateKey);
 
-		expect(signer.chain).toEqual(avalancheFuji);
-		expect(signer.transport).toBe("mock-transport");
-		expect(signer.account).toBeDefined();
-		expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
-		expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
-	});
+    expect(signer.chain).toEqual(avalancheFuji);
+    expect(signer.transport).toBe("mock-transport");
+    expect(signer.account).toBeDefined();
+    expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
+    expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
+  });
 
-	it("should create a wallet client for skale-base-sepolia network with private key", () => {
-		const signer = createSigner("skale-base-sepolia", mockPrivateKey);
+  it("should create a wallet client for skale-base-sepolia network with private key", () => {
+    const signer = createSigner("skale-base-sepolia", mockPrivateKey);
 
-		expect(signer.chain).toEqual(skaleBaseSepolia);
-		expect(signer.transport).toBe("mock-transport");
-		expect(signer.account).toBeDefined();
-		expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
-		expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
-	});
+    expect(signer.chain).toEqual(skaleBaseSepolia);
+    expect(signer.transport).toBe("mock-transport");
+    expect(signer.account).toBeDefined();
+    expect(signer.account.address).toBe("0x1234567890123456789012345678901234567890");
+    expect(privateKeyToAccount).toHaveBeenCalledWith(mockPrivateKey);
+  });
 
-	it("should throw an error for unsupported network", () => {
-		expect(() => createSigner("unsupported-network", mockPrivateKey)).toThrow(
-			"Unsupported network: unsupported-network",
-		);
-	});
+  it("should throw an error for unsupported network", () => {
+    expect(() => createSigner("unsupported-network", mockPrivateKey)).toThrow(
+      "Unsupported network: unsupported-network",
+    );
+  });
 
-	it("should throw an error for empty network", () => {
-		expect(() => createSigner("", mockPrivateKey)).toThrow(
-			"NETWORK environment variable is not set",
-		);
-	});
+  it("should throw an error for empty network", () => {
+    expect(() => createSigner("", mockPrivateKey)).toThrow(
+      "NETWORK environment variable is not set",
+    );
+  });
 
-	it("should throw an error for undefined network", () => {
-		expect(() => createSigner(undefined as unknown as string, mockPrivateKey)).toThrow(
-			"NETWORK environment variable is not set",
-		);
-	});
+  it("should throw an error for undefined network", () => {
+    expect(() => createSigner(undefined as unknown as string, mockPrivateKey)).toThrow(
+      "NETWORK environment variable is not set",
+    );
+  });
 
-	it("should handle different private key formats", () => {
-		const differentPrivateKey =
-			"0xabcdef1234567890123456789012345678901234567890123456789012345678" as const;
-		const signer = createSigner("base", differentPrivateKey);
+  it("should handle different private key formats", () => {
+    const differentPrivateKey =
+      "0xabcdef1234567890123456789012345678901234567890123456789012345678" as const;
+    const signer = createSigner("base", differentPrivateKey);
 
-		expect(privateKeyToAccount).toHaveBeenCalledWith(differentPrivateKey);
-		expect(signer.account).toBeDefined();
-	});
+    expect(privateKeyToAccount).toHaveBeenCalledWith(differentPrivateKey);
+    expect(signer.account).toBeDefined();
+  });
 
-	it("should create unique signers for the same network with different private keys", () => {
-		const privateKey1 =
-			"0x1111111111111111111111111111111111111111111111111111111111111111" as const;
-		const privateKey2 =
-			"0x2222222222222222222222222222222222222222222222222222222222222222" as const;
+  it("should create unique signers for the same network with different private keys", () => {
+    const privateKey1 =
+      "0x1111111111111111111111111111111111111111111111111111111111111111" as const;
+    const privateKey2 =
+      "0x2222222222222222222222222222222222222222222222222222222222222222" as const;
 
-		const signer1 = createSigner("base", privateKey1);
-		const signer2 = createSigner("base", privateKey2);
+    const signer1 = createSigner("base", privateKey1);
+    const signer2 = createSigner("base", privateKey2);
 
-		expect(signer1.account).toBeDefined();
-		expect(signer2.account).toBeDefined();
-		expect(privateKeyToAccount).toHaveBeenCalledWith(privateKey1);
-		expect(privateKeyToAccount).toHaveBeenCalledWith(privateKey2);
-	});
+    expect(signer1.account).toBeDefined();
+    expect(signer2.account).toBeDefined();
+    expect(privateKeyToAccount).toHaveBeenCalledWith(privateKey1);
+    expect(privateKeyToAccount).toHaveBeenCalledWith(privateKey2);
+  });
 
-	it("should extend wallet client with eip712WalletActions for ZK stack chains", () => {
-		mockExtend.mockClear();
-		mockEip712WalletActionsFn.mockClear();
+  it("should extend wallet client with eip712WalletActions for ZK stack chains", () => {
+    mockExtend.mockClear();
+    mockEip712WalletActionsFn.mockClear();
 
-		const signer = createSigner("abstract", mockPrivateKey);
+    const signer = createSigner("abstract", mockPrivateKey);
 
-		// Should call eip712WalletActions for ZK Stack chains
-		expect(mockEip712WalletActionsFn).toHaveBeenCalledTimes(1);
-		expect(mockExtend).toHaveBeenCalledTimes(2);
-		expect(signer.chain).toEqual(abstract);
-		expect(signer.account).toBeDefined();
-	});
+    // Should call eip712WalletActions for ZK Stack chains
+    expect(mockEip712WalletActionsFn).toHaveBeenCalledTimes(1);
+    expect(mockExtend).toHaveBeenCalledTimes(2);
+    expect(signer.chain).toEqual(abstract);
+    expect(signer.account).toBeDefined();
+  });
 
-	it("should NOT extend with eip712WalletActions for non ZK stack chains", () => {
-		mockExtend.mockClear();
-		mockEip712WalletActionsFn.mockClear();
+  it("should NOT extend with eip712WalletActions for non ZK stack chains", () => {
+    mockExtend.mockClear();
+    mockEip712WalletActionsFn.mockClear();
 
-		const signer = createSigner("base", mockPrivateKey);
+    const signer = createSigner("base", mockPrivateKey);
 
-		// Should only call extend once for publicActions on non-ZK Stack chains
-		expect(mockEip712WalletActionsFn).toHaveBeenCalledTimes(0);
-		expect(mockExtend).toHaveBeenCalledTimes(1);
-		expect(signer.chain).toEqual(base);
-		expect(signer.account).toBeDefined();
-	});
+    // Should only call extend once for publicActions on non-ZK Stack chains
+    expect(mockEip712WalletActionsFn).toHaveBeenCalledTimes(0);
+    expect(mockExtend).toHaveBeenCalledTimes(1);
+    expect(signer.chain).toEqual(base);
+    expect(signer.account).toBeDefined();
+  });
 });

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -1,30 +1,30 @@
 import { createPublicClient, createWalletClient, http, publicActions } from "viem";
 import type {
-	Chain,
-	Transport,
-	Client,
-	Account,
-	RpcSchema,
-	PublicActions,
-	WalletActions,
-	PublicClient,
-	LocalAccount,
+  Chain,
+  Transport,
+  Client,
+  Account,
+  RpcSchema,
+  PublicActions,
+  WalletActions,
+  PublicClient,
+  LocalAccount,
 } from "viem";
 import {
-	baseSepolia,
-	avalancheFuji,
-	base,
-	sei,
-	seiTestnet,
-	polygon,
-	polygonAmoy,
-	peaq,
-	avalanche,
-	iotexTestnet,
-	iotex,
-	abstract,
-	abstractTestnet,
-	story,
+  baseSepolia,
+  avalancheFuji,
+  base,
+  sei,
+  seiTestnet,
+  polygon,
+  polygonAmoy,
+  peaq,
+  avalanche,
+  iotexTestnet,
+  iotex,
+  abstract,
+  abstractTestnet,
+  story,
 } from "viem/chains";
 import { skaleBaseSepolia } from "../custom-chains";
 import { privateKeyToAccount } from "viem/accounts";
@@ -33,21 +33,21 @@ import { eip712WalletActions } from "viem/zksync";
 
 // Create a public client for reading data
 export type SignerWallet<
-	chain extends Chain = Chain,
-	transport extends Transport = Transport,
-	account extends Account = Account,
+  chain extends Chain = Chain,
+  transport extends Transport = Transport,
+  account extends Account = Account,
 > = Client<
-	transport,
-	chain,
-	account,
-	RpcSchema,
-	PublicActions<transport, chain, account> & WalletActions<chain, account>
+  transport,
+  chain,
+  account,
+  RpcSchema,
+  PublicActions<transport, chain, account> & WalletActions<chain, account>
 >;
 
 export type ConnectedClient<
-	transport extends Transport = Transport,
-	chain extends Chain | undefined = Chain,
-	account extends Account | undefined = undefined,
+  transport extends Transport = Transport,
+  chain extends Chain | undefined = Chain,
+  account extends Account | undefined = undefined,
 > = PublicClient<transport, chain, account>;
 
 export type EvmSigner = SignerWallet<Chain, Transport, Account> | LocalAccount;
@@ -59,14 +59,14 @@ export type EvmSigner = SignerWallet<Chain, Transport, Account> | LocalAccount;
  * @returns A public client instance connected to the specified chain
  */
 export function createConnectedClient(
-	network: string,
+  network: string,
 ): ConnectedClient<Transport, Chain, undefined> {
-	const chain = getChainFromNetwork(network);
+  const chain = getChainFromNetwork(network);
 
-	return createPublicClient({
-		chain,
-		transport: http(),
-	}).extend(publicActions);
+  return createPublicClient({
+    chain,
+    transport: http(),
+  }).extend(publicActions);
 }
 
 /**
@@ -76,11 +76,11 @@ export function createConnectedClient(
  * @returns A public client instance connected to Base Sepolia
  */
 export function createClientSepolia(): ConnectedClient<Transport, typeof baseSepolia, undefined> {
-	return createConnectedClient("base-sepolia") as ConnectedClient<
-		Transport,
-		typeof baseSepolia,
-		undefined
-	>;
+  return createConnectedClient("base-sepolia") as ConnectedClient<
+    Transport,
+    typeof baseSepolia,
+    undefined
+  >;
 }
 
 /**
@@ -90,15 +90,15 @@ export function createClientSepolia(): ConnectedClient<Transport, typeof baseSep
  * @returns A public client instance connected to Avalanche Fuji
  */
 export function createClientAvalancheFuji(): ConnectedClient<
-	Transport,
-	typeof avalancheFuji,
-	undefined
+  Transport,
+  typeof avalancheFuji,
+  undefined
 > {
-	return createConnectedClient("avalanche-fuji") as ConnectedClient<
-		Transport,
-		typeof avalancheFuji,
-		undefined
-	>;
+  return createConnectedClient("avalanche-fuji") as ConnectedClient<
+    Transport,
+    typeof avalancheFuji,
+    undefined
+  >;
 }
 
 /**
@@ -109,19 +109,19 @@ export function createClientAvalancheFuji(): ConnectedClient<
  * @returns A wallet client instance connected to the specified chain with the provided private key
  */
 export function createSigner(network: string, privateKey: Hex): SignerWallet<Chain> {
-	const chain = getChainFromNetwork(network);
+  const chain = getChainFromNetwork(network);
 
-	const walletClient = createWalletClient({
-		chain,
-		transport: http(),
-		account: privateKeyToAccount(privateKey),
-	});
+  const walletClient = createWalletClient({
+    chain,
+    transport: http(),
+    account: privateKeyToAccount(privateKey),
+  });
 
-	if (isZkStackChain(chain)) {
-		return walletClient.extend(publicActions).extend(eip712WalletActions());
-	}
+  if (isZkStackChain(chain)) {
+    return walletClient.extend(publicActions).extend(eip712WalletActions());
+  }
 
-	return walletClient.extend(publicActions);
+  return walletClient.extend(publicActions);
 }
 
 /**
@@ -132,7 +132,7 @@ export function createSigner(network: string, privateKey: Hex): SignerWallet<Cha
  * @returns A wallet client instance connected to Base Sepolia with the provided private key
  */
 export function createSignerSepolia(privateKey: Hex): SignerWallet<typeof baseSepolia> {
-	return createSigner("base-sepolia", privateKey) as SignerWallet<typeof baseSepolia>;
+  return createSigner("base-sepolia", privateKey) as SignerWallet<typeof baseSepolia>;
 }
 
 /**
@@ -143,7 +143,7 @@ export function createSignerSepolia(privateKey: Hex): SignerWallet<typeof baseSe
  * @returns A wallet client instance connected to Avalanche Fuji with the provided private key
  */
 export function createSignerAvalancheFuji(privateKey: Hex): SignerWallet<typeof avalancheFuji> {
-	return createSigner("avalanche-fuji", privateKey) as SignerWallet<typeof avalancheFuji>;
+  return createSigner("avalanche-fuji", privateKey) as SignerWallet<typeof avalancheFuji>;
 }
 
 /**
@@ -153,15 +153,15 @@ export function createSignerAvalancheFuji(privateKey: Hex): SignerWallet<typeof 
  * @returns True if the wallet is a signer wallet, false otherwise
  */
 export function isSignerWallet<
-	TChain extends Chain = Chain,
-	TTransport extends Transport = Transport,
-	TAccount extends Account = Account,
+  TChain extends Chain = Chain,
+  TTransport extends Transport = Transport,
+  TAccount extends Account = Account,
 >(
-	wallet: SignerWallet<TChain, TTransport, TAccount> | LocalAccount,
+  wallet: SignerWallet<TChain, TTransport, TAccount> | LocalAccount,
 ): wallet is SignerWallet<TChain, TTransport, TAccount> {
-	return (
-		typeof wallet === "object" && wallet !== null && "chain" in wallet && "transport" in wallet
-	);
+  return (
+    typeof wallet === "object" && wallet !== null && "chain" in wallet && "transport" in wallet
+  );
 }
 
 /**
@@ -171,23 +171,23 @@ export function isSignerWallet<
  * @returns True if the wallet is an account, false otherwise
  */
 export function isAccount<
-	TChain extends Chain = Chain,
-	TTransport extends Transport = Transport,
-	TAccount extends Account = Account,
+  TChain extends Chain = Chain,
+  TTransport extends Transport = Transport,
+  TAccount extends Account = Account,
 >(wallet: SignerWallet<TChain, TTransport, TAccount> | LocalAccount): wallet is LocalAccount {
-	const w = wallet as LocalAccount;
-	return (
-		typeof wallet === "object" &&
-		wallet !== null &&
-		typeof w.address === "string" &&
-		typeof w.type === "string" &&
-		// Check for essential signing capabilities
-		typeof w.sign === "function" &&
-		typeof w.signMessage === "function" &&
-		typeof w.signTypedData === "function" &&
-		// Check for transaction signing (required by LocalAccount)
-		typeof w.signTransaction === "function"
-	);
+  const w = wallet as LocalAccount;
+  return (
+    typeof wallet === "object" &&
+    wallet !== null &&
+    typeof w.address === "string" &&
+    typeof w.type === "string" &&
+    // Check for essential signing capabilities
+    typeof w.sign === "function" &&
+    typeof w.signMessage === "function" &&
+    typeof w.signTypedData === "function" &&
+    // Check for transaction signing (required by LocalAccount)
+    typeof w.signTransaction === "function"
+  );
 }
 
 /**
@@ -197,49 +197,49 @@ export function isAccount<
  * @returns The corresponding Chain object
  */
 export function getChainFromNetwork(network: string | undefined): Chain {
-	if (!network) {
-		throw new Error("NETWORK environment variable is not set");
-	}
+  if (!network) {
+    throw new Error("NETWORK environment variable is not set");
+  }
 
-	switch (network) {
-		case "abstract":
-			return abstract;
-		case "abstract-testnet":
-			return abstractTestnet;
-		case "base":
-			return base;
-		case "base-sepolia":
-			return baseSepolia;
-		case "avalanche":
-			return avalanche;
-		case "avalanche-fuji":
-			return avalancheFuji;
-		case "sei":
-			return sei;
-		case "sei-testnet":
-			return seiTestnet;
-		case "polygon":
-			return polygon;
-		case "polygon-amoy":
-			return polygonAmoy;
-		case "peaq":
-			return peaq;
-		case "story":
-			return story;
-		case "iotex":
-			return iotex;
-		case "iotex-testnet":
-			return iotexTestnet;
-		case "skale-base-sepolia":
-			return skaleBaseSepolia;
-		default:
-			throw new Error(`Unsupported network: ${network}`);
-	}
+  switch (network) {
+    case "abstract":
+      return abstract;
+    case "abstract-testnet":
+      return abstractTestnet;
+    case "base":
+      return base;
+    case "base-sepolia":
+      return baseSepolia;
+    case "avalanche":
+      return avalanche;
+    case "avalanche-fuji":
+      return avalancheFuji;
+    case "sei":
+      return sei;
+    case "sei-testnet":
+      return seiTestnet;
+    case "polygon":
+      return polygon;
+    case "polygon-amoy":
+      return polygonAmoy;
+    case "peaq":
+      return peaq;
+    case "story":
+      return story;
+    case "iotex":
+      return iotex;
+    case "iotex-testnet":
+      return iotexTestnet;
+    case "skale-base-sepolia":
+      return skaleBaseSepolia;
+    default:
+      throw new Error(`Unsupported network: ${network}`);
+  }
 }
 
 const ZKSTACK_CHAIN_IDS = new Set([
-	2741, // Abstract Mainnet
-	11124, // Abstract Sepolia Testnet
+  2741, // Abstract Mainnet
+  11124, // Abstract Sepolia Testnet
 ]);
 
 /**
@@ -249,5 +249,5 @@ const ZKSTACK_CHAIN_IDS = new Set([
  * @returns True if the chain is a ZK stack chain
  */
 export function isZkStackChain(chain: Chain): boolean {
-	return ZKSTACK_CHAIN_IDS.has(chain.id);
+  return ZKSTACK_CHAIN_IDS.has(chain.id);
 }

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -1,52 +1,53 @@
 import { createPublicClient, createWalletClient, http, publicActions } from "viem";
 import type {
-  Chain,
-  Transport,
-  Client,
-  Account,
-  RpcSchema,
-  PublicActions,
-  WalletActions,
-  PublicClient,
-  LocalAccount,
+	Chain,
+	Transport,
+	Client,
+	Account,
+	RpcSchema,
+	PublicActions,
+	WalletActions,
+	PublicClient,
+	LocalAccount,
 } from "viem";
 import {
-  baseSepolia,
-  avalancheFuji,
-  base,
-  sei,
-  seiTestnet,
-  polygon,
-  polygonAmoy,
-  peaq,
-  avalanche,
-  iotexTestnet,
-  iotex,
-  abstract,
-  abstractTestnet,
-  story,
+	baseSepolia,
+	avalancheFuji,
+	base,
+	sei,
+	seiTestnet,
+	polygon,
+	polygonAmoy,
+	peaq,
+	avalanche,
+	iotexTestnet,
+	iotex,
+	abstract,
+	abstractTestnet,
+	story,
 } from "viem/chains";
+import { skaleBaseSepolia } from "../custom-chains";
 import { privateKeyToAccount } from "viem/accounts";
 import { Hex } from "viem";
 import { eip712WalletActions } from "viem/zksync";
 
 // Create a public client for reading data
 export type SignerWallet<
-  chain extends Chain = Chain,
-  transport extends Transport = Transport,
-  account extends Account = Account,
+	chain extends Chain = Chain,
+	transport extends Transport = Transport,
+	account extends Account = Account,
 > = Client<
-  transport,
-  chain,
-  account,
-  RpcSchema,
-  PublicActions<transport, chain, account> & WalletActions<chain, account>
+	transport,
+	chain,
+	account,
+	RpcSchema,
+	PublicActions<transport, chain, account> & WalletActions<chain, account>
 >;
 
 export type ConnectedClient<
-  transport extends Transport = Transport,
-  chain extends Chain | undefined = Chain,
-  account extends Account | undefined = undefined,
+	transport extends Transport = Transport,
+	chain extends Chain | undefined = Chain,
+	account extends Account | undefined = undefined,
 > = PublicClient<transport, chain, account>;
 
 export type EvmSigner = SignerWallet<Chain, Transport, Account> | LocalAccount;
@@ -58,14 +59,14 @@ export type EvmSigner = SignerWallet<Chain, Transport, Account> | LocalAccount;
  * @returns A public client instance connected to the specified chain
  */
 export function createConnectedClient(
-  network: string,
+	network: string,
 ): ConnectedClient<Transport, Chain, undefined> {
-  const chain = getChainFromNetwork(network);
+	const chain = getChainFromNetwork(network);
 
-  return createPublicClient({
-    chain,
-    transport: http(),
-  }).extend(publicActions);
+	return createPublicClient({
+		chain,
+		transport: http(),
+	}).extend(publicActions);
 }
 
 /**
@@ -75,11 +76,11 @@ export function createConnectedClient(
  * @returns A public client instance connected to Base Sepolia
  */
 export function createClientSepolia(): ConnectedClient<Transport, typeof baseSepolia, undefined> {
-  return createConnectedClient("base-sepolia") as ConnectedClient<
-    Transport,
-    typeof baseSepolia,
-    undefined
-  >;
+	return createConnectedClient("base-sepolia") as ConnectedClient<
+		Transport,
+		typeof baseSepolia,
+		undefined
+	>;
 }
 
 /**
@@ -89,15 +90,15 @@ export function createClientSepolia(): ConnectedClient<Transport, typeof baseSep
  * @returns A public client instance connected to Avalanche Fuji
  */
 export function createClientAvalancheFuji(): ConnectedClient<
-  Transport,
-  typeof avalancheFuji,
-  undefined
+	Transport,
+	typeof avalancheFuji,
+	undefined
 > {
-  return createConnectedClient("avalanche-fuji") as ConnectedClient<
-    Transport,
-    typeof avalancheFuji,
-    undefined
-  >;
+	return createConnectedClient("avalanche-fuji") as ConnectedClient<
+		Transport,
+		typeof avalancheFuji,
+		undefined
+	>;
 }
 
 /**
@@ -108,19 +109,19 @@ export function createClientAvalancheFuji(): ConnectedClient<
  * @returns A wallet client instance connected to the specified chain with the provided private key
  */
 export function createSigner(network: string, privateKey: Hex): SignerWallet<Chain> {
-  const chain = getChainFromNetwork(network);
+	const chain = getChainFromNetwork(network);
 
-  const walletClient = createWalletClient({
-    chain,
-    transport: http(),
-    account: privateKeyToAccount(privateKey),
-  });
+	const walletClient = createWalletClient({
+		chain,
+		transport: http(),
+		account: privateKeyToAccount(privateKey),
+	});
 
-  if (isZkStackChain(chain)) {
-    return walletClient.extend(publicActions).extend(eip712WalletActions());
-  }
+	if (isZkStackChain(chain)) {
+		return walletClient.extend(publicActions).extend(eip712WalletActions());
+	}
 
-  return walletClient.extend(publicActions);
+	return walletClient.extend(publicActions);
 }
 
 /**
@@ -131,7 +132,7 @@ export function createSigner(network: string, privateKey: Hex): SignerWallet<Cha
  * @returns A wallet client instance connected to Base Sepolia with the provided private key
  */
 export function createSignerSepolia(privateKey: Hex): SignerWallet<typeof baseSepolia> {
-  return createSigner("base-sepolia", privateKey) as SignerWallet<typeof baseSepolia>;
+	return createSigner("base-sepolia", privateKey) as SignerWallet<typeof baseSepolia>;
 }
 
 /**
@@ -142,7 +143,7 @@ export function createSignerSepolia(privateKey: Hex): SignerWallet<typeof baseSe
  * @returns A wallet client instance connected to Avalanche Fuji with the provided private key
  */
 export function createSignerAvalancheFuji(privateKey: Hex): SignerWallet<typeof avalancheFuji> {
-  return createSigner("avalanche-fuji", privateKey) as SignerWallet<typeof avalancheFuji>;
+	return createSigner("avalanche-fuji", privateKey) as SignerWallet<typeof avalancheFuji>;
 }
 
 /**
@@ -152,15 +153,15 @@ export function createSignerAvalancheFuji(privateKey: Hex): SignerWallet<typeof 
  * @returns True if the wallet is a signer wallet, false otherwise
  */
 export function isSignerWallet<
-  TChain extends Chain = Chain,
-  TTransport extends Transport = Transport,
-  TAccount extends Account = Account,
+	TChain extends Chain = Chain,
+	TTransport extends Transport = Transport,
+	TAccount extends Account = Account,
 >(
-  wallet: SignerWallet<TChain, TTransport, TAccount> | LocalAccount,
+	wallet: SignerWallet<TChain, TTransport, TAccount> | LocalAccount,
 ): wallet is SignerWallet<TChain, TTransport, TAccount> {
-  return (
-    typeof wallet === "object" && wallet !== null && "chain" in wallet && "transport" in wallet
-  );
+	return (
+		typeof wallet === "object" && wallet !== null && "chain" in wallet && "transport" in wallet
+	);
 }
 
 /**
@@ -170,23 +171,23 @@ export function isSignerWallet<
  * @returns True if the wallet is an account, false otherwise
  */
 export function isAccount<
-  TChain extends Chain = Chain,
-  TTransport extends Transport = Transport,
-  TAccount extends Account = Account,
+	TChain extends Chain = Chain,
+	TTransport extends Transport = Transport,
+	TAccount extends Account = Account,
 >(wallet: SignerWallet<TChain, TTransport, TAccount> | LocalAccount): wallet is LocalAccount {
-  const w = wallet as LocalAccount;
-  return (
-    typeof wallet === "object" &&
-    wallet !== null &&
-    typeof w.address === "string" &&
-    typeof w.type === "string" &&
-    // Check for essential signing capabilities
-    typeof w.sign === "function" &&
-    typeof w.signMessage === "function" &&
-    typeof w.signTypedData === "function" &&
-    // Check for transaction signing (required by LocalAccount)
-    typeof w.signTransaction === "function"
-  );
+	const w = wallet as LocalAccount;
+	return (
+		typeof wallet === "object" &&
+		wallet !== null &&
+		typeof w.address === "string" &&
+		typeof w.type === "string" &&
+		// Check for essential signing capabilities
+		typeof w.sign === "function" &&
+		typeof w.signMessage === "function" &&
+		typeof w.signTypedData === "function" &&
+		// Check for transaction signing (required by LocalAccount)
+		typeof w.signTransaction === "function"
+	);
 }
 
 /**
@@ -196,47 +197,49 @@ export function isAccount<
  * @returns The corresponding Chain object
  */
 export function getChainFromNetwork(network: string | undefined): Chain {
-  if (!network) {
-    throw new Error("NETWORK environment variable is not set");
-  }
+	if (!network) {
+		throw new Error("NETWORK environment variable is not set");
+	}
 
-  switch (network) {
-    case "abstract":
-      return abstract;
-    case "abstract-testnet":
-      return abstractTestnet;
-    case "base":
-      return base;
-    case "base-sepolia":
-      return baseSepolia;
-    case "avalanche":
-      return avalanche;
-    case "avalanche-fuji":
-      return avalancheFuji;
-    case "sei":
-      return sei;
-    case "sei-testnet":
-      return seiTestnet;
-    case "polygon":
-      return polygon;
-    case "polygon-amoy":
-      return polygonAmoy;
-    case "peaq":
-      return peaq;
-    case "story":
-      return story;
-    case "iotex":
-      return iotex;
-    case "iotex-testnet":
-      return iotexTestnet;
-    default:
-      throw new Error(`Unsupported network: ${network}`);
-  }
+	switch (network) {
+		case "abstract":
+			return abstract;
+		case "abstract-testnet":
+			return abstractTestnet;
+		case "base":
+			return base;
+		case "base-sepolia":
+			return baseSepolia;
+		case "avalanche":
+			return avalanche;
+		case "avalanche-fuji":
+			return avalancheFuji;
+		case "sei":
+			return sei;
+		case "sei-testnet":
+			return seiTestnet;
+		case "polygon":
+			return polygon;
+		case "polygon-amoy":
+			return polygonAmoy;
+		case "peaq":
+			return peaq;
+		case "story":
+			return story;
+		case "iotex":
+			return iotex;
+		case "iotex-testnet":
+			return iotexTestnet;
+		case "skale-base-sepolia":
+			return skaleBaseSepolia;
+		default:
+			throw new Error(`Unsupported network: ${network}`);
+	}
 }
 
 const ZKSTACK_CHAIN_IDS = new Set([
-  2741, // Abstract Mainnet
-  11124, // Abstract Sepolia Testnet
+	2741, // Abstract Mainnet
+	11124, // Abstract Sepolia Testnet
 ]);
 
 /**
@@ -246,5 +249,5 @@ const ZKSTACK_CHAIN_IDS = new Set([
  * @returns True if the chain is a ZK stack chain
  */
 export function isZkStackChain(chain: Chain): boolean {
-  return ZKSTACK_CHAIN_IDS.has(chain.id);
+	return ZKSTACK_CHAIN_IDS.has(chain.id);
 }

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -1,69 +1,69 @@
 import { z } from "zod";
 
 export const NetworkSchema = z.enum([
-	"abstract",
-	"abstract-testnet",
-	"base-sepolia",
-	"base",
-	"avalanche-fuji",
-	"avalanche",
-	"iotex",
-	"solana-devnet",
-	"solana",
-	"sei",
-	"sei-testnet",
-	"polygon",
-	"polygon-amoy",
-	"peaq",
-	"story",
-	"skale-base-sepolia"
+  "abstract",
+  "abstract-testnet",
+  "base-sepolia",
+  "base",
+  "avalanche-fuji",
+  "avalanche",
+  "iotex",
+  "solana-devnet",
+  "solana",
+  "sei",
+  "sei-testnet",
+  "polygon",
+  "polygon-amoy",
+  "peaq",
+  "story",
+  "skale-base-sepolia",
 ]);
 export type Network = z.infer<typeof NetworkSchema>;
 
 // evm
 export const SupportedEVMNetworks: Network[] = [
-	"abstract",
-	"abstract-testnet",
-	"base-sepolia",
-	"base",
-	"avalanche-fuji",
-	"avalanche",
-	"iotex",
-	"sei",
-	"sei-testnet",
-	"polygon",
-	"polygon-amoy",
-	"peaq",
-	"story",
-	"skale-base-sepolia"
+  "abstract",
+  "abstract-testnet",
+  "base-sepolia",
+  "base",
+  "avalanche-fuji",
+  "avalanche",
+  "iotex",
+  "sei",
+  "sei-testnet",
+  "polygon",
+  "polygon-amoy",
+  "peaq",
+  "story",
+  "skale-base-sepolia",
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
-	["abstract", 2741],
-	["abstract-testnet", 11124],
-	["base-sepolia", 84532],
-	["base", 8453],
-	["avalanche-fuji", 43113],
-	["avalanche", 43114],
-	["iotex", 4689],
-	["sei", 1329],
-	["sei-testnet", 1328],
-	["polygon", 137],
-	["polygon-amoy", 80002],
-	["peaq", 3338],
-	["story", 1514],
-	["skale-base-sepolia", 324705682]
+  ["abstract", 2741],
+  ["abstract-testnet", 11124],
+  ["base-sepolia", 84532],
+  ["base", 8453],
+  ["avalanche-fuji", 43113],
+  ["avalanche", 43114],
+  ["iotex", 4689],
+  ["sei", 1329],
+  ["sei-testnet", 1328],
+  ["polygon", 137],
+  ["polygon-amoy", 80002],
+  ["peaq", 3338],
+  ["story", 1514],
+  ["skale-base-sepolia", 324705682],
 ]);
 
 // svm
 export const SupportedSVMNetworks: Network[] = ["solana-devnet", "solana"];
 export const SvmNetworkToChainId = new Map<Network, number>([
-	["solana-devnet", 103],
-	["solana", 101],
+  ["solana-devnet", 103],
+  ["solana", 101],
 ]);
 
 export const ChainIdToNetwork = Object.fromEntries(
-	[...SupportedEVMNetworks, ...SupportedSVMNetworks].map(network => [
-		EvmNetworkToChainId.get(network),
-		network,
-	]),
+  [...SupportedEVMNetworks, ...SupportedSVMNetworks].map(network => [
+    EvmNetworkToChainId.get(network),
+    network,
+  ]),
 ) as Record<number, Network>;

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -1,66 +1,69 @@
 import { z } from "zod";
 
 export const NetworkSchema = z.enum([
-  "abstract",
-  "abstract-testnet",
-  "base-sepolia",
-  "base",
-  "avalanche-fuji",
-  "avalanche",
-  "iotex",
-  "solana-devnet",
-  "solana",
-  "sei",
-  "sei-testnet",
-  "polygon",
-  "polygon-amoy",
-  "peaq",
-  "story",
+	"abstract",
+	"abstract-testnet",
+	"base-sepolia",
+	"base",
+	"avalanche-fuji",
+	"avalanche",
+	"iotex",
+	"solana-devnet",
+	"solana",
+	"sei",
+	"sei-testnet",
+	"polygon",
+	"polygon-amoy",
+	"peaq",
+	"story",
+	"skale-base-sepolia"
 ]);
 export type Network = z.infer<typeof NetworkSchema>;
 
 // evm
 export const SupportedEVMNetworks: Network[] = [
-  "abstract",
-  "abstract-testnet",
-  "base-sepolia",
-  "base",
-  "avalanche-fuji",
-  "avalanche",
-  "iotex",
-  "sei",
-  "sei-testnet",
-  "polygon",
-  "polygon-amoy",
-  "peaq",
-  "story",
+	"abstract",
+	"abstract-testnet",
+	"base-sepolia",
+	"base",
+	"avalanche-fuji",
+	"avalanche",
+	"iotex",
+	"sei",
+	"sei-testnet",
+	"polygon",
+	"polygon-amoy",
+	"peaq",
+	"story",
+	"skale-base-sepolia"
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
-  ["abstract", 2741],
-  ["abstract-testnet", 11124],
-  ["base-sepolia", 84532],
-  ["base", 8453],
-  ["avalanche-fuji", 43113],
-  ["avalanche", 43114],
-  ["iotex", 4689],
-  ["sei", 1329],
-  ["sei-testnet", 1328],
-  ["polygon", 137],
-  ["polygon-amoy", 80002],
-  ["peaq", 3338],
-  ["story", 1514],
+	["abstract", 2741],
+	["abstract-testnet", 11124],
+	["base-sepolia", 84532],
+	["base", 8453],
+	["avalanche-fuji", 43113],
+	["avalanche", 43114],
+	["iotex", 4689],
+	["sei", 1329],
+	["sei-testnet", 1328],
+	["polygon", 137],
+	["polygon-amoy", 80002],
+	["peaq", 3338],
+	["story", 1514],
+	["skale-base-sepolia", 324705682]
 ]);
 
 // svm
 export const SupportedSVMNetworks: Network[] = ["solana-devnet", "solana"];
 export const SvmNetworkToChainId = new Map<Network, number>([
-  ["solana-devnet", 103],
-  ["solana", 101],
+	["solana-devnet", 103],
+	["solana", 101],
 ]);
 
 export const ChainIdToNetwork = Object.fromEntries(
-  [...SupportedEVMNetworks, ...SupportedSVMNetworks].map(network => [
-    EvmNetworkToChainId.get(network),
-    network,
-  ]),
+	[...SupportedEVMNetworks, ...SupportedSVMNetworks].map(network => [
+		EvmNetworkToChainId.get(network),
+		network,
+	]),
 ) as Record<number, Network>;


### PR DESCRIPTION
## Description

This adds official support to the x402 Typescript SDK to add support for SKALE Base Sepolia Testnet.
This is critical as networks not added explicitly are not supported by the package today blocking our developers.

## Tests

For TypeScript: Run `pnpm test` from the `/typescript` directory
Proof of Success: https://app.warp.dev/block/AcHKwkqGF7WR7xGD5mbHtG

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits