### PR TITLE
v2: go settlement failure and initOnStart fixes

### DIFF
--- a/examples/go/facilitator/README.md
+++ b/examples/go/facilitator/README.md
@@ -60,7 +60,7 @@ For production deployments with additional features (Bazaar discovery, multiple 
 
 ## Prerequisites
 
-- Go 1.21 or higher
+- Go 1.24 or higher
 - EVM private key with Base Sepolia ETH for transaction fees
 - SVM private key with Solana Devnet SOL for transaction fees (optional)
 

--- a/go/Makefile
+++ b/go/Makefile
@@ -6,6 +6,7 @@ GOBIN := $(GOPATH)/bin
 GOLANGCI_LINT := $(GOBIN)/golangci-lint
 GOLANGCI_LINT_VERSION := v2.7.2
 MOCKGEN := $(GOBIN)/mockgen
+GOIMPORTS := $(GOBIN)/goimports
 
 # Default target
 all: fmt lint test build
@@ -59,10 +60,10 @@ lint-fix: $(GOLANGCI_LINT)
 	@$(GOLANGCI_LINT) run --fix ./...
 
 ## fmt: Format code
-fmt:
+fmt: $(GOIMPORTS)
 	@echo "Formatting code..."
 	@go fmt ./...
-	@goimports -w .
+	@$(GOIMPORTS) -w .
 
 ## clean: Clean build artifacts
 clean:
@@ -83,7 +84,7 @@ deps:
 	@go mod tidy
 
 ## deps-dev: Install development dependencies
-deps-dev: $(GOLANGCI_LINT) $(MOCKGEN)
+deps-dev: $(GOLANGCI_LINT) $(MOCKGEN) $(GOIMPORTS)
 	@echo "Development dependencies installed"
 
 ## generate: Generate code (mocks, etc.)
@@ -122,11 +123,15 @@ release: clean verify build
 # Tool installations
 $(GOLANGCI_LINT):
 	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 $(MOCKGEN):
 	@echo "Installing mockgen..."
 	@go install github.com/golang/mock/mockgen@latest
+
+$(GOIMPORTS):
+	@echo "Installing goimports..."
+	@go install golang.org/x/tools/cmd/goimports@latest
 
 # Print variables for debugging
 ## vars: Print Makefile variables
@@ -135,3 +140,4 @@ vars:
 	@echo "GOBIN: $(GOBIN)"
 	@echo "GOLANGCI_LINT: $(GOLANGCI_LINT)"
 	@echo "MOCKGEN: $(MOCKGEN)"
+	@echo "GOIMPORTS: $(GOIMPORTS)"

--- a/go/README.md
+++ b/go/README.md
@@ -31,7 +31,7 @@ These core classes are **framework-agnostic** and can be used in any context (HT
 The package exports HTTP-specific wrappers around the core classes:
 
 - **`x402http.HTTPClient`** - Wraps `http.Client` with automatic payment handling for clients
-- **`x402http.HTTPResourceServer`** - Integrates resource server with HTTP request processing
+- **`x402http.HTTPServer`** - Integrates resource server with HTTP request processing
 - **`x402http.HTTPFacilitatorClient`** - HTTP client for calling facilitator endpoints
 
 These wrappers handle HTTP-specific concerns like headers, status codes, and request/response serialization.
@@ -196,6 +196,7 @@ github.com/coinbase/x402/go
 │   └── *_hooks.go             - Lifecycle hooks
 │
 ├── http/                      - HTTP transport layer
+│   ├── http.go                - Type aliases and convenience functions
 │   ├── client.go              - HTTP client wrapper
 │   ├── server.go              - HTTP server integration
 │   ├── facilitator_client.go  - Facilitator HTTP client
@@ -220,7 +221,10 @@ github.com/coinbase/x402/go
 │
 └── types/                     - Type definitions
     ├── v1.go                  - V1 protocol types
-    └── v2.go                  - V2 protocol types
+    ├── v2.go                  - V2 protocol types
+    ├── helpers.go             - Version detection utilities
+    ├── raw.go                 - Raw type handling
+    └── extensions.go          - Extension type definitions
 ```
 
 ## Supported Networks

--- a/go/http/gin/README.md
+++ b/go/http/gin/README.md
@@ -1,0 +1,284 @@
+# x402 Gin Middleware
+
+Gin middleware integration for the x402 Payment Protocol. This package provides middleware for adding x402 payment requirements to your Gin applications.
+
+## Installation
+
+```bash
+go get github.com/coinbase/x402/go
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+	"time"
+
+	x402 "github.com/coinbase/x402/go"
+	x402http "github.com/coinbase/x402/go/http"
+	ginmw "github.com/coinbase/x402/go/http/gin"
+	evm "github.com/coinbase/x402/go/mechanisms/evm/exact/server"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+
+	facilitator := x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: "https://facilitator.x402.org",
+	})
+
+	routes := x402http.RoutesConfig{
+		"GET /protected": {
+			Scheme:      "exact",
+			PayTo:       "0xYourAddress",
+			Price:       "$0.10",
+			Network:     "eip155:84532",
+			Description: "Access to premium content",
+		},
+	}
+
+	r.Use(ginmw.PaymentMiddleware(routes,
+		ginmw.WithFacilitatorClient(facilitator),
+		ginmw.WithScheme("eip155:*", evm.NewExactEvmScheme()),
+	))
+
+	r.GET("/protected", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "This content is behind a paywall"})
+	})
+
+	r.Run(":8080")
+}
+```
+
+## Configuration
+
+The `PaymentMiddleware` function accepts routes and optional configuration functions:
+
+```go
+func PaymentMiddleware(
+	routes x402http.RoutesConfig,
+	opts ...MiddlewareOption,
+) gin.HandlerFunc
+```
+
+### Configuration Options
+
+- `WithFacilitatorClient(client)` - Add a facilitator client
+- `WithScheme(network, server)` - Register a payment scheme
+- `WithPaywallConfig(config)` - Configure paywall UI
+- `WithSyncFacilitatorOnStart(bool)` - Sync with facilitator on startup (default: true)
+- `WithTimeout(duration)` - Set payment operation timeout (default: 30s)
+- `WithErrorHandler(handler)` - Custom error handler
+- `WithSettlementHandler(handler)` - Settlement callback
+
+## Route Configuration
+
+Define which routes require payment:
+
+```go
+routes := x402http.RoutesConfig{
+	"GET /api/data": {
+		Scheme:      "exact",
+		PayTo:       "0xYourAddress",
+		Price:       "$0.10",
+		Network:     "eip155:84532",
+		Description: "API data access",
+	},
+	"POST /api/compute": {
+		Scheme:      "exact",
+		PayTo:       "0xYourAddress",
+		Price:       "$1.00",
+		Network:     "eip155:8453",
+		Description: "Compute operation",
+	},
+}
+```
+
+Routes support wildcards:
+- `"GET /api/premium/*"` - Matches all GET requests under `/api/premium/`
+- `"* /api/data"` - Matches all HTTP methods to `/api/data`
+
+## Paywall Configuration
+
+Configure the paywall UI for browser requests:
+
+```go
+paywallConfig := &x402http.PaywallConfig{
+	AppName: "My API Service",
+	AppLogo: "https://myapp.com/logo.svg",
+	Testnet: true,
+}
+
+r.Use(ginmw.PaymentMiddleware(routes,
+	ginmw.WithFacilitatorClient(facilitator),
+	ginmw.WithScheme("eip155:*", evm.NewExactEvmScheme()),
+	ginmw.WithPaywallConfig(paywallConfig),
+))
+```
+
+The paywall includes:
+- EVM wallet support (MetaMask, Coinbase Wallet, etc.)
+- Solana wallet support (Phantom, Solflare, etc.)
+- USDC balance checking and chain switching
+- Onramp integration for mainnet
+
+## Advanced Usage
+
+### Multiple Payment Schemes
+
+Register schemes for different networks:
+
+```go
+import (
+	evm "github.com/coinbase/x402/go/mechanisms/evm/exact/server"
+	svm "github.com/coinbase/x402/go/mechanisms/svm/exact/server"
+)
+
+r.Use(ginmw.PaymentMiddleware(routes,
+	ginmw.WithFacilitatorClient(facilitator),
+	ginmw.WithScheme("eip155:*", evm.NewExactEvmScheme()),
+	ginmw.WithScheme("solana:*", svm.NewExactSvmScheme()),
+))
+```
+
+### Custom Facilitator Client
+
+Configure with custom authentication:
+
+```go
+facilitator := x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+	URL: "https://your-facilitator.com",
+	CreateAuthHeaders: func() (*x402http.FacilitatorAuthHeaders, error) {
+		return &x402http.FacilitatorAuthHeaders{
+			Verify: map[string]string{"Authorization": "Bearer verify-token"},
+			Settle: map[string]string{"Authorization": "Bearer settle-token"},
+		}, nil
+	},
+})
+```
+
+### Settlement Handler
+
+Track successful payments:
+
+```go
+r.Use(ginmw.PaymentMiddleware(routes,
+	ginmw.WithFacilitatorClient(facilitator),
+	ginmw.WithScheme("eip155:*", evm.NewExactEvmScheme()),
+	ginmw.WithSettlementHandler(func(c *gin.Context, settlement *x402.SettleResponse) {
+		log.Printf("Payment settled - Payer: %s, Tx: %s",
+			settlement.Payer,
+			settlement.Transaction,
+		)
+		c.Header("X-Payment-Receipt", settlement.Transaction)
+	}),
+))
+```
+
+### Error Handler
+
+Custom error handling:
+
+```go
+r.Use(ginmw.PaymentMiddleware(routes,
+	ginmw.WithFacilitatorClient(facilitator),
+	ginmw.WithScheme("eip155:*", evm.NewExactEvmScheme()),
+	ginmw.WithErrorHandler(func(c *gin.Context, err error) {
+		log.Printf("Payment error: %v", err)
+		c.JSON(http.StatusPaymentRequired, gin.H{
+			"error": err.Error(),
+		})
+	}),
+))
+```
+
+## Complete Example
+
+```go
+package main
+
+import (
+	"log"
+	"time"
+
+	x402 "github.com/coinbase/x402/go"
+	x402http "github.com/coinbase/x402/go/http"
+	ginmw "github.com/coinbase/x402/go/http/gin"
+	evm "github.com/coinbase/x402/go/mechanisms/evm/exact/server"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+
+	facilitator := x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: "https://facilitator.x402.org",
+	})
+
+	routes := x402http.RoutesConfig{
+		"GET /api/data": {
+			Scheme:      "exact",
+			PayTo:       "0xYourAddress",
+			Price:       "$0.10",
+			Network:     "eip155:84532",
+			Description: "Basic data access",
+		},
+		"POST /api/compute": {
+			Scheme:      "exact",
+			PayTo:       "0xYourAddress",
+			Price:       "$1.00",
+			Network:     "eip155:8453",
+			Description: "Compute operation",
+		},
+	}
+
+	paywallConfig := &x402http.PaywallConfig{
+		AppName: "My API Service",
+		AppLogo: "/logo.svg",
+		Testnet: true,
+	}
+
+	r.Use(ginmw.PaymentMiddleware(routes,
+		ginmw.WithFacilitatorClient(facilitator),
+		ginmw.WithScheme("eip155:*", evm.NewExactEvmScheme()),
+		ginmw.WithPaywallConfig(paywallConfig),
+		ginmw.WithTimeout(60*time.Second),
+		ginmw.WithSettlementHandler(func(c *gin.Context, settlement *x402.SettleResponse) {
+			log.Printf("✅ Payment settled: %s", settlement.Transaction)
+		}),
+	))
+
+	r.GET("/api/data", func(c *gin.Context) {
+		c.JSON(200, gin.H{"data": "Protected content"})
+	})
+
+	r.POST("/api/compute", func(c *gin.Context) {
+		c.JSON(200, gin.H{"result": "Computation complete"})
+	})
+
+	r.GET("/", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "Welcome"})
+	})
+
+	r.Run(":8080")
+}
+```
+
+## Convenience Functions
+
+For simple use cases, use the convenience function:
+
+```go
+r.Use(ginmw.SimplePaymentMiddleware(
+	"0xYourAddress",
+	"$0.10",
+	"eip155:84532",
+	"https://facilitator.x402.org",
+))
+```
+
+This applies payment requirements to all routes.
+```

