### PR TITLE
fix:await async express routes

### DIFF
--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -299,6 +299,12 @@ export function paymentMiddleware(
     let bufferedCalls: BufferedCall[] = [];
     let settled = false;
 
+    // Create a promise that resolves when the handler finishes and calls res.end()
+    let endCalled: () => void;
+    const endPromise = new Promise<void>(resolve => {
+      endCalled = resolve;
+    });
+
     res.writeHead = function (...args: Parameters<typeof originalWriteHead>) {
       if (!settled) {
         bufferedCalls.push(["writeHead", args]);
@@ -318,6 +324,8 @@ export function paymentMiddleware(
     res.end = function (...args: Parameters<typeof originalEnd>) {
       if (!settled) {
         bufferedCalls.push(["end", args]);
+        // Signal that the handler has finished
+        endCalled();
         return res;
       }
       return originalEnd(...args);
@@ -332,7 +340,10 @@ export function paymentMiddleware(
     };
 
     // Proceed to the next middleware or route handler
-    await next();
+    next();
+
+    // Wait for the handler to actually call res.end() before checking status
+    await endPromise;
 
     // If the response from the protected route is >= 400, do not settle payment
     if (res.statusCode >= 400) {
@@ -356,7 +367,6 @@ export function paymentMiddleware(
     try {
       const settleResponse = await settle(decodedPayment, selectedPaymentRequirements);
       const responseHeader = settleResponseHeader(settleResponse);
-      res.setHeader("X-PAYMENT-RESPONSE", responseHeader);
 
       // if the settle fails, return an error
       if (!settleResponse.success) {
@@ -368,18 +378,18 @@ export function paymentMiddleware(
         });
         return;
       }
+
+      res.setHeader("X-PAYMENT-RESPONSE", responseHeader);
     } catch (error) {
       console.error(error);
-      // If settlement fails and the response hasn't been sent yet, return an error
-      if (!res.headersSent) {
-        bufferedCalls = [];
-        res.status(402).json({
-          x402Version,
-          error: error instanceof Error ? error.message : "Payment settlement failed",
-          accepts: toJsonSafe(paymentRequirements),
-        });
-        return;
-      }
+      // If settlement fails, don't send the buffered response
+      bufferedCalls = [];
+      res.status(402).json({
+        x402Version,
+        error: error instanceof Error ? error.message : "Payment settlement failed",
+        accepts: toJsonSafe(paymentRequirements),
+      });
+      return;
     } finally {
       settled = true;
       res.writeHead = originalWriteHead;


### PR DESCRIPTION
## Description

The express middleware does not actually await the route handler to complete. 
Thus for asyn operations the following `res.statusCode >= 400` is ineffective and settlement might be triggered for failed API calls similar to the next middleware issue fixed here: https://github.com/coinbase/x402/pull/664

Proposed solution:
- Add a promise that resolves when res.end() is called by the handler
- When buffered res.end() is called signal that the response is ready
- Check res.statusCode only after resolves 

## Tests

Modified express example with protected routes:
```
app.get("/error", (req, res) => {
  res.status(500).send({ error: "Request timeout" });
});

app.get("/error-async", (req, res) => {
  setTimeout(() => {
    res.status(500).send({ error: "Request timeout" });
  }, 1000);
});
```

Before:

- Client output for error route: 
`{ error: 'Request timeout' }`
- Client output for error-async route: 
```
{ error: 'Request timeout' }
{
  success: true,
  transaction: '0xb0f94f5471b7cd01a90ff6da98d0cd82afb8c1309a8edfe0271f3d7ca767be29',
  network: 'base-sepolia',
  payer: '0xE33A295AF5C90A0649DFBECfDf9D604789B892e2'
}
```

After:

- Client output for error route: 
`{ error: 'Request timeout' }`
- Client output for error-async route: 
`{ error: 'Request timeout' }`


<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 