### PR TITLE
docs: fix incorrect path to Express server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ app.use(
   // How much you want to charge, and where you want the funds to land
   paymentMiddleware("0xYourAddress", { "/your-endpoint": "$0.01" })
 );
-// That's it! See examples/typescript/servers/express.ts for a complete example. Instruction below for running on base-sepolia.
+// That's it! See examples/typescript/servers/express/index.ts for a complete example. Instruction below for running on base-sepolia.
 ```
 
 ## Philosophy


### PR DESCRIPTION
Fixed reference to Express server example in main README.The comment incorrectly pointed to `examples/typescript/servers/express.ts`which doesn't exist. Updated to correct path: `examples/typescript/servers/express/index.ts`