### PR TITLE
feat: add erc20ApprovalGasSponsoring extension to permit2 in Go

### DIFF
--- a/e2e/facilitators/go/main.go
+++ b/e2e/facilitators/go/main.go
@@ -19,6 +19,7 @@ import (
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/extensions/bazaar"
 	"github.com/coinbase/x402/go/extensions/eip2612gassponsor"
+	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
 	exttypes "github.com/coinbase/x402/go/extensions/types"
 	evmmech "github.com/coinbase/x402/go/mechanisms/evm"
 	evm "github.com/coinbase/x402/go/mechanisms/evm/exact/facilitator"
@@ -777,6 +778,12 @@ func main() {
 
 	// Register the EIP-2612 Gas Sponsoring extension
 	facilitator.RegisterExtension(eip2612gassponsor.EIP2612GasSponsoring)
+
+	// Register the ERC-20 Approval Gas Sponsoring extension
+	// Note: In production, provide a real SmartWalletBatchSigner implementation.
+	// For e2e tests, the extension is registered but SmartWalletSigner is nil
+	// (disables batch settlement; server still advertises the extension capability).
+	facilitator.RegisterExtension(erc20approvalgassponsor.NewFacilitatorExtension(nil))
 
 	// Lifecycle hooks for payment tracking and discovery
 	facilitator.

--- a/e2e/servers/gin/main.go
+++ b/e2e/servers/gin/main.go
@@ -11,6 +11,7 @@ import (
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/extensions/bazaar"
 	"github.com/coinbase/x402/go/extensions/eip2612gassponsor"
+	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
 	"github.com/coinbase/x402/go/extensions/types"
 	x402http "github.com/coinbase/x402/go/http"
 	ginmw "github.com/coinbase/x402/go/http/gin"
@@ -126,7 +127,7 @@ func main() {
 				},
 			},
 			Extensions: map[string]interface{}{
-				types.BAZAAR: discoveryExtension,
+				types.BAZAAR.Key(): discoveryExtension,
 			},
 		},
 		"GET /protected-svm": {
@@ -139,7 +140,7 @@ func main() {
 				},
 			},
 			Extensions: map[string]interface{}{
-				types.BAZAAR: discoveryExtension,
+				types.BAZAAR.Key(): discoveryExtension,
 			},
 		},
 		// Permit2 endpoint - explicitly requires Permit2 flow instead of EIP-3009
@@ -161,10 +162,14 @@ func main() {
 			},
 			Extensions: func() map[string]interface{} {
 				ext := map[string]interface{}{
-					types.BAZAAR: discoveryExtension,
+					types.BAZAAR.Key(): discoveryExtension,
 				}
 				// Add EIP-2612 gas sponsoring extension
 				for k, v := range eip2612gassponsor.DeclareEip2612GasSponsoringExtension() {
+					ext[k] = v
+				}
+				// Add ERC-20 approval gas sponsoring extension (fallback for tokens without EIP-2612)
+				for k, v := range erc20approvalgassponsor.DeclareErc20ApprovalGasSponsoringExtension() {
 					ext[k] = v
 				}
 				return ext

--- a/go/extensions/erc20approvalgassponsor/facilitator.go
+++ b/go/extensions/erc20approvalgassponsor/facilitator.go
@@ -1,0 +1,84 @@
+package erc20approvalgassponsor
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// ExtractErc20ApprovalGasSponsoringInfo extracts the ERC-20 approval gas sponsoring info
+// from a payment payload's extensions map.
+//
+// Returns the info if the extension is present and contains the required
+// client-populated fields, or nil if not present or incomplete.
+func ExtractErc20ApprovalGasSponsoringInfo(extensions map[string]interface{}) (*Info, error) {
+	if extensions == nil {
+		return nil, nil
+	}
+
+	extRaw, ok := extensions[ERC20ApprovalGasSponsoring]
+	if !ok {
+		return nil, nil
+	}
+
+	// Marshal and unmarshal to get the extension structure
+	extJSON, err := json.Marshal(extRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal erc20ApprovalGasSponsoring extension: %w", err)
+	}
+
+	var ext Extension
+	if err := json.Unmarshal(extJSON, &ext); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal erc20ApprovalGasSponsoring extension: %w", err)
+	}
+
+	// Marshal and unmarshal info to get the typed struct
+	infoJSON, err := json.Marshal(ext.Info)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal erc20ApprovalGasSponsoring info: %w", err)
+	}
+
+	var info Info
+	if err := json.Unmarshal(infoJSON, &info); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal erc20ApprovalGasSponsoring info: %w", err)
+	}
+
+	// Check that the client has populated the required fields
+	if info.From == "" || info.Asset == "" || info.Spender == "" ||
+		info.Amount == "" || info.SignedTransaction == "" || info.Version == "" {
+		return nil, nil
+	}
+
+	return &info, nil
+}
+
+// ExtractErc20ApprovalGasSponsoringInfoFromPayloadBytes extracts the ERC-20 approval
+// gas sponsoring info from raw payment payload JSON bytes.
+func ExtractErc20ApprovalGasSponsoringInfoFromPayloadBytes(payloadBytes []byte) (*Info, error) {
+	var payload struct {
+		Extensions map[string]interface{} `json:"extensions"`
+	}
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+
+	return ExtractErc20ApprovalGasSponsoringInfo(payload.Extensions)
+}
+
+var (
+	erc20AddressPattern = regexp.MustCompile(`^0x[a-fA-F0-9]{40}$`)
+	erc20NumericPattern = regexp.MustCompile(`^[0-9]+$`)
+	erc20HexPattern     = regexp.MustCompile(`^0x[a-fA-F0-9]+$`)
+	erc20VersionPattern = regexp.MustCompile(`^[0-9]+(\.[0-9]+)*$`)
+)
+
+// ValidateErc20ApprovalGasSponsoringInfo validates that the ERC-20 approval gas sponsoring
+// info has valid format for all fields.
+func ValidateErc20ApprovalGasSponsoringInfo(info *Info) bool {
+	return erc20AddressPattern.MatchString(info.From) &&
+		erc20AddressPattern.MatchString(info.Asset) &&
+		erc20AddressPattern.MatchString(info.Spender) &&
+		erc20NumericPattern.MatchString(info.Amount) &&
+		erc20HexPattern.MatchString(info.SignedTransaction) &&
+		erc20VersionPattern.MatchString(info.Version)
+}

--- a/go/extensions/erc20approvalgassponsor/facilitator_test.go
+++ b/go/extensions/erc20approvalgassponsor/facilitator_test.go
@@ -1,0 +1,202 @@
+package erc20approvalgassponsor
+
+import (
+	"testing"
+)
+
+func TestExtractErc20ApprovalGasSponsoringInfo(t *testing.T) {
+	t.Run("returns nil for nil extensions", func(t *testing.T) {
+		result, err := ExtractErc20ApprovalGasSponsoringInfo(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != nil {
+			t.Fatal("expected nil result for nil extensions")
+		}
+	})
+
+	t.Run("returns nil for missing extension", func(t *testing.T) {
+		extensions := map[string]interface{}{
+			"otherExtension": map[string]interface{}{},
+		}
+		result, err := ExtractErc20ApprovalGasSponsoringInfo(extensions)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != nil {
+			t.Fatal("expected nil result for missing extension")
+		}
+	})
+
+	t.Run("returns nil for server-only info (incomplete)", func(t *testing.T) {
+		extensions := map[string]interface{}{
+			ERC20ApprovalGasSponsoring: map[string]interface{}{
+				"info": map[string]interface{}{
+					"description": "test",
+					"version":     "1",
+				},
+				"schema": map[string]interface{}{},
+			},
+		}
+		result, err := ExtractErc20ApprovalGasSponsoringInfo(extensions)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != nil {
+			t.Fatal("expected nil result for incomplete info")
+		}
+	})
+
+	t.Run("extracts valid info", func(t *testing.T) {
+		extensions := map[string]interface{}{
+			ERC20ApprovalGasSponsoring: map[string]interface{}{
+				"info": map[string]interface{}{
+					"from":              "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+					"asset":             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+					"spender":           "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+					"amount":            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+					"signedTransaction": "0xdeadbeef01020304",
+					"version":           "1",
+				},
+				"schema": map[string]interface{}{},
+			},
+		}
+		result, err := ExtractErc20ApprovalGasSponsoringInfo(extensions)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result == nil {
+			t.Fatal("expected non-nil result")
+		}
+		if result.From != "0x857b06519E91e3A54538791bDbb0E22373e36b66" {
+			t.Errorf("unexpected from: %s", result.From)
+		}
+		if result.SignedTransaction != "0xdeadbeef01020304" {
+			t.Errorf("unexpected signedTransaction: %s", result.SignedTransaction)
+		}
+		if result.Version != "1" {
+			t.Errorf("unexpected version: %s", result.Version)
+		}
+	})
+
+	t.Run("returns nil when signedTransaction is empty", func(t *testing.T) {
+		extensions := map[string]interface{}{
+			ERC20ApprovalGasSponsoring: map[string]interface{}{
+				"info": map[string]interface{}{
+					"from":              "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+					"asset":             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+					"spender":           "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+					"amount":            "100",
+					"signedTransaction": "",
+					"version":           "1",
+				},
+				"schema": map[string]interface{}{},
+			},
+		}
+		result, err := ExtractErc20ApprovalGasSponsoringInfo(extensions)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != nil {
+			t.Fatal("expected nil result for empty signedTransaction")
+		}
+	})
+}
+
+func TestValidateErc20ApprovalGasSponsoringInfo(t *testing.T) {
+	t.Run("validates correct info", func(t *testing.T) {
+		info := &Info{
+			From:              "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+			Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			Spender:           "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+			Amount:            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+			SignedTransaction: "0x02f8ab8284540181ef85012a05f2008261a894036cbd53842c5426634e7929541ec2318f3dcf7e80b844095ea7b3000000000022d473030f116ddee9f6b43ac78ba3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			Version:           "1",
+		}
+		if !ValidateErc20ApprovalGasSponsoringInfo(info) {
+			t.Fatal("expected valid info")
+		}
+	})
+
+	t.Run("rejects invalid from address", func(t *testing.T) {
+		info := &Info{
+			From:              "invalid",
+			Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			Spender:           "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+			Amount:            "100",
+			SignedTransaction: "0xabc123",
+			Version:           "1",
+		}
+		if ValidateErc20ApprovalGasSponsoringInfo(info) {
+			t.Fatal("expected invalid info for bad from address")
+		}
+	})
+
+	t.Run("rejects invalid signedTransaction hex", func(t *testing.T) {
+		info := &Info{
+			From:              "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+			Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			Spender:           "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+			Amount:            "100",
+			SignedTransaction: "not-hex",
+			Version:           "1",
+		}
+		if ValidateErc20ApprovalGasSponsoringInfo(info) {
+			t.Fatal("expected invalid info for bad signedTransaction")
+		}
+	})
+
+	t.Run("rejects invalid version", func(t *testing.T) {
+		info := &Info{
+			From:              "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+			Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			Spender:           "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+			Amount:            "100",
+			SignedTransaction: "0xabc123",
+			Version:           "v1.0",
+		}
+		if ValidateErc20ApprovalGasSponsoringInfo(info) {
+			t.Fatal("expected invalid info for bad version format")
+		}
+	})
+
+	t.Run("rejects non-numeric amount", func(t *testing.T) {
+		info := &Info{
+			From:              "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+			Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			Spender:           "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+			Amount:            "not-a-number",
+			SignedTransaction: "0xabc123",
+			Version:           "1",
+		}
+		if ValidateErc20ApprovalGasSponsoringInfo(info) {
+			t.Fatal("expected invalid info for bad amount")
+		}
+	})
+}
+
+func TestNewFacilitatorExtension(t *testing.T) {
+	t.Run("key is correct", func(t *testing.T) {
+		ext := NewFacilitatorExtension(nil)
+		if ext.Key() != ERC20ApprovalGasSponsoring {
+			t.Errorf("unexpected key: %s, expected: %s", ext.Key(), ERC20ApprovalGasSponsoring)
+		}
+	})
+
+	t.Run("signer is set", func(t *testing.T) {
+		ext := NewFacilitatorExtension(nil)
+		if ext.SmartWalletSigner != nil {
+			t.Error("expected nil signer")
+		}
+	})
+
+	t.Run("signer is preserved when non-nil", func(t *testing.T) {
+		// We can't easily create a real signer, but we can test that
+		// the FacilitatorExt struct holds the value correctly.
+		// With nil we already tested above; the struct assignment is trivial.
+		ext := &FacilitatorExt{SmartWalletSigner: nil}
+		if ext.Key() != ERC20ApprovalGasSponsoring {
+			t.Errorf("unexpected key from struct literal: %s", ext.Key())
+		}
+	})
+}

--- a/go/extensions/erc20approvalgassponsor/server.go
+++ b/go/extensions/erc20approvalgassponsor/server.go
@@ -1,0 +1,69 @@
+package erc20approvalgassponsor
+
+// DeclareErc20ApprovalGasSponsoringExtension creates the extension declaration
+// for inclusion in PaymentRequired.extensions.
+//
+// The server advertises that it (or its facilitator) supports ERC-20 raw approval
+// gas sponsoring as a fallback for tokens that do not implement EIP-2612.
+// The client will populate the info with the signed approval transaction.
+//
+// Returns a map keyed by the extension identifier.
+//
+// Example:
+//
+//	extensions := erc20approvalgassponsor.DeclareErc20ApprovalGasSponsoringExtension()
+//	// Include in PaymentRequired.Extensions
+func DeclareErc20ApprovalGasSponsoringExtension() map[string]interface{} {
+	return map[string]interface{}{
+		ERC20ApprovalGasSponsoring: Extension{
+			Info: ServerInfo{
+				Description: "The facilitator accepts a pre-signed ERC-20 approve(Permit2, amount) transaction to sponsor Permit2 allowance gas.",
+				Version:     "1",
+			},
+			Schema: erc20ApprovalGasSponsoringSchema(),
+		},
+	}
+}
+
+// erc20ApprovalGasSponsoringSchema returns the JSON Schema for the extension info.
+func erc20ApprovalGasSponsoringSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"from": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^0x[a-fA-F0-9]{40}$",
+				"description": "The address of the sender (token owner).",
+			},
+			"asset": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^0x[a-fA-F0-9]{40}$",
+				"description": "The address of the ERC-20 token contract.",
+			},
+			"spender": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^0x[a-fA-F0-9]{40}$",
+				"description": "The address of the spender (Canonical Permit2).",
+			},
+			"amount": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^[0-9]+$",
+				"description": "The approval amount (uint256 as decimal string).",
+			},
+			"signedTransaction": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^0x[a-fA-F0-9]+$",
+				"description": "The RLP-encoded signed approve transaction as a 0x-prefixed hex string.",
+			},
+			"version": map[string]interface{}{
+				"type":        "string",
+				"pattern":     `^[0-9]+(\.[0-9]+)*$`,
+				"description": "Schema version identifier.",
+			},
+		},
+		"required": []string{
+			"from", "asset", "spender", "amount", "signedTransaction", "version",
+		},
+	}
+}

