### PR TITLE
feat: add x402-discover package for tool discovery

### DIFF
--- a/typescript/packages/x402-discover/README.md
+++ b/typescript/packages/x402-discover/README.md
@@ -1,0 +1,109 @@
+# x402-discover
+
+Discovery API and CLI for finding x402-enabled tools and APIs.
+
+Agents need a way to discover x402 tools programmatically. This service queries facilitators directly and exposes a simple HTTP API.
+
+## Quick Start
+
+```bash
+# Install
+npm install
+
+# Run the API server
+npm run serve
+
+# Or use the CLI
+npx tsx src/cli.ts list
+```
+
+## API Endpoints
+
+```
+GET /                       API info
+GET /search?q=<query>       Search tools by keyword
+GET /tools                  List all tools (?network=, ?limit=, ?offset=)
+GET /price?url=<url>        Get pricing for a specific endpoint
+GET /facilitators           List known facilitators
+GET /health                 Health check
+```
+
+### Example: Search for tools
+
+```bash
+curl "http://localhost:3402/search?q=weather"
+```
+
+```json
+{
+  "query": "weather",
+  "count": 1,
+  "tools": [
+    {
+      "url": "https://436e0xdu.nx.link/forecast",
+      "description": "Zeus - GET Get weather forecast",
+      "price": "$0.003",
+      "network": "base",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0xB469Ff156592B1C964C526db01ee17812680fE66"
+    }
+  ]
+}
+```
+
+## CLI Usage
+
+```bash
+# Search for tools by keyword
+npx tsx src/cli.ts search "trading"
+
+# List all available tools (with facilitator status)
+npx tsx src/cli.ts list -v
+
+# Filter by network
+npx tsx src/cli.ts list --network base
+
+# Get pricing for a specific endpoint
+npx tsx src/cli.ts price https://example.com/api/endpoint
+
+# List known facilitators
+npx tsx src/cli.ts facilitators
+```
+
+## Programmatic Usage
+
+```typescript
+import { searchTools, fetchAllResources, fetchPricing } from "x402-discover";
+
+// Search for tools
+const tools = await searchTools("twitter");
+
+// Get all tools with status
+const { tools, status } = await fetchAllResources();
+
+// Get pricing for a specific endpoint
+const pricing = await fetchPricing("https://example.com/api");
+```
+
+## How it works
+
+x402-discover queries known x402 facilitators for their registered resources. Facilitators maintain registries of x402-enabled endpoints through their `/discovery/resources` endpoints.
+
+Features:
+- **Pagination** - Fetches all tools from facilitators (up to 1000 per facilitator)
+- **Caching** - 5 minute TTL to avoid hammering facilitators
+- **Network normalization** - Converts `eip155:8453` to `base`
+- **Facilitator status** - Reports which facilitators are healthy
+
+## Adding facilitators
+
+Edit `src/facilitators.ts`:
+
+```typescript
+{
+  id: "your-facilitator",
+  name: "Your Facilitator",
+  url: "https://your-facilitator.com",
+  status: "unknown",
+}
+```

