### PR TITLE
feat(coinbase-x402): add e2e test workflow

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -313,38 +313,11 @@ jobs:
 
             COMMENT_BODY+="**Network:** ${NETWORK} | **Total:** ${TOTAL} | **Passed:** ${PASSED} | **Failed:** ${FAILED}"$'\n\n'
 
-            # Facilitator breakdown
-            FACILITATOR_ROWS=$(jq -r '.breakdowns.byFacilitator | to_entries[] | "| \(.key) | \(.value.passed) | \(.value.failed) |"' e2e/e2e-results.json)
-            if [ -n "$FACILITATOR_ROWS" ]; then
-              COMMENT_BODY+="### By Facilitator"$'\n'
-              COMMENT_BODY+="| Facilitator | Passed | Failed |"$'\n'
-              COMMENT_BODY+="|---|---|---|"$'\n'
-              COMMENT_BODY+="${FACILITATOR_ROWS}"$'\n\n'
-            fi
-
-            # Server breakdown
-            SERVER_ROWS=$(jq -r '.breakdowns.byServer | to_entries[] | "| \(.key) | \(.value.passed) | \(.value.failed) |"' e2e/e2e-results.json)
-            if [ -n "$SERVER_ROWS" ]; then
-              COMMENT_BODY+="### By Server"$'\n'
-              COMMENT_BODY+="| Server | Passed | Failed |"$'\n'
-              COMMENT_BODY+="|---|---|---|"$'\n'
-              COMMENT_BODY+="${SERVER_ROWS}"$'\n\n'
-            fi
-
-            # Client breakdown
-            CLIENT_ROWS=$(jq -r '.breakdowns.byClient | to_entries[] | "| \(.key) | \(.value.passed) | \(.value.failed) |"' e2e/e2e-results.json)
-            if [ -n "$CLIENT_ROWS" ]; then
-              COMMENT_BODY+="### By Client"$'\n'
-              COMMENT_BODY+="| Client | Passed | Failed |"$'\n'
-              COMMENT_BODY+="|---|---|---|"$'\n'
-              COMMENT_BODY+="${CLIENT_ROWS}"$'\n\n'
-            fi
-
-            # Failed test details
-            FAILED_DETAILS=$(jq -r '.results[] | select(.passed == false) | "| #\(.testNumber) | \(.client) | \(.server) | \(.endpoint) | \(.facilitator) | \(.error // "Unknown") |"' e2e/e2e-results.json)
+            # Failed test details (only shown when there are failures)
+            FAILED_DETAILS=$(jq -r '.results[] | select(.passed == false) | "| \(.testNumber) | \(.client) | \(.server) | \(.endpoint) | \(.facilitator) | \(.error // "Unknown") |"' e2e/e2e-results.json)
             if [ -n "$FAILED_DETAILS" ]; then
               COMMENT_BODY+="### Failed Tests"$'\n'
-              COMMENT_BODY+="| # | Client | Server | Endpoint | Facilitator | Error |"$'\n'
+              COMMENT_BODY+="| Test | Client | Server | Endpoint | Facilitator | Error |"$'\n'
               COMMENT_BODY+="|---|---|---|---|---|---|"$'\n'
               COMMENT_BODY+="${FAILED_DETAILS}"$'\n\n'
             fi

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -229,11 +229,14 @@ jobs:
             ARGS="$ARGS --families=${{ inputs.families }}"
           fi
 
-          if [ "${{ inputs.minimize }}" = "true" ]; then
+          # Default to --min and -v when inputs are not provided (e.g. push trigger)
+          MINIMIZE="${{ inputs.minimize }}"
+          if [ "$MINIMIZE" = "true" ] || [ -z "$MINIMIZE" ]; then
             ARGS="$ARGS --min"
           fi
 
-          if [ "${{ inputs.verbose }}" = "true" ]; then
+          VERBOSE="${{ inputs.verbose }}"
+          if [ "$VERBOSE" = "true" ] || [ -z "$VERBOSE" ]; then
             ARGS="$ARGS -v"
           fi
 

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -170,9 +170,11 @@ jobs:
 
       # --- Install Dependencies ---
 
