### PR TITLE
feat(split): add split payment scheme for multi-recipient payments

### DIFF
--- a/python/x402/mechanisms/evm/split/__init__.py
+++ b/python/x402/mechanisms/evm/split/__init__.py
@@ -1,0 +1,42 @@
+"""EVM split payment scheme.
+
+The `split` scheme extends x402 to support multi-recipient payments.
+A single payment authorization is signed by the client, the facilitator
+settles on-chain, then distributes to N recipients via internal ledger
+credits, on-chain transfers, or batch multicall.
+
+Usage (client):
+    from x402.mechanisms.evm.split.register import register_split_evm_client
+    register_split_evm_client(client, signer)
+
+Usage (server):
+    from x402.mechanisms.evm.split.register import register_split_evm_server
+    register_split_evm_server(server)
+
+Usage (facilitator):
+    from x402.mechanisms.evm.split.register import register_split_evm_facilitator
+    register_split_evm_facilitator(facilitator, signer, networks="eip155:84532")
+"""
+
+from .client import SplitEvmScheme as SplitEvmClientScheme
+from .constants import SCHEME_SPLIT
+from .facilitator import SplitEvmScheme as SplitEvmFacilitatorScheme
+from .register import (
+    register_split_evm_client,
+    register_split_evm_facilitator,
+    register_split_evm_server,
+)
+from .server import SplitEvmScheme as SplitEvmServerScheme
+from .types import SplitConfig, SplitRecipient
+
+__all__ = [
+    "SCHEME_SPLIT",
+    "SplitConfig",
+    "SplitEvmClientScheme",
+    "SplitEvmFacilitatorScheme",
+    "SplitEvmServerScheme",
+    "SplitRecipient",
+    "register_split_evm_client",
+    "register_split_evm_facilitator",
+    "register_split_evm_server",
+]

--- a/python/x402/mechanisms/evm/split/client.py
+++ b/python/x402/mechanisms/evm/split/client.py
@@ -1,0 +1,123 @@
+"""EVM client implementation for the Split payment scheme."""
+
+from datetime import timedelta
+from typing import Any
+
+from ....schemas import PaymentRequirements
+from ..eip712 import build_typed_data_for_signing
+from ..signer import ClientEvmSigner
+from ..types import ExactEIP3009Authorization, ExactEIP3009Payload, TypedDataField
+from ..utils import (
+    create_nonce,
+    create_validity_window,
+    get_asset_info,
+    get_evm_chain_id,
+)
+from .constants import SCHEME_SPLIT
+
+
+class SplitEvmScheme:
+    """EVM client implementation for the Split payment scheme.
+
+    From the client's perspective, a split payment is identical to an exact
+    payment — the client signs a single EIP-3009 authorization to the
+    facilitator's escrow address. The facilitator handles distribution.
+
+    Implements SchemeNetworkClient protocol.
+    """
+
+    scheme = SCHEME_SPLIT
+
+    def __init__(self, signer: ClientEvmSigner):
+        """Create SplitEvmScheme.
+
+        Args:
+            signer: EVM signer for payment authorizations.
+        """
+        self._signer = signer
+
+    def create_payment_payload(
+        self,
+        requirements: PaymentRequirements,
+    ) -> dict[str, Any]:
+        """Create signed EIP-3009 inner payload.
+
+        The payload is identical to exact — client pays the total amount
+        to the facilitator's escrow address (requirements.pay_to).
+        The split is handled server-side by the facilitator.
+
+        Args:
+            requirements: Payment requirements (includes recipients in extra).
+
+        Returns:
+            Inner payload dict (authorization + signature).
+        """
+        nonce = create_nonce()
+        valid_after, valid_before = create_validity_window(
+            timedelta(seconds=requirements.max_timeout_seconds or 3600)
+        )
+
+        authorization = ExactEIP3009Authorization(
+            from_address=self._signer.address,
+            to=requirements.pay_to,
+            value=requirements.amount,
+            valid_after=str(valid_after),
+            valid_before=str(valid_before),
+            nonce=nonce,
+        )
+
+        signature = self._sign_authorization(authorization, requirements)
+
+        payload = ExactEIP3009Payload(authorization=authorization, signature=signature)
+
+        return payload.to_dict()
+
+    def _sign_authorization(
+        self,
+        authorization: ExactEIP3009Authorization,
+        requirements: PaymentRequirements,
+    ) -> str:
+        """Sign EIP-3009 authorization using EIP-712.
+
+        Same as exact scheme — the split is transparent to the signer.
+
+        Args:
+            authorization: The authorization to sign.
+            requirements: Payment requirements with EIP-712 domain info.
+
+        Returns:
+            Hex-encoded signature with 0x prefix.
+        """
+        chain_id = get_evm_chain_id(str(requirements.network))
+
+        extra = requirements.extra or {}
+        if "name" not in extra:
+            try:
+                asset_info = get_asset_info(str(requirements.network), requirements.asset)
+                extra["name"] = asset_info["name"]
+                extra["version"] = asset_info.get("version", "1")
+            except ValueError:
+                raise ValueError(
+                    "EIP-712 domain parameters (name, version) required in extra"
+                ) from None
+
+        name = extra["name"]
+        version = extra.get("version", "1")
+
+        domain, types, primary_type, message = build_typed_data_for_signing(
+            authorization,
+            chain_id,
+            requirements.asset,
+            name,
+            version,
+        )
+
+        typed_fields: dict[str, list[TypedDataField]] = {}
+        for type_name, fields in types.items():
+            typed_fields[type_name] = [
+                TypedDataField(name=f["name"], type=f["type"]) for f in fields
+            ]
+
+        sig_bytes = self._signer.sign_typed_data(domain, typed_fields, primary_type, message)
+
+        return "0x" + sig_bytes.hex()

