### PR TITLE
refactor(go): replace panic with proper error handling in HTTP encodi…

### DIFF
--- a/go/http/client_test.go
+++ b/go/http/client_test.go
@@ -67,7 +67,10 @@ func TestEncodePaymentSignatureHeader(t *testing.T) {
 				t.Fatalf("Failed to marshal payload: %v", err)
 			}
 
-			headers := client.EncodePaymentSignatureHeader(payloadBytes)
+			headers, err := client.EncodePaymentSignatureHeader(payloadBytes)
+			if err != nil {
+				t.Fatalf("Failed to encode payment signature header: %v", err)
+			}
 			if _, exists := headers[tt.expected]; !exists {
 				t.Errorf("Expected header %s not found", tt.expected)
 			}

--- a/go/test/integration/http_test.go
+++ b/go/test/integration/http_test.go
@@ -188,7 +188,10 @@ func TestHTTPIntegration(t *testing.T) {
 
 		// Marshal payload to bytes for header encoding
 		payloadBytes, _ := json.Marshal(payload)
-		requestHeaders := httpClient.EncodePaymentSignatureHeader(payloadBytes)
+		requestHeaders, err := httpClient.EncodePaymentSignatureHeader(payloadBytes)
+		if err != nil {
+			t.Fatalf("Failed to encode payment signature header: %v", err)
+		}
 
 		// Update mock adapter with payment header
 		mockAdapter.headers = requestHeaders


### PR DESCRIPTION
## Summary

  This PR replaces `panic()` calls with idiomatic Go error returns in the HTTP client and server encoding functions. Using `panic()` for recoverable errors violates Go best practices and
  can cause application crashes when processing malformed input.

  ## Problem

  The following functions were using `panic()` to handle errors:

  1. **`EncodePaymentSignatureHeader`** (`go/http/client.go:44, 60`)
     - Panicked on version detection failure
     - Panicked on unsupported x402 version

  2. **`encodePaymentRequiredHeader`** (`go/http/client.go:384`)
     - Panicked on JSON marshal failure

  3. **`encodePaymentResponseHeader`** (`go/http/client.go:408`)
     - Panicked on JSON marshal failure

  ### Why This Is a Problem

  - **DoS Vulnerability**: Malformed HTTP headers from untrusted sources can crash the entire application
  - **Go Best Practices Violation**: The [Effective Go](https://go.dev/doc/effective_go#panic) documentation explicitly states that panic should only be used for truly exceptional,
  unrecoverable situations
  - **No Recovery Path**: Callers cannot handle these errors gracefully since panics bypass normal error handling
  - **Testing Difficulty**: Functions that panic are harder to test for error conditions

  ## Solution

  Changed all affected functions to return `error` as a second return value:

  | Function | Before | After |
  |----------|--------|-------|
  | `EncodePaymentSignatureHeader` | `map[string]string` | `(map[string]string, error)` |
  | `encodePaymentRequiredHeader` | `string` | `(string, error)` |
  | `encodePaymentResponseHeader` | `string` | `(string, error)` |
  | `createHTTPResponseV2` | `*HTTPResponseInstructions` | `(*HTTPResponseInstructions, error)` |
  | `createSettlementHeaders` | `map[string]string` | `(map[string]string, error)` |

  ## Changes Made

  ### `go/http/client.go`
  - `EncodePaymentSignatureHeader`: Returns error instead of panicking on version detection failure or unsupported version
  - `encodePaymentRequiredHeader`: Returns error instead of panicking on marshal failure
  - `encodePaymentResponseHeader`: Returns error instead of panicking on marshal failure
  - Updated `RoundTrip` to handle errors from `EncodePaymentSignatureHeader`

  ### `go/http/server.go`
  - `createHTTPResponseV2`: Returns error and handles `encodePaymentRequiredHeader` errors
  - `createSettlementHeaders`: Returns error and handles `encodePaymentResponseHeader` errors
  - `createHTTPResponse` (legacy): Updated signature for consistency
  - Updated `ProcessHTTPRequest` to handle errors from `createHTTPResponseV2`
  - Updated `ProcessSettlement` to handle errors from `createSettlementHeaders`

  ### `go/http/client_test.go`
  - Updated `TestEncodePaymentSignatureHeader` to handle new error return

  ### `go/test/integration/http_test.go`
  - Updated integration test to handle new error return

  ## Error Handling Strategy

  When encoding functions fail:
  - **In `RoundTrip`**: Returns error to caller, allowing proper HTTP error handling
  - **In `ProcessHTTPRequest`**: Returns 500 Internal Server Error with descriptive message
  - **In `ProcessSettlement`**: Sets `Success: false` with error reason

  ## Backward Compatibility

  This is a **breaking change** for direct callers of the affected functions. However:
  - The change follows Go conventions and is expected behavior
  - Callers should already be prepared for potential errors in encoding operations
  - The fix prevents potential DoS vulnerabilities