-      - name: Install TypeScript SDK dependencies
+      - name: Install and build TypeScript SDK
         working-directory: ./typescript
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
 
       - name: Install E2E dependencies
         working-directory: ./e2e

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -106,6 +106,32 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # --- Validate Required Secrets ---
+      # Fail fast before installing anything if secrets are missing.
+
+      - name: Validate required secrets
+        run: |
+          MISSING=()
+
+          if [ -z "${{ secrets.CLIENT_EVM_PRIVATE_KEY }}" ]; then MISSING+=("CLIENT_EVM_PRIVATE_KEY"); fi
+          if [ -z "${{ secrets.CLIENT_SVM_PRIVATE_KEY }}" ]; then MISSING+=("CLIENT_SVM_PRIVATE_KEY"); fi
+          if [ -z "${{ secrets.FACILITATOR_EVM_PRIVATE_KEY }}" ]; then MISSING+=("FACILITATOR_EVM_PRIVATE_KEY"); fi
+          if [ -z "${{ secrets.FACILITATOR_SVM_PRIVATE_KEY }}" ]; then MISSING+=("FACILITATOR_SVM_PRIVATE_KEY"); fi
+          if [ -z "${{ secrets.SERVER_EVM_ADDRESS }}" ]; then MISSING+=("SERVER_EVM_ADDRESS"); fi
+          if [ -z "${{ secrets.SERVER_SVM_ADDRESS }}" ]; then MISSING+=("SERVER_SVM_ADDRESS"); fi
+
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${MISSING[*]}"
+            echo ""
+            echo "The following secrets must be configured in Settings > Secrets and variables > Actions:"
+            for secret in "${MISSING[@]}"; do
+              echo "  - $secret"
+            done
+            exit 1
+          fi
+
+          echo "All required secrets are present."
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.ref }}

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -60,6 +60,10 @@
 name: E2E Tests
 
 on:
+  # TODO: revert to workflow_dispatch only before merging
+  push:
+    branches:
+      - feat/e2e-test-workflow
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -60,10 +60,6 @@
 name: E2E Tests
 
 on:
-  # TODO: revert to workflow_dispatch only before merging
-  push:
-    branches:
-      - feat/e2e-test-workflow
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -211,11 +211,11 @@ jobs:
         id: e2e
         working-directory: ./e2e
         run: |
-          ARGS="--testnet"
+          ARGS=""
 
           # Apply workflow_dispatch inputs (or defaults)
           ARGS="$ARGS --transport=${{ inputs.transport || 'http' }}"
-          ARGS="$ARGS --facilitators=${{ inputs.facilitators || 'go,typescript,python' }}"
+          ARGS="$ARGS --facilitators=${{ inputs.facilitators || 'go,python,typescript' }}"
 
           if [ -n "${{ inputs.servers }}" ]; then
             ARGS="$ARGS --servers=${{ inputs.servers }}"
@@ -239,6 +239,8 @@ jobs:
           if [ "$VERBOSE" = "true" ]; then
             ARGS="$ARGS -v"
           fi
+
+          ARGS="$ARGS --parallel"
 
           ARGS="$ARGS --log-file=e2e-results.log --output-json=e2e-results.json"
 

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -191,16 +191,14 @@ jobs:
       - name: Create .env file
         working-directory: ./e2e
         run: |
