### PR TITLE
fix: github workflows for evm/paywall deploys which depend on extensions

### DIFF
--- a/.github/workflows/publish_npm_scoped_x402_evm.yml
+++ b/.github/workflows/publish_npm_scoped_x402_evm.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./typescript
         run: |
           pnpm install --frozen-lockfile
-          pnpm -r --filter=@x402/core --filter=@x402/evm run build
+          pnpm -r --filter=@x402/core --filter=@x402/extensions --filter=@x402/evm run build
       
       - name: Publish @x402/evm package
         working-directory: ./typescript/packages/mechanisms/evm

--- a/.github/workflows/publish_npm_scoped_x402_paywall.yml
+++ b/.github/workflows/publish_npm_scoped_x402_paywall.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: ./typescript
         run: |
           pnpm install --frozen-lockfile
-          pnpm -r --filter=@x402/core --filter=@x402/evm --filter=@x402/svm --filter=@x402/paywall run build
+          pnpm -r --filter=@x402/core --filter=@x402/extensions --filter=@x402/evm --filter=@x402/svm --filter=@x402/paywall run build
       
       - name: Publish @x402/paywall package
         working-directory: ./typescript/packages/http/paywall


### PR DESCRIPTION
fix: github workflows for evm/paywall deploys which depend on extensions