### PR TITLE
chore: apply ruff format and lint fixes to Python codebase

### DIFF
--- a/.github/workflows/check_python.yml
+++ b/.github/workflows/check_python.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Lint
         run: uvx ruff check
+
+      - name: Check formatting
+        run: uvx ruff format --check


### PR DESCRIPTION
## Description

Apply `uvx ruff format` and `uvx ruff check --fix` across the entire Python SDK to bring all files in line with the project's formatting and linting standards.

No functional changes — this is purely a formatting and lint cleanup pass covering 68 Python files.

## Tests

- `uv run pytest` from `python/x402/` — **645 passed**, 32 skipped, 0 failures
- `pnpm test` from `typescript/` — all 35 test tasks passed (no TypeScript changes, run for confidence)
- `make test` from `go/` — all packages pass (no Go changes, run for confidence)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip) — N/A, no user-facing changes