### PR TITLE
feat: add facilitator attestation and feedback aggregator to 8004-reputation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ __pycache__/
 **/.DS_Store
 e2e/facilitators/external-proxies/*
 !e2e/facilitators/external-proxies/README.md
-typescript/package-lock.json
+typescript/package-lock.jsonpnpm-lock.yaml

--- a/specs/extensions/8004-reputation.md
+++ b/specs/extensions/8004-reputation.md
@@ -1,0 +1,484 @@
+# Extension: `8004-reputation`
+
+## Summary
+
+The `8004-reputation` extension enables **on-chain reputation and proof-of-settlement** for x402 agents. It integrates with ERC-8004 compliant reputation registries and provides:
+
+- **Agent identity declaration**: Agents advertise their ERC-8004 registrations
+- **Facilitator settlement attestation**: Facilitators cryptographically attest to successful settlements
+- **Feedback aggregation protocol**: Gas-free feedback submission through trusted aggregators
+
+---
+
+## `PaymentRequired`
+
+A resource server advertises reputation support by including the `8004-reputation` extension in the `extensions` object of the **402 Payment Required** response.
+
+### Example: Single-Chain Agent (Base)
+
+```json
+{
+  "x402Version": 2,
+  "resource": {
+    "url": "https://agent.example/weather",
+    "description": "Weather data API"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0xAgentWallet123456...",
+      "amount": "1000",
+      "maxTimeoutSeconds": 60
+    }
+  ],
+  "extensions": {
+    "8004-reputation": {
+      "info": {
+        "version": "1.0.0",
+        "registrations": [
+          {
+            "agentRegistry": "eip155:8453:0x8004A818BFB912233c491871b3d84c89A494BD9e",
+            "agentId": "42",
+            "reputationRegistry": "eip155:8453:0x8004B663C4a7e45d78F2D05C8e4A5a3D3D5e7890"
+          }
+        ],
+        "endpoint": "https://agent.example/weather",
+        "feedbackAggregator": {
+          "endpoint": "https://x402.dexter.cash/feedback",
+          "networks": ["eip155:8453", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],
+          "gasSponsored": true
+        }
+      },
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+          },
+          "registrations": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "properties": {
+                "agentRegistry": { "type": "string" },
+                "agentId": { "type": "string" },
+                "reputationRegistry": { "type": "string" }
+              },
+              "required": ["agentRegistry", "agentId", "reputationRegistry"]
+            }
+          },
+          "endpoint": {
+            "type": "string",
+            "format": "uri"
+          },
+          "feedbackAggregator": {
+            "type": "object",
+            "properties": {
+              "endpoint": { "type": "string", "format": "uri" },
+              "networks": { "type": "array", "items": { "type": "string" } },
+              "gasSponsored": { "type": "boolean" }
+            },
+            "required": ["endpoint"]
+          }
+        },
+        "required": ["version", "registrations"]
+      }
+    }
+  }
+}
+```
+
+### Example: Multi-Chain Agent (Base + Solana)
+
+```json
+{
+  "x402Version": 2,
+  "resource": {
+    "url": "https://agent.example/weather",
+    "description": "Weather data API"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0xBaseWallet...",
+      "amount": "1000"
+    },
+    {
+      "scheme": "exact",
+      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "payTo": "SolanaWallet...",
+      "amount": "1000"
+    }
+  ],
+  "extensions": {
+    "8004-reputation": {
+      "info": {
+        "version": "1.0.0",
+        "registrations": [
+          {
+            "agentRegistry": "eip155:8453:0x8004A818BFB912233c491871b3d84c89A494BD9e",
+            "agentId": "42",
+            "reputationRegistry": "eip155:8453:0x8004B663C4a7e45d78F2D05C8e4A5a3D3D5e7890"
+          },
+          {
+            "agentRegistry": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe",
+            "agentId": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "reputationRegistry": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe"
+          }
+        ]
+      },
+      "schema": { /* same as above */ }
+    }
+  }
+}
+```
+
+---
+
+## ReputationInfo Structure
+
+### Required Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | string | Yes | Extension version (e.g., `"1.0.0"`) |
+| `registrations` | array | Yes | Agent identity registrations (at least one) |
+| `endpoint` | string | No | Agent's service endpoint URL |
+| `feedbackAggregator` | object | No | Aggregator for gas-free feedback submission |
+
+### AgentRegistration Object
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentRegistry` | string | Yes | CAIP-10 Identity Registry address |
+| `agentId` | string | Yes | Agent identifier (tokenId for EVM, mint address for Solana) |
+| `reputationRegistry` | string | Yes | CAIP-10 Reputation Registry address |
+
+**Note:** ERC-8004 separates identity (ERC-721 NFT registry) from reputation (feedback storage). On Solana (SATI), both may be the same program address.
+
+### FeedbackAggregator Object
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `endpoint` | string | Yes | HTTPS endpoint accepting feedback submissions |
+| `networks` | string[] | No | CAIP-2 networks the aggregator supports |
+| `gasSponsored` | boolean | No | Whether aggregator pays on-chain gas (default: false) |
+
+---
+
+## Facilitator Settlement Attestation
+
+Facilitators MAY include a signed attestation in the `PAYMENT-RESPONSE` proving they executed the payment settlement. This provides an independent trust signal that complements agent signatures.
+
+### Motivation
+
+The `proofOfPayment.txHash` in feedback files can reference any transaction. Facilitator attestation provides cryptographic proof from the entity that actually settled the payment, preventing:
+
+- Fake feedback using arbitrary transaction references
+- Reputation attacks without service consumption
+
+### Attestation in PAYMENT-RESPONSE
+
+After successful settlement, facilitators add attestation data to the response extensions:
+
+```json
+{
+  "success": true,
+  "transaction": "5A2CSREGntKZu8f2...",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "payer": "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+  "extensions": {
+    "8004-reputation": {
+      "facilitatorAttestation": {
+        "facilitatorId": "eip155:8453:0x8004F123...",
+        "settledAt": 1737763200,
+        "settledAmount": "1000",
+        "settledAsset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "payTo": "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5",
+        "payer": "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+        "attestationSignature": "0x789ghi..."
+      }
+    }
+  }
+}
+```
+
+### FacilitatorAttestation Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `facilitatorId` | string | Yes | CAIP-10 facilitator identifier |
+| `settledAt` | number | Yes | Unix timestamp of settlement |
+| `settledAmount` | string | Yes | Amount in atomic units |
+| `settledAsset` | string | Yes | Token address/mint |
+| `payTo` | string | Yes | Recipient address |
+| `payer` | string | Yes | Payer address |
+| `attestationSignature` | string | Yes | Facilitator signature |
+
+### Attestation Signature
+
+The facilitator signs a message binding the attestation to the specific settlement:
+
+```
+message = keccak256(
+  UTF8(taskRef) || UTF8(settledAmount) || UTF8(settledAsset) || 
+  UTF8(payTo) || UTF8(payer) || uint64BE(settledAt)
+)
+attestationSignature = sign(message, facilitatorPrivateKey)
+```
+
+Where `taskRef` is derived from the settlement: `{network}:{transaction}` in CAIP-220 format.
+
+### When to Include
+
+Facilitators SHOULD include attestation when:
+- Agent advertises `8004-reputation` extension
+- Settlement succeeds
+- Facilitator has signing capability
+
+---
+
+## feedbackAggregator Protocol
+
+The `feedbackAggregator` field enables gas-free, batched feedback submission through trusted intermediaries.
+
+### Aggregator Submission Protocol
+
+#### Request
+
+Clients POST feedback to the aggregator endpoint:
+
+```http
+POST /feedback HTTP/1.1
+Content-Type: application/json
+
+{
+  "taskRef": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:5A2CSREGntKZu8f2...",
+  "interactionHash": "0x123abc456def...",
+  "agentSignature": "a1b2c3d4e5f6...",
+  
+  "agentId": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+  "reputationRegistry": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe",
+  
+  "value": 95,
+  "valueDecimals": 0,
+  "tag1": "x402-delivered",
+  "tag2": "proof-of-settlement",
+  
+  "clientAddress": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+  "clientSignature": "fedcba987654...",
+  
+  "facilitatorAttestation": { /* optional */ }
+}
+```
+
+#### Request Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `taskRef` | string | Yes | CAIP-220 payment transaction reference |
+| `interactionHash` | string | No | From agent's signed response (if available) |
+| `agentSignature` | string | No | From agent's signed response (if available) |
+| `agentId` | string | Yes | Target agent identifier |
+| `reputationRegistry` | string | Yes | CAIP-10 reputation registry |
+| `value` | number | Yes | Feedback score (0-100 recommended) |
+| `valueDecimals` | number | Yes | Decimal precision (0 = integer) |
+| `tag1` | string | No | Primary category tag |
+| `tag2` | string | No | Evidence level tag |
+| `clientAddress` | string | Yes | CAIP-10 client wallet |
+| `clientSignature` | string | Yes | Client signature over feedback |
+| `facilitatorAttestation` | object | No | Facilitator attestation from settlement |
+
+#### Client Signature
+
+Clients MUST sign to prove feedback authenticity:
+
+```
+message = keccak256(UTF8(agentId) || UTF8(taskRef) || int128BE(value) || uint8(valueDecimals))
+clientSignature = sign(message, clientPrivateKey)
+```
+
+#### Response
+
+Success (202 Accepted):
+```json
+{
+  "accepted": true,
+  "feedbackId": "fb_abc123",
+  "status": "queued"
+}
+```
+
+Error (400 Bad Request):
+```json
+{
+  "accepted": false,
+  "error": "invalid_task_ref",
+  "message": "taskRef not found in aggregator settlement records"
+}
+```
+
+#### Error Codes
+
+| Code | Description |
+|------|-------------|
+| `invalid_task_ref` | taskRef not in aggregator's settlement records |
+| `invalid_client_signature` | Signature verification failed |
+| `duplicate_feedback` | Feedback for this taskRef already submitted |
+| `unsupported_network` | Registry network not supported |
+
+### Aggregator Requirements
+
+Aggregators MUST:
+1. Validate `taskRef` against settlements they processed
+2. Verify `clientSignature` against `clientAddress`
+3. Preserve client attribution when submitting on-chain
+
+Aggregators SHOULD:
+1. Verify facilitator attestation if provided
+2. Deduplicate by `taskRef`
+3. Include original submission in `feedbackURI` for auditability
+
+### Trust Model
+
+Aggregators are trusted to:
+- Honestly relay feedback to the chain
+- Not fabricate feedback (client signatures provide non-repudiation)
+- Not censor feedback (multiple aggregators provide redundancy)
+
+---
+
+## Tag Conventions
+
+### Outcome Tags (tag1)
+
+| tag1 | Description | Typical Value |
+|------|-------------|---------------|
+| `x402-delivered` | Resource delivered successfully | 80-100 |
+| `x402-failed` | Resource delivery failed | 0-20 |
+| `x402-timeout` | Response exceeded timeout | 20-40 |
+| `x402-quality` | Subjective quality rating | 0-100 |
+| `x402-payment-verified` | Facilitator verified payment | 100 |
+
+### Evidence Tags (tag2)
+
+| tag2 | Description |
+|------|-------------|
+| `proof-of-payment` | Feedback includes valid taskRef |
+| `proof-of-service` | Feedback includes agent signature |
+| `proof-of-settlement` | Facilitator attested to settlement |
+| `client-claim` | Client claim without cryptographic proof |
+
+---
+
+## Security Considerations
+
+### Sybil Attack Prevention
+
+- Feedback requires a corresponding payment (`taskRef` validation)
+- Cost of attack = cost of payments
+- Facilitator attestation adds independent verification
+
+### Replay Prevention
+
+- Each `taskRef` can only have one feedback submission
+- Aggregators MUST deduplicate by `taskRef`
+- Attestations are bound to specific timestamps
+
+### Aggregator Misbehavior
+
+- Clients can verify submissions on-chain
+- Multiple aggregators provide redundancy
+- Audit trail in `feedbackURI` enables accountability
+
+### Key Management
+
+- Attestation signing keys SHOULD be separate from fee payer keys
+- Use HSM or secure key management for high-volume facilitators
+- Implement key rotation with overlap periods
+
+---
+
+## Implementation Notes
+
+### For Resource Servers
+
+```typescript
+import { declareReputationExtension, REPUTATION } from '@x402/extensions/reputation';
+
+const extension = declareReputationExtension({
+  registrations: [{
+    agentRegistry: "eip155:8453:0x8004A818...",
+    agentId: "42",
+    reputationRegistry: "eip155:8453:0x8004B663..."
+  }],
+  feedbackAggregator: {
+    endpoint: "https://x402.dexter.cash/feedback",
+    gasSponsored: true
+  }
+});
+
+const routes = {
+  "POST /api": {
+    price: "$0.01",
+    extensions: { [REPUTATION]: extension }
+  }
+};
+```
+
+### For Facilitators
+
+```typescript
+import { createReputationServerExtension } from '@x402/extensions/reputation';
+
+const extension = createReputationServerExtension({
+  attestation: {
+    facilitatorId: "eip155:8453:0x8004F123...",
+    sign: async (msg) => wallet.signMessage(msg)
+  }
+});
+
+server.registerExtension(extension);
+```
+
+### For Clients
+
+```typescript
+import {
+  createAndSubmitFeedback,
+  extractReputationFromSettlement
+} from '@x402/extensions/reputation';
+
+const settlementData = extractReputationFromSettlement(response.extensions);
+
+await createAndSubmitFeedback({
+  aggregatorEndpoint: "https://x402.dexter.cash/feedback",
+  taskRef: `${response.network}:${response.transaction}`,
+  facilitatorAttestation: settlementData?.facilitatorAttestation,
+  agentId: "42",
+  reputationRegistry: "eip155:8453:0x8004B663...",
+  value: 95,
+  tag1: "x402-delivered",
+  tag2: "proof-of-settlement",
+  clientAddress: myWallet.address,
+  sign: myWallet.signMessage
+});
+```
+
+---
+
+## References
+
+- [ERC-8004: Trustless Agents](https://eips.ethereum.org/EIPS/eip-8004)
+- [SATI Specification](https://github.com/cascade-fyi/sati)
+- [CAIP-2: Chain ID](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md)
+- [CAIP-10: Account ID](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
+- [CAIP-220: Transaction Reference](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-220.md)

--- a/typescript/packages/extensions/package.json
+++ b/typescript/packages/extensions/package.json
@@ -77,6 +77,16 @@
         "types": "./dist/cjs/sign-in-with-x/index.d.ts",
         "default": "./dist/cjs/sign-in-with-x/index.js"
       }
+    },
+    "./reputation": {
+      "import": {
+        "types": "./dist/esm/reputation/index.d.mts",
+        "default": "./dist/esm/reputation/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/reputation/index.d.ts",
+        "default": "./dist/cjs/reputation/index.js"
+      }
     }
   },
   "files": [

--- a/typescript/packages/extensions/src/index.ts
+++ b/typescript/packages/extensions/src/index.ts
@@ -11,10 +11,36 @@ export * from "./sign-in-with-x";
 // 8004-Reputation extension
 // Export explicitly to avoid name collisions
 export { REPUTATION } from "./reputation";
-export { reputationServerExtension, createReputationServerExtension, declareReputationExtension } from "./reputation/server";
-export { createAttestation, verifyAttestation, createTaskRef, extractNetworkFromTaskRef, extractTxHashFromTaskRef } from "./reputation/attestation";
-export { createFeedbackSubmission, submitFeedback, createAndSubmitFeedback, extractReputationFromSettlement, extractReputationFromPaymentRequired, getAggregatorEndpoint, determineEvidenceTag } from "./reputation/aggregator";
-export { validateReputationExtension, extractReputationData, validateFeedbackSubmission, hasReputationExtension, getAgentRegistrations, getFeedbackAggregator, findRegistrationForNetwork } from "./reputation/facilitator";
+export {
+  reputationServerExtension,
+  createReputationServerExtension,
+  declareReputationExtension,
+} from "./reputation/server";
+export {
+  createAttestation,
+  verifyAttestation,
+  createTaskRef,
+  extractNetworkFromTaskRef,
+  extractTxHashFromTaskRef,
+} from "./reputation/attestation";
+export {
+  createFeedbackSubmission,
+  submitFeedback,
+  createAndSubmitFeedback,
+  extractReputationFromSettlement,
+  extractReputationFromPaymentRequired,
+  getAggregatorEndpoint,
+  determineEvidenceTag,
+} from "./reputation/aggregator";
+export {
+  validateReputationExtension,
+  extractReputationData,
+  validateFeedbackSubmission,
+  hasReputationExtension,
+  getAgentRegistrations,
+  getFeedbackAggregator,
+  findRegistrationForNetwork,
+} from "./reputation/facilitator";
 
 // Re-export reputation types with distinct names
 export type {
@@ -44,11 +70,6 @@ export type {
   VerifyAttestationResult,
 } from "./reputation/attestation";
 
-export type {
-  CreateFeedbackParams,
-} from "./reputation/aggregator";
+export type { CreateFeedbackParams } from "./reputation/aggregator";
 
-export type {
-  ReputationServerExtensionConfig,
-  DeclareReputationConfig,
-} from "./reputation/server";
+export type { ReputationServerExtensionConfig, DeclareReputationConfig } from "./reputation/server";

--- a/typescript/packages/extensions/src/index.ts
+++ b/typescript/packages/extensions/src/index.ts
@@ -7,3 +7,48 @@ export { bazaarResourceServerExtension } from "./bazaar/server";
 
 // Sign-in-with-x extension
 export * from "./sign-in-with-x";
+
+// 8004-Reputation extension
+// Export explicitly to avoid name collisions
+export { REPUTATION } from "./reputation";
+export { reputationServerExtension, createReputationServerExtension, declareReputationExtension } from "./reputation/server";
+export { createAttestation, verifyAttestation, createTaskRef, extractNetworkFromTaskRef, extractTxHashFromTaskRef } from "./reputation/attestation";
+export { createFeedbackSubmission, submitFeedback, createAndSubmitFeedback, extractReputationFromSettlement, extractReputationFromPaymentRequired, getAggregatorEndpoint, determineEvidenceTag } from "./reputation/aggregator";
+export { validateReputationExtension, extractReputationData, validateFeedbackSubmission, hasReputationExtension, getAgentRegistrations, getFeedbackAggregator, findRegistrationForNetwork } from "./reputation/facilitator";
+
+// Re-export reputation types with distinct names
+export type {
+  AgentRegistration,
+  ReputationInfo,
+  FeedbackAggregator,
+  InteractionData,
+  FacilitatorAttestation,
+  ReputationSettlementExtension,
+  FeedbackSubmission,
+  FeedbackResponse,
+  FacilitatorAttestationConfig,
+  FacilitatorSigner,
+  ReputationRequiredExtension,
+} from "./reputation";
+
+export type {
+  ReputationValidationResult,
+  ExtractedReputationData,
+  ValidateFeedbackParams,
+  ValidateFeedbackResult,
+} from "./reputation/facilitator";
+
+export type {
+  CreateAttestationParams,
+  VerifyAttestationParams,
+  VerifyAttestationResult,
+} from "./reputation/attestation";
+
+export type {
+  CreateFeedbackParams,
+} from "./reputation/aggregator";
+
+export type {
+  ReputationServerExtensionConfig,
+  DeclareReputationConfig,
+} from "./reputation/server";

--- a/typescript/packages/extensions/src/reputation/aggregator.ts
+++ b/typescript/packages/extensions/src/reputation/aggregator.ts
@@ -1,0 +1,338 @@
+/**
+ * Feedback Aggregator Client
+ *
+ * Utilities for submitting feedback to aggregator endpoints.
+ * Aggregators handle gas-free, batched submission to on-chain Reputation Registries.
+ */
+
+/// <reference lib="dom" />
+
+import type {
+  FeedbackSubmission,
+  FeedbackResponse,
+  FacilitatorAttestation,
+  ReputationInfo,
+  ReputationSettlementExtension,
+} from "./types";
+
+// Use globalThis for cross-platform compatibility
+const encoder = new globalThis.TextEncoder();
+
+// ============================================================================
+// Client Signature Generation
+// ============================================================================
+
+/**
+ * Builds the message that clients must sign for feedback submission
+ *
+ * Message format:
+ * keccak256(UTF8(agentId) || UTF8(taskRef) || int128BE(value) || uint8(valueDecimals))
+ *
+ * @param agentId - Target agent identifier
+ * @param taskRef - CAIP-220 payment transaction reference
+ * @param value - Feedback score
+ * @param valueDecimals - Decimal precision for value
+ * @returns Message bytes to sign
+ */
+export function buildClientFeedbackMessage(
+  agentId: string,
+  taskRef: string,
+  value: number,
+  valueDecimals: number,
+): Uint8Array {
+
+  const agentIdBytes = encoder.encode(agentId);
+  const taskRefBytes = encoder.encode(taskRef);
+
+  // value as 16-byte big-endian (int128)
+  // Note: JavaScript numbers are 64-bit, so we use BigInt for safety
+  const valueBytes = new Uint8Array(16);
+  const valueView = new DataView(valueBytes.buffer);
+  // For simplicity, store as int64 in the high bytes
+  valueView.setBigInt64(8, BigInt(Math.floor(value)), false);
+
+  // valueDecimals as 1 byte
+  const decimalsBytes = new Uint8Array([valueDecimals]);
+
+  // Concatenate
+  const totalLength =
+    agentIdBytes.length + taskRefBytes.length + valueBytes.length + decimalsBytes.length;
+
+  const message = new Uint8Array(totalLength);
+  let offset = 0;
+
+  message.set(agentIdBytes, offset);
+  offset += agentIdBytes.length;
+  message.set(taskRefBytes, offset);
+  offset += taskRefBytes.length;
+  message.set(valueBytes, offset);
+  offset += valueBytes.length;
+  message.set(decimalsBytes, offset);
+
+  return message;
+}
+
+/**
+ * Hash the client feedback message
+ * Uses SHA-256 (replace with keccak256 in production)
+ */
+export async function hashClientFeedbackMessage(message: Uint8Array): Promise<Uint8Array> {
+  // Note: We create a new ArrayBuffer to ensure compatibility with strict TypeScript settings
+  const buffer = new ArrayBuffer(message.length);
+  new Uint8Array(buffer).set(message);
+  const hashBuffer = await globalThis.crypto.subtle.digest("SHA-256", buffer);
+  return new Uint8Array(hashBuffer);
+}
+
+// ============================================================================
+// Feedback Submission
+// ============================================================================
+
+/**
+ * Parameters for creating a feedback submission
+ */
+export interface CreateFeedbackParams {
+  // From settlement response
+  taskRef: string;
+  interactionHash?: string;
+  agentSignature?: string;
+  facilitatorAttestation?: FacilitatorAttestation;
+
+  // Target agent
+  agentId: string;
+  reputationRegistry: string;
+
+  // Feedback content
+  value: number;
+  valueDecimals?: number;
+  tag1?: string;
+  tag2?: string;
+  comment?: string;
+
+  // Client info
+  clientAddress: string;
+
+  // Client signing function
+  sign: (message: Uint8Array) => Promise<string>;
+}
+
+/**
+ * Creates a signed feedback submission
+ *
+ * @param params - Feedback parameters
+ * @returns Complete signed feedback submission
+ *
+ * @example
+ * ```typescript
+ * const feedback = await createFeedbackSubmission({
+ *   taskRef: settlementResponse.extensions["8004-reputation"].taskRef,
+ *   agentSignature: settlementResponse.extensions["8004-reputation"].agentSignature,
+ *   agentId: "42",
+ *   reputationRegistry: "eip155:8453:0x8004B663...",
+ *   value: 95,
+ *   tag1: "x402-delivered",
+ *   tag2: "proof-of-service",
+ *   clientAddress: "eip155:8453:0x857b0651...",
+ *   sign: async (msg) => wallet.signMessage(msg)
+ * });
+ * ```
+ */
+export async function createFeedbackSubmission(
+  params: CreateFeedbackParams,
+): Promise<FeedbackSubmission> {
+  const {
+    taskRef,
+    interactionHash,
+    agentSignature,
+    facilitatorAttestation,
+    agentId,
+    reputationRegistry,
+    value,
+    valueDecimals = 0,
+    tag1,
+    tag2,
+    comment,
+    clientAddress,
+    sign,
+  } = params;
+
+  // Build and sign the feedback message
+  const message = buildClientFeedbackMessage(agentId, taskRef, value, valueDecimals);
+  const hash = await hashClientFeedbackMessage(message);
+  const clientSignature = await sign(hash);
+
+  const submission: FeedbackSubmission = {
+    taskRef,
+    agentId,
+    reputationRegistry,
+    value,
+    valueDecimals,
+    clientAddress,
+    clientSignature,
+  };
+
+  // Add optional fields
+  if (interactionHash) submission.interactionHash = interactionHash;
+  if (agentSignature) submission.agentSignature = agentSignature;
+  if (facilitatorAttestation) submission.facilitatorAttestation = facilitatorAttestation;
+  if (tag1) submission.tag1 = tag1;
+  if (tag2) submission.tag2 = tag2;
+  if (comment) submission.comment = comment;
+
+  return submission;
+}
+
+/**
+ * Submits feedback to an aggregator endpoint
+ *
+ * @param endpoint - Aggregator endpoint URL
+ * @param submission - Signed feedback submission
+ * @returns Aggregator response
+ *
+ * @example
+ * ```typescript
+ * const response = await submitFeedback(
+ *   "https://x402.dexter.cash/feedback",
+ *   feedback
+ * );
+ *
+ * if (response.accepted) {
+ *   console.log("Feedback queued:", response.feedbackId);
+ * } else {
+ *   console.error("Submission failed:", response.error);
+ * }
+ * ```
+ */
+export async function submitFeedback(
+  endpoint: string,
+  submission: FeedbackSubmission,
+): Promise<FeedbackResponse> {
+  const response = await globalThis.fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(submission),
+  });
+
+  const data = (await response.json()) as FeedbackResponse;
+
+  // Handle HTTP errors
+  if (!response.ok && !data.error) {
+    return {
+      accepted: false,
+      error: "http_error",
+      message: `HTTP ${response.status}: ${response.statusText}`,
+    };
+  }
+
+  return data;
+}
+
+// ============================================================================
+// Extraction Helpers
+// ============================================================================
+
+/**
+ * Extracts reputation data from a settlement response for feedback submission
+ *
+ * @param settlementExtensions - Extensions from settlement response
+ * @returns Reputation extension data or null
+ */
+export function extractReputationFromSettlement(
+  settlementExtensions?: Record<string, unknown>,
+): ReputationSettlementExtension | null {
+  if (!settlementExtensions) return null;
+
+  const reputation = settlementExtensions["8004-reputation"];
+  if (!reputation || typeof reputation !== "object") return null;
+
+  return reputation as ReputationSettlementExtension;
+}
+
+/**
+ * Extracts reputation info from PaymentRequired response
+ *
+ * @param paymentRequiredExtensions - Extensions from 402 response
+ * @returns ReputationInfo or null
+ */
+export function extractReputationFromPaymentRequired(
+  paymentRequiredExtensions?: Record<string, unknown>,
+): ReputationInfo | null {
+  if (!paymentRequiredExtensions) return null;
+
+  const reputation = paymentRequiredExtensions["8004-reputation"];
+  if (!reputation || typeof reputation !== "object") return null;
+
+  const ext = reputation as { info?: ReputationInfo };
+  return ext.info ?? null;
+}
+
+/**
+ * Gets the feedback aggregator endpoint from PaymentRequired
+ *
+ * @param paymentRequiredExtensions - Extensions from 402 response
+ * @returns Aggregator endpoint URL or null
+ */
+export function getAggregatorEndpoint(
+  paymentRequiredExtensions?: Record<string, unknown>,
+): string | null {
+  const info = extractReputationFromPaymentRequired(paymentRequiredExtensions);
+  return info?.feedbackAggregator?.endpoint ?? null;
+}
+
+// ============================================================================
+// Convenience Functions
+// ============================================================================
+
+/**
+ * Complete flow: Create and submit feedback in one call
+ *
+ * @param params - Feedback parameters including aggregator endpoint
+ * @returns Aggregator response
+ *
+ * @example
+ * ```typescript
+ * // After receiving settlement response
+ * const response = await createAndSubmitFeedback({
+ *   aggregatorEndpoint: reputationInfo.feedbackAggregator.endpoint,
+ *   taskRef: settlementExtension.taskRef,
+ *   agentSignature: settlementExtension.agentSignature,
+ *   facilitatorAttestation: settlementExtension.facilitatorAttestation,
+ *   agentId: reputationInfo.registrations[0].agentId,
+ *   reputationRegistry: reputationInfo.registrations[0].reputationRegistry,
+ *   value: 95,
+ *   tag1: "x402-delivered",
+ *   tag2: "proof-of-settlement",
+ *   clientAddress: myWalletAddress,
+ *   sign: wallet.signMessage
+ * });
+ * ```
+ */
+export async function createAndSubmitFeedback(
+  params: CreateFeedbackParams & { aggregatorEndpoint: string },
+): Promise<FeedbackResponse> {
+  const { aggregatorEndpoint, ...feedbackParams } = params;
+  const submission = await createFeedbackSubmission(feedbackParams);
+  return submitFeedback(aggregatorEndpoint, submission);
+}
+
+/**
+ * Determines the appropriate tag2 based on available proofs
+ *
+ * @param hasAgentSignature - Whether agent signature is available
+ * @param hasFacilitatorAttestation - Whether facilitator attestation is available
+ * @returns Recommended tag2 value
+ */
+export function determineEvidenceTag(
+  hasAgentSignature: boolean,
+  hasFacilitatorAttestation: boolean,
+): string {
+  if (hasFacilitatorAttestation) {
+    return "proof-of-settlement";
+  }
+  if (hasAgentSignature) {
+    return "proof-of-service";
+  }
+  return "proof-of-payment";
+}

