### PR TITLE
Add Scroll Network Support

### DIFF
--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -9,6 +9,7 @@ import {
   Transport,
 } from "viem";
 import { getNetworkId } from "../../../shared";
+import { Network } from "../../../types/shared";
 import { getVersion, getERC20Balance } from "../../../shared/evm";
 import {
   usdcABI as abi,
@@ -25,6 +26,73 @@ import {
   ExactEvmPayload,
 } from "../../../types/verify";
 import { SCHEME } from "../../exact";
+
+// TODO: This is a temporary implementation to handle Scroll mainnet limitations.
+// The logic should be removed once Scroll upgrades their USDC contract to support bytes signatures.
+
+// Scroll mainnet chain ID
+const SCROLL_MAINNET_CHAIN_ID = 534352;
+
+/**
+ * Checks if the given network is Scroll mainnet
+ *
+ * @param network - The network string to check
+ * @returns True if the network is Scroll mainnet, false otherwise
+ */
+function isScrollMainnet(network: Network): boolean {
+  try {
+    const chainId = getNetworkId(network);
+    return chainId === SCROLL_MAINNET_CHAIN_ID;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks if an address is a Smart Contract Wallet by checking if it has contract code
+ *
+ * @param client - The client to use for blockchain interactions
+ * @param address - The address to check
+ * @returns True if the address has contract code (is a SCW), false otherwise
+ */
+async function isSmartContractWallet<
+  transport extends Transport,
+  chain extends Chain,
+  account extends Account | undefined,
+>(client: ConnectedClient<transport, chain, account>, address: Address): Promise<boolean> {
+  try {
+    const code = await client.getCode({ address });
+    // Handle undefined case - if getCode returns undefined, treat as EOA
+    if (code === undefined || code === null) {
+      return false;
+    }
+    // Check if code exists and is not empty (EOAs have "0x" as their code)
+    return code !== "0x" && code.length > 2;
+  } catch {
+    // If there's any error (network issues, invalid address, etc.), treat as EOA
+    return false;
+  }
+}
+
+/**
+ * Converts a bytes signature to v, r, s components for Scroll mainnet
+ *
+ * @param signature - The bytes signature to convert
+ * @returns Object containing v, r, s components
+ */
+function convertSignatureToVrs(signature: Hex): { v: number; r: Hex; s: Hex } {
+  // Remove the 0x prefix and ensure we have 65 bytes (130 hex characters)
+  const sig = signature.slice(2);
+  if (sig.length !== 130) {
+    throw new Error("Invalid signature length");
+  }
+
+  const r = `0x${sig.slice(0, 64)}` as Hex;
+  const s = `0x${sig.slice(64, 128)}` as Hex;
+  const v = parseInt(sig.slice(128, 130), 16);
+
+  return { v, r, s };
+}
 
 /**
  * Verifies a payment payload against the required payment details
@@ -275,23 +343,55 @@ export async function settle<transport extends Transport, chain extends Chain>(
   const { signature: unwrappedSignature } = parseErc6492Signature(payload.signature as Hex);
   const parsedSig = parseSignature(unwrappedSignature);
 
-  const tx = await wallet.writeContract({
-    address: paymentRequirements.asset as Address,
-    abi,
-    functionName: "transferWithAuthorization" as const,
-    args: [
-      payload.authorization.from as Address,
-      payload.authorization.to as Address,
-      BigInt(payload.authorization.value),
-      BigInt(payload.authorization.validAfter),
-      BigInt(payload.authorization.validBefore),
-      payload.authorization.nonce as Hex,
-      (parsedSig.v as number | undefined) || parsedSig.yParity,
-      parsedSig.r,
-      parsedSig.s,
-    ],
-    chain: wallet.chain as Chain,
-  });
+  // Extract v, r, s for Scroll mainnet
+  const v = (parsedSig.v as number | undefined) || parsedSig.yParity;
+  const r = parsedSig.r;
+  const s = parsedSig.s;
+
+  // Helper function for networks that use bytes signature format
+  const transferWithBytesSignature = async () => {
+    return await wallet.writeContract({
+      address: paymentRequirements.asset as Address,
+      abi,
+      functionName: "transferWithAuthorization" as const,
+      args: [
+        payload.authorization.from as Address,
+        payload.authorization.to as Address,
+        BigInt(payload.authorization.value),
+        BigInt(payload.authorization.validAfter),
+        BigInt(payload.authorization.validBefore),
+        payload.authorization.nonce as Hex,
+        unwrappedSignature,
+      ],
+      chain: wallet.chain as Chain,
+    });
+  };
+
+  // Helper function for Scroll mainnet that uses v, r, s signature format
+  const transferWithVrsSignature = async () => {
+    return await wallet.writeContract({
+      address: paymentRequirements.asset as Address,
+      abi,
+      functionName: "transferWithAuthorization" as const,
+      args: [
+        payload.authorization.from as Address,
+        payload.authorization.to as Address,
+        BigInt(payload.authorization.value),
+        BigInt(payload.authorization.validAfter),
+        BigInt(payload.authorization.validBefore),
+        payload.authorization.nonce as Hex,
+        v,
+        r,
+        s,
+      ],
+      chain: wallet.chain as Chain,
+    });
+  };
+
+  // Call the appropriate function based on network
+  const tx = isScrollMainnet(paymentPayload.network)
+    ? await transferWithVrsSignature()
+    : await transferWithBytesSignature();
 
   const receipt = await wallet.waitForTransactionReceipt({ hash: tx });
 

--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -49,52 +49,6 @@ function isScrollMainnet(network: Network): boolean {
 }
 
 /**
- * Checks if an address is a Smart Contract Wallet by checking if it has contract code
- *
- * @param client - The client to use for blockchain interactions
- * @param address - The address to check
- * @returns True if the address has contract code (is a SCW), false otherwise
- */
-async function isSmartContractWallet<
-  transport extends Transport,
-  chain extends Chain,
-  account extends Account | undefined,
->(client: ConnectedClient<transport, chain, account>, address: Address): Promise<boolean> {
-  try {
-    const code = await client.getCode({ address });
-    // Handle undefined case - if getCode returns undefined, treat as EOA
-    if (code === undefined || code === null) {
-      return false;
-    }
-    // Check if code exists and is not empty (EOAs have "0x" as their code)
-    return code !== "0x" && code.length > 2;
-  } catch {
-    // If there's any error (network issues, invalid address, etc.), treat as EOA
-    return false;
-  }
-}
-
-/**
- * Converts a bytes signature to v, r, s components for Scroll mainnet
- *
- * @param signature - The bytes signature to convert
- * @returns Object containing v, r, s components
- */
-function convertSignatureToVrs(signature: Hex): { v: number; r: Hex; s: Hex } {
-  // Remove the 0x prefix and ensure we have 65 bytes (130 hex characters)
-  const sig = signature.slice(2);
-  if (sig.length !== 130) {
-    throw new Error("Invalid signature length");
-  }
-
-  const r = `0x${sig.slice(0, 64)}` as Hex;
-  const s = `0x${sig.slice(64, 128)}` as Hex;
-  const v = parseInt(sig.slice(128, 130), 16);
-
-  return { v, r, s };
-}
-
-/**
  * Verifies a payment payload against the required payment details
  *
  * This function performs several verification steps:

--- a/typescript/packages/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/x402/src/types/shared/evm/config.ts
@@ -72,6 +72,10 @@ export const config: Record<string, ChainConfig> = {
     usdcAddress: "0x2e08028E3C4c2356572E096d8EF835cD5C6030bD",
     usdcName: "Bridged USDC (SKALE Bridge)",
   },
+  "534352": {
+    usdcAddress: "0x06eFdBFf2a14a7c8E15944D1F4A48F9F95F663A4",
+    usdcName: "USD Coin",
+  },
 };
 
 export type ChainConfig = {

--- a/typescript/packages/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/x402/src/types/shared/evm/wallet.ts
@@ -26,6 +26,7 @@ import {
   abstractTestnet,
   story,
   eduChain,
+  scroll,
 } from "viem/chains";
 import { skaleBaseSepolia } from "../custom-chains";
 import { privateKeyToAccount } from "viem/accounts";
@@ -235,6 +236,8 @@ export function getChainFromNetwork(network: string | undefined): Chain {
       return iotexTestnet;
     case "skale-base-sepolia":
       return skaleBaseSepolia;
+    case "scroll":
+      return scroll;
     default:
       throw new Error(`Unsupported network: ${network}`);
   }

--- a/typescript/packages/x402/src/types/shared/network.ts
+++ b/typescript/packages/x402/src/types/shared/network.ts
@@ -18,6 +18,7 @@ export const NetworkSchema = z.enum([
   "story",
   "educhain",
   "skale-base-sepolia",
+  "scroll",
 ]);
 export type Network = z.infer<typeof NetworkSchema>;
 
@@ -38,6 +39,7 @@ export const SupportedEVMNetworks: Network[] = [
   "story",
   "educhain",
   "skale-base-sepolia",
+  "scroll",
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
   ["abstract", 2741],
@@ -55,6 +57,7 @@ export const EvmNetworkToChainId = new Map<Network, number>([
   ["story", 1514],
   ["educhain", 41923],
   ["skale-base-sepolia", 324705682],
+  ["scroll", 534352],
 ]);
 
 // svm

--- a/typescript/packages/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/x402/src/types/verify/x402Specs.ts
@@ -54,6 +54,7 @@ export const ErrorReasons = [
   "unsupported_scheme",
   "unexpected_settle_error",
   "unexpected_verify_error",
+  "smart_contract_wallet_not_supported_on_scroll",
 ] as const;
 
 // Refiners


### PR DESCRIPTION
## Description
Added Scroll Mainnet (534352) chain support, add special handling in facilitator.ts for Scroll Mainnet due to Scroll Mainnet USDC contract doesn't support bytes signature but v,r,s only.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [✅] I have formatted and linted my code
- [✅] All new and existing tests pass
- [✅] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 