### PR TITLE
chore: omit branch check from publish in workflow

### DIFF
--- a/.github/workflows/publish_npm_coinbase_x402.yml
+++ b/.github/workflows/publish_npm_coinbase_x402.yml
@@ -43,7 +43,7 @@ jobs:
           # Check if running on @coinbase/x402 branch
           if [[ "${{ github.ref }}" == "refs/heads/@coinbase/x402" ]]; then
             echo "Publishing to NPM (@coinbase/x402 branch)"
-            pnpm publish --provenance --access public
+            pnpm publish --provenance --access public --no-git-checks
           else
             echo "Dry run only (non-release branch: ${{ github.ref }})"
             pnpm publish --dry-run --no-git-checks


### PR DESCRIPTION
chore: omit branch check from publish in workflow