### PR TITLE
fix: throw on total facilitator failure in initialize()

### DIFF
--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -347,6 +347,12 @@ export class x402ResourceServer {
         console.warn(`Failed to fetch supported kinds from facilitator: ${error}`);
       }
     }
+
+    if (this.supportedResponsesMap.size === 0) {
+      throw new Error(
+        "Failed to initialize: no supported payment kinds loaded from any facilitator.",
+      );
+    }
   }
 
   /**

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -190,6 +190,24 @@ describe("x402ResourceServer", () => {
       expect(workingClient.getSupportedCalls).toBe(1);
     });
 
+    it("should throw if all facilitators fail", async () => {
+      const failingClient1 = new MockFacilitatorClient(buildSupportedResponse());
+      failingClient1.getSupported = async () => {
+        throw new Error("Network error");
+      };
+
+      const failingClient2 = new MockFacilitatorClient(buildSupportedResponse());
+      failingClient2.getSupported = async () => {
+        throw new Error("Rate limited");
+      };
+
+      const server = new x402ResourceServer([failingClient1, failingClient2]);
+
+      await expect(server.initialize()).rejects.toThrow(
+        "Failed to initialize: no supported payment kinds loaded from any facilitator",
+      );
+    });
+
     it("should clear existing mappings on re-initialization", async () => {
       const mockClient1 = new MockFacilitatorClient(
         buildSupportedResponse({


### PR DESCRIPTION
## Problem

`x402ResourceServer.initialize()` catches errors from each facilitator's `getSupported()` call individually (correct — allows partial success with multiple facilitators), but when **all** facilitators fail it silently completes with an empty `supportedResponsesMap`. Every subsequent `buildPaymentRequirements` call then throws with a confusing "Facilitator does not support scheme" error.

This is particularly painful in serverless environments. On a cold start, N concurrent lambda/edge function instances boot simultaneously and blast the facilitator with `/supported` requests. The facilitator returns `429 Too Many Requests`, all calls fail, and every instance silently initializes with empty maps. All paid routes are broken until the next cold start, with no clear signal of what went wrong.

## Fix

After the facilitator loop in `initialize()`, throw if no supported kinds were loaded:

```typescript
if (this.supportedResponsesMap.size === 0) {
  throw new Error(
    "Failed to initialize: no supported payment kinds loaded from any facilitator.",
  );
}
```

This lets callers detect and handle the failure (retry, crash loudly, return 503) instead of silently serving broken routes.

## Current downstream workaround

We currently work around this by hardcoding the `getSupported()` response for EVM exact, since the response is static and never changes:

```typescript
function cachedClient(inner: FacilitatorClient, network: Network): FacilitatorClient {
  return {
    verify: inner.verify.bind(inner),
    settle: inner.settle.bind(inner),
    getSupported: async (): Promise<SupportedResponse> => ({
      kinds: [{ x402Version: 2, scheme: "exact", network }],
      extensions: [],
      signers: {},
    }),
  };
}
```

This avoids the `getSupported()` call entirely and eliminates the cold-start race. With this fix, the workaround would no longer be strictly necessary — callers could catch the `initialize()` error and retry with backoff.

## Test

Added a test for the all-facilitators-fail case. Existing tests pass (53/53).