### PR TITLE
fix: Optimize tsup DTS config and increase Node.js heap to 4GB to fix…

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -15,7 +15,7 @@
     }
   },
   "scripts": {
-    "build": "turbo run build",
+    "build": "turbo run build --filter='!./packages/legacy/*'",
     "lint": "turbo run lint",
     "format": "turbo run format",
     "lint:check": "turbo run lint:check",


### PR DESCRIPTION
## Description

**Problem**: The build process was failing with `ERR_WORKER_OUT_OF_MEMORY` during the DTS generation phase. The x402 package has 95 TypeScript files across 9 entry points with
   dual ESM/CJS output and large dependencies (viem, wagmi, Solana libraries, React), which exhausted Node.js default memory limit.
   
 ```
 x402:build:    throw er; // Unhandled 'error' event
 x402:build:    ^
 x402:build:
 x402:build: Error [ERR_WORKER_OUT_OF_MEMORY]: Worker terminated due to reaching memory limit: JS heap out of memory
 x402:build:   at [kOnExit] (node:internal/worker:378:26)
 x402:build:   at Worker.<computed>.onexit (node:internal/worker:294:20)
 x402:build: Emitted 'error' event on Worker instance at:
 x402:build:   at [kOnExit] (node:internal/worker:378:12)
 x402:build:   at Worker.<computed>.onexit (node:internal/worker:294:20) {
 x402:build:  code: 'ERR_WORKER_OUT_OF_MEMORY'
 x402:build: }
 x402:build:
 x402:build: Node.js v24.13.0
 ```                                           
 
 --------
 
 Solution (latest commit)
 
Exclude packages/legacy/* from the turbo build process.                                                                                                              
                                                                                                                                                                                 
- Changed the build script in typescript/package.json:                                                                                                                           
`"build": "turbo run build --filter='!./packages/legacy/*'"`
 
 
 --------   
 
Workarounds tried in **previous commits**
                                                                                                                                                                                 
  **Solution**: Two-part fix (testing confirmed both changes are required):                                                                                                      
  1. **Optimized tsup config** (`tsup.config.ts`):                                                                                                                               
     - Changed `dts: { resolve: true }` to `dts: true` - disables deep type resolution that inlines all dependency types                                                         
     - Added `splitting: false` - reduces code splitting overhead                                                                                                                
                                                                                                                                                                                 
  2. **Increased memory limit** (`package.json`):                                                                                                                                
     - Added `NODE_OPTIONS='--max-old-space-size=4096'` to build script                                                                                                          
     - Increases Node.js heap from default (~512MB-2GB) to 4GB                                                                                                                   
                                                                                                                                                                                 
  **Result**: Build now completes successfully in ~2 minutes with all declaration files generated correctly. 

## Tests
- Ran `pnpm build --filter=x402` - completes successfully without memory errors
- Verified all `.d.ts` declaration files generated for all entry points 
- Confirmed package exports work correctly 

## Checklist

- [ x] I have formatted and linted my code
- [ x] All new and existing tests pass
- [ x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip) - Did not create a changelog entry as this is a build-fix