### PR TITLE
Use the specification interface for transferWithAuthorization

### DIFF
--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -1,4 +1,13 @@
-import { Account, Address, Chain, getAddress, Hex, parseErc6492Signature, Transport } from "viem";
+import {
+  Account,
+  Address,
+  Chain,
+  getAddress,
+  Hex,
+  parseErc6492Signature,
+  parseSignature,
+  Transport,
+} from "viem";
 import { getNetworkId } from "../../../shared";
 import { getVersion, getERC20Balance } from "../../../shared/evm";
 import {
@@ -203,6 +212,7 @@ export async function settle<transport extends Transport, chain extends Chain>(
 
   // Returns the original signature (no-op) if the signature is not a 6492 signature
   const { signature } = parseErc6492Signature(payload.signature as Hex);
+  const parsedSig = parseSignature(signature);
 
   const tx = await wallet.writeContract({
     address: paymentRequirements.asset as Address,
@@ -215,7 +225,9 @@ export async function settle<transport extends Transport, chain extends Chain>(
       BigInt(payload.authorization.validAfter),
       BigInt(payload.authorization.validBefore),
       payload.authorization.nonce as Hex,
-      signature,
+      (parsedSig.v as number | undefined) || parsedSig.yParity,
+      parsedSig.r,
+      parsedSig.s,
     ],
     chain: wallet.chain as Chain,
   });


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

This PR changes the interface of `transferWithAuthorization` to follow the specification.

Currently, the following interface for transferWithAuthorization is used.

```
// 0xcf092995
function transferWithAuthorization(
    address from,
    address to,
    uint256 value,
    uint256 validAfter,
    uint256 validBefore,
    bytes32 nonce,
    bytes signature
) external;
```

But this isn't spec interface. The correct one is this:

```
// 0xe3ee160e
function transferWithAuthorization(
    address from,
    address to,
    uint256 value,
    uint256 validAfter,
    uint256 validBefore,
    bytes32 nonce,
    uint8 v,
    bytes32 r,
    bytes32 s
) external;
```

Other EIP-3009 tokens may not support the first interface (I found [JPYC](https://etherscan.io/address/0xE7C3D8C9a439feDe00D2600032D5dB0Be71C3c29#writeProxyContract)  doesn't support it.).

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 