### PR TITLE
Add structured decline/failure context for payments

### DIFF
--- a/go/http/client.go
+++ b/go/http/client.go
@@ -424,3 +424,51 @@ func decodePaymentResponseHeader(header string) (*x402.SettleResponse, error) {
 
 	return &response, nil
 }
+
+// EncodePaymentDeclineHeader encodes a payment decline as base64
+func EncodePaymentDeclineHeader(decline *x402.PaymentDecline) string {
+	data, err := json.Marshal(decline)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal payment decline: %v", err))
+	}
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+// DecodePaymentDeclineHeader decodes a base64 payment decline header
+func DecodePaymentDeclineHeader(header string) (*x402.PaymentDecline, error) {
+	data, err := base64.StdEncoding.DecodeString(header)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base64 encoding: %w", err)
+	}
+
+	var decline x402.PaymentDecline
+	if err := json.Unmarshal(data, &decline); err != nil {
+		return nil, fmt.Errorf("invalid payment decline JSON: %w", err)
+	}
+
+	return &decline, nil
+}
+
+// EncodeIntentTraceHeader encodes an intent trace as base64
+func EncodeIntentTraceHeader(trace *x402.IntentTrace) string {
+	data, err := json.Marshal(trace)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal intent trace: %v", err))
+	}
+	return base64.StdEncoding.EncodeToString(data)
+}
+
+// DecodeIntentTraceHeader decodes a base64 intent trace header
+func DecodeIntentTraceHeader(header string) (*x402.IntentTrace, error) {
+	data, err := base64.StdEncoding.DecodeString(header)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base64 encoding: %w", err)
+	}
+
+	var trace x402.IntentTrace
+	if err := json.Unmarshal(data, &trace); err != nil {
+		return nil, fmt.Errorf("invalid intent trace JSON: %w", err)
+	}
+
+	return &trace, nil
+}

--- a/java/src/main/java/com/coinbase/x402/client/SettlementResponse.java
+++ b/java/src/main/java/com/coinbase/x402/client/SettlementResponse.java
@@ -1,16 +1,21 @@
 package com.coinbase.x402.client;
 
+import com.coinbase.x402.model.IntentTrace;
+
 /** JSON returned by POST /settle on the facilitator. */
 public class SettlementResponse {
     /** Whether the payment settlement succeeded. */
     public boolean success;
-    
+
     /** Error message if settlement failed. */
-    public String  error;
-    
+    public String error;
+
     /** Transaction hash of the settled payment. */
-    public String  txHash;
-    
+    public String txHash;
+
     /** Network ID where the settlement occurred. */
-    public String  networkId;
+    public String networkId;
+
+    /** Structured context for why settlement failed. */
+    public IntentTrace intentTrace;
 }

--- a/java/src/main/java/com/coinbase/x402/client/VerificationResponse.java
+++ b/java/src/main/java/com/coinbase/x402/client/VerificationResponse.java
@@ -1,11 +1,16 @@
 package com.coinbase.x402.client;
 
+import com.coinbase.x402.model.IntentTrace;
+
 /** JSON returned by POST /verify on the facilitator. */
 public class VerificationResponse {
     /** Whether the payment verification succeeded. */
     public boolean isValid;
-    
+
     /** Reason for verification failure (if isValid is false). */
-    public String  invalidReason;
+    public String invalidReason;
+
+    /** Structured context for why verification failed. */
+    public IntentTrace intentTrace;
 }
 

--- a/java/src/main/java/com/coinbase/x402/model/IntentTrace.java
+++ b/java/src/main/java/com/coinbase/x402/model/IntentTrace.java
@@ -1,0 +1,49 @@
+package com.coinbase.x402.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * Provides structured context for payment decisions.
+ * Used to communicate why a payment was declined or failed.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IntentTrace {
+    /** Enumerated code identifying the primary reason. */
+    @JsonProperty("reason_code")
+    public String reasonCode;
+
+    /** Human-readable summary (max 500 chars). */
+    @JsonProperty("trace_summary")
+    public String traceSummary;
+
+    /** Flat key-value object for additional context. Values must be String, Number, or Boolean. */
+    public Map<String, Object> metadata;
+
+    /** Suggested action to resolve the issue. */
+    public Remediation remediation;
+
+    /** Default constructor for Jackson. */
+    public IntentTrace() {}
+
+    /** Constructor with required fields. */
+    public IntentTrace(String reasonCode) {
+        this.reasonCode = reasonCode;
+    }
+
+    /** Constructor with reason code and summary. */
+    public IntentTrace(String reasonCode, String traceSummary) {
+        this.reasonCode = reasonCode;
+        this.traceSummary = traceSummary;
+    }
+
+    /** Constructor with all fields. */
+    public IntentTrace(String reasonCode, String traceSummary, Map<String, Object> metadata, Remediation remediation) {
+        this.reasonCode = reasonCode;
+        this.traceSummary = traceSummary;
+        this.metadata = metadata;
+        this.remediation = remediation;
+    }
+}

--- a/java/src/main/java/com/coinbase/x402/model/PaymentDecline.java
+++ b/java/src/main/java/com/coinbase/x402/model/PaymentDecline.java
@@ -1,0 +1,42 @@
+package com.coinbase.x402.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.Map;
+
+/**
+ * Payment decline message sent by clients when they choose not to pay.
+ * Includes optional intent trace to explain the reason for declining.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PaymentDecline {
+    /** Protocol version (must be 2). */
+    public int x402Version;
+
+    /** Must be true to indicate this is a decline message. */
+    public boolean decline = true;
+
+    /** Resource that was declined. */
+    public Map<String, String> resource;
+
+    /** Structured context for why the payment was declined. */
+    public IntentTrace intentTrace;
+
+    /** Default constructor for Jackson. */
+    public PaymentDecline() {}
+
+    /** Constructor with required fields. */
+    public PaymentDecline(int x402Version, Map<String, String> resource) {
+        this.x402Version = x402Version;
+        this.decline = true;
+        this.resource = resource;
+    }
+
+    /** Constructor with all fields. */
+    public PaymentDecline(int x402Version, Map<String, String> resource, IntentTrace intentTrace) {
+        this.x402Version = x402Version;
+        this.decline = true;
+        this.resource = resource;
+        this.intentTrace = intentTrace;
+    }
+}

