### PR TITLE
strip query params from resource for bazaar

### DIFF
--- a/go/extensions/bazaar/bazaar_test.go
+++ b/go/extensions/bazaar/bazaar_test.go
@@ -415,6 +415,191 @@ func TestExtractDiscoveredResourceFromPaymentPayload_FullFlow(t *testing.T) {
 		assert.Equal(t, 1, info.X402Version)
 	})
 
+	t.Run("should strip query params from v2 resourceUrl", func(t *testing.T) {
+		extension, _ := bazaar.DeclareDiscoveryExtension(
+			bazaar.MethodGET,
+			map[string]interface{}{"city": "NYC"},
+			bazaar.JSONSchema{
+				"properties": map[string]interface{}{
+					"city": map[string]interface{}{"type": "string"},
+				},
+			},
+			"",
+			nil,
+		)
+
+		requirements := x402.PaymentRequirements{
+			Scheme:  "exact",
+			Network: "eip155:8453",
+		}
+
+		paymentPayload := x402.PaymentPayload{
+			X402Version: 2,
+			Accepted:    requirements,
+			Payload:     map[string]interface{}{},
+			Resource: &x402.ResourceInfo{
+				URL: "https://api.example.com/weather?city=NYC&units=metric",
+			},
+			Extensions: map[string]interface{}{
+				bazaar.BAZAAR: extension,
+			},
+		}
+
+		payloadBytes, _ := json.Marshal(paymentPayload)
+		requirementsBytes, _ := json.Marshal(requirements)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentPayload(payloadBytes, requirementsBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/weather", info.ResourceURL)
+	})
+
+	t.Run("should strip hash sections from v2 resourceUrl", func(t *testing.T) {
+		extension, _ := bazaar.DeclareDiscoveryExtension(
+			bazaar.MethodGET,
+			map[string]interface{}{},
+			bazaar.JSONSchema{"properties": map[string]interface{}{}},
+			"",
+			nil,
+		)
+
+		requirements := x402.PaymentRequirements{
+			Scheme:  "exact",
+			Network: "eip155:8453",
+		}
+
+		paymentPayload := x402.PaymentPayload{
+			X402Version: 2,
+			Accepted:    requirements,
+			Payload:     map[string]interface{}{},
+			Resource: &x402.ResourceInfo{
+				URL: "https://api.example.com/docs#section-1",
+			},
+			Extensions: map[string]interface{}{
+				bazaar.BAZAAR: extension,
+			},
+		}
+
+		payloadBytes, _ := json.Marshal(paymentPayload)
+		requirementsBytes, _ := json.Marshal(requirements)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentPayload(payloadBytes, requirementsBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/docs", info.ResourceURL)
+	})
+
+	t.Run("should strip both query params and hash from v2 resourceUrl", func(t *testing.T) {
+		extension, _ := bazaar.DeclareDiscoveryExtension(
+			bazaar.MethodGET,
+			map[string]interface{}{},
+			bazaar.JSONSchema{"properties": map[string]interface{}{}},
+			"",
+			nil,
+		)
+
+		requirements := x402.PaymentRequirements{
+			Scheme:  "exact",
+			Network: "eip155:8453",
+		}
+
+		paymentPayload := x402.PaymentPayload{
+			X402Version: 2,
+			Accepted:    requirements,
+			Payload:     map[string]interface{}{},
+			Resource: &x402.ResourceInfo{
+				URL: "https://api.example.com/page?foo=bar#anchor",
+			},
+			Extensions: map[string]interface{}{
+				bazaar.BAZAAR: extension,
+			},
+		}
+
+		payloadBytes, _ := json.Marshal(paymentPayload)
+		requirementsBytes, _ := json.Marshal(requirements)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentPayload(payloadBytes, requirementsBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/page", info.ResourceURL)
+	})
+
+	t.Run("should strip query params from v1 resourceUrl", func(t *testing.T) {
+		v1Requirements := map[string]interface{}{
+			"scheme":            "exact",
+			"network":           "eip155:8453",
+			"maxAmountRequired": "10000",
+			"resource":          "https://api.example.com/search?q=test&page=1",
+			"description":       "Search",
+			"mimeType":          "application/json",
+			"outputSchema": map[string]interface{}{
+				"input": map[string]interface{}{
+					"type":         "http",
+					"method":       "GET",
+					"discoverable": true,
+					"queryParams": map[string]interface{}{
+						"q":    "string",
+						"page": "number",
+					},
+				},
+			},
+			"payTo":             "0x...",
+			"maxTimeoutSeconds": 300,
+			"asset":             "0x...",
+		}
+
+		v1Payload := map[string]interface{}{
+			"x402Version": 1,
+			"scheme":      "exact",
+			"network":     "eip155:8453",
+			"payload":     map[string]interface{}{},
+		}
+
+		payloadBytes, _ := json.Marshal(v1Payload)
+		requirementsBytes, _ := json.Marshal(v1Requirements)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentPayload(payloadBytes, requirementsBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/search", info.ResourceURL)
+	})
+
+	t.Run("should strip hash sections from v1 resourceUrl", func(t *testing.T) {
+		v1Requirements := map[string]interface{}{
+			"scheme":            "exact",
+			"network":           "eip155:8453",
+			"maxAmountRequired": "10000",
+			"resource":          "https://api.example.com/docs#section",
+			"description":       "Docs",
+			"mimeType":          "application/json",
+			"outputSchema": map[string]interface{}{
+				"input": map[string]interface{}{
+					"type":         "http",
+					"method":       "GET",
+					"discoverable": true,
+				},
+			},
+			"payTo":             "0x...",
+			"maxTimeoutSeconds": 300,
+			"asset":             "0x...",
+		}
+
+		v1Payload := map[string]interface{}{
+			"x402Version": 1,
+			"scheme":      "exact",
+			"network":     "eip155:8453",
+			"payload":     map[string]interface{}{},
+		}
+
+		payloadBytes, _ := json.Marshal(v1Payload)
+		requirementsBytes, _ := json.Marshal(v1Requirements)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentPayload(payloadBytes, requirementsBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/docs", info.ResourceURL)
+	})
+
 	t.Run("should return nil when no discovery info is present", func(t *testing.T) {
 		requirements := x402.PaymentRequirements{
 			Scheme:  "exact",
@@ -1101,6 +1286,178 @@ func TestExtractDiscoveredResourceFromPaymentRequired(t *testing.T) {
 		bodyInput, ok := info.DiscoveryInfo.Input.(bazaar.BodyInput)
 		require.True(t, ok)
 		assert.Equal(t, bazaar.BodyTypeJSON, bodyInput.BodyType)
+	})
+
+	t.Run("v2: should strip query params from resourceUrl", func(t *testing.T) {
+		extension, err := bazaar.DeclareDiscoveryExtension(
+			bazaar.MethodGET,
+			map[string]interface{}{"city": "NYC"},
+			bazaar.JSONSchema{
+				"properties": map[string]interface{}{
+					"city": map[string]interface{}{"type": "string"},
+				},
+			},
+			"",
+			nil,
+		)
+		require.NoError(t, err)
+
+		paymentRequired := x402.PaymentRequired{
+			X402Version: 2,
+			Resource: &x402.ResourceInfo{
+				URL: "https://api.example.com/weather?city=NYC&units=metric",
+			},
+			Accepts: []x402.PaymentRequirements{
+				{
+					Scheme:  "exact",
+					Network: "eip155:8453",
+				},
+			},
+			Extensions: map[string]interface{}{
+				"bazaar": extension,
+			},
+		}
+
+		paymentRequiredBytes, _ := json.Marshal(paymentRequired)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentRequired(paymentRequiredBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/weather", info.ResourceURL)
+	})
+
+	t.Run("v2: should strip hash sections from resourceUrl", func(t *testing.T) {
+		extension, err := bazaar.DeclareDiscoveryExtension(
+			bazaar.MethodGET,
+			map[string]interface{}{},
+			bazaar.JSONSchema{"properties": map[string]interface{}{}},
+			"",
+			nil,
+		)
+		require.NoError(t, err)
+
+		paymentRequired := x402.PaymentRequired{
+			X402Version: 2,
+			Resource: &x402.ResourceInfo{
+				URL: "https://api.example.com/docs#section-1",
+			},
+			Accepts: []x402.PaymentRequirements{
+				{
+					Scheme:  "exact",
+					Network: "eip155:8453",
+				},
+			},
+			Extensions: map[string]interface{}{
+				"bazaar": extension,
+			},
+		}
+
+		paymentRequiredBytes, _ := json.Marshal(paymentRequired)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentRequired(paymentRequiredBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/docs", info.ResourceURL)
+	})
+
+	t.Run("v2: should strip both query params and hash from resourceUrl", func(t *testing.T) {
+		extension, err := bazaar.DeclareDiscoveryExtension(
+			bazaar.MethodGET,
+			map[string]interface{}{},
+			bazaar.JSONSchema{"properties": map[string]interface{}{}},
+			"",
+			nil,
+		)
+		require.NoError(t, err)
+
+		paymentRequired := x402.PaymentRequired{
+			X402Version: 2,
+			Resource: &x402.ResourceInfo{
+				URL: "https://api.example.com/page?foo=bar#anchor",
+			},
+			Accepts: []x402.PaymentRequirements{
+				{
+					Scheme:  "exact",
+					Network: "eip155:8453",
+				},
+			},
+			Extensions: map[string]interface{}{
+				"bazaar": extension,
+			},
+		}
+
+		paymentRequiredBytes, _ := json.Marshal(paymentRequired)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentRequired(paymentRequiredBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/page", info.ResourceURL)
+	})
+
+	t.Run("v1: should strip query params from resourceUrl", func(t *testing.T) {
+		v1PaymentRequired := map[string]interface{}{
+			"x402Version": 1,
+			"accepts": []interface{}{
+				map[string]interface{}{
+					"scheme":            "exact",
+					"network":           "eip155:8453",
+					"maxAmountRequired": "1000000",
+					"resource":          "https://api.example.com/search?q=test&page=1",
+					"payTo":             "0x123",
+					"asset":             "0x456",
+					"maxTimeoutSeconds": 300,
+					"outputSchema": map[string]interface{}{
+						"input": map[string]interface{}{
+							"type":         "http",
+							"method":       "GET",
+							"discoverable": true,
+							"queryParams": map[string]interface{}{
+								"q":    "string",
+								"page": "number",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		paymentRequiredBytes, _ := json.Marshal(v1PaymentRequired)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentRequired(paymentRequiredBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/search", info.ResourceURL)
+	})
+
+	t.Run("v1: should strip hash sections from resourceUrl", func(t *testing.T) {
+		v1PaymentRequired := map[string]interface{}{
+			"x402Version": 1,
+			"accepts": []interface{}{
+				map[string]interface{}{
+					"scheme":            "exact",
+					"network":           "eip155:8453",
+					"maxAmountRequired": "1000000",
+					"resource":          "https://api.example.com/docs#section",
+					"payTo":             "0x123",
+					"asset":             "0x456",
+					"maxTimeoutSeconds": 300,
+					"outputSchema": map[string]interface{}{
+						"input": map[string]interface{}{
+							"type":         "http",
+							"method":       "GET",
+							"discoverable": true,
+						},
+					},
+				},
+			},
+		}
+
+		paymentRequiredBytes, _ := json.Marshal(v1PaymentRequired)
+
+		info, err := bazaar.ExtractDiscoveredResourceFromPaymentRequired(paymentRequiredBytes, true)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "https://api.example.com/docs", info.ResourceURL)
 	})
 
 	t.Run("v1: should extract discovery info from accepts[0].outputSchema", func(t *testing.T) {

--- a/go/extensions/bazaar/facilitator.go
+++ b/go/extensions/bazaar/facilitator.go
@@ -3,6 +3,7 @@ package bazaar
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/extensions/types"
@@ -212,12 +213,26 @@ func ExtractDiscoveredResourceFromPaymentPayload(
 		return nil, fmt.Errorf("failed to extract method from discovery info")
 	}
 
+	// Strip query params and hash for discovery cataloging
+	normalizedURL := stripQueryParams(resourceURL)
+
 	return &DiscoveredResource{
-		ResourceURL:   resourceURL,
+		ResourceURL:   normalizedURL,
 		Method:        method,
 		X402Version:   version,
 		DiscoveryInfo: discoveryInfo,
 	}, nil
+}
+
+// stripQueryParams removes query parameters and fragments from a URL for cataloging
+func stripQueryParams(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL // Return original if parsing fails
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
 }
 
 // ExtractDiscoveredResourceFromPaymentRequired extracts a discovered resource from a 402 PaymentRequired response.
@@ -347,8 +362,11 @@ func ExtractDiscoveredResourceFromPaymentRequired(
 		return nil, fmt.Errorf("failed to extract method from discovery info")
 	}
 
+	// Strip query params and hash for discovery cataloging
+	normalizedURL := stripQueryParams(resourceURL)
+
 	return &DiscoveredResource{
-		ResourceURL:   resourceURL,
+		ResourceURL:   normalizedURL,
 		Method:        method,
 		X402Version:   version,
 		DiscoveryInfo: discoveryInfo,


### PR DESCRIPTION
## Description

Go equivalent changes to https://github.com/coinbase/x402/pull/897, stripping query params from resource url for bazaar

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 