--- a/go/extensions/erc20approvalgassponsor/types.go
+++ b/go/extensions/erc20approvalgassponsor/types.go
@@ -1,0 +1,80 @@
+// Package erc20approvalgassponsor provides types and helpers for the ERC-20 Approval Gas Sponsoring extension.
+//
+// This extension enables gasless approval of the Permit2 contract for tokens
+// that do not implement EIP-2612. The client pre-signs a raw ERC-20 approve(Permit2, amount)
+// transaction; the facilitator uses its smart wallet to batch-execute the approval and
+// settle atomically.
+package erc20approvalgassponsor
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// ERC20ApprovalGasSponsoring is the extension identifier string.
+const ERC20ApprovalGasSponsoring = "erc20ApprovalGasSponsoring"
+
+// Info contains the ERC-20 approval data populated by the client.
+// The facilitator uses this to batch [approve] + [settle] atomically.
+type Info struct {
+	// From is the address of the sender (token owner).
+	From string `json:"from"`
+	// Asset is the address of the ERC-20 token contract.
+	Asset string `json:"asset"`
+	// Spender is the address of the spender (Canonical Permit2).
+	Spender string `json:"spender"`
+	// Amount is the approval amount (uint256 as decimal string). Typically MaxUint256.
+	Amount string `json:"amount"`
+	// SignedTransaction is the RLP-encoded signed approve transaction as a hex string (0x-prefixed).
+	SignedTransaction string `json:"signedTransaction"`
+	// Version is the schema version identifier.
+	Version string `json:"version"`
+}
+
+// ServerInfo is the server-side info included in PaymentRequired.
+// Contains a description and version; the client populates the rest.
+type ServerInfo struct {
+	Description string `json:"description"`
+	Version     string `json:"version"`
+}
+
+// Extension represents the full extension object as it appears in
+// PaymentRequired.extensions and PaymentPayload.extensions.
+type Extension struct {
+	Info   interface{}            `json:"info"`
+	Schema map[string]interface{} `json:"schema"`
+}
+
+// BatchCall represents a single call in a batch transaction.
+type BatchCall struct {
+	To    string
+	Value *big.Int
+	Data  []byte
+}
+
+// SmartWalletBatchSigner can sign and submit atomic batch transactions.
+type SmartWalletBatchSigner interface {
+	// SendBatchTransaction submits an atomic batch of calls and returns the tx hash.
+	SendBatchTransaction(ctx context.Context, calls []BatchCall) (string, error)
+	// WaitForTransactionReceipt waits for a batch transaction to be mined.
+	WaitForTransactionReceipt(ctx context.Context, txHash string) (*evm.TransactionReceipt, error)
+}
+
+// FacilitatorExt is the facilitator-side extension that holds the batch signer.
+// It implements x402.FacilitatorExtension via its Key() method.
+type FacilitatorExt struct {
+	SmartWalletSigner SmartWalletBatchSigner
+}
+
+// Key returns the extension identifier. Implements x402.FacilitatorExtension.
+func (e *FacilitatorExt) Key() string { return ERC20ApprovalGasSponsoring }
+
+// NewFacilitatorExtension creates a FacilitatorExt with the given batch signer.
+// Pass nil for signer to register the extension key without enabling batch settlement
+// (e.g. for e2e tests where the server advertises the capability but settlement
+// via this path is not exercised).
+func NewFacilitatorExtension(signer SmartWalletBatchSigner) *FacilitatorExt {
+	return &FacilitatorExt{SmartWalletSigner: signer}
+}

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -52,6 +52,10 @@ const (
 	// Permit2DeadlineBuffer is the time buffer (in seconds) added when checking
 	// deadline expiration to account for block propagation time.
 	Permit2DeadlineBuffer = 6
+
+	// ERC20ApproveFunctionSelector is the 4-byte function selector for approve(address,uint256).
+	// keccak256("approve(address,uint256)") = 0x095ea7b3...
+	ERC20ApproveFunctionSelector = "0x095ea7b3"
 )
 
 var (

--- a/go/mechanisms/evm/exact/client/erc20approval.go
+++ b/go/mechanisms/evm/exact/client/erc20approval.go
@@ -1,0 +1,121 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+
+	ethabi "github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// Erc20ApprovalClientConfig configures ERC-20 approval transaction signing.
+type Erc20ApprovalClientConfig struct {
+	// ApprovalMode controls the approve amount: "infinite" (default) uses MaxUint256,
+	// "exact" uses the exact required payment amount.
+	ApprovalMode string // "infinite" or "exact"
+}
+
+// Erc20ApprovalClientSigner is an optional interface for signers that can sign
+// raw Ethereum transactions. This is needed for ERC-20 raw approval gas sponsoring.
+// Gate behind a type assertion in trySignErc20Approval.
+type Erc20ApprovalClientSigner interface {
+	// Address returns the signer's Ethereum address.
+	Address() string
+	// PendingNonceAt returns the pending nonce for the given address.
+	PendingNonceAt(ctx context.Context, address string) (uint64, error)
+	// SuggestGasTipCap suggests a gas tip cap (EIP-1559 priority fee).
+	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+	// SuggestGasPrice suggests a legacy gas price (used as fallback gas fee cap).
+	SuggestGasPrice(ctx context.Context) (*big.Int, error)
+	// SignRawTransaction builds a DynamicFeeTx and returns RLP-encoded signed bytes.
+	SignRawTransaction(ctx context.Context, chainID *big.Int, to string, data []byte,
+		nonce uint64, gasLimit uint64, gasFeeCap *big.Int, gasTipCap *big.Int) ([]byte, error)
+}
+
+// approveGasLimit is a conservative gas limit for an ERC-20 approve() call.
+const approveGasLimit = uint64(60000)
+
+// SignErc20ApprovalTransaction creates and signs an ERC-20 approve(Permit2, amount)
+// transaction for use with the ERC-20 Approval Gas Sponsoring extension.
+//
+// The signed transaction is returned in the Info struct; the facilitator will
+// include it in a batch call alongside the Permit2 settle.
+//
+// config may be nil (defaults to "infinite" approval).
+func SignErc20ApprovalTransaction(
+	ctx context.Context,
+	signer Erc20ApprovalClientSigner,
+	tokenAddress string,
+	chainID *big.Int,
+	amount *big.Int,
+	config *Erc20ApprovalClientConfig,
+) (*erc20approvalgassponsor.Info, error) {
+	// Default approval mode
+	approvalMode := "infinite"
+	if config != nil && config.ApprovalMode != "" {
+		approvalMode = config.ApprovalMode
+	}
+
+	// Determine approval amount
+	var approvalAmount *big.Int
+	if approvalMode == "exact" {
+		approvalAmount = new(big.Int).Set(amount)
+	} else {
+		approvalAmount = evm.MaxUint256()
+	}
+
+	normalizedToken := evm.NormalizeAddress(tokenAddress)
+	spender := evm.PERMIT2Address
+
+	// ABI-encode approve(spender, amount)
+	parsedABI, err := ethabi.JSON(bytes.NewReader(evm.ERC20ApproveABI))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ERC20 approve ABI: %w", err)
+	}
+
+	calldata, err := parsedABI.Pack("approve", common.HexToAddress(spender), approvalAmount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode approve calldata: %w", err)
+	}
+
+	// Get pending nonce
+	nonce, err := signer.PendingNonceAt(ctx, signer.Address())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pending nonce: %w", err)
+	}
+
+	// Get gas prices
+	gasTipCap, err := signer.SuggestGasTipCap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gas tip cap: %w", err)
+	}
+
+	gasPrice, err := signer.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gas price: %w", err)
+	}
+
+	// Use gas price as fee cap (conservative upper bound)
+	gasFeeCap := gasPrice
+
+	// Sign the raw transaction
+	rlpBytes, err := signer.SignRawTransaction(ctx, chainID, normalizedToken, calldata,
+		nonce, approveGasLimit, gasFeeCap, gasTipCap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign raw transaction: %w", err)
+	}
+
+	return &erc20approvalgassponsor.Info{
+		From:              signer.Address(),
+		Asset:             normalizedToken,
+		Spender:           spender,
+		Amount:            approvalAmount.String(),
+		SignedTransaction: evm.BytesToHex(rlpBytes),
+		Version:           "1",
+	}, nil
+}

