### PR TITLE
feat(python): Add Polygon Amoy network support

### DIFF
--- a/python/x402/src/x402/chains.py
+++ b/python/x402/src/x402/chains.py
@@ -3,6 +3,7 @@ NETWORK_TO_ID = {
     "base": "8453",
     "avalanche-fuji": "43113",
     "avalanche": "43114",
+    "polygon-amoy": "80002",
 }
 
 
@@ -52,6 +53,15 @@ KNOWN_TOKENS = {
         {
             "human_name": "usdc",
             "address": "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+            "name": "USDC",
+            "decimals": 6,
+            "version": "2",
+        }
+    ],
+    "80002": [
+        {
+            "human_name": "usdc",
+            "address": "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
             "name": "USDC",
             "decimals": 6,
             "version": "2",

--- a/python/x402/src/x402/networks.py
+++ b/python/x402/src/x402/networks.py
@@ -1,11 +1,12 @@
 from typing import Literal
 
 
-SupportedNetworks = Literal["base", "base-sepolia", "avalanche-fuji", "avalanche"]
+SupportedNetworks = Literal["base", "base-sepolia", "avalanche-fuji", "avalanche", "polygon-amoy"]
 
 EVM_NETWORK_TO_CHAIN_ID = {
     "base-sepolia": 84532,
     "base": 8453,
     "avalanche-fuji": 43113,
     "avalanche": 43114,
+    "polygon-amoy": 80002,
 }

--- a/python/x402/tests/test_polygon_amoy.py
+++ b/python/x402/tests/test_polygon_amoy.py
@@ -1,0 +1,48 @@
+"""Test Polygon Amoy network support"""
+
+import pytest
+from x402.networks import SupportedNetworks, EVM_NETWORK_TO_CHAIN_ID
+from x402.chains import NETWORK_TO_ID, KNOWN_TOKENS, get_chain_id, get_default_token_address
+
+
+def test_polygon_amoy_supported_network():
+    """Test that polygon-amoy is in SupportedNetworks"""
+    assert "polygon-amoy" in SupportedNetworks.__args__
+
+
+def test_polygon_amoy_chain_id_mapping():
+    """Test that polygon-amoy maps to correct chain ID"""
+    assert EVM_NETWORK_TO_CHAIN_ID["polygon-amoy"] == 80002
+    assert NETWORK_TO_ID["polygon-amoy"] == "80002"
+
+
+def test_polygon_amoy_known_tokens():
+    """Test that USDC token is configured for Polygon Amoy"""
+    assert "80002" in KNOWN_TOKENS
+    usdc_tokens = KNOWN_TOKENS["80002"]
+    assert len(usdc_tokens) == 1
+    
+    usdc_token = usdc_tokens[0]
+    assert usdc_token["human_name"] == "usdc"
+    assert usdc_token["address"] == "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"
+    assert usdc_token["name"] == "USDC"
+    assert usdc_token["decimals"] == 6
+    assert usdc_token["version"] == "2"
+
+
+def test_get_chain_id_polygon_amoy():
+    """Test get_chain_id function works with polygon-amoy"""
+    chain_id = get_chain_id("polygon-amoy")
+    assert chain_id == "80002"
+
+
+def test_get_default_token_address_polygon_amoy():
+    """Test get_default_token_address works for Polygon Amoy"""
+    usdc_address = get_default_token_address("80002", "usdc")
+    assert usdc_address == "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"
+
+
+def test_get_chain_id_direct_chain_id():
+    """Test that direct chain ID still works"""
+    chain_id = get_chain_id("80002")
+    assert chain_id == "80002"


### PR DESCRIPTION
## Summary

This PR adds Polygon Amoy testnet support to the Python x402 SDK, bringing it to parity with the TypeScript implementation.

## Changes

### `networks.py`
- Added `polygon-amoy` to the `SupportedNetworks` Literal type
- Added chain ID mapping: `polygon-amoy: 80002` to `EVM_NETWORK_TO_CHAIN_ID`

### `chains.py`
- Added `polygon-amoy: "80002"` to `NETWORK_TO_ID` mapping
- Added USDC token configuration for chain ID `80002`:
  - Address: `0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582`
  - Name: `USDC`
  - Decimals: `6`
  - Version: `2`

### Tests
- Added comprehensive test suite in `test_polygon_amoy.py` covering:
  - Network support verification
  - Chain ID mappings
  - USDC token configuration
  - Utility function compatibility

## Testing

All existing tests pass (87 tests) plus 6 new tests for Polygon Amoy support:

```
tests/test_polygon_amoy.py::test_polygon_amoy_supported_network PASSED
tests/test_polygon_amoy.py::test_polygon_amoy_chain_id_mapping PASSED
tests/test_polygon_amoy.py::test_polygon_amoy_known_tokens PASSED
tests/test_polygon_amoy.py::test_get_chain_id_polygon_amoy PASSED
tests/test_polygon_amoy.py::test_get_default_token_address_polygon_amoy PASSED
tests/test_polygon_amoy.py::test_get_chain_id_direct_chain_id PASSED
```

Fixes #670