### PR TITLE
feat: add Monad and Monad Testnet support

### DIFF
--- a/typescript/packages/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/x402/src/types/shared/evm/config.ts
@@ -72,6 +72,14 @@ export const config: Record<string, ChainConfig> = {
     usdcAddress: "0x2e08028E3C4c2356572E096d8EF835cD5C6030bD",
     usdcName: "Bridged USDC (SKALE Bridge)",
   },
+  "143": {
+    usdcAddress: "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+    usdcName: "USDC",
+  },
+  "10143": {
+    usdcAddress: "0x534b2f3A21130d7a60830c2Df862319e593943A3",
+    usdcName: "USDC",
+  },
 };
 
 export type ChainConfig = {

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -26,6 +26,8 @@ import {
   abstractTestnet,
   story,
   eduChain,
+  monad,
+  monadTestnet,
 } from "viem/chains";
 import { skaleBaseSepolia } from "../custom-chains";
 import { privateKeyToAccount } from "viem/accounts";
@@ -235,6 +237,10 @@ export function getChainFromNetwork(network: string | undefined): Chain {
       return iotexTestnet;
     case "skale-base-sepolia":
       return skaleBaseSepolia;
+    case "monad":
+      return monad;
+    case "monad-testnet":
+      return monadTestnet;
     default:
       throw new Error(`Unsupported network: ${network}`);
   }

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -18,6 +18,8 @@ export const NetworkSchema = z.enum([
   "story",
   "educhain",
   "skale-base-sepolia",
+  "monad",
+  "monad-testnet",
 ]);
 export type Network = z.infer<typeof NetworkSchema>;
 
@@ -38,6 +40,8 @@ export const SupportedEVMNetworks: Network[] = [
   "story",
   "educhain",
   "skale-base-sepolia",
+  "monad",
+  "monad-testnet",
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
   ["abstract", 2741],
@@ -55,6 +59,8 @@ export const EvmNetworkToChainId = new Map<Network, number>([
   ["story", 1514],
   ["educhain", 41923],
   ["skale-base-sepolia", 324705682],
+  ["monad", 143],
+  ["monad-testnet", 10143],
 ]);
 
 // svm


### PR DESCRIPTION
## Description

Adds support for the Monad chain (Chain ID 143) and Monad Testnet (Chain ID 10143).

Changes:
- Added USDC configuration for Monad and Monad Testnet.
- Imported `monad` and `monadTestnet` chains from `viem/chains`.
- Updated `NetworkSchema` and mappings to support `monad` and `monad-testnet`.

## Tests

Verified changes by running the following commands in the `typescript` directory:

- `npm test`: All 250 tests passed across 18 test files.
- `npm run build`: Build completed successfully, ensuring type safety.
- `npm run lint:check`: No linting errors.
- `npm run format:check`: Code is correctly formatted.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