--- a/go/http/gin/builder.go
+++ b/go/http/gin/builder.go
@@ -100,7 +100,7 @@ func X402Payment(config Config) gin.HandlerFunc {
 
 	// Convert to middleware options
 	opts := []MiddlewareOption{
-		WithInitializeOnStart(initialize),
+		WithSyncFacilitatorOnStart(initialize),
 		WithTimeout(config.Timeout),
 	}
 

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -84,8 +84,8 @@ type MiddlewareConfig struct {
 	// Paywall configuration
 	PaywallConfig *x402http.PaywallConfig
 
-	// Initialize on startup
-	InitializeOnStart bool
+	// Sync with facilitator on start
+	SyncFacilitatorOnStart bool
 
 	// Custom error handler
 	ErrorHandler func(*gin.Context, error)
@@ -130,10 +130,10 @@ func WithPaywallConfig(config *x402http.PaywallConfig) MiddlewareOption {
 	}
 }
 
-// WithInitializeOnStart sets whether to initialize on startup
-func WithInitializeOnStart(initialize bool) MiddlewareOption {
+// WithSyncFacilitatorOnStart sets whether to sync with facilitator on startup
+func WithSyncFacilitatorOnStart(sync bool) MiddlewareOption {
 	return func(c *MiddlewareConfig) {
-		c.InitializeOnStart = initialize
+		c.SyncFacilitatorOnStart = sync
 	}
 }
 
@@ -168,7 +168,7 @@ func PaymentMiddleware(routes x402http.RoutesConfig, opts ...MiddlewareOption) g
 		Routes:             routes,
 		FacilitatorClients: []x402.FacilitatorClient{},
 		Schemes:            []SchemeRegistration{},
-		InitializeOnStart:  true,
+		SyncFacilitatorOnStart: true,
 		Timeout:            30 * time.Second,
 	}
 
@@ -192,7 +192,7 @@ func PaymentMiddleware(routes x402http.RoutesConfig, opts ...MiddlewareOption) g
 	}
 
 	// Initialize if requested - queries facilitator /supported to populate facilitatorClients map
