### PR TITLE
feat: add Permit2 client support with direct approval flow

### DIFF
--- a/typescript/packages/mechanisms/evm/src/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/constants.ts
@@ -10,6 +10,30 @@ export const authorizationTypes = {
   ],
 } as const;
 
+/**
+ * Permit2 EIP-712 types for signing PermitWitnessTransferFrom.
+ * Must match the exact format expected by the Permit2 contract.
+ */
+export const permit2WitnessTypes = {
+  PermitWitnessTransferFrom: [
+    { name: "permitted", type: "TokenPermissions" },
+    { name: "spender", type: "address" },
+    { name: "nonce", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+    { name: "witness", type: "Witness" },
+  ],
+  TokenPermissions: [
+    { name: "token", type: "address" },
+    { name: "amount", type: "uint256" },
+  ],
+  Witness: [
+    { name: "extra", type: "bytes" },
+    { name: "to", type: "address" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+} as const;
+
 // EIP3009 ABI for transferWithAuthorization function
 export const eip3009ABI = [
   {
@@ -58,4 +82,110 @@ export const eip3009ABI = [
     stateMutability: "view",
     type: "function",
   },
+] as const;
+
+/**
+ * Canonical Permit2 contract address.
+ * Same address on all EVM chains via CREATE2 deployment.
+ *
+ * @see https://github.com/Uniswap/permit2
+ */
+export const PERMIT2_ADDRESS = "0x000000000022D473030F116dDEE9F6B43aC78BA3" as const;
+
+/**
+ * x402ExactPermit2Proxy contract address.
+ * Vanity address: 0x4020...0001 for easy recognition.
+ * This address is deterministic based on:
+ * - Arachnid's deterministic deployer (0x4e59b44847b379578588920cA78FbF26c0B4956C)
+ * - Vanity-mined salt for prefix 0x4020 and suffix 0001
+ * - Contract bytecode + constructor args (PERMIT2_ADDRESS)
+ */
+export const x402ExactPermit2ProxyAddress = "0x4020B671C4c523a852c11a5EC58F27F235e80001" as const;
+
+/**
+ * x402UptoPermit2Proxy contract address.
+ * Vanity address: 0x4020...0002 for easy recognition.
+ * This address is deterministic based on:
+ * - Arachnid's deterministic deployer (0x4e59b44847b379578588920cA78FbF26c0B4956C)
+ * - Vanity-mined salt for prefix 0x4020 and suffix 0002
+ * - Contract bytecode + constructor args (PERMIT2_ADDRESS)
+ */
+export const x402UptoPermit2ProxyAddress = "0x40209D7168c33Fbb5E6EccF6f00a3D54A52f0002" as const;
+
+/**
+ * x402ExactPermit2Proxy ABI - settle function for exact payment scheme.
+ */
+export const x402ExactPermit2ProxyABI = [
+  {
+    type: "constructor",
+    inputs: [{ name: "_permit2", type: "address", internalType: "address" }],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "PERMIT2",
+    inputs: [],
+    outputs: [{ name: "", type: "address", internalType: "contract ISignatureTransfer" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "WITNESS_TYPEHASH",
+    inputs: [],
+    outputs: [{ name: "", type: "bytes32", internalType: "bytes32" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "WITNESS_TYPE_STRING",
+    inputs: [],
+    outputs: [{ name: "", type: "string", internalType: "string" }],
+    stateMutability: "view",
+  },
+  {
+    type: "function",
+    name: "settle",
+    inputs: [
+      {
+        name: "permit",
+        type: "tuple",
+        internalType: "struct ISignatureTransfer.PermitTransferFrom",
+        components: [
+          {
+            name: "permitted",
+            type: "tuple",
+            internalType: "struct ISignatureTransfer.TokenPermissions",
+            components: [
+              { name: "token", type: "address", internalType: "address" },
+              { name: "amount", type: "uint256", internalType: "uint256" },
+            ],
+          },
+          { name: "nonce", type: "uint256", internalType: "uint256" },
+          { name: "deadline", type: "uint256", internalType: "uint256" },
+        ],
+      },
+      { name: "owner", type: "address", internalType: "address" },
+      {
+        name: "witness",
+        type: "tuple",
+        internalType: "struct x402BasePermit2Proxy.Witness",
+        components: [
+          { name: "to", type: "address", internalType: "address" },
+          { name: "validAfter", type: "uint256", internalType: "uint256" },
+          { name: "validBefore", type: "uint256", internalType: "uint256" },
+          { name: "extra", type: "bytes", internalType: "bytes" },
+        ],
+      },
+      { name: "signature", type: "bytes", internalType: "bytes" },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  { type: "event", name: "Settled", inputs: [], anonymous: false },
+  { type: "error", name: "InvalidDestination", inputs: [] },
+  { type: "error", name: "InvalidOwner", inputs: [] },
+  { type: "error", name: "InvalidPermit2Address", inputs: [] },
+  { type: "error", name: "PaymentExpired", inputs: [] },
+  { type: "error", name: "PaymentTooEarly", inputs: [] },
+  { type: "error", name: "ReentrancyGuardReentrantCall", inputs: [] },
 ] as const;

--- a/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
@@ -1,0 +1,91 @@
+import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import { getAddress } from "viem";
+import { authorizationTypes } from "../../constants";
+import { ClientEvmSigner } from "../../signer";
+import { ExactEIP3009Payload } from "../../types";
+import { createNonce } from "../../utils";
+
+/**
+ * Creates an EIP-3009 (transferWithAuthorization) payload.
+ *
+ * @param signer - The EVM signer for client operations
+ * @param x402Version - The x402 protocol version
+ * @param paymentRequirements - The payment requirements
+ * @returns Promise resolving to a payment payload result
+ */
+export async function createEIP3009Payload(
+  signer: ClientEvmSigner,
+  x402Version: number,
+  paymentRequirements: PaymentRequirements,
+): Promise<PaymentPayloadResult> {
+  const nonce = createNonce();
+  const now = Math.floor(Date.now() / 1000);
+
+  const authorization: ExactEIP3009Payload["authorization"] = {
+    from: signer.address,
+    to: getAddress(paymentRequirements.payTo),
+    value: paymentRequirements.amount,
+    validAfter: (now - 600).toString(),
+    validBefore: (now + paymentRequirements.maxTimeoutSeconds).toString(),
+    nonce,
+  };
+
+  const signature = await signEIP3009Authorization(signer, authorization, paymentRequirements);
+
+  const payload: ExactEIP3009Payload = {
+    authorization,
+    signature,
+  };
+
+  return {
+    x402Version,
+    payload,
+  };
+}
+
+/**
+ * Sign the EIP-3009 authorization using EIP-712.
+ *
+ * @param signer - The EVM signer
+ * @param authorization - The authorization to sign
+ * @param requirements - The payment requirements
+ * @returns Promise resolving to the signature
+ */
+async function signEIP3009Authorization(
+  signer: ClientEvmSigner,
+  authorization: ExactEIP3009Payload["authorization"],
+  requirements: PaymentRequirements,
+): Promise<`0x${string}`> {
+  const chainId = parseInt(requirements.network.split(":")[1]);
+
+  if (!requirements.extra?.name || !requirements.extra?.version) {
+    throw new Error(
+      `EIP-712 domain parameters (name, version) are required in payment requirements for asset ${requirements.asset}`,
+    );
+  }
+
+  const { name, version } = requirements.extra;
+
+  const domain = {
+    name,
+    version,
+    chainId,
+    verifyingContract: getAddress(requirements.asset),
+  };
+
+  const message = {
+    from: getAddress(authorization.from),
+    to: getAddress(authorization.to),
+    value: BigInt(authorization.value),
+    validAfter: BigInt(authorization.validAfter),
+    validBefore: BigInt(authorization.validBefore),
+    nonce: authorization.nonce,
+  };
+
+  return await signer.signTypedData({
+    domain,
+    types: authorizationTypes,
+    primaryType: "TransferWithAuthorization",
+    message,
+  });
+}

--- a/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
@@ -1,8 +1,8 @@
-import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import { PaymentRequirements } from "@x402/core/types";
 import { getAddress } from "viem";
 import { authorizationTypes } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
-import { ExactEIP3009Payload } from "../../types";
+import { ExactEIP3009Payload, PaymentPayloadResult } from "../../types";
 import { createNonce } from "../../utils";
 
 /**

--- a/typescript/packages/mechanisms/evm/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/index.ts
@@ -1,3 +1,9 @@
 export { ExactEvmScheme } from "./scheme";
 export { registerExactEvmScheme } from "./register";
 export type { EvmClientConfig } from "./register";
+export {
+  createPermit2ApprovalTx,
+  getPermit2AllowanceReadParams,
+  erc20AllowanceAbi,
+  type Permit2AllowanceParams,
+} from "./permit2";

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -1,14 +1,16 @@
 import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
 import { encodeFunctionData, getAddress } from "viem";
-import { permit2WitnessTypes, PERMIT2_ADDRESS, x402ExactPermit2ProxyAddress } from "../../constants";
+import {
+  permit2WitnessTypes,
+  PERMIT2_ADDRESS,
+  x402ExactPermit2ProxyAddress,
+} from "../../constants";
 import { ClientEvmSigner } from "../../signer";
 import { ExactPermit2Payload } from "../../types";
 import { createPermit2Nonce } from "../../utils";
 
 /** Maximum uint256 value for unlimited approval. */
-const MAX_UINT256 = BigInt(
-  "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-);
+const MAX_UINT256 = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
 /**
  * Creates a Permit2 payload using the x402Permit2Proxy witness pattern.

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -1,4 +1,4 @@
-import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import { PaymentRequirements } from "@x402/core/types";
 import { encodeFunctionData, getAddress } from "viem";
 import {
   permit2WitnessTypes,
@@ -6,7 +6,7 @@ import {
   x402ExactPermit2ProxyAddress,
 } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
-import { ExactPermit2Payload } from "../../types";
+import { ExactPermit2Payload, PaymentPayloadResult } from "../../types";
 import { createPermit2Nonce } from "../../utils";
 
 /** Maximum uint256 value for unlimited approval. */

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -1,0 +1,218 @@
+import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
+import { encodeFunctionData, getAddress } from "viem";
+import { permit2WitnessTypes, PERMIT2_ADDRESS, x402ExactPermit2ProxyAddress } from "../../constants";
+import { ClientEvmSigner } from "../../signer";
+import { ExactPermit2Payload } from "../../types";
+import { createPermit2Nonce } from "../../utils";
+
+/** Maximum uint256 value for unlimited approval. */
+const MAX_UINT256 = BigInt(
+  "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+);
+
+/**
+ * Creates a Permit2 payload using the x402Permit2Proxy witness pattern.
+ * The spender is set to x402Permit2Proxy, which enforces that funds
+ * can only be sent to the witness.to address.
+ *
+ * @param signer - The EVM signer for client operations
+ * @param x402Version - The x402 protocol version
+ * @param paymentRequirements - The payment requirements
+ * @returns Promise resolving to a payment payload result
+ */
+export async function createPermit2Payload(
+  signer: ClientEvmSigner,
+  x402Version: number,
+  paymentRequirements: PaymentRequirements,
+): Promise<PaymentPayloadResult> {
+  const now = Math.floor(Date.now() / 1000);
+  const nonce = createPermit2Nonce();
+
+  const validAfter = (now - 600).toString();
+  const validBefore = (now + paymentRequirements.maxTimeoutSeconds).toString();
+  const deadline = validBefore;
+
+  const permit2Authorization: ExactPermit2Payload["permit2Authorization"] = {
+    from: signer.address,
+    permitted: {
+      token: getAddress(paymentRequirements.asset),
+      amount: paymentRequirements.amount,
+    },
+    spender: x402ExactPermit2ProxyAddress,
+    nonce,
+    deadline,
+    witness: {
+      to: getAddress(paymentRequirements.payTo),
+      validAfter,
+      validBefore,
+      extra: "0x",
+    },
+  };
+
+  const signature = await signPermit2Authorization(
+    signer,
+    permit2Authorization,
+    paymentRequirements,
+  );
+
+  const payload: ExactPermit2Payload = {
+    signature,
+    permit2Authorization,
+  };
+
+  return {
+    x402Version,
+    payload,
+  };
+}
+
+/**
+ * Sign the Permit2 authorization using EIP-712 with witness data.
+ * The signature authorizes the x402Permit2Proxy to transfer tokens on behalf of the signer.
+ *
+ * @param signer - The EVM signer
+ * @param permit2Authorization - The Permit2 authorization parameters
+ * @param requirements - The payment requirements
+ * @returns Promise resolving to the signature
+ */
+async function signPermit2Authorization(
+  signer: ClientEvmSigner,
+  permit2Authorization: ExactPermit2Payload["permit2Authorization"],
+  requirements: PaymentRequirements,
+): Promise<`0x${string}`> {
+  const chainId = parseInt(requirements.network.split(":")[1]);
+
+  const domain = {
+    name: "Permit2",
+    chainId,
+    verifyingContract: PERMIT2_ADDRESS,
+  };
+
+  const message = {
+    permitted: {
+      token: getAddress(permit2Authorization.permitted.token),
+      amount: BigInt(permit2Authorization.permitted.amount),
+    },
+    spender: getAddress(permit2Authorization.spender),
+    nonce: BigInt(permit2Authorization.nonce),
+    deadline: BigInt(permit2Authorization.deadline),
+    witness: {
+      extra: permit2Authorization.witness.extra,
+      to: getAddress(permit2Authorization.witness.to),
+      validAfter: BigInt(permit2Authorization.witness.validAfter),
+      validBefore: BigInt(permit2Authorization.witness.validBefore),
+    },
+  };
+
+  return await signer.signTypedData({
+    domain,
+    types: permit2WitnessTypes,
+    primaryType: "PermitWitnessTransferFrom",
+    message,
+  });
+}
+
+/**
+ * ERC20 approve ABI for encoding approval transactions.
+ */
+const erc20ApproveAbi = [
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/**
+ * ERC20 allowance ABI for checking approval status.
+ */
+export const erc20AllowanceAbi = [
+  {
+    type: "function",
+    name: "allowance",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
+/**
+ * Creates transaction data to approve Permit2 to spend tokens.
+ * The user sends this transaction (paying gas) before using Permit2 flow.
+ *
+ * @param tokenAddress - The ERC20 token contract address
+ * @returns Transaction data to send for approval
+ *
+ * @example
+ * ```typescript
+ * const tx = createPermit2ApprovalTx("0x...");
+ * await walletClient.sendTransaction({
+ *   to: tx.to,
+ *   data: tx.data,
+ * });
+ * ```
+ */
+export function createPermit2ApprovalTx(tokenAddress: `0x${string}`): {
+  to: `0x${string}`;
+  data: `0x${string}`;
+} {
+  const data = encodeFunctionData({
+    abi: erc20ApproveAbi,
+    functionName: "approve",
+    args: [PERMIT2_ADDRESS, MAX_UINT256],
+  });
+
+  return {
+    to: getAddress(tokenAddress),
+    data,
+  };
+}
+
+/**
+ * Parameters for checking Permit2 allowance.
+ * Application provides these to check if approval is needed.
+ */
+export interface Permit2AllowanceParams {
+  tokenAddress: `0x${string}`;
+  ownerAddress: `0x${string}`;
+}
+
+/**
+ * Returns contract read parameters for checking Permit2 allowance.
+ * Use with a public client to check if the user has approved Permit2.
+ *
+ * @param params - The allowance check parameters
+ * @returns Contract read parameters for checking allowance
+ *
+ * @example
+ * ```typescript
+ * const readParams = getPermit2AllowanceReadParams({
+ *   tokenAddress: "0x...",
+ *   ownerAddress: "0x...",
+ * });
+ *
+ * const allowance = await publicClient.readContract(readParams);
+ * const needsApproval = allowance < requiredAmount;
+ * ```
+ */
+export function getPermit2AllowanceReadParams(params: Permit2AllowanceParams): {
+  address: `0x${string}`;
+  abi: typeof erc20AllowanceAbi;
+  functionName: "allowance";
+  args: [`0x${string}`, `0x${string}`];
+} {
+  return {
+    address: getAddress(params.tokenAddress),
+    abi: erc20AllowanceAbi,
+    functionName: "allowance",
+    args: [getAddress(params.ownerAddress), PERMIT2_ADDRESS],
+  };
+}

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -1,13 +1,20 @@
-import { PaymentPayload, PaymentRequirements, SchemeNetworkClient } from "@x402/core/types";
-import { getAddress } from "viem";
-import { authorizationTypes } from "../../constants";
+import {
+  PaymentRequirements,
+  SchemeNetworkClient,
+  PaymentPayloadResult,
+} from "@x402/core/types";
 import { ClientEvmSigner } from "../../signer";
-import { ExactEvmPayloadV2 } from "../../types";
-import { createNonce } from "../../utils";
+import { AssetTransferMethod } from "../../types";
+import { createEIP3009Payload } from "./eip3009";
+import { createPermit2Payload } from "./permit2";
 
 /**
  * EVM client implementation for the Exact payment scheme.
+ * Supports both EIP-3009 (transferWithAuthorization) and Permit2 flows.
  *
+ * Routes to the appropriate authorization method based on
+ * `requirements.extra.assetTransferMethod`. Defaults to EIP-3009
+ * for backward compatibility with older facilitators.
  */
 export class ExactEvmScheme implements SchemeNetworkClient {
   readonly scheme = "exact";
@@ -21,83 +28,23 @@ export class ExactEvmScheme implements SchemeNetworkClient {
 
   /**
    * Creates a payment payload for the Exact scheme.
+   * Routes to EIP-3009 or Permit2 based on requirements.extra.assetTransferMethod.
    *
    * @param x402Version - The x402 protocol version
    * @param paymentRequirements - The payment requirements
-   * @returns Promise resolving to a payment payload
+   * @returns Promise resolving to a payment payload result
    */
   async createPaymentPayload(
     x402Version: number,
     paymentRequirements: PaymentRequirements,
-  ): Promise<Pick<PaymentPayload, "x402Version" | "payload">> {
-    const nonce = createNonce();
-    const now = Math.floor(Date.now() / 1000);
+  ): Promise<PaymentPayloadResult> {
+    const assetTransferMethod =
+      (paymentRequirements.extra?.assetTransferMethod as AssetTransferMethod) ?? "eip3009";
 
-    const authorization: ExactEvmPayloadV2["authorization"] = {
-      from: this.signer.address,
-      to: getAddress(paymentRequirements.payTo),
-      value: paymentRequirements.amount,
-      validAfter: (now - 600).toString(), // 10 minutes before
-      validBefore: (now + paymentRequirements.maxTimeoutSeconds).toString(),
-      nonce,
-    };
-
-    // Sign the authorization
-    const signature = await this.signAuthorization(authorization, paymentRequirements);
-
-    const payload: ExactEvmPayloadV2 = {
-      authorization,
-      signature,
-    };
-
-    return {
-      x402Version,
-      payload,
-    };
-  }
-
-  /**
-   * Sign the EIP-3009 authorization using EIP-712
-   *
-   * @param authorization - The authorization to sign
-   * @param requirements - The payment requirements
-   * @returns Promise resolving to the signature
-   */
-  private async signAuthorization(
-    authorization: ExactEvmPayloadV2["authorization"],
-    requirements: PaymentRequirements,
-  ): Promise<`0x${string}`> {
-    const chainId = parseInt(requirements.network.split(":")[1]);
-
-    if (!requirements.extra?.name || !requirements.extra?.version) {
-      throw new Error(
-        `EIP-712 domain parameters (name, version) are required in payment requirements for asset ${requirements.asset}`,
-      );
+    if (assetTransferMethod === "permit2") {
+      return createPermit2Payload(this.signer, x402Version, paymentRequirements);
     }
 
-    const { name, version } = requirements.extra;
-
-    const domain = {
-      name,
-      version,
-      chainId,
-      verifyingContract: getAddress(requirements.asset),
-    };
-
-    const message = {
-      from: getAddress(authorization.from),
-      to: getAddress(authorization.to),
-      value: BigInt(authorization.value),
-      validAfter: BigInt(authorization.validAfter),
-      validBefore: BigInt(authorization.validBefore),
-      nonce: authorization.nonce,
-    };
-
-    return await this.signer.signTypedData({
-      domain,
-      types: authorizationTypes,
-      primaryType: "TransferWithAuthorization",
-      message,
-    });
+    return createEIP3009Payload(this.signer, x402Version, paymentRequirements);
   }
 }

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -1,6 +1,6 @@
-import { PaymentRequirements, SchemeNetworkClient, PaymentPayloadResult } from "@x402/core/types";
+import { PaymentRequirements, SchemeNetworkClient } from "@x402/core/types";
 import { ClientEvmSigner } from "../../signer";
-import { AssetTransferMethod } from "../../types";
+import { AssetTransferMethod, PaymentPayloadResult } from "../../types";
 import { createEIP3009Payload } from "./eip3009";
 import { createPermit2Payload } from "./permit2";
 

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -1,8 +1,4 @@
-import {
-  PaymentRequirements,
-  SchemeNetworkClient,
-  PaymentPayloadResult,
-} from "@x402/core/types";
+import { PaymentRequirements, SchemeNetworkClient, PaymentPayloadResult } from "@x402/core/types";
 import { ClientEvmSigner } from "../../signer";
 import { AssetTransferMethod } from "../../types";
 import { createEIP3009Payload } from "./eip3009";

--- a/typescript/packages/mechanisms/evm/src/index.ts
+++ b/typescript/packages/mechanisms/evm/src/index.ts
@@ -4,9 +4,38 @@
  * This module provides the EVM-specific implementation of the x402 payment protocol.
  */
 
-// Export EVM implementation modules here
-// The actual implementation logic will be added by copying from the core/src/schemes/evm folder
-
+// Exact scheme client
 export { ExactEvmScheme } from "./exact";
+export {
+  createPermit2ApprovalTx,
+  getPermit2AllowanceReadParams,
+  erc20AllowanceAbi,
+  type Permit2AllowanceParams,
+} from "./exact/client";
+
+// Signers
 export { toClientEvmSigner, toFacilitatorEvmSigner } from "./signer";
 export type { ClientEvmSigner, FacilitatorEvmSigner } from "./signer";
+
+// Types
+export type {
+  AssetTransferMethod,
+  ExactEIP3009Payload,
+  ExactPermit2Payload,
+  ExactEvmPayloadV1,
+  ExactEvmPayloadV2,
+  Permit2Witness,
+  Permit2Authorization,
+} from "./types";
+export { isPermit2Payload, isEIP3009Payload } from "./types";
+
+// Constants
+export {
+  PERMIT2_ADDRESS,
+  x402ExactPermit2ProxyAddress,
+  x402UptoPermit2ProxyAddress,
+  permit2WitnessTypes,
+  authorizationTypes,
+  eip3009ABI,
+  x402ExactPermit2ProxyABI,
+} from "./constants";

--- a/typescript/packages/mechanisms/evm/src/types.ts
+++ b/typescript/packages/mechanisms/evm/src/types.ts
@@ -1,3 +1,10 @@
+import { PaymentPayload } from "@x402/core/types";
+
+/**
+ * Result of createPaymentPayload - the core payload fields.
+ */
+export type PaymentPayloadResult = Pick<PaymentPayload, "x402Version" | "payload">;
+
 /**
  * Asset transfer methods for the exact EVM scheme.
  * - eip3009: Uses transferWithAuthorization (USDC, etc.) - recommended for compatible tokens

--- a/typescript/packages/mechanisms/evm/src/types.ts
+++ b/typescript/packages/mechanisms/evm/src/types.ts
@@ -1,3 +1,13 @@
+/**
+ * Asset transfer methods for the exact EVM scheme.
+ * - eip3009: Uses transferWithAuthorization (USDC, etc.) - recommended for compatible tokens
+ * - permit2: Uses Permit2 + x402Permit2Proxy - universal fallback for any ERC-20
+ */
+export type AssetTransferMethod = "eip3009" | "permit2";
+
+/**
+ * EIP-3009 payload for tokens with native transferWithAuthorization support.
+ */
 export type ExactEIP3009Payload = {
   signature?: `0x${string}`;
   authorization: {
@@ -10,6 +20,64 @@ export type ExactEIP3009Payload = {
   };
 };
 
+/**
+ * Permit2 witness data structure.
+ * Matches the Witness struct in x402Permit2Proxy contract.
+ */
+export type Permit2Witness = {
+  to: `0x${string}`;
+  validAfter: string;
+  validBefore: string;
+  extra: `0x${string}`;
+};
+
+/**
+ * Permit2 authorization parameters.
+ * Used to reconstruct the signed message for verification.
+ */
+export type Permit2Authorization = {
+  permitted: {
+    token: `0x${string}`;
+    amount: string;
+  };
+  spender: `0x${string}`;
+  nonce: string;
+  deadline: string;
+  witness: Permit2Witness;
+};
+
+/**
+ * Permit2 payload for tokens using the Permit2 + x402Permit2Proxy flow.
+ */
+export type ExactPermit2Payload = {
+  signature: `0x${string}`;
+  permit2Authorization: Permit2Authorization & {
+    from: `0x${string}`;
+  };
+};
+
 export type ExactEvmPayloadV1 = ExactEIP3009Payload;
 
-export type ExactEvmPayloadV2 = ExactEIP3009Payload;
+export type ExactEvmPayloadV2 = ExactEIP3009Payload | ExactPermit2Payload;
+
+/**
+ * Type guard to check if a payload is a Permit2 payload.
+ * Permit2 payloads have a `permit2Authorization` field.
+ *
+ * @param payload - The payload to check.
+ * @returns True if the payload is a Permit2 payload, false otherwise.
+ */
+export function isPermit2Payload(payload: ExactEvmPayloadV2): payload is ExactPermit2Payload {
+  return "permit2Authorization" in payload;
+}
+
+/**
+ * Type guard to check if a payload is an EIP-3009 payload.
+ * EIP-3009 payloads have an `authorization` field.
+ *
+ * @param payload - The payload to check.
+ * @returns True if the payload is an EIP-3009 payload, false otherwise.
+ */
+export function isEIP3009Payload(payload: ExactEvmPayloadV2): payload is ExactEIP3009Payload {
+  return "authorization" in payload;
+}

--- a/typescript/packages/mechanisms/evm/src/utils.ts
+++ b/typescript/packages/mechanisms/evm/src/utils.ts
@@ -18,20 +18,35 @@ export function getEvmChainId(network: EvmNetworkV1): number {
 }
 
 /**
- * Create a random 32-byte nonce for authorization
+ * Get the crypto object from the global scope.
+ *
+ * @returns The crypto object
+ * @throws Error if crypto API is not available
+ */
+function getCrypto(): Crypto {
+  const cryptoObj = globalThis.crypto as Crypto | undefined;
+  if (!cryptoObj) {
+    throw new Error("Crypto API not available");
+  }
+  return cryptoObj;
+}
+
+/**
+ * Create a random 32-byte nonce for EIP-3009 authorization.
  *
  * @returns A hex-encoded 32-byte nonce
  */
 export function createNonce(): `0x${string}` {
-  // Use dynamic import to avoid require() in ESM context
-  const cryptoObj =
-    typeof globalThis.crypto !== "undefined"
-      ? globalThis.crypto
-      : (globalThis as { crypto?: Crypto }).crypto;
+  return toHex(getCrypto().getRandomValues(new Uint8Array(32)));
+}
 
-  if (!cryptoObj) {
-    throw new Error("Crypto API not available");
-  }
-
-  return toHex(cryptoObj.getRandomValues(new Uint8Array(32)));
+/**
+ * Creates a random 256-bit nonce for Permit2.
+ * Permit2 uses uint256 nonces (not bytes32 like EIP-3009).
+ *
+ * @returns A string representation of the random nonce
+ */
+export function createPermit2Nonce(): string {
+  const randomBytes = getCrypto().getRandomValues(new Uint8Array(32));
+  return BigInt(toHex(randomBytes)).toString();
 }

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -405,3 +405,221 @@ describe("Permit2 Approval Helpers", () => {
     });
   });
 });
+
+/**
+ * Tests for the Permit2 approval flow pattern.
+ * These tests demonstrate how apps should check allowance and handle approval.
+ */
+describe("Permit2 Approval Flow", () => {
+  /**
+   * Helper to simulate checking allowance and determining if approval is needed.
+   * This mirrors what an app would do with a real publicClient.
+   */
+  function checkNeedsApproval(currentAllowance: bigint, requiredAmount: bigint): boolean {
+    return currentAllowance < requiredAmount;
+  }
+
+  describe("Allowance Check Logic", () => {
+    it("should detect when approval is needed (zero allowance)", () => {
+      const currentAllowance = BigInt(0);
+      const requiredAmount = BigInt("1000000"); // 1 USDC
+
+      expect(checkNeedsApproval(currentAllowance, requiredAmount)).toBe(true);
+    });
+
+    it("should detect when approval is needed (insufficient allowance)", () => {
+      const currentAllowance = BigInt("500000"); // 0.5 USDC
+      const requiredAmount = BigInt("1000000"); // 1 USDC
+
+      expect(checkNeedsApproval(currentAllowance, requiredAmount)).toBe(true);
+    });
+
+    it("should detect when approval is NOT needed (exact allowance)", () => {
+      const currentAllowance = BigInt("1000000"); // 1 USDC
+      const requiredAmount = BigInt("1000000"); // 1 USDC
+
+      expect(checkNeedsApproval(currentAllowance, requiredAmount)).toBe(false);
+    });
+
+    it("should detect when approval is NOT needed (excess allowance)", () => {
+      const currentAllowance = BigInt("10000000"); // 10 USDC
+      const requiredAmount = BigInt("1000000"); // 1 USDC
+
+      expect(checkNeedsApproval(currentAllowance, requiredAmount)).toBe(false);
+    });
+
+    it("should detect when approval is NOT needed (max uint256 allowance)", () => {
+      const maxUint256 = BigInt(
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      );
+      const requiredAmount = BigInt("1000000000000"); // Large amount
+
+      expect(checkNeedsApproval(maxUint256, requiredAmount)).toBe(false);
+    });
+  });
+
+  describe("Full Approval Flow Simulation", () => {
+    const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`;
+    const ownerAddress = "0x1234567890123456789012345678901234567890" as `0x${string}`;
+    const requiredAmount = BigInt("1000000");
+
+    /**
+     * Simulates the full approval flow an app would implement.
+     * Returns the steps taken and whether approval was triggered.
+     */
+    async function simulateApprovalFlow(
+      mockAllowance: bigint,
+      mockSendTransaction: () => Promise<`0x${string}`>,
+    ): Promise<{
+      checkedAllowance: boolean;
+      approvalSent: boolean;
+      approvalTxHash?: `0x${string}`;
+    }> {
+      const result = {
+        checkedAllowance: false,
+        approvalSent: false,
+        approvalTxHash: undefined as `0x${string}` | undefined,
+      };
+
+      // Step 1: Get read params for allowance check
+      const readParams = getPermit2AllowanceReadParams({
+        tokenAddress,
+        ownerAddress,
+      });
+      expect(readParams).toBeDefined();
+
+      // Step 2: Simulate reading allowance (would be publicClient.readContract in real app)
+      const currentAllowance = mockAllowance;
+      result.checkedAllowance = true;
+
+      // Step 3: Check if approval needed
+      if (checkNeedsApproval(currentAllowance, requiredAmount)) {
+        // Step 4: Create approval transaction
+        const tx = createPermit2ApprovalTx(tokenAddress);
+        expect(tx.to).toBeDefined();
+        expect(tx.data).toBeDefined();
+
+        // Step 5: Send transaction (would be walletClient.sendTransaction in real app)
+        result.approvalTxHash = await mockSendTransaction();
+        result.approvalSent = true;
+      }
+
+      return result;
+    }
+
+    it("should trigger approval when allowance is zero", async () => {
+      const mockTxHash = "0xabc123" as `0x${string}`;
+      const result = await simulateApprovalFlow(BigInt(0), async () => mockTxHash);
+
+      expect(result.checkedAllowance).toBe(true);
+      expect(result.approvalSent).toBe(true);
+      expect(result.approvalTxHash).toBe(mockTxHash);
+    });
+
+    it("should trigger approval when allowance is insufficient", async () => {
+      const mockTxHash = "0xdef456" as `0x${string}`;
+      const result = await simulateApprovalFlow(BigInt("500000"), async () => mockTxHash);
+
+      expect(result.checkedAllowance).toBe(true);
+      expect(result.approvalSent).toBe(true);
+      expect(result.approvalTxHash).toBe(mockTxHash);
+    });
+
+    it("should skip approval when allowance is sufficient", async () => {
+      const result = await simulateApprovalFlow(BigInt("10000000"), async () => {
+        throw new Error("Should not send transaction");
+      });
+
+      expect(result.checkedAllowance).toBe(true);
+      expect(result.approvalSent).toBe(false);
+      expect(result.approvalTxHash).toBeUndefined();
+    });
+
+    it("should skip approval when allowance is max uint256", async () => {
+      const maxUint256 = BigInt(
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      );
+      const result = await simulateApprovalFlow(maxUint256, async () => {
+        throw new Error("Should not send transaction");
+      });
+
+      expect(result.checkedAllowance).toBe(true);
+      expect(result.approvalSent).toBe(false);
+    });
+  });
+
+  describe("Approval + Permit2 Payload Creation Flow", () => {
+    let mockSigner: ClientEvmSigner;
+    let client: ExactEvmScheme;
+
+    beforeEach(() => {
+      mockSigner = {
+        address: "0x1234567890123456789012345678901234567890",
+        signTypedData: vi.fn().mockResolvedValue("0xmocksignature123456789"),
+      };
+      client = new ExactEvmScheme(mockSigner);
+    });
+
+    it("should complete full flow: check allowance -> approve -> create payload", async () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`;
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: tokenAddress,
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      // Step 1: Check allowance (simulated as zero)
+      const readParams = getPermit2AllowanceReadParams({
+        tokenAddress,
+        ownerAddress: mockSigner.address,
+      });
+      expect(readParams.functionName).toBe("allowance");
+
+      const mockAllowance = BigInt(0);
+      const needsApproval = mockAllowance < BigInt(requirements.amount);
+      expect(needsApproval).toBe(true);
+
+      // Step 2: Create and "send" approval tx
+      const approvalTx = createPermit2ApprovalTx(tokenAddress);
+      expect(approvalTx.to.toLowerCase()).toBe(tokenAddress.toLowerCase());
+      // In real app: await walletClient.sendTransaction(approvalTx)
+
+      // Step 3: Create Permit2 payload (after approval)
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(isPermit2Payload(result.payload)).toBe(true);
+      expect(result.payload.permit2Authorization).toBeDefined();
+      expect(result.payload.signature).toBeDefined();
+    });
+
+    it("should skip approval and directly create payload when already approved", async () => {
+      const tokenAddress = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as `0x${string}`;
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453",
+        amount: "1000000",
+        asset: tokenAddress,
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { assetTransferMethod: "permit2" },
+      };
+
+      // Step 1: Check allowance (simulated as max uint256 - already approved)
+      const maxUint256 = BigInt(
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      );
+      const needsApproval = maxUint256 < BigInt(requirements.amount);
+      expect(needsApproval).toBe(false);
+
+      // Step 2: Skip approval, directly create payload
+      const result = await client.createPaymentPayload(2, requirements);
+
+      expect(isPermit2Payload(result.payload)).toBe(true);
+      expect(result.payload.permit2Authorization).toBeDefined();
+    });
+  });
+});

--- a/typescript/packages/mechanisms/evm/test/unit/types.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/types.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import type { ExactEvmPayloadV1, ExactEvmPayloadV2 } from "../../src/types";
+import type {
+  ExactEvmPayloadV1,
+  ExactEvmPayloadV2,
+  ExactEIP3009Payload,
+  ExactPermit2Payload,
+} from "../../src/types";
+import { isPermit2Payload, isEIP3009Payload } from "../../src/types";
 
 describe("EVM Types", () => {
   describe("ExactEvmPayloadV1", () => {
@@ -39,7 +45,7 @@ describe("EVM Types", () => {
   });
 
   describe("ExactEvmPayloadV2", () => {
-    it("should have the same structure as V1", () => {
+    it("should accept EIP-3009 payload structure", () => {
       const payload: ExactEvmPayloadV2 = {
         signature: "0x1234567890abcdef",
         authorization: {
@@ -55,6 +61,86 @@ describe("EVM Types", () => {
       // V2 should be compatible with V1
       const payloadV1: ExactEvmPayloadV1 = payload;
       expect(payloadV1).toEqual(payload);
+    });
+
+    it("should accept Permit2 payload structure", () => {
+      const payload: ExactPermit2Payload = {
+        signature: "0x1234567890abcdef",
+        permit2Authorization: {
+          from: "0x1234567890123456789012345678901234567890",
+          permitted: {
+            token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            amount: "1000000",
+          },
+          spender: "0x4020B671C4c523a852c11a5EC58F27F235e80001",
+          nonce: "12345",
+          deadline: "1234567890",
+          witness: {
+            to: "0x9876543210987654321098765432109876543210",
+            validAfter: "1234567000",
+            validBefore: "1234567890",
+            extra: "0x",
+          },
+        },
+      };
+
+      expect(payload.signature).toBeDefined();
+      expect(payload.permit2Authorization).toBeDefined();
+      expect(payload.permit2Authorization.permitted.token).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    });
+  });
+
+  describe("Type Guards", () => {
+    const eip3009Payload: ExactEIP3009Payload = {
+      signature: "0x1234567890abcdef",
+      authorization: {
+        from: "0x1234567890123456789012345678901234567890",
+        to: "0x9876543210987654321098765432109876543210",
+        value: "100000",
+        validAfter: "1234567890",
+        validBefore: "1234567890",
+        nonce: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      },
+    };
+
+    const permit2Payload: ExactPermit2Payload = {
+      signature: "0x1234567890abcdef",
+      permit2Authorization: {
+        from: "0x1234567890123456789012345678901234567890",
+        permitted: {
+          token: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          amount: "1000000",
+        },
+        spender: "0x4020B671C4c523a852c11a5EC58F27F235e80001",
+        nonce: "12345",
+        deadline: "1234567890",
+        witness: {
+          to: "0x9876543210987654321098765432109876543210",
+          validAfter: "1234567000",
+          validBefore: "1234567890",
+          extra: "0x",
+        },
+      },
+    };
+
+    describe("isEIP3009Payload", () => {
+      it("should return true for EIP-3009 payload", () => {
+        expect(isEIP3009Payload(eip3009Payload)).toBe(true);
+      });
+
+      it("should return false for Permit2 payload", () => {
+        expect(isEIP3009Payload(permit2Payload)).toBe(false);
+      });
+    });
+
+    describe("isPermit2Payload", () => {
+      it("should return true for Permit2 payload", () => {
+        expect(isPermit2Payload(permit2Payload)).toBe(true);
+      });
+
+      it("should return false for EIP-3009 payload", () => {
+        expect(isPermit2Payload(eip3009Payload)).toBe(false);
+      });
     });
   });
 });


### PR DESCRIPTION
## Description
- Add client-side Permit2 payload creation for tokens without EIP-3009 support
- Route between EIP-3009 and Permit2 based on `requirements.extra.assetTransferMethod`
- Provide approval helpers for apps to check/prompt user approval (user pays gas)

## Changes
- Add `AssetTransferMethod`, `ExactPermit2Payload`, type guards
- Add Permit2 constants (addresses, EIP-712 types, ABIs)
- Add `createPermit2Payload()` using x402Permit2Proxy witness pattern
- Add `createPermit2ApprovalTx()` and `getPermit2AllowanceReadParams()` helpers
- Refactor: extract EIP-3009 to separate module for cleaner routing

## Usage
```
// Check if approval needed
const allowance = await publicClient.readContract(
  getPermit2AllowanceReadParams({ tokenAddress, ownerAddress })
);
if (allowance < amount) {
  await walletClient.sendTransaction(createPermit2ApprovalTx(tokenAddress));
}

// Create payload (server sets assetTransferMethod: "permit2")
const payload = await client.createPaymentPayload(2, requirements);
```

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 