### PR TITLE
Refactor SVM client and verification logic to remove create ATA instruction

### DIFF
--- a/typescript/packages/x402/src/schemes/exact/svm/client.test.ts
+++ b/typescript/packages/x402/src/schemes/exact/svm/client.test.ts
@@ -19,9 +19,6 @@ vi.mock("@solana-program/token-2022", async importOriginal => {
     ...actual,
     findAssociatedTokenPda: vi.fn(),
     getTransferCheckedInstruction: vi.fn().mockReturnValue({ instruction: "mock_transfer" }),
-    getCreateAssociatedTokenInstruction: vi
-      .fn()
-      .mockReturnValue({ instruction: "mock_create_ata" }),
     fetchMint: vi.fn(),
   };
 });
@@ -139,13 +136,12 @@ describe("SVM Client", () => {
       );
       const findAtaSpy = vi.spyOn(token2022, "findAssociatedTokenPda");
       const transferIxSpy = vi.spyOn(token2022, "getTransferCheckedInstruction");
-      const createAtaIxSpy = vi.spyOn(token2022, "getCreateAssociatedTokenInstruction");
 
       // Act
       await createAndSignPayment(clientSigner, 1, paymentRequirements);
 
       // Assert
-      expect(findAtaSpy).toHaveBeenCalledTimes(3); // once for sender, once for receiver, once for create ix
+      expect(findAtaSpy).toHaveBeenCalledTimes(2); // once for sender, once for receiver
       expect(findAtaSpy).toHaveBeenCalledWith({
         mint: paymentRequirements.asset,
         owner: clientSigner.address,
@@ -161,7 +157,6 @@ describe("SVM Client", () => {
         expect.any(Object),
         expect.objectContaining({ programAddress: token.TOKEN_PROGRAM_ADDRESS }),
       );
-      expect(createAtaIxSpy).not.toHaveBeenCalled(); // ATA already exists
     });
 
     it("should create and sign a payment for a token-2022 token", async () => {
@@ -176,13 +171,12 @@ describe("SVM Client", () => {
       } as any);
       const findAtaSpy = vi.spyOn(token2022, "findAssociatedTokenPda");
       const transferIxSpy = vi.spyOn(token2022, "getTransferCheckedInstruction");
-      const createAtaIxSpy = vi.spyOn(token2022, "getCreateAssociatedTokenInstruction");
 
       // Act
       await createAndSignPayment(clientSigner, 1, paymentRequirements);
 
       // Assert
-      expect(findAtaSpy).toHaveBeenCalledTimes(3);
+      expect(findAtaSpy).toHaveBeenCalledTimes(2);
       expect(findAtaSpy).toHaveBeenCalledWith({
         mint: paymentRequirements.asset,
         owner: clientSigner.address,
@@ -197,48 +191,6 @@ describe("SVM Client", () => {
       expect(transferIxSpy).toHaveBeenCalledWith(
         expect.any(Object),
         expect.objectContaining({ programAddress: token2022.TOKEN_2022_PROGRAM_ADDRESS }),
-      );
-      expect(createAtaIxSpy).not.toHaveBeenCalled();
-    });
-
-    it("should create ATA if it does not exist", async () => {
-      // Arrange
-      vi.spyOn(solanaKit, "fetchEncodedAccount").mockResolvedValue({ exists: false } as any);
-      const createAtaSpy = vi.spyOn(token2022, "getCreateAssociatedTokenInstruction");
-      const findAtaSpy = vi.spyOn(token2022, "findAssociatedTokenPda");
-      const appendIxSpy = vi.spyOn(solanaKit, "appendTransactionMessageInstructions");
-
-      // Act
-      await createAndSignPayment(clientSigner, 1, paymentRequirements);
-      // Assert
-      expect(findAtaSpy).toHaveBeenCalledTimes(3); // once for dest, once for src, once for create ix
-      expect(findAtaSpy).toHaveBeenCalledWith({
-        mint: paymentRequirements.asset,
-        owner: paymentRequirements.payTo,
-        tokenProgram: token.TOKEN_PROGRAM_ADDRESS,
-      });
-      expect(createAtaSpy).toHaveBeenCalledOnce();
-      expect(createAtaSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tokenProgram: token.TOKEN_PROGRAM_ADDRESS,
-        }),
-      );
-      expect(appendIxSpy).toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ instruction: "mock_create_ata" })]),
-        expect.any(Object),
-      );
-    });
-
-    it("should throw an error if feePayer is not provided when creating ATA", async () => {
-      // Arrange
-      vi.spyOn(solanaKit, "fetchEncodedAccount").mockResolvedValue({ exists: false } as any);
-      const paymentReqsWithoutFeePayer = { ...paymentRequirements, extra: {} };
-
-      // Act & Assert
-      await expect(
-        createAndSignPayment(clientSigner, 1, paymentReqsWithoutFeePayer),
-      ).rejects.toThrow(
-        "feePayer is required in paymentRequirements.extra in order to set the facilitator as the fee payer for the create associated token account instruction",
       );
     });
 

