### PR TITLE
svm: bump default compute unit limit to 8_000

### DIFF
--- a/go/mechanisms/svm/constants.go
+++ b/go/mechanisms/svm/constants.go
@@ -21,7 +21,7 @@ const (
 	MaxComputeUnitPriceMicrolamports = 5_000_000
 
 	// DefaultComputeUnitLimit is the default compute unit limit for transactions
-	DefaultComputeUnitLimit uint32 = 6500
+	DefaultComputeUnitLimit uint32 = 8000
 
 	// DefaultCommitment is the default commitment level for transactions
 	DefaultCommitment = rpc.CommitmentConfirmed

--- a/typescript/packages/mechanisms/svm/src/constants.ts
+++ b/typescript/packages/mechanisms/svm/src/constants.ts
@@ -29,7 +29,7 @@ export const USDC_TESTNET_ADDRESS = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncD
  */
 export const DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS = 1;
 export const MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS = 5_000_000; // 5 lamports
-export const DEFAULT_COMPUTE_UNIT_LIMIT = 6500;
+export const DEFAULT_COMPUTE_UNIT_LIMIT = 8_000;
 
 /**
  * Solana address validation regex (base58, 32-44 characters)


### PR DESCRIPTION
## Description

Bump the compute unit limit from 6500 to 8000.

It seems like the previous limit of 6500 might've been too strict and doesn't match the currently observed compute units on mainnet (6592).

This PR bumps it to 8000 to keep some buffer, since we are no longer estimating the compute unit usage ahead of time.

For context: the reason we are not estimating the compute unit usage ahead of time (in the client or facilitator) is that it saves an RPC call on each, making the user experience faster. Since the transaction is quite simple (simple `TransferChecked`), a static limit vs 2 RPC calls seems like the right tradeoff.

This may change again in the future after discussion on https://github.com/coinbase/x402/issues/828 

## Tests

All tests pass as before.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits