### PR TITLE
fix: python SVM client signer v1

### DIFF
--- a/e2e/servers/gin/main.go
+++ b/e2e/servers/gin/main.go
@@ -125,11 +125,11 @@ func main() {
 					Network: evmNetwork,
 				},
 			},
-			Extensions: map[string]interface{}{
-				types.BAZAAR: discoveryExtension,
-			},
+		Extensions: map[string]interface{}{
+			types.BAZAAR.Key(): discoveryExtension,
 		},
-		"GET /protected-svm": {
+	},
+	"GET /protected-svm": {
 			Accepts: x402http.PaymentOptions{
 				{
 					Scheme:  "exact",
@@ -138,11 +138,11 @@ func main() {
 					Network: svmNetwork,
 				},
 			},
-			Extensions: map[string]interface{}{
-				types.BAZAAR: discoveryExtension,
-			},
+		Extensions: map[string]interface{}{
+			types.BAZAAR.Key(): discoveryExtension,
 		},
-		// Permit2 endpoint - explicitly requires Permit2 flow instead of EIP-3009
+	},
+	// Permit2 endpoint - explicitly requires Permit2 flow instead of EIP-3009
 		"GET /protected-permit2": {
 			Accepts: x402http.PaymentOptions{
 				{
@@ -160,9 +160,9 @@ func main() {
 				},
 			},
 			Extensions: func() map[string]interface{} {
-				ext := map[string]interface{}{
-					types.BAZAAR: discoveryExtension,
-				}
+			ext := map[string]interface{}{
+				types.BAZAAR.Key(): discoveryExtension,
+			}
 				// Add EIP-2612 gas sponsoring extension
 				for k, v := range eip2612gassponsor.DeclareEip2612GasSponsoringExtension() {
 					ext[k] = v

--- a/python/x402/changelog.d/v1-svm-signers.bugfix.md
+++ b/python/x402/changelog.d/v1-svm-signers.bugfix.md
@@ -1,0 +1,1 @@
+Fixed SVM V1 client transaction signing to use `VersionedTransaction.populate()` with explicit signature slots, matching the V2 approach and fixing "not enough signers" errors.

--- a/python/x402/mechanisms/svm/exact/v1/client.py
+++ b/python/x402/mechanisms/svm/exact/v1/client.py
@@ -10,6 +10,7 @@ try:
     from solders.instruction import AccountMeta, Instruction
     from solders.message import MessageV0
     from solders.pubkey import Pubkey
+    from solders.signature import Signature
     from solders.transaction import VersionedTransaction
 except ImportError as e:
     raise ImportError(
@@ -196,11 +197,15 @@ class ExactSvmSchemeV1:
             recent_blockhash=blockhash,
         )
 
-        # Create transaction
-        tx = VersionedTransaction(message, [])
+        # Create a partially-signed transaction
+        # Signers: index 0 = fee_payer (facilitator), index 1 = payer_pubkey (client)
+        # For VersionedTransaction with MessageV0, prepend 0x80 version byte before signing
+        msg_bytes_with_version = bytes([0x80]) + bytes(message)
+        client_signature = self._signer.keypair.sign_message(msg_bytes_with_version)
 
-        # Sign with client keypair (as token authority)
-        tx.sign([self._signer.keypair])
+        # Client is at index 1, fee_payer placeholder at index 0
+        signatures = [Signature.default(), client_signature]
+        tx = VersionedTransaction.populate(message, signatures)
 
         # Encode to base64
         tx_base64 = base64.b64encode(bytes(tx)).decode("utf-8")


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

* Python's Solana implementation for v1 compatibility was signing the entire transaction, rather than doing the partial signature approach using a placeholder for the facilitators' signature.
* Gin e2e server had outdated code

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 