--- a/typescript/packages/x402/src/schemes/exact/svm/client.ts
+++ b/typescript/packages/x402/src/schemes/exact/svm/client.ts
@@ -151,7 +151,7 @@ async function createTransferInstructions(
   paymentRequirements: PaymentRequirements,
   config?: X402Config,
 ): Promise<Instruction[]> {
-  const { asset } = paymentRequirements;
+  const { asset, maxAmountRequired: amount, payTo } = paymentRequirements;
 
   const rpc = getRpcClient(paymentRequirements.network, config?.svmConfig?.rpcUrl);
   const tokenMint = await fetchMint(rpc, asset as Address);
@@ -164,8 +164,6 @@ async function createTransferInstructions(
   ) {
     throw new Error("Asset was not created by a known token program");
   }
-
-  const { maxAmountRequired: amount, payTo } = paymentRequirements;
 
   const [sourceATA] = await findAssociatedTokenPda({
     mint: asset as Address,

--- a/typescript/packages/x402/src/schemes/exact/svm/client.ts
+++ b/typescript/packages/x402/src/schemes/exact/svm/client.ts
@@ -9,7 +9,6 @@ import {
   partiallySignTransactionMessageWithSigners,
   prependTransactionMessageInstruction,
   getBase64EncodedWireTransaction,
-  fetchEncodedAccount,
   TransactionSigner,
   Instruction,
 } from "@solana/kit";
@@ -18,7 +17,6 @@ import { X402Config } from "../../../types/config";
 import {
   fetchMint,
   findAssociatedTokenPda,
-  getCreateAssociatedTokenInstruction,
   getTransferCheckedInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
 } from "@solana-program/token-2022";
@@ -104,7 +102,7 @@ async function createTransferTransactionMessage(
   const rpc = getRpcClient(paymentRequirements.network, config?.svmConfig?.rpcUrl);
 
   // create the transfer instruction
-  const transferInstructions = await createAtaAndTransferInstructions(
+  const transferInstructions = await createTransferInstructions(
     client,
     paymentRequirements,
     config,
@@ -146,9 +144,9 @@ async function createTransferTransactionMessage(
  * @param client - The signer instance used to create the transfer instruction
  * @param paymentRequirements - The payment requirements
  * @param config - Optional configuration for X402 operations (e.g., custom RPC URLs)
- * @returns A promise that resolves to the create ATA (if needed) and transfer instruction
+ * @returns A promise that resolves to the transfer instruction array
  */
-async function createAtaAndTransferInstructions(
+async function createTransferInstructions(
   client: TransactionSigner,
   paymentRequirements: PaymentRequirements,
   config?: X402Config,
@@ -167,104 +165,7 @@ async function createAtaAndTransferInstructions(
     throw new Error("Asset was not created by a known token program");
   }
 
-  const instructions: Instruction[] = [];
-
-  // create the ATA (if needed)
-  const createAtaIx = await createAtaInstructionOrUndefined(
-    paymentRequirements,
-    tokenProgramAddress,
-    config,
-  );
-  if (createAtaIx) {
-    instructions.push(createAtaIx);
-  }
-
-  // create the transfer instruction
-  const transferIx = await createTransferInstruction(
-    client,
-    paymentRequirements,
-    tokenMint.data.decimals,
-    tokenProgramAddress,
-  );
-  instructions.push(transferIx);
-
-  return instructions;
-}
-
-/**
- * Returns a create ATA instruction for the payTo address if the ATA account does not exist.
- * The create ATA instruction will be paid for by the feePayer in the payment requirements.
- *
- * This function will work for both spl-token and token-2022.
- *
- * Returns undefined if the ATA account already exists.
- *
- * @param paymentRequirements - The payment requirements
- * @param tokenProgramAddress - The address of the token program
- * @param config - Optional configuration for X402 operations (e.g., custom RPC URLs)
- * @returns A promise that resolves to the create ATA instruction or undefined if the ATA account already exists
- * @throws an error if the feePayer is not provided in the payment requirements
- */
-async function createAtaInstructionOrUndefined(
-  paymentRequirements: PaymentRequirements,
-  tokenProgramAddress: Address,
-  config?: X402Config,
-): Promise<Instruction | undefined> {
-  const { asset, payTo, extra } = paymentRequirements;
-  const feePayer = extra?.feePayer as Address;
-
-  // feePayer is required
-  if (!feePayer) {
-    throw new Error(
-      "feePayer is required in paymentRequirements.extra in order to set the " +
-        "facilitator as the fee payer for the create associated token account instruction",
-    );
-  }
-
-  // derive the ATA of the payTo address
-  const [destinationATAAddress] = await findAssociatedTokenPda({
-    mint: asset as Address,
-    owner: payTo as Address,
-    tokenProgram: tokenProgramAddress,
-  });
-
-  // check if the ATA exists
-  const rpc = getRpcClient(paymentRequirements.network, config?.svmConfig?.rpcUrl);
-  const maybeAccount = await fetchEncodedAccount(rpc, destinationATAAddress);
-
-  // if the ATA does not exist, return an instruction to create it
-  if (!maybeAccount.exists) {
-    return getCreateAssociatedTokenInstruction({
-      payer: paymentRequirements.extra?.feePayer as TransactionSigner<string>,
-      ata: destinationATAAddress,
-      owner: payTo as Address,
-      mint: asset as Address,
-      tokenProgram: tokenProgramAddress,
-    });
-  }
-
-  // if the ATA exists, return undefined
-  return undefined;
-}
-
-/**
- * Creates a transfer instruction for the given client and payment requirements.
- * This function will create a transfer instruction for a token created by either
- * the token program or the token-2022 program.
- *
- * @param client - The signer instance who's tokens will be debited from
- * @param paymentRequirements - The payment requirements
- * @param decimals - The decimals of the token
- * @param tokenProgramAddress - The address of the token program
- * @returns A promise that resolves to the transfer instruction
- */
-async function createTransferInstruction(
-  client: TransactionSigner,
-  paymentRequirements: PaymentRequirements,
-  decimals: number,
-  tokenProgramAddress: Address,
-): Promise<Instruction> {
-  const { asset, maxAmountRequired: amount, payTo } = paymentRequirements;
+  const { maxAmountRequired: amount, payTo } = paymentRequirements;
 
   const [sourceATA] = await findAssociatedTokenPda({
     mint: asset as Address,
@@ -278,15 +179,16 @@ async function createTransferInstruction(
     tokenProgram: tokenProgramAddress,
   });
 
-  return getTransferCheckedInstruction(
+  const transferIx = getTransferCheckedInstruction(
     {
       source: sourceATA,
       mint: asset as Address,
       destination: destinationATA,
       authority: client,
       amount: BigInt(amount),
-      decimals: decimals,
+      decimals: tokenMint.data.decimals,
     },
     { programAddress: tokenProgramAddress },
   );
+  return [transferIx];
 }


### PR DESCRIPTION
## Description

Refactor SVM client and verification logic to remove create ATA instruction handling

- Removed create associated token account (ATA) instruction logic from SVM client and tests.
- Updated transfer instruction handling to assume destination ATA exists.
- Adjusted verification functions to reflect changes in instruction expectations.
- Cleaned up related test cases to remove references to create ATA instructions.


## Tests

Updated existing tests.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