--- a/typescript/packages/x402-discover/package-lock.json
+++ b/typescript/packages/x402-discover/package-lock.json
@@ -1,0 +1,605 @@
+{
+  "name": "x402-discover",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "x402-discover",
+      "version": "0.1.0",
+      "dependencies": {
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "x402-discover": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.3.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
+      "integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
+      "integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
+      "integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
+      "integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.1.tgz",
+      "integrity": "sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
+      "integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
+      "integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
+      "integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
+      "integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
+      "integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
+      "integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
+      "integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
+      "integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
+      "integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
+      "integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
+      "integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
+      "integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
+      "integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
+      "integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
+      "integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
+      "integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
+      "integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
+      "integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.1.tgz",
+      "integrity": "sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.1",
+        "@esbuild/android-arm": "0.27.1",
+        "@esbuild/android-arm64": "0.27.1",
+        "@esbuild/android-x64": "0.27.1",
+        "@esbuild/darwin-arm64": "0.27.1",
+        "@esbuild/darwin-x64": "0.27.1",
+        "@esbuild/freebsd-arm64": "0.27.1",
+        "@esbuild/freebsd-x64": "0.27.1",
+        "@esbuild/linux-arm": "0.27.1",
+        "@esbuild/linux-arm64": "0.27.1",
+        "@esbuild/linux-ia32": "0.27.1",
+        "@esbuild/linux-loong64": "0.27.1",
+        "@esbuild/linux-mips64el": "0.27.1",
+        "@esbuild/linux-ppc64": "0.27.1",
+        "@esbuild/linux-riscv64": "0.27.1",
+        "@esbuild/linux-s390x": "0.27.1",
+        "@esbuild/linux-x64": "0.27.1",
+        "@esbuild/netbsd-arm64": "0.27.1",
+        "@esbuild/netbsd-x64": "0.27.1",
+        "@esbuild/openbsd-arm64": "0.27.1",
+        "@esbuild/openbsd-x64": "0.27.1",
+        "@esbuild/openharmony-arm64": "0.27.1",
+        "@esbuild/sunos-x64": "0.27.1",
+        "@esbuild/win32-arm64": "0.27.1",
+        "@esbuild/win32-ia32": "0.27.1",
+        "@esbuild/win32-x64": "0.27.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/typescript/packages/x402-discover/package.json
+++ b/typescript/packages/x402-discover/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "x402-discover",
+  "version": "0.1.0",
+  "description": "Discovery client and CLI for x402 tools/resources",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "x402-discover": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/cli.ts",
+    "serve": "tsx src/server.ts",
+    "start": "node dist/cli.js"
+  },
+  "dependencies": {
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/typescript/packages/x402-discover/src/cli.ts
+++ b/typescript/packages/x402-discover/src/cli.ts
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { searchTools, fetchAllResources, fetchPricing, listFacilitators } from "./client.js";
+
+const program = new Command();
+
+program
+  .name("x402-discover")
+  .description("Discover x402-enabled tools and APIs")
+  .version("0.1.0");
+
+program
+  .command("search <query>")
+  .description("Search for tools by keyword")
+  .option("-l, --limit <number>", "Max results", "20")
+  .action(async (query: string, options: { limit: string }) => {
+    const limit = parseInt(options.limit);
+    console.log(`Searching for "${query}"...\n`);
+
+    const tools = await searchTools(query);
+    const results = tools.slice(0, limit);
+
+    if (results.length === 0) {
+      console.log("No tools found.");
+      return;
+    }
+
+    console.log(`Found ${tools.length} tools (showing ${results.length}):\n`);
+
+    for (const tool of results) {
+      console.log(`  ${tool.url}`);
+      console.log(`    Price: ${tool.price} (${tool.network})`);
+      if (tool.description) {
+        console.log(`    ${tool.description}`);
+      }
+      console.log();
+    }
+  });
+
+program
+  .command("list")
+  .description("List all available tools")
+  .option("-l, --limit <number>", "Max results", "50")
+  .option("-n, --network <network>", "Filter by network")
+  .option("-v, --verbose", "Show facilitator status")
+  .action(async (options: { limit: string; network?: string; verbose?: boolean }) => {
+    const limit = parseInt(options.limit);
+    console.log("Fetching tools from facilitators...\n");
+
+    const { tools: allTools, status } = await fetchAllResources();
+
+    if (options.verbose) {
+      console.log("Facilitator Status:");
+      for (const s of status) {
+        const icon = s.status === "success" ? "✓" : s.status === "partial" ? "◐" : "✗";
+        const cached = s.cached ? " (cached)" : "";
+        console.log(`  ${icon} ${s.facilitatorName}: ${s.toolCount} tools${cached}`);
+        if (s.error) {
+          console.log(`    ⚠ ${s.error}`);
+        }
+      }
+      console.log();
+    }
+
+    let tools = allTools;
+    if (options.network) {
+      tools = tools.filter((t) =>
+        t.network.toLowerCase().includes(options.network!.toLowerCase())
+      );
+    }
+
+    const results = tools.slice(0, limit);
+
+    if (results.length === 0) {
+      console.log("No tools found.");
+      return;
+    }
+
+    console.log(`Found ${tools.length} tools (showing ${results.length}):\n`);
+
+    for (const tool of results) {
+      console.log(`  ${tool.url}`);
+      console.log(`    Price: ${tool.price} | Network: ${tool.network}`);
+      if (tool.description) {
+        console.log(`    ${tool.description}`);
+      }
+      console.log();
+    }
+  });
+
+program
+  .command("price <url>")
+  .description("Fetch pricing for a specific endpoint")
+  .action(async (url: string) => {
+    console.log(`Fetching pricing for ${url}...\n`);
+
+    const pricing = await fetchPricing(url);
+
+    if (!pricing || pricing.length === 0) {
+      console.log("Could not fetch pricing. Endpoint may be down or not x402-enabled.");
+      return;
+    }
+
+    console.log("Payment options:\n");
+
+    for (const option of pricing) {
+      const price = BigInt(option.maxAmountRequired);
+      const priceFormatted = `$${(Number(price) / 1e6).toFixed(4)}`;
+
+      console.log(`  Network: ${option.network}`);
+      console.log(`  Price: ${priceFormatted} (${option.maxAmountRequired} atomic units)`);
+      console.log(`  Asset: ${option.asset}`);
+      console.log(`  Pay to: ${option.payTo}`);
+      if (option.description) {
+        console.log(`  Description: ${option.description}`);
+      }
+      console.log();
+    }
+  });
+
+program
+  .command("facilitators")
+  .description("List known facilitators")
+  .action(() => {
+    const facilitators = listFacilitators();
+
+    console.log("Known x402 facilitators:\n");
+
+    for (const f of facilitators) {
+      console.log(`  ${f.name}`);
+      console.log(`    ${f.url}`);
+      console.log();
+    }
+  });
+
+program.parse();

--- a/typescript/packages/x402-discover/src/client.ts
+++ b/typescript/packages/x402-discover/src/client.ts
@@ -1,0 +1,247 @@
+import { facilitators, type Facilitator } from "./facilitators.js";
+import type { Resource, DiscoveryResponse, Tool, PaymentRequirements } from "./types.js";
+
+// Simple in-memory cache
+interface CacheEntry {
+  tools: Tool[];
+  timestamp: number;
+  facilitatorId: string;
+}
+
+const cache: Map<string, CacheEntry> = new Map();
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+// Convert atomic units to human readable price
+// Assumes 6 decimals (USDC)
+function formatPrice(atomicUnits: string, decimals = 6): string {
+  try {
+    // Handle decimal strings (some APIs return "$0.01" format already)
+    if (atomicUnits.includes(".") || atomicUnits.startsWith("$")) {
+      return atomicUnits.startsWith("$") ? atomicUnits : `$${atomicUnits}`;
+    }
+
+    const value = BigInt(atomicUnits);
+    const divisor = BigInt(10 ** decimals);
+    const whole = value / divisor;
+    const fraction = value % divisor;
+    const fractionStr = fraction.toString().padStart(decimals, "0");
+    // Trim trailing zeros but keep at least 2 decimal places
+    const trimmed = fractionStr.replace(/0+$/, "").padEnd(2, "0");
+    return `$${whole}.${trimmed}`;
+  } catch {
+    return atomicUnits; // Return as-is if parsing fails
+  }
+}
+
+// Normalize network names
+function normalizeNetwork(network: string): string {
+  const mapping: Record<string, string> = {
+    "eip155:8453": "base",
+    "eip155:84532": "base-sepolia",
+    "eip155:1": "ethereum",
+    "eip155:137": "polygon",
+  };
+  return mapping[network] || network;
+}
+
+// Fetch all resources from a single facilitator with pagination
+async function fetchAllFromFacilitator(
+  facilitator: Facilitator
+): Promise<{ resources: Resource[]; error?: string }> {
+  const allResources: Resource[] = [];
+  let offset = 0;
+  const limit = 100;
+  let hasMore = true;
+
+  const endpoint = facilitator.listEndpoint || "/discovery/resources";
+
+  while (hasMore) {
+    const url = `${facilitator.url}${endpoint}?limit=${limit}&offset=${offset}`;
+
+    try {
+      let response = await fetch(url, {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(10000), // 10s timeout
+      });
+
+      // Try alternate endpoints if primary fails
+      if (!response.ok) {
+        const altUrls = [
+          `${facilitator.url}/list?limit=${limit}&offset=${offset}`,
+          `${facilitator.url}/resources?limit=${limit}&offset=${offset}`,
+        ];
+
+        for (const altUrl of altUrls) {
+          try {
+            response = await fetch(altUrl, {
+              headers: { Accept: "application/json" },
+              signal: AbortSignal.timeout(10000),
+            });
+            if (response.ok) break;
+          } catch {
+            // Continue trying
+          }
+        }
+      }
+
+      if (!response.ok) {
+        return { resources: allResources, error: `HTTP ${response.status}` };
+      }
+
+      const data: DiscoveryResponse = await response.json();
+      const items = data.items || [];
+      allResources.push(...items);
+
+      // Check if there are more pages
+      if (items.length < limit) {
+        hasMore = false;
+      } else {
+        offset += limit;
+      }
+
+      // Safety limit - don't fetch more than 1000 items per facilitator
+      if (offset >= 1000) {
+        hasMore = false;
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err.message : "Unknown error";
+      return { resources: allResources, error };
+    }
+  }
+
+  return { resources: allResources };
+}
+
+// Fetch status for debugging
+export interface FetchStatus {
+  facilitatorId: string;
+  facilitatorName: string;
+  status: "success" | "partial" | "failed";
+  toolCount: number;
+  error?: string;
+  cached: boolean;
+}
+
+// Fetch all resources from all facilitators with caching
+export async function fetchAllResources(options: { skipCache?: boolean } = {}): Promise<{
+  tools: Tool[];
+  status: FetchStatus[];
+}> {
+  const allTools: Tool[] = [];
+  const status: FetchStatus[] = [];
+  const now = Date.now();
+
+  const results = await Promise.allSettled(
+    facilitators.map(async (f) => {
+      // Check cache first
+      const cached = cache.get(f.id);
+      if (!options.skipCache && cached && now - cached.timestamp < CACHE_TTL) {
+        return { facilitator: f, tools: cached.tools, cached: true };
+      }
+
+      const { resources, error } = await fetchAllFromFacilitator(f);
+      const tools: Tool[] = [];
+
+      for (const resource of resources) {
+        tools.push(...resourceToTools(resource, f.id));
+      }
+
+      // Update cache
+      cache.set(f.id, { tools, timestamp: now, facilitatorId: f.id });
+
+      return { facilitator: f, tools, error, cached: false };
+    })
+  );
+
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      const { facilitator, tools, error, cached } = result.value;
+      allTools.push(...tools);
+
+      status.push({
+        facilitatorId: facilitator.id,
+        facilitatorName: facilitator.name,
+        status: error ? (tools.length > 0 ? "partial" : "failed") : "success",
+        toolCount: tools.length,
+        error,
+        cached,
+      });
+    } else {
+      // Promise rejected entirely
+      const facilitator = facilitators.find(f =>
+        result.reason?.message?.includes(f.url)
+      );
+      status.push({
+        facilitatorId: facilitator?.id || "unknown",
+        facilitatorName: facilitator?.name || "Unknown",
+        status: "failed",
+        toolCount: 0,
+        error: result.reason?.message || "Unknown error",
+        cached: false,
+      });
+    }
+  }
+
+  return { tools: allTools, status };
+}
+
+// Convert a resource to Tool(s) - one per payment option
+function resourceToTools(resource: Resource, facilitatorId: string): Tool[] {
+  return resource.accepts.map((accept) => ({
+    url: resource.resource,
+    description: accept.description || resource.metadata?.category || "",
+    price: formatPrice(accept.maxAmountRequired),
+    priceRaw: accept.maxAmountRequired,
+    network: normalizeNetwork(accept.network),
+    networkRaw: accept.network,
+    asset: accept.asset,
+    payTo: accept.payTo,
+    facilitator: facilitatorId,
+  }));
+}
+
+// Search tools by keyword
+export async function searchTools(query: string): Promise<Tool[]> {
+  const { tools } = await fetchAllResources();
+  const q = query.toLowerCase();
+
+  return tools.filter(
+    (t) =>
+      t.url.toLowerCase().includes(q) ||
+      t.description.toLowerCase().includes(q)
+  );
+}
+
+// Fetch pricing for a specific URL by hitting it without payment
+export async function fetchPricing(url: string): Promise<PaymentRequirements[] | null> {
+  try {
+    // Try GET first
+    let response = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
+
+    // If 405, try POST
+    if (response.status === 405) {
+      response = await fetch(url, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+      });
+    }
+
+    if (response.status === 402) {
+      const data = await response.json();
+      return data.accepts || null;
+    }
+
+    return null;
+  } catch (error) {
+    console.error(`Failed to fetch pricing for ${url}:`, error);
+    return null;
+  }
+}
+
+// List all known facilitators
+export function listFacilitators(): Facilitator[] {
+  return facilitators;
+}

