### PR TITLE
Add x402lint to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402lint/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402lint/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402lint",
+  "description": "Validate x402 payment configurations. CLI, SDK, website, and Claude skill for checking configs, addresses, networks, and amounts.",
+  "logoUrl": "/logos/x402lint.svg",
+  "websiteUrl": "https://x402lint.com",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/x402lint.svg
+++ b/typescript/site/public/logos/x402lint.svg
@@ -1,0 +1,4 @@
+<svg width="89" height="89" viewBox="0 0 89 89" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="89" height="89" fill="#00D992"/>
+<path d="M31 45L39.6786 54L58 35" stroke="white" stroke-width="11.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Summary

- Adds [x402lint](https://x402lint.com) to ecosystem partners under **Infrastructure & Tooling**

x402lint validates x402 payment configurations. Available as:
- **Website**: [x402lint.com](https://x402lint.com) — paste a config and get instant validation
- **CLI**: `npx x402lint config.json` or `npx x402lint https://your-api.com/resource`
- **SDK**: `npm i x402lint` — programmatic validation with `check()` and `validate()`
- **Claude skill**: `npx skills add https://github.com/rawgroundbeef/x402lint` — Claude generates and validates configs

## Files changed

| File | Purpose |
|------|---------|
| `typescript/site/app/ecosystem/partners-data/x402lint/metadata.json` | Partner metadata |
| `typescript/site/public/logos/x402lint.svg` | Logo |

🤖 Generated with [Claude Code](https://claude.com/claude-code)