-          cat > .env << 'ENVEOF'
-          SERVER_EVM_ADDRESS=${{ secrets.SERVER_EVM_ADDRESS }}
-          SERVER_SVM_ADDRESS=${{ secrets.SERVER_SVM_ADDRESS }}
-          CLIENT_EVM_PRIVATE_KEY=${{ secrets.CLIENT_EVM_PRIVATE_KEY }}
-          CLIENT_SVM_PRIVATE_KEY=${{ secrets.CLIENT_SVM_PRIVATE_KEY }}
-          FACILITATOR_EVM_PRIVATE_KEY=${{ secrets.FACILITATOR_EVM_PRIVATE_KEY }}
-          FACILITATOR_SVM_PRIVATE_KEY=${{ secrets.FACILITATOR_SVM_PRIVATE_KEY }}
-          BASE_SEPOLIA_RPC_URL=${{ secrets.BASE_SEPOLIA_RPC_URL }}
-          SOLANA_DEVNET_RPC_URL=${{ secrets.SOLANA_DEVNET_RPC_URL }}
-          ENVEOF
+          {
+            echo "SERVER_EVM_ADDRESS=${{ secrets.SERVER_EVM_ADDRESS }}"
+            echo "SERVER_SVM_ADDRESS=${{ secrets.SERVER_SVM_ADDRESS }}"
+            echo "CLIENT_EVM_PRIVATE_KEY=${{ secrets.CLIENT_EVM_PRIVATE_KEY }}"
+            echo "CLIENT_SVM_PRIVATE_KEY=${{ secrets.CLIENT_SVM_PRIVATE_KEY }}"
+            echo "FACILITATOR_EVM_PRIVATE_KEY=${{ secrets.FACILITATOR_EVM_PRIVATE_KEY }}"
+            echo "FACILITATOR_SVM_PRIVATE_KEY=${{ secrets.FACILITATOR_SVM_PRIVATE_KEY }}"
+          } > .env
 
       # --- Run E2E Tests ---
       # Uses programmatic mode (CLI filter flags) to bypass the interactive

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,0 +1,344 @@
+# E2E Test Workflow for x402 Protocol
+#
+# This workflow runs the full end-to-end test suite which validates the x402
+# payment protocol across multiple languages (TypeScript, Go, Python),
+# frameworks, transports (HTTP, MCP), and blockchain networks.
+#
+# Trigger: Manual only (workflow_dispatch). Select the branch to test from
+# the "Use workflow from" dropdown in the GitHub Actions UI.
+#
+# ============================================================================
+# REQUIRED GITHUB SECRETS
+# ============================================================================
+#
+# The following secrets must be configured in the repository settings
+# (Settings > Secrets and variables > Actions) for this workflow to succeed.
+#
+# --- Wallet Keys (Required) ---
+#
+# CLIENT_EVM_PRIVATE_KEY:
+#   EVM private key for the client wallet that makes payments.
+#   Must be funded with testnet USDC on Base Sepolia.
+#   Format: 0x-prefixed hex string (e.g., 0x4df9...)
+#
+# CLIENT_SVM_PRIVATE_KEY:
+#   Solana private key for the client wallet that makes payments.
+#   Must be funded with devnet USDC on Solana Devnet.
+#   Format: base58 encoded string
+#
+# FACILITATOR_EVM_PRIVATE_KEY:
+#   EVM private key for the facilitator wallet that verifies/settles payments.
+#   Format: 0x-prefixed hex string
+#
+# FACILITATOR_SVM_PRIVATE_KEY:
+#   Solana private key for the facilitator wallet that verifies/settles payments.
+#   Format: base58 encoded string
+#
+# SERVER_EVM_ADDRESS:
+#   EVM address where server payments are sent (payee address).
+#   Format: 0x-prefixed hex address (e.g., 0x122F...)
+#
+# SERVER_SVM_ADDRESS:
+#   Solana address where server payments are sent (payee address).
+#   Format: base58 encoded public key
+#
+# --- RPC URLs (Optional) ---
+#
+# These are optional. If not set, the test suite falls back to public defaults.
+# Setting custom RPC URLs is recommended for reliability in CI.
+#
+# BASE_SEPOLIA_RPC_URL:
+#   Custom RPC URL for Base Sepolia testnet.
+#   Default: https://sepolia.base.org
+#
+# SOLANA_DEVNET_RPC_URL:
+#   Custom RPC URL for Solana Devnet.
+#   Default: https://api.devnet.solana.com
+#
+# ============================================================================
+
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test (leave empty to use the branch selected above)"
+        required: false
+        default: ""
+      transport:
+        description: "Transports to test (comma-separated: http,mcp)"
+        required: false
+        default: "http"
+      facilitators:
+        description: "Facilitators to test (comma-separated: go,typescript,python)"
+        required: false
+        default: "go,typescript,python"
+      servers:
+        description: "Servers to test (comma-separated: express,hono,gin,flask,fastapi,next)"
+        required: false
+      clients:
+        description: "Clients to test (comma-separated: axios,fetch,go-http,httpx,requests)"
+        required: false
+      families:
+        description: "Protocol families (comma-separated: evm,svm)"
+        required: false
+      minimize:
+        description: "Use coverage-based test minimization (--min)"
+        type: boolean
+        default: true
+      verbose:
+        description: "Enable verbose logging"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      # --- Language Runtimes ---
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+          cache-dependency-path: |
+            e2e/pnpm-lock.yaml
+            typescript/pnpm-lock.yaml
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache-dependency-path: |
+            go/go.sum
+            e2e/**/go.sum
+
+      - name: Setup Python (uv)
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install
+
+      # --- Install Dependencies ---
+
+      - name: Install TypeScript SDK dependencies
+        working-directory: ./typescript
+        run: pnpm install --frozen-lockfile
+
+      - name: Install E2E dependencies
+        working-directory: ./e2e
+        run: pnpm install --frozen-lockfile
+
+      # --- Build & Setup E2E Components ---
+      # setup.sh runs install.sh and build.sh for all servers, clients, and
+      # facilitators (TypeScript, Go, and Python components).
+
+      - name: Setup E2E components
+        working-directory: ./e2e
+        run: ./setup.sh -v
+
+      # --- Write Environment File ---
+
+      - name: Create .env file
+        working-directory: ./e2e
+        run: |
+          cat > .env << 'ENVEOF'
+          SERVER_EVM_ADDRESS=${{ secrets.SERVER_EVM_ADDRESS }}
+          SERVER_SVM_ADDRESS=${{ secrets.SERVER_SVM_ADDRESS }}
+          CLIENT_EVM_PRIVATE_KEY=${{ secrets.CLIENT_EVM_PRIVATE_KEY }}
+          CLIENT_SVM_PRIVATE_KEY=${{ secrets.CLIENT_SVM_PRIVATE_KEY }}
+          FACILITATOR_EVM_PRIVATE_KEY=${{ secrets.FACILITATOR_EVM_PRIVATE_KEY }}
+          FACILITATOR_SVM_PRIVATE_KEY=${{ secrets.FACILITATOR_SVM_PRIVATE_KEY }}
+          BASE_SEPOLIA_RPC_URL=${{ secrets.BASE_SEPOLIA_RPC_URL }}
+          SOLANA_DEVNET_RPC_URL=${{ secrets.SOLANA_DEVNET_RPC_URL }}
+          ENVEOF
+
+      # --- Run E2E Tests ---
+      # Uses programmatic mode (CLI filter flags) to bypass the interactive
+      # prompt that `pnpm test` opens by default. Any --flag triggers
+      # programmatic mode in the test runner (see e2e/src/cli/args.ts).
+
+      - name: Run E2E tests
+        id: e2e
+        working-directory: ./e2e
+        run: |
+          ARGS="--testnet"
+
+          # Apply workflow_dispatch inputs (or defaults)
+          ARGS="$ARGS --transport=${{ inputs.transport || 'http' }}"
+          ARGS="$ARGS --facilitators=${{ inputs.facilitators || 'go,typescript,python' }}"
+
+          if [ -n "${{ inputs.servers }}" ]; then
+            ARGS="$ARGS --servers=${{ inputs.servers }}"
+          fi
+
+          if [ -n "${{ inputs.clients }}" ]; then
+            ARGS="$ARGS --clients=${{ inputs.clients }}"
+          fi
+
+          if [ -n "${{ inputs.families }}" ]; then
+            ARGS="$ARGS --families=${{ inputs.families }}"
+          fi
+
+          if [ "${{ inputs.minimize }}" = "true" ]; then
+            ARGS="$ARGS --min"
+          fi
+
+          if [ "${{ inputs.verbose }}" = "true" ]; then
+            ARGS="$ARGS -v"
+          fi
+
+          ARGS="$ARGS --log-file=e2e-results.log --output-json=e2e-results.json"
+
+          echo "Running: pnpm test $ARGS"
+
+          # Run tests but capture exit code so we can still comment on the PR
+          set +e
+          pnpm test $ARGS
+          TEST_EXIT_CODE=$?
+          set -e
+
+          echo "test_exit_code=$TEST_EXIT_CODE" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      # --- Upload Results ---
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-log
+          path: |
+            e2e/e2e-results.log
+            e2e/e2e-results.json
+          retention-days: 14
+
+      # --- Comment on PR ---
+      # Find any open PR for the tested branch, delete previous E2E comments
+      # from this workflow, and post a new comment with results.
+
+      - name: Comment results on PR
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TEST_EXIT_CODE: ${{ steps.e2e.outputs.test_exit_code }}
+        run: |
+          BRANCH="${{ inputs.branch || github.ref_name }}"
+
+          # Find open PR for this branch
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for branch '$BRANCH', skipping comment."
+            exit 0
+          fi
+
+          echo "Found PR #$PR_NUMBER for branch '$BRANCH'"
+
+          # Delete previous E2E comments from this workflow
+          COMMENT_IDS=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq '.[] | select(.body | contains("<!-- x402-e2e-results -->")) | .id' 2>/dev/null || true)
+
+          for CID in $COMMENT_IDS; do
+            echo "Deleting previous E2E comment $CID"
+            gh api --method DELETE "repos/${{ github.repository }}/issues/comments/$CID" 2>/dev/null || true
+          done
+
+          # Build comment body from JSON results
+          COMMENT_BODY="<!-- x402-e2e-results -->"$'\n'
+
+          if [ -f e2e/e2e-results.json ]; then
+            TOTAL=$(jq '.summary.total' e2e/e2e-results.json)
+            PASSED=$(jq '.summary.passed' e2e/e2e-results.json)
+            FAILED=$(jq '.summary.failed' e2e/e2e-results.json)
+            NETWORK=$(jq -r '.summary.networkMode' e2e/e2e-results.json)
+
+            if [ "$FAILED" = "0" ]; then
+              COMMENT_BODY+="## :white_check_mark: E2E Tests Passed"$'\n\n'
+            else
+              COMMENT_BODY+="## :x: E2E Tests Failed"$'\n\n'
+            fi
+
+            COMMENT_BODY+="**Network:** ${NETWORK} | **Total:** ${TOTAL} | **Passed:** ${PASSED} | **Failed:** ${FAILED}"$'\n\n'
+
+            # Facilitator breakdown
+            FACILITATOR_ROWS=$(jq -r '.breakdowns.byFacilitator | to_entries[] | "| \(.key) | \(.value.passed) | \(.value.failed) |"' e2e/e2e-results.json)
+            if [ -n "$FACILITATOR_ROWS" ]; then
+              COMMENT_BODY+="### By Facilitator"$'\n'
+              COMMENT_BODY+="| Facilitator | Passed | Failed |"$'\n'
+              COMMENT_BODY+="|---|---|---|"$'\n'
+              COMMENT_BODY+="${FACILITATOR_ROWS}"$'\n\n'
+            fi
+
+            # Server breakdown
+            SERVER_ROWS=$(jq -r '.breakdowns.byServer | to_entries[] | "| \(.key) | \(.value.passed) | \(.value.failed) |"' e2e/e2e-results.json)
+            if [ -n "$SERVER_ROWS" ]; then
+              COMMENT_BODY+="### By Server"$'\n'
+              COMMENT_BODY+="| Server | Passed | Failed |"$'\n'
+              COMMENT_BODY+="|---|---|---|"$'\n'
+              COMMENT_BODY+="${SERVER_ROWS}"$'\n\n'
+            fi
+
+            # Client breakdown
+            CLIENT_ROWS=$(jq -r '.breakdowns.byClient | to_entries[] | "| \(.key) | \(.value.passed) | \(.value.failed) |"' e2e/e2e-results.json)
+            if [ -n "$CLIENT_ROWS" ]; then
+              COMMENT_BODY+="### By Client"$'\n'
+              COMMENT_BODY+="| Client | Passed | Failed |"$'\n'
+              COMMENT_BODY+="|---|---|---|"$'\n'
+              COMMENT_BODY+="${CLIENT_ROWS}"$'\n\n'
+            fi
+
+            # Failed test details
+            FAILED_DETAILS=$(jq -r '.results[] | select(.passed == false) | "| #\(.testNumber) | \(.client) | \(.server) | \(.endpoint) | \(.facilitator) | \(.error // "Unknown") |"' e2e/e2e-results.json)
+            if [ -n "$FAILED_DETAILS" ]; then
+              COMMENT_BODY+="### Failed Tests"$'\n'
+              COMMENT_BODY+="| # | Client | Server | Endpoint | Facilitator | Error |"$'\n'
+              COMMENT_BODY+="|---|---|---|---|---|---|"$'\n'
+              COMMENT_BODY+="${FAILED_DETAILS}"$'\n\n'
+            fi
+          else
+            # No JSON output — tests likely crashed before producing results
+            if [ "$TEST_EXIT_CODE" != "0" ]; then
+              COMMENT_BODY+="## :x: E2E Tests Failed"$'\n\n'
+              COMMENT_BODY+="Test runner exited with code ${TEST_EXIT_CODE} before producing results."$'\n'
+              COMMENT_BODY+="Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."$'\n'
+            else
+              COMMENT_BODY+="## :warning: E2E Tests — No Results"$'\n\n'
+              COMMENT_BODY+="No structured output was produced. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."$'\n'
+            fi
+          fi
+
+          COMMENT_BODY+=$'\n'"<sub>Run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})</sub>"$'\n'
+
+          # Post new comment
+          gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+          echo "Posted E2E results comment on PR #$PR_NUMBER"
+
+      # --- Fail the workflow if tests failed ---
+
+      - name: Check test result
+        if: always()
+        run: |
+          if [ "${{ steps.e2e.outputs.test_exit_code }}" != "0" ]; then
+            echo "E2E tests failed with exit code ${{ steps.e2e.outputs.test_exit_code }}"
+            exit 1
+          fi

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -166,7 +166,7 @@ jobs:
           enable-cache: true
 
       - name: Install Python
