### PR TITLE
feat(typescript): x402-express - support dynamic payTo with function returning address

### DIFF
--- a/typescript/packages/x402-express/README.md
+++ b/typescript/packages/x402-express/README.md
@@ -44,7 +44,7 @@ app.listen(3000);
 
 The `paymentMiddleware` function accepts three parameters:
 
-1. `payTo`: Your receiving address (`0x${string}`)
+1. `payTo`: Your receiving address (`0x${string}`) or a function that returns your receiving address with the express request and response objects available to you (``(req: Request, res: Response) => `0x${string}` ``)
 2. `routes`: Route configurations for protected endpoints
 3. `facilitator`: (Optional) Configuration for the x402 facilitator service
 4. `paywall`: (Optional) Configuration for the built-in paywall

--- a/typescript/packages/x402-express/src/index.ts
+++ b/typescript/packages/x402-express/src/index.ts
@@ -73,7 +73,10 @@ import { useFacilitator } from "x402/verify";
  * ```
  */
 export function paymentMiddleware(
-  payTo: Address | SolanaAddress,
+  payTo:
+    | Address
+    | SolanaAddress
+    | ((req: Request, res: Response) => Address | SolanaAddress | Promise<Address | SolanaAddress>),
   routes: RoutesConfig,
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
@@ -117,6 +120,8 @@ export function paymentMiddleware(
       resource || (`${req.protocol}://${req.headers.host}${req.path}` as Resource);
 
     let paymentRequirements: PaymentRequirements[] = [];
+
+    payTo = typeof payTo === "function" ? await payTo(req, res) : payTo;
 
     // TODO: create a shared middleware function to build payment requirements
     // evm networks


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

While tinkering around with x402 on some side projects, I've found there are a number of cases where I want to dynamically change the payTo address for a given request that comes through. Here are a couple of examples, but there are many more:

- Customers who create their own endpoints should get paid when users hit their endpoints
- If my API has customer specific info in it, let that customer get paid and not a static address

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

I copied tests that already existed in [index.test.ts](https://github.com/coinbase/x402/blob/main/typescript/packages/x402-express/src/index.test.ts) with a static `payTo` and implemented a simple async function with setTimeout to return an address for `payTo` to test the same logic.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 