### PR TITLE
fix(clients): remove invalid Access-Control-Expose-Headers request header

### DIFF
--- a/python/x402/src/x402/clients/httpx.py
+++ b/python/x402/src/x402/clients/httpx.py
@@ -56,7 +56,6 @@ class HttpxHooks:
             request = response.request
 
             request.headers["X-Payment"] = payment_header
-            request.headers["Access-Control-Expose-Headers"] = "X-Payment-Response"
 
             # Retry the request
             async with AsyncClient() as client:

--- a/python/x402/src/x402/clients/requests.py
+++ b/python/x402/src/x402/clients/requests.py
@@ -66,7 +66,6 @@ class x402HTTPAdapter(HTTPAdapter):
             # Mark as retry and add payment header
             self._is_retry = True
             request.headers["X-Payment"] = payment_header
-            request.headers["Access-Control-Expose-Headers"] = "X-Payment-Response"
 
             retry_response = super().send(request, **kwargs)
 

--- a/python/x402/tests/clients/test_httpx.py
+++ b/python/x402/tests/clients/test_httpx.py
@@ -124,10 +124,6 @@ async def test_on_response_payment_flow(hooks, payment_requirements):
         assert mock_client.send.called
         retry_request = mock_client.send.call_args[0][0]
         assert retry_request.headers["X-Payment"] == mock_header
-        assert (
-            retry_request.headers["Access-Control-Expose-Headers"]
-            == "X-Payment-Response"
-        )
 
         # Verify the mocked methods were called with correct arguments
         hooks.client.select_payment_requirements.assert_called_once_with(

--- a/python/x402/tests/clients/test_requests.py
+++ b/python/x402/tests/clients/test_requests.py
@@ -200,10 +200,6 @@ def test_adapter_payment_flow(adapter, payment_requirements):
         retry_call = mock_send.call_args_list[1]
         retry_request = retry_call[0][0]
         assert retry_request.headers["X-Payment"] == mock_header
-        assert (
-            retry_request.headers["Access-Control-Expose-Headers"]
-            == "X-Payment-Response"
-        )
 
 
 def test_adapter_payment_error(adapter, payment_requirements):

--- a/typescript/packages/x402-axios/src/index.test.ts
+++ b/typescript/packages/x402-axios/src/index.test.ts
@@ -141,7 +141,6 @@ describe("withPaymentInterceptor()", () => {
       ...error.config,
       headers: new AxiosHeaders({
         "X-PAYMENT": paymentHeader,
-        "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
       }),
       __is402Retry: true,
     });

--- a/typescript/packages/x402-axios/src/index.ts
+++ b/typescript/packages/x402-axios/src/index.ts
@@ -99,7 +99,6 @@ export function withPaymentInterceptor(
         (originalConfig as { __is402Retry?: boolean }).__is402Retry = true;
 
         originalConfig.headers["X-PAYMENT"] = paymentHeader;
-        originalConfig.headers["Access-Control-Expose-Headers"] = "X-PAYMENT-RESPONSE";
 
         const secondResponse = await axiosClient.request(originalConfig);
         return secondResponse;

--- a/typescript/packages/x402-fetch/src/index.test.ts
+++ b/typescript/packages/x402-fetch/src/index.test.ts
@@ -102,7 +102,6 @@ describe("fetchWithPayment()", () => {
       headers: {
         "Content-Type": "application/json",
         "X-PAYMENT": paymentHeader,
-        "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
       },
       __is402Retry: true,
     } as RequestInitWithRetry);

--- a/typescript/packages/x402-fetch/src/index.ts
+++ b/typescript/packages/x402-fetch/src/index.ts
@@ -106,7 +106,6 @@ export function wrapFetchWithPayment(
       headers: {
         ...(init?.headers || {}),
         "X-PAYMENT": paymentHeader,
-        "Access-Control-Expose-Headers": "X-PAYMENT-RESPONSE",
       },
       __is402Retry: true,
     };


### PR DESCRIPTION
## Summary
- Removes the incorrect `Access-Control-Expose-Headers` header from client request headers in x402-fetch, x402-axios, and Python clients (httpx, requests)
- This header is a RESPONSE header per the CORS spec and has no effect when sent in a request
- Server-side middlewares are responsible for setting this header in their responses

## Background
`Access-Control-Expose-Headers` is a CORS response header that tells browsers which headers from the response are accessible to JavaScript. Setting it as a request header does nothing.

The fix removes the header from:
- `typescript/packages/x402-fetch/src/index.ts`
- `typescript/packages/x402-axios/src/index.ts`
- `python/x402/src/x402/clients/httpx.py`
- `python/x402/src/x402/clients/requests.py`

## Test plan
- Updated unit tests to remove expectations for this header
- Existing tests should still pass as the functionality is unchanged (the header never did anything)