--- a/python/x402/mechanisms/evm/split/constants.py
+++ b/python/x402/mechanisms/evm/split/constants.py
@@ -1,0 +1,3 @@
+"""Constants for the split payment scheme."""
+
+SCHEME_SPLIT = "split"

--- a/python/x402/mechanisms/evm/split/facilitator.py
+++ b/python/x402/mechanisms/evm/split/facilitator.py
@@ -1,0 +1,264 @@
+"""EVM facilitator implementation for the Split payment scheme."""
+
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from ....schemas import (
+    Network,
+    PaymentPayload,
+    PaymentRequirements,
+    SettleResponse,
+    VerifyResponse,
+)
+from ..constants import SCHEME_EXACT
+from ..signer import FacilitatorEvmSigner
+from ..types import ExactEIP3009Payload
+from ..utils import get_asset_info, get_evm_chain_id, get_network_config, hex_to_bytes
+from ..verify import verify_universal_signature
+from .constants import SCHEME_SPLIT
+from .types import SplitConfig, SplitRecipient
+
+
+@dataclass
+class SplitEvmSchemeConfig:
+    """Configuration for SplitEvmScheme facilitator.
+
+    Attributes:
+        deploy_erc4337_with_eip6492: Enable ERC-6492 smart wallet deployment.
+        settlement_callback: Optional callback for split distribution.
+            Called with (recipients, shares, tx_hash) after settlement.
+    """
+
+    deploy_erc4337_with_eip6492: bool = False
+    settlement_callback: Any = None  # Callable for custom split logic
+
+
+class SplitEvmScheme:
+    """EVM facilitator implementation for the Split payment scheme.
+
+    Verifies and settles split payments on EVM networks.
+    The on-chain settlement (EIP-3009 transfer to escrow) reuses
+    exact scheme logic. Split distribution is handled post-settlement
+    via a configurable callback (e.g., internal ledger, on-chain transfers).
+
+    Attributes:
+        scheme: The scheme identifier ("split").
+    """
+
+    scheme = SCHEME_SPLIT
+
+    def __init__(
+        self,
+        signer: FacilitatorEvmSigner,
+        config: SplitEvmSchemeConfig | None = None,
+    ):
+        """Create SplitEvmScheme facilitator.
+
+        Args:
+            signer: EVM signer for verification and settlement.
+            config: Optional configuration.
+        """
+        self._signer = signer
+        self._config = config or SplitEvmSchemeConfig()
+
+    def get_extra(self, network: Network) -> dict[str, Any] | None:
+        return None
+
+    def get_signers(self, network: Network) -> list[str]:
+        return [self._signer.address]
+
+    def verify(
+        self,
+        payload: PaymentPayload,
+        requirements: PaymentRequirements,
+    ) -> VerifyResponse:
+        """Verify split payment payload.
+
+        Validates:
+        - Scheme and network match
+        - EIP-712 signature is valid
+        - Recipient is facilitator escrow (payTo)
+        - Amount >= total required
+        - Split recipients are valid (sum to 10000 bps)
+
+        Args:
+            payload: Payment payload from client.
+            requirements: Payment requirements.
+
+        Returns:
+            VerifyResponse with is_valid and payer.
+        """
+        try:
+            inner = payload.payload
+            if isinstance(inner, str):
+                inner = json.loads(inner)
+
+            eip3009 = ExactEIP3009Payload.from_dict(inner)
+            auth = eip3009.authorization
+
+            if payload.scheme != SCHEME_SPLIT:
+                return VerifyResponse(
+                    is_valid=False,
+                    invalid_reason=f"Expected scheme '{SCHEME_SPLIT}', got '{payload.scheme}'",
+                    payer=auth.from_address,
+                )
+
+            if int(auth.value) < int(requirements.amount):
+                return VerifyResponse(
+                    is_valid=False,
+                    invalid_reason=f"Amount {auth.value} < required {requirements.amount}",
+                    payer=auth.from_address,
+                )
+
+            if auth.to.lower() != requirements.pay_to.lower():
+                return VerifyResponse(
+                    is_valid=False,
+                    invalid_reason=f"Recipient {auth.to} != escrow {requirements.pay_to}",
+                    payer=auth.from_address,
+                )
+
+            extra = requirements.extra or {}
+            if "recipients" in extra:
+                try:
+                    split_config = SplitConfig.from_dict_list(extra["recipients"])
+                    split_config.validate()
+                except ValueError as e:
+                    return VerifyResponse(
+                        is_valid=False,
+                        invalid_reason=f"Invalid split config: {e}",
+                        payer=auth.from_address,
+                    )
+
+            chain_id = get_evm_chain_id(str(requirements.network))
+            asset_info = get_asset_info(str(requirements.network), requirements.asset)
+
+            sig_valid = verify_universal_signature(
+                self._signer,
+                auth,
+                eip3009.signature,
+                chain_id,
+                requirements.asset,
+                asset_info["name"],
+                asset_info.get("version", "1"),
+            )
+
+            if not sig_valid:
+                return VerifyResponse(
+                    is_valid=False,
+                    invalid_reason="Invalid EIP-712 signature",
+                    payer=auth.from_address,
+                )
+
+            return VerifyResponse(
+                is_valid=True,
+                payer=auth.from_address,
+            )
+
+        except Exception as e:
+            return VerifyResponse(
+                is_valid=False,
+                invalid_reason=f"Verification error: {e}",
+            )
+
+    def settle(
+        self,
+        payload: PaymentPayload,
+        requirements: PaymentRequirements,
+    ) -> SettleResponse:
+        """Settle split payment on-chain and distribute to recipients.
+
+        1. Re-verify payment
+        2. Execute transferWithAuthorization to escrow (same as exact)
+        3. Calculate per-recipient shares
+        4. Execute split distribution (via callback or default)
+        5. Return SettleResponse with per-recipient breakdown
+
+        Args:
+            payload: Payment payload from client.
+            requirements: Payment requirements with split config.
+
+        Returns:
+            SettleResponse with success, transaction, and split details.
+        """
+        # Re-verify
+        verify_result = self.verify(payload, requirements)
+        if not verify_result.is_valid:
+            return SettleResponse(
+                success=False,
+                transaction="",
+                network=str(requirements.network),
+                payer=verify_result.payer or "",
+            )
+
+        try:
+            inner = payload.payload
+            if isinstance(inner, str):
+                inner = json.loads(inner)
+
+            eip3009 = ExactEIP3009Payload.from_dict(inner)
+            auth = eip3009.authorization
+
+            chain_id = get_evm_chain_id(str(requirements.network))
+
+            tx_hash = self._signer.transfer_with_authorization(
+                token=requirements.asset,
+                from_addr=auth.from_address,
+                to=auth.to,
+                value=int(auth.value),
+                valid_after=int(auth.valid_after),
+                valid_before=int(auth.valid_before),
+                nonce=hex_to_bytes(auth.nonce),
+                signature=hex_to_bytes(eip3009.signature),
+            )
+
+            total_amount = int(auth.value)
+            extra = requirements.extra or {}
+            splits_result = []
+
+            if "recipients" in extra:
+                split_config = SplitConfig.from_dict_list(extra["recipients"])
+                shares = split_config.calculate_shares(total_amount)
+
+                for address, amount in shares:
+                    method = "internal"
+
+                    if self._config.settlement_callback:
+                        method = self._config.settlement_callback(
+                            address, amount, tx_hash
+                        ) or "internal"
+
+                    recipient = next(
+                        (r for r in split_config.recipients if r.address == address),
+                        None,
+                    )
+                    splits_result.append({
+                        "address": address,
+                        "amount": str(amount),
+                        "method": method,
+                        "label": recipient.label if recipient else "",
+                    })
+            else:
+                splits_result.append({
+                    "address": auth.to,
+                    "amount": str(total_amount),
+                    "method": "onchain",
+                })
+
+            return SettleResponse(
+                success=True,
+                transaction=tx_hash if isinstance(tx_hash, str) else f"0x{tx_hash.hex()}",
+                network=str(requirements.network),
+                payer=auth.from_address,
+                extra={"splits": splits_result},
+            )
+
+        except Exception as e:
+            return SettleResponse(
+                success=False,
+                transaction="",
+                network=str(requirements.network),
+                payer=verify_result.payer or "",
+                extra={"error": str(e)},
+            )