--- a/typescript/packages/x402-discover/src/facilitators.ts
+++ b/typescript/packages/x402-discover/src/facilitators.ts
@@ -1,0 +1,64 @@
+// Known x402 facilitators with discovery endpoints
+export interface Facilitator {
+  id: string;
+  name: string;
+  url: string;
+  listEndpoint?: string; // defaults to /discovery/resources
+  status: "active" | "degraded" | "unknown";
+  lastChecked?: number;
+  lastError?: string;
+}
+
+export const facilitators: Facilitator[] = [
+  {
+    id: "coinbase",
+    name: "Coinbase",
+    url: "https://x402.org/facilitator",
+    status: "active",
+  },
+  {
+    id: "thirdweb",
+    name: "Thirdweb",
+    url: "https://api.thirdweb.com/v1/payments/x402",
+    status: "active",
+  },
+  {
+    id: "heurist",
+    name: "Heurist",
+    url: "https://facilitator.heurist.xyz",
+    status: "active",
+  },
+  {
+    id: "aurracloud",
+    name: "AurraCloud",
+    url: "https://aurracloud.com/x402",
+    status: "unknown",
+  },
+  {
+    id: "questflow",
+    name: "Questflow",
+    url: "https://api.questflow.ai/x402",
+    status: "unknown",
+  },
+  {
+    id: "daydreams",
+    name: "Daydreams",
+    url: "https://router.daydreams.systems",
+    status: "unknown",
+  },
+  // Known dead/unreachable - kept for reference but marked degraded
+  // {
+  //   id: "payai",
+  //   name: "PayAI",
+  //   url: "https://api.payai.network",
+  //   status: "degraded",
+  //   lastError: "DNS resolution failed",
+  // },
+  // {
+  //   id: "corbits",
+  //   name: "Corbits",
+  //   url: "https://corbits.xyz/facilitator",
+  //   status: "degraded",
+  //   lastError: "DNS resolution failed",
+  // },
+];

