### PR TITLE
feat: update mcp spec

### DIFF
--- a/specs/transports-v1/mcp.md
+++ b/specs/transports-v1/mcp.md
@@ -19,10 +19,10 @@ When a tool requires payment, servers MUST return a tool result with `isError: t
 
 ### Server Requirements
 
-Servers MUST provide `PaymentRequired` in both formats for client compatibility:
+Servers MUST provide `PaymentRequired` in `content[0].text` and SHOULD also provide `structuredContent`:
 
-1. **`structuredContent`**: Direct `PaymentRequired` object
-2. **`content[0].text`**: JSON-encoded fallback
+1. **`content[0].text`** (REQUIRED): JSON-encoded with `x402/error` wrapper
+2. **`structuredContent`** (OPTIONAL): Direct `PaymentRequired` object for enhanced client compatibility
 
 **Required Response Format:**
 

--- a/specs/transports-v1/mcp.md
+++ b/specs/transports-v1/mcp.md
@@ -2,27 +2,37 @@
 
 ## Summary
 
-The MCP transport implements x402 payment flows over the Model Context Protocol using JSON-RPC messages. This enables AI agents and MCP clients to seamlessly pay for tools and resources independent of the underlying MCP transport.
+The MCP transport implements x402 payment flows over the Model Context Protocol. This enables AI agents and MCP clients to seamlessly pay for tools and resources.
 
-The flow described below can be used for any MCP request/response cycle: tool calls, resources or client/server initialization.
+## Payment Flow Overview
+
+1. Client calls a paid tool without payment
+2. Server returns a tool result with `isError: true` and `PaymentRequired` data
+3. Client extracts payment requirements and creates a `PaymentPayload`
+4. Client retries the tool call with payment in `_meta["x402/payment"]`
+5. Server verifies payment, executes tool, settles payment
+6. Server returns tool result with settlement info in `_meta["x402/payment-response"]`
 
 ## Payment Required Signaling
 
-The server indicates payment is required using JSON-RPC's native error format with a 402 status code.
+When a tool requires payment, servers MUST return a tool result with `isError: true` containing the `PaymentRequired` data.
 
-**Mechanism**: JSON-RPC error response with `code: 402` and `PaymentRequirementsResponse` in `error.data`
-**Data Format**: `PaymentRequirementsResponse` schema in `error.data` field
+### Server Requirements
 
-**Example:**
+Servers MUST provide `PaymentRequired` in both formats for client compatibility:
+
+1. **`structuredContent`**: Direct `PaymentRequired` object
+2. **`content[0].text`**: JSON-encoded fallback
+
+**Required Response Format:**
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "error": {
-    "code": 402,
-    "message": "Payment required",
-    "data": {
+  "result": {
+    "isError": true,
+    "structuredContent": {
       "x402Version": 1,
       "error": "Payment required to access this resource",
       "accepts": [
@@ -35,7 +45,6 @@ The server indicates payment is required using JSON-RPC's native error format wi
           "resource": "mcp://tool/financial_analysis",
           "description": "Advanced financial analysis tool",
           "mimeType": "application/json",
-          "outputSchema": null,
           "maxTimeoutSeconds": 60,
           "extra": {
             "name": "USDC",
@@ -43,17 +52,51 @@ The server indicates payment is required using JSON-RPC's native error format wi
           }
         }
       ]
-    }
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"x402/error\":{\"code\":402,\"message\":\"Payment required\",\"data\":{...}}}"
+      }
+    ]
   }
 }
 ```
+
+### Client Requirements
+
+Clients MUST check for `PaymentRequired` in this priority order:
+
+1. `structuredContent` - Check for direct `PaymentRequired` object
+2. `structuredContent["x402/error"].data` - Check for wrapped format  
+3. `content[0].text` - Parse JSON and check for `PaymentRequired` or `x402/error` wrapper
+
+### x402/error Wrapper Schema
+
+The `content[0].text` fallback uses this wrapper structure:
+
+```json
+{
+  "x402/error": {
+    "code": 402,
+    "message": "Human-readable error message",
+    "data": { /* PaymentRequired */ }
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | number | MUST be `402` for payment-required errors |
+| `message` | string | Human-readable error description |
+| `data` | PaymentRequired | The payment requirements object |
 
 ## Payment Payload Transmission
 
 Clients send payment data using the MCP `_meta` field with key `x402/payment`.
 
 **Mechanism**: `_meta["x402/payment"]` field in request parameters
-**Data Format**: `PaymentPayload` schema in metadata field
+**Data Format**: `PaymentPayload` schema
 
 **Example (Tool Call with Payment):**
 
@@ -95,9 +138,9 @@ Clients send payment data using the MCP `_meta` field with key `x402/payment`.
 Servers communicate payment settlement results using the `_meta["x402/payment-response"]` field.
 
 **Mechanism**: `_meta["x402/payment-response"]` field in response result
-**Data Format**: `SettlementResponse` schema in metadata field
+**Data Format**: `SettlementResponse` schema
 
-**Example (Successful Tool Response):**
+### Successful Settlement
 
 ```json
 {
@@ -122,89 +165,46 @@ Servers communicate payment settlement results using the `_meta["x402/payment-re
 }
 ```
 
-**Example (Payment Failure):**
+### Settlement Failure
+
+When payment settlement fails, servers MUST return a tool result with `isError: true` containing the failure details. The response follows the same format as Payment Required Signaling, with additional settlement failure information.
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "error": {
-    "code": 402,
-    "message": "Payment settlement failed: insufficient funds",
-    "data": {
+  "result": {
+    "isError": true,
+    "structuredContent": {
       "x402Version": 1,
       "error": "Payment settlement failed: insufficient funds",
       "accepts": [
-        /* original payment requirements */
+        { /* original payment requirements */ }
       ],
       "x402/payment-response": {
         "success": false,
         "errorReason": "insufficient_funds",
         "transaction": "",
-        "network": "base-sepolia",
-        "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+        "network": "base-sepolia"
       }
-    }
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"x402/error\":{\"code\":402,\"message\":\"Payment settlement failed\",\"data\":{...}}}"
+      }
+    ]
   }
 }
 ```
 
 ## Error Handling
 
-MCP transport maps x402 errors to appropriate JSON-RPC mechanisms:
-
-| x402 Error       | JSON-RPC Response | Code   | Description                                                    |
-| ---------------- | ----------------- | ------ | -------------------------------------------------------------- |
-| Payment Required | Error Response    | 402    | Payment required with `PaymentRequirementsResponse` in `data` |
-| Payment Failed   | Error Response    | 402    | Payment settlement failed with failure details in `data`      |
-| Invalid Payment  | Error Response    | -32602 | Malformed payment payload or invalid parameters                |
-| Server Error     | Error Response    | -32603 | Internal server error during payment processing                |
-| Parse Error      | Error Response    | -32700 | Invalid JSON in payment payload                                |
-| Method Error     | Error Response    | -32601 | Unsupported x402 method or capability                          |
-
-### Payment-Related Errors (402)
-
-Payment-related errors use JSON-RPC's native error format with code 402 and structured data:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "error": {
-    "code": 402,
-    "message": "Payment required to access this resource",
-    "data": {
-      "x402Version": 1,
-      "error": "Payment required to access this resource",
-      "accepts": [
-        /* PaymentRequirements array */
-      ]
-    }
-  }
-}
-```
-
-### Protocol Errors (Technical Issues)
-
-Technical errors use standard JSON-RPC error responses:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "error": {
-    "code": -32602,
-    "message": "Invalid parameters: malformed payment payload in _meta['x402/payment']"
-  }
-}
-```
-
-**Common Protocol Error Examples:**
-
-- **Parse Error (-32700)**: Invalid JSON in `_meta["x402/payment"]` field
-- **Invalid Params (-32602)**: Missing required payment fields or invalid payment schema
-- **Internal Error (-32603)**: Payment processor unavailable or blockchain network error
-- **Method Not Found (-32601)**: Server doesn't support x402 payments for the requested method
+| Error Type | Response | Description |
+|------------|----------|-------------|
+| Payment Required | Tool result with `isError: true` | No payment provided, returns `PaymentRequired` |
+| Payment Invalid | Tool result with `isError: true` | Payment verification failed, returns `PaymentRequired` with reason |
+| Settlement Failed | Tool result with `isError: true` | Settlement failed after execution, returns failure details |
 
 ## References
 

--- a/specs/transports-v2/mcp.md
+++ b/specs/transports-v2/mcp.md
@@ -19,10 +19,10 @@ When a tool requires payment, servers MUST return a tool result with `isError: t
 
 ### Server Requirements
 
-Servers MUST provide `PaymentRequired` in both formats for client compatibility:
+Servers MUST provide `PaymentRequired` in `content[0].text` and SHOULD also provide `structuredContent`:
 
-1. **`structuredContent`**: Direct `PaymentRequired` object
-2. **`content[0].text`**: JSON-encoded fallback
+1. **`content[0].text`** (REQUIRED): JSON-encoded with `x402/error` wrapper
+2. **`structuredContent`** (OPTIONAL): Direct `PaymentRequired` object for enhanced client compatibility
 
 **Required Response Format:**
 

--- a/specs/transports-v2/mcp.md
+++ b/specs/transports-v2/mcp.md
@@ -17,14 +17,19 @@ The MCP transport implements x402 payment flows over the Model Context Protocol.
 
 When a tool requires payment, servers MUST return a tool result with `isError: true` containing the `PaymentRequired` data.
 
+**Mechanism**: Tool result with `isError: true`, `structuredContent`, and `content` fields  
+**Data Format**: `PaymentRequired` schema
+
 ### Server Requirements
 
-Servers MUST provide `PaymentRequired` in `content[0].text` and SHOULD also provide `structuredContent`:
+Servers MUST provide the `PaymentRequired` in both formats:
 
-1. **`content[0].text`** (REQUIRED): JSON-encoded with `x402/error` wrapper
-2. **`structuredContent`** (OPTIONAL): Direct `PaymentRequired` object for enhanced client compatibility
+1. **`structuredContent`** (REQUIRED): Direct `PaymentRequired` object
+2. **`content[0].text`** (REQUIRED): JSON-encoded string of the same `PaymentRequired` object
 
-**Required Response Format:**
+Both fields contain identical data - `content[0].text` is simply `JSON.stringify(structuredContent)` for clients that cannot access structured content.
+
+**Response Format:**
 
 ```json
 {
@@ -58,7 +63,7 @@ Servers MUST provide `PaymentRequired` in `content[0].text` and SHOULD also prov
     "content": [
       {
         "type": "text",
-        "text": "{\"x402/error\":{\"code\":402,\"message\":\"Payment required\",\"data\":{...}}}"
+        "text": "{\"x402Version\":2,\"error\":\"Payment required to access this resource\",\"resource\":{\"url\":\"mcp://tool/financial_analysis\",\"description\":\"Advanced financial analysis tool\",\"mimeType\":\"application/json\"},\"accepts\":[{\"scheme\":\"exact\",\"network\":\"eip155:84532\",\"amount\":\"10000\",\"asset\":\"0x036CbD53842c5426634e7929541eC2318f3dCF7e\",\"payTo\":\"0x209693Bc6afc0C5328bA36FaF03C514EF312287C\",\"maxTimeoutSeconds\":60,\"extra\":{\"name\":\"USDC\",\"version\":\"2\"}}]}"
       }
     ]
   }
@@ -67,31 +72,10 @@ Servers MUST provide `PaymentRequired` in `content[0].text` and SHOULD also prov
 
 ### Client Requirements
 
-Clients MUST check for `PaymentRequired` in this priority order:
+Clients SHOULD prefer `structuredContent` when available, falling back to parsing `content[0].text`:
 
-1. `structuredContent` - Check for direct `PaymentRequired` object
-2. `structuredContent["x402/error"].data` - Check for wrapped format  
-3. `content[0].text` - Parse JSON and check for `PaymentRequired` or `x402/error` wrapper
-
-### x402/error Wrapper Schema
-
-The `content[0].text` fallback uses this wrapper structure:
-
-```json
-{
-  "x402/error": {
-    "code": 402,
-    "message": "Human-readable error message",
-    "data": { /* PaymentRequired */ }
-  }
-}
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `code` | number | MUST be `402` for payment-required errors |
-| `message` | string | Human-readable error description |
-| `data` | PaymentRequired | The payment requirements object |
+1. Check if `result.structuredContent` exists and contains `x402Version` and `accepts` fields
+2. If not, parse `result.content[0].text` as JSON and check for the same fields
 
 ## Payment Payload Transmission
 
@@ -184,7 +168,7 @@ Servers communicate payment settlement results using the `_meta["x402/payment-re
 
 ### Settlement Failure
 
-When payment settlement fails, servers MUST return a tool result with `isError: true` containing the failure details. The response follows the same format as Payment Required Signaling, with additional settlement failure information.
+When payment settlement fails, servers return a tool result with `isError: true`. The response follows the same format as Payment Required Signaling. If settlement fails after the tool has already executed, the server should not return the tool's content - only the payment error.
 
 ```json
 {
@@ -194,26 +178,31 @@ When payment settlement fails, servers MUST return a tool result with `isError: 
     "isError": true,
     "structuredContent": {
       "x402Version": 2,
-      "error": "Payment settlement failed: insufficient funds",
+      "error": "Settlement failed",
       "resource": {
         "url": "mcp://tool/financial_analysis",
         "description": "Advanced financial analysis tool",
         "mimeType": "application/json"
       },
       "accepts": [
-        { /* original payment requirements */ }
-      ],
-      "x402/payment-response": {
-        "success": false,
-        "errorReason": "insufficient_funds",
-        "transaction": "",
-        "network": "eip155:84532"
-      }
+        {
+          "scheme": "exact",
+          "network": "eip155:84532",
+          "amount": "10000",
+          "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+          "maxTimeoutSeconds": 60,
+          "extra": {
+            "name": "USDC",
+            "version": "2"
+          }
+        }
+      ]
     },
     "content": [
       {
         "type": "text",
-        "text": "{\"x402/error\":{\"code\":402,\"message\":\"Payment settlement failed\",\"data\":{...}}}"
+        "text": "{\"x402Version\":2,\"error\":\"Settlement failed\",\"resource\":{\"url\":\"mcp://tool/financial_analysis\",\"description\":\"Advanced financial analysis tool\",\"mimeType\":\"application/json\"},\"accepts\":[...]}"
       }
     ]
   }
@@ -227,8 +216,6 @@ When payment settlement fails, servers MUST return a tool result with `isError: 
 | Payment Required | Tool result with `isError: true` | No payment provided, returns `PaymentRequired` |
 | Payment Invalid | Tool result with `isError: true` | Payment verification failed, returns `PaymentRequired` with reason |
 | Settlement Failed | Tool result with `isError: true` | Settlement failed after execution, returns failure details |
-
-Clients SHOULD detect the format by checking the `x402Version` field and handle both accordingly.
 
 ## References
 


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Updated the MCP transport specifications (V1 and V2) to document the actual wire protocol used by implementations.

**Why**
The previous spec described an ideal JSON-RPC error format (error.data containing PaymentRequired), but no implementation actually uses this because:
1. The MCP SDK converts JSON-RPC errors to tool results with isError: true
In this conversion, the error.data field is lost
2. Both @x402/mcp and ethanniser/x402-mcp work around this by returning tool results directly (not throwing JSON-RPC errors)
3. The spec was documenting a protocol that couldn't be implemented with the standard MCP SDK.

**The Fix**
Updated the spec to document what implementations actually do:
* **Before**: JSON-RPC error with error.data
* **After**: Tool result with isError: true, structuredContent, and content[0].text fallback
This ensures a third implementation can follow the spec and interoperate with existing implementations.

**Key Spec Changes**
1. Payment Required returns tool result with isError: true, not JSON-RPC error
2. Servers MUST provide both structuredContent and content[0].text fallback
3. Clients MUST check both formats in priority order
4. Added clear Payment Flow Overview
5. Simplified Error Handling table
