### PR TITLE
Preserve headers and request body in fetch client

### DIFF
--- a/typescript/packages/http/fetch/src/index.test.ts
+++ b/typescript/packages/http/fetch/src/index.test.ts
@@ -150,12 +150,13 @@ describe("wrapFetchWithPayment()", () => {
     ).rejects.toThrow("Payment already attempted");
   });
 
-  it("should reject if missing fetch request config", async () => {
-    mockFetch.mockResolvedValue(createResponse(402, validPaymentRequired));
+  it("should allow optional fetch request config", async () => {
+    const successResponse = createResponse(200, { data: "success" });
 
-    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
-      "Missing fetch request configuration",
-    );
+    mockFetch.mockResolvedValueOnce(createResponse(402, validPaymentRequired));
+    mockFetch.mockResolvedValueOnce(successResponse);
+
+    await expect(wrappedFetch("https://api.example.com")).resolves.toBe(successResponse);
   });
 
   it("should reject with descriptive error if payment requirements parsing fails", async () => {

--- a/typescript/packages/http/fetch/src/index.ts
+++ b/typescript/packages/http/fetch/src/index.ts
@@ -92,14 +92,17 @@ export function wrapFetchWithPayment(
       throw new Error("Payment already attempted");
     }
 
+    // Retain headers from initial call 
+    const headers = new Headers(init?.headers);
+    for (const [key, value] of Object.entries(paymentHeaders)) {
+      headers.set(key, value);
+    }
+    headers.set("Access-Control-Expose-Headers", "PAYMENT-RESPONSE,X-PAYMENT-RESPONSE");
+
     // Create new request with payment header
     const newInit = {
       ...init,
-      headers: {
-        ...(init?.headers || {}),
-        ...paymentHeaders,
-        "Access-Control-Expose-Headers": "PAYMENT-RESPONSE,X-PAYMENT-RESPONSE",
-      },
+      headers,
       __is402Retry: true,
     };
 

--- a/typescript/packages/http/fetch/src/index.ts
+++ b/typescript/packages/http/fetch/src/index.ts
@@ -87,13 +87,8 @@ export function wrapFetchWithPayment(
     // Encode payment header
     const paymentHeaders = httpClient.encodePaymentSignatureHeader(paymentPayload);
 
-    // Ensure we have request init
-    if (!init) {
-      throw new Error("Missing fetch request configuration");
-    }
-
     // Check if this is already a retry to prevent infinite loops
-    if ((init as { __is402Retry?: boolean }).__is402Retry) {
+    if (init && (init as { __is402Retry?: boolean }).__is402Retry) {
       throw new Error("Payment already attempted");
     }
 
@@ -101,7 +96,7 @@ export function wrapFetchWithPayment(
     const newInit = {
       ...init,
       headers: {
-        ...(init.headers || {}),
+        ...(init?.headers || {}),
         ...paymentHeaders,
         "Access-Control-Expose-Headers": "PAYMENT-RESPONSE,X-PAYMENT-RESPONSE",
       },


### PR DESCRIPTION
## Description

A collection of fixes for the v2 fetch client:

- allow optional fetch request init config as in https://github.com/coinbase/x402/pull/660 for v1 by @0xRAG 
- preserve headers object during 402 retry, v1 PR https://github.com/coinbase/x402/pull/314 by @dankelleher
- fixes "request body is already used" error reported in https://github.com/coinbase/x402/issues/752, similar to https://github.com/coinbase/x402/pull/753 by @juchiast that targeted v1

## Tests

```
📊 Test Summary
==============
✅ Passed: 2
❌ Failed: 0
📈 Total: 2

📋 Detailed Test Results
========================

✅ PASSED TESTS:

  # 1: fetch → express → /protected
      Facilitator: typescript | Network: eip155:84532 | Tx: 0x5060992a...
  # 2: fetch → express → /protected-svm
      Facilitator: typescript | Network: solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1 | Tx: LKzj1HZaH3...

📊 Breakdown by Facilitator:
   typescript      ✅ 2 / ❌ 0 (100%)

📊 Breakdown by Server:
   express              ✅ 2 / ❌ 0 (100%)

📊 Breakdown by Client:
   fetch                ✅ 2 / ❌ 0 (100%)
```

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 