--- a/python/x402/mechanisms/evm/split/register.py
+++ b/python/x402/mechanisms/evm/split/register.py
@@ -1,0 +1,116 @@
+"""Registration helpers for EVM split payment schemes."""
+
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from x402 import (
+        x402Client,
+        x402ClientSync,
+        x402Facilitator,
+        x402FacilitatorSync,
+        x402ResourceServer,
+        x402ResourceServerSync,
+    )
+
+    from ..signer import ClientEvmSigner, FacilitatorEvmSigner
+
+# Type vars for accepting both async and sync variants
+ClientT = TypeVar("ClientT", "x402Client", "x402ClientSync")
+ServerT = TypeVar("ServerT", "x402ResourceServer", "x402ResourceServerSync")
+FacilitatorT = TypeVar("FacilitatorT", "x402Facilitator", "x402FacilitatorSync")
+
+
+def register_split_evm_client(
+    client: ClientT,
+    signer: "ClientEvmSigner",
+    networks: str | list[str] | None = None,
+    policies: list | None = None,
+) -> ClientT:
+    """Register EVM split payment schemes to x402Client.
+
+    Args:
+        client: x402Client instance.
+        signer: EVM signer for payment authorizations.
+        networks: Optional specific network(s) (default: eip155:* wildcard).
+        policies: Optional payment policies.
+
+    Returns:
+        Client for chaining.
+    """
+    from .client import SplitEvmScheme as SplitEvmClientScheme
+
+    scheme = SplitEvmClientScheme(signer)
+
+    if networks:
+        if isinstance(networks, str):
+            networks = [networks]
+        for network in networks:
+            client.register(network, scheme)
+    else:
+        client.register("eip155:*", scheme)
+
+    if policies:
+        for policy in policies:
+            client.register_policy(policy)
+
+    return client
+
+
+def register_split_evm_server(
+    server: ServerT,
+    networks: str | list[str] | None = None,
+) -> ServerT:
+    """Register EVM split payment schemes to x402ResourceServer.
+
+    Args:
+        server: x402ResourceServer instance.
+        networks: Optional specific network(s) (default: eip155:* wildcard).
+
+    Returns:
+        Server for chaining.
+    """
+    from .server import SplitEvmScheme as SplitEvmServerScheme
+
+    scheme = SplitEvmServerScheme()
+
+    if networks:
+        if isinstance(networks, str):
+            networks = [networks]
+        for network in networks:
+            server.register(network, scheme)
+    else:
+        server.register("eip155:*", scheme)
+
+    return server
+
+
+def register_split_evm_facilitator(
+    facilitator: FacilitatorT,
+    signer: "FacilitatorEvmSigner",
+    networks: str | list[str],
+    settlement_callback: object | None = None,
+) -> FacilitatorT:
+    """Register EVM split payment schemes to x402Facilitator.
+
+    Args:
+        facilitator: x402Facilitator instance.
+        signer: EVM signer for verification/settlement.
+        networks: Network(s) to register.
+        settlement_callback: Optional callback for split distribution.
+
+    Returns:
+        Facilitator for chaining.
+    """
+    from .facilitator import SplitEvmScheme as SplitEvmFacilitatorScheme
+    from .facilitator import SplitEvmSchemeConfig
+
+    config = SplitEvmSchemeConfig(
+        settlement_callback=settlement_callback,
+    )
+    scheme = SplitEvmFacilitatorScheme(signer, config)
+
+    if isinstance(networks, str):
+        networks = [networks]
+    facilitator.register(networks, scheme)
+
+    return facilitator

