### PR TITLE
fix(python): camelCase serialization + auto-wrap LocalAccount

### DIFF
--- a/python/x402/changelog.d/1120.bugfix.md
+++ b/python/x402/changelog.d/1120.bugfix.md
@@ -1,0 +1,1 @@
+Added serialize_by_alias=True to BaseX402Model so model_dump_json() produces spec-compliant camelCase by default

--- a/python/x402/changelog.d/1121.bugfix.md
+++ b/python/x402/changelog.d/1121.bugfix.md
@@ -1,0 +1,1 @@
+Auto-wrap eth_account LocalAccount in EthAccountSigner when passed to ExactEvmScheme or ExactEvmSchemeV1

--- a/python/x402/mechanisms/evm/exact/register.py
+++ b/python/x402/mechanisms/evm/exact/register.py
@@ -44,8 +44,10 @@ def register_exact_evm_client(
         Client for chaining.
     """
     from .client import ExactEvmScheme as ExactEvmClientScheme
+    from .client import _wrap_if_local_account
     from .v1.client import ExactEvmSchemeV1 as ExactEvmClientSchemeV1
 
+    signer = _wrap_if_local_account(signer)
     scheme = ExactEvmClientScheme(signer)
 
     if networks:

--- a/python/x402/mechanisms/evm/exact/v1/client.py
+++ b/python/x402/mechanisms/evm/exact/v1/client.py
@@ -1,5 +1,7 @@
 """EVM client implementation for Exact payment scheme (V1 legacy)."""
 
+from __future__ import annotations
+
 import json
 import time
 from typing import Any
@@ -33,9 +35,13 @@ class ExactEvmSchemeV1:
         """Create ExactEvmSchemeV1.
 
         Args:
-            signer: EVM signer for payment authorizations.
+            signer: EVM signer for payment authorizations. Can also be an
+                eth_account LocalAccount, which will be auto-wrapped in
+                EthAccountSigner.
         """
-        self._signer = signer
+        from ..client import _wrap_if_local_account
+
+        self._signer = _wrap_if_local_account(signer)
 
     def create_payment_payload(
         self,

--- a/python/x402/schemas/base.py
+++ b/python/x402/schemas/base.py
@@ -26,6 +26,7 @@ class BaseX402Model(BaseModel):
     model_config = ConfigDict(
         alias_generator=to_camel,
         populate_by_name=True,
+        serialize_by_alias=True,
         from_attributes=True,
     )
 

--- a/python/x402/tests/unit/http/test_utils.py
+++ b/python/x402/tests/unit/http/test_utils.py
@@ -47,6 +47,41 @@ def make_v2_payload(signature: str = "0x123") -> PaymentPayload:
     )
 
 
+class TestCamelCaseSerialization:
+    """Tests that model_dump_json() produces camelCase by default (#1120)."""
+
+    def test_payment_payload_serializes_camel_case(self):
+        """model_dump_json() should produce camelCase without by_alias."""
+        payload = make_v2_payload()
+        data = json.loads(payload.model_dump_json())
+
+        assert "x402Version" in data
+        assert "x402_version" not in data
+
+    def test_payment_requirements_serializes_camel_case(self):
+        """PaymentRequirements fields should serialize as camelCase."""
+        req = make_payment_requirements()
+        data = json.loads(req.model_dump_json())
+
+        assert "payTo" in data
+        assert "pay_to" not in data
+        assert "maxTimeoutSeconds" in data
+        assert "max_timeout_seconds" not in data
+
+    def test_payment_required_serializes_camel_case(self):
+        """PaymentRequired should serialize as camelCase."""
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+        data = json.loads(payment_required.model_dump_json())
+
+        assert "x402Version" in data
+        assert "x402_version" not in data
+        assert "payTo" in data["accepts"][0]
+        assert "maxTimeoutSeconds" in data["accepts"][0]
+
+
 class TestSafeBase64:
     """Tests for base64 encode/decode utilities."""
 


### PR DESCRIPTION
## Summary

- **#1120**: Add `serialize_by_alias=True` to `BaseX402Model.model_config` so `model_dump_json()` produces spec-compliant camelCase (`x402Version`, `payTo`, `maxTimeoutSeconds`) by default — users no longer need to pass `by_alias=True` manually
- **#1121**: Auto-wrap `eth_account.LocalAccount` in `EthAccountSigner` when passed to `ExactEvmScheme` or `ExactEvmSchemeV1`, preventing the confusing `ValueError` from mismatched `sign_typed_data` signatures

Fixes #1120
Fixes #1121

## Test plan

- [x] 3 new tests for camelCase serialization (PaymentPayload, PaymentRequirements, PaymentRequired)
- [x] 3 new tests for LocalAccount auto-wrap (auto-wrap, address preserved, no double-wrap)
- [x] All 42 existing + new tests pass