### PR TITLE
Add batch-settlement payment scheme and Cloudflare network specification

### DIFF
--- a/specs/extensions/http-message-signatures.md
+++ b/specs/extensions/http-message-signatures.md
@@ -1,0 +1,128 @@
+# Extension: `http-message-signatures`
+
+## Summary
+
+The `http-message-signatures` extension establishes the **identity** of the paying agent through cryptographic signatures (RFC 9421). This extension is used by network implementations that authenticate payment commitments using HTTP Message Signatures.
+
+## Purpose
+
+Establishes the cryptographic identity of the paying agent and provides information on how to associate that identity with the network for billing.
+
+## Extension Definition
+
+```json
+{
+  "http-message-signatures": {
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "registrationUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the network's setup endpoint and documentation"
+        },
+        "signatureSchemes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Supported cryptographic signature algorithms"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Supported signature tags for validation"
+        }
+      },
+      "required": ["registrationUrl", "signatureSchemes"]
+    },
+    "info": {
+      "registrationUrl": "https://network.example.com/signature-agents",
+      "signatureSchemes": ["ed25519", "ecdsa-p256-sha256", "rsa-pss-sha512"],
+      "tags": ["web-bot-auth", "agent-browser-auth"]
+    }
+  }
+}
+```
+
+## Fields
+
+- **`registrationUrl`** (required): URL to the network's documentation and setup endpoint where signature agents can associate their identity with a billing identity
+- **`signatureSchemes`** (required): Array of supported cryptographic algorithms (e.g., `["ed25519", "ecdsa-p256-sha256", "rsa-pss-sha512"]`)
+- **`tags`** (required): Array of supported signature tags that identify the purpose (e.g., `["web-bot-auth"]`)
+
+**Schema Omission**: The `schema` field is optional and may be omitted from responses to reduce header size. When omitted, clients should reference this specification for field definitions.
+
+## Usage
+
+Networks that use HTTP Message Signatures for authentication include this extension in the `PaymentRequired` response to inform clients:
+
+1. Where to register their signature agent with the network (`registrationUrl`)
+2. Which cryptographic algorithms are supported (`signatureSchemes`)
+3. Which signature tags are accepted for validation (`tags`)
+
+The client must:
+
+1. Host their public keys at `/.well-known/http-message-signatures-directory` (per draft-meunier-http-message-signatures-directory)
+2. Register their signature agent URL with the network via the `registrationUrl`
+3. Sign HTTP requests using HTTP Message Signatures (RFC 9421) with the appropriate tag
+
+## Server-Signed Responses
+
+Servers can sign responses per RFC 9421 Section 3.1 to provide integrity for payment data. This enables clients to verify that `PAYMENT-REQUIRED` and `PAYMENT-RESPONSE` headers have not been modified, and to pin a specific version of terms to a transaction.
+
+### Covered Components
+
+Per RFC 9421 Section 2.2.9, responses can include `@status` in the signature. Per Section 2.4, servers can bind response signatures to request components using the `req` flag. For x402, servers signing responses should include:
+
+- `@status`: HTTP status code
+- `payment-required` or `payment-response`: The x402 header
+- Request binding: `"@authority";req`, `"@path";req`
+
+### Example
+
+```http
+HTTP/2 200 OK
+Content-Type: text/html
+PAYMENT-RESPONSE: eyJhbW91bnQiOiI1IiwiYXNzZXQiOiJVU0QiLCJleHRlbnNpb25zIjp7InRlcm1zIjp7ImluZm8iOnsiZm9ybWF0IjoidXJpIiwidGVybXMiOiJodHRwczovL2V4YW1wbGUuY29tL3Rlcm1zLXYyLjAubWQifX19fQ==
+Signature-Input: resp=("@status" "payment-response" "@authority";req "@path";req);created=1700000000;keyid="server-key";tag="x402-response"
+Signature: resp=:abc123...==:
+```
+
+Servers publishing response signatures should host their public keys at `/.well-known/http-message-signatures-directory`.
+
+## Example Networks
+
+- **Cloudflare** (`cloudflare:402`): Uses this extension with `ed25519` signatures and `web-bot-auth` tag
+
+## Example
+
+```json
+{
+  "extensions": {
+    "http-message-signatures": {
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "registrationUrl": { "type": "string", "format": "uri" },
+          "signatureSchemes": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "tags": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["registrationUrl", "signatureSchemes"]
+      },
+      "info": {
+        "registrationUrl": "https://developers.cloudflare.com/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/verify-ai-crawler/",
+        "signatureSchemes": ["ed25519"],
+        "tags": ["web-bot-auth"]
+      }
+    }
+  }
+}
+```

--- a/specs/schemes/batch-settlement/batch_settlement.md
+++ b/specs/schemes/batch-settlement/batch_settlement.md
@@ -1,0 +1,75 @@
+# Scheme: `batch-settlement`
+
+## Summary
+
+`batch-settlement` is a payment scheme in which the client provides a cryptographic payment commitment at request time, but the transfer of value is not executed synchronously during that request. The commitment is accepted, access is granted immediately, and financial settlement occurs later through a process defined by the network binding.
+
+Per-request on-chain settlement may not be ideal for some real-world use cases. `batch-settlement` exists to serve situations where gas fees exceed the value of individual requests, block confirmation time is incompatible with HTTP response latency, request volume requires batched settlement, or settlement happens through infrastructure that operates asynchronously from HTTP (payment channels, fiat billing systems, stablecoin invoices).
+
+The model of how a commitment is formed, what backs it, and how it is eventually redeemed,is defined entirely by the network binding.
+
+## Protocol behavior
+
+For `exact` and `upto`, verification and settlement happen in a single pass: the commitment is validated, a transaction is broadcast, and value has moved. The settlement result contains an on-chain transaction hash.
+
+For `batch-settlement`, verification confirms the commitment is valid, but settlement stores it rather than executing a transfer. The settlement result contains a commitment identifier, but value moves later, through the network binding's redemption process.
+
+### Commitment identifier
+
+The settlement result MUST include a non-empty commitment identifier on success. This identifier is meaningful to the network binding; a token, a voucher ID, channel receipt hash, account ledger reference, or equivalent.
+
+## Commitment models
+
+Network bindings may choose one of two trust models for backing the client's commitment.
+
+### Capital-backed
+
+The client's commitment is backed by on-chain capital committed before or during the session such as pre-funded escrow, a payment channel, or a delegated authorization against a wallet balance. The trust anchor is the client's own funds. No network intermediary is required to underwrite access.
+
+### Credit-backed
+
+The client's commitment is backed by a verified identity associated with a billing account managed by a trusted network intermediary. No on-chain capital is required from the client. The network authenticates the identity, underwrites the access obligation, and settles with the resource server through off-chain infrastructure on a defined schedule.
+
+## Use cases
+
+**Escrow-backed micropayments.** An AI agent pre-funds an on-chain escrow at session start. Each sub-cent API call produces a signed voucher drawn against that balance. The provider accumulates vouchers and redeems them in a single on-chain transaction at session end, keeping per-request gas cost to zero.
+
+**Payment channel streaming.** A client and provider open a payment channel once. Each request increments a signed running total (a receipt). The provider closes the channel periodically, collecting accumulated value in one settlement regardless of how many individual requests were made.
+
+**Delegated authorization.** A client delegates spending authority to an operator against their wallet balance. The operator signs commitments per request on the client's behalf. The provider collects authorizations and settles them through the delegation contract.
+
+**Credit-backed content licensing.** A content publisher monetizes AI crawler access. Crawlers authenticate via a network-registered identity backed by a billing account. The network verifies each request, accumulates usage, and invoices the crawler operator on a billing cycle with no wallet or on-chain interaction required from the client.
+
+## Settlement lifecycle
+
+All `batch-settlement` network bindings share this abstract lifecycle. The network binding defines the specifics of each phase.
+
+1. **Commit.** The client produces a cryptographic payment commitment and attaches it to the request. The commitment is validated and stored. The resource is served immediately.
+
+2. **Accumulate.** The network retains the commitment in a voucher store, channel state, account ledger, or billing system. The network binding defines who stores commitments, where, and for how long.
+
+3. **Redeem.** Value is transferred out of band through an on-chain contract call, a channel close, a fiat batch invoice, or any rail the network defines. The trigger, timing, and mechanism are network-defined.
+
+## Appendix
+
+### Network requirements
+
+Every `batch-settlement` network binding MUST specify:
+
+1. **Commitment format** — the structure and encoding of the payment payload, including all fields required for verification and redemption.
+2. **Verification rules** — how the commitment is validated: signature scheme, balance or credit check, replay prevention, expiry.
+3. **Storage behavior** — what constitutes a stored commitment for this network, and what the commitment identifier contains on success.
+4. **Double-spend prevention** — how the network ensures the same commitment cannot be accepted or redeemed more than once.
+5. **Commitment expiry** — when commitments become invalid and what happens to unaccepted commitments after expiry.
+6. **Redemption** — who triggers redemption, when, and through what rail.
+7. **Trust model** — whether the trust anchor is the client's on-chain capital (capital-backed) or a network intermediary (credit-backed), and what guarantee the seller has of eventual settlement.
+
+### Extensions
+
+Network bindings may use optional extensions to communicate additional requirements in the `PaymentRequired` response. See the [extensions directory](../../extensions/) for available specifications.
+
+### Related schemes
+
+[`exact`](../exact/scheme_exact.md) — value is transferred immediately per request.
+
+[`upto`](../upto/scheme_upto.md) — value is transferred immediately, variable amount up to a client-authorized maximum.