-        run: uv python install
+        run: uv python install 3.13
 
       # --- Install Dependencies ---
 
@@ -236,7 +236,7 @@ jobs:
           fi
 
           VERBOSE="${{ inputs.verbose }}"
-          if [ "$VERBOSE" = "true" ] || [ -z "$VERBOSE" ]; then
+          if [ "$VERBOSE" = "true" ]; then
             ARGS="$ARGS -v"
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ e2e/facilitators/external-proxies/*
 !e2e/facilitators/external-proxies/README.md
 typescript/package-lock.json
 .pnpm-store/
+TASK.md

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,7 +11,7 @@
     "install:all": "pnpm install && ./setup.sh",
     "install:all:legacy": "pnpm install && ./setup.sh --legacy",
     "clean": "rm -rf dist",
-    "clean:ports": "lsof -ti:4022,4023,4024,4025,4026,4027,4028,4029,4030,4031,4032,4033 | xargs kill -9 2>/dev/null || echo 'Ports cleared'",
+    "clean:ports": "lsof -ti:4022-4060 | xargs kill -9 2>/dev/null || echo 'Ports cleared'",
     "permit2:approve": "tsx scripts/permit2-approval.ts approve"
   },
   "dependencies": {

--- a/e2e/src/cli/args.ts
+++ b/e2e/src/cli/args.ts
@@ -14,6 +14,8 @@ export interface ParsedArgs {
   showHelp: boolean;
   minimize: boolean;
   networkMode?: NetworkMode;  // undefined = prompt user, set = skip prompt
+  parallel: boolean;
+  concurrency: number;
 }
 
 export function parseArgs(): ParsedArgs {
@@ -26,7 +28,9 @@ export function parseArgs(): ParsedArgs {
       verbose: false,
       filters: {},
       showHelp: true,
-      minimize: false
+      minimize: false,
+      parallel: false,
+      concurrency: 4,
     };
   }
 
@@ -54,6 +58,11 @@ export function parseArgs(): ParsedArgs {
 
   // Parse minimize flag
   const minimize = args.includes('--min');
+
+  // Parse parallel mode flags
+  const parallel = args.includes('--parallel');
+  const concurrencyArg = args.find(arg => arg.startsWith('--concurrency='))?.split('=')[1];
+  const concurrency = concurrencyArg ? parseInt(concurrencyArg, 10) : 4;
 
   // Parse network mode (optional - if not set, will prompt in interactive mode)
   let networkMode: NetworkMode | undefined;
@@ -88,7 +97,9 @@ export function parseArgs(): ParsedArgs {
     },
     showHelp: false,
     minimize,
-    networkMode
+    networkMode,
+    parallel,
+    concurrency,
   };
 }
 
@@ -125,6 +136,8 @@ export function printHelp(): void {
   console.log('  --log-file=<path>          Save verbose output to file');
   console.log('  --output-json=<path>       Write structured JSON results to file');
   console.log('  --min                      Minimize tests (coverage-based skipping)');
+  console.log('  --parallel                 Run server+facilitator combos concurrently');
+  console.log('  --concurrency=<N>          Max concurrent combos (default: 4, requires --parallel)');
   console.log('  -h, --help                 Show this help message');
   console.log('');
   console.log('Examples:');
@@ -134,6 +147,8 @@ export function printHelp(): void {
   console.log('  pnpm test --min -v                                  # Minimize with verbose');
   console.log('  pnpm test --transport=mcp                                # MCP transport only');
   console.log('  pnpm test --mainnet --facilitators=go --servers=express  # Mainnet programmatic');
+  console.log('  pnpm test --testnet --min --parallel -v                   # Parallel mode');
+  console.log('  pnpm test --testnet --min --parallel --concurrency=2 -v   # Limited concurrency');
   console.log('');
   console.log('Note: --mainnet requires funded wallets with real tokens!');
   console.log('');

--- a/e2e/src/cli/args.ts
+++ b/e2e/src/cli/args.ts
@@ -9,6 +9,7 @@ export interface ParsedArgs {
   mode: 'interactive' | 'programmatic';
   verbose: boolean;
   logFile?: string;
+  outputJson?: string;
   filters: TestFilters;
   showHelp: boolean;
   minimize: boolean;
@@ -48,6 +49,9 @@ export function parseArgs(): ParsedArgs {
   // Parse log file
   const logFile = args.find(arg => arg.startsWith('--log-file='))?.split('=')[1];
 
+  // Parse JSON output file
+  const outputJson = args.find(arg => arg.startsWith('--output-json='))?.split('=')[1];
+
   // Parse minimize flag
   const minimize = args.includes('--min');
 
@@ -72,6 +76,7 @@ export function parseArgs(): ParsedArgs {
     mode,
     verbose,
     logFile,
+    outputJson,
     filters: {
       transports,
       facilitators,
@@ -118,6 +123,7 @@ export function printHelp(): void {
   console.log('Options:');
   console.log('  -v, --verbose              Enable verbose logging');
   console.log('  --log-file=<path>          Save verbose output to file');
+  console.log('  --output-json=<path>       Write structured JSON results to file');
   console.log('  --min                      Minimize tests (coverage-based skipping)');
   console.log('  -h, --help                 Show this help message');
   console.log('');

--- a/e2e/src/concurrency.ts
+++ b/e2e/src/concurrency.ts
@@ -1,0 +1,78 @@
+/**
+ * Concurrency utilities for parallel E2E test execution.
+ *
+ * - Semaphore: bounds how many combos run at once.
+ * - FacilitatorLock: async mutex keyed by facilitator name, used to serialize
+ *   EVM tests through the same facilitator (prevents nonce collisions).
+ */
+
+/**
+ * Counting semaphore that limits concurrent async operations.
+ */
+export class Semaphore {
+  private permits: number;
+  private waiters: Array<() => void> = [];
+
+  constructor(permits: number) {
+    this.permits = permits;
+  }
+
+  async acquire(): Promise<() => void> {
+    if (this.permits > 0) {
+      this.permits--;
+      return () => this.release();
+    }
+
+    return new Promise<() => void>((resolve) => {
+      this.waiters.push(() => {
+        this.permits--;
+        resolve(() => this.release());
+      });
+    });
+  }
+
+  private release(): void {
+    this.permits++;
+    const next = this.waiters.shift();
+    if (next) {
+      next();
+    }
+  }
+}
+
+/**
+ * Per-facilitator async mutex for EVM tests.
+ *
+ * EVM transactions use `PendingNonceAt()` — two concurrent EVM tests routed
+ * through the same facilitator will get the same nonce and one will fail.
+ * This lock serializes EVM tests per facilitator while allowing SVM tests
+ * (which use blockhash + random memo) to proceed freely.
+ */
+export class FacilitatorLock {
+  private locks = new Map<string, Promise<void>>();
+
+  /**
+   * Acquire the EVM lock for a facilitator. Returns a release function.
+   * Only call this for EVM tests — SVM tests should skip locking entirely.
+   */
+  async acquire(facilitatorName: string): Promise<() => void> {
+    const key = `evm:${facilitatorName}`;
+
+    // Wait for the current holder (if any) to finish
+    while (this.locks.has(key)) {
+      await this.locks.get(key);
+    }
+
+    // Set up our own lock
+    let releaseFn: () => void;
+    const lockPromise = new Promise<void>((resolve) => {
+      releaseFn = resolve;
+    });
+    this.locks.set(key, lockPromise);
+
+    return () => {
+      this.locks.delete(key);
+      releaseFn!();
+    };
+  }
+}

