### PR TITLE
fix: x402-next settlement failure handling

### DIFF
--- a/typescript/packages/x402-hono/src/index.test.ts
+++ b/typescript/packages/x402-hono/src/index.test.ts
@@ -902,6 +902,71 @@ describe("paymentMiddleware()", () => {
     );
   });
 
+  it("should return 402 if payment verification throws an error", async () => {
+    (mockContext.req.header as ReturnType<typeof vi.fn>).mockImplementation((name: string) => {
+      if (name === "X-PAYMENT") return encodedValidPayment;
+      return undefined;
+    });
+
+    // Mock findMatchingPaymentRequirements to return a valid requirement
+    vi.mocked(findMatchingPaymentRequirements).mockReturnValue({
+      scheme: "exact",
+      network: "base-sepolia",
+      maxAmountRequired: "1000",
+      resource: "https://api.example.com/resource",
+      description: "Test payment",
+      mimeType: "application/json",
+      payTo: "0x1234567890123456789012345678901234567890",
+      maxTimeoutSeconds: 300,
+      asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      outputSchema: {
+        input: {
+          type: "http",
+          method: "GET",
+          queryParams: { type: "string" },
+        },
+        output: { type: "object" },
+      },
+      extra: {
+        name: "USDC",
+        version: "2",
+      },
+    });
+
+    // Mock verify to throw an error
+    (mockVerify as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Facilitator connection failed"),
+    );
+
+    await middleware(mockContext, mockNext);
+
+    expect(mockContext.json).toHaveBeenCalledWith(
+      {
+        x402Version: 1,
+        error: "Facilitator connection failed",
+        accepts: [
+          {
+            scheme: "exact",
+            network: "base-sepolia",
+            maxAmountRequired: "1000",
+            resource: "https://api.example.com/resource",
+            description: "Test payment",
+            mimeType: "application/json",
+            payTo: "0x1234567890123456789012345678901234567890",
+            maxTimeoutSeconds: 300,
+            asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+            outputSchema,
+            extra: {
+              name: "USDC",
+              version: "2",
+            },
+          },
+        ],
+      },
+      402,
+    );
+  });
+
   it("should handle settlement after response", async () => {
     (mockContext.req.header as ReturnType<typeof vi.fn>).mockImplementation((name: string) => {
       if (name === "X-PAYMENT") return encodedValidPayment;

--- a/typescript/packages/x402-hono/src/index.ts
+++ b/typescript/packages/x402-hono/src/index.ts
@@ -283,14 +283,28 @@ export function paymentMiddleware(
       );
     }
 
-    const verification = await verify(decodedPayment, selectedPaymentRequirements);
+    try {
+      const verification = await verify(decodedPayment, selectedPaymentRequirements);
 
-    if (!verification.isValid) {
+      if (!verification.isValid) {
+        return c.json(
+          {
+            error: errorMessages?.verificationFailed || verification.invalidReason,
+            accepts: paymentRequirements,
+            payer: verification.payer,
+            x402Version,
+          },
+          402,
+        );
+      }
+    } catch (error) {
+      console.error("Payment verification failed:", error);
       return c.json(
         {
-          error: errorMessages?.verificationFailed || verification.invalidReason,
+          error:
+            errorMessages?.verificationFailed ||
+            (error instanceof Error ? error.message : "Payment verification failed"),
           accepts: paymentRequirements,
-          payer: verification.payer,
           x402Version,
         },
         402,

--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -184,25 +184,57 @@ export function paymentMiddleware(
  *
  * @example
  * ```typescript
+ * // Simple configuration - Protected route with $0.01 USDC on base-sepolia
  * import { NextRequest, NextResponse } from "next/server";
- * import { withX402, Address, Network, Resource } from "x402-next";
+ * import { withX402 } from "x402-next";
  *
  * const handler = async (request: NextRequest) => {
- *   return NextResponse.json({
- *     report: { weather: "sunny", temperature: 70 }
- *   });
+ *   return NextResponse.json({ message: "Success" });
  * };
  *
  * export const GET = withX402(
  *   handler,
- *   process.env.RESOURCE_WALLET_ADDRESS as Address,
+ *   '0x123...', // payTo address
  *   {
- *     price: "$0.01",
- *     network: process.env.NETWORK as Network,
- *     config: { description: "Access to weather API" }
+ *     price: '$0.01', // USDC amount in dollars
+ *     network: 'base-sepolia'
  *   },
- *   { url: process.env.NEXT_PUBLIC_FACILITATOR_URL as Resource },
- *   { appName: "My App", appLogo: "/logo.png" }
+ *   // Optional facilitator configuration. Defaults to x402.org/facilitator for testnet usage
+ * );
+ *
+ * // Advanced configuration - Custom payment settings & facilitator
+ * export const POST = withX402(
+ *   handler,
+ *   '0x123...', // payTo: The address to receive payments
+ *   {
+ *     price: {
+ *       amount: '100000',
+ *       asset: {
+ *         address: '0xabc',
+ *         decimals: 18,
+ *         eip712: {
+ *           name: 'WETH',
+ *           version: '1'
+ *         }
+ *       }
+ *     },
+ *     network: 'base',
+ *     config: {
+ *       description: 'Access to premium content'
+ *     }
+ *   },
+ *   {
+ *     url: 'https://facilitator.example.com',
+ *     createAuthHeaders: async () => ({
+ *       verify: { "Authorization": "Bearer token" },
+ *       settle: { "Authorization": "Bearer token" }
+ *     })
+ *   },
+ *   {
+ *     cdpClientKey: 'your-cdp-client-key',
+ *     appLogo: '/images/logo.svg',
+ *     appName: 'My App',
+ *   }
  * );
  * ```
  */

--- a/typescript/packages/x402-next/src/paymentMiddleware.test.ts
+++ b/typescript/packages/x402-next/src/paymentMiddleware.test.ts
@@ -125,6 +125,7 @@ describe("paymentMiddleware()", () => {
     createAuthHeaders: async () => ({
       verify: { Authorization: "Bearer token" },
       settle: { Authorization: "Bearer token" },
+      supported: { Authorization: "Bearer token" },
     }),
   };
 
@@ -617,7 +618,60 @@ describe("paymentMiddleware()", () => {
     const json = await response.json();
     expect(json).toEqual({
       x402Version: 1,
-      error: expect.any(Object),
+      error: "Settlement failed",
+      accepts: [
+        {
+          scheme: "exact",
+          network: "base-sepolia",
+          maxAmountRequired: "1000",
+          resource: "https://api.example.com/resource",
+          description: "Test payment",
+          mimeType: "application/json",
+          payTo: "0x1234567890123456789012345678901234567890",
+          maxTimeoutSeconds: 300,
+          outputSchema,
+          asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          extra: {
+            name: "USDC",
+            version: "2",
+          },
+        },
+      ],
+    });
+  });
+
+  it("should handle unsuccessful settlement (success = false)", async () => {
+    const validPayment = "valid-payment-header";
+    const request = {
+      ...mockRequest,
+      headers: new Headers({
+        "X-PAYMENT": validPayment,
+      }),
+    } as NextRequest;
+
+    const decodedPayment = {
+      scheme: "exact",
+      network: "base-sepolia",
+      x402Version: 1,
+    };
+    mockDecodePayment.mockReturnValue(decodedPayment);
+
+    (mockVerify as ReturnType<typeof vi.fn>).mockResolvedValue({ isValid: true });
+    (mockSettle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      errorReason: "invalid_transaction_state",
+      transaction: "0x123",
+      network: "base-sepolia",
+      payer: "0x123",
+    });
+
+    const response = await middleware(request);
+
+    expect(response.status).toBe(402);
+    const json = await response.json();
+    expect(json).toEqual({
+      x402Version: 1,
+      error: "invalid_transaction_state",
       accepts: [
         {
           scheme: "exact",

--- a/typescript/packages/x402-next/src/utils.ts
+++ b/typescript/packages/x402-next/src/utils.ts
@@ -344,13 +344,17 @@ export async function settlePayment(
           }),
         ),
       );
+      return response;
+    } else {
+      throw new Error(settlement.errorReason);
     }
-    return response;
   } catch (error) {
     return new NextResponse(
       JSON.stringify({
         x402Version,
-        error: errorMessages?.settlementFailed || error,
+        error:
+          errorMessages?.settlementFailed ||
+          (error instanceof Error ? error.message : "Failed to settle payment"),
         accepts: paymentRequirements,
       }),
       { status: 402, headers: { "Content-Type": "application/json" } },

--- a/typescript/packages/x402-next/src/utils.ts
+++ b/typescript/packages/x402-next/src/utils.ts
@@ -21,6 +21,9 @@ import {
   Network,
   Price,
   PaymentMiddlewareConfig,
+  SupportedPaymentKindsResponse,
+  VerifyResponse,
+  SettleResponse,
 } from "x402/types";
 import { safeBase64Encode } from "x402/shared";
 
@@ -43,9 +46,7 @@ export async function buildPaymentRequirements(
   config: PaymentMiddlewareConfig,
   resourceUrl: Resource,
   method: string,
-  supported: () => Promise<{
-    kinds: Array<{ network: string; scheme: string; extra?: { feePayer?: string } }>;
-  }>,
+  supported: () => Promise<SupportedPaymentKindsResponse>,
 ): Promise<PaymentRequirements[]> {
   const { description, mimeType, maxTimeoutSeconds, inputSchema, outputSchema, discoverable } =
     config;
@@ -219,7 +220,7 @@ export async function verifyPayment(
   verify: (
     payment: PaymentPayload,
     requirements: PaymentRequirements,
-  ) => Promise<{ isValid: boolean; invalidReason?: string; payer?: string }>,
+  ) => Promise<VerifyResponse>,
   errorMessages?: PaymentMiddlewareConfig["errorMessages"],
 ): Promise<
   | { decodedPayment: PaymentPayload; selectedRequirements: PaymentRequirements }
@@ -323,7 +324,7 @@ export async function settlePayment(
   settle: (
     payment: PaymentPayload,
     requirements: PaymentRequirements,
-  ) => Promise<{ success: boolean; transaction?: string; network?: string; payer?: string }>,
+  ) => Promise<SettleResponse>,
   x402Version: number,
   errorMessages?: PaymentMiddlewareConfig["errorMessages"],
   paymentRequirements?: PaymentRequirements[],

--- a/typescript/packages/x402-next/src/utils.ts
+++ b/typescript/packages/x402-next/src/utils.ts
@@ -217,10 +217,7 @@ export async function verifyPayment(
   paymentHeader: string,
   paymentRequirements: PaymentRequirements[],
   x402Version: number,
-  verify: (
-    payment: PaymentPayload,
-    requirements: PaymentRequirements,
-  ) => Promise<VerifyResponse>,
+  verify: (payment: PaymentPayload, requirements: PaymentRequirements) => Promise<VerifyResponse>,
   errorMessages?: PaymentMiddlewareConfig["errorMessages"],
 ): Promise<
   | { decodedPayment: PaymentPayload; selectedRequirements: PaymentRequirements }
@@ -321,10 +318,7 @@ export async function settlePayment(
   response: NextResponse,
   decodedPayment: PaymentPayload,
   selectedPaymentRequirements: PaymentRequirements,
-  settle: (
-    payment: PaymentPayload,
-    requirements: PaymentRequirements,
-  ) => Promise<SettleResponse>,
+  settle: (payment: PaymentPayload, requirements: PaymentRequirements) => Promise<SettleResponse>,
   x402Version: number,
   errorMessages?: PaymentMiddlewareConfig["errorMessages"],
   paymentRequirements?: PaymentRequirements[],


### PR DESCRIPTION

## Description

The x402-next` implementation only handles exceptions during settlement but doesn't handle the case where settlement returns { settlement.success: false }. This means protected content could be served even when the payment wasn't properly settled.

## Changes

- Handle `settlement.success == false` in `x402-next` similar to `x402-hono` implementation
- Wrapped `x402-hono` payment verification in try-catch
- Improved JSDoc and typing for withX402 

## Tests

Added new unit tests to cover `settlement.success == false` in `x402-next` and verify throwing error in `x402-hono`

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 