### PR TITLE
fix(mcp): support x402 v2 protocol

### DIFF
--- a/examples/typescript/legacy/mcp-embedded-wallet/package.json
+++ b/examples/typescript/legacy/mcp-embedded-wallet/package.json
@@ -41,8 +41,9 @@
     "turbo": "^2.5.5",
     "viem": "^2.21.26",
     "winston": "^3.17.0",
-    "x402": "workspace:*",
-    "x402-axios": "workspace:*",
+    "@x402/axios": "workspace:*",
+    "@x402/core": "workspace:*",
+    "@x402/evm": "workspace:*",
     "zod": "^3.23.8",
     "zustand": "^5.0.6"
   },

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -2336,6 +2336,15 @@ importers:
       '@radix-ui/themes':
         specifier: ^3.2.1
         version: 3.2.1(@types/react-dom@19.2.1(@types/react@19.2.1))(@types/react@19.2.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@x402/axios':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/http/axios
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/core
+      '@x402/evm':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/mechanisms/evm
       axios:
         specifier: ^1.10.0
         version: 1.13.2
@@ -2360,12 +2369,6 @@ importers:
       winston:
         specifier: ^3.17.0
         version: 3.17.0
-      x402:
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/legacy/x402
-      x402-axios:
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/legacy/x402-axios
       zod:
         specifier: ^3.23.8
         version: 3.25.76


### PR DESCRIPTION
## Description

Update MCP embedded wallet to use v2 packages (@x402/axios, @x402/core, @x402/evm) instead of legacy x402-axios. This adds support for reading payment requirements from the PAYMENT-REQUIRED header (v2) in addition to response body (v1).

Fixes: coinbase/payments-mcp#22

## Tests

- Type checked with `pnpm exec tsc --noEmit`
- Verified package dependencies resolve correctly

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [ ] My commits are signed (required for merge)