-	if config.InitializeOnStart {
+	if config.SyncFacilitatorOnStart {
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 		if err := server.Initialize(ctx); err != nil {
@@ -202,10 +202,6 @@ func PaymentMiddleware(routes x402http.RoutesConfig, opts ...MiddlewareOption) g
 
 	// Create middleware handler
 	return func(c *gin.Context) {
-		// Create context with timeout
-		ctx, cancel := context.WithTimeout(c.Request.Context(), config.Timeout)
-		defer cancel()
-
 		// Create adapter and request context
 		adapter := NewGinAdapter(c)
 		reqCtx := x402http.HTTPRequestContext{
@@ -214,7 +210,16 @@ func PaymentMiddleware(routes x402http.RoutesConfig, opts ...MiddlewareOption) g
 			Method:  c.Request.Method,
 		}
 
-		// Process HTTP request
+		// Check if route requires payment before waiting for initialization
+		if !server.RequiresPayment(reqCtx) {
+			c.Next()
+			return
+		}
+
+		// Create context with timeout
+		ctx, cancel := context.WithTimeout(c.Request.Context(), config.Timeout)
+		defer cancel()
+
 		result := server.ProcessHTTPRequest(ctx, reqCtx, config.PaywallConfig)
 
 		// Debug logging for request processing
@@ -297,48 +302,47 @@ func handlePaymentVerified(c *gin.Context, server *x402http.HTTPServer, ctx cont
 	fmt.Printf("   PaymentRequirements: %+v\n", result.PaymentRequirements)
 
 	// Process settlement
-	settlementHeaders, err := server.ProcessSettlement(
+	settleResult := server.ProcessSettlement(
 		ctx,
 		*result.PaymentPayload,
 		*result.PaymentRequirements,
-		writer.statusCode,
 	)
 
 	fmt.Printf("🔍 [GIN SETTLEMENT DEBUG] Settlement completed\n")
-	fmt.Printf("   Error: %v\n", err)
-	fmt.Printf("   Headers: %+v\n", settlementHeaders)
+	fmt.Printf("   Success: %v\n", settleResult.Success)
+	fmt.Printf("   ErrorReason: %v\n", settleResult.ErrorReason)
 
-	if err != nil {
-		// Settlement failed
+	// Check settlement success 
+	if !settleResult.Success {
+		errorReason := settleResult.ErrorReason
+		if errorReason == "" {
+			errorReason = "Settlement failed"
+		}
 		if config.ErrorHandler != nil {
-			config.ErrorHandler(c, fmt.Errorf("settlement failed: %w", err))
+			config.ErrorHandler(c, fmt.Errorf("settlement failed: %s", errorReason))
 		} else {
-			// Default error handling
-			c.JSON(http.StatusInternalServerError, gin.H{
+			c.JSON(http.StatusPaymentRequired, gin.H{
 				"error":   "Settlement failed",
-				"details": err.Error(),
+				"details": errorReason,
 			})
 		}
 		return
 	}
 
 	// Add settlement headers
-	if settlementHeaders != nil {
-		for key, value := range settlementHeaders {
-			c.Header(key, value)
-		}
+	for key, value := range settleResult.Headers {
+		c.Header(key, value)
+	}
 
-		// Call settlement handler if configured
-		if config.SettlementHandler != nil && settlementHeaders["PAYMENT-RESPONSE"] != "" {
-			// Decode settlement response
-			httpClient := x402http.Newx402HTTPClient(x402.Newx402Client())
-			headers := make(map[string]string)
-			for k, v := range settlementHeaders {
-				headers[k] = v
-			}
-			settleResponse, _ := httpClient.GetPaymentSettleResponse(headers)
-			config.SettlementHandler(c, settleResponse)
+	// Call settlement handler if configured
+	if config.SettlementHandler != nil {
+		settleResponse := &x402.SettleResponse{
+			Success:     true,
+			Transaction: settleResult.Transaction,
+			Network:     settleResult.Network,
+			Payer:       settleResult.Payer,
 		}
+		config.SettlementHandler(c, settleResponse)
 	}
 
 	// Write captured response
@@ -409,7 +413,7 @@ func SimplePaymentMiddleware(payTo string, price string, network x402.Network, f
 
 	return PaymentMiddleware(routes,
 		WithFacilitatorClient(facilitator),
-		WithInitializeOnStart(true),
+		WithSyncFacilitatorOnStart(true),
 	)
 }
 

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -165,11 +165,11 @@ func WithTimeout(timeout time.Duration) MiddlewareOption {
 // PaymentMiddleware creates Gin middleware for x402 payment handling
 func PaymentMiddleware(routes x402http.RoutesConfig, opts ...MiddlewareOption) gin.HandlerFunc {
 	config := &MiddlewareConfig{
-		Routes:             routes,
-		FacilitatorClients: []x402.FacilitatorClient{},
-		Schemes:            []SchemeRegistration{},
+		Routes:                 routes,
+		FacilitatorClients:     []x402.FacilitatorClient{},
+		Schemes:                []SchemeRegistration{},
 		SyncFacilitatorOnStart: true,
-		Timeout:            30 * time.Second,
+		Timeout:                30 * time.Second,
 	}
 
 	// Apply options
@@ -312,7 +312,7 @@ func handlePaymentVerified(c *gin.Context, server *x402http.HTTPServer, ctx cont
 	fmt.Printf("   Success: %v\n", settleResult.Success)
 	fmt.Printf("   ErrorReason: %v\n", settleResult.ErrorReason)
 
-	// Check settlement success 
+	// Check settlement success
 	if !settleResult.Success {
 		errorReason := settleResult.ErrorReason
 		if errorReason == "" {
@@ -368,6 +368,11 @@ func (w *responseCapture) WriteHeader(code int) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	w.writeHeaderLocked(code)
+}
+
+// writeHeaderLocked sets the status code (must be called with lock held)
+func (w *responseCapture) writeHeaderLocked(code int) {
 	if !w.written {
 		w.statusCode = code
 		w.written = true
@@ -380,7 +385,7 @@ func (w *responseCapture) Write(data []byte) (int, error) {
 	defer w.mu.Unlock()
 
 	if !w.written {
-		w.WriteHeader(http.StatusOK)
+		w.writeHeaderLocked(http.StatusOK)
 	}
 	return w.body.Write(data)
 }

--- a/go/http/gin/middleware_test.go
+++ b/go/http/gin/middleware_test.go
@@ -1,0 +1,1120 @@
+package gin
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	x402 "github.com/coinbase/x402/go"
+	x402http "github.com/coinbase/x402/go/http"
+	"github.com/coinbase/x402/go/types"
+	"github.com/gin-gonic/gin"
+)
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// ============================================================================
+// Mock Implementations
+// ============================================================================
+
+// mockSchemeServer implements x402.SchemeNetworkServer for testing
+type mockSchemeServer struct {
+	scheme string
+}
+
+func (m *mockSchemeServer) Scheme() string {
+	return m.scheme
+}
+
+func (m *mockSchemeServer) ParsePrice(price x402.Price, network x402.Network) (x402.AssetAmount, error) {
+	return x402.AssetAmount{
+		Asset:  "USDC",
+		Amount: "1000000",
+	}, nil
+}
+
+func (m *mockSchemeServer) EnhancePaymentRequirements(ctx context.Context, base types.PaymentRequirements, supported types.SupportedKind, extensions []string) (types.PaymentRequirements, error) {
+	return base, nil
+}
+
+// mockFacilitatorClient implements x402.FacilitatorClient for testing
+type mockFacilitatorClient struct {
+	verifyFunc    func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error)
+	settleFunc    func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.SettleResponse, error)
+	supportedFunc func(ctx context.Context) (x402.SupportedResponse, error)
+}
+
+func (m *mockFacilitatorClient) Verify(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error) {
+	if m.verifyFunc != nil {
+		return m.verifyFunc(ctx, payloadBytes, requirementsBytes)
+	}
+	return &x402.VerifyResponse{IsValid: true, Payer: "0xmock"}, nil
+}
+
+func (m *mockFacilitatorClient) Settle(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.SettleResponse, error) {
+	if m.settleFunc != nil {
+		return m.settleFunc(ctx, payloadBytes, requirementsBytes)
+	}
+	return &x402.SettleResponse{Success: true, Transaction: "0xtx", Network: "eip155:1", Payer: "0xmock"}, nil
+}
+
+func (m *mockFacilitatorClient) GetSupported(ctx context.Context) (x402.SupportedResponse, error) {
+	if m.supportedFunc != nil {
+		return m.supportedFunc(ctx)
+	}
+	return x402.SupportedResponse{
+		Kinds: []x402.SupportedKind{
+			{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+		},
+		Extensions: []string{},
+		Signers:    make(map[string][]string),
+	}, nil
+}
+
+func (m *mockFacilitatorClient) Identifier() string {
+	return "mock"
+}
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+// createTestRouter creates a Gin router for testing
+func createTestRouter() *gin.Engine {
+	router := gin.New()
+	return router
+}
+
+// createPaymentHeader creates a base64-encoded payment header for testing
+func createPaymentHeader(payTo string) string {
+	payload := x402.PaymentPayload{
+		X402Version: 2,
+		Payload:     map[string]interface{}{"sig": "test"},
+		Accepted: x402.PaymentRequirements{
+			Scheme:            "exact",
+			Network:           "eip155:1",
+			Asset:             "USDC",
+			Amount:            "1000000",
+			PayTo:             payTo,
+			MaxTimeoutSeconds: 300,
+			Extra: map[string]interface{}{
+				"resourceUrl": "http://example.com/api",
+			},
+		},
+	}
+
+	payloadJSON, _ := json.Marshal(payload)
+	return base64.StdEncoding.EncodeToString(payloadJSON)
+}
+
+// ============================================================================
+// GinAdapter Tests
+// ============================================================================
+
+func TestGinAdapter_GetHeader(t *testing.T) {
+	router := createTestRouter()
+	var adapter *GinAdapter
+
+	router.GET("/test", func(c *gin.Context) {
+		adapter = NewGinAdapter(c)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-Custom-Header", "test-value")
+	req.Header.Set("payment-signature", "sig-data")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if adapter.GetHeader("X-Custom-Header") != "test-value" {
+		t.Error("Expected X-Custom-Header to be 'test-value'")
+	}
+
+	if adapter.GetHeader("payment-signature") != "sig-data" {
+		t.Error("Expected payment-signature header")
+	}
+}
+
+func TestGinAdapter_GetMethod(t *testing.T) {
+	tests := []struct {
+		method   string
+		expected string
+	}{
+		{"GET", "GET"},
+		{"POST", "POST"},
+		{"PUT", "PUT"},
+		{"DELETE", "DELETE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			router := createTestRouter()
+			var adapter *GinAdapter
+
+			router.Handle(tt.method, "/test", func(c *gin.Context) {
+				adapter = NewGinAdapter(c)
+			})
+
+			req := httptest.NewRequest(tt.method, "/test", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if adapter.GetMethod() != tt.expected {
+				t.Errorf("Expected method %s, got %s", tt.expected, adapter.GetMethod())
+			}
+		})
+	}
+}
+
+func TestGinAdapter_GetPath(t *testing.T) {
+	router := createTestRouter()
+	var adapter *GinAdapter
+
+	router.GET("/api/users/:id", func(c *gin.Context) {
+		adapter = NewGinAdapter(c)
+	})
+
+	req := httptest.NewRequest("GET", "/api/users/123", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if adapter.GetPath() != "/api/users/123" {
+		t.Errorf("Expected path '/api/users/123', got '%s'", adapter.GetPath())
+	}
+}
+
+func TestGinAdapter_GetURL(t *testing.T) {
+	router := createTestRouter()
+	var adapter *GinAdapter
+
+	router.GET("/api/test", func(c *gin.Context) {
+		adapter = NewGinAdapter(c)
+	})
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Host = "example.com"
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	expected := "http://example.com/api/test"
+	if adapter.GetURL() != expected {
+		t.Errorf("Expected URL '%s', got '%s'", expected, adapter.GetURL())
+	}
+}
+
+func TestGinAdapter_GetAcceptHeader(t *testing.T) {
+	router := createTestRouter()
+	var adapter *GinAdapter
+
+	router.GET("/test", func(c *gin.Context) {
+		adapter = NewGinAdapter(c)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Accept", "text/html")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if adapter.GetAcceptHeader() != "text/html" {
+		t.Errorf("Expected Accept header 'text/html', got '%s'", adapter.GetAcceptHeader())
+	}
+}
+
+func TestGinAdapter_GetUserAgent(t *testing.T) {
+	router := createTestRouter()
+	var adapter *GinAdapter
+
+	router.GET("/test", func(c *gin.Context) {
+		adapter = NewGinAdapter(c)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if adapter.GetUserAgent() != "Mozilla/5.0" {
+		t.Errorf("Expected User-Agent 'Mozilla/5.0', got '%s'", adapter.GetUserAgent())
+	}
+}
+
+// ============================================================================
+// PaymentMiddleware Tests
+// ============================================================================
+
+func TestPaymentMiddleware_CallsNextWhenNoPaymentRequired(t *testing.T) {
+	routes := x402http.RoutesConfig{
+		"GET /api": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	router := createTestRouter()
+	router.Use(PaymentMiddleware(routes, WithSyncFacilitatorOnStart(false)))
+
+	nextCalled := false
+	router.GET("/public", func(c *gin.Context) {
+		nextCalled = true
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if !nextCalled {
+		t.Error("Expected next() to be called for non-protected route")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestPaymentMiddleware_Returns402JSONForPaymentError(t *testing.T) {
+	mockClient := &mockFacilitatorClient{
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"GET /api": x402http.RouteConfig{
+			Scheme:      "exact",
+			PayTo:       "0xtest",
+			Price:       "$1.00",
+			Network:     "eip155:1",
+			Description: "API access",
+		},
+	}
+
+	router := createTestRouter()
+	router.Use(PaymentMiddleware(routes,
+		WithFacilitatorClient(mockClient),
+		WithScheme("eip155:1", mockServer),
+		WithSyncFacilitatorOnStart(true),
+		WithTimeout(5*time.Second),
+	))
+
+	router.GET("/api", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "protected"})
+	})
+
+	req := httptest.NewRequest("GET", "/api", nil)
+	req.Header.Set("Accept", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("Expected status 402, got %d", w.Code)
+	}
+
+	if w.Header().Get("PAYMENT-REQUIRED") == "" {
+		t.Error("Expected PAYMENT-REQUIRED header")
+	}
+}
+
+func TestPaymentMiddleware_Returns402HTMLForBrowserRequest(t *testing.T) {
+	mockClient := &mockFacilitatorClient{
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"*": x402http.RouteConfig{
+			Scheme:      "exact",
+			PayTo:       "0xtest",
+			Price:       "$5.00",
+			Network:     "eip155:1",
+			Description: "Premium content",
+		},
+	}
+
+	paywallConfig := &x402http.PaywallConfig{
+		AppName:      "Test App",
+		CDPClientKey: "test-key",
+	}
+
+	router := createTestRouter()
+	router.Use(PaymentMiddleware(routes,
+		WithFacilitatorClient(mockClient),
+		WithScheme("eip155:1", mockServer),
+		WithPaywallConfig(paywallConfig),
+		WithSyncFacilitatorOnStart(true),
+		WithTimeout(5*time.Second),
+	))
+
+	router.GET("/content", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "protected"})
+	})
+
+	req := httptest.NewRequest("GET", "/content", nil)
+	req.Header.Set("Accept", "text/html")
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("Expected status 402, got %d", w.Code)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if !bytes.Contains([]byte(contentType), []byte("text/html")) {
+		t.Errorf("Expected Content-Type to contain 'text/html', got '%s'", contentType)
+	}
+
+	body := w.Body.String()
+	if !bytes.Contains([]byte(body), []byte("Payment Required")) {
+		t.Error("Expected 'Payment Required' in HTML body")
+	}
+	if !bytes.Contains([]byte(body), []byte("Test App")) {
+		t.Error("Expected app name in HTML body")
+	}
+	if !bytes.Contains([]byte(body), []byte("test-key")) {
+		t.Error("Expected CDP client key in HTML body")
+	}
+}
+
+func TestPaymentMiddleware_SettlesAndReturnsResponseForVerifiedPayment(t *testing.T) {
+	settleCalled := false
+
+	mockClient := &mockFacilitatorClient{
+		verifyFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error) {
+			return &x402.VerifyResponse{IsValid: true, Payer: "0xpayer"}, nil
+		},
+		settleFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.SettleResponse, error) {
+			settleCalled = true
+			return &x402.SettleResponse{
+				Success:     true,
+				Transaction: "0xtx",
+				Network:     "eip155:1",
+				Payer:       "0xpayer",
+			}, nil
+		},
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"POST /api": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	router := createTestRouter()
+	router.Use(PaymentMiddleware(routes,
+		WithFacilitatorClient(mockClient),
+		WithScheme("eip155:1", mockServer),
+		WithSyncFacilitatorOnStart(true),
+		WithTimeout(5*time.Second),
+	))
+
+	router.POST("/api", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "protected-data"})
+	})
+
+	req := httptest.NewRequest("POST", "/api", nil)
+	req.Header.Set("PAYMENT-SIGNATURE", createPaymentHeader("0xtest"))
+	req.Host = "example.com"
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+
+	if !settleCalled {
+		t.Error("Expected settlement to be called")
+	}
+
+	if w.Header().Get("PAYMENT-RESPONSE") == "" {
+		t.Error("Expected PAYMENT-RESPONSE header")
+	}
+}
+
+func TestPaymentMiddleware_SkipsSettlementWhenHandlerReturns400OrHigher(t *testing.T) {
+	settleCalled := false
+
+	mockClient := &mockFacilitatorClient{
+		verifyFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error) {
+			return &x402.VerifyResponse{IsValid: true, Payer: "0xpayer"}, nil
+		},
+		settleFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.SettleResponse, error) {
+			settleCalled = true
+			return &x402.SettleResponse{Success: true, Transaction: "0xtx"}, nil
+		},
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"POST /api": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	router := createTestRouter()
+	router.Use(PaymentMiddleware(routes,
+		WithFacilitatorClient(mockClient),
+		WithScheme("eip155:1", mockServer),
+		WithSyncFacilitatorOnStart(true),
+		WithTimeout(5*time.Second),
+	))
+
+	router.POST("/api", func(c *gin.Context) {
+		// Handler returns error
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+	})
+
+	req := httptest.NewRequest("POST", "/api", nil)
+	req.Header.Set("PAYMENT-SIGNATURE", createPaymentHeader("0xtest"))
+	req.Host = "example.com"
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %d", w.Code)
+	}
+
+	if settleCalled {
+		t.Error("Settlement should NOT be called when handler returns >= 400")
+	}
+}
+
+func TestPaymentMiddleware_Returns402WhenSettlementFails(t *testing.T) {
+	mockClient := &mockFacilitatorClient{
+		verifyFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error) {
+			return &x402.VerifyResponse{IsValid: true, Payer: "0xpayer"}, nil
+		},
+		settleFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.SettleResponse, error) {
+			return &x402.SettleResponse{
+				Success:     false,
+				ErrorReason: "Insufficient funds",
+			}, nil
+		},
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"POST /api": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	router := createTestRouter()
+	router.Use(PaymentMiddleware(routes,
+		WithFacilitatorClient(mockClient),
+		WithScheme("eip155:1", mockServer),
+		WithSyncFacilitatorOnStart(true),
+		WithTimeout(5*time.Second),
+	))
+
+	router.POST("/api", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "protected-data"})
+	})
+
+	req := httptest.NewRequest("POST", "/api", nil)
+	req.Header.Set("PAYMENT-SIGNATURE", createPaymentHeader("0xtest"))
+	req.Host = "example.com"
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("Expected status 402, got %d", w.Code)
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	if response["error"] != "Settlement failed" {
+		t.Errorf("Expected error 'Settlement failed', got '%v'", response["error"])
+	}
+	if response["details"] != "Insufficient funds" {
+		t.Errorf("Expected details 'Insufficient funds', got '%v'", response["details"])
+	}
+}
+
+func TestPaymentMiddleware_CustomErrorHandler(t *testing.T) {
+	customHandlerCalled := false
+
+	mockClient := &mockFacilitatorClient{
+		verifyFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error) {
+			return &x402.VerifyResponse{IsValid: true, Payer: "0xpayer"}, nil
+		},
+		settleFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.SettleResponse, error) {
+			return &x402.SettleResponse{
+				Success:     false,
+				ErrorReason: "Settlement rejected",
+			}, nil
+		},
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"POST /api": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	customErrorHandler := func(c *gin.Context, err error) {
+		customHandlerCalled = true
+		c.JSON(http.StatusPaymentRequired, gin.H{
+			"custom_error": err.Error(),
+		})
+	}
+
+	router := createTestRouter()
+	router.Use(PaymentMiddleware(routes,
+		WithFacilitatorClient(mockClient),
+		WithScheme("eip155:1", mockServer),
+		WithErrorHandler(customErrorHandler),
+		WithSyncFacilitatorOnStart(true),
+		WithTimeout(5*time.Second),
+	))
+
+	router.POST("/api", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "protected-data"})
+	})
+
+	req := httptest.NewRequest("POST", "/api", nil)
+	req.Header.Set("PAYMENT-SIGNATURE", createPaymentHeader("0xtest"))
+	req.Host = "example.com"
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if !customHandlerCalled {
+		t.Error("Expected custom error handler to be called")
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	if response["custom_error"] == nil {
+		t.Error("Expected custom_error in response")
+	}
+}
+
+func TestPaymentMiddleware_CustomSettlementHandler(t *testing.T) {
+	settlementHandlerCalled := false
+	var capturedSettleResponse *x402.SettleResponse
+
+	mockClient := &mockFacilitatorClient{
+		verifyFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error) {
+			return &x402.VerifyResponse{IsValid: true, Payer: "0xpayer"}, nil
+		},
+		settleFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.SettleResponse, error) {
+			return &x402.SettleResponse{
+				Success:     true,
+				Transaction: "0xtx123",
+				Network:     "eip155:1",
+				Payer:       "0xpayer",
+			}, nil
+		},
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"POST /api": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	customSettlementHandler := func(c *gin.Context, settleResponse *x402.SettleResponse) {
+		settlementHandlerCalled = true
+		capturedSettleResponse = settleResponse
+		// Add custom header
+		c.Header("X-Transaction-ID", settleResponse.Transaction)
+	}
+
+	router := createTestRouter()
+	router.Use(PaymentMiddleware(routes,
+		WithFacilitatorClient(mockClient),
+		WithScheme("eip155:1", mockServer),
+		WithSettlementHandler(customSettlementHandler),
+		WithSyncFacilitatorOnStart(true),
+		WithTimeout(5*time.Second),
+	))
+
+	router.POST("/api", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "protected-data"})
+	})
+
+	req := httptest.NewRequest("POST", "/api", nil)
+	req.Header.Set("PAYMENT-SIGNATURE", createPaymentHeader("0xtest"))
+	req.Host = "example.com"
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	if !settlementHandlerCalled {
+		t.Error("Expected custom settlement handler to be called")
+	}
+
+	if capturedSettleResponse == nil {
+		t.Fatal("Expected settle response to be captured")
+	}
+
+	if capturedSettleResponse.Transaction != "0xtx123" {
+		t.Errorf("Expected transaction '0xtx123', got '%s'", capturedSettleResponse.Transaction)
+	}
+
+	if w.Header().Get("X-Transaction-ID") != "0xtx123" {
+		t.Error("Expected custom X-Transaction-ID header")
+	}
+}
+
+func TestPaymentMiddleware_WithTimeout(t *testing.T) {
+	mockClient := &mockFacilitatorClient{
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"*": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	timeout := 10 * time.Second
+
+	router := createTestRouter()
+	router.Use(PaymentMiddleware(routes,
+		WithFacilitatorClient(mockClient),
+		WithScheme("eip155:1", mockServer),
+		WithTimeout(timeout),
+		WithSyncFacilitatorOnStart(true),
+	))
+
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	// Verify the middleware is created and requires payment
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Route should require payment
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("Expected status 402, got %d", w.Code)
+	}
+}
+
+// ============================================================================
+// X402Payment (Builder Pattern) Tests
+// ============================================================================
+
+func TestX402Payment_CreatesWorkingMiddleware(t *testing.T) {
+	mockClient := &mockFacilitatorClient{
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"GET /api": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	router := createTestRouter()
+	router.Use(X402Payment(Config{
+		Routes:      routes,
+		Facilitator: mockClient,
+		Schemes: []SchemeConfig{
+			{Network: "eip155:1", Server: mockServer},
+		},
+		Initialize: true,
+		Timeout:    5 * time.Second,
+	}))
+
+	router.GET("/api", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "protected"})
+	})
+
+	// Test non-protected route passes through
+	router.GET("/public", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "public"})
+	})
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200 for public route, got %d", w.Code)
+	}
+
+	// Test protected route requires payment
+	req = httptest.NewRequest("GET", "/api", nil)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("Expected status 402 for protected route, got %d", w.Code)
+	}
+}
+
+func TestX402Payment_RegistersMultipleFacilitators(t *testing.T) {
+	mockClient1 := &mockFacilitatorClient{
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+	mockClient2 := &mockFacilitatorClient{
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"*": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	// This should not panic and properly register multiple facilitators
+	router := createTestRouter()
+	router.Use(X402Payment(Config{
+		Routes:       routes,
+		Facilitators: []x402.FacilitatorClient{mockClient1, mockClient2},
+		Schemes: []SchemeConfig{
+			{Network: "eip155:1", Server: mockServer},
+		},
+		Initialize: true,
+	}))
+
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("Expected status 402, got %d", w.Code)
+	}
+}
+
+func TestX402Payment_RegistersMultipleSchemes(t *testing.T) {
+	mockServer1 := &mockSchemeServer{scheme: "exact"}
+	mockServer2 := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"*": x402http.RouteConfig{
+			Scheme:  "exact",
+			PayTo:   "0xtest",
+			Price:   "$1.00",
+			Network: "eip155:1",
+		},
+	}
+
+	// This should not panic
+	router := createTestRouter()
+	router.Use(X402Payment(Config{
+		Routes: routes,
+		Schemes: []SchemeConfig{
+			{Network: "eip155:1", Server: mockServer1},
+			{Network: "eip155:8453", Server: mockServer2},
+		},
+		Initialize: false,
+	}))
+
+	router.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("Expected status 402, got %d", w.Code)
+	}
+}
+
+// ============================================================================
+// responseCapture Tests
+// ============================================================================
+
+func TestResponseCapture_CapturesStatusCode(t *testing.T) {
+	capture := &responseCapture{
+		ResponseWriter: &mockGinResponseWriter{
+			ResponseRecorder: httptest.NewRecorder(),
+		},
+		body:       &bytes.Buffer{},
+		statusCode: http.StatusOK,
+	}
+
+	capture.WriteHeader(http.StatusCreated)
+
+	if capture.statusCode != http.StatusCreated {
+		t.Errorf("Expected status 201, got %d", capture.statusCode)
+	}
+}
+
+func TestResponseCapture_CapturesBody(t *testing.T) {
+	capture := &responseCapture{
+		ResponseWriter: &mockGinResponseWriter{
+			ResponseRecorder: httptest.NewRecorder(),
+		},
+		body:       &bytes.Buffer{},
+		statusCode: http.StatusOK,
+	}
+
+	data := []byte(`{"message":"test"}`)
+	n, err := capture.Write(data)
+
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if n != len(data) {
+		t.Errorf("Expected to write %d bytes, wrote %d", len(data), n)
+	}
+	if capture.body.String() != `{"message":"test"}` {
+		t.Errorf("Expected body '%s', got '%s'", `{"message":"test"}`, capture.body.String())
+	}
+}
+
+func TestResponseCapture_WriteString(t *testing.T) {
+	capture := &responseCapture{
+		ResponseWriter: &mockGinResponseWriter{
+			ResponseRecorder: httptest.NewRecorder(),
+		},
+		body:       &bytes.Buffer{},
+		statusCode: http.StatusOK,
+	}
+
+	n, err := capture.WriteString("hello world")
+
+	if err != nil {
+		t.Fatalf("WriteString failed: %v", err)
+	}
+	if n != 11 {
+		t.Errorf("Expected to write 11 bytes, wrote %d", n)
+	}
+	if capture.body.String() != "hello world" {
+		t.Errorf("Expected body 'hello world', got '%s'", capture.body.String())
+	}
+}
+
+func TestResponseCapture_WriteHeaderOnlyOnce(t *testing.T) {
+	capture := &responseCapture{
+		ResponseWriter: &mockGinResponseWriter{
+			ResponseRecorder: httptest.NewRecorder(),
+		},
+		body:       &bytes.Buffer{},
+		statusCode: http.StatusOK,
+	}
+
+	capture.WriteHeader(http.StatusCreated)
+	capture.WriteHeader(http.StatusAccepted) // Should be ignored
+
+	if capture.statusCode != http.StatusCreated {
+		t.Errorf("Expected status 201 (first call), got %d", capture.statusCode)
+	}
+}
+
+// mockGinResponseWriter implements gin.ResponseWriter for testing
+type mockGinResponseWriter struct {
+	*httptest.ResponseRecorder
+	status int
+	size   int
+}
+
+func (m *mockGinResponseWriter) Status() int {
+	return m.status
+}
+
+func (m *mockGinResponseWriter) Size() int {
+	return m.size
+}
+
+func (m *mockGinResponseWriter) Written() bool {
+	return m.size > 0
+}
+
+func (m *mockGinResponseWriter) WriteHeader(code int) {
+	m.status = code
+	m.ResponseRecorder.WriteHeader(code)
+}
+
+func (m *mockGinResponseWriter) WriteHeaderNow() {}
+
+func (m *mockGinResponseWriter) Write(data []byte) (int, error) {
+	n, err := m.ResponseRecorder.Write(data)
+	m.size += n
+	return n, err
+}
+
+func (m *mockGinResponseWriter) WriteString(s string) (int, error) {
+	return m.Write([]byte(s))
+}
+
+func (m *mockGinResponseWriter) Pusher() http.Pusher {
+	return nil
+}
+
+func (m *mockGinResponseWriter) CloseNotify() <-chan bool {
+	return make(chan bool)
+}
+
+func (m *mockGinResponseWriter) Flush() {
+	m.ResponseRecorder.Flush()
+}
+
+func (m *mockGinResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, nil
+}