--- a/typescript/packages/x402-discover/src/index.ts
+++ b/typescript/packages/x402-discover/src/index.ts
@@ -1,0 +1,5 @@
+// x402-discover - Discovery client for x402 tools/resources
+export { searchTools, fetchAllResources, fetchPricing, listFacilitators } from "./client.js";
+export { facilitators } from "./facilitators.js";
+export type { Facilitator } from "./facilitators.js";
+export type { Resource, Tool, PaymentRequirements, DiscoveryResponse } from "./types.js";

--- a/typescript/packages/x402-discover/src/server.ts
+++ b/typescript/packages/x402-discover/src/server.ts
@@ -1,0 +1,147 @@
+import { createServer, IncomingMessage, ServerResponse } from "http";
+import { URL } from "url";
+import { searchTools, fetchAllResources, fetchPricing, listFacilitators } from "./client.js";
+
+const PORT = parseInt(process.env.PORT || "3402");
+
+// Simple JSON response helper
+function json(res: ServerResponse, data: unknown, status = 200) {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  });
+  res.end(JSON.stringify(data));
+}
+
+// Parse URL and query params
+function parseRequest(req: IncomingMessage): { path: string; query: URLSearchParams } {
+  const url = new URL(req.url || "/", `http://localhost:${PORT}`);
+  return { path: url.pathname, query: url.searchParams };
+}
+
+// Request handler
+async function handleRequest(req: IncomingMessage, res: ServerResponse) {
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+    res.end();
+    return;
+  }
+
+  const { path, query } = parseRequest(req);
+
+  try {
+    // GET /search?q=<query>
+    if (path === "/search" && req.method === "GET") {
+      const q = query.get("q");
+      if (!q) {
+        return json(res, { error: "Missing query parameter 'q'" }, 400);
+      }
+
+      const tools = await searchTools(q);
+      const limit = parseInt(query.get("limit") || "50");
+
+      return json(res, {
+        query: q,
+        count: tools.length,
+        tools: tools.slice(0, limit),
+      });
+    }
+
+    // GET /tools
+    if (path === "/tools" && req.method === "GET") {
+      const { tools, status } = await fetchAllResources();
+
+      const network = query.get("network");
+      const limit = parseInt(query.get("limit") || "100");
+      const offset = parseInt(query.get("offset") || "0");
+
+      let filtered = tools;
+      if (network) {
+        filtered = tools.filter((t) =>
+          t.network.toLowerCase().includes(network.toLowerCase())
+        );
+      }
+
+      const paginated = filtered.slice(offset, offset + limit);
+
+      return json(res, {
+        count: filtered.length,
+        limit,
+        offset,
+        tools: paginated,
+        facilitators: status,
+      });
+    }
+
+    // GET /price?url=<url>
+    if (path === "/price" && req.method === "GET") {
+      const url = query.get("url");
+      if (!url) {
+        return json(res, { error: "Missing query parameter 'url'" }, 400);
+      }
+
+      const pricing = await fetchPricing(url);
+      if (!pricing) {
+        return json(res, {
+          url,
+          error: "Could not fetch pricing. Endpoint may be down or not x402-enabled.",
+        }, 404);
+      }
+
+      return json(res, { url, accepts: pricing });
+    }
+
+    // GET /facilitators
+    if (path === "/facilitators" && req.method === "GET") {
+      return json(res, { facilitators: listFacilitators() });
+    }
+
+    // GET /health
+    if (path === "/health" && req.method === "GET") {
+      return json(res, { status: "ok", timestamp: Date.now() });
+    }
+
+    // GET / - API docs
+    if (path === "/" && req.method === "GET") {
+      return json(res, {
+        name: "x402-discover",
+        version: "0.1.0",
+        description: "Discovery API for x402 tools",
+        endpoints: {
+          "GET /search?q=<query>": "Search tools by keyword",
+          "GET /tools": "List all tools (supports ?network=, ?limit=, ?offset=)",
+          "GET /price?url=<url>": "Get pricing for a specific endpoint",
+          "GET /facilitators": "List known facilitators",
+          "GET /health": "Health check",
+        },
+      });
+    }
+
+    // 404
+    return json(res, { error: "Not found" }, 404);
+  } catch (err) {
+    console.error("Error handling request:", err);
+    return json(res, { error: "Internal server error" }, 500);
+  }
+}
+
+// Start server
+const server = createServer(handleRequest);
+
+server.listen(PORT, () => {
+  console.log(`x402-discover API running on http://localhost:${PORT}`);
+  console.log();
+  console.log("Endpoints:");
+  console.log(`  GET /search?q=<query>  - Search tools`);
+  console.log(`  GET /tools             - List all tools`);
+  console.log(`  GET /price?url=<url>   - Get pricing`);
+  console.log(`  GET /facilitators      - List facilitators`);
+  console.log(`  GET /health            - Health check`);
+});

