### PR TITLE
feat: Add Permit2 facilitator support

### DIFF
--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -717,10 +717,14 @@ export class x402HTTPResourceServer {
     customHtml?: string,
     unpaidResponse?: UnpaidResponseResult,
   ): HTTPResponseInstructions {
+    // Use 412 Precondition Failed for permit2_allowance_required error
+    // This signals client needs to approve Permit2 before retrying
+    const status = paymentRequired.error === "permit2_allowance_required" ? 412 : 402;
+
     if (isWebBrowser) {
       const html = this.generatePaywallHTML(paymentRequired, paywallConfig, customHtml);
       return {
-        status: 402,
+        status,
         headers: { "Content-Type": "text/html" },
         body: html,
         isHtml: true,
@@ -734,7 +738,7 @@ export class x402HTTPResourceServer {
     const body = unpaidResponse ? unpaidResponse.body : {};
 
     return {
-      status: 402,
+      status,
       headers: {
         "Content-Type": contentType,
         ...response.headers,

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -17,6 +17,7 @@ export type {
   SchemeNetworkFacilitator,
   SchemeNetworkServer,
   MoneyParser,
+  PaymentPayloadResult,
 } from "./mechanisms";
 export type { PaymentRequirementsV1, PaymentRequiredV1, PaymentPayloadV1 } from "./v1";
 export type {

--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -15,13 +15,19 @@ import { Price, Network, AssetAmount } from ".";
  */
 export type MoneyParser = (amount: number, network: Network) => Promise<AssetAmount | null>;
 
+/**
+ * Result of createPaymentPayload - the core payload fields.
+ * Contains the x402 version and the scheme-specific payload data.
+ */
+export type PaymentPayloadResult = Pick<PaymentPayload, "x402Version" | "payload">;
+
 export interface SchemeNetworkClient {
   readonly scheme: string;
 
   createPaymentPayload(
     x402Version: number,
     paymentRequirements: PaymentRequirements,
-  ): Promise<Pick<PaymentPayload, "x402Version" | "payload">>;
+  ): Promise<PaymentPayloadResult>;
 }
 
 export interface SchemeNetworkFacilitator {

--- a/typescript/packages/mechanisms/evm/src/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/constants.ts
@@ -13,6 +13,7 @@ export const authorizationTypes = {
 /**
  * Permit2 EIP-712 types for signing PermitWitnessTransferFrom.
  * Must match the exact format expected by the Permit2 contract.
+ * Note: Types must be in ALPHABETICAL order after the primary type (TokenPermissions < Witness).
  */
 export const permit2WitnessTypes = {
   PermitWitnessTransferFrom: [
@@ -27,10 +28,9 @@ export const permit2WitnessTypes = {
     { name: "amount", type: "uint256" },
   ],
   Witness: [
-    { name: "extra", type: "bytes" },
     { name: "to", type: "address" },
     { name: "validAfter", type: "uint256" },
-    { name: "validBefore", type: "uint256" },
+    { name: "extra", type: "bytes" },
   ],
 } as const;
 
@@ -172,7 +172,6 @@ export const x402ExactPermit2ProxyABI = [
         components: [
           { name: "to", type: "address", internalType: "address" },
           { name: "validAfter", type: "uint256", internalType: "uint256" },
-          { name: "validBefore", type: "uint256", internalType: "uint256" },
           { name: "extra", type: "bytes", internalType: "bytes" },
         ],
       },

--- a/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
@@ -1,8 +1,8 @@
-import { PaymentRequirements } from "@x402/core/types";
+import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
 import { getAddress } from "viem";
 import { authorizationTypes } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
-import { ExactEIP3009Payload, PaymentPayloadResult } from "../../types";
+import { ExactEIP3009Payload } from "../../types";
 import { createNonce } from "../../utils";
 
 /**

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -1,4 +1,4 @@
-import { PaymentRequirements } from "@x402/core/types";
+import { PaymentRequirements, PaymentPayloadResult } from "@x402/core/types";
 import { encodeFunctionData, getAddress } from "viem";
 import {
   permit2WitnessTypes,
@@ -6,7 +6,7 @@ import {
   x402ExactPermit2ProxyAddress,
 } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
-import { ExactPermit2Payload, PaymentPayloadResult } from "../../types";
+import { ExactPermit2Payload } from "../../types";
 import { createPermit2Nonce } from "../../utils";
 
 /** Maximum uint256 value for unlimited approval. */

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -30,9 +30,10 @@ export async function createPermit2Payload(
   const now = Math.floor(Date.now() / 1000);
   const nonce = createPermit2Nonce();
 
+  // Lower time bound - allow some clock skew
   const validAfter = (now - 600).toString();
-  const validBefore = (now + paymentRequirements.maxTimeoutSeconds).toString();
-  const deadline = validBefore;
+  // Upper time bound is enforced by Permit2's deadline field
+  const deadline = (now + paymentRequirements.maxTimeoutSeconds).toString();
 
   const permit2Authorization: ExactPermit2Payload["permit2Authorization"] = {
     from: signer.address,
@@ -46,7 +47,6 @@ export async function createPermit2Payload(
     witness: {
       to: getAddress(paymentRequirements.payTo),
       validAfter,
-      validBefore,
       extra: "0x",
     },
   };
@@ -99,10 +99,9 @@ async function signPermit2Authorization(
     nonce: BigInt(permit2Authorization.nonce),
     deadline: BigInt(permit2Authorization.deadline),
     witness: {
-      extra: permit2Authorization.witness.extra,
       to: getAddress(permit2Authorization.witness.to),
       validAfter: BigInt(permit2Authorization.witness.validAfter),
-      validBefore: BigInt(permit2Authorization.witness.validBefore),
+      extra: permit2Authorization.witness.extra,
     },
   };
 

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -1,6 +1,6 @@
-import { PaymentRequirements, SchemeNetworkClient } from "@x402/core/types";
+import { PaymentRequirements, SchemeNetworkClient, PaymentPayloadResult } from "@x402/core/types";
 import { ClientEvmSigner } from "../../signer";
-import { AssetTransferMethod, PaymentPayloadResult } from "../../types";
+import { AssetTransferMethod } from "../../types";
 import { createEIP3009Payload } from "./eip3009";
 import { createPermit2Payload } from "./permit2";
 

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -1,0 +1,343 @@
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import { getAddress, Hex, isAddressEqual, parseErc6492Signature, parseSignature } from "viem";
+import { authorizationTypes, eip3009ABI } from "../../constants";
+import { FacilitatorEvmSigner } from "../../signer";
+import { ExactEIP3009Payload } from "../../types";
+
+export interface EIP3009FacilitatorConfig {
+  /**
+   * If enabled, the facilitator will deploy ERC-4337 smart wallets
+   * via EIP-6492 when encountering undeployed contract signatures.
+   *
+   * @default false
+   */
+  deployERC4337WithEIP6492: boolean;
+}
+
+/**
+ * Verifies an EIP-3009 payment payload.
+ *
+ * @param signer - The facilitator signer for contract reads
+ * @param payload - The payment payload to verify
+ * @param requirements - The payment requirements
+ * @param eip3009Payload - The EIP-3009 specific payload
+ * @returns Promise resolving to verification response
+ */
+export async function verifyEIP3009(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  eip3009Payload: ExactEIP3009Payload,
+): Promise<VerifyResponse> {
+  const payer = eip3009Payload.authorization.from;
+
+  // Verify scheme matches
+  if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
+    return {
+      isValid: false,
+      invalidReason: "unsupported_scheme",
+      payer,
+    };
+  }
+
+  // Get chain configuration
+  if (!requirements.extra?.name || !requirements.extra?.version) {
+    return {
+      isValid: false,
+      invalidReason: "missing_eip712_domain",
+      payer,
+    };
+  }
+
+  const { name, version } = requirements.extra;
+  const erc20Address = getAddress(requirements.asset);
+
+  // Verify network matches
+  if (payload.accepted.network !== requirements.network) {
+    return {
+      isValid: false,
+      invalidReason: "network_mismatch",
+      payer,
+    };
+  }
+
+  // Build typed data for signature verification
+  const permitTypedData = {
+    types: authorizationTypes,
+    primaryType: "TransferWithAuthorization" as const,
+    domain: {
+      name,
+      version,
+      chainId: parseInt(requirements.network.split(":")[1]),
+      verifyingContract: erc20Address,
+    },
+    message: {
+      from: eip3009Payload.authorization.from,
+      to: eip3009Payload.authorization.to,
+      value: BigInt(eip3009Payload.authorization.value),
+      validAfter: BigInt(eip3009Payload.authorization.validAfter),
+      validBefore: BigInt(eip3009Payload.authorization.validBefore),
+      nonce: eip3009Payload.authorization.nonce,
+    },
+  };
+
+  // Verify signature
+  try {
+    const recoveredAddress = await signer.verifyTypedData({
+      address: eip3009Payload.authorization.from,
+      ...permitTypedData,
+      signature: eip3009Payload.signature!,
+    });
+
+    if (!recoveredAddress) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_evm_payload_signature",
+        payer,
+      };
+    }
+  } catch {
+    // Signature verification failed - could be an undeployed smart wallet
+    // Check if smart wallet is deployed
+    const signature = eip3009Payload.signature!;
+    const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
+    const isSmartWallet = signatureLength > 130; // 65 bytes = 130 hex chars for EOA
+
+    if (isSmartWallet) {
+      const payerAddress = eip3009Payload.authorization.from;
+      const bytecode = await signer.getCode({ address: payerAddress });
+
+      if (!bytecode || bytecode === "0x") {
+        // Wallet is not deployed. Check if it's EIP-6492 with deployment info.
+        const erc6492Data = parseErc6492Signature(signature);
+        const hasDeploymentInfo =
+          erc6492Data.address &&
+          erc6492Data.data &&
+          !isAddressEqual(erc6492Data.address, "0x0000000000000000000000000000000000000000");
+
+        if (!hasDeploymentInfo) {
+          // Non-EIP-6492 undeployed smart wallet - will always fail at settlement
+          return {
+            isValid: false,
+            invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
+            payer: payerAddress,
+          };
+        }
+        // EIP-6492 signature with deployment info - allow through
+      } else {
+        // Wallet is deployed but signature still failed - invalid signature
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_evm_payload_signature",
+          payer,
+        };
+      }
+    } else {
+      // EOA signature failed
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_evm_payload_signature",
+        payer,
+      };
+    }
+  }
+
+  // Verify payment recipient matches
+  if (getAddress(eip3009Payload.authorization.to) !== getAddress(requirements.payTo)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_exact_evm_payload_recipient_mismatch",
+      payer,
+    };
+  }
+
+  // Verify validBefore is in the future (with 6 second buffer for block time)
+  const now = Math.floor(Date.now() / 1000);
+  if (BigInt(eip3009Payload.authorization.validBefore) < BigInt(now + 6)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_exact_evm_payload_authorization_valid_before",
+      payer,
+    };
+  }
+
+  // Verify validAfter is not in the future
+  if (BigInt(eip3009Payload.authorization.validAfter) > BigInt(now)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_exact_evm_payload_authorization_valid_after",
+      payer,
+    };
+  }
+
+  // Check balance
+  try {
+    const balance = (await signer.readContract({
+      address: erc20Address,
+      abi: eip3009ABI,
+      functionName: "balanceOf",
+      args: [eip3009Payload.authorization.from],
+    })) as bigint;
+
+    if (BigInt(balance) < BigInt(requirements.amount)) {
+      return {
+        isValid: false,
+        invalidReason: "insufficient_funds",
+        payer,
+      };
+    }
+  } catch {
+    // If we can't check balance, continue with other validations
+  }
+
+  // Verify amount is sufficient
+  if (BigInt(eip3009Payload.authorization.value) < BigInt(requirements.amount)) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_exact_evm_payload_authorization_value",
+      payer,
+    };
+  }
+
+  return {
+    isValid: true,
+    invalidReason: undefined,
+    payer,
+  };
+}
+
+/**
+ * Settles an EIP-3009 payment by executing transferWithAuthorization.
+ *
+ * @param signer - The facilitator signer for contract writes
+ * @param payload - The payment payload to settle
+ * @param requirements - The payment requirements
+ * @param eip3009Payload - The EIP-3009 specific payload
+ * @param config - Facilitator configuration
+ * @returns Promise resolving to settlement response
+ */
+export async function settleEIP3009(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  eip3009Payload: ExactEIP3009Payload,
+  config: EIP3009FacilitatorConfig,
+): Promise<SettleResponse> {
+  const payer = eip3009Payload.authorization.from;
+
+  // Re-verify before settling
+  const valid = await verifyEIP3009(signer, payload, requirements, eip3009Payload);
+  if (!valid.isValid) {
+    return {
+      success: false,
+      network: payload.accepted.network,
+      transaction: "",
+      errorReason: valid.invalidReason ?? "invalid_scheme",
+      payer,
+    };
+  }
+
+  try {
+    // Parse ERC-6492 signature if applicable
+    const parseResult = parseErc6492Signature(eip3009Payload.signature!);
+    const { signature, address: factoryAddress, data: factoryCalldata } = parseResult;
+
+    // Deploy ERC-4337 smart wallet via EIP-6492 if configured and needed
+    if (
+      config.deployERC4337WithEIP6492 &&
+      factoryAddress &&
+      factoryCalldata &&
+      !isAddressEqual(factoryAddress, "0x0000000000000000000000000000000000000000")
+    ) {
+      // Check if smart wallet is already deployed
+      const bytecode = await signer.getCode({ address: payer });
+
+      if (!bytecode || bytecode === "0x") {
+        // Wallet not deployed - attempt deployment
+        const deployTx = await signer.sendTransaction({
+          to: factoryAddress as Hex,
+          data: factoryCalldata as Hex,
+        });
+
+        // Wait for deployment transaction
+        await signer.waitForTransactionReceipt({ hash: deployTx });
+      }
+    }
+
+    // Determine if this is an ECDSA signature (EOA) or smart wallet signature
+    const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
+    const isECDSA = signatureLength === 130;
+
+    let tx: Hex;
+    if (isECDSA) {
+      // For EOA wallets, parse signature into v, r, s and use that overload
+      const parsedSig = parseSignature(signature);
+
+      tx = await signer.writeContract({
+        address: getAddress(requirements.asset),
+        abi: eip3009ABI,
+        functionName: "transferWithAuthorization",
+        args: [
+          getAddress(eip3009Payload.authorization.from),
+          getAddress(eip3009Payload.authorization.to),
+          BigInt(eip3009Payload.authorization.value),
+          BigInt(eip3009Payload.authorization.validAfter),
+          BigInt(eip3009Payload.authorization.validBefore),
+          eip3009Payload.authorization.nonce,
+          (parsedSig.v as number | undefined) || parsedSig.yParity,
+          parsedSig.r,
+          parsedSig.s,
+        ],
+      });
+    } else {
+      // For smart wallets, use the bytes signature overload
+      tx = await signer.writeContract({
+        address: getAddress(requirements.asset),
+        abi: eip3009ABI,
+        functionName: "transferWithAuthorization",
+        args: [
+          getAddress(eip3009Payload.authorization.from),
+          getAddress(eip3009Payload.authorization.to),
+          BigInt(eip3009Payload.authorization.value),
+          BigInt(eip3009Payload.authorization.validAfter),
+          BigInt(eip3009Payload.authorization.validBefore),
+          eip3009Payload.authorization.nonce,
+          signature,
+        ],
+      });
+    }
+
+    // Wait for transaction confirmation
+    const receipt = await signer.waitForTransactionReceipt({ hash: tx });
+
+    if (receipt.status !== "success") {
+      return {
+        success: false,
+        errorReason: "invalid_transaction_state",
+        transaction: tx,
+        network: payload.accepted.network,
+        payer,
+      };
+    }
+
+    return {
+      success: true,
+      transaction: tx,
+      network: payload.accepted.network,
+      payer,
+    };
+  } catch {
+    return {
+      success: false,
+      errorReason: "transaction_failed",
+      transaction: "",
+      network: payload.accepted.network,
+      payer,
+    };
+  }
+}

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -1,0 +1,307 @@
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import { getAddress } from "viem";
+import {
+  eip3009ABI,
+  PERMIT2_ADDRESS,
+  permit2WitnessTypes,
+  x402ExactPermit2ProxyABI,
+  x402ExactPermit2ProxyAddress,
+} from "../../constants";
+import { FacilitatorEvmSigner } from "../../signer";
+import { ExactPermit2Payload } from "../../types";
+
+// ERC20 allowance ABI for checking Permit2 approval
+const erc20AllowanceABI = [
+  {
+    type: "function",
+    name: "allowance",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
+/**
+ * Verifies a Permit2 payment payload.
+ *
+ * @param signer - The facilitator signer for contract reads
+ * @param payload - The payment payload to verify
+ * @param requirements - The payment requirements
+ * @param permit2Payload - The Permit2 specific payload
+ * @returns Promise resolving to verification response
+ */
+export async function verifyPermit2(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  permit2Payload: ExactPermit2Payload,
+): Promise<VerifyResponse> {
+  const payer = permit2Payload.permit2Authorization.from;
+
+  // Verify scheme matches
+  if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
+    return {
+      isValid: false,
+      invalidReason: "unsupported_scheme",
+      payer,
+    };
+  }
+
+  // Verify network matches
+  if (payload.accepted.network !== requirements.network) {
+    return {
+      isValid: false,
+      invalidReason: "network_mismatch",
+      payer,
+    };
+  }
+
+  const chainId = parseInt(requirements.network.split(":")[1]);
+  const tokenAddress = getAddress(requirements.asset);
+
+  // Verify spender is the x402ExactPermit2Proxy
+  if (
+    getAddress(permit2Payload.permit2Authorization.spender) !==
+    getAddress(x402ExactPermit2ProxyAddress)
+  ) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_spender",
+      payer,
+    };
+  }
+
+  // Verify witness.to matches payTo
+  if (
+    getAddress(permit2Payload.permit2Authorization.witness.to) !== getAddress(requirements.payTo)
+  ) {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_recipient_mismatch",
+      payer,
+    };
+  }
+
+  // Verify deadline not expired (with 6 second buffer for block time)
+  const now = Math.floor(Date.now() / 1000);
+  if (BigInt(permit2Payload.permit2Authorization.deadline) < BigInt(now + 6)) {
+    return {
+      isValid: false,
+      invalidReason: "permit2_deadline_expired",
+      payer,
+    };
+  }
+
+  // Verify validAfter is not in the future
+  if (BigInt(permit2Payload.permit2Authorization.witness.validAfter) > BigInt(now)) {
+    return {
+      isValid: false,
+      invalidReason: "permit2_not_yet_valid",
+      payer,
+    };
+  }
+
+  // Verify amount is sufficient
+  if (BigInt(permit2Payload.permit2Authorization.permitted.amount) < BigInt(requirements.amount)) {
+    return {
+      isValid: false,
+      invalidReason: "permit2_insufficient_amount",
+      payer,
+    };
+  }
+
+  // Verify token matches
+  if (getAddress(permit2Payload.permit2Authorization.permitted.token) !== tokenAddress) {
+    return {
+      isValid: false,
+      invalidReason: "permit2_token_mismatch",
+      payer,
+    };
+  }
+
+  // Build typed data for Permit2 signature verification
+  const permit2TypedData = {
+    types: permit2WitnessTypes,
+    primaryType: "PermitWitnessTransferFrom" as const,
+    domain: {
+      name: "Permit2",
+      chainId,
+      verifyingContract: PERMIT2_ADDRESS,
+    },
+    message: {
+      permitted: {
+        token: getAddress(permit2Payload.permit2Authorization.permitted.token),
+        amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
+      },
+      spender: getAddress(permit2Payload.permit2Authorization.spender),
+      nonce: BigInt(permit2Payload.permit2Authorization.nonce),
+      deadline: BigInt(permit2Payload.permit2Authorization.deadline),
+      witness: {
+        to: getAddress(permit2Payload.permit2Authorization.witness.to),
+        validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
+        extra: permit2Payload.permit2Authorization.witness.extra,
+      },
+    },
+  };
+
+  // Verify signature
+  try {
+    const isValid = await signer.verifyTypedData({
+      address: payer,
+      ...permit2TypedData,
+      signature: permit2Payload.signature,
+    });
+
+    if (!isValid) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_permit2_signature",
+        payer,
+      };
+    }
+  } catch {
+    return {
+      isValid: false,
+      invalidReason: "invalid_permit2_signature",
+      payer,
+    };
+  }
+
+  // Check Permit2 allowance
+  try {
+    const allowance = (await signer.readContract({
+      address: tokenAddress,
+      abi: erc20AllowanceABI,
+      functionName: "allowance",
+      args: [payer, PERMIT2_ADDRESS],
+    })) as bigint;
+
+    if (allowance < BigInt(requirements.amount)) {
+      return {
+        isValid: false,
+        invalidReason: "permit2_allowance_required",
+        payer,
+      };
+    }
+  } catch {
+    // If we can't check allowance, continue - settlement will fail if insufficient
+  }
+
+  // Check balance
+  try {
+    const balance = (await signer.readContract({
+      address: tokenAddress,
+      abi: eip3009ABI,
+      functionName: "balanceOf",
+      args: [payer],
+    })) as bigint;
+
+    if (balance < BigInt(requirements.amount)) {
+      return {
+        isValid: false,
+        invalidReason: "insufficient_funds",
+        payer,
+      };
+    }
+  } catch {
+    // If we can't check balance, continue with other validations
+  }
+
+  return {
+    isValid: true,
+    invalidReason: undefined,
+    payer,
+  };
+}
+
+/**
+ * Settles a Permit2 payment by calling the x402ExactPermit2Proxy.
+ *
+ * @param signer - The facilitator signer for contract writes
+ * @param payload - The payment payload to settle
+ * @param requirements - The payment requirements
+ * @param permit2Payload - The Permit2 specific payload
+ * @returns Promise resolving to settlement response
+ */
+export async function settlePermit2(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  permit2Payload: ExactPermit2Payload,
+): Promise<SettleResponse> {
+  const payer = permit2Payload.permit2Authorization.from;
+
+  // Re-verify before settling
+  const valid = await verifyPermit2(signer, payload, requirements, permit2Payload);
+  if (!valid.isValid) {
+    return {
+      success: false,
+      network: payload.accepted.network,
+      transaction: "",
+      errorReason: valid.invalidReason ?? "invalid_scheme",
+      payer,
+    };
+  }
+
+  try {
+    // Call x402ExactPermit2Proxy.settle()
+    const tx = await signer.writeContract({
+      address: x402ExactPermit2ProxyAddress,
+      abi: x402ExactPermit2ProxyABI,
+      functionName: "settle",
+      args: [
+        {
+          permitted: {
+            token: getAddress(permit2Payload.permit2Authorization.permitted.token),
+            amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
+          },
+          nonce: BigInt(permit2Payload.permit2Authorization.nonce),
+          deadline: BigInt(permit2Payload.permit2Authorization.deadline),
+        },
+        payer,
+        {
+          to: getAddress(permit2Payload.permit2Authorization.witness.to),
+          validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
+          extra: permit2Payload.permit2Authorization.witness.extra,
+        },
+        permit2Payload.signature,
+      ],
+    });
+
+    // Wait for transaction confirmation
+    const receipt = await signer.waitForTransactionReceipt({ hash: tx });
+
+    if (receipt.status !== "success") {
+      return {
+        success: false,
+        errorReason: "invalid_transaction_state",
+        transaction: tx,
+        network: payload.accepted.network,
+        payer,
+      };
+    }
+
+    return {
+      success: true,
+      transaction: tx,
+      network: payload.accepted.network,
+      payer,
+    };
+  } catch {
+    return {
+      success: false,
+      errorReason: "transaction_failed",
+      transaction: "",
+      network: payload.accepted.network,
+      payer,
+    };
+  }
+}

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
@@ -5,10 +5,10 @@ import {
   SettleResponse,
   VerifyResponse,
 } from "@x402/core/types";
