### PR TITLE
chore: Bump to 1.0.1

### DIFF
--- a/typescript/packages/coinbase-x402/package.json
+++ b/typescript/packages/coinbase-x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/x402",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/packages/coinbase-x402/src/index.ts
+++ b/typescript/packages/coinbase-x402/src/index.ts
@@ -5,7 +5,7 @@ import { CreateHeaders } from "x402/verify";
 const COINBASE_FACILITATOR_BASE_URL = "https://api.cdp.coinbase.com";
 const COINBASE_FACILITATOR_V2_ROUTE = "/platform/v2/x402";
 
-const X402_SDK_VERSION = "1.0.0";
+const X402_SDK_VERSION = "1.0.1";
 const CDP_SDK_VERSION = "1.29.0";
 
 /**

--- a/typescript/packages/x402/package.json
+++ b/typescript/packages/x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
Bump core and @coinbase/x402 TS packages to 1.0.1