### PR TITLE
ecosystem: add PEAC Protocol

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/peac-protocol/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/peac-protocol/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "PEAC Protocol",
+  "description": "Cryptographic receipt layer for x402 payments. On success, return a signed PEAC-Receipt header that binds payment proof to the delivered response and policy, verifiable offline.",
+  "logoUrl": "/logos/peac-protocol.svg",
+  "websiteUrl": "https://x402.peacprotocol.org",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/peac-protocol.svg
+++ b/typescript/site/public/logos/peac-protocol.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 56" role="img" aria-label="PEAC Protocol">
+  <title>PEAC Protocol</title>
+  <defs>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&amp;display=swap');
+      .logo { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; }
+    </style>
+  </defs>
+  <text x="80" y="32" class="logo" font-size="36" font-weight="600" letter-spacing="-1" text-anchor="middle" fill="#000">PEAC</text>
+  <text x="80" y="46" class="logo" font-size="9" font-weight="400" letter-spacing="3.5" text-anchor="middle" fill="#666">PROTOCOL</text>
+</svg>


### PR DESCRIPTION
## Description

Add PEAC Protocol to the x402 ecosystem page.

**PEAC Protocol adds verifiable interaction records to x402 payment flows.**

After an HTTP 402 payment succeeds, the server can return a signed PEAC receipt that binds the payment proof, request/response, and policy terms into a portable record. Anyone can verify it independently (including offline) for reconciliation, disputes, and audits—without relying on either party's internal logs.

**Project Details:**
- **Website:** https://peacprotocol.org
- **Category:** Infrastructure & Tooling
- **GitHub:** https://github.com/peacprotocol/peac
- **npm:** [@peac/rails-x402](https://www.npmjs.com/package/@peac/rails-x402)
- **Live Demo:** https://x402.peacprotocol.org

## Tests

This PR only adds a new partner metadata JSON file to the ecosystem page. No code logic changes.

- [x] Verified the metadata.json follows the standard template format
- [x] Confirmed the logo file exists at `/logos/peac-protocol.svg`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)