### PR TITLE
Add x402jobs to ecosystem

### DIFF
--- a/app/ecosystem/partners-data/x402jobs/metadata.json
+++ b/app/ecosystem/partners-data/x402jobs/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402jobs",
+  "description": "Visual workflow builder for x402. Chain paid resources, set your markup, publish as an endpoint anyone can pay to run. Build once, earn on every call.",
+  "logoUrl": "/logos/x402jobs.svg",
+  "websiteUrl": "https://x402.jobs",
+  "category": "Infrastructure & Tooling"
+}

--- a/public/logos/x402jobs.svg
+++ b/public/logos/x402jobs.svg
@@ -1,0 +1,16 @@
+<svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_391_16)">
+<rect width="500" height="500" fill="white"/>
+<path d="M500 0.000144958H0.000144958V500H500V0.000144958Z" fill="url(#paint0_linear_391_16)"/>
+<path d="M273.438 78.125L132.812 273.438H226.562L203.125 421.875L343.75 226.562H250L273.438 78.125Z" fill="white"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_391_16" x1="-2.65602e-05" y1="2.34185e-05" x2="500" y2="500" gradientUnits="userSpaceOnUse">
+<stop stop-color="#10B981"/>
+<stop offset="1" stop-color="#14B8A6"/>
+</linearGradient>
+<clipPath id="clip0_391_16">
+<rect width="500" height="500" fill="white"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary

Adds **x402jobs** to the x402 ecosystem page.

- **Name:** x402jobs
- **Category:** Infrastructure & Tooling
- **Website:** https://x402.jobs
- **Description:** Visual workflow builder for x402. Chain paid resources, set your markup, publish as an endpoint anyone can pay to run. Build once, earn on every call.

## Changes

- Added `app/ecosystem/partners-data/x402jobs/metadata.json`
- Added `public/logos/x402jobs.svg`