### PR TITLE
svm: add agentic program signature verification (parity with EIP-1271)

### DIFF
--- a/specs/schemes/exact/scheme_exact_svm.md
+++ b/specs/schemes/exact/scheme_exact_svm.md
@@ -178,3 +178,43 @@ Implementations MAY additionally enforce simple unix-timestamp bounds via `Payme
 
 - `extra.validAfter`: unix seconds, reject if current time is earlier.
 - `extra.validBefore`: unix seconds, reject if current time is equal or later.
+
+### Example: Program-Based Payer
+
+An agentic payer program can signal verification success by setting return data to
+`x402_svm_ok_v1` and performing the payment (for example via CPI to Token/Token-2022):
+
+```rs
+use solana_program::{
+    account_info::AccountInfo,
+    entrypoint::ProgramResult,
+    program::set_return_data,
+    pubkey::Pubkey,
+};
+
+const SOLANA_MAGIC_OK: &[u8] = b"x402_svm_ok_v1";
+
+pub fn process_instruction(
+    _program_id: &Pubkey,
+    _accounts: &[AccountInfo],
+    _data: &[u8],
+) -> ProgramResult {
+    // 1) Verify whatever authorization or policy your wallet requires.
+    // 2) Transfer tokens to the recipient ATA (CPI to Token/Token-2022).
+    // 3) Signal x402 verification success:
+    set_return_data(SOLANA_MAGIC_OK);
+    Ok(())
+}
+```
+
+Facilitators enable the mode explicitly:
+
+```ts
+import { registerExactSvmScheme } from "@x402/svm/exact/facilitator";
+
+registerExactSvmScheme(facilitator, {
+  signer: svmSigner,
+  networks: "solana:*",
+  enableAgenticSVM: true,
+});
+```

--- a/specs/schemes/exact/scheme_exact_svm.md
+++ b/specs/schemes/exact/scheme_exact_svm.md
@@ -106,15 +106,18 @@ A facilitator verifying an `exact`-scheme SVM payment MUST enforce all of the fo
 
 1. Instruction layout
 
-- The decompiled transaction MUST contain 3 to 5 instructions in this order:
+- The decompiled transaction MUST contain 3 to 6 instructions in this order:
   1. Compute Budget: Set Compute Unit Limit
   2. Compute Budget: Set Compute Unit Price
   3. SPL Token or Token-2022 TransferChecked
-  4. (Optional) Lighthouse program instruction (Phantom wallet protection)
-  5. (Optional) Lighthouse program instruction (Solflare wallet protection)
+  4. (Optional) Lighthouse program instruction (Phantom wallet protection) OR Memo program instruction
+  5. (Optional) Lighthouse program instruction (Solflare wallet protection) OR Memo program instruction
+  6. (Optional) Memo program instruction
 
-- If a 4th or 5th instruction is present, the program MUST be the Lighthouse program (`L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`).
-- Phantom wallet injects 1 Lighthouse instruction; Solflare injects 2.
+- If an optional instruction is present, the program MUST be either:
+  - Lighthouse (`L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`), or
+  - Memo (`MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr`).
+- Phantom wallet injects 1 Lighthouse instruction; Solflare injects 2 Lighthouse instructions.
 - These Lighthouse instructions are wallet-injected user protection mechanisms and MUST be allowed to support these wallets.
 
 2. Fee payer (facilitator) safety
@@ -140,6 +143,38 @@ A facilitator verifying an `exact`-scheme SVM payment MUST enforce all of the fo
 
 6. Amount
 
-- The `amount` in TransferChecked MUST equal `PaymentRequirements.amount` exactly.
+- The `amount` in TransferChecked MUST be greater than or equal to `PaymentRequirements.amount`.
 
 These checks are security-critical to ensure the fee payer cannot be tricked into transferring their own funds or sponsoring unintended actions. Implementations MAY introduce stricter limits (e.g., lower compute price caps) but MUST NOT relax the above constraints.
+
+## Agentic Program Wallet Verification (Optional)
+
+Some Solana wallets are program-based (no transaction signature from the “payer” address). For facilitators that want parity with EIP-1271-style smart wallet verification on EVM, the SVM `exact` facilitator MAY support an opt-in “agentic program verification” mode.
+
+### Facilitator Config
+
+Implementations MAY support an opt-in configuration flag:
+
+```ts
+{ enableAgenticSVM: false }
+```
+
+This mode MUST default to `false` to preserve backwards compatibility.
+
+### Verification Behavior
+
+When `enableAgenticSVM` is enabled and the 3rd instruction is not a Token/Token-2022 `TransferChecked`, a facilitator MAY treat the 3rd instruction’s program id as the payer and verify it via simulation:
+
+1. The payer address MUST be an executable program account.
+2. The fully signed transaction MUST successfully simulate.
+3. The simulation MUST include `returnData` set by the payer program, and the returned bytes MUST equal `SOLANA_MAGIC_OK` (`x402_svm_ok_v1`).
+4. The payer program MUST be invoked exactly once (no re-entrancy).
+5. The fee payer’s lamports MUST be conserved (the program MUST NOT modify the fee payer’s account state during simulation).
+6. The recipient’s associated token account balance MUST increase by at least `PaymentRequirements.amount`.
+
+### Optional Timelock
+
+Implementations MAY additionally enforce simple unix-timestamp bounds via `PaymentRequirements.extra`:
+
+- `extra.validAfter`: unix seconds, reject if current time is earlier.
+- `extra.validBefore`: unix seconds, reject if current time is equal or later.

--- a/typescript/packages/mechanisms/svm/README.md
+++ b/typescript/packages/mechanisms/svm/README.md
@@ -174,6 +174,54 @@ The exact payment scheme uses SPL Token `TransferChecked` instruction with:
 - Source/destination ATAs (Associated Token Accounts)
 - Partial signing (client signs, facilitator completes and submits)
 
+## Agentic Program Wallets (Optional)
+
+Some Solana wallets and agentic flows are program-based (no traditional transaction signature from
+the payer address). The SVM Exact facilitator can optionally verify these payments via RPC
+simulation and a return-data magic value (parity concept with EIP-1271 on EVM).
+
+### Enabling On The Facilitator
+
+Via the registration helper:
+
+```ts
+import { registerExactSvmScheme } from "@x402/svm/exact/facilitator";
+
+registerExactSvmScheme(facilitator, {
+  signer: facilitatorSigner,
+  networks: "solana:*",
+  enableAgenticSVM: true,
+});
+```
+
+Or directly on the scheme:
+
+```ts
+import { ExactSvmScheme } from "@x402/svm/exact/facilitator";
+
+facilitator.register(
+  "solana:*",
+  new ExactSvmScheme(facilitatorSigner, { enableAgenticSVM: true }),
+);
+```
+
+### Optional Timelock Bounds
+
+Resource servers MAY include unix-second bounds in `PaymentRequirements.extra`:
+
+```json
+{
+  "feePayer": "EwWqGE4ZFKLofuestmU4LDdK7XM1N4ALgdZccwYugwGd",
+  "validAfter": 1700000000,
+  "validBefore": 1700003600
+}
+```
+
+### Tradeoffs
+
+Agentic verification adds an RPC `simulateTransaction` round-trip (plus a few account lookups) per
+verification, so it will be higher latency than the signature-only path.
+
 ## Development
 
 ```bash
