### PR TITLE
feat: Add Permit2 verification and settlement in facilitator

### DIFF
--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -21,6 +21,7 @@ export interface ResourceConfig {
   price: Price;
   network: Network;
   maxTimeoutSeconds?: number;
+  extra?: Record<string, unknown>;
 }
 
 /**
@@ -426,6 +427,7 @@ export class x402ResourceServer {
       maxTimeoutSeconds: resourceConfig.maxTimeoutSeconds || 300, // Default 5 minutes
       extra: {
         ...parsedPrice.extra,
+        ...resourceConfig.extra,
       },
     };
 
@@ -459,6 +461,7 @@ export class x402ResourceServer {
       price: Price | ((context: TContext) => Price | Promise<Price>);
       network: Network;
       maxTimeoutSeconds?: number;
+      extra?: Record<string, unknown>;
     }>,
     context: TContext,
   ): Promise<PaymentRequirements[]> {
@@ -477,6 +480,7 @@ export class x402ResourceServer {
         price: resolvedPrice,
         network: option.network,
         maxTimeoutSeconds: option.maxTimeoutSeconds,
+        extra: option.extra,
       };
 
       // Use existing buildPaymentRequirements for each option

--- a/typescript/packages/mechanisms/evm/src/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/constants.ts
@@ -10,6 +10,44 @@ export const authorizationTypes = {
   ],
 } as const;
 
+/**
+ * Permit2 EIP-712 types for signing PermitWitnessTransferFrom.
+ * Must match the exact format expected by the Permit2 contract.
+ */
+export const permit2WitnessTypes = {
+  PermitWitnessTransferFrom: [
+    { name: "permitted", type: "TokenPermissions" },
+    { name: "spender", type: "address" },
+    { name: "nonce", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+    { name: "witness", type: "Witness" },
+  ],
+  TokenPermissions: [
+    { name: "token", type: "address" },
+    { name: "amount", type: "uint256" },
+  ],
+  Witness: [
+    { name: "extra", type: "bytes" },
+    { name: "to", type: "address" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+} as const;
+
+/**
+ * EIP-2612 permit types for gasless approval signatures.
+ * Used with the eip2612GasSponsoring extension.
+ */
+export const eip2612PermitTypes = {
+  Permit: [
+    { name: "owner", type: "address" },
+    { name: "spender", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "nonce", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+  ],
+} as const;
+
 // EIP3009 ABI for transferWithAuthorization function
 export const eip3009ABI = [
   {

--- a/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
@@ -1,0 +1,91 @@
+import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import { getAddress } from "viem";
+import { authorizationTypes } from "../../constants";
+import { ClientEvmSigner } from "../../signer";
+import { ExactEIP3009Payload } from "../../types";
+import { createNonce } from "../../utils";
+
+/**
+ * Creates an EIP-3009 (transferWithAuthorization) payload.
+ *
+ * @param signer - The EVM signer for client operations
+ * @param x402Version - The x402 protocol version
+ * @param paymentRequirements - The payment requirements
+ * @returns Promise resolving to a payment payload result
+ */
+export async function createEIP3009Payload(
+  signer: ClientEvmSigner,
+  x402Version: number,
+  paymentRequirements: PaymentRequirements,
+): Promise<PaymentPayloadResult> {
+  const nonce = createNonce();
+  const now = Math.floor(Date.now() / 1000);
+
+  const authorization: ExactEIP3009Payload["authorization"] = {
+    from: signer.address,
+    to: getAddress(paymentRequirements.payTo),
+    value: paymentRequirements.amount,
+    validAfter: (now - 600).toString(),
+    validBefore: (now + paymentRequirements.maxTimeoutSeconds).toString(),
+    nonce,
+  };
+
+  const signature = await signEIP3009Authorization(signer, authorization, paymentRequirements);
+
+  const payload: ExactEIP3009Payload = {
+    authorization,
+    signature,
+  };
+
+  return {
+    x402Version,
+    payload,
+  };
+}
+
+/**
+ * Sign the EIP-3009 authorization using EIP-712.
+ *
+ * @param signer - The EVM signer
+ * @param authorization - The authorization to sign
+ * @param requirements - The payment requirements
+ * @returns Promise resolving to the signature
+ */
+async function signEIP3009Authorization(
+  signer: ClientEvmSigner,
+  authorization: ExactEIP3009Payload["authorization"],
+  requirements: PaymentRequirements,
+): Promise<`0x${string}`> {
+  const chainId = parseInt(requirements.network.split(":")[1]);
+
+  if (!requirements.extra?.name || !requirements.extra?.version) {
+    throw new Error(
+      `EIP-712 domain parameters (name, version) are required in payment requirements for asset ${requirements.asset}`,
+    );
+  }
+
+  const { name, version } = requirements.extra;
+
+  const domain = {
+    name,
+    version,
+    chainId,
+    verifyingContract: getAddress(requirements.asset),
+  };
+
+  const message = {
+    from: getAddress(authorization.from),
+    to: getAddress(authorization.to),
+    value: BigInt(authorization.value),
+    validAfter: BigInt(authorization.validAfter),
+    validBefore: BigInt(authorization.validBefore),
+    nonce: authorization.nonce,
+  };
+
+  return await signer.signTypedData({
+    domain,
+    types: authorizationTypes,
+    primaryType: "TransferWithAuthorization",
+    message,
+  });
+}

--- a/typescript/packages/mechanisms/evm/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/index.ts
@@ -4,4 +4,8 @@ export type { EvmClientConfig } from "./register";
 export {
   EIP2612_GAS_SPONSORING_EXTENSION,
   type EIP2612GasSponsoringExtension,
+  createPermit2ApprovalTx,
+  getPermit2AllowanceReadParams,
+  erc20AllowanceAbi,
+  type Permit2AllowanceParams,
 } from "./permit2";

--- a/typescript/packages/mechanisms/evm/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/index.ts
@@ -1,3 +1,7 @@
 export { ExactEvmScheme } from "./scheme";
 export { registerExactEvmScheme } from "./register";
 export type { EvmClientConfig } from "./register";
+export {
+  EIP2612_GAS_SPONSORING_EXTENSION,
+  type EIP2612GasSponsoringExtension,
+} from "./permit2";

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -1,0 +1,108 @@
+import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import { getAddress } from "viem";
+import { permit2WitnessTypes, PERMIT2_ADDRESS, x402Permit2ProxyAddress } from "../../constants";
+import { ClientEvmSigner } from "../../signer";
+import { ExactPermit2Payload } from "../../types";
+import { createPermit2Nonce } from "../../utils";
+
+/**
+ * Creates a Permit2 payload using the x402Permit2Proxy witness pattern.
+ * The spender is set to x402Permit2Proxy, which enforces that funds
+ * can only be sent to the witness.to address.
+ *
+ * @param signer - The EVM signer for client operations
+ * @param x402Version - The x402 protocol version
+ * @param paymentRequirements - The payment requirements
+ * @returns Promise resolving to a payment payload result
+ */
+export async function createPermit2Payload(
+  signer: ClientEvmSigner,
+  x402Version: number,
+  paymentRequirements: PaymentRequirements,
+): Promise<PaymentPayloadResult> {
+  const now = Math.floor(Date.now() / 1000);
+  const nonce = createPermit2Nonce();
+
+  const validAfter = (now - 600).toString();
+  const validBefore = (now + paymentRequirements.maxTimeoutSeconds).toString();
+  const deadline = validBefore;
+
+  const permit2Authorization: ExactPermit2Payload["permit2Authorization"] = {
+    from: signer.address,
+    permitted: {
+      token: getAddress(paymentRequirements.asset),
+      amount: paymentRequirements.amount,
+    },
+    spender: x402Permit2ProxyAddress,
+    nonce,
+    deadline,
+    witness: {
+      to: getAddress(paymentRequirements.payTo),
+      validAfter,
+      validBefore,
+      extra: "0x",
+    },
+  };
+
+  const signature = await signPermit2Authorization(
+    signer,
+    permit2Authorization,
+    paymentRequirements,
+  );
+
+  const payload: ExactPermit2Payload = {
+    signature,
+    permit2Authorization,
+  };
+
+  return {
+    x402Version,
+    payload,
+  };
+}
+
+/**
+ * Sign the Permit2 authorization using EIP-712 with witness data.
+ * The signature authorizes the x402Permit2Proxy to transfer tokens on behalf of the signer.
+ *
+ * @param signer - The EVM signer
+ * @param permit2Authorization - The Permit2 authorization parameters
+ * @param requirements - The payment requirements
+ * @returns Promise resolving to the signature
+ */
+async function signPermit2Authorization(
+  signer: ClientEvmSigner,
+  permit2Authorization: ExactPermit2Payload["permit2Authorization"],
+  requirements: PaymentRequirements,
+): Promise<`0x${string}`> {
+  const chainId = parseInt(requirements.network.split(":")[1]);
+
+  const domain = {
+    name: "Permit2",
+    chainId,
+    verifyingContract: PERMIT2_ADDRESS,
+  };
+
+  const message = {
+    permitted: {
+      token: getAddress(permit2Authorization.permitted.token),
+      amount: BigInt(permit2Authorization.permitted.amount),
+    },
+    spender: getAddress(permit2Authorization.spender),
+    nonce: BigInt(permit2Authorization.nonce),
+    deadline: BigInt(permit2Authorization.deadline),
+    witness: {
+      extra: permit2Authorization.witness.extra,
+      to: getAddress(permit2Authorization.witness.to),
+      validAfter: BigInt(permit2Authorization.witness.validAfter),
+      validBefore: BigInt(permit2Authorization.witness.validBefore),
+    },
+  };
+
+  return await signer.signTypedData({
+    domain,
+    types: permit2WitnessTypes,
+    primaryType: "PermitWitnessTransferFrom",
+    message,
+  });
+}

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -1,24 +1,51 @@
-import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import {
+  PaymentRequirements,
+  PaymentPayloadResult,
+  PaymentCreationContext,
+} from "@x402/core/types";
 import { getAddress } from "viem";
-import { permit2WitnessTypes, PERMIT2_ADDRESS, x402Permit2ProxyAddress } from "../../constants";
+import {
+  permit2WitnessTypes,
+  PERMIT2_ADDRESS,
+  x402Permit2ProxyAddress,
+  eip2612PermitTypes,
+} from "../../constants";
 import { ClientEvmSigner } from "../../signer";
-import { ExactPermit2Payload } from "../../types";
+import { EIP2612PermitParams, ExactPermit2Payload } from "../../types";
 import { createPermit2Nonce } from "../../utils";
+
+/**
+ * Extension name for EIP-2612 gas sponsoring
+ */
+export const EIP2612_GAS_SPONSORING_EXTENSION = "eip2612GasSponsoring";
+
+/**
+ * Extension data for eip2612GasSponsoring.
+ * Contains the EIP-2612 permit signature to approve Permit2.
+ */
+export interface EIP2612GasSponsoringExtension {
+  permit: EIP2612PermitParams;
+}
 
 /**
  * Creates a Permit2 payload using the x402Permit2Proxy witness pattern.
  * The spender is set to x402Permit2Proxy, which enforces that funds
  * can only be sent to the witness.to address.
  *
+ * If the facilitator supports eip2612GasSponsoring and the user provides
+ * an EIP-2612 nonce, an approval permit will be included in extensions.
+ *
  * @param signer - The EVM signer for client operations
  * @param x402Version - The x402 protocol version
  * @param paymentRequirements - The payment requirements
+ * @param context - Optional context with facilitator info and EIP-2612 nonce
  * @returns Promise resolving to a payment payload result
  */
 export async function createPermit2Payload(
   signer: ClientEvmSigner,
   x402Version: number,
   paymentRequirements: PaymentRequirements,
+  context?: PaymentCreationContext & { eip2612Nonce?: bigint },
 ): Promise<PaymentPayloadResult> {
   const now = Math.floor(Date.now() / 1000);
   const nonce = createPermit2Nonce();
@@ -55,9 +82,93 @@ export async function createPermit2Payload(
     permit2Authorization,
   };
 
-  return {
+  const result: PaymentPayloadResult = {
     x402Version,
     payload,
+  };
+
+  // Add EIP-2612 permit extension if facilitator supports it and nonce is provided
+  if (context?.eip2612Nonce !== undefined && supportsEIP2612GasSponsoring(context)) {
+    const permitExtension = await createEIP2612PermitExtension(
+      signer,
+      paymentRequirements,
+      context.eip2612Nonce,
+      permit2Authorization.deadline,
+    );
+    result.extensions = {
+      [EIP2612_GAS_SPONSORING_EXTENSION]: permitExtension,
+    };
+  }
+
+  return result;
+}
+
+/**
+ * Check if the facilitator supports EIP-2612 gas sponsoring extension.
+ */
+function supportsEIP2612GasSponsoring(context: PaymentCreationContext): boolean {
+  return (
+    context.facilitatorSupported?.extensions?.includes(EIP2612_GAS_SPONSORING_EXTENSION) ?? false
+  );
+}
+
+/**
+ * Creates an EIP-2612 permit extension for approving Permit2 to spend tokens.
+ * This allows the facilitator to call token.permit() before settling via Permit2.
+ *
+ * @param signer - The EVM signer
+ * @param requirements - The payment requirements (contains token address and EIP-712 domain)
+ * @param nonce - The user's current nonce for the token's permit function
+ * @param deadline - When the permit expires
+ * @returns The EIP-2612 permit parameters
+ */
+async function createEIP2612PermitExtension(
+  signer: ClientEvmSigner,
+  requirements: PaymentRequirements,
+  nonce: bigint,
+  deadline: string,
+): Promise<EIP2612GasSponsoringExtension> {
+  const { name, version } = requirements.extra as { name: string; version: string };
+  const chainId = parseInt(requirements.network.split(":")[1]);
+
+  // Approve Permit2 for max uint256 (standard for permits)
+  const value = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+  const domain = {
+    name,
+    version,
+    chainId,
+    verifyingContract: getAddress(requirements.asset),
+  };
+
+  const message = {
+    owner: signer.address,
+    spender: PERMIT2_ADDRESS,
+    value,
+    nonce,
+    deadline: BigInt(deadline),
+  };
+
+  const signature = await signer.signTypedData({
+    domain,
+    types: eip2612PermitTypes,
+    primaryType: "Permit",
+    message,
+  });
+
+  // Parse signature into v, r, s
+  const r = `0x${signature.slice(2, 66)}` as `0x${string}`;
+  const s = `0x${signature.slice(66, 130)}` as `0x${string}`;
+  const v = parseInt(signature.slice(130, 132), 16);
+
+  return {
+    permit: {
+      value: value.toString(),
+      deadline,
+      v,
+      r,
+      s,
+    },
   };
 }
 

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -7,7 +7,7 @@ import { encodeFunctionData, getAddress } from "viem";
 import {
   permit2WitnessTypes,
   PERMIT2_ADDRESS,
-  x402Permit2ProxyAddress,
+  x402ExactPermit2ProxyAddress,
   eip2612PermitTypes,
 } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
@@ -63,7 +63,7 @@ export async function createPermit2Payload(
       token: getAddress(paymentRequirements.asset),
       amount: paymentRequirements.amount,
     },
-    spender: x402Permit2ProxyAddress,
+    spender: x402ExactPermit2ProxyAddress,
     nonce,
     deadline,
     witness: {

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -33,19 +33,19 @@ export class ExactEvmScheme implements SchemeNetworkClient {
    *
    * @param x402Version - The x402 protocol version
    * @param paymentRequirements - The payment requirements
-   * @param _context - Optional context for extension support (not yet implemented)
+   * @param context - Optional context for extension support
    * @returns Promise resolving to a payment payload result
    */
   async createPaymentPayload(
     x402Version: number,
     paymentRequirements: PaymentRequirements,
-    _context?: PaymentCreationContext,
+    context?: PaymentCreationContext,
   ): Promise<PaymentPayloadResult> {
     const assetTransferMethod =
       (paymentRequirements.extra?.assetTransferMethod as AssetTransferMethod) ?? "eip3009";
 
     if (assetTransferMethod === "permit2") {
-      return createPermit2Payload(this.signer, x402Version, paymentRequirements);
+      return createPermit2Payload(this.signer, x402Version, paymentRequirements, context);
     }
 
     return createEIP3009Payload(this.signer, x402Version, paymentRequirements);

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -4,15 +4,18 @@ import {
   PaymentPayloadResult,
   PaymentCreationContext,
 } from "@x402/core/types";
-import { getAddress } from "viem";
-import { authorizationTypes } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
-import { ExactEvmPayloadV2 } from "../../types";
-import { createNonce } from "../../utils";
+import { AssetTransferMethod } from "../../types";
+import { createEIP3009Payload } from "./eip3009";
+import { createPermit2Payload } from "./permit2";
 
 /**
  * EVM client implementation for the Exact payment scheme.
+ * Supports both EIP-3009 (transferWithAuthorization) and Permit2 flows.
  *
+ * Routes to the appropriate authorization method based on
+ * `requirements.extra.assetTransferMethod`. Defaults to EIP-3009
+ * for backward compatibility with older facilitators.
  */
 export class ExactEvmScheme implements SchemeNetworkClient {
   readonly scheme = "exact";
@@ -26,85 +29,25 @@ export class ExactEvmScheme implements SchemeNetworkClient {
 
   /**
    * Creates a payment payload for the Exact scheme.
+   * Routes to EIP-3009 or Permit2 based on requirements.extra.assetTransferMethod.
    *
    * @param x402Version - The x402 protocol version
    * @param paymentRequirements - The payment requirements
-   * @param _ - Optional context for extension support (not yet implemented)
+   * @param _context - Optional context for extension support (not yet implemented)
    * @returns Promise resolving to a payment payload result
    */
   async createPaymentPayload(
     x402Version: number,
     paymentRequirements: PaymentRequirements,
-    _?: PaymentCreationContext,
+    _context?: PaymentCreationContext,
   ): Promise<PaymentPayloadResult> {
-    const nonce = createNonce();
-    const now = Math.floor(Date.now() / 1000);
+    const assetTransferMethod =
+      (paymentRequirements.extra?.assetTransferMethod as AssetTransferMethod) ?? "eip3009";
 
-    const authorization: ExactEvmPayloadV2["authorization"] = {
-      from: this.signer.address,
-      to: getAddress(paymentRequirements.payTo),
-      value: paymentRequirements.amount,
-      validAfter: (now - 600).toString(), // 10 minutes before
-      validBefore: (now + paymentRequirements.maxTimeoutSeconds).toString(),
-      nonce,
-    };
-
-    // Sign the authorization
-    const signature = await this.signAuthorization(authorization, paymentRequirements);
-
-    const payload: ExactEvmPayloadV2 = {
-      authorization,
-      signature,
-    };
-
-    return {
-      x402Version,
-      payload,
-    };
-  }
-
-  /**
-   * Sign the EIP-3009 authorization using EIP-712
-   *
-   * @param authorization - The authorization to sign
-   * @param requirements - The payment requirements
-   * @returns Promise resolving to the signature
-   */
-  private async signAuthorization(
-    authorization: ExactEvmPayloadV2["authorization"],
-    requirements: PaymentRequirements,
-  ): Promise<`0x${string}`> {
-    const chainId = parseInt(requirements.network.split(":")[1]);
-
-    if (!requirements.extra?.name || !requirements.extra?.version) {
-      throw new Error(
-        `EIP-712 domain parameters (name, version) are required in payment requirements for asset ${requirements.asset}`,
-      );
+    if (assetTransferMethod === "permit2") {
+      return createPermit2Payload(this.signer, x402Version, paymentRequirements);
     }
 
-    const { name, version } = requirements.extra;
-
-    const domain = {
-      name,
-      version,
-      chainId,
-      verifyingContract: getAddress(requirements.asset),
-    };
-
-    const message = {
-      from: getAddress(authorization.from),
-      to: getAddress(authorization.to),
-      value: BigInt(authorization.value),
-      validAfter: BigInt(authorization.validAfter),
-      validBefore: BigInt(authorization.validBefore),
-      nonce: authorization.nonce,
-    };
-
-    return await this.signer.signTypedData({
-      domain,
-      types: authorizationTypes,
-      primaryType: "TransferWithAuthorization",
-      message,
-    });
+    return createEIP3009Payload(this.signer, x402Version, paymentRequirements);
   }
 }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -1,0 +1,367 @@
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import { getAddress, Hex, isAddressEqual, parseErc6492Signature, parseSignature } from "viem";
+import { authorizationTypes, eip3009ABI } from "../../constants";
+import { FacilitatorEvmSigner } from "../../signer";
+import { ExactEIP3009Payload } from "../../types";
+
+/**
+ * Verifies an EIP-3009 (transferWithAuthorization) payment payload.
+ *
+ * @param signer - The EVM signer for facilitator operations
+ * @param payload - The payment payload to verify
+ * @param requirements - The payment requirements
+ * @param eip3009Payload - The EIP-3009 specific payload data
+ * @returns Promise resolving to verification response
+ */
+export async function verifyEIP3009(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  eip3009Payload: ExactEIP3009Payload,
+): Promise<VerifyResponse> {
+  const payer = eip3009Payload.authorization.from;
+
+  // Verify scheme matches
+  if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
+    return {
+      isValid: false,
+      invalidReason: "unsupported_scheme",
+      payer,
+    };
+  }
+
+  // Get chain configuration
+  if (!requirements.extra?.name || !requirements.extra?.version) {
+    return {
+      isValid: false,
+      invalidReason: "missing_eip712_domain",
+      payer,
+    };
+  }
+
+  const { name, version } = requirements.extra;
+  const erc20Address = getAddress(requirements.asset);
+
+  // Verify network matches
+  if (payload.accepted.network !== requirements.network) {
+    return {
+      isValid: false,
+      invalidReason: "network_mismatch",
+      payer,
+    };
+  }
+
+  // Build typed data for signature verification
+  const permitTypedData = {
+    types: authorizationTypes,
+    primaryType: "TransferWithAuthorization" as const,
+    domain: {
+      name,
+      version,
+      chainId: parseInt(requirements.network.split(":")[1]),
+      verifyingContract: erc20Address,
+    },
+    message: {
+      from: eip3009Payload.authorization.from,
+      to: eip3009Payload.authorization.to,
+      value: BigInt(eip3009Payload.authorization.value),
+      validAfter: BigInt(eip3009Payload.authorization.validAfter),
+      validBefore: BigInt(eip3009Payload.authorization.validBefore),
+      nonce: eip3009Payload.authorization.nonce,
+    },
+  };
+
+  // Verify signature
+  try {
+    const recoveredAddress = await signer.verifyTypedData({
+      address: eip3009Payload.authorization.from,
+      ...permitTypedData,
+      signature: eip3009Payload.signature!,
+    });
+
+    if (!recoveredAddress) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_evm_payload_signature",
+        payer,
+      };
+    }
+  } catch {
+    // Signature verification failed - could be an undeployed smart wallet
+    // Check if smart wallet is deployed
+    const signature = eip3009Payload.signature!;
+    const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
+    const isSmartWallet = signatureLength > 130; // 65 bytes = 130 hex chars for EOA
+
+    if (isSmartWallet) {
+      const payerAddress = eip3009Payload.authorization.from;
+      const bytecode = await signer.getCode({ address: payerAddress });
+
+      if (!bytecode || bytecode === "0x") {
+        // Wallet is not deployed. Check if it's EIP-6492 with deployment info.
+        // EIP-6492 signatures contain factory address and calldata needed for deployment.
+        // Non-EIP-6492 undeployed wallets cannot succeed (no way to deploy them).
+        const erc6492Data = parseErc6492Signature(signature);
+        const hasDeploymentInfo =
+          erc6492Data.address &&
+          erc6492Data.data &&
+          !isAddressEqual(erc6492Data.address, "0x0000000000000000000000000000000000000000");
+
+        if (!hasDeploymentInfo) {
+          // Non-EIP-6492 undeployed smart wallet - will always fail at settlement
+          // since EIP-3009 requires on-chain EIP-1271 validation
+          return {
+            isValid: false,
+            invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
+            payer: payerAddress,
+          };
+        }
+        // EIP-6492 signature with deployment info - allow through
+        // Facilitators with sponsored deployment support can handle this in settle()
+      } else {
+        // Wallet is deployed but signature still failed - invalid signature
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_evm_payload_signature",
+          payer,
+        };
+      }
+    } else {
+      // EOA signature failed
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_evm_payload_signature",
+        payer,
+      };
+    }
+  }
+
+  // Verify payment recipient matches
+  if (getAddress(eip3009Payload.authorization.to) !== getAddress(requirements.payTo)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_exact_evm_payload_recipient_mismatch",
+      payer,
+    };
+  }
+
+  // Verify validBefore is in the future (with 6 second buffer for block time)
+  const now = Math.floor(Date.now() / 1000);
+  if (BigInt(eip3009Payload.authorization.validBefore) < BigInt(now + 6)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_exact_evm_payload_authorization_valid_before",
+      payer,
+    };
+  }
+
+  // Verify validAfter is not in the future
+  if (BigInt(eip3009Payload.authorization.validAfter) > BigInt(now)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_exact_evm_payload_authorization_valid_after",
+      payer,
+    };
+  }
+
+  // Check balance
+  try {
+    const balance = (await signer.readContract({
+      address: erc20Address,
+      abi: eip3009ABI,
+      functionName: "balanceOf",
+      args: [eip3009Payload.authorization.from],
+    })) as bigint;
+
+    if (BigInt(balance) < BigInt(requirements.amount)) {
+      return {
+        isValid: false,
+        invalidReason: "insufficient_funds",
+        payer,
+      };
+    }
+  } catch {
+    // If we can't check balance, continue with other validations
+  }
+
+  // Verify amount is sufficient
+  if (BigInt(eip3009Payload.authorization.value) < BigInt(requirements.amount)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_exact_evm_payload_authorization_value",
+      payer,
+    };
+  }
+
+  return {
+    isValid: true,
+    invalidReason: undefined,
+    payer,
+  };
+}
+
+/**
+ * Configuration for EIP-3009 settlement.
+ */
+export interface EIP3009SettleConfig {
+  /**
+   * If enabled, the facilitator will deploy ERC-4337 smart wallets
+   * via EIP-6492 when encountering undeployed contract signatures.
+   */
+  deployERC4337WithEIP6492: boolean;
+}
+
+/**
+ * Settles an EIP-3009 (transferWithAuthorization) payment by executing the transfer.
+ *
+ * @param signer - The EVM signer for facilitator operations
+ * @param config - Configuration for settlement
+ * @param payload - The payment payload to settle
+ * @param requirements - The payment requirements
+ * @param eip3009Payload - The EIP-3009 specific payload data
+ * @param verifyFn - Function to verify the payload before settling
+ * @returns Promise resolving to settlement response
+ */
+export async function settleEIP3009(
+  signer: FacilitatorEvmSigner,
+  config: EIP3009SettleConfig,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  eip3009Payload: ExactEIP3009Payload,
+  verifyFn: () => Promise<VerifyResponse>,
+): Promise<SettleResponse> {
+  const payer = eip3009Payload.authorization.from;
+
+  // Re-verify before settling
+  const valid = await verifyFn();
+  if (!valid.isValid) {
+    return {
+      success: false,
+      network: payload.accepted.network,
+      transaction: "",
+      errorReason: valid.invalidReason ?? "invalid_scheme",
+      payer,
+    };
+  }
+
+  try {
+    // Parse ERC-6492 signature if applicable
+    const parseResult = parseErc6492Signature(eip3009Payload.signature!);
+    const { signature, address: factoryAddress, data: factoryCalldata } = parseResult;
+
+    // Deploy ERC-4337 smart wallet via EIP-6492 if configured and needed
+    if (
+      config.deployERC4337WithEIP6492 &&
+      factoryAddress &&
+      factoryCalldata &&
+      !isAddressEqual(factoryAddress, "0x0000000000000000000000000000000000000000")
+    ) {
+      // Check if smart wallet is already deployed
+      const payerAddress = eip3009Payload.authorization.from;
+      const bytecode = await signer.getCode({ address: payerAddress });
+
+      if (!bytecode || bytecode === "0x") {
+        // Wallet not deployed - attempt deployment
+        try {
+          console.log(`Deploying ERC-4337 smart wallet for ${payerAddress} via EIP-6492`);
+
+          // Send the factory calldata directly as a transaction
+          // The factoryCalldata already contains the complete encoded function call
+          const deployTx = await signer.sendTransaction({
+            to: factoryAddress as Hex,
+            data: factoryCalldata as Hex,
+          });
+
+          // Wait for deployment transaction
+          await signer.waitForTransactionReceipt({ hash: deployTx });
+          console.log(`Successfully deployed smart wallet for ${payerAddress}`);
+        } catch (deployError) {
+          console.error("Smart wallet deployment failed:", deployError);
+          // Deployment failed - cannot proceed
+          throw deployError;
+        }
+      } else {
+        console.log(`Smart wallet for ${payerAddress} already deployed, skipping deployment`);
+      }
+    }
+
+    // Determine if this is an ECDSA signature (EOA) or smart wallet signature
+    // ECDSA signatures are exactly 65 bytes (130 hex chars without 0x)
+    const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
+    const isECDSA = signatureLength === 130;
+
+    let tx: Hex;
+    if (isECDSA) {
+      // For EOA wallets, parse signature into v, r, s and use that overload
+      const parsedSig = parseSignature(signature);
+
+      tx = await signer.writeContract({
+        address: getAddress(requirements.asset),
+        abi: eip3009ABI,
+        functionName: "transferWithAuthorization",
+        args: [
+          getAddress(eip3009Payload.authorization.from),
+          getAddress(eip3009Payload.authorization.to),
+          BigInt(eip3009Payload.authorization.value),
+          BigInt(eip3009Payload.authorization.validAfter),
+          BigInt(eip3009Payload.authorization.validBefore),
+          eip3009Payload.authorization.nonce,
+          (parsedSig.v as number | undefined) || parsedSig.yParity,
+          parsedSig.r,
+          parsedSig.s,
+        ],
+      });
+    } else {
+      // For smart wallets, use the bytes signature overload
+      // The signature contains WebAuthn/P256 or other ERC-1271 compatible signature data
+      tx = await signer.writeContract({
+        address: getAddress(requirements.asset),
+        abi: eip3009ABI,
+        functionName: "transferWithAuthorization",
+        args: [
+          getAddress(eip3009Payload.authorization.from),
+          getAddress(eip3009Payload.authorization.to),
+          BigInt(eip3009Payload.authorization.value),
+          BigInt(eip3009Payload.authorization.validAfter),
+          BigInt(eip3009Payload.authorization.validBefore),
+          eip3009Payload.authorization.nonce,
+          signature,
+        ],
+      });
+    }
+
+    // Wait for transaction confirmation
+    const receipt = await signer.waitForTransactionReceipt({ hash: tx });
+
+    if (receipt.status !== "success") {
+      return {
+        success: false,
+        errorReason: "invalid_transaction_state",
+        transaction: tx,
+        network: payload.accepted.network,
+        payer,
+      };
+    }
+
+    return {
+      success: true,
+      transaction: tx,
+      network: payload.accepted.network,
+      payer,
+    };
+  } catch (error) {
+    console.error("Failed to settle transaction:", error);
+    return {
+      success: false,
+      errorReason: "transaction_failed",
+      transaction: "",
+      network: payload.accepted.network,
+      payer,
+    };
+  }
+}

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -1,0 +1,311 @@
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import { getAddress, Hex } from "viem";
+import {
+  eip3009ABI,
+  permit2WitnessTypes,
+  PERMIT2_ADDRESS,
+  x402ExactPermit2ProxyAddress,
+  x402ExactPermit2ProxyABI,
+} from "../../constants";
+import { EIP2612_GAS_SPONSORING_EXTENSION } from "../client/permit2";
+import { FacilitatorEvmSigner } from "../../signer";
+import { EIP2612PermitParams, ExactPermit2Payload } from "../../types";
+
+/**
+ * Verifies a Permit2 payment payload.
+ *
+ * @param signer - The EVM signer for facilitator operations
+ * @param payload - The payment payload to verify
+ * @param requirements - The payment requirements
+ * @param permit2Payload - The Permit2-specific payload data
+ * @returns Promise resolving to verification response
+ */
+export async function verifyPermit2(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  permit2Payload: ExactPermit2Payload,
+): Promise<VerifyResponse> {
+  const payer = permit2Payload.permit2Authorization.from;
+
+  if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
+    return {
+      isValid: false,
+      invalidReason: "unsupported_scheme",
+      payer,
+    };
+  }
+
+  if (payload.accepted.network !== requirements.network) {
+    return {
+      isValid: false,
+      invalidReason: "network_mismatch",
+      payer,
+    };
+  }
+
+  const chainId = parseInt(requirements.network.split(":")[1]);
+
+  if (
+    getAddress(permit2Payload.permit2Authorization.spender) !==
+    getAddress(x402ExactPermit2ProxyAddress)
+  ) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_spender",
+      payer,
+    };
+  }
+
+  if (
+    getAddress(permit2Payload.permit2Authorization.witness.to) !== getAddress(requirements.payTo)
+  ) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_witness_recipient",
+      payer,
+    };
+  }
+
+  if (
+    getAddress(permit2Payload.permit2Authorization.permitted.token) !==
+    getAddress(requirements.asset)
+  ) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_token",
+      payer,
+    };
+  }
+
+  if (BigInt(permit2Payload.permit2Authorization.permitted.amount) < BigInt(requirements.amount)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_amount",
+      payer,
+    };
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  if (BigInt(permit2Payload.permit2Authorization.deadline) < BigInt(now + 6)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_deadline",
+      payer,
+    };
+  }
+
+  if (BigInt(permit2Payload.permit2Authorization.witness.validBefore) < BigInt(now + 6)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_witness_valid_before",
+      payer,
+    };
+  }
+
+  if (BigInt(permit2Payload.permit2Authorization.witness.validAfter) > BigInt(now)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_witness_valid_after",
+      payer,
+    };
+  }
+
+  const permit2TypedData = {
+    types: permit2WitnessTypes,
+    primaryType: "PermitWitnessTransferFrom" as const,
+    domain: {
+      name: "Permit2",
+      chainId,
+      verifyingContract: PERMIT2_ADDRESS,
+    },
+    message: {
+      permitted: {
+        token: getAddress(permit2Payload.permit2Authorization.permitted.token),
+        amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
+      },
+      spender: getAddress(permit2Payload.permit2Authorization.spender),
+      nonce: BigInt(permit2Payload.permit2Authorization.nonce),
+      deadline: BigInt(permit2Payload.permit2Authorization.deadline),
+      witness: {
+        extra: permit2Payload.permit2Authorization.witness.extra,
+        to: getAddress(permit2Payload.permit2Authorization.witness.to),
+        validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
+        validBefore: BigInt(permit2Payload.permit2Authorization.witness.validBefore),
+      },
+    },
+  };
+
+  try {
+    const recoveredAddress = await signer.verifyTypedData({
+      address: payer,
+      ...permit2TypedData,
+      signature: permit2Payload.signature,
+    });
+
+    if (!recoveredAddress) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_permit2_signature",
+        payer,
+      };
+    }
+  } catch {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_signature",
+      payer,
+    };
+  }
+
+  try {
+    const balance = (await signer.readContract({
+      address: getAddress(requirements.asset),
+      abi: eip3009ABI,
+      functionName: "balanceOf",
+      args: [payer],
+    })) as bigint;
+
+    if (balance < BigInt(requirements.amount)) {
+      return {
+        isValid: false,
+        invalidReason: "insufficient_funds",
+        payer,
+      };
+    }
+  } catch {
+    // If we can't check balance, continue with other validations
+  }
+
+  return {
+    isValid: true,
+    invalidReason: undefined,
+    payer,
+  };
+}
+
+/**
+ * Settles a Permit2 payment by executing the transfer.
+ *
+ * @param signer - The EVM signer for facilitator operations
+ * @param payload - The payment payload to settle
+ * @param requirements - The payment requirements
+ * @param permit2Payload - The Permit2-specific payload data
+ * @param verifyFn - Function to verify the payload before settling
+ * @returns Promise resolving to settlement response
+ */
+export async function settlePermit2(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  permit2Payload: ExactPermit2Payload,
+  verifyFn: () => Promise<VerifyResponse>,
+): Promise<SettleResponse> {
+  const payer = permit2Payload.permit2Authorization.from;
+
+  const valid = await verifyFn();
+  if (!valid.isValid) {
+    return {
+      success: false,
+      network: payload.accepted.network,
+      transaction: "",
+      errorReason: valid.invalidReason ?? "invalid_payload",
+      payer,
+    };
+  }
+
+  try {
+    const permit = {
+      permitted: {
+        token: getAddress(permit2Payload.permit2Authorization.permitted.token),
+        amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
+      },
+      nonce: BigInt(permit2Payload.permit2Authorization.nonce),
+      deadline: BigInt(permit2Payload.permit2Authorization.deadline),
+    };
+
+    const witness = {
+      to: getAddress(permit2Payload.permit2Authorization.witness.to),
+      validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
+      validBefore: BigInt(permit2Payload.permit2Authorization.witness.validBefore),
+      extra: permit2Payload.permit2Authorization.witness.extra,
+    };
+
+    const eip2612Extension = payload.extensions?.[EIP2612_GAS_SPONSORING_EXTENSION] as
+      | { permit: EIP2612PermitParams }
+      | undefined;
+
+    let tx: Hex;
+
+    if (eip2612Extension) {
+      const permit2612 = {
+        value: BigInt(eip2612Extension.permit.value),
+        deadline: BigInt(eip2612Extension.permit.deadline),
+        r: eip2612Extension.permit.r,
+        s: eip2612Extension.permit.s,
+        v: eip2612Extension.permit.v,
+      };
+
+      tx = await signer.writeContract({
+        address: x402ExactPermit2ProxyAddress,
+        abi: x402ExactPermit2ProxyABI,
+        functionName: "settleWith2612",
+        args: [
+          permit2612,
+          permit,
+          BigInt(requirements.amount),
+          getAddress(payer),
+          witness,
+          permit2Payload.signature,
+        ],
+      });
+    } else {
+      tx = await signer.writeContract({
+        address: x402ExactPermit2ProxyAddress,
+        abi: x402ExactPermit2ProxyABI,
+        functionName: "settle",
+        args: [
+          permit,
+          BigInt(requirements.amount),
+          getAddress(payer),
+          witness,
+          permit2Payload.signature,
+        ],
+      });
+    }
+
+    const receipt = await signer.waitForTransactionReceipt({ hash: tx });
+
+    if (receipt.status !== "success") {
+      return {
+        success: false,
+        errorReason: "invalid_transaction_state",
+        transaction: tx,
+        network: payload.accepted.network,
+        payer,
+      };
+    }
+
+    return {
+      success: true,
+      transaction: tx,
+      network: payload.accepted.network,
+      payer,
+    };
+  } catch (error) {
+    console.error("Failed to settle Permit2 transaction:", error);
+    return {
+      success: false,
+      errorReason: "transaction_failed",
+      transaction: "",
+      network: payload.accepted.network,
+      payer,
+    };
+  }
+}

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
@@ -5,24 +5,15 @@ import {
   SettleResponse,
   VerifyResponse,
 } from "@x402/core/types";
