### PR TITLE
fix(ts): guard against undefined resource in SIWX settle hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ e2e/legacy/servers/gin/gin
 
 # Agent artifacts
 TASK.md
+.claude/

--- a/typescript/.changeset/siwx-resource-nullcheck.md
+++ b/typescript/.changeset/siwx-resource-nullcheck.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": patch
+---
+
+Guard against undefined `resource` in SIWX settle hook to prevent runtime crash when `PaymentPayload.resource` is absent


### PR DESCRIPTION
## Description

`createSIWxSettleHook` accesses `paymentPayload.resource.url` without a null check. Since `PaymentPayload.resource` is optional per the v2 spec (section 5.2.2), this crashes at runtime if a payment payload without a `resource` field reaches this hook.

Adds a null guard and early return, consistent with how the bazaar facilitator handles optional resource fields.

Related: #1156, #1154

## Tests

- `pnpm build` passes (35/35 tasks)
- `pnpm test` passes (35/35 tasks, including 206 `@x402/extensions` tests)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes