### PR TITLE
fix: support ERC-6492 signatures from undeployed smart wallets

### DIFF
--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -66,22 +66,9 @@ export async function verify<
 
   const exactEvmPayload = payload.payload as ExactEvmPayload;
 
-  const payerAddress = exactEvmPayload.authorization.from as Address;
-  const signature = exactEvmPayload.signature;
-
-  const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
-  const isSmartWallet = signatureLength > 130;
-
-  if (isSmartWallet) {
-    const bytecode = await client.getCode({ address: payerAddress });
-    if (!bytecode || bytecode === "0x") {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
-        payer: payerAddress,
-      };
-    }
-  }
+  // Note: We no longer reject undeployed smart wallets here.
+  // viem's verifyTypedData handles ERC-6492 signatures correctly by
+  // simulating wallet deployment before signature verification.
 
   // Verify payload version
   if (payload.scheme !== SCHEME || paymentRequirements.scheme !== SCHEME) {


### PR DESCRIPTION
Closes #623

## Summary

- Remove unnecessary smart wallet deployment check that blocked ERC-6492 signatures
- viem's `verifyTypedData` already handles ERC-6492 signatures correctly by simulating wallet deployment before signature verification
- This enables payments from Coinbase Smart Wallet, Privy embedded wallets, and other smart wallets that may not be deployed yet

## Problem

The facilitator was rejecting payment signatures from undeployed smart wallets with the error `invalid_exact_evm_payload_undeployed_smart_wallet`. 

However, ERC-6492 defines a standard for signatures from undeployed contracts, and viem's signature verification already supports this standard.

## Solution

Remove the bytecode check that was blocking these signatures. The underlying viem verification handles ERC-6492 correctly.