### PR TITLE
fix: e2e tests skip transportMethods not supported by all parties

### DIFF
--- a/e2e/clients/axios/test.config.json
+++ b/e2e/clients/axios/test.config.json
@@ -10,6 +10,9 @@
     1,
     2
   ],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
   "environment": {
     "required": [
       "EVM_PRIVATE_KEY",

--- a/e2e/clients/fetch/test.config.json
+++ b/e2e/clients/fetch/test.config.json
@@ -10,6 +10,9 @@
     1,
     2
   ],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
   "environment": {
     "required": [
       "EVM_PRIVATE_KEY",

--- a/e2e/clients/go-http/test.config.json
+++ b/e2e/clients/go-http/test.config.json
@@ -10,6 +10,9 @@
     1,
     2
   ],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
   "environment": {
     "required": [
       "EVM_PRIVATE_KEY",

--- a/e2e/clients/httpx/test.config.json
+++ b/e2e/clients/httpx/test.config.json
@@ -10,6 +10,9 @@
     1,
     2
   ],
+  "evm": {
+    "transferMethods": ["eip3009"]
+  },
   "description": "Python httpx client with x402 v2 payment hooks",
   "environment": {
     "required": [

--- a/e2e/clients/mcp-go/test.config.json
+++ b/e2e/clients/mcp-go/test.config.json
@@ -9,6 +9,9 @@
   "x402Versions": [
     2
   ],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
   "environment": {
     "required": [
       "EVM_PRIVATE_KEY",

--- a/e2e/clients/mcp-python/test.config.json
+++ b/e2e/clients/mcp-python/test.config.json
@@ -9,6 +9,9 @@
   "x402Versions": [
     2
   ],
+  "evm": {
+    "transferMethods": ["eip3009"]
+  },
   "environment": {
     "required": [
       "EVM_PRIVATE_KEY",

--- a/e2e/clients/mcp-typescript/test.config.json
+++ b/e2e/clients/mcp-typescript/test.config.json
@@ -9,6 +9,9 @@
   "x402Versions": [
     2
   ],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
   "environment": {
     "required": [
       "EVM_PRIVATE_KEY",

--- a/e2e/clients/requests/test.config.json
+++ b/e2e/clients/requests/test.config.json
@@ -10,6 +10,9 @@
     1,
     2
   ],
+  "evm": {
+    "transferMethods": ["eip3009"]
+  },
   "description": "Python requests client with x402 v2 HTTP adapter",
   "environment": {
     "required": [

--- a/e2e/clients/text-client-protocol.txt
+++ b/e2e/clients/text-client-protocol.txt
@@ -15,6 +15,14 @@ Clients must declare which protocol families they support in their test.config.j
 Clients must declare which x402 protocol versions they support using the `x402Versions` field:
 - **x402Versions**: Array of supported x402 protocol versions (e.g., [1, 2])
 
+## EVM Transfer Method Support
+Clients that support the EVM protocol family must declare which transfer methods they support using the `evm.transferMethods` field:
+- **eip3009**: EIP-3009 transferWithAuthorization
+- **permit2**: Uniswap Permit2 approval-based transfer
+
+If the `evm` field is omitted, the client is assumed to only support `["eip3009"]`.
+The test suite uses this to skip scenarios where a server endpoint requires a transfer method the client does not support.
+
 Example configuration:
 ```json
 {
@@ -23,6 +31,9 @@ Example configuration:
   "language": "typescript",
   "protocolFamilies": ["evm"],
   "x402Versions": [1, 2],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
   "environment": {
     "required": ["EVM_PRIVATE_KEY", "RESOURCE_SERVER_URL", "ENDPOINT_PATH"],
     "optional": []
@@ -38,8 +49,29 @@ Multi-protocol client example:
   "language": "typescript",
   "protocolFamilies": ["evm", "svm"],
   "x402Versions": [1, 2],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
   "environment": {
     "required": ["EVM_PRIVATE_KEY", "SVM_PRIVATE_KEY", "RESOURCE_SERVER_URL", "ENDPOINT_PATH"],
+    "optional": []
+  }
+}
+```
+
+Python client example (eip3009 only):
+```json
+{
+  "name": "my-python-client",
+  "type": "client",
+  "language": "python",
+  "protocolFamilies": ["evm"],
+  "x402Versions": [1, 2],
+  "evm": {
+    "transferMethods": ["eip3009"]
+  },
+  "environment": {
+    "required": ["EVM_PRIVATE_KEY", "RESOURCE_SERVER_URL", "ENDPOINT_PATH"],
     "optional": []
   }
 }

--- a/e2e/facilitators/go/test.config.json
+++ b/e2e/facilitators/go/test.config.json
@@ -13,6 +13,9 @@
   "extensions": [
     "bazaar"
   ],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
   "environment": {
     "required": [
       "PORT",

--- a/e2e/facilitators/python/test.config.json
+++ b/e2e/facilitators/python/test.config.json
@@ -13,6 +13,9 @@
   "extensions": [
     "bazaar"
   ],
+  "evm": {
+    "transferMethods": ["eip3009"]
+  },
   "environment": {
     "required": [
       "PORT",

--- a/e2e/facilitators/text-facilitator-protocol.txt
+++ b/e2e/facilitators/text-facilitator-protocol.txt
@@ -19,6 +19,14 @@ Facilitators must declare which x402 protocol versions they support using the `x
 Facilitators must declare which protocol extensions they support using the `extensions` field:
 - **extensions**: Array of supported extension names (e.g., ["bazaar"])
 
+## EVM Transfer Method Support
+Facilitators that support the EVM protocol family must declare which transfer methods they support using the `evm.transferMethods` field:
+- **eip3009**: EIP-3009 transferWithAuthorization
+- **permit2**: Uniswap Permit2 approval-based transfer
+
+If the `evm` field is omitted, the facilitator is assumed to only support `["eip3009"]`.
+The test suite uses this to skip scenarios where a server endpoint requires a transfer method the facilitator does not support.
+
 Example configuration:
 ```json
 {
@@ -28,6 +36,28 @@ Example configuration:
   "protocolFamilies": ["evm"],
   "x402Versions": [2],
   "extensions": ["bazaar"],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
+  "environment": {
+    "required": ["PORT", "EVM_PRIVATE_KEY", "EVM_NETWORK"],
+    "optional": ["SVM_PRIVATE_KEY", "SVM_NETWORK"]
+  }
+}
+```
+
+Python facilitator example (eip3009 only):
+```json
+{
+  "name": "python",
+  "type": "facilitator",
+  "language": "python",
+  "protocolFamilies": ["evm"],
+  "x402Versions": [2],
+  "extensions": ["bazaar"],
+  "evm": {
+    "transferMethods": ["eip3009"]
+  },
   "environment": {
     "required": ["PORT", "EVM_PRIVATE_KEY", "EVM_NETWORK"],
     "optional": ["SVM_PRIVATE_KEY", "SVM_NETWORK"]

--- a/e2e/facilitators/typescript/test.config.json
+++ b/e2e/facilitators/typescript/test.config.json
@@ -13,6 +13,9 @@
   "extensions": [
     "bazaar"
   ],
+  "evm": {
+    "transferMethods": ["eip3009", "permit2"]
+  },
   "environment": {
     "required": [
       "PORT",

--- a/e2e/servers/express/test.config.json
+++ b/e2e/servers/express/test.config.json
@@ -12,7 +12,8 @@
       "method": "GET",
       "description": "Protected endpoint requiring EIP-3009 payment",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/protected-permit2",
@@ -20,7 +21,7 @@
       "description": "Protected endpoint requiring Permit2 payment",
       "requiresPayment": true,
       "protocolFamily": "evm",
-      "permit2": true
+      "transferMethod": "permit2"
     },
     {
       "path": "/protected-svm",

--- a/e2e/servers/fastapi/test.config.json
+++ b/e2e/servers/fastapi/test.config.json
@@ -13,14 +13,16 @@
       "method": "GET",
       "description": "Protected endpoint requiring payment",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/protected-2",
       "method": "GET",
       "description": "Protected endpoint requiring ERC20 payment",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/protected-svm",

--- a/e2e/servers/flask/test.config.json
+++ b/e2e/servers/flask/test.config.json
@@ -13,7 +13,8 @@
       "method": "GET",
       "description": "Protected endpoint requiring payment",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/protected-svm",

--- a/e2e/servers/gin/test.config.json
+++ b/e2e/servers/gin/test.config.json
@@ -13,7 +13,8 @@
       "method": "GET",
       "description": "Protected endpoint requiring EIP-3009 payment",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/protected-permit2",
@@ -21,7 +22,7 @@
       "description": "Protected endpoint requiring Permit2 payment",
       "requiresPayment": true,
       "protocolFamily": "evm",
-      "permit2": true
+      "transferMethod": "permit2"
     },
     {
       "path": "/protected-svm",

--- a/e2e/servers/hono/test.config.json
+++ b/e2e/servers/hono/test.config.json
@@ -12,7 +12,8 @@
       "method": "GET",
       "description": "Protected endpoint requiring payment",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/protected-svm",

--- a/e2e/servers/mcp-go/test.config.json
+++ b/e2e/servers/mcp-go/test.config.json
@@ -10,7 +10,8 @@
       "method": "tool",
       "description": "Paid weather tool via MCP transport",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/health",

--- a/e2e/servers/mcp-python/test.config.json
+++ b/e2e/servers/mcp-python/test.config.json
@@ -10,7 +10,8 @@
       "method": "tool",
       "description": "Paid weather tool via MCP transport",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/health",

--- a/e2e/servers/mcp-typescript/test.config.json
+++ b/e2e/servers/mcp-typescript/test.config.json
@@ -10,7 +10,8 @@
       "method": "tool",
       "description": "Paid weather tool via MCP transport",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/health",

--- a/e2e/servers/next/test.config.json
+++ b/e2e/servers/next/test.config.json
@@ -12,7 +12,8 @@
       "method": "GET",
       "description": "Protected endpoint using proxy middleware",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/api/protected-svm-proxy",
@@ -26,7 +27,8 @@
       "method": "GET",
       "description": "Protected endpoint using withX402 wrapper",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/api/protected-svm-withx402",

--- a/e2e/servers/text-server-protocol.txt
+++ b/e2e/servers/text-server-protocol.txt
@@ -18,6 +18,14 @@ Servers must declare which x402 protocol version they implement using the `x402V
 Servers may declare which protocol extensions they support using the `extensions` field:
 - **extensions**: Array of supported extension names (e.g., ["bazaar"])
 
+## EVM Transfer Method
+For EVM endpoints, servers must declare the `transferMethod` used for the payment transfer:
+- **eip3009**: EIP-3009 transferWithAuthorization (default if omitted)
+- **permit2**: Uniswap Permit2 approval-based transfer
+
+The `transferMethod` field is only applicable to endpoints with `"protocolFamily": "evm"`.
+The test suite uses this field to ensure the client and facilitator both support the required transfer method before generating a test scenario.
+
 Example configuration:
 ```json
 {
@@ -30,9 +38,18 @@ Example configuration:
     {
       "path": "/protected",
       "method": "GET",
-      "description": "Protected endpoint requiring EVM payment",
+      "description": "Protected endpoint requiring EIP-3009 payment",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
+    },
+    {
+      "path": "/protected-permit2",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2"
     },
     {
       "path": "/health",
@@ -57,7 +74,8 @@ Multi-protocol server example:
       "method": "GET",
       "description": "Protected endpoint requiring EVM payment",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/svm-protected", 

--- a/e2e/src/discovery.ts
+++ b/e2e/src/discovery.ts
@@ -265,10 +265,26 @@ export class TestDiscovery {
             continue;
           }
 
+          // For EVM endpoints, check transfer method compatibility with client
+          if (endpointProtocolFamily === 'evm') {
+            const endpointTransferMethod = endpoint.transferMethod || 'eip3009';
+            const clientTransferMethods = client.config.evm?.transferMethods || ['eip3009'];
+            if (!clientTransferMethods.includes(endpointTransferMethod)) {
+              verboseLog(`  ⚠️  Skipping ${client.name} ↔ ${server.name} ${endpoint.path}: Transfer method mismatch (client supports [${clientTransferMethods.join(', ')}], endpoint requires ${endpointTransferMethod})`);
+              continue;
+            }
+          }
+
           // Find facilitators that support this protocol family and version
           const matchingFacilitators = facilitators.filter(f => {
             const supportsProtocol = f.config.protocolFamilies?.includes(endpointProtocolFamily);
             const supportsVersion = f.config.x402Versions?.includes(serverVersion);
+            // For EVM, also check transfer method support
+            if (endpointProtocolFamily === 'evm') {
+              const endpointTransferMethod = endpoint.transferMethod || 'eip3009';
+              const facilTransferMethods = f.config.evm?.transferMethods || ['eip3009'];
+              if (!facilTransferMethods.includes(endpointTransferMethod)) return false;
+            }
             return supportsProtocol && supportsVersion;
           });
 
@@ -318,7 +334,9 @@ export class TestDiscovery {
       const protocolFamilies = client.config.protocolFamilies || ['evm'];
       const versions = client.config.x402Versions || [1];
       const transport = client.config.transport || 'http';
-      log(`   - ${client.name} (${client.config.language}) [${transport}] v[${versions.join(', ')}] [${protocolFamilies.join(', ')}]`);
+      const evmTransferMethods = client.config.evm?.transferMethods || ['eip3009'];
+      const evmInfo = protocolFamilies.includes('evm') ? ` evm:${evmTransferMethods.join(',')}` : '';
+      log(`   - ${client.name} (${client.config.language}) [${transport}] v[${versions.join(', ')}] [${protocolFamilies.join(', ')}]${evmInfo}`);
     });
 
     log(`🏛️ Facilitators found: ${facilitators.length}`);
@@ -329,7 +347,9 @@ export class TestDiscovery {
     regularFacilitators.forEach(facilitator => {
       const protocolFamilies = facilitator.config.protocolFamilies || ['evm'];
       const versions = facilitator.config.x402Versions || [2];
-      log(`   - ${facilitator.name} (${facilitator.config.language}) v[${versions.join(', ')}] [${protocolFamilies.join(', ')}]`);
+      const evmTransferMethods = facilitator.config.evm?.transferMethods || ['eip3009'];
+      const evmInfo = protocolFamilies.includes('evm') ? ` evm:${evmTransferMethods.join(',')}` : '';
+      log(`   - ${facilitator.name} (${facilitator.config.language}) v[${versions.join(', ')}] [${protocolFamilies.join(', ')}]${evmInfo}`);
     });
     
     if (externalFacilitators.length > 0) {
@@ -337,7 +357,9 @@ export class TestDiscovery {
       externalFacilitators.forEach(facilitator => {
         const protocolFamilies = facilitator.config.protocolFamilies || ['evm'];
         const versions = facilitator.config.x402Versions || [2];
-        log(`     - ${facilitator.name} (${facilitator.config.language}) v[${versions.join(', ')}] [${protocolFamilies.join(', ')}]`);
+        const evmTransferMethods = facilitator.config.evm?.transferMethods || ['eip3009'];
+        const evmInfo = protocolFamilies.includes('evm') ? ` evm:${evmTransferMethods.join(',')}` : '';
+        log(`     - ${facilitator.name} (${facilitator.config.language}) v[${versions.join(', ')}] [${protocolFamilies.join(', ')}]${evmInfo}`);
       });
     }
 

--- a/e2e/src/sampling.ts
+++ b/e2e/src/sampling.ts
@@ -31,12 +31,14 @@ export class CoverageTracker {
 
   /**
    * Generate a coverage key for an endpoint
-   * Format: "server-name-endpoint-path-protocolFamily-vVersion"
+   * Format: "server-name-endpoint-path-protocolFamily-transferMethod-vVersion"
    * 
-   * This ensures each unique endpoint on a server is tested separately.
+   * This ensures each unique endpoint on a server is tested separately,
+   * including different EVM transfer methods (eip3009 vs permit2).
    */
-  private getEndpointCoverageKey(serverName: string, endpointPath: string, protocolFamily: string, version: number): string {
-    return `${serverName}-${endpointPath}-${protocolFamily}-v${version}`;
+  private getEndpointCoverageKey(serverName: string, endpointPath: string, protocolFamily: string, version: number, transferMethod?: string): string {
+    const method = protocolFamily === 'evm' ? (transferMethod || 'eip3009') : '';
+    return `${serverName}-${endpointPath}-${protocolFamily}${method ? `-${method}` : ''}-v${version}`;
   }
 
   /**
@@ -74,7 +76,8 @@ export class CoverageTracker {
       scenario.server.name,
       scenario.endpoint.path,
       protocolFamily,
-      version
+      version,
+      scenario.endpoint.transferMethod
     );
 
     // Check if ANY component hasn't been covered yet
@@ -121,7 +124,8 @@ export class CoverageTracker {
       scenario.server.name,
       scenario.endpoint.path,
       protocolFamily,
-      version
+      version,
+      scenario.endpoint.transferMethod
     );
 
     this.clientsCovered.add(clientKey);

--- a/e2e/src/types.ts
+++ b/e2e/src/types.ts
@@ -2,6 +2,7 @@ import type { NetworkSet } from './networks/networks';
 
 export type ProtocolFamily = 'evm' | 'svm';
 export type Transport = 'http' | 'mcp';
+export type TransferMethod = 'eip3009' | 'permit2';
 
 export interface ClientResult {
   success: boolean;
@@ -44,7 +45,7 @@ export interface TestEndpoint {
   description: string;
   requiresPayment?: boolean;
   protocolFamily?: ProtocolFamily;
-  permit2?: boolean; // Endpoint requires Permit2 approval
+  transferMethod?: TransferMethod;
   health?: boolean;
   close?: boolean;
 }
@@ -58,6 +59,9 @@ export interface TestConfig {
   x402Version?: number;
   x402Versions?: number[];
   extensions?: string[];
+  evm?: {
+    transferMethods: TransferMethod[];
+  };
   endpoints?: TestEndpoint[];
   supportedMethods?: string[];
   capabilities?: {

--- a/e2e/templates/server-ts/test.config.json
+++ b/e2e/templates/server-ts/test.config.json
@@ -12,7 +12,8 @@
       "method": "GET",
       "description": "Protected endpoint requiring payment",
       "requiresPayment": true,
-      "protocolFamily": "evm"
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
     },
     {
       "path": "/health",

--- a/e2e/templates/server/test.config.json
+++ b/e2e/templates/server/test.config.json
@@ -14,7 +14,8 @@
       "method": "<GET/POST/PATCH/DELETE/OPTIONS/HEAD>",
       "description": "<endpoint-description>",
       "requiresPayment": true,
-      "protocolFamily": "<evm/svm>"
+      "protocolFamily": "<evm/svm>",
+      "transferMethod": "<eip3009/permit2> (EVM only)"
     },
     {
       "path": "/health",


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Updates e2e tests to be aware of the intended `transportMethod` of a given EVM gated endpoint ahead of time, and allows clients/facilitators to declare support for EVM transportMethod.

Test suite now skips tests where not all parties support the method in question

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 