### PR TITLE
feat: upgrade facilitator extension registration

### DIFF
--- a/e2e/facilitators/go/main.go
+++ b/e2e/facilitators/go/main.go
@@ -18,6 +18,7 @@ import (
 
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/extensions/bazaar"
+	"github.com/coinbase/x402/go/extensions/eip2612gassponsor"
 	exttypes "github.com/coinbase/x402/go/extensions/types"
 	evmmech "github.com/coinbase/x402/go/mechanisms/evm"
 	evm "github.com/coinbase/x402/go/mechanisms/evm/exact/facilitator"
@@ -775,7 +776,7 @@ func main() {
 	facilitator.RegisterExtension(exttypes.BAZAAR)
 
 	// Register the EIP-2612 Gas Sponsoring extension
-	facilitator.RegisterExtension("eip2612GasSponsoring")
+	facilitator.RegisterExtension(eip2612gassponsor.EIP2612GasSponsoring)
 
 	// Lifecycle hooks for payment tracking and discovery
 	facilitator.
@@ -1073,7 +1074,7 @@ func main() {
 			"svmNetwork":          svmNetwork,
 			"facilitator":         "go",
 			"version":             "2.0.0",
-			"extensions":          []string{exttypes.BAZAAR},
+			"extensions":          []string{exttypes.BAZAAR.Key()},
 			"discoveredResources": bazaarCatalog.GetCount(),
 		})
 	})

--- a/e2e/facilitators/typescript/index.ts
+++ b/e2e/facilitators/typescript/index.ts
@@ -339,7 +339,7 @@ app.get("/health", (req, res) => {
     svmNetwork: SVM_NETWORK,
     facilitator: "typescript",
     version: "2.0.0",
-    extensions: [BAZAAR],
+    extensions: [BAZAAR.key],
     discoveredResources: bazaarCatalog.getCount(),
   });
 });

--- a/go/.changes/unreleased/changed-20260218-172621.yaml
+++ b/go/.changes/unreleased/changed-20260218-172621.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Upgraded facilitator extension registration from string keys to FacilitatorExtension objects. Added FacilitatorContext to SchemeNetworkFacilitator functions
+time: 2026-02-18T17:26:21.195315-05:00

--- a/go/extensions/bazaar/bazaar_test.go
+++ b/go/extensions/bazaar/bazaar_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestBazaarConstant(t *testing.T) {
-	assert.Equal(t, "bazaar", bazaar.BAZAAR)
+	assert.Equal(t, "bazaar", bazaar.BAZAAR.Key())
 }
 
 func TestDeclareDiscoveryExtension_GET(t *testing.T) {
@@ -350,7 +350,7 @@ func TestExtractDiscoveredResourceFromPaymentPayload_FullFlow(t *testing.T) {
 				URL: "https://api.example.com/data",
 			},
 			Extensions: map[string]interface{}{
-				bazaar.BAZAAR: extension,
+				bazaar.BAZAAR.Key(): extension,
 			},
 		}
 
@@ -442,7 +442,7 @@ func TestExtractDiscoveredResourceFromPaymentPayload_FullFlow(t *testing.T) {
 				URL: "https://api.example.com/weather?city=NYC&units=metric",
 			},
 			Extensions: map[string]interface{}{
-				bazaar.BAZAAR: extension,
+				bazaar.BAZAAR.Key(): extension,
 			},
 		}
 
@@ -477,7 +477,7 @@ func TestExtractDiscoveredResourceFromPaymentPayload_FullFlow(t *testing.T) {
 				URL: "https://api.example.com/docs#section-1",
 			},
 			Extensions: map[string]interface{}{
-				bazaar.BAZAAR: extension,
+				bazaar.BAZAAR.Key(): extension,
 			},
 		}
 
@@ -512,7 +512,7 @@ func TestExtractDiscoveredResourceFromPaymentPayload_FullFlow(t *testing.T) {
 				URL: "https://api.example.com/page?foo=bar#anchor",
 			},
 			Extensions: map[string]interface{}{
-				bazaar.BAZAAR: extension,
+				bazaar.BAZAAR.Key(): extension,
 			},
 		}
 
@@ -981,7 +981,7 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 			},
 			"accepts": []interface{}{},
 			"extensions": map[string]interface{}{
-				bazaar.BAZAAR: extension,
+				bazaar.BAZAAR.Key(): extension,
 			},
 		})
 
@@ -989,7 +989,7 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 		_ = json.Unmarshal(paymentRequiredJSON, &paymentRequired)
 
 		// 3. Facilitator receives and validates
-		bazaarExtRaw := paymentRequired["extensions"].(map[string]interface{})[bazaar.BAZAAR]
+		bazaarExtRaw := paymentRequired["extensions"].(map[string]interface{})[bazaar.BAZAAR.Key()]
 		bazaarExtJSON, _ := json.Marshal(bazaarExtRaw)
 		var bazaarExt bazaar.DiscoveryExtension
 		_ = json.Unmarshal(bazaarExtJSON, &bazaarExt)
@@ -1118,7 +1118,7 @@ func TestIntegration_FullWorkflow(t *testing.T) {
 				URL: "https://api.example.com/items",
 			},
 			Extensions: map[string]interface{}{
-				bazaar.BAZAAR: v2Extension,
+				bazaar.BAZAAR.Key(): v2Extension,
 			},
 		}
 

