### PR TITLE
chore: bump @x402/evm package version

### DIFF
--- a/typescript/packages/mechanisms/evm/package.json
+++ b/typescript/packages/mechanisms/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402/evm",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
chore: bump `@x402/evm` package version to `2.0.0`