--- a/e2e/src/facilitators/facilitator-manager.ts
+++ b/e2e/src/facilitators/facilitator-manager.ts
@@ -1,0 +1,66 @@
+import { verboseLog } from '../logger';
+import { waitForHealth } from '../health';
+import type { FacilitatorConfig } from './generic-facilitator';
+import type { NetworkSet } from '../networks/networks';
+
+interface Facilitator {
+  start: (config: FacilitatorConfig) => Promise<void>;
+  health: () => Promise<{ success: boolean }>;
+  getUrl: () => string;
+  stop: () => Promise<void>;
+}
+
+/**
+ * Manages the async lifecycle of a facilitator process: start, health-check,
+ * ready-gate, and stop.
+ */
+export class FacilitatorManager {
+  private facilitator: Facilitator;
+  private port: number;
+  private readyPromise: Promise<string | null>;
+  private url: string | null = null;
+
+  constructor(facilitator: Facilitator, port: number, networks: NetworkSet) {
+    this.facilitator = facilitator;
+    this.port = port;
+
+    // Start facilitator and health checks asynchronously
+    this.readyPromise = this.startAndWaitForHealth(networks);
+  }
+
+  private async startAndWaitForHealth(networks: NetworkSet): Promise<string | null> {
+    verboseLog(`  🏛️ Starting facilitator on port ${this.port}...`);
+
+    await this.facilitator.start({
+      port: this.port,
+      evmPrivateKey: process.env.FACILITATOR_EVM_PRIVATE_KEY,
+      svmPrivateKey: process.env.FACILITATOR_SVM_PRIVATE_KEY,
+      networks,
+    });
+
+    const healthy = await waitForHealth(
+      () => this.facilitator.health(),
+      { label: 'Facilitator' },
+    );
+
+    if (healthy) {
+      this.url = this.facilitator.getUrl();
+      return this.url;
+    }
+    return null;
+  }
+
+  async ready(): Promise<string | null> {
+    return this.readyPromise;
+  }
+
+  getProxy(): Facilitator {
+    return this.facilitator;
+  }
+
+  async stop(): Promise<void> {
+    if (this.facilitator) {
+      await this.facilitator.stop();
+    }
+  }
+}

