### PR TITLE
OnPaymentRequired client-side hook

### DIFF
--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -105,4 +105,4 @@ export {
   FacilitatorClient,
   FacilitatorConfig,
 } from "./httpFacilitatorClient";
-export { x402HTTPClient } from "./x402HTTPClient";
+export { x402HTTPClient, PaymentRequiredContext, PaymentRequiredHook } from "./x402HTTPClient";

--- a/typescript/packages/core/test/unit/http/x402HTTPClient.hooks.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPClient.hooks.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { x402HTTPClient, PaymentRequiredHook } from "../../../src/http/x402HTTPClient";
+import { x402Client } from "../../../src/client/x402Client";
+import { buildPaymentRequired } from "../../mocks";
+
+describe("x402HTTPClient", () => {
+  describe("onPaymentRequired hook", () => {
+    it("should return this for chaining", () => {
+      const client = new x402Client();
+      const httpClient = new x402HTTPClient(client);
+      const hook: PaymentRequiredHook = async () => undefined;
+
+      const result = httpClient.onPaymentRequired(hook);
+
+      expect(result).toBe(httpClient);
+    });
+
+    it("should allow chaining multiple hooks", () => {
+      const client = new x402Client();
+      const httpClient = new x402HTTPClient(client);
+      const hook1: PaymentRequiredHook = async () => undefined;
+      const hook2: PaymentRequiredHook = async () => undefined;
+
+      const result = httpClient.onPaymentRequired(hook1).onPaymentRequired(hook2);
+
+      expect(result).toBe(httpClient);
+    });
+  });
+
+  describe("handlePaymentRequired", () => {
+    it("should return null when no hooks are registered", async () => {
+      const client = new x402Client();
+      const httpClient = new x402HTTPClient(client);
+      const paymentRequired = buildPaymentRequired();
+
+      const result = await httpClient.handlePaymentRequired(paymentRequired);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return headers when a hook provides them", async () => {
+      const client = new x402Client();
+      const httpClient = new x402HTTPClient(client);
+      const expectedHeaders = { Authorization: "Bearer token123" };
+      const hook: PaymentRequiredHook = async () => ({ headers: expectedHeaders });
+      httpClient.onPaymentRequired(hook);
+
+      const paymentRequired = buildPaymentRequired();
+      const result = await httpClient.handlePaymentRequired(paymentRequired);
+
+      expect(result).toEqual(expectedHeaders);
+    });
+
+    it("should return null when hook returns void", async () => {
+      const client = new x402Client();
+      const httpClient = new x402HTTPClient(client);
+      const hook: PaymentRequiredHook = async () => undefined;
+      httpClient.onPaymentRequired(hook);
+
+      const paymentRequired = buildPaymentRequired();
+      const result = await httpClient.handlePaymentRequired(paymentRequired);
+
+      expect(result).toBeNull();
+    });
+
+    it("should run hooks in order and first to return headers wins", async () => {
+      const client = new x402Client();
+      const httpClient = new x402HTTPClient(client);
+      const executionOrder: number[] = [];
+
+      const hook1: PaymentRequiredHook = async () => {
+        executionOrder.push(1);
+        return { headers: { "X-Hook": "first" } };
+      };
+      const hook2: PaymentRequiredHook = async () => {
+        executionOrder.push(2);
+        return { headers: { "X-Hook": "second" } };
+      };
+
+      httpClient.onPaymentRequired(hook1).onPaymentRequired(hook2);
+
+      const paymentRequired = buildPaymentRequired();
+      const result = await httpClient.handlePaymentRequired(paymentRequired);
+
+      expect(result).toEqual({ "X-Hook": "first" });
+      expect(executionOrder).toEqual([1]); // Second hook should not be called
+    });
+
+    it("should skip hooks that return void and continue to next", async () => {
+      const client = new x402Client();
+      const httpClient = new x402HTTPClient(client);
+      const executionOrder: number[] = [];
+
+      const hook1: PaymentRequiredHook = async () => {
+        executionOrder.push(1);
+        return undefined;
+      };
+      const hook2: PaymentRequiredHook = async () => {
+        executionOrder.push(2);
+        return { headers: { "X-Hook": "second" } };
+      };
+
+      httpClient.onPaymentRequired(hook1).onPaymentRequired(hook2);
+
+      const paymentRequired = buildPaymentRequired();
+      const result = await httpClient.handlePaymentRequired(paymentRequired);
+
+      expect(result).toEqual({ "X-Hook": "second" });
+      expect(executionOrder).toEqual([1, 2]);
+    });
+
+    it("should pass paymentRequired context to hooks", async () => {
+      const client = new x402Client();
+      const httpClient = new x402HTTPClient(client);
+      const paymentRequired = buildPaymentRequired({
+        resource: { url: "https://test.com", description: "Test", mimeType: "text/plain" },
+      });
+
+      let receivedContext: unknown;
+      const hook: PaymentRequiredHook = async ctx => {
+        receivedContext = ctx;
+        return undefined;
+      };
+      httpClient.onPaymentRequired(hook);
+
+      await httpClient.handlePaymentRequired(paymentRequired);
+
+      expect(receivedContext).toEqual({ paymentRequired });
+    });
+
+    it("should return null when all hooks return void", async () => {
+      const client = new x402Client();
+      const httpClient = new x402HTTPClient(client);
+
+      const hook1: PaymentRequiredHook = async () => undefined;
+      const hook2: PaymentRequiredHook = async () => undefined;
+
+      httpClient.onPaymentRequired(hook1).onPaymentRequired(hook2);
+
+      const paymentRequired = buildPaymentRequired();
+      const result = await httpClient.handlePaymentRequired(paymentRequired);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/typescript/packages/http/axios/src/index.test.ts
+++ b/typescript/packages/http/axios/src/index.test.ts
@@ -15,6 +15,7 @@ vi.mock("@x402/core/client", () => {
   const MockX402HTTPClient = vi.fn();
   MockX402HTTPClient.prototype.getPaymentRequiredResponse = vi.fn();
   MockX402HTTPClient.prototype.encodePaymentSignatureHeader = vi.fn();
+  MockX402HTTPClient.prototype.handlePaymentRequired = vi.fn();
 
   const MockX402Client = vi.fn() as ReturnType<typeof vi.fn> & {
     fromConfig: ReturnType<typeof vi.fn>;
@@ -122,6 +123,9 @@ describe("wrapAxiosWithPayment()", () => {
     ).mockReturnValue({
       "PAYMENT-SIGNATURE": "encoded-payment-header",
     });
+    (
+      MockX402HTTPClient.prototype.handlePaymentRequired as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(null);
 
     // Set up the interceptor
     wrapAxiosWithPayment(mockAxiosClient, mockClient);

--- a/typescript/packages/http/fetch/src/index.test.ts
+++ b/typescript/packages/http/fetch/src/index.test.ts
@@ -8,6 +8,7 @@ vi.mock("@x402/core/client", () => {
   const MockX402HTTPClient = vi.fn();
   MockX402HTTPClient.prototype.getPaymentRequiredResponse = vi.fn();
   MockX402HTTPClient.prototype.encodePaymentSignatureHeader = vi.fn();
+  MockX402HTTPClient.prototype.handlePaymentRequired = vi.fn();
 
   const MockX402Client = vi.fn() as ReturnType<typeof vi.fn> & {
     fromConfig: ReturnType<typeof vi.fn>;
@@ -90,6 +91,9 @@ describe("wrapFetchWithPayment()", () => {
     ).mockReturnValue({
       "PAYMENT-SIGNATURE": "encoded-payment-header",
     });
+    (
+      MockX402HTTPClient.prototype.handlePaymentRequired as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(null);
 
     wrappedFetch = wrapFetchWithPayment(mockFetch, mockClient);
   });
@@ -444,6 +448,9 @@ describe("wrapFetchWithPaymentFromConfig()", () => {
       resource: { url: "test", description: "test", mimeType: "text/plain" },
       accepts: [],
     });
+    (
+      MockX402HTTPClient.prototype.handlePaymentRequired as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(null);
   });
 
   it("should create client from config and wrap fetch", async () => {


### PR DESCRIPTION
## Description

Adds `onPaymentRequired` hook to `x402HTTPClient`. Can provide alternative authentication headers or continue the payment flow:
- void : Continue to payment processing (default behavior)
- { headers: Record<string, string> } : Try these headers first before payment → e.g. SIWX (https://github.com/coinbase/x402/pull/921), API-key
- If retry with hook headers still returns 402, automatically falls back to payment

This mirrors the server-side `onProtectedRequest` hook on `x402HTTPResourceServer` in https://github.com/coinbase/x402/pull/1010.

## Example usage

```
const client = new x402Client();
registerExactEvmScheme(client, { signer });

const httpClient = new x402HTTPClient(client)
  .onPaymentRequired(hook);

const fetchWithPayment = wrapFetchWithPayment(fetch, httpClient);
```

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 