### PR TITLE
Fix ECDSA Recovery Byte

### DIFF
--- a/go/mechanisms/evm/exact/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/facilitator/scheme.go
@@ -276,6 +276,9 @@ func (f *ExactEvmScheme) Settle(
 		r := signatureBytes[0:32]
 		s := signatureBytes[32:64]
 		v := signatureBytes[64]
+		if v == 0 || v == 1 {
+			v = v + 27
+		}
 
 		txHash, err = f.signer.WriteContract(
 			ctx,

--- a/go/mechanisms/evm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/v1/facilitator/scheme.go
@@ -285,6 +285,9 @@ func (f *ExactEvmSchemeV1) Settle(
 		r := signatureBytes[0:32]
 		s := signatureBytes[32:64]
 		v := signatureBytes[64]
+		if v == 0 || v == 1 {
+			v = v + 27
+		}
 
 		txHash, err = f.signer.WriteContract(
 			ctx,


### PR DESCRIPTION
## Description

Fixes the ECDSA recovery byte (`v`) normalization bug in EVM facilitator settlement.

Some signing libraries encode `v` as `0/1` (raw yParity), but EVM's `ecrecover` expects `27/28`. When signatures with `v=0/1` are passed to `transferWithAuthorization`, the contract recovers the wrong signer address and reverts — even though the signature is cryptographically valid.

This adds normalization (`if v == 0 || v == 1 { v = v + 27 }`) to the EOA settlement path in both v2 and v1 facilitators.

**Files changed:**
- `go/mechanisms/evm/exact/facilitator/scheme.go` (v2)
- `go/mechanisms/evm/exact/v1/facilitator/scheme.go` (v1)

## Tests

- Ran `make test` from `/go` — all tests pass
- Ran `make fmt` from `/go` — code formatted
- Validated fix against OpenZeppelin ECDSA.sol and EIP-3009 spec

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)