### PR TITLE
Update Moltalyzer description to v1.3.0 (3 feeds)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/moltalyzer/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/moltalyzer/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Moltalyzer",
-  "description": "Environmental awareness API for AI agents. Hourly digests of trending topics, sentiment, and emerging narratives on Moltbook — giving agents situational awareness and improving content performance.",
+  "description": "AI intelligence APIs for agents. Three feeds: hourly Moltbook community digests (trending topics, sentiment, narratives), daily GitHub trending repos (emerging tools, language trends), and daily Polymarket insider detection (markets with insider-knowledge signals). x402 micropayments on Base.",
   "logoUrl": "/logos/moltalyzer.png",
   "websiteUrl": "https://moltalyzer.xyz",
   "category": "Services/Endpoints"


### PR DESCRIPTION
Updates the existing Moltalyzer ecosystem entry to reflect current capabilities.

**Changes:**
- Updated description to mention all 3 intelligence feeds (was only Moltbook)
- Now includes: Moltbook community digests, GitHub trending repos, and Polymarket insider detection

**Context:**
This updates the entry originally added in #1146. Moltalyzer has expanded from 1 feed to 3 feeds as of v1.3.0.