-import { getAddress, Hex, isAddressEqual, parseErc6492Signature, parseSignature } from "viem";
-import { authorizationTypes, eip3009ABI } from "../../constants";
 import { FacilitatorEvmSigner } from "../../signer";
 import { ExactEvmPayloadV2, ExactEIP3009Payload, isPermit2Payload } from "../../types";
+import { verifyEIP3009, settleEIP3009 } from "./eip3009";
+import { verifyPermit2, settlePermit2 } from "./permit2";
 
 export interface ExactEvmSchemeConfig {
   /**
@@ -22,6 +22,7 @@ export interface ExactEvmSchemeConfig {
 
 /**
  * EVM facilitator implementation for the Exact payment scheme.
+ * Routes between EIP-3009 and Permit2 based on payload type.
  */
 export class ExactEvmScheme implements SchemeNetworkFacilitator {
   readonly scheme = "exact";
@@ -67,6 +68,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
 
   /**
    * Verifies a payment payload.
+   * Routes to the appropriate verification logic based on payload type.
    *
    * @param payload - The payment payload to verify
    * @param requirements - The payment requirements
@@ -78,199 +80,19 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
   ): Promise<VerifyResponse> {
     const rawPayload = payload.payload as ExactEvmPayloadV2;
 
-    // Reject Permit2 payloads - facilitator only supports EIP-3009 currently
+    // Route based on payload type
     if (isPermit2Payload(rawPayload)) {
-      return {
-        isValid: false,
-        invalidReason: "unsupported_payload_type",
-        payer: rawPayload.permit2Authorization.from,
-      };
+      return verifyPermit2(this.signer, payload, requirements, rawPayload);
     }
 
     // Type-narrowed to EIP-3009 payload
-    const exactEvmPayload: ExactEIP3009Payload = rawPayload;
-
-    // Verify scheme matches
-    if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
-      return {
-        isValid: false,
-        invalidReason: "unsupported_scheme",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Get chain configuration
-    if (!requirements.extra?.name || !requirements.extra?.version) {
-      return {
-        isValid: false,
-        invalidReason: "missing_eip712_domain",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    const { name, version } = requirements.extra;
-    const erc20Address = getAddress(requirements.asset);
-
-    // Verify network matches
-    if (payload.accepted.network !== requirements.network) {
-      return {
-        isValid: false,
-        invalidReason: "network_mismatch",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Build typed data for signature verification
-    const permitTypedData = {
-      types: authorizationTypes,
-      primaryType: "TransferWithAuthorization" as const,
-      domain: {
-        name,
-        version,
-        chainId: parseInt(requirements.network.split(":")[1]),
-        verifyingContract: erc20Address,
-      },
-      message: {
-        from: exactEvmPayload.authorization.from,
-        to: exactEvmPayload.authorization.to,
-        value: BigInt(exactEvmPayload.authorization.value),
-        validAfter: BigInt(exactEvmPayload.authorization.validAfter),
-        validBefore: BigInt(exactEvmPayload.authorization.validBefore),
-        nonce: exactEvmPayload.authorization.nonce,
-      },
-    };
-
-    // Verify signature
-    try {
-      const recoveredAddress = await this.signer.verifyTypedData({
-        address: exactEvmPayload.authorization.from,
-        ...permitTypedData,
-        signature: exactEvmPayload.signature!,
-      });
-
-      if (!recoveredAddress) {
-        return {
-          isValid: false,
-          invalidReason: "invalid_exact_evm_payload_signature",
-          payer: exactEvmPayload.authorization.from,
-        };
-      }
-    } catch {
-      // Signature verification failed - could be an undeployed smart wallet
-      // Check if smart wallet is deployed
-      const signature = exactEvmPayload.signature!;
-      const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
-      const isSmartWallet = signatureLength > 130; // 65 bytes = 130 hex chars for EOA
-
-      if (isSmartWallet) {
-        const payerAddress = exactEvmPayload.authorization.from;
-        const bytecode = await this.signer.getCode({ address: payerAddress });
-
-        if (!bytecode || bytecode === "0x") {
-          // Wallet is not deployed. Check if it's EIP-6492 with deployment info.
-          // EIP-6492 signatures contain factory address and calldata needed for deployment.
-          // Non-EIP-6492 undeployed wallets cannot succeed (no way to deploy them).
-          const erc6492Data = parseErc6492Signature(signature);
-          const hasDeploymentInfo =
-            erc6492Data.address &&
-            erc6492Data.data &&
-            !isAddressEqual(erc6492Data.address, "0x0000000000000000000000000000000000000000");
-
-          if (!hasDeploymentInfo) {
-            // Non-EIP-6492 undeployed smart wallet - will always fail at settlement
-            // since EIP-3009 requires on-chain EIP-1271 validation
-            return {
-              isValid: false,
-              invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
-              payer: payerAddress,
-            };
-          }
-          // EIP-6492 signature with deployment info - allow through
-          // Facilitators with sponsored deployment support can handle this in settle()
-        } else {
-          // Wallet is deployed but signature still failed - invalid signature
-          return {
-            isValid: false,
-            invalidReason: "invalid_exact_evm_payload_signature",
-            payer: exactEvmPayload.authorization.from,
-          };
-        }
-      } else {
-        // EOA signature failed
-        return {
-          isValid: false,
-          invalidReason: "invalid_exact_evm_payload_signature",
-          payer: exactEvmPayload.authorization.from,
-        };
-      }
-    }
-
-    // Verify payment recipient matches
-    if (getAddress(exactEvmPayload.authorization.to) !== getAddress(requirements.payTo)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_recipient_mismatch",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Verify validBefore is in the future (with 6 second buffer for block time)
-    const now = Math.floor(Date.now() / 1000);
-    if (BigInt(exactEvmPayload.authorization.validBefore) < BigInt(now + 6)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_authorization_valid_before",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Verify validAfter is not in the future
-    if (BigInt(exactEvmPayload.authorization.validAfter) > BigInt(now)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_authorization_valid_after",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    // Check balance
-    try {
-      const balance = (await this.signer.readContract({
-        address: erc20Address,
-        abi: eip3009ABI,
-        functionName: "balanceOf",
-        args: [exactEvmPayload.authorization.from],
-      })) as bigint;
-
-      if (BigInt(balance) < BigInt(requirements.amount)) {
-        return {
-          isValid: false,
-          invalidReason: "insufficient_funds",
-          payer: exactEvmPayload.authorization.from,
-        };
-      }
-    } catch {
-      // If we can't check balance, continue with other validations
-    }
-
-    // Verify amount is sufficient
-    if (BigInt(exactEvmPayload.authorization.value) < BigInt(requirements.amount)) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_authorization_value",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    return {
-      isValid: true,
-      invalidReason: undefined,
-      payer: exactEvmPayload.authorization.from,
-    };
+    const eip3009Payload: ExactEIP3009Payload = rawPayload;
+    return verifyEIP3009(this.signer, payload, requirements, eip3009Payload);
   }
 
   /**
    * Settles a payment by executing the transfer.
+   * Routes to the appropriate settlement logic based on payload type.
    *
    * @param payload - The payment payload to settle
    * @param requirements - The payment requirements
@@ -282,146 +104,13 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
   ): Promise<SettleResponse> {
     const rawPayload = payload.payload as ExactEvmPayloadV2;
 
-    // Reject Permit2 payloads - facilitator only supports EIP-3009 currently
+    // Route based on payload type
     if (isPermit2Payload(rawPayload)) {
-      return {
-        success: false,
-        network: payload.accepted.network,
-        transaction: "",
-        errorReason: "unsupported_payload_type",
-        payer: rawPayload.permit2Authorization.from,
-      };
+      return settlePermit2(this.signer, payload, requirements, rawPayload);
     }
 
     // Type-narrowed to EIP-3009 payload
-    const exactEvmPayload: ExactEIP3009Payload = rawPayload;
-
-    // Re-verify before settling
-    const valid = await this.verify(payload, requirements);
-    if (!valid.isValid) {
-      return {
-        success: false,
-        network: payload.accepted.network,
-        transaction: "",
-        errorReason: valid.invalidReason ?? "invalid_scheme",
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
-
-    try {
-      // Parse ERC-6492 signature if applicable
-      const parseResult = parseErc6492Signature(exactEvmPayload.signature!);
-      const { signature, address: factoryAddress, data: factoryCalldata } = parseResult;
-
-      // Deploy ERC-4337 smart wallet via EIP-6492 if configured and needed
-      if (
-        this.config.deployERC4337WithEIP6492 &&
-        factoryAddress &&
-        factoryCalldata &&
-        !isAddressEqual(factoryAddress, "0x0000000000000000000000000000000000000000")
-      ) {
-        // Check if smart wallet is already deployed
-        const payerAddress = exactEvmPayload.authorization.from;
-        const bytecode = await this.signer.getCode({ address: payerAddress });
-
-        if (!bytecode || bytecode === "0x") {
-          // Wallet not deployed - attempt deployment
-          try {
-            console.log(`Deploying ERC-4337 smart wallet for ${payerAddress} via EIP-6492`);
-
-            // Send the factory calldata directly as a transaction
-            // The factoryCalldata already contains the complete encoded function call
-            const deployTx = await this.signer.sendTransaction({
-              to: factoryAddress as Hex,
-              data: factoryCalldata as Hex,
-            });
-
-            // Wait for deployment transaction
-            await this.signer.waitForTransactionReceipt({ hash: deployTx });
-            console.log(`Successfully deployed smart wallet for ${payerAddress}`);
-          } catch (deployError) {
-            console.error("Smart wallet deployment failed:", deployError);
-            // Deployment failed - cannot proceed
-            throw deployError;
-          }
-        } else {
-          console.log(`Smart wallet for ${payerAddress} already deployed, skipping deployment`);
-        }
-      }
-
-      // Determine if this is an ECDSA signature (EOA) or smart wallet signature
-      // ECDSA signatures are exactly 65 bytes (130 hex chars without 0x)
-      const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
-      const isECDSA = signatureLength === 130;
-
-      let tx: Hex;
-      if (isECDSA) {
-        // For EOA wallets, parse signature into v, r, s and use that overload
-        const parsedSig = parseSignature(signature);
-
-        tx = await this.signer.writeContract({
-          address: getAddress(requirements.asset),
-          abi: eip3009ABI,
-          functionName: "transferWithAuthorization",
-          args: [
-            getAddress(exactEvmPayload.authorization.from),
-            getAddress(exactEvmPayload.authorization.to),
-            BigInt(exactEvmPayload.authorization.value),
-            BigInt(exactEvmPayload.authorization.validAfter),
-            BigInt(exactEvmPayload.authorization.validBefore),
-            exactEvmPayload.authorization.nonce,
-            (parsedSig.v as number | undefined) || parsedSig.yParity,
-            parsedSig.r,
-            parsedSig.s,
-          ],
-        });
-      } else {
-        // For smart wallets, use the bytes signature overload
-        // The signature contains WebAuthn/P256 or other ERC-1271 compatible signature data
-        tx = await this.signer.writeContract({
-          address: getAddress(requirements.asset),
-          abi: eip3009ABI,
-          functionName: "transferWithAuthorization",
-          args: [
-            getAddress(exactEvmPayload.authorization.from),
-            getAddress(exactEvmPayload.authorization.to),
-            BigInt(exactEvmPayload.authorization.value),
-            BigInt(exactEvmPayload.authorization.validAfter),
-            BigInt(exactEvmPayload.authorization.validBefore),
-            exactEvmPayload.authorization.nonce,
-            signature,
-          ],
-        });
-      }
-
-      // Wait for transaction confirmation
-      const receipt = await this.signer.waitForTransactionReceipt({ hash: tx });
-
-      if (receipt.status !== "success") {
-        return {
-          success: false,
-          errorReason: "invalid_transaction_state",
-          transaction: tx,
-          network: payload.accepted.network,
-          payer: exactEvmPayload.authorization.from,
-        };
-      }
-
-      return {
-        success: true,
-        transaction: tx,
-        network: payload.accepted.network,
-        payer: exactEvmPayload.authorization.from,
-      };
-    } catch (error) {
-      console.error("Failed to settle transaction:", error);
-      return {
-        success: false,
-        errorReason: "transaction_failed",
-        transaction: "",
-        network: payload.accepted.network,
-        payer: exactEvmPayload.authorization.from,
-      };
-    }
+    const eip3009Payload: ExactEIP3009Payload = rawPayload;
+    return settleEIP3009(this.signer, payload, requirements, eip3009Payload, this.config);
   }
 }

--- a/typescript/packages/mechanisms/evm/src/types.ts
+++ b/typescript/packages/mechanisms/evm/src/types.ts
@@ -30,11 +30,11 @@ export type ExactEIP3009Payload = {
 /**
  * Permit2 witness data structure.
  * Matches the Witness struct in x402Permit2Proxy contract.
+ * Note: Upper time bound is enforced by Permit2's `deadline` field, not a witness field.
  */
 export type Permit2Witness = {
   to: `0x${string}`;
   validAfter: string;
-  validBefore: string;
   extra: `0x${string}`;
 };
 

--- a/typescript/packages/mechanisms/evm/src/types.ts
+++ b/typescript/packages/mechanisms/evm/src/types.ts
@@ -1,10 +1,3 @@
-import { PaymentPayload } from "@x402/core/types";
-
-/**
- * Result of createPaymentPayload - the core payload fields.
- */
-export type PaymentPayloadResult = Pick<PaymentPayload, "x402Version" | "payload">;
-
 /**
  * Asset transfer methods for the exact EVM scheme.
  * - eip3009: Uses transferWithAuthorization (USDC, etc.) - recommended for compatible tokens

--- a/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
@@ -21,10 +21,11 @@ describe("ExactEvmScheme (Facilitator)", () => {
 
     // Create mock facilitator signer
     mockFacilitatorSigner = {
-      address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+      getAddresses: vi.fn().mockReturnValue(["0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0"]),
       readContract: vi.fn().mockResolvedValue(0n), // Mock nonce state
       verifyTypedData: vi.fn().mockResolvedValue(true), // Mock signature verification
       writeContract: vi.fn().mockResolvedValue("0xtxhash"),
+      sendTransaction: vi.fn().mockResolvedValue("0xtxhash"),
       waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success" }),
       getCode: vi.fn().mockResolvedValue("0x"),
     };
@@ -244,8 +245,8 @@ describe("ExactEvmScheme (Facilitator)", () => {
     });
   });
 
-  describe("Permit2 payload rejection", () => {
-    it("should reject Permit2 payloads with unsupported_payload_type", async () => {
+  describe("Permit2 payload verification", () => {
+    it("should verify Permit2 payloads with valid signature and allowance", async () => {
       const requirements: PaymentRequirements = {
         scheme: "exact",
         network: "eip155:84532",
@@ -256,7 +257,9 @@ describe("ExactEvmScheme (Facilitator)", () => {
         extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
       };
 
-      // Create a Permit2 payload structure
+      // Mock readContract to return sufficient allowance and balance
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt("10000000000"));
+
       const permit2Payload: PaymentPayload = {
         x402Version: 2,
         payload: {
@@ -273,7 +276,50 @@ describe("ExactEvmScheme (Facilitator)", () => {
             witness: {
               to: requirements.payTo,
               validAfter: "0",
-              validBefore: "999999999999",
+              extra: "0x",
+            },
+          },
+        },
+        accepted: requirements,
+        resource: { url: "", description: "", mimeType: "" },
+      };
+
+      const result = await facilitator.verify(permit2Payload, requirements);
+
+      expect(result.isValid).toBe(true);
+      expect(result.payer).toBe(mockClientSigner.address);
+    });
+
+    it("should reject Permit2 payloads with insufficient allowance", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:84532",
+        amount: "1000000",
+        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
+      };
+
+      // Mock readContract to return zero allowance
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt(0));
+
+      const permit2Payload: PaymentPayload = {
+        x402Version: 2,
+        payload: {
+          signature: "0xmocksignature",
+          permit2Authorization: {
+            from: mockClientSigner.address,
+            permitted: {
+              token: requirements.asset,
+              amount: requirements.amount,
+            },
+            spender: x402ExactPermit2ProxyAddress,
+            nonce: "12345",
+            deadline: "999999999999",
+            witness: {
+              to: requirements.payTo,
+              validAfter: "0",
               extra: "0x",
             },
           },
@@ -285,11 +331,11 @@ describe("ExactEvmScheme (Facilitator)", () => {
       const result = await facilitator.verify(permit2Payload, requirements);
 
       expect(result.isValid).toBe(false);
-      expect(result.invalidReason).toBe("unsupported_payload_type");
+      expect(result.invalidReason).toBe("permit2_allowance_required");
       expect(result.payer).toBe(mockClientSigner.address);
     });
 
-    it("should reject Permit2 payloads in settle with unsupported_payload_type", async () => {
+    it("should reject Permit2 payloads with expired deadline", async () => {
       const requirements: PaymentRequirements = {
         scheme: "exact",
         network: "eip155:84532",
@@ -300,7 +346,137 @@ describe("ExactEvmScheme (Facilitator)", () => {
         extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
       };
 
-      // Create a Permit2 payload structure
+      const permit2Payload: PaymentPayload = {
+        x402Version: 2,
+        payload: {
+          signature: "0xmocksignature",
+          permit2Authorization: {
+            from: mockClientSigner.address,
+            permitted: {
+              token: requirements.asset,
+              amount: requirements.amount,
+            },
+            spender: x402ExactPermit2ProxyAddress,
+            nonce: "12345",
+            deadline: "1", // Expired deadline
+            witness: {
+              to: requirements.payTo,
+              validAfter: "0",
+              extra: "0x",
+            },
+          },
+        },
+        accepted: requirements,
+        resource: { url: "", description: "", mimeType: "" },
+      };
+
+      const result = await facilitator.verify(permit2Payload, requirements);
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("permit2_deadline_expired");
+      expect(result.payer).toBe(mockClientSigner.address);
+    });
+
+    it("should reject Permit2 payloads with wrong spender", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:84532",
+        amount: "1000000",
+        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
+      };
+
+      const permit2Payload: PaymentPayload = {
+        x402Version: 2,
+        payload: {
+          signature: "0xmocksignature",
+          permit2Authorization: {
+            from: mockClientSigner.address,
+            permitted: {
+              token: requirements.asset,
+              amount: requirements.amount,
+            },
+            spender: "0x0000000000000000000000000000000000000001", // Wrong spender
+            nonce: "12345",
+            deadline: "999999999999",
+            witness: {
+              to: requirements.payTo,
+              validAfter: "0",
+              extra: "0x",
+            },
+          },
+        },
+        accepted: requirements,
+        resource: { url: "", description: "", mimeType: "" },
+      };
+
+      const result = await facilitator.verify(permit2Payload, requirements);
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("invalid_permit2_spender");
+      expect(result.payer).toBe(mockClientSigner.address);
+    });
+
+    it("should reject Permit2 payloads with recipient mismatch", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:84532",
+        amount: "1000000",
+        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
+      };
+
+      const permit2Payload: PaymentPayload = {
+        x402Version: 2,
+        payload: {
+          signature: "0xmocksignature",
+          permit2Authorization: {
+            from: mockClientSigner.address,
+            permitted: {
+              token: requirements.asset,
+              amount: requirements.amount,
+            },
+            spender: x402ExactPermit2ProxyAddress,
+            nonce: "12345",
+            deadline: "999999999999",
+            witness: {
+              to: "0x0000000000000000000000000000000000000001", // Wrong recipient
+              validAfter: "0",
+              extra: "0x",
+            },
+          },
+        },
+        accepted: requirements,
+        resource: { url: "", description: "", mimeType: "" },
+      };
+
+      const result = await facilitator.verify(permit2Payload, requirements);
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("invalid_permit2_recipient_mismatch");
+      expect(result.payer).toBe(mockClientSigner.address);
+    });
+  });
+
+  describe("Permit2 settlement", () => {
+    it("should settle Permit2 payloads successfully", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:84532",
+        amount: "1000000",
+        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
+      };
+
+      // Mock readContract to return sufficient allowance and balance
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt("10000000000"));
+
       const permit2Payload: PaymentPayload = {
         x402Version: 2,
         payload: {
@@ -317,7 +493,52 @@ describe("ExactEvmScheme (Facilitator)", () => {
             witness: {
               to: requirements.payTo,
               validAfter: "0",
-              validBefore: "999999999999",
+              extra: "0x",
+            },
+          },
+        },
+        accepted: requirements,
+        resource: { url: "", description: "", mimeType: "" },
+      };
+
+      const result = await facilitator.settle(permit2Payload, requirements);
+
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe("0xtxhash");
+      expect(result.payer).toBe(mockClientSigner.address);
+      expect(mockFacilitatorSigner.writeContract).toHaveBeenCalled();
+    });
+
+    it("should fail Permit2 settlement when verification fails", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:84532",
+        amount: "1000000",
+        asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        maxTimeoutSeconds: 300,
+        extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
+      };
+
+      // Mock readContract to return zero allowance
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt(0));
+
+      const permit2Payload: PaymentPayload = {
+        x402Version: 2,
+        payload: {
+          signature: "0xmocksignature",
+          permit2Authorization: {
+            from: mockClientSigner.address,
+            permitted: {
+              token: requirements.asset,
+              amount: requirements.amount,
+            },
+            spender: x402ExactPermit2ProxyAddress,
+            nonce: "12345",
+            deadline: "999999999999",
+            witness: {
+              to: requirements.payTo,
+              validAfter: "0",
               extra: "0x",
             },
           },
@@ -329,7 +550,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
       const result = await facilitator.settle(permit2Payload, requirements);
 
       expect(result.success).toBe(false);
-      expect(result.errorReason).toBe("unsupported_payload_type");
+      expect(result.errorReason).toBe("permit2_allowance_required");
       expect(result.payer).toBe(mockClientSigner.address);
     });
   });

--- a/typescript/packages/mechanisms/evm/test/unit/types.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/types.test.ts
@@ -78,7 +78,6 @@ describe("EVM Types", () => {
           witness: {
             to: "0x9876543210987654321098765432109876543210",
             validAfter: "1234567000",
-            validBefore: "1234567890",
             extra: "0x",
           },
         },
@@ -117,7 +116,6 @@ describe("EVM Types", () => {
         witness: {
           to: "0x9876543210987654321098765432109876543210",
           validAfter: "1234567000",
-          validBefore: "1234567890",
           extra: "0x",
         },
       },


### PR DESCRIPTION
### Description

Adds Permit2 verification and settlement to the EVM facilitator, enabling the full Permit2 payment flow.

Note: resource server changes to come

## Changes

**Core:**
- Export `PaymentPayloadResult` type from `@x402/core/types`
- Return HTTP 412 for `permit2_allowance_required` error (per spec)

**EVM Facilitator:**
- Extract EIP-3009 logic to `eip3009.ts`
- Extract Permit2 logic to `permit2.ts`  
- Route `verify()` and `settle()` based on payload type
- Remove `validBefore` from `Permit2Witness` (enforced by `deadline` instead)

**Tests:**
- Add Permit2 verification tests (allowance, deadline, spender, recipient)
- Add Permit2 settlement tests
- Add 412 status code test for `permit2_allowance_required`

---

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 