--- a/typescript/packages/extensions/src/reputation/aggregator.ts
+++ b/typescript/packages/extensions/src/reputation/aggregator.ts
@@ -40,7 +40,6 @@ export function buildClientFeedbackMessage(
   value: number,
   valueDecimals: number,
 ): Uint8Array {
-
   const agentIdBytes = encoder.encode(agentId);
   const taskRefBytes = encoder.encode(taskRef);
 
@@ -75,6 +74,9 @@ export function buildClientFeedbackMessage(
 /**
  * Hash the client feedback message
  * Uses SHA-256 (replace with keccak256 in production)
+ *
+ * @param message - The message bytes to hash
+ * @returns SHA-256 hash of the message as Uint8Array
  */
 export async function hashClientFeedbackMessage(message: Uint8Array): Promise<Uint8Array> {
   // Note: We create a new ArrayBuffer to ensure compatibility with strict TypeScript settings

--- a/typescript/packages/extensions/src/reputation/attestation.ts
+++ b/typescript/packages/extensions/src/reputation/attestation.ts
@@ -1,0 +1,372 @@
+/**
+ * Facilitator Attestation Utilities
+ *
+ * Functions for creating and verifying facilitator settlement attestations.
+ * Attestations prove that a facilitator executed a specific payment settlement.
+ */
+
+/// <reference lib="dom" />
+
+import type {
+  FacilitatorAttestation,
+  FacilitatorAttestationConfig,
+  FacilitatorSigner,
+} from "./types";
+
+// Use globalThis for cross-platform compatibility
+const encoder = new globalThis.TextEncoder();
+
+// ============================================================================
+// Attestation Creation
+// ============================================================================
+
+/**
+ * Parameters for creating a facilitator attestation
+ */
+export interface CreateAttestationParams {
+  /**
+   * CAIP-220 payment transaction reference
+   */
+  taskRef: string;
+
+  /**
+   * Amount in atomic units
+   */
+  settledAmount: string;
+
+  /**
+   * Token address/mint
+   */
+  settledAsset: string;
+
+  /**
+   * Recipient address
+   */
+  payTo: string;
+
+  /**
+   * Payer address
+   */
+  payer: string;
+
+  /**
+   * Unix timestamp of settlement (defaults to now)
+   */
+  settledAt?: number;
+}
+
+/**
+ * Builds the attestation message for signing
+ *
+ * Message format:
+ * keccak256(UTF8(taskRef) || UTF8(settledAmount) || UTF8(settledAsset) ||
+ *           UTF8(payTo) || UTF8(payer) || uint64BE(settledAt))
+ */
+export function buildAttestationMessage(params: CreateAttestationParams): Uint8Array {
+  const settledAt = params.settledAt ?? Math.floor(Date.now() / 1000);
+
+  // Concatenate all fields as UTF-8 bytes
+  const taskRefBytes = encoder.encode(params.taskRef);
+  const amountBytes = encoder.encode(params.settledAmount);
+  const assetBytes = encoder.encode(params.settledAsset);
+  const payToBytes = encoder.encode(params.payTo);
+  const payerBytes = encoder.encode(params.payer);
+
+  // settledAt as 8-byte big-endian
+  const timestampBytes = new Uint8Array(8);
+  const view = new DataView(timestampBytes.buffer);
+  view.setBigUint64(0, BigInt(settledAt), false); // false = big-endian
+
+  // Concatenate all
+  const totalLength =
+    taskRefBytes.length +
+    amountBytes.length +
+    assetBytes.length +
+    payToBytes.length +
+    payerBytes.length +
+    timestampBytes.length;
+
+  const message = new Uint8Array(totalLength);
+  let offset = 0;
+
+  message.set(taskRefBytes, offset);
+  offset += taskRefBytes.length;
+  message.set(amountBytes, offset);
+  offset += amountBytes.length;
+  message.set(assetBytes, offset);
+  offset += assetBytes.length;
+  message.set(payToBytes, offset);
+  offset += payToBytes.length;
+  message.set(payerBytes, offset);
+  offset += payerBytes.length;
+  message.set(timestampBytes, offset);
+
+  return message;
+}
+
+/**
+ * Hash the attestation message using keccak256
+ *
+ * Note: This uses a simple implementation. In production, you'd use
+ * a proper keccak256 library like @noble/hashes or ethers.
+ */
+export async function hashAttestationMessage(message: Uint8Array): Promise<Uint8Array> {
+  // Use SubtleCrypto SHA-256 as fallback
+  // In production, you should use keccak256 from @noble/hashes
+  // For now, we'll use SHA-256 which is available in all environments
+  // TODO: Replace with keccak256 when integrating with x402/core dependencies
+  // Note: We create a new ArrayBuffer to ensure compatibility with strict TypeScript settings
+  const buffer = new ArrayBuffer(message.length);
+  new Uint8Array(buffer).set(message);
+  const hashBuffer = await globalThis.crypto.subtle.digest("SHA-256", buffer);
+  return new Uint8Array(hashBuffer);
+}
+
+/**
+ * Creates a facilitator attestation for a settlement
+ *
+ * @param params - Settlement parameters to attest
+ * @param config - Facilitator configuration with signing function
+ * @returns Complete attestation object
+ *
+ * @example
+ * ```typescript
+ * const attestation = await createAttestation(
+ *   {
+ *     taskRef: "solana:5eykt4...:5A2CSREG...",
+ *     settledAmount: "1000",
+ *     settledAsset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+ *     payTo: "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5",
+ *     payer: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+ *   },
+ *   {
+ *     facilitatorId: "eip155:8453:0x8004F123...",
+ *     sign: async (msg) => signWithPrivateKey(msg)
+ *   }
+ * );
+ * ```
+ */
+export async function createAttestation(
+  params: CreateAttestationParams,
+  config: FacilitatorAttestationConfig,
+): Promise<FacilitatorAttestation> {
+  const settledAt = params.settledAt ?? Math.floor(Date.now() / 1000);
+
+  // Build and hash the message
+  const message = buildAttestationMessage({ ...params, settledAt });
+  const hash = await hashAttestationMessage(message);
+
+  // Sign the hash
+  const signature = await config.sign(hash);
+
+  return {
+    facilitatorId: config.facilitatorId,
+    settledAt,
+    settledAmount: params.settledAmount,
+    settledAsset: params.settledAsset,
+    payTo: params.payTo,
+    payer: params.payer,
+    attestationSignature: signature,
+  };
+}
+
+// ============================================================================
+// Attestation Verification
+// ============================================================================
+
+/**
+ * Parameters for verifying an attestation
+ */
+export interface VerifyAttestationParams {
+  /**
+   * The attestation to verify
+   */
+  attestation: FacilitatorAttestation;
+
+  /**
+   * Expected taskRef (from settlement response)
+   */
+  taskRef: string;
+
+  /**
+   * Valid signers from facilitator registration file
+   */
+  signers: FacilitatorSigner[];
+
+  /**
+   * Signature verification function
+   * Should return true if signature is valid for the message and public key
+   */
+  verify: (message: Uint8Array, signature: string, publicKey: string, algorithm: string) => Promise<boolean>;
+}
+
+/**
+ * Result of attestation verification
+ */
+export interface VerifyAttestationResult {
+  valid: boolean;
+  error?: string;
+  signer?: FacilitatorSigner;
+}
+
+/**
+ * Verifies a facilitator attestation
+ *
+ * @param params - Verification parameters
+ * @returns Verification result with optional error message
+ *
+ * @example
+ * ```typescript
+ * const result = await verifyAttestation({
+ *   attestation: settlementResponse.extensions["8004-reputation"].facilitatorAttestation,
+ *   taskRef: "solana:5eykt4...:5A2CSREG...",
+ *   signers: facilitatorRegistration.signers,
+ *   verify: async (msg, sig, pubkey, algo) => ed25519.verify(sig, msg, pubkey)
+ * });
+ *
+ * if (result.valid) {
+ *   console.log("Attestation verified by:", result.signer?.comment);
+ * }
+ * ```
+ */
+export async function verifyAttestation(
+  params: VerifyAttestationParams,
+): Promise<VerifyAttestationResult> {
+  const { attestation, taskRef, signers, verify } = params;
+
+  // Filter for currently valid signers
+  const now = Math.floor(Date.now() / 1000);
+  const validSigners = signers.filter(
+    (s) => s.validFrom <= now && (s.validUntil === null || s.validUntil > now),
+  );
+
+  if (validSigners.length === 0) {
+    return { valid: false, error: "No valid signers found" };
+  }
+
+  // Reconstruct the message that was signed
+  const message = buildAttestationMessage({
+    taskRef,
+    settledAmount: attestation.settledAmount,
+    settledAsset: attestation.settledAsset,
+    payTo: attestation.payTo,
+    payer: attestation.payer,
+    settledAt: attestation.settledAt,
+  });
+  const hash = await hashAttestationMessage(message);
+
+  // Try each valid signer
+  for (const signer of validSigners) {
+    try {
+      const isValid = await verify(
+        hash,
+        attestation.attestationSignature,
+        signer.publicKey,
+        signer.algorithm,
+      );
+
+      if (isValid) {
+        return { valid: true, signer };
+      }
+    } catch {
+      // Try next signer
+      continue;
+    }
+  }
+
+  return { valid: false, error: "Signature verification failed for all signers" };
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Extracts network from a CAIP-220 taskRef
+ *
+ * @param taskRef - CAIP-220 format: "{namespace}:{chainId}:{txHash}"
+ * @returns CAIP-2 network identifier
+ *
+ * @example
+ * ```typescript
+ * const network = extractNetworkFromTaskRef("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:5A2CSREG...");
+ * // Returns: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+ * ```
+ */
+export function extractNetworkFromTaskRef(taskRef: string): string {
+  const parts = taskRef.split(":");
+  if (parts.length < 3) {
+    throw new Error(`Invalid taskRef format: ${taskRef}`);
+  }
+  return `${parts[0]}:${parts[1]}`;
+}
+
+/**
+ * Extracts transaction hash from a CAIP-220 taskRef
+ *
+ * @param taskRef - CAIP-220 format: "{namespace}:{chainId}:{txHash}"
+ * @returns Transaction hash/signature
+ */
+export function extractTxHashFromTaskRef(taskRef: string): string {
+  const parts = taskRef.split(":");
+  if (parts.length < 3) {
+    throw new Error(`Invalid taskRef format: ${taskRef}`);
+  }
+  return parts.slice(2).join(":"); // Handle case where txHash might contain ":"
+}
+
+/**
+ * Creates a CAIP-220 taskRef from components
+ *
+ * @param network - CAIP-2 network identifier
+ * @param txHash - Transaction hash/signature
+ * @returns CAIP-220 taskRef
+ */
+export function createTaskRef(network: string, txHash: string): string {
+  return `${network}:${txHash}`;
+}
+
+/**
+ * Validates that an attestation matches settlement data
+ *
+ * @param attestation - Attestation to validate
+ * @param expected - Expected values from settlement
+ * @returns true if attestation matches expected values
+ */
+export function validateAttestationData(
+  attestation: FacilitatorAttestation,
+  expected: {
+    payer?: string;
+    payTo?: string;
+    amount?: string;
+    asset?: string;
+  },
+): boolean {
+  if (expected.payer && attestation.payer !== expected.payer) {
+    return false;
+  }
+  if (expected.payTo && attestation.payTo !== expected.payTo) {
+    return false;
+  }
+  if (expected.amount && attestation.settledAmount !== expected.amount) {
+    return false;
+  }
+  if (expected.asset && attestation.settledAsset !== expected.asset) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Converts attestation to hex-encoded string for transport
+ */
+export function encodeAttestation(attestation: FacilitatorAttestation): string {
+  return JSON.stringify(attestation);
+}
+
+/**
+ * Decodes attestation from string
+ */
+export function decodeAttestation(encoded: string): FacilitatorAttestation {
+  return JSON.parse(encoded) as FacilitatorAttestation;
+}

--- a/typescript/packages/extensions/src/reputation/facilitator.ts
+++ b/typescript/packages/extensions/src/reputation/facilitator.ts
@@ -48,17 +48,18 @@ export function validateReputationExtension(
       return { valid: true };
     }
 
-    const errors =
-      validate.errors?.map((err) => {
-        const path = err.instancePath || "(root)";
-        return `${path}: ${err.message}`;
-      }) || ["Unknown validation error"];
+    const errors = validate.errors?.map(err => {
+      const path = err.instancePath || "(root)";
+      return `${path}: ${err.message}`;
+    }) || ["Unknown validation error"];
 
     return { valid: false, errors };
   } catch (error) {
     return {
       valid: false,
-      errors: [`Schema validation failed: ${error instanceof Error ? error.message : String(error)}`],
+      errors: [
+        `Schema validation failed: ${error instanceof Error ? error.message : String(error)}`,
+      ],
     };
   }
 }
@@ -139,7 +140,7 @@ export function extractReputationData(
 
     // Find registration matching the payment network
     const paymentNetwork = paymentRequirements.network;
-    const matchingRegistration = agentInfo.registrations.find((reg) => {
+    const matchingRegistration = agentInfo.registrations.find(reg => {
       // Extract network from CAIP-10 agentRegistry
       // Format: "{namespace}:{chainId}:{address}"
       const parts = reg.agentRegistry.split(":");
@@ -179,9 +180,7 @@ export interface ValidateFeedbackParams {
    * Function to check if taskRef corresponds to a real settlement
    * Should return settlement data if found
    */
-  lookupSettlement: (
-    taskRef: string,
-  ) => Promise<{
+  lookupSettlement: (taskRef: string) => Promise<{
     found: boolean;
     payer?: string;
     payTo?: string;
@@ -282,10 +281,14 @@ export async function validateFeedbackSubmission(
 
   // Extract address from CAIP-10 format if needed
   const clientAddress = submission.clientAddress.includes(":")
-    ? submission.clientAddress.split(":").pop() ?? submission.clientAddress
+    ? (submission.clientAddress.split(":").pop() ?? submission.clientAddress)
     : submission.clientAddress;
 
-  const signatureValid = await verifyClientSignature(hash, submission.clientSignature, clientAddress);
+  const signatureValid = await verifyClientSignature(
+    hash,
+    submission.clientSignature,
+    clientAddress,
+  );
   if (!signatureValid) {
     return {
       valid: false,
@@ -303,6 +306,9 @@ export async function validateFeedbackSubmission(
 
 /**
  * Checks if payment payload contains reputation extension
+ *
+ * @param paymentPayload - The payment payload to check
+ * @returns True if the payload contains a reputation extension
  */
 export function hasReputationExtension(paymentPayload: PaymentPayload): boolean {
   return !!(paymentPayload.extensions && paymentPayload.extensions[REPUTATION]);
@@ -310,6 +316,9 @@ export function hasReputationExtension(paymentPayload: PaymentPayload): boolean 
 
 /**
  * Gets agent registrations from payment payload
+ *
+ * @param paymentPayload - The payment payload to extract registrations from
+ * @returns Array of agent registrations, or empty array if none found
  */
 export function getAgentRegistrations(paymentPayload: PaymentPayload): AgentRegistration[] {
   if (!paymentPayload.extensions) return [];
@@ -320,6 +329,9 @@ export function getAgentRegistrations(paymentPayload: PaymentPayload): AgentRegi
 
 /**
  * Gets feedback aggregator endpoint from payment payload
+ *
+ * @param paymentPayload - The payment payload to extract aggregator from
+ * @returns The feedback aggregator endpoint URL, or undefined if not set
  */
 export function getFeedbackAggregator(paymentPayload: PaymentPayload): string | undefined {
   if (!paymentPayload.extensions) return undefined;
@@ -330,12 +342,16 @@ export function getFeedbackAggregator(paymentPayload: PaymentPayload): string | 
 
 /**
  * Finds the agent registration matching a specific network
+ *
+ * @param registrations - Array of agent registrations to search
+ * @param network - Network identifier to match (e.g., "solana-mainnet")
+ * @returns The matching registration, or undefined if not found
  */
 export function findRegistrationForNetwork(
   registrations: AgentRegistration[],
   network: string,
 ): AgentRegistration | undefined {
-  return registrations.find((reg) => {
+  return registrations.find(reg => {
     const parts = reg.agentRegistry.split(":");
     if (parts.length >= 2) {
       const regNetwork = `${parts[0]}:${parts[1]}`;
@@ -347,6 +363,7 @@ export function findRegistrationForNetwork(
 
 /**
  * Extracts network from CAIP-10 address
+ *
  * @param caip10Address - Format: "{namespace}:{chainId}:{address}"
  * @returns CAIP-2 network or null
  */
@@ -360,6 +377,7 @@ export function extractNetworkFromCaip10(caip10Address: string): string | null {
 
 /**
  * Extracts address from CAIP-10 format
+ *
  * @param caip10Address - Format: "{namespace}:{chainId}:{address}"
  * @returns The address part or the original string
  */

--- a/typescript/packages/extensions/src/reputation/facilitator.ts
+++ b/typescript/packages/extensions/src/reputation/facilitator.ts
@@ -1,0 +1,372 @@
+/**
+ * Facilitator-side Reputation Extension Utilities
+ *
+ * Functions for facilitators to:
+ * - Validate reputation extension data
+ * - Extract agent identity information
+ * - Process feedback submissions (for aggregators)
+ */
+
+import Ajv from "ajv/dist/2020.js";
+import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import type {
+  ReputationInfo,
+  ReputationRequiredExtension,
+  FeedbackSubmission,
+  AgentRegistration,
+} from "./types";
+import { REPUTATION } from "./types";
+import { buildClientFeedbackMessage, hashClientFeedbackMessage } from "./aggregator";
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Validation result for reputation extensions
+ */
+export interface ReputationValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+/**
+ * Validates a reputation extension's info against its schema
+ *
+ * @param extension - The reputation extension containing info and schema
+ * @returns Validation result
+ */
+export function validateReputationExtension(
+  extension: ReputationRequiredExtension,
+): ReputationValidationResult {
+  try {
+    const ajv = new Ajv({ strict: false, allErrors: true });
+    const validate = ajv.compile(extension.schema);
+    const valid = validate(extension.info);
+
+    if (valid) {
+      return { valid: true };
+    }
+
+    const errors =
+      validate.errors?.map((err) => {
+        const path = err.instancePath || "(root)";
+        return `${path}: ${err.message}`;
+      }) || ["Unknown validation error"];
+
+    return { valid: false, errors };
+  } catch (error) {
+    return {
+      valid: false,
+      errors: [`Schema validation failed: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+}
+
+// ============================================================================
+// Extraction
+// ============================================================================
+
+/**
+ * Extracted reputation data from payment flow
+ */
+export interface ExtractedReputationData {
+  /**
+   * Agent's reputation info from PaymentRequired
+   */
+  agentInfo: ReputationInfo;
+
+  /**
+   * Registration matching the payment network (if found)
+   */
+  matchingRegistration?: AgentRegistration;
+
+  /**
+   * Resource URL being paid for
+   */
+  resourceUrl: string;
+
+  /**
+   * x402 version
+   */
+  x402Version: number;
+}
+
+/**
+ * Extracts reputation data from payment payload
+ *
+ * @param paymentPayload - The payment payload from client
+ * @param paymentRequirements - The payment requirements
+ * @param validate - Whether to validate against schema (default: true)
+ * @returns Extracted data or null if not present/invalid
+ */
+export function extractReputationData(
+  paymentPayload: PaymentPayload,
+  paymentRequirements: PaymentRequirements,
+  validate: boolean = true,
+): ExtractedReputationData | null {
+  // Only support v2
+  if (paymentPayload.x402Version !== 2) {
+    return null;
+  }
+
+  // Check for reputation extension
+  if (!paymentPayload.extensions) {
+    return null;
+  }
+
+  const reputationExt = paymentPayload.extensions[REPUTATION];
+  if (!reputationExt || typeof reputationExt !== "object") {
+    return null;
+  }
+
+  try {
+    const extension = reputationExt as ReputationRequiredExtension;
+
+    // Validate if requested
+    if (validate && extension.schema) {
+      const result = validateReputationExtension(extension);
+      if (!result.valid) {
+        console.warn(`Reputation extension validation failed: ${result.errors?.join(", ")}`);
+        return null;
+      }
+    }
+
+    const agentInfo = extension.info;
+    if (!agentInfo?.registrations?.length) {
+      return null;
+    }
+
+    // Find registration matching the payment network
+    const paymentNetwork = paymentRequirements.network;
+    const matchingRegistration = agentInfo.registrations.find((reg) => {
+      // Extract network from CAIP-10 agentRegistry
+      // Format: "{namespace}:{chainId}:{address}"
+      const parts = reg.agentRegistry.split(":");
+      if (parts.length >= 2) {
+        const regNetwork = `${parts[0]}:${parts[1]}`;
+        return regNetwork === paymentNetwork;
+      }
+      return false;
+    });
+
+    return {
+      agentInfo,
+      matchingRegistration,
+      resourceUrl: paymentPayload.resource?.url ?? "",
+      x402Version: paymentPayload.x402Version,
+    };
+  } catch (error) {
+    console.warn(`Failed to extract reputation data: ${error}`);
+    return null;
+  }
+}
+
+// ============================================================================
+// Aggregator Functions (for feedback processing)
+// ============================================================================
+
+/**
+ * Parameters for validating a feedback submission
+ */
+export interface ValidateFeedbackParams {
+  /**
+   * The feedback submission to validate
+   */
+  submission: FeedbackSubmission;
+
+  /**
+   * Function to check if taskRef corresponds to a real settlement
+   * Should return settlement data if found
+   */
+  lookupSettlement: (
+    taskRef: string,
+  ) => Promise<{
+    found: boolean;
+    payer?: string;
+    payTo?: string;
+    amount?: string;
+    asset?: string;
+  } | null>;
+
+  /**
+   * Function to verify client signature
+   */
+  verifyClientSignature: (
+    message: Uint8Array,
+    signature: string,
+    address: string,
+  ) => Promise<boolean>;
+
+  /**
+   * Function to check for duplicate submissions
+   */
+  checkDuplicate?: (taskRef: string) => Promise<boolean>;
+}
+
+/**
+ * Result of feedback validation
+ */
+export interface ValidateFeedbackResult {
+  valid: boolean;
+  error?: string;
+  errorCode?:
+    | "invalid_task_ref"
+    | "invalid_client_signature"
+    | "duplicate_feedback"
+    | "settlement_mismatch";
+}
+
+/**
+ * Validates a feedback submission (for aggregators)
+ *
+ * @param params - Validation parameters
+ * @returns Validation result
+ *
+ * @example
+ * ```typescript
+ * // In aggregator endpoint
+ * const result = await validateFeedbackSubmission({
+ *   submission: req.body,
+ *   lookupSettlement: async (taskRef) => {
+ *     return db.settlements.findOne({ taskRef });
+ *   },
+ *   verifyClientSignature: async (msg, sig, addr) => {
+ *     return verifySignature(msg, sig, addr);
+ *   },
+ *   checkDuplicate: async (taskRef) => {
+ *     return db.feedback.exists({ taskRef });
+ *   }
+ * });
+ *
+ * if (!result.valid) {
+ *   return res.status(400).json({ error: result.errorCode, message: result.error });
+ * }
+ * ```
+ */
+export async function validateFeedbackSubmission(
+  params: ValidateFeedbackParams,
+): Promise<ValidateFeedbackResult> {
+  const { submission, lookupSettlement, verifyClientSignature, checkDuplicate } = params;
+
+  // 1. Check for duplicates
+  if (checkDuplicate) {
+    const isDuplicate = await checkDuplicate(submission.taskRef);
+    if (isDuplicate) {
+      return {
+        valid: false,
+        error: "Feedback for this taskRef already submitted",
+        errorCode: "duplicate_feedback",
+      };
+    }
+  }
+
+  // 2. Validate taskRef against settlement records
+  const settlement = await lookupSettlement(submission.taskRef);
+  if (!settlement?.found) {
+    return {
+      valid: false,
+      error: "taskRef not found in aggregator settlement records",
+      errorCode: "invalid_task_ref",
+    };
+  }
+
+  // 3. Verify client signature
+  const message = buildClientFeedbackMessage(
+    submission.agentId,
+    submission.taskRef,
+    submission.value,
+    submission.valueDecimals,
+  );
+  const hash = await hashClientFeedbackMessage(message);
+
+  // Extract address from CAIP-10 format if needed
+  const clientAddress = submission.clientAddress.includes(":")
+    ? submission.clientAddress.split(":").pop() ?? submission.clientAddress
+    : submission.clientAddress;
+
+  const signatureValid = await verifyClientSignature(hash, submission.clientSignature, clientAddress);
+  if (!signatureValid) {
+    return {
+      valid: false,
+      error: "Client signature verification failed",
+      errorCode: "invalid_client_signature",
+    };
+  }
+
+  return { valid: true };
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Checks if payment payload contains reputation extension
+ */
+export function hasReputationExtension(paymentPayload: PaymentPayload): boolean {
+  return !!(paymentPayload.extensions && paymentPayload.extensions[REPUTATION]);
+}
+
+/**
+ * Gets agent registrations from payment payload
+ */
+export function getAgentRegistrations(paymentPayload: PaymentPayload): AgentRegistration[] {
+  if (!paymentPayload.extensions) return [];
+
+  const ext = paymentPayload.extensions[REPUTATION] as ReputationRequiredExtension | undefined;
+  return ext?.info?.registrations ?? [];
+}
+
+/**
+ * Gets feedback aggregator endpoint from payment payload
+ */
+export function getFeedbackAggregator(paymentPayload: PaymentPayload): string | undefined {
+  if (!paymentPayload.extensions) return undefined;
+
+  const ext = paymentPayload.extensions[REPUTATION] as ReputationRequiredExtension | undefined;
+  return ext?.info?.feedbackAggregator?.endpoint;
+}
+
+/**
+ * Finds the agent registration matching a specific network
+ */
+export function findRegistrationForNetwork(
+  registrations: AgentRegistration[],
+  network: string,
+): AgentRegistration | undefined {
+  return registrations.find((reg) => {
+    const parts = reg.agentRegistry.split(":");
+    if (parts.length >= 2) {
+      const regNetwork = `${parts[0]}:${parts[1]}`;
+      return regNetwork === network;
+    }
+    return false;
+  });
+}
+
+/**
+ * Extracts network from CAIP-10 address
+ * @param caip10Address - Format: "{namespace}:{chainId}:{address}"
+ * @returns CAIP-2 network or null
+ */
+export function extractNetworkFromCaip10(caip10Address: string): string | null {
+  const parts = caip10Address.split(":");
+  if (parts.length >= 2) {
+    return `${parts[0]}:${parts[1]}`;
+  }
+  return null;
+}
+
+/**
+ * Extracts address from CAIP-10 format
+ * @param caip10Address - Format: "{namespace}:{chainId}:{address}"
+ * @returns The address part or the original string
+ */
+export function extractAddressFromCaip10(caip10Address: string): string {
+  const parts = caip10Address.split(":");
+  if (parts.length >= 3) {
+    return parts.slice(2).join(":"); // Handle addresses with colons
+  }
+  return caip10Address;
+}

--- a/typescript/packages/extensions/src/reputation/index.ts
+++ b/typescript/packages/extensions/src/reputation/index.ts
@@ -1,0 +1,201 @@
+/**
+ * 8004-Reputation Extension for x402
+ *
+ * This extension enables on-chain reputation for x402 agents through:
+ * - Agent identity declaration (ERC-8004 compliant registries)
+ * - Facilitator settlement attestation
+ * - Feedback aggregation protocol
+ *
+ * ## Overview
+ *
+ * The reputation extension adds trust signals to x402 payment flows:
+ *
+ * 1. **Agent Identity**: Servers declare their ERC-8004 registration in PaymentRequired
+ * 2. **Facilitator Attestation**: Facilitators can attest to successful settlements
+ * 3. **Feedback Aggregation**: Gas-free feedback submission through trusted aggregators
+ *
+ * ## For Resource Servers (Agents)
+ *
+ * Declare reputation support in your route configuration:
+ *
+ * ```typescript
+ * import { declareReputationExtension, REPUTATION } from '@x402/extensions/reputation';
+ *
+ * const extension = declareReputationExtension({
+ *   registrations: [{
+ *     agentRegistry: "eip155:8453:0x8004A818...",
+ *     agentId: "42",
+ *     reputationRegistry: "eip155:8453:0x8004B663..."
+ *   }],
+ *   feedbackAggregator: {
+ *     endpoint: "https://x402.dexter.cash/feedback",
+ *     gasSponsored: true
+ *   }
+ * });
+ *
+ * const routes = {
+ *   "POST /api": {
+ *     price: "$0.01",
+ *     extensions: { [REPUTATION]: extension }
+ *   }
+ * };
+ * ```
+ *
+ * ## For Facilitators
+ *
+ * Add attestation to settlement responses:
+ *
+ * ```typescript
+ * import { createReputationServerExtension } from '@x402/extensions/reputation';
+ *
+ * const extension = createReputationServerExtension({
+ *   attestation: {
+ *     facilitatorId: "eip155:8453:0x8004F123...",
+ *     sign: async (msg) => wallet.signMessage(msg)
+ *   }
+ * });
+ *
+ * server.registerExtension(extension);
+ * ```
+ *
+ * ## For Clients
+ *
+ * Submit feedback after receiving service:
+ *
+ * ```typescript
+ * import {
+ *   createAndSubmitFeedback,
+ *   extractReputationFromSettlement,
+ *   extractReputationFromPaymentRequired
+ * } from '@x402/extensions/reputation';
+ *
+ * // After settlement
+ * const reputationInfo = extractReputationFromPaymentRequired(paymentRequired.extensions);
+ * const settlementData = extractReputationFromSettlement(settlementResponse.extensions);
+ *
+ * if (reputationInfo?.feedbackAggregator) {
+ *   await createAndSubmitFeedback({
+ *     aggregatorEndpoint: reputationInfo.feedbackAggregator.endpoint,
+ *     taskRef: settlementData.taskRef,
+ *     facilitatorAttestation: settlementData.facilitatorAttestation,
+ *     agentId: reputationInfo.registrations[0].agentId,
+ *     reputationRegistry: reputationInfo.registrations[0].reputationRegistry,
+ *     value: 95,
+ *     tag1: "x402-delivered",
+ *     tag2: "proof-of-settlement",
+ *     clientAddress: myWallet.address,
+ *     sign: myWallet.signMessage
+ *   });
+ * }
+ * ```
+ */
+
+// Extension identifier
+export { REPUTATION } from "./types";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type {
+  // Agent identity
+  AgentRegistration,
+  ReputationInfo,
+  FeedbackAggregator,
+
+  // Settlement response
+  InteractionData,
+  FacilitatorAttestation,
+  ReputationSettlementExtension,
+
+  // Feedback submission
+  FeedbackSubmission,
+  FeedbackResponse,
+  FeedbackErrorCode,
+  FeedbackTag1,
+  FeedbackTag2,
+
+  // Extension declaration
+  ReputationRequiredExtension,
+  ReputationInfoSchema,
+
+  // Facilitator config
+  FacilitatorAttestationConfig,
+  FacilitatorSigner,
+} from "./types";
+
+// ============================================================================
+// Server Extension (for resource servers and facilitators)
+// ============================================================================
+
+export {
+  createReputationServerExtension,
+  reputationServerExtension,
+  declareReputationExtension,
+} from "./server";
+
+export type { ReputationServerExtensionConfig, DeclareReputationConfig } from "./server";
+
+// ============================================================================
+// Attestation Utilities
+// ============================================================================
+
+export {
+  createAttestation,
+  verifyAttestation,
+  buildAttestationMessage,
+  hashAttestationMessage,
+  extractNetworkFromTaskRef,
+  extractTxHashFromTaskRef,
+  createTaskRef,
+  validateAttestationData,
+  encodeAttestation,
+  decodeAttestation,
+} from "./attestation";
+
+export type {
+  CreateAttestationParams,
+  VerifyAttestationParams,
+  VerifyAttestationResult,
+} from "./attestation";
+
+// ============================================================================
+// Aggregator Client (for clients submitting feedback)
+// ============================================================================
+
+export {
+  createFeedbackSubmission,
+  submitFeedback,
+  createAndSubmitFeedback,
+  buildClientFeedbackMessage,
+  hashClientFeedbackMessage,
+  extractReputationFromSettlement,
+  extractReputationFromPaymentRequired,
+  getAggregatorEndpoint,
+  determineEvidenceTag,
+} from "./aggregator";
+
+export type { CreateFeedbackParams } from "./aggregator";
+
+// ============================================================================
+// Facilitator Utilities (for facilitators and aggregators)
+// ============================================================================
+
+export {
+  validateReputationExtension,
+  extractReputationData,
+  validateFeedbackSubmission,
+  hasReputationExtension,
+  getAgentRegistrations,
+  getFeedbackAggregator,
+  findRegistrationForNetwork,
+  extractNetworkFromCaip10,
+  extractAddressFromCaip10,
+} from "./facilitator";
+
+export type {
+  ReputationValidationResult,
+  ExtractedReputationData,
+  ValidateFeedbackParams,
+  ValidateFeedbackResult,
+} from "./facilitator";

--- a/typescript/packages/extensions/src/reputation/server.ts
+++ b/typescript/packages/extensions/src/reputation/server.ts
@@ -31,6 +31,7 @@ export interface ReputationServerExtensionConfig {
 
   /**
    * Whether to include attestation only when agent declares reputation extension
+   *
    * @default true
    */
   requireAgentDeclaration?: boolean;
@@ -72,12 +73,16 @@ export function createReputationServerExtension(
      *
      * Called after successful payment settlement. Adds:
      * - facilitatorAttestation: Signed proof that this facilitator settled the payment
+     *
+     * @param declaration - The agent's reputation declaration from PaymentRequired
+     * @param context - Settlement context containing result, requirements, and payload
+     * @returns Reputation extension data with facilitator attestation, or undefined if not applicable
      */
     enrichSettlementResponse: async (
       declaration: unknown,
       context: SettleResultContext,
     ): Promise<ReputationSettlementExtension | undefined> => {
-      const { result, requirements, paymentPayload } = context;
+      const { result, requirements } = context;
 
       // Only add to successful settlements
       if (!result.success) {
@@ -206,7 +211,7 @@ export function declareReputationExtension(config: DeclareReputationConfig) {
 
   const info: ReputationInfo = {
     version,
-    registrations: registrations.map((r) => ({
+    registrations: registrations.map(r => ({
       agentRegistry: r.agentRegistry,
       agentId: r.agentId,
       reputationRegistry: r.reputationRegistry,

--- a/typescript/packages/extensions/src/reputation/server.ts
+++ b/typescript/packages/extensions/src/reputation/server.ts
@@ -1,0 +1,272 @@
+/**
+ * Server-side Reputation Extension
+ *
+ * Implements ResourceServerExtension for the 8004-reputation extension.
+ * Adds facilitator attestation to settlement responses.
+ */
+
+import type { ResourceServerExtension, SettleResultContext } from "@x402/core/types";
+import { REPUTATION } from "./types";
+import type {
+  FacilitatorAttestation,
+  FacilitatorAttestationConfig,
+  ReputationInfo,
+  ReputationSettlementExtension,
+} from "./types";
+import { createAttestation, createTaskRef } from "./attestation";
+
+// ============================================================================
+// Server Extension Configuration
+// ============================================================================
+
+/**
+ * Configuration for the reputation server extension
+ */
+export interface ReputationServerExtensionConfig {
+  /**
+   * Facilitator attestation configuration
+   * If provided, attestations will be added to settlement responses
+   */
+  attestation?: FacilitatorAttestationConfig;
+
+  /**
+   * Whether to include attestation only when agent declares reputation extension
+   * @default true
+   */
+  requireAgentDeclaration?: boolean;
+}
+
+/**
+ * Creates the reputation server extension with optional facilitator attestation
+ *
+ * @param config - Extension configuration
+ * @returns ResourceServerExtension instance
+ *
+ * @example
+ * ```typescript
+ * // Basic usage - just pass through agent's reputation info
+ * const extension = createReputationServerExtension();
+ *
+ * // With facilitator attestation
+ * const extension = createReputationServerExtension({
+ *   attestation: {
+ *     facilitatorId: "eip155:8453:0x8004F123...",
+ *     sign: async (msg) => wallet.signMessage(msg)
+ *   }
+ * });
+ *
+ * // Register with x402 server
+ * server.registerExtension(extension);
+ * ```
+ */
+export function createReputationServerExtension(
+  config: ReputationServerExtensionConfig = {},
+): ResourceServerExtension {
+  const { attestation: attestationConfig, requireAgentDeclaration = true } = config;
+
+  return {
+    key: REPUTATION,
+
+    /**
+     * Enriches settlement response with facilitator attestation
+     *
+     * Called after successful payment settlement. Adds:
+     * - facilitatorAttestation: Signed proof that this facilitator settled the payment
+     */
+    enrichSettlementResponse: async (
+      declaration: unknown,
+      context: SettleResultContext,
+    ): Promise<ReputationSettlementExtension | undefined> => {
+      const { result, requirements, paymentPayload } = context;
+
+      // Only add to successful settlements
+      if (!result.success) {
+        return undefined;
+      }
+
+      // Check if agent declared reputation extension
+      const agentDeclaration = declaration as ReputationInfo | undefined;
+      if (requireAgentDeclaration && !agentDeclaration?.registrations?.length) {
+        return undefined;
+      }
+
+      // If no attestation config, return undefined (no facilitator attestation)
+      if (!attestationConfig) {
+        return undefined;
+      }
+
+      // Build taskRef from settlement result
+      const taskRef = createTaskRef(result.network, result.transaction);
+
+      // Create facilitator attestation
+      let facilitatorAttestation: FacilitatorAttestation | undefined;
+      try {
+        facilitatorAttestation = await createAttestation(
+          {
+            taskRef,
+            settledAmount: requirements.amount,
+            settledAsset: requirements.asset,
+            payTo: requirements.payTo,
+            payer: result.payer ?? "",
+          },
+          attestationConfig,
+        );
+      } catch (error) {
+        // Log but don't fail the settlement
+        console.warn("[8004-reputation] Failed to create attestation:", error);
+        return undefined;
+      }
+
+      // Return extension data for settlement response
+      return {
+        facilitatorAttestation,
+      };
+    },
+  };
+}
+
+/**
+ * Default reputation server extension without attestation
+ *
+ * Use this when you want to support the reputation extension
+ * but don't want to provide facilitator attestations.
+ */
+export const reputationServerExtension: ResourceServerExtension = createReputationServerExtension();
+
+// ============================================================================
+// Declaration Helpers
+// ============================================================================
+
+/**
+ * Configuration for declaring reputation support in PaymentRequired
+ */
+export interface DeclareReputationConfig {
+  /**
+   * Extension version
+   */
+  version?: string;
+
+  /**
+   * Agent registrations on ERC-8004 compliant registries
+   */
+  registrations: Array<{
+    agentRegistry: string;
+    agentId: string;
+    reputationRegistry: string;
+  }>;
+
+  /**
+   * Service endpoint URL
+   */
+  endpoint?: string;
+
+  /**
+   * Feedback aggregator configuration
+   */
+  feedbackAggregator?: {
+    endpoint: string;
+    networks?: string[];
+    gasSponsored?: boolean;
+  };
+}
+
+/**
+ * Creates a reputation extension declaration for PaymentRequired
+ *
+ * @param config - Declaration configuration
+ * @returns Extension object with info and schema
+ *
+ * @example
+ * ```typescript
+ * const extension = declareReputationExtension({
+ *   registrations: [{
+ *     agentRegistry: "eip155:8453:0x8004A818...",
+ *     agentId: "42",
+ *     reputationRegistry: "eip155:8453:0x8004B663..."
+ *   }],
+ *   feedbackAggregator: {
+ *     endpoint: "https://x402.dexter.cash/feedback",
+ *     gasSponsored: true
+ *   }
+ * });
+ *
+ * // Use in route config
+ * const routes = {
+ *   "POST /api": {
+ *     price: "$0.01",
+ *     extensions: {
+ *       [REPUTATION]: extension
+ *     }
+ *   }
+ * };
+ * ```
+ */
+export function declareReputationExtension(config: DeclareReputationConfig) {
+  const { version = "1.0.0", registrations, endpoint, feedbackAggregator } = config;
+
+  const info: ReputationInfo = {
+    version,
+    registrations: registrations.map((r) => ({
+      agentRegistry: r.agentRegistry,
+      agentId: r.agentId,
+      reputationRegistry: r.reputationRegistry,
+    })),
+  };
+
+  if (endpoint) {
+    info.endpoint = endpoint;
+  }
+
+  if (feedbackAggregator) {
+    info.feedbackAggregator = {
+      endpoint: feedbackAggregator.endpoint,
+    };
+    if (feedbackAggregator.networks) {
+      info.feedbackAggregator.networks = feedbackAggregator.networks;
+    }
+    if (feedbackAggregator.gasSponsored !== undefined) {
+      info.feedbackAggregator.gasSponsored = feedbackAggregator.gasSponsored;
+    }
+  }
+
+  return {
+    info,
+    schema: {
+      $schema: "https://json-schema.org/draft/2020-12/schema" as const,
+      type: "object" as const,
+      properties: {
+        version: {
+          type: "string" as const,
+          pattern: "^\\d+\\.\\d+\\.\\d+$",
+        },
+        registrations: {
+          type: "array" as const,
+          minItems: 1,
+          items: {
+            type: "object" as const,
+            properties: {
+              agentRegistry: { type: "string" as const },
+              agentId: { type: "string" as const },
+              reputationRegistry: { type: "string" as const },
+            },
+            required: ["agentRegistry", "agentId", "reputationRegistry"] as const,
+          },
+        },
+        endpoint: {
+          type: "string" as const,
+          format: "uri",
+        },
+        feedbackAggregator: {
+          type: "object" as const,
+          properties: {
+            endpoint: { type: "string" as const, format: "uri" },
+            networks: { type: "array" as const, items: { type: "string" as const } },
+            gasSponsored: { type: "boolean" as const },
+          },
+          required: ["endpoint"] as const,
+        },
+      },
+      required: ["version", "registrations"] as const,
+    },
+  };
+}

--- a/typescript/packages/extensions/src/reputation/types.ts
+++ b/typescript/packages/extensions/src/reputation/types.ts
@@ -1,0 +1,364 @@
+/**
+ * Type definitions for the 8004-Reputation Extension
+ *
+ * This extension enables on-chain reputation for x402 agents through:
+ * - Agent identity declaration (ERC-8004 compliant)
+ * - Facilitator settlement attestation
+ * - Feedback aggregation protocol
+ */
+
+/**
+ * Extension identifier constant
+ */
+export const REPUTATION = "8004-reputation";
+
+// ============================================================================
+// Agent Identity Types (from PaymentRequired)
+// ============================================================================
+
+/**
+ * Agent registration on an ERC-8004 compliant registry
+ */
+export interface AgentRegistration {
+  /**
+   * CAIP-10 format: {namespace}:{chainId}:{identityRegistry}
+   * Examples:
+   * - EVM: "eip155:8453:0x8004A818BFB912233c491871b3d84c89A494BD9e"
+   * - Solana: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:satiRkxEiwZ51cv8PRu8UMzuaqeaNU9jABo6oAFMsLe"
+   */
+  agentRegistry: string;
+
+  /**
+   * Agent identifier:
+   * - EVM: ERC-721 tokenId from the Identity Registry
+   * - Solana: Agent account/mint address
+   */
+  agentId: string;
+
+  /**
+   * CAIP-10 Reputation Registry address
+   * May equal agentRegistry on Solana where one program handles both
+   */
+  reputationRegistry: string;
+}
+
+/**
+ * Feedback aggregator configuration
+ */
+export interface FeedbackAggregator {
+  /**
+   * HTTPS endpoint accepting feedback submissions
+   */
+  endpoint: string;
+
+  /**
+   * CAIP-2 networks the aggregator supports for on-chain submission
+   */
+  networks?: string[];
+
+  /**
+   * Whether aggregator pays submission gas
+   * @default false
+   */
+  gasSponsored?: boolean;
+}
+
+/**
+ * Reputation info declared by server in PaymentRequired
+ */
+export interface ReputationInfo {
+  /**
+   * Extension version
+   */
+  version: string;
+
+  /**
+   * Agent registrations (at least one required)
+   */
+  registrations: AgentRegistration[];
+
+  /**
+   * Agent's service endpoint URL
+   */
+  endpoint?: string;
+
+  /**
+   * Optional feedback aggregator for gas-free submission
+   */
+  feedbackAggregator?: FeedbackAggregator;
+}
+
+// ============================================================================
+// Settlement Response Types (PAYMENT-RESPONSE)
+// ============================================================================
+
+/**
+ * Interaction data included in settlement response
+ * Agent signs this to prove service delivery
+ */
+export interface InteractionData {
+  /**
+   * CAIP-2 payment network (convenience field)
+   */
+  networkId: string;
+
+  /**
+   * Agent identifier on this network
+   */
+  agentId: string;
+
+  /**
+   * CAIP-220 payment transaction reference
+   */
+  taskRef: string;
+
+  /**
+   * keccak256(UTF8(taskRef) || UTF8(requestBody) || UTF8(responseBody))
+   * Hex-encoded
+   */
+  interactionHash: string;
+
+  /**
+   * Agent signature over interactionHash
+   * Hex-encoded
+   */
+  agentSignature: string;
+
+  /**
+   * Unix timestamp (metadata, not part of signed message)
+   */
+  timestamp: number;
+}
+
+/**
+ * Facilitator attestation proving settlement occurred
+ * Signed by the facilitator that executed the payment
+ */
+export interface FacilitatorAttestation {
+  /**
+   * CAIP-10 facilitator identifier
+   * If registered: "eip155:8453:0x..."
+   * If not: fee payer address "solana:5eykt4...:FeePayerAddress..."
+   */
+  facilitatorId: string;
+
+  /**
+   * Unix timestamp of settlement
+   */
+  settledAt: number;
+
+  /**
+   * Amount in atomic units
+   */
+  settledAmount: string;
+
+  /**
+   * Token address/mint that was transferred
+   */
+  settledAsset: string;
+
+  /**
+   * Recipient address
+   */
+  payTo: string;
+
+  /**
+   * Payer address
+   */
+  payer: string;
+
+  /**
+   * Facilitator signature over attestation
+   * message = keccak256(taskRef || settledAmount || settledAsset || payTo || payer || settledAt)
+   */
+  attestationSignature: string;
+}
+
+/**
+ * Complete reputation extension data in settlement response
+ */
+export interface ReputationSettlementExtension {
+  /**
+   * Interaction data with agent signature (if agent provides)
+   */
+  networkId?: string;
+  agentId?: string;
+  taskRef?: string;
+  interactionHash?: string;
+  agentSignature?: string;
+  timestamp?: number;
+
+  /**
+   * Facilitator attestation (if facilitator provides)
+   */
+  facilitatorAttestation?: FacilitatorAttestation;
+}
+
+// ============================================================================
+// Feedback Submission Types
+// ============================================================================
+
+/**
+ * Feedback submission to aggregator endpoint
+ */
+export interface FeedbackSubmission {
+  // From PAYMENT-RESPONSE
+  taskRef: string;
+  interactionHash?: string;
+  agentSignature?: string;
+
+  // Target agent
+  agentId: string;
+  reputationRegistry: string;
+
+  // Feedback content
+  value: number;
+  valueDecimals: number;
+  tag1?: string;
+  tag2?: string;
+  comment?: string;
+
+  // Client proof
+  clientAddress: string;
+  clientSignature: string;
+
+  // Optional facilitator attestation
+  facilitatorAttestation?: FacilitatorAttestation;
+}
+
+/**
+ * Aggregator response to feedback submission
+ */
+export interface FeedbackResponse {
+  accepted: boolean;
+  feedbackId?: string;
+  status?: "queued" | "submitted" | "confirmed";
+  estimatedOnChainTime?: string;
+  error?: string;
+  message?: string;
+}
+
+/**
+ * Standard error codes from aggregator
+ */
+export type FeedbackErrorCode =
+  | "invalid_task_ref"
+  | "invalid_client_signature"
+  | "invalid_agent_signature"
+  | "duplicate_feedback"
+  | "unsupported_network"
+  | "rate_limited";
+
+// ============================================================================
+// Extension Declaration Types
+// ============================================================================
+
+/**
+ * Full extension structure in PaymentRequired
+ */
+export interface ReputationRequiredExtension {
+  info: ReputationInfo;
+  schema: ReputationInfoSchema;
+}
+
+/**
+ * JSON Schema for ReputationInfo validation
+ */
+export interface ReputationInfoSchema {
+  $schema: "https://json-schema.org/draft/2020-12/schema";
+  type: "object";
+  properties: {
+    version: {
+      type: "string";
+      pattern: string;
+    };
+    registrations: {
+      type: "array";
+      minItems: 1;
+      items: {
+        type: "object";
+        properties: {
+          agentRegistry: { type: "string" };
+          agentId: { type: "string" };
+          reputationRegistry: { type: "string" };
+        };
+        required: ["agentRegistry", "agentId", "reputationRegistry"];
+      };
+    };
+    endpoint?: {
+      type: "string";
+      format: "uri";
+    };
+    feedbackAggregator?: {
+      type: "object";
+      properties: {
+        endpoint: { type: "string"; format: "uri" };
+        networks: { type: "array"; items: { type: "string" } };
+        gasSponsored: { type: "boolean" };
+      };
+      required: ["endpoint"];
+    };
+  };
+  required: ["version", "registrations"];
+}
+
+// ============================================================================
+// Facilitator Configuration Types
+// ============================================================================
+
+/**
+ * Configuration for facilitator attestation
+ */
+export interface FacilitatorAttestationConfig {
+  /**
+   * CAIP-10 facilitator identifier
+   */
+  facilitatorId: string;
+
+  /**
+   * Signing function for attestation
+   * Should sign the message and return hex-encoded signature
+   */
+  sign: (message: Uint8Array) => Promise<string>;
+
+  /**
+   * Signing algorithm
+   * @default "secp256k1"
+   */
+  algorithm?: "secp256k1" | "ed25519";
+}
+
+/**
+ * Signer information from facilitator registration file
+ */
+export interface FacilitatorSigner {
+  publicKey: string;
+  algorithm: "secp256k1" | "ed25519";
+  role: "owner" | "delegate";
+  validFrom: number;
+  validUntil: number | null;
+  comment?: string;
+}
+
+// ============================================================================
+// Tag Conventions
+// ============================================================================
+
+/**
+ * Standard tag1 values for x402 feedback
+ */
+export type FeedbackTag1 =
+  | "x402-delivered"
+  | "x402-failed"
+  | "x402-timeout"
+  | "x402-quality"
+  | "x402-payment-verified";
+
+/**
+ * Standard tag2 values for evidence level
+ */
+export type FeedbackTag2 =
+  | "proof-of-payment"
+  | "proof-of-service"
+  | "proof-of-settlement"
+  | "client-claim";

--- a/typescript/packages/extensions/src/reputation/types.ts
+++ b/typescript/packages/extensions/src/reputation/types.ts
@@ -58,6 +58,7 @@ export interface FeedbackAggregator {
 
   /**
    * Whether aggregator pays submission gas
+   *
    * @default false
    */
   gasSponsored?: boolean;
@@ -323,6 +324,7 @@ export interface FacilitatorAttestationConfig {
 
   /**
    * Signing algorithm
+   *
    * @default "secp256k1"
    */
   algorithm?: "secp256k1" | "ed25519";

--- a/typescript/packages/extensions/test/reputation.test.ts
+++ b/typescript/packages/extensions/test/reputation.test.ts
@@ -345,7 +345,7 @@ describe("hasReputationExtension", () => {
     const payload = {
       x402Version: 2,
       resource: { url: "https://example.com", description: "", mimeType: "" },
-      accepted: {} as any,
+      accepted: {} as Record<string, unknown>,
       payload: {},
       extensions: {
         [REPUTATION]: { info: {}, schema: {} },
@@ -359,7 +359,7 @@ describe("hasReputationExtension", () => {
     const payload = {
       x402Version: 2,
       resource: { url: "https://example.com", description: "", mimeType: "" },
-      accepted: {} as any,
+      accepted: {} as Record<string, unknown>,
       payload: {},
     };
 
@@ -387,7 +387,10 @@ describe("findRegistrationForNetwork", () => {
   });
 
   it("should find Solana registration", () => {
-    const reg = findRegistrationForNetwork(registrations, "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp");
+    const reg = findRegistrationForNetwork(
+      registrations,
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    );
     expect(reg?.agentId).toBe("7xKXtg...");
   });
 
@@ -409,7 +412,8 @@ describe("CAIP utilities", () => {
   });
 
   it("should handle Solana CAIP-10", () => {
-    const caip10 = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+    const caip10 =
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
     const network = extractNetworkFromCaip10(caip10);
     const address = extractAddressFromCaip10(caip10);
 

--- a/typescript/packages/extensions/test/reputation.test.ts
+++ b/typescript/packages/extensions/test/reputation.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Tests for 8004-Reputation Extension
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  REPUTATION,
+  declareReputationExtension,
+  createAttestation,
+  verifyAttestation,
+  createTaskRef,
+  extractNetworkFromTaskRef,
+  extractTxHashFromTaskRef,
+  createFeedbackSubmission,
+  determineEvidenceTag,
+  validateReputationExtension,
+  hasReputationExtension,
+  findRegistrationForNetwork,
+  extractNetworkFromCaip10,
+  extractAddressFromCaip10,
+} from "../src/reputation";
+import type {
+  FacilitatorAttestation,
+  FacilitatorSigner,
+  ReputationRequiredExtension,
+} from "../src/reputation";
+
+describe("REPUTATION constant", () => {
+  it("should equal '8004-reputation'", () => {
+    expect(REPUTATION).toBe("8004-reputation");
+  });
+});
+
+describe("declareReputationExtension", () => {
+  it("should create a valid extension declaration", () => {
+    const extension = declareReputationExtension({
+      registrations: [
+        {
+          agentRegistry: "eip155:8453:0x8004A818BFB912233c491871b3d84c89A494BD9e",
+          agentId: "42",
+          reputationRegistry: "eip155:8453:0x8004B663C4a7e45d78F2D05C8e4A5a3D3D5e7890",
+        },
+      ],
+    });
+
+    expect(extension.info.version).toBe("1.0.0");
+    expect(extension.info.registrations).toHaveLength(1);
+    expect(extension.info.registrations[0].agentId).toBe("42");
+    expect(extension.schema.$schema).toBe("https://json-schema.org/draft/2020-12/schema");
+  });
+
+  it("should include feedbackAggregator when provided", () => {
+    const extension = declareReputationExtension({
+      registrations: [
+        {
+          agentRegistry: "eip155:8453:0x8004A818...",
+          agentId: "42",
+          reputationRegistry: "eip155:8453:0x8004B663...",
+        },
+      ],
+      feedbackAggregator: {
+        endpoint: "https://x402.dexter.cash/feedback",
+        gasSponsored: true,
+      },
+    });
+
+    expect(extension.info.feedbackAggregator).toBeDefined();
+    expect(extension.info.feedbackAggregator?.endpoint).toBe("https://x402.dexter.cash/feedback");
+    expect(extension.info.feedbackAggregator?.gasSponsored).toBe(true);
+  });
+
+  it("should support multi-chain registrations", () => {
+    const extension = declareReputationExtension({
+      registrations: [
+        {
+          agentRegistry: "eip155:8453:0x8004A818...",
+          agentId: "42",
+          reputationRegistry: "eip155:8453:0x8004B663...",
+        },
+        {
+          agentRegistry: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:satiRkx...",
+          agentId: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+          reputationRegistry: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:satiRkx...",
+        },
+      ],
+    });
+
+    expect(extension.info.registrations).toHaveLength(2);
+  });
+});
+
+describe("taskRef utilities", () => {
+  const sampleTaskRef = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:5A2CSREGntKZu8f2abc123";
+
+  it("should extract network from taskRef", () => {
+    const network = extractNetworkFromTaskRef(sampleTaskRef);
+    expect(network).toBe("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp");
+  });
+
+  it("should extract txHash from taskRef", () => {
+    const txHash = extractTxHashFromTaskRef(sampleTaskRef);
+    expect(txHash).toBe("5A2CSREGntKZu8f2abc123");
+  });
+
+  it("should create taskRef from components", () => {
+    const taskRef = createTaskRef("eip155:8453", "0x1234567890abcdef");
+    expect(taskRef).toBe("eip155:8453:0x1234567890abcdef");
+  });
+
+  it("should handle EVM taskRef", () => {
+    const evmTaskRef = "eip155:8453:0x1234567890abcdef1234567890abcdef12345678";
+    const network = extractNetworkFromTaskRef(evmTaskRef);
+    const txHash = extractTxHashFromTaskRef(evmTaskRef);
+
+    expect(network).toBe("eip155:8453");
+    expect(txHash).toBe("0x1234567890abcdef1234567890abcdef12345678");
+  });
+});
+
+describe("createAttestation", () => {
+  it("should create a valid attestation", async () => {
+    const mockSign = vi.fn().mockResolvedValue("0xmocksignature123");
+
+    const attestation = await createAttestation(
+      {
+        taskRef: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:5A2CSREG...",
+        settledAmount: "1000",
+        settledAsset: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        payTo: "CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5",
+        payer: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
+      },
+      {
+        facilitatorId: "eip155:8453:0x8004F123...",
+        sign: mockSign,
+      },
+    );
+
+    expect(attestation.facilitatorId).toBe("eip155:8453:0x8004F123...");
+    expect(attestation.settledAmount).toBe("1000");
+    expect(attestation.settledAsset).toBe("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+    expect(attestation.payTo).toBe("CKPKJWNdJEqa81x7CkZ14BVPiY6y16Sxs7owznqtWYp5");
+    expect(attestation.payer).toBe("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+    expect(attestation.attestationSignature).toBe("0xmocksignature123");
+    expect(attestation.settledAt).toBeDefined();
+    expect(mockSign).toHaveBeenCalled();
+  });
+
+  it("should use provided settledAt timestamp", async () => {
+    const mockSign = vi.fn().mockResolvedValue("0xsig");
+    const timestamp = 1737763200;
+
+    const attestation = await createAttestation(
+      {
+        taskRef: "eip155:8453:0x123...",
+        settledAmount: "1000",
+        settledAsset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        payTo: "0xAgentWallet...",
+        payer: "0xPayerWallet...",
+        settledAt: timestamp,
+      },
+      {
+        facilitatorId: "eip155:8453:0xFacilitator...",
+        sign: mockSign,
+      },
+    );
+
+    expect(attestation.settledAt).toBe(timestamp);
+  });
+});
+
+describe("verifyAttestation", () => {
+  const validSigner: FacilitatorSigner = {
+    publicKey: "04abc123...",
+    algorithm: "secp256k1",
+    role: "owner",
+    validFrom: Math.floor(Date.now() / 1000) - 3600, // 1 hour ago
+    validUntil: null,
+  };
+
+  const expiredSigner: FacilitatorSigner = {
+    publicKey: "04expired...",
+    algorithm: "secp256k1",
+    role: "owner",
+    validFrom: Math.floor(Date.now() / 1000) - 7200, // 2 hours ago
+    validUntil: Math.floor(Date.now() / 1000) - 3600, // expired 1 hour ago
+  };
+
+  it("should verify valid attestation", async () => {
+    const attestation: FacilitatorAttestation = {
+      facilitatorId: "eip155:8453:0x...",
+      settledAt: Math.floor(Date.now() / 1000),
+      settledAmount: "1000",
+      settledAsset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      payTo: "0xAgent...",
+      payer: "0xPayer...",
+      attestationSignature: "0xvalidsig",
+    };
+
+    const mockVerify = vi.fn().mockResolvedValue(true);
+
+    const result = await verifyAttestation({
+      attestation,
+      taskRef: "eip155:8453:0x123...",
+      signers: [validSigner],
+      verify: mockVerify,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.signer).toEqual(validSigner);
+  });
+
+  it("should reject with no valid signers", async () => {
+    const attestation: FacilitatorAttestation = {
+      facilitatorId: "eip155:8453:0x...",
+      settledAt: Math.floor(Date.now() / 1000),
+      settledAmount: "1000",
+      settledAsset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      payTo: "0xAgent...",
+      payer: "0xPayer...",
+      attestationSignature: "0xsig",
+    };
+
+    const result = await verifyAttestation({
+      attestation,
+      taskRef: "eip155:8453:0x123...",
+      signers: [expiredSigner], // Only expired signer
+      verify: vi.fn(),
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("No valid signers");
+  });
+
+  it("should reject invalid signature", async () => {
+    const attestation: FacilitatorAttestation = {
+      facilitatorId: "eip155:8453:0x...",
+      settledAt: Math.floor(Date.now() / 1000),
+      settledAmount: "1000",
+      settledAsset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      payTo: "0xAgent...",
+      payer: "0xPayer...",
+      attestationSignature: "0xinvalid",
+    };
+
+    const mockVerify = vi.fn().mockResolvedValue(false);
+
+    const result = await verifyAttestation({
+      attestation,
+      taskRef: "eip155:8453:0x123...",
+      signers: [validSigner],
+      verify: mockVerify,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Signature verification failed");
+  });
+});
+
+describe("createFeedbackSubmission", () => {
+  it("should create a signed feedback submission", async () => {
+    const mockSign = vi.fn().mockResolvedValue("0xclientsig123");
+
+    const submission = await createFeedbackSubmission({
+      taskRef: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:5A2CSREG...",
+      agentId: "42",
+      reputationRegistry: "eip155:8453:0x8004B663...",
+      value: 95,
+      valueDecimals: 0,
+      tag1: "x402-delivered",
+      tag2: "proof-of-settlement",
+      clientAddress: "eip155:8453:0x857b0651...",
+      sign: mockSign,
+    });
+
+    expect(submission.taskRef).toBe("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:5A2CSREG...");
+    expect(submission.agentId).toBe("42");
+    expect(submission.value).toBe(95);
+    expect(submission.tag1).toBe("x402-delivered");
+    expect(submission.tag2).toBe("proof-of-settlement");
+    expect(submission.clientSignature).toBe("0xclientsig123");
+    expect(mockSign).toHaveBeenCalled();
+  });
+
+  it("should include facilitator attestation when provided", async () => {
+    const attestation: FacilitatorAttestation = {
+      facilitatorId: "eip155:8453:0xFac...",
+      settledAt: 1737763200,
+      settledAmount: "1000",
+      settledAsset: "0x833589...",
+      payTo: "0xAgent...",
+      payer: "0xPayer...",
+      attestationSignature: "0xfacsig",
+    };
+
+    const submission = await createFeedbackSubmission({
+      taskRef: "eip155:8453:0x123...",
+      facilitatorAttestation: attestation,
+      agentId: "42",
+      reputationRegistry: "eip155:8453:0x8004B663...",
+      value: 100,
+      clientAddress: "eip155:8453:0x857b0651...",
+      sign: vi.fn().mockResolvedValue("0xsig"),
+    });
+
+    expect(submission.facilitatorAttestation).toEqual(attestation);
+  });
+});
+
+describe("determineEvidenceTag", () => {
+  it("should return proof-of-settlement when facilitator attestation exists", () => {
+    const tag = determineEvidenceTag(true, true);
+    expect(tag).toBe("proof-of-settlement");
+  });
+
+  it("should return proof-of-service when only agent signature exists", () => {
+    const tag = determineEvidenceTag(true, false);
+    expect(tag).toBe("proof-of-service");
+  });
+
+  it("should return proof-of-payment when neither exists", () => {
+    const tag = determineEvidenceTag(false, false);
+    expect(tag).toBe("proof-of-payment");
+  });
+});
+
+describe("validateReputationExtension", () => {
+  it("should validate a correct extension", () => {
+    const extension = declareReputationExtension({
+      registrations: [
+        {
+          agentRegistry: "eip155:8453:0x8004A818...",
+          agentId: "42",
+          reputationRegistry: "eip155:8453:0x8004B663...",
+        },
+      ],
+    });
+
+    const result = validateReputationExtension(extension as ReputationRequiredExtension);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("hasReputationExtension", () => {
+  it("should return true when extension exists", () => {
+    const payload = {
+      x402Version: 2,
+      resource: { url: "https://example.com", description: "", mimeType: "" },
+      accepted: {} as any,
+      payload: {},
+      extensions: {
+        [REPUTATION]: { info: {}, schema: {} },
+      },
+    };
+
+    expect(hasReputationExtension(payload)).toBe(true);
+  });
+
+  it("should return false when no extensions", () => {
+    const payload = {
+      x402Version: 2,
+      resource: { url: "https://example.com", description: "", mimeType: "" },
+      accepted: {} as any,
+      payload: {},
+    };
+
+    expect(hasReputationExtension(payload)).toBe(false);
+  });
+});
+
+describe("findRegistrationForNetwork", () => {
+  const registrations = [
+    {
+      agentRegistry: "eip155:8453:0x8004A818...",
+      agentId: "42",
+      reputationRegistry: "eip155:8453:0x8004B663...",
+    },
+    {
+      agentRegistry: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:satiRkx...",
+      agentId: "7xKXtg...",
+      reputationRegistry: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:satiRkx...",
+    },
+  ];
+
+  it("should find EVM registration", () => {
+    const reg = findRegistrationForNetwork(registrations, "eip155:8453");
+    expect(reg?.agentId).toBe("42");
+  });
+
+  it("should find Solana registration", () => {
+    const reg = findRegistrationForNetwork(registrations, "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp");
+    expect(reg?.agentId).toBe("7xKXtg...");
+  });
+
+  it("should return undefined for unknown network", () => {
+    const reg = findRegistrationForNetwork(registrations, "eip155:1");
+    expect(reg).toBeUndefined();
+  });
+});
+
+describe("CAIP utilities", () => {
+  it("should extract network from CAIP-10", () => {
+    const network = extractNetworkFromCaip10("eip155:8453:0x8004A818...");
+    expect(network).toBe("eip155:8453");
+  });
+
+  it("should extract address from CAIP-10", () => {
+    const address = extractAddressFromCaip10("eip155:8453:0x8004A818...");
+    expect(address).toBe("0x8004A818...");
+  });
+
+  it("should handle Solana CAIP-10", () => {
+    const caip10 = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+    const network = extractNetworkFromCaip10(caip10);
+    const address = extractAddressFromCaip10(caip10);
+
+    expect(network).toBe("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp");
+    expect(address).toBe("7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU");
+  });
+});


### PR DESCRIPTION
## Summary

Adds two features to the `8004-reputation` extension that address open questions from #931:

1. **`feedbackAggregator` Protocol** - Specification for the `feedbackAggregator` field (addresses @phdargen's [question](https://github.com/coinbase/x402/pull/1024#discussion_r2030847923))
2. **`facilitatorAttestation`** - Optional settlement attestation from facilitators (builds on @MonteCrypto999's [point](https://github.com/coinbase/x402/issues/931#issuecomment-2933816144) about reputation attacks)

## Motivation

### feedbackAggregator

From @phdargen's review of #1024:
> "feedbackAggregator isn't further specified. Is this reserved for future use, outside the scope of this PR for version 1?"

This PR specifies the aggregator protocol: submission format, validation requirements, and trust model.

### facilitatorAttestation

From @MonteCrypto999 in #931:
> "At these price points, an attacker can destroy an agent's reputation with just $1 worth of payments without even consuming the services."

Facilitator attestation provides cryptographic proof from the settlement processor, adding an independent trust signal that complements agent signatures.

## Changes

- `specs/extensions/8004-reputation.md` - Added feedbackAggregator protocol and facilitatorAttestation sections
- `typescript/packages/extensions/src/reputation/` - TypeScript implementation
- `typescript/packages/extensions/test/reputation.test.ts` - Test coverage

## Design Notes

- Both features are **optional** - backward compatible with existing implementations
- Uses existing `enrichSettlementResponse` hook for attestation
- Aligns with ERC-8004's Validation Registry concept

## References

- Extends: #1024
- Discussion: #931
- ERC-8004: https://eips.ethereum.org/EIPS/eip-8004

CC: @tenequm @ruhil6789