### PR TITLE
fix(ts): remove duplicate server ResourceInfo; use wire-format type directly

### DIFF
--- a/typescript/.changeset/remove-duplicate-resource-info.md
+++ b/typescript/.changeset/remove-duplicate-resource-info.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Remove duplicate server-local `ResourceInfo` interface; use the wire-format `ResourceInfo` from `types/payments.ts` directly throughout the server module.

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -1,5 +1,5 @@
 export { x402ResourceServer } from "./x402ResourceServer";
-export type { ResourceConfig, ResourceInfo, SettleResultContext } from "./x402ResourceServer";
+export type { ResourceConfig, SettleResultContext } from "./x402ResourceServer";
 
 export { HTTPFacilitatorClient } from "../http/httpFacilitatorClient";
 export type { FacilitatorClient, FacilitatorConfig } from "../http/httpFacilitatorClient";

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -5,7 +5,12 @@ import {
   SupportedResponse,
   SupportedKind,
 } from "../types/facilitator";
-import { PaymentPayload, PaymentRequirements, PaymentRequired } from "../types/payments";
+import {
+  PaymentPayload,
+  PaymentRequirements,
+  PaymentRequired,
+  ResourceInfo,
+} from "../types/payments";
 import { SchemeNetworkServer } from "../types/mechanisms";
 import { Price, Network, ResourceServerExtension, VerifyError } from "../types";
 import { deepEqual, findByNetworkAndScheme } from "../utils";
@@ -23,15 +28,6 @@ export interface ResourceConfig {
   network: Network;
   maxTimeoutSeconds?: number;
   extra?: Record<string, unknown>; // Scheme-specific additional data
-}
-
-/**
- * Resource information for PaymentRequired response
- */
-export interface ResourceInfo {
-  url: string;
-  description: string;
-  mimeType: string;
 }
 
 /**


### PR DESCRIPTION
## Description

The server module in `@x402/core` defines a `ResourceInfo` interface for the PaymentRequired response body that shares its name with the wire-format `ResourceInfo` in `types/payments.ts`. Once the wire-format fields are made optional (see #1154), these identically-named interfaces will have different optionality — a source of confusion.

This renames the server version to `ResourceMetadata` to make the distinction explicit. The `types/payments.ts` `ResourceInfo` is the canonical wire-format type per the v2 spec; the server's `ResourceMetadata` describes what the server includes in the 402 body so clients know what they are paying for.

Note: `ResourceConfig` was the original rename target but was already taken by an existing interface in the same file (payment configuration for route setup).

Related: #1155

## Tests

- `pnpm build` passes (35/35 tasks)
- `pnpm test` passes (35/35 tasks)
- All imports updated, no dead references
- Only 3 files changed — very contained scope

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes