### PR TITLE
fix(java): skip settlement for error responses (4xx/5xx)

### DIFF
--- a/java/src/main/java/com/coinbase/x402/server/PaymentFilter.java
+++ b/java/src/main/java/com/coinbase/x402/server/PaymentFilter.java
@@ -146,6 +146,11 @@ public class PaymentFilter implements Filter {
         chain.doFilter(req, res);
 
         /* -------- settlement (return errors to user) ------------- */
+        // Don't settle if response failed (4xx/5xx status codes)
+        if (response.getStatus() >= 400) {
+            return;
+        }
+
         try {
             SettlementResponse sr = facilitator.settle(header, buildRequirements(path));
             if (sr == null || !sr.success) {


### PR DESCRIPTION
## Summary

Adds response status code check before settlement in Java PaymentFilter for the main branch.
Skips settlement if handler returns 4xx/5xx to prevent charging users for failed requests.

## Changes

- Add `response.getStatus() >= 400` check before calling `facilitator.settle()`
- Add unit tests for 4xx and 5xx response scenarios
- Update existing test to mock `resp.getStatus()` 

## Related

- #721 - Same fix for development-v2 branch
- #722 - Go equivalent fix for main branch