### PR TITLE
fix(ts): include PAYMENT-RESPONSE header on settlement failure responses

### DIFF
--- a/typescript/.changeset/fix-settlement-failure-header.md
+++ b/typescript/.changeset/fix-settlement-failure-header.md
@@ -1,0 +1,8 @@
+---
+'@x402/core': patch
+'@x402/express': patch
+'@x402/hono': patch
+'@x402/next': patch
+---
+
+Include PAYMENT-RESPONSE header on settlement failure responses

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -744,6 +744,8 @@ describe("x402HTTPResourceServer", () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.errorReason).toBe("Insufficient funds");
+        expect(result.headers).toBeDefined();
+        expect(result.headers["PAYMENT-RESPONSE"]).toBeDefined();
       }
     });
   });

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -240,6 +240,9 @@ export function paymentMiddlewareFromHTTPServer(
           // If settlement fails, return an error and do not send the buffered response
           if (!settleResult.success) {
             bufferedCalls = [];
+            Object.entries(settleResult.headers).forEach(([key, value]) => {
+              res.setHeader(key, value);
+            });
             res.status(402).json({
               error: "Settlement failed",
               details: settleResult.errorReason,

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -71,7 +71,10 @@ function setupMockHttpServer(
   processResult: HTTPProcessResult,
   settlementResult:
     | { success: true; headers: Record<string, string> }
-    | { success: false; errorReason: string } = { success: true, headers: {} },
+    | { success: false; errorReason: string; headers: Record<string, string> } = {
+    success: true,
+    headers: {},
+  },
 ): void {
   mockProcessHTTPRequest.mockResolvedValue(processResult);
   mockProcessSettlement.mockResolvedValue(settlementResult);
@@ -388,7 +391,11 @@ describe("paymentMiddleware", () => {
         paymentPayload: mockPaymentPayload,
         paymentRequirements: mockPaymentRequirements,
       },
-      { success: false, errorReason: "Insufficient funds" },
+      {
+        success: false,
+        errorReason: "Insufficient funds",
+        headers: { "PAYMENT-RESPONSE": "settlement-failed-encoded" },
+      },
     );
 
     const middleware = paymentMiddleware(
@@ -417,6 +424,7 @@ describe("paymentMiddleware", () => {
       },
       402,
     );
+    expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("settlement-failed-encoded");
   });
 
   it("passes paywallConfig to processHTTPRequest", async () => {

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -178,6 +178,9 @@ export function paymentMiddlewareFromHTTPServer(
               },
               402,
             );
+            Object.entries(settleResult.headers).forEach(([key, value]) => {
+              res.headers.set(key, value);
+            });
           } else {
             // Settlement succeeded - add headers to response
             Object.entries(settleResult.headers).forEach(([key, value]) => {

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -87,7 +87,10 @@ function createMockHttpServer(
   processResult: HTTPProcessResult,
   settlementResult:
     | { success: true; headers: Record<string, string> }
-    | { success: false; errorReason: string } = { success: true, headers: {} },
+    | { success: false; errorReason: string; headers: Record<string, string> } = {
+    success: true,
+    headers: {},
+  },
 ): x402HTTPResourceServer {
   return {
     processHTTPRequest: vi.fn().mockResolvedValue(processResult),
@@ -274,7 +277,11 @@ describe("paymentProxy", () => {
         paymentPayload: mockPaymentPayload,
         paymentRequirements: mockPaymentRequirements,
       },
-      { success: false, errorReason: "Insufficient funds" },
+      {
+        success: false,
+        errorReason: "Insufficient funds",
+        headers: { "PAYMENT-RESPONSE": "settlement-failed-encoded" },
+      },
     );
     setupMockCreateHttpServer(mockServer);
 
@@ -285,6 +292,7 @@ describe("paymentProxy", () => {
     const body = await response.json();
     expect(body.error).toBe("Settlement failed");
     expect(body.details).toBe("Insufficient funds");
+    expect(response.headers.get("PAYMENT-RESPONSE")).toBe("settlement-failed-encoded");
   });
 });
 
@@ -392,7 +400,11 @@ describe("withX402", () => {
         paymentPayload: mockPaymentPayload,
         paymentRequirements: mockPaymentRequirements,
       },
-      { success: false, errorReason: "Insufficient funds" },
+      {
+        success: false,
+        errorReason: "Insufficient funds",
+        headers: { "PAYMENT-RESPONSE": "settlement-failed-encoded" },
+      },
     );
     setupMockCreateHttpServer(mockServer);
     const handler = vi.fn().mockResolvedValue(NextResponse.json({ data: "protected" }));
@@ -405,6 +417,7 @@ describe("withX402", () => {
     const body = await response.json();
     expect(body.error).toBe("Settlement failed");
     expect(body.details).toBe("Insufficient funds");
+    expect(response.headers.get("PAYMENT-RESPONSE")).toBe("settlement-failed-encoded");
   });
 });
 

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -265,6 +265,7 @@ describe("handleSettlement", () => {
       errorReason: "Insufficient funds",
       transaction: "",
       network: "eip155:84532",
+      headers: { "PAYMENT-RESPONSE": "settlement-failed-encoded" },
     });
     const response = new NextResponse("OK", { status: 200 });
 
@@ -279,6 +280,7 @@ describe("handleSettlement", () => {
     const body = (await result.json()) as { error: string; details: string };
     expect(body.error).toBe("Settlement failed");
     expect(body.details).toBe("Insufficient funds");
+    expect(result.headers.get("PAYMENT-RESPONSE")).toBe("settlement-failed-encoded");
   });
 
   it("returns 402 error response when settlement throws", async () => {

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -151,7 +151,7 @@ export async function handleSettlement(
         }),
         {
           status: 402,
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", ...result.headers },
         },
       );
     }


### PR DESCRIPTION
## Description

The v2 spec requires `PAYMENT-RESPONSE` on all settlement responses (`specs/transports-v2/http.md`, lines 117-153). The TS middleware sets it on success but not on failure, so clients throw "Payment response header not found" instead of getting the structured error.

Closes #1127

### What changed

- `ProcessSettleFailureResponse` now includes `headers` (same as the success type)
- All three failure paths in `processSettlement()` generate settlement headers
- Express, Hono, and Next.js middleware set the header on failure responses, matching the success path

9 files, +69 -14.

## Tests

- Settlement failure tests across all four packages now assert `PAYMENT-RESPONSE` is present
- Failure mocks updated to match the new type
- All ~1,470 tests pass (`pnpm test` from `typescript/`), prettier and lint clean

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes