### PR TITLE
Fix wrong links in documentation

### DIFF
--- a/docs/core-concepts/client-server.md
+++ b/docs/core-concepts/client-server.md
@@ -70,5 +70,5 @@ This interaction is stateless, HTTP-native, and compatible with both human appli
 
 Next, explore:
 
-* [Facilitator](/core-concepts/facilitator) — how servers verify and settle payments
-* [HTTP 402](/core-concepts/http-402) — how servers communicate payment requirements to clients
+* [Facilitator](/docs/core-concepts/facilitator.md) — how servers verify and settle payments
+* [HTTP 402](/docs/core-concepts/http-402.md) — how servers communicate payment requirements to clients

--- a/docs/core-concepts/facilitator.md
+++ b/docs/core-concepts/facilitator.md
@@ -57,5 +57,5 @@ The facilitator acts as an independent verification and settlement layer within 
 
 Next, explore:
 
-* [Client / Server](/core-concepts/client-server) — understand the roles and responsibilities of clients and servers
-* [HTTP 402](/core-concepts/http-402) — understand how payment requirements are communicated to clients
+* [Client / Server](/docs/core-concepts/client-server.md) — understand the roles and responsibilities of clients and servers
+* [HTTP 402](/docs/core-concepts/http-402.md) — understand how payment requirements are communicated to clients


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description
fix wrong links in documentation so that agents can read it.
<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->


## Tests
nope
<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 