### PR TITLE
fix(evm): Ensure full v1 EVM network compatibility

### DIFF
--- a/typescript/packages/mechanisms/evm/src/exact/v1/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/client/scheme.ts
@@ -10,6 +10,7 @@ import { authorizationTypes } from "../../../constants";
 import { ClientEvmSigner } from "../../../signer";
 import { ExactEvmPayloadV1 } from "../../../types";
 import { createNonce, getEvmChainId } from "../../../utils";
+import { EvmNetworkV1 } from "../../../v1";
 
 /**
  * EVM client implementation for the Exact payment scheme (V1).
@@ -77,7 +78,7 @@ export class ExactEvmSchemeV1 implements SchemeNetworkClient {
     authorization: ExactEvmPayloadV1["authorization"],
     requirements: PaymentRequirementsV1,
   ): Promise<`0x${string}`> {
-    const chainId = getEvmChainId(requirements.network);
+    const chainId = getEvmChainId(requirements.network as EvmNetworkV1);
 
     if (!requirements.extra?.name || !requirements.extra?.version) {
       throw new Error(

--- a/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
@@ -12,6 +12,7 @@ import { authorizationTypes, eip3009ABI } from "../../../constants";
 import { FacilitatorEvmSigner } from "../../../signer";
 import { ExactEvmPayloadV1 } from "../../../types";
 import { getEvmChainId } from "../../../utils";
+import { EvmNetworkV1 } from "../../../v1";
 
 export interface ExactEvmSchemeV1Config {
   /**
@@ -93,7 +94,16 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
     }
 
     // Get chain configuration
-    const chainId = getEvmChainId(payloadV1.network);
+    let chainId: number;
+    try {
+      chainId = getEvmChainId(payloadV1.network as EvmNetworkV1);
+    } catch {
+      return {
+        isValid: false,
+        invalidReason: `invalid_network`,
+        payer: exactEvmPayload.authorization.from,
+      };
+    }
 
     if (!requirements.extra?.name || !requirements.extra?.version) {
       return {

--- a/typescript/packages/mechanisms/evm/src/utils.ts
+++ b/typescript/packages/mechanisms/evm/src/utils.ts
@@ -1,5 +1,5 @@
 import { toHex } from "viem";
-import { Network } from "@x402/core/types";
+import { EVM_NETWORK_CHAIN_ID_MAP, EvmNetworkV1 } from "./v1";
 
 /**
  * Extract chain ID from network string (e.g., "base-sepolia" -> 84532)
@@ -7,17 +7,14 @@ import { Network } from "@x402/core/types";
  *
  * @param network - The network identifier
  * @returns The numeric chain ID
+ * @throws Error if the network is not supported
  */