--- a/go/http/server_test.go
+++ b/go/http/server_test.go
@@ -384,25 +384,16 @@ func TestProcessSettlement(t *testing.T) {
 		Payload:     map[string]interface{}{},
 	}
 
-	// Test successful response (should settle)
-	headers, err := server.ProcessSettlement(ctx, payload, requirements, 200)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	// Test settlement processing
+	result := server.ProcessSettlement(ctx, payload, requirements)
+	if !result.Success {
+		t.Fatalf("Unexpected failure: %v", result.ErrorReason)
 	}
-	if headers == nil {
+	if result.Headers == nil {
 		t.Fatal("Expected settlement headers")
 	}
-	if headers["PAYMENT-RESPONSE"] == "" {
+	if result.Headers["PAYMENT-RESPONSE"] == "" {
 		t.Error("Expected PAYMENT-RESPONSE header")
-	}
-
-	// Test failed response (should not settle)
-	headers, err = server.ProcessSettlement(ctx, payload, requirements, 400)
-	if err != nil {
-		t.Fatalf("Unexpected error for 400: %v", err)
-	}
-	if headers != nil {
-		t.Error("Expected no headers for failed response")
 	}
 }
 

--- a/go/signers/evm/README.md
+++ b/go/signers/evm/README.md
@@ -6,7 +6,7 @@ Client-side EIP-712 signing for Ethereum-based x402 payments.
 
 ```go
 import (
-    "github.com/coinbase/x402/go/mechanisms/evm"
+    evmclient "github.com/coinbase/x402/go/mechanisms/evm/exact/client"
     evmsigners "github.com/coinbase/x402/go/signers/evm"
 )
 
@@ -16,8 +16,8 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Use with ExactEvmClient
-evmClient := evm.NewExactEvmClient(signer)
+// Use with ExactEvmScheme
+evmScheme := evmclient.NewExactEvmScheme(signer)
 ```
 
 ## API
@@ -57,7 +57,7 @@ The helper implements `evm.ClientEvmSigner`:
 ```go
 type ClientEvmSigner interface {
     Address() string
-    SignTypedData(domain TypedDataDomain, types map[string][]TypedDataField, 
+    SignTypedData(ctx context.Context, domain TypedDataDomain, types map[string][]TypedDataField, 
                   primaryType string, message map[string]interface{}) ([]byte, error)
 }
 ```

--- a/go/signers/svm/README.md
+++ b/go/signers/svm/README.md
@@ -6,7 +6,7 @@ Client-side Ed25519 signing for Solana-based x402 payments.
 
 ```go
 import (
-    "github.com/coinbase/x402/go/mechanisms/svm"
+    svmclient "github.com/coinbase/x402/go/mechanisms/svm/exact/client"
     svmsigners "github.com/coinbase/x402/go/signers/svm"
 )
 
@@ -16,8 +16,8 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Use with ExactSvmClient
-svmClient := svm.NewExactSvmClient(signer)
+// Use with ExactSvmScheme
+svmScheme := svmclient.NewExactSvmScheme(signer)
 ```
 
 ## API
@@ -60,7 +60,7 @@ The helper implements `svm.ClientSvmSigner`:
 ```go
 type ClientSvmSigner interface {
     Address() solana.PublicKey
-    SignTransaction(tx *solana.Transaction) error
+    SignTransaction(ctx context.Context, tx *solana.Transaction) error
 }
 ```
 

--- a/go/test/integration/http_test.go
+++ b/go/test/integration/http_test.go
@@ -205,26 +205,25 @@ func TestHTTPIntegration(t *testing.T) {
 		}
 
 		// Process settlement (simulating successful response)
-		settlementHeaders, err := server.ProcessSettlement(
+		settlementResult := server.ProcessSettlement(
 			ctx,
 			*httpProcessResult2.PaymentPayload,
 			*httpProcessResult2.PaymentRequirements,
-			200, // Success status
 		)
-		if err != nil {
-			t.Fatalf("Failed to process settlement: %v", err)
+		if !settlementResult.Success {
+			t.Fatalf("Failed to process settlement: %v", settlementResult.ErrorReason)
 		}
 
-		if settlementHeaders == nil {
+		if settlementResult.Headers == nil {
 			t.Fatal("Expected settlement headers")
 		}
 
-		if settlementHeaders["PAYMENT-RESPONSE"] == "" {
+		if settlementResult.Headers["PAYMENT-RESPONSE"] == "" {
 			t.Error("Expected PAYMENT-RESPONSE header")
 		}
 
 		// Decode and verify settlement response
-		settleData, err := base64.StdEncoding.DecodeString(settlementHeaders["PAYMENT-RESPONSE"])
+		settleData, err := base64.StdEncoding.DecodeString(settlementResult.Headers["PAYMENT-RESPONSE"])
 		if err != nil {
 			t.Fatalf("Failed to decode settlement response: %v", err)
 		}


### PR DESCRIPTION
## Description

- Go equivalent fixes for settleResponse failure check (https://github.com/coinbase/x402/pull/707) and initOnStart issues (https://github.com/coinbase/x402/pull/716)
- Updated existing unit tests and added new ones for gin middleware
- Updated Makefile to get 'make verify' running
- Fixed mutex deadlock in responseCapture.Write(): calling WriteHeader() while already holding the lock would cause a deadlock when Write() is invoked without a prior WriteHeader() call (not hit in typical usage with c.JSON() as in server examples, but exposed by unit tests)

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 