### PR TITLE
evm: verify smart wallet signatures via eip-1271

### DIFF
--- a/typescript/packages/mechanisms/evm/README.md
+++ b/typescript/packages/mechanisms/evm/README.md
@@ -159,6 +159,17 @@ Supports any ERC-3009 compatible token:
 - EURC
 - Any token implementing `transferWithAuthorization()`
 
+## Smart Wallet Signatures
+
+Facilitator integrations often wire `verifyTypedData` from their own signer stack. Some stacks only do
+EOA-style ECDSA recovery, which can reject valid ERC-1271 contract wallet signatures.
+
+To keep verification aligned with on-chain settlement, x402 falls back to explicit ERC-1271
+`isValidSignature` checks when typed-data verification fails for a deployed contract wallet.
+
+For undeployed ERC-4337 wallets, x402 only accepts EIP-6492 signatures when
+`deployERC4337WithEIP6492` is enabled.
+
 ## Development
 
 ```bash

--- a/typescript/packages/mechanisms/evm/src/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/constants.ts
@@ -83,6 +83,22 @@ export const eip3009ABI = [
   },
 ] as const;
 
+// EIP-1271 magic value returned by isValidSignature(bytes32,bytes) on success.
+export const EIP1271_MAGIC_VALUE = "0x1626ba7e" as const;
+
+export const eip1271ABI = [
+  {
+    type: "function",
+    name: "isValidSignature",
+    inputs: [
+      { name: "hash", type: "bytes32" },
+      { name: "signature", type: "bytes" },
+    ],
+    outputs: [{ name: "magicValue", type: "bytes4" }],
+    stateMutability: "view",
+  },
+] as const;
+
 /**
  * EIP-2612 Permit EIP-712 types for signing token.permit().
  */

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -115,6 +115,8 @@ export async function verifyEIP3009(
     isValidSignature = false;
   }
 
+  // Some facilitator signers only do EOA recovery in verifyTypedData.
+  // If that path fails, verify deployed contract wallets with ERC-1271.
   if (!isValidSignature) {
     let bytecode: `0x${string}` | undefined;
     try {

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -33,6 +33,7 @@ export interface EIP3009FacilitatorConfig {
  * @param payload - The payment payload to verify
  * @param requirements - The payment requirements
  * @param eip3009Payload - The EIP-3009 specific payload
+ * @param config - Facilitator configuration
  * @returns Promise resolving to verification response
  */
 export async function verifyEIP3009(
@@ -56,7 +57,9 @@ export async function verifyEIP3009(
   }
 
   // Get chain configuration
-  if (!requirements.extra?.name || !requirements.extra?.version) {
+  const name = requirements.extra?.name;
+  const version = requirements.extra?.version;
+  if (typeof name !== "string" || typeof version !== "string") {
     return {
       isValid: false,
       invalidReason: "missing_eip712_domain",
@@ -64,7 +67,6 @@ export async function verifyEIP3009(
     };
   }
 
-  const { name, version } = requirements.extra;
   const erc20Address = getAddress(requirements.asset);
 
   // Verify network matches

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -4,8 +4,15 @@ import {
   SettleResponse,
   VerifyResponse,
 } from "@x402/core/types";
-import { getAddress, Hex, isAddressEqual, parseErc6492Signature, parseSignature } from "viem";
-import { authorizationTypes, eip3009ABI } from "../../constants";
+import {
+  getAddress,
+  hashTypedData,
+  Hex,
+  isAddressEqual,
+  parseErc6492Signature,
+  parseSignature,
+} from "viem";
+import { authorizationTypes, EIP1271_MAGIC_VALUE, eip1271ABI, eip3009ABI } from "../../constants";
 import { FacilitatorEvmSigner } from "../../signer";
 import { ExactEIP3009Payload } from "../../types";
 
@@ -33,6 +40,9 @@ export async function verifyEIP3009(
   payload: PaymentPayload,
   requirements: PaymentRequirements,
   eip3009Payload: ExactEIP3009Payload,
+  config: Pick<EIP3009FacilitatorConfig, "deployERC4337WithEIP6492"> = {
+    deployERC4337WithEIP6492: false,
+  },
 ): Promise<VerifyResponse> {
   const payer = eip3009Payload.authorization.from;
 
@@ -86,51 +96,50 @@ export async function verifyEIP3009(
     },
   };
 
-  // Verify signature
+  const signedPayload = eip3009Payload.signature!;
+  const erc6492Data = parseErc6492Signature(signedPayload);
+  const signatureLength = erc6492Data.signature.startsWith("0x")
+    ? erc6492Data.signature.length - 2
+    : erc6492Data.signature.length;
+
+  let isValidSignature = false;
   try {
-    const recoveredAddress = await signer.verifyTypedData({
-      address: eip3009Payload.authorization.from,
+    isValidSignature = await signer.verifyTypedData({
+      address: payer,
       ...permitTypedData,
-      signature: eip3009Payload.signature!,
+      signature: signedPayload,
     });
-
-    if (!recoveredAddress) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_signature",
-        payer,
-      };
-    }
   } catch {
-    // Signature verification failed - could be an undeployed smart wallet
-    // Check if smart wallet is deployed
-    const signature = eip3009Payload.signature!;
-    const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
-    const isSmartWallet = signatureLength > 130; // 65 bytes = 130 hex chars for EOA
+    isValidSignature = false;
+  }
 
-    if (isSmartWallet) {
-      const payerAddress = eip3009Payload.authorization.from;
-      const bytecode = await signer.getCode({ address: payerAddress });
+  if (!isValidSignature) {
+    let bytecode: `0x${string}` | undefined;
+    try {
+      bytecode = await signer.getCode({ address: payer });
+    } catch {
+      bytecode = undefined;
+    }
 
-      if (!bytecode || bytecode === "0x") {
-        // Wallet is not deployed. Check if it's EIP-6492 with deployment info.
-        const erc6492Data = parseErc6492Signature(signature);
-        const hasDeploymentInfo =
-          erc6492Data.address &&
-          erc6492Data.data &&
-          !isAddressEqual(erc6492Data.address, "0x0000000000000000000000000000000000000000");
+    if (bytecode && bytecode !== "0x") {
+      const digest = hashTypedData(permitTypedData);
 
-        if (!hasDeploymentInfo) {
-          // Non-EIP-6492 undeployed smart wallet - will always fail at settlement
+      try {
+        const magicValue = (await signer.readContract({
+          address: payer,
+          abi: eip1271ABI,
+          functionName: "isValidSignature",
+          args: [digest, erc6492Data.signature],
+        })) as unknown;
+
+        if (typeof magicValue !== "string" || magicValue.toLowerCase() !== EIP1271_MAGIC_VALUE) {
           return {
             isValid: false,
-            invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
-            payer: payerAddress,
+            invalidReason: "invalid_exact_evm_payload_signature",
+            payer,
           };
         }
-        // EIP-6492 signature with deployment info - allow through
-      } else {
-        // Wallet is deployed but signature still failed - invalid signature
+      } catch {
         return {
           isValid: false,
           invalidReason: "invalid_exact_evm_payload_signature",
@@ -138,12 +147,34 @@ export async function verifyEIP3009(
         };
       }
     } else {
-      // EOA signature failed
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_evm_payload_signature",
-        payer,
-      };
+      const hasDeploymentInfo =
+        erc6492Data.address &&
+        erc6492Data.data &&
+        !isAddressEqual(erc6492Data.address, "0x0000000000000000000000000000000000000000");
+
+      if (hasDeploymentInfo) {
+        if (config.deployERC4337WithEIP6492) {
+          // Facilitators with sponsored deployment support can handle this in settle().
+        } else {
+          return {
+            isValid: false,
+            invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
+            payer,
+          };
+        }
+      } else if (signatureLength > 130) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
+          payer,
+        };
+      } else {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_evm_payload_signature",
+          payer,
+        };
+      }
     }
   }
 
@@ -232,7 +263,7 @@ export async function settleEIP3009(
   const payer = eip3009Payload.authorization.from;
 
   // Re-verify before settling
-  const valid = await verifyEIP3009(signer, payload, requirements, eip3009Payload);
+  const valid = await verifyEIP3009(signer, payload, requirements, eip3009Payload, config);
   if (!valid.isValid) {
     return {
       success: false,
@@ -270,12 +301,16 @@ export async function settleEIP3009(
       }
     }
 
-    // Determine if this is an ECDSA signature (EOA) or smart wallet signature
-    const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
-    const isECDSA = signatureLength === 130;
+    let bytecode: `0x${string}` | undefined;
+    try {
+      bytecode = await signer.getCode({ address: payer });
+    } catch {
+      bytecode = undefined;
+    }
+    const isContractWallet = Boolean(bytecode && bytecode !== "0x");
 
     let tx: Hex;
-    if (isECDSA) {
+    if (!isContractWallet) {
       // For EOA wallets, parse signature into v, r, s and use that overload
       const parsedSig = parseSignature(signature);
 
@@ -296,7 +331,7 @@ export async function settleEIP3009(
         ],
       });
     } else {
-      // For smart wallets, use the bytes signature overload
+      // For smart wallets, use the bytes signature overload regardless of signature length.
       tx = await signer.writeContract({
         address: getAddress(requirements.asset),
         abi: eip3009ABI,

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -182,6 +182,8 @@ export async function verifyPermit2(
     isValidSignature = false;
   }
 
+  // Some facilitator signers only do EOA recovery in verifyTypedData.
+  // If that path fails, verify deployed contract wallets with ERC-1271.
   if (!isValidSignature) {
     let bytecode: `0x${string}` | undefined;
     try {

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -9,9 +9,11 @@ import {
   validateEip2612GasSponsoringInfo,
 } from "@x402/extensions";
 import type { Eip2612GasSponsoringInfo } from "@x402/extensions";
-import { getAddress } from "viem";
+import { getAddress, hashTypedData, parseErc6492Signature } from "viem";
 import {
   eip3009ABI,
+  EIP1271_MAGIC_VALUE,
+  eip1271ABI,
   PERMIT2_ADDRESS,
   permit2WitnessTypes,
   x402ExactPermit2ProxyABI,
@@ -166,26 +168,59 @@ export async function verifyPermit2(
   };
 
   // Verify signature
+  const signedPayload = permit2Payload.signature;
+  const erc6492Data = parseErc6492Signature(signedPayload);
+
+  let isValidSignature = false;
   try {
-    const isValid = await signer.verifyTypedData({
+    isValidSignature = await signer.verifyTypedData({
       address: payer,
       ...permit2TypedData,
-      signature: permit2Payload.signature,
+      signature: signedPayload,
     });
+  } catch {
+    isValidSignature = false;
+  }
 
-    if (!isValid) {
+  if (!isValidSignature) {
+    let bytecode: `0x${string}` | undefined;
+    try {
+      bytecode = await signer.getCode({ address: payer });
+    } catch {
+      bytecode = undefined;
+    }
+
+    if (bytecode && bytecode !== "0x") {
+      const digest = hashTypedData(permit2TypedData);
+      try {
+        const magicValue = (await signer.readContract({
+          address: payer,
+          abi: eip1271ABI,
+          functionName: "isValidSignature",
+          args: [digest, erc6492Data.signature],
+        })) as unknown;
+
+        if (typeof magicValue !== "string" || magicValue.toLowerCase() !== EIP1271_MAGIC_VALUE) {
+          return {
+            isValid: false,
+            invalidReason: "invalid_permit2_signature",
+            payer,
+          };
+        }
+      } catch {
+        return {
+          isValid: false,
+          invalidReason: "invalid_permit2_signature",
+          payer,
+        };
+      }
+    } else {
       return {
         isValid: false,
         invalidReason: "invalid_permit2_signature",
         payer,
       };
     }
-  } catch {
-    return {
-      isValid: false,
-      invalidReason: "invalid_permit2_signature",
-      payer,
-    };
   }
 
   // Check Permit2 allowance

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
@@ -87,7 +87,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
 
     // Type-narrowed to EIP-3009 payload
     const eip3009Payload: ExactEIP3009Payload = rawPayload;
-    return verifyEIP3009(this.signer, payload, requirements, eip3009Payload);
+    return verifyEIP3009(this.signer, payload, requirements, eip3009Payload, this.config);
   }
 
   /**

--- a/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
@@ -117,7 +117,9 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
       };
     }
 
-    if (!requirements.extra?.name || !requirements.extra?.version) {
+    const name = requirements.extra?.name;
+    const version = requirements.extra?.version;
+    if (typeof name !== "string" || typeof version !== "string") {
       return {
         isValid: false,
         invalidReason: "missing_eip712_domain",
@@ -125,7 +127,6 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
       };
     }
 
-    const { name, version } = requirements.extra;
     const erc20Address = getAddress(requirements.asset);
 
     // Verify network matches

--- a/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
@@ -7,8 +7,20 @@ import {
   VerifyResponse,
 } from "@x402/core/types";
 import { PaymentRequirementsV1 } from "@x402/core/types/v1";
-import { getAddress, Hex, isAddressEqual, parseErc6492Signature, parseSignature } from "viem";
-import { authorizationTypes, eip3009ABI } from "../../../constants";
+import {
+  getAddress,
+  hashTypedData,
+  Hex,
+  isAddressEqual,
+  parseErc6492Signature,
+  parseSignature,
+} from "viem";
+import {
+  authorizationTypes,
+  EIP1271_MAGIC_VALUE,
+  eip1271ABI,
+  eip3009ABI,
+} from "../../../constants";
 import { FacilitatorEvmSigner } from "../../../signer";
 import { ExactEvmPayloadV1 } from "../../../types";
 import { getEvmChainId } from "../../../utils";
@@ -146,67 +158,86 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
     };
 
     // Verify signature
+    const signedPayload = exactEvmPayload.signature!;
+    const erc6492Data = parseErc6492Signature(signedPayload);
+    const signatureLength = erc6492Data.signature.startsWith("0x")
+      ? erc6492Data.signature.length - 2
+      : erc6492Data.signature.length;
+
+    let isValidSignature = false;
     try {
-      const recoveredAddress = await this.signer.verifyTypedData({
+      isValidSignature = await this.signer.verifyTypedData({
         address: exactEvmPayload.authorization.from,
         ...permitTypedData,
-        signature: exactEvmPayload.signature!,
+        signature: signedPayload,
       });
-
-      if (!recoveredAddress) {
-        return {
-          isValid: false,
-          invalidReason: "invalid_exact_evm_payload_signature",
-          payer: exactEvmPayload.authorization.from,
-        };
-      }
     } catch {
-      // Signature verification failed - could be an undeployed smart wallet
-      // Check if smart wallet is deployed
-      const signature = exactEvmPayload.signature!;
-      const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
-      const isSmartWallet = signatureLength > 130; // 65 bytes = 130 hex chars for EOA
+      isValidSignature = false;
+    }
 
-      if (isSmartWallet) {
-        const payerAddress = exactEvmPayload.authorization.from;
-        const bytecode = await this.signer.getCode({ address: payerAddress });
+    if (!isValidSignature) {
+      const payerAddress = exactEvmPayload.authorization.from;
+      let bytecode: `0x${string}` | undefined;
+      try {
+        bytecode = await this.signer.getCode({ address: payerAddress });
+      } catch {
+        bytecode = undefined;
+      }
 
-        if (!bytecode || bytecode === "0x") {
-          // Wallet is not deployed. Check if it's EIP-6492 with deployment info.
-          // EIP-6492 signatures contain factory address and calldata needed for deployment.
-          // Non-EIP-6492 undeployed wallets cannot succeed (no way to deploy them).
-          const erc6492Data = parseErc6492Signature(signature);
-          const hasDeploymentInfo =
-            erc6492Data.address &&
-            erc6492Data.data &&
-            !isAddressEqual(erc6492Data.address, "0x0000000000000000000000000000000000000000");
+      if (bytecode && bytecode !== "0x") {
+        const digest = hashTypedData(permitTypedData);
 
-          if (!hasDeploymentInfo) {
-            // Non-EIP-6492 undeployed smart wallet - will always fail at settlement
-            // since EIP-3009 requires on-chain EIP-1271 validation
+        try {
+          const magicValue = (await this.signer.readContract({
+            address: payerAddress,
+            abi: eip1271ABI,
+            functionName: "isValidSignature",
+            args: [digest, erc6492Data.signature],
+          })) as unknown;
+
+          if (typeof magicValue !== "string" || magicValue.toLowerCase() !== EIP1271_MAGIC_VALUE) {
+            return {
+              isValid: false,
+              invalidReason: "invalid_exact_evm_payload_signature",
+              payer: payerAddress,
+            };
+          }
+        } catch {
+          return {
+            isValid: false,
+            invalidReason: "invalid_exact_evm_payload_signature",
+            payer: payerAddress,
+          };
+        }
+      } else {
+        const hasDeploymentInfo =
+          erc6492Data.address &&
+          erc6492Data.data &&
+          !isAddressEqual(erc6492Data.address, "0x0000000000000000000000000000000000000000");
+
+        if (hasDeploymentInfo) {
+          if (this.config.deployERC4337WithEIP6492) {
+            // Facilitators with sponsored deployment support can handle this in settle().
+          } else {
             return {
               isValid: false,
               invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
               payer: payerAddress,
             };
           }
-          // EIP-6492 signature with deployment info - allow through
-          // Facilitators with sponsored deployment support can handle this in settle()
+        } else if (signatureLength > 130) {
+          return {
+            isValid: false,
+            invalidReason: "invalid_exact_evm_payload_undeployed_smart_wallet",
+            payer: payerAddress,
+          };
         } else {
-          // Wallet is deployed but signature still failed - invalid signature
           return {
             isValid: false,
             invalidReason: "invalid_exact_evm_payload_signature",
-            payer: exactEvmPayload.authorization.from,
+            payer: payerAddress,
           };
         }
-      } else {
-        // EOA signature failed
-        return {
-          isValid: false,
-          invalidReason: "invalid_exact_evm_payload_signature",
-          payer: exactEvmPayload.authorization.from,
-        };
       }
     }
 
@@ -342,13 +373,16 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
         }
       }
 
-      // Determine if this is an ECDSA signature (EOA) or smart wallet signature
-      // ECDSA signatures are exactly 65 bytes (130 hex chars without 0x)
-      const signatureLength = signature.startsWith("0x") ? signature.length - 2 : signature.length;
-      const isECDSA = signatureLength === 130;
+      let bytecode: `0x${string}` | undefined;
+      try {
+        bytecode = await this.signer.getCode({ address: exactEvmPayload.authorization.from });
+      } catch {
+        bytecode = undefined;
+      }
+      const isContractWallet = Boolean(bytecode && bytecode !== "0x");
 
       let tx: Hex;
-      if (isECDSA) {
+      if (!isContractWallet) {
         // For EOA wallets, parse signature into v, r, s and use that overload
         const parsedSig = parseSignature(signature);
 
@@ -369,8 +403,7 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
           ],
         });
       } else {
-        // For smart wallets, use the bytes signature overload
-        // The signature contains WebAuthn/P256 or other ERC-1271 compatible signature data
+        // For smart wallets, use the bytes signature overload regardless of signature length.
         tx = await this.signer.writeContract({
           address: getAddress(requirements.asset),
           abi: eip3009ABI,

--- a/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
@@ -176,6 +176,8 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
       isValidSignature = false;
     }
 
+    // Some facilitator signers only do EOA recovery in verifyTypedData.
+    // If that path fails, verify deployed contract wallets with ERC-1271.
     if (!isValidSignature) {
       const payerAddress = exactEvmPayload.authorization.from;
       let bytecode: `0x${string}` | undefined;

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -37,7 +37,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: {
           name: "USD Coin",
@@ -59,7 +59,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { name: "USD Coin", version: "2" },
       };
@@ -80,7 +80,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { name: "USD Coin", version: "2" },
       };
@@ -101,7 +101,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 600, // 10 minutes
         extra: { name: "USD Coin", version: "2" },
       };
@@ -122,7 +122,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { name: "USD Coin", version: "2" },
       };
@@ -133,7 +133,7 @@ describe("ExactEvmScheme (Client)", () => {
     });
 
     it("should use requirements.payTo as to", async () => {
-      const payToAddress = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0";
+      const payToAddress = "0x742d35cc6634c0532925a3b844bc9e7595f0beb0";
 
       const requirements: PaymentRequirements = {
         scheme: "exact",
@@ -156,7 +156,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "2500000", // 2.5 USDC
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { name: "USD Coin", version: "2" },
       };
@@ -172,7 +172,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { name: "USD Coin", version: "2" },
       };
@@ -190,7 +190,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:1", // Ethereum mainnet
         amount: "1000000",
         asset: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { name: "USD Coin", version: "2" },
       };
@@ -207,7 +207,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { name: "USD Coin", version: "2" },
       };
@@ -229,7 +229,7 @@ describe("ExactEvmScheme (Client)", () => {
           network: "eip155:8453",
           amount: "1000000",
           asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
           maxTimeoutSeconds: 300,
           extra: { name: "USD Coin", version: "2" },
         };
@@ -247,7 +247,7 @@ describe("ExactEvmScheme (Client)", () => {
           network: "eip155:8453",
           amount: "1000000",
           asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
           maxTimeoutSeconds: 300,
           extra: { name: "USD Coin", version: "2", assetTransferMethod: "eip3009" },
         };
@@ -264,7 +264,7 @@ describe("ExactEvmScheme (Client)", () => {
           network: "eip155:8453",
           amount: "1000000",
           asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-          payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+          payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
           maxTimeoutSeconds: 300,
           extra: { name: "USD Coin", version: "2", assetTransferMethod: "permit2" },
         };
@@ -285,7 +285,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { assetTransferMethod: "permit2" },
       };
@@ -306,7 +306,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { assetTransferMethod: "permit2" },
       };
@@ -318,7 +318,7 @@ describe("ExactEvmScheme (Client)", () => {
     });
 
     it("should set witness.to to payTo address", async () => {
-      const payToAddress = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0";
+      const payToAddress = "0x742d35cc6634c0532925a3b844bc9e7595f0beb0";
       const requirements: PaymentRequirements = {
         scheme: "exact",
         network: "eip155:8453",
@@ -343,7 +343,7 @@ describe("ExactEvmScheme (Client)", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { assetTransferMethod: "permit2" },
       };
@@ -568,7 +568,7 @@ describe("Permit2 Approval Flow", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: tokenAddress,
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { assetTransferMethod: "permit2" },
       };
@@ -604,7 +604,7 @@ describe("Permit2 Approval Flow", () => {
         network: "eip155:8453",
         amount: "1000000",
         asset: tokenAddress,
-        payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+        payTo: "0x742d35cc6634c0532925a3b844bc9e7595f0beb0",
         maxTimeoutSeconds: 300,
         extra: { assetTransferMethod: "permit2" },
       };


### PR DESCRIPTION
### Summary

Adds EIP-1271 (EIP-712 digest + isValidSignature) fallback verification for deployed smart contract wallets in the EVM exact facilitator.

- EIP-3009 transferWithAuthorization verification now falls back to EIP-1271 when verifyTypedData fails
- Permit2 witness verification now falls back to EIP-1271 when verifyTypedData fails
- EIP-3009 settlement selects the bytes-signature overload based on onchain code presence (not signature length)
- EIP-6492 undeployed signatures are treated as valid only when deployERC4337WithEIP6492 is enabled

### Tests

- Added unit coverage for EIP-1271 verification paths (v1 + v2).