--- a/go/mechanisms/evm/exact/client/erc20approval_test.go
+++ b/go/mechanisms/evm/exact/client/erc20approval_test.go
@@ -1,0 +1,203 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	ethabi "github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// mockErc20ApprovalSigner implements Erc20ApprovalClientSigner for tests.
+type mockErc20ApprovalSigner struct {
+	privateKey *ecdsa.PrivateKey
+	address    string
+	calldata   []byte // stored calldata from the last SignRawTransaction call
+}
+
+func newMockErc20ApprovalSigner(t *testing.T) *mockErc20ApprovalSigner {
+	t.Helper()
+	pk, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(pk.PublicKey).Hex()
+	return &mockErc20ApprovalSigner{privateKey: pk, address: addr}
+}
+
+func (m *mockErc20ApprovalSigner) Address() string { return m.address }
+
+func (m *mockErc20ApprovalSigner) PendingNonceAt(_ context.Context, _ string) (uint64, error) {
+	return 0, nil
+}
+
+func (m *mockErc20ApprovalSigner) SuggestGasTipCap(_ context.Context) (*big.Int, error) {
+	return big.NewInt(1e9), nil // 1 gwei
+}
+
+func (m *mockErc20ApprovalSigner) SuggestGasPrice(_ context.Context) (*big.Int, error) {
+	return big.NewInt(10e9), nil // 10 gwei
+}
+
+func (m *mockErc20ApprovalSigner) SignRawTransaction(
+	_ context.Context,
+	chainID *big.Int,
+	to string,
+	data []byte,
+	nonce uint64,
+	gasLimit uint64,
+	gasFeeCap *big.Int,
+	gasTipCap *big.Int,
+) ([]byte, error) {
+	// Store calldata for assertion in tests
+	m.calldata = make([]byte, len(data))
+	copy(m.calldata, data)
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: gasTipCap,
+		GasFeeCap: gasFeeCap,
+		Gas:       gasLimit,
+		To:        func() *common.Address { a := common.HexToAddress(to); return &a }(),
+		Data:      data,
+	})
+
+	signer := types.LatestSignerForChainID(chainID)
+	signed, err := types.SignTx(tx, signer, m.privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return signed.MarshalBinary()
+}
+
+// decodeApproveCalldata decodes approve(address,uint256) calldata and returns spender, amount.
+func decodeApproveCalldata(t *testing.T, calldata []byte) (string, *big.Int) {
+	t.Helper()
+	if len(calldata) < 4 {
+		t.Fatal("calldata too short")
+	}
+
+	parsedABI, err := ethabi.JSON(bytes.NewReader(evm.ERC20ApproveABI))
+	if err != nil {
+		t.Fatalf("failed to parse ABI: %v", err)
+	}
+
+	args, err := parsedABI.Methods["approve"].Inputs.Unpack(calldata[4:])
+	if err != nil {
+		t.Fatalf("failed to unpack calldata: %v", err)
+	}
+
+	spender := args[0].(common.Address).Hex()
+	amount := args[1].(*big.Int)
+	return spender, amount
+}
+
+func TestSignErc20ApprovalTransaction_Infinite(t *testing.T) {
+	signer := newMockErc20ApprovalSigner(t)
+	ctx := context.Background()
+	chainID := big.NewInt(84532) // Base Sepolia
+	tokenAddress := "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+	amount := big.NewInt(1000000) // 1 USDC
+
+	info, err := SignErc20ApprovalTransaction(ctx, signer, tokenAddress, chainID, amount, &Erc20ApprovalClientConfig{
+		ApprovalMode: "infinite",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil info")
+	}
+
+	// Verify fields
+	if !strings.EqualFold(info.From, signer.Address()) {
+		t.Errorf("from mismatch: %s vs %s", info.From, signer.Address())
+	}
+	if !strings.EqualFold(info.Asset, tokenAddress) {
+		t.Errorf("asset mismatch: %s vs %s", info.Asset, tokenAddress)
+	}
+	if !strings.EqualFold(info.Spender, evm.PERMIT2Address) {
+		t.Errorf("spender mismatch: %s vs %s", info.Spender, evm.PERMIT2Address)
+	}
+	if info.Amount != evm.MaxUint256().String() {
+		t.Errorf("expected MaxUint256 amount, got: %s", info.Amount)
+	}
+	if !strings.HasPrefix(info.SignedTransaction, "0x") {
+		t.Errorf("signedTransaction missing 0x prefix: %s", info.SignedTransaction)
+	}
+
+	// Verify the calldata encodes approve(Permit2, MaxUint256)
+	spender, approvedAmount := decodeApproveCalldata(t, signer.calldata)
+	if !strings.EqualFold(spender, evm.PERMIT2Address) {
+		t.Errorf("calldata spender mismatch: %s", spender)
+	}
+	if approvedAmount.Cmp(evm.MaxUint256()) != 0 {
+		t.Errorf("calldata amount not MaxUint256: %s", approvedAmount)
+	}
+
+	// Verify function selector
+	selectorHex := hex.EncodeToString(signer.calldata[:4])
+	if selectorHex != "095ea7b3" {
+		t.Errorf("unexpected function selector: %s", selectorHex)
+	}
+}
+
+func TestSignErc20ApprovalTransaction_Exact(t *testing.T) {
+	signer := newMockErc20ApprovalSigner(t)
+	ctx := context.Background()
+	chainID := big.NewInt(84532)
+	tokenAddress := "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+	exactAmount := big.NewInt(5000000) // 5 USDC
+
+	info, err := SignErc20ApprovalTransaction(ctx, signer, tokenAddress, chainID, exactAmount, &Erc20ApprovalClientConfig{
+		ApprovalMode: "exact",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Amount != exactAmount.String() {
+		t.Errorf("expected exact amount %s, got: %s", exactAmount.String(), info.Amount)
+	}
+
+	// Verify the calldata encodes approve(Permit2, exactAmount)
+	spender, approvedAmount := decodeApproveCalldata(t, signer.calldata)
+	if !strings.EqualFold(spender, evm.PERMIT2Address) {
+		t.Errorf("calldata spender mismatch: %s", spender)
+	}
+	if approvedAmount.Cmp(exactAmount) != 0 {
+		t.Errorf("calldata amount mismatch: expected %s, got %s", exactAmount, approvedAmount)
+	}
+}
+
+func TestSignErc20ApprovalTransaction_DefaultsToInfinite(t *testing.T) {
+	signer := newMockErc20ApprovalSigner(t)
+	ctx := context.Background()
+	chainID := big.NewInt(84532)
+	tokenAddress := "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+	amount := big.NewInt(1000000)
+
+	// nil config should default to "infinite"
+	info, err := SignErc20ApprovalTransaction(ctx, signer, tokenAddress, chainID, amount, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Amount != evm.MaxUint256().String() {
+		t.Errorf("nil config should default to infinite approval, got amount: %s", info.Amount)
+	}
+
+	_, approvedAmount := decodeApproveCalldata(t, signer.calldata)
+	if approvedAmount.Cmp(evm.MaxUint256()) != 0 {
+		t.Errorf("nil config should use MaxUint256 in calldata, got: %s", approvedAmount)
+	}
+}

--- a/go/mechanisms/evm/exact/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/facilitator/errors.go
@@ -52,4 +52,12 @@ const (
 	ErrPermit2InvalidOwner           = "permit2_invalid_owner"
 	ErrPermit2PaymentTooEarly        = "permit2_payment_too_early"
 	ErrPermit2InvalidNonce           = "permit2_invalid_nonce"
+
+	// ERC-20 Approval Gas Sponsoring errors
+	ErrErc20GasSponsoringNotConfigured = "erc20_gas_sponsoring_not_configured"
+	ErrErc20InvalidSignedTx            = "erc20_invalid_signed_transaction"
+	ErrErc20SignerMismatch             = "erc20_signer_mismatch"
+	ErrErc20TokenMismatch              = "erc20_token_mismatch"
+	ErrErc20SpenderNotPermit2          = "erc20_spender_not_permit2"
+	ErrErc20InvalidCalldata            = "erc20_invalid_calldata"
 )

--- a/go/mechanisms/evm/exact/facilitator/permit2_erc20_test.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2_erc20_test.go
@@ -1,0 +1,321 @@
+package facilitator
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+	"strings"
+	"testing"
+
+	ethabi "github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	x402 "github.com/coinbase/x402/go"
+	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// buildTestSignedApproveTx builds a valid signed approve(Permit2, MaxUint256) tx for tests.
+func buildTestSignedApproveTx(t *testing.T, tokenAddress string, chainID *big.Int) (string, string) {
+	t.Helper()
+	pk, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	from := crypto.PubkeyToAddress(pk.PublicKey).Hex()
+
+	parsedABI, err := ethabi.JSON(bytes.NewReader(evm.ERC20ApproveABI))
+	if err != nil {
+		t.Fatalf("failed to parse ABI: %v", err)
+	}
+	calldata, err := parsedABI.Pack("approve", common.HexToAddress(evm.PERMIT2Address), evm.MaxUint256())
+	if err != nil {
+		t.Fatalf("failed to pack calldata: %v", err)
+	}
+
+	to := common.HexToAddress(tokenAddress)
+	tx := ethTypes.NewTx(&ethTypes.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     0,
+		GasTipCap: big.NewInt(1e9),
+		GasFeeCap: big.NewInt(10e9),
+		Gas:       60000,
+		To:        &to,
+		Data:      calldata,
+	})
+
+	signer := ethTypes.LatestSignerForChainID(chainID)
+	signed, err := ethTypes.SignTx(tx, signer, pk)
+	if err != nil {
+		t.Fatalf("failed to sign tx: %v", err)
+	}
+
+	rlpBytes, err := signed.MarshalBinary()
+	if err != nil {
+		t.Fatalf("failed to marshal tx: %v", err)
+	}
+
+	return from, "0x" + evm.BytesToHex(rlpBytes)[2:]
+}
+
+func TestValidateErc20ApprovalForPayment(t *testing.T) {
+	chainID := big.NewInt(84532) // Base Sepolia
+	tokenAddress := "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+
+	from, signedTx := buildTestSignedApproveTx(t, tokenAddress, chainID)
+
+	t.Run("accepts valid ERC-20 approval info", func(t *testing.T) {
+		info := &erc20approvalgassponsor.Info{
+			From:              from,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction:  signedTx,
+			Version:           "1",
+		}
+		result := validateErc20ApprovalForPayment(context.Background(), nil, info, from, tokenAddress, chainID)
+		if result != "" {
+			t.Errorf("expected valid, got error: %s", result)
+		}
+	})
+
+	t.Run("rejects mismatched from/payer", func(t *testing.T) {
+		wrongPayer := "0x0000000000000000000000000000000000000001"
+		info := &erc20approvalgassponsor.Info{
+			From:              from,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            "100",
+			SignedTransaction:  signedTx,
+			Version:           "1",
+		}
+		result := validateErc20ApprovalForPayment(context.Background(), nil, info, wrongPayer, tokenAddress, chainID)
+		if result != ErrErc20SignerMismatch {
+			t.Errorf("expected %s, got: %s", ErrErc20SignerMismatch, result)
+		}
+	})
+
+	t.Run("rejects mismatched asset/token", func(t *testing.T) {
+		wrongToken := "0x0000000000000000000000000000000000000002"
+		info := &erc20approvalgassponsor.Info{
+			From:              from,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            "100",
+			SignedTransaction:  signedTx,
+			Version:           "1",
+		}
+		result := validateErc20ApprovalForPayment(context.Background(), nil, info, from, wrongToken, chainID)
+		if result != ErrErc20TokenMismatch {
+			t.Errorf("expected %s, got: %s", ErrErc20TokenMismatch, result)
+		}
+	})
+
+	t.Run("rejects wrong spender (not Permit2)", func(t *testing.T) {
+		// Build a tx that approves a wrong spender
+		pk, err := crypto.GenerateKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+		fromAddr := crypto.PubkeyToAddress(pk.PublicKey).Hex()
+
+		parsedABI, _ := ethabi.JSON(bytes.NewReader(evm.ERC20ApproveABI))
+		wrongSpender := common.HexToAddress("0x0000000000000000000000000000000000000003")
+		calldata, _ := parsedABI.Pack("approve", wrongSpender, evm.MaxUint256())
+		to := common.HexToAddress(tokenAddress)
+		tx := ethTypes.NewTx(&ethTypes.DynamicFeeTx{
+			ChainID: chainID, Nonce: 0,
+			GasTipCap: big.NewInt(1e9), GasFeeCap: big.NewInt(10e9),
+			Gas: 60000, To: &to, Data: calldata,
+		})
+		signer := ethTypes.LatestSignerForChainID(chainID)
+		signed, _ := ethTypes.SignTx(tx, signer, pk)
+		rlpBytes, _ := signed.MarshalBinary()
+		wrongSpenderTx := evm.BytesToHex(rlpBytes)
+
+		info := &erc20approvalgassponsor.Info{
+			From:             fromAddr,
+			Asset:            tokenAddress,
+			Spender:          evm.PERMIT2Address, // correct spender in info
+			Amount:           "100",
+			SignedTransaction: wrongSpenderTx,    // but wrong spender in tx
+			Version:          "1",
+		}
+		result := validateErc20ApprovalForPayment(context.Background(), nil, info, fromAddr, tokenAddress, chainID)
+		if result != ErrErc20SpenderNotPermit2 {
+			t.Errorf("expected %s, got: %s", ErrErc20SpenderNotPermit2, result)
+		}
+	})
+
+	t.Run("rejects invalid signedTransaction (odd-length hex fails decode)", func(t *testing.T) {
+		// "0xABC" has 3 hex chars (odd) → passes regex but hex.DecodeString fails
+		info := &erc20approvalgassponsor.Info{
+			From:              from,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            "100",
+			SignedTransaction:  "0xABC", // odd-length hex: passes regex, fails decode
+			Version:           "1",
+		}
+		result := validateErc20ApprovalForPayment(context.Background(), nil, info, from, tokenAddress, chainID)
+		if result != ErrErc20InvalidSignedTx {
+			t.Errorf("expected %s, got: %s", ErrErc20InvalidSignedTx, result)
+		}
+	})
+
+	t.Run("rejects invalid RLP transaction", func(t *testing.T) {
+		info := &erc20approvalgassponsor.Info{
+			From:              from,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            "100",
+			SignedTransaction:  "0xdeadbeef", // valid hex but invalid RLP tx
+			Version:           "1",
+		}
+		result := validateErc20ApprovalForPayment(context.Background(), nil, info, from, tokenAddress, chainID)
+		if result != ErrErc20InvalidSignedTx {
+			t.Errorf("expected %s, got: %s", ErrErc20InvalidSignedTx, result)
+		}
+	})
+}
+
+func TestExtractCalldataFromSignedTx(t *testing.T) {
+	chainID := big.NewInt(84532)
+	tokenAddress := "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+
+	_, signedTx := buildTestSignedApproveTx(t, tokenAddress, chainID)
+
+	t.Run("extracts calldata from valid signed tx", func(t *testing.T) {
+		calldata, err := extractCalldataFromSignedTx(signedTx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(calldata) < 4 {
+			t.Fatal("calldata too short")
+		}
+		// Should start with approve(address,uint256) selector 0x095ea7b3
+		selectorHex := evm.BytesToHex(calldata[:4])
+		if !strings.EqualFold(selectorHex, evm.ERC20ApproveFunctionSelector) {
+			t.Errorf("unexpected selector: %s", selectorHex)
+		}
+	})
+
+	t.Run("returns error for invalid hex", func(t *testing.T) {
+		_, err := extractCalldataFromSignedTx("0xZZZZ")
+		if err == nil {
+			t.Fatal("expected error for invalid hex")
+		}
+	})
+
+	t.Run("returns error for invalid RLP", func(t *testing.T) {
+		_, err := extractCalldataFromSignedTx("0xdeadbeef")
+		if err == nil {
+			t.Fatal("expected error for invalid RLP transaction")
+		}
+	})
+}
+
+// mockSmartWalletBatchSigner implements SmartWalletBatchSigner for tests.
+type mockSmartWalletBatchSigner struct {
+	capturedCalls []erc20approvalgassponsor.BatchCall
+	returnTxHash  string
+	returnErr     error
+}
+
+func (m *mockSmartWalletBatchSigner) SendBatchTransaction(_ context.Context, calls []erc20approvalgassponsor.BatchCall) (string, error) {
+	m.capturedCalls = calls
+	if m.returnErr != nil {
+		return "", m.returnErr
+	}
+	if m.returnTxHash == "" {
+		return "0xbatchhash1234", nil
+	}
+	return m.returnTxHash, nil
+}
+
+func (m *mockSmartWalletBatchSigner) WaitForTransactionReceipt(_ context.Context, _ string) (*evm.TransactionReceipt, error) {
+	return &evm.TransactionReceipt{Status: evm.TxStatusSuccess}, nil
+}
+
+func TestSettlePermit2_ERC20Extension_ErrorWhenNotConfigured(t *testing.T) {
+	// Test that SettlePermit2 returns ErrErc20GasSponsoringNotConfigured
+	// when no extension is registered in the FacilitatorContext.
+	// We create a FacilitatorContext without the ERC-20 extension registered.
+	fctx := x402.NewFacilitatorContext(map[string]x402.FacilitatorExtension{})
+
+	// Verify that GetExtension returns nil for an unregistered key
+	ext := fctx.GetExtension(erc20approvalgassponsor.ERC20ApprovalGasSponsoring)
+	if ext != nil {
+		t.Fatal("expected nil extension for unregistered key")
+	}
+
+	// The FacilitatorExt type assertion should fail for nil
+	_, ok := ext.(*erc20approvalgassponsor.FacilitatorExt)
+	if ok {
+		t.Fatal("expected type assertion to fail for nil")
+	}
+}
+
+func TestSettlePermit2_ERC20Extension_NilSmartWalletSigner(t *testing.T) {
+	// Test that FacilitatorExt with nil SmartWalletSigner is detected
+	ext := erc20approvalgassponsor.NewFacilitatorExtension(nil)
+	if ext.SmartWalletSigner != nil {
+		t.Fatal("expected nil SmartWalletSigner")
+	}
+
+	// FacilitatorContext with nil-signer extension
+	fctx := x402.NewFacilitatorContext(map[string]x402.FacilitatorExtension{
+		erc20approvalgassponsor.ERC20ApprovalGasSponsoring: ext,
+	})
+
+	extRaw := fctx.GetExtension(erc20approvalgassponsor.ERC20ApprovalGasSponsoring)
+	facilitatorExt, ok := extRaw.(*erc20approvalgassponsor.FacilitatorExt)
+	if !ok {
+		t.Fatal("expected type assertion to succeed")
+	}
+	if facilitatorExt.SmartWalletSigner != nil {
+		t.Fatal("expected nil SmartWalletSigner")
+	}
+	// This simulates the condition that would trigger ErrErc20GasSponsoringNotConfigured
+}
+
+func TestSettlePermit2_ERC20Extension_BatchCallsCorrect(t *testing.T) {
+	// Test that the batch signer receives the correct calls
+	chainID := big.NewInt(84532)
+	tokenAddress := "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+
+	_, signedTx := buildTestSignedApproveTx(t, tokenAddress, chainID)
+
+	// Extract calldata to verify it's passed correctly
+	calldata, err := extractCalldataFromSignedTx(signedTx)
+	if err != nil {
+		t.Fatalf("failed to extract calldata: %v", err)
+	}
+
+	mockSigner := &mockSmartWalletBatchSigner{}
+	calls := []erc20approvalgassponsor.BatchCall{
+		{To: evm.NormalizeAddress(tokenAddress), Data: calldata},
+		{To: evm.X402ExactPermit2ProxyAddress, Data: []byte{0x01, 0x02}},
+	}
+
+	txHash, err := mockSigner.SendBatchTransaction(context.Background(), calls)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if txHash == "" {
+		t.Fatal("expected non-empty tx hash")
+	}
+	if len(mockSigner.capturedCalls) != 2 {
+		t.Errorf("expected 2 calls, got %d", len(mockSigner.capturedCalls))
+	}
+	// First call should target the token contract (approval)
+	if !strings.EqualFold(mockSigner.capturedCalls[0].To, evm.NormalizeAddress(tokenAddress)) {
+		t.Errorf("first call should target token: %s", mockSigner.capturedCalls[0].To)
+	}
+	// Second call should target the Permit2 proxy (settle)
+	if !strings.EqualFold(mockSigner.capturedCalls[1].To, evm.X402ExactPermit2ProxyAddress) {
+		t.Errorf("second call should target permit2 proxy: %s", mockSigner.capturedCalls[1].To)
+	}
+}

--- a/go/mechanisms/evm/exact/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/facilitator/scheme.go
@@ -76,7 +76,7 @@ func (f *ExactEvmScheme) Verify(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
-	_ *x402.FacilitatorContext,
+	fctx *x402.FacilitatorContext,
 ) (*x402.VerifyResponse, error) {
 	// Check if this is a Permit2 payload and route accordingly
 	if evm.IsPermit2Payload(payload.Payload) {
@@ -84,7 +84,7 @@ func (f *ExactEvmScheme) Verify(
 		if err != nil {
 			return nil, x402.NewVerifyError(ErrInvalidPayload, "", fmt.Sprintf("failed to parse Permit2 payload: %s", err.Error()))
 		}
-		return VerifyPermit2(ctx, f.signer, payload, requirements, permit2Payload)
+		return VerifyPermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx)
 	}
 
 	// Default to EIP-3009 verification
@@ -238,7 +238,7 @@ func (f *ExactEvmScheme) Settle(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
-	_ *x402.FacilitatorContext,
+	fctx *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	// Check if this is a Permit2 payload and route accordingly
 	if evm.IsPermit2Payload(payload.Payload) {
@@ -247,7 +247,7 @@ func (f *ExactEvmScheme) Settle(
 			network := x402.Network(payload.Accepted.Network)
 			return nil, x402.NewSettleError(ErrInvalidPayload, "", network, "", fmt.Sprintf("failed to parse Permit2 payload: %s", err.Error()))
 		}
-		return SettlePermit2(ctx, f.signer, payload, requirements, permit2Payload)
+		return SettlePermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx)
 	}
 
 	// Default to EIP-3009 settlement

--- a/go/test/unit/evm_client_facilitator_test.go
+++ b/go/test/unit/evm_client_facilitator_test.go
@@ -529,7 +529,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for invalid spender")
 		}
@@ -555,7 +555,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for recipient mismatch")
 		}
@@ -581,7 +581,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for expired deadline")
 		}
@@ -607,7 +607,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for not-yet-valid payment")
 		}
@@ -633,7 +633,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for insufficient amount")
 		}
