### PR TITLE
Increase EvmMaxAtomicUnits to 78

### DIFF
--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -4,7 +4,7 @@ import { SvmAddressRegex } from "../shared/svm";
 import { Base64EncodedRegex } from "../../shared/base64";
 
 // Constants
-const EvmMaxAtomicUnits = 18;
+const EvmMaxAtomicUnits = 78;
 const EvmAddressRegex = /^0x[0-9a-fA-F]{40}$/;
 const MixedAddressRegex = /^0x[a-fA-F0-9]{40}|[A-Za-z0-9][A-Za-z0-9-]{0,34}[A-Za-z0-9]$/;
 const HexEncoded64ByteRegex = /^0x[0-9a-fA-F]{64}$/;


### PR DESCRIPTION
## Description

Increase EvmMaxAtomicUnits to 78 to support arbitrary ERC20 token amounts.

Closes #548 

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
 