### PR TITLE
feat: fix resourceUrl when hono server is behind reverse proxy

### DIFF
--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -110,7 +110,21 @@ export function paymentMiddleware(
     }
     const { maxAmountRequired, asset } = atomicAmountForAsset;
 
-    const resourceUrl: Resource = resource || (c.req.url as Resource);
+    let resourceUrl = resource;
+    if (!resourceUrl) {
+      const forwardedProto = c.req.header("X-Forwarded-Proto");
+      const forwardedHost = c.req.header("X-Forwarded-Host");
+
+      if (forwardedProto && forwardedHost) {
+        // Handle reverse proxy scenarios by reconstructing URL using forwarded headers from reverse proxy
+        const url = new URL(c.req.url);
+        resourceUrl =
+          `${forwardedProto}://${forwardedHost}${url.pathname}${url.search}` as Resource;
+      } else {
+        // Fall back to default behavior when not behind a reverse proxy
+        resourceUrl = c.req.url as Resource;
+      }
+    }
 
     let paymentRequirements: PaymentRequirements[] = [];
 


### PR DESCRIPTION
## Fix: Hono middleware now correctly handles reverse proxy environments

### Problem
When the Hono middleware was deployed behind reverse proxies (Vercel, Railway, etc.), the resource URL in payment requirements would incorrectly use `http://` instead of `https://`, causing discovery failures. This occurred because Hono servers behind reverse proxies operate in an HTTP context, and unlike Express or Next.js, Hono doesn't automatically handle reverse proxy environments.

### Root Cause
The middleware was directly using `c.req.url` to construct the resource URL. In reverse proxy environments, this URL reflects the internal HTTP connection between the proxy and the server, not the external HTTPS connection from the client to the proxy. The reverse proxy sets `X-Forwarded-Proto` and `X-Forwarded-Host` headers to indicate the original protocol and host, but the middleware wasn't checking for these headers.

Related Hono issue: https://github.com/honojs/node-server/issues/146

### Solution
The middleware now:
1. Checks for `X-Forwarded-Proto` and `X-Forwarded-Host` headers when no custom `resource` is configured
2. Reconstructs the resource URL using these forwarded headers if present, ensuring the correct protocol (https) and host
3. Falls back to the original behavior (`c.req.url`) when not behind a reverse proxy

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 