### PR TITLE
chore: bring back @coinbase/x402 publish workflow

### DIFF
--- a/.github/workflows/publish_npm_coinbase_x402.yml
+++ b/.github/workflows/publish_npm_coinbase_x402.yml
@@ -1,0 +1,52 @@
+name: Publish coinbase-x402 package to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-npm-coinbase-x402:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/@coinbase/x402' && 'npm' || '' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          version: 10.7.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+          cache-dependency-path: ./typescript
+
+      - name: Install and build
+        working-directory: ./typescript
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm -r --filter=x402 --filter=@coinbase/x402 run build
+      
+      - name: Publish coinbase-x402 package
+        working-directory: ./typescript/packages/coinbase-x402
+        run: |
+          # Get package information directly
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          
+          echo "Package: $PACKAGE_NAME@$PACKAGE_VERSION"
+          
+          # Check if running on @coinbase/x402 branch
+          if [[ "${{ github.ref }}" == "refs/heads/@coinbase/x402" ]]; then
+            echo "Publishing to NPM (@coinbase/x402 branch)"
+            pnpm publish --provenance --access public
+          else
+            echo "Dry run only (non-release branch: ${{ github.ref }})"
+            pnpm publish --dry-run --no-git-checks
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 


### PR DESCRIPTION
chore: bring back @coinbase/x402 publish workflow

The actual code to deploy the `@coinbase/x402` package no longer exists on main. It will live on the `@coinbase/x402` branch for the forseable future, and be refactored into a separate repo