### PR TITLE
fix getUrl() for express

### DIFF
--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -162,8 +162,12 @@ export function extractDiscoveryInfo(
     return null;
   }
 
+  // Strip query params (?) and hash sections (#) for discovery cataloging
+  const url = new URL(resourceUrl);
+  const normalizedResourceUrl = `${url.origin}${url.pathname}`;
+
   return {
-    resourceUrl,
+    resourceUrl: normalizedResourceUrl,
     method: discoveryInfo.input.method,
     x402Version: paymentPayload.x402Version,
     discoveryInfo,

--- a/typescript/packages/http/express/src/adapter.test.ts
+++ b/typescript/packages/http/express/src/adapter.test.ts
@@ -13,11 +13,13 @@ import { ExpressAdapter } from "./adapter";
  * @param options.body - Request body.
  * @param options.protocol - Request protocol (default: "https").
  * @param options.host - Request host (default: "example.com").
+ * @param options.originalUrl - Original URL including query string (defaults to path).
  * @returns A mock Express Request.
  */
 function createMockRequest(
   options: {
     path?: string;
+    originalUrl?: string;
     method?: string;
     headers?: Record<string, string>;
     query?: Record<string, string | string[]>;
@@ -27,11 +29,13 @@ function createMockRequest(
   } = {},
 ): Request {
   const headers = options.headers || {};
+  const path = options.path || "/api/test";
 
   const mockRequest = {
     header: vi.fn((name: string) => headers[name]),
     method: options.method || "GET",
-    path: options.path || "/api/test",
+    path,
+    originalUrl: options.originalUrl || path,
     protocol: options.protocol || "https",
     headers: {
       host: options.host || "example.com",
@@ -97,6 +101,17 @@ describe("ExpressAdapter", () => {
       });
       const adapter = new ExpressAdapter(req);
       expect(adapter.getUrl()).toBe("https://example.com/api/test");
+    });
+
+    it("returns the full URL including query parameters", () => {
+      const req = createMockRequest({
+        path: "/api/test",
+        originalUrl: "/api/test?city=NYC&units=metric",
+        protocol: "https",
+        host: "example.com",
+      });
+      const adapter = new ExpressAdapter(req);
+      expect(adapter.getUrl()).toBe("https://example.com/api/test?city=NYC&units=metric");
     });
   });
 

--- a/typescript/packages/http/express/src/adapter.ts
+++ b/typescript/packages/http/express/src/adapter.ts
@@ -47,7 +47,7 @@ export class ExpressAdapter implements HTTPAdapter {
    * @returns The full request URL
    */
   getUrl(): string {
-    return `${this.req.protocol}://${this.req.headers.host}${this.req.path}`;
+    return `${this.req.protocol}://${this.req.headers.host}${this.req.originalUrl}`;
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes bug reported in Issue [894](https://github.com/coinbase/x402/issues/894), where the Express adapter's getUrl() method used req.path instead of req.originalUrl, causing query parameters to be stripped from the URL passed to the paywall after payment.

## Tests

Manually tested with modified express example that includes query parameters.

Before: getting "Error checking Cross-Origin-Opener-Policy: HTTP error! status: 400" after signing tx in paywall UI
After: tx settles and API response is shown


<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 