-import { getAddress, Hex, isAddressEqual, parseErc6492Signature, parseSignature } from "viem";
-import {
-  authorizationTypes,
-  eip3009ABI,
-  permit2WitnessTypes,
-  PERMIT2_ADDRESS,
-  x402ExactPermit2ProxyAddress,
-  x402ExactPermit2ProxyABI,
-} from "../../constants";
-import { EIP2612_GAS_SPONSORING_EXTENSION } from "../client/permit2";
 import { FacilitatorEvmSigner } from "../../signer";
 import {
-  EIP2612PermitParams,
   ExactEIP3009Payload,
   ExactEvmPayloadV2,
   ExactPermit2Payload,
   isPermit2Payload,
 } from "../../types";
+import { verifyEIP3009, settleEIP3009 } from "./eip3009";
+import { verifyPermit2, settlePermit2 } from "./permit2";
 
 export interface ExactEvmSchemeConfig {
   /**
@@ -36,6 +27,10 @@ export interface ExactEvmSchemeConfig {
 
 /**
  * EVM facilitator implementation for the Exact payment scheme.
+ * Supports both EIP-3009 (transferWithAuthorization) and Permit2 flows.
+ *
+ * Routes to the appropriate verification and settlement method based on
+ * the payload type (EIP-3009 or Permit2).
  */
 export class ExactEvmScheme implements SchemeNetworkFacilitator {
   readonly scheme = "exact";
@@ -81,6 +76,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
 
   /**
    * Verifies a payment payload.
+   * Routes to EIP-3009 or Permit2 verification based on payload type.
    *
    * @param payload - The payment payload to verify
    * @param requirements - The payment requirements
@@ -93,192 +89,15 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
     const rawPayload = payload.payload as ExactEvmPayloadV2;
 
     if (isPermit2Payload(rawPayload)) {
-      return this.verifyPermit2(payload, requirements, rawPayload);
+      return verifyPermit2(this.signer, payload, requirements, rawPayload);
     }
 
-    const exactEvmPayload: ExactEIP3009Payload = rawPayload;
-
-    // Verify scheme matches
-    if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
-      return {
-        isValid: false,
-        invalidReason: "unsupported_scheme",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Get chain configuration
-    if (!requirements.extra?.name || !requirements.extra?.version) {
-      return {
-        isValid: false,
-        invalidReason: "missing_eip712_domain",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    const { name, version } = requirements.extra;
-    const erc20Address = getAddress(requirements.asset);
-
-    // Verify network matches
-    if (payload.accepted.network !== requirements.network) {
-      return {
-        isValid: false,
-        invalidReason: "network_mismatch",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Build typed data for signature verification
-    const permitTypedData = {
-      types: authorizationTypes,
-      primaryType: "TransferWithAuthorization" as const,
-      domain: {
-        name,
-        version,
-        chainId: parseInt(requirements.network.split(":")[1]),
-        verifyingContract: erc20Address,
-      },
-      message: {
-        from: exactEvmPayload.authorization.from,
-        to: exactEvmPayload.authorization.to,
-        value: BigInt(exactEvmPayload.authorization.value),
-        validAfter: BigInt(exactEvmPayload.authorization.validAfter),
-        validBefore: BigInt(exactEvmPayload.authorization.validBefore),
-        nonce: exactEvmPayload.authorization.nonce,
-      },
-    };
-
-    // Verify signature
-    try {
-      const recoveredAddress = await this.signer.verifyTypedData({
-        address: exactEvmPayload.authorization.from,
-        ...permitTypedData,
-        signature: exactEvmPayload.signature!,
-      });
-
-      if (!recoveredAddress) {
-        return {
-          isValid: false,
-          invalidReason: "invalid_exact_evm_payload_signature",
-          payer: exactEvmPayload.authorization.from,
-        };
-      }
-    } catch {
-      // Signature verification failed - could be an undeployed smart wallet
-      // Check if smart wallet is deployed
-      const signature = exactEvmPayload.signature!;
-      const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
-      const isSmartWallet = signatureLength > 130; // 65 bytes = 130 hex chars for EOA
-
-      if (isSmartWallet) {
-        const payerAddress = exactEvmPayload.authorization.from;
-        const bytecode = await this.signer.getCode({ address: payerAddress });
-
-        if (!bytecode || bytecode === "0x") {
-          // Wallet is not deployed. Check if it's EIP-6492 with deployment info.
-          // EIP-6492 signatures contain factory address and calldata needed for deployment.
-          // Non-EIP-6492 undeployed wallets cannot succeed (no way to deploy them).
-          const erc6492Data = parseErc6492Signature(signature);
-          const hasDeploymentInfo =
-            erc6492Data.address &&
-            erc6492Data.data &&
-            !isAddressEqual(erc6492Data.address, "0x0000000000000000000000000000000000000000");
-
-          if (!hasDeploymentInfo) {
-            // Non-EIP-6492 undeployed smart wallet - will always fail at settlement
-            // since EIP-3009 requires on-chain EIP-1271 validation
-            return {
-              isValid: false,
-              invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
-              payer: payerAddress,
-            };
-          }
-          // EIP-6492 signature with deployment info - allow through
-          // Facilitators with sponsored deployment support can handle this in settle()
-        } else {
-          // Wallet is deployed but signature still failed - invalid signature
-          return {
-            isValid: false,
-            invalidReason: "invalid_exact_evm_payload_signature",
-            payer: exactEvmPayload.authorization.from,
-          };
-        }
-      } else {
-        // EOA signature failed
-        return {
-          isValid: false,
-          invalidReason: "invalid_exact_evm_payload_signature",
-          payer: exactEvmPayload.authorization.from,
-        };
-      }
-    }
-
-    // Verify payment recipient matches
-    if (getAddress(exactEvmPayload.authorization.to) !== getAddress(requirements.payTo)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_recipient_mismatch",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Verify validBefore is in the future (with 6 second buffer for block time)
-    const now = Math.floor(Date.now() / 1000);
-    if (BigInt(exactEvmPayload.authorization.validBefore) < BigInt(now + 6)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_authorization_valid_before",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Verify validAfter is not in the future
-    if (BigInt(exactEvmPayload.authorization.validAfter) > BigInt(now)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_authorization_valid_after",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Check balance
-    try {
-      const balance = (await this.signer.readContract({
-        address: erc20Address,
-        abi: eip3009ABI,
-        functionName: "balanceOf",
-        args: [exactEvmPayload.authorization.from],
-      })) as bigint;
-
-      if (BigInt(balance) < BigInt(requirements.amount)) {
-        return {
-          isValid: false,
-          invalidReason: "insufficient_funds",
-          payer: exactEvmPayload.authorization.from,
-        };
-      }
-    } catch {
-      // If we can't check balance, continue with other validations
-    }
-
-    // Verify amount is sufficient
-    if (BigInt(exactEvmPayload.authorization.value) < BigInt(requirements.amount)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_authorization_value",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    return {
-      isValid: true,
-      invalidReason: undefined,
-      payer: exactEvmPayload.authorization.from,
-    };
+    return verifyEIP3009(this.signer, payload, requirements, rawPayload as ExactEIP3009Payload);
   }
 
   /**
    * Settles a payment by executing the transfer.
+   * Routes to EIP-3009 or Permit2 settlement based on payload type.
    *
    * @param payload - The payment payload to settle
    * @param requirements - The payment requirements
@@ -291,427 +110,23 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
     const rawPayload = payload.payload as ExactEvmPayloadV2;
 
     if (isPermit2Payload(rawPayload)) {
-      return this.settlePermit2(payload, requirements, rawPayload);
+      return settlePermit2(
+        this.signer,
+        payload,
+        requirements,
+        rawPayload as ExactPermit2Payload,
+        () => verifyPermit2(this.signer, payload, requirements, rawPayload),
+      );
     }
 
-    const exactEvmPayload: ExactEIP3009Payload = rawPayload;
-
-    // Re-verify before settling
-    const valid = await this.verify(payload, requirements);
-    if (!valid.isValid) {
-      return {
-        success: false,
-        network: payload.accepted.network,
-        transaction: "",
-        errorReason: valid.invalidReason ?? "invalid_scheme",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    try {
-      // Parse ERC-6492 signature if applicable
-      const parseResult = parseErc6492Signature(exactEvmPayload.signature!);
-      const { signature, address: factoryAddress, data: factoryCalldata } = parseResult;
-
-      // Deploy ERC-4337 smart wallet via EIP-6492 if configured and needed
-      if (
-        this.config.deployERC4337WithEIP6492 &&
-        factoryAddress &&
-        factoryCalldata &&
-        !isAddressEqual(factoryAddress, "0x0000000000000000000000000000000000000000")
-      ) {
-        // Check if smart wallet is already deployed
-        const payerAddress = exactEvmPayload.authorization.from;
-        const bytecode = await this.signer.getCode({ address: payerAddress });
-
-        if (!bytecode || bytecode === "0x") {
-          // Wallet not deployed - attempt deployment
-          try {
-            console.log(`Deploying ERC-4337 smart wallet for ${payerAddress} via EIP-6492`);
-
-            // Send the factory calldata directly as a transaction
-            // The factoryCalldata already contains the complete encoded function call
-            const deployTx = await this.signer.sendTransaction({
-              to: factoryAddress as Hex,
-              data: factoryCalldata as Hex,
-            });
-
-            // Wait for deployment transaction
-            await this.signer.waitForTransactionReceipt({ hash: deployTx });
-            console.log(`Successfully deployed smart wallet for ${payerAddress}`);
-          } catch (deployError) {
-            console.error("Smart wallet deployment failed:", deployError);
-            // Deployment failed - cannot proceed
-            throw deployError;
-          }
-        } else {
-          console.log(`Smart wallet for ${payerAddress} already deployed, skipping deployment`);
-        }
-      }
-
-      // Determine if this is an ECDSA signature (EOA) or smart wallet signature
-      // ECDSA signatures are exactly 65 bytes (130 hex chars without 0x)
-      const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
-      const isECDSA = signatureLength === 130;
-
-      let tx: Hex;
-      if (isECDSA) {
-        // For EOA wallets, parse signature into v, r, s and use that overload
-        const parsedSig = parseSignature(signature);
-
-        tx = await this.signer.writeContract({
-          address: getAddress(requirements.asset),
-          abi: eip3009ABI,
-          functionName: "transferWithAuthorization",
-          args: [
-            getAddress(exactEvmPayload.authorization.from),
-            getAddress(exactEvmPayload.authorization.to),
-            BigInt(exactEvmPayload.authorization.value),
-            BigInt(exactEvmPayload.authorization.validAfter),
-            BigInt(exactEvmPayload.authorization.validBefore),
-            exactEvmPayload.authorization.nonce,
-            (parsedSig.v as number | undefined) || parsedSig.yParity,
-            parsedSig.r,
-            parsedSig.s,
-          ],
-        });
-      } else {
-        // For smart wallets, use the bytes signature overload
-        // The signature contains WebAuthn/P256 or other ERC-1271 compatible signature data
-        tx = await this.signer.writeContract({
-          address: getAddress(requirements.asset),
-          abi: eip3009ABI,
-          functionName: "transferWithAuthorization",
-          args: [
-            getAddress(exactEvmPayload.authorization.from),
-            getAddress(exactEvmPayload.authorization.to),
-            BigInt(exactEvmPayload.authorization.value),
-            BigInt(exactEvmPayload.authorization.validAfter),
-            BigInt(exactEvmPayload.authorization.validBefore),
-            exactEvmPayload.authorization.nonce,
-            signature,
-          ],
-        });
-      }
-
-      // Wait for transaction confirmation
-      const receipt = await this.signer.waitForTransactionReceipt({ hash: tx });
-
-      if (receipt.status !== "success") {
-        return {
-          success: false,
-          errorReason: "invalid_transaction_state",
-          transaction: tx,
-          network: payload.accepted.network,
-          payer: exactEvmPayload.authorization.from,
-        };
-      }
-
-      return {
-        success: true,
-        transaction: tx,
-        network: payload.accepted.network,
-        payer: exactEvmPayload.authorization.from,
-      };
-    } catch (error) {
-      console.error("Failed to settle transaction:", error);
-      return {
-        success: false,
-        errorReason: "transaction_failed",
-        transaction: "",
-        network: payload.accepted.network,
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-  }
-
-  /**
-   * Verifies a Permit2 payment payload.
-   *
-   * @param payload - The payment payload to verify
-   * @param requirements - The payment requirements
-   * @param permit2Payload - The Permit2-specific payload data
-   * @returns Promise resolving to verification response
-   */
-  private async verifyPermit2(
-    payload: PaymentPayload,
-    requirements: PaymentRequirements,
-    permit2Payload: ExactPermit2Payload,
-  ): Promise<VerifyResponse> {
-    const payer = permit2Payload.permit2Authorization.from;
-
-    if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
-      return {
-        isValid: false,
-        invalidReason: "unsupported_scheme",
-        payer,
-      };
-    }
-
-    if (payload.accepted.network !== requirements.network) {
-      return {
-        isValid: false,
-        invalidReason: "network_mismatch",
-        payer,
-      };
-    }
-
-    const chainId = parseInt(requirements.network.split(":")[1]);
-
-    if (
-      getAddress(permit2Payload.permit2Authorization.spender) !==
-      getAddress(x402ExactPermit2ProxyAddress)
-    ) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_permit2_spender",
-        payer,
-      };
-    }
-
-    if (
-      getAddress(permit2Payload.permit2Authorization.witness.to) !== getAddress(requirements.payTo)
-    ) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_permit2_witness_recipient",
-        payer,
-      };
-    }
-
-    if (
-      getAddress(permit2Payload.permit2Authorization.permitted.token) !==
-      getAddress(requirements.asset)
-    ) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_permit2_token",
-        payer,
-      };
-    }
-
-    if (
-      BigInt(permit2Payload.permit2Authorization.permitted.amount) < BigInt(requirements.amount)
-    ) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_permit2_amount",
-        payer,
-      };
-    }
-
-    const now = Math.floor(Date.now() / 1000);
-
-    if (BigInt(permit2Payload.permit2Authorization.deadline) < BigInt(now + 6)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_permit2_deadline",
-        payer,
-      };
-    }
-
-    if (BigInt(permit2Payload.permit2Authorization.witness.validBefore) < BigInt(now + 6)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_permit2_witness_valid_before",
-        payer,
-      };
-    }
-
-    if (BigInt(permit2Payload.permit2Authorization.witness.validAfter) > BigInt(now)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_permit2_witness_valid_after",
-        payer,
-      };
-    }
-
-    const permit2TypedData = {
-      types: permit2WitnessTypes,
-      primaryType: "PermitWitnessTransferFrom" as const,
-      domain: {
-        name: "Permit2",
-        chainId,
-        verifyingContract: PERMIT2_ADDRESS,
-      },
-      message: {
-        permitted: {
-          token: getAddress(permit2Payload.permit2Authorization.permitted.token),
-          amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
-        },
-        spender: getAddress(permit2Payload.permit2Authorization.spender),
-        nonce: BigInt(permit2Payload.permit2Authorization.nonce),
-        deadline: BigInt(permit2Payload.permit2Authorization.deadline),
-        witness: {
-          extra: permit2Payload.permit2Authorization.witness.extra,
-          to: getAddress(permit2Payload.permit2Authorization.witness.to),
-          validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
-          validBefore: BigInt(permit2Payload.permit2Authorization.witness.validBefore),
-        },
-      },
-    };
-
-    try {
-      const recoveredAddress = await this.signer.verifyTypedData({
-        address: payer,
-        ...permit2TypedData,
-        signature: permit2Payload.signature,
-      });
-
-      if (!recoveredAddress) {
-        return {
-          isValid: false,
-          invalidReason: "invalid_permit2_signature",
-          payer,
-        };
-      }
-    } catch {
-      return {
-        isValid: false,
-        invalidReason: "invalid_permit2_signature",
-        payer,
-      };
-    }
-
-    try {
-      const balance = (await this.signer.readContract({
-        address: getAddress(requirements.asset),
-        abi: eip3009ABI,
-        functionName: "balanceOf",
-        args: [payer],
-      })) as bigint;
-
-      if (balance < BigInt(requirements.amount)) {
-        return {
-          isValid: false,
-          invalidReason: "insufficient_funds",
-          payer,
-        };
-      }
-    } catch {
-      // If we can't check balance, continue with other validations
-    }
-
-    return {
-      isValid: true,
-      invalidReason: undefined,
-      payer,
-    };
-  }
-
-  /**
-   * Settles a Permit2 payment by executing the transfer.
-   *
-   * @param payload - The payment payload to settle
-   * @param requirements - The payment requirements
-   * @param permit2Payload - The Permit2-specific payload data
-   * @returns Promise resolving to settlement response
-   */
-  private async settlePermit2(
-    payload: PaymentPayload,
-    requirements: PaymentRequirements,
-    permit2Payload: ExactPermit2Payload,
-  ): Promise<SettleResponse> {
-    const payer = permit2Payload.permit2Authorization.from;
-
-    const valid = await this.verifyPermit2(payload, requirements, permit2Payload);
-    if (!valid.isValid) {
-      return {
-        success: false,
-        network: payload.accepted.network,
-        transaction: "",
-        errorReason: valid.invalidReason ?? "invalid_payload",
-        payer,
-      };
-    }
-
-    try {
-      const permit = {
-        permitted: {
-          token: getAddress(permit2Payload.permit2Authorization.permitted.token),
-          amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
-        },
-        nonce: BigInt(permit2Payload.permit2Authorization.nonce),
-        deadline: BigInt(permit2Payload.permit2Authorization.deadline),
-      };
-
-      const witness = {
-        to: getAddress(permit2Payload.permit2Authorization.witness.to),
-        validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
-        validBefore: BigInt(permit2Payload.permit2Authorization.witness.validBefore),
-        extra: permit2Payload.permit2Authorization.witness.extra,
-      };
-
-      const eip2612Extension = payload.extensions?.[EIP2612_GAS_SPONSORING_EXTENSION] as
-        | { permit: EIP2612PermitParams }
-        | undefined;
-
-      let tx: Hex;
-
-      if (eip2612Extension) {
-        const permit2612 = {
-          value: BigInt(eip2612Extension.permit.value),
-          deadline: BigInt(eip2612Extension.permit.deadline),
-          r: eip2612Extension.permit.r,
-          s: eip2612Extension.permit.s,
-          v: eip2612Extension.permit.v,
-        };
-
-        tx = await this.signer.writeContract({
-          address: x402ExactPermit2ProxyAddress,
-          abi: x402ExactPermit2ProxyABI,
-          functionName: "settleWith2612",
-          args: [
-            permit2612,
-            permit,
-            BigInt(requirements.amount),
-            getAddress(payer),
-            witness,
-            permit2Payload.signature,
-          ],
-        });
-      } else {
-        tx = await this.signer.writeContract({
-          address: x402ExactPermit2ProxyAddress,
-          abi: x402ExactPermit2ProxyABI,
-          functionName: "settle",
-          args: [
-            permit,
-            BigInt(requirements.amount),
-            getAddress(payer),
-            witness,
-            permit2Payload.signature,
-          ],
-        });
-      }
-
-      const receipt = await this.signer.waitForTransactionReceipt({ hash: tx });
-
-      if (receipt.status !== "success") {
-        return {
-          success: false,
-          errorReason: "invalid_transaction_state",
-          transaction: tx,
-          network: payload.accepted.network,
-          payer,
-        };
-      }
-
-      return {
-        success: true,
-        transaction: tx,
-        network: payload.accepted.network,
-        payer,
-      };
-    } catch (error) {
-      console.error("Failed to settle Permit2 transaction:", error);
-      return {
-        success: false,
-        errorReason: "transaction_failed",
-        transaction: "",
-        network: payload.accepted.network,
-        payer,
-      };
-    }
+    const eip3009Payload = rawPayload as ExactEIP3009Payload;
+    return settleEIP3009(
+      this.signer,
+      { deployERC4337WithEIP6492: this.config.deployERC4337WithEIP6492 },
+      payload,
+      requirements,
+      eip3009Payload,
+      () => verifyEIP3009(this.signer, payload, requirements, eip3009Payload),
+    );
   }
 }