@@ -197,4 +245,3 @@ pnpm format
 - `@x402/fetch` - HTTP wrapper with automatic payment handling
 - `@x402/evm` - EVM/Ethereum implementation
 - `@solana/web3.js` - Solana JavaScript SDK (peer dependency)
-

--- a/typescript/packages/mechanisms/svm/src/constants.ts
+++ b/typescript/packages/mechanisms/svm/src/constants.ts
@@ -8,6 +8,12 @@ export const COMPUTE_BUDGET_PROGRAM_ADDRESS = "ComputeBudget11111111111111111111
 export const MEMO_PROGRAM_ADDRESS = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
 
 /**
+ * Magic value returned by agentic program verifiers during simulation.
+ * Parity concept with EIP-1271's `isValidSignature` magic value on EVM.
+ */
+export const SOLANA_MAGIC_OK = "x402_svm_ok_v1";
+
+/**
  * Phantom/Solflare Lighthouse program address
  * Phantom and Solflare wallets inject Lighthouse instructions for user protection on mainnet transactions.
  * - Phantom adds 1 Lighthouse instruction (4th instruction)

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/agentic.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/agentic.ts
@@ -1,0 +1,266 @@
+import { getBase64Encoder, type Address } from "@solana/kit";
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import { findAssociatedTokenPda, TOKEN_2022_PROGRAM_ADDRESS } from "@solana-program/token-2022";
+import { SOLANA_MAGIC_OK } from "../../constants";
+import type { FacilitatorSvmSigner } from "../../signer";
+import { createRpcClient } from "../../utils";
+
+type SimulatedAccountInfo = {
+  lamports?: number;
+  data?: unknown;
+};
+
+type SimulateTransactionResult = {
+  value: {
+    err: unknown;
+    logs?: string[] | null;
+    returnData?: {
+      programId: string;
+      data: [string, string];
+    } | null;
+    accounts?: (SimulatedAccountInfo | null)[] | null;
+  };
+};
+
+/**
+ * Parse a bigint-like value from mixed runtime inputs (RPC responses, config, etc).
+ *
+ * @param value - Value to parse.
+ * @returns Parsed bigint or null.
+ */
+function parseBigInt(value: unknown): bigint | null {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return BigInt(Math.trunc(value));
+  if (typeof value === "string" && value.trim() !== "" && /^-?\d+$/.test(value.trim())) {
+    return BigInt(value.trim());
+  }
+  return null;
+}
+
+/**
+ * Extract token amount (smallest units) from a jsonParsed token account payload.
+ *
+ * @param data - The `value.data` field from a jsonParsed account response.
+ * @returns Token amount as bigint, or null when unavailable.
+ */
+function parseTokenAmountFromParsedAccount(data: unknown): bigint | null {
+  if (!data || typeof data !== "object") return null;
+
+  const parsed = (data as { parsed?: unknown }).parsed;
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const info = (parsed as { info?: unknown }).info;
+  if (!info || typeof info !== "object") return null;
+
+  const tokenAmount = (info as { tokenAmount?: unknown }).tokenAmount;
+  if (!tokenAmount || typeof tokenAmount !== "object") return null;
+
+  return parseBigInt((tokenAmount as { amount?: unknown }).amount);
+}
+
+/**
+ * Count how many times a program was invoked in simulation logs.
+ *
+ * @param logs - Simulation log messages.
+ * @param programId - Program id to count.
+ * @returns Number of invocations found.
+ */
+function countProgramInvocations(logs: string[] | null | undefined, programId: string): number {
+  if (!logs) return 0;
+  const needle = `Program ${programId} invoke`;
+  return logs.reduce((count, line) => (line.includes(needle) ? count + 1 : count), 0);
+}
+
+/**
+ * Validate the simulation returnData matches the expected program and magic value.
+ *
+ * @param returnData - Simulation returnData object.
+ * @param expectedProgramId - Program expected to set the returnData.
+ * @returns true when the magic value matches.
+ */
+function isMagicOk(
+  returnData: SimulateTransactionResult["value"]["returnData"] | null | undefined,
+  expectedProgramId: string,
+): boolean {
+  if (!returnData) return false;
+  if (returnData.programId !== expectedProgramId) return false;
+
+  const [data, encoding] = returnData.data;
+  if (encoding !== "base64") return false;
+
+  const decoded = getBase64Encoder().encode(data);
+  const expected = new TextEncoder().encode(SOLANA_MAGIC_OK);
+  if (decoded.length !== expected.length) return false;
+
+  for (let i = 0; i < expected.length; i += 1) {
+    if (decoded[i] !== expected[i]) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Parse optional timelock bounds from `PaymentRequirements.extra`.
+ *
+ * @param extra - The `extra` object from `PaymentRequirements`.
+ * @returns Parsed bounds, when present and numeric.
+ */
+function parseTimelock(extra: Record<string, unknown> | undefined): {
+  validAfter?: bigint;
+  validBefore?: bigint;
+} {
+  if (!extra) return {};
+
+  const validAfter = parseBigInt(extra.validAfter);
+  const validBefore = parseBigInt(extra.validBefore);
+
+  return {
+    ...(validAfter !== null ? { validAfter } : {}),
+    ...(validBefore !== null ? { validBefore } : {}),
+  };
+}
+
+export type VerifyAgenticProgramArgs = {
+  signer: FacilitatorSvmSigner;
+  network: string;
+  transaction: string;
+  feePayer: Address;
+  payerProgram: Address;
+  assetMint: Address;
+  payTo: Address;
+  minAmount: bigint;
+  extra?: Record<string, unknown>;
+};
+
+export type VerifyAgenticProgramResult =
+  | { ok: true }
+  | { ok: false; invalidReason: string; invalidMessage?: string };
+
+/**
+ * Verify an agentic program wallet payment by simulating the transaction and enforcing invariants.
+ *
+ * @param args - Agentic verification arguments.
+ * @returns Verification result.
+ */
+export async function verifyAgenticProgram(
+  args: VerifyAgenticProgramArgs,
+): Promise<VerifyAgenticProgramResult> {
+  const rpc = createRpcClient(args.network as never);
+
+  const programInfo = await rpc
+    .getAccountInfo(args.payerProgram as never, { encoding: "base64" })
+    .send();
+  if (!programInfo.value || programInfo.value.executable !== true) {
+    return { ok: false, invalidReason: "invalid_exact_svm_agentic_payer_not_program" };
+  }
+
+  const { validAfter, validBefore } = parseTimelock(args.extra);
+  if (validAfter !== undefined || validBefore !== undefined) {
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    if (validAfter !== undefined && now < validAfter) {
+      return { ok: false, invalidReason: "invalid_exact_svm_agentic_timelock_not_started" };
+    }
+    if (validBefore !== undefined && now >= validBefore) {
+      return { ok: false, invalidReason: "invalid_exact_svm_agentic_timelock_expired" };
+    }
+  }
+
+  const mintInfo = await rpc.getAccountInfo(args.assetMint as never, { encoding: "base64" }).send();
+  const tokenProgramOwner = mintInfo.value?.owner?.toString();
+  if (
+    tokenProgramOwner !== TOKEN_PROGRAM_ADDRESS.toString() &&
+    tokenProgramOwner !== TOKEN_2022_PROGRAM_ADDRESS.toString()
+  ) {
+    return { ok: false, invalidReason: "invalid_exact_svm_payload_mint_unknown_program" };
+  }
+
+  const tokenProgram =
+    tokenProgramOwner === TOKEN_PROGRAM_ADDRESS.toString()
+      ? (TOKEN_PROGRAM_ADDRESS as Address)
+      : (TOKEN_2022_PROGRAM_ADDRESS as Address);
+
+  const [expectedDestATA] = await findAssociatedTokenPda({
+    mint: args.assetMint,
+    owner: args.payTo,
+    tokenProgram,
+  });
+
+  const preDest = await rpc
+    .getAccountInfo(expectedDestATA as never, { encoding: "jsonParsed" })
+    .send();
+  const preDestAmount = preDest.value
+    ? (parseTokenAmountFromParsedAccount(preDest.value.data) ?? BigInt(0))
+    : BigInt(0);
+
+  const preFeePayer = await rpc
+    .getAccountInfo(args.feePayer as never, { encoding: "base64" })
+    .send();
+  const preFeePayerLamports = parseBigInt(preFeePayer.value?.lamports) ?? BigInt(0);
+
+  let fullySignedTransaction: string;
+  try {
+    fullySignedTransaction = await args.signer.signTransaction(
+      args.transaction,
+      args.feePayer,
+      args.network,
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, invalidReason: "transaction_signing_failed", invalidMessage: message };
+  }
+
+  const simulation = (await rpc
+    .simulateTransaction(fullySignedTransaction as never, {
+      sigVerify: true,
+      replaceRecentBlockhash: false,
+      commitment: "confirmed",
+      encoding: "base64",
+      accounts: {
+        encoding: "jsonParsed",
+        addresses: [expectedDestATA.toString(), args.feePayer.toString()],
+      },
+    })
+    .send()) as SimulateTransactionResult;
+
+  if (simulation.value.err) {
+    const errStr = JSON.stringify(simulation.value.err, (_, v) =>
+      typeof v === "bigint" ? v.toString() : v,
+    );
+    return {
+      ok: false,
+      invalidReason: "transaction_simulation_failed",
+      invalidMessage: errStr,
+    };
+  }
+
+  if (!isMagicOk(simulation.value.returnData, args.payerProgram.toString())) {
+    return { ok: false, invalidReason: "invalid_svm_agentic_signature" };
+  }
+
+  const invocations = countProgramInvocations(simulation.value.logs, args.payerProgram.toString());
+  if (invocations !== 1) {
+    return { ok: false, invalidReason: "invalid_exact_svm_agentic_reentrancy" };
+  }
+
+  const [postDestAccount, postFeePayerAccount] = simulation.value.accounts ?? [];
+  const postDestAmount = postDestAccount
+    ? (parseTokenAmountFromParsedAccount(postDestAccount.data) ?? null)
+    : null;
+  if (postDestAmount === null) {
+    return { ok: false, invalidReason: "invalid_exact_svm_agentic_missing_recipient_account" };
+  }
+
+  if (postFeePayerAccount) {
+    const postLamports = parseBigInt(postFeePayerAccount.lamports) ?? preFeePayerLamports;
+    if (postLamports !== preFeePayerLamports) {
+      return { ok: false, invalidReason: "invalid_exact_svm_agentic_lamport_conservation" };
+    }
+  }
+
+  const delta = postDestAmount - preDestAmount;
+  if (delta < args.minAmount) {
+    return { ok: false, invalidReason: "invalid_exact_svm_payload_amount_insufficient" };
+  }
+
+  return { ok: true };
+}

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/register.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/register.ts
@@ -16,6 +16,11 @@ export interface SvmFacilitatorConfig {
 
   /**
    * Enable agentic program wallet verification for SVM Exact.
+   *
+   * When enabled, the facilitator may accept program-based payers (no traditional transaction
+   * signature from the payer address) by verifying via RPC simulation + returnData magic
+   * (`SOLANA_MAGIC_OK`).
+   *
    * Defaults to off for backwards compatibility.
    */
   enableAgenticSVM?: boolean;

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/register.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/register.ts
@@ -15,6 +15,12 @@ export interface SvmFacilitatorConfig {
   signer: FacilitatorSvmSigner;
 
   /**
+   * Enable agentic program wallet verification for SVM Exact.
+   * Defaults to off for backwards compatibility.
+   */
+  enableAgenticSVM?: boolean;
+
+  /**
    * Networks to register (single network or array of networks)
    * Examples: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", ["solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"]
    */
@@ -48,10 +54,16 @@ export function registerExactSvmScheme(
   config: SvmFacilitatorConfig,
 ): x402Facilitator {
   // Register V2 scheme with specified networks
-  facilitator.register(config.networks, new ExactSvmScheme(config.signer));
+  facilitator.register(
+    config.networks,
+    new ExactSvmScheme(config.signer, { enableAgenticSVM: config.enableAgenticSVM }),
+  );
 
   // Register all V1 networks
-  facilitator.registerV1(NETWORKS as Network[], new ExactSvmSchemeV1(config.signer));
+  facilitator.registerV1(
+    NETWORKS as Network[],
+    new ExactSvmSchemeV1(config.signer, { enableAgenticSVM: config.enableAgenticSVM }),
+  );
 
   return facilitator;
 }

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -35,6 +35,15 @@ import { decodeTransactionFromPayload, getTokenPayerFromTransaction } from "../.
 import { verifyAgenticProgram, type VerifyAgenticProgramArgs } from "./agentic";
 
 export type SvmExactFacilitatorConfig = {
+  /**
+   * Enables agentic program-based payer verification on SVM (parity concept with EIP-1271).
+   *
+   * When enabled, if the transaction's 3rd instruction is not a Token/Token-2022 TransferChecked,
+   * the facilitator may treat that instruction's program id as the payer and verify via
+   * `simulateTransaction` + `SOLANA_MAGIC_OK` return data.
+   *
+   * Defaults to false.
+   */
   enableAgenticSVM?: boolean;
 };
 

--- a/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
@@ -33,6 +33,8 @@ import {
 import type { FacilitatorSvmSigner } from "../../../signer";
 import type { ExactSvmPayloadV1 } from "../../../types";
 import { decodeTransactionFromPayload, getTokenPayerFromTransaction } from "../../../utils";
+import { verifyAgenticProgram, type VerifyAgenticProgramArgs } from "../../facilitator/agentic";
+import type { SvmExactFacilitatorConfig } from "../../facilitator/scheme";
 
 /**
  * SVM facilitator implementation for the Exact payment scheme (V1).
@@ -45,9 +47,13 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
    * Creates a new ExactSvmFacilitatorV1 instance.
    *
    * @param signer - The SVM RPC client for facilitator operations
+   * @param config - Optional configuration for verification behavior
    * @returns ExactSvmFacilitatorV1 instance
    */
-  constructor(private readonly signer: FacilitatorSvmSigner) {}
+  constructor(
+    private readonly signer: FacilitatorSvmSigner,
+    private readonly config: SvmExactFacilitatorConfig = {},
+  ) {}
 
   /**
    * Get mechanism-specific extra data for the supported kinds endpoint.
@@ -141,6 +147,8 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
     }
 
     const compiled = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
+    const staticAccounts = compiled.staticAccounts ?? [];
+    const compiledInstructions = compiled.instructions ?? [];
     const decompiled = decompileTransactionMessage(compiled);
     const instructions = decompiled.instructions ?? [];
 
@@ -171,13 +179,20 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
       };
     }
 
-    const payer = getTokenPayerFromTransaction(transaction);
-    if (!payer) {
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_svm_payload_no_transfer_instruction",
-        payer: "",
-      };
+    const feePayer = requirementsV1.extra.feePayer as Address;
+    const feePayerStr = feePayer.toString();
+    for (const ix of compiledInstructions) {
+      const accountIndices: number[] = ix.accountIndices ?? [];
+      for (const idx of accountIndices) {
+        const addr = staticAccounts[idx]?.toString();
+        if (addr === feePayerStr) {
+          return {
+            isValid: false,
+            invalidReason: "invalid_exact_svm_payload_fee_payer_in_instruction_accounts",
+            payer: "",
+          };
+        }
+      }
     }
 
     // Step 4: Verify Transfer Instruction
@@ -188,10 +203,73 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
       programAddress !== TOKEN_PROGRAM_ADDRESS.toString() &&
       programAddress !== TOKEN_2022_PROGRAM_ADDRESS.toString()
     ) {
+      if (!this.config.enableAgenticSVM) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_svm_payload_no_transfer_instruction",
+          payer: "",
+        };
+      }
+
+      const optionalInstructions = instructions.slice(3);
+      const invalidReasonByIndex = [
+        "invalid_exact_svm_payload_unknown_fourth_instruction",
+        "invalid_exact_svm_payload_unknown_fifth_instruction",
+        "invalid_exact_svm_payload_unknown_sixth_instruction",
+      ];
+
+      for (let i = 0; i < optionalInstructions.length; i += 1) {
+        const programAddress = optionalInstructions[i].programAddress.toString();
+        if (
+          programAddress === LIGHTHOUSE_PROGRAM_ADDRESS ||
+          programAddress === MEMO_PROGRAM_ADDRESS
+        ) {
+          continue;
+        }
+
+        return {
+          isValid: false,
+          invalidReason:
+            invalidReasonByIndex[i] ?? "invalid_exact_svm_payload_unknown_optional_instruction",
+          payer: "",
+        };
+      }
+
+      const agenticResult = await verifyAgenticProgram({
+        signer: this.signer,
+        network: requirements.network,
+        transaction: exactSvmPayload.transaction,
+        feePayer,
+        payerProgram: transferIx.programAddress,
+        assetMint: requirements.asset as Address,
+        payTo: requirements.payTo as Address,
+        minAmount: BigInt(requirementsV1.maxAmountRequired),
+        extra: requirementsV1.extra,
+      } satisfies VerifyAgenticProgramArgs);
+
+      const payer = transferIx.programAddress.toString();
+      if (!agenticResult.ok) {
+        return {
+          isValid: false,
+          invalidReason: agenticResult.invalidReason,
+          invalidMessage: agenticResult.invalidMessage,
+          payer,
+        };
+      }
+
+      return {
+        isValid: true,
+        invalidReason: undefined,
+        payer,
+      };
+    }
+
+    const payer = getTokenPayerFromTransaction(transaction);
+    if (!payer) {
       return {
         isValid: false,
         invalidReason: "invalid_exact_svm_payload_no_transfer_instruction",
-        payer,
+        payer: "",
       };
     }
 
@@ -298,8 +376,6 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
     // Step 6: Sign and Simulate Transaction
     // CRITICAL: Simulation proves transaction will succeed (catches insufficient balance, invalid accounts, etc)
     try {
-      const feePayer = requirementsV1.extra.feePayer as Address;
-
       // Sign transaction with the feePayer's signer
       const fullySignedTransaction = await this.signer.signTransaction(
         exactSvmPayload.transaction,

--- a/typescript/packages/mechanisms/svm/test/unit/agentic.facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/agentic.facilitator.test.ts
@@ -1,0 +1,434 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExactSvmScheme as ExactSvmFacilitator } from "../../src/exact/facilitator/scheme";
+import { ExactSvmSchemeV1 as ExactSvmFacilitatorV1 } from "../../src/exact/v1/facilitator/scheme";
+import type { FacilitatorSvmSigner } from "../../src/signer";
+import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import type { PaymentPayloadV1, PaymentRequirementsV1 } from "@x402/core/types/v1";
+import {
+  appendTransactionMessageInstructions,
+  createTransactionMessage,
+  getBase64EncodedWireTransaction,
+  getBase64Decoder,
+  partiallySignTransactionMessageWithSigners,
+  pipe,
+  prependTransactionMessageInstruction,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Address,
+} from "@solana/kit";
+import {
+  getSetComputeUnitLimitInstruction,
+  setTransactionMessageComputeUnitPrice,
+} from "@solana-program/compute-budget";
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import {
+  MEMO_PROGRAM_ADDRESS,
+  SOLANA_DEVNET_CAIP2,
+  SOLANA_MAGIC_OK,
+  USDC_DEVNET_ADDRESS,
+} from "../../src/constants";
+
+vi.mock("../../src/utils", async () => {
+  const actual = await vi.importActual<typeof import("../../src/utils")>("../../src/utils");
+  return {
+    ...actual,
+    createRpcClient: vi.fn(),
+  };
+});
+
+function buildAgenticTransactionBase64(args: {
+  feePayer: Address;
+  payerProgram: Address;
+}): Promise<string> {
+  const memoIx = {
+    programAddress: MEMO_PROGRAM_ADDRESS as Address,
+    accounts: [] as const,
+    data: new TextEncoder().encode("nonce"),
+  };
+
+  const agenticIx = {
+    programAddress: args.payerProgram,
+    accounts: [] as const,
+    data: new Uint8Array([1, 2, 3]),
+  };
+
+  const txMsg = pipe(
+    createTransactionMessage({ version: 0 }),
+    tx => setTransactionMessageComputeUnitPrice(1, tx),
+    tx => setTransactionMessageFeePayer(args.feePayer, tx),
+    tx =>
+      prependTransactionMessageInstruction(
+        getSetComputeUnitLimitInstruction({ units: 20_000 }),
+        tx,
+      ),
+    tx => appendTransactionMessageInstructions([agenticIx, memoIx], tx),
+    tx =>
+      setTransactionMessageLifetimeUsingBlockhash(
+        { blockhash: "11111111111111111111111111111111", lastValidBlockHeight: 123n },
+        tx,
+      ),
+  );
+
+  return partiallySignTransactionMessageWithSigners(txMsg).then(tx =>
+    getBase64EncodedWireTransaction(tx),
+  );
+}
+
+describe("SVM Exact Facilitator (agentic program verification)", () => {
+  const feePayer = "8ZJ5n3j7xR7BPFfP4P7mP9oU5R5p4WfB9eY2cX5h7YpG" as Address;
+  const payerProgram = "BPFLoader1111111111111111111111111111111111" as Address;
+  const payTo = "4Nd1mQ4wE2YqCpt9d2bX9vLkqQ7qkQ7gJgS6pCz6eGxX" as Address;
+
+  let mockSigner: FacilitatorSvmSigner;
+  let agenticTx: string;
+
+  const base64MagicOk = getBase64Decoder().decode(new TextEncoder().encode(SOLANA_MAGIC_OK));
+
+  beforeEach(async () => {
+    agenticTx = await buildAgenticTransactionBase64({ feePayer, payerProgram });
+
+    mockSigner = {
+      getAddresses: () => [feePayer],
+      signTransaction: vi.fn().mockResolvedValue(agenticTx),
+      simulateTransaction: vi.fn(),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+    };
+  });
+
+  function mockRpc(args?: {
+    returnDataProgramId?: string;
+    returnDataBase64?: string | null;
+    invocationCount?: number;
+    preFeePayerLamports?: number;
+    postFeePayerLamports?: number;
+    preRecipientAmount?: string;
+    postRecipientAmount?: string;
+  }) {
+    const {
+      returnDataProgramId = payerProgram.toString(),
+      returnDataBase64 = base64MagicOk,
+      invocationCount = 1,
+      preFeePayerLamports = 1_000_000,
+      postFeePayerLamports = preFeePayerLamports,
+      preRecipientAmount = "0",
+      postRecipientAmount = "1000",
+    } = args ?? {};
+
+    const logs = [
+      ...Array.from(
+        { length: invocationCount },
+        (_, i) => `Program ${payerProgram} invoke [${i + 1}]`,
+      ),
+      `Program ${payerProgram} success`,
+    ];
+
+    const returnData =
+      returnDataBase64 === null
+        ? null
+        : {
+            programId: returnDataProgramId,
+            data: [returnDataBase64, "base64"] as [string, string],
+          };
+
+    return {
+      getAccountInfo: vi.fn().mockImplementation((address: string, config?: unknown) => {
+        const encoding =
+          typeof config === "object" && config && "encoding" in config
+            ? (config as { encoding?: unknown }).encoding
+            : undefined;
+
+        if (address === payerProgram) {
+          return {
+            send: vi.fn().mockResolvedValue({
+              value: { executable: true, owner: "BPFLoader1111111111111111111111111111111111" },
+            }),
+          };
+        }
+
+        if (address === USDC_DEVNET_ADDRESS) {
+          return {
+            send: vi.fn().mockResolvedValue({
+              value: { owner: TOKEN_PROGRAM_ADDRESS.toString() },
+            }),
+          };
+        }
+
+        if (address === feePayer && encoding === "base64") {
+          return {
+            send: vi.fn().mockResolvedValue({
+              value: { lamports: preFeePayerLamports },
+            }),
+          };
+        }
+
+        if (encoding === "jsonParsed") {
+          return {
+            send: vi.fn().mockResolvedValue({
+              value: {
+                data: {
+                  parsed: { info: { tokenAmount: { amount: preRecipientAmount } } },
+                },
+              },
+            }),
+          };
+        }
+
+        return { send: vi.fn().mockResolvedValue({ value: null }) };
+      }),
+
+      simulateTransaction: vi.fn().mockImplementation((_tx: string, config?: unknown) => {
+        const addresses =
+          typeof config === "object" &&
+          config &&
+          "accounts" in config &&
+          (config as { accounts?: unknown }).accounts &&
+          typeof (config as { accounts: { addresses?: unknown } }).accounts.addresses !==
+            "undefined"
+            ? ((config as { accounts: { addresses: string[] } }).accounts.addresses as string[])
+            : [];
+
+        const accounts = addresses.map(addr => {
+          if (addr === feePayer.toString()) {
+            return { lamports: postFeePayerLamports };
+          }
+          return {
+            data: {
+              parsed: { info: { tokenAmount: { amount: postRecipientAmount } } },
+            },
+          };
+        });
+
+        return {
+          send: vi.fn().mockResolvedValue({
+            value: {
+              err: null,
+              logs,
+              returnData,
+              accounts,
+            },
+          }),
+        };
+      }),
+    };
+  }
+
+  it("accepts agentic program payments when enabled and magic ok is returned", async () => {
+    const { createRpcClient } = await import("../../src/utils");
+    (createRpcClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockRpc());
+
+    const facilitator = new ExactSvmFacilitator(mockSigner, { enableAgenticSVM: true });
+
+    const payload: PaymentPayload = {
+      x402Version: 2,
+      resource: {
+        url: "https://example.com/protected",
+        description: "Test",
+        mimeType: "application/json",
+      },
+      accepted: {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "1000",
+        payTo: payTo,
+        maxTimeoutSeconds: 60,
+        extra: { feePayer },
+      },
+      payload: { transaction: agenticTx },
+    };
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "1000",
+      payTo: payTo,
+      maxTimeoutSeconds: 60,
+      extra: { feePayer },
+    };
+
+    const result = await facilitator.verify(payload, requirements);
+    expect(result.isValid).toBe(true);
+    expect(result.payer).toBe(payerProgram);
+  });
+
+  it("rejects agentic program payments when disabled", async () => {
+    const facilitator = new ExactSvmFacilitator(mockSigner, { enableAgenticSVM: false });
+
+    const payload: PaymentPayload = {
+      x402Version: 2,
+      resource: {
+        url: "https://example.com/protected",
+        description: "Test",
+        mimeType: "application/json",
+      },
+      accepted: {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "1000",
+        payTo: payTo,
+        maxTimeoutSeconds: 60,
+        extra: { feePayer },
+      },
+      payload: { transaction: agenticTx },
+    };
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "1000",
+      payTo: payTo,
+      maxTimeoutSeconds: 60,
+      extra: { feePayer },
+    };
+
+    const result = await facilitator.verify(payload, requirements);
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_exact_svm_payload_no_transfer_instruction");
+  });
+
+  it("rejects when agentic program does not return magic ok", async () => {
+    const { createRpcClient } = await import("../../src/utils");
+    (createRpcClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockRpc({ returnDataBase64: null }),
+    );
+
+    const facilitator = new ExactSvmFacilitator(mockSigner, { enableAgenticSVM: true });
+
+    const payload: PaymentPayload = {
+      x402Version: 2,
+      resource: { url: "https://example.com", description: "Test", mimeType: "application/json" },
+      accepted: {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "1000",
+        payTo: payTo,
+        maxTimeoutSeconds: 60,
+        extra: { feePayer },
+      },
+      payload: { transaction: agenticTx },
+    };
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "1000",
+      payTo: payTo,
+      maxTimeoutSeconds: 60,
+      extra: { feePayer },
+    };
+
+    const result = await facilitator.verify(payload, requirements);
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_svm_agentic_signature");
+  });
+
+  it("rejects on agentic reentrancy (multiple invocations)", async () => {
+    const { createRpcClient } = await import("../../src/utils");
+    (createRpcClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockRpc({ invocationCount: 2 }),
+    );
+
+    const facilitator = new ExactSvmFacilitator(mockSigner, { enableAgenticSVM: true });
+
+    const payload: PaymentPayload = {
+      x402Version: 2,
+      resource: { url: "https://example.com", description: "Test", mimeType: "application/json" },
+      accepted: {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "1000",
+        payTo: payTo,
+        maxTimeoutSeconds: 60,
+        extra: { feePayer },
+      },
+      payload: { transaction: agenticTx },
+    };
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "1000",
+      payTo: payTo,
+      maxTimeoutSeconds: 60,
+      extra: { feePayer },
+    };
+
+    const result = await facilitator.verify(payload, requirements);
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_exact_svm_agentic_reentrancy");
+  });
+
+  it("rejects on lamport conservation failure", async () => {
+    const { createRpcClient } = await import("../../src/utils");
+    (createRpcClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockRpc({ preFeePayerLamports: 1_000_000, postFeePayerLamports: 999_000 }),
+    );
+
+    const facilitator = new ExactSvmFacilitator(mockSigner, { enableAgenticSVM: true });
+
+    const payload: PaymentPayload = {
+      x402Version: 2,
+      resource: { url: "https://example.com", description: "Test", mimeType: "application/json" },
+      accepted: {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "1000",
+        payTo: payTo,
+        maxTimeoutSeconds: 60,
+        extra: { feePayer },
+      },
+      payload: { transaction: agenticTx },
+    };
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "1000",
+      payTo: payTo,
+      maxTimeoutSeconds: 60,
+      extra: { feePayer },
+    };
+
+    const result = await facilitator.verify(payload, requirements);
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_exact_svm_agentic_lamport_conservation");
+  });
+
+  it("supports V1 facilitator with agentic program verification", async () => {
+    const { createRpcClient } = await import("../../src/utils");
+    (createRpcClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockRpc());
+
+    const facilitator = new ExactSvmFacilitatorV1(mockSigner, { enableAgenticSVM: true });
+
+    const payloadV1: PaymentPayloadV1 = {
+      x402Version: 1,
+      scheme: "exact",
+      network: "solana-devnet",
+      payload: { transaction: agenticTx },
+    };
+
+    const requirementsV1: PaymentRequirementsV1 = {
+      scheme: "exact",
+      network: "solana-devnet",
+      asset: USDC_DEVNET_ADDRESS,
+      maxAmountRequired: "1000",
+      payTo: payTo,
+      maxTimeoutSeconds: 60,
+      extra: { feePayer },
+    };
+
+    const result = await facilitator.verify(payloadV1 as never, requirementsV1 as never);
+    expect(result.isValid).toBe(true);
+    expect(result.payer).toBe(payerProgram);
+  });
+});


### PR DESCRIPTION
Adds an opt-in verifier path for SVM Exact to support program-based (agentic) wallets, mirroring the EVM EIP-1271 fallback concept.

Key changes:
- New facilitator config flag: enableAgenticSVM (default off).
- When enabled and the 3rd instruction is not a Token/Token-2022 TransferChecked, treat the 3rd instruction's program id as the payer and verify via RPC simulation.
- Simulation requirements:
  - payer program account must be executable
  - simulation must succeed
  - payer program must set returnData to SOLANA_MAGIC_OK (x402_svm_ok_v1)
  - payer program must be invoked exactly once
  - fee payer lamports must be conserved in simulation
  - recipient ATA balance must increase by >= required amount
- Optional timelock bounds via PaymentRequirements.extra: validAfter / validBefore (unix seconds).
- Unit tests for V1 + V2 agentic paths.
- Spec update: specs/schemes/exact/scheme_exact_svm.md

This is intended as a follow-up to the smart-wallet signature verification work on EVM (#1220), extending the same parity goal to SVM.