### PR TITLE
fix(paywall): add clearer error messaging for OnchainKitProvider config

### DIFF
--- a/typescript/packages/legacy/x402/src/paywall/src/Providers.tsx
+++ b/typescript/packages/legacy/x402/src/paywall/src/Providers.tsx
@@ -2,7 +2,12 @@ import { OnchainKitProvider } from "@coinbase/onchainkit";
 import type { ReactNode } from "react";
 import { base, baseSepolia } from "viem/chains";
 
-import { choosePaymentRequirement, isEvmNetwork } from "./paywallUtils";
+import {
+  assertValidProviderConfig,
+  choosePaymentRequirement,
+  isEvmNetwork,
+  validateProviderConfig,
+} from "./paywallUtils";
 import "./window.d.ts";
 
 type ProvidersProps = {
@@ -10,13 +15,100 @@ type ProvidersProps = {
 };
 
 /**
- * Providers component for the paywall
+ * Error boundary fallback component for configuration errors.
+ *
+ * @param root0 - The component props
+ * @param root0.errors - Array of error messages to display
+ * @returns A React element displaying the configuration errors
+ */
+function ConfigurationError({ errors }: { errors: string[] }) {
+  return (
+    <div
+      style={{
+        padding: "20px",
+        margin: "20px",
+        border: "1px solid #dc2626",
+        borderRadius: "8px",
+        backgroundColor: "#fef2f2",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <h2 style={{ color: "#dc2626", margin: "0 0 16px 0" }}>x402 Configuration Error</h2>
+      <p style={{ color: "#7f1d1d", margin: "0 0 12px 0" }}>
+        The OnchainKitProvider could not be initialized due to configuration issues:
+      </p>
+      <ul style={{ color: "#7f1d1d", margin: "0 0 16px 0", paddingLeft: "20px" }}>
+        {errors.map((error, i) => (
+          <li key={i} style={{ marginBottom: "8px" }}>
+            {error}
+          </li>
+        ))}
+      </ul>
+      <p style={{ color: "#7f1d1d", margin: 0, fontSize: "14px" }}>
+        See documentation:{" "}
+        <a
+          href="https://github.com/coinbase/x402#provider-configuration"
+          style={{ color: "#2563eb" }}
+        >
+          https://github.com/coinbase/x402#provider-configuration
+        </a>
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Providers component for the paywall.
+ *
+ * Wraps children with OnchainKitProvider for EVM networks. Performs early
+ * configuration validation and surfaces clear error messages if the
+ * configuration is invalid.
+ *
+ * Required configuration (via window.x402):
+ * - `paymentRequirements`: Payment requirements object or array
+ * - `cdpClientKey`: CDP API key for OnchainKit (get one at https://portal.cdp.coinbase.com/)
+ *
+ * Optional configuration:
+ * - `appName`: Application name shown in wallet prompts
+ * - `appLogo`: Application logo URL
+ * - `testnet`: Whether to use testnet networks (default: true)
  *
  * @param props - The component props
  * @param props.children - The children of the Providers component
- * @returns The Providers component
+ * @returns The Providers component or an error display if misconfigured
+ *
+ * @example
+ * ```typescript
+ * // Minimal configuration
+ * window.x402 = {
+ *   paymentRequirements: { network: "base", scheme: "exact", ... },
+ *   cdpClientKey: "your-cdp-api-key",
+ *   currentUrl: window.location.href,
+ * };
+ * ```
  */
 export function Providers({ children }: ProvidersProps) {
+  // Perform early validation with clear error messages
+  // Note: requireApiKey is false because cdpClientKey is optional for basic paywall functionality
+  // but OnchainKit features may be limited without it
+  const validationResult = validateProviderConfig(window.x402, { requireApiKey: false });
+
+  if (!validationResult.isValid) {
+    // In development, show a helpful error UI
+    if (process.env.NODE_ENV !== "production") {
+      return <ConfigurationError errors={validationResult.errors} />;
+    }
+    // In production, throw to be caught by error boundaries
+    assertValidProviderConfig(window.x402);
+  }
+
+  // Log warnings for non-critical issues
+  if (validationResult.warnings.length > 0) {
+    validationResult.warnings.forEach(warning => {
+      console.warn(`[x402] ${warning}`);
+    });
+  }
+
   const { testnet = true, cdpClientKey, appName, appLogo, paymentRequirements } = window.x402;
   const selectedRequirement = choosePaymentRequirement(paymentRequirements, testnet);
 

--- a/typescript/packages/legacy/x402/src/paywall/src/paywallUtils.test.ts
+++ b/typescript/packages/legacy/x402/src/paywall/src/paywallUtils.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import type { PaymentRequirements } from "../../types/verify";
 import {
+  assertValidProviderConfig,
   choosePaymentRequirement,
   getNetworkDisplayName,
   isEvmNetwork,
   isSvmNetwork,
   normalizePaymentRequirements,
+  validateProviderConfig,
 } from "./paywallUtils";
 
 const baseRequirement: PaymentRequirements = {
@@ -78,5 +80,114 @@ describe("paywallUtils", () => {
     expect(isEvmNetwork("solana")).toBe(false);
     expect(isSvmNetwork("solana")).toBe(true);
     expect(isSvmNetwork("base")).toBe(false);
+  });
+});
+
+describe("validateProviderConfig", () => {
+  it("returns error when config is null or undefined", () => {
+    const result = validateProviderConfig(null);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("x402 configuration is missing");
+  });
+
+  it("returns error when paymentRequirements is missing", () => {
+    const result = validateProviderConfig({
+      cdpClientKey: "test-key",
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some(e => e.includes("paymentRequirements"))).toBe(true);
+  });
+
+  it("returns error when paymentRequirements is empty array", () => {
+    const result = validateProviderConfig({
+      cdpClientKey: "test-key",
+      paymentRequirements: [],
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some(e => e.includes("empty"))).toBe(true);
+  });
+
+  it("returns error when payment requirement is missing network", () => {
+    const result = validateProviderConfig({
+      cdpClientKey: "test-key",
+      paymentRequirements: { scheme: "exact" } as PaymentRequirements,
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some(e => e.includes("network"))).toBe(true);
+  });
+
+  it("returns error when payment requirement is missing scheme", () => {
+    const result = validateProviderConfig({
+      cdpClientKey: "test-key",
+      paymentRequirements: { network: "base" } as PaymentRequirements,
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some(e => e.includes("scheme"))).toBe(true);
+  });
+
+  it("returns error when cdpClientKey is missing and required", () => {
+    const result = validateProviderConfig(
+      { paymentRequirements: baseRequirement },
+      { requireApiKey: true },
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some(e => e.includes("cdpClientKey"))).toBe(true);
+  });
+
+  it("returns warning when cdpClientKey is missing but not required", () => {
+    const result = validateProviderConfig(
+      { paymentRequirements: baseRequirement },
+      { requireApiKey: false },
+    );
+    expect(result.isValid).toBe(true);
+    expect(result.warnings.some(w => w.includes("cdpClientKey"))).toBe(true);
+  });
+
+  it("returns warning when appName is missing", () => {
+    const result = validateProviderConfig({
+      paymentRequirements: baseRequirement,
+      cdpClientKey: "test-key",
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.warnings.some(w => w.includes("appName"))).toBe(true);
+  });
+
+  it("returns valid result for complete configuration", () => {
+    const result = validateProviderConfig({
+      paymentRequirements: baseRequirement,
+      cdpClientKey: "test-key",
+      appName: "Test App",
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+describe("assertValidProviderConfig", () => {
+  it("throws descriptive error for invalid config", () => {
+    expect(() => assertValidProviderConfig(null)).toThrow(
+      /OnchainKitProvider configuration is invalid/,
+    );
+  });
+
+  it("throws error with numbered list of issues", () => {
+    expect(() => assertValidProviderConfig(null)).toThrow(/1\./);
+  });
+
+  it("throws error with documentation link", () => {
+    expect(() => assertValidProviderConfig(null)).toThrow(/github\.com\/coinbase\/x402/);
+  });
+
+  it("does not throw for valid config", () => {
+    expect(() =>
+      assertValidProviderConfig(
+        {
+          paymentRequirements: baseRequirement,
+          cdpClientKey: "test-key",
+        },
+        { requireApiKey: true },
+      ),
+    ).not.toThrow();
   });
 });

--- a/typescript/packages/legacy/x402/src/paywall/src/paywallUtils.ts
+++ b/typescript/packages/legacy/x402/src/paywall/src/paywallUtils.ts
@@ -2,6 +2,164 @@ import { selectPaymentRequirements } from "../../client";
 import type { PaymentRequirements } from "../../types/verify";
 import { Network, SupportedEVMNetworks, SupportedSVMNetworks } from "../../types/shared";
 
+/**
+ * Configuration options for the x402 provider.
+ */
+export interface X402ProviderConfig {
+  cdpClientKey?: string;
+  appName?: string;
+  appLogo?: string;
+  paymentRequirements?: PaymentRequirements | PaymentRequirements[];
+  testnet?: boolean;
+}
+
+/**
+ * Result of provider configuration validation.
+ */
+export interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Validates the x402 provider configuration and returns detailed error messages.
+ *
+ * This function performs early validation to surface configuration issues
+ * with clear, actionable error messages before the provider initializes.
+ *
+ * @param config - The provider configuration to validate.
+ * @param options - Additional validation options.
+ * @param options.requireApiKey - Whether the CDP API key is required (default: true for production).
+ * @returns Validation result with errors and warnings.
+ *
+ * @example
+ * ```typescript
+ * const result = validateProviderConfig(window.x402);
+ * if (!result.isValid) {
+ *   console.error('Configuration errors:', result.errors);
+ * }
+ * ```
+ */
+export function validateProviderConfig(
+  config: X402ProviderConfig | undefined | null,
+  options: { requireApiKey?: boolean } = {},
+): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const { requireApiKey = true } = options;
+
+  // Check if config exists
+  if (!config) {
+    errors.push(
+      "x402 configuration is missing. Ensure window.x402 is defined with required fields: " +
+        "{ paymentRequirements, currentUrl }. " +
+        "See: https://github.com/coinbase/x402#configuration",
+    );
+    return { isValid: false, errors, warnings };
+  }
+
+  // Validate paymentRequirements
+  if (!config.paymentRequirements) {
+    errors.push(
+      'Missing required field "paymentRequirements" in x402 configuration. ' +
+        "This field must contain a PaymentRequirements object or array. " +
+        'Example: { paymentRequirements: { network: "base", scheme: "exact", ... } }',
+    );
+  } else {
+    const requirements = normalizePaymentRequirements(config.paymentRequirements);
+    if (requirements.length === 0) {
+      errors.push(
+        'Field "paymentRequirements" is empty. At least one payment requirement must be provided.',
+      );
+    } else {
+      // Validate each requirement has required fields
+      requirements.forEach((req, index) => {
+        if (!req.network) {
+          errors.push(
+            `Payment requirement at index ${index} is missing required field "network". ` +
+              `Supported networks: ${[...SupportedEVMNetworks, ...SupportedSVMNetworks].join(", ")}`,
+          );
+        }
+        if (!req.scheme) {
+          errors.push(`Payment requirement at index ${index} is missing required field "scheme".`);
+        }
+      });
+    }
+  }
+
+  // Validate CDP API key
+  if (requireApiKey && !config.cdpClientKey) {
+    errors.push(
+      'Missing "cdpClientKey" (CDP API key) in x402 configuration. ' +
+        "This key is required for OnchainKit wallet functionality. " +
+        "Get your API key at: https://portal.cdp.coinbase.com/ " +
+        'Then set it via: window.x402.cdpClientKey = "your-api-key"',
+    );
+  } else if (!config.cdpClientKey) {
+    warnings.push(
+      'No "cdpClientKey" provided. Wallet functionality may be limited. ' +
+        "Get an API key at: https://portal.cdp.coinbase.com/",
+    );
+  }
+
+  // Validate appName and appLogo (optional but recommended)
+  if (!config.appName) {
+    warnings.push('Consider setting "appName" for a better user experience in wallet prompts.');
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Validates the provider configuration and throws a descriptive error if invalid.
+ *
+ * Use this function to fail fast with clear error messages during provider initialization.
+ *
+ * @param config - The provider configuration to validate.
+ * @param options - Additional validation options.
+ * @param options.requireApiKey - Whether the CDP API key is required (default: true).
+ * @throws Error with detailed message if configuration is invalid.
+ *
+ * @example
+ * ```typescript
+ * // In your provider component:
+ * assertValidProviderConfig(window.x402);
+ * ```
+ */
+export function assertValidProviderConfig(
+  config: X402ProviderConfig | undefined | null,
+  options: { requireApiKey?: boolean } = {},
+): asserts config is X402ProviderConfig & {
+  paymentRequirements: PaymentRequirements | PaymentRequirements[];
+} {
+  const result = validateProviderConfig(config, options);
+
+  if (!result.isValid) {
+    const errorMessage = [
+      "OnchainKitProvider configuration is invalid:",
+      "",
+      ...result.errors.map((e, i) => `  ${i + 1}. ${e}`),
+      "",
+      "For complete configuration documentation, see:",
+      "https://github.com/coinbase/x402#provider-configuration",
+    ].join("\n");
+
+    throw new Error(errorMessage);
+  }
+
+  // Log warnings in development
+  if (result.warnings.length > 0 && typeof console !== "undefined") {
+    result.warnings.forEach(warning => {
+      console.warn(`[x402] ${warning}`);
+    });
+  }
+}
+
 const EVM_TESTNETS = new Set<Network>(["base-sepolia"]);
 const SVM_TESTNETS = new Set<Network>(["solana-devnet"]);
 


### PR DESCRIPTION
## Summary

Adds early configuration validation with descriptive error messages when OnchainKitProvider is misconfigured.

- Add `validateProviderConfig()` and `assertValidProviderConfig()` utilities in `paywallUtils.ts`
- Validate required fields (`paymentRequirements`) with specific error messages naming the problematic field
- Show visual error component in development mode for immediate feedback
- Throw descriptive errors in production for error boundary handling
- Include remediation suggestions with documentation links
- Add 13 unit tests for validation functions

## Example Error Output

When configuration is invalid, developers now see:

```
OnchainKitProvider configuration is invalid:

  1. Missing required field "paymentRequirements" in x402 configuration.
     This field must contain a PaymentRequirements object or array.
     Example: { paymentRequirements: { network: "base", scheme: "exact", ... } }

For complete configuration documentation, see:
https://github.com/coinbase/x402#provider-configuration
```

## Test plan

- [x] All 270 tests pass (13 new tests added)
- [x] Lint passes
- [x] Build passes
- [ ] Manual testing with missing/invalid config

Closes #793