### PR TITLE
docs: Revise instruction count to 3 for SVM payments

### DIFF
--- a/specs/schemes/exact/scheme_exact_svm.md
+++ b/specs/schemes/exact/scheme_exact_svm.md
@@ -92,10 +92,9 @@ A facilitator verifying an `exact`-scheme SVM payment MUST enforce all of the fo
 
 1. Instruction layout
 
-- The decompiled transaction MUST contain either 3 or 4 instructions in this exact order:
+- The decompiled transaction MUST contain 3 instructions in this exact order:
   1. Compute Budget: Set Compute Unit Limit
   2. Compute Budget: Set Compute Unit Price
-  3. Optional: Associated Token Account Create (when the destination ATA does not yet exist)
   4. SPL Token or Token-2022 TransferChecked
 
 2. Fee payer (facilitator) safety


### PR DESCRIPTION
Updated instruction count requirement for exact-scheme SVM payments.

## Description

Updated outdated scheme spec

## Tests

N/A

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits