### PR TITLE
fix(java): update FacilitatorClient to use PaymentPayload JSON objects 

### DIFF
--- a/java/src/main/java/com/coinbase/x402/client/FacilitatorClient.java
+++ b/java/src/main/java/com/coinbase/x402/client/FacilitatorClient.java
@@ -1,5 +1,6 @@
 package com.coinbase.x402.client;
 
+import com.coinbase.x402.model.PaymentPayload;
 import com.coinbase.x402.model.PaymentRequirements;
 
 import java.io.IOException;
@@ -8,28 +9,28 @@ import java.util.Set;
 /** Contract for calling an x402 facilitator (HTTP, gRPC, mock, etc.). */
 public interface FacilitatorClient {
     /**
-     * Verifies a payment header against the given requirements.
+     * Verifies a payment payload against the given requirements.
      *
-     * @param paymentHeader the X-402 payment header to verify
+     * @param paymentPayload the payment payload to verify
      * @param req the payment requirements to validate against
      * @return verification response indicating if payment is valid
      * @throws IOException if HTTP request fails or returns non-200 status
      * @throws InterruptedException if the request is interrupted
      */
-    VerificationResponse verify(String paymentHeader,
+    VerificationResponse verify(PaymentPayload paymentPayload,
                                 PaymentRequirements req)
             throws IOException, InterruptedException;
 
     /**
      * Settles a verified payment on the blockchain.
      *
-     * @param paymentHeader the X-402 payment header to settle
+     * @param paymentPayload the payment payload to settle
      * @param req the payment requirements for settlement
      * @return settlement response with transaction details if successful
      * @throws IOException if HTTP request fails or returns non-200 status
      * @throws InterruptedException if the request is interrupted
      */
-    SettlementResponse settle(String paymentHeader,
+    SettlementResponse settle(PaymentPayload paymentPayload,
                               PaymentRequirements req)
             throws IOException, InterruptedException;
 

--- a/java/src/main/java/com/coinbase/x402/client/HttpFacilitatorClient.java
+++ b/java/src/main/java/com/coinbase/x402/client/HttpFacilitatorClient.java
@@ -1,5 +1,6 @@
 package com.coinbase.x402.client;
 
+import com.coinbase.x402.model.PaymentPayload;
 import com.coinbase.x402.model.PaymentRequirements;
 import com.coinbase.x402.util.Json;
 
@@ -38,13 +39,13 @@ public class HttpFacilitatorClient implements FacilitatorClient {
     /* ------------------------------------------------ verify ------------- */
 
     @Override
-    public VerificationResponse verify(String paymentHeader,
+    public VerificationResponse verify(PaymentPayload paymentPayload,
                                        PaymentRequirements req)
             throws IOException, InterruptedException {
 
         Map<String,Object> body = Map.of(
-                "x402Version", 1,
-                "paymentHeader", paymentHeader,
+                "x402Version", paymentPayload.x402Version,
+                "paymentPayload", paymentPayload,
                 "paymentRequirements", req
         );
 
@@ -65,13 +66,13 @@ public class HttpFacilitatorClient implements FacilitatorClient {
     /* ------------------------------------------------ settle ------------- */
 
     @Override
-    public SettlementResponse settle(String paymentHeader,
+    public SettlementResponse settle(PaymentPayload paymentPayload,
                                      PaymentRequirements req)
             throws IOException, InterruptedException {
 
         Map<String,Object> body = Map.of(
-                "x402Version", 1,
-                "paymentHeader", paymentHeader,
+                "x402Version", paymentPayload.x402Version,
+                "paymentPayload", paymentPayload,
                 "paymentRequirements", req
         );
 

--- a/java/src/main/java/com/coinbase/x402/server/PaymentFilter.java
+++ b/java/src/main/java/com/coinbase/x402/server/PaymentFilter.java
@@ -109,7 +109,7 @@ public class PaymentFilter implements Filter {
                 return;
             }
 
-            vr = facilitator.verify(header, buildRequirements(path));
+            vr = facilitator.verify(payload, buildRequirements(path));
         } catch (IllegalArgumentException ex) {
             // Malformed payment header - client error
             respond402(response, path, "malformed X-PAYMENT header");
@@ -152,7 +152,7 @@ public class PaymentFilter implements Filter {
         }
 
         try {
-            SettlementResponse sr = facilitator.settle(header, buildRequirements(path));
+            SettlementResponse sr = facilitator.settle(payload, buildRequirements(path));
             if (sr == null || !sr.success) {
                 // Settlement failed - return 402 if headers not sent yet
                 if (!response.isCommitted()) {

--- a/java/src/test/java/com/coinbase/x402/client/HttpFacilitatorClientTest.java
+++ b/java/src/test/java/com/coinbase/x402/client/HttpFacilitatorClientTest.java
@@ -1,10 +1,12 @@
 package com.coinbase.x402.client;
 
+import com.coinbase.x402.model.PaymentPayload;
 import com.coinbase.x402.model.PaymentRequirements;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -27,6 +29,23 @@ class HttpFacilitatorClientTest {
     void setUp() {
         wm.resetAll();
         client = new HttpFacilitatorClient("http://localhost:" + wm.port());
+    }
+
+    /** Helper to create a minimal PaymentPayload for testing */
+    private PaymentPayload createTestPayload() {
+        PaymentPayload payload = new PaymentPayload();
+        payload.x402Version = 1;
+        payload.scheme = "exact";
+        payload.network = "base-sepolia";
+        payload.payload = Map.of(
+            "signature", "0xtest",
+            "authorization", Map.of(
+                "from", "0xPayer",
+                "to", "0xReceiver",
+                "value", "1000000"
+            )
+        );
+        return payload;
     }
     
     @Test
@@ -59,11 +78,12 @@ class HttpFacilitatorClientTest {
                 .withHeader("Content-Type","application/json")
                 .withBody("{\"success\":true,\"txHash\":\"0xabc\",\"networkId\":\"1\"}")));
 
+        PaymentPayload payload = createTestPayload();
         PaymentRequirements req = new PaymentRequirements();
-        VerificationResponse vr = client.verify("header", req);
+        VerificationResponse vr = client.verify(payload, req);
         assertTrue(vr.isValid);
 
-        SettlementResponse sr = client.settle("header", req);
+        SettlementResponse sr = client.settle(payload, req);
         assertTrue(sr.success);
         assertEquals("0xabc", sr.txHash);
     }
@@ -114,9 +134,10 @@ class HttpFacilitatorClientTest {
                 .withHeader("Content-Type","application/json")
                 .withBody("{\"isValid\":false,\"invalidReason\":\"insufficient balance\"}")));
 
+        PaymentPayload payload = createTestPayload();
         PaymentRequirements req = new PaymentRequirements();
-        VerificationResponse response = client.verify("header", req);
-        
+        VerificationResponse response = client.verify(payload, req);
+
         assertFalse(response.isValid);
         assertEquals("insufficient balance", response.invalidReason);
     }
@@ -129,9 +150,10 @@ class HttpFacilitatorClientTest {
                 .withHeader("Content-Type","application/json")
                 .withBody("{\"success\":true}")));  // Missing txHash and networkId
 
+        PaymentPayload payload = createTestPayload();
         PaymentRequirements req = new PaymentRequirements();
-        SettlementResponse response = client.settle("header", req);
-        
+        SettlementResponse response = client.settle(payload, req);
+
         assertTrue(response.success);
         assertNull(response.txHash);  // Should be null since it wasn't in the response
         assertNull(response.networkId);
@@ -145,9 +167,10 @@ class HttpFacilitatorClientTest {
                 .withHeader("Content-Type","application/json")
                 .withBody("{\"success\":false,\"error\":\"payment timed out\"}")));
 
+        PaymentPayload payload = createTestPayload();
         PaymentRequirements req = new PaymentRequirements();
-        SettlementResponse response = client.settle("header", req);
-        
+        SettlementResponse response = client.settle(payload, req);
+
         assertFalse(response.success);
         assertEquals("payment timed out", response.error);
     }
@@ -156,42 +179,45 @@ class HttpFacilitatorClientTest {
     void testNetworkTimeout() {
         // Test with a non-existent server to simulate network issues
         HttpFacilitatorClient badClient = new HttpFacilitatorClient("http://localhost:1");  // Port 1 should not be listening
-        
+
+        PaymentPayload payload = createTestPayload();
         PaymentRequirements req = new PaymentRequirements();
-        
+
         // Both methods should throw an exception
-        assertThrows(Exception.class, () -> badClient.verify("header", req));
-        assertThrows(Exception.class, () -> badClient.settle("header", req));
+        assertThrows(Exception.class, () -> badClient.verify(payload, req));
+        assertThrows(Exception.class, () -> badClient.settle(payload, req));
         assertThrows(Exception.class, () -> badClient.supported());
     }
 
     @Test
     void verifyRejectsNon200Status() {
+        PaymentPayload payload = createTestPayload();
         PaymentRequirements req = new PaymentRequirements();
-        
+
         // Test HTTP 201 - should be rejected even though it's successful
         wm.stubFor(post(urlEqualTo("/verify"))
             .willReturn(aResponse()
                 .withStatus(201)
                 .withHeader("Content-Type", "application/json")
                 .withBody("{\"isValid\":true}")));
-        
-        Exception ex = assertThrows(Exception.class, () -> client.verify("header", req));
+
+        Exception ex = assertThrows(Exception.class, () -> client.verify(payload, req));
         assertTrue(ex.getMessage().contains("HTTP 201"));
     }
 
     @Test
     void settleRejectsNon200Status() {
+        PaymentPayload payload = createTestPayload();
         PaymentRequirements req = new PaymentRequirements();
-        
-        // Test HTTP 404 
+
+        // Test HTTP 404
         wm.stubFor(post(urlEqualTo("/settle"))
             .willReturn(aResponse()
                 .withStatus(404)
                 .withHeader("Content-Type", "application/json")
                 .withBody("{\"error\":\"not found\"}")));
-        
-        Exception ex = assertThrows(Exception.class, () -> client.settle("header", req));
+
+        Exception ex = assertThrows(Exception.class, () -> client.settle(payload, req));
         assertTrue(ex.getMessage().contains("HTTP 404"));
         assertTrue(ex.getMessage().contains("not found"));
     }
@@ -212,15 +238,16 @@ class HttpFacilitatorClientTest {
 
     @Test
     void verifyHandles400BadRequest() {
+        PaymentPayload payload = createTestPayload();
         PaymentRequirements req = new PaymentRequirements();
-        
+
         wm.stubFor(post(urlEqualTo("/verify"))
             .willReturn(aResponse()
                 .withStatus(400)
                 .withHeader("Content-Type", "application/json")
                 .withBody("{\"error\":\"invalid payment header\"}")));
-        
-        Exception ex = assertThrows(Exception.class, () -> client.verify("header", req));
+
+        Exception ex = assertThrows(Exception.class, () -> client.verify(payload, req));
         assertTrue(ex.getMessage().contains("HTTP 400"));
         assertTrue(ex.getMessage().contains("invalid payment header"));
     }

--- a/java/src/test/java/com/coinbase/x402/integration/FilterIntegrationTest.java
+++ b/java/src/test/java/com/coinbase/x402/integration/FilterIntegrationTest.java
@@ -37,12 +37,16 @@ class FilterIntegrationTest {
     static void startJetty() throws Exception {
         // ----- stub facilitator -----------------------------------------
         FacilitatorClient stubFac = new FacilitatorClient() {
-            @Override public VerificationResponse verify(String hdr, com.coinbase.x402.model.PaymentRequirements r) {
+            @Override public VerificationResponse verify(PaymentPayload payload, com.coinbase.x402.model.PaymentRequirements r) {
                 VerificationResponse vr = new VerificationResponse();
                 vr.isValid = true;                       // always accept
                 return vr;
             }
-            @Override public com.coinbase.x402.client.SettlementResponse settle(String h, com.coinbase.x402.model.PaymentRequirements r) { return new com.coinbase.x402.client.SettlementResponse(); }
+            @Override public com.coinbase.x402.client.SettlementResponse settle(PaymentPayload payload, com.coinbase.x402.model.PaymentRequirements r) {
+                com.coinbase.x402.client.SettlementResponse sr = new com.coinbase.x402.client.SettlementResponse();
+                sr.success = true;
+                return sr;
+            }
             @Override public java.util.Set<com.coinbase.x402.client.Kind> supported() { return java.util.Set.of(); }
         };
 

--- a/java/src/test/java/com/coinbase/x402/server/PaymentFilterTest.java
+++ b/java/src/test/java/com/coinbase/x402/server/PaymentFilterTest.java
@@ -88,7 +88,7 @@ class PaymentFilterTest {
         // facilitator says it's valid
         VerificationResponse vr = new VerificationResponse();
         vr.isValid = true;
-        when(fac.verify(eq(header), any())).thenReturn(vr);
+        when(fac.verify(any(PaymentPayload.class), any())).thenReturn(vr);
 
         // handler returns 200 OK
         when(resp.getStatus()).thenReturn(HttpServletResponse.SC_OK);
@@ -98,14 +98,14 @@ class PaymentFilterTest {
         sr.success = true;
         sr.txHash = "0xabcdef1234567890";
         sr.networkId = "base-sepolia";
-        when(fac.settle(eq(header), any())).thenReturn(sr);
+        when(fac.settle(any(PaymentPayload.class), any())).thenReturn(sr);
 
         filter.doFilter(req, resp, chain);
 
         verify(chain).doFilter(req, resp);
         verify(resp, never()).setStatus(HttpServletResponse.SC_PAYMENT_REQUIRED);
-        verify(fac).verify(eq(header), any());
-        verify(fac).settle(eq(header), any());
+        verify(fac).verify(any(PaymentPayload.class), any());
+        verify(fac).settle(any(PaymentPayload.class), any());
     }
 
     /* ------------ error response skips settlement ------------------------- */
@@ -123,7 +123,7 @@ class PaymentFilterTest {
 
         VerificationResponse vr = new VerificationResponse();
         vr.isValid = true;
-        when(fac.verify(eq(header), any())).thenReturn(vr);
+        when(fac.verify(any(PaymentPayload.class), any())).thenReturn(vr);
 
         // handler returns 500 error
         when(resp.getStatus()).thenReturn(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -150,7 +150,7 @@ class PaymentFilterTest {
 
         VerificationResponse vr = new VerificationResponse();
         vr.isValid = true;
-        when(fac.verify(eq(header), any())).thenReturn(vr);
+        when(fac.verify(any(PaymentPayload.class), any())).thenReturn(vr);
 
         // handler returns 404 error
         when(resp.getStatus()).thenReturn(HttpServletResponse.SC_NOT_FOUND);
@@ -180,7 +180,7 @@ class PaymentFilterTest {
         VerificationResponse vr = new VerificationResponse();
         vr.isValid = false;
         vr.invalidReason = "insufficient funds";
-        when(fac.verify(eq(header), any())).thenReturn(vr);
+        when(fac.verify(any(PaymentPayload.class), any())).thenReturn(vr);
 
         filter.doFilter(req, resp, chain);
 
@@ -292,10 +292,10 @@ class PaymentFilterTest {
         // Verification succeeds
         VerificationResponse vr = new VerificationResponse();
         vr.isValid = true;
-        when(fac.verify(eq(header), any())).thenReturn(vr);
-        
+        when(fac.verify(any(PaymentPayload.class), any())).thenReturn(vr);
+
         // But settlement throws exception (should return 402)
-        doThrow(new IOException("Network error")).when(fac).settle(any(), any());
+        doThrow(new IOException("Network error")).when(fac).settle(any(PaymentPayload.class), any());
         
         filter.doFilter(req, resp, chain);
         
@@ -304,8 +304,8 @@ class PaymentFilterTest {
         verify(resp).setStatus(HttpServletResponse.SC_PAYMENT_REQUIRED);
         
         // Verify and settle were both called
-        verify(fac).verify(eq(header), any());
-        verify(fac).settle(eq(header), any());
+        verify(fac).verify(any(PaymentPayload.class), any());
+        verify(fac).settle(any(PaymentPayload.class), any());
     }
 
     /* ------------ settlement failure returns 402 */
@@ -325,13 +325,13 @@ class PaymentFilterTest {
         // Verification succeeds
         VerificationResponse vr = new VerificationResponse();
         vr.isValid = true;
-        when(fac.verify(eq(header), any())).thenReturn(vr);
-        
+        when(fac.verify(any(PaymentPayload.class), any())).thenReturn(vr);
+
         // Settlement fails (facilitator returns success=false)
         SettlementResponse sr = new SettlementResponse();
         sr.success = false;
         sr.error = "insufficient balance";
-        when(fac.settle(eq(header), any())).thenReturn(sr);
+        when(fac.settle(any(PaymentPayload.class), any())).thenReturn(sr);
         
         filter.doFilter(req, resp, chain);
         
@@ -340,8 +340,8 @@ class PaymentFilterTest {
         verify(resp).setStatus(HttpServletResponse.SC_PAYMENT_REQUIRED);
         
         // Verify and settle were both called
-        verify(fac).verify(eq(header), any());
-        verify(fac).settle(eq(header), any());
+        verify(fac).verify(any(PaymentPayload.class), any());
+        verify(fac).settle(any(PaymentPayload.class), any());
     }
 
     /* ------------ payer extraction from payment payload ---------------- */
@@ -387,14 +387,14 @@ class PaymentFilterTest {
         // Verification succeeds
         VerificationResponse vr = new VerificationResponse();
         vr.isValid = true;
-        when(fac.verify(eq(header), any())).thenReturn(vr);
+        when(fac.verify(any(PaymentPayload.class), any())).thenReturn(vr);
         
         // Settlement succeeds  
         SettlementResponse sr = new SettlementResponse();
         sr.success = true;
         sr.txHash = "0xabcdef1234567890";
         sr.networkId = "base-sepolia";
-        when(fac.settle(eq(header), any())).thenReturn(sr);
+        when(fac.settle(any(PaymentPayload.class), any())).thenReturn(sr);
         
         filter.doFilter(req, resp, chain);
         
@@ -439,14 +439,14 @@ class PaymentFilterTest {
         // Verification succeeds
         VerificationResponse vr = new VerificationResponse();
         vr.isValid = true;
-        when(fac.verify(eq(header), any())).thenReturn(vr);
+        when(fac.verify(any(PaymentPayload.class), any())).thenReturn(vr);
         
         // Settlement succeeds  
         SettlementResponse sr = new SettlementResponse();
         sr.success = true;
         sr.txHash = "0xabcdef1234567890";
         sr.networkId = "base-sepolia";
-        when(fac.settle(eq(header), any())).thenReturn(sr);
+        when(fac.settle(any(PaymentPayload.class), any())).thenReturn(sr);
         
         filter.doFilter(req, resp, chain);
         
@@ -488,14 +488,14 @@ class PaymentFilterTest {
         // Verification succeeds
         VerificationResponse vr = new VerificationResponse();
         vr.isValid = true;
-        when(fac.verify(eq(header), any())).thenReturn(vr);
+        when(fac.verify(any(PaymentPayload.class), any())).thenReturn(vr);
         
         // Settlement succeeds  
         SettlementResponse sr = new SettlementResponse();
         sr.success = true;
         sr.txHash = "0xabcdef1234567890";
         sr.networkId = "base-sepolia";
-        when(fac.settle(eq(header), any())).thenReturn(sr);
+        when(fac.settle(any(PaymentPayload.class), any())).thenReturn(sr);
         
         filter.doFilter(req, resp, chain);
         
@@ -531,7 +531,7 @@ class PaymentFilterTest {
         when(req.getHeader("X-PAYMENT")).thenReturn(header);
         
         // Make facilitator throw IOException during verify
-        when(fac.verify(any(), any())).thenThrow(new IOException("Network timeout"));
+        when(fac.verify(any(PaymentPayload.class), any())).thenThrow(new IOException("Network timeout"));
         
         filter.doFilter(req, resp, chain);
         
@@ -559,7 +559,7 @@ class PaymentFilterTest {
         when(req.getHeader("X-PAYMENT")).thenReturn(header);
         
         // Make facilitator throw unexpected exception during verify
-        when(fac.verify(any(), any())).thenThrow(new RuntimeException("Unexpected error"));
+        when(fac.verify(any(PaymentPayload.class), any())).thenThrow(new RuntimeException("Unexpected error"));
         
         filter.doFilter(req, resp, chain);
         


### PR DESCRIPTION
## Description

This PR fixes the Java SDK's FacilitatorClient interface to align with the Coinbase/x402.org facilitator API format.                                                            
                                                                                                                                                                                  
  Problem: The current Java SDK sends payment data as a base64-encoded string in the paymentHeader field, but the Coinbase facilitator API expects a JSON object in the           
  paymentPayload field (as documented in the x402.org spec).                                                                                                                      
                                                                                                                                                                                  
  Solution:                                                                                                                                                                       
  - Updated FacilitatorClient interface signatures to accept PaymentPayload objects instead of String paymentHeader                                                               
  - Modified HttpFacilitatorClient to send paymentPayload as a JSON object in the request body                                                                                    
  - Updated PaymentFilter to pass the decoded PaymentPayload to the facilitator (it was already decoding the header but then passing the raw string)                              
  - Updated all SDK tests to use the new signatures                                                                                                                               
                                                                                                                                                                                  
  This change makes the Java SDK compatible with Coinbase's production facilitator and any other facilitators following the x402.org specification.

Closes #974 

## Tests
- HttpFacilitatorClientTest - Updated all test methods to create and pass PaymentPayload objects                                                                                
- PaymentFilterTest - Updated mock expectations to accept PaymentPayload parameters                                                                                             
- FilterIntegrationTest - Updated stub facilitator implementation to match new interface  

`mvn -q -f java/pom.xml compile` -> Compiles successfully

```
cd java/
mvn test -> All tests pass
```

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits