### PR TITLE
fix: Use bytes signature for smart wallet EIP-3009 transfers

### DIFF
--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.test.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.test.ts
@@ -33,12 +33,6 @@ vi.mock("viem", async importOriginal => {
       // Non-EIP-6492: just return signature
       return { signature: sig };
     }),
-    parseSignature: vi.fn(() => ({
-      r: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as `0x${string}`,
-      s: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" as `0x${string}`,
-      v: 27,
-      yParity: 0,
-    })),
   };
 });
 
@@ -164,6 +158,15 @@ describe("facilitator - smart wallet deployment check", () => {
       await verify(client, payload, mockPaymentRequirements);
 
       expect(client.getCode).not.toHaveBeenCalled();
+    });
+
+    it("should accept deployed smart wallet during verify", async () => {
+      const client = createMockClient("0x608060405234801561001057600080fd5b50");
+      const payload = createMockPayload({ signatureLength: 200 });
+
+      const result = await verify(client, payload, mockPaymentRequirements);
+
+      expect(result.isValid).toBe(true);
     });
   });
 

--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.test.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.test.ts
@@ -259,7 +259,7 @@ describe("facilitator - smart wallet deployment check", () => {
 
       expect(wallet.writeContract).toHaveBeenCalledWith(
         expect.objectContaining({
-          args: expect.arrayContaining([28n, mockR, mockS]),
+          args: expect.arrayContaining([28, mockR, mockS]),
         }),
       );
     });

--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -296,6 +296,7 @@ export async function settle<transport extends Transport, chain extends Chain>(
   } else {
     // EOA: Use (v, r, s) overload for maximum compatibility
     const parsedSig = parseSignature(payload.signature as Hex);
+    const v = parsedSig.v !== undefined ? Number(parsedSig.v) : 27 + parsedSig.yParity;
 
     tx = await wallet.writeContract({
       address: paymentRequirements.asset as Address,
@@ -308,7 +309,7 @@ export async function settle<transport extends Transport, chain extends Chain>(
         BigInt(payload.authorization.validAfter),
         BigInt(payload.authorization.validBefore),
         payload.authorization.nonce as Hex,
-        parsedSig.v ?? (parsedSig.yParity === 0 ? 27 : 28),
+        v,
         parsedSig.r,
         parsedSig.s,
       ],

--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -1,13 +1,4 @@
-import {
-  Account,
-  Address,
-  Chain,
-  getAddress,
-  Hex,
-  parseErc6492Signature,
-  parseSignature,
-  Transport,
-} from "viem";
+import { Account, Address, Chain, getAddress, Hex, parseErc6492Signature, Transport } from "viem";
 import { getNetworkId } from "../../../shared";
 import { getVersion, getERC20Balance } from "../../../shared/evm";
 import {
@@ -271,10 +262,6 @@ export async function settle<transport extends Transport, chain extends Chain>(
     }
   }
 
-  // Returns the original signature (no-op) if the signature is not a 6492 signature
-  const { signature: unwrappedSignature } = parseErc6492Signature(payload.signature as Hex);
-  const parsedSig = parseSignature(unwrappedSignature);
-
   const tx = await wallet.writeContract({
     address: paymentRequirements.asset as Address,
     abi,
@@ -286,9 +273,7 @@ export async function settle<transport extends Transport, chain extends Chain>(
       BigInt(payload.authorization.validAfter),
       BigInt(payload.authorization.validBefore),
       payload.authorization.nonce as Hex,
-      (parsedSig.v as number | undefined) || parsedSig.yParity,
-      parsedSig.r,
-      parsedSig.s,
+      payload.signature as Hex,
     ],
     chain: wallet.chain as Chain,
   });

--- a/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/x402/src/schemes/exact/evm/facilitator.ts
@@ -308,7 +308,7 @@ export async function settle<transport extends Transport, chain extends Chain>(
         BigInt(payload.authorization.validAfter),
         BigInt(payload.authorization.validBefore),
         payload.authorization.nonce as Hex,
-        (parsedSig.v as number | undefined) || parsedSig.yParity,
+        parsedSig.v ?? (parsedSig.yParity === 0 ? 27 : 28),
         parsedSig.r,
         parsedSig.s,
       ],


### PR DESCRIPTION
The facilitator's `settle` function was calling `parseSignature()` on all signatures, which failed for smart wallets with:

```
Error: expected valid s: 1 <= n < 115792089237316195423570985008687907852837564279074904382605163141518161494337, got 0
```

### Solution

Use the `bytes signature` overload of `transferWithAuthorization` instead of the `(v, r, s)` overload for smart wallets.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 