--- a/e2e/src/health.ts
+++ b/e2e/src/health.ts
@@ -1,0 +1,43 @@
+import { verboseLog } from './logger';
+
+export interface WaitForHealthOptions {
+  maxAttempts?: number;
+  intervalMs?: number;
+  initialDelayMs?: number;
+  label?: string;
+}
+
+/**
+ * Retry a health-check function until it reports success or attempts are
+ * exhausted. Returns true when healthy, false on timeout.
+ */
+export async function waitForHealth(
+  healthCheck: () => Promise<{ success: boolean }>,
+  options?: WaitForHealthOptions,
+): Promise<boolean> {
+  const maxAttempts = options?.maxAttempts ?? 10;
+  const intervalMs = options?.intervalMs ?? 2000;
+  const initialDelayMs = options?.initialDelayMs ?? 0;
+  const label = options?.label ?? 'Service';
+
+  if (initialDelayMs > 0) {
+    await new Promise(resolve => setTimeout(resolve, initialDelayMs));
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const result = await healthCheck();
+    verboseLog(` 🔍 ${label} health check ${attempt}/${maxAttempts}: ${result.success ? '✅' : '❌'}`);
+
+    if (result.success) {
+      verboseLog(`  ✅ ${label} is healthy`);
+      return true;
+    }
+
+    if (attempt < maxAttempts) {
+      await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  verboseLog(`  ❌ ${label} failed to become healthy`);
+  return false;
+}

--- a/e2e/src/logger.ts
+++ b/e2e/src/logger.ts
@@ -96,6 +96,19 @@ export function errorLog(message: string, toFile: boolean = true): void {
 }
 
 /**
+ * Create a combo-prefixed logger for parallel mode.
+ * Returns functions that prepend a tag like [combo-0 express+go] to every message.
+ */
+export function createComboLogger(comboIndex: number, serverName: string, facilitatorName: string | undefined) {
+  const tag = `[combo-${comboIndex} ${serverName}+${facilitatorName || 'none'}]`;
+  return {
+    log: (message: string, toFile?: boolean) => log(`${tag} ${message}`, toFile),
+    verboseLog: (message: string, toFile?: boolean) => verboseLog(`${tag} ${message}`, toFile),
+    errorLog: (message: string, toFile?: boolean) => errorLog(`${tag} ${message}`, toFile),
+  };
+}
+
+/**
  * Close the logger and its file streams
  */
 export function close(): void {


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description
- Refactors E2E test suite to support increased parallelization via the `--parallel` flag
- Adds a manual workflow to run E2E suites on demand against a branch (only those with write access can run it)
<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 