### PR TITLE
fix ajv import

### DIFF
--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -7,7 +7,7 @@
  * Supports both v2 (extensions in PaymentRequired) and v1 (outputSchema in PaymentRequirements).
  */
 
-import Ajv from "ajv/dist/2020";
+import Ajv from "ajv/dist/2020.js";
 import type { PaymentPayload, PaymentRequirements, PaymentRequirementsV1 } from "@x402/core/types";
 import type { DiscoveryExtension, DiscoveryInfo } from "./types";
 import { BAZAAR } from "./types";


### PR DESCRIPTION
## Description

Fixes a build issue for next projects using the Bazaar discovery extensions:
```
@x402/next-example:build: Failed to load bazaar extension: Error: Cannot find module 'x402/typescript/packages/extensions/node_modules/ajv/dist/2020' imported from 402/typescript/packages/extensions/dist/esm/chunk-STXY3Q5R.mjs
@x402/next-example:build: Did you mean to import "ajv/dist/2020.js"?
@x402/next-example:build:     at ignore-listed frames {
@x402/next-example:build:   code: 'ERR_MODULE_NOT_FOUND',
@x402/next-example:build:   url: 'file:///x402/typescript/packages/extensions/node_modules/ajv/dist/2020'
```

Closes https://github.com/coinbase/x402/issues/876

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 