### PR TITLE
fix: clarify facilitator create_headers async contract

### DIFF
--- a/python/x402/src/x402/facilitator.py
+++ b/python/x402/src/x402/facilitator.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Awaitable, Callable, Optional
 from typing_extensions import (
     TypedDict,
 )  # use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12
@@ -18,11 +18,11 @@ class FacilitatorConfig(TypedDict, total=False):
 
     Attributes:
         url: The base URL for the facilitator service
-        create_headers: Optional function to create authentication headers
+        create_headers: Optional async function to create authentication headers
     """
 
     url: str
-    create_headers: Callable[[], dict[str, dict[str, str]]]
+    create_headers: Callable[[], Awaitable[dict[str, dict[str, str]]]]
 
 
 class FacilitatorClient:


### PR DESCRIPTION
The docs claimed create_headers could be a plain function, but the client always awaits it, leading to runtime errors for sync callbacks. I updated the docstring and type so it clearly requires an async callable returning the headers.