### PR TITLE
feat(gin): preserve params in paywall

### DIFF
--- a/go/.changes/unreleased/fixed-20260220-093321.yaml
+++ b/go/.changes/unreleased/fixed-20260220-093321.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: preserve query params in paywall redirect
+time: 2026-02-20T09:33:21.369429+01:00

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -53,7 +53,7 @@ func (a *GinAdapter) GetURL() string {
 	if host == "" {
 		host = a.ctx.GetHeader("Host")
 	}
-	return fmt.Sprintf("%s://%s%s", scheme, host, a.ctx.Request.URL.Path)
+	return fmt.Sprintf("%s://%s%s", scheme, host, a.ctx.Request.URL.RequestURI())
 }
 
 // GetAcceptHeader gets the Accept header

--- a/go/http/gin/middleware_test.go
+++ b/go/http/gin/middleware_test.go
@@ -199,21 +199,46 @@ func TestGinAdapter_GetPath(t *testing.T) {
 }
 
 func TestGinAdapter_GetURL(t *testing.T) {
-	router := createTestRouter()
-	var adapter *GinAdapter
+	tests := []struct {
+		name     string
+		target   string
+		expected string
+	}{
+		{
+			name:     "with query params",
+			target:   "/api/test?id=1",
+			expected: "http://example.com/api/test?id=1",
+		},
+		{
+			name:     "without query params",
+			target:   "/api/test",
+			expected: "http://example.com/api/test",
+		},
+		{
+			name:     "with multiple query params",
+			target:   "/api/test?id=1&foo=bar",
+			expected: "http://example.com/api/test?id=1&foo=bar",
+		},
+	}
 
-	router.GET("/api/test", func(c *gin.Context) {
-		adapter = NewGinAdapter(c)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := createTestRouter()
+			var adapter *GinAdapter
 
-	req := httptest.NewRequest("GET", "/api/test", nil)
-	req.Host = "example.com"
-	w := httptest.NewRecorder()
-	router.ServeHTTP(w, req)
+			router.GET("/api/test", func(c *gin.Context) {
+				adapter = NewGinAdapter(c)
+			})
 
-	expected := "http://example.com/api/test"
-	if adapter.GetURL() != expected {
-		t.Errorf("Expected URL '%s', got '%s'", expected, adapter.GetURL())
+			req := httptest.NewRequest("GET", tt.target, nil)
+			req.Host = "example.com"
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if adapter.GetURL() != tt.expected {
+				t.Errorf("Expected URL '%s', got '%s'", tt.expected, adapter.GetURL())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

When a browser hits a payment-gated endpoint with query parameters (e.g. `/api/data?foo=bar`), the x402 paywall HTML is served correctly, but the embedded `currentUrl` is missing the query string. After the user pays, the paywall JS retries the
request to the bare path `/api/data` without `?foo=bar` causing the upstream to receive an incomplete request.

The root cause is in GinAdapter.GetURL():

```
// middleware.go
func (a *GinAdapter) GetURL() string {
    ...
    return fmt.Sprintf("%s://%s%s", scheme, host, a.ctx.Request.URL.Path) // UI drops query string
}
```

URL.Path contains only the path segment. `currentUrl` in the generated paywall HTML is derived from this value (via `resourceInfo.URL`), so the paywall JS calls:

```
fetch("https://host/api/data", { headers: { "PAYMENT-SIGNATURE": ... } })
// should be:
fetch("https://host/api/data?foo=bar", { headers: { "PAYMENT-SIGNATURE": ... } })
```

Non-browser clients (e.g. the Go `PaymentRoundTripper`) are unaffected because they clone the original request with `req.Clone(ctx)`, preserving the full URL.

Fix

Use `RequestURI()` instead of `URL.Path`. `RequestURI()` returns the unmodified request-target (path + query string, e.g. `/api/data?foo=bar`)


## Tests

I extended `middleware_test.go` (`TestGinAdapter_GetURL`) file and added a case to cover 3 cases to make sure previous behaviour is working as expected:

- no query params
- one query param
- multiple query params

### Reproduction

You can revert to `URL.Path` and run tests. Cases with query param(s) will fail.

### Reproduction in UI

1. Set up a payment-gated Gin route
2. Visit it from a browser with a query param, e.g. ?foo=bar
3. Complete the paywall payment
4. Observe the retried request arrives at the handler with an empty query string

The same endpoint works correctly when called from the Go HTTP client.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)