### PR TITLE
specs: add zk-relay scheme for privacy-preserving ZK payments

### DIFF
--- a/specs/schemes/zk-relay/client_proving.md
+++ b/specs/schemes/zk-relay/client_proving.md
@@ -1,0 +1,91 @@
+# Client-Side Proof Generation: `zk-relay`
+
+## Overview
+
+Unlike the `exact` scheme where the client signs a message with their wallet, `zk-relay` requires the client to generate a zero-knowledge proof entirely in the browser using WASM. This document describes the client-side proving pipeline.
+
+## Pipeline
+
+```
+Note Data (secret, nullifier, amount, assetId)
+          |
+          v
+    Commitment = Poseidon(secret, nullifier, amount, assetId)
+          |
+          v
+    Merkle Proof = tree.getProof(leafIndex)
+          |
+          v
+    Circuit Inputs = {
+      root, nullifierHash, amount, assetId, recipient,
+      secret, nullifier, pathElements, pathIndices
+    }
+          |
+          v
+    Noir Witness Generation (noir_js WASM)
+          |
+          v
+    UltraHonk Proof Generation (bb.js WASM)
+          |
+          v
+    { proof: Uint8Array, publicInputs: string[] }
+```
+
+## Dependencies
+
+| Package              | Version            | Purpose                        |
+|----------------------|--------------------|--------------------------------|
+| `@noir-lang/noir_js` | `1.0.0-beta.18`   | Witness generation from Noir circuits |
+| `@aztec/bb.js`       | `2.1.11`           | UltraHonk proof generation (WASM) |
+
+Version alignment between these packages is critical. The Solidity verifier contract MUST be generated from the same `bb.js` version used for proof generation. Using `bb` CLI instead of `bb.js` will produce incompatible verifiers.
+
+## Browser Requirements
+
+### SharedArrayBuffer
+
+The `bb.js` WASM backend uses multi-threading via `SharedArrayBuffer` for proof generation. This requires the page to be served with the following HTTP headers:
+
+```
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: credentialless
+```
+
+If `crossOriginIsolated` is `false`, the prover falls back to single-threaded mode, which increases proof generation time from ~3 seconds to ~15 seconds.
+
+### Common Reference String (CRS)
+
+The UltraHonk proof system requires a Common Reference String (CRS). The `bb.js` library fetches it from `https://crs.aztec.network/` and caches it in IndexedDB.
+
+For production deployments, the CRS SHOULD be pre-downloaded and served from the application's own domain to avoid cross-origin fetch failures. The CRS data consists of:
+
+| File     | Size       | Description                              |
+|----------|------------|------------------------------------------|
+| `g1.dat` | ~2,097 KB  | G1 group elements (32769 points x 64 bytes) |
+| `g2.dat` | 128 bytes  | G2 group element                         |
+
+The CRS is stored in IndexedDB under the database `keyval-store`, object store `keyval`, with keys `g1Data` and `g2Data`.
+
+## Circuit Compilation
+
+Circuits are compiled with `nargo` (version 1.0.0-beta.18) to produce JSON artifacts containing the ACIR bytecode. These artifacts are served as static files and loaded by the client at proof generation time.
+
+| Circuit    | Subgroup Size | CRS Points Required | Approximate Proof Time |
+|------------|---------------|---------------------|------------------------|
+| `shield`   | 2,048         | 2,049               | ~1.5s (multi-threaded) |
+| `burn`     | 32,768        | 32,769              | ~3s (multi-threaded)   |
+| `transfer` | 32,768        | 32,769              | ~3s (multi-threaded)   |
+
+## Proof Format
+
+The generated proof is a `Uint8Array` in the UltraHonk serialization format. To submit it to the facilitator, it is converted to a `0x`-prefixed hex string:
+
+```javascript
+const proofHex = '0x' + Array.from(proof).map(b => b.toString(16).padStart(2, '0')).join('')
+```
+
+The public inputs are returned as an array of field element strings. The order matches the circuit's public input declaration:
+
+```
+[root, nullifierHash, amount, assetId, recipient]
+```

