### PR TITLE
Allowing a function as `routeConfig` in `withX402`

### DIFF
--- a/typescript/packages/x402-next/src/index.ts
+++ b/typescript/packages/x402-next/src/index.ts
@@ -241,7 +241,7 @@ export function paymentMiddleware(
 export function withX402<T = unknown>(
   handler: (request: NextRequest) => Promise<NextResponse<T>>,
   payTo: Address | SolanaAddress,
-  routeConfig: RouteConfig,
+  routeConfig: RouteConfig | ((req: NextRequest) => Promise<RouteConfig>),
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
 ): (request: NextRequest) => Promise<NextResponse<T | unknown>> {
@@ -251,7 +251,11 @@ export function withX402<T = unknown>(
   return async function wrappedHandler(request: NextRequest) {
     const method = request.method.toUpperCase();
     const pathname = request.nextUrl.pathname;
-    const { price, network, config = {} } = routeConfig;
+
+    const resolvedConfig =
+      typeof routeConfig === "function" ? await routeConfig(request) : routeConfig;
+
+    const { price, network, config = {} } = resolvedConfig;
     const { customPaywallHtml, resource, errorMessages } = config;
 
     const resourceUrl =


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

This PR introduces a way to dynamically provide a `routeConfig` argument based on the `NextRequest` and whatever else the developer might need by making the `routeConfig` parameter of `withX402` either a `RouteConfig` type or a `(req: NextRequest) => Promise<RouteConfig>` function.

Developers can now pass a function that will construct the right `routeConfig` according to any custom logic, like dynamic pricing based on the user making the request or based on the specific resource being bought.

Closes #608.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

After making these changes, I tried protecting a NextJS endpoint with `withX402` using both the static config (what the package currently offers) and using a function that fetches the price from a DB depending on what's in the request's body and returns a `routeConfig` object using that price.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 