### PR TITLE
Expose payer information in Hono

### DIFF
--- a/typescript/packages/x402-hono/src/index.test.ts
+++ b/typescript/packages/x402-hono/src/index.test.ts
@@ -857,6 +857,56 @@ describe("paymentMiddleware()", () => {
     expect(mockNext).toHaveBeenCalled();
   });
 
+  it("should expose payer information in context after successful verification", async () => {
+    const payerAddress = "0xPayerAddress123456789012345678901234567890";
+
+    (mockContext.req.header as ReturnType<typeof vi.fn>).mockImplementation((name: string) => {
+      if (name === "X-PAYMENT") return encodedValidPayment;
+      return undefined;
+    });
+
+    // Mock findMatchingPaymentRequirements to return a valid requirement
+    vi.mocked(findMatchingPaymentRequirements).mockReturnValue({
+      scheme: "exact",
+      network: "base-sepolia",
+      maxAmountRequired: "1000",
+      resource: "https://api.example.com/resource",
+      description: "Test payment",
+      mimeType: "application/json",
+      payTo: "0x1234567890123456789012345678901234567890",
+      maxTimeoutSeconds: 300,
+      asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      outputSchema: {
+        input: {
+          type: "http",
+          method: "GET",
+          queryParams: { type: "string" },
+        },
+        output: { type: "object" },
+      },
+      extra: {
+        name: "USDC",
+        version: "2",
+      },
+    });
+
+    // Mock verification to return valid with a payer address
+    (mockVerify as ReturnType<typeof vi.fn>).mockResolvedValue({
+      isValid: true,
+      payer: payerAddress,
+    });
+
+    // Add a set method mock to the context
+    const setSpy = vi.fn();
+    mockContext.set = setSpy;
+
+    await middleware(mockContext, mockNext);
+
+    // Verify that c.set was called with the payer information
+    expect(setSpy).toHaveBeenCalledWith("x402.payer", payerAddress);
+    expect(mockNext).toHaveBeenCalled();
+  });
+
   it("should return 402 if payment verification fails", async () => {
     const invalidPayment = "invalid-payment-header";
     (mockContext.req.header as ReturnType<typeof vi.fn>).mockImplementation((name: string) => {

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -283,6 +283,10 @@ export function paymentMiddleware(
       );
     }
 
+    if (verification.payer) {
+      c.set("x402.payer", verification.payer);
+    }
+
     // Proceed with request
     await next();
 


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

If a payment was valid, expose the payer information to the next middleware/handler in a Hono web application.

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

Added test "should expose payer information in context after successful verification".
<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 