--- a/typescript/packages/x402-discover/src/types.ts
+++ b/typescript/packages/x402-discover/src/types.ts
@@ -1,0 +1,52 @@
+// x402 Payment Requirements from the spec
+export interface PaymentRequirements {
+  scheme: string;
+  network: string;
+  maxAmountRequired: string;
+  asset: string;
+  payTo: string;
+  resource: string;
+  description?: string;
+  mimeType?: string;
+  maxTimeoutSeconds?: number;
+  outputSchema?: unknown;
+  extra?: Record<string, unknown>;
+}
+
+// Resource/Tool as returned by discovery
+export interface Resource {
+  resource: string; // URL
+  type: string; // "http"
+  x402Version: number;
+  accepts: PaymentRequirements[];
+  lastUpdated?: number;
+  metadata?: {
+    category?: string;
+    provider?: string;
+    [key: string]: unknown;
+  };
+}
+
+// Discovery API response
+export interface DiscoveryResponse {
+  x402Version: number;
+  items: Resource[];
+  pagination?: {
+    limit: number;
+    offset: number;
+    total: number;
+  };
+}
+
+// Simplified tool for display/search
+export interface Tool {
+  url: string;
+  description: string;
+  price: string; // human readable e.g. "$0.01"
+  priceRaw: string; // atomic units
+  network: string; // normalized e.g. "base"
+  networkRaw?: string; // original e.g. "eip155:8453"
+  asset: string;
+  payTo: string;
+  facilitator: string;
+}

--- a/typescript/packages/x402-discover/tsconfig.json
+++ b/typescript/packages/x402-discover/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

Adds x402-discover - a discovery API and CLI for finding x402-enabled tools and endpoints. Queries facilitators directly for their registered resources.

## Problem

No native discovery in x402. Agents need to already know endpoint URLs. Can't ask "what tools exist for X?"

## Solution

Facilitators already have `/discovery/resources` endpoints. This package exposes that data through a simple API.

## API

```
GET /search?q=<query>       Search tools by keyword
GET /tools                  List all tools
GET /price?url=<url>        Get pricing for an endpoint  
GET /facilitators           List facilitators
```

## CLI

```bash
x402-discover search "trading"
x402-discover list -v
x402-discover price https://example.com/api
```

## Features

- Pagination support
- 5 min caching
- Network normalization
- Facilitator health reporting

## Test

```bash
cd typescript/packages/x402-discover
npm install
npm run serve
curl "http://localhost:3402/search?q=weather"
```