@@ -659,7 +659,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for token mismatch")
 		}
@@ -685,7 +685,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for invalid deadline format")
 		}
@@ -719,7 +719,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongSchemePayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongSchemePayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for scheme mismatch")
 		}
@@ -753,7 +753,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongNetworkPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongNetworkPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for network mismatch")
 		}
@@ -1069,7 +1069,7 @@ func TestSettlePermit2_EIP2612Routing(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1103,7 +1103,7 @@ func TestSettlePermit2_EIP2612Routing(t *testing.T) {
 			// No extensions
 		}
 
-		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}


### PR DESCRIPTION
Implements the erc20ApprovalGasSponsoring facilitator extension, enabling gasless ERC-20 approval via atomic smart-wallet batch calls (fund gas + approve + settle) when Permit2 allowance is insufficient and EIP-2612 is unavailable.

- New package go/extensions/erc20approvalgassponsor (types, server, facilitator, tests)
- New client-side SignErc20ApprovalTransaction with infinite/exact approval modes
- VerifyPermit2 falls back to ERC-20 approval validation when EIP-2612 absent
- SettlePermit2 dispatches atomic batch via SmartWalletBatchSigner from FacilitatorContext
- FacilitatorContext now threaded through ExactEvmScheme.Settle instead of discarded
- ERC20ApproveABI constant added to evm/constants.go
- E2E facilitator and Gin server updated to register/advertise the extension

<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 