### PR TITLE
Add onProtectedRequest hook

### DIFF
--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -99,6 +99,7 @@ export {
   ProcessSettleFailureResponse,
   RouteValidationError,
   RouteConfigurationError,
+  RequestHook,
 } from "./x402HTTPResourceServer";
 export {
   HTTPFacilitatorClient,

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -99,7 +99,7 @@ export {
   ProcessSettleFailureResponse,
   RouteValidationError,
   RouteConfigurationError,
-  RequestHook,
+  ProtectedRequestHook,
 } from "./x402HTTPResourceServer";
 export {
   HTTPFacilitatorClient,

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -164,7 +164,7 @@ export type RoutesConfig = Record<string, RouteConfig> | RouteConfig;
  * - `{ grantAccess: true }` - Grant access without requiring payment
  * - `{ abort: true; reason: string }` - Deny the request (returns 403)
  */
-export type RequestHook = (
+export type ProtectedRequestHook = (
   context: HTTPRequestContext,
   routeConfig: RouteConfig,
 ) => Promise<void | { grantAccess: true } | { abort: true; reason: string }>;
@@ -274,7 +274,7 @@ export class x402HTTPResourceServer {
   private compiledRoutes: CompiledRoute[] = [];
   private routesConfig: RoutesConfig;
   private paywallProvider?: PaywallProvider;
-  private requestHooks: RequestHook[] = [];
+  private protectedRequestHooks: ProtectedRequestHook[] = [];
 
   /**
    * Creates a new x402HTTPResourceServer instance.
@@ -365,8 +365,8 @@ export class x402HTTPResourceServer {
    * @param hook - The request hook function
    * @returns The x402HTTPResourceServer instance for chaining
    */
-  onRequest(hook: RequestHook): this {
-    this.requestHooks.push(hook);
+  onProtectedRequest(hook: ProtectedRequestHook): this {
+    this.protectedRequestHooks.push(hook);
     return this;
   }
 
@@ -391,7 +391,7 @@ export class x402HTTPResourceServer {
     }
 
     // Execute request hooks before any payment processing
-    for (const hook of this.requestHooks) {
+    for (const hook of this.protectedRequestHooks) {
       const result = await hook(context, routeConfig);
       if (result && "grantAccess" in result) {
         return { type: "no-payment-required" };

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -1,5 +1,5 @@
 export { x402ResourceServer } from "./x402ResourceServer";
-export type { ResourceConfig, ResourceInfo } from "./x402ResourceServer";
+export type { ResourceConfig, ResourceInfo, SettleResultContext } from "./x402ResourceServer";
 
 export { HTTPFacilitatorClient } from "../http/httpFacilitatorClient";
 export type { FacilitatorClient, FacilitatorConfig } from "../http/httpFacilitatorClient";

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -639,40 +639,24 @@ export class x402ResourceServer {
         verifyResult = await facilitatorClient.verify(paymentPayload, requirements);
       }
 
-      // Execute appropriate hooks based on verification success
-      if (verifyResult.isValid) {
-        // Execute afterVerify hooks only on success
-        const resultContext: VerifyResultContext = {
-          ...context,
-          result: verifyResult,
-        };
+      // Execute afterVerify hooks
+      const resultContext: VerifyResultContext = {
+        ...context,
+        result: verifyResult,
+      };
 
-        for (const hook of this.afterVerifyHooks) {
-          await hook(resultContext);
-        }
-      } else {
-        // Execute onVerifyFailure hooks when verification returns invalid
-        const failureContext: VerifyFailureContext = {
-          ...context,
-          error: new Error(verifyResult.invalidReason || "Verification failed"),
-        };
-
-        for (const hook of this.onVerifyFailureHooks) {
-          const result = await hook(failureContext);
-          if (result && "recovered" in result && result.recovered) {
-            return result.result;
-          }
-        }
+      for (const hook of this.afterVerifyHooks) {
+        await hook(resultContext);
       }
 
       return verifyResult;
     } catch (error) {
-      // Execute onVerifyFailure hooks when an exception is thrown
       const failureContext: VerifyFailureContext = {
         ...context,
         error: error as Error,
       };
 
+      // Execute onVerifyFailure hooks
       for (const hook of this.onVerifyFailureHooks) {
         const result = await hook(failureContext);
         if (result && "recovered" in result && result.recovered) {
@@ -746,30 +730,14 @@ export class x402ResourceServer {
         settleResult = await facilitatorClient.settle(paymentPayload, requirements);
       }
 
-      // Execute appropriate hooks based on settlement success
-      if (settleResult.success) {
-        // Execute afterSettle hooks only on success
-        const resultContext: SettleResultContext = {
-          ...context,
-          result: settleResult,
-        };
+      // Execute afterSettle hooks
+      const resultContext: SettleResultContext = {
+        ...context,
+        result: settleResult,
+      };
 
-        for (const hook of this.afterSettleHooks) {
-          await hook(resultContext);
-        }
-      } else {
-        // Execute onSettleFailure hooks when settlement returns failure
-        const failureContext: SettleFailureContext = {
-          ...context,
-          error: new Error(settleResult.errorReason || "Settlement failed"),
-        };
-
-        for (const hook of this.onSettleFailureHooks) {
-          const result = await hook(failureContext);
-          if (result && "recovered" in result && result.recovered) {
-            return result.result;
-          }
-        }
+      for (const hook of this.afterSettleHooks) {
+        await hook(resultContext);
       }
 
       // Let declared extensions add data to settlement response
@@ -797,12 +765,12 @@ export class x402ResourceServer {
 
       return settleResult;
     } catch (error) {
-      // Execute onSettleFailure hooks when an exception is thrown
       const failureContext: SettleFailureContext = {
         ...context,
         error: error as Error,
       };
 
+      // Execute onSettleFailure hooks
       for (const hook of this.onSettleFailureHooks) {
         const result = await hook(failureContext);
         if (result && "recovered" in result && result.recovered) {

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -639,24 +639,40 @@ export class x402ResourceServer {
         verifyResult = await facilitatorClient.verify(paymentPayload, requirements);
       }
 
-      // Execute afterVerify hooks
-      const resultContext: VerifyResultContext = {
-        ...context,
-        result: verifyResult,
-      };
+      // Execute appropriate hooks based on verification success
+      if (verifyResult.isValid) {
+        // Execute afterVerify hooks only on success
+        const resultContext: VerifyResultContext = {
+          ...context,
+          result: verifyResult,
+        };
 
-      for (const hook of this.afterVerifyHooks) {
-        await hook(resultContext);
+        for (const hook of this.afterVerifyHooks) {
+          await hook(resultContext);
+        }
+      } else {
+        // Execute onVerifyFailure hooks when verification returns invalid
+        const failureContext: VerifyFailureContext = {
+          ...context,
+          error: new Error(verifyResult.invalidReason || "Verification failed"),
+        };
+
+        for (const hook of this.onVerifyFailureHooks) {
+          const result = await hook(failureContext);
+          if (result && "recovered" in result && result.recovered) {
+            return result.result;
+          }
+        }
       }
 
       return verifyResult;
     } catch (error) {
+      // Execute onVerifyFailure hooks when an exception is thrown
       const failureContext: VerifyFailureContext = {
         ...context,
         error: error as Error,
       };
 
-      // Execute onVerifyFailure hooks
       for (const hook of this.onVerifyFailureHooks) {
         const result = await hook(failureContext);
         if (result && "recovered" in result && result.recovered) {
@@ -730,14 +746,30 @@ export class x402ResourceServer {
         settleResult = await facilitatorClient.settle(paymentPayload, requirements);
       }
 
-      // Execute afterSettle hooks
-      const resultContext: SettleResultContext = {
-        ...context,
-        result: settleResult,
-      };
+      // Execute appropriate hooks based on settlement success
+      if (settleResult.success) {
+        // Execute afterSettle hooks only on success
+        const resultContext: SettleResultContext = {
+          ...context,
+          result: settleResult,
+        };
 
-      for (const hook of this.afterSettleHooks) {
-        await hook(resultContext);
+        for (const hook of this.afterSettleHooks) {
+          await hook(resultContext);
+        }
+      } else {
+        // Execute onSettleFailure hooks when settlement returns failure
+        const failureContext: SettleFailureContext = {
+          ...context,
+          error: new Error(settleResult.errorReason || "Settlement failed"),
+        };
+
+        for (const hook of this.onSettleFailureHooks) {
+          const result = await hook(failureContext);
+          if (result && "recovered" in result && result.recovered) {
+            return result.result;
+          }
+        }
       }
 
       // Let declared extensions add data to settlement response
@@ -765,12 +797,12 @@ export class x402ResourceServer {
 
       return settleResult;
     } catch (error) {
+      // Execute onSettleFailure hooks when an exception is thrown
       const failureContext: SettleFailureContext = {
         ...context,
         error: error as Error,
       };
 
-      // Execute onSettleFailure hooks
       for (const hook of this.onSettleFailureHooks) {
         const result = await hook(failureContext);
         if (result && "recovered" in result && result.recovered) {

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceServer.hooks.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceServer.hooks.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   x402HTTPResourceServer,
   HTTPRequestContext,
   HTTPAdapter,
+  RouteConfig,
+  ProtectedRequestHook,
 } from "../../../src/http/x402HTTPResourceServer";
 import { x402ResourceServer } from "../../../src/server/x402ResourceServer";
 import {
@@ -61,379 +63,654 @@ class MockHTTPAdapter implements HTTPAdapter {
 }
 
 describe("x402HTTPResourceServer Hooks", () => {
-  let extensionResourceServer: x402ResourceServer;
-  let extensionMockFacilitator: MockFacilitatorClient;
-  let extensionMockScheme: MockSchemeNetworkServer;
+  describe("Extension Hooks", () => {
+    let extensionResourceServer: x402ResourceServer;
+    let extensionMockFacilitator: MockFacilitatorClient;
+    let extensionMockScheme: MockSchemeNetworkServer;
 
-  beforeEach(async () => {
-    // Create a fresh ResourceServer for extension tests to avoid interference
-    extensionMockFacilitator = new MockFacilitatorClient(
-      buildSupportedResponse({
-        kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
-      }),
-      buildVerifyResponse({ isValid: true }),
-    );
-
-    extensionResourceServer = new x402ResourceServer(extensionMockFacilitator);
-
-    extensionMockScheme = new MockSchemeNetworkServer("exact", {
-      amount: "1000000",
-      asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-      extra: {},
-    });
-
-    extensionResourceServer.register("eip155:8453" as Network, extensionMockScheme);
-    await extensionResourceServer.initialize();
-  });
-
-  describe("enrichSettlementResponse", () => {
-    it("should enrich settlement response with extensions", async () => {
-      const receiptExtension: ResourceServerExtension = {
-        key: "receipt",
-        enrichSettlementResponse: async (_declaration: unknown, _context: SettleResultContext) => {
-          // Return just the extension data for this key, not the entire result
-          return {
-            receipt: "Receipt",
-          };
-        },
-      };
-
-      extensionResourceServer.registerExtension(receiptExtension);
-
-      const routes = {
-        "/api/test": {
-          accepts: {
-            scheme: "exact",
-            payTo: "0xabc",
-            price: "$1.00" as Price,
-            network: "eip155:8453" as Network,
-          },
-          extensions: {
-            receipt: {},
-          },
-        },
-      };
-
-      const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
-
-      const payload = buildPaymentPayload();
-      const requirements = buildPaymentRequirements({
-        scheme: "exact",
-        network: "eip155:8453" as Network,
-      });
-
-      // Set up mock to return a successful settlement
-      extensionMockFacilitator.setSettleResponse(
-        buildSettleResponse({
-          success: true,
-          transaction: "0x40d32f49a3fa2356275083e348d53fca876df3a140d72a71cf26c9cbaab359d9",
-          network: "eip155:8453" as Network,
-          payer: "0xE33A295AF5C90A0649DFBECfDf9D604789B892e2",
+    beforeEach(async () => {
+      // Create a fresh ResourceServer for extension tests to avoid interference
+      extensionMockFacilitator = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
         }),
+        buildVerifyResponse({ isValid: true }),
       );
 
-      const result = await httpServer.processSettlement(
-        payload,
-        requirements,
-        routes["/api/test"].extensions,
-      );
+      extensionResourceServer = new x402ResourceServer(extensionMockFacilitator);
 
-      expect(result.success).toBe(true);
-      if (result.success) {
-        // Check that extensions were added
-        expect((result as any).extensions).toBeDefined();
-        expect((result as any).extensions.receipt).toBeDefined();
-        expect((result as any).extensions.receipt.receipt).toBe("Receipt");
-        expect(result.transaction).toBe(
-          "0x40d32f49a3fa2356275083e348d53fca876df3a140d72a71cf26c9cbaab359d9",
-        );
-        expect(result.network).toBe("eip155:8453");
-        expect(result.payer).toBe("0xE33A295AF5C90A0649DFBECfDf9D604789B892e2");
-      }
-    });
-
-    it("should handle multiple extensions enriching settlement response", async () => {
-      const receiptExtension: ResourceServerExtension = {
-        key: "receipt",
-        enrichSettlementResponse: async (_declaration: unknown, context: SettleResultContext) => {
-          return {
-            ...context.result,
-            extensions: {
-              ...(context.result.extensions || {}),
-              receipt: { receipt: "Receipt" },
-            },
-          };
-        },
-      };
-
-      const attestationExtension: ResourceServerExtension = {
-        key: "attestation",
-        enrichSettlementResponse: async (_declaration: unknown, context: SettleResultContext) => {
-          return {
-            ...context.result,
-            extensions: {
-              ...(context.result.extensions || {}),
-              attestation: { attestationId: "attest-123" },
-            },
-          };
-        },
-      };
-
-      extensionResourceServer.registerExtension(receiptExtension);
-      extensionResourceServer.registerExtension(attestationExtension);
-
-      const routes = {
-        "/api/test": {
-          accepts: {
-            scheme: "exact",
-            payTo: "0xabc",
-            price: "$1.00" as Price,
-            network: "eip155:8453" as Network,
-          },
-          extensions: {
-            receipt: {},
-            attestation: {},
-          },
-        },
-      };
-
-      const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
-
-      const payload = buildPaymentPayload();
-      const requirements = buildPaymentRequirements({
-        scheme: "exact",
-        network: "eip155:8453" as Network,
+      extensionMockScheme = new MockSchemeNetworkServer("exact", {
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        extra: {},
       });
 
-      extensionMockFacilitator.setSettleResponse(buildSettleResponse({ success: true }));
-
-      const result = await httpServer.processSettlement(
-        payload,
-        requirements,
-        routes["/api/test"].extensions,
-      );
-
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect((result as any).extensions).toBeDefined();
-        expect((result as any).extensions.receipt).toBeDefined();
-        expect((result as any).extensions.attestation).toBeDefined();
-      }
+      extensionResourceServer.register("eip155:8453" as Network, extensionMockScheme);
+      await extensionResourceServer.initialize();
     });
 
-    it("should continue processing if extension hook throws error", async () => {
-      const errorExtension: ResourceServerExtension = {
-        key: "error-extension",
-        enrichSettlementResponse: async (_declaration: unknown, _context: SettleResultContext) => {
-          throw new Error("Extension error");
-        },
-      };
-
-      extensionResourceServer.registerExtension(errorExtension);
-
-      const routes = {
-        "/api/test": {
-          accepts: {
-            scheme: "exact",
-            payTo: "0xabc",
-            price: "$1.00" as Price,
-            network: "eip155:8453" as Network,
-          },
-          extensions: {
-            "error-extension": {},
-          },
-        },
-      };
-
-      const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
-
-      const payload = buildPaymentPayload();
-      const requirements = buildPaymentRequirements({
-        scheme: "exact",
-        network: "eip155:8453" as Network,
-      });
-
-      extensionMockFacilitator.setSettleResponse(buildSettleResponse({ success: true }));
-
-      // Should not throw, should continue with unenriched response
-      const result = await httpServer.processSettlement(
-        payload,
-        requirements,
-        routes["/api/test"].extensions,
-      );
-
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe("enrichPaymentRequiredResponse", () => {
-    it("should enrich PaymentRequired response before sending 402", async () => {
-      const paymentRequiredExtension: ResourceServerExtension = {
-        key: "payment-required-enricher",
-        enrichPaymentRequiredResponse: async (
-          _declaration: unknown,
-          _context: PaymentRequiredContext,
-        ) => {
-          // Return just the extension data for this key, not the entire response
-          return {
-            metadata: "test-metadata",
-          };
-        },
-      };
-
-      extensionResourceServer.registerExtension(paymentRequiredExtension);
-
-      const routes = {
-        "/api/test": {
-          accepts: {
-            scheme: "exact",
-            payTo: "0xabc",
-            price: "$1.00" as Price,
-            network: "eip155:8453" as Network,
-          },
-          extensions: {
-            existing: "existing-value",
-            "payment-required-enricher": {},
-          },
-        },
-      };
-
-      const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
-
-      const adapter = new MockHTTPAdapter();
-      const context: HTTPRequestContext = {
-        adapter,
-        path: "/api/test",
-        method: "GET",
-      };
-
-      const result = await httpServer.processHTTPRequest(context);
-
-      expect(result.type).toBe("payment-error");
-      if (result.type === "payment-error") {
-        const paymentRequiredHeader = result.response.headers["PAYMENT-REQUIRED"];
-        const decoded = decodePaymentRequiredHeader(paymentRequiredHeader);
-        expect(decoded.extensions).toBeDefined();
-        if (decoded.extensions) {
-          expect(decoded.extensions["payment-required-enricher"]).toBeDefined();
-          expect((decoded.extensions["payment-required-enricher"] as any).metadata).toBe(
-            "test-metadata",
-          );
-        }
-      }
-    });
-  });
-
-  describe("Integration: All hooks together", () => {
-    it("should apply all extension hooks in sequence", async () => {
-      const allHooksExtension: ResourceServerExtension = {
-        key: "all-hooks",
-        enrichPaymentRequiredResponse: async (
-          _declaration: unknown,
-          _context: PaymentRequiredContext,
-        ) => {
-          // Return just the extension data for this key
-          return {
-            paymentRequiredEnriched: true,
-          };
-        },
-        enrichSettlementResponse: async (_declaration: unknown, _context: SettleResultContext) => {
-          // Return just the extension data for this key
-          return {
-            receipt: {
+    describe("enrichSettlementResponse", () => {
+      it("should enrich settlement response with extensions", async () => {
+        const receiptExtension: ResourceServerExtension = {
+          key: "receipt",
+          enrichSettlementResponse: async (
+            _declaration: unknown,
+            _context: SettleResultContext,
+          ) => {
+            // Return just the extension data for this key, not the entire result
+            return {
               receipt: "Receipt",
+            };
+          },
+        };
+
+        extensionResourceServer.registerExtension(receiptExtension);
+
+        const routes = {
+          "/api/test": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
             },
-          };
-        },
-      };
-
-      extensionResourceServer.registerExtension(allHooksExtension);
-
-      const routes = {
-        "/api/test": {
-          accepts: {
-            scheme: "exact",
-            payTo: "0xabc",
-            price: "$1.00" as Price,
-            network: "eip155:8453" as Network,
+            extensions: {
+              receipt: {},
+            },
           },
-          extensions: {
-            "all-hooks": {},
-          },
-        },
-      };
+        };
 
-      const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
+        const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
 
-      // Test payment requirements enrichment
-      const adapter1 = new MockHTTPAdapter();
-      const context1: HTTPRequestContext = {
-        adapter: adapter1,
-        path: "/api/test",
-        method: "GET",
-      };
-
-      const result1 = await httpServer.processHTTPRequest(context1);
-      expect(result1.type).toBe("payment-error");
-      if (result1.type !== "payment-error") {
-        throw new Error("Expected payment-error");
-      }
-
-      const paymentRequiredHeader = result1.response.headers["PAYMENT-REQUIRED"];
-      const decoded = decodePaymentRequiredHeader(paymentRequiredHeader);
-      expect(decoded.extensions).toBeDefined();
-      if (decoded.extensions) {
-        expect((decoded.extensions["all-hooks"] as any).paymentRequiredEnriched).toBe(true);
-      }
-
-      // Test verification and settlement enrichment
-      // Get requirements from the PaymentRequired response
-      const paymentRequired = decoded;
-
-      const payload = buildPaymentPayload({
-        accepted: paymentRequired.accepts[0],
-        resource: paymentRequired.resource,
-      });
-      const paymentHeader = encodePaymentSignatureHeader(payload);
-
-      const adapter2 = new MockHTTPAdapter({
-        "payment-signature": paymentHeader,
-      });
-
-      const context2: HTTPRequestContext = {
-        adapter: adapter2,
-        path: "/api/test",
-        method: "GET",
-      };
-
-      extensionMockFacilitator.setVerifyResponse(buildVerifyResponse({ isValid: true }));
-      extensionMockFacilitator.setSettleResponse(
-        buildSettleResponse({
-          success: true,
-          transaction: "0x40d32f49a3fa2356275083e348d53fca876df3a140d72a71cf26c9cbaab359d9",
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
           network: "eip155:8453" as Network,
-          payer: "0xE33A295AF5C90A0649DFBECfDf9D604789B892e2",
-        }),
-      );
+        });
 
-      const result2 = await httpServer.processHTTPRequest(context2);
-      expect(result2.type).toBe("payment-verified");
+        // Set up mock to return a successful settlement
+        extensionMockFacilitator.setSettleResponse(
+          buildSettleResponse({
+            success: true,
+            transaction: "0x40d32f49a3fa2356275083e348d53fca876df3a140d72a71cf26c9cbaab359d9",
+            network: "eip155:8453" as Network,
+            payer: "0xE33A295AF5C90A0649DFBECfDf9D604789B892e2",
+          }),
+        );
 
-      if (result2.type === "payment-verified") {
-        const settleResult = await httpServer.processSettlement(
-          result2.paymentPayload,
-          result2.paymentRequirements,
+        const result = await httpServer.processSettlement(
+          payload,
+          requirements,
           routes["/api/test"].extensions,
         );
 
-        expect(settleResult.success).toBe(true);
-        if (settleResult.success) {
-          expect((settleResult as any).extensions).toBeDefined();
-          expect((settleResult as any).extensions["all-hooks"]).toBeDefined();
-          expect((settleResult as any).extensions["all-hooks"].receipt).toBeDefined();
-          expect((settleResult as any).extensions["all-hooks"].receipt.receipt).toBe("Receipt");
+        expect(result.success).toBe(true);
+        if (result.success) {
+          // Check that extensions were added
+          expect((result as any).extensions).toBeDefined();
+          expect((result as any).extensions.receipt).toBeDefined();
+          expect((result as any).extensions.receipt.receipt).toBe("Receipt");
+          expect(result.transaction).toBe(
+            "0x40d32f49a3fa2356275083e348d53fca876df3a140d72a71cf26c9cbaab359d9",
+          );
+          expect(result.network).toBe("eip155:8453");
+          expect(result.payer).toBe("0xE33A295AF5C90A0649DFBECfDf9D604789B892e2");
         }
-      }
+      });
+
+      it("should handle multiple extensions enriching settlement response", async () => {
+        const receiptExtension: ResourceServerExtension = {
+          key: "receipt",
+          enrichSettlementResponse: async (_declaration: unknown, context: SettleResultContext) => {
+            return {
+              ...context.result,
+              extensions: {
+                ...(context.result.extensions || {}),
+                receipt: { receipt: "Receipt" },
+              },
+            };
+          },
+        };
+
+        const attestationExtension: ResourceServerExtension = {
+          key: "attestation",
+          enrichSettlementResponse: async (_declaration: unknown, context: SettleResultContext) => {
+            return {
+              ...context.result,
+              extensions: {
+                ...(context.result.extensions || {}),
+                attestation: { attestationId: "attest-123" },
+              },
+            };
+          },
+        };
+
+        extensionResourceServer.registerExtension(receiptExtension);
+        extensionResourceServer.registerExtension(attestationExtension);
+
+        const routes = {
+          "/api/test": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+            extensions: {
+              receipt: {},
+              attestation: {},
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
+
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+        });
+
+        extensionMockFacilitator.setSettleResponse(buildSettleResponse({ success: true }));
+
+        const result = await httpServer.processSettlement(
+          payload,
+          requirements,
+          routes["/api/test"].extensions,
+        );
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect((result as any).extensions).toBeDefined();
+          expect((result as any).extensions.receipt).toBeDefined();
+          expect((result as any).extensions.attestation).toBeDefined();
+        }
+      });
+
+      it("should continue processing if extension hook throws error", async () => {
+        const errorExtension: ResourceServerExtension = {
+          key: "error-extension",
+          enrichSettlementResponse: async (
+            _declaration: unknown,
+            _context: SettleResultContext,
+          ) => {
+            throw new Error("Extension error");
+          },
+        };
+
+        extensionResourceServer.registerExtension(errorExtension);
+
+        const routes = {
+          "/api/test": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+            extensions: {
+              "error-extension": {},
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
+
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+        });
+
+        extensionMockFacilitator.setSettleResponse(buildSettleResponse({ success: true }));
+
+        // Should not throw, should continue with unenriched response
+        const result = await httpServer.processSettlement(
+          payload,
+          requirements,
+          routes["/api/test"].extensions,
+        );
+
+        expect(result.success).toBe(true);
+      });
+    });
+
+    describe("enrichPaymentRequiredResponse", () => {
+      it("should enrich PaymentRequired response before sending 402", async () => {
+        const paymentRequiredExtension: ResourceServerExtension = {
+          key: "payment-required-enricher",
+          enrichPaymentRequiredResponse: async (
+            _declaration: unknown,
+            _context: PaymentRequiredContext,
+          ) => {
+            // Return just the extension data for this key, not the entire response
+            return {
+              metadata: "test-metadata",
+            };
+          },
+        };
+
+        extensionResourceServer.registerExtension(paymentRequiredExtension);
+
+        const routes = {
+          "/api/test": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+            extensions: {
+              existing: "existing-value",
+              "payment-required-enricher": {},
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/test",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(result.type).toBe("payment-error");
+        if (result.type === "payment-error") {
+          const paymentRequiredHeader = result.response.headers["PAYMENT-REQUIRED"];
+          const decoded = decodePaymentRequiredHeader(paymentRequiredHeader);
+          expect(decoded.extensions).toBeDefined();
+          if (decoded.extensions) {
+            expect(decoded.extensions["payment-required-enricher"]).toBeDefined();
+            expect((decoded.extensions["payment-required-enricher"] as any).metadata).toBe(
+              "test-metadata",
+            );
+          }
+        }
+      });
+    });
+
+    describe("Integration: All hooks together", () => {
+      it("should apply all extension hooks in sequence", async () => {
+        const allHooksExtension: ResourceServerExtension = {
+          key: "all-hooks",
+          enrichPaymentRequiredResponse: async (
+            _declaration: unknown,
+            _context: PaymentRequiredContext,
+          ) => {
+            // Return just the extension data for this key
+            return {
+              paymentRequiredEnriched: true,
+            };
+          },
+          enrichSettlementResponse: async (
+            _declaration: unknown,
+            _context: SettleResultContext,
+          ) => {
+            // Return just the extension data for this key
+            return {
+              receipt: {
+                receipt: "Receipt",
+              },
+            };
+          },
+        };
+
+        extensionResourceServer.registerExtension(allHooksExtension);
+
+        const routes = {
+          "/api/test": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+            extensions: {
+              "all-hooks": {},
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(extensionResourceServer, routes);
+
+        // Test payment requirements enrichment
+        const adapter1 = new MockHTTPAdapter();
+        const context1: HTTPRequestContext = {
+          adapter: adapter1,
+          path: "/api/test",
+          method: "GET",
+        };
+
+        const result1 = await httpServer.processHTTPRequest(context1);
+        expect(result1.type).toBe("payment-error");
+        if (result1.type !== "payment-error") {
+          throw new Error("Expected payment-error");
+        }
+
+        const paymentRequiredHeader = result1.response.headers["PAYMENT-REQUIRED"];
+        const decoded = decodePaymentRequiredHeader(paymentRequiredHeader);
+        expect(decoded.extensions).toBeDefined();
+        if (decoded.extensions) {
+          expect((decoded.extensions["all-hooks"] as any).paymentRequiredEnriched).toBe(true);
+        }
+
+        // Test verification and settlement enrichment
+        // Get requirements from the PaymentRequired response
+        const paymentRequired = decoded;
+
+        const payload = buildPaymentPayload({
+          accepted: paymentRequired.accepts[0],
+          resource: paymentRequired.resource,
+        });
+        const paymentHeader = encodePaymentSignatureHeader(payload);
+
+        const adapter2 = new MockHTTPAdapter({
+          "payment-signature": paymentHeader,
+        });
+
+        const context2: HTTPRequestContext = {
+          adapter: adapter2,
+          path: "/api/test",
+          method: "GET",
+        };
+
+        extensionMockFacilitator.setVerifyResponse(buildVerifyResponse({ isValid: true }));
+        extensionMockFacilitator.setSettleResponse(
+          buildSettleResponse({
+            success: true,
+            transaction: "0x40d32f49a3fa2356275083e348d53fca876df3a140d72a71cf26c9cbaab359d9",
+            network: "eip155:8453" as Network,
+            payer: "0xE33A295AF5C90A0649DFBECfDf9D604789B892e2",
+          }),
+        );
+
+        const result2 = await httpServer.processHTTPRequest(context2);
+        expect(result2.type).toBe("payment-verified");
+
+        if (result2.type === "payment-verified") {
+          const settleResult = await httpServer.processSettlement(
+            result2.paymentPayload,
+            result2.paymentRequirements,
+            routes["/api/test"].extensions,
+          );
+
+          expect(settleResult.success).toBe(true);
+          if (settleResult.success) {
+            expect((settleResult as any).extensions).toBeDefined();
+            expect((settleResult as any).extensions["all-hooks"]).toBeDefined();
+            expect((settleResult as any).extensions["all-hooks"].receipt).toBeDefined();
+            expect((settleResult as any).extensions["all-hooks"].receipt.receipt).toBe("Receipt");
+          }
+        }
+      });
+    });
+  });
+
+  describe("ProtectedRequestHook", () => {
+    let ResourceServer: x402ResourceServer;
+    let mockFacilitator: MockFacilitatorClient;
+    let mockScheme: MockSchemeNetworkServer;
+
+    const testNetwork = "eip155:8453" as Network;
+    const testRoutes = {
+      "/api/protected": {
+        accepts: {
+          scheme: "exact",
+          payTo: "0xabc",
+          price: "$1.00" as Price,
+          network: testNetwork,
+        },
+      },
+    };
+
+    beforeEach(async () => {
+      mockFacilitator = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: testNetwork }],
+        }),
+        buildVerifyResponse({ isValid: true }),
+      );
+
+      ResourceServer = new x402ResourceServer(mockFacilitator);
+
+      mockScheme = new MockSchemeNetworkServer("exact", {
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        extra: {},
+      });
+
+      ResourceServer.register(testNetwork, mockScheme);
+      await ResourceServer.initialize();
+    });
+
+    describe("hook registration", () => {
+      it("should return this for chaining", () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook: ProtectedRequestHook = async () => {};
+
+        const result = httpServer.onProtectedRequest(hook);
+
+        expect(result).toBe(httpServer);
+      });
+    });
+
+    describe("hook returning void", () => {
+      it("should continue to payment processing when hook returns void", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook = vi.fn().mockResolvedValue(undefined);
+
+        httpServer.onProtectedRequest(hook);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/protected",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(hook).toHaveBeenCalled();
+        expect(result.type).toBe("payment-error"); // No payment provided
+        if (result.type === "payment-error") {
+          expect(result.response.status).toBe(402);
+        }
+      });
+    });
+
+    describe("hook returning grantAccess", () => {
+      it("should grant access without payment when hook returns grantAccess", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook = vi.fn().mockResolvedValue({ grantAccess: true });
+
+        httpServer.onProtectedRequest(hook);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/protected",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(hook).toHaveBeenCalled();
+        expect(result.type).toBe("no-payment-required");
+      });
+    });
+
+    describe("hook returning abort", () => {
+      it("should return 403 when hook returns abort", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook = vi.fn().mockResolvedValue({ abort: true, reason: "Access denied" });
+
+        httpServer.onProtectedRequest(hook);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/protected",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(hook).toHaveBeenCalled();
+        expect(result.type).toBe("payment-error");
+        if (result.type === "payment-error") {
+          expect(result.response.status).toBe(403);
+          expect(result.response.body).toEqual({ error: "Access denied" });
+        }
+      });
+    });
+
+    describe("multiple hooks", () => {
+      it("should stop at first hook returning grantAccess", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook1 = vi.fn().mockResolvedValue({ grantAccess: true });
+        const hook2 = vi.fn().mockResolvedValue({ abort: true, reason: "Should not reach" });
+
+        httpServer.onProtectedRequest(hook1);
+        httpServer.onProtectedRequest(hook2);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/protected",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(hook1).toHaveBeenCalled();
+        expect(hook2).not.toHaveBeenCalled();
+        expect(result.type).toBe("no-payment-required");
+      });
+
+      it("should stop at first hook returning abort", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook1 = vi.fn().mockResolvedValue({ abort: true, reason: "Blocked" });
+        const hook2 = vi.fn().mockResolvedValue({ grantAccess: true });
+
+        httpServer.onProtectedRequest(hook1);
+        httpServer.onProtectedRequest(hook2);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/protected",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(hook1).toHaveBeenCalled();
+        expect(hook2).not.toHaveBeenCalled();
+        expect(result.type).toBe("payment-error");
+        if (result.type === "payment-error") {
+          expect(result.response.status).toBe(403);
+        }
+      });
+
+      it("should continue through hooks returning void", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook1 = vi.fn().mockResolvedValue(undefined);
+        const hook2 = vi.fn().mockResolvedValue(undefined);
+        const hook3 = vi.fn().mockResolvedValue({ grantAccess: true });
+
+        httpServer.onProtectedRequest(hook1);
+        httpServer.onProtectedRequest(hook2);
+        httpServer.onProtectedRequest(hook3);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/protected",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(hook1).toHaveBeenCalled();
+        expect(hook2).toHaveBeenCalled();
+        expect(hook3).toHaveBeenCalled();
+        expect(result.type).toBe("no-payment-required");
+      });
+    });
+
+    describe("hook arguments", () => {
+      it("should receive HTTPRequestContext", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        let receivedContext: HTTPRequestContext | undefined;
+
+        const hook: ProtectedRequestHook = async context => {
+          receivedContext = context;
+        };
+
+        httpServer.onProtectedRequest(hook);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/protected",
+          method: "GET",
+        };
+
+        await httpServer.processHTTPRequest(context);
+
+        expect(receivedContext).toBeDefined();
+        expect(receivedContext?.path).toBe("/api/protected");
+        expect(receivedContext?.method).toBe("GET");
+        expect(receivedContext?.adapter).toBe(adapter);
+      });
+
+      it("should receive RouteConfig", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        let receivedRouteConfig: RouteConfig | undefined;
+
+        const hook: ProtectedRequestHook = async (_context, routeConfig) => {
+          receivedRouteConfig = routeConfig;
+        };
+
+        httpServer.onProtectedRequest(hook);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/protected",
+          method: "GET",
+        };
+
+        await httpServer.processHTTPRequest(context);
+
+        expect(receivedRouteConfig).toBeDefined();
+        expect(receivedRouteConfig?.accepts).toBeDefined();
+      });
+    });
+
+    describe("hooks on unprotected routes", () => {
+      it("should not call hooks for routes without payment config", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook = vi.fn().mockResolvedValue({ grantAccess: true });
+
+        httpServer.onProtectedRequest(hook);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/public", // Not in testRoutes
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(hook).not.toHaveBeenCalled();
+        expect(result.type).toBe("no-payment-required");
+      });
     });
   });
 });

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -454,13 +454,18 @@ describe("paymentMiddlewareFromConfig", () => {
     mockRequiresPayment = vi.fn().mockReturnValue(true);
 
     vi.mocked(HTTPResourceServer).mockImplementation(
-      () =>
+      (server, routes) =>
         ({
           initialize: vi.fn().mockResolvedValue(undefined),
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
         }) as unknown as x402HTTPResourceServer,
     );
 
@@ -522,12 +527,17 @@ describe("ExpressAdapter", () => {
     mockRequiresPayment = vi.fn().mockReturnValue(true);
 
     vi.mocked(HTTPResourceServer).mockImplementation(
-      () =>
+      (server, routes) =>
         ({
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
         }) as unknown as x402HTTPResourceServer,
     );
   });

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -44,13 +44,19 @@ vi.mock("@x402/core/server", () => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     registerExtension: vi.fn(),
     register: vi.fn(),
+    hasExtension: vi.fn().mockReturnValue(false),
   })),
-  x402HTTPResourceServer: vi.fn().mockImplementation(() => ({
+  x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     processHTTPRequest: mockProcessHTTPRequest,
     processSettlement: mockProcessSettlement,
     registerPaywallProvider: mockRegisterPaywallProvider,
     requiresPayment: mockRequiresPayment,
+    routes: routes,
+    server: server || {
+      hasExtension: vi.fn().mockReturnValue(false),
+      registerExtension: vi.fn(),
+    },
   })),
 }));
 
@@ -158,12 +164,17 @@ describe("paymentMiddleware", () => {
 
     // Reset the mock implementation
     vi.mocked(HTTPResourceServer).mockImplementation(
-      () =>
+      (server, routes) =>
         ({
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
         }) as unknown as x402HTTPResourceServer,
     );
   });

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -18,6 +18,11 @@ import { ExpressAdapter } from "./adapter";
  * @returns True if any route has extensions.bazaar defined
  */
 function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
+  // Handle null/undefined routes (defensive programming)
+  if (!routes || typeof routes !== "object") {
+    return false;
+  }
+
   // Handle single route config
   if ("accepts" in routes) {
     return !!(routes.extensions && "bazaar" in routes.extensions);
@@ -45,14 +50,11 @@ export interface SchemeRegistration {
 }
 
 /**
- * Express payment middleware for x402 protocol (direct server instance).
+ * Express payment middleware for x402 protocol (direct HTTP server instance).
  *
- * Use this when you want to pass a pre-configured x402ResourceServer instance.
- * This provides more flexibility for testing, custom configuration, and reusing
- * server instances across multiple middlewares.
+ * Use this when you need to configure HTTP-level hooks.
  *
- * @param routes - Route configurations for protected endpoints
- * @param server - Pre-configured x402ResourceServer instance
+ * @param httpServer - Pre-configured x402HTTPResourceServer instance
  * @param paywallConfig - Optional configuration for the built-in paywall UI
  * @param paywall - Optional custom paywall provider (overrides default)
  * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
@@ -60,26 +62,23 @@ export interface SchemeRegistration {
  *
  * @example
  * ```typescript
- * import { paymentMiddleware } from "@x402/express";
- * import { x402ResourceServer } from "@x402/core/server";
- * import { registerExactEvmScheme } from "@x402/evm/exact/server";
+ * import { paymentMiddlewareFromHTTPServer, x402ResourceServer, x402HTTPResourceServer } from "@x402/express";
  *
- * const server = new x402ResourceServer(myFacilitatorClient);
- * registerExactEvmScheme(server, { signer: myServerSigner });
+ * const resourceServer = new x402ResourceServer(facilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme())
  *
- * app.use(paymentMiddleware(routes, server, paywallConfig));
+ * const httpServer = new x402HTTPResourceServer(resourceServer, routes)
+ *   .onRequest(requestHook);
+ *
+ * app.use(paymentMiddlewareFromHTTPServer(httpServer));
  * ```
  */
-export function paymentMiddleware(
-  routes: RoutesConfig,
-  server: x402ResourceServer,
+export function paymentMiddlewareFromHTTPServer(
+  httpServer: x402HTTPResourceServer,
   paywallConfig?: PaywallConfig,
   paywall?: PaywallProvider,
   syncFacilitatorOnStart: boolean = true,
 ) {
-  // Create the x402 HTTP server instance with the resource server
-  const httpServer = new x402HTTPResourceServer(server, routes);
-
   // Register custom paywall provider if provided
   if (paywall) {
     httpServer.registerPaywallProvider(paywall);
@@ -92,10 +91,10 @@ export function paymentMiddleware(
   // Dynamically register bazaar extension if routes declare it and not already registered
   // Skip if pre-registered (e.g., in serverless environments where static imports are used)
   let bazaarPromise: Promise<void> | null = null;
-  if (checkIfBazaarNeeded(routes) && !server.hasExtension("bazaar")) {
+  if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import("@x402/extensions/bazaar")
       .then(({ bazaarResourceServerExtension }) => {
-        server.registerExtension(bazaarResourceServerExtension);
+        httpServer.server.registerExtension(bazaarResourceServerExtension);
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);
@@ -287,6 +286,48 @@ export function paymentMiddleware(
         return;
     }
   };
+}
+
+/**
+ * Express payment middleware for x402 protocol (direct server instance).
+ *
+ * Use this when you want to pass a pre-configured x402ResourceServer instance.
+ * This provides more flexibility for testing, custom configuration, and reusing
+ * server instances across multiple middlewares.
+ *
+ * @param routes - Route configurations for protected endpoints
+ * @param server - Pre-configured x402ResourceServer instance
+ * @param paywallConfig - Optional configuration for the built-in paywall UI
+ * @param paywall - Optional custom paywall provider (overrides default)
+ * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
+ * @returns Express middleware handler
+ *
+ * @example
+ * ```typescript
+ * import { paymentMiddleware } from "@x402/express";
+ *
+ * const server = new x402ResourceServer(myFacilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme());
+ *
+ * app.use(paymentMiddleware(routes, server, paywallConfig));
+ * ```
+ */
+export function paymentMiddleware(
+  routes: RoutesConfig,
+  server: x402ResourceServer,
+  paywallConfig?: PaywallConfig,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart: boolean = true,
+) {
+  // Create the x402 HTTP server instance with the resource server
+  const httpServer = new x402HTTPResourceServer(server, routes);
+
+  return paymentMiddlewareFromHTTPServer(
+    httpServer,
+    paywallConfig,
+    paywall,
+    syncFacilitatorOnStart,
+  );
 }
 
 /**

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -18,11 +18,6 @@ import { ExpressAdapter } from "./adapter";
  * @returns True if any route has extensions.bazaar defined
  */
 function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  // Handle null/undefined routes (defensive programming)
-  if (!routes || typeof routes !== "object") {
-    return false;
-  }
-
   // Handle single route config
   if ("accepts" in routes) {
     return !!(routes.extensions && "bazaar" in routes.extensions);
@@ -68,7 +63,7 @@ export interface SchemeRegistration {
  *   .register(NETWORK, new ExactEvmScheme())
  *
  * const httpServer = new x402HTTPResourceServer(resourceServer, routes)
- *   .onRequest(requestHook);
+ *   .onProtectedRequest(requestHook);
  *
  * app.use(paymentMiddlewareFromHTTPServer(httpServer));
  * ```

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -44,13 +44,19 @@ vi.mock("@x402/core/server", () => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     registerExtension: vi.fn(),
     register: vi.fn(),
+    hasExtension: vi.fn().mockReturnValue(false),
   })),
-  x402HTTPResourceServer: vi.fn().mockImplementation(() => ({
+  x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     processHTTPRequest: mockProcessHTTPRequest,
     processSettlement: mockProcessSettlement,
     registerPaywallProvider: mockRegisterPaywallProvider,
     requiresPayment: mockRequiresPayment,
+    routes: routes,
+    server: server || {
+      hasExtension: vi.fn().mockReturnValue(false),
+      registerExtension: vi.fn(),
+    },
   })),
 }));
 
@@ -155,12 +161,17 @@ describe("paymentMiddleware", () => {
 
     // Reset the mock implementation
     vi.mocked(HTTPResourceServer).mockImplementation(
-      () =>
+      (server, routes) =>
         ({
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
         }) as unknown as x402HTTPResourceServer,
     );
   });

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -457,13 +457,18 @@ describe("paymentMiddlewareFromConfig", () => {
     mockRequiresPayment = vi.fn().mockReturnValue(true);
 
     vi.mocked(HTTPResourceServer).mockImplementation(
-      () =>
+      (server, routes) =>
         ({
           initialize: vi.fn().mockResolvedValue(undefined),
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
         }) as unknown as x402HTTPResourceServer,
     );
 
@@ -524,12 +529,17 @@ describe("HonoAdapter", () => {
     mockRequiresPayment = vi.fn().mockReturnValue(true);
 
     vi.mocked(HTTPResourceServer).mockImplementation(
-      () =>
+      (server, routes) =>
         ({
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
         }) as unknown as x402HTTPResourceServer,
     );
   });

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -18,11 +18,6 @@ import { HonoAdapter } from "./adapter";
  * @returns True if any route has extensions.bazaar defined
  */
 function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  // Handle null/undefined routes (defensive programming)
-  if (!routes || typeof routes !== "object") {
-    return false;
-  }
-
   // Handle single route config
   if ("accepts" in routes) {
     return !!(routes.extensions && "bazaar" in routes.extensions);
@@ -68,7 +63,7 @@ export interface SchemeRegistration {
  *   .register(NETWORK, new ExactEvmScheme());
  *
  * const httpServer = new x402HTTPResourceServer(resourceServer, routes)
- *   .onRequest(requestHook);
+ *   .onProtectedRequest(requestHook);
  *
  * app.use(paymentMiddlewareFromHTTPServer(httpServer));
  * ```

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -18,6 +18,11 @@ import { HonoAdapter } from "./adapter";
  * @returns True if any route has extensions.bazaar defined
  */
 function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
+  // Handle null/undefined routes (defensive programming)
+  if (!routes || typeof routes !== "object") {
+    return false;
+  }
+
   // Handle single route config
   if ("accepts" in routes) {
     return !!(routes.extensions && "bazaar" in routes.extensions);
@@ -45,14 +50,11 @@ export interface SchemeRegistration {
 }
 
 /**
- * Hono payment middleware for x402 protocol (direct server instance).
+ * Hono payment middleware for x402 protocol (direct HTTP server instance).
  *
- * Use this when you want to pass a pre-configured x402ResourceServer instance.
- * This provides more flexibility for testing, custom configuration, and reusing
- * server instances across multiple middlewares.
+ * Use this when you need to configure HTTP-level hooks.
  *
- * @param routes - Route configurations for protected endpoints
- * @param server - Pre-configured x402ResourceServer instance
+ * @param httpServer - Pre-configured x402HTTPResourceServer instance
  * @param paywallConfig - Optional configuration for the built-in paywall UI
  * @param paywall - Optional custom paywall provider (overrides default)
  * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
@@ -60,26 +62,23 @@ export interface SchemeRegistration {
  *
  * @example
  * ```typescript
- * import { paymentMiddleware } from "@x402/hono";
- * import { x402ResourceServer } from "@x402/core/server";
- * import { registerExactEvmScheme } from "@x402/evm/exact/server";
+ * import { paymentMiddlewareFromHTTPServer, x402ResourceServer, x402HTTPResourceServer } from "@x402/hono";
  *
- * const server = new x402ResourceServer(myFacilitatorClient);
- * registerExactEvmScheme(server, {});
+ * const resourceServer = new x402ResourceServer(facilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme());
  *
- * app.use(paymentMiddleware(routes, server, paywallConfig));
+ * const httpServer = new x402HTTPResourceServer(resourceServer, routes)
+ *   .onRequest(requestHook);
+ *
+ * app.use(paymentMiddlewareFromHTTPServer(httpServer));
  * ```
  */
-export function paymentMiddleware(
-  routes: RoutesConfig,
-  server: x402ResourceServer,
+export function paymentMiddlewareFromHTTPServer(
+  httpServer: x402HTTPResourceServer,
   paywallConfig?: PaywallConfig,
   paywall?: PaywallProvider,
   syncFacilitatorOnStart: boolean = true,
 ): MiddlewareHandler {
-  // Create the x402 HTTP server instance with the resource server
-  const httpServer = new x402HTTPResourceServer(server, routes);
-
   // Register custom paywall provider if provided
   if (paywall) {
     httpServer.registerPaywallProvider(paywall);
@@ -92,10 +91,10 @@ export function paymentMiddleware(
   // Dynamically register bazaar extension if routes declare it and not already registered
   // Skip if pre-registered (e.g., in serverless environments where static imports are used)
   let bazaarPromise: Promise<void> | null = null;
-  if (checkIfBazaarNeeded(routes) && !server.hasExtension("bazaar")) {
+  if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import("@x402/extensions/bazaar")
       .then(({ bazaarResourceServerExtension }) => {
-        server.registerExtension(bazaarResourceServerExtension);
+        httpServer.server.registerExtension(bazaarResourceServerExtension);
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);
@@ -207,6 +206,48 @@ export function paymentMiddleware(
         return;
     }
   };
+}
+
+/**
+ * Hono payment middleware for x402 protocol (direct server instance).
+ *
+ * Use this when you want to pass a pre-configured x402ResourceServer instance.
+ * This provides more flexibility for testing, custom configuration, and reusing
+ * server instances across multiple middlewares.
+ *
+ * @param routes - Route configurations for protected endpoints
+ * @param server - Pre-configured x402ResourceServer instance
+ * @param paywallConfig - Optional configuration for the built-in paywall UI
+ * @param paywall - Optional custom paywall provider (overrides default)
+ * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
+ * @returns Hono middleware handler
+ *
+ * @example
+ * ```typescript
+ * import { paymentMiddleware } from "@x402/hono";
+ *
+ * const server = new x402ResourceServer(myFacilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme());
+ *
+ * app.use(paymentMiddleware(routes, server, paywallConfig));
+ * ```
+ */
+export function paymentMiddleware(
+  routes: RoutesConfig,
+  server: x402ResourceServer,
+  paywallConfig?: PaywallConfig,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart: boolean = true,
+): MiddlewareHandler {
+  // Create the x402 HTTP server instance with the resource server
+  const httpServer = new x402HTTPResourceServer(server, routes);
+
+  return paymentMiddlewareFromHTTPServer(
+    httpServer,
+    paywallConfig,
+    paywall,
+    syncFacilitatorOnStart,
+  );
 }
 
 /**

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -6,7 +6,7 @@ import type {
   PaywallProvider,
   FacilitatorClient,
 } from "@x402/core/server";
-import { x402ResourceServer } from "@x402/core/server";
+import { x402ResourceServer, x402HTTPResourceServer } from "@x402/core/server";
 import type { PaymentPayload, PaymentRequirements, SchemeNetworkServer } from "@x402/core/types";
 import { paymentProxy, paymentProxyFromConfig, withX402, type SchemeRegistration } from "./index";
 
@@ -21,14 +21,33 @@ vi.mock("./utils", async () => {
   };
 });
 
+// Shared mock functions storage - will be populated by tests
+const mockFunctions = {
+  processHTTPRequest: vi.fn(),
+  processSettlement: vi.fn(),
+  requiresPayment: vi.fn().mockReturnValue(true),
+};
+
 // Mock @x402/core/server
 vi.mock("@x402/core/server", () => ({
   x402ResourceServer: vi.fn().mockImplementation(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     registerExtension: vi.fn(),
     register: vi.fn(),
+    hasExtension: vi.fn().mockReturnValue(false),
   })),
-  x402HTTPResourceServer: vi.fn(),
+  x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    registerPaywallProvider: vi.fn(),
+    processHTTPRequest: (...args: unknown[]) => mockFunctions.processHTTPRequest(...args),
+    processSettlement: (...args: unknown[]) => mockFunctions.processSettlement(...args),
+    requiresPayment: (...args: unknown[]) => mockFunctions.requiresPayment(...args),
+    routes: routes || {},
+    server: server || {
+      hasExtension: vi.fn().mockReturnValue(false),
+      registerExtension: vi.fn(),
+    },
+  })),
 }));
 
 // --- Test Fixtures ---
@@ -74,7 +93,13 @@ function createMockHttpServer(
     processHTTPRequest: vi.fn().mockResolvedValue(processResult),
     processSettlement: vi.fn().mockResolvedValue(settlementResult),
     registerPaywallProvider: vi.fn(),
+    initialize: vi.fn().mockResolvedValue(undefined),
     requiresPayment: vi.fn().mockReturnValue(true),
+    routes: mockRoutes,
+    server: {
+      hasExtension: vi.fn().mockReturnValue(false),
+      registerExtension: vi.fn(),
+    },
   } as unknown as x402HTTPResourceServer;
 }
 
@@ -102,11 +127,19 @@ function createMockRequest(
 }
 
 /**
- * Sets up createHttpServer mock to return the provided server.
+ * Sets up the mock x402HTTPResourceServer constructor to return instances
+ * with the provided mock server's behavior.
  *
- * @param mockServer - The mock x402HTTPResourceServer to return.
+ * @param mockServer - The mock x402HTTPResourceServer to use as template.
  */
 function setupMockCreateHttpServer(mockServer: x402HTTPResourceServer): void {
+  // Replace the shared mock functions with the ones from mockServer
+  // This allows the mock constructor to use the configured mocks
+  mockFunctions.processHTTPRequest = mockServer.processHTTPRequest as ReturnType<typeof vi.fn>;
+  mockFunctions.processSettlement = mockServer.processSettlement as ReturnType<typeof vi.fn>;
+  mockFunctions.requiresPayment = mockServer.requiresPayment as ReturnType<typeof vi.fn>;
+
+  // Also set up createHttpServer mock for backward compatibility
   vi.mocked(createHttpServer).mockReturnValue({
     httpServer: mockServer,
     init: vi.fn().mockResolvedValue(undefined),
@@ -116,6 +149,10 @@ function setupMockCreateHttpServer(mockServer: x402HTTPResourceServer): void {
 describe("paymentProxy", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset shared mock functions
+    mockFunctions.processHTTPRequest = vi.fn();
+    mockFunctions.processSettlement = vi.fn();
+    mockFunctions.requiresPayment = vi.fn().mockReturnValue(true);
   });
 
   it("returns NextResponse.next() when no-payment-required", async () => {
@@ -210,7 +247,7 @@ describe("paymentProxy", () => {
 
     paymentProxy(mockRoutes, {} as unknown as x402ResourceServer, undefined, paywall);
 
-    expect(createHttpServer).toHaveBeenCalledWith(mockRoutes, expect.anything(), paywall, true);
+    expect(x402HTTPResourceServer).toHaveBeenCalledWith(expect.anything(), mockRoutes);
   });
 
   it("returns 402 when settlement throws error", async () => {
@@ -419,6 +456,6 @@ describe("paymentProxyFromConfig", () => {
 
     paymentProxyFromConfig(mockRoutes, undefined, undefined, paywallConfig, paywall, false);
 
-    expect(createHttpServer).toHaveBeenCalledWith(mockRoutes, expect.anything(), paywall, false);
+    expect(x402HTTPResourceServer).toHaveBeenCalledWith(expect.anything(), mockRoutes);
   });
 });

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -50,7 +50,7 @@ export interface SchemeRegistration {
  *   .register(NETWORK, new ExactEvmScheme());
  *
  * const httpServer = new x402HTTPResourceServer(resourceServer, routes)
- *   .onRequest(requestHook);
+ *   .onProtectedRequest(requestHook);
  *
  * export const proxy = paymentProxyFromHTTPServer(httpServer);
  * ```
@@ -228,7 +228,7 @@ export function paymentProxyFromConfig(
  *   .register(NETWORK, new ExactEvmScheme());
  *
  * const httpServer = new x402HTTPResourceServer(resourceServer, { "*": routeConfig })
- *   .onRequest(requestHook);
+ *   .onProtectedRequest(requestHook);
  *
  * const handler = async (request: NextRequest) => {
  *   return NextResponse.json({ data: "protected content" });
@@ -369,11 +369,6 @@ export function withX402<T = unknown>(
  * @returns True if any route has extensions.bazaar defined
  */
 function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  // Handle null/undefined routes (defensive programming)
-  if (!routes || typeof routes !== "object") {
-    return false;
-  }
-
   // Handle single route config
   if ("accepts" in routes) {
     return !!(routes.extensions && "bazaar" in routes.extensions);

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -9,11 +9,12 @@ import {
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { NextRequest, NextResponse } from "next/server";
 import {
-  createHttpServer,
+  prepareHttpServer,
   createRequestContext,
   handlePaymentError,
   handleSettlement,
 } from "./utils";
+import { x402HTTPResourceServer } from "@x402/core/server";
 
 /**
  * Configuration for registering a payment scheme with a specific network
@@ -31,14 +32,11 @@ export interface SchemeRegistration {
 }
 
 /**
- * Next.js payment proxy for x402 protocol (direct server instance).
+ * Next.js payment proxy for x402 protocol (direct HTTP server instance).
  *
- * Use this when you want to pass a pre-configured x402ResourceServer instance.
- * This provides more flexibility for testing, custom configuration, and reusing
- * server instances across multiple proxies.
+ * Use this when you need to configure HTTP-level hooks.
  *
- * @param routes - Route configurations for protected endpoints
- * @param server - Pre-configured x402ResourceServer instance
+ * @param httpServer - Pre-configured x402HTTPResourceServer instance
  * @param paywallConfig - Optional configuration for the built-in paywall UI
  * @param paywall - Optional custom paywall provider (overrides default)
  * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
@@ -46,32 +44,32 @@ export interface SchemeRegistration {
  *
  * @example
  * ```typescript
- * import { paymentProxy } from "@x402/next";
- * import { x402ResourceServer } from "@x402/core/server";
- * import { registerExactEvmScheme } from "@x402/evm/exact/server";
+ * import { paymentProxyFromHTTPServer, x402ResourceServer, x402HTTPResourceServer } from "@x402/next";
  *
- * const server = new x402ResourceServer(myFacilitatorClient);
- * registerExactEvmScheme(server, {});
+ * const resourceServer = new x402ResourceServer(facilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme());
  *
- * export const proxy = paymentProxy(routes, server, paywallConfig);
+ * const httpServer = new x402HTTPResourceServer(resourceServer, routes)
+ *   .onRequest(requestHook);
+ *
+ * export const proxy = paymentProxyFromHTTPServer(httpServer);
  * ```
  */
-export function paymentProxy(
-  routes: RoutesConfig,
-  server: x402ResourceServer,
+export function paymentProxyFromHTTPServer(
+  httpServer: x402HTTPResourceServer,
   paywallConfig?: PaywallConfig,
   paywall?: PaywallProvider,
   syncFacilitatorOnStart: boolean = true,
 ) {
-  const { httpServer, init } = createHttpServer(routes, server, paywall, syncFacilitatorOnStart);
+  const { init } = prepareHttpServer(httpServer, paywall, syncFacilitatorOnStart);
 
   // Dynamically register bazaar extension if routes declare it and not already registered
   // Skip if pre-registered (e.g., in serverless environments where static imports are used)
   let bazaarPromise: Promise<void> | null = null;
-  if (checkIfBazaarNeeded(routes) && !server.hasExtension("bazaar")) {
+  if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import(/* webpackIgnore: true */ "@x402/extensions/bazaar")
       .then(({ bazaarResourceServerExtension }) => {
-        server.registerExtension(bazaarResourceServerExtension);
+        httpServer.server.registerExtension(bazaarResourceServerExtension);
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);
@@ -126,6 +124,43 @@ export function paymentProxy(
 }
 
 /**
+ * Next.js payment proxy for x402 protocol (direct server instance).
+ *
+ * Use this when you want to pass a pre-configured x402ResourceServer instance.
+ * This provides more flexibility for testing, custom configuration, and reusing
+ * server instances across multiple proxies.
+ *
+ * @param routes - Route configurations for protected endpoints
+ * @param server - Pre-configured x402ResourceServer instance
+ * @param paywallConfig - Optional configuration for the built-in paywall UI
+ * @param paywall - Optional custom paywall provider (overrides default)
+ * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
+ * @returns Next.js proxy handler
+ *
+ * @example
+ * ```typescript
+ * import { paymentProxy } from "@x402/next";
+ *
+ * const server = new x402ResourceServer(myFacilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme());
+ *
+ * export const proxy = paymentProxy(routes, server, paywallConfig);
+ * ```
+ */
+export function paymentProxy(
+  routes: RoutesConfig,
+  server: x402ResourceServer,
+  paywallConfig?: PaywallConfig,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart: boolean = true,
+) {
+  // Create the x402 HTTP server instance with the resource server
+  const httpServer = new x402HTTPResourceServer(server, routes);
+
+  return paymentProxyFromHTTPServer(httpServer, paywallConfig, paywall, syncFacilitatorOnStart);
+}
+
+/**
  * Next.js payment proxy for x402 protocol (configuration-based).
  *
  * Use this when you want to quickly set up proxy with simple configuration.
@@ -173,15 +208,12 @@ export function paymentProxyFromConfig(
 }
 
 /**
- * Wraps a Next.js App Router API route handler with x402 payment protection.
+ * Wraps a Next.js App Router API route handler with x402 payment protection (HTTP server instance).
  *
- * Unlike `paymentProxy` which works as middleware, `withX402` wraps individual route handlers
- * and guarantees that payment settlement only occurs after the handler returns a successful
- * response (status < 400). This provides more precise control over when payments are settled.
+ * Use this when you need to configure HTTP-level hooks.
  *
  * @param routeHandler - The API route handler function to wrap
- * @param routeConfig - Payment configuration for this specific route
- * @param server - Pre-configured x402ResourceServer instance
+ * @param httpServer - Pre-configured x402HTTPResourceServer instance
  * @param paywallConfig - Optional configuration for the built-in paywall UI
  * @param paywall - Optional custom paywall provider (overrides default)
  * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
@@ -190,50 +222,37 @@ export function paymentProxyFromConfig(
  * @example
  * ```typescript
  * import { NextRequest, NextResponse } from "next/server";
- * import { withX402 } from "@x402/next";
- * import { x402ResourceServer } from "@x402/core/server";
- * import { registerExactEvmScheme } from "@x402/evm/exact/server";
+ * import { withX402FromHTTPServer, x402ResourceServer, x402HTTPResourceServer } from "@x402/next";
  *
- * const server = new x402ResourceServer(myFacilitatorClient);
- * registerExactEvmScheme(server, {});
+ * const resourceServer = new x402ResourceServer(facilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme());
+ *
+ * const httpServer = new x402HTTPResourceServer(resourceServer, { "*": routeConfig })
+ *   .onRequest(requestHook);
  *
  * const handler = async (request: NextRequest) => {
  *   return NextResponse.json({ data: "protected content" });
  * };
  *
- * export const GET = withX402(
- *   handler,
- *   {
- *     accepts: {
- *       scheme: "exact",
- *       payTo: "0x123...",
- *       price: "$0.01",
- *       network: "eip155:84532",
- *     },
- *     description: "Access to protected API",
- *   },
- *   server,
- * );
+ * export const GET = withX402FromHTTPServer(handler, httpServer);
  * ```
  */
-export function withX402<T = unknown>(
+export function withX402FromHTTPServer<T = unknown>(
   routeHandler: (request: NextRequest) => Promise<NextResponse<T>>,
-  routeConfig: RouteConfig,
-  server: x402ResourceServer,
+  httpServer: x402HTTPResourceServer,
   paywallConfig?: PaywallConfig,
   paywall?: PaywallProvider,
   syncFacilitatorOnStart: boolean = true,
 ): (request: NextRequest) => Promise<NextResponse<T>> {
-  const routes = { "*": routeConfig };
-  const { httpServer, init } = createHttpServer(routes, server, paywall, syncFacilitatorOnStart);
+  const { init } = prepareHttpServer(httpServer, paywall, syncFacilitatorOnStart);
 
   // Dynamically register bazaar extension if route declares it and not already registered
   // Skip if pre-registered (e.g., in serverless environments where static imports are used)
   let bazaarPromise: Promise<void> | null = null;
-  if (checkIfBazaarNeeded(routes) && !server.hasExtension("bazaar")) {
+  if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import(/* webpackIgnore: true */ "@x402/extensions/bazaar")
       .then(({ bazaarResourceServerExtension }) => {
-        server.registerExtension(bazaarResourceServerExtension);
+        httpServer.server.registerExtension(bazaarResourceServerExtension);
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);
@@ -241,6 +260,7 @@ export function withX402<T = unknown>(
   }
 
   return async (request: NextRequest): Promise<NextResponse<T>> => {
+    // Only initialize when processing a protected route
     await init();
 
     // Await bazaar extension loading if needed
@@ -280,12 +300,80 @@ export function withX402<T = unknown>(
 }
 
 /**
+ * Wraps a Next.js App Router API route handler with x402 payment protection.
+ *
+ * Unlike `paymentProxy` which works as middleware, `withX402` wraps individual route handlers
+ * and guarantees that payment settlement only occurs after the handler returns a successful
+ * response (status < 400). This provides more precise control over when payments are settled.
+ *
+ * @param routeHandler - The API route handler function to wrap
+ * @param routeConfig - Payment configuration for this specific route
+ * @param server - Pre-configured x402ResourceServer instance
+ * @param paywallConfig - Optional configuration for the built-in paywall UI
+ * @param paywall - Optional custom paywall provider (overrides default)
+ * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
+ * @returns A wrapped Next.js route handler
+ *
+ * @example
+ * ```typescript
+ * import { NextRequest, NextResponse } from "next/server";
+ * import { withX402 } from "@x402/next";
+ *
+ * const server = new x402ResourceServer(myFacilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme());
+ *
+ * const handler = async (request: NextRequest) => {
+ *   return NextResponse.json({ data: "protected content" });
+ * };
+ *
+ * export const GET = withX402(
+ *   handler,
+ *   {
+ *     accepts: {
+ *       scheme: "exact",
+ *       payTo: "0x123...",
+ *       price: "$0.01",
+ *       network: "eip155:84532",
+ *     },
+ *     description: "Access to protected API",
+ *   },
+ *   server,
+ * );
+ * ```
+ */
+export function withX402<T = unknown>(
+  routeHandler: (request: NextRequest) => Promise<NextResponse<T>>,
+  routeConfig: RouteConfig,
+  server: x402ResourceServer,
+  paywallConfig?: PaywallConfig,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart: boolean = true,
+): (request: NextRequest) => Promise<NextResponse<T>> {
+  const routes = { "*": routeConfig };
+  // Create the x402 HTTP server instance with the resource server
+  const httpServer = new x402HTTPResourceServer(server, routes);
+
+  return withX402FromHTTPServer(
+    routeHandler,
+    httpServer,
+    paywallConfig,
+    paywall,
+    syncFacilitatorOnStart,
+  );
+}
+
+/**
  * Check if any routes in the configuration declare bazaar extensions
  *
  * @param routes - Route configuration
  * @returns True if any route has extensions.bazaar defined
  */
 function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
+  // Handle null/undefined routes (defensive programming)
+  if (!routes || typeof routes !== "object") {
+    return false;
+  }
+
   // Handle single route config
   if ("accepts" in routes) {
     return !!(routes.extensions && "bazaar" in routes.extensions);
@@ -307,7 +395,11 @@ export type {
 
 export type { PaywallProvider, PaywallConfig, RouteConfig } from "@x402/core/server";
 
-export { RouteConfigurationError } from "@x402/core/server";
+export {
+  x402ResourceServer,
+  x402HTTPResourceServer,
+  RouteConfigurationError,
+} from "@x402/core/server";
 
 export type { RouteValidationError } from "@x402/core/server";
 

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -19,23 +19,18 @@ export interface HttpServerInstance {
 }
 
 /**
- * Creates and configures the x402 HTTP server with initialization logic
+ * Prepares an existing x402HTTPResourceServer with initialization logic
  *
- * @param routes - The route configuration for the server
- * @param server - The x402 resource server instance
+ * @param httpServer - Pre-configured x402HTTPResourceServer instance
  * @param paywall - Optional paywall provider for custom payment UI
  * @param syncFacilitatorOnStart - Whether to sync with the facilitator on start (defaults to true)
  * @returns The HTTP server instance with initialization function
  */
-export function createHttpServer(
-  routes: RoutesConfig,
-  server: x402ResourceServer,
+export function prepareHttpServer(
+  httpServer: x402HTTPResourceServer,
   paywall?: PaywallProvider,
   syncFacilitatorOnStart: boolean = true,
 ): HttpServerInstance {
-  // Create the x402 HTTP server instance with the resource server
-  const httpServer = new x402HTTPResourceServer(server, routes);
-
   // Register custom paywall provider if provided
   if (paywall) {
     httpServer.registerPaywallProvider(paywall);
@@ -55,6 +50,27 @@ export function createHttpServer(
       }
     },
   };
+}
+
+/**
+ * Creates and configures the x402 HTTP server with initialization logic
+ *
+ * @param routes - The route configuration for the server
+ * @param server - The x402 resource server instance
+ * @param paywall - Optional paywall provider for custom payment UI
+ * @param syncFacilitatorOnStart - Whether to sync with the facilitator on start (defaults to true)
+ * @returns The HTTP server instance with initialization function
+ */
+export function createHttpServer(
+  routes: RoutesConfig,
+  server: x402ResourceServer,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart: boolean = true,
+): HttpServerInstance {
+  // Create the x402 HTTP server instance with the resource server
+  const httpServer = new x402HTTPResourceServer(server, routes);
+
+  return prepareHttpServer(httpServer, paywall, syncFacilitatorOnStart);
 }
 
 /**


### PR DESCRIPTION
## Description

Adds new onProtectedRequest hook that runs in `x402HTTPResourceServer` on every request to a protected route, before payment processing. Can grant access without payment, deny the request or continue the payment flow:
- `void` - Continue to payment processing (default behavior)
- `{ grantAccess: true }` - Grant access without requiring payment -> eg access with SIWX (https://github.com/coinbase/x402/pull/921) or API-key, free trial
- `{ abort: true; reason: string }` - Deny the request (returns 403) -> eg block wallet address, geo-block

Adds new `paymentMiddlewareFromHTTPServer` functions that directly take `x402HTTPResourceServer` as input instead of creating it internally from `x402ResourceServer` as the `paymentMiddleware` functions. 

```
const resourceServer = new x402ResourceServer(facilitatorClient)
    .register(NETWORK, new ExactEvmScheme());
 
  const httpServer = new x402HTTPResourceServer(resourceServer, routes)
    .onProtectedRequest(requestHook);
 
  app.use(paymentMiddlewareFromHTTPServer(httpServer));
```
## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 