### PR TITLE
fix: Add missing EVM network mappings to @x402/evm

### DIFF
--- a/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
@@ -178,26 +178,102 @@ export class ExactEvmScheme implements SchemeNetworkServer {
   private getDefaultAsset(network: Network): { address: string; name: string; version: string } {
     // Map of network to USDC info including EIP-712 domain parameters
     const usdcInfo: Record<string, { address: string; name: string; version: string }> = {
+      // Base
       "eip155:8453": {
         address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
         name: "USD Coin",
         version: "2",
-      }, // Base mainnet USDC
+      },
       "eip155:84532": {
         address: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
         name: "USDC",
         version: "2",
-      }, // Base Sepolia USDC
+      },
+      // Ethereum
       "eip155:1": {
         address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         name: "USD Coin",
         version: "2",
-      }, // Ethereum mainnet USDC
+      },
       "eip155:11155111": {
         address: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
         name: "USDC",
         version: "2",
-      }, // Sepolia USDC
+      },
+      // Avalanche
+      "eip155:43114": {
+        address: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+        name: "USD Coin",
+        version: "2",
+      },
+      "eip155:43113": {
+        address: "0x5425890298aed601595a70AB815c96711a31Bc65",
+        name: "USD Coin",
+        version: "2",
+      },
+      // Polygon
+      "eip155:137": {
+        address: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+        name: "USD Coin",
+        version: "2",
+      },
+      "eip155:80002": {
+        address: "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
+        name: "USDC",
+        version: "2",
+      },
+      // Sei
+      "eip155:1329": {
+        address: "0xe15fc38f6d8c56af07bbcbe3baf5708a2bf42392",
+        name: "USDC",
+        version: "2",
+      },
+      "eip155:1328": {
+        address: "0x4fcf1784b31630811181f670aea7a7bef803eaed",
+        name: "USDC",
+        version: "2",
+      },
+      // Abstract (ZK Stack)
+      "eip155:2741": {
+        address: "0x84a71ccd554cc1b02749b35d22f684cc8ec987e1",
+        name: "Bridged USDC",
+        version: "2",
+      },
+      "eip155:11124": {
+        address: "0xe4C7fBB0a626ed208021ccabA6Be1566905E2dFc",
+        name: "Bridged USDC",
+        version: "2",
+      },
+      // IoTeX
+      "eip155:4689": {
+        address: "0xcdf79194c6c285077a58da47641d4dbe51f63542",
+        name: "Bridged USDC",
+        version: "2",
+      },
+      // Peaq
+      "eip155:3338": {
+        address: "0xbbA60da06c2c5424f03f7434542280FCAd453d10",
+        name: "USDC",
+        version: "2",
+      },
+      // Story
+      "eip155:1514": {
+        address: "0xF1815bd50389c46847f0Bda824eC8da914045D14",
+        name: "Bridged USDC",
+        version: "2",
+      },
+      // Educhain
+      "eip155:41923": {
+        address: "0x12a272A581feE5577A5dFa371afEB4b2F3a8C2F8",
+        name: "Bridged USDC (Stargate)",
+        version: "2",
+      },
+      // SKALE Base Sepolia
+      "eip155:324705682": {
+        address: "0x2e08028E3C4c2356572E096d8EF835cD5C6030bD",
+        name: "Bridged USDC (SKALE Bridge)",
+        version: "2",
+      },
     };
 
     const assetInfo = usdcInfo[network];

--- a/typescript/packages/mechanisms/evm/src/utils.ts
+++ b/typescript/packages/mechanisms/evm/src/utils.ts
@@ -10,12 +10,34 @@ import { Network } from "@x402/core/types";
  */
 export function getEvmChainId(network: Network): number {
   const networkMap: Record<string, number> = {
+    // Base
     base: 8453,
     "base-sepolia": 84532,
+    // Ethereum
     ethereum: 1,
     sepolia: 11155111,
+    // Avalanche
+    avalanche: 43114,
+    "avalanche-fuji": 43113,
+    // Polygon
     polygon: 137,
     "polygon-amoy": 80002,
+    // Sei
+    sei: 1329,
+    "sei-testnet": 1328,
+    // Abstract (ZK Stack)
+    abstract: 2741,
+    "abstract-testnet": 11124,
+    // IoTeX
+    iotex: 4689,
+    // Peaq
+    peaq: 3338,
+    // Story
+    story: 1514,
+    // Educhain
+    educhain: 41923,
+    // SKALE Base Sepolia
+    "skale-base-sepolia": 324705682,
   };
   return networkMap[network] || 1;
 }

--- a/typescript/packages/mechanisms/evm/test/unit/server.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/server.test.ts
@@ -71,6 +71,50 @@ describe("ExactEvmScheme (Server)", () => {
       });
     });
 
+    describe("SKALE Base Sepolia network", () => {
+      const network = "eip155:324705682";
+
+      it("should use SKALE USDC address", async () => {
+        const result = await server.parsePrice("1.00", network);
+        expect(result.asset).toBe("0x2e08028E3C4c2356572E096d8EF835cD5C6030bD");
+        expect(result.amount).toBe("1000000");
+        expect(result.extra).toEqual({ name: "Bridged USDC (SKALE Bridge)", version: "2" });
+      });
+    });
+
+    describe("Avalanche mainnet network", () => {
+      const network = "eip155:43114";
+
+      it("should use Avalanche USDC address", async () => {
+        const result = await server.parsePrice("1.00", network);
+        expect(result.asset).toBe("0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E");
+        expect(result.amount).toBe("1000000");
+        expect(result.extra).toEqual({ name: "USD Coin", version: "2" });
+      });
+    });
+
+    describe("Polygon mainnet network", () => {
+      const network = "eip155:137";
+
+      it("should use Polygon USDC address", async () => {
+        const result = await server.parsePrice("1.00", network);
+        expect(result.asset).toBe("0x3c499c542cef5e3811e1192ce70d8cc03d5c3359");
+        expect(result.amount).toBe("1000000");
+        expect(result.extra).toEqual({ name: "USD Coin", version: "2" });
+      });
+    });
+
+    describe("Abstract mainnet network", () => {
+      const network = "eip155:2741";
+
+      it("should use Abstract USDC address", async () => {
+        const result = await server.parsePrice("1.00", network);
+        expect(result.asset).toBe("0x84a71ccd554cc1b02749b35d22f684cc8ec987e1");
+        expect(result.amount).toBe("1000000");
+        expect(result.extra).toEqual({ name: "Bridged USDC", version: "2" });
+      });
+    });
+
     describe("pre-parsed price objects", () => {
       it("should handle pre-parsed price objects with asset", async () => {
         const result = await server.parsePrice(

--- a/typescript/packages/mechanisms/evm/test/unit/utils.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/utils.test.ts
@@ -27,6 +27,34 @@ describe("EVM Utils", () => {
       expect(getEvmChainId("polygon-amoy")).toBe(80002);
     });
 
+    it("should return correct chain ID for Avalanche", () => {
+      expect(getEvmChainId("avalanche")).toBe(43114);
+    });
+
+    it("should return correct chain ID for Avalanche Fuji", () => {
+      expect(getEvmChainId("avalanche-fuji")).toBe(43113);
+    });
+
+    it("should return correct chain ID for Sei", () => {
+      expect(getEvmChainId("sei")).toBe(1329);
+    });
+
+    it("should return correct chain ID for Sei Testnet", () => {
+      expect(getEvmChainId("sei-testnet")).toBe(1328);
+    });
+
+    it("should return correct chain ID for Abstract", () => {
+      expect(getEvmChainId("abstract")).toBe(2741);
+    });
+
+    it("should return correct chain ID for Abstract Testnet", () => {
+      expect(getEvmChainId("abstract-testnet")).toBe(11124);
+    });
+
+    it("should return correct chain ID for SKALE Base Sepolia", () => {
+      expect(getEvmChainId("skale-base-sepolia")).toBe(324705682);
+    });
+
     it("should return default chain ID (1) for unknown networks", () => {
       expect(getEvmChainId("unknown-network")).toBe(1);
     });


### PR DESCRIPTION
## 
  Summary
  - The v2 `@x402/evm` package was missing USDC address mappings for most supported networks
  - Only Base, Base Sepolia, Ethereum, and Sepolia were configured in `getDefaultAsset()`
  - This caused transactions on other networks (like SKALE) to either fail or use wrong addresses

  ## Root Cause of #773
  The transactions in the issue were sent to `0x036CbD53842c5426634e7929541eC2318f3dCF7e` (Base Sepolia USDC)
   **on SKALE chain**, where that address has no code. This explains:
  - "Settlement succeeds but no funds transferred" - tx hits empty address, succeeds, does nothing
  - "Same data can be settled multiple times" - no contract = no nonce tracking
  - "balanceOf/authorizationState missing" - wrong address has no code

  The SKALE USDC contract (`0x2e08028E3C4c2356572E096d8EF835cD5C6030bD`) is fully EIP-3009 compliant.

  ## Changes
  - `packages/mechanisms/evm/src/exact/server/scheme.ts` - Added all 15 EVM networks to `getDefaultAsset()`
  - `packages/mechanisms/evm/src/utils.ts` - Added all networks to `getEvmChainId()`
  - Added tests for new network mappings

  Fixes #773