--- a/specs/schemes/batch-settlement/batch_settlement_cloudflare.md
+++ b/specs/schemes/batch-settlement/batch_settlement_cloudflare.md
@@ -1,0 +1,390 @@
+# Scheme: `batch-settlement` `cloudflare:402`
+
+## Summary
+
+The `batch-settlement` scheme on the Cloudflare network `cloudflare:402` enables access to resources through cryptographically signed payment commitments that are settled later through the network's infrastructure.
+
+**Network Identifier**: `cloudflare:402`
+**Trust Model**: Credit-backed (see [batch_settlement.md](./batch_settlement.md#credit-backed))
+
+**Authentication Method**: This implementation uses **HTTP Message Signatures (RFC 9421)** to authenticate payment commitments. The network acts as a trusted intermediary to provide immediate resource access while settlement is batched and handled later.
+
+## Protocol Flow
+
+The protocol flow for `batch-settlement` on the network (Cloudflare) includes an initial setup step, followed by client-driven payment with optional pre-authorization:
+
+### First-time Setup (Client)
+
+1. Host public keys at a `.well-known` endpoint (e.g., `https://mycrawler.com/.well-known/http-message-signatures-directory`)
+2. Submit signature agent URL to the `registrationUrl` from the `http-message-signatures` extension (e.g., `https://developers.cloudflare.com/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/verify-ai-crawler/`)
+3. The network (Cloudflare) associates signature agent URL with a billing identity for settlement
+
+### Payment Flow (Per Request)
+
+1. Makes an HTTP request to a **Resource Server**.
+2. **Resource Server** responds with a `402 Payment Required` status. The response includes a PAYMENT-REQUIRED header (base64-encoded JSON) containing payment requirements with the `batch-settlement` scheme and `cloudflare:402` network with `payTo` set to `merchant`. The response also includes the `http-message-signatures` extension indicating where to find documentation on associating the HTTP message signature agent with the network.
+3. **Client** constructs a payment payload containing the payment commitment (amount, asset) and signs the HTTP request using **HTTP Message Signatures (RFC 9421)**. The client includes `Signature-Agent`, `Signature-Input`, and `Signature` headers along with the PAYMENT-SIGNATURE header.
+4. **Client** sends a new HTTP request with the PAYMENT-SIGNATURE header (base64-encoded JSON) and HTTP Message Signature headers.
+5. **Resource Server** verifies the signature agent is recognized by the network (Cloudflare) and fetches the public key.
+6. **Resource Server** verifies the HTTP Message Signature is valid using the fetched public key.
+7. **Resource Server** validates the payment amount and asset match the requirements.
+8. **Resource Server**, upon successful verification, grants the **Client** access to the resource and includes a PAYMENT-RESPONSE header (base64-encoded JSON) confirming the payment commitment.
+9. The network (Cloudflare) acts as Merchant of Record, handling batched settlement and billing the identity associated with the signature agent.
+
+**Pre-Authorized Flow**: Clients with pre-authorized payment agreements can include the PAYMENT-SIGNATURE header and HTTP Message Signature headers in their initial request (step 1), bypassing the 402 response and proceeding directly to verification and access.
+
+**Note on HTTP Message Signatures**: All requests are signed using HTTP Message Signatures (RFC 9421). The signature agent's `.well-known/http-message-signatures-directory` URL must be known to the network (Cloudflare) and associated with a billing identity for settlement. This conforms to [draft-meunier-http-message-signatures-directory-04](https://datatracker.ietf.org/doc/html/draft-meunier-http-message-signatures-directory-04).
+
+## PaymentRequired for batch-settlement
+
+The `batch-settlement` scheme on the Cloudflare network uses the standard x402 `PaymentRequired` fields. The Cloudflare implementation includes the `http-message-signatures` extension to communicate authentication requirements.
+
+> **Note on Price Availability**: The `amount` field in `accepts` may not be available in all responses. Price information is only guaranteed when the HTTP Message Signature extension is correctly parsed and the signature agent is recognized. When price is not available, clients should retry with authentication.
+
+### Header Size Constraints
+
+HTTP intermediaries may reject headers larger than 2KB. To minimize header size, the `cloudflare:402` network:
+
+- Omits `schema` from extensions (schemas are documented in the extension specifications)
+- May omit optional `resource` fields (`description`, `website`) when not available
+
+**Required fields:**
+
+- `x402Version`
+- `accepts[].scheme`, `accepts[].network`, `accepts[].amount`, `accepts[].asset`, `accepts[].payTo`
+- `accepts[].extra.version`: Network implementation version (semver format)
+- `extensions.http-message-signatures.info.registrationUrl`, `extensions.http-message-signatures.info.signatureSchemes`, `extensions.http-message-signatures.info.tags`
+
+```http
+HTTP/2 402 Payment Required
+Content-Type: text/html
+PAYMENT-REQUIRED: eyJ4NDAyVmVyc2lvbiI6IDIsICJlcnJvciI6ICJObyBQQVlNRU5ULVNJR05BVFVSRSBoZWFkZXIgcHJvdmlkZWQiLCAicmVzb3VyY2UiOiB7InVybCI6ICJodHRwczovL2V4YW1wbGUuY29tL2FydGljbGUiLCAiZGVzY3JpcHRpb24iOiAiUHJlbWl1bSBhcnRpY2xlIGNvbnRlbnQiLCAibWltZVR5cGUiOiAidGV4dC9odG1sIn0sICJhY2NlcHRzIjogWy4uLl19
+
+<!DOCTYPE html>
+<html>
+  <head><title>Payment Required</title></head>
+  <body>This content requires payment.</body>
+</html>
+```
+
+**Decoded PAYMENT-REQUIRED header:**
+
+```json
+{
+  "x402Version": 2,
+  "error": "No PAYMENT-SIGNATURE header provided",
+  "resource": {
+    "url": "https://example.com/article",
+    "mimeType": "text/html"
+  },
+  "accepts": [
+    {
+      "scheme": "batch-settlement",
+      "network": "cloudflare:402",
+      "amount": "1",
+      "asset": "USD",
+      "payTo": "merchant",
+      "extra": {
+        "version": "1.0.0"
+      }
+    }
+  ],
+  "extensions": {
+    "http-message-signatures": {
+      "info": {
+        "registrationUrl": "https://developers.cloudflare.com/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/verify-ai-crawler/",
+        "signatureSchemes": ["ed25519"],
+        "tags": ["web-bot-auth"]
+      }
+    }
+  }
+}
+```
+
+**PaymentRequirements fields:**
+
+- `scheme`: Must be `"batch-settlement"`
+- `network`: Must be `"cloudflare:402"` (CAIP-2 format)
+- `asset`: The asset identifier (e.g., `"USD"` for fiat currency - ISO 4217 format)
+- `payTo`: Must be `"merchant"` (constant indicating the network handles settlement)
+- `amount`: Payment amount in smallest unit of the asset (e.g., cents for USD)
+- `maxTimeoutSeconds`: Maximum time allowed for payment completion (optional, see note below)
+- `extra.version`: Network implementation version in semver format (see [Network Version](#network-version))
+
+> **Note on Timeouts**: When the `maxTimeoutSeconds` is omitted or set to `0`, the network makes no timing guarantees on price validity. Clients should not cache pricing information across requests when timeout is zero or absent.
+
+**Extensions:**
+
+The Cloudflare implementation uses the `http-message-signatures` extension to communicate authentication requirements:
+
+- `extensions.http-message-signatures`: Communicates Cloudflare's authentication requirements
+  - `info.registrationUrl`: URL to the network's setup documentation (`https://developers.cloudflare.com/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/verify-ai-crawler/`) - this is intended for human-driven setup; a programmatic API endpoint may be provided in future versions
+  - `info.signatureSchemes`: Supported algorithms (`["ed25519"]`)
+  - `info.tags`: Supported signature tags (`["web-bot-auth"]`)
+
+Note: `payTo` is set to `"merchant"` as the network handles settlement.
+
+## PAYMENT-SIGNATURE Header Payload
+
+The client sends a PAYMENT-SIGNATURE header containing base64-encoded JSON with the payment payload.
+
+```http
+GET /article HTTP/2
+Host: example.com
+Signature-Agent: mycrawler.com
+Signature-Input: sig=("@authority" "signature-agent" "payment-signature"); created=1700000000; expires=1700011111; keyid="ba3e64=="; tag="web-bot-auth"
+Signature: sig=:abc123...==:
+PAYMENT-SIGNATURE: eyJ4NDAyVmVyc2lvbiI6MiwicGF5bG9hZCI6eyJhbW91bnQiOiI1IiwiYXNzZXQiOiJVU0QifSwiYWNjZXB0ZWQiOnsic2NoZW1lIjoiYmF0Y2gtc2V0dGxlbWVudCIsIm5ldHdvcmsiOiJjbG91ZGZsYXJlOjQwMiIsImFtb3VudCI6IjUiLCJhc3NldCI6IlVTRCIsInBheVRvIjoibWVyY2hhbnQiLCJtYXhUaW1lb3V0U2Vjb25kcyI6MzB9fQ==
+```
+
+**Decoded PAYMENT-SIGNATURE header:**
+
+```json
+{
+  "x402Version": 2,
+  "payload": {
+    "amount": "5",
+    "asset": "USD"
+  },
+  "accepted": {
+    "scheme": "batch-settlement",
+    "network": "cloudflare:402",
+    "amount": "5",
+    "asset": "USD",
+    "payTo": "merchant",
+    "maxTimeoutSeconds": 30
+  }
+}
+```
+
+The `payload` field contains:
+
+- `amount`: Payment amount in smallest unit of the asset (e.g., cents for USD)
+- `asset`: Asset identifier (e.g., `"USD"`)
+
+**Note**: The `signatureAgent` and `signature` are NOT in the payment payload. They come from the HTTP Message Signature headers (`Signature-Agent` and `Signature` headers) as defined in RFC 9421.
+
+The `accepted` field contains the full `PaymentRequirements` object that this payment fulfills (without extensions, as those are at the top level).
+
+**Note on Extensions**: According to v2 spec, clients must echo the extensions from the `PaymentRequired` response. However, extensions are not part of the `accepted` field since `accepted` contains only the specific `PaymentRequirements` object from the `accepts` array. Extensions would be echoed at the top level of the payment payload if the client needs to respond to them.
+
+## Verification
+
+Steps to verify a payment for the `batch-settlement` scheme, the network (Cloudflare) implements:
+
+1. **Verify HTTP Message Signature is valid**: Validate the HTTP Message Signature (RFC 9421) from the `Signature` header using the public key fetched from the `Signature-Agent` header URL
+2. **Verify signature agent is recognized by the network**: Confirm the signature agent URL (from `Signature-Agent` header) is known to the network (Cloudflare) and associated with a billing identity
+3. **Verify amount and asset are sufficient**: Ensure the payment amount and asset meet the requirements
+4. **Verify timestamp freshness**: Ensure the payment is not expired (typically within 30 seconds)
+5. **Verify accepted field matches**: Verify the `accepted` field matches one of the offered `PaymentRequirements`
+
+### Verification Pseudocode
+
+```javascript
+function verifyBatchSettlementPayment(paymentPayload, signatureAgentHeader, httpSignature) {
+  // 1. Verify signature agent is recognized by the network and get billing info
+  const agentInfo = await verifySignatureAgentWithNetwork(signatureAgentHeader);
+
+  if (!agentInfo.isRecognized) {
+    return { valid: false, reason: "signature_agent_unknown" };
+  }
+
+  // 2. Fetch public key from signature agent's .well-known/http-message-signatures-directory endpoint
+  const publicKey = await fetchPublicKey(signatureAgentHeader, agentInfo.keyId);
+
+  if (!publicKey) {
+    return { valid: false, reason: "server_error" };
+  }
+
+  // 3. Verify HTTP Message Signature using the public key
+  const isSignatureValid = verifyHttpMessageSignature(
+    httpSignature,
+    publicKey,
+    buildCanonicalString(paymentPayload)
+  );
+
+  if (!isSignatureValid) {
+    return { valid: false, reason: "invalid_signature" };
+  }
+
+  // 4. Verify payment signature header is correctly structured
+  if (!isValidPaymentSignature(paymentPayload)) {
+    return { valid: false, reason: "invalid_payment" };
+  }
+
+  // 5. Verify amount/asset are sufficient for the resource
+  const isSufficientPayment = checkPaymentSufficiency(
+    paymentPayload.accepted.amount,
+    paymentPayload.accepted.asset,
+  );
+
+  if (!isSufficientPayment) {
+    return { valid: false, reason: "invalid_payment" };
+  }
+
+  // billingIdentifier is an arbitrary network identifier (e.g., account ID)
+  // used by the network to rollup and bill charges for this signature agent
+  return { valid: true, reason: null, billingIdentifier: agentInfo.billingIdentifier };
+}
+```
+
+## Settlement
+
+The network (Cloudflare) acts as Merchant of Record, aggregating payment commitments, billing the identity associated with each signature agent, and distributing revenue to content owners on a periodic basis through traditional off-chain financial rails.
+
+## PAYMENT-RESPONSE Header
+
+Upon successful verification, the server includes a PAYMENT-RESPONSE header (base64-encoded JSON) in the 200 OK response.
+
+```http
+HTTP/2 200 OK
+Content-Type: text/html
+PAYMENT-RESPONSE: eyJhbW91bnQiOiAiNSIsICJhc3NldCI6ICJVU0QiLCAibmV0d29yayI6ICJjbG91ZGZsYXJlOjQwMiIsICJ0aW1lc3RhbXAiOiAxNzMwODcyOTY4LCAiZXh0ZW5zaW9ucyI6IHsidGVybXMiOiB7ImluZm8iOiB7ImZvcm1hdCI6ICJ1cmkiLCAidGVybXMiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9wcGMvdGVybXMubWQifX19fQ==
+
+<!DOCTYPE html>
+<html>
+  <head><title>Premium Article</title></head>
+  <body><article>Premium content...</article></body>
+</html>
+```
+
+**Decoded PAYMENT-RESPONSE header:**
+
+```json
+{
+  "amount": "5",
+  "asset": "USD",
+  "network": "cloudflare:402",
+  "timestamp": 1730872968
+}
+
+## Appendix
+
+### Network-Specific Implementation
+
+The network (Cloudflare) implements the `batch-settlement` scheme with the following details:
+
+**Registration URL**: `https://developers.cloudflare.com/ai-crawl-control/features/pay-per-crawl/use-pay-per-crawl-as-ai-owner/verify-ai-crawler/`
+
+> **Note**: This URL is intended for human-driven setup and documentation. It provides instructions for the onboarding process including Web Bot Auth setup, verified bot policy compliance, and verification request submission. A programmatic API endpoint for automated registration may be provided in future versions.
+
+This URL provides:
+
+1. **Setup instructions**: How to submit your signature agent's `.well-known/http-message-signatures-directory` URL to the network
+2. **Billing identity association**: How to associate your signature agent with a billing identity for settlement
+3. **Public key requirements**: What public key formats and algorithms are supported
+4. **Verification process**: How the network verifies HTTP Message Signatures
+
+**Supported Tags**: `["web-bot-auth", "agent-browser-auth"]`
+
+**Setup Process**:
+
+1. Client hosts their public keys at a `.well-known/http-message-signatures-directory` endpoint (e.g., `https://mycrawler.com/.well-known/http-message-signatures-directory`)
+2. Client submits this URL to the network via the network URL endpoint
+3. The network associates the signature agent URL with a billing identity
+4. Client can now sign requests using HTTP Message Signatures, with the `Signature-Agent` header pointing to their `.well-known/http-message-signatures-directory` URL
+5. Resource servers verify signatures by fetching public keys from the `Signature-Agent` URL and validating the signature agent is known to the network
+
+### Network Registration Terms
+
+The following operational details are established during registration with the network (via `registrationUrl`) and are not part of the x402 protocol itself:
+
+- **Settlement periods**: Frequency of billing cycles (e.g., daily, weekly)
+- **Payment failure handling**: What happens if batched payments cannot be settled
+- **Rate limits and quotas**: Usage restrictions per billing period
+- **Dispute resolution**: Process for handling billing disputes
+
+These terms may vary by account and are subject to the network's terms of service.
+
+**Note**: For the full extension definition, see [`http-message-signatures`](../../extensions/http-message-signatures.md).
+
+**Example HTTP Request with Message Signatures**:
+
+```http
+GET /article HTTP/2
+Host: example.com
+User-Agent: Mozilla/5.0 Chrome/113.0.0 MyCrawler/1.0
+Signature-Agent: mycrawler.com
+Signature-Input: sig=("@authority" "signature-agent" "payment-signature"); created=1700000000; expires=1700011111; keyid="ba3e64=="; tag="web-bot-auth"
+Signature: sig=:abc123...==:
+
+Payment-Signature: eyJ4NDAyVmVyc2lvbiI6IDIsIC4uLn0=
+```
+
+The `Signature-Agent` header indicates where to find the client's public keys (e.g., `mycrawler.com`). This URL must be known to the network (Cloudflare) and associated with a billing identity. The `registrationUrl` in the extension points to the network's documentation on how to associate your signature agent.
+
+### Security Considerations
+
+**HTTP Message Signature Verification**:
+
+- All requests must be signed using HTTP Message Signatures (RFC 9421)
+- The signature **MUST** include the following components:
+  - `@authority`: The target server authority
+  - `signature-agent`: The signature agent header value
+  - `payment-signature`: The PAYMENT-SIGNATURE header (lowercase per RFC 9421)
+- This ensures the payment commitment is cryptographically bound to the HTTP request
+- Servers verify signatures by:
+  1. Fetching the public key from the URL in the `Signature-Agent` header
+  2. Validating the signature using the fetched public key
+  3. Confirming the signature agent URL is known to the network (Cloudflare)
+
+**Billing Identity Association**:
+
+- The signature agent URL (from `Signature-Agent` HTTP header) must be known to the network (Cloudflare)
+- The network maintains the association between signature agent URLs and billing identities with account IDs
+- The signature agent is identified by the `Signature-Agent` header
+
+**Stateless Verification**:
+
+- Servers do not need to maintain payment state or track attempts
+- All verification can be performed stateless by validating the signature and billing identity association
+- No database lookups or session management required
+
+### Error Codes
+
+Error codes for batch-settlement payment failures on the Cloudflare network:
+
+- `blocked`: Payment required to access resource
+- `price_not_acceptable`: Payment amount does not match requirements
+- `payment_failed`: Signature agent not associated with valid billing identity
+- `invalid_signature`: Invalid or missing `Signature-Input` or `Signature` headers
+- `signature_agent_unknown`: Signature agent not recognized by network (Cloudflare)
+- `invalid_payment_signature`: Invalid or malformed `PAYMENT-SIGNATURE` header
+- `origin_error`: Server error during payment processing
+- `unknown`: Unknown error
+
+### Pre-Authorized Access
+
+Clients with pre-authorized payment agreements can include the PAYMENT-SIGNATURE header in their initial request, bypassing the 402 response:
+
+```http
+GET /article HTTP/2
+Host: example.com
+Signature-Agent: mycrawler.com
+Signature-Input: sig=("@authority" "signature-agent" "payment-signature"); created=1700000000; expires=1700011111; keyid="ba3e64=="; tag="web-bot-auth"
+Signature: sig=:abc123...==:
+
+Payment-Signature: eyJ4NDAyVmVyc2lvbiI6MiwicGF5bG9hZCI6eyJhbW91bnQiOiIxMDAwMCIsImFzc2V0IjoiVVNEIn0sImFjY2VwdGVkIjp7Ii4uLiJ9fQ==
+```
+
+If the payment is valid, the server responds directly with `200 OK` and the requested content, skipping the 402 negotiation phase.
+
+### Comparison with Exact Scheme
+
+| Feature          | Exact + EVM/SVM                  | Batch-Settlement + Cloudflare           |
+| ---------------- | -------------------------------- | --------------------------------------- |
+| Settlement       | Immediate blockchain transaction | Batched off-chain settlement            |
+| Transaction Fees | Gas fees required                | No transaction fees                     |
+| Currency         | Cryptocurrency (USDC, etc.)      | Fiat (USD, etc.)                        |
+| Infrastructure   | Blockchain wallet required       | Cloudflare account required             |
+| Trust Model      | Trustless blockchain             | Trusted Merchant of Record (Cloudflare) |
+
+### Network Version
+
+The `extra.version` field uses semantic versioning (semver) to signal changes in network behavior. Clients should check this field to detect breaking changes.
+
+**Changelog:**
+
+| Version | Date    | Changes         |
+| ------- | ------- | --------------- |
+| `1.0.0` | 2026-01 | Initial release |


### PR DESCRIPTION
## Description

Introduces the **batch-settlement payment scheme** for x402, enabling instant resource access through cryptographic payment commitments where settlement occurs later through a process defined by the network binding.

The core scheme spec defines protocol behavior, two commitment models (capital-backed and credit-backed), and the abstract settlement lifecycle — designed to unify the multiple deferred-settlement PRs under a single parent scheme.

The Cloudflare network binding (`cloudflare:402`) provides a credit-backed implementation using HTTP Message Signatures (RFC 9421) for authentication and fiat batch billing.

#### What's Included

| File | Description |
|------|-------------|
| `specs/schemes/batch-settlement/batch_settlement.md` | Core scheme definition — protocol behavior, commitment models, use cases, network requirements |
| `specs/schemes/batch-settlement/batch_settlement_cloudflare.md` | Cloudflare `cloudflare:402` network binding |
| `specs/extensions/http-message-signatures.md` | Extension for RFC 9421 authentication |

> **Note**: The `terms` extension has been split out for separate review.

> **Note on naming**: The scheme is named `batch-settlement` as a starting point. Open to discussion on `batch-settlement` vs `batch` vs `batched` — easier to shorten than lengthen.

## Tests
None, this is a **spec-only PR** (no SDK implementation).

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] **SKIPPED** added a changelog fragment for user-facing changes (docs-only changes can skip)