--- a/python/x402/mechanisms/evm/split/server.py
+++ b/python/x402/mechanisms/evm/split/server.py
@@ -1,0 +1,154 @@
+"""EVM server implementation for the Split payment scheme."""
+
+from collections.abc import Callable
+
+from ....schemas import AssetAmount, Network, PaymentRequirements, Price, SupportedKind
+from ..utils import (
+    get_asset_info,
+    get_network_config,
+    parse_amount,
+    parse_money_to_decimal,
+)
+from .constants import SCHEME_SPLIT
+from .types import SplitConfig
+
+# Type alias for money parser (sync)
+MoneyParser = Callable[[float, str], AssetAmount | None]
+
+
+class SplitEvmScheme:
+    """EVM server implementation for the Split payment scheme.
+
+    Parses prices and enhances payment requirements with split recipients
+    and EIP-712 domain info.
+
+    Attributes:
+        scheme: The scheme identifier ("split").
+    """
+
+    scheme = SCHEME_SPLIT
+
+    def __init__(self) -> None:
+        """Create SplitEvmScheme."""
+        self._money_parsers: list[MoneyParser] = []
+
+    def register_money_parser(self, parser: MoneyParser) -> "SplitEvmScheme":
+        """Register custom money parser.
+
+        Args:
+            parser: Custom function to convert amount to AssetAmount.
+
+        Returns:
+            Self for chaining.
+        """
+        self._money_parsers.append(parser)
+        return self
+
+    def parse_price(self, price: Price, network: Network) -> AssetAmount:
+        """Parse price into asset amount.
+
+        Same as exact scheme — parses total price.
+
+        Args:
+            price: Price to parse (string, number, or AssetAmount dict).
+            network: Network identifier.
+
+        Returns:
+            AssetAmount with amount, asset, and extra fields.
+        """
+        # Already an AssetAmount (dict with 'amount' key)
+        if isinstance(price, dict) and "amount" in price:
+            if not price.get("asset"):
+                raise ValueError(f"Asset address required for AssetAmount on {network}")
+            return AssetAmount(
+                amount=price["amount"],
+                asset=price["asset"],
+                extra=price.get("extra", {}),
+            )
+
+        # Already an AssetAmount object
+        if isinstance(price, AssetAmount):
+            if not price.asset:
+                raise ValueError(f"Asset address required for AssetAmount on {network}")
+            return price
+
+        # Parse Money to decimal
+        decimal_amount = parse_money_to_decimal(price)
+
+        # Try custom parsers
+        for parser in self._money_parsers:
+            result = parser(decimal_amount, str(network))
+            if result is not None:
+                return result
+
+        # Default: convert to USDC
+        return self._default_money_conversion(decimal_amount, str(network))
+
+    def enhance_payment_requirements(
+        self,
+        requirements: PaymentRequirements,
+        supported_kind: SupportedKind,
+        extension_keys: list[str],
+    ) -> PaymentRequirements:
+        """Add split-specific enhancements to payment requirements.
+
+        - Validates split recipients if present
+        - Fills in default asset if not specified
+        - Adds EIP-712 domain parameters
+        - Converts decimal amounts to smallest unit
+
+        Args:
+            requirements: Base payment requirements.
+            supported_kind: Supported kind from facilitator.
+            extension_keys: Extension keys being used.
+
+        Returns:
+            Enhanced payment requirements with validated split config.
+        """
+        config = get_network_config(str(requirements.network))
+
+        # Default asset
+        if not requirements.asset:
+            requirements.asset = config["default_asset"]["address"]
+
+        asset_info = get_asset_info(str(requirements.network), requirements.asset)
+
+        # Ensure amount is in smallest unit
+        if "." in requirements.amount:
+            requirements.amount = str(parse_amount(requirements.amount, asset_info["decimals"]))
+
+        # Add EIP-712 domain params
+        if requirements.extra is None:
+            requirements.extra = {}
+        if "name" not in requirements.extra:
+            requirements.extra["name"] = asset_info["name"]
+        if "version" not in requirements.extra:
+            requirements.extra["version"] = asset_info["version"]
+
+        # Validate split recipients if present
+        if "recipients" in requirements.extra:
+            split_config = SplitConfig.from_dict_list(requirements.extra["recipients"])
+            split_config.validate()
+
+        return requirements
+
+    def _default_money_conversion(self, amount: float, network: str) -> AssetAmount:
+        """Convert decimal amount to USDC AssetAmount.
+
+        Args:
+            amount: Decimal amount (e.g., 1.50).
+            network: Network identifier.
+
+        Returns:
+            AssetAmount in USDC.
+        """
+        config = get_network_config(network)
+        asset = config["default_asset"]
+
+        token_amount = int(amount * (10 ** asset["decimals"]))
+
+        return AssetAmount(
+            amount=str(token_amount),
+            asset=asset["address"],
+            extra={"name": asset["name"], "version": asset["version"]},
+        )

