### PR TITLE
Don't generate new paywall files automatically on build

### DIFF
--- a/typescript/packages/http/paywall/package.json
+++ b/typescript/packages/http/paywall/package.json
@@ -9,7 +9,7 @@
     "start": "tsx --env-file=.env index.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "build": "pnpm build:paywall && tsup",
+    "build": "tsup",
     "build:paywall": "tsx src/evm/build.ts && tsx src/svm/build.ts",
     "watch": "tsc --watch",
     "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",


### PR DESCRIPTION
Paywall was automatically re-generating the template files on every build. This is not necessary.