### PR TITLE
feat(specs): Add subscribe scheme specification for recurring payments

### DIFF
--- a/specs/schemes/subscribe/scheme_subscribe.md
+++ b/specs/schemes/subscribe/scheme_subscribe.md
@@ -1,0 +1,464 @@
+# Scheme: `subscribe`
+
+## Summary
+
+The `subscribe` scheme enables recurring subscription-based payments for internet resources. Unlike the `exact` scheme which transfers a specific amount per request, `subscribe` allows clients to authorize periodic payments for ongoing access to resources over a defined billing cycle.
+
+This scheme complements `exact` by enabling hybrid monetization strategies where services can offer both pay-per-use and subscription-based pricing models. Clients (including autonomous AI agents) can intelligently choose between schemes based on usage patterns and cost optimization.
+
+## Use Cases
+
+- **SaaS API Access**: Monthly/annual subscriptions for API endpoints with usage limits
+- **Premium Content**: Recurring access to paywalled articles, videos, or data feeds
+- **AI Agent Services**: Subscription plans for agents consuming multiple tools/resources
+- **Data Streams**: Continuous access to real-time market data, weather feeds, or analytics
+- **Tiered Access**: Multiple subscription tiers with different rate limits or features
+
+## Subscription Lifecycle
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         SUBSCRIPTION LIFECYCLE                               │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│   ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────────┐          │
+│   │ DISCOVER │───▶│SUBSCRIBE │───▶│  ACCESS  │───▶│RENEW/CANCEL  │          │
+│   └──────────┘    └──────────┘    └──────────┘    └──────────────┘          │
+│        │               │               │                  │                  │
+│        ▼               ▼               ▼                  ▼                  │
+│   402 Response    Pay First      Present Proof      Auto-renew or           │
+│   with tiers      Billing        Each Request       Cancel                   │
+│                   Cycle                                                      │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Phase 1: Discovery
+
+The resource server advertises subscription options alongside other payment schemes in the `402 Payment Required` response. This enables clients to compare pricing models and select the most cost-effective option.
+
+### Phase 2: Subscription Initiation
+
+The client selects a subscription tier and submits a cryptographic authorization for the first billing period. The authorization includes:
+- Selected tier identifier
+- Billing cycle duration
+- Maximum amount per cycle
+- Renewal preferences
+
+### Phase 3: Access with Subscription Proof
+
+Once subscribed, the client presents a "subscription proof" with each request. This proof is verified without requiring a new payment, enabling efficient access within the subscription period.
+
+### Phase 4: Renewal or Cancellation
+
+Before the billing cycle ends, the subscription is either:
+- **Auto-renewed**: Client pre-authorizes future payments
+- **Manually renewed**: Client submits new authorization
+- **Cancelled**: Subscription ends at cycle completion
+
+## PaymentRequirements Schema
+
+When a resource server requires subscription payment, it includes `subscribe` options in the `accepts` array:
+
+```json
+{
+  "x402Version": 2,
+  "error": "Payment required for premium access",
+  "resource": {
+    "url": "https://api.example.com/premium-data",
+    "description": "Real-time market data API",
+    "mimeType": "application/json"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "amount": "1000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "maxTimeoutSeconds": 60,
+      "extra": {
+        "name": "USDC",
+        "version": "2"
+      }
+    },
+    {
+      "scheme": "subscribe",
+      "network": "eip155:8453",
+      "amount": "5000000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "maxTimeoutSeconds": 300,
+      "extra": {
+        "name": "USDC",
+        "version": "2",
+        "subscriptionDetails": {
+          "tierId": "pro",
+          "tierName": "Pro Plan",
+          "billingCycle": "monthly",
+          "billingCycleSeconds": 2592000,
+          "features": ["unlimited_requests", "priority_support", "advanced_analytics"],
+          "rateLimits": {
+            "requestsPerMinute": 1000,
+            "requestsPerDay": 100000
+          },
+          "renewalPolicy": "auto",
+          "gracePeriodSeconds": 86400,
+          "cancellationPolicy": "end_of_cycle"
+        }
+      }
+    },
+    {
+      "scheme": "subscribe",
+      "network": "eip155:8453",
+      "amount": "50000000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "maxTimeoutSeconds": 300,
+      "extra": {
+        "name": "USDC",
+        "version": "2",
+        "subscriptionDetails": {
+          "tierId": "enterprise",
+          "tierName": "Enterprise Plan",
+          "billingCycle": "annual",
+          "billingCycleSeconds": 31536000,
+          "features": ["unlimited_requests", "dedicated_support", "custom_integrations", "sla_guarantee"],
+          "rateLimits": {
+            "requestsPerMinute": 10000,
+            "requestsPerDay": null
+          },
+          "renewalPolicy": "manual",
+          "gracePeriodSeconds": 604800,
+          "cancellationPolicy": "end_of_cycle"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Subscription-Specific Fields in `extra`
+
+| Field Name             | Type     | Required | Description                                                      |
+| ---------------------- | -------- | -------- | ---------------------------------------------------------------- |
+| `subscriptionDetails`  | `object` | Required | Container for subscription-specific configuration                |
+
+### `subscriptionDetails` Object
+
+| Field Name              | Type       | Required | Description                                                                          |
+| ----------------------- | ---------- | -------- | ------------------------------------------------------------------------------------ |
+| `tierId`                | `string`   | Required | Unique identifier for the subscription tier                                          |
+| `tierName`              | `string`   | Required | Human-readable name for the tier                                                     |
+| `billingCycle`          | `string`   | Required | Billing cycle type: `"daily"`, `"weekly"`, `"monthly"`, `"annual"`, or `"custom"`    |
+| `billingCycleSeconds`   | `number`   | Required | Duration of billing cycle in seconds                                                 |
+| `features`              | `array`    | Optional | List of features included in this tier                                               |
+| `rateLimits`            | `object`   | Optional | Rate limiting configuration for this tier                                            |
+| `renewalPolicy`         | `string`   | Required | `"auto"` for automatic renewal, `"manual"` for manual renewal                        |
+| `gracePeriodSeconds`    | `number`   | Optional | Time after expiry during which access continues while awaiting renewal               |
+| `cancellationPolicy`    | `string`   | Required | `"immediate"` or `"end_of_cycle"`                                                    |
+| `trialPeriodSeconds`    | `number`   | Optional | Duration of free trial period (if applicable)                                        |
+| `maxRenewals`           | `number`   | Optional | Maximum number of automatic renewals (null for unlimited)                            |
+
+## PaymentPayload Schema
+
+### Initial Subscription
+
+When subscribing, the client sends a `PaymentPayload` with subscription authorization:
+
+```json
+{
+  "x402Version": 2,
+  "resource": {
+    "url": "https://api.example.com/premium-data",
+    "description": "Real-time market data API",
+    "mimeType": "application/json"
+  },
+  "accepted": {
+    "scheme": "subscribe",
+    "network": "eip155:8453",
+    "amount": "5000000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "name": "USDC",
+      "version": "2",
+      "subscriptionDetails": {
+        "tierId": "pro",
+        "tierName": "Pro Plan",
+        "billingCycle": "monthly",
+        "billingCycleSeconds": 2592000,
+        "renewalPolicy": "auto",
+        "gracePeriodSeconds": 86400,
+        "cancellationPolicy": "end_of_cycle"
+      }
+    }
+  },
+  "payload": {
+    "signature": "0x...",
+    "authorization": {
+      "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "value": "5000000",
+      "validAfter": "1740672089",
+      "validBefore": "1743264089",
+      "nonce": "0x..."
+    },
+    "subscriptionPayload": {
+      "action": "subscribe",
+      "tierId": "pro",
+      "startTimestamp": "1740672089",
+      "renewalAuthorizations": []
+    }
+  }
+}
+```
+
+### Subscription Payload Fields
+
+| Field Name               | Type     | Required | Description                                                      |
+| ------------------------ | -------- | -------- | ---------------------------------------------------------------- |
+| `action`                 | `string` | Required | `"subscribe"`, `"renew"`, or `"cancel"`                          |
+| `tierId`                 | `string` | Required | The tier being subscribed to                                     |
+| `startTimestamp`         | `string` | Required | Unix timestamp when subscription begins                          |
+| `renewalAuthorizations`  | `array`  | Optional | Pre-signed authorizations for future billing cycles              |
+
+### Pre-authorized Renewals (Optional)
+
+For `auto` renewal subscriptions, clients MAY include pre-signed authorizations for future billing cycles:
+
+```json
+{
+  "renewalAuthorizations": [
+    {
+      "cycleNumber": 2,
+      "signature": "0x...",
+      "authorization": {
+        "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+        "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+        "value": "5000000",
+        "validAfter": "1743264089",
+        "validBefore": "1745856089",
+        "nonce": "0x..."
+      }
+    },
+    {
+      "cycleNumber": 3,
+      "signature": "0x...",
+      "authorization": {
+        "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+        "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+        "value": "5000000",
+        "validAfter": "1745856089",
+        "validBefore": "1748448089",
+        "nonce": "0x..."
+      }
+    }
+  ]
+}
+```
+
+## Subscription Proof (Access Verification)
+
+Once subscribed, clients present a subscription proof for subsequent requests without requiring new payments:
+
+### X-SUBSCRIPTION-PROOF Header
+
+```json
+{
+  "subscriptionId": "sub_abc123xyz",
+  "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+  "tierId": "pro",
+  "network": "eip155:8453",
+  "currentCycleStart": "1740672089",
+  "currentCycleEnd": "1743264089",
+  "signature": "0x..."
+}
+```
+
+The signature is over the subscription proof fields, signed by the subscriber's wallet, enabling cryptographic verification without blockchain queries for each request.
+
+### Subscription Proof Fields
+
+| Field Name          | Type     | Required | Description                                           |
+| ------------------- | -------- | -------- | ----------------------------------------------------- |
+| `subscriptionId`    | `string` | Required | Unique identifier issued by the resource server       |
+| `subscriber`        | `string` | Required | Wallet address of the subscriber                      |
+| `tierId`            | `string` | Required | Active subscription tier                              |
+| `network`           | `string` | Required | Network identifier in CAIP-2 format                   |
+| `currentCycleStart` | `string` | Required | Unix timestamp of current billing cycle start         |
+| `currentCycleEnd`   | `string` | Required | Unix timestamp of current billing cycle end           |
+| `signature`         | `string` | Required | Subscriber's signature over the proof fields          |
+
+## SettlementResponse Schema
+
+### Initial Subscription Settlement
+
+```json
+{
+  "success": true,
+  "transaction": "0x1234567890abcdef...",
+  "network": "eip155:8453",
+  "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+  "subscriptionDetails": {
+    "subscriptionId": "sub_abc123xyz",
+    "tierId": "pro",
+    "status": "active",
+    "currentCycleStart": "1740672089",
+    "currentCycleEnd": "1743264089",
+    "nextRenewalDate": "1743264089",
+    "autoRenewEnabled": true
+  }
+}
+```
+
+### Renewal Settlement
+
+```json
+{
+  "success": true,
+  "transaction": "0xabcdef1234567890...",
+  "network": "eip155:8453",
+  "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+  "subscriptionDetails": {
+    "subscriptionId": "sub_abc123xyz",
+    "tierId": "pro",
+    "status": "active",
+    "cycleNumber": 3,
+    "currentCycleStart": "1745856089",
+    "currentCycleEnd": "1748448089",
+    "nextRenewalDate": "1748448089",
+    "autoRenewEnabled": true
+  }
+}
+```
+
+## Verification
+
+Facilitators and resource servers MUST perform the following verification steps:
+
+### Initial Subscription Verification
+
+1. **Signature Validation**: Verify the payment signature is valid and signed by `authorization.from`
+2. **Balance Verification**: Confirm the subscriber has sufficient token balance
+3. **Amount Validation**: Ensure payment amount matches the tier's billing amount
+4. **Time Window Check**: Verify authorization is within its valid time range
+5. **Tier Validation**: Confirm the selected `tierId` exists and is available
+6. **Parameter Matching**: Ensure all parameters match the advertised `PaymentRequirements`
+7. **Transaction Simulation**: Simulate the transfer to ensure it would succeed
+
+### Subscription Proof Verification
+
+1. **Signature Validation**: Verify the proof signature matches the subscriber address
+2. **Subscription Status**: Check subscription is active (not cancelled or expired)
+3. **Time Validation**: Verify current time is within `currentCycleStart` and `currentCycleEnd`
+4. **Tier Matching**: Confirm the tier grants access to the requested resource
+5. **Rate Limit Check**: Verify subscriber hasn't exceeded tier rate limits
+
+### Renewal Verification
+
+1. **Pre-authorization Validation**: If using pre-signed renewals, verify the authorization for the current cycle
+2. **Subscription Continuity**: Verify the subscription was active in the previous cycle
+3. **Amount Consistency**: Ensure renewal amount matches the tier pricing
+
+## Settlement
+
+### Initial Subscription Settlement
+
+Settlement for the first billing cycle follows the same pattern as the `exact` scheme:
+
+1. Call `transferWithAuthorization` (EIP-3009) or `permitWitnessTransferFrom` (Permit2) with the subscription payment
+2. Record subscription details in the resource server's subscription registry
+3. Issue a `subscriptionId` to the client
+4. Return the `SettlementResponse` with subscription details
+
+### Renewal Settlement
+
+For subscriptions with pre-authorized renewals:
+
+1. At the start of each billing cycle, the facilitator executes the pre-signed authorization
+2. If the authorization fails (insufficient funds, revoked, etc.), enter grace period
+3. Notify the subscriber of renewal success or failure
+4. Update subscription status accordingly
+
+### Cancellation
+
+Cancellation does not involve a blockchain transaction but updates the subscription registry:
+
+1. Client sends cancellation request with signed proof of intent
+2. Server marks subscription for non-renewal
+3. Access continues until `currentCycleEnd` (for `end_of_cycle` policy)
+4. No refunds are processed (unless explicitly supported by the service)
+
+## Security Considerations
+
+### Replay Attack Prevention
+
+- Each authorization includes a unique nonce preventing reuse
+- Pre-signed renewal authorizations have non-overlapping validity windows
+- Subscription proofs include cycle timestamps preventing cross-cycle replay
+
+### Authorization Scope
+
+- Subscribers control the exact amount and duration of each authorization
+- Pre-signed renewals can be revoked by spending the nonce before the validity window
+- Facilitators cannot modify amounts, recipients, or timing
+
+### Subscription State Management
+
+- Resource servers MUST maintain accurate subscription state
+- Grace periods provide buffer for failed renewals without immediate access loss
+- Subscribers can query their subscription status at any time
+
+### Rate Limiting
+
+- Tier-based rate limits prevent abuse even with valid subscriptions
+- Resource servers SHOULD implement per-subscriber tracking
+- Exceeded limits SHOULD return appropriate error responses, not payment requests
+
+## Agent Optimization
+
+AI agents can automatically optimize payment strategy by comparing costs:
+
+```
+IF (expected_requests_per_cycle * exact_price) > subscription_price THEN
+    USE subscribe scheme
+ELSE
+    USE exact scheme
+END IF
+```
+
+This enables autonomous cost optimization without human intervention.
+
+## Appendix
+
+### Standard Billing Cycles
+
+| Cycle     | Seconds     | Description         |
+| --------- | ----------- | ------------------- |
+| `daily`   | 86400       | 24 hours            |
+| `weekly`  | 604800      | 7 days              |
+| `monthly` | 2592000     | 30 days             |
+| `annual`  | 31536000    | 365 days            |
+| `custom`  | (variable)  | Custom duration     |
+
+### Error Codes
+
+| Error Code                        | Description                                            |
+| --------------------------------- | ------------------------------------------------------ |
+| `subscription_not_found`          | No active subscription for the subscriber              |
+| `subscription_expired`            | Subscription has ended and was not renewed             |
+| `subscription_cancelled`          | Subscription was cancelled                             |
+| `tier_not_available`              | Requested tier is not currently available              |
+| `rate_limit_exceeded`             | Subscriber exceeded tier rate limits                   |
+| `renewal_failed`                  | Automatic renewal failed (insufficient funds, etc.)    |
+| `invalid_subscription_proof`      | Subscription proof signature or data is invalid        |
+| `grace_period_expired`            | Grace period ended without successful renewal          |
+
+### References
+
+- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009)
+- [Permit2 Documentation](https://docs.uniswap.org/contracts/permit2/overview)
+- [x402 Protocol Specification](../../x402-specification-v2.md)
+- [Exact Scheme Specification](../exact/scheme_exact.md)

--- a/specs/schemes/subscribe/scheme_subscribe.md
+++ b/specs/schemes/subscribe/scheme_subscribe.md
@@ -396,13 +396,38 @@ When subscribing, the client sends a `PaymentPayload` with the schedule commitme
 
 Cancellation uses a client-chosen `nonce` for replay protection; the registry records used nonces.
 
-## Active-Subscription Proof (Access Verification)
+## Subscription Extension (Access Verification)
 
-Once subscribed, clients present an active-subscription proof for subsequent requests without requiring new payments. The proof travels as the `subscription` extension in `PaymentPayload.extensions`.
+Once subscribed, clients present a **fresh possession proof** for subsequent requests without requiring new payments. The proof travels as the `subscription` extension in `PaymentPayload.extensions`:
 
-The resource server verifies the proof by calling `isActive(subscriptionId)` on the on-chain registry. The extension info is a **pointer to verify**, never a trusted claim.
+```json
+{
+  "extensions": {
+    "subscription": {
+      "info": {
+        "subscriptionId": "0xabcdef...",
+        "issuedAt": 1740672089,
+        "audience": "https://api.example.com",
+        "signature": "0x..."
+      }
+    }
+  }
+}
+```
 
-Full extension definition and field tables are in [`scheme_subscribe_evm.md`](./scheme_subscribe_evm.md).
+The `signature` is an EIP-712 signature over `SubscriptionAccess(bytes32 subscriptionId, uint256 issuedAt, string audience)`. The server verifies:
+
+1. The subscription exists via `getSubscription(subscriptionId)`
+2. The recovered signer equals the registry-stored subscriber (possession proof)
+3. The proof is fresh: `|now - issuedAt| <= maxProofAge` (RECOMMENDED 60 seconds)
+4. If `audience` is present, it matches the served origin
+5. The subscription `isActive()` and tier sufficiency
+
+**Why a fresh proof?** The registry's public state proves subscription existence, not requester identity. An unauthenticated echo would let anyone free-ride using on-chain public data. The short-lived signature bounds replay to `maxProofAge`; the optional `audience` further restricts replay to the intended origin.
+
+**Failure paths:** If verification fails (invalid signature, stale proof, not found, expired, cancelled, tier insufficient), the server returns `402 Payment Required` with `exact` and `subscribe` options, enabling graceful fallback to per-request payment or subscription renewal.
+
+Full extension definition, JSON Schema, EIP-712 type, verification flow, and request/response fixtures are in [`scheme_subscribe_evm.md`](./scheme_subscribe_evm.md).
 
 ## SettlementResponse Schema
 

--- a/specs/schemes/subscribe/scheme_subscribe.md
+++ b/specs/schemes/subscribe/scheme_subscribe.md
@@ -57,7 +57,7 @@ The client selects a subscription tier and:
 
 1. **Builds the Merkle schedule** from the advertised terms (see [Merkle Schedule Commitment](#merkle-schedule-commitment))
 2. **Signs an EIP-712 commitment** binding the schedule root, subscriber, asset, payTo, registry, chainId, tierId, start, expiry, and maxPerPeriod
-3. **Establishes a standing ERC-20 allowance** to the registry (gaslessly via EIP-2612 permit or Permit2, submitted by the facilitator)
+3. **Establishes a standing ERC-20 allowance** to the registry (gaslessly via EIP-2612 permit, submitted by the facilitator)
 
 ### Phase 3: Access with Subscription Proof
 
@@ -133,15 +133,11 @@ After `expiry` timestamp or a recorded `cancel`, no further charges are valid re
 
 ## Trust Model
 
-The facilitator is trusted for **liveness only**: it operates the Merkle tree and proofs off-chain and submits charges on-chain. The facilitator has **no safety authority** — it cannot:
-
-- Overcharge (fee <= maxPerPeriod, fee matches leaf, cursor is monotonic)
-- Charge early (before validFrom) or late (after validTo + gracePeriodSeconds)
-- Charge past expiry or cancel (hard on-chain checks)
-- Redirect funds (payTo/asset/registry bound in commitment)
-- Double-charge (cursor increments only on successful transfer)
+The facilitator is trusted for **liveness only**: it operates the Merkle tree and proofs off-chain and submits charges on-chain. The facilitator has **no safety authority** — it cannot overcharge, charge early/late, charge past expiry/cancel, redirect funds, or double-charge.
 
 **Facilitator compromise degrades to denial of service, never theft beyond the signed schedule.**
+
+For detailed security analysis (per-attack enumeration, replay prevention, allowance exposure, extension threat model, grace-period edge cases), see [`scheme_subscribe_evm.md` §11](./scheme_subscribe_evm.md#11-security-considerations).
 
 ## Merkle Schedule Commitment
 
@@ -202,7 +198,7 @@ The `subscriptionId` is the keccak256 hash of the ABI-encoded commitment struct,
 The client establishes an ERC-20 allowance from `subscriber` to `registry` for the total committed spend. Gasless options:
 
 - **EIP-2612 Permit**: Client signs a permit; facilitator submits it bundled with `subscribe()`
-- **Permit2**: Client signs a Permit2 allowance; facilitator submits via the Permit2 contract
+- **Permit2** (future): Deferred to a future version; see EVM network doc §2.3
 
 The allowance SHOULD equal the sum of all `fee` values in the schedule. This makes the allowance itself an on-chain aggregate cap — when it depletes, charges fail.
 
@@ -505,7 +501,7 @@ Facilitators and resource servers MUST perform the following verification steps:
 ### Initial Subscription Settlement
 
 1. Verify the EIP-712 commitment signature
-2. If gasless allowance: execute the bundled EIP-2612 permit or Permit2 approval
+2. If gasless allowance: execute the bundled EIP-2612 permit
 3. Execute `subscribe(commitment, signature)` on the registry
 4. Registry stores commitment, sets `cursor = 0`, records `start` and `expiry`
 5. Optionally charge period 0 immediately (or defer to first `chargePeriod` call)

--- a/specs/schemes/subscribe/scheme_subscribe.md
+++ b/specs/schemes/subscribe/scheme_subscribe.md
@@ -83,10 +83,10 @@ Each billing period MUST be settled at most once. The registry maintains a monot
 
 ### 2. Time-Window Validity
 
-Each charge MUST fall within the leaf's time window: `validFrom <= block.timestamp <= validTo`. Charges outside the window revert.
+Each charge MUST fall within the chargeable window: `validFrom <= block.timestamp <= validTo + gracePeriodSeconds`. The grace period extends the window to allow retries on failed charges without advancing to the next period.
 
-- Rationale: Prevents early charges (before the period starts) and late charges (after expiry or grace).
-- Implementation: The Merkle leaf encodes `(periodIndex, fee, validFrom, validTo)`; the registry verifies timestamps on every charge.
+- Rationale: Prevents early charges (before the period starts) and ensures charges happen within a bounded retry window.
+- Implementation: The Merkle leaf encodes `(periodIndex, fee, validFrom, validTo)`; the registry extends the window by `gracePeriodSeconds` (a signed commitment field) for retry tolerance.
 
 ### 3. Commitment Binding
 
@@ -136,10 +136,10 @@ After `expiry` timestamp or a recorded `cancel`, no further charges are valid re
 The facilitator is trusted for **liveness only**: it operates the Merkle tree and proofs off-chain and submits charges on-chain. The facilitator has **no safety authority** — it cannot:
 
 - Overcharge (fee <= maxPerPeriod, fee matches leaf, cursor is monotonic)
-- Charge early or late (validFrom/validTo enforced)
+- Charge early (before validFrom) or late (after validTo + gracePeriodSeconds)
 - Charge past expiry or cancel (hard on-chain checks)
 - Redirect funds (payTo/asset/registry bound in commitment)
-- Double-charge (cursor increments on success)
+- Double-charge (cursor increments only on successful transfer)
 
 **Facilitator compromise degrades to denial of service, never theft beyond the signed schedule.**
 
@@ -191,10 +191,11 @@ SubscriptionCommitment {
   uint256 start;
   uint256 expiry;
   uint256 maxPerPeriod;
+  uint256 gracePeriodSeconds;
 }
 ```
 
-The `subscriptionId` is the keccak256 hash of the ABI-encoded commitment struct, ensuring uniqueness and binding all parameters.
+The `subscriptionId` is the keccak256 hash of the ABI-encoded commitment struct, ensuring uniqueness and binding all parameters. Note that `gracePeriodSeconds` is client-signed because it extends the chargeable window and thus affects fund exposure.
 
 ### Funding: Standing Allowance
 
@@ -463,7 +464,7 @@ Facilitators and resource servers MUST perform the following verification steps:
 
 1. **Merkle Proof**: Verify the leaf `(periodIndex, fee, validFrom, validTo)` with the stored root
 2. **Cursor Check**: Verify `periodIndex == cursor`
-3. **Time Window**: Verify `validFrom <= block.timestamp <= validTo`
+3. **Time Window**: Verify `validFrom <= block.timestamp <= validTo + gracePeriodSeconds`
 4. **Fee Cap**: Verify `fee <= maxPerPeriod`
 5. **Not Cancelled/Expired**: Verify `!cancelled && block.timestamp <= expiry`
 6. **Balance/Allowance**: Verify sufficient funds for `transferFrom`
@@ -545,7 +546,7 @@ Error codes follow the V2 `invalid_<scheme>_<detail>` naming convention where ap
 | `invalid_subscribe_commitment` | Commitment signature invalid or parameter mismatch |
 | `invalid_subscribe_proof` | Merkle proof does not verify against stored root |
 | `invalid_subscribe_cursor` | periodIndex does not match current cursor |
-| `invalid_subscribe_window` | Charge attempted outside validFrom/validTo window |
+| `invalid_subscribe_window` | Charge attempted outside chargeable window [validFrom, validTo + gracePeriodSeconds] |
 | `invalid_subscribe_fee` | fee exceeds maxPerPeriod |
 | `subscription_not_found` | No subscription for the given subscriptionId |
 | `subscription_expired` | Subscription has passed its expiry timestamp |