--- a/java/src/main/java/com/coinbase/x402/model/Remediation.java
+++ b/java/src/main/java/com/coinbase/x402/model/Remediation.java
@@ -1,0 +1,47 @@
+package com.coinbase.x402.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides actionable guidance to clients on how to fix a payment failure.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Remediation {
+    /** Suggested action (e.g., "top_up", "retry", "switch_network"). */
+    public String action;
+
+    /** Why this action would help. */
+    public String reason;
+
+    /** Action-specific parameters. */
+    private Map<String, Object> extra = new HashMap<>();
+
+    /** Default constructor for Jackson. */
+    public Remediation() {}
+
+    /** Constructor with required fields. */
+    public Remediation(String action) {
+        this.action = action;
+    }
+
+    /** Constructor with all common fields. */
+    public Remediation(String action, String reason) {
+        this.action = action;
+        this.reason = reason;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getExtra() {
+        return extra;
+    }
+
+    @JsonAnySetter
+    public void setExtra(String key, Object value) {
+        this.extra.put(key, value);
+    }
+}

--- a/java/src/main/java/com/coinbase/x402/model/SettlementResponseHeader.java
+++ b/java/src/main/java/com/coinbase/x402/model/SettlementResponseHeader.java
@@ -10,24 +10,37 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class SettlementResponseHeader {
     /** Whether the settlement was successful. */
     public boolean success;
-    
+
     /** Transaction hash of the settled payment. */
     public String transaction;
-    
+
     /** Network ID where the settlement occurred. */
     public String network;
-    
+
     /** Wallet address of the person who made the payment (can be null). */
     public String payer;
-    
+
+    /** Structured context for why settlement failed (can be null). */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public IntentTrace intentTrace;
+
     /** Default constructor for Jackson. */
     public SettlementResponseHeader() {}
-    
-    /** Constructor with all fields. */
+
+    /** Constructor with all fields (without intentTrace). */
     public SettlementResponseHeader(boolean success, String transaction, String network, String payer) {
         this.success = success;
         this.transaction = transaction;
         this.network = network;
         this.payer = payer;
+    }
+
+    /** Constructor with all fields including intentTrace. */
+    public SettlementResponseHeader(boolean success, String transaction, String network, String payer, IntentTrace intentTrace) {
+        this.success = success;
+        this.transaction = transaction;
+        this.network = network;
+        this.payer = payer;
+        this.intentTrace = intentTrace;
     }
 }

--- a/python/x402/src/x402/encoding.py
+++ b/python/x402/src/x402/encoding.py
@@ -1,5 +1,8 @@
 import base64
+import json
 from typing import Union
+
+from x402.types import IntentTrace, PaymentDecline
 
 
 def safe_base64_encode(data: Union[str, bytes]) -> str:
@@ -26,3 +29,53 @@ def safe_base64_decode(data: str) -> str:
         Decoded utf-8 string
     """
     return base64.b64decode(data).decode("utf-8")
+
+
+def encode_payment_decline_header(decline: PaymentDecline) -> str:
+    """Encode a payment decline to base64 header value.
+
+    Args:
+        decline: Payment decline object
+
+    Returns:
+        Base64 encoded string
+    """
+    return safe_base64_encode(decline.model_dump_json(by_alias=True))
+
+
+def decode_payment_decline_header(header: str) -> PaymentDecline:
+    """Decode a base64 payment decline header.
+
+    Args:
+        header: Base64 encoded payment decline header
+
+    Returns:
+        Decoded PaymentDecline object
+    """
+    json_str = safe_base64_decode(header)
+    return PaymentDecline.model_validate_json(json_str)
+
+
+def encode_intent_trace_header(trace: IntentTrace) -> str:
+    """Encode an intent trace to base64 header value.
+
+    Args:
+        trace: Intent trace object
+
+    Returns:
+        Base64 encoded string
+    """
+    return safe_base64_encode(trace.model_dump_json(by_alias=True))
+
+
+def decode_intent_trace_header(header: str) -> IntentTrace:
+    """Decode a base64 intent trace header.
+
+    Args:
+        header: Base64 encoded intent trace header
+
+    Returns:
+        Decoded IntentTrace object
+    """
+    json_str = safe_base64_decode(header)
+    return IntentTrace.model_validate_json(json_str)

--- a/python/x402/src/x402/fastapi/middleware.py
+++ b/python/x402/src/x402/fastapi/middleware.py
@@ -12,7 +12,7 @@ from x402.common import (
     x402_VERSION,
     find_matching_payment_requirements,
 )
-from x402.encoding import safe_base64_decode
+from x402.encoding import safe_base64_decode, decode_payment_decline_header
 from x402.facilitator import FacilitatorClient, FacilitatorConfig
 from x402.path import path_is_match
 from x402.paywall import is_browser_request, get_paywall_html
@@ -153,6 +153,21 @@ def require_payment(
                     status_code=status_code,
                     headers=headers,
                 )
+
+        # Check for payment decline header first
+        decline_header = request.headers.get("PAYMENT-DECLINE", "")
+        if decline_header:
+            try:
+                decline = decode_payment_decline_header(decline_header)
+                # Return 200 OK acknowledgment for decline
+                return JSONResponse(
+                    content={"acknowledged": True},
+                    status_code=200,
+                    headers={"Content-Type": "application/json"},
+                )
+            except Exception:
+                # Invalid decline header, continue with normal payment flow
+                pass
 
         # Check for payment header
         payment_header = request.headers.get("X-PAYMENT", "")

--- a/python/x402/tests/test_encoding.py
+++ b/python/x402/tests/test_encoding.py
@@ -1,5 +1,13 @@
 import pytest
-from x402.encoding import safe_base64_encode, safe_base64_decode
+from x402.encoding import (
+    safe_base64_encode,
+    safe_base64_decode,
+    encode_payment_decline_header,
+    decode_payment_decline_header,
+    encode_intent_trace_header,
+    decode_intent_trace_header,
+)
+from x402.types import IntentTrace, PaymentDecline, ResourceInfoSimple, Remediation
 
 
 def test_safe_base64_encode():
@@ -79,3 +87,108 @@ def test_encode_decode_roundtrip():
         assert decoded == test_bytes.decode("utf-8"), (
             f"Roundtrip failed for bytes: {test_bytes}"
         )
+
+
+def test_encode_decode_intent_trace():
+    """Test encoding and decoding of IntentTrace objects."""
+    # Test with minimal intent trace
+    trace = IntentTrace(reason_code="insufficient_funds")
+    encoded = encode_intent_trace_header(trace)
+    decoded = decode_intent_trace_header(encoded)
+    assert decoded.reason_code == "insufficient_funds"
+    assert decoded.trace_summary is None
+    assert decoded.metadata is None
+    assert decoded.remediation is None
+
+    # Test with full intent trace
+    trace_full = IntentTrace(
+        reason_code="insufficient_funds",
+        trace_summary="User has 5 USDC, needs 10 USDC",
+        metadata={"required_amount": "10000000", "available_balance": "5000000"},
+        remediation=Remediation(
+            action="top_up",
+            reason="Add more USDC to your wallet",
+        ),
+    )
+    encoded_full = encode_intent_trace_header(trace_full)
+    decoded_full = decode_intent_trace_header(encoded_full)
+    assert decoded_full.reason_code == "insufficient_funds"
+    assert decoded_full.trace_summary == "User has 5 USDC, needs 10 USDC"
+    assert decoded_full.metadata["required_amount"] == "10000000"
+    assert decoded_full.remediation.action == "top_up"
+
+
+def test_encode_decode_payment_decline():
+    """Test encoding and decoding of PaymentDecline objects."""
+    # Test with minimal decline (no intent trace)
+    resource = ResourceInfoSimple(url="https://example.com/resource")
+    decline = PaymentDecline(
+        x402_version=2,
+        decline=True,
+        resource=resource,
+    )
+    encoded = encode_payment_decline_header(decline)
+    decoded = decode_payment_decline_header(encoded)
+    assert decoded.x402_version == 2
+    assert decoded.decline is True
+    assert decoded.resource.url == "https://example.com/resource"
+    assert decoded.intent_trace is None
+
+    # Test with intent trace
+    trace = IntentTrace(
+        reason_code="user_declined",
+        trace_summary="Price too high for user budget",
+        metadata={"requested_price": "10000000"},
+        remediation=Remediation(
+            action="lower_price",
+            reason="Consider offering a lower price tier",
+        ),
+    )
+    decline_with_trace = PaymentDecline(
+        x402_version=2,
+        decline=True,
+        resource=ResourceInfoSimple(
+            url="https://example.com/premium",
+            description="Premium content",
+            mime_type="application/json",
+        ),
+        intent_trace=trace,
+    )
+    encoded_with_trace = encode_payment_decline_header(decline_with_trace)
+    decoded_with_trace = decode_payment_decline_header(encoded_with_trace)
+    assert decoded_with_trace.x402_version == 2
+    assert decoded_with_trace.resource.description == "Premium content"
+    assert decoded_with_trace.intent_trace.reason_code == "user_declined"
+    assert decoded_with_trace.intent_trace.remediation.action == "lower_price"
+
+
+def test_intent_trace_roundtrip():
+    """Test that IntentTrace survives encode/decode roundtrip."""
+    test_cases = [
+        IntentTrace(reason_code="insufficient_funds"),
+        IntentTrace(
+            reason_code="signature_expired",
+            trace_summary="Signature expired at 1234567890",
+        ),
+        IntentTrace(
+            reason_code="recipient_mismatch",
+            metadata={"expected": "0xabc", "provided": "0xdef"},
+        ),
+        IntentTrace(
+            reason_code="amount_mismatch",
+            trace_summary="Amount doesn't match requirements",
+            metadata={"required": "100", "provided": "50"},
+            remediation=Remediation(action="retry", reason="Submit correct amount"),
+        ),
+    ]
+
+    for trace in test_cases:
+        encoded = encode_intent_trace_header(trace)
+        decoded = decode_intent_trace_header(encoded)
+        assert decoded.reason_code == trace.reason_code
+        assert decoded.trace_summary == trace.trace_summary
+        if trace.metadata:
+            for key, value in trace.metadata.items():
+                assert decoded.metadata[key] == value
+        if trace.remediation:
+            assert decoded.remediation.action == trace.remediation.action

--- a/specs/rfc-intent-traces.md
+++ b/specs/rfc-intent-traces.md
@@ -1,0 +1,609 @@
+# RFC: x402 Intent Traces
+
+**Status:** Implemented
+**Version:** 2025-12-17
+**Scope:** Extension to support structured intent context for payment decisions.
+
+This RFC extends the x402 protocol to support **Intent Tracing**. It defines a schema for clients to transmit structured data regarding _why_ a payment was declined, and for servers to provide richer context on _why_ a payment failed. This specification enables resource servers to transition from blind pricing to data-driven optimization.
+
+---
+
+## 1. Motivation
+
+In the current x402 protocol, when a client declines to pay for a resource, the server receives no signal—the client simply doesn't submit a `PaymentPayload`. When payments fail, servers return error codes like `insufficient_funds` but provide no context about what the client might do differently.
+
+**Agentic Commerce** changes this paradigm. When an AI agent manages payments on behalf of a user, a "declined payment" is no longer a silent exit; it is often a reasoned decision based on specific constraints (e.g., price exceeds budget, wrong network, untrusted facilitator).
+
+This RFC proposes capturing that decision as an **Intent Trace**. By standardizing this signal, we convert declined payments from dead ends into actionable data points, where resource servers can:
+
+- Understand _why_ clients aren't paying
+- Optimize pricing based on real objections
+- Offer alternative payment options dynamically
+- Build trust through transparent negotiation
+
+---
+
+## 2. Design Rationale
+
+### 2.1 Why Structured Data?
+
+A free-text decline reason would be simpler but less actionable. Structured `reason_code` values enable:
+
+- **Automated routing:** Servers can trigger different workflows per reason (e.g., `price_sensitivity` → offer lower-tier option).
+- **Analytics aggregation:** Standardized codes allow servers to quantify decline causes across requests.
+- **Future extensibility:** A subsequent RFC MAY define **Counter-Offers** keyed to specific reason codes.
+
+### 2.2 Why Bidirectional?
+
+Unlike the Agentic Commerce Protocol where intent traces flow only from client to server (cart abandonment), x402 benefits from bidirectional traces:
+
+- **Client → Server (Decline Trace):** Why the client chose not to pay after receiving `PaymentRequired`.
+- **Server → Client (Failure Trace):** Richer context when verification or settlement fails, including remediation hints.
+
+### 2.3 Why Optional?
+
+The `intent_trace` is optional to maintain backward compatibility. Clients and servers that do not support this extension simply omit the trace data, and the protocol proceeds as before.
+
+### 2.4 Privacy Considerations
+
+Intent Traces are:
+
+- **Explicit:** The client transmits intent only when it chooses to decline.
+- **Scoped:** Data is sent only to the resource server involved, not broadcast.
+- **Minimal:** The schema encourages structured codes over free-text to reduce information leakage.
+
+---
+
+## 3. Specification Changes
+
+This RFC adds a new message type and extends existing response schemas.
+
+### 3.1 New Message Type: Payment Decline
+
+Clients MAY send a `PaymentDecline` message when they receive `PaymentRequired` but choose not to pay. This is distinct from simply not responding—it actively communicates the reason.
+
+**Schema:**
+
+```json
+{
+  "x402Version": 2,
+  "decline": true,
+  "resource": {
+    "url": "https://api.example.com/premium-data"
+  },
+  "intent_trace": {
+    "reason_code": "price_sensitivity",
+    "trace_summary": "Requested amount exceeds agent budget allocation for this resource category.",
+    "metadata": {
+      "max_budget": "5000",
+      "requested_amount": "10000",
+      "budget_category": "market_data"
+    }
+  }
+}
+```
+
+### 3.2 Extended Response Schema: VerifyResponse
+
+The `VerifyResponse` schema is extended to include an optional `intent_trace` for richer failure context:
+
+```json
+{
+  "isValid": false,
+  "invalidReason": "insufficient_funds",
+  "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+  "intent_trace": {
+    "reason_code": "insufficient_funds",
+    "trace_summary": "Wallet balance is below required amount.",
+    "metadata": {
+      "required_amount": "10000",
+      "available_balance": "3500",
+      "shortfall": "6500",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913"
+    },
+    "remediation": {
+      "action": "top_up",
+      "min_amount": "6500",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913",
+      "network": "eip155:8453"
+    }
+  }
+}
+```
+
+### 3.3 Extended Response Schema: SettleResponse
+
+The `SettleResponse` schema is extended similarly:
+
+```json
+{
+  "success": false,
+  "errorReason": "invalid_transaction_state",
+  "network": "eip155:8453",
+  "transaction": "0x...",
+  "intent_trace": {
+    "reason_code": "transaction_reverted",
+    "trace_summary": "On-chain transaction reverted during execution.",
+    "metadata": {
+      "revert_reason": "ERC20: transfer amount exceeds balance",
+      "gas_used": "45000",
+      "block_number": "12345678"
+    },
+    "remediation": {
+      "action": "retry_with_fresh_authorization",
+      "reason": "Balance changed between verification and settlement"
+    }
+  }
+}
+```
+
+---
+
+## 4. Schema Definitions
+
+### 4.1 IntentTrace Object
+
+| Field Name    | Type     | Required | Description                                                    |
+| ------------- | -------- | -------- | -------------------------------------------------------------- |
+| `reason_code` | `string` | Required | Enumerated code identifying the primary reason (see §4.2). **Validator hint:** Treat as lenient enum—accept any string value; unknown codes map to `other`. |
+| `trace_summary` | `string` | Optional | Human-readable summary (max 500 chars)                       |
+| `metadata`    | `object` | Optional | Flat key-value object for additional context                   |
+| `remediation` | `object` | Optional | Suggested action to resolve the issue                          |
+
+### 4.2 Reason Codes
+
+#### Client Decline Reason Codes
+
+Codes used when a client declines to pay after receiving `PaymentRequired`:
+
+| Code                    | Description                                                         |
+| ----------------------- | ------------------------------------------------------------------- |
+| `price_sensitivity`     | Total price exceeds client's budget or value assessment             |
+| `budget_exceeded`       | Payment would exceed allocated budget for this category/session     |
+| `wrong_network`         | Client cannot or prefers not to pay on the offered network(s)       |
+| `wrong_asset`           | Client does not hold or prefers not to use the offered asset(s)     |
+| `insufficient_balance`  | Client knows it has insufficient funds before attempting            |
+| `untrusted_facilitator` | Client does not trust the facilitator for this payment              |
+| `untrusted_recipient`   | Client does not trust the `payTo` address                           |
+| `timing_deferred`       | Client intends to pay later, not an objection to terms              |
+| `comparison`            | Client is comparing options across multiple providers               |
+| `rate_limit_concern`    | Client concerned about rate of spend or transaction frequency       |
+| `gas_cost_concern`      | Expected transaction fees make the payment uneconomical             |
+| `authorization_denied`  | User/policy denied authorization for this payment                   |
+| `other`                 | Fallback for reasons not covered above                              |
+
+#### Verification/Settlement Failure Reason Codes
+
+Codes used when the server/facilitator explains why a payment failed:
+
+| Code                    | Description                                                         |
+| ----------------------- | ------------------------------------------------------------------- |
+| `insufficient_funds`    | Wallet balance below required amount                                |
+| `signature_invalid`     | Payment authorization signature failed verification                 |
+| `signature_expired`     | Authorization past `validBefore` timestamp                          |
+| `signature_not_yet_valid` | Authorization before `validAfter` timestamp                       |
+| `amount_mismatch`       | Authorized amount doesn't match requirements                        |
+| `recipient_mismatch`    | Authorization recipient doesn't match `payTo`                       |
+| `nonce_already_used`    | Replay attack detected—nonce previously consumed                    |
+| `network_mismatch`      | Payment submitted on wrong network                                  |
+| `asset_mismatch`        | Payment uses wrong token contract                                   |
+| `transaction_reverted`  | On-chain transaction reverted during execution                      |
+| `transaction_timeout`   | Settlement didn't complete within `maxTimeoutSeconds`               |
+| `facilitator_error`     | Facilitator encountered an internal error                           |
+| `smart_wallet_error`    | ERC-4337 smart wallet deployment or execution failed                |
+| `other`                 | Fallback for errors not covered above                               |
+
+### 4.3 Metadata Object
+
+- Keys MUST be strings.
+- Values MUST be strings, numbers, or booleans. Arrays and nested objects are NOT permitted.
+- Monetary values SHOULD be strings representing atomic token units (consistent with x402 amount formatting).
+- Implementations MAY impose limits on key count (e.g., 20 keys) and total payload size (e.g., 4KB).
+
+### 4.4 Remediation Object
+
+| Field Name | Type     | Required | Description                                              |
+| ---------- | -------- | -------- | -------------------------------------------------------- |
+| `action`   | `string` | Required | Suggested action (e.g., `top_up`, `retry`, `switch_network`) |
+| `reason`   | `string` | Optional | Why this action would help                               |
+| Additional fields | varies | Optional | Action-specific parameters (e.g., `min_amount`, `network`) |
+
+---
+
+## 5. Transport Bindings
+
+### 5.1 HTTP Transport
+
+#### Client Decline
+
+Clients send a decline by making a request to the same resource URL with a `PAYMENT-DECLINE` header containing the base64url-encoded `PaymentDecline` JSON:
+
+```http
+GET /premium-data HTTP/1.1
+Host: api.example.com
+PAYMENT-DECLINE: eyJ4NDAyVmVyc2lvbiI6MiwiZGVjbGluZSI6dHJ1ZSwicmVzb3VyY2UiOnsidXJsIjoiaHR0cHM6Ly9hcGkuZXhhbXBsZS5jb20vcHJlbWl1bS1kYXRhIn0sImludGVudF90cmFjZSI6eyJyZWFzb25fY29kZSI6InByaWNlX3NlbnNpdGl2aXR5In19
+```
+
+The server SHOULD respond with `200 OK` to acknowledge receipt of the decline. The response body is empty or contains acknowledgment metadata.
+
+#### Failure Response
+
+When returning a `402 Payment Required` after a failed payment attempt, the server MAY include an `X-PAYMENT-INTENT-TRACE` header with base64url-encoded intent trace JSON:
+
+```http
+HTTP/1.1 402 Payment Required
+Content-Type: application/json
+PAYMENT-REQUIRED: <base64url-encoded PaymentRequired>
+X-PAYMENT-INTENT-TRACE: <base64url-encoded IntentTrace>
+```
+
+### 5.2 A2A Transport
+
+#### Client Decline
+
+Clients send a decline using a message with `x402.payment.status: "payment-declined"` and `x402.payment.intent_trace`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "message/send",
+  "id": "req-004",
+  "params": {
+    "message": {
+      "taskId": "task-123",
+      "role": "user",
+      "parts": [
+        { "kind": "text", "text": "I'm declining this payment." }
+      ],
+      "metadata": {
+        "x402.payment.status": "payment-declined",
+        "x402.payment.intent_trace": {
+          "reason_code": "price_sensitivity",
+          "trace_summary": "Amount exceeds my budget for API calls.",
+          "metadata": {
+            "max_budget": "5000000",
+            "requested_amount": "10000000"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Failure Response
+
+Servers include intent traces in failure responses via `x402.payment.intent_trace`:
+
+```json
+{
+  "kind": "task",
+  "id": "task-123",
+  "status": {
+    "state": "failed",
+    "message": {
+      "kind": "message",
+      "role": "agent",
+      "parts": [
+        { "kind": "text", "text": "Payment failed: insufficient funds." }
+      ],
+      "metadata": {
+        "x402.payment.status": "payment-failed",
+        "x402.payment.error": "insufficient_funds",
+        "x402.payment.intent_trace": {
+          "reason_code": "insufficient_funds",
+          "trace_summary": "Wallet balance is below required amount.",
+          "metadata": {
+            "required_amount": "10000000",
+            "available_balance": "3500000",
+            "shortfall": "6500000"
+          },
+          "remediation": {
+            "action": "top_up",
+            "min_amount": "6500000",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913",
+            "network": "eip155:8453"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### 5.3 MCP Transport
+
+#### Client Decline
+
+Clients send a decline using the `_meta` field:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "get_premium_data",
+    "arguments": {},
+    "_meta": {
+      "x402/payment": {
+        "decline": true,
+        "intent_trace": {
+          "reason_code": "budget_exceeded",
+          "trace_summary": "This call would exceed my session budget.",
+          "metadata": {
+            "session_budget_remaining": "2000000",
+            "requested_amount": "5000000"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Failure Response
+
+Servers include intent traces in the error response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": 402,
+    "message": "Payment required",
+    "data": {
+      "x402Version": 2,
+      "error": "Payment verification failed",
+      "resource": { "url": "tool://get_premium_data" },
+      "accepts": [...],
+      "intent_trace": {
+        "reason_code": "signature_expired",
+        "trace_summary": "Authorization expired before settlement.",
+        "metadata": {
+          "valid_before": "1740672154",
+          "current_time": "1740672200",
+          "expired_by_seconds": 46
+        },
+        "remediation": {
+          "action": "retry_with_fresh_authorization",
+          "suggested_valid_before_offset": 120
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## 6. Example Interactions
+
+### 6.1 Client Declines Due to Price (HTTP)
+
+**Step 1:** Client requests resource, receives `PaymentRequired`:
+
+```http
+HTTP/1.1 402 Payment Required
+PAYMENT-REQUIRED: <PaymentRequired with amount: 10000000>
+```
+
+**Step 2:** Client declines with intent trace:
+
+```http
+GET /premium-data HTTP/1.1
+PAYMENT-DECLINE: <base64url PaymentDecline>
+```
+
+Decoded `PaymentDecline`:
+```json
+{
+  "x402Version": 2,
+  "decline": true,
+  "resource": { "url": "https://api.example.com/premium-data" },
+  "intent_trace": {
+    "reason_code": "price_sensitivity",
+    "trace_summary": "Agent budget allows max $0.05 per API call; this costs $0.10.",
+    "metadata": {
+      "max_acceptable_amount": "5000000",
+      "requested_amount": "10000000",
+      "currency_context": "USDC on Base"
+    }
+  }
+}
+```
+
+**Step 3:** Server acknowledges:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "acknowledged": true,
+  "message": "Decline recorded. Consider our economy tier at $0.03/call."
+}
+```
+
+### 6.2 Payment Fails with Remediation Hint (A2A)
+
+```json
+{
+  "kind": "task",
+  "id": "task-456",
+  "status": {
+    "state": "input-required",
+    "message": {
+      "role": "agent",
+      "parts": [{ "kind": "text", "text": "Payment failed. Please retry with updated authorization." }],
+      "metadata": {
+        "x402.payment.status": "payment-failed",
+        "x402.payment.intent_trace": {
+          "reason_code": "signature_expired",
+          "trace_summary": "Your payment authorization expired 46 seconds before we could settle it.",
+          "metadata": {
+            "valid_before": "1740672154",
+            "settlement_attempted_at": "1740672200"
+          },
+          "remediation": {
+            "action": "retry_with_fresh_authorization",
+            "reason": "Network congestion delayed settlement",
+            "suggested_valid_before_offset": 300
+          }
+        },
+        "x402.payment.required": { ... }
+      }
+    }
+  }
+}
+```
+
+---
+
+## 7. Error Handling
+
+If an `intent_trace` contains **structurally invalid data** (e.g., wrong types, nested objects in `metadata`), the receiver SHOULD:
+
+- **For client declines:** Accept the decline but log/ignore the malformed trace.
+- **For server responses:** Include the trace anyway if partially valid, or omit if completely malformed.
+
+Unrecognized `reason_code` values are NOT errors—receivers SHOULD treat unknown codes as equivalent to `other` for processing purposes.
+
+---
+
+## 8. Security & Privacy Considerations
+
+### 8.1 Data Minimization
+
+- Agents SHOULD NOT transmit wallet private keys, seed phrases, or authentication credentials in trace data.
+- The `trace_summary` field SHOULD avoid PII unless the client explicitly intends to share it.
+- Servers SHOULD NOT require intent traces—they are voluntary signals.
+
+### 8.2 Replay Considerations
+
+Intent traces are informational and do not authorize any payment. They have no replay risk as they do not move funds.
+
+### 8.3 Rate Limiting
+
+Servers MAY rate-limit decline messages to prevent abuse (e.g., a client spamming declines with different reason codes).
+
+---
+
+## 9. Operational Considerations
+
+### 9.1 Backward Compatibility
+
+- **Servers** that do not implement Intent Traces MUST still accept requests that include decline messages or intent trace headers. They SHOULD ignore unrecognized fields and proceed normally.
+- **Clients** receiving responses with `intent_trace` fields they don't understand SHOULD ignore them.
+
+### 9.2 Forward Compatibility
+
+If a receiver encounters an unrecognized `reason_code`, it SHOULD accept the trace and treat the unknown code as equivalent to `other` for processing purposes. The `reason_code` enum is explicitly extensible.
+
+### 9.3 Analytics Use Cases
+
+Resource servers can use intent traces to:
+
+- **Price optimization:** Track `price_sensitivity` declines to find optimal price points.
+- **Network expansion:** Track `wrong_network` declines to prioritize new network support.
+- **UX improvement:** Track `untrusted_facilitator` to identify trust barriers.
+- **Failure reduction:** Track remediation success rates to improve suggested actions.
+
+---
+
+## 10. Conformance Checklist
+
+To claim compliance with the **Intent Traces** extension:
+
+**For Clients:**
+- [ ] **MAY** send `PaymentDecline` messages with `intent_trace` when declining to pay.
+- [ ] **MUST** include `x402Version` and `resource` fields in `PaymentDecline`.
+- [ ] **SHOULD** use standardized `reason_code` values where applicable.
+- [ ] **MUST NOT** include PII or secrets in trace data unless explicitly authorized.
+
+**For Servers:**
+- [ ] **MAY** include `intent_trace` in `VerifyResponse` and `SettleResponse` for failures.
+- [ ] **MAY** include `remediation` hints to help clients resolve issues.
+- [ ] **MUST** accept decline messages even if not processing the trace data.
+- [ ] **SHOULD** accept unrecognized `reason_code` values and treat as `other`.
+- [ ] **MUST NOT** require intent traces for normal protocol operation.
+
+**For Facilitators:**
+- [ ] **MAY** include `intent_trace` in verify/settle responses.
+- [ ] **SHOULD** include `remediation` hints for actionable failures.
+
+---
+
+## 11. Future Extensions
+
+This RFC establishes the foundation for:
+
+- **Counter-Offers:** Servers responding to `price_sensitivity` with alternative pricing.
+- **Budget Negotiation:** Clients advertising budget constraints, servers optimizing offerings.
+- **Trust Signals:** Clients explaining trust requirements, servers providing attestations.
+
+These extensions are out of scope for this RFC and will be addressed in future proposals.
+
+---
+
+## 12. Implementation Status
+
+This RFC has been implemented across all x402 SDKs. Below is a summary of the implementation:
+
+### Core Types
+
+| Language   | File                                                      | Types Implemented                                      |
+| ---------- | --------------------------------------------------------- | ------------------------------------------------------ |
+| TypeScript | `packages/core/src/types/facilitator.ts`                  | `IntentTrace`, `Remediation`                           |
+| TypeScript | `packages/core/src/types/payments.ts`                     | `PaymentDecline`                                       |
+| Go         | `types.go`                                                | `IntentTrace`, `Remediation`, `PaymentDecline`         |
+| Python     | `x402/types.py`                                           | `IntentTrace`, `Remediation`, `PaymentDecline`         |
+| Java       | `model/IntentTrace.java`, `model/Remediation.java`        | `IntentTrace`, `Remediation`, `PaymentDecline`         |
+
+### HTTP Transport
+
+| Language   | File                                                      | Functions/Features                                     |
+| ---------- | --------------------------------------------------------- | ------------------------------------------------------ |
+| TypeScript | `packages/core/src/http/index.ts`                         | `encodePaymentDeclineHeader`, `decodePaymentDeclineHeader`, `encodeIntentTraceHeader`, `decodeIntentTraceHeader` |
+| TypeScript | `packages/core/src/http/x402HTTPResourceServer.ts`        | Decline header detection and acknowledgment            |
+| Go         | `http/client.go`                                          | `EncodePaymentDeclineHeader`, `DecodePaymentDeclineHeader`, `EncodeIntentTraceHeader`, `DecodeIntentTraceHeader` |
+| Go         | `http/server.go`                                          | `PAYMENT-DECLINE` header handling                      |
+| Python     | `x402/encoding.py`                                        | `encode_payment_decline_header`, `decode_payment_decline_header`, `encode_intent_trace_header`, `decode_intent_trace_header` |
+
+### Middleware/Filters
+
+| Language   | File                                                      | Feature                                                |
+| ---------- | --------------------------------------------------------- | ------------------------------------------------------ |
+| Python     | `x402/flask/middleware.py`                                | `PAYMENT-DECLINE` header handling                      |
+| Python     | `x402/fastapi/middleware.py`                              | `PAYMENT-DECLINE` header handling                      |
+| Java       | `server/PaymentFilter.java`                               | `PAYMENT-DECLINE` header handling                      |
+
+### Facilitator Logic (Intent Trace Helpers)
+
+| Language   | File                                                      | Helper Functions                                       |
+| ---------- | --------------------------------------------------------- | ------------------------------------------------------ |
+| TypeScript | `packages/core/src/utils/intentTrace.ts`                  | `createInsufficientFundsTrace`, `createSignatureExpiredTrace`, `createSignatureNotYetValidTrace`, `createInvalidSignatureTrace`, `createRecipientMismatchTrace`, `createAmountMismatchTrace`, `createTransactionRevertedTrace`, `createUndeployedWalletTrace`, `createGenericFailureTrace` |
+| TypeScript | `packages/mechanisms/evm/src/exact/facilitator/scheme.ts` | Intent traces integrated into verification/settlement failures |
+
+### Extended Response Types
+
+All languages extend `VerifyResponse` and `SettleResponse` with optional `intentTrace` field:
+
+- TypeScript: `packages/core/src/types/facilitator.ts`
+- Go: `types.go`
+- Python: `x402/types.py`
+- Java: `client/VerificationResponse.java`, `client/SettlementResponse.java`
+
+### Tests
+
+| Language   | File                                                      | Test Coverage                                          |
+| ---------- | --------------------------------------------------------- | ------------------------------------------------------ |
+| Go         | `http/client_test.go`                                     | `TestEncodeDecodeIntentTrace`, `TestEncodeDecodePaymentDecline`, `TestDecodeInvalidIntentTraceHeader`, `TestDecodeInvalidPaymentDeclineHeader` |
+| Python     | `tests/test_encoding.py`                                  | `test_encode_decode_intent_trace`, `test_encode_decode_payment_decline`, `test_intent_trace_roundtrip` |
+
+---
+
+## 13. Change Log
+
+- **2025-12-17:** Initial proposal for x402 Intent Traces. Adapted from Agentic Commerce Protocol RFC. Defined bidirectional trace schema with client decline codes and server failure codes. Added remediation hints. Specified transport bindings for HTTP, A2A, and MCP.
+- **2025-12-17:** Implementation completed across TypeScript, Go, Python, and Java SDKs.
+- **2025-12-17:** Fixed examples to use string formatting for monetary values per §4.3. Added lenient enum validator hint for `reason_code`.

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -1,5 +1,10 @@
-import { SettleResponse } from "../types";
-import { PaymentPayload, PaymentRequired, PaymentRequirements } from "../types/payments";
+import { IntentTrace, SettleResponse } from "../types";
+import {
+  PaymentDecline,
+  PaymentPayload,
+  PaymentRequired,
+  PaymentRequirements,
+} from "../types/payments";
 import { Base64EncodedRegex, safeBase64Decode, safeBase64Encode } from "../utils";
 
 // HTTP Methods that typically use query parameters
@@ -77,6 +82,52 @@ export function decodePaymentResponseHeader(paymentResponseHeader: string): Sett
     throw new Error("Invalid payment response header");
   }
   return JSON.parse(safeBase64Decode(paymentResponseHeader)) as SettleResponse;
+}
+
+/**
+ * Encodes a payment decline as a base64 header value.
+ *
+ * @param paymentDecline - The payment decline to encode
+ * @returns Base64 encoded string representation of the payment decline
+ */
+export function encodePaymentDeclineHeader(paymentDecline: PaymentDecline): string {
+  return safeBase64Encode(JSON.stringify(paymentDecline));
+}
+
+/**
+ * Decodes a base64 payment decline header into a payment decline object.
+ *
+ * @param paymentDeclineHeader - The base64 encoded payment decline header
+ * @returns The decoded payment decline object
+ */
+export function decodePaymentDeclineHeader(paymentDeclineHeader: string): PaymentDecline {
+  if (!Base64EncodedRegex.test(paymentDeclineHeader)) {
+    throw new Error("Invalid payment decline header");
+  }
+  return JSON.parse(safeBase64Decode(paymentDeclineHeader)) as PaymentDecline;
+}
+
+/**
+ * Encodes an intent trace as a base64 header value.
+ *
+ * @param intentTrace - The intent trace to encode
+ * @returns Base64 encoded string representation of the intent trace
+ */
+export function encodeIntentTraceHeader(intentTrace: IntentTrace): string {
+  return safeBase64Encode(JSON.stringify(intentTrace));
+}
+
+/**
+ * Decodes a base64 intent trace header into an intent trace object.
+ *
+ * @param intentTraceHeader - The base64 encoded intent trace header
+ * @returns The decoded intent trace object
+ */
+export function decodeIntentTraceHeader(intentTraceHeader: string): IntentTrace {
+  if (!Base64EncodedRegex.test(intentTraceHeader)) {
+    throw new Error("Invalid intent trace header");
+  }
+  return JSON.parse(safeBase64Decode(intentTraceHeader)) as IntentTrace;
 }
 
 // Export HTTP service and types

--- a/typescript/packages/core/src/types/facilitator.ts
+++ b/typescript/packages/core/src/types/facilitator.ts
@@ -1,6 +1,34 @@
 import { PaymentPayload, PaymentRequirements } from "./payments";
 import { Network } from "./";
 
+/**
+ * Remediation hint for resolving payment issues.
+ * Provides actionable guidance to clients on how to fix a failure.
+ */
+export type Remediation = {
+  /** Suggested action (e.g., "top_up", "retry", "switch_network") */
+  action: string;
+  /** Why this action would help */
+  reason?: string;
+  /** Action-specific parameters */
+  [key: string]: unknown;
+};
+
+/**
+ * Intent trace for structured payment decision context.
+ * Used to communicate why a payment was declined or failed.
+ */
+export type IntentTrace = {
+  /** Enumerated code identifying the primary reason */
+  reason_code: string;
+  /** Human-readable summary (max 500 chars) */
+  trace_summary?: string;
+  /** Flat key-value object for additional context */
+  metadata?: Record<string, string | number | boolean>;
+  /** Suggested action to resolve the issue */
+  remediation?: Remediation;
+};
+
 export type VerifyRequest = {
   paymentPayload: PaymentPayload;
   paymentRequirements: PaymentRequirements;
@@ -10,6 +38,8 @@ export type VerifyResponse = {
   isValid: boolean;
   invalidReason?: string;
   payer?: string;
+  /** Structured context for why verification failed */
+  intentTrace?: IntentTrace;
 };
 
 export type SettleRequest = {
@@ -23,6 +53,8 @@ export type SettleResponse = {
   payer?: string;
   transaction: string;
   network: Network;
+  /** Structured context for why settlement failed */
+  intentTrace?: IntentTrace;
 };
 
 export type SupportedKind = {

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -4,8 +4,15 @@ export type {
   SettleRequest,
   SettleResponse,
   SupportedResponse,
+  IntentTrace,
+  Remediation,
 } from "./facilitator";
-export type { PaymentRequirements, PaymentPayload, PaymentRequired } from "./payments";
+export type {
+  PaymentRequirements,
+  PaymentPayload,
+  PaymentRequired,
+  PaymentDecline,
+} from "./payments";
 export type {
   SchemeNetworkClient,
   SchemeNetworkFacilitator,

--- a/typescript/packages/core/src/types/payments.ts
+++ b/typescript/packages/core/src/types/payments.ts
@@ -1,4 +1,5 @@
 import { Network } from "./";
+import { IntentTrace } from "./facilitator";
 
 export interface ResourceInfo {
   url: string;
@@ -30,4 +31,16 @@ export type PaymentPayload = {
   accepted: PaymentRequirements;
   payload: Record<string, unknown>;
   extensions?: Record<string, unknown>;
+};
+
+/**
+ * Payment decline message sent by clients when they choose not to pay.
+ * Includes optional intent trace to explain the reason for declining.
+ */
+export type PaymentDecline = {
+  x402Version: number;
+  decline: true;
+  resource: ResourceInfo;
+  /** Structured context for why the payment was declined */
+  intentTrace?: IntentTrace;
 };

--- a/typescript/packages/core/src/utils/index.ts
+++ b/typescript/packages/core/src/utils/index.ts
@@ -148,3 +148,18 @@ export function deepEqual(obj1: unknown, obj2: unknown): boolean {
     return JSON.stringify(obj1) === JSON.stringify(obj2);
   }
 }
+
+// Export intent trace utilities
+export {
+  FailureReasonCodes,
+  createInsufficientFundsTrace,
+  createSignatureExpiredTrace,
+  createSignatureNotYetValidTrace,
+  createInvalidSignatureTrace,
+  createRecipientMismatchTrace,
+  createAmountMismatchTrace,
+  createTransactionRevertedTrace,
+  createUndeployedWalletTrace,
+  createGenericFailureTrace,
+} from "./intentTrace";
+export type { FailureReasonCode } from "./intentTrace";

--- a/typescript/packages/core/src/utils/intentTrace.ts
+++ b/typescript/packages/core/src/utils/intentTrace.ts
@@ -1,0 +1,232 @@
+import { IntentTrace, Remediation } from "../types";
+
+/**
+ * Standard reason codes for verification/settlement failures.
+ * These codes provide machine-readable categorization of failures.
+ */
+export const FailureReasonCodes = {
+  // Balance/Funds
+  INSUFFICIENT_FUNDS: "insufficient_funds",
+
+  // Signature issues
+  SIGNATURE_INVALID: "signature_invalid",
+  SIGNATURE_EXPIRED: "signature_expired",
+  SIGNATURE_NOT_YET_VALID: "signature_not_yet_valid",
+
+  // Amount/Value issues
+  AMOUNT_MISMATCH: "amount_mismatch",
+  RECIPIENT_MISMATCH: "recipient_mismatch",
+
+  // Network/Asset issues
+  NETWORK_MISMATCH: "network_mismatch",
+  ASSET_MISMATCH: "asset_mismatch",
+
+  // Transaction issues
+  NONCE_ALREADY_USED: "nonce_already_used",
+  TRANSACTION_REVERTED: "transaction_reverted",
+  TRANSACTION_TIMEOUT: "transaction_timeout",
+
+  // Wallet issues
+  SMART_WALLET_ERROR: "smart_wallet_error",
+  UNDEPLOYED_WALLET: "undeployed_wallet",
+
+  // System errors
+  FACILITATOR_ERROR: "facilitator_error",
+  OTHER: "other",
+} as const;
+
+export type FailureReasonCode = (typeof FailureReasonCodes)[keyof typeof FailureReasonCodes];
+
+/**
+ * Create an intent trace for insufficient funds failure.
+ */
+export function createInsufficientFundsTrace(
+  requiredAmount: string,
+  availableBalance: string,
+  asset: string,
+  network: string,
+): IntentTrace {
+  const shortfall = (BigInt(requiredAmount) - BigInt(availableBalance)).toString();
+
+  return {
+    reason_code: FailureReasonCodes.INSUFFICIENT_FUNDS,
+    trace_summary: "Wallet balance is below required amount.",
+    metadata: {
+      required_amount: requiredAmount,
+      available_balance: availableBalance,
+      shortfall,
+    },
+    remediation: {
+      action: "top_up",
+      reason: "Add more funds to complete this payment",
+      min_amount: shortfall,
+      asset,
+      network,
+    },
+  };
+}
+
+/**
+ * Create an intent trace for expired signature/authorization.
+ */
+export function createSignatureExpiredTrace(
+  validBefore: string,
+  currentTime: number,
+): IntentTrace {
+  const expiredBySeconds = currentTime - parseInt(validBefore);
+
+  return {
+    reason_code: FailureReasonCodes.SIGNATURE_EXPIRED,
+    trace_summary: "Payment authorization has expired.",
+    metadata: {
+      valid_before: validBefore,
+      current_time: currentTime,
+      expired_by_seconds: expiredBySeconds,
+    },
+    remediation: {
+      action: "retry_with_fresh_authorization",
+      reason: "Create a new authorization with a later validBefore timestamp",
+      suggested_valid_before_offset: 300, // 5 minutes
+    },
+  };
+}
+
+/**
+ * Create an intent trace for signature not yet valid.
+ */
+export function createSignatureNotYetValidTrace(
+  validAfter: string,
+  currentTime: number,
+): IntentTrace {
+  const waitSeconds = parseInt(validAfter) - currentTime;
+
+  return {
+    reason_code: FailureReasonCodes.SIGNATURE_NOT_YET_VALID,
+    trace_summary: "Payment authorization is not yet valid.",
+    metadata: {
+      valid_after: validAfter,
+      current_time: currentTime,
+      wait_seconds: waitSeconds,
+    },
+    remediation: {
+      action: "wait_and_retry",
+      reason: `Wait ${waitSeconds} seconds before retrying`,
+      wait_seconds: waitSeconds,
+    },
+  };
+}
+
+/**
+ * Create an intent trace for invalid signature.
+ */
+export function createInvalidSignatureTrace(payer: string): IntentTrace {
+  return {
+    reason_code: FailureReasonCodes.SIGNATURE_INVALID,
+    trace_summary: "Payment authorization signature failed verification.",
+    metadata: {
+      payer,
+    },
+    remediation: {
+      action: "retry_with_correct_signature",
+      reason: "Ensure the authorization is signed with the correct private key",
+    },
+  };
+}
+
+/**
+ * Create an intent trace for recipient mismatch.
+ */
+export function createRecipientMismatchTrace(
+  expectedRecipient: string,
+  providedRecipient: string,
+): IntentTrace {
+  return {
+    reason_code: FailureReasonCodes.RECIPIENT_MISMATCH,
+    trace_summary: "Authorization recipient does not match payment requirements.",
+    metadata: {
+      expected_recipient: expectedRecipient,
+      provided_recipient: providedRecipient,
+    },
+    remediation: {
+      action: "retry_with_correct_recipient",
+      reason: "Create authorization with the correct payTo address",
+      correct_recipient: expectedRecipient,
+    },
+  };
+}
+
+/**
+ * Create an intent trace for amount mismatch.
+ */
+export function createAmountMismatchTrace(
+  requiredAmount: string,
+  providedAmount: string,
+): IntentTrace {
+  return {
+    reason_code: FailureReasonCodes.AMOUNT_MISMATCH,
+    trace_summary: "Authorized amount is less than required.",
+    metadata: {
+      required_amount: requiredAmount,
+      provided_amount: providedAmount,
+      shortfall: (BigInt(requiredAmount) - BigInt(providedAmount)).toString(),
+    },
+    remediation: {
+      action: "retry_with_correct_amount",
+      reason: "Create authorization with at least the required amount",
+      min_amount: requiredAmount,
+    },
+  };
+}
+
+/**
+ * Create an intent trace for transaction revert.
+ */
+export function createTransactionRevertedTrace(
+  revertReason?: string,
+  txHash?: string,
+): IntentTrace {
+  return {
+    reason_code: FailureReasonCodes.TRANSACTION_REVERTED,
+    trace_summary: "On-chain transaction reverted during execution.",
+    metadata: {
+      revert_reason: revertReason || "Unknown",
+      ...(txHash && { transaction_hash: txHash }),
+    },
+    remediation: {
+      action: "retry_with_fresh_authorization",
+      reason: "Balance or approval state may have changed since verification",
+    },
+  };
+}
+
+/**
+ * Create an intent trace for undeployed smart wallet.
+ */
+export function createUndeployedWalletTrace(walletAddress: string): IntentTrace {
+  return {
+    reason_code: FailureReasonCodes.UNDEPLOYED_WALLET,
+    trace_summary: "Smart wallet is not deployed and signature lacks deployment info.",
+    metadata: {
+      wallet_address: walletAddress,
+    },
+    remediation: {
+      action: "deploy_wallet_first",
+      reason: "Deploy the smart wallet before attempting payment, or use EIP-6492 signature with deployment info",
+    },
+  };
+}
+
+/**
+ * Create a generic intent trace for other failures.
+ */
+export function createGenericFailureTrace(
+  errorCode: string,
+  summary: string,
+  metadata?: Record<string, string | number | boolean>,
+): IntentTrace {
+  return {
+    reason_code: errorCode,
+    trace_summary: summary,
+    metadata,
+  };
+}


### PR DESCRIPTION
# Abstract
Extend x402 with optional intent traces so clients can explain why they decline to pay and servers can return structured context when verification/settlement fails. Adds an `intent_trace` object (reason_code, trace_summary, metadata, optional remediation) to decline messages and failure responses, with transport bindings for HTTP headers, A2A metadata, and MCP `_meta`.

# Motivation
Today a declined or failed x402 payment is a dead end: clients stay silent or servers return terse codes (e.g., `insufficient_funds`) with no signal about budget, network, or timing constraints. This forces guesswork in pricing and UX. Structured intent traces turn non-payments into actionable signals: a decline with `price_sensitivity` or `timing_deferred` tells the server whether to counter-offer now or follow up later; a failure trace with `signature_expired` plus remediation hints lets clients retry successfully.

# Why structured and bidirectional?
- **Structured codes** power routing and analytics; free text does not. Codes cover client-side decisions (price, network/asset, trust, timing) and server-side failures (insufficient_funds, signature_invalid/expired, transaction_reverted, etc.), with an extensible enum.
- **Bidirectional**: Clients send decline traces; servers send failure traces (verify/settle) with optional remediation so agents can auto-resolve.
- **Optional**: Preserves backward compatibility. Non-supporting parties ignore traces and continue the protocol.

# Specification
- **New message**: `PaymentDecline` may include `intent_trace`.
- **Extended responses**: `VerifyResponse` and `SettleResponse` may include `intent_trace` and optional `remediation`.
- **Reason codes**:
  - Client declines: `price_sensitivity`, `budget_exceeded`, `wrong_network`, `wrong_asset`, `insufficient_balance`, `untrusted_facilitator`, `untrusted_recipient`, `timing_deferred`, `comparison`, `rate_limit_concern`, `gas_cost_concern`, `authorization_denied`, `other`.
  - Server failures: `insufficient_funds`, `signature_invalid`, `signature_expired`, `signature_not_yet_valid`, `amount_mismatch`, `recipient_mismatch`, `nonce_already_used`, `network_mismatch`, `asset_mismatch`, `transaction_reverted`, `transaction_timeout`, `facilitator_error`, `smart_wallet_error`, `other`.
- **Schema rules**:
  - `metadata`: flat object; values are string/number/boolean only; no arrays/nested objects.
  - Monetary values: strings in atomic units (x402 convention).
  - `remediation`: optional action hint (e.g., `top_up`, `retry_with_fresh_authorization`, `switch_network`).
  - **Lenient enum**: Enums are for documentation/tooling; validators SHOULD accept unknown `reason_code` values and treat them as `other` (forward compatibility).
- **Transports**:
  - HTTP: `PAYMENT-DECLINE` header (base64url PaymentDecline JSON); server may return `X-PAYMENT-INTENT-TRACE` with failure context.
  - A2A: metadata keys `x402.payment.status`, `x402.payment.intent_trace`.
  - MCP: `_meta` block under `x402/payment` with `decline` and `intent_trace`.
- **Semantics**:
  - Traces are optional and write-only; protocol must proceed even if traces are ignored.
  - Unknown reason codes MUST NOT cause errors.
  - Structurally invalid traces should be ignored/logged, not block the flow.

# Privacy
- Intent traces are explicit, scoped to the resource server, and encourage structured data to avoid leakage.
- Clients SHOULD avoid PII in `trace_summary`; secrets (keys, auth) must never be included.

# Files Changed
- `x402/specs/rfc-intent-traces.md` — Spec, examples, transports, conformance, and validator guidance.
- Go: `go/http/client.go`, `go/http/client_test.go`, `go/http/server.go`, `go/types.go` — Header encode/decode, decline handling, types.
- Java: `java/src/main/java/.../IntentTrace.java`, `PaymentDecline.java`, `Remediation.java`, `SettlementResponse.java`, `VerificationResponse.java`, `SettlementResponseHeader.java`, `PaymentFilter.java` — Types plus HTTP filter wiring.
- Python: `python/x402/src/x402/encoding.py`, `middleware.py`, `types.py`, `tests/test_encoding.py` — Header helpers, middleware, types, tests.
- TypeScript: `typescript/packages/core/src/index.ts`, `typescript/packages/core/src/http/x402HTTPResourceServer.ts`, `typescript/packages/mechanisms/evm/src/exact/facilitator.ts` — Exports, HTTP resource server handling, facilitator intent trace helpers.