### PR TITLE
feat: Add extra field to ResourceConfig for assetTransferMethod

### DIFF
--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -21,6 +21,7 @@ export interface ResourceConfig {
   price: Price;
   network: Network;
   maxTimeoutSeconds?: number;
+  extra?: Record<string, unknown>;
 }
 
 /**
@@ -426,6 +427,7 @@ export class x402ResourceServer {
       maxTimeoutSeconds: resourceConfig.maxTimeoutSeconds || 300, // Default 5 minutes
       extra: {
         ...parsedPrice.extra,
+        ...resourceConfig.extra,
       },
     };
 
@@ -459,6 +461,7 @@ export class x402ResourceServer {
       price: Price | ((context: TContext) => Price | Promise<Price>);
       network: Network;
       maxTimeoutSeconds?: number;
+      extra?: Record<string, unknown>;
     }>,
     context: TContext,
   ): Promise<PaymentRequirements[]> {
@@ -477,6 +480,7 @@ export class x402ResourceServer {
         price: resolvedPrice,
         network: option.network,
         maxTimeoutSeconds: option.maxTimeoutSeconds,
+        extra: option.extra,
       };
 
       // Use existing buildPaymentRequirements for each option


### PR DESCRIPTION
## Description

Adds an `extra` field to `ResourceConfig` that passes through to `PaymentRequirements`, enabling servers to specify `assetTransferMethod` preference.

### Changes
- Add `extra?: Record<string, unknown>` to `ResourceConfig` interface
- Pass `extra` through `buildPaymentRequirementsFromOptions()`
- Merge `extra` into payment requirements in `buildPaymentRequirements()`

### Usage

```typescript
const server = createX402Server({
  // ...
  resources: [{
    path: "/api/premium",
    price: "$0.01",
    extra: {
      assetTransferMethod: "permit2"  // or "eip3009" (default)
    }
  }]
});
```

### Breaking Changes
None - `extra` is optional.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 