### PR TITLE
Add Apollo Intelligence Network to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/apollo-intelligence/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/apollo-intelligence/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Apollo Intelligence Network",
+  "description": "27 x402-gated API endpoints delivering curated intelligence feeds, DeFi data, OSINT tools, crypto prices, real-time X/Twitter search, and residential proxy infrastructure for AI agents. Pay per request with USDC on Base — no API keys, no subscriptions.",
+  "logoUrl": "/logos/apollo-intelligence.svg",
+  "websiteUrl": "https://apolloai.team",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/apollo-intelligence.svg
+++ b/typescript/site/public/logos/apollo-intelligence.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="glow" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ff6b35;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#ff8c5a;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="200" height="200" rx="32" fill="#0a0a0a"/>
+  <circle cx="100" cy="72" r="32" fill="url(#glow)" opacity="0.9"/>
+  <circle cx="100" cy="72" r="20" fill="#0a0a0a"/>
+  <circle cx="100" cy="72" r="12" fill="url(#glow)" opacity="0.7"/>
+  <rect x="72" y="110" width="12" height="52" rx="4" fill="#ff6b35" opacity="0.85"/>
+  <rect x="94" y="104" width="12" height="58" rx="4" fill="#ff6b35"/>
+  <rect x="116" y="110" width="12" height="52" rx="4" fill="#ff6b35" opacity="0.85"/>
+  <rect x="64" y="156" width="72" height="8" rx="4" fill="#ff6b35" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
## Adding Apollo Intelligence Network

**Category:** Services/Endpoints

**Description:** Apollo Intelligence Network provides 27 x402-gated API endpoints on Base mainnet, including:

- **Intelligence Feeds** — Agent intel, pain points, agentic trends, keyword opportunities, micro-SaaS ideas, GitHub trending, Product Hunt launches
- **Crypto & DeFi** — Live prices, trending coins, DeFi yields (18K+ pools), protocol data (7K+ protocols)
- **OSINT** — IP threat intelligence (4-source), domain intel (DNS+SSL+geo+threats)
- **Search & Scraping** — Real-time X/Twitter search, web scraping with 190+ country residential proxies
- **Utility** — FX rates (30+ currencies), weekly digest, value bundles

All endpoints use x402 v2 with Bazaar SDK extensions for machine-readable discovery. Pay per request with USDC on Base — no API keys or subscriptions needed.

**Links:**
- Website: https://apolloai.team
- Discovery: https://apolloai.team/.well-known/x402
- MCP Server: https://www.npmjs.com/package/@apollo_ai/mcp-proxy (26 tools, 530+ installs)
- x402scan: https://www.x402scan.com/server/3e61cb80-3b13-48cc-be79-db9dd85f57a4

**Checklist:**
- [x] Working mainnet integration (Base, eip155:8453)
- [x] API documentation (discovery doc + MCP)
- [x] x402 v2 Bazaar extensions on all endpoints
- [x] Logo and metadata added