--- a/specs/schemes/zk-relay/facilitator_api.md
+++ b/specs/schemes/zk-relay/facilitator_api.md
@@ -1,0 +1,180 @@
+# Facilitator API Reference: `zk-relay`
+
+## Overview
+
+The `zk-relay` facilitator exposes a standard set of x402 endpoints plus scheme-specific endpoints for Merkle tree state and indexer data. All endpoints are served over HTTPS.
+
+## Standard x402 Endpoints
+
+### `GET /supported`
+
+Returns the schemes and networks supported by this facilitator.
+
+**Response:**
+
+```json
+{
+  "x402Version": 2,
+  "schemes": ["zk-relay"],
+  "networks": ["eip155:8453"]
+}
+```
+
+### `POST /verify`
+
+Validates a proof and its public inputs without submitting on-chain. Use this to check proof validity before committing to settlement.
+
+**Request Body:**
+
+```json
+{
+  "proof": "0x1a2b3c...",
+  "nullifierHash": "0x4d5e6f...",
+  "amount": "1000000000000000",
+  "assetId": 0,
+  "recipient": "0x6Bf5713D59066A4a55CdAD90f7E007d5209aDaE7",
+  "root": "0x7a8b9c..."
+}
+```
+
+**Response (valid):**
+
+```json
+{
+  "valid": true
+}
+```
+
+**Response (invalid):**
+
+```json
+{
+  "valid": false,
+  "error": "Nullifier already spent"
+}
+```
+
+### `POST /settle`
+
+Submits the proof on-chain by calling `unshield()` on the zkWrapper contract. This endpoint is idempotent: if a settlement with the same nullifier is already in progress or completed, the existing transaction hash is returned.
+
+**Request Body:** Same as `/verify`.
+
+**Response (success):**
+
+```json
+{
+  "success": true,
+  "txHash": "0xabc123..."
+}
+```
+
+**Response (failure):**
+
+```json
+{
+  "success": false,
+  "error": "Proof verification failed on-chain"
+}
+```
+
+### `GET /status`
+
+Returns the facilitator's operational status.
+
+**Response:**
+
+```json
+{
+  "status": "active",
+  "network": "eip155:8453",
+  "contract": "0x278652aA8383cBa29b68165926d0534e52BcD368",
+  "relayerAddress": "0x214999174d5925aB5744e176f433e1585705Ad4d",
+  "balance": "0.0217",
+  "pendingTxCount": 0,
+  "circuitBreaker": {
+    "paused": false
+  },
+  "indexer": {
+    "enabled": true,
+    "lastBlock": 42235100,
+    "commitmentCount": 12,
+    "merkleRoot": "0x..."
+  }
+}
+```
+
+## Scheme-Specific Endpoints
+
+### `GET /api/ceaser/merkle-root`
+
+Returns the current Merkle tree root. Prefers the locally indexed root (instant) with an on-chain fallback.
+
+**Response:**
+
+```json
+{
+  "root": "0x7a8b9c...",
+  "source": "indexer"
+}
+```
+
+### `GET /api/ceaser/indexer/status`
+
+Returns the indexer synchronization state.
+
+**Response:**
+
+```json
+{
+  "enabled": true,
+  "synced": true,
+  "lastBlock": 42235100,
+  "commitmentCount": 12,
+  "merkleRoot": "0x..."
+}
+```
+
+### `GET /api/ceaser/indexer/commitments`
+
+Returns all commitments known to the indexer, enabling the client to reconstruct the Merkle tree locally for proof generation.
+
+**Response:**
+
+```json
+{
+  "commitments": [
+    "0xaaa...",
+    "0xbbb...",
+    "0xccc..."
+  ],
+  "count": 3,
+  "merkleRoot": "0x..."
+}
+```
+
+### `GET /api/ceaser/indexer/commitment/:index`
+
+Returns a single commitment by its leaf index.
+
+**Response:**
+
+```json
+{
+  "index": 0,
+  "commitment": "0xaaa...",
+  "blockNumber": 42230490
+}
+```
+
+## Error Codes
+
+| HTTP Status | Error                    | Description                                      |
+|-------------|--------------------------|--------------------------------------------------|
+| 400         | `INVALID_PROOF_FORMAT`   | Proof bytes are malformed or wrong length         |
+| 400         | `INVALID_AMOUNT`         | Amount is not a valid fixed denomination          |
+| 400         | `INVALID_RECIPIENT`      | Recipient address is zero or malformed            |
+| 409         | `NULLIFIER_ALREADY_SPENT`| The nullifier has been used in a prior withdrawal |
+| 409         | `ROOT_NOT_RECOGNIZED`    | The Merkle root is not in the contract's history  |
+| 429         | `RATE_LIMITED`           | Per-address or global rate limit exceeded         |
+| 503         | `FACILITATOR_PAUSED`     | Circuit breaker is active due to failures or low balance |