--- a/python/x402/mechanisms/evm/split/types.py
+++ b/python/x402/mechanisms/evm/split/types.py
@@ -1,0 +1,97 @@
+"""EVM split scheme types."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SplitRecipient:
+    """A recipient in a split payment.
+
+    Attributes:
+        address: Wallet address (EVM hex format).
+        bps: Basis points allocation (1-10000, where 10000 = 100%).
+        label: Optional human-readable label.
+    """
+
+    address: str
+    bps: int
+    label: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"address": self.address, "bps": self.bps}
+        if self.label:
+            d["label"] = self.label
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "SplitRecipient":
+        return cls(
+            address=data["address"],
+            bps=data["bps"],
+            label=data.get("label", ""),
+        )
+
+
+@dataclass
+class SplitConfig:
+    """Configuration for a split payment.
+
+    Attributes:
+        recipients: List of split recipients.
+    """
+
+    recipients: list[SplitRecipient] = field(default_factory=list)
+
+    def validate(self) -> None:
+        """Validate split configuration.
+
+        Raises:
+            ValueError: If recipients are invalid.
+        """
+        if not self.recipients:
+            raise ValueError("Split must have at least 1 recipient")
+
+        total_bps = sum(r.bps for r in self.recipients)
+        if total_bps != 10000:
+            raise ValueError(
+                f"Recipient bps must sum to 10000, got {total_bps}"
+            )
+
+        for r in self.recipients:
+            if not 1 <= r.bps <= 10000:
+                raise ValueError(
+                    f"Each recipient bps must be 1-10000, got {r.bps} for {r.address}"
+                )
+
+    def calculate_shares(self, total_amount: int) -> list[tuple[str, int]]:
+        """Calculate each recipient's share of the total amount.
+
+        Uses floor division with remainder allocated to first recipient.
+
+        Args:
+            total_amount: Total amount in smallest unit (e.g., USDC micro-units).
+
+        Returns:
+            List of (address, amount) tuples.
+        """
+        shares: list[tuple[str, int]] = []
+        distributed = 0
+
+        for i, recipient in enumerate(self.recipients):
+            if i == len(self.recipients) - 1:
+                # Last recipient gets remainder to avoid dust
+                share = total_amount - distributed
+            else:
+                share = (total_amount * recipient.bps) // 10000
+            shares.append((recipient.address, share))
+            distributed += share
+
+        return shares
+
+    def to_dict_list(self) -> list[dict[str, Any]]:
+        return [r.to_dict() for r in self.recipients]
+
+    @classmethod
+    def from_dict_list(cls, data: list[dict[str, Any]]) -> "SplitConfig":
+        return cls(recipients=[SplitRecipient.from_dict(d) for d in data])

--- a/python/x402/tests/test_split_types.py
+++ b/python/x402/tests/test_split_types.py
@@ -1,0 +1,126 @@
+"""Tests for the x402 split payment scheme types."""
+
+import pytest
+
+from x402.mechanisms.evm.split.types import SplitConfig, SplitRecipient
+
+
+class TestSplitRecipient:
+    """Tests for SplitRecipient dataclass."""
+
+    def test_to_dict_with_label(self):
+        r = SplitRecipient(address="0xABC", bps=7000, label="artist")
+        d = r.to_dict()
+        assert d == {"address": "0xABC", "bps": 7000, "label": "artist"}
+
+    def test_to_dict_without_label(self):
+        r = SplitRecipient(address="0xABC", bps=7000)
+        d = r.to_dict()
+        assert d == {"address": "0xABC", "bps": 7000}
+        assert "label" not in d
+
+    def test_from_dict(self):
+        r = SplitRecipient.from_dict({"address": "0xABC", "bps": 7000, "label": "artist"})
+        assert r.address == "0xABC"
+        assert r.bps == 7000
+        assert r.label == "artist"
+
+    def test_from_dict_no_label(self):
+        r = SplitRecipient.from_dict({"address": "0xABC", "bps": 7000})
+        assert r.label == ""
+
+
+class TestSplitConfig:
+    """Tests for SplitConfig validation and share calculation."""
+
+    def _make_config(self, bps_list):
+        return SplitConfig(
+            recipients=[
+                SplitRecipient(address=f"0x{i:040x}", bps=bps)
+                for i, bps in enumerate(bps_list)
+            ]
+        )
+
+    def test_valid_single_recipient(self):
+        config = self._make_config([10000])
+        config.validate()  # Should not raise
+
+    def test_valid_three_recipients(self):
+        config = self._make_config([7000, 2000, 1000])
+        config.validate()  # Should not raise
+
+    def test_invalid_empty(self):
+        config = SplitConfig(recipients=[])
+        with pytest.raises(ValueError, match="at least 1"):
+            config.validate()
+
+    def test_invalid_bps_sum(self):
+        config = self._make_config([7000, 2000])  # Sum = 9000
+        with pytest.raises(ValueError, match="sum to 10000"):
+            config.validate()
+
+    def test_invalid_bps_zero(self):
+        config = self._make_config([10000, 0])
+        with pytest.raises(ValueError, match="1-10000"):
+            config.validate()
+
+    def test_invalid_bps_negative(self):
+        config = SplitConfig(
+            recipients=[SplitRecipient(address="0xABC", bps=-1)]
+        )
+        with pytest.raises(ValueError):
+            config.validate()
+
+    # ── Share calculation ──────────────────────────────────────────────
+
+    def test_shares_exact_division(self):
+        config = self._make_config([5000, 3000, 2000])
+        shares = config.calculate_shares(100000)
+        amounts = [s[1] for s in shares]
+        assert amounts == [50000, 30000, 20000]
+        assert sum(amounts) == 100000
+
+    def test_shares_with_remainder(self):
+        config = self._make_config([3333, 3333, 3334])
+        shares = config.calculate_shares(100000)
+        amounts = [s[1] for s in shares]
+        # 3333*100000/10000 = 33330, 3333*100000/10000 = 33330
+        # Last gets remainder: 100000 - 33330 - 33330 = 33340
+        assert amounts[0] == 33330
+        assert amounts[1] == 33330
+        assert amounts[2] == 33340
+        assert sum(amounts) == 100000
+
+    def test_shares_single_recipient(self):
+        config = self._make_config([10000])
+        shares = config.calculate_shares(100000)
+        assert shares == [(f"0x{0:040x}", 100000)]
+
+    def test_shares_small_amount(self):
+        """Test with very small amount where rounding matters."""
+        config = self._make_config([7000, 2000, 1000])
+        shares = config.calculate_shares(10)  # 10 micro-USDC
+        amounts = [s[1] for s in shares]
+        assert amounts[0] == 7   # floor(10 * 7000 / 10000) = 7
+        assert amounts[1] == 2   # floor(10 * 2000 / 10000) = 2
+        assert amounts[2] == 1   # remainder: 10 - 7 - 2 = 1
+        assert sum(amounts) == 10
+
+    def test_shares_addresses_preserved(self):
+        config = self._make_config([7000, 2000, 1000])
+        shares = config.calculate_shares(100000)
+        addresses = [s[0] for s in shares]
+        assert addresses[0] == f"0x{0:040x}"
+        assert addresses[1] == f"0x{1:040x}"
+        assert addresses[2] == f"0x{2:040x}"
+
+    # ── Serialization ─────────────────────────────────────────────────
+
+    def test_round_trip(self):
+        config = self._make_config([7000, 2000, 1000])
+        dicts = config.to_dict_list()
+        config2 = SplitConfig.from_dict_list(dicts)
+        assert len(config2.recipients) == 3
+        assert config2.recipients[0].bps == 7000
+        assert config2.recipients[1].bps == 2000
+        assert config2.recipients[2].bps == 1000

--- a/specs/schemes/split/scheme_split.md
+++ b/specs/schemes/split/scheme_split.md
@@ -1,0 +1,74 @@
+# Scheme: `split`
+
+## Summary
+
+`split` is a scheme that transfers a specific total amount of funds from a client to multiple recipients in configurable proportions. The resource server specifies the total price and an array of recipients with basis point allocations (1 bps = 0.01%, 10000 bps = 100%).
+
+The facilitator receives a single payment authorization from the client and distributes funds to N recipients. Distribution may happen on-chain (individual transfers or via a splitter contract) or off-chain (internal ledger credits) depending on the facilitator's capabilities.
+
+`split` is a superset of `exact` — a single recipient at 10000 bps is equivalent to an `exact` payment.
+
+## Example Use Cases
+
+- Music streaming royalty splits (artist, producer, label, platform)
+- Marketplace payments with platform fees
+- Multi-party service payments (e.g., driver + platform in ride-sharing)
+- DAO treasury distributions
+- Affiliate commission payments
+- Content creator revenue sharing
+
+## PaymentRequirements Extensions
+
+The `split` scheme adds a `recipients` field to `PaymentRequirements.extra`:
+
+```json
+{
+  "scheme": "split",
+  "network": "eip155:84532",
+  "amount": "100000",
+  "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  "payTo": "0xFacilitatorEscrow...",
+  "maxTimeoutSeconds": 120,
+  "extra": {
+    "recipients": [
+      { "address": "0xArtist...", "bps": 7000, "label": "artist" },
+      { "address": "0xProducer...", "bps": 2000, "label": "producer" },
+      { "address": "0xPlatform...", "bps": 1000, "label": "platform" }
+    ]
+  }
+}
+```
+
+### Recipient Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `address` | string | Yes | Recipient wallet address (network-specific format) |
+| `bps` | integer | Yes | Basis points allocation (1-10000) |
+| `label` | string | No | Human-readable label for the recipient |
+
+### Validation Rules
+
+- `recipients` array MUST contain at least 1 entry
+- Sum of all `bps` values MUST equal exactly 10000
+- Each `bps` value MUST be between 1 and 10000 (inclusive)
+- `payTo` MUST be the facilitator's escrow/clearing address
+- `amount` is the TOTAL payment amount (not per-recipient)
+
+## Appendix
+
+### Rounding
+
+When splitting amounts, integer division may produce remainders. The facilitator MUST:
+1. Calculate each recipient's share as `floor(totalAmount * bps / 10000)`
+2. Allocate the remainder (dust) to the last recipient in the array
+3. Ensure the sum of all distributed amounts equals the total amount exactly
+
+### Settlement Methods
+
+Facilitators MAY use any combination of:
+- **On-chain transfers**: Individual `transfer` calls per recipient
+- **Batch contracts**: A single multicall or splitter contract
+- **Internal ledger**: Off-chain credits for recipients who have accounts with the facilitator
+
+The settlement method SHOULD be indicated in the `SettleResponse.extra` field.

--- a/specs/schemes/split/scheme_split_evm.md
+++ b/specs/schemes/split/scheme_split_evm.md
@@ -1,0 +1,83 @@
+# Scheme: `split` `evm`
+
+## Summary
+
+EVM implementation of the `split` payment scheme. Uses EIP-3009 `transferWithAuthorization` for the single on-chain transfer, with the facilitator's escrow address as the recipient. The facilitator then distributes funds to N recipients via internal ledger credits, individual transfers, or batch multicall.
+
+## `X-Payment` Header Payload
+
+The client constructs the same EIP-3009 payload as `exact` — the split is transparent to the client:
+
+```json
+{
+  "x402_version": 2,
+  "scheme": "split",
+  "network": "eip155:84532",
+  "payload": {
+    "authorization": {
+      "from": "0xPayer...",
+      "to": "0xFacilitatorEscrow...",
+      "value": "100000",
+      "validAfter": "0",
+      "validBefore": "1739300000",
+      "nonce": "0x..."
+    },
+    "signature": "0x..."
+  }
+}
+```
+
+Key difference from `exact`: the `to` field is the facilitator's escrow address, not a final recipient. The facilitator handles distribution.
+
+## Verification
+
+1. Parse `X-Payment` header and decode split payload
+2. Validate scheme is `"split"` and network matches `eip155:*`
+3. Verify EIP-712 signature (same as `exact`)
+4. Verify `to` matches `payTo` (facilitator escrow)
+5. Verify `value` >= `amount` (total payment)
+6. Validate `recipients` in requirements:
+   - At least 1 recipient
+   - All `bps` sum to exactly 10000
+   - All addresses are valid EVM addresses
+
+## Settlement
+
+1. Execute `transferWithAuthorization` to move funds to facilitator escrow (same as `exact`)
+2. For each recipient in the split rule:
+   a. Calculate share: `floor(totalAmount * bps / 10000)`
+   b. Distribute via one of:
+      - **Internal credit**: Add to recipient's facilitator-side balance
+      - **On-chain transfer**: Execute `transfer(recipient, share)` on the token contract
+      - **Batch**: Use multicall contract for gas efficiency
+3. Return `SettleResponse` with per-recipient breakdown:
+
+```json
+{
+  "success": true,
+  "transaction": "0x...",
+  "network": "eip155:84532",
+  "payer": "0xPayer...",
+  "extra": {
+    "splits": [
+      { "address": "0xArtist...", "amount": "70000", "method": "internal" },
+      { "address": "0xProducer...", "amount": "20000", "method": "internal" },
+      { "address": "0xPlatform...", "amount": "10000", "method": "internal" }
+    ]
+  }
+}
+```
+
+## Appendix
+
+### Compatibility with `exact`
+
+A `split` payment with a single recipient at 10000 bps is functionally identical to an `exact` payment. Facilitators SHOULD optimize this case by skipping the escrow step and transferring directly to the recipient.
+
+### Gas Considerations
+
+| Method | Gas Cost | Latency |
+|--------|----------|---------|
+| Internal credit | 0 | <1ms |
+| Individual transfers | ~50k per recipient | ~3s per tx |
+| Batch multicall | ~30k per recipient | ~3s total |


### PR DESCRIPTION
## Summary

Adds a new `split` payment scheme that enables multi-recipient payments with a single client signature. The resource server specifies recipients and basis point allocations; the facilitator handles distribution.

`split` is a superset of `exact` — a single recipient at 10000 bps is functionally identical to an `exact` payment.

## Use Cases

- Music streaming royalty splits (artist, producer, label, platform)
- Marketplace payments with platform fees
- Multi-party service payments (driver + platform)
- Affiliate commission payments

## What is included

### Specs (`specs/schemes/split/`)

- `scheme_split.md` — Scheme overview: recipients array, basis points, rounding rules, settlement methods
- `scheme_split_evm.md` — EVM implementation: EIP-3009 payload, verification steps, settlement with per-recipient breakdown

### Python reference implementation (`python/x402/mechanisms/evm/split/`)

- `types.py` — `SplitRecipient` and `SplitConfig` dataclasses with `calculate_shares()` using floor division + remainder allocation
- `client.py` — Client-side scheme (reuses exact EIP-3009 signing, split is transparent to client)
- `server.py` — Server-side scheme with price parsing and split validation
- `facilitator.py` — Facilitator-side scheme: verify + settle + distribute via configurable callback
- `register.py` — Registration helpers for client/server/facilitator
- `constants.py` — Scheme identifier

### Tests (`python/x402/tests/`)

- `test_split_types.py` — 16 unit tests covering validation, share calculation, rounding, and serialization

## Design Decisions

- Client-side is identical to `exact` — no new signing logic needed
- Facilitators MAY distribute via on-chain transfers, batch multicall, or internal ledger credits
- Basis points (1-10000) for deterministic integer math — no floating point
- Remainder (dust) allocated to last recipient to ensure sum equals total

## Testing

```bash
cd python/x402 && uv run pytest tests/test_split_types.py -v
# 16 passed
```