### PR TITLE
fix: streaming responses in express middleware

### DIFF
--- a/typescript/packages/x402-express/src/index.test.ts
+++ b/typescript/packages/x402-express/src/index.test.ts
@@ -170,6 +170,9 @@ describe("paymentMiddleware()", () => {
       send: vi.fn().mockReturnThis(),
       setHeader: vi.fn().mockReturnThis(),
       end: vi.fn().mockReturnThis(),
+      write: vi.fn().mockReturnValue(true),
+      writeHead: vi.fn().mockReturnThis(),
+      flushHeaders: vi.fn(),
       headersSent: false,
     } as unknown as Response;
     mockNext = vi.fn();

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -285,19 +285,50 @@ export function paymentMiddleware(
       return;
     }
 
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    type EndArgs =
-      | [cb?: () => void]
-      | [chunk: any, cb?: () => void]
-      | [chunk: any, encoding: BufferEncoding, cb?: () => void];
-    /* eslint-enable @typescript-eslint/no-explicit-any */
-
+    // Intercept and buffer all core methods that can commit response to client
+    const originalWriteHead = res.writeHead.bind(res);
+    const originalWrite = res.write.bind(res);
     const originalEnd = res.end.bind(res);
-    let endArgs: EndArgs | null = null;
+    const originalFlushHeaders = res.flushHeaders.bind(res);
 
-    res.end = function (...args: EndArgs) {
-      endArgs = args;
-      return res; // maintain correct return type
+    type BufferedCall =
+      | ["writeHead", Parameters<typeof originalWriteHead>]
+      | ["write", Parameters<typeof originalWrite>]
+      | ["end", Parameters<typeof originalEnd>]
+      | ["flushHeaders", []];
+    let bufferedCalls: BufferedCall[] = [];
+    let settled = false;
+
+    res.writeHead = function (...args: Parameters<typeof originalWriteHead>) {
+      if (!settled) {
+        bufferedCalls.push(["writeHead", args]);
+        return res;
+      }
+      return originalWriteHead(...args);
+    } as typeof originalWriteHead;
+
+    res.write = function (...args: Parameters<typeof originalWrite>) {
+      if (!settled) {
+        bufferedCalls.push(["write", args]);
+        return true;
+      }
+      return originalWrite(...args);
+    } as typeof originalWrite;
+
+    res.end = function (...args: Parameters<typeof originalEnd>) {
+      if (!settled) {
+        bufferedCalls.push(["end", args]);
+        return res;
+      }
+      return originalEnd(...args);
+    } as typeof originalEnd;
+
+    res.flushHeaders = function () {
+      if (!settled) {
+        bufferedCalls.push(["flushHeaders", []]);
+        return;
+      }
+      return originalFlushHeaders();
     };
 
     // Proceed to the next middleware or route handler
@@ -305,10 +336,20 @@ export function paymentMiddleware(
 
     // If the response from the protected route is >= 400, do not settle payment
     if (res.statusCode >= 400) {
+      settled = true; // stop intercepting calls
+      res.writeHead = originalWriteHead;
+      res.write = originalWrite;
       res.end = originalEnd;
-      if (endArgs) {
-        originalEnd(...(endArgs as Parameters<typeof res.end>));
+      res.flushHeaders = originalFlushHeaders;
+      // Replay all buffered calls in order
+      for (const [method, args] of bufferedCalls) {
+        if (method === "writeHead")
+          originalWriteHead(...(args as Parameters<typeof originalWriteHead>));
+        else if (method === "write") originalWrite(...(args as Parameters<typeof originalWrite>));
+        else if (method === "end") originalEnd(...(args as Parameters<typeof originalEnd>));
+        else if (method === "flushHeaders") originalFlushHeaders();
       }
+      bufferedCalls = [];
       return;
     }
 
@@ -319,6 +360,7 @@ export function paymentMiddleware(
 
       // if the settle fails, return an error
       if (!settleResponse.success) {
+        bufferedCalls = [];
         res.status(402).json({
           x402Version,
           error: settleResponse.errorReason,
@@ -330,6 +372,7 @@ export function paymentMiddleware(
       console.error(error);
       // If settlement fails and the response hasn't been sent yet, return an error
       if (!res.headersSent) {
+        bufferedCalls = [];
         res.status(402).json({
           x402Version,
           error,
@@ -338,10 +381,21 @@ export function paymentMiddleware(
         return;
       }
     } finally {
+      settled = true;
+      res.writeHead = originalWriteHead;
+      res.write = originalWrite;
       res.end = originalEnd;
-      if (endArgs) {
-        originalEnd(...(endArgs as Parameters<typeof res.end>));
+      res.flushHeaders = originalFlushHeaders;
+
+      // Replay all buffered calls in order
+      for (const [method, args] of bufferedCalls) {
+        if (method === "writeHead")
+          originalWriteHead(...(args as Parameters<typeof originalWriteHead>));
+        else if (method === "write") originalWrite(...(args as Parameters<typeof originalWrite>));
+        else if (method === "end") originalEnd(...(args as Parameters<typeof originalEnd>));
+        else if (method === "flushHeaders") originalFlushHeaders();
       }
+      bufferedCalls = [];
     }
   };
 }


### PR DESCRIPTION
## Description

**Problem:**
The Express payment middleware only intercepts `res.end()` (internally called by `res.send()`), which allows streaming responses like `res.write()` to send data to the client before payment settlement completed

**Fix:**
- Intercept all response methods that can commit data to the client: writeHead, write, end, and flushHeaders
- Buffer all calls to these methods until payment settlement completes
- After successful settlement, replay all buffered calls in the original order
- Updated test mocks to include the newly intercepted methods

## Tests

Tested with modified servers/express example:

```
// Normal endpoint as sanity check
app.get("/weather", (req, res) => {
  res.send({
    report: {
      streaming: "false",
      weather: "sunny",
      temperature: 70,
    },
  });
});

// Streaming endpoint using res.write() and res.writeHead() 
app.get("/streaming-weather", (req, res) => {
  res.writeHead(200, { "Content-Type": "application/json" });
  res.write(
    JSON.stringify({
      report: {
        streaming: "true",
        weather: "sunny",
        temperature: 70,
      },
    }),
  );
  res.end();
});

```

Fetch client output before:

```
{ report: { streaming: 'false', weather: 'sunny', temperature: 70 } }
{
  success: true,
  transaction: '0x8dc480d3e238eb2d77c28a8ecf5dabe37a70f718755501734edc159a7709658f',
  network: 'base-sepolia',
  payer: '0xE33A295AF5C90A0649DFBECfDf9D604789B892e2'
}

{ report: { streaming: 'true', weather: 'sunny', temperature: 70 } }
SyntaxError: Unexpected token 'e" is not valid JSON
```
-> client receives no payment header

And server throws: `Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client`

Fetch client output after fix:

```
{ report: { streaming: 'false', weather: 'sunny', temperature: 70 } }
{
  success: true,
  transaction: '0x150565ae9a8af4170b6328bd4661e89233d0a7ea5ed3b6a94e48a7a87ef0af07',
  network: 'base-sepolia',
  payer: '0xE33A295AF5C90A0649DFBECfDf9D604789B892e2'
}

{ report: { streaming: 'true', weather: 'sunny', temperature: 70 } }
{
  success: true,
  transaction: '0x3f4a942271d23d713b31d60ef2deafe570ddb579ef4e17bf4086f6053fff62df',
  network: 'base-sepolia',
  payer: '0xE33A295AF5C90A0649DFBECfDf9D604789B892e2'
}
```




<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 