### PR TITLE
feat(go): add BSC support and explicit network selection

### DIFF
--- a/go/bin/example_config.json
+++ b/go/bin/example_config.json
@@ -3,7 +3,7 @@
   "amount": 0.01,
   "payTo": "0x0000000000000000000000000000000000000000",
   "facilitatorURL": "https://x402.org/facilitator",
-  "testnet": true,
+  "network": "base-sepolia",
   "description": "Example paywall",
   "mimeType": "application/json",
   "maxTimeoutSeconds": 60,

--- a/go/bin/proxy_demo.go
+++ b/go/bin/proxy_demo.go
@@ -43,7 +43,7 @@ func main() {
 			config.PayTo,
 			x402gin.WithFacilitatorConfig(facilitatorConfig),
 			x402gin.WithResource(config.TargetURL),
-			x402gin.WithTestnet(config.Testnet),
+			x402gin.WithNetwork(config.Network),
 			x402gin.WithDescription(config.Description),
 			x402gin.WithMimeType(config.MimeType),
 			x402gin.WithMaxTimeoutSeconds(config.MaxTimeoutSeconds),
@@ -62,10 +62,10 @@ type ProxyConfig struct {
 	Amount            float64                                      `json:"amount"`
 	PayTo             string                                       `json:"payTo"`
 	Description       string                                       `json:"description"`
+	Network           string                                       `json:"network"`
 	FacilitatorURL    string                                       `json:"facilitatorURL"`
 	MimeType          string                                       `json:"mimeType"`
 	MaxTimeoutSeconds int                                          `json:"maxTimeoutSeconds"`
-	Testnet           bool                                         `json:"testnet"`
 	Headers           map[string]string                            `json:"headers"`
 	CreateAuthHeaders func() (map[string]map[string]string, error) `json:"-"`
 }
@@ -115,7 +115,6 @@ func loadConfig(configPath string) (*ProxyConfig, error) {
 	config := &ProxyConfig{
 		// default values
 		FacilitatorURL:    "https://x402.org/facilitator",
-		Testnet:           true,
 		MaxTimeoutSeconds: 60,
 	}
 
@@ -128,7 +127,7 @@ func loadConfig(configPath string) (*ProxyConfig, error) {
 		return nil, fmt.Errorf("error parsing config file: %w", err)
 	}
 
-	if config.TargetURL == "" || config.Amount == 0 || config.PayTo == "" {
+	if config.TargetURL == "" || config.Amount == 0 || config.PayTo == "" || config.Network == "" {
 		return nil, fmt.Errorf("config is missing required fields")
 	}
 

--- a/go/examples/mainnet/mainnet.go
+++ b/go/examples/mainnet/mainnet.go
@@ -46,7 +46,7 @@ func main() {
 			x402gin.WithFacilitatorConfig(facilitatorConfig),
 			x402gin.WithDescription("A premium programming joke"),
 			x402gin.WithResource("https://api.example.com/premium-joke"),
-			x402gin.WithTestnet(false), // Use mainnet!
+			x402gin.WithNetwork("base"),
 		),
 		func(c *gin.Context) {
 			c.JSON(200, gin.H{

--- a/go/pkg/types/types.go
+++ b/go/pkg/types/types.go
@@ -91,14 +91,10 @@ func DecodePaymentPayloadFromBase64(encoded string) (*PaymentPayload, error) {
 }
 
 // SetUSDCInfo sets the USDC token information in the Extra field of PaymentRequirements
-func (p *PaymentRequirements) SetUSDCInfo(isTestnet bool) error {
+func (p *PaymentRequirements) SetUSDCInfo(tokenName string) error {
 	usdcInfo := map[string]any{
-		"name":    "USDC",
+		"name":    tokenName,
 		"version": "2",
-	}
-
-	if !isTestnet {
-		usdcInfo["name"] = "USD Coin"
 	}
 
 	jsonBytes, err := json.Marshal(usdcInfo)


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

- add BSC mainnet/testnet metadata (USDC address, decimals, token name) to the Go middleware
- require callers to specify networks via `WithNetwork`, defaulting to base-sepolia when omitted
- update proxy demo, examples, and config to use the new network flow and run amounts through high-precision scaling

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 