### PR TITLE
add PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,68 @@
+# Language labels
+typescript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'typescript/**/*.ts'
+          - 'typescript/**/*.tsx'
+
+python:
+  - changed-files:
+      - any-glob-to-any-file: 'python/**/*.py'
+
+go:
+  - changed-files:
+      - any-glob-to-any-file: 'go/**/*.go'
+
+java:
+  - changed-files:
+      - any-glob-to-any-file: 'java/**/*.java'
+
+# SDK - v2 core packages only
+sdk:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'typescript/packages/core/**'
+          - 'typescript/packages/extensions/**'
+          - 'typescript/packages/http/**'
+          - 'typescript/packages/mechanisms/**'
+          - 'python/x402/**'
+          - 'go/*.go'
+          - 'go/http/**'
+          - 'go/mechanisms/**'
+          - 'go/signers/**'
+          - 'go/extensions/**'
+          - 'go/types/**'
+          - 'go/test/**'
+
+# Legacy packages and examples
+legacy:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'typescript/packages/legacy/**'
+          - 'python/legacy/**'
+          - 'go/legacy/**'
+          - 'java/**'
+          - 'examples/typescript/legacy/**'
+          - 'examples/python/legacy/**'
+
+# Examples
+examples:
+  - changed-files:
+      - any-glob-to-any-file: 'examples/**'
+
+# Protocol specifications
+specs:
+  - changed-files:
+      - any-glob-to-any-file: 'specs/**'
+
+# CI/CD workflows
+ci:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
+
+# Ecosystem partner additions
+ecosystem:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'typescript/site/app/ecosystem/partners-data/**'
+          - 'typescript/site/public/logos/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: "Pull Request Labeler"
+
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true
+


### PR DESCRIPTION
## Description

Adds PR labeler to help with PR triage, similar to [agentkit workflow](https://github.com/coinbase/agentkit/blob/main/.github/labeler.yml):

Label | Matches
-- | --
typescript | All TypeScript files
python | All Python files
go | All Go files
java | All Java files
sdk | V2 packages only 
legacy | Legacy packages (TS/Python/Go legacy folders + all Java)
examples | Example code
specs | Protocol specifications
ci | GitHub Actions
ecosystem | Partner metadata & logos



## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 