### PR TITLE
feat(evm): add MegaETH mainnet support

### DIFF
--- a/go/.changes/unreleased/megaeth-support.yaml
+++ b/go/.changes/unreleased/megaeth-support.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add MegaETH mainnet (chain ID 4326) support with USDM as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -58,6 +58,7 @@ var (
 	// Network chain IDs
 	ChainIDBase        = big.NewInt(8453)
 	ChainIDBaseSepolia = big.NewInt(84532)
+	ChainIDMegaETH     = big.NewInt(4326)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -108,6 +109,26 @@ var (
 				Name:     "USDC",
 				Version:  "2",
 				Decimals: DefaultDecimals,
+			},
+		},
+		// MegaETH Mainnet
+		"eip155:4326": {
+			ChainID: ChainIDMegaETH,
+			DefaultAsset: AssetInfo{
+				Address:  "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7", // USDM (MegaUSD)
+				Name:     "MegaUSD",
+				Version:  "1",
+				Decimals: 18,
+			},
+		},
+		// MegaETH Mainnet (legacy v1 format)
+		"megaeth": {
+			ChainID: ChainIDMegaETH,
+			DefaultAsset: AssetInfo{
+				Address:  "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+				Name:     "MegaUSD",
+				Version:  "1",
+				Decimals: 18,
 			},
 		},
 	}

--- a/python/x402/changelog.d/megaeth-support.feature.md
+++ b/python/x402/changelog.d/megaeth-support.feature.md
@@ -1,0 +1,1 @@
+Add MegaETH mainnet (chain ID 4326) support with USDM as the default stablecoin

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -159,6 +159,24 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             },
         },
     },
+    # MegaETH Mainnet
+    "eip155:4326": {
+        "chain_id": 4326,
+        "default_asset": {
+            "address": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "name": "MegaUSD",
+            "version": "1",
+            "decimals": 18,
+        },
+        "supported_assets": {
+            "USDM": {
+                "address": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+                "name": "MegaUSD",
+                "version": "1",
+                "decimals": 18,
+            },
+        },
+    },
 }
 
 # Network aliases (legacy names to CAIP-2)
@@ -170,6 +188,7 @@ NETWORK_ALIASES: dict[str, str] = {
     "mainnet": "eip155:1",
     "polygon": "eip155:137",
     "avalanche": "eip155:43114",
+    "megaeth": "eip155:4326",
 }
 
 # V1 supported networks (legacy name-based)
@@ -189,6 +208,7 @@ V1_NETWORKS = [
     "story",
     "educhain",
     "skale-base-sepolia",
+    "megaeth",
 ]
 
 # V1 network name to chain ID mapping
@@ -209,6 +229,7 @@ V1_NETWORK_CHAIN_IDS: dict[str, int] = {
     "story": 1513,
     "educhain": 656476,
     "skale-base-sepolia": 1444673419,
+    "megaeth": 4326,
 }
 
 # EIP-3009 ABIs

--- a/python/x402/tests/unit/mechanisms/svm/test_signer.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_signer.py
@@ -111,7 +111,9 @@ class TestFacilitatorKeypairSigner:
         # CompactU16(1) = 0x01, then 64 zero bytes for signature, then legacy message header
         legacy_tx_bytes = bytes([0x01])  # 1 signature
         legacy_tx_bytes += bytes(64)  # Empty signature
-        legacy_tx_bytes += bytes([0x01, 0x00, 0x00])  # Legacy header: numReqSigs=1, numReadonlySigned=0, numReadonlyUnsigned=0
+        legacy_tx_bytes += bytes(
+            [0x01, 0x00, 0x00]
+        )  # Legacy header: numReqSigs=1, numReadonlySigned=0, numReadonlyUnsigned=0
         legacy_tx_bytes += bytes([0x01])  # 1 account key
         legacy_tx_bytes += bytes(32)  # Account key
         legacy_tx_bytes += bytes(32)  # Recent blockhash

--- a/typescript/.changeset/add-megaeth-support.md
+++ b/typescript/.changeset/add-megaeth-support.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": minor
+---
+
+Add MegaETH mainnet (chain ID 4326) support with USDM as the default stablecoin

--- a/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
@@ -201,6 +201,12 @@ export class ExactEvmScheme implements SchemeNetworkServer {
         version: "2",
         decimals: 6,
       }, // Base Sepolia USDC
+      "eip155:4326": {
+        address: "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+        name: "MegaUSD",
+        version: "1",
+        decimals: 18,
+      }, // MegaETH mainnet USDM
     };
 
     const assetInfo = stablecoins[network];

--- a/typescript/packages/mechanisms/evm/src/v1/index.ts
+++ b/typescript/packages/mechanisms/evm/src/v1/index.ts
@@ -18,6 +18,7 @@ export const EVM_NETWORK_CHAIN_ID_MAP = {
   story: 1514,
   educhain: 41923,
   "skale-base-sepolia": 324705682,
+  megaeth: 4326,
 } as const;
 
 export type EvmNetworkV1 = keyof typeof EVM_NETWORK_CHAIN_ID_MAP;


### PR DESCRIPTION
Add MegaETH (chain ID 4326) with USDM as the default stablecoin.

Chain Details:
- Chain ID: 4326
- CAIP-2: eip155:4326
- RPC: https://mainnet.megaeth.com/rpc

Default Asset (USDM / MegaUSD):
- Address: 0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7
- EIP-712 name: MegaUSD
- EIP-712 version: 1
- Decimals: 18
- Supports EIP-2612 permit

Infrastructure:
- Permit2 is deployed at canonical address
- x402Permit2Proxy deployment needed for Permit2 flow

Note: USDM does not support EIP-3009, so payments will use Permit2 asset transfer method once proxy is deployed.

<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description
Add MegaETH mainnet (chain ID 4326) support with USDM as default stablecoin.

## Tests
[x] TypeScript: 35 tasks pass
[x] Go: all packages pass
[x] On-chain verification of Permit2 & USDM EIP-712 params

## Checklist
[x] Formatted/linted
[x] Tests pass  
[x] Commits signed ← needs your GPG key
[x] Changelog fragments added
