### PR TITLE
remove requirements from payment response header

### DIFF
--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -1,5 +1,5 @@
 import { SettleResponse } from "../types";
-import { PaymentPayload, PaymentRequired, PaymentRequirements } from "../types/payments";
+import { PaymentPayload, PaymentRequired } from "../types/payments";
 import { Base64EncodedRegex, safeBase64Decode, safeBase64Encode } from "../utils";
 
 // HTTP Methods that typically use query parameters
@@ -60,9 +60,7 @@ export function decodePaymentRequiredHeader(paymentRequiredHeader: string): Paym
  * @param paymentResponse - The payment response to encode
  * @returns Base64 encoded string representation of the payment response
  */
-export function encodePaymentResponseHeader(
-  paymentResponse: SettleResponse & { requirements: PaymentRequirements },
-): string {
+export function encodePaymentResponseHeader(paymentResponse: SettleResponse): string {
   return safeBase64Encode(JSON.stringify(paymentResponse));
 }
 

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -477,7 +477,7 @@ export class x402HTTPResourceServer {
       return {
         ...settleResponse,
         success: true,
-        headers: this.createSettlementHeaders(settleResponse, requirements),
+        headers: this.createSettlementHeaders(settleResponse),
         requirements,
       };
     } catch (error) {
@@ -676,17 +676,10 @@ export class x402HTTPResourceServer {
    * Create settlement response headers
    *
    * @param settleResponse - Settlement response
-   * @param requirements - Payment requirements that were settled
    * @returns Headers to add to response
    */
-  private createSettlementHeaders(
-    settleResponse: SettleResponse,
-    requirements: PaymentRequirements,
-  ): Record<string, string> {
-    const encoded = encodePaymentResponseHeader({
-      ...settleResponse,
-      requirements,
-    });
+  private createSettlementHeaders(settleResponse: SettleResponse): Record<string, string> {
+    const encoded = encodePaymentResponseHeader(settleResponse);
     return { "PAYMENT-RESPONSE": encoded };
   }
 


### PR DESCRIPTION
## Description

Removes `requirements` from payment response header to align ts with both the go implementation and the specifications at [5.3 SettlementResponse Schema](https://github.com/coinbase/x402/blob/main/specs/x402-specification-v2.md)

`selectedRequirements` info could be obtained from lifecycle hooks if needed

Closes https://github.com/coinbase/x402/issues/836 

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 