--- a/go/extensions/bazaar/facilitator.go
+++ b/go/extensions/bazaar/facilitator.go
@@ -161,7 +161,7 @@ func ExtractDiscoveredResourceFromPaymentPayload(
 
 		// Extract discovery info from extensions
 		if payload.Extensions != nil {
-			if bazaarExt, ok := payload.Extensions[types.BAZAAR]; ok {
+			if bazaarExt, ok := payload.Extensions[types.BAZAAR.Key()]; ok {
 				extensionJSON, err := json.Marshal(bazaarExt)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal bazaar extension: %w", err)
@@ -312,7 +312,7 @@ func ExtractDiscoveredResourceFromPaymentRequired(
 
 		// First check PaymentRequired.extensions for bazaar extension
 		if paymentRequired.Extensions != nil {
-			if bazaarExt, ok := paymentRequired.Extensions[types.BAZAAR]; ok {
+			if bazaarExt, ok := paymentRequired.Extensions[types.BAZAAR.Key()]; ok {
 				extensionJSON, err := json.Marshal(bazaarExt)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal bazaar extension: %w", err)

--- a/go/extensions/bazaar/server.go
+++ b/go/extensions/bazaar/server.go
@@ -8,7 +8,7 @@ import (
 type bazaarResourceServerExtension struct{}
 
 func (e *bazaarResourceServerExtension) Key() string {
-	return types.BAZAAR
+	return types.BAZAAR.Key()
 }
 
 func (e *bazaarResourceServerExtension) EnrichDeclaration(

--- a/go/extensions/bazaar/types.go
+++ b/go/extensions/bazaar/types.go
@@ -3,8 +3,8 @@ package bazaar
 // Re-export types from the shared types package for convenience
 import "github.com/coinbase/x402/go/extensions/types"
 
-// Re-export extension constant
-const BAZAAR = types.BAZAAR
+// Re-export extension identifier
+var BAZAAR = types.BAZAAR
 
 // Re-export method constants
 const (

--- a/go/extensions/eip2612gassponsor/facilitator.go
+++ b/go/extensions/eip2612gassponsor/facilitator.go
@@ -16,7 +16,7 @@ func ExtractEip2612GasSponsoringInfo(extensions map[string]interface{}) (*Info, 
 		return nil, nil
 	}
 
-	extRaw, ok := extensions[EIP2612GasSponsoring]
+	extRaw, ok := extensions[EIP2612GasSponsoring.Key()]
 	if !ok {
 		return nil, nil
 	}

--- a/go/extensions/eip2612gassponsor/facilitator_test.go
+++ b/go/extensions/eip2612gassponsor/facilitator_test.go
@@ -30,7 +30,7 @@ func TestExtractEip2612GasSponsoringInfo(t *testing.T) {
 
 	t.Run("returns nil for server-only info (incomplete)", func(t *testing.T) {
 		extensions := map[string]interface{}{
-			EIP2612GasSponsoring: map[string]interface{}{
+			EIP2612GasSponsoring.Key(): map[string]interface{}{
 				"info": map[string]interface{}{
 					"description": "test",
 					"version":     "1",
@@ -49,7 +49,7 @@ func TestExtractEip2612GasSponsoringInfo(t *testing.T) {
 
 	t.Run("extracts valid info", func(t *testing.T) {
 		extensions := map[string]interface{}{
-			EIP2612GasSponsoring: map[string]interface{}{
+			EIP2612GasSponsoring.Key(): map[string]interface{}{
 				"info": map[string]interface{}{
 					"from":      "0x857b06519E91e3A54538791bDbb0E22373e36b66",
 					"asset":     "0x036CbD53842c5426634e7929541eC2318f3dCF7e",

--- a/go/extensions/eip2612gassponsor/server.go
+++ b/go/extensions/eip2612gassponsor/server.go
@@ -15,7 +15,7 @@ package eip2612gassponsor
 //	// Include in PaymentRequired.Extensions
 func DeclareEip2612GasSponsoringExtension() map[string]interface{} {
 	return map[string]interface{}{
-		EIP2612GasSponsoring: Extension{
+		EIP2612GasSponsoring.Key(): Extension{
 			Info: ServerInfo{
 				Description: "The facilitator accepts EIP-2612 gasless Permit to `Permit2` canonical contract.",
 				Version:     "1",

--- a/go/extensions/eip2612gassponsor/types.go
+++ b/go/extensions/eip2612gassponsor/types.go
@@ -5,8 +5,10 @@
 // facilitator submits it on-chain via x402Permit2Proxy.settleWithPermit.
 package eip2612gassponsor
 
-// EIP2612GasSponsoring is the extension identifier constant.
-const EIP2612GasSponsoring = "eip2612GasSponsoring"
+import x402 "github.com/coinbase/x402/go"
+
+// EIP2612GasSponsoring is the extension identifier for the EIP-2612 gas sponsoring extension.
+var EIP2612GasSponsoring = x402.NewFacilitatorExtension("eip2612GasSponsoring")
 
 // Info contains the EIP-2612 permit data populated by the client.
 // The facilitator uses this to call settleWithPermit.

--- a/go/extensions/types/types.go
+++ b/go/extensions/types/types.go
@@ -2,10 +2,12 @@ package types
 
 import (
 	"encoding/json"
+
+	x402 "github.com/coinbase/x402/go"
 )
 
-// Extension identifier constant for the Bazaar discovery extension
-const BAZAAR = "bazaar"
+// BAZAAR is the extension identifier for the Bazaar discovery extension.
+var BAZAAR = x402.NewFacilitatorExtension("bazaar")
 
 // QueryParamMethods are HTTP methods that use query parameters
 type QueryParamMethods string

--- a/go/facilitator_hooks_test.go
+++ b/go/facilitator_hooks_test.go
@@ -374,14 +374,14 @@ func (m *mockSchemeFacilitator) GetSigners(_ Network) []string {
 	return []string{}
 }
 
-func (m *mockSchemeFacilitator) Verify(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements) (*VerifyResponse, error) {
+func (m *mockSchemeFacilitator) Verify(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements, _ *FacilitatorContext) (*VerifyResponse, error) {
 	if m.verifyFunc != nil {
 		return m.verifyFunc(ctx, payload, requirements)
 	}
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockSchemeFacilitator) Settle(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements) (*SettleResponse, error) {
+func (m *mockSchemeFacilitator) Settle(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements, _ *FacilitatorContext) (*SettleResponse, error) {
 	if m.settleFunc != nil {
 		return m.settleFunc(ctx, payload, requirements)
 	}

--- a/go/facilitator_test.go
+++ b/go/facilitator_test.go
@@ -31,14 +31,14 @@ func (m *mockSchemeNetworkFacilitatorV1) GetSigners(_ Network) []string {
 	return []string{}
 }
 
-func (m *mockSchemeNetworkFacilitatorV1) Verify(ctx context.Context, payload types.PaymentPayloadV1, requirements types.PaymentRequirementsV1) (*VerifyResponse, error) {
+func (m *mockSchemeNetworkFacilitatorV1) Verify(ctx context.Context, payload types.PaymentPayloadV1, requirements types.PaymentRequirementsV1, _ *FacilitatorContext) (*VerifyResponse, error) {
 	return &VerifyResponse{
 		IsValid: true,
 		Payer:   "0xmockpayer",
 	}, nil
 }
 
-func (m *mockSchemeNetworkFacilitatorV1) Settle(ctx context.Context, payload types.PaymentPayloadV1, requirements types.PaymentRequirementsV1) (*SettleResponse, error) {
+func (m *mockSchemeNetworkFacilitatorV1) Settle(ctx context.Context, payload types.PaymentPayloadV1, requirements types.PaymentRequirementsV1, _ *FacilitatorContext) (*SettleResponse, error) {
 	return &SettleResponse{
 		Success:     true,
 		Transaction: "0xmocktx",
@@ -70,7 +70,7 @@ func (m *mockSchemeNetworkFacilitator) GetSigners(_ Network) []string {
 	return []string{}
 }
 
-func (m *mockSchemeNetworkFacilitator) Verify(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements) (*VerifyResponse, error) {
+func (m *mockSchemeNetworkFacilitator) Verify(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements, _ *FacilitatorContext) (*VerifyResponse, error) {
 	if m.verifyFunc != nil {
 		return m.verifyFunc(ctx, payload, requirements)
 	}
@@ -80,7 +80,7 @@ func (m *mockSchemeNetworkFacilitator) Verify(ctx context.Context, payload types
 	}, nil
 }
 
-func (m *mockSchemeNetworkFacilitator) Settle(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements) (*SettleResponse, error) {
+func (m *mockSchemeNetworkFacilitator) Settle(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements, _ *FacilitatorContext) (*SettleResponse, error) {
 	if m.settleFunc != nil {
 		return m.settleFunc(ctx, payload, requirements)
 	}
@@ -159,21 +159,21 @@ func TestFacilitatorRegister(t *testing.T) {
 func TestFacilitatorRegisterExtension(t *testing.T) {
 	facilitator := Newx402Facilitator()
 
-	facilitator.RegisterExtension("bazaar")
+	facilitator.RegisterExtension(NewFacilitatorExtension("bazaar"))
 	if len(facilitator.extensions) != 1 {
 		t.Fatal("Expected 1 extension")
 	}
-	if facilitator.extensions[0] != "bazaar" {
+	if facilitator.extensions["bazaar"] == nil {
 		t.Fatal("Expected 'bazaar' extension")
 	}
 
 	// Test duplicate registration (should not add twice)
-	facilitator.RegisterExtension("bazaar")
+	facilitator.RegisterExtension(NewFacilitatorExtension("bazaar"))
 	if len(facilitator.extensions) != 1 {
 		t.Fatal("Expected extension to not be duplicated")
 	}
 
-	facilitator.RegisterExtension("sign_in_with_x")
+	facilitator.RegisterExtension(NewFacilitatorExtension("sign_in_with_x"))
 	if len(facilitator.extensions) != 2 {
 		t.Fatal("Expected 2 extensions")
 	}
@@ -507,7 +507,7 @@ func TestFacilitatorGetSupported(t *testing.T) {
 	facilitator.Register([]Network{"eip155:1"}, mockFacilitatorV2_1)
 	facilitator.Register([]Network{"eip155:8453"}, mockFacilitatorV2_2)
 	facilitator.RegisterV1([]Network{"eip155:1"}, mockFacilitatorV1_1)
-	facilitator.RegisterExtension("bazaar")
+	facilitator.RegisterExtension(NewFacilitatorExtension("bazaar"))
 
 	supported := facilitator.GetSupported()
 

--- a/go/interfaces.go
+++ b/go/interfaces.go
@@ -73,8 +73,8 @@ type SchemeNetworkFacilitatorV1 interface {
 	//   - SVM: Returns fee payer addresses
 	GetSigners(network Network) []string
 
-	Verify(ctx context.Context, payload types.PaymentPayloadV1, requirements types.PaymentRequirementsV1) (*VerifyResponse, error)
-	Settle(ctx context.Context, payload types.PaymentPayloadV1, requirements types.PaymentRequirementsV1) (*SettleResponse, error)
+	Verify(ctx context.Context, payload types.PaymentPayloadV1, requirements types.PaymentRequirementsV1, fctx *FacilitatorContext) (*VerifyResponse, error)
+	Settle(ctx context.Context, payload types.PaymentPayloadV1, requirements types.PaymentRequirementsV1, fctx *FacilitatorContext) (*SettleResponse, error)
 }
 
 // Note: No SchemeNetworkServerV1 - new SDK servers are V2 only
@@ -111,6 +111,45 @@ type ClientExtension interface {
 	// is present in paymentRequired.Extensions. Allows the extension to enrich the
 	// payload with extension-specific data (e.g., signing an EIP-2612 permit).
 	EnrichPaymentPayload(ctx context.Context, payload types.PaymentPayload, required types.PaymentRequired) (types.PaymentPayload, error)
+}
+
+// FacilitatorExtension is the base interface for extensions registered with x402Facilitator.
+// Extensions are stored by key and made available to mechanism implementations via FacilitatorContext.
+// Specific extensions embed this and add their own capabilities (e.g., a batch signer).
+type FacilitatorExtension interface {
+	Key() string
+}
+
+// facilitatorExtension is a simple concrete implementation of FacilitatorExtension.
+type facilitatorExtension struct {
+	key string
+}
+
+func (e facilitatorExtension) Key() string { return e.key }
+
+// NewFacilitatorExtension creates a FacilitatorExtension with the given key.
+func NewFacilitatorExtension(key string) FacilitatorExtension {
+	return facilitatorExtension{key: key}
+}
+
+// FacilitatorContext provides access to registered facilitator extensions.
+// Passed to SchemeNetworkFacilitator.Verify/Settle so mechanism implementations
+// can retrieve extension-provided capabilities.
+type FacilitatorContext struct {
+	extensions map[string]FacilitatorExtension
+}
+
+// NewFacilitatorContext creates a FacilitatorContext from the given extensions map.
+func NewFacilitatorContext(extensions map[string]FacilitatorExtension) *FacilitatorContext {
+	return &FacilitatorContext{extensions: extensions}
+}
+
+// GetExtension returns the extension registered under the given key, or nil.
+func (c *FacilitatorContext) GetExtension(key string) FacilitatorExtension {
+	if c == nil || c.extensions == nil {
+		return nil
+	}
+	return c.extensions[key]
 }
 
 // SchemeNetworkServer is implemented by server-side payment mechanisms (V2)
@@ -167,8 +206,8 @@ type SchemeNetworkFacilitator interface {
 	//   - SVM: Returns fee payer addresses
 	GetSigners(network Network) []string
 
-	Verify(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements) (*VerifyResponse, error)
-	Settle(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements) (*SettleResponse, error)
+	Verify(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements, fctx *FacilitatorContext) (*VerifyResponse, error)
+	Settle(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements, fctx *FacilitatorContext) (*SettleResponse, error)
 }
 
 // ============================================================================

--- a/go/mechanisms/evm/exact/client/scheme.go
+++ b/go/mechanisms/evm/exact/client/scheme.go
@@ -103,7 +103,7 @@ func (c *ExactEvmScheme) trySignEip2612Permit(
 	if extensions == nil {
 		return nil, nil
 	}
-	if _, ok := extensions[eip2612gassponsor.EIP2612GasSponsoring]; !ok {
+	if _, ok := extensions[eip2612gassponsor.EIP2612GasSponsoring.Key()]; !ok {
 		return nil, nil
 	}
 
@@ -159,7 +159,7 @@ func (c *ExactEvmScheme) trySignEip2612Permit(
 	}
 
 	return map[string]interface{}{
-		eip2612gassponsor.EIP2612GasSponsoring: map[string]interface{}{
+		eip2612gassponsor.EIP2612GasSponsoring.Key(): map[string]interface{}{
 			"info": info,
 		},
 	}, nil

--- a/go/mechanisms/evm/exact/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/facilitator/scheme.go
@@ -76,6 +76,7 @@ func (f *ExactEvmScheme) Verify(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
+	_ *x402.FacilitatorContext,
 ) (*x402.VerifyResponse, error) {
 	// Check if this is a Permit2 payload and route accordingly
 	if evm.IsPermit2Payload(payload.Payload) {
@@ -237,6 +238,7 @@ func (f *ExactEvmScheme) Settle(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
+	_ *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	// Check if this is a Permit2 payload and route accordingly
 	if evm.IsPermit2Payload(payload.Payload) {

--- a/go/mechanisms/evm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/v1/facilitator/scheme.go
@@ -76,6 +76,7 @@ func (f *ExactEvmSchemeV1) Verify(
 	ctx context.Context,
 	payload types.PaymentPayloadV1,
 	requirements types.PaymentRequirementsV1,
+	_ *x402.FacilitatorContext,
 ) (*x402.VerifyResponse, error) {
 	// Validate scheme (v1 has scheme at top level)
 	if payload.Scheme != evm.SchemeExact || requirements.Scheme != evm.SchemeExact {
@@ -211,11 +212,12 @@ func (f *ExactEvmSchemeV1) Settle(
 	ctx context.Context,
 	payload types.PaymentPayloadV1,
 	requirements types.PaymentRequirementsV1,
+	fctx *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	network := x402.Network(payload.Network)
 
 	// First verify the payment
-	verifyResp, err := f.Verify(ctx, payload, requirements)
+	verifyResp, err := f.Verify(ctx, payload, requirements, fctx)
 	if err != nil {
 		// Convert VerifyError to SettleError
 		ve := &x402.VerifyError{}

--- a/go/mechanisms/svm/exact/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/facilitator/scheme.go
@@ -68,6 +68,7 @@ func (f *ExactSvmScheme) Verify(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
+	_ *x402.FacilitatorContext,
 ) (*x402.VerifyResponse, error) {
 	network := x402.Network(requirements.Network)
 
@@ -222,11 +223,12 @@ func (f *ExactSvmScheme) Settle(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
+	fctx *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	network := x402.Network(requirements.Network)
 
 	// First verify the payment
-	verifyResp, err := f.Verify(ctx, payload, requirements)
+	verifyResp, err := f.Verify(ctx, payload, requirements, fctx)
 	if err != nil {
 		// Convert VerifyError to SettleError
 		ve := &x402.VerifyError{}

--- a/go/mechanisms/svm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/scheme.go
@@ -69,6 +69,7 @@ func (f *ExactSvmSchemeV1) Verify(
 	ctx context.Context,
 	payload types.PaymentPayloadV1,
 	requirements types.PaymentRequirementsV1,
+	_ *x402.FacilitatorContext,
 ) (*x402.VerifyResponse, error) {
 	network := x402.Network(requirements.Network)
 
@@ -219,11 +220,12 @@ func (f *ExactSvmSchemeV1) Settle(
 	ctx context.Context,
 	payload types.PaymentPayloadV1,
 	requirements types.PaymentRequirementsV1,
+	fctx *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	network := x402.Network(payload.Network)
 
 	// First verify the payment
-	verifyResp, err := f.Verify(ctx, payload, requirements)
+	verifyResp, err := f.Verify(ctx, payload, requirements, fctx)
 	if err != nil {
 		// Convert VerifyError to SettleError
 		ve := &x402.VerifyError{}

--- a/go/test/mocks/cash/cash.go
+++ b/go/test/mocks/cash/cash.go
@@ -81,7 +81,7 @@ func (f *SchemeNetworkFacilitator) GetSigners(_ x402.Network) []string {
 }
 
 // Verify verifies a V2 payment payload against requirements (typed)
-func (f *SchemeNetworkFacilitator) Verify(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements) (*x402.VerifyResponse, error) {
+func (f *SchemeNetworkFacilitator) Verify(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements, _ *x402.FacilitatorContext) (*x402.VerifyResponse, error) {
 	// Extract payload fields
 	signature, ok := payload.Payload["signature"].(string)
 	if !ok {
@@ -121,11 +121,11 @@ func (f *SchemeNetworkFacilitator) Verify(ctx context.Context, payload types.Pay
 }
 
 // Settle settles a V2 payment (typed)
-func (f *SchemeNetworkFacilitator) Settle(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements) (*x402.SettleResponse, error) {
+func (f *SchemeNetworkFacilitator) Settle(ctx context.Context, payload types.PaymentPayload, requirements types.PaymentRequirements, fctx *x402.FacilitatorContext) (*x402.SettleResponse, error) {
 	network := x402.Network(requirements.Network)
 
 	// First verify the payment
-	verifyResponse, err := f.Verify(ctx, payload, requirements)
+	verifyResponse, err := f.Verify(ctx, payload, requirements, fctx)
 	if err != nil {
 		// Convert VerifyError to SettleError
 		var ve *x402.VerifyError

--- a/go/test/unit/evm_client_facilitator_test.go
+++ b/go/test/unit/evm_client_facilitator_test.go
@@ -799,7 +799,7 @@ func TestVerifyEIP3009TimingValidation(t *testing.T) {
 
 	t.Run("Rejects validAfter in the future", func(t *testing.T) {
 		payload := makePayload("9999999999", "99999999999")
-		_, err := scheme.Verify(ctx, payload, requirements)
+		_, err := scheme.Verify(ctx, payload, requirements, nil)
 		if err == nil {
 			t.Fatal("Expected error for validAfter in the future")
 		}
@@ -810,7 +810,7 @@ func TestVerifyEIP3009TimingValidation(t *testing.T) {
 
 	t.Run("Rejects expired validBefore", func(t *testing.T) {
 		payload := makePayload("0", "1")
-		_, err := scheme.Verify(ctx, payload, requirements)
+		_, err := scheme.Verify(ctx, payload, requirements, nil)
 		if err == nil {
 			t.Fatal("Expected error for expired validBefore")
 		}
@@ -821,7 +821,7 @@ func TestVerifyEIP3009TimingValidation(t *testing.T) {
 
 	t.Run("Accepts valid timing window", func(t *testing.T) {
 		payload := makePayload("0", "99999999999")
-		_, err := scheme.Verify(ctx, payload, requirements)
+		_, err := scheme.Verify(ctx, payload, requirements, nil)
 		// Should not fail with a timing error (may fail on nonce/signature checks, which is expected)
 		if err != nil {
 			if strings.Contains(err.Error(), evmfacilitator.ErrValidAfterInFuture) {

--- a/python/x402/changelog.d/facilitator-extension-objects.feature.md
+++ b/python/x402/changelog.d/facilitator-extension-objects.feature.md
@@ -1,0 +1,1 @@
+Upgraded facilitator extension registration from string keys to FacilitatorExtension dataclass. Added FacilitatorContext passed through SchemeNetworkFacilitator.verify/settle for mechanism access to extension capabilities.

--- a/python/x402/client.py
+++ b/python/x402/client.py
@@ -166,9 +166,7 @@ class x402Client(x402ClientBase):
         extensions: dict[str, Any] | None,
     ) -> PaymentPayload:
         """Create V2 payment payload using generator."""
-        gen = self._create_payment_payload_v2_core(
-            payment_required, resource, extensions
-        )
+        gen = self._create_payment_payload_v2_core(payment_required, resource, extensions)
         result = None
         try:
             while True:
@@ -231,9 +229,7 @@ class x402ClientSync(x402ClientBase):
         # Type the hook lists for sync-only
         self._before_payment_creation_hooks: list[SyncBeforePaymentCreationHook] = []
         self._after_payment_creation_hooks: list[SyncAfterPaymentCreationHook] = []
-        self._on_payment_creation_failure_hooks: list[
-            SyncOnPaymentCreationFailureHook
-        ] = []
+        self._on_payment_creation_failure_hooks: list[SyncOnPaymentCreationFailureHook] = []
 
     # ========================================================================
     # Factory Methods
@@ -266,9 +262,7 @@ class x402ClientSync(x402ClientBase):
         self._after_payment_creation_hooks.append(hook)
         return self
 
-    def on_payment_creation_failure(
-        self, hook: SyncOnPaymentCreationFailureHook
-    ) -> Self:
+    def on_payment_creation_failure(self, hook: SyncOnPaymentCreationFailureHook) -> Self:
         """Register hook on failure. Return RecoveredPayloadResult to recover."""
         self._on_payment_creation_failure_hooks.append(hook)
         return self
@@ -318,9 +312,7 @@ class x402ClientSync(x402ClientBase):
         extensions: dict[str, Any] | None,
     ) -> PaymentPayload:
         """Create V2 payment payload using generator."""
-        gen = self._create_payment_payload_v2_core(
-            payment_required, resource, extensions
-        )
+        gen = self._create_payment_payload_v2_core(payment_required, resource, extensions)
         result = None
         try:
             while True:

--- a/python/x402/client_base.py
+++ b/python/x402/client_base.py
@@ -66,9 +66,7 @@ class x402ClientConfig:
 
     schemes: list[SchemeRegistration]
     policies: list[PaymentPolicy] | None = None
-    payment_requirements_selector: PaymentRequirementsSelector | None = field(
-        default=None
-    )
+    payment_requirements_selector: PaymentRequirementsSelector | None = field(default=None)
 
 
 # Hook types - support both sync and async (for async class auto-detection)
@@ -209,18 +207,14 @@ class x402ClientBase:
                 supported.append(req)
 
         if not supported:
-            raise NoMatchingRequirementsError(
-                "No payment requirements match registered schemes"
-            )
+            raise NoMatchingRequirementsError("No payment requirements match registered schemes")
 
         # Apply policies
         filtered: list[RequirementsView] = list(supported)
         for policy in self._policies:
             filtered = policy(2, filtered)
             if not filtered:
-                raise NoMatchingRequirementsError(
-                    "All requirements filtered out by policies"
-                )
+                raise NoMatchingRequirementsError("All requirements filtered out by policies")
 
         # Select final
         return self._selector(2, filtered)  # type: ignore[return-value]
@@ -238,18 +232,14 @@ class x402ClientBase:
                 supported.append(req)
 
         if not supported:
-            raise NoMatchingRequirementsError(
-                "No payment requirements match registered schemes"
-            )
+            raise NoMatchingRequirementsError("No payment requirements match registered schemes")
 
         # Apply policies
         filtered: list[RequirementsView] = list(supported)
         for policy in self._policies:
             filtered = policy(1, filtered)
             if not filtered:
-                raise NoMatchingRequirementsError(
-                    "All requirements filtered out by policies"
-                )
+                raise NoMatchingRequirementsError("All requirements filtered out by policies")
 
         # Select final
         return self._selector(1, filtered)  # type: ignore[return-value]

--- a/python/x402/extensions/bazaar/facilitator.py
+++ b/python/x402/extensions/bazaar/facilitator.py
@@ -107,15 +107,11 @@ def validate_discovery_extension(extension: DiscoveryExtension) -> ValidationRes
         return ValidationResult(valid=True)
 
     except jsonschema.ValidationError as e:
-        path = (
-            "/".join(str(p) for p in e.absolute_path) if e.absolute_path else "(root)"
-        )
+        path = "/".join(str(p) for p in e.absolute_path) if e.absolute_path else "(root)"
         return ValidationResult(valid=False, errors=[f"{path}: {e.message}"])
 
     except Exception as e:
-        return ValidationResult(
-            valid=False, errors=[f"Schema validation failed: {e!s}"]
-        )
+        return ValidationResult(valid=False, errors=[f"Schema validation failed: {e!s}"])
 
 
 def _get_method_from_info(info: DiscoveryInfo | dict[str, Any]) -> str:
@@ -189,8 +185,8 @@ def extract_discovery_info(
         resource_url = resource.get("url", "") if isinstance(resource, dict) else ""
 
         extensions = payload_dict.get("extensions", {})
-        if extensions and BAZAAR in extensions:
-            bazaar_ext = extensions[BAZAAR]
+        if extensions and BAZAAR.key in extensions:
+            bazaar_ext = extensions[BAZAAR.key]
 
             if bazaar_ext and isinstance(bazaar_ext, dict):
                 try:
@@ -242,11 +238,7 @@ def extract_discovery_info(
     else:
         # V1: description and mime_type are in PaymentRequirements
         description = requirements_dict.get("description") or None
-        mime_type = (
-            requirements_dict.get("mimeType")
-            or requirements_dict.get("mime_type")
-            or None
-        )
+        mime_type = requirements_dict.get("mimeType") or requirements_dict.get("mime_type") or None
 
     return DiscoveredResource(
         resource_url=normalized_url,

--- a/python/x402/extensions/bazaar/resource_service.py
+++ b/python/x402/extensions/bazaar/resource_service.py
@@ -268,4 +268,4 @@ def declare_discovery_extension(
         )
 
     # Convert to dict excluding None values
-    return {BAZAAR: extension.model_dump(by_alias=True, exclude_none=True)}
+    return {BAZAAR.key: extension.model_dump(by_alias=True, exclude_none=True)}

--- a/python/x402/extensions/bazaar/server.py
+++ b/python/x402/extensions/bazaar/server.py
@@ -42,7 +42,7 @@ class BazaarResourceServerExtension:
     @property
     def key(self) -> str:
         """Extension key."""
-        return BAZAAR
+        return BAZAAR.key
 
     def enrich_declaration(
         self,

--- a/python/x402/extensions/bazaar/types.py
+++ b/python/x402/extensions/bazaar/types.py
@@ -6,8 +6,10 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-# Extension identifier constant for the Bazaar discovery extension
-BAZAAR = "bazaar"
+from x402.interfaces import FacilitatorExtension
+
+# Extension identifier for the Bazaar discovery extension.
+BAZAAR = FacilitatorExtension(key="bazaar")
 
 # HTTP method types
 QueryParamMethods = Literal["GET", "HEAD", "DELETE"]

--- a/python/x402/extensions/bazaar/v1/facilitator.py
+++ b/python/x402/extensions/bazaar/v1/facilitator.py
@@ -153,9 +153,9 @@ def extract_discovery_info_v1(
             print("Endpoint method:", info.input.method)
         ```
     """
-    output_schema = payment_requirements.get(
-        "outputSchema"
-    ) or payment_requirements.get("output_schema")
+    output_schema = payment_requirements.get("outputSchema") or payment_requirements.get(
+        "output_schema"
+    )
 
     # Check if outputSchema exists and has the expected structure
     if not output_schema or not _has_v1_output_schema(output_schema):
@@ -178,9 +178,7 @@ def extract_discovery_info_v1(
 
     # Extract headers if present (check both camelCase and snake_case)
     headers_raw = (
-        v1_input.get("headerFields")
-        or v1_input.get("header_fields")
-        or v1_input.get("headers")
+        v1_input.get("headerFields") or v1_input.get("header_fields") or v1_input.get("headers")
     )
     headers = headers_raw if isinstance(headers_raw, dict) else None
 
@@ -205,9 +203,7 @@ def extract_discovery_info_v1(
     if is_body_method(method):
         # Body method (POST, PUT, PATCH)
         body, body_type = _extract_body_info(v1_input)
-        query_params = _extract_query_params(
-            v1_input
-        )  # Some POST requests also have query params
+        query_params = _extract_query_params(v1_input)  # Some POST requests also have query params
 
         body_input = BodyInput(
             type="http",

--- a/python/x402/facilitator.py
+++ b/python/x402/facilitator.py
@@ -56,7 +56,7 @@ class x402Facilitator(x402FacilitatorBase):
             ["eip155:8453", "eip155:84532"],
             ExactEvmFacilitatorScheme(wallet=facilitator_wallet),
         )
-        facilitator.register_extension("bazaar")
+        facilitator.register_extension(FacilitatorExtension(key="bazaar"))
 
         # Verify payment
         result = await facilitator.verify(payload, requirements)
@@ -140,9 +140,7 @@ class x402Facilitator(x402FacilitatorBase):
             SchemeNotFoundError: If no facilitator registered for scheme/network.
             PaymentAbortedError: If a before hook aborts.
         """
-        gen = self._verify_core(
-            payload, requirements, payload_bytes, requirements_bytes
-        )
+        gen = self._verify_core(payload, requirements, payload_bytes, requirements_bytes)
         result = None
         try:
             while True:
@@ -179,9 +177,7 @@ class x402Facilitator(x402FacilitatorBase):
             SchemeNotFoundError: If no facilitator registered for scheme/network.
             PaymentAbortedError: If a before hook aborts.
         """
-        gen = self._settle_core(
-            payload, requirements, payload_bytes, requirements_bytes
-        )
+        gen = self._settle_core(payload, requirements, payload_bytes, requirements_bytes)
         result = None
         try:
             while True:
@@ -298,9 +294,7 @@ class x402FacilitatorSync(x402FacilitatorBase):
             SchemeNotFoundError: If no facilitator registered for scheme/network.
             PaymentAbortedError: If a before hook aborts.
         """
-        gen = self._verify_core(
-            payload, requirements, payload_bytes, requirements_bytes
-        )
+        gen = self._verify_core(payload, requirements, payload_bytes, requirements_bytes)
         result = None
         try:
             while True:
@@ -337,9 +331,7 @@ class x402FacilitatorSync(x402FacilitatorBase):
             SchemeNotFoundError: If no facilitator registered for scheme/network.
             PaymentAbortedError: If a before hook aborts.
         """
-        gen = self._settle_core(
-            payload, requirements, payload_bytes, requirements_bytes
-        )
+        gen = self._settle_core(payload, requirements, payload_bytes, requirements_bytes)
         result = None
         try:
             while True:

--- a/python/x402/http/clients/httpx.py
+++ b/python/x402/http/clients/httpx.py
@@ -110,26 +110,18 @@ class x402AsyncTransport(AsyncBaseTransport):
             except json.JSONDecodeError:
                 pass
 
-            payment_required = self._http_client.get_payment_required_response(
-                get_header, body
-            )
+            payment_required = self._http_client.get_payment_required_response(get_header, body)
 
             # Create payment payload
-            payment_payload = await self._client.create_payment_payload(
-                payment_required
-            )
+            payment_payload = await self._client.create_payment_payload(payment_required)
 
             # Encode payment headers
-            payment_headers = self._http_client.encode_payment_signature_header(
-                payment_payload
-            )
+            payment_headers = self._http_client.encode_payment_signature_header(payment_payload)
 
             # Clone request with payment headers and retry flag
             new_headers = dict(request.headers)
             new_headers.update(payment_headers)
-            new_headers["Access-Control-Expose-Headers"] = (
-                "PAYMENT-RESPONSE,X-PAYMENT-RESPONSE"
-            )
+            new_headers["Access-Control-Expose-Headers"] = "PAYMENT-RESPONSE,X-PAYMENT-RESPONSE"
 
             # Mark as retry in extensions
             new_extensions = dict(request.extensions)

--- a/python/x402/http/clients/requests.py
+++ b/python/x402/http/clients/requests.py
@@ -132,17 +132,13 @@ class x402HTTPAdapter(HTTPAdapter):
             except (json.JSONDecodeError, UnicodeDecodeError):
                 pass
 
-            payment_required = self._http_client.get_payment_required_response(
-                get_header, body
-            )
+            payment_required = self._http_client.get_payment_required_response(get_header, body)
 
             # Create payment payload (sync)
             payment_payload = self._client.create_payment_payload(payment_required)
 
             # Encode payment headers
-            payment_headers = self._http_client.encode_payment_signature_header(
-                payment_payload
-            )
+            payment_headers = self._http_client.encode_payment_signature_header(payment_payload)
 
             # Create a copy of the request for retry (don't modify original)
             retry_request = request.copy()

--- a/python/x402/http/facilitator_client.py
+++ b/python/x402/http/facilitator_client.py
@@ -77,9 +77,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
         if self._http_client is None:
             import httpx
 
-            self._http_client = httpx.AsyncClient(
-                timeout=self._timeout, follow_redirects=True
-            )
+            self._http_client = httpx.AsyncClient(timeout=self._timeout, follow_redirects=True)
         return self._http_client
 
     async def aclose(self) -> None:
@@ -235,9 +233,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
     ) -> VerifyResponse:
         """Internal verify via HTTP (async)."""
         client = self._get_async_client()
-        request_body = self._build_request_body(
-            version, payload_dict, requirements_dict
-        )
+        request_body = self._build_request_body(version, payload_dict, requirements_dict)
 
         response = await client.post(
             f"{self._url}/verify",
@@ -246,9 +242,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
         )
 
         if response.status_code != 200:
-            raise ValueError(
-                f"Facilitator verify failed ({response.status_code}): {response.text}"
-            )
+            raise ValueError(f"Facilitator verify failed ({response.status_code}): {response.text}")
 
         return VerifyResponse.model_validate(response.json())
 
@@ -260,9 +254,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
     ) -> SettleResponse:
         """Internal settle via HTTP (async)."""
         client = self._get_async_client()
-        request_body = self._build_request_body(
-            version, payload_dict, requirements_dict
-        )
+        request_body = self._build_request_body(version, payload_dict, requirements_dict)
 
         response = await client.post(
             f"{self._url}/settle",
@@ -271,9 +263,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
         )
 
         if response.status_code != 200:
-            raise ValueError(
-                f"Facilitator settle failed ({response.status_code}): {response.text}"
-            )
+            raise ValueError(f"Facilitator settle failed ({response.status_code}): {response.text}")
 
         return SettleResponse.model_validate(response.json())
 
@@ -305,9 +295,7 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
         if self._http_client is None:
             import httpx
 
-            self._http_client = httpx.Client(
-                timeout=self._timeout, follow_redirects=True
-            )
+            self._http_client = httpx.Client(timeout=self._timeout, follow_redirects=True)
         return self._http_client
 
     def close(self) -> None:
@@ -461,9 +449,7 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
     ) -> VerifyResponse:
         """Internal verify via HTTP."""
         client = self._get_client()
-        request_body = self._build_request_body(
-            version, payload_dict, requirements_dict
-        )
+        request_body = self._build_request_body(version, payload_dict, requirements_dict)
 
         response = client.post(
             f"{self._url}/verify",
@@ -472,9 +458,7 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
         )
 
         if response.status_code != 200:
-            raise ValueError(
-                f"Facilitator verify failed ({response.status_code}): {response.text}"
-            )
+            raise ValueError(f"Facilitator verify failed ({response.status_code}): {response.text}")
 
         return VerifyResponse.model_validate(response.json())
 
@@ -486,9 +470,7 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
     ) -> SettleResponse:
         """Internal settle via HTTP."""
         client = self._get_client()
-        request_body = self._build_request_body(
-            version, payload_dict, requirements_dict
-        )
+        request_body = self._build_request_body(version, payload_dict, requirements_dict)
 
         response = client.post(
             f"{self._url}/settle",
@@ -497,8 +479,6 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
         )
 
         if response.status_code != 200:
-            raise ValueError(
-                f"Facilitator settle failed ({response.status_code}): {response.text}"
-            )
+            raise ValueError(f"Facilitator settle failed ({response.status_code}): {response.text}")
 
         return SettleResponse.model_validate(response.json())

--- a/python/x402/http/facilitator_client_base.py
+++ b/python/x402/http/facilitator_client_base.py
@@ -143,16 +143,12 @@ class FacilitatorConfig:
 class HTTPFacilitatorClientBase:
     """Base class with shared logic for HTTP facilitator clients."""
 
-    def __init__(
-        self, config: FacilitatorConfig | dict[str, Any] | None = None
-    ) -> None:
+    def __init__(self, config: FacilitatorConfig | dict[str, Any] | None = None) -> None:
         """Create HTTP facilitator client."""
         if isinstance(config, dict):
             url = config.get("url", DEFAULT_FACILITATOR_URL)
             create_headers = config.get("create_headers")
-            auth_provider = (
-                CreateHeadersAuthProvider(create_headers) if create_headers else None
-            )
+            auth_provider = CreateHeadersAuthProvider(create_headers) if create_headers else None
 
             self._url = url.rstrip("/")
             self._timeout = 30.0

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -264,8 +264,7 @@ def payment_middleware(
             path=request.url.path,
             method=request.method,
             payment_header=(
-                adapter.get_header("payment-signature")
-                or adapter.get_header("x-payment")
+                adapter.get_header("payment-signature") or adapter.get_header("x-payment")
             ),
         )
 
@@ -444,9 +443,7 @@ class PaymentMiddlewareASGI(BaseHTTPMiddleware):
             paywall_provider: Optional custom paywall provider.
         """
         super().__init__(app)
-        self._middleware = payment_middleware(
-            routes, server, paywall_config, paywall_provider
-        )
+        self._middleware = payment_middleware(routes, server, paywall_config, paywall_provider)
 
     async def dispatch(
         self,

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -350,8 +350,7 @@ class PaymentMiddleware:
                 path=request.path,
                 method=request.method,
                 payment_header=(
-                    adapter.get_header("payment-signature")
-                    or adapter.get_header("x-payment")
+                    adapter.get_header("payment-signature") or adapter.get_header("x-payment")
                 ),
             )
 
@@ -365,9 +364,7 @@ class PaymentMiddleware:
                 self._init_done = True
 
             # Process payment request synchronously (no asyncio overhead)
-            result = self._http_server.process_http_request(
-                context, self._paywall_config
-            )
+            result = self._http_server.process_http_request(context, self._paywall_config)
 
             if result.type == "no-payment-required":
                 return self._original_wsgi(environ, start_response)

--- a/python/x402/http/paywall/__init__.py
+++ b/python/x402/http/paywall/__init__.py
@@ -151,9 +151,7 @@ class EvmPaywallHandler:
         current_url = config.current_url if config else ""
 
         amount = _get_display_amount(payment_required)
-        payment_required_json = payment_required.model_dump(
-            by_alias=True, exclude_none=True
-        )
+        payment_required_json = payment_required.model_dump(by_alias=True, exclude_none=True)
 
         x402_config = {
             "amount": amount,
@@ -178,11 +176,7 @@ class EvmPaywallHandler:
         """Generate fallback HTML when template not available."""
         amount = _get_display_amount(payment_required)
         app_name = config.app_name if config else ""
-        title = (
-            f"{html.escape(app_name)} - Payment Required"
-            if app_name
-            else "Payment Required"
-        )
+        title = f"{html.escape(app_name)} - Payment Required" if app_name else "Payment Required"
 
         return f"""<!DOCTYPE html>
 <html>
@@ -234,9 +228,7 @@ class SvmPaywallHandler:
         current_url = config.current_url if config else ""
 
         amount = _get_display_amount(payment_required)
-        payment_required_json = payment_required.model_dump(
-            by_alias=True, exclude_none=True
-        )
+        payment_required_json = payment_required.model_dump(by_alias=True, exclude_none=True)
 
         x402_config = {
             "amount": amount,
@@ -261,11 +253,7 @@ class SvmPaywallHandler:
         """Generate fallback HTML when template not available."""
         amount = _get_display_amount(payment_required)
         app_name = config.app_name if config else ""
-        title = (
-            f"{html.escape(app_name)} - Payment Required"
-            if app_name
-            else "Payment Required"
-        )
+        title = f"{html.escape(app_name)} - Payment Required" if app_name else "Payment Required"
 
         return f"""<!DOCTYPE html>
 <html>
@@ -397,11 +385,7 @@ class PaywallProvider:
             app_name=config.app_name if config and config.app_name else self.app_name,
             app_logo=config.app_logo if config and config.app_logo else self.app_logo,
             testnet=config.testnet if config else self.testnet,
-            current_url=(
-                config.current_url
-                if config and config.current_url
-                else self.current_url
-            ),
+            current_url=(config.current_url if config and config.current_url else self.current_url),
         )
 
         # Find first handler that supports the payment requirements
@@ -409,9 +393,7 @@ class PaywallProvider:
             req_dict = requirement.model_dump(by_alias=True, exclude_none=True)
             for handler in self.handlers:
                 if handler.supports(req_dict):
-                    return handler.generate_html(
-                        req_dict, payment_required, merged_config
-                    )
+                    return handler.generate_html(req_dict, payment_required, merged_config)
 
         networks = ", ".join(
             req.network for req in payment_required.accepts if hasattr(req, "network")

--- a/python/x402/http/utils.py
+++ b/python/x402/http/utils.py
@@ -48,9 +48,7 @@ def encode_payment_required_header(
     payment_required: PaymentRequired | PaymentRequiredV1,
 ) -> str:
     """Encode a PaymentRequired object as a base64 header value."""
-    return safe_base64_encode(
-        payment_required.model_dump_json(by_alias=True, exclude_none=True)
-    )
+    return safe_base64_encode(payment_required.model_dump_json(by_alias=True, exclude_none=True))
 
 
 def decode_payment_required_header(
@@ -69,9 +67,7 @@ def decode_payment_required_header(
 
 def encode_payment_response_header(settle_response: SettleResponse) -> str:
     """Encode a SettleResponse object as a base64 header value."""
-    return safe_base64_encode(
-        settle_response.model_dump_json(by_alias=True, exclude_none=True)
-    )
+    return safe_base64_encode(settle_response.model_dump_json(by_alias=True, exclude_none=True))
 
 
 def decode_payment_response_header(header_value: str) -> SettleResponse:

--- a/python/x402/http/x402_http_server.py
+++ b/python/x402/http/x402_http_server.py
@@ -55,9 +55,7 @@ class x402HTTPResourceServer(x402HTTPServerBase):
         ```
     """
 
-    def register_paywall_provider(
-        self, provider: PaywallProvider
-    ) -> x402HTTPResourceServer:
+    def register_paywall_provider(self, provider: PaywallProvider) -> x402HTTPResourceServer:
         """Register custom paywall provider for HTML generation.
 
         Args:
@@ -275,9 +273,7 @@ class x402HTTPResourceServerSync(x402HTTPServerBase):
 
         super().__init__(server, routes)  # type: ignore[arg-type]
 
-    def register_paywall_provider(
-        self, provider: PaywallProvider
-    ) -> x402HTTPResourceServerSync:
+    def register_paywall_provider(self, provider: PaywallProvider) -> x402HTTPResourceServerSync:
         """Register custom paywall provider for HTML generation.
 
         Args:

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -137,9 +137,7 @@ class x402HTTPServerBase:
 
         for pattern, config in normalized.items():
             verb, regex = self._parse_route_pattern(pattern)
-            self._compiled_routes.append(
-                CompiledRoute(verb=verb, regex=regex, config=config)
-            )
+            self._compiled_routes.append(CompiledRoute(verb=verb, regex=regex, config=config))
 
     def _parse_route_config(self, config: dict[str, Any]) -> RouteConfig:
         """Parse a raw dict into a RouteConfig."""
@@ -173,9 +171,7 @@ class x402HTTPServerBase:
             resource=config.get("resource"),
             description=config.get("description"),
             mime_type=config.get("mimeType", config.get("mime_type")),
-            custom_paywall_html=config.get(
-                "customPaywallHtml", config.get("custom_paywall_html")
-            ),
+            custom_paywall_html=config.get("customPaywallHtml", config.get("custom_paywall_html")),
             unpaid_response_body=config.get(
                 "unpaidResponseBody", config.get("unpaid_response_body")
             ),
@@ -205,9 +201,7 @@ class x402HTTPServerBase:
         if errors:
             raise RouteConfigurationError(errors)
 
-    def register_paywall_provider(
-        self, provider: PaywallProvider
-    ) -> x402HTTPServerBase:
+    def register_paywall_provider(self, provider: PaywallProvider) -> x402HTTPServerBase:
         """Register custom paywall provider for HTML generation.
 
         Args:
@@ -447,9 +441,7 @@ class x402HTTPServerBase:
     # Internal Methods
     # =========================================================================
 
-    def _extract_payment(
-        self, adapter: HTTPAdapter
-    ) -> PaymentPayload | PaymentPayloadV1 | None:
+    def _extract_payment(self, adapter: HTTPAdapter) -> PaymentPayload | PaymentPayloadV1 | None:
         """Extract payment from HTTP headers (V2 only)."""
         # Check V2 header (case-insensitive)
         header = adapter.get_header(PAYMENT_SIGNATURE_HEADER) or adapter.get_header(
@@ -504,9 +496,7 @@ class x402HTTPServerBase:
             status=402,
             headers={
                 "Content-Type": content_type,
-                PAYMENT_REQUIRED_HEADER: encode_payment_required_header(
-                    payment_required
-                ),
+                PAYMENT_REQUIRED_HEADER: encode_payment_required_header(payment_required),
             },
             body=body,
         )
@@ -537,9 +527,7 @@ class x402HTTPServerBase:
 
             for option in options:
                 # Check scheme registered
-                if not self._server.has_registered_scheme(
-                    option.network, option.scheme
-                ):
+                if not self._server.has_registered_scheme(option.network, option.scheme):
                     errors.append(
                         RouteValidationError(
                             route_pattern=pattern,
@@ -552,9 +540,7 @@ class x402HTTPServerBase:
                     continue
 
                 # Check facilitator support
-                supported_kind = self._server.get_supported_kind(
-                    2, option.network, option.scheme
-                )
+                supported_kind = self._server.get_supported_kind(2, option.network, option.scheme)
                 if not supported_kind:
                     errors.append(
                         RouteValidationError(
@@ -679,7 +665,9 @@ class x402HTTPServerBase:
             "displayAmount": round(display_amount, 2),
             "currentUrl": current_url,
         }
-        config_script = f"<script>\n    window.x402 = {htmlsafe_json_dumps(x402_config)};\n</script>"
+        config_script = (
+            f"<script>\n    window.x402 = {htmlsafe_json_dumps(x402_config)};\n</script>"
+        )
 
         return template.replace("</body>", config_script + "</body>")
 
@@ -692,9 +680,7 @@ class x402HTTPServerBase:
         display_amount = self._get_display_amount(payment_required)
         resource_desc = ""
         if payment_required.resource:
-            resource_desc = (
-                payment_required.resource.description or payment_required.resource.url
-            )
+            resource_desc = payment_required.resource.description or payment_required.resource.url
 
         app_logo = ""
         app_name = ""
@@ -703,15 +689,9 @@ class x402HTTPServerBase:
                 app_logo = f'<img src="{html.escape(config.app_logo)}" alt="{html.escape(config.app_name or "")}" style="max-width: 200px;">'
             app_name = config.app_name or ""
 
-        payment_data = payment_required.model_dump_json(
-            by_alias=True, exclude_none=True
-        )
+        payment_data = payment_required.model_dump_json(by_alias=True, exclude_none=True)
 
-        title = (
-            f"{html.escape(app_name)} - Payment Required"
-            if app_name
-            else "Payment Required"
-        )
+        title = f"{html.escape(app_name)} - Payment Required" if app_name else "Payment Required"
 
         return f"""<!DOCTYPE html>
 <html>

--- a/python/x402/mcp/client.py
+++ b/python/x402/mcp/client.py
@@ -127,9 +127,7 @@ class x402MCPSession:
             return self._build_result(result, payment_made=False)
 
         # Create payment payload using the x402 client
-        payment_payload = await self._x402_client.create_payment_payload(
-            payment_required
-        )
+        payment_payload = await self._x402_client.create_payment_payload(payment_required)
 
         # Serialize for transmission
         payload_dict = payment_payload.model_dump(by_alias=True)
@@ -147,9 +145,7 @@ class x402MCPSession:
         """Convert MCP result to MCPToolCallResult."""
         payment_response = None
         if hasattr(result, "meta") and result.meta:
-            meta_dict = (
-                dict(result.meta) if not isinstance(result.meta, dict) else result.meta
-            )
+            meta_dict = dict(result.meta) if not isinstance(result.meta, dict) else result.meta
             pr = meta_dict.get(MCP_PAYMENT_RESPONSE_META_KEY)
             if pr:
                 try:

--- a/python/x402/mcp/client_async.py
+++ b/python/x402/mcp/client_async.py
@@ -188,9 +188,7 @@ class x402MCPClient:
                 hook_result = await hook_result
             if hook_result:
                 if hook_result.abort:
-                    raise PaymentRequiredError(
-                        "Payment aborted by hook", payment_required
-                    )
+                    raise PaymentRequiredError("Payment aborted by hook", payment_required)
                 if hook_result.payment:
                     return await self.call_tool_with_payment(
                         name, args, hook_result.payment, **kwargs
@@ -296,9 +294,7 @@ class x402MCPClient:
         result = await self._call_mcp_tool(call_params, **kwargs)
         return extract_payment_required_from_result(result)
 
-    async def _call_mcp_tool(
-        self, params: dict[str, Any], **kwargs: Any
-    ) -> MCPToolResult:
+    async def _call_mcp_tool(self, params: dict[str, Any], **kwargs: Any) -> MCPToolResult:
         """Call underlying async MCP client tool method.
 
         Args:
@@ -362,9 +358,7 @@ class x402MCPClient:
         if hasattr(self._mcp_client, "unsubscribe_resource"):
             await self._mcp_client.unsubscribe_resource(uri)
         else:
-            raise NotImplementedError(
-                "MCP client does not support unsubscribe_resource"
-            )
+            raise NotImplementedError("MCP client does not support unsubscribe_resource")
 
     async def list_prompts(self) -> Any:
         """List available prompts from the server."""
@@ -421,9 +415,7 @@ class x402MCPClient:
         if hasattr(self._mcp_client, "send_roots_list_changed"):
             await self._mcp_client.send_roots_list_changed()
         else:
-            raise NotImplementedError(
-                "MCP client does not support send_roots_list_changed"
-            )
+            raise NotImplementedError("MCP client does not support send_roots_list_changed")
 
 
 # ============================================================================

--- a/python/x402/mcp/server.py
+++ b/python/x402/mcp/server.py
@@ -127,9 +127,7 @@ def create_payment_wrapper(
             payment_data = _extract_payment_from_context(ctx)
 
             if not payment_data:
-                return _create_payment_required_result(
-                    accepts, tool_resource, "Payment Required"
-                )
+                return _create_payment_required_result(accepts, tool_resource, "Payment Required")
 
             # Parse payment payload
             try:
@@ -142,9 +140,7 @@ def create_payment_wrapper(
                 )
 
             if asyncio.iscoroutinefunction(resource_server.verify_payment):
-                verify_result = await resource_server.verify_payment(
-                    payload, accepts[0]
-                )
+                verify_result = await resource_server.verify_payment(payload, accepts[0])
             else:
                 verify_result = await asyncio.to_thread(
                     resource_server.verify_payment, payload, accepts[0]
@@ -182,9 +178,7 @@ def create_payment_wrapper(
                     result = handler(**kwargs)
             except Exception as e:
                 return CallToolResult(
-                    content=[
-                        TextContent(type="text", text=f"Tool execution error: {e}")
-                    ],
+                    content=[TextContent(type="text", text=f"Tool execution error: {e}")],
                     isError=True,
                 )
 
@@ -205,9 +199,7 @@ def create_payment_wrapper(
 
             mcp_result = MCPToolResultType(
                 content=(
-                    [{"type": "text", "text": result_text}]
-                    if isinstance(result_text, str)
-                    else []
+                    [{"type": "text", "text": result_text}] if isinstance(result_text, str) else []
                 ),
                 is_error=False,
                 meta={},
@@ -232,9 +224,7 @@ def create_payment_wrapper(
 
             try:
                 if asyncio.iscoroutinefunction(resource_server.settle_payment):
-                    settle_result = await resource_server.settle_payment(
-                        payload, accepts[0]
-                    )
+                    settle_result = await resource_server.settle_payment(payload, accepts[0])
                 else:
                     settle_result = await asyncio.to_thread(
                         resource_server.settle_payment, payload, accepts[0]

--- a/python/x402/mcp/server_async.py
+++ b/python/x402/mcp/server_async.py
@@ -25,10 +25,7 @@ from .utils import (
 # Async tool handler type
 AsyncToolHandler = Callable[
     [dict[str, Any], MCPToolContext],
-    MCPToolResult
-    | dict[str, Any]
-    | Awaitable[MCPToolResult]
-    | Awaitable[dict[str, Any]],
+    MCPToolResult | dict[str, Any] | Awaitable[MCPToolResult] | Awaitable[dict[str, Any]],
 ]
 
 
@@ -136,15 +133,11 @@ def create_payment_wrapper(
         ```
     """
     if not config.accepts:
-        raise ValueError(
-            "PaymentWrapperConfig.accepts must have at least one payment requirement"
-        )
+        raise ValueError("PaymentWrapperConfig.accepts must have at least one payment requirement")
 
     # Return wrapper function that takes a handler and returns a wrapped handler
     def wrapper(handler: AsyncToolHandler) -> AsyncToolHandler:
-        async def wrapped_handler(
-            args: dict[str, Any], extra: dict[str, Any]
-        ) -> MCPToolResult:
+        async def wrapped_handler(args: dict[str, Any], extra: dict[str, Any]) -> MCPToolResult:
             # Extract _meta from extra
             meta = extra.get("_meta", {})
             if not isinstance(meta, dict):
@@ -327,12 +320,8 @@ async def _create_payment_required_result_async(
     from ..schemas import ResourceInfo as CoreResourceInfo
 
     resource_info = CoreResourceInfo(
-        url=create_tool_resource_url(
-            tool_name, config.resource.url if config.resource else None
-        ),
-        description=(
-            config.resource.description if config.resource else f"Tool: {tool_name}"
-        ),
+        url=create_tool_resource_url(tool_name, config.resource.url if config.resource else None),
+        description=(config.resource.description if config.resource else f"Tool: {tool_name}"),
         mime_type=config.resource.mime_type if config.resource else "application/json",
     )
 
@@ -379,12 +368,8 @@ async def _create_settlement_failed_result_async(
     from ..schemas import ResourceInfo as CoreResourceInfo
 
     resource_info = CoreResourceInfo(
-        url=create_tool_resource_url(
-            tool_name, config.resource.url if config.resource else None
-        ),
-        description=(
-            config.resource.description if config.resource else f"Tool: {tool_name}"
-        ),
+        url=create_tool_resource_url(tool_name, config.resource.url if config.resource else None),
+        description=(config.resource.description if config.resource else f"Tool: {tool_name}"),
         mime_type=config.resource.mime_type if config.resource else "application/json",
     )
 

--- a/python/x402/mcp/server_sync.py
+++ b/python/x402/mcp/server_sync.py
@@ -50,9 +50,7 @@ def create_payment_wrapper_sync(
         )
 
     def wrapper(handler: SyncToolHandler) -> SyncToolHandler:
-        def wrapped_handler(
-            args: dict[str, Any], extra: dict[str, Any]
-        ) -> MCPToolResult:
+        def wrapped_handler(args: dict[str, Any], extra: dict[str, Any]) -> MCPToolResult:
             meta = extra.get("_meta", {})
             if not isinstance(meta, dict):
                 meta = {}
@@ -92,9 +90,7 @@ def create_payment_wrapper_sync(
                     "No matching payment requirements found",
                 )
 
-            verify_result = resource_server.verify_payment(
-                payment_payload, payment_requirements
-            )
+            verify_result = resource_server.verify_payment(payment_payload, payment_requirements)
 
             if not verify_result.is_valid:
                 reason = verify_result.invalid_reason or "Payment verification failed"
@@ -200,15 +196,9 @@ def _create_payment_required_result_sync(
     from ..schemas import ResourceInfo as SchemaResourceInfo
 
     resource_info = SchemaResourceInfo(
-        url=create_tool_resource_url(
-            tool_name, config.resource.url if config.resource else None
-        ),
-        description=(
-            config.resource.description if config.resource else f"Tool: {tool_name}"
-        ),
-        mime_type=(
-            config.resource.mime_type if config.resource else "application/json"
-        ),
+        url=create_tool_resource_url(tool_name, config.resource.url if config.resource else None),
+        description=(config.resource.description if config.resource else f"Tool: {tool_name}"),
+        mime_type=(config.resource.mime_type if config.resource else "application/json"),
     )
 
     payment_required = resource_server.create_payment_required_response(
@@ -242,15 +232,9 @@ def _create_settlement_failed_result_sync(
     from ..schemas import ResourceInfo as SchemaResourceInfo
 
     resource_info = SchemaResourceInfo(
-        url=create_tool_resource_url(
-            tool_name, config.resource.url if config.resource else None
-        ),
-        description=(
-            config.resource.description if config.resource else f"Tool: {tool_name}"
-        ),
-        mime_type=(
-            config.resource.mime_type if config.resource else "application/json"
-        ),
+        url=create_tool_resource_url(tool_name, config.resource.url if config.resource else None),
+        description=(config.resource.description if config.resource else f"Tool: {tool_name}"),
+        mime_type=(config.resource.mime_type if config.resource else "application/json"),
     )
 
     resource_server.create_payment_required_response(
@@ -269,8 +253,7 @@ def _create_settlement_failed_result_sync(
     error_data = {
         "x402Version": 2,
         "accepts": [
-            r.model_dump(by_alias=True) if hasattr(r, "model_dump") else r
-            for r in config.accepts
+            r.model_dump(by_alias=True) if hasattr(r, "model_dump") else r for r in config.accepts
         ],
         "error": f"Payment settlement failed: {error_message}",
         MCP_PAYMENT_RESPONSE_META_KEY: settlement_failure,

--- a/python/x402/mcp/tests/conftest.py
+++ b/python/x402/mcp/tests/conftest.py
@@ -57,9 +57,7 @@ SAMPLE_SETTLE_RESPONSE_DICT = {
 class MockMCPResult:
     """Configurable mock MCP result for testing."""
 
-    def __init__(
-        self, content=None, is_error=False, meta=None, structured_content=None
-    ):
+    def __init__(self, content=None, is_error=False, meta=None, structured_content=None):
         self.content = content or [{"type": "text", "text": "pong"}]
         self.isError = is_error
         self._meta = meta or {}
@@ -118,9 +116,7 @@ class MockResourceServer:
 class MockAsyncMCPResult:
     """Configurable mock MCP result for async testing."""
 
-    def __init__(
-        self, content=None, is_error=False, meta=None, structured_content=None
-    ):
+    def __init__(self, content=None, is_error=False, meta=None, structured_content=None):
         self.content = content or [{"type": "text", "text": "pong"}]
         self.isError = is_error
         self._meta = meta or {}
@@ -162,9 +158,7 @@ class MockAsyncResourceServer:
             side_effect=self._create_payment_required_response_real
         )
 
-    async def _create_payment_required_response_real(
-        self, accepts, resource_info, error_msg
-    ):
+    async def _create_payment_required_response_real(self, accepts, resource_info, error_msg):
         return PaymentRequired(
             x402_version=2,
             accepts=accepts,

--- a/python/x402/mcp/tests/test_client.py
+++ b/python/x402/mcp/tests/test_client.py
@@ -202,9 +202,7 @@ def test_wrap_mcp_client_with_payment():
     mock_mcp = MockMCPClient()
     mock_payment = MockPaymentClient()
 
-    client = wrap_mcp_client_with_payment_sync(
-        mock_mcp, mock_payment, auto_payment=True
-    )
+    client = wrap_mcp_client_with_payment_sync(mock_mcp, mock_payment, auto_payment=True)
     assert isinstance(client, x402MCPClientSync)
     assert client.client == mock_mcp
     assert client.payment_client == mock_payment
@@ -220,9 +218,7 @@ def test_wrap_mcp_client_with_payment_from_config():
 
     client = wrap_mcp_client_with_payment_from_config_sync(
         mock_mcp,
-        schemes=[
-            {"network": "eip155:84532", "client": ExactEvmClientScheme(mock_signer)}
-        ],
+        schemes=[{"network": "eip155:84532", "client": ExactEvmClientScheme(mock_signer)}],
         auto_payment=True,
     )
 
@@ -423,9 +419,7 @@ def test_x402_mcp_client_hook_custom_payment():
 
     from x402.mcp.types import PaymentRequiredHookResult
 
-    client.on_payment_required(
-        lambda ctx: PaymentRequiredHookResult(payment=custom_payload)
-    )
+    client.on_payment_required(lambda ctx: PaymentRequiredHookResult(payment=custom_payload))
 
     result = client.call_tool("paid_tool", {})
 

--- a/python/x402/mcp/tests/test_client_async.py
+++ b/python/x402/mcp/tests/test_client_async.py
@@ -11,9 +11,7 @@ from x402.schemas import PaymentPayload, PaymentRequired
 class MockAsyncMCPResult:
     """Mock MCP result for free tool."""
 
-    def __init__(
-        self, content=None, is_error=False, meta=None, structured_content=None
-    ):
+    def __init__(self, content=None, is_error=False, meta=None, structured_content=None):
         self.content = content or [{"type": "text", "text": "pong"}]
         self.isError = is_error
         self._meta = meta or {}
@@ -439,9 +437,7 @@ async def test_x402_mcp_client_async_hook_custom_payment():
 
     from x402.mcp.types import PaymentRequiredHookResult
 
-    client.on_payment_required(
-        lambda ctx: PaymentRequiredHookResult(payment=custom_payload)
-    )
+    client.on_payment_required(lambda ctx: PaymentRequiredHookResult(payment=custom_payload))
 
     result = await client.call_tool("paid_tool", {})
     assert result.payment_made is True

--- a/python/x402/mcp/tests/test_server.py
+++ b/python/x402/mcp/tests/test_server.py
@@ -22,9 +22,7 @@ class MockResourceServer:
         self.verify_payment = Mock()
         self.settle_payment = Mock()
         # Create a Mock that wraps the real method so we can track calls
-        self._create_payment_required_response_impl = (
-            self._create_payment_required_response_real
-        )
+        self._create_payment_required_response_impl = self._create_payment_required_response_real
         self.create_payment_required_response = MagicMock(
             side_effect=self._create_payment_required_response_real
         )
@@ -115,9 +113,7 @@ def test_create_payment_wrapper_basic_flow():
     args = {"test": "value"}
     extra = {
         "_meta": {
-            "x402/payment": (
-                payload.model_dump() if hasattr(payload, "model_dump") else payload
-            )
+            "x402/payment": (payload.model_dump() if hasattr(payload, "model_dump") else payload)
         },
         "toolName": "test",
     }
@@ -206,9 +202,7 @@ def test_create_payment_wrapper_verification_failure():
     args = {}
     extra = {
         "_meta": {
-            "x402/payment": (
-                payload.model_dump() if hasattr(payload, "model_dump") else payload
-            )
+            "x402/payment": (payload.model_dump() if hasattr(payload, "model_dump") else payload)
         },
         "toolName": "test",
     }
@@ -314,11 +308,7 @@ def test_create_payment_wrapper_abort_on_before_execution():
     wrapped = paid(handler)
     result = wrapped(
         {"test": "value"},
-        {
-            "_meta": {
-                "x402/payment": {"x402Version": 2, "payload": {"signature": "0x123"}}
-            }
-        },
+        {"_meta": {"x402/payment": {"x402Version": 2, "payload": {"signature": "0x123"}}}},
     )
 
     assert len(handler_called) == 0, "Handler should not be called when hook aborts"
@@ -351,18 +341,11 @@ def test_create_payment_wrapper_settlement_failure():
     wrapped = paid(handler)
     result = wrapped(
         {"test": "value"},
-        {
-            "_meta": {
-                "x402/payment": {"x402Version": 2, "payload": {"signature": "0x123"}}
-            }
-        },
+        {"_meta": {"x402/payment": {"x402Version": 2, "payload": {"signature": "0x123"}}}},
     )
 
     assert result.is_error is True
-    assert (
-        "settlement" in str(result.content).lower()
-        or result.structured_content is not None
-    )
+    assert "settlement" in str(result.content).lower() or result.structured_content is not None
 
 
 def test_create_payment_wrapper_handler_error_no_settlement():

--- a/python/x402/mcp/tests/test_server_async.py
+++ b/python/x402/mcp/tests/test_server_async.py
@@ -27,9 +27,7 @@ class MockAsyncResourceServer:
             )
         )
         # Create an AsyncMock that wraps the real method so we can track calls
-        self._create_payment_required_response_impl = (
-            self._create_payment_required_response_real
-        )
+        self._create_payment_required_response_impl = self._create_payment_required_response_real
         self.create_payment_required_response = AsyncMock(
             side_effect=self._create_payment_required_response_real
         )
@@ -50,9 +48,7 @@ class MockAsyncResourceServer:
                 return req
         return None
 
-    async def _create_payment_required_response_real(
-        self, accepts, resource_info, error_msg
-    ):
+    async def _create_payment_required_response_real(self, accepts, resource_info, error_msg):
         """Real implementation of create payment required response."""
         from x402.schemas import PaymentRequired
 
@@ -111,9 +107,7 @@ async def test_create_payment_wrapper_async_basic_flow():
     args = {"test": "value"}
     extra = {
         "_meta": {
-            "x402/payment": (
-                payload.model_dump() if hasattr(payload, "model_dump") else payload
-            )
+            "x402/payment": (payload.model_dump() if hasattr(payload, "model_dump") else payload)
         },
         "toolName": "test",
     }
@@ -204,9 +198,7 @@ async def test_create_payment_wrapper_async_verification_failure():
     args = {}
     extra = {
         "_meta": {
-            "x402/payment": (
-                payload.model_dump() if hasattr(payload, "model_dump") else payload
-            )
+            "x402/payment": (payload.model_dump() if hasattr(payload, "model_dump") else payload)
         },
         "toolName": "test",
     }
@@ -384,10 +376,7 @@ async def test_create_payment_wrapper_async_settlement_failure():
     )
 
     assert result.is_error is True
-    assert (
-        "settlement" in str(result.content).lower()
-        or result.structured_content is not None
-    )
+    assert "settlement" in str(result.content).lower() or result.structured_content is not None
 
 
 @pytest.mark.asyncio

--- a/python/x402/mcp/tests/test_utils.py
+++ b/python/x402/mcp/tests/test_utils.py
@@ -43,9 +43,7 @@ def test_extract_payment_from_meta_valid():
     )
     params = {
         "_meta": {
-            "x402/payment": (
-                payload.model_dump() if hasattr(payload, "model_dump") else payload
-            )
+            "x402/payment": (payload.model_dump() if hasattr(payload, "model_dump") else payload)
         }
     }
     result = extract_payment_from_meta(params)
@@ -167,18 +165,14 @@ def test_create_payment_required_error():
     error = create_payment_required_error(payment_required)
     assert error.code == 402
     assert str(error) == "Payment required" or (
-        hasattr(error, "args")
-        and len(error.args) > 0
-        and error.args[0] == "Payment required"
+        hasattr(error, "args") and len(error.args) > 0 and error.args[0] == "Payment required"
     )
     assert error.payment_required == payment_required
 
     # Test custom message
     error = create_payment_required_error(payment_required, "Custom error")
     assert str(error) == "Custom error" or (
-        hasattr(error, "args")
-        and len(error.args) > 0
-        and error.args[0] == "Custom error"
+        hasattr(error, "args") and len(error.args) > 0 and error.args[0] == "Custom error"
     )
 
 
@@ -288,9 +282,7 @@ def test_attach_payment_response_to_meta():
         network="eip155:84532",
     )
 
-    result = MCPToolResult(
-        content=[{"type": "text", "text": "success"}], is_error=False, meta=None
-    )
+    result = MCPToolResult(content=[{"type": "text", "text": "success"}], is_error=False, meta=None)
 
     updated = attach_payment_response_to_meta(result, settle_response)
 
@@ -366,9 +358,7 @@ def test_extract_payment_from_meta_json_string():
         },
         payload={"signature": "0x123"},
     )
-    payload_json = json.dumps(
-        payload.model_dump() if hasattr(payload, "model_dump") else payload
-    )
+    payload_json = json.dumps(payload.model_dump() if hasattr(payload, "model_dump") else payload)
     params = {
         "_meta": {
             "x402/payment": payload_json,

--- a/python/x402/mcp/utils.py
+++ b/python/x402/mcp/utils.py
@@ -45,9 +45,7 @@ def extract_payment_from_meta(params: dict[str, Any]) -> PaymentPayload | None:
         return None
 
 
-def attach_payment_to_meta(
-    params: dict[str, Any], payload: PaymentPayload
-) -> dict[str, Any]:
+def attach_payment_to_meta(params: dict[str, Any], payload: PaymentPayload) -> dict[str, Any]:
     """Attach payment payload to request params.
 
     Args:
@@ -58,9 +56,7 @@ def attach_payment_to_meta(
         New params dict with payment in _meta
     """
     result = params.copy()
-    meta = (
-        result.get("_meta", {}).copy() if isinstance(result.get("_meta"), dict) else {}
-    )
+    meta = result.get("_meta", {}).copy() if isinstance(result.get("_meta"), dict) else {}
     meta[MCP_PAYMENT_META_KEY] = (
         payload.model_dump(by_alias=True) if hasattr(payload, "model_dump") else payload
     )
@@ -114,9 +110,7 @@ def attach_payment_response_to_meta(
     """
     new_meta = result.meta.copy() if result.meta else {}
     new_meta[MCP_PAYMENT_RESPONSE_META_KEY] = (
-        response.model_dump(by_alias=True)
-        if hasattr(response, "model_dump")
-        else response
+        response.model_dump(by_alias=True) if hasattr(response, "model_dump") else response
     )
     return MCPToolResult(
         content=result.content,
@@ -179,9 +173,7 @@ def _extract_payment_required_from_object(
 
     try:
         # Normalize camelCase to snake_case for Pydantic
-        normalized = {
-            ("x402_version" if k == "x402Version" else k): v for k, v in obj.items()
-        }
+        normalized = {("x402_version" if k == "x402Version" else k): v for k, v in obj.items()}
         return PaymentRequired(**normalized)
     except (TypeError, ValueError, KeyError):
         return None
@@ -282,9 +274,7 @@ def extract_payment_required_from_error(error: Any) -> PaymentRequired | None:
         return None
 
     # Normalize camelCase to snake_case for Pydantic
-    normalized_data = {
-        ("x402_version" if k == "x402Version" else k): v for k, v in data.items()
-    }
+    normalized_data = {("x402_version" if k == "x402Version" else k): v for k, v in data.items()}
     return _extract_payment_required_from_object(normalized_data)
 
 

--- a/python/x402/mechanisms/evm/eip712.py
+++ b/python/x402/mechanisms/evm/eip712.py
@@ -86,9 +86,7 @@ def _encode_data(
             if isinstance(value, bytes):
                 encoded_values.append(keccak(value))
             else:
-                encoded_values.append(
-                    keccak(bytes.fromhex(str(value).removeprefix("0x")))
-                )
+                encoded_values.append(keccak(bytes.fromhex(str(value).removeprefix("0x"))))
         elif field_type == "bytes32":
             if isinstance(value, bytes):
                 encoded_values.append(value)
@@ -210,9 +208,7 @@ def hash_eip3009_authorization(
         "nonce": bytes.fromhex(authorization.nonce.removeprefix("0x")),
     }
 
-    return hash_typed_data(
-        domain, AUTHORIZATION_TYPES, "TransferWithAuthorization", message
-    )
+    return hash_typed_data(domain, AUTHORIZATION_TYPES, "TransferWithAuthorization", message)
 
 
 def build_typed_data_for_signing(

--- a/python/x402/mechanisms/evm/exact/client.py
+++ b/python/x402/mechanisms/evm/exact/client.py
@@ -96,9 +96,7 @@ class ExactEvmScheme:
         if "name" not in extra:
             # Try to get from asset info
             try:
-                asset_info = get_asset_info(
-                    str(requirements.network), requirements.asset
-                )
+                asset_info = get_asset_info(str(requirements.network), requirements.asset)
                 extra["name"] = asset_info["name"]
                 extra["version"] = asset_info.get("version", "1")
             except ValueError:
@@ -124,8 +122,6 @@ class ExactEvmScheme:
                 TypedDataField(name=f["name"], type=f["type"]) for f in fields
             ]
 
-        sig_bytes = self._signer.sign_typed_data(
-            domain, typed_fields, primary_type, message
-        )
+        sig_bytes = self._signer.sign_typed_data(domain, typed_fields, primary_type, message)
 
         return "0x" + sig_bytes.hex()

--- a/python/x402/mechanisms/evm/exact/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/facilitator.py
@@ -103,6 +103,7 @@ class ExactEvmScheme:
         self,
         payload: PaymentPayload,
         requirements: PaymentRequirements,
+        context=None,
     ) -> VerifyResponse:
         """Verify EIP-3009 payment payload.
 
@@ -134,9 +135,7 @@ class ExactEvmScheme:
 
         # Validate network
         if payload.accepted.network != requirements.network:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer=payer
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer=payer)
 
         # Get configs
         try:
@@ -217,9 +216,7 @@ class ExactEvmScheme:
 
         # Verify signature
         if not evm_payload.signature:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_INVALID_SIGNATURE, payer=payer
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_INVALID_SIGNATURE, payer=payer)
 
         signature = hex_to_bytes(evm_payload.signature)
         hash_bytes = hash_eip3009_authorization(
@@ -252,6 +249,7 @@ class ExactEvmScheme:
         self,
         payload: PaymentPayload,
         requirements: PaymentRequirements,
+        context=None,
     ) -> SettleResponse:
         """Settle EIP-3009 payment on-chain.
 
@@ -268,7 +266,7 @@ class ExactEvmScheme:
             SettleResponse with success, transaction, and payer.
         """
         # First verify
-        verify_result = self.verify(payload, requirements)
+        verify_result = self.verify(payload, requirements, context)
         if not verify_result.is_valid:
             return SettleResponse(
                 success=False,

--- a/python/x402/mechanisms/evm/exact/register.py
+++ b/python/x402/mechanisms/evm/exact/register.py
@@ -124,9 +124,7 @@ def register_exact_evm_facilitator(
     from .v1.facilitator import ExactEvmSchemeV1 as ExactEvmFacilitatorSchemeV1
     from .v1.facilitator import ExactEvmSchemeV1Config
 
-    config = ExactEvmSchemeConfig(
-        deploy_erc4337_with_eip6492=deploy_erc4337_with_eip6492
-    )
+    config = ExactEvmSchemeConfig(deploy_erc4337_with_eip6492=deploy_erc4337_with_eip6492)
     scheme = ExactEvmFacilitatorScheme(signer, config)
 
     if isinstance(networks, str):
@@ -134,9 +132,7 @@ def register_exact_evm_facilitator(
     facilitator.register(networks, scheme)
 
     # Register V1
-    v1_config = ExactEvmSchemeV1Config(
-        deploy_erc4337_with_eip6492=deploy_erc4337_with_eip6492
-    )
+    v1_config = ExactEvmSchemeV1Config(deploy_erc4337_with_eip6492=deploy_erc4337_with_eip6492)
     v1_scheme = ExactEvmFacilitatorSchemeV1(signer, v1_config)
     facilitator.register_v1(V1_NETWORKS, v1_scheme)
 

--- a/python/x402/mechanisms/evm/exact/server.py
+++ b/python/x402/mechanisms/evm/exact/server.py
@@ -125,9 +125,7 @@ class ExactEvmScheme:
 
         # Ensure amount is in smallest unit
         if "." in requirements.amount:
-            requirements.amount = str(
-                parse_amount(requirements.amount, asset_info["decimals"])
-            )
+            requirements.amount = str(parse_amount(requirements.amount, asset_info["decimals"]))
 
         # Add EIP-712 domain params
         if requirements.extra is None:

--- a/python/x402/mechanisms/evm/exact/v1/client.py
+++ b/python/x402/mechanisms/evm/exact/v1/client.py
@@ -126,8 +126,6 @@ class ExactEvmSchemeV1:
                 TypedDataField(name=f["name"], type=f["type"]) for f in fields
             ]
 
-        sig_bytes = self._signer.sign_typed_data(
-            domain, typed_fields, primary_type, message
-        )
+        sig_bytes = self._signer.sign_typed_data(domain, typed_fields, primary_type, message)
 
         return "0x" + sig_bytes.hex()

--- a/python/x402/mechanisms/evm/exact/v1/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/v1/facilitator.py
@@ -101,6 +101,7 @@ class ExactEvmSchemeV1:
         self,
         payload: PaymentPayloadV1,
         requirements: PaymentRequirementsV1,
+        context=None,
     ) -> VerifyResponse:
         """Verify EIP-3009 payment payload (V1).
 
@@ -128,9 +129,7 @@ class ExactEvmSchemeV1:
 
         # V1: Validate network at top level
         if payload.network != requirements.network:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer=payer
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer=payer)
 
         # V1: Legacy chain ID lookup
         try:
@@ -200,9 +199,7 @@ class ExactEvmSchemeV1:
 
         # Verify signature
         if not evm_payload.signature:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_INVALID_SIGNATURE, payer=payer
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_INVALID_SIGNATURE, payer=payer)
 
         signature = hex_to_bytes(evm_payload.signature)
         hash_bytes = hash_eip3009_authorization(
@@ -235,6 +232,7 @@ class ExactEvmSchemeV1:
         self,
         payload: PaymentPayloadV1,
         requirements: PaymentRequirementsV1,
+        context=None,
     ) -> SettleResponse:
         """Settle EIP-3009 payment on-chain (V1).
 
@@ -248,7 +246,7 @@ class ExactEvmSchemeV1:
             SettleResponse with success, transaction, and payer.
         """
         # First verify
-        verify_result = self.verify(payload, requirements)
+        verify_result = self.verify(payload, requirements, context)
         if not verify_result.is_valid:
             return SettleResponse(
                 success=False,

--- a/python/x402/mechanisms/evm/signers.py
+++ b/python/x402/mechanisms/evm/signers.py
@@ -411,10 +411,7 @@ class FacilitatorWeb3Signer:
             Balance in smallest unit.
         """
         # Native balance
-        if (
-            not token_address
-            or token_address == "0x0000000000000000000000000000000000000000"
-        ):
+        if not token_address or token_address == "0x0000000000000000000000000000000000000000":
             return self._w3.eth.get_balance(Web3.to_checksum_address(address))
 
         # ERC20 balance

--- a/python/x402/mechanisms/evm/verify.py
+++ b/python/x402/mechanisms/evm/verify.py
@@ -35,9 +35,7 @@ def verify_eoa_signature(
         ValueError: If signature length is invalid.
     """
     if len(signature) != 65:
-        raise ValueError(
-            f"Invalid EOA signature length: expected 65, got {len(signature)}"
-        )
+        raise ValueError(f"Invalid EOA signature length: expected 65, got {len(signature)}")
 
     # Extract r, s, v
     r = signature[:32]
@@ -159,7 +157,5 @@ def verify_universal_signature(
         return (False, sig_data)
 
     # Deployed contract - use EIP-1271
-    valid = verify_eip1271_signature(
-        signer, signer_address, hash, sig_data.inner_signature
-    )
+    valid = verify_eip1271_signature(signer, signer_address, hash, sig_data.inner_signature)
     return (valid, sig_data)

--- a/python/x402/mechanisms/svm/constants.py
+++ b/python/x402/mechanisms/svm/constants.py
@@ -62,12 +62,8 @@ V1_NETWORKS = [
 ERR_UNSUPPORTED_SCHEME = "unsupported_scheme"
 ERR_NETWORK_MISMATCH = "network_mismatch"
 ERR_INVALID_PAYLOAD = "invalid_exact_svm_payload"
-ERR_TRANSACTION_DECODE_FAILED = (
-    "invalid_exact_svm_payload_transaction_could_not_be_decoded"
-)
-ERR_INVALID_INSTRUCTION_COUNT = (
-    "invalid_exact_svm_payload_transaction_instructions_length"
-)
+ERR_TRANSACTION_DECODE_FAILED = "invalid_exact_svm_payload_transaction_could_not_be_decoded"
+ERR_INVALID_INSTRUCTION_COUNT = "invalid_exact_svm_payload_transaction_instructions_length"
 ERR_UNKNOWN_FOURTH_INSTRUCTION = "invalid_exact_svm_payload_unknown_fourth_instruction"
 ERR_UNKNOWN_FIFTH_INSTRUCTION = "invalid_exact_svm_payload_unknown_fifth_instruction"
 ERR_UNKNOWN_SIXTH_INSTRUCTION = "invalid_exact_svm_payload_unknown_sixth_instruction"
@@ -77,16 +73,16 @@ ERR_INVALID_COMPUTE_LIMIT = (
 ERR_INVALID_COMPUTE_PRICE = (
     "invalid_exact_svm_payload_transaction_instructions_compute_price_instruction"
 )
-ERR_COMPUTE_PRICE_TOO_HIGH = "invalid_exact_svm_payload_transaction_instructions_compute_price_instruction_too_high"
+ERR_COMPUTE_PRICE_TOO_HIGH = (
+    "invalid_exact_svm_payload_transaction_instructions_compute_price_instruction_too_high"
+)
 ERR_NO_TRANSFER_INSTRUCTION = "invalid_exact_svm_payload_no_transfer_instruction"
 ERR_MINT_MISMATCH = "invalid_exact_svm_payload_mint_mismatch"
 ERR_RECIPIENT_MISMATCH = "invalid_exact_svm_payload_recipient_mismatch"
 ERR_AMOUNT_INSUFFICIENT = "invalid_exact_svm_payload_amount_insufficient"
 ERR_FEE_PAYER_MISSING = "invalid_exact_svm_payload_missing_fee_payer"
 ERR_FEE_PAYER_NOT_MANAGED = "fee_payer_not_managed_by_facilitator"
-ERR_FEE_PAYER_TRANSFERRING = (
-    "invalid_exact_svm_payload_transaction_fee_payer_transferring_funds"
-)
+ERR_FEE_PAYER_TRANSFERRING = "invalid_exact_svm_payload_transaction_fee_payer_transferring_funds"
 ERR_SIMULATION_FAILED = "transaction_simulation_failed"
 ERR_TRANSACTION_FAILED = "transaction_failed"
 

--- a/python/x402/mechanisms/svm/exact/client.py
+++ b/python/x402/mechanisms/svm/exact/client.py
@@ -105,9 +105,7 @@ class ExactSvmScheme:
         extra = requirements.extra or {}
         fee_payer_str = extra.get("feePayer")
         if not fee_payer_str:
-            raise ValueError(
-                "feePayer is required in requirements.extra for SVM transactions"
-            )
+            raise ValueError("feePayer is required in requirements.extra for SVM transactions")
         fee_payer = Pubkey.from_string(fee_payer_str)
 
         mint = Pubkey.from_string(requirements.asset)
@@ -140,12 +138,8 @@ class ExactSvmScheme:
         decimals = mint_data[44]
 
         # Derive ATAs
-        source_ata_str = derive_ata(
-            self._signer.address, requirements.asset, str(token_program)
-        )
-        dest_ata_str = derive_ata(
-            requirements.pay_to, requirements.asset, str(token_program)
-        )
+        source_ata_str = derive_ata(self._signer.address, requirements.asset, str(token_program))
+        dest_ata_str = derive_ata(requirements.pay_to, requirements.asset, str(token_program))
         source_ata = Pubkey.from_string(source_ata_str)
         dest_ata = Pubkey.from_string(dest_ata_str)
 
@@ -154,9 +148,7 @@ class ExactSvmScheme:
 
         # 1. SetComputeUnitLimit instruction
         # Data: [2 (discriminator), u32 units (little-endian)]
-        set_cu_limit_data = bytes([2]) + DEFAULT_COMPUTE_UNIT_LIMIT.to_bytes(
-            4, "little"
-        )
+        set_cu_limit_data = bytes([2]) + DEFAULT_COMPUTE_UNIT_LIMIT.to_bytes(4, "little")
         set_cu_limit_ix = Instruction(
             program_id=compute_budget_program,
             accounts=[],
@@ -165,9 +157,9 @@ class ExactSvmScheme:
 
         # 2. SetComputeUnitPrice instruction
         # Data: [3 (discriminator), u64 microLamports (little-endian)]
-        set_cu_price_data = bytes(
-            [3]
-        ) + DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS.to_bytes(8, "little")
+        set_cu_price_data = bytes([3]) + DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS.to_bytes(
+            8, "little"
+        )
         set_cu_price_ix = Instruction(
             program_id=compute_budget_program,
             accounts=[],

--- a/python/x402/mechanisms/svm/exact/facilitator.py
+++ b/python/x402/mechanisms/svm/exact/facilitator.py
@@ -109,6 +109,7 @@ class ExactSvmScheme:
         self,
         payload: PaymentPayload,
         requirements: PaymentRequirements,
+        context=None,
     ) -> VerifyResponse:
         """Verify SPL token payment payload.
 
@@ -135,25 +136,16 @@ class ExactSvmScheme:
         network = str(requirements.network)
 
         # Step 1: Validate Payment Requirements
-        if (
-            payload.accepted.scheme != SCHEME_EXACT
-            or requirements.scheme != SCHEME_EXACT
-        ):
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_UNSUPPORTED_SCHEME, payer=""
-            )
+        if payload.accepted.scheme != SCHEME_EXACT or requirements.scheme != SCHEME_EXACT:
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_UNSUPPORTED_SCHEME, payer="")
 
         if str(payload.accepted.network) != str(requirements.network):
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer=""
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer="")
 
         extra = requirements.extra or {}
         fee_payer_str = extra.get("feePayer")
         if not fee_payer_str or not isinstance(fee_payer_str, str):
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_FEE_PAYER_MISSING, payer=""
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_FEE_PAYER_MISSING, payer="")
 
         # Verify that the requested feePayer is managed by this facilitator
         signer_addresses = self._signer.get_addresses()
@@ -261,9 +253,7 @@ class ExactSvmScheme:
                     if idx < len(invalid_reasons)
                     else ERR_UNKNOWN_SIXTH_INSTRUCTION
                 )
-                return VerifyResponse(
-                    is_valid=False, invalid_reason=reason, payer=payer
-                )
+                return VerifyResponse(is_valid=False, invalid_reason=reason, payer=payer)
 
         # Parse transfer instruction
         transfer_accounts = list(transfer_ix.accounts)
@@ -299,9 +289,7 @@ class ExactSvmScheme:
         # Verify mint address matches requirements
         mint_str = str(mint)
         if mint_str != requirements.asset:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_MINT_MISMATCH, payer=payer
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_MINT_MISMATCH, payer=payer)
 
         # Verify destination ATA matches expected ATA for payTo address
         expected_dest_ata = derive_ata(
@@ -344,6 +332,7 @@ class ExactSvmScheme:
         self,
         payload: PaymentPayload,
         requirements: PaymentRequirements,
+        context=None,
     ) -> SettleResponse:
         """Settle SPL token payment on-chain.
 
@@ -363,7 +352,7 @@ class ExactSvmScheme:
         network = str(payload.accepted.network)
 
         # First verify
-        verify_result = self.verify(payload, requirements)
+        verify_result = self.verify(payload, requirements, context)
         if not verify_result.is_valid:
             return SettleResponse(
                 success=False,

--- a/python/x402/mechanisms/svm/exact/v1/client.py
+++ b/python/x402/mechanisms/svm/exact/v1/client.py
@@ -108,9 +108,7 @@ class ExactSvmSchemeV1:
         extra = requirements.extra or {}
         fee_payer_str = extra.get("feePayer")
         if not fee_payer_str:
-            raise ValueError(
-                "feePayer is required in requirements.extra for SVM transactions"
-            )
+            raise ValueError("feePayer is required in requirements.extra for SVM transactions")
         fee_payer = Pubkey.from_string(fee_payer_str)
 
         mint = Pubkey.from_string(requirements.asset)
@@ -136,12 +134,8 @@ class ExactSvmSchemeV1:
         decimals = mint_data[44]
 
         # Derive ATAs
-        source_ata_str = derive_ata(
-            self._signer.address, requirements.asset, str(token_program)
-        )
-        dest_ata_str = derive_ata(
-            requirements.pay_to, requirements.asset, str(token_program)
-        )
+        source_ata_str = derive_ata(self._signer.address, requirements.asset, str(token_program))
+        dest_ata_str = derive_ata(requirements.pay_to, requirements.asset, str(token_program))
         source_ata = Pubkey.from_string(source_ata_str)
         dest_ata = Pubkey.from_string(dest_ata_str)
 
@@ -150,9 +144,7 @@ class ExactSvmSchemeV1:
 
         # 1. SetComputeUnitLimit instruction
         # Data: [2 (discriminator), u32 units (little-endian)]
-        set_cu_limit_data = bytes([2]) + DEFAULT_COMPUTE_UNIT_LIMIT.to_bytes(
-            4, "little"
-        )
+        set_cu_limit_data = bytes([2]) + DEFAULT_COMPUTE_UNIT_LIMIT.to_bytes(4, "little")
         set_cu_limit_ix = Instruction(
             program_id=compute_budget_program,
             accounts=[],
@@ -161,9 +153,9 @@ class ExactSvmSchemeV1:
 
         # 2. SetComputeUnitPrice instruction
         # Data: [3 (discriminator), u64 microLamports (little-endian)]
-        set_cu_price_data = bytes(
-            [3]
-        ) + DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS.to_bytes(8, "little")
+        set_cu_price_data = bytes([3]) + DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS.to_bytes(
+            8, "little"
+        )
         set_cu_price_ix = Instruction(
             program_id=compute_budget_program,
             accounts=[],

--- a/python/x402/mechanisms/svm/exact/v1/facilitator.py
+++ b/python/x402/mechanisms/svm/exact/v1/facilitator.py
@@ -102,6 +102,7 @@ class ExactSvmSchemeV1:
         self,
         payload: PaymentPayloadV1,
         requirements: PaymentRequirementsV1,
+        context=None,
     ) -> VerifyResponse:
         """Verify SPL token payment payload (V1).
 
@@ -121,22 +122,16 @@ class ExactSvmSchemeV1:
 
         # V1: Validate scheme at top level
         if payload.scheme != SCHEME_EXACT or requirements.scheme != SCHEME_EXACT:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_UNSUPPORTED_SCHEME, payer=""
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_UNSUPPORTED_SCHEME, payer="")
 
         # V1: Validate network at top level
         if payload.network != requirements.network:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer=""
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_NETWORK_MISMATCH, payer="")
 
         extra = requirements.extra or {}
         fee_payer_str = extra.get("feePayer")
         if not fee_payer_str or not isinstance(fee_payer_str, str):
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_FEE_PAYER_MISSING, payer=""
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_FEE_PAYER_MISSING, payer="")
 
         # Verify that the requested feePayer is managed by this facilitator
         signer_addresses = self._signer.get_addresses()
@@ -244,9 +239,7 @@ class ExactSvmSchemeV1:
                     if idx < len(invalid_reasons)
                     else ERR_UNKNOWN_SIXTH_INSTRUCTION
                 )
-                return VerifyResponse(
-                    is_valid=False, invalid_reason=reason, payer=payer
-                )
+                return VerifyResponse(is_valid=False, invalid_reason=reason, payer=payer)
 
         # Parse transfer instruction
         transfer_accounts = list(transfer_ix.accounts)
@@ -281,9 +274,7 @@ class ExactSvmSchemeV1:
         # Verify mint address matches requirements
         mint_str = str(mint)
         if mint_str != requirements.asset:
-            return VerifyResponse(
-                is_valid=False, invalid_reason=ERR_MINT_MISMATCH, payer=payer
-            )
+            return VerifyResponse(is_valid=False, invalid_reason=ERR_MINT_MISMATCH, payer=payer)
 
         # Verify destination ATA
         expected_dest_ata = derive_ata(
@@ -322,6 +313,7 @@ class ExactSvmSchemeV1:
         self,
         payload: PaymentPayloadV1,
         requirements: PaymentRequirementsV1,
+        context=None,
     ) -> SettleResponse:
         """Settle SPL token payment on-chain (V1).
 
@@ -338,7 +330,7 @@ class ExactSvmSchemeV1:
         network = payload.network
 
         # First verify
-        verify_result = self.verify(payload, requirements)
+        verify_result = self.verify(payload, requirements, context)
         if not verify_result.is_valid:
             return SettleResponse(
                 success=False,

--- a/python/x402/mechanisms/svm/signers.py
+++ b/python/x402/mechanisms/svm/signers.py
@@ -187,9 +187,7 @@ class FacilitatorKeypairSigner:
         """
         if fee_payer not in self._keypairs:
             available = ", ".join(self._keypairs.keys())
-            raise ValueError(
-                f"No signer for fee payer {fee_payer}. Available: {available}"
-            )
+            raise ValueError(f"No signer for fee payer {fee_payer}. Available: {available}")
 
         keypair = self._keypairs[fee_payer]
 

--- a/python/x402/mechanisms/svm/utils.py
+++ b/python/x402/mechanisms/svm/utils.py
@@ -335,9 +335,7 @@ def derive_ata(owner: str, mint: str, token_program: str | None = None) -> str:
     """
     from solders.pubkey import Pubkey
 
-    ASSOCIATED_TOKEN_PROGRAM_ID = Pubkey.from_string(
-        "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
-    )
+    ASSOCIATED_TOKEN_PROGRAM_ID = Pubkey.from_string("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL")
 
     if token_program is None:
         token_program = TOKEN_PROGRAM_ADDRESS

--- a/python/x402/schemas/errors.py
+++ b/python/x402/schemas/errors.py
@@ -16,9 +16,7 @@ class VerifyError(PaymentError):
         payer: The payer's address (if known).
     """
 
-    def __init__(
-        self, reason: str, message: str | None = None, payer: str | None = None
-    ):
+    def __init__(self, reason: str, message: str | None = None, payer: str | None = None):
         self.invalid_reason = reason
         self.invalid_message = message
         self.reason = reason

--- a/python/x402/server.py
+++ b/python/x402/server.py
@@ -165,9 +165,7 @@ class x402ResourceServer(x402ResourceServerBase):
             PaymentAbortedError: If a before hook aborts.
             RuntimeError: If not initialized.
         """
-        gen = self._verify_payment_core(
-            payload, requirements, payload_bytes, requirements_bytes
-        )
+        gen = self._verify_payment_core(payload, requirements, payload_bytes, requirements_bytes)
         result = None
         try:
             while True:
@@ -211,9 +209,7 @@ class x402ResourceServer(x402ResourceServerBase):
             PaymentAbortedError: If a before hook aborts.
             RuntimeError: If not initialized.
         """
-        gen = self._settle_payment_core(
-            payload, requirements, payload_bytes, requirements_bytes
-        )
+        gen = self._settle_payment_core(payload, requirements, payload_bytes, requirements_bytes)
         result = None
         try:
             while True:
@@ -271,9 +267,7 @@ class x402ResourceServerSync(x402ResourceServerBase):
 
     def __init__(
         self,
-        facilitator_clients: (
-            FacilitatorClientSync | list[FacilitatorClientSync] | None
-        ) = None,
+        facilitator_clients: (FacilitatorClientSync | list[FacilitatorClientSync] | None) = None,
     ) -> None:
         """Initialize sync x402ResourceServer."""
         # Runtime validation - catch mismatched sync/async early
@@ -374,9 +368,7 @@ class x402ResourceServerSync(x402ResourceServerBase):
             PaymentAbortedError: If a before hook aborts.
             RuntimeError: If not initialized.
         """
-        gen = self._verify_payment_core(
-            payload, requirements, payload_bytes, requirements_bytes
-        )
+        gen = self._verify_payment_core(payload, requirements, payload_bytes, requirements_bytes)
         result = None
         try:
             while True:
@@ -420,9 +412,7 @@ class x402ResourceServerSync(x402ResourceServerBase):
             PaymentAbortedError: If a before hook aborts.
             RuntimeError: If not initialized.
         """
-        gen = self._settle_payment_core(
-            payload, requirements, payload_bytes, requirements_bytes
-        )
+        gen = self._settle_payment_core(payload, requirements, payload_bytes, requirements_bytes)
         result = None
         try:
             while True:

--- a/python/x402/server_base.py
+++ b/python/x402/server_base.py
@@ -97,18 +97,14 @@ class FacilitatorClientSync(Protocol):
 # Type Aliases - Support both sync and async hooks
 # ============================================================================
 
-BeforeVerifyHook = Callable[
-    [VerifyContext], Awaitable[AbortResult | None] | AbortResult | None
-]
+BeforeVerifyHook = Callable[[VerifyContext], Awaitable[AbortResult | None] | AbortResult | None]
 AfterVerifyHook = Callable[[VerifyResultContext], Awaitable[None] | None]
 OnVerifyFailureHook = Callable[
     [VerifyFailureContext],
     Awaitable[RecoveredVerifyResult | None] | RecoveredVerifyResult | None,
 ]
 
-BeforeSettleHook = Callable[
-    [SettleContext], Awaitable[AbortResult | None] | AbortResult | None
-]
+BeforeSettleHook = Callable[[SettleContext], Awaitable[AbortResult | None] | AbortResult | None]
 AfterSettleHook = Callable[[SettleResultContext], Awaitable[None] | None]
 OnSettleFailureHook = Callable[
     [SettleFailureContext],
@@ -146,9 +142,7 @@ class x402ResourceServerBase:
 
     def __init__(
         self,
-        facilitator_clients: (
-            _AnyFacilitatorClient | list[_AnyFacilitatorClient] | None
-        ) = None,
+        facilitator_clients: (_AnyFacilitatorClient | list[_AnyFacilitatorClient] | None) = None,
     ) -> None:
         """Initialize base server."""
         # Normalize to list
@@ -163,9 +157,7 @@ class x402ResourceServerBase:
         self._schemes: dict[Network, dict[str, SchemeNetworkServer]] = {}
 
         # Facilitator client map: network -> scheme -> client
-        self._facilitator_clients_map: dict[
-            Network, dict[str, _AnyFacilitatorClient]
-        ] = {}
+        self._facilitator_clients_map: dict[Network, dict[str, _AnyFacilitatorClient]] = {}
 
         # Supported responses from facilitators
         self._supported_responses: dict[Network, dict[str, SupportedResponse]] = {}
@@ -462,9 +454,7 @@ class x402ResourceServerBase:
                     requirements=requirements,
                     payload_bytes=payload_bytes,
                     requirements_bytes=requirements_bytes,
-                    error=Exception(
-                        verify_result.invalid_reason or "Verification failed"
-                    ),
+                    error=Exception(verify_result.invalid_reason or "Verification failed"),
                 )
                 for hook in self._on_verify_failure_hooks:
                     result = yield ("failure", hook, failure_context)

--- a/python/x402/tests/integrations/test_async_behavior.py
+++ b/python/x402/tests/integrations/test_async_behavior.py
@@ -85,9 +85,7 @@ class TestAsyncHTTPHooks:
 
     def setup_method(self) -> None:
         """Set up async test fixtures."""
-        self.facilitator = x402Facilitator().register(
-            ["x402:cash"], CashSchemeNetworkFacilitator()
-        )
+        self.facilitator = x402Facilitator().register(["x402:cash"], CashSchemeNetworkFacilitator())
         facilitator_client = CashFacilitatorClient(self.facilitator)
         self.resource_server = x402ResourceServer(facilitator_client)
         self.resource_server.register("x402:cash", CashSchemeNetworkServer())
@@ -285,9 +283,7 @@ class TestAsyncClientHooks:
 
     def setup_method(self) -> None:
         """Set up async test fixtures."""
-        self.facilitator = x402Facilitator().register(
-            ["x402:cash"], CashSchemeNetworkFacilitator()
-        )
+        self.facilitator = x402Facilitator().register(["x402:cash"], CashSchemeNetworkFacilitator())
         facilitator_client = CashFacilitatorClient(self.facilitator)
         self.server = x402ResourceServer(facilitator_client)
         self.server.register("x402:cash", CashSchemeNetworkServer())
@@ -377,9 +373,7 @@ class TestAsyncPaymentFlow:
             description="Async resource",
             mime_type="application/json",
         )
-        payment_required = self.server.create_payment_required_response(
-            accepts, resource
-        )
+        payment_required = self.server.create_payment_required_response(accepts, resource)
 
         # Native async calls
         payment_payload = await self.client.create_payment_payload(payment_required)

--- a/python/x402/tests/integrations/test_core.py
+++ b/python/x402/tests/integrations/test_core.py
@@ -209,9 +209,7 @@ class TestCorePaymentFlow:
         payment_payload = components.create_payment_payload(payment_required)
 
         # Server maps payment payload to requirements
-        accepted = components.server.find_matching_requirements(
-            accepts, payment_payload
-        )
+        accepted = components.server.find_matching_requirements(accepts, payment_payload)
         assert accepted is not None
 
         # Server verifies the payment
@@ -249,9 +247,7 @@ class TestCorePaymentFlow:
     ) -> None:
         """Test that facilitator can verify and settle payments directly."""
         requirements = build_cash_payment_requirements("Recipient", "USD", "5")
-        payment_required = components.server.create_payment_required_response(
-            [requirements]
-        )
+        payment_required = components.server.create_payment_required_response([requirements])
         payload = components.create_payment_payload(payment_required)
 
         # Verify directly with facilitator
@@ -269,9 +265,7 @@ class TestCorePaymentFlow:
     ) -> None:
         """Test that invalid signatures fail verification."""
         requirements = build_cash_payment_requirements("Recipient", "USD", "5")
-        payment_required = components.server.create_payment_required_response(
-            [requirements]
-        )
+        payment_required = components.server.create_payment_required_response([requirements])
         payload = components.create_payment_payload(payment_required)
 
         # Tamper with the payload
@@ -292,9 +286,7 @@ class TestCorePaymentFlow:
 
         # Try to match against different requirements
         different_accepts = [build_cash_payment_requirements("Company B", "USD", "99")]
-        result = components.server.find_matching_requirements(
-            different_accepts, payload
-        )
+        result = components.server.find_matching_requirements(different_accepts, payload)
 
         assert result is None
 
@@ -361,9 +353,7 @@ class TestServerInitialization:
     ) -> None:
         """Test that server raises error if not initialized."""
         requirements = build_cash_payment_requirements("Test", "USD", "1")
-        payment_required = uninitialized_server.create_payment_required_response(
-            [requirements]
-        )
+        payment_required = uninitialized_server.create_payment_required_response([requirements])
 
         # Create a valid client to make payload
         client = x402ClientSync().register("x402:cash", CashSchemeNetworkClient("Test"))
@@ -415,9 +405,7 @@ class TestClientPolicies:
 class TestSyncHooks:
     """Tests for sync hooks - these apply to both sync and async classes."""
 
-    def test_client_after_payment_creation_hook(
-        self, components: ComponentsFixture
-    ) -> None:
+    def test_client_after_payment_creation_hook(self, components: ComponentsFixture) -> None:
         """Test that after_payment_creation hook is called."""
         hook_called = False
         received_payload = None

--- a/python/x402/tests/integrations/test_evm.py
+++ b/python/x402/tests/integrations/test_evm.py
@@ -248,9 +248,7 @@ class TestEvmIntegrationV2:
             description="Premium API Access",
             mime_type="application/json",
         )
-        payment_required = self.server.create_payment_required_response(
-            accepts, resource
-        )
+        payment_required = self.server.create_payment_required_response(accepts, resource)
 
         # Verify V2
         assert payment_required.x402_version == 2

--- a/python/x402/tests/integrations/test_http_integration.py
+++ b/python/x402/tests/integrations/test_http_integration.py
@@ -243,9 +243,7 @@ class TestHTTPIntegration:
                 payment_required
             )
 
-        request_headers = components.http_client.encode_payment_signature_header(
-            payment_payload
-        )
+        request_headers = components.http_client.encode_payment_signature_header(payment_payload)
 
         # Retry with payment
         mock_adapter_with_payment = MockHTTPAdapter(
@@ -303,9 +301,7 @@ class TestDynamicPricing:
     """Tests for dynamic pricing - run against both sync and async implementations."""
 
     @pytest.fixture(params=["sync", "async"])
-    def components_factory(
-        self, request: pytest.FixtureRequest
-    ) -> type[HTTPComponentsFixture]:
+    def components_factory(self, request: pytest.FixtureRequest) -> type[HTTPComponentsFixture]:
         """Returns factory for creating components with custom routes."""
 
         class Factory:

--- a/python/x402/tests/integrations/test_mcp_evm.py
+++ b/python/x402/tests/integrations/test_mcp_evm.py
@@ -127,9 +127,7 @@ class MCPClientAdapter:
             if isinstance(item, TextContent):
                 content.append({"type": "text", "text": item.text})
             else:
-                content.append(
-                    {"type": getattr(item, "type", "text"), "text": str(item)}
-                )
+                content.append({"type": getattr(item, "type", "text"), "text": str(item)})
 
         return type(
             "MCPResult",
@@ -139,9 +137,7 @@ class MCPClientAdapter:
                 "isError": result.isError,  # MCP SDK uses camelCase
                 "_meta": result.meta if hasattr(result, "meta") and result.meta else {},
                 "structuredContent": (
-                    result.structuredContent
-                    if hasattr(result, "structuredContent")
-                    else None
+                    result.structuredContent if hasattr(result, "structuredContent") else None
                 ),
             },
         )()
@@ -200,9 +196,7 @@ class TestMCPEVMIntegration:
     def test_free_tool_works_without_payment(self):
         """Test that free tools work without payment."""
         # Create FastMCP server with port configuration
-        mcp_server = FastMCP(
-            "x402-test-server", json_response=True, port=TEST_PORT_FREE
-        )
+        mcp_server = FastMCP("x402-test-server", json_response=True, port=TEST_PORT_FREE)
 
         # Register free tool
         @mcp_server.tool()
@@ -239,9 +233,7 @@ class TestMCPEVMIntegration:
         try:
             # Connect client
             async def run_client():
-                async with streamable_http_client(
-                    f"http://localhost:{TEST_PORT_FREE}/mcp"
-                ) as (
+                async with streamable_http_client(f"http://localhost:{TEST_PORT_FREE}/mcp") as (
                     read_stream,
                     write_stream,
                     _,
@@ -313,9 +305,7 @@ class TestMCPEVMIntegration:
         )
 
         # Create FastMCP server with port configuration
-        mcp_server = FastMCP(
-            "x402-test-server", json_response=True, port=TEST_PORT_PAID
-        )
+        mcp_server = FastMCP("x402-test-server", json_response=True, port=TEST_PORT_PAID)
 
         # Register free tool
         @mcp_server.tool()
@@ -362,9 +352,7 @@ class TestMCPEVMIntegration:
         try:
             # Connect client
             async def run_client():
-                async with streamable_http_client(
-                    f"http://localhost:{TEST_PORT_PAID}/mcp"
-                ) as (
+                async with streamable_http_client(f"http://localhost:{TEST_PORT_PAID}/mcp") as (
                     read_stream,
                     write_stream,
                     _,
@@ -382,9 +370,7 @@ class TestMCPEVMIntegration:
                         )
 
                         # Call paid tool - this makes a REAL blockchain transaction!
-                        print(
-                            "\n🔄 Starting paid tool call with real blockchain settlement...\n"
-                        )
+                        print("\n🔄 Starting paid tool call with real blockchain settlement...\n")
 
                         result = x402_mcp.call_tool("get_weather", {"city": "New York"})
 

--- a/python/x402/tests/integrations/test_svm.py
+++ b/python/x402/tests/integrations/test_svm.py
@@ -205,9 +205,7 @@ class TestSvmIntegrationV2:
             description="Premium API Access",
             mime_type="application/json",
         )
-        payment_required = self.server.create_payment_required_response(
-            accepts, resource
-        )
+        payment_required = self.server.create_payment_required_response(accepts, resource)
 
         # Verify V2
         assert payment_required.x402_version == 2

--- a/python/x402/tests/mocks/cash.py
+++ b/python/x402/tests/mocks/cash.py
@@ -58,9 +58,7 @@ class CashSchemeNetworkClient:
         Returns:
             Inner payload dict with signature and validity.
         """
-        valid_until = int(time.time() * 1000) + (
-            requirements.max_timeout_seconds * 1000
-        )
+        valid_until = int(time.time() * 1000) + (requirements.max_timeout_seconds * 1000)
         return {
             "signature": f"~{self._payer}",
             "validUntil": str(valid_until),
@@ -107,6 +105,7 @@ class CashSchemeNetworkFacilitator:
         self,
         payload: PaymentPayload,
         requirements: PaymentRequirements,
+        context=None,
     ) -> VerifyResponse:
         """Verify a cash payment.
 
@@ -117,6 +116,7 @@ class CashSchemeNetworkFacilitator:
         Args:
             payload: The payment payload.
             requirements: The payment requirements.
+            context: Optional facilitator context.
 
         Returns:
             VerifyResponse with is_valid=True or False.
@@ -151,6 +151,7 @@ class CashSchemeNetworkFacilitator:
         self,
         payload: PaymentPayload,
         requirements: PaymentRequirements,
+        context=None,
     ) -> SettleResponse:
         """Settle a cash payment.
 
@@ -163,7 +164,7 @@ class CashSchemeNetworkFacilitator:
         Returns:
             SettleResponse with success=True or False.
         """
-        verify_result = self.verify(payload, requirements)
+        verify_result = self.verify(payload, requirements, context)
 
         if not verify_result.is_valid:
             return SettleResponse(

--- a/python/x402/tests/unit/core/test_from_config.py
+++ b/python/x402/tests/unit/core/test_from_config.py
@@ -236,10 +236,7 @@ class TestFromConfigMatchesManualRegistration:
         config_client = x402Client.from_config(config)
 
         # Both should have same registered schemes
-        assert (
-            manual_client.get_registered_schemes()
-            == config_client.get_registered_schemes()
-        )
+        assert manual_client.get_registered_schemes() == config_client.get_registered_schemes()
         assert len(manual_client._policies) == len(config_client._policies)
 
     def test_sync_client_equivalence(self):
@@ -262,8 +259,5 @@ class TestFromConfigMatchesManualRegistration:
         config_client = x402ClientSync.from_config(config)
 
         # Both should have same registered schemes
-        assert (
-            manual_client.get_registered_schemes()
-            == config_client.get_registered_schemes()
-        )
+        assert manual_client.get_registered_schemes() == config_client.get_registered_schemes()
         assert len(manual_client._policies) == len(config_client._policies)

--- a/python/x402/tests/unit/extensions/bazaar/test_facilitator.py
+++ b/python/x402/tests/unit/extensions/bazaar/test_facilitator.py
@@ -22,7 +22,7 @@ class TestValidateDiscoveryExtension:
             input_schema={"properties": {"query": {"type": "string"}}},
         )
 
-        result = validate_discovery_extension(ext[BAZAAR])
+        result = validate_discovery_extension(ext[BAZAAR.key])
         assert result.valid is True
         assert len(result.errors) == 0
 
@@ -34,7 +34,7 @@ class TestValidateDiscoveryExtension:
             body_type="json",
         )
 
-        result = validate_discovery_extension(ext[BAZAAR])
+        result = validate_discovery_extension(ext[BAZAAR.key])
         assert result.valid is True
 
 
@@ -49,14 +49,14 @@ class TestExtractDiscoveryInfo:
         )
 
         # Convert extension to dict format for payload
-        ext_dict = ext[BAZAAR]
+        ext_dict = ext[BAZAAR.key]
         if hasattr(ext_dict, "model_dump"):
             ext_dict = ext_dict.model_dump(by_alias=True)
 
         payload = {
             "x402Version": 2,
             "resource": {"url": "https://api.example.com/weather"},
-            "extensions": {BAZAAR: ext_dict},
+            "extensions": {BAZAAR.key: ext_dict},
             "accepted": {},
         }
         requirements = {"scheme": "exact", "network": "eip155:8453"}
@@ -75,14 +75,14 @@ class TestExtractDiscoveryInfo:
             body_type="json",
         )
 
-        ext_dict = ext[BAZAAR]
+        ext_dict = ext[BAZAAR.key]
         if hasattr(ext_dict, "model_dump"):
             ext_dict = ext_dict.model_dump(by_alias=True)
 
         payload = {
             "x402Version": 2,
             "resource": {"url": "https://api.example.com/translate"},
-            "extensions": {BAZAAR: ext_dict},
+            "extensions": {BAZAAR.key: ext_dict},
             "accepted": {},
         }
         requirements = {}
@@ -124,16 +124,14 @@ class TestExtractDiscoveryInfo:
             input_schema={"properties": {"city": {"type": "string"}}},
         )
 
-        ext_dict = ext[BAZAAR]
+        ext_dict = ext[BAZAAR.key]
         if hasattr(ext_dict, "model_dump"):
             ext_dict = ext_dict.model_dump(by_alias=True)
 
         payload = {
             "x402Version": 2,
-            "resource": {
-                "url": "https://api.example.com/weather?city=NYC&units=metric"
-            },
-            "extensions": {BAZAAR: ext_dict},
+            "resource": {"url": "https://api.example.com/weather?city=NYC&units=metric"},
+            "extensions": {BAZAAR.key: ext_dict},
             "accepted": {},
         }
 
@@ -149,14 +147,14 @@ class TestExtractDiscoveryInfo:
             input_schema={"properties": {}},
         )
 
-        ext_dict = ext[BAZAAR]
+        ext_dict = ext[BAZAAR.key]
         if hasattr(ext_dict, "model_dump"):
             ext_dict = ext_dict.model_dump(by_alias=True)
 
         payload = {
             "x402Version": 2,
             "resource": {"url": "https://api.example.com/docs#section-1"},
-            "extensions": {BAZAAR: ext_dict},
+            "extensions": {BAZAAR.key: ext_dict},
             "accepted": {},
         }
 
@@ -172,14 +170,14 @@ class TestExtractDiscoveryInfo:
             input_schema={"properties": {}},
         )
 
-        ext_dict = ext[BAZAAR]
+        ext_dict = ext[BAZAAR.key]
         if hasattr(ext_dict, "model_dump"):
             ext_dict = ext_dict.model_dump(by_alias=True)
 
         payload = {
             "x402Version": 2,
             "resource": {"url": "https://api.example.com/page?foo=bar#anchor"},
-            "extensions": {BAZAAR: ext_dict},
+            "extensions": {BAZAAR.key: ext_dict},
             "accepted": {},
         }
 
@@ -267,7 +265,7 @@ class TestExtractDiscoveryInfoFromExtension:
             input={"q": "test"},
         )
 
-        info = extract_discovery_info_from_extension(ext[BAZAAR])
+        info = extract_discovery_info_from_extension(ext[BAZAAR.key])
         assert isinstance(info, QueryDiscoveryInfo)
 
     def test_extract_without_validation(self) -> None:
@@ -276,7 +274,7 @@ class TestExtractDiscoveryInfoFromExtension:
             input={"q": "test"},
         )
 
-        info = extract_discovery_info_from_extension(ext[BAZAAR], validate=False)
+        info = extract_discovery_info_from_extension(ext[BAZAAR.key], validate=False)
         assert info is not None
 
 
@@ -289,7 +287,7 @@ class TestValidateAndExtract:
             input={"query": "test"},
         )
 
-        result = validate_and_extract(ext[BAZAAR])
+        result = validate_and_extract(ext[BAZAAR.key])
         assert result.valid is True
         assert result.info is not None
         assert len(result.errors) == 0
@@ -301,6 +299,6 @@ class TestValidateAndExtract:
             body_type="json",
         )
 
-        result = validate_and_extract(ext[BAZAAR])
+        result = validate_and_extract(ext[BAZAAR.key])
         assert result.valid is True
         assert isinstance(result.info, BodyDiscoveryInfo)

--- a/python/x402/tests/unit/extensions/bazaar/test_resource_service.py
+++ b/python/x402/tests/unit/extensions/bazaar/test_resource_service.py
@@ -20,8 +20,8 @@ class TestDeclareDiscoveryExtension:
             },
         )
 
-        assert BAZAAR in result
-        ext = result[BAZAAR]
+        assert BAZAAR.key in result
+        ext = result[BAZAAR.key]
         assert isinstance(ext, dict)
         assert ext["info"]["input"]["queryParams"] == {"city": "San Francisco"}
 
@@ -36,7 +36,7 @@ class TestDeclareDiscoveryExtension:
             ),
         )
 
-        ext = result[BAZAAR]
+        ext = result[BAZAAR.key]
         assert isinstance(ext, dict)
         assert ext["info"]["output"] is not None
         assert ext["info"]["output"]["type"] == "json"
@@ -56,8 +56,8 @@ class TestDeclareDiscoveryExtension:
             body_type="json",
         )
 
-        assert BAZAAR in result
-        ext = result[BAZAAR]
+        assert BAZAAR.key in result
+        ext = result[BAZAAR.key]
         assert isinstance(ext, dict)
         assert ext["info"]["input"]["bodyType"] == "json"
         assert ext["info"]["input"]["body"] == {"name": "John", "age": 30}
@@ -70,7 +70,7 @@ class TestDeclareDiscoveryExtension:
             body_type="form-data",
         )
 
-        ext = result[BAZAAR]
+        ext = result[BAZAAR.key]
         assert isinstance(ext, dict)
         assert ext["info"]["input"]["bodyType"] == "form-data"
 
@@ -81,7 +81,7 @@ class TestDeclareDiscoveryExtension:
             body_type="text",
         )
 
-        ext = result[BAZAAR]
+        ext = result[BAZAAR.key]
         assert isinstance(ext, dict)
         assert ext["info"]["input"]["bodyType"] == "text"
 
@@ -92,7 +92,7 @@ class TestDeclareDiscoveryExtension:
             input_schema={"properties": {"q": {"type": "string"}}},
         )
 
-        ext = result[BAZAAR]
+        ext = result[BAZAAR.key]
         schema = ext["schema"]
         assert "$schema" in schema
         assert schema["type"] == "object"
@@ -103,8 +103,8 @@ class TestDeclareDiscoveryExtension:
         """Test creating an extension with minimal config."""
         result = declare_discovery_extension()
 
-        assert BAZAAR in result
-        ext = result[BAZAAR]
+        assert BAZAAR.key in result
+        ext = result[BAZAAR.key]
         assert isinstance(ext, dict)
         assert ext["info"]["input"]["type"] == "http"
 
@@ -117,6 +117,6 @@ class TestDeclareDiscoveryExtension:
             ),
         )
 
-        ext = result[BAZAAR]
+        ext = result[BAZAAR.key]
         schema = ext["schema"]
         assert "output" in schema["properties"]

--- a/python/x402/tests/unit/extensions/bazaar/test_server.py
+++ b/python/x402/tests/unit/extensions/bazaar/test_server.py
@@ -23,23 +23,21 @@ class TestBazaarResourceServerExtension:
 
     def test_extension_key(self) -> None:
         """Test extension key is correct."""
-        assert bazaar_resource_server_extension.key == BAZAAR
+        assert bazaar_resource_server_extension.key == BAZAAR.key
 
     def test_enrich_with_http_context(self) -> None:
         """Test enriching declaration with HTTP context."""
         ext = declare_discovery_extension(
             input={"query": "test"},
         )
-        declaration = ext[BAZAAR]
+        declaration = ext[BAZAAR.key]
 
         # Convert to dict if needed
         if hasattr(declaration, "model_dump"):
             declaration = declaration.model_dump(by_alias=True)
 
         context = MockHTTPRequest(method="GET")
-        enriched = bazaar_resource_server_extension.enrich_declaration(
-            declaration, context
-        )
+        enriched = bazaar_resource_server_extension.enrich_declaration(declaration, context)
 
         assert enriched["info"]["input"]["method"] == "GET"
 
@@ -49,15 +47,13 @@ class TestBazaarResourceServerExtension:
             input={"data": "test"},
             body_type="json",
         )
-        declaration = ext[BAZAAR]
+        declaration = ext[BAZAAR.key]
 
         if hasattr(declaration, "model_dump"):
             declaration = declaration.model_dump(by_alias=True)
 
         context = MockHTTPRequest(method="POST")
-        enriched = bazaar_resource_server_extension.enrich_declaration(
-            declaration, context
-        )
+        enriched = bazaar_resource_server_extension.enrich_declaration(declaration, context)
 
         assert enriched["info"]["input"]["method"] == "POST"
 
@@ -66,15 +62,13 @@ class TestBazaarResourceServerExtension:
         ext = declare_discovery_extension(
             input={"query": "test"},
         )
-        declaration = ext[BAZAAR]
+        declaration = ext[BAZAAR.key]
 
         if hasattr(declaration, "model_dump"):
             declaration = declaration.model_dump(by_alias=True)
 
         # Pass None context
-        enriched = bazaar_resource_server_extension.enrich_declaration(
-            declaration, None
-        )
+        enriched = bazaar_resource_server_extension.enrich_declaration(declaration, None)
 
         # Should return unchanged (no method injection)
         assert enriched == declaration
@@ -84,7 +78,7 @@ class TestBazaarResourceServerExtension:
         ext = declare_discovery_extension(
             input={"query": "test"},
         )
-        declaration = ext[BAZAAR]
+        declaration = ext[BAZAAR.key]
 
         if hasattr(declaration, "model_dump"):
             declaration = declaration.model_dump(by_alias=True)
@@ -101,15 +95,13 @@ class TestBazaarResourceServerExtension:
         ext = declare_discovery_extension(
             input={"query": "test"},
         )
-        declaration = ext[BAZAAR]
+        declaration = ext[BAZAAR.key]
 
         if hasattr(declaration, "model_dump"):
             declaration = declaration.model_dump(by_alias=True)
 
         context = MockHTTPRequest(method="DELETE")
-        enriched = bazaar_resource_server_extension.enrich_declaration(
-            declaration, context
-        )
+        enriched = bazaar_resource_server_extension.enrich_declaration(declaration, context)
 
         schema = enriched.get("schema", {})
         input_schema = schema.get("properties", {}).get("input", {})
@@ -127,15 +119,13 @@ class TestBazaarResourceServerExtension:
                 },
             },
         )
-        declaration = ext[BAZAAR]
+        declaration = ext[BAZAAR.key]
 
         if hasattr(declaration, "model_dump"):
             declaration = declaration.model_dump(by_alias=True)
 
         context = MockHTTPRequest(method="GET")
-        enriched = bazaar_resource_server_extension.enrich_declaration(
-            declaration, context
-        )
+        enriched = bazaar_resource_server_extension.enrich_declaration(declaration, context)
 
         # Check original data preserved
         assert enriched["info"]["input"]["type"] == "http"

--- a/python/x402/tests/unit/extensions/bazaar/test_types.py
+++ b/python/x402/tests/unit/extensions/bazaar/test_types.py
@@ -21,7 +21,7 @@ class TestConstants:
 
     def test_bazaar_constant(self) -> None:
         """Test BAZAAR constant value."""
-        assert BAZAAR == "bazaar"
+        assert BAZAAR.key == "bazaar"
 
 
 class TestMethodChecks:

--- a/python/x402/tests/unit/http/clients/test_httpx.py
+++ b/python/x402/tests/unit/http/clients/test_httpx.py
@@ -679,9 +679,7 @@ class TestErrorHandlingTransport:
     async def test_should_raise_payment_error_on_client_error(self):
         """Should raise PaymentError when client fails."""
         mock_client = MagicMock()
-        mock_client.create_payment_payload = AsyncMock(
-            side_effect=Exception("Client error")
-        )
+        mock_client.create_payment_payload = AsyncMock(side_effect=Exception("Client error"))
 
         payment_required = PaymentRequired(
             x402_version=2,

--- a/python/x402/tests/unit/http/clients/test_requests.py
+++ b/python/x402/tests/unit/http/clients/test_requests.py
@@ -115,9 +115,7 @@ class TestX402HTTPAdapter:
         mock_response.status_code = 200
         mock_response.content = b'{"data": "test"}'
 
-        with patch.object(
-            requests.adapters.HTTPAdapter, "send", return_value=mock_response
-        ):
+        with patch.object(requests.adapters.HTTPAdapter, "send", return_value=mock_response):
             response = adapter.send(mock_request)
 
         assert response == mock_response
@@ -275,9 +273,7 @@ class TestX402HTTPAdapter:
         mock_402_response.headers = {}  # No valid payment info
         mock_402_response.content = b"not json"
 
-        with patch.object(
-            requests.adapters.HTTPAdapter, "send", return_value=mock_402_response
-        ):
+        with patch.object(requests.adapters.HTTPAdapter, "send", return_value=mock_402_response):
             with pytest.raises(PaymentError):
                 adapter.send(mock_request)
 
@@ -514,9 +510,7 @@ class TestBasicFunctionalityWithFixtures:
             (301, b"redirect"),
         ],
     )
-    def test_should_return_non_402_response_directly(
-        self, adapter, status_code, content
-    ):
+    def test_should_return_non_402_response_directly(self, adapter, status_code, content):
         """Should return non-402 responses without payment handling."""
         mock_response = _create_response(status_code, content)
 
@@ -549,9 +543,7 @@ class TestErrorHandlingWithFixtures:
 
     def test_should_raise_payment_error_on_client_error(self, adapter):
         """Should raise PaymentError when client fails."""
-        adapter._client.create_payment_payload = MagicMock(
-            side_effect=Exception("Client error")
-        )
+        adapter._client.create_payment_payload = MagicMock(side_effect=Exception("Client error"))
         mock_402 = _create_response(402, b"{}")
 
         with patch("requests.adapters.HTTPAdapter.send", return_value=mock_402):

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -216,9 +216,7 @@ class TestFastAPIAdapter:
 
     def test_get_query_params(self):
         """Test getting query parameters."""
-        request = make_mock_fastapi_request(
-            query_params={"city": "london", "units": "metric"}
-        )
+        request = make_mock_fastapi_request(query_params={"city": "london", "units": "metric"})
         adapter = FastAPIAdapter(request)
 
         params = adapter.get_query_params()
@@ -292,9 +290,7 @@ class TestPaymentMiddleware:
             )
         }
 
-        middleware = payment_middleware(
-            routes, mock_server, sync_facilitator_on_start=False
-        )
+        middleware = payment_middleware(routes, mock_server, sync_facilitator_on_start=False)
 
         request = make_mock_fastapi_request(path="/api/public")
         expected_response = MagicMock()
@@ -316,9 +312,7 @@ class TestPaymentMiddleware:
                 mock_http_server_class,
             )
 
-            middleware = payment_middleware(
-                routes, mock_server, sync_facilitator_on_start=False
-            )
+            middleware = payment_middleware(routes, mock_server, sync_facilitator_on_start=False)
             response = await middleware(request, call_next)
 
         assert response == expected_response

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -212,9 +212,7 @@ class TestFlaskAdapter:
 
     def test_get_query_params(self):
         """Test getting query parameters."""
-        request = make_mock_flask_request(
-            query_params={"city": "london", "units": "metric"}
-        )
+        request = make_mock_flask_request(query_params={"city": "london", "units": "metric"})
         adapter = FlaskAdapter(request)
 
         params = adapter.get_query_params()
@@ -311,9 +309,7 @@ class TestResponseWrapper:
 
         wrapper.send_response([b"body_data"])
 
-        original_start_response.assert_called_once_with(
-            "200 OK", [("Content-Type", "text/plain")]
-        )
+        original_start_response.assert_called_once_with("200 OK", [("Content-Type", "text/plain")])
         write_mock.assert_any_call(b"write_data")
         write_mock.assert_any_call(b"body_data")
 
@@ -357,9 +353,7 @@ class TestPaymentMiddleware:
         routes = {}
 
         original_wsgi = app.wsgi_app
-        middleware = PaymentMiddleware(
-            app, routes, mock_server, sync_facilitator_on_start=False
-        )
+        middleware = PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=False)
 
         assert middleware._original_wsgi == original_wsgi
 
@@ -373,9 +367,7 @@ class TestPaymentMiddlewareFunction:
         mock_server = MagicMock()
         routes = {}
 
-        result = payment_middleware(
-            app, routes, mock_server, sync_facilitator_on_start=False
-        )
+        result = payment_middleware(app, routes, mock_server, sync_facilitator_on_start=False)
 
         assert isinstance(result, PaymentMiddleware)
 
@@ -428,9 +420,7 @@ class TestFlaskMiddlewareIntegration:
         }
 
         # Create middleware with mocked http server
-        with patch(
-            "x402.http.middleware.flask.x402HTTPResourceServerSync"
-        ) as mock_http_server:
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
             mock_http_server_instance = MagicMock()
             mock_http_server_instance.requires_payment.return_value = False
             mock_http_server.return_value = mock_http_server_instance
@@ -463,21 +453,17 @@ class TestFlaskMiddlewareIntegration:
         }
 
         # Create middleware with mocked http server
-        with patch(
-            "x402.http.middleware.flask.x402HTTPResourceServerSync"
-        ) as mock_http_server:
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
             mock_http_server_instance = MagicMock()
             mock_http_server_instance.requires_payment.return_value = True
-            mock_http_server_instance.process_http_request.return_value = (
-                HTTPProcessResult(
-                    type="payment-error",
-                    response=HTTPResponseInstructions(
-                        status=402,
-                        headers={"PAYMENT-REQUIRED": "encoded_header"},
-                        body={"error": "Payment required"},
-                        is_html=False,
-                    ),
-                )
+            mock_http_server_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-error",
+                response=HTTPResponseInstructions(
+                    status=402,
+                    headers={"PAYMENT-REQUIRED": "encoded_header"},
+                    body={"error": "Payment required"},
+                    is_html=False,
+                ),
             )
             mock_http_server.return_value = mock_http_server_instance
 
@@ -510,23 +496,17 @@ class TestFlaskMiddlewareIntegration:
         payment_payload = make_v2_payload()
         payment_requirements = make_payment_requirements()
 
-        with patch(
-            "x402.http.middleware.flask.x402HTTPResourceServerSync"
-        ) as mock_http_server:
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
             mock_http_server_instance = MagicMock()
             mock_http_server_instance.requires_payment.return_value = True
-            mock_http_server_instance.process_http_request.return_value = (
-                HTTPProcessResult(
-                    type="payment-verified",
-                    payment_payload=payment_payload,
-                    payment_requirements=payment_requirements,
-                )
+            mock_http_server_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
             )
-            mock_http_server_instance.process_settlement.return_value = (
-                ProcessSettleResult(
-                    success=True,
-                    headers={"PAYMENT-RESPONSE": "settlement_encoded"},
-                )
+            mock_http_server_instance.process_settlement.return_value = ProcessSettleResult(
+                success=True,
+                headers={"PAYMENT-RESPONSE": "settlement_encoded"},
             )
             mock_http_server.return_value = mock_http_server_instance
 
@@ -555,23 +535,17 @@ class TestFlaskMiddlewareIntegration:
         payment_payload = make_v2_payload()
         payment_requirements = make_payment_requirements()
 
-        with patch(
-            "x402.http.middleware.flask.x402HTTPResourceServerSync"
-        ) as mock_http_server:
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
             mock_http_server_instance = MagicMock()
             mock_http_server_instance.requires_payment.return_value = True
-            mock_http_server_instance.process_http_request.return_value = (
-                HTTPProcessResult(
-                    type="payment-verified",
-                    payment_payload=payment_payload,
-                    payment_requirements=payment_requirements,
-                )
+            mock_http_server_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
             )
-            mock_http_server_instance.process_settlement.return_value = (
-                ProcessSettleResult(
-                    success=False,
-                    error_reason="Insufficient funds",
-                )
+            mock_http_server_instance.process_settlement.return_value = ProcessSettleResult(
+                success=False,
+                error_reason="Insufficient funds",
             )
             mock_http_server.return_value = mock_http_server_instance
 

--- a/python/x402/tests/unit/http/test_x402_http_client.py
+++ b/python/x402/tests/unit/http/test_x402_http_client.py
@@ -58,9 +58,7 @@ def make_v2_payload(signature: str = "0xmock") -> PaymentPayload:
 class MockX402Client:
     """Mock async x402Client for testing."""
 
-    def __init__(
-        self, payload_to_return: PaymentPayload | PaymentPayloadV1 | None = None
-    ):
+    def __init__(self, payload_to_return: PaymentPayload | PaymentPayloadV1 | None = None):
         self.payload_to_return = payload_to_return or make_v2_payload()
         self.create_payment_calls: list = []
 
@@ -72,9 +70,7 @@ class MockX402Client:
 class MockX402ClientSync:
     """Mock sync x402ClientSync for testing."""
 
-    def __init__(
-        self, payload_to_return: PaymentPayload | PaymentPayloadV1 | None = None
-    ):
+    def __init__(self, payload_to_return: PaymentPayload | PaymentPayloadV1 | None = None):
         self.payload_to_return = payload_to_return or make_v2_payload()
         self.create_payment_calls: list = []
 

--- a/python/x402/tests/unit/mechanisms/evm/test_server.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_server.py
@@ -442,9 +442,7 @@ class TestRegisterMoneyParser:
 
             server.register_money_parser(error_parser)
 
-            with pytest.raises(
-                RuntimeError, match="Parser error: amount exceeds limit"
-            ):
+            with pytest.raises(RuntimeError, match="Parser error: amount exceeds limit"):
                 server.parse_price(50, network)
 
     class TestChainingAndFluentApi:
@@ -460,9 +458,7 @@ class TestRegisterMoneyParser:
             def parser2(amount: float, network: str) -> AssetAmount | None:
                 return None
 
-            result = server.register_money_parser(parser1).register_money_parser(
-                parser2
-            )
+            result = server.register_money_parser(parser1).register_money_parser(parser2)
 
             assert result is server
 
@@ -556,9 +552,7 @@ class TestRegisterMoneyParser:
             assert sepolia_result.asset == "0xTestToken123456789012345678901234567890"
 
             mainnet_result = server.parse_price(10, "eip155:8453")
-            assert (
-                mainnet_result.asset == get_asset_info("eip155:8453", "USDC")["address"]
-            )
+            assert mainnet_result.asset == get_asset_info("eip155:8453", "USDC")["address"]
 
         def test_should_support_tiered_pricing(self):
             """Should support tiered pricing."""

--- a/python/x402/tests/unit/mechanisms/evm/test_signer.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_signer.py
@@ -63,9 +63,7 @@ class TestEthAccountSigner:
             "nonce": "0x" + "00" * 32,
         }
 
-        signature = signer.sign_typed_data(
-            domain, types, "TransferWithAuthorization", message
-        )
+        signature = signer.sign_typed_data(domain, types, "TransferWithAuthorization", message)
 
         assert signature is not None
         assert isinstance(signature, bytes)

--- a/python/x402/tests/unit/mechanisms/evm/test_types.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_types.py
@@ -165,9 +165,7 @@ class TestExactEIP3009Payload:
         serialized = original.to_dict()
         restored = ExactEIP3009Payload.from_dict(serialized)
 
-        assert (
-            restored.authorization.from_address == original.authorization.from_address
-        )
+        assert restored.authorization.from_address == original.authorization.from_address
         assert restored.authorization.to == original.authorization.to
         assert restored.authorization.value == original.authorization.value
         assert restored.signature == original.signature

--- a/python/x402/tests/unit/mechanisms/svm/test_duplicate_tx.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_duplicate_tx.py
@@ -98,21 +98,16 @@ class TestFixedBlockhashProducesDistinctTransactions:
         print(f"Transaction 2 (first 80 chars): {tx2_base64[:80]}...")
         print(f"Transactions are DISTINCT: {tx1_base64 != tx2_base64}")
 
-    def test_memo_instruction_present(
-        self, mock_rpc_client, test_keypair, test_requirements
-    ):
+    def test_memo_instruction_present(self, mock_rpc_client, test_keypair, test_requirements):
         signer = KeypairSigner(test_keypair)
         client = ExactSvmClientScheme(signer)
 
         with patch.object(client, "_get_client", return_value=mock_rpc_client):
             payload = client.create_payment_payload(test_requirements)
 
-        tx = decode_transaction_from_payload(
-            ExactSvmPayload(transaction=payload["transaction"])
-        )
+        tx = decode_transaction_from_payload(ExactSvmPayload(transaction=payload["transaction"]))
         programs = [
-            str(tx.message.account_keys[ix.program_id_index])
-            for ix in tx.message.instructions
+            str(tx.message.account_keys[ix.program_id_index]) for ix in tx.message.instructions
         ]
 
         assert MEMO_PROGRAM_ADDRESS in programs
@@ -130,9 +125,7 @@ class TestFixedBlockhashProducesDistinctTransactions:
 
             def get_blockhash():
                 call_count[0] += 1
-                blockhash = (
-                    FIXED_BLOCKHASH if call_count[0] == 1 else FIXED_BLOCKHASH_ALT
-                )
+                blockhash = FIXED_BLOCKHASH if call_count[0] == 1 else FIXED_BLOCKHASH_ALT
                 mock_resp = MagicMock()
                 mock_resp.value.blockhash = Hash.from_string(blockhash)
                 return mock_resp
@@ -154,9 +147,9 @@ class TestFixedBlockhashProducesDistinctTransactions:
         tx1_base64 = payload1["transaction"]
         tx2_base64 = payload2["transaction"]
 
-        assert (
-            tx1_base64 != tx2_base64
-        ), "CONTROL TEST PASSED: Different blockhash produces different transactions"
+        assert tx1_base64 != tx2_base64, (
+            "CONTROL TEST PASSED: Different blockhash produces different transactions"
+        )
 
         print("\n=== CONTROL TEST: DIFFERENT BLOCKHASH ===")
         print(f"Transaction 1 (first 80 chars): {tx1_base64[:80]}...")
@@ -184,9 +177,7 @@ class TestAttackScenarioSimulation:
         payments_attempted = 10
         payments_settled = 10
 
-        seller_loss_percent = (
-            (payments_attempted - payments_settled) / payments_attempted
-        ) * 100
+        seller_loss_percent = ((payments_attempted - payments_settled) / payments_attempted) * 100
 
         assert seller_loss_percent == 0
 
@@ -196,9 +187,9 @@ class TestAttackScenarioSimulation:
 
         requests_per_slot = slot_time_ms // typical_api_latency_ms
 
-        assert (
-            requests_per_slot > 1
-        ), f"Multiple requests ({requests_per_slot}) can arrive within a single slot"
+        assert requests_per_slot > 1, (
+            f"Multiple requests ({requests_per_slot}) can arrive within a single slot"
+        )
 
 
 class TestMitigationHookPoints:
@@ -249,9 +240,7 @@ class TestMemoDataIsValidUTF8:
             extra={"feePayer": str(fee_payer.pubkey())},
         )
 
-    def test_memo_data_is_valid_utf8(
-        self, mock_rpc_client, test_keypair, test_requirements
-    ):
+    def test_memo_data_is_valid_utf8(self, mock_rpc_client, test_keypair, test_requirements):
         """Verify memo data is valid UTF-8 (SPL Memo requirement)."""
         signer = KeypairSigner(test_keypair)
         client = ExactSvmClientScheme(signer)
@@ -259,9 +248,7 @@ class TestMemoDataIsValidUTF8:
         with patch.object(client, "_get_client", return_value=mock_rpc_client):
             payload = client.create_payment_payload(test_requirements)
 
-        tx = decode_transaction_from_payload(
-            ExactSvmPayload(transaction=payload["transaction"])
-        )
+        tx = decode_transaction_from_payload(ExactSvmPayload(transaction=payload["transaction"]))
 
         # Find memo instruction (index 3)
         assert len(tx.message.instructions) >= 4
@@ -280,16 +267,14 @@ class TestMemoDataIsValidUTF8:
 
         # Should be hex-encoded (32 chars for 16 bytes)
         expected_len = 32
-        assert (
-            len(memo_data) == expected_len
-        ), f"Memo should be hex-encoded (expected {expected_len} chars, got {len(memo_data)})"
+        assert len(memo_data) == expected_len, (
+            f"Memo should be hex-encoded (expected {expected_len} chars, got {len(memo_data)})"
+        )
 
         # Should only contain valid hex characters
         import re
 
-        assert re.match(
-            r"^[0-9a-f]+$", memo_string
-        ), "Memo data should only contain hex characters"
+        assert re.match(r"^[0-9a-f]+$", memo_string), "Memo data should only contain hex characters"
 
         print("\n=== UTF-8 VALIDITY CONFIRMED ===")
         print(f"Memo data: {memo_string}")
@@ -329,23 +314,16 @@ class TestMemoInstructionHasNoSigners:
             extra={"feePayer": str(Keypair.from_seed(bytes([2] * 32)).pubkey())},
         )
 
-    def test_memo_has_empty_accounts(
-        self, mock_rpc_client, test_keypair, test_requirements
-    ):
+    def test_memo_has_empty_accounts(self, mock_rpc_client, test_keypair, test_requirements):
         """Empty accounts is critical - signers break facilitator verification."""
         client = ExactSvmClientScheme(KeypairSigner(test_keypair))
 
         with patch.object(client, "_get_client", return_value=mock_rpc_client):
             payload = client.create_payment_payload(test_requirements)
 
-        tx = decode_transaction_from_payload(
-            ExactSvmPayload(transaction=payload["transaction"])
-        )
+        tx = decode_transaction_from_payload(ExactSvmPayload(transaction=payload["transaction"]))
         assert len(tx.message.instructions) >= 4
 
         memo_ix = tx.message.instructions[3]
-        assert (
-            str(tx.message.account_keys[memo_ix.program_id_index])
-            == MEMO_PROGRAM_ADDRESS
-        )
+        assert str(tx.message.account_keys[memo_ix.program_id_index]) == MEMO_PROGRAM_ADDRESS
         assert len(memo_ix.accounts) == 0, "memo must have no accounts"

--- a/python/x402/tests/unit/mechanisms/svm/test_server.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_server.py
@@ -369,9 +369,7 @@ class TestRegisterMoneyParser:
 
             server.register_money_parser(error_parser)
 
-            with pytest.raises(
-                RuntimeError, match="Parser error: amount exceeds limit"
-            ):
+            with pytest.raises(RuntimeError, match="Parser error: amount exceeds limit"):
                 server.parse_price(50, SOLANA_MAINNET_CAIP2)
 
     class TestChainingAndFluentApi:
@@ -387,9 +385,7 @@ class TestRegisterMoneyParser:
             def parser2(amount: float, network: str) -> AssetAmount | None:
                 return None
 
-            result = server.register_money_parser(parser1).register_money_parser(
-                parser2
-            )
+            result = server.register_money_parser(parser1).register_money_parser(parser2)
 
             assert result is server
 

--- a/typescript/.changeset/hungry-taxes-ask.md
+++ b/typescript/.changeset/hungry-taxes-ask.md
@@ -1,0 +1,6 @@
+---
+'@x402/extensions': patch
+'@x402/core': patch
+---
+
+Upgraded facilitator extension registration from string keys to FacilitatorExtension objects. Added FacilitatorContext threaded through SchemeNetworkFacilitator.verify/settle for mechanism access to extension capabilities

--- a/typescript/packages/core/src/types/extensions.ts
+++ b/typescript/packages/core/src/types/extensions.ts
@@ -3,6 +3,22 @@ import type { PaymentRequiredContext, SettleResultContext } from "../server/x402
 // Re-export context types from x402ResourceServer for convenience
 export type { PaymentRequiredContext, SettleResultContext };
 
+/**
+ * Base interface for facilitator extensions.
+ * Extensions registered with x402Facilitator are stored by key and made
+ * available to mechanism implementations via FacilitatorContext.
+ *
+ * Specific extensions extend this with additional capabilities:
+ *
+ * @example
+ * interface Erc20GasSponsoringExtension extends FacilitatorExtension {
+ *   batchSigner: SmartWalletBatchSigner;
+ * }
+ */
+export interface FacilitatorExtension {
+  key: string;
+}
+
 export interface ResourceServerExtension {
   key: string;
   /**

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -19,9 +19,11 @@ export type {
   MoneyParser,
   PaymentPayloadResult,
   PaymentPayloadContext,
+  FacilitatorContext,
 } from "./mechanisms";
 export type { PaymentRequirementsV1, PaymentRequiredV1, PaymentPayloadV1 } from "./v1";
 export type {
+  FacilitatorExtension,
   ResourceServerExtension,
   PaymentRequiredContext,
   SettleResultContext,

--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -2,6 +2,7 @@ import { SettleResponse, VerifyResponse } from "./facilitator";
 import { PaymentRequirements } from "./payments";
 import { PaymentPayload } from "./payments";
 import { Price, Network, AssetAmount } from ".";
+import { FacilitatorExtension } from "./extensions";
 
 /**
  * Money parser function that converts a numeric amount to an AssetAmount
@@ -42,6 +43,15 @@ export interface SchemeNetworkClient {
     paymentRequirements: PaymentRequirements,
     context?: PaymentPayloadContext,
   ): Promise<PaymentPayloadResult>;
+}
+
+/**
+ * Context passed to SchemeNetworkFacilitator.verify/settle, providing
+ * access to registered facilitator extensions. Mechanism implementations
+ * use this to retrieve extension-provided capabilities (e.g., a batch signer).
+ */
+export interface FacilitatorContext {
+  getExtension<T extends FacilitatorExtension = FacilitatorExtension>(key: string): T | undefined;
 }
 
 export interface SchemeNetworkFacilitator {
@@ -106,8 +116,16 @@ export interface SchemeNetworkFacilitator {
    */
   getSigners(network: string): string[];
 
-  verify(payload: PaymentPayload, requirements: PaymentRequirements): Promise<VerifyResponse>;
-  settle(payload: PaymentPayload, requirements: PaymentRequirements): Promise<SettleResponse>;
+  verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+    context?: FacilitatorContext,
+  ): Promise<VerifyResponse>;
+  settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+    context?: FacilitatorContext,
+  ): Promise<SettleResponse>;
 }
 
 export interface SchemeNetworkServer {

--- a/typescript/packages/core/test/unit/facilitator/x402Facilitator.test.ts
+++ b/typescript/packages/core/test/unit/facilitator/x402Facilitator.test.ts
@@ -181,7 +181,7 @@ describe("x402Facilitator", () => {
     it("should register extension", () => {
       const facilitator = new x402Facilitator();
 
-      const result = facilitator.registerExtension("bazaar");
+      const result = facilitator.registerExtension({ key: "bazaar" });
 
       expect(result).toBe(facilitator);
       expect(facilitator.getExtensions()).toEqual(["bazaar"]);
@@ -190,7 +190,7 @@ describe("x402Facilitator", () => {
     it("should register multiple extensions", () => {
       const facilitator = new x402Facilitator();
 
-      facilitator.registerExtension("bazaar").registerExtension("sign_in_with_x");
+      facilitator.registerExtension({ key: "bazaar" }).registerExtension({ key: "sign_in_with_x" });
 
       expect(facilitator.getExtensions()).toEqual(["bazaar", "sign_in_with_x"]);
     });
@@ -199,16 +199,16 @@ describe("x402Facilitator", () => {
       const facilitator = new x402Facilitator();
 
       facilitator
-        .registerExtension("bazaar")
-        .registerExtension("bazaar")
-        .registerExtension("bazaar");
+        .registerExtension({ key: "bazaar" })
+        .registerExtension({ key: "bazaar" })
+        .registerExtension({ key: "bazaar" });
 
       expect(facilitator.getExtensions()).toEqual(["bazaar"]);
     });
 
     it("should return copy of extensions array", () => {
       const facilitator = new x402Facilitator();
-      facilitator.registerExtension("bazaar");
+      facilitator.registerExtension({ key: "bazaar" });
 
       const extensions = facilitator.getExtensions();
       extensions.push("modified");

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -129,7 +129,7 @@ export function extractDiscoveryInfo(
     resourceUrl = paymentPayload.resource?.url ?? "";
 
     if (paymentPayload.extensions) {
-      const bazaarExtension = paymentPayload.extensions[BAZAAR];
+      const bazaarExtension = paymentPayload.extensions[BAZAAR.key];
 
       if (bazaarExtension && typeof bazaarExtension === "object") {
         try {

--- a/typescript/packages/extensions/src/bazaar/index.ts
+++ b/typescript/packages/extensions/src/bazaar/index.ts
@@ -33,7 +33,7 @@
  *   resource: { ... },
  *   accepts: [ ... ],
  *   extensions: {
- *     [BAZAAR]: extension
+ *     [BAZAAR.key]: extension
  *   }
  * };
  * ```

--- a/typescript/packages/extensions/src/bazaar/server.ts
+++ b/typescript/packages/extensions/src/bazaar/server.ts
@@ -35,7 +35,7 @@ interface ExtensionDeclaration {
 }
 
 export const bazaarResourceServerExtension: ResourceServerExtension = {
-  key: BAZAAR,
+  key: BAZAAR.key,
 
   enrichDeclaration: (declaration, transportContext) => {
     if (!isHTTPRequestContext(transportContext)) {

--- a/typescript/packages/extensions/src/bazaar/types.ts
+++ b/typescript/packages/extensions/src/bazaar/types.ts
@@ -4,10 +4,12 @@
 
 import type { BodyMethods, QueryParamMethods } from "@x402/core/http";
 
+import type { FacilitatorExtension } from "@x402/core/types";
+
 /**
- * Extension identifier constant for the Bazaar discovery extension
+ * Extension identifier for the Bazaar discovery extension.
  */
-export const BAZAAR = "bazaar";
+export const BAZAAR: FacilitatorExtension = { key: "bazaar" };
 
 /**
  * Discovery info for query parameter methods (GET, HEAD, DELETE)

--- a/typescript/packages/extensions/src/eip2612-gas-sponsoring/facilitator.ts
+++ b/typescript/packages/extensions/src/eip2612-gas-sponsoring/facilitator.ts
@@ -28,7 +28,7 @@ export function extractEip2612GasSponsoringInfo(
     return null;
   }
 
-  const extension = paymentPayload.extensions[EIP2612_GAS_SPONSORING] as
+  const extension = paymentPayload.extensions[EIP2612_GAS_SPONSORING.key] as
     | Eip2612GasSponsoringExtension
     | undefined;
 

--- a/typescript/packages/extensions/src/eip2612-gas-sponsoring/resourceService.ts
+++ b/typescript/packages/extensions/src/eip2612-gas-sponsoring/resourceService.ts
@@ -88,8 +88,9 @@ export function declareEip2612GasSponsoringExtension(): Record<
   string,
   Eip2612GasSponsoringExtension
 > {
+  const key = EIP2612_GAS_SPONSORING.key;
   return {
-    [EIP2612_GAS_SPONSORING]: {
+    [key]: {
       info: {
         description:
           "The facilitator accepts EIP-2612 gasless Permit to `Permit2` canonical contract.",

--- a/typescript/packages/extensions/src/eip2612-gas-sponsoring/types.ts
+++ b/typescript/packages/extensions/src/eip2612-gas-sponsoring/types.ts
@@ -6,10 +6,12 @@
  * facilitator submits it on-chain via `x402Permit2Proxy.settleWithPermit`.
  */
 
+import type { FacilitatorExtension } from "@x402/core/types";
+
 /**
- * Extension identifier constant for the EIP-2612 gas sponsoring extension.
+ * Extension identifier for the EIP-2612 gas sponsoring extension.
  */
-export const EIP2612_GAS_SPONSORING = "eip2612GasSponsoring";
+export const EIP2612_GAS_SPONSORING: FacilitatorExtension = { key: "eip2612GasSponsoring" };
 
 /**
  * EIP-2612 gas sponsoring info populated by the client.

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -19,7 +19,7 @@ import type { HTTPAdapter, HTTPRequestContext } from "@x402/core/http";
 describe("Bazaar Discovery Extension", () => {
   describe("BAZAAR constant", () => {
     it("should export the correct extension identifier", () => {
-      expect(BAZAAR).toBe("bazaar");
+      expect(BAZAAR.key).toBe("bazaar");
     });
   });
 
@@ -324,7 +324,7 @@ describe("Bazaar Discovery Extension", () => {
         accepted: {} as unknown,
         resource: { url: "http://example.com/test" },
         extensions: {
-          [BAZAAR]: extension,
+          [BAZAAR.key]: extension,
         },
       };
 
@@ -359,7 +359,7 @@ describe("Bazaar Discovery Extension", () => {
           mimeType: "application/json",
         },
         extensions: {
-          [BAZAAR]: extension,
+          [BAZAAR.key]: extension,
         },
       };
 
@@ -391,7 +391,7 @@ describe("Bazaar Discovery Extension", () => {
           mimeType: "text/html",
         },
         extensions: {
-          [BAZAAR]: extension,
+          [BAZAAR.key]: extension,
         },
       };
 
@@ -421,7 +421,7 @@ describe("Bazaar Discovery Extension", () => {
           mimeType: "text/html",
         },
         extensions: {
-          [BAZAAR]: extension,
+          [BAZAAR.key]: extension,
         },
       };
 
@@ -986,11 +986,11 @@ describe("Bazaar Discovery Extension", () => {
         },
         accepts: [],
         extensions: {
-          [BAZAAR]: extension,
+          [BAZAAR.key]: extension,
         },
       };
 
-      const bazaarExt = paymentRequired.extensions?.[BAZAAR] as DiscoveryExtension;
+      const bazaarExt = paymentRequired.extensions?.[BAZAAR.key] as DiscoveryExtension;
       expect(bazaarExt).toBeDefined();
 
       const validation = validateDiscoveryExtension(bazaarExt);
@@ -1084,7 +1084,7 @@ describe("Bazaar Discovery Extension", () => {
         accepted: {} as unknown,
         resource: { url: "http://example.com/v2" },
         extensions: {
-          [BAZAAR]: v2Extension,
+          [BAZAAR.key]: v2Extension,
         },
       };
 

--- a/typescript/packages/extensions/test/eip2612-gas-sponsoring.test.ts
+++ b/typescript/packages/extensions/test/eip2612-gas-sponsoring.test.ts
@@ -18,7 +18,7 @@ import type { PaymentPayload } from "@x402/core/types";
 describe("EIP-2612 Gas Sponsoring Extension", () => {
   describe("EIP2612_GAS_SPONSORING constant", () => {
     it("should export the correct extension identifier", () => {
-      expect(EIP2612_GAS_SPONSORING).toBe("eip2612GasSponsoring");
+      expect(EIP2612_GAS_SPONSORING.key).toBe("eip2612GasSponsoring");
     });
   });
 

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -116,7 +116,7 @@ export class ExactEvmScheme implements SchemeNetworkClient {
     context?: PaymentPayloadContext,
   ): Promise<Record<string, unknown> | undefined> {
     // Check if server advertises eip2612GasSponsoring
-    if (!context?.extensions?.[EIP2612_GAS_SPONSORING]) {
+    if (!context?.extensions?.[EIP2612_GAS_SPONSORING.key]) {
       return undefined;
     }
 
@@ -163,7 +163,7 @@ export class ExactEvmScheme implements SchemeNetworkClient {
     );
 
     return {
-      [EIP2612_GAS_SPONSORING]: { info },
+      [EIP2612_GAS_SPONSORING.key]: { info },
     };
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

Upgrades the x402Facilitator extension system across all three SDK languages (TypeScript, Go, Python) from string-based registration to object-based registration, aligning it with how x402Client and x402ResourceServer already handle extensions.

**Before**: facilitator.registerExtension("bazaar") -- extensions were stored as plain string keys with no way for mechanism implementations to access extension-provided capabilities during verify/settle.

**After**: facilitator.registerExtension(BAZAAR) -- extensions are FacilitatorExtension objects stored by key, and a FacilitatorContext is threaded through to SchemeNetworkFacilitator.verify()/settle(), enabling mechanisms to retrieve extension objects and use their capabilities (e.g., a batch signer for atomic transaction bundling).

#### Motivation

This is the infrastructure change needed to support extensions like erc20ApprovalGasSponsoring (spec: specs/extensions/erc20_gas_sponsoring.md), which requires the facilitator's EVM mechanism to access a smart wallet signer with batching support during settlement. The previous string-only registration made this impossible -- mechanisms had no way to access anything beyond the extension's name.

#### What changed
* New types: FacilitatorExtension (base type with key property) and FacilitatorContext (provides getExtension(key) to mechanisms)
* Interface change: SchemeNetworkFacilitator.verify/settle gains an optional context parameter (backward compatible for existing mechanism impls)
* Storage change: Internal extension storage upgraded from string array to key-indexed map/dict
* Constant change: BAZAAR and EIP2612_GAS_SPONSORING constants changed from string literals to FacilitatorExtension instances; all string-context usages updated to .key
* Context forwarding: Settle methods that internally call Verify now properly forward the FacilitatorContext

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 