--- a/specs/schemes/subscribe/scheme_subscribe.md
+++ b/specs/schemes/subscribe/scheme_subscribe.md
@@ -141,6 +141,8 @@ For detailed security analysis (per-attack enumeration, replay prevention, allow
 
 ## Merkle Schedule Commitment
 
+**Terminology:** This specification uses "period" for the mechanism (the indexed unit of the Merkle schedule) and "billing cycle" for the human-facing tier configuration (`billingCycle`, `billingCycleSeconds`). These map 1:1: each billing cycle corresponds to exactly one period in the schedule.
+
 ### Leaf Structure
 
 Each leaf in the Merkle tree represents one billing period:

--- a/specs/schemes/subscribe/scheme_subscribe.md
+++ b/specs/schemes/subscribe/scheme_subscribe.md
@@ -14,6 +14,19 @@ This scheme complements `exact` by enabling hybrid monetization strategies where
 - **Data Streams**: Continuous access to real-time market data, weather feeds, or analytics
 - **Tiered Access**: Multiple subscription tiers with different rate limits or features
 
+## Why Not Existing Schemes?
+
+Subscription billing requires periodic charges against a single client commitment. Existing schemes do not support this pattern:
+
+| Scheme | Limitation for Subscriptions |
+|--------|------------------------------|
+| **`exact`** / raw EIP-3009 | Single-use nonce per authorization. A 12-month subscription would require 12 separate client signatures, defeating the purpose of "authorize once, charge periodically." |
+| **`auth-capture`** | Authorize-once / capture-once semantics. The `preApprovalExpiry = now + maxTimeoutSeconds` construction (~60 seconds) cannot span a billing term measured in days or months. |
+| **`upto`** | Single settlement per authorization. After one charge, the authorization is consumed; no mechanism for subsequent periodic charges. |
+| **`batch-settlement`** | Escrow vouchers designed for micropayment aggregation. No term/tier/renewal semantics; commitment redemption is one-shot, not periodic. |
+
+The `subscribe` scheme introduces a Merkle schedule commitment that allows one client signature to authorize an entire billing schedule, with on-chain guardrails enforcing per-period caps, time windows, and a monotonic charge cursor.
+
 ## Subscription Lifecycle
 
 ```
@@ -22,13 +35,14 @@ This scheme complements `exact` by enabling hybrid monetization strategies where
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                              │
 │   ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────────┐          │
-│   │ DISCOVER │───▶│SUBSCRIBE │───▶│  ACCESS  │───▶│RENEW/CANCEL  │          │
+│   │ DISCOVER │───▶│SUBSCRIBE │───▶│  ACCESS  │───▶│ CHARGE/CANCEL│          │
 │   └──────────┘    └──────────┘    └──────────┘    └──────────────┘          │
 │        │               │               │                  │                  │
 │        ▼               ▼               ▼                  ▼                  │
-│   402 Response    Pay First      Present Proof      Auto-renew or           │
-│   with tiers      Billing        Each Request       Cancel                   │
-│                   Cycle                                                      │
+│   402 Response    Commit to       Present Proof      Facilitator             │
+│   with tiers      Schedule        Each Request       charges next            │
+│                   + Allowance                        period; no new          │
+│                                                      client signature        │
 │                                                                              │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -39,22 +53,157 @@ The resource server advertises subscription options alongside other payment sche
 
 ### Phase 2: Subscription Initiation
 
-The client selects a subscription tier and submits a cryptographic authorization for the first billing period. The authorization includes:
-- Selected tier identifier
-- Billing cycle duration
-- Maximum amount per cycle
-- Renewal preferences
+The client selects a subscription tier and:
+
+1. **Builds the Merkle schedule** from the advertised terms (see [Merkle Schedule Commitment](#merkle-schedule-commitment))
+2. **Signs an EIP-712 commitment** binding the schedule root, subscriber, asset, payTo, registry, chainId, tierId, start, expiry, and maxPerPeriod
+3. **Establishes a standing ERC-20 allowance** to the registry (gaslessly via EIP-2612 permit or Permit2, submitted by the facilitator)
 
 ### Phase 3: Access with Subscription Proof
 
-Once subscribed, the client presents a "subscription proof" with each request. This proof is verified without requiring a new payment, enabling efficient access within the subscription period.
+Once subscribed, the client presents an active-subscription proof via the `subscription` extension echoed in `PaymentPayload.extensions`. The resource server verifies the proof against the on-chain registry. No payment is required for access requests within an active subscription period.
 
-### Phase 4: Renewal or Cancellation
+### Phase 4: Periodic Charges and Cancellation
 
-Before the billing cycle ends, the subscription is either:
-- **Auto-renewed**: Client pre-authorizes future payments
-- **Manually renewed**: Client submits new authorization
-- **Cancelled**: Subscription ends at cycle completion
+At each billing period boundary:
+
+- **Charge**: The facilitator submits the next scheduled charge with a Merkle proof. No new client signature is needed — the original commitment covers the entire schedule.
+- **Cancel**: The client signs a cancellation request (with replay protection). The registry records the cancellation; no charges after the current period are possible.
+
+## Core Properties (MUST)
+
+The `subscribe` scheme MUST enforce the following properties across ALL network implementations:
+
+### 1. Per-Period Single Settlement (Monotonic Cursor)
+
+Each billing period MUST be settled at most once. The registry maintains a monotonic cursor; a charge succeeds only when `periodIndex == cursor`, and `cursor` increments on success.
+
+- Rationale: Prevents double-charging and enforces sequential billing.
+- Implementation: On EVM, the registry stores `cursor` per subscription; `chargePeriod` reverts if `periodIndex != cursor`.
+
+### 2. Time-Window Validity
+
+Each charge MUST fall within the leaf's time window: `validFrom <= block.timestamp <= validTo`. Charges outside the window revert.
+
+- Rationale: Prevents early charges (before the period starts) and late charges (after expiry or grace).
+- Implementation: The Merkle leaf encodes `(periodIndex, fee, validFrom, validTo)`; the registry verifies timestamps on every charge.
+
+### 3. Commitment Binding
+
+The client's EIP-712 commitment MUST cryptographically bind:
+
+- `subscriber` — the paying address
+- `payTo` — the recipient address
+- `asset` — the token contract
+- `registry` — the subscription registry contract
+- `chainId` — the network
+- `tierId` — the subscription tier
+- `root` — the Merkle root of the billing schedule
+
+The facilitator cannot redirect funds, change the asset, or substitute the registry.
+
+- Rationale: All critical parameters are signed; tampering is cryptographically detectable.
+- Implementation: The registry verifies the EIP-712 signature in `subscribe()` and stores the commitment hash.
+
+### 4. Per-Period Cap Enforcement
+
+The charged fee MUST NOT exceed `maxPerPeriod` from the signed commitment, regardless of what the Merkle leaf claims.
+
+- Rationale: Bounds worst-case per-charge exposure even if the facilitator provides a malicious proof.
+- Implementation: `chargePeriod` reverts if `leaf.fee > commitment.maxPerPeriod`.
+
+### 5. Aggregate Spend Bound
+
+Cumulative spend is bounded by:
+
+- The sum of fees in the signed Merkle schedule (client recomputes before signing)
+- The standing ERC-20 allowance to the registry (SHOULD equal total committed spend)
+
+When the allowance depletes or balance is insufficient, the charge fails and the subscription enters grace period.
+
+- Rationale: The allowance doubles as an on-chain aggregate cap; the client controls total exposure.
+- Implementation: The registry calls `transferFrom`; ERC-20 reverts if allowance or balance is insufficient.
+
+### 6. Expiry and Cancel Halt All Future Charges
+
+After `expiry` timestamp or a recorded `cancel`, no further charges are valid regardless of otherwise-valid Merkle proofs.
+
+- Rationale: Hard boundary on subscription lifetime; client retains exit control.
+- Implementation: `chargePeriod` checks `block.timestamp <= expiry` and `!cancelled` before any transfer.
+
+## Trust Model
+
+The facilitator is trusted for **liveness only**: it operates the Merkle tree and proofs off-chain and submits charges on-chain. The facilitator has **no safety authority** — it cannot:
+
+- Overcharge (fee <= maxPerPeriod, fee matches leaf, cursor is monotonic)
+- Charge early or late (validFrom/validTo enforced)
+- Charge past expiry or cancel (hard on-chain checks)
+- Redirect funds (payTo/asset/registry bound in commitment)
+- Double-charge (cursor increments on success)
+
+**Facilitator compromise degrades to denial of service, never theft beyond the signed schedule.**
+
+## Merkle Schedule Commitment
+
+### Leaf Structure
+
+Each leaf in the Merkle tree represents one billing period:
+
+```
+leaf = keccak256(keccak256(abi.encode(periodIndex, fee, validFrom, validTo)))
+```
+
+The double-hash follows the OpenZeppelin MerkleProof convention to prevent second-preimage attacks.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `periodIndex` | `uint256` | Zero-indexed billing period number |
+| `fee` | `uint256` | Amount to charge for this period (in token atomic units) |
+| `validFrom` | `uint256` | Unix timestamp when this period's charge becomes valid |
+| `validTo` | `uint256` | Unix timestamp when this period's charge expires |
+
+### Tree Construction
+
+Clients MUST build the Merkle tree themselves from the advertised `subscriptionDetails`:
+
+1. For each period `i` from `0` to `N-1`:
+   - `validFrom = start + (i * billingCycleSeconds)`
+   - `validTo = start + ((i + 1) * billingCycleSeconds) + gracePeriodSeconds`
+   - `fee = amount` (from `PaymentRequirements`)
+2. Compute each leaf using the double-hash formula
+3. Build a binary Merkle tree; the root is `root`
+
+**Critical**: Clients MUST NOT sign a root they did not recompute. Blind-signing a facilitator-provided root would allow arbitrary charges.
+
+### EIP-712 Commitment
+
+The client signs an EIP-712 typed data structure:
+
+```
+SubscriptionCommitment {
+  bytes32 root;
+  address subscriber;
+  address asset;
+  address payTo;
+  address registry;
+  uint256 chainId;
+  string tierId;
+  uint256 start;
+  uint256 expiry;
+  uint256 maxPerPeriod;
+}
+```
+
+The `subscriptionId` is the keccak256 hash of the ABI-encoded commitment struct, ensuring uniqueness and binding all parameters.
+
+### Funding: Standing Allowance
+
+The client establishes an ERC-20 allowance from `subscriber` to `registry` for the total committed spend. Gasless options:
+
+- **EIP-2612 Permit**: Client signs a permit; facilitator submits it bundled with `subscribe()`
+- **Permit2**: Client signs a Permit2 allowance; facilitator submits via the Permit2 contract
+
+The allowance SHOULD equal the sum of all `fee` values in the schedule. This makes the allowance itself an on-chain aggregate cap — when it depletes, charges fail.
 
 ## PaymentRequirements Schema
 
@@ -92,17 +241,18 @@ When a resource server requires subscription payment, it includes `subscribe` op
       "extra": {
         "name": "USDC",
         "version": "2",
+        "registry": "0x402SubscriptionRegistryAddress",
         "subscriptionDetails": {
           "tierId": "pro",
           "tierName": "Pro Plan",
           "billingCycle": "monthly",
           "billingCycleSeconds": 2592000,
+          "periodCount": 12,
           "features": ["unlimited_requests", "priority_support", "advanced_analytics"],
           "rateLimits": {
             "requestsPerMinute": 1000,
             "requestsPerDay": 100000
           },
-          "renewalPolicy": "auto",
           "gracePeriodSeconds": 86400,
           "cancellationPolicy": "end_of_cycle"
         }
@@ -118,17 +268,18 @@ When a resource server requires subscription payment, it includes `subscribe` op
       "extra": {
         "name": "USDC",
         "version": "2",
+        "registry": "0x402SubscriptionRegistryAddress",
         "subscriptionDetails": {
           "tierId": "enterprise",
           "tierName": "Enterprise Plan",
           "billingCycle": "annual",
           "billingCycleSeconds": 31536000,
+          "periodCount": 1,
           "features": ["unlimited_requests", "dedicated_support", "custom_integrations", "sla_guarantee"],
           "rateLimits": {
             "requestsPerMinute": 10000,
             "requestsPerDay": null
           },
-          "renewalPolicy": "manual",
           "gracePeriodSeconds": 604800,
           "cancellationPolicy": "end_of_cycle"
         }
@@ -140,31 +291,31 @@ When a resource server requires subscription payment, it includes `subscribe` op
 
 ### Subscription-Specific Fields in `extra`
 
-| Field Name             | Type     | Required | Description                                                      |
-| ---------------------- | -------- | -------- | ---------------------------------------------------------------- |
-| `subscriptionDetails`  | `object` | Required | Container for subscription-specific configuration                |
+| Field Name | Type | Required | Description |
+|------------|------|----------|-------------|
+| `registry` | `string` | Required | Address of the on-chain SubscriptionRegistry contract |
+| `subscriptionDetails` | `object` | Required | Container for subscription-specific configuration |
 
 ### `subscriptionDetails` Object
 
-| Field Name              | Type       | Required | Description                                                                          |
-| ----------------------- | ---------- | -------- | ------------------------------------------------------------------------------------ |
-| `tierId`                | `string`   | Required | Unique identifier for the subscription tier                                          |
-| `tierName`              | `string`   | Required | Human-readable name for the tier                                                     |
-| `billingCycle`          | `string`   | Required | Billing cycle type: `"daily"`, `"weekly"`, `"monthly"`, `"annual"`, or `"custom"`    |
-| `billingCycleSeconds`   | `number`   | Required | Duration of billing cycle in seconds                                                 |
-| `features`              | `array`    | Optional | List of features included in this tier                                               |
-| `rateLimits`            | `object`   | Optional | Rate limiting configuration for this tier                                            |
-| `renewalPolicy`         | `string`   | Required | `"auto"` for automatic renewal, `"manual"` for manual renewal                        |
-| `gracePeriodSeconds`    | `number`   | Optional | Time after expiry during which access continues while awaiting renewal               |
-| `cancellationPolicy`    | `string`   | Required | `"immediate"` or `"end_of_cycle"`                                                    |
-| `trialPeriodSeconds`    | `number`   | Optional | Duration of free trial period (if applicable)                                        |
-| `maxRenewals`           | `number`   | Optional | Maximum number of automatic renewals (null for unlimited)                            |
+| Field Name | Type | Required | Description |
+|------------|------|----------|-------------|
+| `tierId` | `string` | Required | Unique identifier for the subscription tier |
+| `tierName` | `string` | Required | Human-readable name for the tier |
+| `billingCycle` | `string` | Required | Billing cycle type: `"daily"`, `"weekly"`, `"monthly"`, `"annual"`, or `"custom"` |
+| `billingCycleSeconds` | `number` | Required | Duration of billing cycle in seconds |
+| `periodCount` | `number` | Required | Number of billing periods in the subscription term |
+| `features` | `array` | Optional | List of features included in this tier |
+| `rateLimits` | `object` | Optional | Rate limiting configuration for this tier |
+| `gracePeriodSeconds` | `number` | Optional | Time after a failed charge during which access continues |
+| `cancellationPolicy` | `string` | Required | `"immediate"` or `"end_of_cycle"` |
+| `trialPeriodSeconds` | `number` | Optional | Duration of free trial period (if applicable) |
 
 ## PaymentPayload Schema
 
-### Initial Subscription
+### Subscribe Action
 
-When subscribing, the client sends a `PaymentPayload` with subscription authorization:
+When subscribing, the client sends a `PaymentPayload` with the schedule commitment:
 
 ```json
 {
@@ -184,112 +335,73 @@ When subscribing, the client sends a `PaymentPayload` with subscription authoriz
     "extra": {
       "name": "USDC",
       "version": "2",
+      "registry": "0x402SubscriptionRegistryAddress",
       "subscriptionDetails": {
         "tierId": "pro",
         "tierName": "Pro Plan",
         "billingCycle": "monthly",
         "billingCycleSeconds": 2592000,
-        "renewalPolicy": "auto",
+        "periodCount": 12,
         "gracePeriodSeconds": 86400,
         "cancellationPolicy": "end_of_cycle"
       }
     }
   },
   "payload": {
-    "signature": "0x...",
-    "authorization": {
-      "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-      "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-      "value": "5000000",
-      "validAfter": "1740672089",
-      "validBefore": "1743264089",
-      "nonce": "0x..."
-    },
-    "subscriptionPayload": {
-      "action": "subscribe",
+    "action": "subscribe",
+    "commitment": {
+      "root": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "registry": "0x402SubscriptionRegistryAddress",
+      "chainId": 8453,
       "tierId": "pro",
-      "startTimestamp": "1740672089",
-      "renewalAuthorizations": []
-    }
+      "start": "1740672089",
+      "expiry": "1772208089",
+      "maxPerPeriod": "5000000"
+    },
+    "commitmentSignature": "0x...",
+    "allowanceMethod": "eip2612-permit",
+    "bundledPermitSignature": "0x..."
   }
 }
 ```
 
 ### Subscription Payload Fields
 
-| Field Name               | Type     | Required | Description                                                      |
-| ------------------------ | -------- | -------- | ---------------------------------------------------------------- |
-| `action`                 | `string` | Required | `"subscribe"`, `"renew"`, or `"cancel"`                          |
-| `tierId`                 | `string` | Required | The tier being subscribed to                                     |
-| `startTimestamp`         | `string` | Required | Unix timestamp when subscription begins                          |
-| `renewalAuthorizations`  | `array`  | Optional | Pre-signed authorizations for future billing cycles              |
+| Field Name | Type | Required | Description |
+|------------|------|----------|-------------|
+| `action` | `string` | Required | `"subscribe"`, `"cancel"`, or `"updateRoot"` |
+| `commitment` | `object` | Required | The EIP-712 commitment struct (for subscribe/updateRoot) |
+| `commitmentSignature` | `string` | Required | EIP-712 signature over the commitment |
+| `allowanceMethod` | `string` | Required | `"eip2612-permit"`, `"permit2"`, or `"direct-approve"` |
+| `bundledPermitSignature` | `string` | Conditional | Required if `allowanceMethod` is `"eip2612-permit"` or `"permit2"` |
 
-### Pre-authorized Renewals (Optional)
-
-For `auto` renewal subscriptions, clients MAY include pre-signed authorizations for future billing cycles:
-
-```json
-{
-  "renewalAuthorizations": [
-    {
-      "cycleNumber": 2,
-      "signature": "0x...",
-      "authorization": {
-        "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-        "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-        "value": "5000000",
-        "validAfter": "1743264089",
-        "validBefore": "1745856089",
-        "nonce": "0x..."
-      }
-    },
-    {
-      "cycleNumber": 3,
-      "signature": "0x...",
-      "authorization": {
-        "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-        "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-        "value": "5000000",
-        "validAfter": "1745856089",
-        "validBefore": "1748448089",
-        "nonce": "0x..."
-      }
-    }
-  ]
-}
-```
-
-## Subscription Proof (Access Verification)
-
-Once subscribed, clients present a subscription proof for subsequent requests without requiring new payments:
-
-### X-SUBSCRIPTION-PROOF Header
+### Cancel Action
 
 ```json
 {
-  "subscriptionId": "sub_abc123xyz",
-  "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-  "tierId": "pro",
-  "network": "eip155:8453",
-  "currentCycleStart": "1740672089",
-  "currentCycleEnd": "1743264089",
-  "signature": "0x..."
+  "x402Version": 2,
+  "accepted": { "scheme": "subscribe", "..." : "..." },
+  "payload": {
+    "action": "cancel",
+    "subscriptionId": "0xabcdef...",
+    "nonce": "12345",
+    "signature": "0x..."
+  }
 }
 ```
 
-The signature is over the subscription proof fields, signed by the subscriber's wallet, enabling cryptographic verification without blockchain queries for each request.
+Cancellation uses a client-chosen `nonce` for replay protection; the registry records used nonces.
 
-### Subscription Proof Fields
+## Active-Subscription Proof (Access Verification)
 
-| Field Name          | Type     | Required | Description                                           |
-| ------------------- | -------- | -------- | ----------------------------------------------------- |
-| `subscriptionId`    | `string` | Required | Unique identifier issued by the resource server       |
-| `subscriber`        | `string` | Required | Wallet address of the subscriber                      |
-| `tierId`            | `string` | Required | Active subscription tier                              |
-| `network`           | `string` | Required | Network identifier in CAIP-2 format                   |
-| `currentCycleStart` | `string` | Required | Unix timestamp of current billing cycle start         |
-| `currentCycleEnd`   | `string` | Required | Unix timestamp of current billing cycle end           |
-| `signature`         | `string` | Required | Subscriber's signature over the proof fields          |
+Once subscribed, clients present an active-subscription proof for subsequent requests without requiring new payments. The proof travels as the `subscription` extension in `PaymentPayload.extensions`.
+
+The resource server verifies the proof by calling `isActive(subscriptionId)` on the on-chain registry. The extension info is a **pointer to verify**, never a trusted claim.
+
+Full extension definition and field tables are in [`scheme_subscribe_evm.md`](./scheme_subscribe_evm.md).
 
 ## SettlementResponse Schema
 
@@ -301,19 +413,19 @@ The signature is over the subscription proof fields, signed by the subscriber's 
   "transaction": "0x1234567890abcdef...",
   "network": "eip155:8453",
   "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-  "subscriptionDetails": {
-    "subscriptionId": "sub_abc123xyz",
+  "extra": {
+    "subscriptionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
     "tierId": "pro",
     "status": "active",
-    "currentCycleStart": "1740672089",
-    "currentCycleEnd": "1743264089",
-    "nextRenewalDate": "1743264089",
-    "autoRenewEnabled": true
+    "cursor": 0,
+    "currentPeriodStart": "1740672089",
+    "currentPeriodEnd": "1743264089",
+    "expiry": "1772208089"
   }
 }
 ```
 
-### Renewal Settlement
+### Charge Settlement
 
 ```json
 {
@@ -321,15 +433,15 @@ The signature is over the subscription proof fields, signed by the subscriber's 
   "transaction": "0xabcdef1234567890...",
   "network": "eip155:8453",
   "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-  "subscriptionDetails": {
-    "subscriptionId": "sub_abc123xyz",
+  "extra": {
+    "subscriptionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
     "tierId": "pro",
     "status": "active",
-    "cycleNumber": 3,
-    "currentCycleStart": "1745856089",
-    "currentCycleEnd": "1748448089",
-    "nextRenewalDate": "1748448089",
-    "autoRenewEnabled": true
+    "cursor": 3,
+    "periodIndex": 3,
+    "fee": "5000000",
+    "currentPeriodStart": "1748448089",
+    "currentPeriodEnd": "1751040089"
   }
 }
 ```
@@ -338,84 +450,65 @@ The signature is over the subscription proof fields, signed by the subscriber's 
 
 Facilitators and resource servers MUST perform the following verification steps:
 
-### Initial Subscription Verification
+### Subscription Initiation Verification
 
-1. **Signature Validation**: Verify the payment signature is valid and signed by `authorization.from`
-2. **Balance Verification**: Confirm the subscriber has sufficient token balance
-3. **Amount Validation**: Ensure payment amount matches the tier's billing amount
-4. **Time Window Check**: Verify authorization is within its valid time range
-5. **Tier Validation**: Confirm the selected `tierId` exists and is available
-6. **Parameter Matching**: Ensure all parameters match the advertised `PaymentRequirements`
-7. **Transaction Simulation**: Simulate the transfer to ensure it would succeed
+1. **Commitment Signature**: Verify the EIP-712 signature over `commitment` recovers to `commitment.subscriber`
+2. **Root Recomputation**: Verify the client-provided `root` matches a tree built from the advertised `subscriptionDetails`
+3. **Parameter Binding**: Ensure `commitment.payTo`, `commitment.asset`, `commitment.registry`, `commitment.chainId` match the `PaymentRequirements`
+4. **Allowance Check**: Verify sufficient allowance exists (or bundled permit is valid)
+5. **Balance Verification**: Confirm the subscriber has sufficient token balance for at least the first period
+6. **Tier Validation**: Confirm the selected `tierId` exists and is available
 
-### Subscription Proof Verification
+### Charge Verification (per period)
 
-1. **Signature Validation**: Verify the proof signature matches the subscriber address
-2. **Subscription Status**: Check subscription is active (not cancelled or expired)
-3. **Time Validation**: Verify current time is within `currentCycleStart` and `currentCycleEnd`
-4. **Tier Matching**: Confirm the tier grants access to the requested resource
-5. **Rate Limit Check**: Verify subscriber hasn't exceeded tier rate limits
+1. **Merkle Proof**: Verify the leaf `(periodIndex, fee, validFrom, validTo)` with the stored root
+2. **Cursor Check**: Verify `periodIndex == cursor`
+3. **Time Window**: Verify `validFrom <= block.timestamp <= validTo`
+4. **Fee Cap**: Verify `fee <= maxPerPeriod`
+5. **Not Cancelled/Expired**: Verify `!cancelled && block.timestamp <= expiry`
+6. **Balance/Allowance**: Verify sufficient funds for `transferFrom`
 
-### Renewal Verification
+### Active-Subscription Proof Verification
 
-1. **Pre-authorization Validation**: If using pre-signed renewals, verify the authorization for the current cycle
-2. **Subscription Continuity**: Verify the subscription was active in the previous cycle
-3. **Amount Consistency**: Ensure renewal amount matches the tier pricing
+1. **Registry Query**: Call `isActive(subscriptionId)` on-chain
+2. **Tier Matching**: Confirm the tier grants access to the requested resource
+3. **Rate Limit Check**: Verify subscriber hasn't exceeded tier rate limits
 
 ## Settlement
 
 ### Initial Subscription Settlement
 
-Settlement for the first billing cycle follows the same pattern as the `exact` scheme:
+1. Verify the EIP-712 commitment signature
+2. If gasless allowance: execute the bundled EIP-2612 permit or Permit2 approval
+3. Execute `subscribe(commitment, signature)` on the registry
+4. Registry stores commitment, sets `cursor = 0`, records `start` and `expiry`
+5. Optionally charge period 0 immediately (or defer to first `chargePeriod` call)
+6. Return `SettlementResponse` with `subscriptionId`
 
-1. Call `transferWithAuthorization` (EIP-3009) or `permitWitnessTransferFrom` (Permit2) with the subscription payment
-2. Record subscription details in the resource server's subscription registry
-3. Issue a `subscriptionId` to the client
-4. Return the `SettlementResponse` with subscription details
+### Periodic Charge Settlement
 
-### Renewal Settlement
+1. Facilitator constructs the Merkle proof for the current `periodIndex`
+2. Execute `chargePeriod(subscriptionId, periodIndex, fee, validFrom, validTo, proof)` on the registry
+3. Registry verifies proof, time window, cursor, fee cap; calls `transferFrom(subscriber, payTo, fee)`
+4. Registry increments `cursor`
+5. Return `SettlementResponse` with updated status
 
-For subscriptions with pre-authorized renewals:
+### Grace Period Handling
 
-1. At the start of each billing cycle, the facilitator executes the pre-signed authorization
-2. If the authorization fails (insufficient funds, revoked, etc.), enter grace period
-3. Notify the subscriber of renewal success or failure
-4. Update subscription status accordingly
+If `chargePeriod` fails (insufficient balance/allowance):
+
+1. Registry enters grace state: `inGracePeriod = true`, `gracePeriodEnd = validTo + gracePeriodSeconds`
+2. Access continues during grace period
+3. A successful charge within grace restores active status
+4. If `block.timestamp > gracePeriodEnd` without successful charge, subscription becomes inactive
 
 ### Cancellation
 
-Cancellation does not involve a blockchain transaction but updates the subscription registry:
-
-1. Client sends cancellation request with signed proof of intent
-2. Server marks subscription for non-renewal
-3. Access continues until `currentCycleEnd` (for `end_of_cycle` policy)
-4. No refunds are processed (unless explicitly supported by the service)
-
-## Security Considerations
-
-### Replay Attack Prevention
-
-- Each authorization includes a unique nonce preventing reuse
-- Pre-signed renewal authorizations have non-overlapping validity windows
-- Subscription proofs include cycle timestamps preventing cross-cycle replay
-
-### Authorization Scope
-
-- Subscribers control the exact amount and duration of each authorization
-- Pre-signed renewals can be revoked by spending the nonce before the validity window
-- Facilitators cannot modify amounts, recipients, or timing
-
-### Subscription State Management
-
-- Resource servers MUST maintain accurate subscription state
-- Grace periods provide buffer for failed renewals without immediate access loss
-- Subscribers can query their subscription status at any time
-
-### Rate Limiting
-
-- Tier-based rate limits prevent abuse even with valid subscriptions
-- Resource servers SHOULD implement per-subscriber tracking
-- Exceeded limits SHOULD return appropriate error responses, not payment requests
+1. Client signs `{ subscriptionId, nonce }` (replay-protected by client-chosen nonce)
+2. Facilitator submits `cancel(subscriptionId, nonce, signature)` to registry
+3. Registry verifies signature, records `cancelled = true`, stores used nonce
+4. Access continues until current period ends (for `end_of_cycle` policy)
+5. All future `chargePeriod` calls revert
 
 ## Agent Optimization
 
@@ -435,30 +528,45 @@ This enables autonomous cost optimization without human intervention.
 
 ### Standard Billing Cycles
 
-| Cycle     | Seconds     | Description         |
-| --------- | ----------- | ------------------- |
-| `daily`   | 86400       | 24 hours            |
-| `weekly`  | 604800      | 7 days              |
-| `monthly` | 2592000     | 30 days             |
-| `annual`  | 31536000    | 365 days            |
-| `custom`  | (variable)  | Custom duration     |
+| Cycle | Seconds | Description |
+|-------|---------|-------------|
+| `daily` | 86400 | 24 hours |
+| `weekly` | 604800 | 7 days |
+| `monthly` | 2592000 | 30 days |
+| `annual` | 31536000 | 365 days |
+| `custom` | (variable) | Custom duration |
 
 ### Error Codes
 
-| Error Code                        | Description                                            |
-| --------------------------------- | ------------------------------------------------------ |
-| `subscription_not_found`          | No active subscription for the subscriber              |
-| `subscription_expired`            | Subscription has ended and was not renewed             |
-| `subscription_cancelled`          | Subscription was cancelled                             |
-| `tier_not_available`              | Requested tier is not currently available              |
-| `rate_limit_exceeded`             | Subscriber exceeded tier rate limits                   |
-| `renewal_failed`                  | Automatic renewal failed (insufficient funds, etc.)    |
-| `invalid_subscription_proof`      | Subscription proof signature or data is invalid        |
-| `grace_period_expired`            | Grace period ended without successful renewal          |
+Error codes follow the V2 `invalid_<scheme>_<detail>` naming convention where applicable.
+
+| Error Code | Description |
+|------------|-------------|
+| `invalid_subscribe_commitment` | Commitment signature invalid or parameter mismatch |
+| `invalid_subscribe_proof` | Merkle proof does not verify against stored root |
+| `invalid_subscribe_cursor` | periodIndex does not match current cursor |
+| `invalid_subscribe_window` | Charge attempted outside validFrom/validTo window |
+| `invalid_subscribe_fee` | fee exceeds maxPerPeriod |
+| `subscription_not_found` | No subscription for the given subscriptionId |
+| `subscription_expired` | Subscription has passed its expiry timestamp |
+| `subscription_cancelled` | Subscription was cancelled |
+| `charge_failed` | Periodic charge failed (insufficient funds/allowance) |
+| `tier_not_available` | Requested tier is not currently available |
+| `rate_limit_exceeded` | Subscriber exceeded tier rate limits |
+| `grace_period_expired` | Grace period ended without successful charge |
+
+### Network-Specific Implementation
+
+Network-specific rules and implementation details are defined in the per-network scheme documents:
+
+- EVM chains: See [`scheme_subscribe_evm.md`](./scheme_subscribe_evm.md)
 
 ### References
 
-- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009)
+- [EIP-712: Typed Structured Data Hashing and Signing](https://eips.ethereum.org/EIPS/eip-712)
+- [EIP-2612: Permit Extension for ERC-20](https://eips.ethereum.org/EIPS/eip-2612)
+- [OpenZeppelin MerkleProof](https://docs.openzeppelin.com/contracts/4.x/api/utils#MerkleProof)
 - [Permit2 Documentation](https://docs.uniswap.org/contracts/permit2/overview)
 - [x402 Protocol Specification](../../x402-specification-v2.md)
 - [Exact Scheme Specification](../exact/scheme_exact.md)
+- [Upto Scheme Specification](../upto/scheme_upto.md)

--- a/specs/schemes/subscribe/scheme_subscribe_evm.md
+++ b/specs/schemes/subscribe/scheme_subscribe_evm.md
@@ -1,0 +1,1161 @@
+# Scheme: `subscribe` on `EVM`
+
+## Summary
+
+The `subscribe` scheme on EVM enables recurring subscription-based payments where the Facilitator pays gas costs while subscribers control the exact flow of funds via cryptographic signatures.
+
+This is implemented via two components:
+
+| Component                    | Purpose                                                                |
+| :--------------------------- | :--------------------------------------------------------------------- |
+| **1. Payment Authorization** | Uses EIP-3009 or Permit2 for each billing cycle payment                |
+| **2. Subscription Registry** | On-chain or off-chain registry tracking subscription state and proofs  |
+
+The scheme supports two subscription models:
+
+| Model                        | Description                                                            | Recommendation                                    |
+| :--------------------------- | :--------------------------------------------------------------------- | :------------------------------------------------ |
+| **Pre-authorized Renewals**  | Client signs multiple future authorizations upfront                    | **Recommended** (Seamless auto-renewal)           |
+| **On-demand Renewals**       | Client signs each renewal when prompted                                | **Flexible** (More control, requires interaction) |
+
+In all cases, the Facilitator cannot modify amounts, recipients, or timing. They serve only as the transaction broadcaster and subscription state manager.
+
+---
+
+## 1. Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│                         SUBSCRIBE SCHEME - EVM ARCHITECTURE                      │
+├─────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│   ┌──────────┐         ┌──────────────┐         ┌────────────────────┐          │
+│   │  CLIENT  │────────▶│  FACILITATOR │────────▶│  x402Subscription  │          │
+│   │          │         │              │         │     Registry       │          │
+│   └──────────┘         └──────────────┘         └────────────────────┘          │
+│        │                      │                          │                       │
+│        │ Signs EIP-3009       │ Broadcasts TX            │ Stores subscription   │
+│        │ authorizations       │ Pays gas                 │ state on-chain        │
+│        │                      │                          │                       │
+│        ▼                      ▼                          ▼                       │
+│   ┌──────────┐         ┌──────────────┐         ┌────────────────────┐          │
+│   │  WALLET  │         │  ERC-20      │         │  RESOURCE SERVER   │          │
+│   │          │         │  (USDC)      │         │                    │          │
+│   └──────────┘         └──────────────┘         └────────────────────┘          │
+│                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Payment Authorization Methods
+
+### 2.1 EIP-3009 (Recommended for USDC)
+
+For tokens supporting `transferWithAuthorization`, each billing cycle payment uses a standard EIP-3009 signature.
+
+**EIP-712 Domain:**
+
+```javascript
+const domain = {
+  name: "USD Coin",      // Token name
+  version: "2",          // Token version
+  chainId: 8453,         // Base mainnet
+  verifyingContract: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+};
+```
+
+**Authorization Types:**
+
+```javascript
+const subscribeAuthorizationTypes = {
+  TransferWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" }
+  ]
+};
+```
+
+### 2.2 Permit2 (Universal Fallback)
+
+For tokens without EIP-3009 support, use Permit2 with the x402SubscriptionProxy contract.
+
+**Witness Type for Subscriptions:**
+
+```javascript
+const SUBSCRIPTION_WITNESS_TYPE_STRING =
+  "SubscriptionWitness witness)SubscriptionWitness(address to,uint256 validAfter,bytes32 subscriptionId,uint256 cycleNumber,bytes extra)TokenPermissions(address token,uint256 amount)";
+
+const SUBSCRIPTION_WITNESS_TYPEHASH = keccak256(
+  "SubscriptionWitness(address to,uint256 validAfter,bytes32 subscriptionId,uint256 cycleNumber,bytes extra)"
+);
+```
+
+---
+
+## 3. PaymentPayload Structure
+
+### 3.1 Initial Subscription (EIP-3009)
+
+```json
+{
+  "x402Version": 2,
+  "resource": {
+    "url": "https://api.example.com/premium-data",
+    "description": "Real-time market data API",
+    "mimeType": "application/json"
+  },
+  "accepted": {
+    "scheme": "subscribe",
+    "network": "eip155:8453",
+    "amount": "5000000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "assetTransferMethod": "eip3009",
+      "name": "USDC",
+      "version": "2",
+      "subscriptionDetails": {
+        "tierId": "pro",
+        "tierName": "Pro Plan",
+        "billingCycle": "monthly",
+        "billingCycleSeconds": 2592000,
+        "renewalPolicy": "auto",
+        "gracePeriodSeconds": 86400
+      }
+    }
+  },
+  "payload": {
+    "signature": "0x...",
+    "authorization": {
+      "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "value": "5000000",
+      "validAfter": "1740672089",
+      "validBefore": "1743264089",
+      "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
+    },
+    "subscriptionPayload": {
+      "action": "subscribe",
+      "tierId": "pro",
+      "startTimestamp": "1740672089",
+      "renewalAuthorizations": [
+        {
+          "cycleNumber": 2,
+          "signature": "0x...",
+          "authorization": {
+            "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+            "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+            "value": "5000000",
+            "validAfter": "1743264089",
+            "validBefore": "1745856089",
+            "nonce": "0x..."
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### 3.2 Initial Subscription (Permit2)
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "subscribe",
+    "network": "eip155:8453",
+    "amount": "5000000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "assetTransferMethod": "permit2",
+      "name": "USDC",
+      "version": "2",
+      "subscriptionDetails": {
+        "tierId": "pro",
+        "billingCycle": "monthly",
+        "billingCycleSeconds": 2592000,
+        "renewalPolicy": "auto"
+      }
+    }
+  },
+  "payload": {
+    "signature": "0x...",
+    "permit2Authorization": {
+      "permitted": {
+        "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        "amount": "5000000"
+      },
+      "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      "spender": "0x_x402SubscriptionProxyAddress",
+      "nonce": "0x...",
+      "deadline": "1743264089",
+      "witness": {
+        "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+        "validAfter": "1740672089",
+        "subscriptionId": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "cycleNumber": "1",
+        "extra": "0x"
+      }
+    },
+    "subscriptionPayload": {
+      "action": "subscribe",
+      "tierId": "pro",
+      "startTimestamp": "1740672089",
+      "renewalAuthorizations": []
+    }
+  }
+}
+```
+
+### 3.3 Subscription Proof Header
+
+For subsequent requests within an active subscription period:
+
+**X-SUBSCRIPTION-PROOF Header (Base64 encoded):**
+
+```json
+{
+  "subscriptionId": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+  "tierId": "pro",
+  "network": "eip155:8453",
+  "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+  "currentCycleNumber": 1,
+  "currentCycleStart": "1740672089",
+  "currentCycleEnd": "1743264089",
+  "signature": "0x..."
+}
+```
+
+**EIP-712 Subscription Proof Types:**
+
+```javascript
+const subscriptionProofTypes = {
+  SubscriptionProof: [
+    { name: "subscriptionId", type: "bytes32" },
+    { name: "subscriber", type: "address" },
+    { name: "tierId", type: "string" },
+    { name: "payTo", type: "address" },
+    { name: "currentCycleNumber", type: "uint256" },
+    { name: "currentCycleStart", type: "uint256" },
+    { name: "currentCycleEnd", type: "uint256" }
+  ]
+};
+```
+
+---
+
+## 4. Verification Logic
+
+### 4.1 Initial Subscription Verification
+
+The facilitator MUST perform these checks in order:
+
+1. **Verify** the `payload.signature` is valid and recovers to `authorization.from`
+
+2. **Verify** the subscriber has sufficient balance of the `asset`:
+   ```solidity
+   require(IERC20(asset).balanceOf(from) >= amount, "insufficient_funds");
+   ```
+
+3. **Verify** the authorization parameters meet requirements:
+   - `authorization.value` >= `accepted.amount`
+   - `authorization.to` == `accepted.payTo`
+   - `block.timestamp` >= `authorization.validAfter`
+   - `block.timestamp` < `authorization.validBefore`
+
+4. **Verify** the subscription details:
+   - `tierId` is valid and available
+   - `billingCycleSeconds` matches the tier configuration
+   - `startTimestamp` is within acceptable range (not in distant past/future)
+
+5. **Verify** renewal authorizations (if provided):
+   - Each authorization has non-overlapping validity windows
+   - Validity windows align with billing cycle boundaries
+   - All authorizations are from the same `from` address
+
+6. **Simulate** the transaction:
+   ```solidity
+   // For EIP-3009
+   token.transferWithAuthorization(from, to, value, validAfter, validBefore, nonce, signature);
+   ```
+
+### 4.2 Subscription Proof Verification
+
+For requests with `X-SUBSCRIPTION-PROOF` header:
+
+1. **Decode** the Base64 subscription proof
+
+2. **Verify** the proof signature:
+   ```javascript
+   const recoveredAddress = ethers.verifyTypedData(
+     domain,
+     subscriptionProofTypes,
+     proofData,
+     proof.signature
+   );
+   require(recoveredAddress === proof.subscriber, "invalid_subscription_proof");
+   ```
+
+3. **Verify** subscription is active:
+   - `block.timestamp` >= `currentCycleStart`
+   - `block.timestamp` < `currentCycleEnd`
+   - Subscription not cancelled
+
+4. **Verify** payment was settled for current cycle:
+   - Query on-chain registry OR
+   - Verify against facilitator's off-chain records
+
+5. **Verify** rate limits (if applicable):
+   - Check subscriber hasn't exceeded tier limits
+
+### 4.3 Renewal Verification
+
+When processing automatic renewals:
+
+1. **Verify** the renewal authorization matches the expected cycle:
+   - `cycleNumber` matches expected next cycle
+   - `validAfter` aligns with cycle start
+   - `validBefore` extends to cycle end
+
+2. **Verify** the subscriber still has sufficient balance
+
+3. **Verify** subscription is in good standing (not cancelled)
+
+4. **Simulate** the renewal transaction
+
+---
+
+## 5. Settlement Logic
+
+### 5.1 Initial Subscription Settlement (EIP-3009)
+
+```solidity
+// 1. Execute the payment
+IERC3009(asset).transferWithAuthorization(
+    authorization.from,
+    authorization.to,
+    authorization.value,
+    authorization.validAfter,
+    authorization.validBefore,
+    authorization.nonce,
+    signature
+);
+
+// 2. Register the subscription (on-chain or off-chain)
+bytes32 subscriptionId = keccak256(abi.encodePacked(
+    subscriber,
+    payTo,
+    tierId,
+    block.timestamp
+));
+
+// 3. Store renewal authorizations (if provided)
+for (uint i = 0; i < renewalAuthorizations.length; i++) {
+    storeRenewalAuth(subscriptionId, renewalAuthorizations[i]);
+}
+
+// 4. Return subscription details
+emit SubscriptionCreated(subscriptionId, subscriber, tierId, cycleEnd);
+```
+
+### 5.2 Initial Subscription Settlement (Permit2)
+
+```solidity
+// Call x402SubscriptionProxy.subscribe()
+x402SubscriptionProxy.subscribe(
+    permit,
+    amount,
+    owner,
+    subscriptionWitness,
+    signature,
+    tierId,
+    billingCycleSeconds
+);
+```
+
+### 5.3 Renewal Settlement
+
+For automatic renewals at cycle boundaries:
+
+```solidity
+function processRenewal(bytes32 subscriptionId) external {
+    Subscription storage sub = subscriptions[subscriptionId];
+    require(block.timestamp >= sub.currentCycleEnd, "cycle_not_ended");
+    require(!sub.cancelled, "subscription_cancelled");
+
+    // Get pre-stored renewal authorization
+    RenewalAuth memory auth = renewalAuths[subscriptionId][sub.cycleNumber + 1];
+    require(auth.signature.length > 0, "no_renewal_auth");
+
+    // Execute the renewal payment
+    IERC3009(sub.asset).transferWithAuthorization(
+        auth.from,
+        auth.to,
+        auth.value,
+        auth.validAfter,
+        auth.validBefore,
+        auth.nonce,
+        auth.signature
+    );
+
+    // Update subscription state
+    sub.cycleNumber++;
+    sub.currentCycleStart = sub.currentCycleEnd;
+    sub.currentCycleEnd = sub.currentCycleStart + sub.billingCycleSeconds;
+
+    emit SubscriptionRenewed(subscriptionId, sub.cycleNumber, sub.currentCycleEnd);
+}
+```
+
+### 5.4 Cancellation Settlement
+
+Cancellation is recorded but does not trigger a blockchain payment:
+
+```solidity
+function cancelSubscription(
+    bytes32 subscriptionId,
+    bytes calldata cancellationSignature
+) external {
+    Subscription storage sub = subscriptions[subscriptionId];
+
+    // Verify cancellation is signed by subscriber
+    bytes32 cancellationHash = keccak256(abi.encodePacked(
+        subscriptionId,
+        "cancel",
+        block.timestamp
+    ));
+    address signer = ECDSA.recover(cancellationHash, cancellationSignature);
+    require(signer == sub.subscriber, "unauthorized");
+
+    // Mark as cancelled (access continues until cycle end)
+    sub.cancelled = true;
+    sub.cancellationTimestamp = block.timestamp;
+
+    // Delete unused renewal authorizations
+    for (uint i = sub.cycleNumber + 1; i <= maxStoredCycles; i++) {
+        delete renewalAuths[subscriptionId][i];
+    }
+
+    emit SubscriptionCancelled(subscriptionId, sub.currentCycleEnd);
+}
+```
+
+---
+
+## 6. Grace Period Handling
+
+When a renewal fails (insufficient funds, expired auth, etc.):
+
+```solidity
+function handleFailedRenewal(bytes32 subscriptionId) internal {
+    Subscription storage sub = subscriptions[subscriptionId];
+
+    // Enter grace period
+    sub.inGracePeriod = true;
+    sub.gracePeriodEnd = sub.currentCycleEnd + sub.gracePeriodSeconds;
+
+    emit SubscriptionGracePeriod(subscriptionId, sub.gracePeriodEnd);
+}
+
+function isSubscriptionActive(bytes32 subscriptionId) public view returns (bool) {
+    Subscription storage sub = subscriptions[subscriptionId];
+
+    if (sub.cancelled && block.timestamp >= sub.currentCycleEnd) {
+        return false;
+    }
+
+    if (sub.inGracePeriod) {
+        return block.timestamp < sub.gracePeriodEnd;
+    }
+
+    return block.timestamp < sub.currentCycleEnd;
+}
+```
+
+---
+
+## 7. Reference Implementation: `x402SubscriptionRegistry`
+
+This contract manages subscription state on-chain for trustless verification.
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+
+interface IERC3009 {
+    function transferWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        bytes memory signature
+    ) external;
+}
+
+contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
+    using ECDSA for bytes32;
+
+    // ============ Constants ============
+
+    bytes32 public constant SUBSCRIPTION_PROOF_TYPEHASH = keccak256(
+        "SubscriptionProof(bytes32 subscriptionId,address subscriber,string tierId,address payTo,uint256 currentCycleNumber,uint256 currentCycleStart,uint256 currentCycleEnd)"
+    );
+
+    bytes32 public constant CANCELLATION_TYPEHASH = keccak256(
+        "CancelSubscription(bytes32 subscriptionId,uint256 timestamp)"
+    );
+
+    // ============ Structs ============
+
+    struct Subscription {
+        address subscriber;
+        address payTo;
+        address asset;
+        string tierId;
+        uint256 amount;
+        uint256 billingCycleSeconds;
+        uint256 gracePeriodSeconds;
+        uint256 cycleNumber;
+        uint256 currentCycleStart;
+        uint256 currentCycleEnd;
+        bool cancelled;
+        bool inGracePeriod;
+        uint256 gracePeriodEnd;
+    }
+
+    struct RenewalAuthorization {
+        address from;
+        address to;
+        uint256 value;
+        uint256 validAfter;
+        uint256 validBefore;
+        bytes32 nonce;
+        bytes signature;
+    }
+
+    struct SubscribeParams {
+        address subscriber;
+        address payTo;
+        address asset;
+        string tierId;
+        uint256 amount;
+        uint256 billingCycleSeconds;
+        uint256 gracePeriodSeconds;
+        uint256 startTimestamp;
+        bytes signature;
+        RenewalAuthorization initialAuth;
+        RenewalAuthorization[] renewalAuths;
+    }
+
+    // ============ State ============
+
+    mapping(bytes32 => Subscription) public subscriptions;
+    mapping(bytes32 => mapping(uint256 => RenewalAuthorization)) public renewalAuthorizations;
+    mapping(address => bytes32[]) public subscriberSubscriptions;
+
+    // ============ Events ============
+
+    event SubscriptionCreated(
+        bytes32 indexed subscriptionId,
+        address indexed subscriber,
+        address indexed payTo,
+        string tierId,
+        uint256 amount,
+        uint256 cycleEnd
+    );
+
+    event SubscriptionRenewed(
+        bytes32 indexed subscriptionId,
+        uint256 cycleNumber,
+        uint256 cycleEnd,
+        bytes32 transactionHash
+    );
+
+    event SubscriptionCancelled(
+        bytes32 indexed subscriptionId,
+        uint256 accessEndsAt
+    );
+
+    event SubscriptionGracePeriod(
+        bytes32 indexed subscriptionId,
+        uint256 gracePeriodEnd
+    );
+
+    event RenewalFailed(
+        bytes32 indexed subscriptionId,
+        uint256 cycleNumber,
+        string reason
+    );
+
+    // ============ Constructor ============
+
+    constructor() EIP712("x402SubscriptionRegistry", "1") {}
+
+    // ============ External Functions ============
+
+    /**
+     * @notice Create a new subscription with initial payment
+     * @param params Subscription parameters including payment authorization
+     */
+    function subscribe(SubscribeParams calldata params)
+        external
+        nonReentrant
+        returns (bytes32 subscriptionId)
+    {
+        // Generate unique subscription ID
+        subscriptionId = keccak256(abi.encodePacked(
+            params.subscriber,
+            params.payTo,
+            params.tierId,
+            params.startTimestamp,
+            block.chainid
+        ));
+
+        require(subscriptions[subscriptionId].subscriber == address(0), "subscription_exists");
+
+        // Execute initial payment via EIP-3009
+        IERC3009(params.asset).transferWithAuthorization(
+            params.initialAuth.from,
+            params.initialAuth.to,
+            params.initialAuth.value,
+            params.initialAuth.validAfter,
+            params.initialAuth.validBefore,
+            params.initialAuth.nonce,
+            params.initialAuth.signature
+        );
+
+        // Create subscription record
+        uint256 cycleEnd = params.startTimestamp + params.billingCycleSeconds;
+
+        subscriptions[subscriptionId] = Subscription({
+            subscriber: params.subscriber,
+            payTo: params.payTo,
+            asset: params.asset,
+            tierId: params.tierId,
+            amount: params.amount,
+            billingCycleSeconds: params.billingCycleSeconds,
+            gracePeriodSeconds: params.gracePeriodSeconds,
+            cycleNumber: 1,
+            currentCycleStart: params.startTimestamp,
+            currentCycleEnd: cycleEnd,
+            cancelled: false,
+            inGracePeriod: false,
+            gracePeriodEnd: 0
+        });
+
+        // Store renewal authorizations
+        for (uint256 i = 0; i < params.renewalAuths.length; i++) {
+            renewalAuthorizations[subscriptionId][i + 2] = params.renewalAuths[i];
+        }
+
+        subscriberSubscriptions[params.subscriber].push(subscriptionId);
+
+        emit SubscriptionCreated(
+            subscriptionId,
+            params.subscriber,
+            params.payTo,
+            params.tierId,
+            params.amount,
+            cycleEnd
+        );
+
+        return subscriptionId;
+    }
+
+    /**
+     * @notice Process automatic renewal for a subscription
+     * @param subscriptionId The subscription to renew
+     */
+    function processRenewal(bytes32 subscriptionId) external nonReentrant {
+        Subscription storage sub = subscriptions[subscriptionId];
+
+        require(sub.subscriber != address(0), "subscription_not_found");
+        require(!sub.cancelled, "subscription_cancelled");
+        require(block.timestamp >= sub.currentCycleEnd, "cycle_not_ended");
+
+        uint256 nextCycle = sub.cycleNumber + 1;
+        RenewalAuthorization storage auth = renewalAuthorizations[subscriptionId][nextCycle];
+
+        require(auth.signature.length > 0, "no_renewal_authorization");
+        require(block.timestamp >= auth.validAfter, "renewal_not_valid_yet");
+        require(block.timestamp < auth.validBefore, "renewal_expired");
+
+        // Check balance before attempting
+        if (IERC20(sub.asset).balanceOf(auth.from) < auth.value) {
+            _enterGracePeriod(subscriptionId);
+            emit RenewalFailed(subscriptionId, nextCycle, "insufficient_funds");
+            return;
+        }
+
+        // Execute renewal payment
+        try IERC3009(sub.asset).transferWithAuthorization(
+            auth.from,
+            auth.to,
+            auth.value,
+            auth.validAfter,
+            auth.validBefore,
+            auth.nonce,
+            auth.signature
+        ) {
+            // Update subscription state
+            sub.cycleNumber = nextCycle;
+            sub.currentCycleStart = sub.currentCycleEnd;
+            sub.currentCycleEnd = sub.currentCycleStart + sub.billingCycleSeconds;
+            sub.inGracePeriod = false;
+            sub.gracePeriodEnd = 0;
+
+            // Clear used authorization
+            delete renewalAuthorizations[subscriptionId][nextCycle];
+
+            emit SubscriptionRenewed(
+                subscriptionId,
+                nextCycle,
+                sub.currentCycleEnd,
+                bytes32(0) // Transaction hash not available in contract
+            );
+        } catch {
+            _enterGracePeriod(subscriptionId);
+            emit RenewalFailed(subscriptionId, nextCycle, "transfer_failed");
+        }
+    }
+
+    /**
+     * @notice Add renewal authorizations for future cycles
+     * @param subscriptionId The subscription to add renewals for
+     * @param startCycle First cycle number for the new authorizations
+     * @param auths Array of renewal authorizations
+     */
+    function addRenewalAuthorizations(
+        bytes32 subscriptionId,
+        uint256 startCycle,
+        RenewalAuthorization[] calldata auths
+    ) external {
+        Subscription storage sub = subscriptions[subscriptionId];
+        require(msg.sender == sub.subscriber, "unauthorized");
+        require(!sub.cancelled, "subscription_cancelled");
+
+        for (uint256 i = 0; i < auths.length; i++) {
+            require(auths[i].from == sub.subscriber, "invalid_from");
+            require(auths[i].to == sub.payTo, "invalid_to");
+            require(auths[i].value == sub.amount, "invalid_amount");
+
+            renewalAuthorizations[subscriptionId][startCycle + i] = auths[i];
+        }
+    }
+
+    /**
+     * @notice Cancel a subscription
+     * @param subscriptionId The subscription to cancel
+     * @param signature Subscriber's signature authorizing cancellation
+     */
+    function cancelSubscription(
+        bytes32 subscriptionId,
+        bytes calldata signature
+    ) external nonReentrant {
+        Subscription storage sub = subscriptions[subscriptionId];
+        require(sub.subscriber != address(0), "subscription_not_found");
+        require(!sub.cancelled, "already_cancelled");
+
+        // Verify cancellation signature
+        bytes32 structHash = keccak256(abi.encode(
+            CANCELLATION_TYPEHASH,
+            subscriptionId,
+            block.timestamp
+        ));
+        bytes32 digest = _hashTypedDataV4(structHash);
+        address signer = ECDSA.recover(digest, signature);
+        require(signer == sub.subscriber, "invalid_signature");
+
+        // Mark as cancelled
+        sub.cancelled = true;
+
+        // Clear future renewal authorizations
+        for (uint256 i = sub.cycleNumber + 1; i <= sub.cycleNumber + 12; i++) {
+            delete renewalAuthorizations[subscriptionId][i];
+        }
+
+        emit SubscriptionCancelled(subscriptionId, sub.currentCycleEnd);
+    }
+
+    // ============ View Functions ============
+
+    /**
+     * @notice Check if a subscription is currently active
+     * @param subscriptionId The subscription to check
+     * @return active Whether the subscription is active
+     */
+    function isActive(bytes32 subscriptionId) external view returns (bool active) {
+        Subscription storage sub = subscriptions[subscriptionId];
+
+        if (sub.subscriber == address(0)) {
+            return false;
+        }
+
+        if (sub.cancelled && block.timestamp >= sub.currentCycleEnd) {
+            return false;
+        }
+
+        if (sub.inGracePeriod) {
+            return block.timestamp < sub.gracePeriodEnd;
+        }
+
+        return block.timestamp < sub.currentCycleEnd;
+    }
+
+    /**
+     * @notice Get subscription details for proof generation
+     * @param subscriptionId The subscription ID
+     */
+    function getSubscription(bytes32 subscriptionId)
+        external
+        view
+        returns (Subscription memory)
+    {
+        return subscriptions[subscriptionId];
+    }
+
+    /**
+     * @notice Verify a subscription proof without state changes
+     * @param subscriptionId The subscription ID
+     * @param subscriber The subscriber address
+     * @param cycleNumber The claimed cycle number
+     * @param cycleStart The claimed cycle start
+     * @param cycleEnd The claimed cycle end
+     * @param signature The proof signature
+     */
+    function verifySubscriptionProof(
+        bytes32 subscriptionId,
+        address subscriber,
+        string calldata tierId,
+        address payTo,
+        uint256 cycleNumber,
+        uint256 cycleStart,
+        uint256 cycleEnd,
+        bytes calldata signature
+    ) external view returns (bool valid, string memory reason) {
+        Subscription storage sub = subscriptions[subscriptionId];
+
+        // Check subscription exists
+        if (sub.subscriber == address(0)) {
+            return (false, "subscription_not_found");
+        }
+
+        // Check subscription matches
+        if (sub.subscriber != subscriber) {
+            return (false, "subscriber_mismatch");
+        }
+
+        if (keccak256(bytes(sub.tierId)) != keccak256(bytes(tierId))) {
+            return (false, "tier_mismatch");
+        }
+
+        if (sub.payTo != payTo) {
+            return (false, "payTo_mismatch");
+        }
+
+        // Check cycle matches
+        if (sub.cycleNumber != cycleNumber ||
+            sub.currentCycleStart != cycleStart ||
+            sub.currentCycleEnd != cycleEnd) {
+            return (false, "cycle_mismatch");
+        }
+
+        // Check timing
+        if (block.timestamp < cycleStart) {
+            return (false, "cycle_not_started");
+        }
+
+        if (block.timestamp >= cycleEnd && !sub.inGracePeriod) {
+            return (false, "cycle_ended");
+        }
+
+        if (sub.inGracePeriod && block.timestamp >= sub.gracePeriodEnd) {
+            return (false, "grace_period_expired");
+        }
+
+        // Verify signature
+        bytes32 structHash = keccak256(abi.encode(
+            SUBSCRIPTION_PROOF_TYPEHASH,
+            subscriptionId,
+            subscriber,
+            keccak256(bytes(tierId)),
+            payTo,
+            cycleNumber,
+            cycleStart,
+            cycleEnd
+        ));
+        bytes32 digest = _hashTypedDataV4(structHash);
+        address signer = ECDSA.recover(digest, signature);
+
+        if (signer != subscriber) {
+            return (false, "invalid_signature");
+        }
+
+        return (true, "");
+    }
+
+    // ============ Internal Functions ============
+
+    function _enterGracePeriod(bytes32 subscriptionId) internal {
+        Subscription storage sub = subscriptions[subscriptionId];
+        sub.inGracePeriod = true;
+        sub.gracePeriodEnd = sub.currentCycleEnd + sub.gracePeriodSeconds;
+
+        emit SubscriptionGracePeriod(subscriptionId, sub.gracePeriodEnd);
+    }
+}
+```
+
+---
+
+## 8. Reference Implementation: `x402SubscriptionProxy` (Permit2)
+
+For tokens without EIP-3009, use this Permit2-based proxy:
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ISignatureTransfer} from "permit2/src/interfaces/ISignatureTransfer.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+contract x402SubscriptionProxy {
+    ISignatureTransfer public immutable PERMIT2;
+
+    // EIP-712 Type for Subscription Witness
+    string public constant SUBSCRIPTION_WITNESS_TYPE_STRING =
+        "SubscriptionWitness witness)SubscriptionWitness(address to,uint256 validAfter,bytes32 subscriptionId,uint256 cycleNumber,bytes extra)TokenPermissions(address token,uint256 amount)";
+
+    bytes32 public constant SUBSCRIPTION_WITNESS_TYPEHASH = keccak256(
+        "SubscriptionWitness(address to,uint256 validAfter,bytes32 subscriptionId,uint256 cycleNumber,bytes extra)"
+    );
+
+    struct SubscriptionWitness {
+        address to;
+        uint256 validAfter;
+        bytes32 subscriptionId;
+        uint256 cycleNumber;
+        bytes extra;
+    }
+
+    event x402SubscriptionPayment(
+        bytes32 indexed subscriptionId,
+        address indexed from,
+        address indexed to,
+        uint256 amount,
+        uint256 cycleNumber
+    );
+
+    constructor(address _permit2) {
+        PERMIT2 = ISignatureTransfer(_permit2);
+    }
+
+    /**
+     * @notice Process a subscription payment via Permit2
+     */
+    function processPayment(
+        ISignatureTransfer.PermitTransferFrom calldata permit,
+        uint256 amount,
+        address owner,
+        SubscriptionWitness calldata witness,
+        bytes calldata signature
+    ) external {
+        require(block.timestamp >= witness.validAfter, "payment_not_valid_yet");
+        require(amount <= permit.permitted.amount, "amount_exceeds_permitted");
+
+        ISignatureTransfer.SignatureTransferDetails memory transferDetails =
+            ISignatureTransfer.SignatureTransferDetails({
+                to: witness.to,
+                requestedAmount: amount
+            });
+
+        bytes32 witnessHash = keccak256(abi.encode(
+            SUBSCRIPTION_WITNESS_TYPEHASH,
+            witness.to,
+            witness.validAfter,
+            witness.subscriptionId,
+            witness.cycleNumber,
+            keccak256(witness.extra)
+        ));
+
+        PERMIT2.permitWitnessTransferFrom(
+            permit,
+            transferDetails,
+            owner,
+            witnessHash,
+            SUBSCRIPTION_WITNESS_TYPE_STRING,
+            signature
+        );
+
+        emit x402SubscriptionPayment(
+            witness.subscriptionId,
+            owner,
+            witness.to,
+            amount,
+            witness.cycleNumber
+        );
+    }
+}
+```
+
+---
+
+## 9. Facilitator API Extensions
+
+### 9.1 POST /subscribe
+
+Create a new subscription:
+
+**Request:**
+```json
+{
+  "paymentPayload": { /* PaymentPayload with subscriptionPayload */ },
+  "paymentRequirements": { /* PaymentRequirements with subscriptionDetails */ }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "subscriptionId": "0x1234...",
+  "transaction": "0xabcd...",
+  "network": "eip155:8453",
+  "payer": "0x857b...",
+  "subscriptionDetails": {
+    "tierId": "pro",
+    "status": "active",
+    "currentCycleStart": "1740672089",
+    "currentCycleEnd": "1743264089",
+    "autoRenewEnabled": true,
+    "storedRenewalCycles": 3
+  }
+}
+```
+
+### 9.2 GET /subscription/{subscriptionId}
+
+Query subscription status:
+
+**Response:**
+```json
+{
+  "subscriptionId": "0x1234...",
+  "subscriber": "0x857b...",
+  "payTo": "0x2096...",
+  "tierId": "pro",
+  "status": "active",
+  "network": "eip155:8453",
+  "asset": "0x8335...",
+  "amount": "5000000",
+  "currentCycle": {
+    "number": 2,
+    "start": "1743264089",
+    "end": "1745856089"
+  },
+  "nextRenewal": {
+    "date": "1745856089",
+    "authorized": true
+  },
+  "cancelled": false
+}
+```
+
+### 9.3 POST /subscription/{subscriptionId}/cancel
+
+Cancel a subscription:
+
+**Request:**
+```json
+{
+  "signature": "0x...",
+  "timestamp": "1740700000"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "subscriptionId": "0x1234...",
+  "accessEndsAt": "1743264089",
+  "refundAmount": "0"
+}
+```
+
+---
+
+## 10. Security Considerations
+
+### 10.1 Replay Attack Prevention
+
+- Each billing cycle uses a unique nonce
+- Pre-signed renewals have non-overlapping `validAfter`/`validBefore` windows
+- Subscription proofs include cycle-specific timestamps
+
+### 10.2 Authorization Scope
+
+- Subscribers control exact amounts per cycle
+- Pre-signed renewals can be invalidated by:
+  - Spending the nonce with a different transaction
+  - Reducing token balance below required amount
+  - Revoking Permit2 allowance (for Permit2 method)
+
+### 10.3 Facilitator Trust Model
+
+- Facilitators CANNOT modify payment amounts or recipients
+- Facilitators CAN delay renewal execution (mitigated by validity windows)
+- On-chain registry provides trustless verification fallback
+
+### 10.4 Front-running Protection
+
+- Renewal transactions can only be executed by the designated facilitator
+- Subscription IDs are deterministic and verifiable
+
+---
+
+## Appendix
+
+### Canonical Contract Addresses
+
+| Contract                    | Address                                      | Networks           |
+| --------------------------- | -------------------------------------------- | ------------------ |
+| `x402SubscriptionRegistry`  | TBD (CREATE2 deployment)                     | All supported EVM  |
+| `x402SubscriptionProxy`     | TBD (CREATE2 deployment)                     | All supported EVM  |
+| `Permit2`                   | `0x000000000022D473030F116dDEE9F6B43aC78BA3` | All supported EVM  |
+
+### Supported Networks
+
+| Network         | Chain ID | CAIP-2 Identifier  |
+| --------------- | -------- | ------------------ |
+| Base Mainnet    | 8453     | `eip155:8453`      |
+| Base Sepolia    | 84532    | `eip155:84532`     |
+| Ethereum        | 1        | `eip155:1`         |
+| Arbitrum One    | 42161    | `eip155:42161`     |
+| Optimism        | 10       | `eip155:10`        |
+| Polygon         | 137      | `eip155:137`       |
+
+### References
+
+- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009)
+- [EIP-712: Typed Structured Data Hashing](https://eips.ethereum.org/EIPS/eip-712)
+- [Permit2 Documentation](https://docs.uniswap.org/contracts/permit2/overview)
+- [x402 Protocol Specification v2](../../x402-specification-v2.md)
+- [Subscribe Scheme Overview](./scheme_subscribe.md)

--- a/specs/schemes/subscribe/scheme_subscribe_evm.md
+++ b/specs/schemes/subscribe/scheme_subscribe_evm.md
@@ -621,7 +621,7 @@ Replay of a captured proof is bounded by `maxProofAge` (RECOMMENDED 60 seconds):
 
 For stricter single-use semantics, servers MAY maintain a short-lived `(issuedAt, signature)` cache (TTL = `maxProofAge`) and reject duplicates. This is optional — freshness alone provides strong replay resistance for most use cases.
 
-**Contrast with previous draft:** An earlier draft used a `cycle` field to produce a proof valid for an entire billing period (up to 30 days). This was a static bearer token: anyone who intercepted it could replay indefinitely within the cycle. Freshness via `issuedAt` is the fix — the signature removal in the interim commit was not the intended resolution.
+See §11.10 for comprehensive extension threat model including forgery, clock skew, and audience scoping analysis.
 
 > **Non-normative:** Servers MAY exchange one verified possession proof for their own session credential (cookie, API key, JWT) to avoid per-request wallet signing for human clients. This is a server-side optimization outside the x402 protocol scope.
 
@@ -1729,55 +1729,190 @@ Some facilitators expose an internal endpoint to trigger immediate charge attemp
 The facilitator is trusted for **liveness only**:
 
 - **Liveness**: The facilitator maintains the Merkle tree off-chain and submits `chargePeriod()` calls at billing boundaries. If the facilitator fails, charges don't happen — but `chargePeriod()` is permissionless, so any party (subscriber, payTo, third party) can submit valid proofs.
-- **Safety**: The facilitator has no safety authority. It cannot overcharge (fee ≤ maxPerPeriod, fee matches Merkle leaf, cursor is monotonic), charge early (before validFrom), charge late (after validTo + gracePeriodSeconds), charge past expiry/cancel (hard on-chain checks), redirect funds (payTo/asset bound in commitment), or double-charge (cursor increments only on successful transfer).
+- **Safety**: The facilitator has no safety authority over fund flows.
+
+**Per-attack enumeration:**
+
+| Attack Vector | On-Chain Mitigation |
+|:--------------|:--------------------|
+| **Overcharge** | `fee <= maxPerPeriod` enforced; fee must match Merkle leaf; cursor is monotonic (one charge per period) |
+| **Early charge** | `block.timestamp >= validFrom` required |
+| **Late charge** | `block.timestamp <= validTo + gracePeriodSeconds` required |
+| **Double charge** | Cursor increments only on successful `transferFrom`; `periodIndex == cursor` required |
+| **Charge past expiry** | `block.timestamp <= expiry` required |
+| **Charge after cancel** | `!cancelled` required |
+| **Redirect funds** | `payTo` bound in signed commitment; stored immutably |
+| **Wrong asset** | `asset` bound in signed commitment; checked at registration |
+| **Cross-chain replay** | `chainId` bound in commitment; `commitment.chainId == block.chainid` checked |
+| **Wrong registry** | `registry` bound in commitment; `commitment.registry == address(this)` checked |
 
 **Facilitator compromise degrades to denial of service, never theft beyond the signed schedule.**
 
-### 11.2 Replay Attack Prevention
+### 11.2 Blind-Signing Prevention (MUST)
 
-- **Commitment uniqueness**: Each commitment produces a unique `subscriptionId` (the struct hash). Duplicate commitments are rejected.
-- **Monotonic cursor**: `chargePeriod()` requires `periodIndex == cursor` and increments cursor on success. Each period can be charged at most once.
-- **Cancellation nonces**: `cancel()` uses signer-chosen nonces recorded in a mapping. Each `(subscriptionId, nonce)` pair can only be used once.
-- **Cross-chain protection**: The commitment binds `chainId`; replay on other chains fails.
+Clients MUST recompute the Merkle root from the advertised `schedule` array before signing the commitment. Blind-signing a facilitator-provided root would allow arbitrary charges up to `maxPerPeriod × periodCount`.
 
-### 11.3 Allowance Exposure
+**Implementation requirement:** Client libraries MUST:
 
-The subscriber grants a standing ERC-20 allowance to the registry. The worst-case exposure is bounded by:
+1. Build the Merkle tree locally from `subscriptionDetails`
+2. Compute the root using the double-hash leaf convention
+3. Reject any payload where `commitment.root` does not match the locally computed root
+4. Display the total committed spend (`sum(schedule[].fee)`) for user confirmation
 
-1. **Allowance amount**: The subscriber controls the allowance; setting it equal to total committed spend caps total exposure.
+### 11.3 Replay Attack Prevention
+
+**Commitment domain separation:**
+
+- The EIP-712 domain binds `{name: "x402SubscriptionRegistry", version: "1", chainId, verifyingContract}`
+- The `subscriptionId` is the commitment struct hash — unique per `(root, subscriber, asset, payTo, registry, chainId, tierId, start, expiry, maxPerPeriod, gracePeriodSeconds)` tuple
+- Duplicate commitments are rejected (`SubscriptionAlreadyExists`)
+
+**Merkle leaf double-hashing:**
+
+Leaves use the OpenZeppelin convention: `keccak256(keccak256(abi.encode(periodIndex, fee, validFrom, validTo)))`. The inner hash prevents second-preimage attacks where an attacker crafts a leaf that is also a valid internal node.
+
+**Monotonic cursor:**
+
+`chargePeriod()` requires `periodIndex == cursor` and increments cursor only on successful transfer. Each period can be charged at most once, in order.
+
+**Cancellation nonces:**
+
+`cancel()` uses signer-chosen nonces recorded in `usedCancelNonces[subscriptionId][nonce]`. Each `(subscriptionId, nonce)` pair can only be used once.
+
+**Cross-chain protection:**
+
+The commitment binds `chainId`; the registry verifies `commitment.chainId == block.chainid`. Replay on other chains fails.
+
+### 11.4 Allowance Exposure
+
+The subscriber grants a standing ERC-20 allowance to the registry. Worst-case exposure is bounded by:
+
+1. **Allowance amount**: The subscriber controls the allowance; setting it equal to total committed spend caps exposure.
 2. **maxPerPeriod**: Each charge is capped regardless of the Merkle leaf claim.
 3. **Merkle root binding**: Only leaves matching the signed root can be charged.
-4. **Time windows**: Charges outside `validFrom..validTo` revert.
+4. **Time windows**: Charges outside `[validFrom, validTo + gracePeriodSeconds]` revert.
 5. **Expiry**: No charges after `expiry` timestamp.
 
-### 11.4 Guardian Pause Scope
+**Token-level revocation as unilateral backstop:**
 
-The guardian can call `pause()` to halt `chargePeriod()` as an emergency measure (e.g., if a critical bug is discovered). The pause is **fund-safe**:
+If a subscriber loses trust in the system, they can call `ERC20.approve(registry, 0)` directly on the token contract to revoke allowance. This is a unilateral action requiring no cooperation from the facilitator or registry. After revocation:
 
-- Pause does NOT move funds
-- Pause does NOT change stored commitments or subscription terms
-- Pause does NOT redirect payments
-- Pause does NOT affect `subscribe()`, `cancel()`, `updateRoot()`, or view functions
+- All future `chargePeriod` calls fail (insufficient allowance)
+- The subscription enters grace period, then becomes inactive
+- No further funds can be pulled regardless of valid Merkle proofs
 
-The guardian is recommended to be a timelock contract to prevent abuse.
+This provides a hard exit path independent of the `cancel()` mechanism.
 
-### 11.5 Codeless Asset Attack Prevention
+### 11.5 Guardian Pause Scope
 
-A low-level `call()` to an address with no bytecode (EOA or undeployed address) returns success with empty return data. This would be misinterpreted by `_safeTransferFrom` as a USDT-style successful transfer, allowing an attacker to register a "free subscription" by specifying a codeless `commitment.asset`.
+The guardian can call `pause()` to halt `chargePeriod()` as an emergency measure. The pause is **fund-safe** — the guardian provably CANNOT:
 
-**Mitigation:** `subscribe()` checks `commitment.asset.code.length == 0` and reverts with `AssetNotContract()` if true. This check is performed once at registration time; the asset cannot change afterward.
+- Move funds (no transfer functions callable by guardian)
+- Change stored commitments or subscription terms (immutable after registration)
+- Redirect payments (payTo is immutably stored)
+- Affect `subscribe()`, `cancel()`, `updateRoot()`, or view functions (not gated by `whenNotPaused`)
+- Permanently lock subscriptions (unpause restores charging)
 
-### 11.6 Return Data Hardening
+The guardian is RECOMMENDED to be a timelock contract (e.g., 24-48 hour delay) to prevent abuse.
 
-The `_safeTransferFrom` function uses exact length checking for return data:
+### 11.6 Permissionless `chargePeriod` Griefing Analysis
+
+Because `chargePeriod()` is permissionless, anyone can submit a valid charge. Potential griefing vectors:
+
+**Front-running the facilitator:**
+
+An attacker submits `chargePeriod` before the facilitator. Result: The charge succeeds, funds move to `payTo`, cursor advances. The facilitator's subsequent call reverts (`InvalidPeriodIndex`). **No fund loss** — the correct party received payment; only the facilitator wasted gas.
+
+**Submitting during pause:**
+
+Calls revert with `ChargePaused`. No state change, no fund movement.
+
+**Submitting invalid proofs:**
+
+Calls revert with `InvalidMerkleProof`. Attacker wastes their own gas.
+
+**Gas-payer note:**
+
+The party submitting `chargePeriod` pays gas. In normal operation, this is the facilitator (who may recoup costs via service fees). In liveness-failure scenarios, the `payTo` address is incentivized to submit charges to collect revenue. The subscriber may also submit to maintain active status.
+
+### 11.7 Grace Period Edge Cases
+
+The chargeable window is `[validFrom, validTo + gracePeriodSeconds]`. Edge cases:
+
+**Charge fails, then allowance restored:**
+
+1. `chargePeriod` at `t1` fails (insufficient allowance) → `inGracePeriod = true`, `gracePeriodEnd = validTo + gracePeriodSeconds`
+2. Subscriber restores allowance at `t2`
+3. Facilitator retries `chargePeriod` at `t3 < gracePeriodEnd` → succeeds, cursor advances, `inGracePeriod = false`
+
+The period is NOT skipped; the same `periodIndex` can be retried until the window closes.
+
+**Cancel during grace:**
+
+Subscriber calls `cancel()` while in grace period. Result: `cancelled = true`. The current period's charge can still be retried (cursor hasn't advanced), but no future periods can be charged. Access policy (immediate vs. end_of_cycle) is enforced off-chain by the resource server.
+
+**Expiry during grace:**
+
+If `expiry` falls within the grace window, the charge can still succeed if `block.timestamp <= expiry`. Once `block.timestamp > expiry`, `chargePeriod` reverts with `SubscriptionExpired` even if `gracePeriodEnd` hasn't passed. Expiry is a hard boundary.
+
+**Multiple grace periods:**
+
+Each period has its own window. If period N fails and enters grace, period N+1's window may overlap. However, `periodIndex == cursor` prevents charging N+1 before N succeeds. Grace periods are sequential, not parallel.
+
+### 11.8 Codeless Asset Attack Prevention
+
+A low-level `call()` to an address with no bytecode (EOA or undeployed address) returns success with empty return data. This would be misinterpreted by `_safeTransferFrom` as a USDT-style successful transfer, allowing a "free subscription" attack.
+
+**Mitigation:** `subscribe()` checks `commitment.asset.code.length == 0` and reverts with `AssetNotContract()` if true. This check is performed once at registration time; the asset address is immutably stored.
+
+### 11.9 Return Data Hardening
+
+The `_safeTransferFrom` function uses exact length checking:
 
 ```solidity
 success = callSuccess && (data.length == 0 || (data.length == 32 && abi.decode(data, (bool))));
 ```
 
-This prevents malformed return data (e.g., non-32-byte responses from proxy contracts or hook-modified tokens) from being decoded as a boolean. Charges with unexpected return data are routed to the grace period path, allowing retry without permanently locking the period.
+This prevents:
 
-> **Note:** Additional analysis (MEV, frontrunning resistance, gas optimization) may be added in subsequent commits.
+- **Non-reverting false returns**: Tokens returning `false` are treated as failed charges (grace period path)
+- **Malformed return data**: Non-32-byte responses (e.g., from misconfigured proxies) are treated as failures
+- **No-return tokens (USDT-style)**: Empty return data is accepted as success (standard behavior)
+
+Charges with unexpected return data route to grace period, allowing retry without permanently locking the period.
+
+### 11.10 Subscription Extension Threat Model
+
+The `subscription` extension carries a fresh possession proof. Threat analysis:
+
+**Forgery (public on-chain data is not identity):**
+
+On-chain data (`subscriptionId`, `subscriber`, `tierId`, `isActive`) is public. An attacker reading the chain could construct a valid-looking echo. The possession proof (`SubscriptionAccess` signature) prevents this: only the holder of the subscriber's private key can produce a valid signature. The server recovers the signer and compares to the registry-stored subscriber.
+
+**Replay:**
+
+A captured proof can be replayed. Mitigations:
+
+1. **Freshness**: `|now - issuedAt| <= maxProofAge` (RECOMMENDED 60s). Replay is bounded to this window.
+2. **Audience scoping**: If `audience` is set, replay is restricted to the specified origin/prefix. A proof for `https://api.example.com` cannot be used at `https://other.example.com`.
+3. **TLS**: Transport encryption prevents passive capture.
+4. **Optional single-use cache**: Servers MAY maintain a `(issuedAt, signature)` cache (TTL = `maxProofAge`) to reject duplicates.
+
+**Clock skew:**
+
+If server and client clocks differ by more than `maxProofAge`, valid proofs may be rejected. Mitigations:
+
+- Servers SHOULD use NTP-synchronized time
+- `maxProofAge` of 60s provides reasonable tolerance for typical skew (<5s)
+- The `|now - issuedAt|` check is symmetric — both future and past proofs are rejected if too far from server time
+
+**Audience scoping:**
+
+The `audience` field is OPTIONAL. When present:
+
+- Servers MUST reject proofs where `audience` does not match the served origin/resource prefix
+- Proofs without `audience` are accepted but have no origin binding (broader replay surface)
+- Clients SHOULD set `audience` to the most specific origin they're accessing
 
 ---
 

--- a/specs/schemes/subscribe/scheme_subscribe_evm.md
+++ b/specs/schemes/subscribe/scheme_subscribe_evm.md
@@ -47,7 +47,7 @@ The client signs once; the facilitator submits periodic charges with Merkle proo
 |:-----|:---------------|
 | **Client** | Builds Merkle tree from advertised terms; signs EIP-712 commitment over `{root, subscriber, asset, payTo, registry, chainId, tierId, start, expiry, maxPerPeriod}`; grants standing ERC-20 allowance to registry (gaslessly via EIP-2612 permit where supported, or direct approve) |
 | **Facilitator** | Maintains the Merkle tree and proofs off-chain; submits `subscribe()` with commitment + allowance signature; submits `chargePeriod()` with Merkle proofs at each billing boundary; trusted for **liveness only** |
-| **Registry** | Immutable on-chain contract; verifies EIP-712 commitment signature; enforces monotonic cursor, per-period cap (`fee <= maxPerPeriod`), time windows (`validFrom <= now <= validTo`), expiry, and cancel; calls `transferFrom(subscriber, payTo, fee)` on success |
+| **Registry** | Immutable on-chain contract; verifies EIP-712 commitment signature; enforces monotonic cursor, per-period cap (`fee <= maxPerPeriod`), time windows (`validFrom <= now <= validTo + gracePeriodSeconds`), expiry, and cancel; calls `transferFrom(subscriber, payTo, fee)` on success |
 | **Token** | Any ERC-20; EIP-2612 support enables gasless allowance approval |
 
 ---
@@ -470,7 +470,9 @@ const subscriptionAccessTypes = {
 
 **Type String:** `SubscriptionAccess(bytes32 subscriptionId,uint256 issuedAt,string audience)`
 
-The `audience` field is hashed per EIP-712 string rules (`keccak256(audience)`). When `audience` is empty, hash the empty string.
+The `audience` field is hashed per EIP-712 string rules (`keccak256(audience)`).
+
+**Empty-audience rule (MUST):** When `audience` is omitted from the client echo, clients MUST sign `SubscriptionAccess` with `audience = ""` (empty string). Servers MUST verify against empty string accordingly. EIP-712 hashes the string unconditionally; omission without this rule breaks signature interoperability.
 
 ### 6.5 Server Declaration (PaymentRequired.extensions)
 
@@ -902,7 +904,7 @@ Before calling `chargePeriod()`:
 
 1. **Construct** Merkle proof for the current `periodIndex`
 2. **Verify** `periodIndex == cursor` (monotonic)
-3. **Verify** `validFrom <= block.timestamp <= validTo`
+3. **Verify** `validFrom <= block.timestamp <= validTo + gracePeriodSeconds`
 4. **Verify** `fee <= maxPerPeriod`
 5. **Verify** `!cancelled && block.timestamp <= expiry`
 6. **Verify** subscriber has sufficient balance and allowance
@@ -1241,6 +1243,12 @@ contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
         );
 
         // Optionally charge period 0 immediately (respects pause via _chargePeriod)
+        // NOTE: A single-period schedule has an empty Merkle proof by construction
+        // (the root IS the leaf hash). The `initialProof.length > 0` gate therefore
+        // skips the initial charge for single-period subscriptions when called with
+        // an empty proof array. The charge remains submittable via chargePeriod()
+        // afterward. Reference implementations MAY use an explicit boolean parameter
+        // (e.g., `chargeInitialPeriod`) instead of proof-length detection.
         if (initialProof.length > 0) {
             _chargePeriod(subscriptionId, initialLeaf, initialProof);
         }

--- a/specs/schemes/subscribe/scheme_subscribe_evm.md
+++ b/specs/schemes/subscribe/scheme_subscribe_evm.md
@@ -2,23 +2,17 @@
 
 ## Summary
 
-The `subscribe` scheme on EVM enables recurring subscription-based payments where the Facilitator pays gas costs while subscribers control the exact flow of funds via cryptographic signatures.
+The `subscribe` scheme on EVM enables recurring subscription-based payments where the Facilitator pays gas costs while subscribers control the exact flow of funds via a single cryptographic commitment over an entire billing schedule.
 
-This is implemented via two components:
+This is implemented via three components:
 
-| Component                    | Purpose                                                                |
-| :--------------------------- | :--------------------------------------------------------------------- |
-| **1. Payment Authorization** | Uses EIP-3009 or Permit2 for each billing cycle payment                |
-| **2. Subscription Registry** | On-chain or off-chain registry tracking subscription state and proofs  |
+| Component | Purpose |
+|:----------|:--------|
+| **1. Schedule Commitment** | Client signs ONE EIP-712 commitment binding a Merkle root of the billing schedule |
+| **2. Standing Allowance** | Client grants ERC-20 allowance to the registry (gaslessly via EIP-2612 permit, or direct approve) |
+| **3. Subscription Registry** | Immutable on-chain contract enforcing commitment, cursor, cap, time windows, and pause |
 
-The scheme supports two subscription models:
-
-| Model                        | Description                                                            | Recommendation                                    |
-| :--------------------------- | :--------------------------------------------------------------------- | :------------------------------------------------ |
-| **Pre-authorized Renewals**  | Client signs multiple future authorizations upfront                    | **Recommended** (Seamless auto-renewal)           |
-| **On-demand Renewals**       | Client signs each renewal when prompted                                | **Flexible** (More control, requires interaction) |
-
-In all cases, the Facilitator cannot modify amounts, recipients, or timing. They serve only as the transaction broadcaster and subscription state manager.
+The client signs once; the facilitator submits periodic charges with Merkle proofs. The registry enforces all safety invariants — the facilitator cannot overcharge, charge early/late, or redirect funds.
 
 ---
 
@@ -34,72 +28,133 @@ In all cases, the Facilitator cannot modify amounts, recipients, or timing. They
 │   │          │         │              │         │     Registry       │          │
 │   └──────────┘         └──────────────┘         └────────────────────┘          │
 │        │                      │                          │                       │
-│        │ Signs EIP-3009       │ Broadcasts TX            │ Stores subscription   │
-│        │ authorizations       │ Pays gas                 │ state on-chain        │
+│        │ Signs EIP-712        │ Maintains tree           │ Immutable contract    │
+│        │ commitment +         │ off-chain; submits       │ enforces: commitment, │
+│        │ allowance permit     │ charges with proofs      │ cursor, cap, windows  │
 │        │                      │                          │                       │
 │        ▼                      ▼                          ▼                       │
 │   ┌──────────┐         ┌──────────────┐         ┌────────────────────┐          │
-│   │  WALLET  │         │  ERC-20      │         │  RESOURCE SERVER   │          │
-│   │          │         │  (USDC)      │         │                    │          │
+│   │  WALLET  │         │  ERC-20      │◀────────│  transferFrom()    │          │
+│   │          │         │  (any token) │         │  on each charge    │          │
 │   └──────────┘         └──────────────┘         └────────────────────┘          │
 │                                                                                  │
 └─────────────────────────────────────────────────────────────────────────────────┘
 ```
 
+### Role Responsibilities
+
+| Role | Responsibility |
+|:-----|:---------------|
+| **Client** | Builds Merkle tree from advertised terms; signs EIP-712 commitment over `{root, subscriber, asset, payTo, registry, chainId, tierId, start, expiry, maxPerPeriod}`; grants standing ERC-20 allowance to registry (gaslessly via EIP-2612 permit where supported, or direct approve) |
+| **Facilitator** | Maintains the Merkle tree and proofs off-chain; submits `subscribe()` with commitment + allowance signature; submits `chargePeriod()` with Merkle proofs at each billing boundary; trusted for **liveness only** |
+| **Registry** | Immutable on-chain contract; verifies EIP-712 commitment signature; enforces monotonic cursor, per-period cap (`fee <= maxPerPeriod`), time windows (`validFrom <= now <= validTo`), expiry, and cancel; calls `transferFrom(subscriber, payTo, fee)` on success |
+| **Token** | Any ERC-20; EIP-2612 support enables gasless allowance approval |
+
 ---
 
-## 2. Payment Authorization Methods
+## 2. Allowance Establishment Methods
 
-### 2.1 EIP-3009 (Recommended for USDC)
+The client must grant the `x402SubscriptionRegistry` contract an ERC-20 allowance covering the total committed spend. V1 supports two methods:
 
-For tokens supporting `transferWithAuthorization`, each billing cycle payment uses a standard EIP-3009 signature.
+### 2.1 EIP-2612 Permit (Recommended)
 
-**EIP-712 Domain:**
+For tokens supporting EIP-2612 (including USDC on Base), the client signs a `permit` authorizing the registry to spend tokens. The facilitator submits this signature bundled with `subscribe()`, making the flow gasless for the client.
+
+**EIP-712 Domain (token contract):**
 
 ```javascript
-const domain = {
+const permitDomain = {
   name: "USD Coin",      // Token name
   version: "2",          // Token version
   chainId: 8453,         // Base mainnet
-  verifyingContract: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  verifyingContract: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" // USDC
 };
 ```
 
-**Authorization Types:**
+**Permit Types:**
 
 ```javascript
-const subscribeAuthorizationTypes = {
-  TransferWithAuthorization: [
-    { name: "from", type: "address" },
-    { name: "to", type: "address" },
+const permitTypes = {
+  Permit: [
+    { name: "owner", type: "address" },
+    { name: "spender", type: "address" },
     { name: "value", type: "uint256" },
-    { name: "validAfter", type: "uint256" },
-    { name: "validBefore", type: "uint256" },
-    { name: "nonce", type: "bytes32" }
+    { name: "nonce", type: "uint256" },
+    { name: "deadline", type: "uint256" }
   ]
 };
 ```
 
-### 2.2 Permit2 (Universal Fallback)
+The `spender` is the `x402SubscriptionRegistry` address. The `value` SHOULD equal the total committed spend (sum of all period fees), making the allowance itself an on-chain aggregate cap.
 
-For tokens without EIP-3009 support, use Permit2 with the x402SubscriptionProxy contract.
+### 2.2 Direct Approve (Non-Gasless Fallback)
 
-**Witness Type for Subscriptions:**
+For tokens without EIP-2612 support, the client submits a standard `ERC20.approve(registry, amount)` transaction directly, paying their own gas. The client must complete this approval before the facilitator can call `subscribe()`.
 
-```javascript
-const SUBSCRIPTION_WITNESS_TYPE_STRING =
-  "SubscriptionWitness witness)SubscriptionWitness(address to,uint256 validAfter,bytes32 subscriptionId,uint256 cycleNumber,bytes extra)TokenPermissions(address token,uint256 amount)";
+### 2.3 Future Work: Permit2 Funding (Non-Normative)
 
-const SUBSCRIPTION_WITNESS_TYPEHASH = keccak256(
-  "SubscriptionWitness(address to,uint256 validAfter,bytes32 subscriptionId,uint256 cycleNumber,bytes extra)"
-);
-```
+> Permit2 support is deferred to a future version. The correct approach would use **AllowanceTransfer** (specifically `PermitSingle`) to grant the registry spend permission through Permit2 — NOT SignatureTransfer with a witness, which is single-use and unsuitable for recurring charges. This requires a second pull path (`PERMIT2.transferFrom`) in the registry contract. Permit2 funding can be added later as a registry variant without changing the scheme semantics.
 
 ---
 
-## 3. PaymentPayload Structure
+## 3. EIP-712 Commitment Structure
 
-### 3.1 Initial Subscription (EIP-3009)
+The client signs a single EIP-712 typed data structure that binds the entire subscription:
+
+### 3.1 EIP-712 Domain (Registry Contract)
+
+```javascript
+const commitmentDomain = {
+  name: "x402SubscriptionRegistry",
+  version: "1",
+  chainId: 8453,
+  verifyingContract: "0x402SubscriptionRegistryAddress" // Registry address
+};
+```
+
+### 3.2 Commitment Types
+
+```javascript
+const commitmentTypes = {
+  SubscriptionCommitment: [
+    { name: "root", type: "bytes32" },
+    { name: "subscriber", type: "address" },
+    { name: "asset", type: "address" },
+    { name: "payTo", type: "address" },
+    { name: "registry", type: "address" },
+    { name: "chainId", type: "uint256" },
+    { name: "tierId", type: "string" },
+    { name: "start", type: "uint256" },
+    { name: "expiry", type: "uint256" },
+    { name: "maxPerPeriod", type: "uint256" }
+  ]
+};
+```
+
+### 3.3 Commitment Fields
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `root` | `bytes32` | Merkle root of the billing schedule (client MUST recompute, never blind-sign) |
+| `subscriber` | `address` | Address that will be charged (signs the commitment) |
+| `asset` | `address` | ERC-20 token contract address |
+| `payTo` | `address` | Recipient address for all charges |
+| `registry` | `address` | The `x402SubscriptionRegistry` contract address |
+| `chainId` | `uint256` | EVM chain ID (prevents cross-chain replay) |
+| `tierId` | `string` | Subscription tier identifier |
+| `start` | `uint256` | Unix timestamp when subscription begins |
+| `expiry` | `uint256` | Unix timestamp after which no charges are valid |
+| `maxPerPeriod` | `uint256` | Maximum fee per charge (safety cap) |
+
+The `subscriptionId` is derived as `keccak256(abi.encode(commitmentStructHash))`, binding all parameters in one identifier.
+
+---
+
+## 4. PaymentPayload Structure
+
+### 4.1 Subscribe Action
+
+When subscribing, the client sends a `PaymentPayload` with the schedule commitment:
 
 ```json
 {
@@ -117,53 +172,79 @@ const SUBSCRIPTION_WITNESS_TYPEHASH = keccak256(
     "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
     "maxTimeoutSeconds": 300,
     "extra": {
-      "assetTransferMethod": "eip3009",
       "name": "USDC",
       "version": "2",
+      "registry": "0x402SubscriptionRegistryAddress",
       "subscriptionDetails": {
         "tierId": "pro",
         "tierName": "Pro Plan",
         "billingCycle": "monthly",
         "billingCycleSeconds": 2592000,
-        "renewalPolicy": "auto",
-        "gracePeriodSeconds": 86400
+        "periodCount": 12,
+        "gracePeriodSeconds": 86400,
+        "cancellationPolicy": "end_of_cycle"
       }
     }
   },
   "payload": {
-    "signature": "0x...",
-    "authorization": {
-      "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-      "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-      "value": "5000000",
-      "validAfter": "1740672089",
-      "validBefore": "1743264089",
-      "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480"
-    },
-    "subscriptionPayload": {
-      "action": "subscribe",
+    "action": "subscribe",
+    "commitment": {
+      "root": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+      "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "registry": "0x402SubscriptionRegistryAddress",
+      "chainId": 8453,
       "tierId": "pro",
-      "startTimestamp": "1740672089",
-      "renewalAuthorizations": [
-        {
-          "cycleNumber": 2,
-          "signature": "0x...",
-          "authorization": {
-            "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-            "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-            "value": "5000000",
-            "validAfter": "1743264089",
-            "validBefore": "1745856089",
-            "nonce": "0x..."
-          }
-        }
-      ]
-    }
+      "start": "1740672089",
+      "expiry": "1772208089",
+      "maxPerPeriod": "5000000"
+    },
+    "commitmentSignature": "0x...",
+    "allowanceMethod": "eip2612-permit",
+    "allowanceSignature": "0x...",
+    "schedule": [
+      { "periodIndex": 0, "fee": "5000000", "validFrom": "1740672089", "validTo": "1743350489" },
+      { "periodIndex": 1, "fee": "5000000", "validFrom": "1743264089", "validTo": "1745942489" },
+      { "periodIndex": 2, "fee": "5000000", "validFrom": "1745856089", "validTo": "1748534489" }
+    ]
   }
 }
 ```
 
-### 3.2 Initial Subscription (Permit2)
+**Note:** The `schedule` array is transported so the facilitator can rebuild the Merkle tree and generate proofs. The `root` in the signed commitment is what cryptographically binds it — the facilitator cannot alter the schedule without invalidating the signature.
+
+### 4.2 Subscribe Payload Fields
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `action` | `string` | Required | `"subscribe"` for new subscriptions |
+| `commitment` | `object` | Required | The EIP-712 commitment struct |
+| `commitmentSignature` | `string` | Required | EIP-712 signature over the commitment (65 bytes, hex) |
+| `allowanceMethod` | `string` | Required | `"eip2612-permit"` or `"direct-approve"` |
+| `allowanceSignature` | `string` | Conditional | Required if `allowanceMethod` is `"eip2612-permit"` |
+| `schedule` | `array` | Required | Array of `{periodIndex, fee, validFrom, validTo}` objects |
+
+### 4.3 Schedule Leaf Structure
+
+Each element in the `schedule` array represents one billing period:
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `periodIndex` | `number` | Zero-indexed billing period number |
+| `fee` | `string` | Amount to charge for this period (in token atomic units) |
+| `validFrom` | `string` | Unix timestamp when this period's charge becomes valid |
+| `validTo` | `string` | Unix timestamp when this period's charge expires (includes grace) |
+
+The Merkle leaf is computed as: `keccak256(keccak256(abi.encode(periodIndex, fee, validFrom, validTo)))` (OpenZeppelin double-hash convention).
+
+### 4.4 Renewal Within Committed Schedule
+
+**Renewal is NOT a client action within a committed schedule.** Once the client signs a commitment covering N periods, the facilitator submits `chargePeriod()` for each period using the stored Merkle proofs. No new client signature is needed until the schedule expires or the client wishes to change tiers.
+
+### 4.5 Cancel Action
+
+To cancel a subscription, the client signs a cancellation request with replay protection:
 
 ```json
 {
@@ -176,315 +257,276 @@ const SUBSCRIPTION_WITNESS_TYPEHASH = keccak256(
     "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
     "maxTimeoutSeconds": 300,
     "extra": {
-      "assetTransferMethod": "permit2",
-      "name": "USDC",
-      "version": "2",
+      "registry": "0x402SubscriptionRegistryAddress",
+      "subscriptionDetails": { "tierId": "pro" }
+    }
+  },
+  "payload": {
+    "action": "cancel",
+    "subscriptionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+    "nonce": "12345",
+    "signature": "0x..."
+  }
+}
+```
+
+**Cancel Payload Fields:**
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `action` | `string` | Required | `"cancel"` |
+| `subscriptionId` | `string` | Required | The subscription to cancel (bytes32, hex) |
+| `subscriber` | `string` | Required | Subscriber address (must match commitment) |
+| `nonce` | `string` | Required | Client-chosen nonce for replay protection |
+| `signature` | `string` | Required | EIP-712 signature over `{subscriptionId, nonce}` |
+
+The registry records used nonces; resubmitting the same `(subscriptionId, nonce)` pair reverts.
+
+### 4.6 Update-Root Action (Tier Change / Re-commitment)
+
+To change tiers, extend a subscription, or modify the schedule, the client signs a new commitment:
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "subscribe",
+    "network": "eip155:8453",
+    "amount": "10000000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "registry": "0x402SubscriptionRegistryAddress",
       "subscriptionDetails": {
-        "tierId": "pro",
+        "tierId": "enterprise",
+        "tierName": "Enterprise Plan",
         "billingCycle": "monthly",
         "billingCycleSeconds": 2592000,
-        "renewalPolicy": "auto"
+        "periodCount": 12
       }
     }
   },
   "payload": {
-    "signature": "0x...",
-    "permit2Authorization": {
-      "permitted": {
-        "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        "amount": "5000000"
-      },
-      "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-      "spender": "0x_x402SubscriptionProxyAddress",
-      "nonce": "0x...",
-      "deadline": "1743264089",
-      "witness": {
-        "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-        "validAfter": "1740672089",
-        "subscriptionId": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "cycleNumber": "1",
-        "extra": "0x"
-      }
+    "action": "update-root",
+    "previousSubscriptionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    "commitment": {
+      "root": "0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321",
+      "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "registry": "0x402SubscriptionRegistryAddress",
+      "chainId": 8453,
+      "tierId": "enterprise",
+      "start": "1772208089",
+      "expiry": "1803744089",
+      "maxPerPeriod": "10000000"
     },
-    "subscriptionPayload": {
-      "action": "subscribe",
-      "tierId": "pro",
-      "startTimestamp": "1740672089",
-      "renewalAuthorizations": []
+    "commitmentSignature": "0x...",
+    "allowanceMethod": "eip2612-permit",
+    "allowanceSignature": "0x...",
+    "schedule": [
+      { "periodIndex": 0, "fee": "10000000", "validFrom": "1772208089", "validTo": "1774886489" }
+    ]
+  }
+}
+```
+
+**Update-Root Payload Fields:**
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `action` | `string` | Required | `"update-root"` |
+| `previousSubscriptionId` | `string` | Optional | Links to previous subscription (for tier migration) |
+| `commitment` | `object` | Required | New EIP-712 commitment struct |
+| `commitmentSignature` | `string` | Required | EIP-712 signature over the new commitment |
+| `allowanceMethod` | `string` | Required | How allowance is established for new schedule |
+| `allowanceSignature` | `string` | Conditional | Required if gasless allowance method |
+| `schedule` | `array` | Required | New billing schedule |
+
+---
+
+## 5. `extra` Field Reference
+
+### 5.1 Fields in `PaymentRequirements.extra`
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `name` | `string` | Conditional | EIP-712 domain name of the token. Required for EIP-2612 permit. |
+| `version` | `string` | Conditional | EIP-712 domain version of the token. Required for EIP-2612 permit. |
+| `registry` | `string` | Required | Address of the `x402SubscriptionRegistry` contract. |
+| `subscriptionDetails` | `object` | Required | Subscription tier configuration (see below). |
+
+### 5.2 Fields in `subscriptionDetails`
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `tierId` | `string` | Required | Unique identifier for the subscription tier. |
+| `tierName` | `string` | Required | Human-readable name for the tier. |
+| `billingCycle` | `string` | Required | `"daily"`, `"weekly"`, `"monthly"`, `"annual"`, or `"custom"`. |
+| `billingCycleSeconds` | `number` | Required | Duration of billing cycle in seconds. |
+| `periodCount` | `number` | Required | Number of billing periods in the subscription term. |
+| `features` | `array` | Optional | List of features included in this tier. |
+| `rateLimits` | `object` | Optional | Rate limiting configuration for this tier. |
+| `gracePeriodSeconds` | `number` | Optional | Time after a failed charge during which access continues. |
+| `cancellationPolicy` | `string` | Required | `"immediate"` or `"end_of_cycle"`. |
+| `trialPeriodSeconds` | `number` | Optional | Duration of free trial period (if applicable). |
+
+---
+
+## 6. Subscription Extension (Access Verification)
+
+Once subscribed, clients present an active-subscription proof for subsequent requests without requiring new payments. The proof travels as the `subscription` extension in `PaymentPayload.extensions`, following the V2 extension pattern (see `payment-identifier` for reference).
+
+### 6.1 Extension Key
+
+```
+subscription
+```
+
+### 6.2 Extension Info Structure
+
+```json
+{
+  "extensions": {
+    "subscription": {
+      "info": {
+        "subscriptionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+        "network": "eip155:8453"
+      }
     }
   }
 }
 ```
 
-### 3.3 Subscription Proof Header
+### 6.3 Verification
 
-For subsequent requests within an active subscription period:
-
-**X-SUBSCRIPTION-PROOF Header (Base64 encoded):**
-
-```json
-{
-  "subscriptionId": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-  "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-  "tierId": "pro",
-  "network": "eip155:8453",
-  "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
-  "currentCycleNumber": 1,
-  "currentCycleStart": "1740672089",
-  "currentCycleEnd": "1743264089",
-  "signature": "0x..."
-}
-```
-
-**EIP-712 Subscription Proof Types:**
+The resource server verifies the proof by calling `isActive(subscriptionId)` on the on-chain registry. The extension info is a **pointer to verify**, never a trusted claim.
 
 ```javascript
-const subscriptionProofTypes = {
-  SubscriptionProof: [
-    { name: "subscriptionId", type: "bytes32" },
-    { name: "subscriber", type: "address" },
-    { name: "tierId", type: "string" },
-    { name: "payTo", type: "address" },
-    { name: "currentCycleNumber", type: "uint256" },
-    { name: "currentCycleStart", type: "uint256" },
-    { name: "currentCycleEnd", type: "uint256" }
-  ]
-};
+const isValid = await registry.isActive(subscriptionId);
+if (!isValid) {
+  return { status: 402, error: "subscription_not_found" };
+}
 ```
 
 ---
 
-## 4. Verification Logic
+## 7. Verification Logic
 
-### 4.1 Initial Subscription Verification
+### 7.1 Subscribe Verification
 
 The facilitator MUST perform these checks in order:
 
-1. **Verify** the `payload.signature` is valid and recovers to `authorization.from`
+1. **Verify** the `commitmentSignature` is valid and recovers to `commitment.subscriber`
 
-2. **Verify** the subscriber has sufficient balance of the `asset`:
-   ```solidity
-   require(IERC20(asset).balanceOf(from) >= amount, "insufficient_funds");
-   ```
+2. **Verify** the Merkle root:
+   - Rebuild the tree from the `schedule` array
+   - Confirm the computed root matches `commitment.root`
 
-3. **Verify** the authorization parameters meet requirements:
-   - `authorization.value` >= `accepted.amount`
-   - `authorization.to` == `accepted.payTo`
-   - `block.timestamp` >= `authorization.validAfter`
-   - `block.timestamp` < `authorization.validBefore`
+3. **Verify** commitment parameters match `PaymentRequirements`:
+   - `commitment.asset` == `accepted.asset`
+   - `commitment.payTo` == `accepted.payTo`
+   - `commitment.registry` == `accepted.extra.registry`
+   - `commitment.chainId` == chain ID from `accepted.network`
+   - `commitment.tierId` == `accepted.extra.subscriptionDetails.tierId`
 
-4. **Verify** the subscription details:
-   - `tierId` is valid and available
-   - `billingCycleSeconds` matches the tier configuration
-   - `startTimestamp` is within acceptable range (not in distant past/future)
+4. **Verify** allowance:
+   - If `allowanceMethod` is `"eip2612-permit"`: validate permit signature
+   - If `allowanceMethod` is `"direct-approve"`: confirm on-chain allowance exists
+   - Confirm allowance >= total committed spend
 
-5. **Verify** renewal authorizations (if provided):
-   - Each authorization has non-overlapping validity windows
-   - Validity windows align with billing cycle boundaries
-   - All authorizations are from the same `from` address
+5. **Verify** the subscriber has sufficient balance for at least the first period
 
-6. **Simulate** the transaction:
-   ```solidity
-   // For EIP-3009
-   token.transferWithAuthorization(from, to, value, validAfter, validBefore, nonce, signature);
-   ```
+6. **Simulate** the `subscribe()` call on the registry
 
-### 4.2 Subscription Proof Verification
+### 7.2 Charge Verification (Facilitator-side, per period)
 
-For requests with `X-SUBSCRIPTION-PROOF` header:
+Before calling `chargePeriod()`:
 
-1. **Decode** the Base64 subscription proof
+1. **Construct** Merkle proof for the current `periodIndex`
+2. **Verify** `periodIndex == cursor` (monotonic)
+3. **Verify** `validFrom <= block.timestamp <= validTo`
+4. **Verify** `fee <= maxPerPeriod`
+5. **Verify** `!cancelled && block.timestamp <= expiry`
+6. **Verify** subscriber has sufficient balance and allowance
 
-2. **Verify** the proof signature:
-   ```javascript
-   const recoveredAddress = ethers.verifyTypedData(
-     domain,
-     subscriptionProofTypes,
-     proofData,
-     proof.signature
-   );
-   require(recoveredAddress === proof.subscriber, "invalid_subscription_proof");
-   ```
+### 7.3 Cancel Verification
 
-3. **Verify** subscription is active:
-   - `block.timestamp` >= `currentCycleStart`
-   - `block.timestamp` < `currentCycleEnd`
-   - Subscription not cancelled
-
-4. **Verify** payment was settled for current cycle:
-   - Query on-chain registry OR
-   - Verify against facilitator's off-chain records
-
-5. **Verify** rate limits (if applicable):
-   - Check subscriber hasn't exceeded tier limits
-
-### 4.3 Renewal Verification
-
-When processing automatic renewals:
-
-1. **Verify** the renewal authorization matches the expected cycle:
-   - `cycleNumber` matches expected next cycle
-   - `validAfter` aligns with cycle start
-   - `validBefore` extends to cycle end
-
-2. **Verify** the subscriber still has sufficient balance
-
-3. **Verify** subscription is in good standing (not cancelled)
-
-4. **Simulate** the renewal transaction
+1. **Verify** the `signature` over `{subscriptionId, nonce}` recovers to `subscriber`
+2. **Verify** `nonce` has not been used before
+3. **Verify** subscription exists and is not already cancelled
 
 ---
 
-## 5. Settlement Logic
+## 8. Settlement Logic
 
-### 5.1 Initial Subscription Settlement (EIP-3009)
+### 8.1 Subscribe Settlement
 
 ```solidity
-// 1. Execute the payment
-IERC3009(asset).transferWithAuthorization(
-    authorization.from,
-    authorization.to,
-    authorization.value,
-    authorization.validAfter,
-    authorization.validBefore,
-    authorization.nonce,
-    signature
+// 1. If gasless allowance, execute permit first
+if (allowanceMethod == "eip2612-permit") {
+    IERC20Permit(asset).permit(subscriber, registry, totalAmount, deadline, v, r, s);
+}
+
+// 2. Execute subscribe on registry
+bytes32 subscriptionId = registry.subscribe(commitment, commitmentSignature);
+
+// 3. Optionally charge period 0 immediately
+registry.chargePeriod(subscriptionId, 0, fee, validFrom, validTo, proof);
+```
+
+### 8.2 Periodic Charge Settlement
+
+```solidity
+// Facilitator calls at each billing boundary
+registry.chargePeriod(
+    subscriptionId,
+    periodIndex,
+    fee,
+    validFrom,
+    validTo,
+    merkleProof
 );
 
-// 2. Register the subscription (on-chain or off-chain)
-bytes32 subscriptionId = keccak256(abi.encodePacked(
-    subscriber,
-    payTo,
-    tierId,
-    block.timestamp
-));
-
-// 3. Store renewal authorizations (if provided)
-for (uint i = 0; i < renewalAuthorizations.length; i++) {
-    storeRenewalAuth(subscriptionId, renewalAuthorizations[i]);
-}
-
-// 4. Return subscription details
-emit SubscriptionCreated(subscriptionId, subscriber, tierId, cycleEnd);
+// Registry internally:
+// 1. Verifies Merkle proof
+// 2. Checks periodIndex == cursor
+// 3. Checks validFrom <= now <= validTo
+// 4. Checks fee <= maxPerPeriod
+// 5. Checks !cancelled && now <= expiry
+// 6. Calls transferFrom(subscriber, payTo, fee)
+// 7. Increments cursor
 ```
 
-### 5.2 Initial Subscription Settlement (Permit2)
+### 8.3 Grace Period Handling
+
+If `chargePeriod` fails due to insufficient balance/allowance:
+
+1. Registry enters grace state: `inGracePeriod = true`
+2. `gracePeriodEnd = validTo + gracePeriodSeconds`
+3. Access continues during grace period
+4. A successful charge within grace restores active status
+5. If `block.timestamp > gracePeriodEnd` without successful charge, `isActive()` returns false
+
+### 8.4 Cancellation Settlement
 
 ```solidity
-// Call x402SubscriptionProxy.subscribe()
-x402SubscriptionProxy.subscribe(
-    permit,
-    amount,
-    owner,
-    subscriptionWitness,
-    signature,
-    tierId,
-    billingCycleSeconds
-);
-```
+registry.cancel(subscriptionId, nonce, signature);
 
-### 5.3 Renewal Settlement
-
-For automatic renewals at cycle boundaries:
-
-```solidity
-function processRenewal(bytes32 subscriptionId) external {
-    Subscription storage sub = subscriptions[subscriptionId];
-    require(block.timestamp >= sub.currentCycleEnd, "cycle_not_ended");
-    require(!sub.cancelled, "subscription_cancelled");
-
-    // Get pre-stored renewal authorization
-    RenewalAuth memory auth = renewalAuths[subscriptionId][sub.cycleNumber + 1];
-    require(auth.signature.length > 0, "no_renewal_auth");
-
-    // Execute the renewal payment
-    IERC3009(sub.asset).transferWithAuthorization(
-        auth.from,
-        auth.to,
-        auth.value,
-        auth.validAfter,
-        auth.validBefore,
-        auth.nonce,
-        auth.signature
-    );
-
-    // Update subscription state
-    sub.cycleNumber++;
-    sub.currentCycleStart = sub.currentCycleEnd;
-    sub.currentCycleEnd = sub.currentCycleStart + sub.billingCycleSeconds;
-
-    emit SubscriptionRenewed(subscriptionId, sub.cycleNumber, sub.currentCycleEnd);
-}
-```
-
-### 5.4 Cancellation Settlement
-
-Cancellation is recorded but does not trigger a blockchain payment:
-
-```solidity
-function cancelSubscription(
-    bytes32 subscriptionId,
-    bytes calldata cancellationSignature
-) external {
-    Subscription storage sub = subscriptions[subscriptionId];
-
-    // Verify cancellation is signed by subscriber
-    bytes32 cancellationHash = keccak256(abi.encodePacked(
-        subscriptionId,
-        "cancel",
-        block.timestamp
-    ));
-    address signer = ECDSA.recover(cancellationHash, cancellationSignature);
-    require(signer == sub.subscriber, "unauthorized");
-
-    // Mark as cancelled (access continues until cycle end)
-    sub.cancelled = true;
-    sub.cancellationTimestamp = block.timestamp;
-
-    // Delete unused renewal authorizations
-    for (uint i = sub.cycleNumber + 1; i <= maxStoredCycles; i++) {
-        delete renewalAuths[subscriptionId][i];
-    }
-
-    emit SubscriptionCancelled(subscriptionId, sub.currentCycleEnd);
-}
+// Registry internally:
+// 1. Verifies signature recovers to subscriber
+// 2. Checks nonce not used
+// 3. Records cancelled = true
+// 4. Stores nonce as used
+// 5. All future chargePeriod calls revert
 ```
 
 ---
 
-## 6. Grace Period Handling
-
-When a renewal fails (insufficient funds, expired auth, etc.):
-
-```solidity
-function handleFailedRenewal(bytes32 subscriptionId) internal {
-    Subscription storage sub = subscriptions[subscriptionId];
-
-    // Enter grace period
-    sub.inGracePeriod = true;
-    sub.gracePeriodEnd = sub.currentCycleEnd + sub.gracePeriodSeconds;
-
-    emit SubscriptionGracePeriod(subscriptionId, sub.gracePeriodEnd);
-}
-
-function isSubscriptionActive(bytes32 subscriptionId) public view returns (bool) {
-    Subscription storage sub = subscriptions[subscriptionId];
-
-    if (sub.cancelled && block.timestamp >= sub.currentCycleEnd) {
-        return false;
-    }
-
-    if (sub.inGracePeriod) {
-        return block.timestamp < sub.gracePeriodEnd;
-    }
-
-    return block.timestamp < sub.currentCycleEnd;
-}
-```
-
----
-
-## 7. Reference Implementation: `x402SubscriptionRegistry`
+## 9. Reference Implementation: `x402SubscriptionRegistry`
 
 This contract manages subscription state on-chain for trustless verification.
 
@@ -495,80 +537,57 @@ pragma solidity ^0.8.20;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-
-interface IERC3009 {
-    function transferWithAuthorization(
-        address from,
-        address to,
-        uint256 value,
-        uint256 validAfter,
-        uint256 validBefore,
-        bytes32 nonce,
-        bytes memory signature
-    ) external;
-}
 
 contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
     using ECDSA for bytes32;
 
     // ============ Constants ============
 
-    bytes32 public constant SUBSCRIPTION_PROOF_TYPEHASH = keccak256(
-        "SubscriptionProof(bytes32 subscriptionId,address subscriber,string tierId,address payTo,uint256 currentCycleNumber,uint256 currentCycleStart,uint256 currentCycleEnd)"
+    bytes32 public constant COMMITMENT_TYPEHASH = keccak256(
+        "SubscriptionCommitment(bytes32 root,address subscriber,address asset,address payTo,address registry,uint256 chainId,string tierId,uint256 start,uint256 expiry,uint256 maxPerPeriod)"
     );
 
     bytes32 public constant CANCELLATION_TYPEHASH = keccak256(
-        "CancelSubscription(bytes32 subscriptionId,uint256 timestamp)"
+        "CancelSubscription(bytes32 subscriptionId,uint256 nonce)"
     );
 
     // ============ Structs ============
 
-    struct Subscription {
+    struct Commitment {
+        bytes32 root;
         address subscriber;
-        address payTo;
         address asset;
+        address payTo;
+        address registry;
+        uint256 chainId;
         string tierId;
-        uint256 amount;
-        uint256 billingCycleSeconds;
+        uint256 start;
+        uint256 expiry;
+        uint256 maxPerPeriod;
+    }
+
+    struct Subscription {
+        bytes32 root;
+        address subscriber;
+        address asset;
+        address payTo;
+        string tierId;
+        uint256 start;
+        uint256 expiry;
+        uint256 maxPerPeriod;
         uint256 gracePeriodSeconds;
-        uint256 cycleNumber;
-        uint256 currentCycleStart;
-        uint256 currentCycleEnd;
+        uint256 cursor;
         bool cancelled;
         bool inGracePeriod;
         uint256 gracePeriodEnd;
     }
 
-    struct RenewalAuthorization {
-        address from;
-        address to;
-        uint256 value;
-        uint256 validAfter;
-        uint256 validBefore;
-        bytes32 nonce;
-        bytes signature;
-    }
-
-    struct SubscribeParams {
-        address subscriber;
-        address payTo;
-        address asset;
-        string tierId;
-        uint256 amount;
-        uint256 billingCycleSeconds;
-        uint256 gracePeriodSeconds;
-        uint256 startTimestamp;
-        bytes signature;
-        RenewalAuthorization initialAuth;
-        RenewalAuthorization[] renewalAuths;
-    }
-
     // ============ State ============
 
     mapping(bytes32 => Subscription) public subscriptions;
-    mapping(bytes32 => mapping(uint256 => RenewalAuthorization)) public renewalAuthorizations;
-    mapping(address => bytes32[]) public subscriberSubscriptions;
+    mapping(bytes32 => mapping(uint256 => bool)) public usedNonces;
 
     // ============ Events ============
 
@@ -577,15 +596,19 @@ contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
         address indexed subscriber,
         address indexed payTo,
         string tierId,
-        uint256 amount,
-        uint256 cycleEnd
+        uint256 expiry
     );
 
-    event SubscriptionRenewed(
+    event PeriodCharged(
         bytes32 indexed subscriptionId,
-        uint256 cycleNumber,
-        uint256 cycleEnd,
-        bytes32 transactionHash
+        uint256 periodIndex,
+        uint256 fee
+    );
+
+    event ChargeFailed(
+        bytes32 indexed subscriptionId,
+        uint256 periodIndex,
+        string reason
     );
 
     event SubscriptionCancelled(
@@ -593,541 +616,34 @@ contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
         uint256 accessEndsAt
     );
 
-    event SubscriptionGracePeriod(
+    event GracePeriodEntered(
         bytes32 indexed subscriptionId,
         uint256 gracePeriodEnd
-    );
-
-    event RenewalFailed(
-        bytes32 indexed subscriptionId,
-        uint256 cycleNumber,
-        string reason
     );
 
     // ============ Constructor ============
 
     constructor() EIP712("x402SubscriptionRegistry", "1") {}
 
-    // ============ External Functions ============
-
-    /**
-     * @notice Create a new subscription with initial payment
-     * @param params Subscription parameters including payment authorization
-     */
-    function subscribe(SubscribeParams calldata params)
-        external
-        nonReentrant
-        returns (bytes32 subscriptionId)
-    {
-        // Generate unique subscription ID
-        subscriptionId = keccak256(abi.encodePacked(
-            params.subscriber,
-            params.payTo,
-            params.tierId,
-            params.startTimestamp,
-            block.chainid
-        ));
-
-        require(subscriptions[subscriptionId].subscriber == address(0), "subscription_exists");
-
-        // Execute initial payment via EIP-3009
-        IERC3009(params.asset).transferWithAuthorization(
-            params.initialAuth.from,
-            params.initialAuth.to,
-            params.initialAuth.value,
-            params.initialAuth.validAfter,
-            params.initialAuth.validBefore,
-            params.initialAuth.nonce,
-            params.initialAuth.signature
-        );
-
-        // Create subscription record
-        uint256 cycleEnd = params.startTimestamp + params.billingCycleSeconds;
-
-        subscriptions[subscriptionId] = Subscription({
-            subscriber: params.subscriber,
-            payTo: params.payTo,
-            asset: params.asset,
-            tierId: params.tierId,
-            amount: params.amount,
-            billingCycleSeconds: params.billingCycleSeconds,
-            gracePeriodSeconds: params.gracePeriodSeconds,
-            cycleNumber: 1,
-            currentCycleStart: params.startTimestamp,
-            currentCycleEnd: cycleEnd,
-            cancelled: false,
-            inGracePeriod: false,
-            gracePeriodEnd: 0
-        });
-
-        // Store renewal authorizations
-        for (uint256 i = 0; i < params.renewalAuths.length; i++) {
-            renewalAuthorizations[subscriptionId][i + 2] = params.renewalAuths[i];
-        }
-
-        subscriberSubscriptions[params.subscriber].push(subscriptionId);
-
-        emit SubscriptionCreated(
-            subscriptionId,
-            params.subscriber,
-            params.payTo,
-            params.tierId,
-            params.amount,
-            cycleEnd
-        );
-
-        return subscriptionId;
-    }
-
-    /**
-     * @notice Process automatic renewal for a subscription
-     * @param subscriptionId The subscription to renew
-     */
-    function processRenewal(bytes32 subscriptionId) external nonReentrant {
-        Subscription storage sub = subscriptions[subscriptionId];
-
-        require(sub.subscriber != address(0), "subscription_not_found");
-        require(!sub.cancelled, "subscription_cancelled");
-        require(block.timestamp >= sub.currentCycleEnd, "cycle_not_ended");
-
-        uint256 nextCycle = sub.cycleNumber + 1;
-        RenewalAuthorization storage auth = renewalAuthorizations[subscriptionId][nextCycle];
-
-        require(auth.signature.length > 0, "no_renewal_authorization");
-        require(block.timestamp >= auth.validAfter, "renewal_not_valid_yet");
-        require(block.timestamp < auth.validBefore, "renewal_expired");
-
-        // Check balance before attempting
-        if (IERC20(sub.asset).balanceOf(auth.from) < auth.value) {
-            _enterGracePeriod(subscriptionId);
-            emit RenewalFailed(subscriptionId, nextCycle, "insufficient_funds");
-            return;
-        }
-
-        // Execute renewal payment
-        try IERC3009(sub.asset).transferWithAuthorization(
-            auth.from,
-            auth.to,
-            auth.value,
-            auth.validAfter,
-            auth.validBefore,
-            auth.nonce,
-            auth.signature
-        ) {
-            // Update subscription state
-            sub.cycleNumber = nextCycle;
-            sub.currentCycleStart = sub.currentCycleEnd;
-            sub.currentCycleEnd = sub.currentCycleStart + sub.billingCycleSeconds;
-            sub.inGracePeriod = false;
-            sub.gracePeriodEnd = 0;
-
-            // Clear used authorization
-            delete renewalAuthorizations[subscriptionId][nextCycle];
-
-            emit SubscriptionRenewed(
-                subscriptionId,
-                nextCycle,
-                sub.currentCycleEnd,
-                bytes32(0) // Transaction hash not available in contract
-            );
-        } catch {
-            _enterGracePeriod(subscriptionId);
-            emit RenewalFailed(subscriptionId, nextCycle, "transfer_failed");
-        }
-    }
-
-    /**
-     * @notice Add renewal authorizations for future cycles
-     * @param subscriptionId The subscription to add renewals for
-     * @param startCycle First cycle number for the new authorizations
-     * @param auths Array of renewal authorizations
-     */
-    function addRenewalAuthorizations(
-        bytes32 subscriptionId,
-        uint256 startCycle,
-        RenewalAuthorization[] calldata auths
-    ) external {
-        Subscription storage sub = subscriptions[subscriptionId];
-        require(msg.sender == sub.subscriber, "unauthorized");
-        require(!sub.cancelled, "subscription_cancelled");
-
-        for (uint256 i = 0; i < auths.length; i++) {
-            require(auths[i].from == sub.subscriber, "invalid_from");
-            require(auths[i].to == sub.payTo, "invalid_to");
-            require(auths[i].value == sub.amount, "invalid_amount");
-
-            renewalAuthorizations[subscriptionId][startCycle + i] = auths[i];
-        }
-    }
-
-    /**
-     * @notice Cancel a subscription
-     * @param subscriptionId The subscription to cancel
-     * @param signature Subscriber's signature authorizing cancellation
-     */
-    function cancelSubscription(
-        bytes32 subscriptionId,
-        bytes calldata signature
-    ) external nonReentrant {
-        Subscription storage sub = subscriptions[subscriptionId];
-        require(sub.subscriber != address(0), "subscription_not_found");
-        require(!sub.cancelled, "already_cancelled");
-
-        // Verify cancellation signature
-        bytes32 structHash = keccak256(abi.encode(
-            CANCELLATION_TYPEHASH,
-            subscriptionId,
-            block.timestamp
-        ));
-        bytes32 digest = _hashTypedDataV4(structHash);
-        address signer = ECDSA.recover(digest, signature);
-        require(signer == sub.subscriber, "invalid_signature");
-
-        // Mark as cancelled
-        sub.cancelled = true;
-
-        // Clear future renewal authorizations
-        for (uint256 i = sub.cycleNumber + 1; i <= sub.cycleNumber + 12; i++) {
-            delete renewalAuthorizations[subscriptionId][i];
-        }
-
-        emit SubscriptionCancelled(subscriptionId, sub.currentCycleEnd);
-    }
-
-    // ============ View Functions ============
-
-    /**
-     * @notice Check if a subscription is currently active
-     * @param subscriptionId The subscription to check
-     * @return active Whether the subscription is active
-     */
-    function isActive(bytes32 subscriptionId) external view returns (bool active) {
-        Subscription storage sub = subscriptions[subscriptionId];
-
-        if (sub.subscriber == address(0)) {
-            return false;
-        }
-
-        if (sub.cancelled && block.timestamp >= sub.currentCycleEnd) {
-            return false;
-        }
-
-        if (sub.inGracePeriod) {
-            return block.timestamp < sub.gracePeriodEnd;
-        }
-
-        return block.timestamp < sub.currentCycleEnd;
-    }
-
-    /**
-     * @notice Get subscription details for proof generation
-     * @param subscriptionId The subscription ID
-     */
-    function getSubscription(bytes32 subscriptionId)
-        external
-        view
-        returns (Subscription memory)
-    {
-        return subscriptions[subscriptionId];
-    }
-
-    /**
-     * @notice Verify a subscription proof without state changes
-     * @param subscriptionId The subscription ID
-     * @param subscriber The subscriber address
-     * @param cycleNumber The claimed cycle number
-     * @param cycleStart The claimed cycle start
-     * @param cycleEnd The claimed cycle end
-     * @param signature The proof signature
-     */
-    function verifySubscriptionProof(
-        bytes32 subscriptionId,
-        address subscriber,
-        string calldata tierId,
-        address payTo,
-        uint256 cycleNumber,
-        uint256 cycleStart,
-        uint256 cycleEnd,
-        bytes calldata signature
-    ) external view returns (bool valid, string memory reason) {
-        Subscription storage sub = subscriptions[subscriptionId];
-
-        // Check subscription exists
-        if (sub.subscriber == address(0)) {
-            return (false, "subscription_not_found");
-        }
-
-        // Check subscription matches
-        if (sub.subscriber != subscriber) {
-            return (false, "subscriber_mismatch");
-        }
-
-        if (keccak256(bytes(sub.tierId)) != keccak256(bytes(tierId))) {
-            return (false, "tier_mismatch");
-        }
-
-        if (sub.payTo != payTo) {
-            return (false, "payTo_mismatch");
-        }
-
-        // Check cycle matches
-        if (sub.cycleNumber != cycleNumber ||
-            sub.currentCycleStart != cycleStart ||
-            sub.currentCycleEnd != cycleEnd) {
-            return (false, "cycle_mismatch");
-        }
-
-        // Check timing
-        if (block.timestamp < cycleStart) {
-            return (false, "cycle_not_started");
-        }
-
-        if (block.timestamp >= cycleEnd && !sub.inGracePeriod) {
-            return (false, "cycle_ended");
-        }
-
-        if (sub.inGracePeriod && block.timestamp >= sub.gracePeriodEnd) {
-            return (false, "grace_period_expired");
-        }
-
-        // Verify signature
-        bytes32 structHash = keccak256(abi.encode(
-            SUBSCRIPTION_PROOF_TYPEHASH,
-            subscriptionId,
-            subscriber,
-            keccak256(bytes(tierId)),
-            payTo,
-            cycleNumber,
-            cycleStart,
-            cycleEnd
-        ));
-        bytes32 digest = _hashTypedDataV4(structHash);
-        address signer = ECDSA.recover(digest, signature);
-
-        if (signer != subscriber) {
-            return (false, "invalid_signature");
-        }
-
-        return (true, "");
-    }
-
-    // ============ Internal Functions ============
-
-    function _enterGracePeriod(bytes32 subscriptionId) internal {
-        Subscription storage sub = subscriptions[subscriptionId];
-        sub.inGracePeriod = true;
-        sub.gracePeriodEnd = sub.currentCycleEnd + sub.gracePeriodSeconds;
-
-        emit SubscriptionGracePeriod(subscriptionId, sub.gracePeriodEnd);
-    }
+    // ... (contract implementation continues in later commit)
 }
 ```
+
+> **Note:** The full registry implementation, including `subscribe()`, `chargePeriod()`, `cancel()`, `updateRoot()`, and `isActive()`, will be specified in a subsequent commit.
 
 ---
 
-## 8. Reference Implementation: `x402SubscriptionProxy` (Permit2)
+## 10. Facilitator API Extensions
 
-For tokens without EIP-3009, use this Permit2-based proxy:
+Subscribe, cancel, and update-root operations flow through the standard `/verify` and `/settle` endpoints using the `action` field in the payload. Status queries are non-normative facilitator conveniences.
 
-```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
-
-import {ISignatureTransfer} from "permit2/src/interfaces/ISignatureTransfer.sol";
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-
-contract x402SubscriptionProxy {
-    ISignatureTransfer public immutable PERMIT2;
-
-    // EIP-712 Type for Subscription Witness
-    string public constant SUBSCRIPTION_WITNESS_TYPE_STRING =
-        "SubscriptionWitness witness)SubscriptionWitness(address to,uint256 validAfter,bytes32 subscriptionId,uint256 cycleNumber,bytes extra)TokenPermissions(address token,uint256 amount)";
-
-    bytes32 public constant SUBSCRIPTION_WITNESS_TYPEHASH = keccak256(
-        "SubscriptionWitness(address to,uint256 validAfter,bytes32 subscriptionId,uint256 cycleNumber,bytes extra)"
-    );
-
-    struct SubscriptionWitness {
-        address to;
-        uint256 validAfter;
-        bytes32 subscriptionId;
-        uint256 cycleNumber;
-        bytes extra;
-    }
-
-    event x402SubscriptionPayment(
-        bytes32 indexed subscriptionId,
-        address indexed from,
-        address indexed to,
-        uint256 amount,
-        uint256 cycleNumber
-    );
-
-    constructor(address _permit2) {
-        PERMIT2 = ISignatureTransfer(_permit2);
-    }
-
-    /**
-     * @notice Process a subscription payment via Permit2
-     */
-    function processPayment(
-        ISignatureTransfer.PermitTransferFrom calldata permit,
-        uint256 amount,
-        address owner,
-        SubscriptionWitness calldata witness,
-        bytes calldata signature
-    ) external {
-        require(block.timestamp >= witness.validAfter, "payment_not_valid_yet");
-        require(amount <= permit.permitted.amount, "amount_exceeds_permitted");
-
-        ISignatureTransfer.SignatureTransferDetails memory transferDetails =
-            ISignatureTransfer.SignatureTransferDetails({
-                to: witness.to,
-                requestedAmount: amount
-            });
-
-        bytes32 witnessHash = keccak256(abi.encode(
-            SUBSCRIPTION_WITNESS_TYPEHASH,
-            witness.to,
-            witness.validAfter,
-            witness.subscriptionId,
-            witness.cycleNumber,
-            keccak256(witness.extra)
-        ));
-
-        PERMIT2.permitWitnessTransferFrom(
-            permit,
-            transferDetails,
-            owner,
-            witnessHash,
-            SUBSCRIPTION_WITNESS_TYPE_STRING,
-            signature
-        );
-
-        emit x402SubscriptionPayment(
-            witness.subscriptionId,
-            owner,
-            witness.to,
-            amount,
-            witness.cycleNumber
-        );
-    }
-}
-```
+> **Note:** Full facilitator API documentation will be specified in a subsequent commit.
 
 ---
 
-## 9. Facilitator API Extensions
+## 11. Security Considerations
 
-### 9.1 POST /subscribe
-
-Create a new subscription:
-
-**Request:**
-```json
-{
-  "paymentPayload": { /* PaymentPayload with subscriptionPayload */ },
-  "paymentRequirements": { /* PaymentRequirements with subscriptionDetails */ }
-}
-```
-
-**Response:**
-```json
-{
-  "success": true,
-  "subscriptionId": "0x1234...",
-  "transaction": "0xabcd...",
-  "network": "eip155:8453",
-  "payer": "0x857b...",
-  "subscriptionDetails": {
-    "tierId": "pro",
-    "status": "active",
-    "currentCycleStart": "1740672089",
-    "currentCycleEnd": "1743264089",
-    "autoRenewEnabled": true,
-    "storedRenewalCycles": 3
-  }
-}
-```
-
-### 9.2 GET /subscription/{subscriptionId}
-
-Query subscription status:
-
-**Response:**
-```json
-{
-  "subscriptionId": "0x1234...",
-  "subscriber": "0x857b...",
-  "payTo": "0x2096...",
-  "tierId": "pro",
-  "status": "active",
-  "network": "eip155:8453",
-  "asset": "0x8335...",
-  "amount": "5000000",
-  "currentCycle": {
-    "number": 2,
-    "start": "1743264089",
-    "end": "1745856089"
-  },
-  "nextRenewal": {
-    "date": "1745856089",
-    "authorized": true
-  },
-  "cancelled": false
-}
-```
-
-### 9.3 POST /subscription/{subscriptionId}/cancel
-
-Cancel a subscription:
-
-**Request:**
-```json
-{
-  "signature": "0x...",
-  "timestamp": "1740700000"
-}
-```
-
-**Response:**
-```json
-{
-  "success": true,
-  "subscriptionId": "0x1234...",
-  "accessEndsAt": "1743264089",
-  "refundAmount": "0"
-}
-```
-
----
-
-## 10. Security Considerations
-
-### 10.1 Replay Attack Prevention
-
-- Each billing cycle uses a unique nonce
-- Pre-signed renewals have non-overlapping `validAfter`/`validBefore` windows
-- Subscription proofs include cycle-specific timestamps
-
-### 10.2 Authorization Scope
-
-- Subscribers control exact amounts per cycle
-- Pre-signed renewals can be invalidated by:
-  - Spending the nonce with a different transaction
-  - Reducing token balance below required amount
-  - Revoking Permit2 allowance (for Permit2 method)
-
-### 10.3 Facilitator Trust Model
-
-- Facilitators CANNOT modify payment amounts or recipients
-- Facilitators CAN delay renewal execution (mitigated by validity windows)
-- On-chain registry provides trustless verification fallback
-
-### 10.4 Front-running Protection
-
-- Renewal transactions can only be executed by the designated facilitator
-- Subscription IDs are deterministic and verifiable
+> **Note:** Full security considerations, including the liveness-vs-safety trust model, replay analysis, and allowance exposure analysis, will be specified in a subsequent commit.
 
 ---
 
@@ -1135,27 +651,25 @@ Cancel a subscription:
 
 ### Canonical Contract Addresses
 
-| Contract                    | Address                                      | Networks           |
-| --------------------------- | -------------------------------------------- | ------------------ |
-| `x402SubscriptionRegistry`  | TBD (CREATE2 deployment)                     | All supported EVM  |
-| `x402SubscriptionProxy`     | TBD (CREATE2 deployment)                     | All supported EVM  |
-| `Permit2`                   | `0x000000000022D473030F116dDEE9F6B43aC78BA3` | All supported EVM  |
+| Contract | Address | Networks |
+|:---------|:--------|:---------|
+| `x402SubscriptionRegistry` | TBD (CREATE2 deployment) | All supported EVM |
 
 ### Supported Networks
 
-| Network         | Chain ID | CAIP-2 Identifier  |
-| --------------- | -------- | ------------------ |
-| Base Mainnet    | 8453     | `eip155:8453`      |
-| Base Sepolia    | 84532    | `eip155:84532`     |
-| Ethereum        | 1        | `eip155:1`         |
-| Arbitrum One    | 42161    | `eip155:42161`     |
-| Optimism        | 10       | `eip155:10`        |
-| Polygon         | 137      | `eip155:137`       |
+| Network | Chain ID | CAIP-2 Identifier |
+|:--------|:---------|:------------------|
+| Base Mainnet | 8453 | `eip155:8453` |
+| Base Sepolia | 84532 | `eip155:84532` |
+| Ethereum | 1 | `eip155:1` |
+| Arbitrum One | 42161 | `eip155:42161` |
+| Optimism | 10 | `eip155:10` |
+| Polygon | 137 | `eip155:137` |
 
 ### References
 
-- [EIP-3009: Transfer With Authorization](https://eips.ethereum.org/EIPS/eip-3009)
 - [EIP-712: Typed Structured Data Hashing](https://eips.ethereum.org/EIPS/eip-712)
-- [Permit2 Documentation](https://docs.uniswap.org/contracts/permit2/overview)
+- [EIP-2612: Permit Extension for ERC-20](https://eips.ethereum.org/EIPS/eip-2612)
+- [OpenZeppelin MerkleProof](https://docs.openzeppelin.com/contracts/4.x/api/utils#MerkleProof)
 - [x402 Protocol Specification v2](../../x402-specification-v2.md)
 - [Subscribe Scheme Overview](./scheme_subscribe.md)

--- a/specs/schemes/subscribe/scheme_subscribe_evm.md
+++ b/specs/schemes/subscribe/scheme_subscribe_evm.md
@@ -126,7 +126,8 @@ const commitmentTypes = {
     { name: "tierId", type: "string" },
     { name: "start", type: "uint256" },
     { name: "expiry", type: "uint256" },
-    { name: "maxPerPeriod", type: "uint256" }
+    { name: "maxPerPeriod", type: "uint256" },
+    { name: "gracePeriodSeconds", type: "uint256" }
   ]
 };
 ```
@@ -145,6 +146,7 @@ const commitmentTypes = {
 | `start` | `uint256` | Unix timestamp when subscription begins |
 | `expiry` | `uint256` | Unix timestamp after which no charges are valid |
 | `maxPerPeriod` | `uint256` | Maximum fee per charge (safety cap) |
+| `gracePeriodSeconds` | `uint256` | Retry window after `validTo` for failed charges |
 
 The `subscriptionId` is derived as `keccak256(abi.encode(commitmentStructHash))`, binding all parameters in one identifier.
 
@@ -198,7 +200,8 @@ When subscribing, the client sends a `PaymentPayload` with the schedule commitme
       "tierId": "pro",
       "start": "1740672089",
       "expiry": "1772208089",
-      "maxPerPeriod": "5000000"
+      "maxPerPeriod": "5000000",
+      "gracePeriodSeconds": "86400"
     },
     "commitmentSignature": "0x...",
     "allowanceMethod": "eip2612-permit",
@@ -528,7 +531,31 @@ registry.cancel(subscriptionId, nonce, signature);
 
 ## 9. Reference Implementation: `x402SubscriptionRegistry`
 
-This contract manages subscription state on-chain for trustless verification.
+This contract manages subscription state on-chain for trustless verification. It is the **canonical reference implementation**; production deployments will use CREATE2 for deterministic addresses across networks.
+
+### 9.1 Immutability Guarantees
+
+The `x402SubscriptionRegistry` is designed as an **immutable, non-upgradeable contract**:
+
+- **No proxy pattern**: The contract is deployed directly, not behind a proxy.
+- **No upgrade path**: There is no mechanism to replace or modify the contract logic.
+- **No owner over fund logic**: No administrative function can redirect payments, modify stored commitments, or alter fund flows.
+- **No selfdestruct/delegatecall**: The contract cannot be destroyed or delegate execution to arbitrary code.
+- **Guardian pause is narrowly scoped**: The sole intervention mechanism is `pause()`/`unpause()`, which ONLY blocks `chargePeriod()`. The guardian cannot move funds, change terms, or redirect payments.
+
+### 9.2 Design Rationale: Why No Stored Pre-Signed Authorizations
+
+Earlier drafts stored `renewalAuthorizations[]` — pre-signed EIP-3009 or Permit2 signatures for future billing cycles. This approach was removed because:
+
+**Public signatures are directly submittable.** Once a pre-signed `transferWithAuthorization` signature is stored on-chain (or even transmitted to the facilitator), anyone can extract and submit it directly to the token contract. This creates a race condition where the registry's state (cursor, subscription status) can desync from actual token transfers. The Merkle schedule commitment model avoids this by having the registry itself call `transferFrom` — the subscriber's allowance to the registry is the only authorization, and the registry enforces all invariants before pulling funds.
+
+### 9.3 Migration Note: Commitment Signature Verification
+
+The previous draft's `SubscribeParams.signature` field was **never verified** against the commitment terms — the contract accepted any signature without checking it recovered to the subscriber or bound the advertised parameters. This implementation **fixes that flaw**: `subscribe()` verifies the EIP-712 commitment signature recovers to `commitment.subscriber`, and the `subscriptionId` is derived deterministically from the commitment struct hash, cryptographically binding all terms.
+
+**gracePeriodSeconds is now client-signed.** The grace period extends the chargeable window to `[validFrom, validTo + gracePeriodSeconds]`, allowing retries on failed charges. Since this affects fund exposure (how long the registry can attempt charges), it is a fund-relevant term and must be signed by the client as part of the commitment.
+
+### 9.4 Contract Implementation
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -540,13 +567,24 @@ import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
+/**
+ * @title x402SubscriptionRegistry
+ * @notice Immutable on-chain registry for x402 subscribe scheme.
+ * @dev Reference implementation — canonical deployments TBD via CREATE2.
+ *
+ * IMMUTABILITY INVARIANTS:
+ * - No proxy, no upgrade path, no selfdestruct, no delegatecall.
+ * - Guardian pause() ONLY blocks chargePeriod(); it CANNOT move funds,
+ *   change stored terms, or redirect payments.
+ * - No administrative function can modify commitments after storage.
+ */
 contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
     using ECDSA for bytes32;
 
     // ============ Constants ============
 
     bytes32 public constant COMMITMENT_TYPEHASH = keccak256(
-        "SubscriptionCommitment(bytes32 root,address subscriber,address asset,address payTo,address registry,uint256 chainId,string tierId,uint256 start,uint256 expiry,uint256 maxPerPeriod)"
+        "SubscriptionCommitment(bytes32 root,address subscriber,address asset,address payTo,address registry,uint256 chainId,string tierId,uint256 start,uint256 expiry,uint256 maxPerPeriod,uint256 gracePeriodSeconds)"
     );
 
     bytes32 public constant CANCELLATION_TYPEHASH = keccak256(
@@ -566,6 +604,14 @@ contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
         uint256 start;
         uint256 expiry;
         uint256 maxPerPeriod;
+        uint256 gracePeriodSeconds;
+    }
+
+    struct Leaf {
+        uint256 periodIndex;
+        uint256 fee;
+        uint256 validFrom;
+        uint256 validTo;
     }
 
     struct Subscription {
@@ -586,8 +632,19 @@ contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
 
     // ============ State ============
 
+    /// @notice Guardian address authorized to pause/unpause chargePeriod.
+    /// @dev Immutable; recommend setting to a timelock contract.
+    address public immutable guardian;
+
+    /// @notice Whether chargePeriod is paused.
+    bool public paused;
+
+    /// @notice Subscription storage by subscriptionId.
     mapping(bytes32 => Subscription) public subscriptions;
-    mapping(bytes32 => mapping(uint256 => bool)) public usedNonces;
+
+    /// @notice Replay protection for cancellation nonces.
+    /// @dev subscriptionId => nonce => used
+    mapping(bytes32 => mapping(uint256 => bool)) public usedCancelNonces;
 
     // ============ Events ============
 
@@ -601,19 +658,15 @@ contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
 
     event PeriodCharged(
         bytes32 indexed subscriptionId,
-        uint256 periodIndex,
-        uint256 fee
+        uint256 indexed periodIndex,
+        uint256 fee,
+        address indexed chargedBy
     );
 
     event ChargeFailed(
         bytes32 indexed subscriptionId,
-        uint256 periodIndex,
+        uint256 indexed periodIndex,
         string reason
-    );
-
-    event SubscriptionCancelled(
-        bytes32 indexed subscriptionId,
-        uint256 accessEndsAt
     );
 
     event GracePeriodEntered(
@@ -621,15 +674,465 @@ contract x402SubscriptionRegistry is EIP712, ReentrancyGuard {
         uint256 gracePeriodEnd
     );
 
+    event GracePeriodCleared(bytes32 indexed subscriptionId);
+
+    event SubscriptionCancelled(
+        bytes32 indexed subscriptionId,
+        uint256 accessEndsAt
+    );
+
+    event Paused(address indexed by);
+    event Unpaused(address indexed by);
+
+    // ============ Errors ============
+
+    error InvalidCommitmentSignature();
+    error SubscriptionAlreadyExists();
+    error SubscriptionNotFound();
+    error SubscriptionCancelled();
+    error SubscriptionExpired();
+    error ChargePaused();
+    error InvalidPeriodIndex();
+    error ChargeWindowNotOpen();
+    error ChargeWindowExpired();
+    error FeeExceedsMax();
+    error InvalidMerkleProof();
+    error CancelNonceUsed();
+    error InvalidCancelSignature();
+    error NotGuardian();
+    error InvalidRegistry();
+    error InvalidChainId();
+    error AssetNotContract();
+
+    // ============ Modifiers ============
+
+    modifier onlyGuardian() {
+        if (msg.sender != guardian) revert NotGuardian();
+        _;
+    }
+
+    modifier whenNotPaused() {
+        if (paused) revert ChargePaused();
+        _;
+    }
+
     // ============ Constructor ============
 
-    constructor() EIP712("x402SubscriptionRegistry", "1") {}
+    /// @param _guardian Address authorized to pause/unpause. Recommend a timelock.
+    constructor(address _guardian) EIP712("x402SubscriptionRegistry", "1") {
+        guardian = _guardian;
+    }
 
-    // ... (contract implementation continues in later commit)
+    // ============ External Functions ============
+
+    /**
+     * @notice Create a new subscription from a signed commitment.
+     * @dev subscribe() may register during pause but must not move funds.
+     *      If initialProof is provided while paused, reverts ChargePaused.
+     * @param commitment The subscription commitment struct (includes gracePeriodSeconds).
+     * @param signature EIP-712 signature over the commitment, by commitment.subscriber.
+     * @param initialLeaf Optional: leaf for period 0 to charge immediately.
+     * @param initialProof Optional: Merkle proof for initialLeaf.
+     * @return subscriptionId The unique subscription identifier.
+     */
+    function subscribe(
+        Commitment calldata commitment,
+        bytes calldata signature,
+        Leaf calldata initialLeaf,
+        bytes32[] calldata initialProof
+    ) external nonReentrant returns (bytes32 subscriptionId) {
+        // Validate commitment binds to this registry and chain
+        if (commitment.registry != address(this)) revert InvalidRegistry();
+        if (commitment.chainId != block.chainid) revert InvalidChainId();
+
+        // Prevent free-subscription attack via EOA asset: a low-level call to a
+        // codeless address returns success with empty data, which _safeTransferFrom
+        // would misread as a USDT-style successful transfer. Checked once at registration.
+        if (commitment.asset.code.length == 0) revert AssetNotContract();
+
+        // Derive subscriptionId from commitment struct hash
+        bytes32 structHash = _hashCommitment(commitment);
+        subscriptionId = structHash;
+
+        // Verify EIP-712 signature recovers to commitment.subscriber
+        bytes32 digest = _hashTypedDataV4(structHash);
+        address signer = ECDSA.recover(digest, signature);
+        if (signer != commitment.subscriber) revert InvalidCommitmentSignature();
+
+        // Reject duplicates
+        if (subscriptions[subscriptionId].subscriber != address(0)) {
+            revert SubscriptionAlreadyExists();
+        }
+
+        // Store subscription (gracePeriodSeconds from signed commitment)
+        subscriptions[subscriptionId] = Subscription({
+            root: commitment.root,
+            subscriber: commitment.subscriber,
+            asset: commitment.asset,
+            payTo: commitment.payTo,
+            tierId: commitment.tierId,
+            start: commitment.start,
+            expiry: commitment.expiry,
+            maxPerPeriod: commitment.maxPerPeriod,
+            gracePeriodSeconds: commitment.gracePeriodSeconds,
+            cursor: 0,
+            cancelled: false,
+            inGracePeriod: false,
+            gracePeriodEnd: 0
+        });
+
+        emit SubscriptionCreated(
+            subscriptionId,
+            commitment.subscriber,
+            commitment.payTo,
+            commitment.tierId,
+            commitment.expiry
+        );
+
+        // Optionally charge period 0 immediately (respects pause via _chargePeriod)
+        if (initialProof.length > 0) {
+            _chargePeriod(subscriptionId, initialLeaf, initialProof);
+        }
+
+        return subscriptionId;
+    }
+
+    /**
+     * @notice Charge a billing period. PERMISSIONLESS — anyone can call.
+     * @dev The facilitator typically calls this, but permissionless design ensures
+     *      liveness is not dependent on a single operator. Pause check is in _chargePeriod.
+     * @param subscriptionId The subscription to charge.
+     * @param leaf The billing period leaf (periodIndex, fee, validFrom, validTo).
+     * @param proof Merkle proof for the leaf against the stored root.
+     */
+    function chargePeriod(
+        bytes32 subscriptionId,
+        Leaf calldata leaf,
+        bytes32[] calldata proof
+    ) external nonReentrant {
+        _chargePeriod(subscriptionId, leaf, proof);
+    }
+
+    /**
+     * @notice Cancel a subscription. Halts all future charges.
+     * @param subscriptionId The subscription to cancel.
+     * @param nonce Signer-chosen nonce for replay protection.
+     * @param signature EIP-712 signature over CancelSubscription(subscriptionId, nonce).
+     */
+    function cancel(
+        bytes32 subscriptionId,
+        uint256 nonce,
+        bytes calldata signature
+    ) external nonReentrant {
+        Subscription storage sub = subscriptions[subscriptionId];
+        if (sub.subscriber == address(0)) revert SubscriptionNotFound();
+        if (sub.cancelled) revert SubscriptionCancelled();
+
+        // Check nonce not used
+        if (usedCancelNonces[subscriptionId][nonce]) revert CancelNonceUsed();
+
+        // Verify EIP-712 signature
+        // NOTE: nonce is signer-chosen, NOT block.timestamp — this fixes the
+        // previous draft's broken cancellation verification where timestamp
+        // was included in the signed struct but was unpredictable at sign time.
+        bytes32 structHash = keccak256(abi.encode(
+            CANCELLATION_TYPEHASH,
+            subscriptionId,
+            nonce
+        ));
+        bytes32 digest = _hashTypedDataV4(structHash);
+        address signer = ECDSA.recover(digest, signature);
+        if (signer != sub.subscriber) revert InvalidCancelSignature();
+
+        // Record nonce as used
+        usedCancelNonces[subscriptionId][nonce] = true;
+
+        // Mark cancelled
+        sub.cancelled = true;
+
+        // Access continues until current period ends (per cancellationPolicy)
+        // The exact semantics depend on off-chain interpretation; on-chain,
+        // isActive() will return true until the current period's validTo.
+        emit SubscriptionCancelled(subscriptionId, sub.expiry);
+    }
+
+    /**
+     * @notice Replace a subscription with a new commitment (tier change, extension).
+     * @dev The old subscription is cancelled; a new subscriptionId is derived from
+     *      the new commitment. Cursor resets to 0 for the new schedule.
+     * @param oldSubscriptionId The subscription being replaced.
+     * @param newCommitment The new commitment struct (includes gracePeriodSeconds).
+     * @param signature EIP-712 signature over newCommitment, by newCommitment.subscriber.
+     * @return newSubscriptionId The new subscription identifier.
+     */
+    function updateRoot(
+        bytes32 oldSubscriptionId,
+        Commitment calldata newCommitment,
+        bytes calldata signature
+    ) external nonReentrant returns (bytes32 newSubscriptionId) {
+        // Validate old subscription exists and belongs to the same subscriber
+        Subscription storage oldSub = subscriptions[oldSubscriptionId];
+        if (oldSub.subscriber == address(0)) revert SubscriptionNotFound();
+        if (oldSub.subscriber != newCommitment.subscriber) {
+            revert InvalidCommitmentSignature(); // subscriber mismatch
+        }
+
+        // Cancel the old subscription
+        if (!oldSub.cancelled) {
+            oldSub.cancelled = true;
+            emit SubscriptionCancelled(oldSubscriptionId, block.timestamp);
+        }
+
+        // Create new subscription via full commitment verification
+        // Cursor resets to 0; new periodIndex space starts fresh
+        Leaf memory emptyLeaf;
+        bytes32[] memory emptyProof;
+        newSubscriptionId = this.subscribe(
+            newCommitment,
+            signature,
+            emptyLeaf,
+            emptyProof
+        );
+
+        return newSubscriptionId;
+    }
+
+    // ============ Guardian Functions ============
+
+    /**
+     * @notice Pause chargePeriod. Guardian-only.
+     * @dev INVARIANT: pause() ONLY blocks chargePeriod. It CANNOT:
+     *      - Move funds
+     *      - Change any stored commitment or subscription terms
+     *      - Redirect payments
+     *      - Affect subscribe(), cancel(), or view functions
+     */
+    function pause() external onlyGuardian {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    /**
+     * @notice Unpause chargePeriod. Guardian-only.
+     */
+    function unpause() external onlyGuardian {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    // ============ View Functions ============
+
+    /**
+     * @notice Check if a subscription is currently active.
+     * @param subscriptionId The subscription to check.
+     * @return active True if subscription grants access.
+     */
+    function isActive(bytes32 subscriptionId) external view returns (bool active) {
+        Subscription storage sub = subscriptions[subscriptionId];
+
+        // Not found
+        if (sub.subscriber == address(0)) {
+            return false;
+        }
+
+        // Cancelled and past expiry
+        if (sub.cancelled && block.timestamp >= sub.expiry) {
+            return false;
+        }
+
+        // In grace period — check if grace has expired
+        if (sub.inGracePeriod) {
+            return block.timestamp < sub.gracePeriodEnd;
+        }
+
+        // Normal active check: not expired
+        return block.timestamp <= sub.expiry;
+    }
+
+    /**
+     * @notice Check if a subscriber has an active subscription.
+     * @param subscriber The subscriber address.
+     * @param subscriptionId The subscription to check.
+     * @return active True if the subscription is active and belongs to subscriber.
+     */
+    function isActiveFor(
+        address subscriber,
+        bytes32 subscriptionId
+    ) external view returns (bool active) {
+        Subscription storage sub = subscriptions[subscriptionId];
+        if (sub.subscriber != subscriber) {
+            return false;
+        }
+        return this.isActive(subscriptionId);
+    }
+
+    /**
+     * @notice Get full subscription details.
+     * @param subscriptionId The subscription to query.
+     * @return sub The subscription struct.
+     */
+    function getSubscription(
+        bytes32 subscriptionId
+    ) external view returns (Subscription memory sub) {
+        return subscriptions[subscriptionId];
+    }
+
+    // ============ Internal Functions ============
+
+    /**
+     * @dev Internal charge logic with whenNotPaused check.
+     *      Reentrancy is handled by nonReentrant on all external entry points.
+     *
+     * CURSOR SEMANTICS: cursor increments ONLY on successful transfer.
+     * The chargeable window is [validFrom, validTo + gracePeriodSeconds] — the
+     * grace period is a per-leaf retry buffer allowing failed charges to be retried
+     * without advancing to the next period.
+     */
+    function _chargePeriod(
+        bytes32 subscriptionId,
+        Leaf calldata leaf,
+        bytes32[] calldata proof
+    ) internal whenNotPaused {
+        Subscription storage sub = subscriptions[subscriptionId];
+
+        // Existence check
+        if (sub.subscriber == address(0)) revert SubscriptionNotFound();
+
+        // Cancelled check
+        if (sub.cancelled) revert SubscriptionCancelled();
+
+        // Expiry check
+        if (block.timestamp > sub.expiry) revert SubscriptionExpired();
+
+        // Cursor check (monotonic, one settlement per period, in order)
+        if (leaf.periodIndex != sub.cursor) revert InvalidPeriodIndex();
+
+        // Time window check: chargeable window is [validFrom, validTo + gracePeriodSeconds]
+        // The grace period extends the window to allow retries on failed charges.
+        if (block.timestamp < leaf.validFrom) revert ChargeWindowNotOpen();
+        if (block.timestamp > leaf.validTo + sub.gracePeriodSeconds) {
+            revert ChargeWindowExpired();
+        }
+
+        // Fee cap check
+        if (leaf.fee > sub.maxPerPeriod) revert FeeExceedsMax();
+
+        // Merkle proof verification (OpenZeppelin double-hash convention)
+        bytes32 leafHash = keccak256(bytes.concat(keccak256(abi.encode(
+            leaf.periodIndex,
+            leaf.fee,
+            leaf.validFrom,
+            leaf.validTo
+        ))));
+        if (!MerkleProof.verify(proof, sub.root, leafHash)) {
+            revert InvalidMerkleProof();
+        }
+
+        // Attempt transfer (cursor increments ONLY on success)
+        bool success = _safeTransferFrom(
+            sub.asset,
+            sub.subscriber,
+            sub.payTo,
+            leaf.fee
+        );
+
+        if (success) {
+            // Increment cursor on success
+            sub.cursor++;
+
+            // Clear grace period if we were in one
+            if (sub.inGracePeriod) {
+                sub.inGracePeriod = false;
+                sub.gracePeriodEnd = 0;
+                emit GracePeriodCleared(subscriptionId);
+            }
+
+            emit PeriodCharged(subscriptionId, leaf.periodIndex, leaf.fee, msg.sender);
+        } else {
+            // On failure: cursor UNCHANGED, enter/remain in grace period
+            // gracePeriodEnd is idempotent if already set
+            if (!sub.inGracePeriod) {
+                sub.inGracePeriod = true;
+                sub.gracePeriodEnd = leaf.validTo + sub.gracePeriodSeconds;
+                emit GracePeriodEntered(subscriptionId, sub.gracePeriodEnd);
+            }
+
+            emit ChargeFailed(subscriptionId, leaf.periodIndex, "transfer_failed");
+        }
+    }
+
+    function _hashCommitment(
+        Commitment calldata c
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            COMMITMENT_TYPEHASH,
+            c.root,
+            c.subscriber,
+            c.asset,
+            c.payTo,
+            c.registry,
+            c.chainId,
+            keccak256(bytes(c.tierId)),
+            c.start,
+            c.expiry,
+            c.maxPerPeriod,
+            c.gracePeriodSeconds
+        ));
+    }
+
+    /**
+     * @dev Safe transferFrom with non-reverting bool semantics.
+     *      Handles: call failure, returns-false tokens, no-return tokens (USDT).
+     * @return success True if transfer succeeded, false otherwise (triggers grace period).
+     */
+    function _safeTransferFrom(
+        address token,
+        address from,
+        address to,
+        uint256 amount
+    ) internal returns (bool success) {
+        // Low-level call to handle tokens that don't return bool (e.g., USDT)
+        (bool callSuccess, bytes memory data) = token.call(
+            abi.encodeWithSelector(
+                IERC20.transferFrom.selector,
+                from,
+                to,
+                amount
+            )
+        );
+
+        // Success requires:
+        // 1. Call did not revert (callSuccess == true)
+        // 2. Either no return data (USDT-style) OR exactly 32 bytes decoding to true
+        // The exact length check prevents malformed return data from being misinterpreted.
+        success = callSuccess && (data.length == 0 || (data.length == 32 && abi.decode(data, (bool))));
+    }
 }
 ```
 
-> **Note:** The full registry implementation, including `subscribe()`, `chargePeriod()`, `cancel()`, `updateRoot()`, and `isActive()`, will be specified in a subsequent commit.
+### 9.5 Function Summary
+
+| Function | Access | Description |
+|:---------|:-------|:------------|
+| `subscribe()` | Public | Create subscription from verified commitment; optionally charge period 0 |
+| `chargePeriod()` | **Permissionless** | Charge a billing period with Merkle proof |
+| `cancel()` | Public (subscriber signature) | Halt all future charges |
+| `updateRoot()` | Public (subscriber signature) | Replace subscription with new commitment |
+| `pause()` | Guardian only | Block `chargePeriod()` — fund-safe emergency stop |
+| `unpause()` | Guardian only | Resume `chargePeriod()` |
+| `isActive()` | View | Check subscription status (grace-aware) |
+| `isActiveFor()` | View | Check status for specific subscriber |
+| `getSubscription()` | View | Retrieve full subscription details |
+
+### 9.6 Permissionless `chargePeriod` Design
+
+`chargePeriod()` is **permissionless** — anyone can call it with a valid Merkle proof. This design choice ensures:
+
+1. **Liveness independence**: If the facilitator goes offline, any third party (including the subscriber or payTo) can submit charges.
+2. **No front-running advantage**: The charge either succeeds (funds move to `payTo`) or fails (grace period). There is no value to extract by front-running.
+3. **MEV resistance**: The outcome is deterministic given the Merkle proof; reordering does not change who receives funds.
+
+The facilitator remains the expected caller for convenience (they maintain the Merkle tree off-chain), but the system does not depend on facilitator honesty for correctness.
 
 ---
 
@@ -643,7 +1146,60 @@ Subscribe, cancel, and update-root operations flow through the standard `/verify
 
 ## 11. Security Considerations
 
-> **Note:** Full security considerations, including the liveness-vs-safety trust model, replay analysis, and allowance exposure analysis, will be specified in a subsequent commit.
+### 11.1 Liveness vs. Safety Trust Model
+
+The facilitator is trusted for **liveness only**:
+
+- **Liveness**: The facilitator maintains the Merkle tree off-chain and submits `chargePeriod()` calls at billing boundaries. If the facilitator fails, charges don't happen — but `chargePeriod()` is permissionless, so any party (subscriber, payTo, third party) can submit valid proofs.
+- **Safety**: The facilitator has no safety authority. It cannot overcharge (fee ≤ maxPerPeriod, fee matches Merkle leaf, cursor is monotonic), charge early (before validFrom), charge late (after validTo + gracePeriodSeconds), charge past expiry/cancel (hard on-chain checks), redirect funds (payTo/asset bound in commitment), or double-charge (cursor increments only on successful transfer).
+
+**Facilitator compromise degrades to denial of service, never theft beyond the signed schedule.**
+
+### 11.2 Replay Attack Prevention
+
+- **Commitment uniqueness**: Each commitment produces a unique `subscriptionId` (the struct hash). Duplicate commitments are rejected.
+- **Monotonic cursor**: `chargePeriod()` requires `periodIndex == cursor` and increments cursor on success. Each period can be charged at most once.
+- **Cancellation nonces**: `cancel()` uses signer-chosen nonces recorded in a mapping. Each `(subscriptionId, nonce)` pair can only be used once.
+- **Cross-chain protection**: The commitment binds `chainId`; replay on other chains fails.
+
+### 11.3 Allowance Exposure
+
+The subscriber grants a standing ERC-20 allowance to the registry. The worst-case exposure is bounded by:
+
+1. **Allowance amount**: The subscriber controls the allowance; setting it equal to total committed spend caps total exposure.
+2. **maxPerPeriod**: Each charge is capped regardless of the Merkle leaf claim.
+3. **Merkle root binding**: Only leaves matching the signed root can be charged.
+4. **Time windows**: Charges outside `validFrom..validTo` revert.
+5. **Expiry**: No charges after `expiry` timestamp.
+
+### 11.4 Guardian Pause Scope
+
+The guardian can call `pause()` to halt `chargePeriod()` as an emergency measure (e.g., if a critical bug is discovered). The pause is **fund-safe**:
+
+- Pause does NOT move funds
+- Pause does NOT change stored commitments or subscription terms
+- Pause does NOT redirect payments
+- Pause does NOT affect `subscribe()`, `cancel()`, `updateRoot()`, or view functions
+
+The guardian is recommended to be a timelock contract to prevent abuse.
+
+### 11.5 Codeless Asset Attack Prevention
+
+A low-level `call()` to an address with no bytecode (EOA or undeployed address) returns success with empty return data. This would be misinterpreted by `_safeTransferFrom` as a USDT-style successful transfer, allowing an attacker to register a "free subscription" by specifying a codeless `commitment.asset`.
+
+**Mitigation:** `subscribe()` checks `commitment.asset.code.length == 0` and reverts with `AssetNotContract()` if true. This check is performed once at registration time; the asset cannot change afterward.
+
+### 11.6 Return Data Hardening
+
+The `_safeTransferFrom` function uses exact length checking for return data:
+
+```solidity
+success = callSuccess && (data.length == 0 || (data.length == 32 && abi.decode(data, (bool))));
+```
+
+This prevents malformed return data (e.g., non-32-byte responses from proxy contracts or hook-modified tokens) from being decoded as a boolean. Charges with unexpected return data are routed to the grace period path, allowing retry without permanently locking the period.
+
+> **Note:** Additional analysis (MEV, frontrunning resistance, gas optimization) may be added in subsequent commits.
 
 ---
 

--- a/specs/schemes/subscribe/scheme_subscribe_evm.md
+++ b/specs/schemes/subscribe/scheme_subscribe_evm.md
@@ -380,38 +380,489 @@ To change tiers, extend a subscription, or modify the schedule, the client signs
 
 ## 6. Subscription Extension (Access Verification)
 
-Once subscribed, clients present an active-subscription proof for subsequent requests without requiring new payments. The proof travels as the `subscription` extension in `PaymentPayload.extensions`, following the V2 extension pattern (see `payment-identifier` for reference).
+Once subscribed, clients present an active-subscription proof for subsequent requests without requiring new payments. The `subscription` extension follows the V2 extension pattern (see `payment-identifier` for reference structure).
+
+**Why a fresh possession proof is REQUIRED.** The registry's public `isActive(subscriptionId)` view function proves subscription existence and status — but this is public on-chain data. The subscriber address is equally public via `getSubscription(subscriptionId)`. An unauthenticated echo containing only these values would let anyone who reads the chain free-ride on another user's subscription. Therefore, each access request MUST include a **fresh possession proof**: an EIP-712 signature over `SubscriptionAccess(subscriptionId, issuedAt, audience)` that demonstrates the requester controls the subscriber's private key. Freshness (`|now - issuedAt| <= maxProofAge`) bounds replay to a short window (RECOMMENDED 60 seconds); the optional `audience` field further restricts replay to the intended origin or resource prefix.
 
 ### 6.1 Extension Key
 
-```
-subscription
+```typescript
+export const SUBSCRIPTION = "subscription";
 ```
 
-### 6.2 Extension Info Structure
+### 6.2 Schema Definition (JSON Schema Draft 2020-12)
+
+The server advertises the `subscription` extension with a schema; the client echoes the extension with populated `info`. The `subscriber` and `tierId` are NOT echoed — the server reads both from the registry via `getSubscription(subscriptionId)`, reducing forgeable surface.
 
 ```json
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "subscriptionId": {
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]{64}$",
+      "description": "The subscription ID (bytes32 hex)"
+    },
+    "issuedAt": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Unix timestamp (seconds) when the proof was signed"
+    },
+    "audience": {
+      "type": "string",
+      "description": "Optional: request origin or URL prefix this proof is scoped to"
+    },
+    "signature": {
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]{130}$",
+      "description": "EIP-712 signature over SubscriptionAccess (65 bytes, hex)"
+    }
+  },
+  "required": ["subscriptionId", "issuedAt", "signature"]
+}
+```
+
+### 6.3 Info Structure
+
+```typescript
+export interface SubscriptionInfo {
+  /** The subscription ID (bytes32 hex, from commitment struct hash) */
+  subscriptionId: `0x${string}`;
+
+  /** Unix timestamp (seconds) when the proof was signed */
+  issuedAt: number;
+
+  /** Optional: request origin or URL prefix this proof is scoped to */
+  audience?: string;
+
+  /** EIP-712 signature over SubscriptionAccess (65 bytes, hex) */
+  signature: `0x${string}`;
+}
+```
+
+### 6.4 EIP-712 SubscriptionAccess Type
+
+The possession proof uses the registry's EIP-712 domain for consistent wallet display. Verification is off-chain only.
+
+**EIP-712 Domain (same as commitment):**
+
+```javascript
+const subscriptionAccessDomain = {
+  name: "x402SubscriptionRegistry",
+  version: "1",
+  chainId: 8453,
+  verifyingContract: "0x402SubscriptionRegistryAddress" // Registry address
+};
+```
+
+**SubscriptionAccess Type:**
+
+```javascript
+const subscriptionAccessTypes = {
+  SubscriptionAccess: [
+    { name: "subscriptionId", type: "bytes32" },
+    { name: "issuedAt", type: "uint256" },
+    { name: "audience", type: "string" }
+  ]
+};
+```
+
+**Type String:** `SubscriptionAccess(bytes32 subscriptionId,uint256 issuedAt,string audience)`
+
+The `audience` field is hashed per EIP-712 string rules (`keccak256(audience)`). When `audience` is empty, hash the empty string.
+
+### 6.5 Server Declaration (PaymentRequired.extensions)
+
+The resource server advertises that it accepts the `subscription` extension for access. The declaration indicates whether a subscription is required (for subscription-only resources) or optional (for hybrid exact + subscribe resources).
+
+```json
+{
+  "x402Version": 2,
+  "resource": { "url": "https://api.example.com/premium-data", "..." : "..." },
+  "accepts": [
+    { "scheme": "exact", "..." : "..." },
+    { "scheme": "subscribe", "..." : "..." }
+  ],
+  "extensions": {
+    "subscription": {
+      "info": {
+        "required": false,
+        "acceptedTiers": ["pro", "enterprise"]
+      },
+      "schema": { "$schema": "https://json-schema.org/draft/2020-12/schema", "..." : "..." }
+    }
+  }
+}
+```
+
+**Server Declaration Fields:**
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `info.required` | `boolean` | If true, this resource ONLY accepts subscription access (no exact fallback). |
+| `info.acceptedTiers` | `string[]` | Optional list of tier IDs that grant access to this resource. If omitted, any active subscription suffices. |
+| `schema` | `object` | JSON Schema for client info validation. |
+
+### 6.6 Client Echo (PaymentPayload.extensions)
+
+The client echoes the extension with a fresh possession proof. The server MUST verify the signature and check on-chain state before granting access.
+
+```json
+{
+  "x402Version": 2,
+  "resource": { "url": "https://api.example.com/premium-data", "..." : "..." },
+  "accepted": { "scheme": "subscribe", "..." : "..." },
+  "payload": {},
   "extensions": {
     "subscription": {
       "info": {
         "subscriptionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-        "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-        "network": "eip155:8453"
+        "issuedAt": 1740672089,
+        "audience": "https://api.example.com",
+        "signature": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b"
       }
     }
   }
 }
 ```
 
-### 6.3 Verification
+**Client Info Fields:**
 
-The resource server verifies the proof by calling `isActive(subscriptionId)` on the on-chain registry. The extension info is a **pointer to verify**, never a trusted claim.
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `subscriptionId` | `string` | Required | The subscription ID (bytes32 hex). |
+| `issuedAt` | `number` | Required | Unix timestamp (seconds) when the proof was signed. |
+| `audience` | `string` | Optional | Request origin or URL prefix this proof is scoped to. |
+| `signature` | `string` | Required | EIP-712 signature over SubscriptionAccess (65 bytes, hex). |
 
-```javascript
-const isValid = await registry.isActive(subscriptionId);
-if (!isValid) {
-  return { status: 402, error: "subscription_not_found" };
+### 6.7 Verification Flow
+
+The resource server (or facilitator on its behalf) MUST perform these checks **in order**:
+
+```typescript
+async function verifySubscriptionAccess(
+  registry: x402SubscriptionRegistry,
+  info: SubscriptionInfo,
+  config: { maxProofAge: number; servedOrigin?: string; acceptedTiers?: string[] }
+): Promise<{ granted: boolean; error?: string }> {
+  // 1. Fetch subscription — MUST exist
+  const sub = await registry.getSubscription(info.subscriptionId);
+  if (sub.subscriber === ADDRESS_ZERO) {
+    return { granted: false, error: "subscription_not_found" };
+  }
+
+  // 2. Recover SubscriptionAccess signer — MUST equal registry-stored subscriber
+  // This is the possession proof: the requester controls the subscriber's key
+  const domain = {
+    name: "x402SubscriptionRegistry",
+    version: "1",
+    chainId: await registry.provider.getNetwork().then(n => n.chainId),
+    verifyingContract: registry.address
+  };
+  const types = {
+    SubscriptionAccess: [
+      { name: "subscriptionId", type: "bytes32" },
+      { name: "issuedAt", type: "uint256" },
+      { name: "audience", type: "string" }
+    ]
+  };
+  const message = {
+    subscriptionId: info.subscriptionId,
+    issuedAt: info.issuedAt,
+    audience: info.audience ?? ""
+  };
+  const recoveredSigner = ethers.verifyTypedData(domain, types, message, info.signature);
+  if (recoveredSigner.toLowerCase() !== sub.subscriber.toLowerCase()) {
+    return { granted: false, error: "invalid_access_signature" };
+  }
+
+  // 3. Freshness check: |now - issuedAt| <= maxProofAge
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - info.issuedAt) > config.maxProofAge) {
+    return { granted: false, error: "stale_access_proof" };
+  }
+
+  // 4. Audience check (if present): MUST match served origin/resource prefix
+  if (info.audience && config.servedOrigin) {
+    if (!config.servedOrigin.startsWith(info.audience)) {
+      return { granted: false, error: "audience_mismatch" };
+    }
+  }
+
+  // 5. Check subscription is active on-chain
+  const isActive = await registry.isActive(info.subscriptionId);
+  if (!isActive) {
+    return { granted: false, error: "subscription_not_active" };
+  }
+
+  // 6. Check tier sufficiency (if acceptedTiers is specified)
+  if (config.acceptedTiers && config.acceptedTiers.length > 0) {
+    if (!config.acceptedTiers.includes(sub.tierId)) {
+      return { granted: false, error: "tier_insufficient" };
+    }
+  }
+
+  return { granted: true };
+}
+```
+
+**Configuration:**
+
+| Parameter | Type | Description |
+|:----------|:-----|:------------|
+| `maxProofAge` | `number` | Maximum allowed `\|now - issuedAt\|` in seconds. RECOMMENDED: 60 seconds. Server-configurable. |
+| `servedOrigin` | `string` | The origin or URL prefix being served; compared against `info.audience` if present. |
+| `acceptedTiers` | `string[]` | Optional list of tier IDs that grant access to this resource. |
+
+### 6.8 Replay Analysis
+
+Replay of a captured proof is bounded by `maxProofAge` (RECOMMENDED 60 seconds): after this window, the proof is stale and rejected. When `audience` is set, replay is further restricted to the same origin — a proof scoped to `https://api.example.com` cannot be replayed against `https://other.example.com`. TLS protects transport-layer capture.
+
+For stricter single-use semantics, servers MAY maintain a short-lived `(issuedAt, signature)` cache (TTL = `maxProofAge`) and reject duplicates. This is optional — freshness alone provides strong replay resistance for most use cases.
+
+**Contrast with previous draft:** An earlier draft used a `cycle` field to produce a proof valid for an entire billing period (up to 30 days). This was a static bearer token: anyone who intercepted it could replay indefinitely within the cycle. Freshness via `issuedAt` is the fix — the signature removal in the interim commit was not the intended resolution.
+
+> **Non-normative:** Servers MAY exchange one verified possession proof for their own session credential (cookie, API key, JWT) to avoid per-request wallet signing for human clients. This is a server-side optimization outside the x402 protocol scope.
+
+### 6.9 Failure Paths (402 Fallback)
+
+When subscription verification fails, the server MUST return a `402 Payment Required` response with the standard `accepts` array, enabling graceful fallback to payment:
+
+| Failure Reason | Behavior |
+|:---------------|:---------|
+| **Subscription not found** | 402 with `exact` + `subscribe` accepts; client can pay per-request or create new subscription |
+| **Invalid access signature** | 402 with `exact` + `subscribe` accepts; signature does not recover to the stored subscriber |
+| **Stale access proof** | 402 with `exact` + `subscribe` accepts; `\|now - issuedAt\|` exceeds `maxProofAge` |
+| **Audience mismatch** | 402 with `exact` + `subscribe` accepts; proof scoped to different origin |
+| **Subscription expired** | 402 with `exact` + `subscribe` accepts; client can renew or pay per-request |
+| **Subscription cancelled** | 402 with `exact` + `subscribe` accepts |
+| **In grace period (still active)** | 200 OK — access continues during grace |
+| **Grace period expired** | 402 with `exact` + `subscribe` accepts |
+| **Tier insufficient** | 402 with only higher-tier `subscribe` options (or `exact` if per-request is allowed) |
+
+**Error response structure:**
+
+```json
+{
+  "x402Version": 2,
+  "error": "Subscription not active",
+  "resource": { "url": "https://api.example.com/premium-data", "..." : "..." },
+  "accepts": [
+    { "scheme": "exact", "amount": "1000", "..." : "..." },
+    { "scheme": "subscribe", "amount": "5000000", "..." : "..." }
+  ],
+  "extensions": {
+    "subscription": {
+      "info": { "required": false, "acceptedTiers": ["pro", "enterprise"] },
+      "schema": { "..." : "..." }
+    }
+  }
+}
+```
+
+### 6.10 Request/Response Fixtures
+
+#### Active Subscriber — Access Granted (200 OK)
+
+**Request:**
+
+```http
+GET /api/premium-data HTTP/1.1
+Host: api.example.com
+X-PAYMENT-SIGNATURE: <base64-encoded payload below>
+```
+
+**Decoded X-PAYMENT-SIGNATURE payload:**
+
+```json
+{
+  "x402Version": 2,
+  "resource": { "url": "https://api.example.com/premium-data" },
+  "accepted": { "scheme": "subscribe" },
+  "payload": {},
+  "extensions": {
+    "subscription": {
+      "info": {
+        "subscriptionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        "issuedAt": 1740672089,
+        "audience": "https://api.example.com",
+        "signature": "0x1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b1b"
+      }
+    }
+  }
+}
+```
+
+**Server verification:**
+
+1. Calls `getSubscription(0xabcdef...)` → returns `{ subscriber: 0x857b06519E91e3A54538791bDbb0E22373e36b66, tierId: "pro", ... }`
+2. Recovers signer from `SubscriptionAccess(subscriptionId, issuedAt, audience)` signature → `0x857b06519E91e3A54538791bDbb0E22373e36b66`
+3. Signer matches stored subscriber ✓
+4. `|now - 1740672089| <= 60` (fresh) ✓
+5. `audience` matches served origin ✓
+6. `isActive(subscriptionId)` → true ✓
+7. `tierId` in `acceptedTiers` ✓
+
+**Response:**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+X-PAYMENT-RESPONSE: eyJzdWJzY3JpcHRpb24iOnsic3RhdHVzIjoiYWN0aXZlIiwiY3VycmVudFBlcmlvZEVuZCI6IjE3NDMyNjQwODkifX0=
+
+{"data": "premium content here"}
+```
+
+**Decoded X-PAYMENT-RESPONSE:**
+
+```json
+{
+  "subscription": {
+    "status": "active",
+    "currentPeriodEnd": "1743264089"
+  }
+}
+```
+
+#### Wrong-Key Signature — Payment Required (402)
+
+**Request:** Valid-looking echo with signature from the wrong key.
+
+```json
+{
+  "x402Version": 2,
+  "resource": { "url": "https://api.example.com/premium-data" },
+  "accepted": { "scheme": "subscribe" },
+  "payload": {},
+  "extensions": {
+    "subscription": {
+      "info": {
+        "subscriptionId": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        "issuedAt": 1740672089,
+        "audience": "https://api.example.com",
+        "signature": "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbe1c"
+      }
+    }
+  }
+}
+```
+
+**Server verification:**
+
+1. Calls `getSubscription(0xabcdef...)` → returns `{ subscriber: 0x857b06519E91e3A54538791bDbb0E22373e36b66, ... }`
+2. Recovers signer from signature → `0xAttacker1234567890123456789012345678901234` (different address)
+3. Signer does NOT match stored subscriber ✗ → **invalid_access_signature**
+
+**Response:**
+
+```http
+HTTP/1.1 402 Payment Required
+Content-Type: application/json
+
+{
+  "x402Version": 2,
+  "error": "Access signature invalid",
+  "resource": { "url": "https://api.example.com/premium-data" },
+  "accepts": [
+    { "scheme": "exact", "amount": "1000", "..." : "..." },
+    { "scheme": "subscribe", "amount": "5000000", "..." : "..." }
+  ]
+}
+```
+
+#### Lapsed Subscriber — Payment Required (402)
+
+**Request:**
+
+```http
+GET /api/premium-data HTTP/1.1
+Host: api.example.com
+X-PAYMENT-SIGNATURE: <base64-encoded payload below>
+```
+
+**Decoded X-PAYMENT-SIGNATURE payload (expired subscription):**
+
+```json
+{
+  "x402Version": 2,
+  "resource": { "url": "https://api.example.com/premium-data" },
+  "accepted": { "scheme": "subscribe" },
+  "payload": {},
+  "extensions": {
+    "subscription": {
+      "info": {
+        "subscriptionId": "0xdeadbeef0000000000000000000000000000000000000000000000000000000",
+        "issuedAt": 1740672089,
+        "signature": "0x1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b1b"
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```http
+HTTP/1.1 402 Payment Required
+Content-Type: application/json
+
+{
+  "x402Version": 2,
+  "error": "Subscription expired",
+  "resource": {
+    "url": "https://api.example.com/premium-data",
+    "description": "Real-time market data API",
+    "mimeType": "application/json"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "amount": "1000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "maxTimeoutSeconds": 60,
+      "extra": { "name": "USDC", "version": "2" }
+    },
+    {
+      "scheme": "subscribe",
+      "network": "eip155:8453",
+      "amount": "5000000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "maxTimeoutSeconds": 300,
+      "extra": {
+        "name": "USDC",
+        "version": "2",
+        "registry": "0x402SubscriptionRegistryAddress",
+        "subscriptionDetails": {
+          "tierId": "pro",
+          "tierName": "Pro Plan",
+          "billingCycle": "monthly",
+          "billingCycleSeconds": 2592000,
+          "periodCount": 12,
+          "gracePeriodSeconds": 86400,
+          "cancellationPolicy": "end_of_cycle"
+        }
+      }
+    }
+  ],
+  "extensions": {
+    "subscription": {
+      "info": { "required": false, "acceptedTiers": ["pro", "enterprise"] },
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "subscriptionId": { "type": "string", "pattern": "^0x[a-fA-F0-9]{64}$" },
+          "subscriber": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" },
+          "tierId": { "type": "string" }
+        },
+        "required": ["subscriptionId", "subscriber"]
+      }
+    }
+  }
 }
 ```
 

--- a/specs/schemes/subscribe/scheme_subscribe_evm.md
+++ b/specs/schemes/subscribe/scheme_subscribe_evm.md
@@ -1587,11 +1587,138 @@ The facilitator remains the expected caller for convenience (they maintain the M
 
 ---
 
-## 10. Facilitator API Extensions
+## 10. Facilitator API
 
-Subscribe, cancel, and update-root operations flow through the standard `/verify` and `/settle` endpoints using the `action` field in the payload. Status queries are non-normative facilitator conveniences.
+The `subscribe` scheme uses the standard V2 facilitator interface. No new normative endpoints are introduced; the `payload.action` field dispatches behavior within `/verify` and `/settle`.
 
-> **Note:** Full facilitator API documentation will be specified in a subsequent commit.
+### 10.1 Endpoint Summary
+
+| Endpoint | Method | Purpose |
+|:---------|:-------|:--------|
+| `/verify` | POST | Validate payload structure, signatures, and terms; return verification result |
+| `/settle` | POST | Execute on-chain transaction(s) for the action; return settlement result |
+| `/supported` | GET | Advertise scheme support (see §10.5) |
+
+### 10.2 Action: `subscribe`
+
+**`/verify` Steps (in order):**
+
+1. **Commitment signature**: Verify the EIP-712 `commitmentSignature` recovers to `commitment.subscriber`
+2. **Terms match requirements**: Confirm `commitment.{asset, payTo, registry, chainId, tierId}` match the corresponding `PaymentRequirements` fields
+3. **Schedule/root recomputation**: Rebuild the Merkle tree from the `schedule` array; confirm computed root equals `commitment.root`
+4. **Allowance path validity**:
+   - If `allowanceMethod` is `"eip2612-permit"`: validate the permit signature parameters (owner, spender, value, deadline)
+   - If `allowanceMethod` is `"direct-approve"`: confirm on-chain allowance >= total committed spend
+5. **Simulation**: Dry-run `subscribe()` call on registry; confirm it would succeed
+
+**`/settle` Steps:**
+
+1. If `allowanceMethod` is `"eip2612-permit"`: execute `permit()` on the token contract
+2. Execute `registry.subscribe(commitment, signature, initialLeaf?, initialProof?)` on-chain
+3. Return `SettlementResponse` with `subscriptionId`, `transaction`, status
+
+### 10.3 Action: `cancel`
+
+**`/verify` Steps:**
+
+1. **Subscription exists**: Confirm `getSubscription(subscriptionId).subscriber != address(0)`
+2. **Signature check**: Verify the EIP-712 `signature` over `CancelSubscription(subscriptionId, nonce)` recovers to the stored subscriber
+3. **Nonce unused**: Confirm `usedCancelNonces[subscriptionId][nonce] == false`
+4. **Not already cancelled**: Confirm `subscription.cancelled == false`
+
+**`/settle` Steps:**
+
+1. Execute `registry.cancel(subscriptionId, nonce, signature)` on-chain
+2. Return `SettlementResponse` with cancellation confirmation
+
+### 10.4 Action: `update-root`
+
+**`/verify` Steps:**
+
+1. **Previous subscription exists**: Confirm `getSubscription(previousSubscriptionId).subscriber != address(0)`
+2. **Subscriber match**: Confirm `previousSubscription.subscriber == newCommitment.subscriber`
+3. **New commitment signature**: Verify the EIP-712 `commitmentSignature` over `newCommitment` recovers to `newCommitment.subscriber`
+4. **Terms match requirements**: Same as `subscribe` action
+5. **Schedule/root recomputation**: Same as `subscribe` action
+6. **Allowance path validity**: Same as `subscribe` action
+7. **Simulation**: Dry-run `updateRoot()` call
+
+**`/settle` Steps:**
+
+1. If gasless allowance: execute permit
+2. Execute `registry.updateRoot(oldSubscriptionId, newCommitment, signature)` on-chain
+3. Return `SettlementResponse` with new `subscriptionId`
+
+### 10.5 GET /supported
+
+Facilitators supporting the `subscribe` scheme MUST include the following in their `/supported` response:
+
+```json
+{
+  "supported": [
+    {
+      "x402Version": 2,
+      "scheme": "subscribe",
+      "network": "eip155:8453"
+    }
+  ],
+  "extensions": ["subscription"]
+}
+```
+
+The `extensions` array indicates support for the `subscription` extension used for access verification.
+
+### 10.6 Recurring Charges (Operational Guidance)
+
+Periodic charges are NOT submitted via the facilitator API — they are direct on-chain transactions. The facilitator's role is **operational**, not protocol-mandated:
+
+**Scheduler responsibilities:**
+
+1. Maintain the Merkle tree and proofs off-chain (constructed from the `schedule` array at subscription time)
+2. Monitor billing boundaries (each leaf's `validFrom` timestamp)
+3. At each boundary, submit `registry.chargePeriod(subscriptionId, leaf, proof)` on-chain
+4. Handle grace period retries if initial charge fails (retry within `validTo + gracePeriodSeconds`)
+
+**Permissionless fallback:** Because `chargePeriod()` is permissionless, the facilitator is the *expected* but not *exclusive* operator. If the facilitator fails:
+
+- The payTo address can submit charges to collect revenue
+- The subscriber can submit charges to maintain active status
+- Any third party with the Merkle proofs can submit charges
+
+This design ensures liveness does not depend on a single operator's availability.
+
+---
+
+## Appendix A: Facilitator Conveniences (Non-Normative)
+
+The following endpoints are common facilitator implementations but are NOT part of the x402 protocol. Implementations MAY vary.
+
+### A.1 GET /subscription/{subscriptionId}
+
+Returns current subscription status for monitoring dashboards or client UIs.
+
+```json
+{
+  "subscriptionId": "0xabcdef...",
+  "subscriber": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+  "tierId": "pro",
+  "status": "active",
+  "cursor": 3,
+  "currentPeriodStart": 1748448089,
+  "currentPeriodEnd": 1751040089,
+  "expiry": 1772208089,
+  "inGracePeriod": false,
+  "cancelled": false
+}
+```
+
+### A.2 GET /subscriptions?subscriber={address}
+
+Lists all subscriptions for a subscriber address. Useful for wallet integrations.
+
+### A.3 POST /charge (Facilitator-initiated)
+
+Some facilitators expose an internal endpoint to trigger immediate charge attempts. This is an implementation detail for scheduler integration, not a protocol requirement.
 
 ---
 


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>Closes #512.</p>
<p>This revision replaces the pre-signed-renewal mechanism from the original draft with a <strong>client-signed Merkle schedule commitment</strong> and a <strong>standing ERC-20 allowance</strong> to an <strong>immutable registry contract</strong>.</p>
<h3>Guardrails</h3>
<p>The registry enforces three on-chain guardrails:</p>
<ol>
<li><strong>Per-period cap</strong> (<code>fee &lt;= maxPerPeriod</code>) — each charge is bounded by a client-signed ceiling, in addition to the per-leaf fee committed under the root</li>
<li><strong>Monotonic cursor</strong> (<code>periodIndex == cursor</code>, cursor++ only on success) — each period settles at most once, in order</li>
<li><strong>Time windows</strong> (<code>validFrom &lt;= now &lt;= validTo + gracePeriodSeconds</code>) — charges cannot occur early or after the retry buffer expires</li>
</ol>
<p>The registry is immutable — no proxy, no upgrade path, no owner authority over fund logic — with one narrowly-scoped exception: a guardian <code>pause()</code> that can only halt charging, and provably cannot move funds, alter terms, or redirect payments. <code>chargePeriod()</code> itself is permissionless: any party holding a valid proof may submit a due charge, so the facilitator is not a liveness single point of failure.</p>
<h3>Trust Model</h3>
<p>The facilitator is trusted for <strong>liveness only</strong>: it maintains the Merkle tree off-chain and submits <code>chargePeriod()</code> calls at billing boundaries. Facilitator compromise degrades to denial of service, never theft beyond the signed schedule — the facilitator cannot overcharge, charge early/late, redirect funds, or double-charge.</p>
<h3>Why Not Existing Schemes?</h3>

Scheme | Limitation
-- | --
exact / raw EIP-3009 | Single-use nonce per authorization. A 12-month subscription would require 12 separate client signatures.
auth-capture | Authorize-once / capture-once. The preApprovalExpiry = now + maxTimeoutSeconds (~60s) cannot span a billing term measured in days or months.
upto | Single settlement per authorization. After one charge, the authorization is consumed.
batch-settlement | Escrow-and-voucher aggregation for micropayments; no term, tier, renewal, or cancellation semantics.


<h3>Backwards Compatibility</h3>
<p>This is a spec-only addition. No changes to:</p>
<ul>
<li>Existing scheme specifications (<code>exact</code>, <code>upto</code>, <code>auth-capture</code>, <code>batch-settlement</code>)</li>
<li>Core protocol types or headers</li>
<li>Any TypeScript/Go/Python packages</li>
</ul>

<hr>
<h2>PR Checklist</h2>
<ul>
<li>[x] I have read the <a href="https://claude.ai/CONTRIBUTING.md">contributing guidelines</a></li>
<li>[x] I have added tests that prove my changes work (N/A — spec only; reference implementation with tests to follow)</li>
<li>[x] I have updated documentation as needed (this PR is documentation)</li>
<li>[ ] I have updated the changelog (skipped — docs-only, no package changes)</li>
<li>[x] My changes do not introduce new warnings or errors</li>
<li>[x] I have verified my changes work in a local development environment (N/A — spec only)</li>

### Why Not Existing Schemes?

| Scheme | Limitation |
|--------|------------|
| `exact` / raw EIP-3009 | Single-use nonce per authorization. A 12-month subscription would require 12 separate client signatures. |
| `auth-capture` | Authorize-once / capture-once. The `preApprovalExpiry = now + maxTimeoutSeconds` (~60s) cannot span a billing term measured in days or months. |
| `upto` | Single settlement per authorization. After one charge, the authorization is consumed. |
| `batch-settlement` | Escrow-and-voucher aggregation for micropayments; no term, tier, renewal, or cancellation semantics. |

### Security Fixes Over Prior Revision

1. **Terms now client-signed**: The EIP-712 commitment binds `{root, subscriber, asset, payTo, registry, chainId, tierId, start, expiry, maxPerPeriod, gracePeriodSeconds}`. The previous draft's signature field was never verified (a dead field).
2. **Cancellation signature now nonce-based**: `cancel()` uses signer-chosen nonces recorded in a mapping, preventing replay. The previous draft had no replay protection on cancellation.

### Scheme Acceptance Criteria

| Criterion | How This Spec Satisfies It |
|-----------|---------------------------|
| **Trust-minimizing** | Facilitator has no safety authority; all fund-flow invariants enforced on-chain; subscriber can revoke allowance unilaterally |
| **HTTP-native** | Uses standard V2 facilitator `/verify` + `/settle` endpoints; `subscription` extension in `PaymentPayload.extensions` |
| **Chain-agnostic** | Base spec (`scheme_subscribe.md`) is network-neutral; EVM-specific details in `scheme_subscribe_evm.md` |
| **Easy** | Client signs once; facilitator handles periodic charges; no per-request wallet interaction after subscription |
| **Backwards-compatible** | Spec-only addition; no changes to existing schemes, core protocol, or packages |
