### PR TITLE
Update facilitator client

### DIFF
--- a/typescript/packages/extensions/src/bazaar/facilitatorClient.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitatorClient.ts
@@ -3,6 +3,7 @@
  */
 
 import { HTTPFacilitatorClient } from "@x402/core/http";
+import type { PaymentRequirements } from "@x402/core/types";
 import { WithExtensions } from "../types";
 
 /**
@@ -31,10 +32,16 @@ export interface ListDiscoveryResourcesParams {
  * A discovered x402 resource from the bazaar.
  */
 export interface DiscoveryResource {
-  /** The URL of the discovered resource */
-  url: string;
-  /** The protocol type of the resource */
+  /** The URL or identifier of the discovered resource */
+  resource: string;
+  /** The protocol type of the resource (e.g., "http") */
   type: string;
+  /** The x402 protocol version supported by this resource */
+  x402Version: number;
+  /** Array of accepted payment methods for this resource */
+  accepts: PaymentRequirements[];
+  /** ISO 8601 timestamp of when the resource was last updated */
+  lastUpdated: string;
   /** Additional metadata about the resource */
   metadata?: Record<string, unknown>;
 }
@@ -43,14 +50,19 @@ export interface DiscoveryResource {
  * Response from listing discovery resources.
  */
 export interface DiscoveryResourcesResponse {
+  /** The x402 protocol version of this response */
+  x402Version: number;
   /** The list of discovered resources */
-  resources: DiscoveryResource[];
-  /** Total count of resources matching the query */
-  total?: number;
-  /** The limit used for this query */
-  limit?: number;
-  /** The offset used for this query */
-  offset?: number;
+  items: DiscoveryResource[];
+  /** Pagination information for the response */
+  pagination: {
+    /** Maximum number of results returned */
+    limit: number;
+    /** Number of results skipped */
+    offset: number;
+    /** Total count of resources matching the query */
+    total: number;
+  };
 }
 
 /**

--- a/typescript/packages/extensions/test/facilitatorClient.test.ts
+++ b/typescript/packages/extensions/test/facilitatorClient.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for Bazaar Client Extension - facilitatorClient
+ *
+ * Tests the client-side discovery types and withBazaar extension.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  withBazaar,
+  type DiscoveryResource,
+  type DiscoveryResourcesResponse,
+  type ListDiscoveryResourcesParams,
+} from "../src/bazaar/facilitatorClient";
+import { HTTPFacilitatorClient } from "@x402/core/http";
+
+describe("Bazaar Client Extension - facilitatorClient", () => {
+  describe("Type definitions", () => {
+    it("DiscoveryResource should have correct shape with all required fields", () => {
+      // Type-level validation - ensures the interface compiles with correct fields
+      const resource: DiscoveryResource = {
+        resource: "https://api.example.com/endpoint",
+        type: "http",
+        x402Version: 2,
+        accepts: [
+          {
+            scheme: "exact",
+            network: "eip155:8453",
+            asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            amount: "10000",
+            payTo: "0x1234567890123456789012345678901234567890",
+            maxTimeoutSeconds: 60,
+            extra: {},
+          },
+        ],
+        lastUpdated: "2024-01-01T00:00:00.000Z",
+        metadata: { category: "weather" },
+      };
+
+      expect(resource.resource).toBe("https://api.example.com/endpoint");
+      expect(resource.type).toBe("http");
+      expect(resource.x402Version).toBe(2);
+      expect(resource.accepts).toHaveLength(1);
+      expect(resource.lastUpdated).toBe("2024-01-01T00:00:00.000Z");
+      expect(resource.metadata).toEqual({ category: "weather" });
+    });
+
+    it("DiscoveryResource should allow optional metadata", () => {
+      const resource: DiscoveryResource = {
+        resource: "https://api.example.com/endpoint",
+        type: "http",
+        x402Version: 1,
+        accepts: [],
+        lastUpdated: "2024-01-01T00:00:00.000Z",
+        // metadata is optional
+      };
+
+      expect(resource.metadata).toBeUndefined();
+    });
+
+    it("DiscoveryResourcesResponse should have correct shape with pagination", () => {
+      const response: DiscoveryResourcesResponse = {
+        x402Version: 2,
+        items: [
+          {
+            resource: "https://api.example.com/endpoint",
+            type: "http",
+            x402Version: 1,
+            accepts: [],
+            lastUpdated: "2024-01-01T00:00:00.000Z",
+          },
+        ],
+        pagination: {
+          limit: 20,
+          offset: 0,
+          total: 100,
+        },
+      };
+
+      expect(response.x402Version).toBe(2);
+      expect(response.items).toHaveLength(1);
+      expect(response.pagination.limit).toBe(20);
+      expect(response.pagination.offset).toBe(0);
+      expect(response.pagination.total).toBe(100);
+    });
+
+    it("ListDiscoveryResourcesParams should accept optional parameters", () => {
+      const params1: ListDiscoveryResourcesParams = {};
+      const params2: ListDiscoveryResourcesParams = { type: "http" };
+      const params3: ListDiscoveryResourcesParams = { type: "http", limit: 10, offset: 5 };
+
+      expect(params1.type).toBeUndefined();
+      expect(params2.type).toBe("http");
+      expect(params3.limit).toBe(10);
+      expect(params3.offset).toBe(5);
+    });
+  });
+
+  describe("withBazaar", () => {
+    let mockFetch: ReturnType<typeof vi.fn>;
+    let originalFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      mockFetch = vi.fn();
+      globalThis.fetch = mockFetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+      vi.restoreAllMocks();
+    });
+
+    it("should extend client with discovery.listResources method", () => {
+      const facilitatorClient = new HTTPFacilitatorClient({
+        url: "https://x402.org/facilitator",
+      });
+
+      const extendedClient = withBazaar(facilitatorClient);
+
+      expect(extendedClient.extensions).toBeDefined();
+      expect(extendedClient.extensions.discovery).toBeDefined();
+      expect(typeof extendedClient.extensions.discovery.listResources).toBe("function");
+    });
+
+    it("should preserve existing extensions when chaining", () => {
+      const facilitatorClient = new HTTPFacilitatorClient({
+        url: "https://x402.org/facilitator",
+      });
+
+      // Simulate a client with existing extensions
+      const clientWithExtensions = facilitatorClient as typeof facilitatorClient & {
+        extensions: { other: { someMethod: () => string } };
+      };
+      clientWithExtensions.extensions = {
+        other: { someMethod: () => "test" },
+      };
+
+      const extendedClient = withBazaar(clientWithExtensions);
+
+      // Should have both the existing and new extensions
+      expect(extendedClient.extensions.discovery).toBeDefined();
+      expect((extendedClient.extensions as { other?: unknown }).other).toBeDefined();
+    });
+
+    it("listResources should call correct endpoint with no params", async () => {
+      const mockResponse: DiscoveryResourcesResponse = {
+        x402Version: 2,
+        items: [],
+        pagination: { limit: 20, offset: 0, total: 0 },
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const facilitatorClient = new HTTPFacilitatorClient({
+        url: "https://x402.org/facilitator",
+      });
+      const extendedClient = withBazaar(facilitatorClient);
+
+      const result = await extendedClient.extensions.discovery.listResources();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe("https://x402.org/facilitator/discovery/resources");
+      expect(options.method).toBe("GET");
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("listResources should include query params when provided", async () => {
+      const mockResponse: DiscoveryResourcesResponse = {
+        x402Version: 2,
+        items: [],
+        pagination: { limit: 10, offset: 5, total: 100 },
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const facilitatorClient = new HTTPFacilitatorClient({
+        url: "https://x402.org/facilitator",
+      });
+      const extendedClient = withBazaar(facilitatorClient);
+
+      await extendedClient.extensions.discovery.listResources({
+        type: "http",
+        limit: 10,
+        offset: 5,
+      });
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toContain("type=http");
+      expect(url).toContain("limit=10");
+      expect(url).toContain("offset=5");
+    });
+
+    it("listResources should throw error on non-ok response", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: () => Promise.resolve("Server error"),
+      });
+
+      const facilitatorClient = new HTTPFacilitatorClient({
+        url: "https://x402.org/facilitator",
+      });
+      const extendedClient = withBazaar(facilitatorClient);
+
+      await expect(extendedClient.extensions.discovery.listResources()).rejects.toThrow(
+        "Facilitator listDiscoveryResources failed (500)",
+      );
+    });
+
+    it("listResources should return properly typed response matching CDP API", async () => {
+      // Mock response matching actual CDP API structure
+      const mockResponse: DiscoveryResourcesResponse = {
+        x402Version: 1,
+        items: [
+          {
+            resource: "https://x402.mode.network/ta/indicators",
+            type: "http",
+            x402Version: 1,
+            accepts: [
+              {
+                scheme: "exact",
+                network: "eip155:8453",
+                asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                amount: "1000",
+                payTo: "0xa2477E16dCB42E2AD80f03FE97D7F1a1646cd1c0",
+                maxTimeoutSeconds: 60,
+                extra: { name: "USD Coin", version: "2" },
+              },
+            ],
+            lastUpdated: "2024-01-01T00:00:00.000Z",
+            metadata: {},
+          },
+        ],
+        pagination: {
+          limit: 1,
+          offset: 0,
+          total: 12234,
+        },
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const facilitatorClient = new HTTPFacilitatorClient({
+        url: "https://x402.org/facilitator",
+      });
+      const extendedClient = withBazaar(facilitatorClient);
+
+      const result = await extendedClient.extensions.discovery.listResources({ limit: 1 });
+
+      // Validate response structure matches our fixed types
+      expect(result.x402Version).toBe(1);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].resource).toBe("https://x402.mode.network/ta/indicators");
+      expect(result.items[0].type).toBe("http");
+      expect(result.items[0].x402Version).toBe(1);
+      expect(result.items[0].accepts).toHaveLength(1);
+      expect(result.items[0].lastUpdated).toBe("2024-01-01T00:00:00.000Z");
+      expect(result.pagination.total).toBe(12234);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Updating the TypeScript facilitator client to match the API. The `@x402/extensions` package had incorrect type definitions for the discovery API response. The types were written incorrectly when the package was first created and never matched what the CDP API actually returns.

## Tests

Added unit tests in test/facilitatorClient.test.ts covering:
- Type shape validation for DiscoveryResource and DiscoveryResourcesResponse
- withBazaar extension correctly adds discovery methods to client
- listResources calls correct endpoint with query params
- Error handling for failed requests
- Response structure matches actual CDP API format


## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
