### PR TITLE
fix(x402-fetch): allow optional fetch request init config

### DIFF
--- a/typescript/packages/x402-fetch/package.json
+++ b/typescript/packages/x402-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-fetch",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/x402-fetch/src/index.test.ts
+++ b/typescript/packages/x402-fetch/src/index.test.ts
@@ -122,16 +122,14 @@ describe("fetchWithPayment()", () => {
     ).rejects.toThrow("Payment already attempted");
   });
 
-  it("should reject if missing request config", async () => {
+  it("should allow optional fetch request config", async () => {
     const errorResponse = createResponse(402, {
       accepts: validPaymentRequirements,
       x402Version: 1,
     });
     mockFetch.mockResolvedValue(errorResponse);
 
-    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
-      "Missing fetch request configuration",
-    );
+    await expect(wrappedFetch("https://api.example.com")).resolves.toBeDefined();
   });
 
   it("should reject if payment amount exceeds maximum", async () => {

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -97,18 +97,14 @@ export function wrapFetchWithPayment(
       config,
     );
 
-    if (!init) {
-      throw new Error("Missing fetch request configuration");
-    }
-
-    if ((init as { __is402Retry?: boolean }).__is402Retry) {
+    if (init && (init as { __is402Retry?: boolean }).__is402Retry) {
       throw new Error("Payment already attempted");
     }
 
     const newInit = {
       ...init,
       headers: {
-        ...(init.headers || {}),
+        ...(init?.headers || {}),
         "X-PAYMENT": paymentHeader,
         "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
       },


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

fetch's request init param is optional.


## Tests

This was tested by building the package and installing into a standalone app with the following code:
```ts
import { useX402 } from "@coinbase/cdp-hooks";

const { fetchWithPayment } = useX402();
const response = await fetchWithPayment(resourceUrl);
```


<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 