### PR TITLE
fix(ts): align TS type optionality with v2 spec

### DIFF
--- a/typescript/.changeset/types-optionality-fix.md
+++ b/typescript/.changeset/types-optionality-fix.md
@@ -1,0 +1,6 @@
+---
+"@x402/core": patch
+"@x402/paywall": patch
+---
+
+Make ResourceInfo.description, ResourceInfo.mimeType, and PaymentPayload.resource optional to match v2 spec

--- a/typescript/packages/core/src/types/payments.ts
+++ b/typescript/packages/core/src/types/payments.ts
@@ -2,8 +2,8 @@ import { Network } from "./";
 
 export interface ResourceInfo {
   url: string;
-  description: string;
-  mimeType: string;
+  description?: string;
+  mimeType?: string;
 }
 
 export type PaymentRequirements = {
@@ -26,7 +26,7 @@ export type PaymentRequired = {
 
 export type PaymentPayload = {
   x402Version: number;
-  resource: ResourceInfo;
+  resource?: ResourceInfo;
   accepted: PaymentRequirements;
   payload: Record<string, unknown>;
   extensions?: Record<string, unknown>;

--- a/typescript/packages/http/paywall/src/types.ts
+++ b/typescript/packages/http/paywall/src/types.ts
@@ -35,8 +35,8 @@ export interface PaymentRequired {
   error?: string;
   resource?: {
     url: string;
-    description: string;
-    mimeType: string;
+    description?: string;
+    mimeType?: string;
   };
   accepts: PaymentRequirements[];
   extensions?: Record<string, unknown>;


### PR DESCRIPTION
## Description

`ResourceInfo.description`, `ResourceInfo.mimeType`, and `PaymentPayload.resource` are required in the TypeScript type definitions but optional per the v2 spec (sections 5.1.2 and 5.2.2).

The Zod schemas in `schemas/index.ts` already had these fields as optional -- this change aligns the manual TS types to match. Also fixes the mirrored `PaymentRequired` type in `@x402/paywall` which had `description` and `mimeType` as required in its inline resource type.

Closes #1154

## Tests

- `pnpm build` passes (all 18 packages)
- `pnpm test` passes (1,470 tests across 17 packages)
- Searched for downstream code that accesses these fields without optional chaining -- no breakage found (existing code already uses `?.` or `|| ""` fallbacks)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes