### PR TITLE
ecosystem: add Ceaser Privacy Protocol

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/ceaser/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/ceaser/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "Ceaser Privacy Protocol",
+  "description": "Privacy-preserving ETH wrapper on Base with zero-knowledge proofs. Shield, transfer, and unshield ETH without revealing your address. x402-compatible facilitator for gasless ZK proof settlement via zk-relay scheme.",
+  "logoUrl": "/logos/ceaser.png",
+  "websiteUrl": "https://ceaser.org",
+  "category": "Facilitators",
+  "facilitator": {
+    "baseUrl": "https://ceaser.org",
+    "networks": ["base"],
+    "schemes": ["zk-relay"],
+    "assets": ["ETH"],
+    "supports": {
+      "verify": true,
+      "settle": true,
+      "supported": true,
+      "list": false
+    }
+  }
+}


### PR DESCRIPTION
Adds Ceaser Privacy Protocol as an ecosystem partner.

Privacy-preserving ETH wrapper on Base with ZK proofs. x402-compatible facilitator for gasless settlement via `zk-relay` scheme.

- **Website**: https://ceaser.org
- **Category**: Facilitators
- **Networks**: Base
- **Scheme**: zk-relay
- **Assets**: ETH

Related: https://github.com/coinbase/x402/pull/1205 (full zk-relay scheme specification)

@Must-be-Ash as requested, ecosystem submission separated from the spec PR.