-export function getEvmChainId(network: Network): number {
-  const networkMap: Record<string, number> = {
-    base: 8453,
-    "base-sepolia": 84532,
-    ethereum: 1,
-    sepolia: 11155111,
-    polygon: 137,
-    "polygon-amoy": 80002,
-  };
-  return networkMap[network] || 1;
+export function getEvmChainId(network: EvmNetworkV1): number {
+  const chainId = EVM_NETWORK_CHAIN_ID_MAP[network];
+  if (!chainId) {
+    throw new Error(`Unsupported network: ${network}`);
+  }
+  return chainId;
 }
 
 /**

--- a/typescript/packages/mechanisms/evm/src/v1/index.ts
+++ b/typescript/packages/mechanisms/evm/src/v1/index.ts
@@ -1,19 +1,25 @@
 export { ExactEvmSchemeV1 } from "../exact/v1";
 
-export const NETWORKS: string[] = [
-  "abstract",
-  "abstract-testnet",
-  "base-sepolia",
-  "base",
-  "avalanche-fuji",
-  "avalanche",
-  "iotex",
-  "sei",
-  "sei-testnet",
-  "polygon",
-  "polygon-amoy",
-  "peaq",
-  "story",
-  "educhain",
-  "skale-base-sepolia",
-];
+export const EVM_NETWORK_CHAIN_ID_MAP = {
+  ethereum: 1,
+  sepolia: 11155111,
+  abstract: 2741,
+  "abstract-testnet": 11124,
+  "base-sepolia": 84532,
+  base: 8453,
+  "avalanche-fuji": 43113,
+  avalanche: 43114,
+  iotex: 4689,
+  sei: 1329,
+  "sei-testnet": 1328,
+  polygon: 137,
+  "polygon-amoy": 80002,
+  peaq: 3338,
+  story: 1514,
+  educhain: 41923,
+  "skale-base-sepolia": 324705682,
+} as const;
+
+export type EvmNetworkV1 = keyof typeof EVM_NETWORK_CHAIN_ID_MAP;
+
+export const NETWORKS: string[] = Object.keys(EVM_NETWORK_CHAIN_ID_MAP);

--- a/typescript/packages/mechanisms/evm/test/unit/utils.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getEvmChainId, createNonce } from "../../src/utils";
+import { EvmNetworkV1 } from "../../src/v1";
 
 describe("EVM Utils", () => {
   describe("getEvmChainId", () => {
@@ -27,8 +28,54 @@ describe("EVM Utils", () => {
       expect(getEvmChainId("polygon-amoy")).toBe(80002);
     });
 
-    it("should return default chain ID (1) for unknown networks", () => {
-      expect(getEvmChainId("unknown-network")).toBe(1);
+    it("should return correct chain ID for Abstract", () => {
+      expect(getEvmChainId("abstract")).toBe(2741);
+    });
+
+    it("should return correct chain ID for Abstract Testnet", () => {
+      expect(getEvmChainId("abstract-testnet")).toBe(11124);
+    });
+
+    it("should return correct chain ID for Avalanche Fuji", () => {
+      expect(getEvmChainId("avalanche-fuji")).toBe(43113);
+    });
+
+    it("should return correct chain ID for Avalanche", () => {
+      expect(getEvmChainId("avalanche")).toBe(43114);
+    });
+
+    it("should return correct chain ID for IoTeX", () => {
+      expect(getEvmChainId("iotex")).toBe(4689);
+    });
+
+    it("should return correct chain ID for Sei", () => {
+      expect(getEvmChainId("sei")).toBe(1329);
+    });
+
+    it("should return correct chain ID for Sei Testnet", () => {
+      expect(getEvmChainId("sei-testnet")).toBe(1328);
+    });
+
+    it("should return correct chain ID for Peaq", () => {
+      expect(getEvmChainId("peaq")).toBe(3338);
+    });
+
+    it("should return correct chain ID for Story", () => {
+      expect(getEvmChainId("story")).toBe(1514);
+    });
+
+    it("should return correct chain ID for Educhain", () => {
+      expect(getEvmChainId("educhain")).toBe(41923);
+    });
+
+    it("should return correct chain ID for Skale Base Sepolia", () => {
+      expect(getEvmChainId("skale-base-sepolia")).toBe(324705682);
+    });
+
+    it("should throw for unsupported network", () => {
+      expect(() => getEvmChainId("unknown-network" as EvmNetworkV1)).toThrow(
+        "Unsupported network: unknown-network",
+      );
     });
   });
 

--- a/typescript/packages/mechanisms/evm/test/unit/v1/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/v1/client.test.ts
@@ -184,5 +184,26 @@ describe("ExactEvmSchemeV1", () => {
       expect(callArgs.domain.chainId).toBe(84532); // Base Sepolia
       expect(callArgs.primaryType).toBe("TransferWithAuthorization");
     });
+
+    it("should throw for unsupported network", async () => {
+      const client = new ExactEvmSchemeV1(mockSigner);
+
+      const requirements: PaymentRequirementsV1 = {
+        scheme: "exact",
+        network: "unknown-network",
+        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        maxAmountRequired: "100000",
+        payTo: "0x9876543210987654321098765432109876543210",
+        maxTimeoutSeconds: 3600,
+        extra: {
+          name: "USDC",
+          version: "2",
+        },
+      };
+
+      await expect(client.createPaymentPayload(1, requirements as never)).rejects.toThrow(
+        "Unsupported network: unknown-network",
+      );
+    });
   });
 });

--- a/typescript/packages/mechanisms/evm/test/unit/v1/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/v1/facilitator.test.ts
@@ -245,6 +245,41 @@ describe("ExactEvmSchemeV1", () => {
       expect(result.isValid).toBe(false);
       expect(result.invalidReason).toBe("invalid_exact_evm_payload_recipient_mismatch");
     });
+
+    it("should reject if network not supported", async () => {
+      const facilitator = new ExactEvmSchemeV1(mockSigner);
+
+      const payload: PaymentPayloadV1 = {
+        x402Version: 1,
+        scheme: "exact",
+        network: "unknown-network",
+        payload: {
+          authorization: {
+            from: "0x1234567890123456789012345678901234567890",
+            to: "0x9876543210987654321098765432109876543210",
+            value: "100000",
+            validAfter: "0",
+            validBefore: "999999999999",
+            nonce: "0x00",
+          },
+        },
+      };
+
+      const requirements: PaymentRequirementsV1 = {
+        scheme: "exact",
+        network: "unknown-network",
+        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        maxAmountRequired: "100000",
+        payTo: "0x9876543210987654321098765432109876543210",
+        maxTimeoutSeconds: 3600,
+        extra: {},
+      };
+
+      const result = await facilitator.verify(payload as never, requirements as never);
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("invalid_network");
+    });
   });
 
   describe("settle", () => {


### PR DESCRIPTION
## Description

v2 is designed to be fully backward-compatible with v1. However, the v1-dependent
utility function `getEvmChainId` did not provide complete support for all EVM
networks supported by v1 and fell back to the Ethereum mainnet chainId by default.

As a result, v2 failed to fully support some EVM networks that were already
supported in v1.

This PR addresses the issue by:
1. Providing full support for all EVM networks supported in v1.
2. Throwing explicit errors for unsupported networks instead of falling back to a
   default chainId.

`typescript/packages/mechanisms/evm/src/utils.ts`

## Tests

Relevant unit tests have been added and  all existing and newly added tests pass.


## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