--- a/typescript/packages/mechanisms/evm/src/index.ts
+++ b/typescript/packages/mechanisms/evm/src/index.ts
@@ -10,10 +10,29 @@
 export { ExactEvmScheme } from "./exact";
 export { toClientEvmSigner, toFacilitatorEvmSigner } from "./signer";
 export type { ClientEvmSigner, FacilitatorEvmSigner } from "./signer";
+
+// Export types
+export type {
+  AssetTransferMethod,
+  ExactEIP3009Payload,
+  ExactPermit2Payload,
+  Permit2Authorization,
+  Permit2Witness,
+  EIP2612PermitParams,
+  ExactEvmPayloadV1,
+  ExactEvmPayloadV2,
+} from "./types";
+export { isPermit2Payload, isEIP3009Payload } from "./types";
+
+// Export constants
 export {
-  x402ExactPermit2ProxyAddress,
-  x402UptoPermit2ProxyAddress,
+  authorizationTypes,
+  permit2WitnessTypes,
+  eip2612PermitTypes,
+  eip3009ABI,
   x402ExactPermit2ProxyABI,
   x402UptoPermit2ProxyABI,
+  x402ExactPermit2ProxyAddress,
+  x402UptoPermit2ProxyAddress,
   PERMIT2_ADDRESS,
 } from "./constants";

