### PR TITLE
feat: Add client-side Permit2 support with EIP-2612 gas sponsoring extension

### DIFF
--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -41,6 +41,13 @@ export interface PaymentCreationContext {
      */
     signers?: Record<string, string[]>;
   };
+
+  /**
+   * Extension-specific data populated by beforePaymentCreation hooks.
+   * Keyed by extension name (e.g., "eip2612GasSponsoring").
+   * Mechanisms can read this to create extension payloads.
+   */
+  extensionData?: Record<string, unknown>;
 }
 
 /**

--- a/typescript/packages/mechanisms/evm/src/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/constants.ts
@@ -10,6 +10,44 @@ export const authorizationTypes = {
   ],
 } as const;
 
+/**
+ * Permit2 EIP-712 types for signing PermitWitnessTransferFrom.
+ * Must match the exact format expected by the Permit2 contract.
+ */
+export const permit2WitnessTypes = {
+  PermitWitnessTransferFrom: [
+    { name: "permitted", type: "TokenPermissions" },
+    { name: "spender", type: "address" },
+    { name: "nonce", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+    { name: "witness", type: "Witness" },
+  ],
+  TokenPermissions: [
+    { name: "token", type: "address" },
+    { name: "amount", type: "uint256" },
+  ],
+  Witness: [
+    { name: "extra", type: "bytes" },
+    { name: "to", type: "address" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+} as const;
+
+/**
+ * EIP-2612 permit types for gasless approval signatures.
+ * Used with the eip2612GasSponsoring extension.
+ */
+export const eip2612PermitTypes = {
+  Permit: [
+    { name: "owner", type: "address" },
+    { name: "spender", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "nonce", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+  ],
+} as const;
+
 // EIP3009 ABI for transferWithAuthorization function
 export const eip3009ABI = [
   {

--- a/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
@@ -1,0 +1,91 @@
+import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import { getAddress } from "viem";
+import { authorizationTypes } from "../../constants";
+import { ClientEvmSigner } from "../../signer";
+import { ExactEIP3009Payload } from "../../types";
+import { createNonce } from "../../utils";
+
+/**
+ * Creates an EIP-3009 (transferWithAuthorization) payload.
+ *
+ * @param signer - The EVM signer for client operations
+ * @param x402Version - The x402 protocol version
+ * @param paymentRequirements - The payment requirements
+ * @returns Promise resolving to a payment payload result
+ */
+export async function createEIP3009Payload(
+  signer: ClientEvmSigner,
+  x402Version: number,
+  paymentRequirements: PaymentRequirements,
+): Promise<PaymentPayloadResult> {
+  const nonce = createNonce();
+  const now = Math.floor(Date.now() / 1000);
+
+  const authorization: ExactEIP3009Payload["authorization"] = {
+    from: signer.address,
+    to: getAddress(paymentRequirements.payTo),
+    value: paymentRequirements.amount,
+    validAfter: (now - 600).toString(),
+    validBefore: (now + paymentRequirements.maxTimeoutSeconds).toString(),
+    nonce,
+  };
+
+  const signature = await signEIP3009Authorization(signer, authorization, paymentRequirements);
+
+  const payload: ExactEIP3009Payload = {
+    authorization,
+    signature,
+  };
+
+  return {
+    x402Version,
+    payload,
+  };
+}
+
+/**
+ * Sign the EIP-3009 authorization using EIP-712.
+ *
+ * @param signer - The EVM signer
+ * @param authorization - The authorization to sign
+ * @param requirements - The payment requirements
+ * @returns Promise resolving to the signature
+ */
+async function signEIP3009Authorization(
+  signer: ClientEvmSigner,
+  authorization: ExactEIP3009Payload["authorization"],
+  requirements: PaymentRequirements,
+): Promise<`0x${string}`> {
+  const chainId = parseInt(requirements.network.split(":")[1]);
+
+  if (!requirements.extra?.name || !requirements.extra?.version) {
+    throw new Error(
+      `EIP-712 domain parameters (name, version) are required in payment requirements for asset ${requirements.asset}`,
+    );
+  }
+
+  const { name, version } = requirements.extra;
+
+  const domain = {
+    name,
+    version,
+    chainId,
+    verifyingContract: getAddress(requirements.asset),
+  };
+
+  const message = {
+    from: getAddress(authorization.from),
+    to: getAddress(authorization.to),
+    value: BigInt(authorization.value),
+    validAfter: BigInt(authorization.validAfter),
+    validBefore: BigInt(authorization.validBefore),
+    nonce: authorization.nonce,
+  };
+
+  return await signer.signTypedData({
+    domain,
+    types: authorizationTypes,
+    primaryType: "TransferWithAuthorization",
+    message,
+  });
+}

--- a/typescript/packages/mechanisms/evm/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/index.ts
@@ -4,6 +4,7 @@ export type { EvmClientConfig } from "./register";
 export {
   EIP2612_GAS_SPONSORING_EXTENSION,
   type EIP2612GasSponsoringExtension,
+  type EIP2612GasSponsoringInput,
   createPermit2ApprovalTx,
   getPermit2AllowanceReadParams,
   erc20AllowanceAbi,

--- a/typescript/packages/mechanisms/evm/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/index.ts
@@ -4,4 +4,8 @@ export type { EvmClientConfig } from "./register";
 export {
   EIP2612_GAS_SPONSORING_EXTENSION,
   type EIP2612GasSponsoringExtension,
+  createPermit2ApprovalTx,
+  getPermit2AllowanceReadParams,
+  erc20AllowanceAbi,
+  type Permit2AllowanceParams,
 } from "./permit2";

--- a/typescript/packages/mechanisms/evm/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/index.ts
@@ -1,3 +1,7 @@
 export { ExactEvmScheme } from "./scheme";
 export { registerExactEvmScheme } from "./register";
 export type { EvmClientConfig } from "./register";
+export {
+  EIP2612_GAS_SPONSORING_EXTENSION,
+  type EIP2612GasSponsoringExtension,
+} from "./permit2";

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -1,0 +1,108 @@
+import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import { getAddress } from "viem";
+import { permit2WitnessTypes, PERMIT2_ADDRESS, x402Permit2ProxyAddress } from "../../constants";
+import { ClientEvmSigner } from "../../signer";
+import { ExactPermit2Payload } from "../../types";
+import { createPermit2Nonce } from "../../utils";
+
+/**
+ * Creates a Permit2 payload using the x402Permit2Proxy witness pattern.
+ * The spender is set to x402Permit2Proxy, which enforces that funds
+ * can only be sent to the witness.to address.
+ *
+ * @param signer - The EVM signer for client operations
+ * @param x402Version - The x402 protocol version
+ * @param paymentRequirements - The payment requirements
+ * @returns Promise resolving to a payment payload result
+ */
+export async function createPermit2Payload(
+  signer: ClientEvmSigner,
+  x402Version: number,
+  paymentRequirements: PaymentRequirements,
+): Promise<PaymentPayloadResult> {
+  const now = Math.floor(Date.now() / 1000);
+  const nonce = createPermit2Nonce();
+
+  const validAfter = (now - 600).toString();
+  const validBefore = (now + paymentRequirements.maxTimeoutSeconds).toString();
+  const deadline = validBefore;
+
+  const permit2Authorization: ExactPermit2Payload["permit2Authorization"] = {
+    from: signer.address,
+    permitted: {
+      token: getAddress(paymentRequirements.asset),
+      amount: paymentRequirements.amount,
+    },
+    spender: x402Permit2ProxyAddress,
+    nonce,
+    deadline,
+    witness: {
+      to: getAddress(paymentRequirements.payTo),
+      validAfter,
+      validBefore,
+      extra: "0x",
+    },
+  };
+
+  const signature = await signPermit2Authorization(
+    signer,
+    permit2Authorization,
+    paymentRequirements,
+  );
+
+  const payload: ExactPermit2Payload = {
+    signature,
+    permit2Authorization,
+  };
+
+  return {
+    x402Version,
+    payload,
+  };
+}
+
+/**
+ * Sign the Permit2 authorization using EIP-712 with witness data.
+ * The signature authorizes the x402Permit2Proxy to transfer tokens on behalf of the signer.
+ *
+ * @param signer - The EVM signer
+ * @param permit2Authorization - The Permit2 authorization parameters
+ * @param requirements - The payment requirements
+ * @returns Promise resolving to the signature
+ */
+async function signPermit2Authorization(
+  signer: ClientEvmSigner,
+  permit2Authorization: ExactPermit2Payload["permit2Authorization"],
+  requirements: PaymentRequirements,
+): Promise<`0x${string}`> {
+  const chainId = parseInt(requirements.network.split(":")[1]);
+
+  const domain = {
+    name: "Permit2",
+    chainId,
+    verifyingContract: PERMIT2_ADDRESS,
+  };
+
+  const message = {
+    permitted: {
+      token: getAddress(permit2Authorization.permitted.token),
+      amount: BigInt(permit2Authorization.permitted.amount),
+    },
+    spender: getAddress(permit2Authorization.spender),
+    nonce: BigInt(permit2Authorization.nonce),
+    deadline: BigInt(permit2Authorization.deadline),
+    witness: {
+      extra: permit2Authorization.witness.extra,
+      to: getAddress(permit2Authorization.witness.to),
+      validAfter: BigInt(permit2Authorization.witness.validAfter),
+      validBefore: BigInt(permit2Authorization.witness.validBefore),
+    },
+  };
+
+  return await signer.signTypedData({
+    domain,
+    types: permit2WitnessTypes,
+    primaryType: "PermitWitnessTransferFrom",
+    message,
+  });
+}

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -1,24 +1,51 @@
-import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import {
+  PaymentRequirements,
+  PaymentPayloadResult,
+  PaymentCreationContext,
+} from "@x402/core/types";
 import { getAddress } from "viem";
-import { permit2WitnessTypes, PERMIT2_ADDRESS, x402Permit2ProxyAddress } from "../../constants";
+import {
+  permit2WitnessTypes,
+  PERMIT2_ADDRESS,
+  x402Permit2ProxyAddress,
+  eip2612PermitTypes,
+} from "../../constants";
 import { ClientEvmSigner } from "../../signer";
-import { ExactPermit2Payload } from "../../types";
+import { EIP2612PermitParams, ExactPermit2Payload } from "../../types";
 import { createPermit2Nonce } from "../../utils";
+
+/**
+ * Extension name for EIP-2612 gas sponsoring
+ */
+export const EIP2612_GAS_SPONSORING_EXTENSION = "eip2612GasSponsoring";
+
+/**
+ * Extension data for eip2612GasSponsoring.
+ * Contains the EIP-2612 permit signature to approve Permit2.
+ */
+export interface EIP2612GasSponsoringExtension {
+  permit: EIP2612PermitParams;
+}
 
 /**
  * Creates a Permit2 payload using the x402Permit2Proxy witness pattern.
  * The spender is set to x402Permit2Proxy, which enforces that funds
  * can only be sent to the witness.to address.
  *
+ * If the facilitator supports eip2612GasSponsoring and the user provides
+ * an EIP-2612 nonce, an approval permit will be included in extensions.
+ *
  * @param signer - The EVM signer for client operations
  * @param x402Version - The x402 protocol version
  * @param paymentRequirements - The payment requirements
+ * @param context - Optional context with facilitator info and EIP-2612 nonce
  * @returns Promise resolving to a payment payload result
  */
 export async function createPermit2Payload(
   signer: ClientEvmSigner,
   x402Version: number,
   paymentRequirements: PaymentRequirements,
+  context?: PaymentCreationContext & { eip2612Nonce?: bigint },
 ): Promise<PaymentPayloadResult> {
   const now = Math.floor(Date.now() / 1000);
   const nonce = createPermit2Nonce();
@@ -55,9 +82,93 @@ export async function createPermit2Payload(
     permit2Authorization,
   };
 
-  return {
+  const result: PaymentPayloadResult = {
     x402Version,
     payload,
+  };
+
+  // Add EIP-2612 permit extension if facilitator supports it and nonce is provided
+  if (context?.eip2612Nonce !== undefined && supportsEIP2612GasSponsoring(context)) {
+    const permitExtension = await createEIP2612PermitExtension(
+      signer,
+      paymentRequirements,
+      context.eip2612Nonce,
+      permit2Authorization.deadline,
+    );
+    result.extensions = {
+      [EIP2612_GAS_SPONSORING_EXTENSION]: permitExtension,
+    };
+  }
+
+  return result;
+}
+
+/**
+ * Check if the facilitator supports EIP-2612 gas sponsoring extension.
+ */
+function supportsEIP2612GasSponsoring(context: PaymentCreationContext): boolean {
+  return (
+    context.facilitatorSupported?.extensions?.includes(EIP2612_GAS_SPONSORING_EXTENSION) ?? false
+  );
+}
+
+/**
+ * Creates an EIP-2612 permit extension for approving Permit2 to spend tokens.
+ * This allows the facilitator to call token.permit() before settling via Permit2.
+ *
+ * @param signer - The EVM signer
+ * @param requirements - The payment requirements (contains token address and EIP-712 domain)
+ * @param nonce - The user's current nonce for the token's permit function
+ * @param deadline - When the permit expires
+ * @returns The EIP-2612 permit parameters
+ */
+async function createEIP2612PermitExtension(
+  signer: ClientEvmSigner,
+  requirements: PaymentRequirements,
+  nonce: bigint,
+  deadline: string,
+): Promise<EIP2612GasSponsoringExtension> {
+  const { name, version } = requirements.extra as { name: string; version: string };
+  const chainId = parseInt(requirements.network.split(":")[1]);
+
+  // Approve Permit2 for max uint256 (standard for permits)
+  const value = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+  const domain = {
+    name,
+    version,
+    chainId,
+    verifyingContract: getAddress(requirements.asset),
+  };
+
+  const message = {
+    owner: signer.address,
+    spender: PERMIT2_ADDRESS,
+    value,
+    nonce,
+    deadline: BigInt(deadline),
+  };
+
+  const signature = await signer.signTypedData({
+    domain,
+    types: eip2612PermitTypes,
+    primaryType: "Permit",
+    message,
+  });
+
+  // Parse signature into v, r, s
+  const r = `0x${signature.slice(2, 66)}` as `0x${string}`;
+  const s = `0x${signature.slice(66, 130)}` as `0x${string}`;
+  const v = parseInt(signature.slice(130, 132), 16);
+
+  return {
+    permit: {
+      value: value.toString(),
+      deadline,
+      v,
+      r,
+      s,
+    },
   };
 }
 

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -7,7 +7,7 @@ import { encodeFunctionData, getAddress } from "viem";
 import {
   permit2WitnessTypes,
   PERMIT2_ADDRESS,
-  x402Permit2ProxyAddress,
+  x402ExactPermit2ProxyAddress,
   eip2612PermitTypes,
 } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
@@ -63,7 +63,7 @@ export async function createPermit2Payload(
       token: getAddress(paymentRequirements.asset),
       amount: paymentRequirements.amount,
     },
-    spender: x402Permit2ProxyAddress,
+    spender: x402ExactPermit2ProxyAddress,
     nonce,
     deadline,
     witness: {

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -33,19 +33,19 @@ export class ExactEvmScheme implements SchemeNetworkClient {
    *
    * @param x402Version - The x402 protocol version
    * @param paymentRequirements - The payment requirements
-   * @param _context - Optional context for extension support (not yet implemented)
+   * @param context - Optional context for extension support
    * @returns Promise resolving to a payment payload result
    */
   async createPaymentPayload(
     x402Version: number,
     paymentRequirements: PaymentRequirements,
-    _context?: PaymentCreationContext,
+    context?: PaymentCreationContext,
   ): Promise<PaymentPayloadResult> {
     const assetTransferMethod =
       (paymentRequirements.extra?.assetTransferMethod as AssetTransferMethod) ?? "eip3009";
 
     if (assetTransferMethod === "permit2") {
-      return createPermit2Payload(this.signer, x402Version, paymentRequirements);
+      return createPermit2Payload(this.signer, x402Version, paymentRequirements, context);
     }
 
     return createEIP3009Payload(this.signer, x402Version, paymentRequirements);

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -4,15 +4,18 @@ import {
   PaymentPayloadResult,
   PaymentCreationContext,
 } from "@x402/core/types";
-import { getAddress } from "viem";
-import { authorizationTypes } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
-import { ExactEvmPayloadV2 } from "../../types";
-import { createNonce } from "../../utils";
+import { AssetTransferMethod } from "../../types";
+import { createEIP3009Payload } from "./eip3009";
+import { createPermit2Payload } from "./permit2";
 
 /**
  * EVM client implementation for the Exact payment scheme.
+ * Supports both EIP-3009 (transferWithAuthorization) and Permit2 flows.
  *
+ * Routes to the appropriate authorization method based on
+ * `requirements.extra.assetTransferMethod`. Defaults to EIP-3009
+ * for backward compatibility with older facilitators.
  */
 export class ExactEvmScheme implements SchemeNetworkClient {
   readonly scheme = "exact";
@@ -26,85 +29,25 @@ export class ExactEvmScheme implements SchemeNetworkClient {
 
   /**
    * Creates a payment payload for the Exact scheme.
+   * Routes to EIP-3009 or Permit2 based on requirements.extra.assetTransferMethod.
    *
    * @param x402Version - The x402 protocol version
    * @param paymentRequirements - The payment requirements
-   * @param _ - Optional context for extension support (not yet implemented)
+   * @param _context - Optional context for extension support (not yet implemented)
    * @returns Promise resolving to a payment payload result
    */
   async createPaymentPayload(
     x402Version: number,
     paymentRequirements: PaymentRequirements,
-    _?: PaymentCreationContext,
+    _context?: PaymentCreationContext,
   ): Promise<PaymentPayloadResult> {
-    const nonce = createNonce();
-    const now = Math.floor(Date.now() / 1000);
+    const assetTransferMethod =
+      (paymentRequirements.extra?.assetTransferMethod as AssetTransferMethod) ?? "eip3009";
 
-    const authorization: ExactEvmPayloadV2["authorization"] = {
-      from: this.signer.address,
-      to: getAddress(paymentRequirements.payTo),
-      value: paymentRequirements.amount,
-      validAfter: (now - 600).toString(), // 10 minutes before
-      validBefore: (now + paymentRequirements.maxTimeoutSeconds).toString(),
-      nonce,
-    };
-
-    // Sign the authorization
-    const signature = await this.signAuthorization(authorization, paymentRequirements);
-
-    const payload: ExactEvmPayloadV2 = {
-      authorization,
-      signature,
-    };
-
-    return {
-      x402Version,
-      payload,
-    };
-  }
-
-  /**
-   * Sign the EIP-3009 authorization using EIP-712
-   *
-   * @param authorization - The authorization to sign
-   * @param requirements - The payment requirements
-   * @returns Promise resolving to the signature
-   */
-  private async signAuthorization(
-    authorization: ExactEvmPayloadV2["authorization"],
-    requirements: PaymentRequirements,
-  ): Promise<`0x${string}`> {
-    const chainId = parseInt(requirements.network.split(":")[1]);
-
-    if (!requirements.extra?.name || !requirements.extra?.version) {
-      throw new Error(
-        `EIP-712 domain parameters (name, version) are required in payment requirements for asset ${requirements.asset}`,
-      );
+    if (assetTransferMethod === "permit2") {
+      return createPermit2Payload(this.signer, x402Version, paymentRequirements);
     }
 
-    const { name, version } = requirements.extra;
-
-    const domain = {
-      name,
-      version,
-      chainId,
-      verifyingContract: getAddress(requirements.asset),
-    };
-
-    const message = {
-      from: getAddress(authorization.from),
-      to: getAddress(authorization.to),
-      value: BigInt(authorization.value),
-      validAfter: BigInt(authorization.validAfter),
-      validBefore: BigInt(authorization.validBefore),
-      nonce: authorization.nonce,
-    };
-
-    return await this.signer.signTypedData({
-      domain,
-      types: authorizationTypes,
-      primaryType: "TransferWithAuthorization",
-      message,
-    });
+    return createEIP3009Payload(this.signer, x402Version, paymentRequirements);
   }
 }

--- a/typescript/packages/mechanisms/evm/src/index.ts
+++ b/typescript/packages/mechanisms/evm/src/index.ts
@@ -10,10 +10,29 @@
 export { ExactEvmScheme } from "./exact";
 export { toClientEvmSigner, toFacilitatorEvmSigner } from "./signer";
 export type { ClientEvmSigner, FacilitatorEvmSigner } from "./signer";
+
+// Export types
+export type {
+  AssetTransferMethod,
+  ExactEIP3009Payload,
+  ExactPermit2Payload,
+  Permit2Authorization,
+  Permit2Witness,
+  EIP2612PermitParams,
+  ExactEvmPayloadV1,
+  ExactEvmPayloadV2,
+} from "./types";
+export { isPermit2Payload, isEIP3009Payload } from "./types";
+
+// Export constants
 export {
-  x402ExactPermit2ProxyAddress,
-  x402UptoPermit2ProxyAddress,
+  authorizationTypes,
+  permit2WitnessTypes,
+  eip2612PermitTypes,
+  eip3009ABI,
   x402ExactPermit2ProxyABI,
   x402UptoPermit2ProxyABI,
+  x402ExactPermit2ProxyAddress,
+  x402UptoPermit2ProxyAddress,
   PERMIT2_ADDRESS,
 } from "./constants";

--- a/typescript/packages/mechanisms/evm/src/types.ts
+++ b/typescript/packages/mechanisms/evm/src/types.ts
@@ -1,3 +1,13 @@
+/**
+ * Asset transfer methods for the exact EVM scheme.
+ * - eip3009: Uses transferWithAuthorization (USDC, etc.) - recommended for compatible tokens
+ * - permit2: Uses Permit2 + x402Permit2Proxy - universal fallback for any ERC-20
+ */
+export type AssetTransferMethod = "eip3009" | "permit2";
+
+/**
+ * EIP-3009 payload for tokens with native transferWithAuthorization support.
+ */
 export type ExactEIP3009Payload = {
   signature?: `0x${string}`;
   authorization: {
@@ -10,6 +20,76 @@ export type ExactEIP3009Payload = {
   };
 };
 
+/**
+ * Permit2 witness data structure.
+ * Matches the Witness struct in x402Permit2Proxy contract.
+ */
+export type Permit2Witness = {
+  to: `0x${string}`;
+  validAfter: string;
+  validBefore: string;
+  extra: `0x${string}`;
+};
+
+/**
+ * Permit2 authorization parameters.
+ * Used to reconstruct the signed message for verification.
+ */
+export type Permit2Authorization = {
+  permitted: {
+    token: `0x${string}`;
+    amount: string;
+  };
+  spender: `0x${string}`;
+  nonce: string;
+  deadline: string;
+  witness: Permit2Witness;
+};
+
+/**
+ * Permit2 payload for tokens using the Permit2 + x402Permit2Proxy flow.
+ */
+export type ExactPermit2Payload = {
+  signature: `0x${string}`;
+  permit2Authorization: Permit2Authorization & {
+    from: `0x${string}`;
+  };
+};
+
+/**
+ * EIP-2612 permit parameters for gasless approval extension.
+ * Used with settleWith2612() on x402Permit2Proxy. Note that this does not support smart wallets signatures.
+ */
+export type EIP2612PermitParams = {
+  value: string;
+  deadline: string;
+  v: number;
+  r: `0x${string}`;
+  s: `0x${string}`;
+};
+
 export type ExactEvmPayloadV1 = ExactEIP3009Payload;
 
-export type ExactEvmPayloadV2 = ExactEIP3009Payload;
+export type ExactEvmPayloadV2 = ExactEIP3009Payload | ExactPermit2Payload;
+
+/**
+ * Type guard to check if a payload is a Permit2 payload.
+ * Permit2 payloads have a `permit2Authorization` field.
+ *
+ * @param payload - The payload to check.
+ * @returns True if the payload is a Permit2 payload, false otherwise.
+ */
+export function isPermit2Payload(payload: ExactEvmPayloadV2): payload is ExactPermit2Payload {
+  return "permit2Authorization" in payload;
+}
+
+/**
+ * Type guard to check if a payload is an EIP-3009 payload.
+ * EIP-3009 payloads have an `authorization` field.
+ *
+ * @param payload - The payload to check.
+ * @returns True if the payload is an EIP-3009 payload, false otherwise.
+ */
+export function isEIP3009Payload(payload: ExactEvmPayloadV2): payload is ExactEIP3009Payload {
+  return "authorization" in payload;
+}

--- a/typescript/packages/mechanisms/evm/src/utils.ts
+++ b/typescript/packages/mechanisms/evm/src/utils.ts
@@ -21,20 +21,35 @@ export function getEvmChainId(network: Network): number {
 }
 
 /**
- * Create a random 32-byte nonce for authorization
+ * Get the crypto object from the global scope.
+ *
+ * @returns The crypto object
+ * @throws Error if crypto API is not available
+ */
+function getCrypto(): Crypto {
+  const cryptoObj = globalThis.crypto as Crypto | undefined;
+  if (!cryptoObj) {
+    throw new Error("Crypto API not available");
+  }
+  return cryptoObj;
+}
+
+/**
+ * Create a random 32-byte nonce for EIP-3009 authorization.
  *
  * @returns A hex-encoded 32-byte nonce
  */
 export function createNonce(): `0x${string}` {
-  // Use dynamic import to avoid require() in ESM context
-  const cryptoObj =
-    typeof globalThis.crypto !== "undefined"
-      ? globalThis.crypto
-      : (globalThis as { crypto?: Crypto }).crypto;
+  return toHex(getCrypto().getRandomValues(new Uint8Array(32)));
+}
 
-  if (!cryptoObj) {
-    throw new Error("Crypto API not available");
-  }
-
-  return toHex(cryptoObj.getRandomValues(new Uint8Array(32)));
+/**
+ * Creates a random 256-bit nonce for Permit2.
+ * Permit2 uses uint256 nonces (not bytes32 like EIP-3009).
+ *
+ * @returns A string representation of the random nonce
+ */
+export function createPermit2Nonce(): string {
+  const randomBytes = getCrypto().getRandomValues(new Uint8Array(32));
+  return BigInt(toHex(randomBytes)).toString();
 }

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../src/exact/client/permit2";
 import type { ClientEvmSigner } from "../../../src/signer";
 import { PaymentRequirements } from "@x402/core/types";
-import { PERMIT2_ADDRESS, x402Permit2ProxyAddress } from "../../../src/constants";
+import { PERMIT2_ADDRESS, x402ExactPermit2ProxyAddress } from "../../../src/constants";
 import { isPermit2Payload, isEIP3009Payload } from "../../../src/types";
 
 describe("ExactEvmScheme (Client)", () => {
@@ -312,7 +312,7 @@ describe("ExactEvmScheme (Client)", () => {
       const result = await client.createPaymentPayload(2, requirements);
 
       expect(result.payload.permit2Authorization.spender.toLowerCase()).toBe(
-        x402Permit2ProxyAddress.toLowerCase(),
+        x402ExactPermit2ProxyAddress.toLowerCase(),
       );
     });
 

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -1,14 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ExactEvmScheme } from "../../../src/exact/client/scheme";
+import {
+  createPermit2ApprovalTx,
+  getPermit2AllowanceReadParams,
+} from "../../../src/exact/client/permit2";
 import type { ClientEvmSigner } from "../../../src/signer";
 import { PaymentRequirements } from "@x402/core/types";
+import { PERMIT2_ADDRESS, x402Permit2ProxyAddress } from "../../../src/constants";
+import { isPermit2Payload, isEIP3009Payload } from "../../../src/types";
 
 describe("ExactEvmScheme (Client)", () => {
   let client: ExactEvmScheme;
   let mockSigner: ClientEvmSigner;
 
   beforeEach(() => {
-    // Create mock signer
     mockSigner = {
       address: "0x1234567890123456789012345678901234567890",
       signTypedData: vi.fn().mockResolvedValue("0xmocksignature123456789"),
@@ -213,6 +218,277 @@ describe("ExactEvmScheme (Client)", () => {
       expect(callArgs.domain.name).toBe("USD Coin");
       expect(callArgs.domain.version).toBe("2");
       expect(callArgs.domain.chainId).toBe(8453);
+    });
+
+    describe("with assetTransferMethod", () => {
+      it("should default to EIP-3009 when assetTransferMethod is not set", async () => {
+        const requirements: PaymentRequirements = {
+          scheme: "exact",
+          network: "eip155:8453",
+          amount: "1000000",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          maxTimeoutSeconds: 300,
+          extra: { name: "USD Coin", version: "2" },
+        };
+
+        const result = await client.createPaymentPayload(2, requirements);
+
+        expect(isEIP3009Payload(result.payload)).toBe(true);
+        expect(isPermit2Payload(result.payload)).toBe(false);
+        expect(result.payload.authorization).toBeDefined();
+      });
+
+      it("should use EIP-3009 when assetTransferMethod is eip3009", async () => {
+        const requirements: PaymentRequirements = {
+          scheme: "exact",
+          network: "eip155:8453",
+          amount: "1000000",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          maxTimeoutSeconds: 300,
+          extra: { name: "USD Coin", version: "2", assetTransferMethod: "eip3009" },
+        };
+
+        const result = await client.createPaymentPayload(2, requirements);
+
+        expect(isEIP3009Payload(result.payload)).toBe(true);
+        expect(result.payload.authorization).toBeDefined();
+      });
+
+      it("should use Permit2 when assetTransferMethod is permit2", async () => {
+        const requirements: PaymentRequirements = {
+          scheme: "exact",
+          network: "eip155:8453",
+          amount: "1000000",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          maxTimeoutSeconds: 300,
+          extra: { name: "USD Coin", version: "2", assetTransferMethod: "permit2" },
+        };
+
+        const result = await client.createPaymentPayload(2, requirements);
+
+        expect(isPermit2Payload(result.payload)).toBe(true);
+        expect(isEIP3009Payload(result.payload)).toBe(false);
+        expect(result.payload.permit2Authorization).toBeDefined();
+      });
+    });
+  });
+
+  describe("createPaymentPayload with Permit2", () => {
+    it("should create Permit2 payload with correct structure", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload;
+
+      expect(isPermit2Payload(payload)).toBe(true);
+      expect(payload.signature).toBeDefined();
+      expect(payload.permit2Authorization).toBeDefined();
+      expect(payload.permit2Authorization.permitted).toBeDefined();
+      expect(payload.permit2Authorization.witness).toBeDefined();
+    });
+
+    it("should set spender to x402Permit2Proxy address", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.spender.toLowerCase()).toBe(
+        x402Permit2ProxyAddress.toLowerCase(),
+      );
+    });
+
+    it("should set witness.to to payTo address", async () => {
+      const payToAddress = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0";
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: payToAddress,
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.witness.to.toLowerCase()).toBe(
+        payToAddress.toLowerCase(),
+      );
+    });
+
+    it("should set permitted.token to asset address", async () => {
+      const assetAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: assetAddress,
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.permitted.token.toLowerCase()).toBe(
+        assetAddress.toLowerCase(),
+      );
+    });
+
+    it("should set permitted.amount to requirements.amount", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "2500000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.permitted.amount).toBe("2500000");
+    });
+
+    it("should set from to signer address", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.from).toBe(mockSigner.address);
+    });
+
+    it("should generate different nonces for each call", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result1 = await client.createPaymentPayload(2, requirements);
+      const result2 = await client.createPaymentPayload(2, requirements);
+
+      expect(result1.payload.permit2Authorization.nonce).not.toBe(
+        result2.payload.permit2Authorization.nonce,
+      );
+    });
+
+    it("should set deadline based on maxTimeoutSeconds", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 600,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const beforeTime = Math.floor(Date.now() / 1000) + 600;
+      const result = await client.createPaymentPayload(2, requirements);
+      const afterTime = Math.floor(Date.now() / 1000) + 600;
+
+      const deadline = parseInt(result.payload.permit2Authorization.deadline);
+
+      expect(deadline).toBeGreaterThanOrEqual(beforeTime);
+      expect(deadline).toBeLessThanOrEqual(afterTime + 1);
+    });
+
+    it("should pass correct EIP-712 domain for Permit2 to signTypedData", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      await client.createPaymentPayload(2, requirements);
+
+      expect(mockSigner.signTypedData).toHaveBeenCalled();
+      const callArgs = (mockSigner.signTypedData as any).mock.calls[0][0];
+      expect(callArgs.domain.name).toBe("Permit2");
+      expect(callArgs.domain.verifyingContract.toLowerCase()).toBe(PERMIT2_ADDRESS.toLowerCase());
+      expect(callArgs.domain.chainId).toBe(8453);
+    });
+  });
+});
+
+describe("Permit2 Helpers", () => {
+  describe("createPermit2ApprovalTx", () => {
+    it("should create approval transaction with correct structure", () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+      const result = createPermit2ApprovalTx(tokenAddress);
+
+      expect(result.to.toLowerCase()).toBe(tokenAddress.toLowerCase());
+      expect(result.data).toBeDefined();
+      expect(result.data.startsWith("0x")).toBe(true);
+    });
+
+    it("should encode approve function selector correctly", () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+      const result = createPermit2ApprovalTx(tokenAddress);
+
+      expect(result.data.slice(0, 10)).toBe("0x095ea7b3");
+    });
+
+    it("should include Permit2 address as spender in calldata", () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+      const result = createPermit2ApprovalTx(tokenAddress);
+
+      const spenderParam = result.data.slice(10, 74);
+      const spenderAddress = "0x" + spenderParam.slice(24);
+      expect(spenderAddress.toLowerCase()).toBe(PERMIT2_ADDRESS.toLowerCase());
+    });
+  });
+
+  describe("getPermit2AllowanceReadParams", () => {
+    it("should return correct read parameters", () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+      const ownerAddress = "0x1234567890123456789012345678901234567890";
+
+      const result = getPermit2AllowanceReadParams({ tokenAddress, ownerAddress });
+
+      expect(result.address.toLowerCase()).toBe(tokenAddress.toLowerCase());
+      expect(result.functionName).toBe("allowance");
+      expect(result.args[1]).toBe(PERMIT2_ADDRESS);
     });
   });
 });

--- a/typescript/packages/mechanisms/evm/test/unit/types.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/types.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import type { ExactEvmPayloadV1, ExactEvmPayloadV2 } from "../../src/types";
+import type {
+  ExactEvmPayloadV1,
+  ExactEvmPayloadV2,
+  ExactEIP3009Payload,
+  ExactPermit2Payload,
+} from "../../src/types";
+import { isEIP3009Payload, isPermit2Payload } from "../../src/types";
 
 describe("EVM Types", () => {
   describe("ExactEvmPayloadV1", () => {
@@ -39,7 +45,7 @@ describe("EVM Types", () => {
   });
 
   describe("ExactEvmPayloadV2", () => {
-    it("should have the same structure as V1", () => {
+    it("should accept EIP-3009 payload structure", () => {
       const payload: ExactEvmPayloadV2 = {
         signature: "0x1234567890abcdef",
         authorization: {
@@ -53,8 +59,97 @@ describe("EVM Types", () => {
       };
 
       // V2 should be compatible with V1
-      const payloadV1: ExactEvmPayloadV1 = payload;
+      const payloadV1: ExactEvmPayloadV1 = payload as ExactEIP3009Payload;
       expect(payloadV1).toEqual(payload);
+    });
+
+    it("should accept Permit2 payload structure", () => {
+      const payload: ExactPermit2Payload = {
+        signature: "0x1234567890abcdef",
+        permit2Authorization: {
+          from: "0x1234567890123456789012345678901234567890",
+          permitted: {
+            token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            amount: "100000",
+          },
+          spender: "0x9876543210987654321098765432109876543210",
+          nonce: "12345678901234567890",
+          deadline: "1234567890",
+          witness: {
+            to: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+            validAfter: "1234567800",
+            validBefore: "1234567890",
+            extra: "0x",
+          },
+        },
+      };
+
+      expect(payload.signature).toBeDefined();
+      expect(payload.permit2Authorization.from).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(payload.permit2Authorization.permitted.token).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(payload.permit2Authorization.witness.to).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    });
+  });
+
+  describe("Type Guards", () => {
+    const eip3009Payload: ExactEIP3009Payload = {
+      signature: "0x1234567890abcdef",
+      authorization: {
+        from: "0x1234567890123456789012345678901234567890",
+        to: "0x9876543210987654321098765432109876543210",
+        value: "100000",
+        validAfter: "1234567890",
+        validBefore: "1234567890",
+        nonce: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      },
+    };
+
+    const permit2Payload: ExactPermit2Payload = {
+      signature: "0x1234567890abcdef",
+      permit2Authorization: {
+        from: "0x1234567890123456789012345678901234567890",
+        permitted: {
+          token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          amount: "100000",
+        },
+        spender: "0x9876543210987654321098765432109876543210",
+        nonce: "12345678901234567890",
+        deadline: "1234567890",
+        witness: {
+          to: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          validAfter: "1234567800",
+          validBefore: "1234567890",
+          extra: "0x",
+        },
+      },
+    };
+
+    describe("isEIP3009Payload", () => {
+      it("should return true for EIP-3009 payload", () => {
+        expect(isEIP3009Payload(eip3009Payload)).toBe(true);
+      });
+
+      it("should return false for Permit2 payload", () => {
+        expect(isEIP3009Payload(permit2Payload)).toBe(false);
+      });
+    });
+
+    describe("isPermit2Payload", () => {
+      it("should return true for Permit2 payload", () => {
+        expect(isPermit2Payload(permit2Payload)).toBe(true);
+      });
+
+      it("should return false for EIP-3009 payload", () => {
+        expect(isPermit2Payload(eip3009Payload)).toBe(false);
+      });
+    });
+
+    it("type guards should be mutually exclusive", () => {
+      const eip3009: ExactEvmPayloadV2 = eip3009Payload;
+      const permit2: ExactEvmPayloadV2 = permit2Payload;
+
+      expect(isEIP3009Payload(eip3009)).toBe(!isPermit2Payload(eip3009));
+      expect(isPermit2Payload(permit2)).toBe(!isEIP3009Payload(permit2));
     });
   });
 });


### PR DESCRIPTION
Adds client-side Permit2 support to the EVM mechanism, enabling an alternative token transfer method alongside existing EIP-3009 (`transferWithAuthorization`). Also introduces infrastructure for extension data to flow from client hooks to mechanisms.

### Changes

#### Core Infrastructure (`@x402/core`)

- **`PaymentCreationContext`**: Added `extensionData?: Record<string, unknown>` - allows mechanisms to receive data populated by hooks
- **`PaymentCreationHookContext`**: Added mutable `extensionData` field - hooks can populate extension-specific data (e.g., EIP-2612 nonce)
- **`x402Client`**: Pass `extensionData` from hooks through to mechanism context

#### Types & Constants (`@x402/evm`)

- Add `ExactPermit2Payload` and `Permit2Authorization` types
- Add `AssetTransferMethod` enum (`"eip3009"` | `"permit2"`)
- Add `isPermit2Payload()` and `isEIP3009Payload()` type guards
- Add Permit2 contract address, `x402ExactPermit2ProxyAddress`, and EIP-712 type definitions

#### Client Implementation (`@x402/evm`)

- **`scheme.ts`**: Routes to correct implementation based on `requirements.extra.assetTransferMethod`
- **`eip3009.ts`**: Extracted EIP-3009 payload creation (refactor)
- **`permit2.ts`**: New Permit2 payload creation with:
  - `createPermit2Payload()` - Creates signed Permit2 payloads with witness data
  - `createPermit2ApprovalTx()` - Helper to build ERC20 approval transaction for Permit2
  - `getPermit2AllowanceReadParams()` - Helper to check current Permit2 allowance
  - EIP-2612 gas sponsoring extension support (spec-compliant `info` schema)

#### Extension Support

- **`EIP2612GasSponsoringExtension`**: Matches spec schema with `info` object containing `from`, `asset`, `spender`, `amount`, `nonce`, `deadline`, `signature`, `version`
- **`EIP2612GasSponsoringInput`**: Type for hooks to provide nonce data
- Extension creation is triggered when hooks populate `extensionData["eip2612GasSponsoring"]`

### Usage

```typescript
import { x402Client } from "@x402/core";
import { ExactEvmScheme, EIP2612_GAS_SPONSORING_EXTENSION } from "@x402/evm";

const client = new x402Client()
  .register("eip155:84532", new ExactEvmScheme(signer))
  .onBeforePaymentCreation(async (ctx) => {
    // Check facilitator support and payment type
    const isPermit2 = ctx.selectedRequirements.extra?.assetTransferMethod === "permit2";
    const supported = ctx.facilitatorSupported?.extensions?.includes(EIP2612_GAS_SPONSORING_EXTENSION);
    
    if (isPermit2 && supported) {
      const nonce = await fetchEIP2612Nonce(ctx.selectedRequirements.asset, signer.address);
      ctx.extensionData[EIP2612_GAS_SPONSORING_EXTENSION] = { nonce };
    }
  });

// Payment creation automatically includes extension if extensionData is populated
const payload = await client.createPaymentPayload(paymentRequired, facilitatorSupported);
```

### Tests

- Unit tests

### Breaking Changes

None. EIP-3009 remains the default behavior when `assetTransferMethod` is not specified.

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 