### PR TITLE
feat: add callback-based signer for EVM and SVM clients

### DIFF
--- a/go/signers/evm/README.md
+++ b/go/signers/evm/README.md
@@ -16,11 +16,29 @@ if err != nil {
     log.Fatal(err)
 }
 
+// Or create signer from a callback
+signer, err = evmsigners.NewClientSigner(address, signFunc)
+if err != nil {
+    log.Fatal(err)
+}
+
 // Use with ExactEvmScheme
 evmScheme := evmclient.NewExactEvmScheme(signer)
 ```
 
 ## API
+
+### NewClientSigner
+
+```go
+func NewClientSigner(address string, signFunc SignTypedDataFunc) (evm.ClientEvmSigner, error)
+```
+
+Creates a client signer from an address and a signing callback.
+
+**Use cases:**
+- MPC / custody / HSM signing
+- Remote signer services
 
 ### NewClientSignerFromPrivateKey
 

--- a/go/signers/svm/README.md
+++ b/go/signers/svm/README.md
@@ -16,11 +16,23 @@ if err != nil {
     log.Fatal(err)
 }
 
+// Or create signer from a callback
+signer, err = svmsigners.NewClientSigner(publicKey, signFunc)
+if err != nil {
+    log.Fatal(err)
+}
+
 // Use with ExactSvmScheme
 svmScheme := svmclient.NewExactSvmScheme(signer)
 ```
 
 ## API
+
+### NewClientSigner
+
+```go
+func NewClientSigner(publicKey solana.PublicKey, signFunc SignTransactionFunc) (svm.ClientSvmSigner, error)
+```
 
 ### NewClientSignerFromPrivateKey
 
@@ -213,4 +225,3 @@ fmt.Println("Public Key:", privateKey.PublicKey())
 - [../evm/README.md](../evm/README.md) - EVM client signer
 - [../../mechanisms/svm/README.md](../../mechanisms/svm/README.md) - SVM mechanism documentation
 - [../README.md](../README.md) - Signers package overview
-


### PR DESCRIPTION
## Description
related to https://github.com/coinbase/x402/issues/1033
Add callback-based client signer helpers to support MPC/HSM/custody integrations, while keeping existing private-key helpers intact. The private-key constructors now wrap the callback-based implementations, and docs/tests are updated accordingly.

## Tests
Added 1 new unit test for the callback-based signer helpers; all tests pass.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits