### PR TITLE
fix: preserve beforeSettle hook abort reason in x402ResourceServer

### DIFF
--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -718,6 +718,9 @@ export class x402ResourceServer {
           });
         }
       } catch (error) {
+        if (error instanceof SettleError) {
+          throw error;
+        }
         throw new SettleError(400, {
           success: false,
           errorReason: "before_settle_hook_error",


### PR DESCRIPTION
## Description
In x402ResourceServer, when the beforeSettle hook deliberately aborts a settlement by throwing a SettleError, the error's original reason was being lost. The catch block surrounding the hook call was catching the intentional SettleError and re-wrapping it with a generic "before_settle_hook_error" reason, making it impossible for callers to distinguish a deliberate abort from an unexpected failure.

The fix:
Added a check in the catch block to re-throw SettleError instances directly, so deliberate abort reasons propagate unchanged. Genuinely unexpected errors are still wrapped as "before_settle_hook_error". This is consistent with how verifyPayment and x402Facilitator already handle the same pattern.

Why it's needed:
Without this fix, any custom abort reason set by a beforeSettle hook (e.g. "sanctions_check_failed", "rate_limit_exceeded") gets silently replaced with the generic "before_settle_hook_error", breaking error handling for consumers that rely on specific error reasons to decide how to respond.

## Tests performed:
1. New unit test added: Added a dedicated test case ("should preserve SettleError abort reason from beforeSettle hook") that verifies when the beforeSettle hook throws a SettleError with a specific reason (e.g. "hook_aborted"), that exact reason is preserved in the resulting error rather than being overwritten with the generic "before_settle_hook_error".
2. Existing tests pass: All existing tests in the x402ResourceServer test suite continue to pass, confirming no regressions — the generic "before_settle_hook_error" wrapping still applies to unexpected (non-SettleError) errors thrown by the hook.