--- a/specs/schemes/zk-relay/scheme_zk_relay.md
+++ b/specs/schemes/zk-relay/scheme_zk_relay.md
@@ -1,0 +1,100 @@
+# Scheme: `zk-relay`
+
+## Summary
+
+`zk-relay` is a scheme for privacy-preserving asset transfers on EVM-compatible networks. A client generates a zero-knowledge proof off-chain, and the facilitator relays the transaction on-chain so that the client never reveals their address or pays gas directly. The facilitator settles the proof and deducts a protocol fee from the withdrawn amount.
+
+Unlike `exact`, where the client signs a transfer of a known amount to a known recipient, `zk-relay` operates on shielded notes. The client destroys a private note by proving knowledge of its secret and nullifier inside a ZK circuit, and the facilitator submits the resulting proof to a smart contract that verifies the proof, nullifies the note, and sends funds to the specified recipient minus fees.
+
+## Use Cases
+
+- Private withdrawal of shielded ETH or ERC-20 tokens without revealing the depositor's address
+- Gasless unshielding where the recipient wallet has zero ETH balance
+- Relayed transactions that break the on-chain link between deposit and withdrawal
+- Privacy-preserving payments where sender and receiver cannot be correlated
+
+## Flow
+
+```
+Client                        Facilitator                    Smart Contract
+  |                                |                              |
+  |-- POST /verify ------------->  |                              |
+  |   { proof, nullifier,         |                              |
+  |     amount, recipient, root } |                              |
+  |                                |-- Validate proof format      |
+  |                                |-- Check nullifier unused     |
+  |                                |-- Check root is known        |
+  |  <-- 200 { valid: true } -----|                              |
+  |                                |                              |
+  |-- POST /settle -------------> |                              |
+  |   { proof, nullifier,         |                              |
+  |     amount, recipient, root } |                              |
+  |                                |-- unshield(proof, ...)  --> |
+  |                                |                              |-- Verify ZK proof
+  |                                |                              |-- Check nullifier
+  |                                |                              |-- Send funds - fee
+  |                                |                              |-- Emit event
+  |  <-- 200 { txHash } ---------|                              |
+```
+
+## Proof System
+
+The scheme is proof-system agnostic but the reference implementation uses:
+
+- **Circuits**: Noir 1.0.0-beta.18
+- **Proof system**: UltraHonk (no trusted setup required)
+- **Hashing**: Poseidon over the BN254 curve
+- **Commitment scheme**: `commitment = Poseidon(secret, nullifier, amount, assetId)`
+- **Nullifier scheme**: `nullifierHash = Poseidon(nullifier, leafIndex)`
+- **Merkle tree**: 24-level Poseidon hash tree
+
+## Security Requirements
+
+### Facilitator
+
+- MUST verify the proof format and public inputs before submitting on-chain.
+- MUST check that the Merkle root is recognized by the contract.
+- MUST check that the nullifier has not been spent.
+- MUST NOT submit proofs that would revert, to avoid wasting gas.
+- MUST enforce rate limiting to prevent abuse.
+- SHOULD implement a circuit breaker that pauses settlement on repeated failures or low balance.
+
+### Smart Contract
+
+- MUST verify the ZK proof on-chain before transferring funds.
+- MUST reject previously-used nullifiers (double-spend prevention).
+- MUST verify the Merkle root against its root history.
+- MUST deduct the protocol fee and send the remainder to the recipient.
+- MUST emit events for all state changes (deposits, withdrawals, transfers).
+
+## Network Support
+
+| Network | Chain ID | Status |
+|---------|----------|--------|
+| Base    | eip155:8453 | Live |
+
+## Appendix
+
+### Reference Implementation
+
+- **Protocol**: [Ceaser Privacy Protocol](https://ceaser.org)
+- **Source**: [github.com/Zyra-V21/ceaaser-privacy](https://github.com/Zyra-V21/ceaaser-privacy)
+- **Contract**: `0x278652aA8383cBa29b68165926d0534e52BcD368` (Base mainnet)
+- **Facilitator**: `https://ceaser.org` (endpoints: `/supported`, `/verify`, `/settle`, `/status`)
+
+### Fee Structure
+
+- Protocol fee: 0.25% of withdrawn amount (0.24% treasury, 0.01% relayer)
+- Gas: paid by the facilitator, not the client
+
+### Fixed Denominations
+
+The protocol uses fixed denominations to preserve amount privacy:
+
+| Denomination | Unit |
+|-------------|------|
+| 0.001       | ETH  |
+| 0.01        | ETH  |
+| 0.1         | ETH  |
+| 1           | ETH  |
+| 10          | ETH  |

--- a/specs/schemes/zk-relay/scheme_zk_relay.md
+++ b/specs/schemes/zk-relay/scheme_zk_relay.md
@@ -107,6 +107,20 @@ The scheme is proof-system agnostic but the reference implementation uses:
 |---------|----------|--------|
 | Base    | eip155:8453 | Live |
 
+## Comparison with `exact`
+
+| Property               | `exact`                            | `zk-relay`                              |
+|------------------------|------------------------------------|-----------------------------------------|
+| Privacy                | None (on-chain transfer visible)   | Full (deposit/withdrawal unlinkable)    |
+| Client signature       | EIP-712 / EIP-3009                 | ZK proof (UltraHonk)                    |
+| Trusted setup          | N/A                                | None required (UltraHonk)              |
+| Gas payer              | Facilitator                        | Facilitator                             |
+| Supported assets       | EIP-3009 tokens, ERC-20 via Permit2| Native ETH, ERC-20 (via assetId)       |
+| Amount flexibility     | Arbitrary amounts                  | Fixed denominations only                |
+| Proof generation       | Wallet signature (instant)         | Client-side WASM (~3-8 seconds)        |
+| On-chain verification  | Signature recovery                 | ZK proof verification (~380k gas)       |
+| Client requirements    | Wallet with signing capability     | Browser with WASM support               |
+
 ## Appendix
 
 ### Reference Implementation

--- a/specs/schemes/zk-relay/scheme_zk_relay.md
+++ b/specs/schemes/zk-relay/scheme_zk_relay.md
@@ -19,22 +19,22 @@ Unlike `exact`, where the client signs a transfer of a known amount to a known r
 Client                        Facilitator                    Smart Contract
   |                                |                              |
   |-- POST /verify ------------->  |                              |
-  |   { proof, nullifier,         |                              |
-  |     amount, recipient, root } |                              |
+  |   { proof, nullifier,          |                              |
+  |     amount, recipient, root }  |                              |
   |                                |-- Validate proof format      |
   |                                |-- Check nullifier unused     |
   |                                |-- Check root is known        |
-  |  <-- 200 { valid: true } -----|                              |
+  |  <-- 200 { valid: true } ----- |                              |
   |                                |                              |
-  |-- POST /settle -------------> |                              |
-  |   { proof, nullifier,         |                              |
-  |     amount, recipient, root } |                              |
-  |                                |-- unshield(proof, ...)  --> |
+  |-- POST /settle ------------->  |                              |
+  |   { proof, nullifier,          |                              |
+  |     amount, recipient, root }  |                              |
+  |                                |-- unshield(proof, ...)   --> |
   |                                |                              |-- Verify ZK proof
   |                                |                              |-- Check nullifier
   |                                |                              |-- Send funds - fee
   |                                |                              |-- Emit event
-  |  <-- 200 { txHash } ---------|                              |
+  |  <-- 200 { txHash } ---------  |                              |
 ```
 
 ## Proof System

--- a/specs/schemes/zk-relay/scheme_zk_relay_evm.md
+++ b/specs/schemes/zk-relay/scheme_zk_relay_evm.md
@@ -1,0 +1,97 @@
+# Scheme: `zk-relay` (EVM)
+
+## Summary
+
+EVM-specific implementation details for the `zk-relay` scheme. This document covers the smart contract interface, proof encoding, and on-chain verification requirements for EVM-compatible networks.
+
+## Smart Contract Interface
+
+### Shield (Deposit)
+
+```solidity
+function shieldETH(
+    bytes calldata proof,
+    bytes32 commitment,
+    uint256 amount,
+    uint256 assetId
+) external payable;
+```
+
+The client deposits a fixed denomination of ETH and provides a commitment that encodes the note's secret, nullifier, amount, and asset identifier. The contract inserts the commitment into a 24-level Poseidon Merkle tree and emits a `Deposit` event.
+
+### Unshield (Withdrawal via Facilitator)
+
+```solidity
+function unshield(
+    bytes calldata proof,
+    bytes32 nullifierHash,
+    uint256 amount,
+    uint256 assetId,
+    address recipient,
+    bytes32 root
+) external;
+```
+
+Only callable by a whitelisted relayer address. The contract verifies the ZK proof on-chain using a Solidity verifier generated from the same proof system (UltraHonk). If verification passes, the contract:
+
+1. Marks the nullifier as spent
+2. Calculates the protocol fee (configurable basis points)
+3. Sends `amount - fee` to the recipient
+4. Sends the fee to the treasury address
+5. Emits an `Unshield` event
+
+### Access Control
+
+- `relayers`: mapping of authorized facilitator addresses
+- `owner`: can add/remove relayers, pause the contract, update fee parameters
+- `treasury`: receives protocol fees
+
+## Proof Encoding
+
+The proof is encoded as a single `bytes` blob in the UltraHonk format:
+
+- Generated client-side using `@aztec/bb.js` (WASM)
+- Serialized as a flat byte array of field elements (32 bytes each)
+- Passed directly to the Solidity verifier's `verify()` function
+- The verifier is generated from `bb.js` (not the `bb` CLI) to ensure version alignment
+
+## Public Inputs
+
+The circuit exposes the following public inputs for on-chain verification:
+
+| Index | Field           | Description                            |
+|-------|-----------------|----------------------------------------|
+| 0     | root            | Merkle tree root at time of proof      |
+| 1     | nullifierHash   | Hash of (nullifier, leafIndex)         |
+| 2     | amount          | Withdrawal amount in wei               |
+| 3     | assetId         | Asset identifier (0 for native ETH)    |
+| 4     | recipient       | Recipient address as uint256           |
+
+## Gas Costs
+
+| Operation       | Gas (approx) |
+|-----------------|-------------|
+| shieldETH       | ~320,000    |
+| unshield        | ~380,000    |
+| privateTransfer | ~400,000    |
+
+## Rate Limiting
+
+The contract enforces two tiers of rate limiting:
+
+- **Per-address**: 50 ETH per hour for both shield and unshield operations
+- **Global per-block**: configurable maximum to prevent block stuffing
+
+## Events
+
+```solidity
+event Deposit(bytes32 indexed commitment, uint256 leafIndex, uint256 amount, uint256 assetId, uint256 timestamp);
+event Unshield(bytes32 indexed nullifierHash, address indexed recipient, uint256 amount, uint256 assetId, uint256 fee);
+event PrivateTransfer(bytes32 indexed nullifierHash, bytes32 indexed newCommitment, uint256 timestamp);
+```
+
+## Network Deployment
+
+| Network | Contract Address                             | Deploy Block |
+|---------|----------------------------------------------|-------------|
+| Base    | `0x278652aA8383cBa29b68165926d0534e52BcD368` | 42230487    |

--- a/specs/schemes/zk-relay/scheme_zk_relay_evm.md
+++ b/specs/schemes/zk-relay/scheme_zk_relay_evm.md
@@ -90,6 +90,117 @@ event Unshield(bytes32 indexed nullifierHash, address indexed recipient, uint256
 event PrivateTransfer(bytes32 indexed nullifierHash, bytes32 indexed newCommitment, uint256 timestamp);
 ```
 
+## `PaymentRequirements` Structure
+
+When a resource server requires payment via `zk-relay`, it returns a `402 Payment Required` response with the following `PaymentRequirements`:
+
+```json
+{
+  "scheme": "zk-relay",
+  "network": "eip155:8453",
+  "amount": "1000000000000000",
+  "asset": "0x0000000000000000000000000000000000000000",
+  "payTo": "0x6Bf5713D59066A4a55CdAD90f7E007d5209aDaE7",
+  "maxTimeoutSeconds": 120,
+  "extra": {
+    "contract": "0x278652aA8383cBa29b68165926d0534e52BcD368",
+    "facilitatorUrl": "https://ceaser.org",
+    "denominations": ["1000000000000000", "10000000000000000", "100000000000000000", "1000000000000000000", "10000000000000000000"],
+    "proofSystem": "ultrahonk",
+    "merkleTreeDepth": 24,
+    "assetId": 0
+  }
+}
+```
+
+Field descriptions for `extra`:
+
+| Field             | Type       | Description                                         |
+|-------------------|------------|-----------------------------------------------------|
+| `contract`        | `address`  | Address of the zkWrapper smart contract              |
+| `facilitatorUrl`  | `string`   | Base URL of the facilitator that will relay the proof |
+| `denominations`   | `string[]` | Accepted note denominations in wei                   |
+| `proofSystem`     | `string`   | Proof system identifier (`ultrahonk`)                |
+| `merkleTreeDepth` | `number`   | Depth of the Poseidon Merkle tree (24)               |
+| `assetId`         | `number`   | Asset identifier (0 for native ETH)                  |
+
+## `PaymentPayload` Structure
+
+The client generates a ZK proof off-chain and sends it to the facilitator:
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "zk-relay",
+    "network": "eip155:8453",
+    "amount": "1000000000000000",
+    "asset": "0x0000000000000000000000000000000000000000",
+    "payTo": "0x6Bf5713D59066A4a55CdAD90f7E007d5209aDaE7",
+    "maxTimeoutSeconds": 120,
+    "extra": {
+      "contract": "0x278652aA8383cBa29b68165926d0534e52BcD368",
+      "facilitatorUrl": "https://ceaser.org"
+    }
+  },
+  "payload": {
+    "proof": "0x1a2b3c...",
+    "nullifierHash": "0x4d5e6f...",
+    "amount": "1000000000000000",
+    "assetId": 0,
+    "recipient": "0x6Bf5713D59066A4a55CdAD90f7E007d5209aDaE7",
+    "root": "0x7a8b9c..."
+  }
+}
+```
+
+Field descriptions for `payload`:
+
+| Field           | Type      | Description                                    |
+|-----------------|-----------|------------------------------------------------|
+| `proof`         | `bytes`   | UltraHonk proof as 0x-prefixed hex string       |
+| `nullifierHash` | `bytes32` | Poseidon hash of (nullifier, leafIndex)          |
+| `amount`        | `string`  | Withdrawal amount in wei                         |
+| `assetId`       | `number`  | Asset identifier (0 for native ETH)              |
+| `recipient`     | `address` | Destination address for withdrawn funds          |
+| `root`          | `bytes32` | Merkle tree root the proof was generated against |
+
+## Verification Logic
+
+The facilitator MUST verify the following before submitting the proof on-chain:
+
+1. **Proof format**: The `proof` field MUST be a valid hex-encoded byte string with length consistent with an UltraHonk proof.
+2. **Root recognition**: The `root` MUST be recognized by the smart contract. The facilitator SHOULD query the contract's `isKnownRoot(root)` function or check against its local indexed Merkle tree.
+3. **Nullifier uniqueness**: The `nullifierHash` MUST NOT have been previously spent. The facilitator SHOULD query the contract's `nullifierHashes(nullifierHash)` mapping.
+4. **Amount validity**: The `amount` MUST correspond to a valid fixed denomination accepted by the contract.
+5. **Recipient address**: The `recipient` MUST be a valid Ethereum address (non-zero, checksummed).
+6. **Rate limit check**: The facilitator SHOULD verify the withdrawal does not exceed per-address rate limits (50 ETH/hour).
+7. **Gas simulation**: The facilitator SHOULD simulate the `unshield()` call via `eth_call` to confirm it would not revert before broadcasting.
+
+If any check fails, the facilitator MUST return an error and MUST NOT submit the transaction on-chain.
+
+## Settlement Logic
+
+Settlement is performed by the facilitator calling the `unshield()` function on the zkWrapper contract:
+
+1. The facilitator constructs a transaction calling `unshield(proof, nullifierHash, amount, assetId, recipient, root)` on the contract.
+2. The facilitator signs and broadcasts the transaction using its whitelisted relayer address.
+3. The contract verifies the ZK proof on-chain via the UltraHonk Solidity verifier.
+4. If verification passes, the contract marks the nullifier as spent, calculates the protocol fee (25 basis points), sends `amount - fee` to the recipient, and sends the fee to the treasury.
+5. The facilitator returns the transaction hash to the client.
+
+**Settlement Response:**
+
+```json
+{
+  "success": true,
+  "transaction": "0xabc123...",
+  "network": "eip155:8453"
+}
+```
+
+If settlement fails (proof invalid, nullifier already spent, insufficient contract balance), the facilitator MUST NOT retry with the same parameters. The facilitator SHOULD return a descriptive error.
+
 ## Network Deployment
 
 | Network | Contract Address                             | Deploy Block |

--- a/typescript/site/app/ecosystem/partners-data/ceaser/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/ceaser/metadata.json
@@ -1,0 +1,17 @@
+{
+  "name": "Ceaser Privacy Protocol",
+  "description": "Privacy-preserving ETH wrapper on Base using Noir/UltraHonk ZK proofs. Shield, transfer, and unshield ETH without revealing the depositor's address. Implements the zk-relay scheme with gasless withdrawals via a facilitator relay.",
+  "logoUrl": "/logos/ceaser.png",
+  "websiteUrl": "https://ceaser.org",
+  "category": "Facilitators",
+  "facilitator": {
+    "baseUrl": "https://ceaser.org",
+    "networks": ["base"],
+    "addresses": {
+      "base": ["0x214999174d5925aB5744e176f433e1585705Ad4d"]
+    },
+    "schemes": ["zk-relay"],
+    "assets": ["ETH"],
+    "supports": { "verify": true, "settle": true, "supported": true, "status": true }
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces the `zk-relay` scheme specification -- a new payment scheme for privacy-preserving asset transfers using zero-knowledge proofs. Unlike the `exact` scheme where transfers are visible on-chain, `zk-relay` breaks the link between depositor and withdrawer using shielded notes and ZK proofs.

### How it works

1. A client shields (deposits) ETH into a smart contract, receiving a private note
2. To withdraw, the client generates a ZK proof in the browser (Noir + UltraHonk via WASM)
3. The proof is sent to a facilitator, which relays it on-chain
4. The smart contract verifies the proof, nullifies the note, and sends funds to the recipient minus a protocol fee
5. No link exists between the deposit and withdrawal addresses

### Key properties

- **No trusted setup**: UltraHonk proof system (transparent setup)
- **Client-side proving**: Proofs generated entirely in the browser (~3s with multi-threading)
- **Gasless withdrawals**: Facilitator pays gas, deducts 0.25% protocol fee
- **Fixed denominations**: Prevents amount-based correlation (0.001 to 10 ETH)
- **Double-spend prevention**: Nullifier-based, enforced on-chain

### Files added

| File | Description |
|------|-------------|
| `specs/schemes/zk-relay/scheme_zk_relay.md` | Scheme overview, flow diagram, proof system, security requirements, comparison with `exact` |
| `specs/schemes/zk-relay/scheme_zk_relay_evm.md` | EVM implementation: contract interface, proof encoding, public inputs, x402 PaymentRequirements/PaymentPayload structures, verification and settlement logic |
| `specs/schemes/zk-relay/facilitator_api.md` | Facilitator API reference with standard x402 endpoints and scheme-specific Merkle tree/indexer endpoints |
| `specs/schemes/zk-relay/client_proving.md` | Client-side proof generation guide: WASM pipeline, dependencies, browser requirements (SharedArrayBuffer, CRS), circuit sizes |
| `ecosystem/ceaser/metadata.json` | Ceaser Privacy Protocol ecosystem partner entry |

### Reference implementation

- **Protocol**: [Ceaser Privacy Protocol](https://ceaser.org)
- **Contract**: `0x278652aA8383cBa29b68165926d0534e52BcD368` (Base mainnet, block 42230487)
- **Facilitator**: `https://ceaser.org` (live, supporting verify/settle/status/supported)
- **Source**: [github.com/Zyra-V21/ceaaser-privacy](https://github.com/Zyra-V21/ceaaser-privacy)

### Network support

| Network | Chain ID | Status |
|---------|----------|--------|
| Base | eip155:8453 | Live |