--- a/typescript/packages/mechanisms/evm/src/types.ts
+++ b/typescript/packages/mechanisms/evm/src/types.ts
@@ -1,3 +1,13 @@
+/**
+ * Asset transfer methods for the exact EVM scheme.
+ * - eip3009: Uses transferWithAuthorization (USDC, etc.) - recommended for compatible tokens
+ * - permit2: Uses Permit2 + x402Permit2Proxy - universal fallback for any ERC-20
+ */
+export type AssetTransferMethod = "eip3009" | "permit2";
+
+/**
+ * EIP-3009 payload for tokens with native transferWithAuthorization support.
+ */
 export type ExactEIP3009Payload = {
   signature?: `0x${string}`;
   authorization: {
@@ -10,6 +20,76 @@ export type ExactEIP3009Payload = {
   };
 };
 
+/**
+ * Permit2 witness data structure.
+ * Matches the Witness struct in x402Permit2Proxy contract.
+ */
+export type Permit2Witness = {
+  to: `0x${string}`;
+  validAfter: string;
+  validBefore: string;
+  extra: `0x${string}`;
+};
+
+/**
+ * Permit2 authorization parameters.
+ * Used to reconstruct the signed message for verification.
+ */
+export type Permit2Authorization = {
+  permitted: {
+    token: `0x${string}`;
+    amount: string;
+  };
+  spender: `0x${string}`;
+  nonce: string;
+  deadline: string;
+  witness: Permit2Witness;
+};
+
+/**
+ * Permit2 payload for tokens using the Permit2 + x402Permit2Proxy flow.
+ */
+export type ExactPermit2Payload = {
+  signature: `0x${string}`;
+  permit2Authorization: Permit2Authorization & {
+    from: `0x${string}`;
+  };
+};
+
+/**
+ * EIP-2612 permit parameters for gasless approval extension.
+ * Used with settleWith2612() on x402Permit2Proxy. Note that this does not support smart wallets signatures.
+ */
+export type EIP2612PermitParams = {
+  value: string;
+  deadline: string;
+  v: number;
+  r: `0x${string}`;
+  s: `0x${string}`;
+};
+
 export type ExactEvmPayloadV1 = ExactEIP3009Payload;
 
-export type ExactEvmPayloadV2 = ExactEIP3009Payload;
+export type ExactEvmPayloadV2 = ExactEIP3009Payload | ExactPermit2Payload;
+
+/**
+ * Type guard to check if a payload is a Permit2 payload.
+ * Permit2 payloads have a `permit2Authorization` field.
+ *
+ * @param payload - The payload to check.
+ * @returns True if the payload is a Permit2 payload, false otherwise.
+ */
+export function isPermit2Payload(payload: ExactEvmPayloadV2): payload is ExactPermit2Payload {
+  return "permit2Authorization" in payload;
+}
+
+/**
+ * Type guard to check if a payload is an EIP-3009 payload.
+ * EIP-3009 payloads have an `authorization` field.
+ *
+ * @param payload - The payload to check.
+ * @returns True if the payload is an EIP-3009 payload, false otherwise.
+ */
+export function isEIP3009Payload(payload: ExactEvmPayloadV2): payload is ExactEIP3009Payload {
+  return "authorization" in payload;
+}

--- a/typescript/packages/mechanisms/evm/src/utils.ts
+++ b/typescript/packages/mechanisms/evm/src/utils.ts
@@ -21,20 +21,35 @@ export function getEvmChainId(network: Network): number {
 }
 
 /**
- * Create a random 32-byte nonce for authorization
+ * Get the crypto object from the global scope.
+ *
+ * @returns The crypto object
+ * @throws Error if crypto API is not available
+ */
+function getCrypto(): Crypto {
+  const cryptoObj = globalThis.crypto as Crypto | undefined;
+  if (!cryptoObj) {
+    throw new Error("Crypto API not available");
+  }
+  return cryptoObj;
+}
+
+/**
+ * Create a random 32-byte nonce for EIP-3009 authorization.
  *
  * @returns A hex-encoded 32-byte nonce
  */
 export function createNonce(): `0x${string}` {
-  // Use dynamic import to avoid require() in ESM context
-  const cryptoObj =
-    typeof globalThis.crypto !== "undefined"
-      ? globalThis.crypto
-      : (globalThis as { crypto?: Crypto }).crypto;
+  return toHex(getCrypto().getRandomValues(new Uint8Array(32)));
+}
 
-  if (!cryptoObj) {
-    throw new Error("Crypto API not available");
-  }
-
-  return toHex(cryptoObj.getRandomValues(new Uint8Array(32)));
+/**
+ * Creates a random 256-bit nonce for Permit2.
+ * Permit2 uses uint256 nonces (not bytes32 like EIP-3009).
+ *
+ * @returns A string representation of the random nonce
+ */
+export function createPermit2Nonce(): string {
+  const randomBytes = getCrypto().getRandomValues(new Uint8Array(32));
+  return BigInt(toHex(randomBytes)).toString();
 }

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../src/exact/client/permit2";
 import type { ClientEvmSigner } from "../../../src/signer";
 import { PaymentRequirements } from "@x402/core/types";
-import { PERMIT2_ADDRESS, x402Permit2ProxyAddress } from "../../../src/constants";
+import { PERMIT2_ADDRESS, x402ExactPermit2ProxyAddress } from "../../../src/constants";
 import { isPermit2Payload, isEIP3009Payload } from "../../../src/types";
 
 describe("ExactEvmScheme (Client)", () => {
@@ -312,7 +312,7 @@ describe("ExactEvmScheme (Client)", () => {
       const result = await client.createPaymentPayload(2, requirements);
 
       expect(result.payload.permit2Authorization.spender.toLowerCase()).toBe(
-        x402Permit2ProxyAddress.toLowerCase(),
+        x402ExactPermit2ProxyAddress.toLowerCase(),
       );
     });
 

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -1,14 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ExactEvmScheme } from "../../../src/exact/client/scheme";
+import {
+  createPermit2ApprovalTx,
+  getPermit2AllowanceReadParams,
+} from "../../../src/exact/client/permit2";
 import type { ClientEvmSigner } from "../../../src/signer";
 import { PaymentRequirements } from "@x402/core/types";
+import { PERMIT2_ADDRESS, x402Permit2ProxyAddress } from "../../../src/constants";
+import { isPermit2Payload, isEIP3009Payload } from "../../../src/types";
 
 describe("ExactEvmScheme (Client)", () => {
   let client: ExactEvmScheme;
   let mockSigner: ClientEvmSigner;
 
   beforeEach(() => {
-    // Create mock signer
     mockSigner = {
       address: "0x1234567890123456789012345678901234567890",
       signTypedData: vi.fn().mockResolvedValue("0xmocksignature123456789"),
@@ -213,6 +218,277 @@ describe("ExactEvmScheme (Client)", () => {
       expect(callArgs.domain.name).toBe("USD Coin");
       expect(callArgs.domain.version).toBe("2");
       expect(callArgs.domain.chainId).toBe(8453);
+    });
+
+    describe("with assetTransferMethod", () => {
+      it("should default to EIP-3009 when assetTransferMethod is not set", async () => {
+        const requirements: PaymentRequirements = {
+          scheme: "exact",
+          network: "eip155:8453",
+          amount: "1000000",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          maxTimeoutSeconds: 300,
+          extra: { name: "USD Coin", version: "2" },
+        };
+
+        const result = await client.createPaymentPayload(2, requirements);
+
+        expect(isEIP3009Payload(result.payload)).toBe(true);
+        expect(isPermit2Payload(result.payload)).toBe(false);
+        expect(result.payload.authorization).toBeDefined();
+      });
+
+      it("should use EIP-3009 when assetTransferMethod is eip3009", async () => {
+        const requirements: PaymentRequirements = {
+          scheme: "exact",
+          network: "eip155:8453",
+          amount: "1000000",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          maxTimeoutSeconds: 300,
+          extra: { name: "USD Coin", version: "2", assetTransferMethod: "eip3009" },
+        };
+
+        const result = await client.createPaymentPayload(2, requirements);
+
+        expect(isEIP3009Payload(result.payload)).toBe(true);
+        expect(result.payload.authorization).toBeDefined();
+      });
+
+      it("should use Permit2 when assetTransferMethod is permit2", async () => {
+        const requirements: PaymentRequirements = {
+          scheme: "exact",
+          network: "eip155:8453",
+          amount: "1000000",
+          asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          maxTimeoutSeconds: 300,
+          extra: { name: "USD Coin", version: "2", assetTransferMethod: "permit2" },
+        };
+
+        const result = await client.createPaymentPayload(2, requirements);
+
+        expect(isPermit2Payload(result.payload)).toBe(true);
+        expect(isEIP3009Payload(result.payload)).toBe(false);
+        expect(result.payload.permit2Authorization).toBeDefined();
+      });
+    });
+  });
+
+  describe("createPaymentPayload with Permit2", () => {
+    it("should create Permit2 payload with correct structure", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload;
+
+      expect(isPermit2Payload(payload)).toBe(true);
+      expect(payload.signature).toBeDefined();
+      expect(payload.permit2Authorization).toBeDefined();
+      expect(payload.permit2Authorization.permitted).toBeDefined();
+      expect(payload.permit2Authorization.witness).toBeDefined();
+    });
+
+    it("should set spender to x402Permit2Proxy address", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.spender.toLowerCase()).toBe(
+        x402Permit2ProxyAddress.toLowerCase(),
+      );
+    });
+
+    it("should set witness.to to payTo address", async () => {
+      const payToAddress = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0";
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: payToAddress,
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.witness.to.toLowerCase()).toBe(
+        payToAddress.toLowerCase(),
+      );
+    });
+
+    it("should set permitted.token to asset address", async () => {
+      const assetAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: assetAddress,
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.permitted.token.toLowerCase()).toBe(
+        assetAddress.toLowerCase(),
+      );
+    });
+
+    it("should set permitted.amount to requirements.amount", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "2500000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.permitted.amount).toBe("2500000");
+    });
+
+    it("should set from to signer address", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(result.payload.permit2Authorization.from).toBe(mockSigner.address);
+    });
+
+    it("should generate different nonces for each call", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const result1 = await client.createPaymentPayload(2, requirements);
+      const result2 = await client.createPaymentPayload(2, requirements);
+
+      expect(result1.payload.permit2Authorization.nonce).not.toBe(
+        result2.payload.permit2Authorization.nonce,
+      );
+    });
+
+    it("should set deadline based on maxTimeoutSeconds", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 600,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      const beforeTime = Math.floor(Date.now() / 1000) + 600;
+      const result = await client.createPaymentPayload(2, requirements);
+      const afterTime = Math.floor(Date.now() / 1000) + 600;
+
+      const deadline = parseInt(result.payload.permit2Authorization.deadline);
+
+      expect(deadline).toBeGreaterThanOrEqual(beforeTime);
+      expect(deadline).toBeLessThanOrEqual(afterTime + 1);
+    });
+
+    it("should pass correct EIP-712 domain for Permit2 to signTypedData", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      await client.createPaymentPayload(2, requirements);
+
+      expect(mockSigner.signTypedData).toHaveBeenCalled();
+      const callArgs = (mockSigner.signTypedData as any).mock.calls[0][0];
+      expect(callArgs.domain.name).toBe("Permit2");
+      expect(callArgs.domain.verifyingContract.toLowerCase()).toBe(PERMIT2_ADDRESS.toLowerCase());
+      expect(callArgs.domain.chainId).toBe(8453);
+    });
+  });
+});
+
+describe("Permit2 Helpers", () => {
+  describe("createPermit2ApprovalTx", () => {
+    it("should create approval transaction with correct structure", () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+      const result = createPermit2ApprovalTx(tokenAddress);
+
+      expect(result.to.toLowerCase()).toBe(tokenAddress.toLowerCase());
+      expect(result.data).toBeDefined();
+      expect(result.data.startsWith("0x")).toBe(true);
+    });
+
+    it("should encode approve function selector correctly", () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+      const result = createPermit2ApprovalTx(tokenAddress);
+
+      expect(result.data.slice(0, 10)).toBe("0x095ea7b3");
+    });
+
+    it("should include Permit2 address as spender in calldata", () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+      const result = createPermit2ApprovalTx(tokenAddress);
+
+      const spenderParam = result.data.slice(10, 74);
+      const spenderAddress = "0x" + spenderParam.slice(24);
+      expect(spenderAddress.toLowerCase()).toBe(PERMIT2_ADDRESS.toLowerCase());
+    });
+  });
+
+  describe("getPermit2AllowanceReadParams", () => {
+    it("should return correct read parameters", () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+      const ownerAddress = "0x1234567890123456789012345678901234567890";
+
+      const result = getPermit2AllowanceReadParams({ tokenAddress, ownerAddress });
+
+      expect(result.address.toLowerCase()).toBe(tokenAddress.toLowerCase());
+      expect(result.functionName).toBe("allowance");
+      expect(result.args[1]).toBe(PERMIT2_ADDRESS);
     });
   });
 });

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -7,7 +7,12 @@ import {
 import type { ClientEvmSigner } from "../../../src/signer";
 import { PaymentRequirements } from "@x402/core/types";
 import { PERMIT2_ADDRESS, x402ExactPermit2ProxyAddress } from "../../../src/constants";
-import { isPermit2Payload, isEIP3009Payload } from "../../../src/types";
+import {
+  isPermit2Payload,
+  isEIP3009Payload,
+  ExactPermit2Payload,
+  ExactEIP3009Payload,
+} from "../../../src/types";
 
 describe("ExactEvmScheme (Client)", () => {
   let client: ExactEvmScheme;
@@ -64,12 +69,14 @@ describe("ExactEvmScheme (Client)", () => {
 
       const result1 = await client.createPaymentPayload(2, requirements);
       const result2 = await client.createPaymentPayload(2, requirements);
+      const payload1 = result1.payload as ExactEIP3009Payload;
+      const payload2 = result2.payload as ExactEIP3009Payload;
 
       // Nonces should be different
-      expect(result1.payload.authorization.nonce).not.toBe(result2.payload.authorization.nonce);
+      expect(payload1.authorization.nonce).not.toBe(payload2.authorization.nonce);
 
       // Nonce should be 32 bytes hex string
-      expect(result1.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/i);
+      expect(payload1.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/i);
     });
 
     it("should set validAfter to 10 minutes before current time", async () => {
@@ -85,9 +92,10 @@ describe("ExactEvmScheme (Client)", () => {
 
       const beforeTime = Math.floor(Date.now() / 1000) - 600;
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactEIP3009Payload;
       const afterTime = Math.floor(Date.now() / 1000) - 600;
 
-      const validAfter = parseInt(result.payload.authorization.validAfter);
+      const validAfter = parseInt(payload.authorization.validAfter);
 
       expect(validAfter).toBeGreaterThanOrEqual(beforeTime);
       expect(validAfter).toBeLessThanOrEqual(afterTime + 1); // Allow 1 second tolerance
@@ -106,9 +114,10 @@ describe("ExactEvmScheme (Client)", () => {
 
       const beforeTime = Math.floor(Date.now() / 1000) + 600;
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactEIP3009Payload;
       const afterTime = Math.floor(Date.now() / 1000) + 600;
 
-      const validBefore = parseInt(result.payload.authorization.validBefore);
+      const validBefore = parseInt(payload.authorization.validBefore);
 
       expect(validBefore).toBeGreaterThanOrEqual(beforeTime);
       expect(validBefore).toBeLessThanOrEqual(afterTime + 1);
@@ -126,8 +135,9 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactEIP3009Payload;
 
-      expect(result.payload.authorization.from).toBe(mockSigner.address);
+      expect(payload.authorization.from).toBe(mockSigner.address);
     });
 
     it("should use requirements.payTo as to", async () => {
@@ -144,8 +154,9 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactEIP3009Payload;
 
-      expect(result.payload.authorization.to.toLowerCase()).toBe(payToAddress.toLowerCase());
+      expect(payload.authorization.to.toLowerCase()).toBe(payToAddress.toLowerCase());
     });
 
     it("should use requirements.amount as value", async () => {
@@ -160,8 +171,9 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactEIP3009Payload;
 
-      expect(result.payload.authorization.value).toBe("2500000");
+      expect(payload.authorization.value).toBe("2500000");
     });
 
     it("should call signTypedData on signer", async () => {
@@ -176,10 +188,11 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactEIP3009Payload;
 
       // Should have called signTypedData
       expect(mockSigner.signTypedData).toHaveBeenCalled();
-      expect(result.payload.signature).toBeDefined();
+      expect(payload.signature).toBeDefined();
     });
 
     it("should handle different networks", async () => {
@@ -194,9 +207,10 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, ethereumRequirements);
+      const payload = result.payload as ExactEIP3009Payload;
 
       expect(result.x402Version).toBe(2);
-      expect(result.payload.authorization).toBeDefined();
+      expect(payload.authorization).toBeDefined();
     });
 
     it("should pass correct EIP-712 domain to signTypedData", async () => {
@@ -233,10 +247,11 @@ describe("ExactEvmScheme (Client)", () => {
         };
 
         const result = await client.createPaymentPayload(2, requirements);
+        const payload = result.payload as ExactEIP3009Payload;
 
-        expect(isEIP3009Payload(result.payload)).toBe(true);
-        expect(isPermit2Payload(result.payload)).toBe(false);
-        expect(result.payload.authorization).toBeDefined();
+        expect(isEIP3009Payload(payload)).toBe(true);
+        expect(isPermit2Payload(payload)).toBe(false);
+        expect(payload.authorization).toBeDefined();
       });
 
       it("should use EIP-3009 when assetTransferMethod is eip3009", async () => {
@@ -251,9 +266,10 @@ describe("ExactEvmScheme (Client)", () => {
         };
 
         const result = await client.createPaymentPayload(2, requirements);
+        const payload = result.payload as ExactEIP3009Payload;
 
-        expect(isEIP3009Payload(result.payload)).toBe(true);
-        expect(result.payload.authorization).toBeDefined();
+        expect(isEIP3009Payload(payload)).toBe(true);
+        expect(payload.authorization).toBeDefined();
       });
 
       it("should use Permit2 when assetTransferMethod is permit2", async () => {
@@ -268,10 +284,11 @@ describe("ExactEvmScheme (Client)", () => {
         };
 
         const result = await client.createPaymentPayload(2, requirements);
+        const payload = result.payload as ExactPermit2Payload;
 
-        expect(isPermit2Payload(result.payload)).toBe(true);
-        expect(isEIP3009Payload(result.payload)).toBe(false);
-        expect(result.payload.permit2Authorization).toBeDefined();
+        expect(isPermit2Payload(payload)).toBe(true);
+        expect(isEIP3009Payload(payload)).toBe(false);
+        expect(payload.permit2Authorization).toBeDefined();
       });
     });
   });
@@ -289,7 +306,7 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
-      const payload = result.payload;
+      const payload = result.payload as ExactPermit2Payload;
 
       expect(isPermit2Payload(payload)).toBe(true);
       expect(payload.signature).toBeDefined();
@@ -310,8 +327,9 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactPermit2Payload;
 
-      expect(result.payload.permit2Authorization.spender.toLowerCase()).toBe(
+      expect(payload.permit2Authorization.spender.toLowerCase()).toBe(
         x402ExactPermit2ProxyAddress.toLowerCase(),
       );
     });
@@ -329,8 +347,9 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactPermit2Payload;
 
-      expect(result.payload.permit2Authorization.witness.to.toLowerCase()).toBe(
+      expect(payload.permit2Authorization.witness.to.toLowerCase()).toBe(
         payToAddress.toLowerCase(),
       );
     });
@@ -348,8 +367,9 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactPermit2Payload;
 
-      expect(result.payload.permit2Authorization.permitted.token.toLowerCase()).toBe(
+      expect(payload.permit2Authorization.permitted.token.toLowerCase()).toBe(
         assetAddress.toLowerCase(),
       );
     });
@@ -366,8 +386,9 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactPermit2Payload;
 
-      expect(result.payload.permit2Authorization.permitted.amount).toBe("2500000");
+      expect(payload.permit2Authorization.permitted.amount).toBe("2500000");
     });
 
     it("should set from to signer address", async () => {
@@ -382,8 +403,9 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactPermit2Payload;
 
-      expect(result.payload.permit2Authorization.from).toBe(mockSigner.address);
+      expect(payload.permit2Authorization.from).toBe(mockSigner.address);
     });
 
     it("should generate different nonces for each call", async () => {
@@ -399,10 +421,10 @@ describe("ExactEvmScheme (Client)", () => {
 
       const result1 = await client.createPaymentPayload(2, requirements);
       const result2 = await client.createPaymentPayload(2, requirements);
+      const payload1 = result1.payload as ExactPermit2Payload;
+      const payload2 = result2.payload as ExactPermit2Payload;
 
-      expect(result1.payload.permit2Authorization.nonce).not.toBe(
-        result2.payload.permit2Authorization.nonce,
-      );
+      expect(payload1.permit2Authorization.nonce).not.toBe(payload2.permit2Authorization.nonce);
     });
 
     it("should set deadline based on maxTimeoutSeconds", async () => {
@@ -417,10 +439,12 @@ describe("ExactEvmScheme (Client)", () => {
       };
 
       const beforeTime = Math.floor(Date.now() / 1000) + 600;
-      const result = await client.createPaymentPayload(2, requirements);
       const afterTime = Math.floor(Date.now() / 1000) + 600;
 
-      const deadline = parseInt(result.payload.permit2Authorization.deadline);
+      const result = await client.createPaymentPayload(2, requirements);
+      const payload = result.payload as ExactPermit2Payload;
+
+      const deadline = parseInt(payload.permit2Authorization.deadline);
 
       expect(deadline).toBeGreaterThanOrEqual(beforeTime);
       expect(deadline).toBeLessThanOrEqual(afterTime + 1);
@@ -483,8 +507,9 @@ describe("Permit2 Helpers", () => {
     it("should return correct read parameters", () => {
       const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
       const ownerAddress = "0x1234567890123456789012345678901234567890";
+      const requiredAmount = BigInt(1000000);
 
-      const result = getPermit2AllowanceReadParams({ tokenAddress, ownerAddress });
+      const result = getPermit2AllowanceReadParams({ tokenAddress, ownerAddress, requiredAmount });
 
       expect(result.address.toLowerCase()).toBe(tokenAddress.toLowerCase());
       expect(result.functionName).toBe("allowance");

--- a/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
@@ -3,7 +3,7 @@ import { ExactEvmScheme } from "../../../src/exact/facilitator/scheme";
 import { ExactEvmScheme as ClientExactEvmScheme } from "../../../src/exact/client/scheme";
 import type { ClientEvmSigner, FacilitatorEvmSigner } from "../../../src/signer";
 import { PaymentRequirements, PaymentPayload } from "@x402/core/types";
-import { x402Permit2ProxyAddress, PERMIT2_ADDRESS } from "../../../src/constants";
+import { x402ExactPermit2ProxyAddress, PERMIT2_ADDRESS } from "../../../src/constants";
 import { ExactPermit2Payload } from "../../../src/types";
 
 describe("ExactEvmScheme (Facilitator)", () => {
@@ -324,7 +324,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
             token: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
             amount: "1000000",
           },
-          spender: x402Permit2ProxyAddress,
+          spender: x402ExactPermit2ProxyAddress,
           nonce: "12345678901234567890",
           deadline: String(now + 600),
           witness: {
@@ -583,7 +583,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
             token: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
             amount: "1000000",
           },
-          spender: x402Permit2ProxyAddress,
+          spender: x402ExactPermit2ProxyAddress,
           nonce: "12345678901234567890",
           deadline: String(now + 600),
           witness: {
@@ -656,7 +656,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
 
       expect(mockFacilitatorSigner.writeContract).toHaveBeenCalled();
       const callArgs = (mockFacilitatorSigner.writeContract as any).mock.calls[0][0];
-      expect(callArgs.address.toLowerCase()).toBe(x402Permit2ProxyAddress.toLowerCase());
+      expect(callArgs.address.toLowerCase()).toBe(x402ExactPermit2ProxyAddress.toLowerCase());
       expect(callArgs.functionName).toBe("settle");
     });
 
@@ -695,7 +695,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
 
       expect(mockFacilitatorSigner.writeContract).toHaveBeenCalled();
       const callArgs = (mockFacilitatorSigner.writeContract as any).mock.calls[0][0];
-      expect(callArgs.address.toLowerCase()).toBe(x402Permit2ProxyAddress.toLowerCase());
+      expect(callArgs.address.toLowerCase()).toBe(x402ExactPermit2ProxyAddress.toLowerCase());
       expect(callArgs.functionName).toBe("settleWith2612");
     });
 

--- a/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
@@ -22,10 +22,11 @@ describe("ExactEvmScheme (Facilitator)", () => {
 
     // Create mock facilitator signer
     mockFacilitatorSigner = {
-      address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+      getAddresses: vi.fn().mockReturnValue(["0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0"]),
       readContract: vi.fn().mockResolvedValue(0n), // Mock nonce state
       verifyTypedData: vi.fn().mockResolvedValue(true), // Mock signature verification
       writeContract: vi.fn().mockResolvedValue("0xtxhash"),
+      sendTransaction: vi.fn().mockResolvedValue("0xtxhash"),
       waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success" }),
       getCode: vi.fn().mockResolvedValue("0x"),
     };
@@ -311,7 +312,9 @@ describe("ExactEvmScheme (Facilitator)", () => {
   });
 
   describe("Permit2 verification", () => {
-    const createPermit2Payload = (overrides?: Partial<ExactPermit2Payload>): ExactPermit2Payload => {
+    const createPermit2Payload = (
+      overrides?: Partial<ExactPermit2Payload>,
+    ): ExactPermit2Payload => {
       const now = Math.floor(Date.now() / 1000);
       return {
         signature: "0xmocksignature",

--- a/typescript/packages/mechanisms/evm/test/unit/types.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/types.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import type { ExactEvmPayloadV1, ExactEvmPayloadV2 } from "../../src/types";
+import type {
+  ExactEvmPayloadV1,
+  ExactEvmPayloadV2,
+  ExactEIP3009Payload,
+  ExactPermit2Payload,
+} from "../../src/types";
+import { isEIP3009Payload, isPermit2Payload } from "../../src/types";
 
 describe("EVM Types", () => {
   describe("ExactEvmPayloadV1", () => {
@@ -39,7 +45,7 @@ describe("EVM Types", () => {
   });
 
   describe("ExactEvmPayloadV2", () => {
-    it("should have the same structure as V1", () => {
+    it("should accept EIP-3009 payload structure", () => {
       const payload: ExactEvmPayloadV2 = {
         signature: "0x1234567890abcdef",
         authorization: {
@@ -53,8 +59,97 @@ describe("EVM Types", () => {
       };
 
       // V2 should be compatible with V1
-      const payloadV1: ExactEvmPayloadV1 = payload;
+      const payloadV1: ExactEvmPayloadV1 = payload as ExactEIP3009Payload;
       expect(payloadV1).toEqual(payload);
+    });
+
+    it("should accept Permit2 payload structure", () => {
+      const payload: ExactPermit2Payload = {
+        signature: "0x1234567890abcdef",
+        permit2Authorization: {
+          from: "0x1234567890123456789012345678901234567890",
+          permitted: {
+            token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            amount: "100000",
+          },
+          spender: "0x9876543210987654321098765432109876543210",
+          nonce: "12345678901234567890",
+          deadline: "1234567890",
+          witness: {
+            to: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+            validAfter: "1234567800",
+            validBefore: "1234567890",
+            extra: "0x",
+          },
+        },
+      };
+
+      expect(payload.signature).toBeDefined();
+      expect(payload.permit2Authorization.from).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(payload.permit2Authorization.permitted.token).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(payload.permit2Authorization.witness.to).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    });
+  });
+
+  describe("Type Guards", () => {
+    const eip3009Payload: ExactEIP3009Payload = {
+      signature: "0x1234567890abcdef",
+      authorization: {
+        from: "0x1234567890123456789012345678901234567890",
+        to: "0x9876543210987654321098765432109876543210",
+        value: "100000",
+        validAfter: "1234567890",
+        validBefore: "1234567890",
+        nonce: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      },
+    };
+
+    const permit2Payload: ExactPermit2Payload = {
+      signature: "0x1234567890abcdef",
+      permit2Authorization: {
+        from: "0x1234567890123456789012345678901234567890",
+        permitted: {
+          token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          amount: "100000",
+        },
+        spender: "0x9876543210987654321098765432109876543210",
+        nonce: "12345678901234567890",
+        deadline: "1234567890",
+        witness: {
+          to: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          validAfter: "1234567800",
+          validBefore: "1234567890",
+          extra: "0x",
+        },
+      },
+    };
+
+    describe("isEIP3009Payload", () => {
+      it("should return true for EIP-3009 payload", () => {
+        expect(isEIP3009Payload(eip3009Payload)).toBe(true);
+      });
+
+      it("should return false for Permit2 payload", () => {
+        expect(isEIP3009Payload(permit2Payload)).toBe(false);
+      });
+    });
+
+    describe("isPermit2Payload", () => {
+      it("should return true for Permit2 payload", () => {
+        expect(isPermit2Payload(permit2Payload)).toBe(true);
+      });
+
+      it("should return false for EIP-3009 payload", () => {
+        expect(isPermit2Payload(eip3009Payload)).toBe(false);
+      });
+    });
+
+    it("type guards should be mutually exclusive", () => {
+      const eip3009: ExactEvmPayloadV2 = eip3009Payload;
+      const permit2: ExactEvmPayloadV2 = permit2Payload;
+
+      expect(isEIP3009Payload(eip3009)).toBe(!isPermit2Payload(eip3009));
+      expect(isPermit2Payload(permit2)).toBe(!isEIP3009Payload(permit2));
     });
   });
 });


### PR DESCRIPTION
## Description

Implements facilitator-side Permit2 support including verification logic, settlement via `x402ExactPermit2Proxy`, and EIP-2612 gas sponsoring.

ERC-20 gasless approval is still WIP

### Changes

**Verification** (`exact/facilitator/scheme.ts`)
- Add `verifyPermit2()` function that validates:
  - Spender is `x402ExactPermit2Proxy` address
  - `witness.to` matches payment recipient
  - Token address matches requirements
  - Amount meets minimum
  - Timing (deadline, validAfter) is correct
  - Signature is valid (supports EOA and EIP-1271 smart wallets)
  - Payer has sufficient token balance
- Route verification based on payload type using `isPermit2Payload()` guard

**Settlement** (`exact/facilitator/scheme.ts`)
- Add `settlePermit2()` function that:
  - Calls `x402ExactPermit2Proxy.settle()` for standard Permit2
  - Calls `x402ExactPermit2Proxy.settleWith2612()` when `eip2612GasSponsoring` extension is present
- Handle transaction submission, waiting, and error cases

### Architecture

```
Client                    Server                  Facilitator
  │                         │                         │
  │  1. Request resource    │                         │
  │ ───────────────────────>│                         │
  │                         │                         │
  │  2. 402 + requirements  │                         │
  │    (assetTransferMethod │                         │
  │     = "permit2")        │                         │
  │ <───────────────────────│                         │
  │                         │                         │
  │  3. Sign Permit2        │                         │
  │     (spender = proxy)   │                         │
  │                         │                         │
  │  4. Request + payload   │                         │
  │ ───────────────────────>│                         │
  │                         │  5. Verify + settle     │
  │                         │ ───────────────────────>│
  │                         │                         │
  │                         │  6. Call proxy.settle() │
  │                         │     or settleWith2612() │
  │                         │                         │
  │  7. Response            │                         │
  │ <───────────────────────│                         │
```

### Breaking Changes
None - EIP-3009 remains the default

## Tests

- Unit tests:
  - Verification: valid payload, invalid spender, wrong recipient, insufficient balance, expired deadline, invalid signature
  - Settlement: standard settle, settleWith2612 with extension, transaction failure handling
- 1 new integration test for full Permit2 flow

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 