### PR TITLE
feat(evm): add Monad mainnet network support (chain ID 143)

### DIFF
--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -59,6 +59,7 @@ var (
 	ChainIDBase        = big.NewInt(8453)
 	ChainIDBaseSepolia = big.NewInt(84532)
 	ChainIDMegaETH     = big.NewInt(4326)
+	ChainIDMonad       = big.NewInt(143)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -129,6 +130,26 @@ var (
 				Name:     "MegaUSD",
 				Version:  "1",
 				Decimals: 18,
+			},
+		},
+		// Monad Mainnet
+		"eip155:143": {
+			ChainID: ChainIDMonad,
+			DefaultAsset: AssetInfo{
+				Address:  "0x754704Bc059F8C67012fEd69BC8A327a5aafb603", // USDC on Monad
+				Name:     "USD Coin",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// Monad Mainnet (legacy v1 format)
+		"monad": {
+			ChainID: ChainIDMonad,
+			DefaultAsset: AssetInfo{
+				Address:  "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+				Name:     "USD Coin",
+				Version:  "2",
+				Decimals: DefaultDecimals,
 			},
 		},
 	}

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -177,6 +177,24 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             },
         },
     },
+    # Monad Mainnet
+    "eip155:143": {
+        "chain_id": 143,
+        "default_asset": {
+            "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+            "name": "USD Coin",
+            "version": "2",
+            "decimals": 6,
+        },
+        "supported_assets": {
+            "USDC": {
+                "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+                "name": "USD Coin",
+                "version": "2",
+                "decimals": 6,
+            },
+        },
+    },
 }
 
 # Network aliases (legacy names to CAIP-2)
@@ -189,6 +207,7 @@ NETWORK_ALIASES: dict[str, str] = {
     "polygon": "eip155:137",
     "avalanche": "eip155:43114",
     "megaeth": "eip155:4326",
+    "monad": "eip155:143",
 }
 
 # V1 supported networks (legacy name-based)
@@ -209,6 +228,7 @@ V1_NETWORKS = [
     "educhain",
     "skale-base-sepolia",
     "megaeth",
+    "monad",
 ]
 
 # V1 network name to chain ID mapping
@@ -230,6 +250,7 @@ V1_NETWORK_CHAIN_IDS: dict[str, int] = {
     "educhain": 656476,
     "skale-base-sepolia": 1444673419,
     "megaeth": 4326,
+    "monad": 143,
 }
 
 # EIP-3009 ABIs

--- a/typescript/packages/mechanisms/evm/src/v1/index.ts
+++ b/typescript/packages/mechanisms/evm/src/v1/index.ts
@@ -19,6 +19,7 @@ export const EVM_NETWORK_CHAIN_ID_MAP = {
   educhain: 41923,
   "skale-base-sepolia": 324705682,
   megaeth: 4326,
+  monad: 143,
 } as const;
 
 export type EvmNetworkV1 = keyof typeof EVM_NETWORK_CHAIN_ID_MAP;


### PR DESCRIPTION
## Description

Add Monad mainnet (chain ID 143) to the EVM network maps across all three SDKs. Monad has native Circle USDC deployed on day 1 with full EIP-3009 (`transferWithAuthorization`) support.

USDC on Monad: `0x754704Bc059F8C67012fEd69BC8A327a5aafb603`

**TypeScript** (`packages/mechanisms/evm/src/v1/index.ts`)
- Add `monad: 143` to `EVM_NETWORK_CHAIN_ID_MAP`

**Python** (`mechanisms/evm/constants.py`)
- Add `monad` to `V1_NETWORKS` and `V1_NETWORK_CHAIN_IDS`
- Add `eip155:143` to `NETWORK_CONFIGS` with USDC asset info
- Add `monad` alias to `NETWORK_ALIASES`

**Go** (`mechanisms/evm/constants.go`)
- Add `ChainIDMonad` var
- Add `eip155:143` and `monad` (legacy v1) entries to `NetworkConfigs`

We have a live x402 deployment on Monad ([Obol](https://obol.fixr.nexus) — agent-to-agent payment protocol) and can confirm USDC payments settle end-to-end on the network.

## Tests

Existing tests pass. No new tests needed — this adds network configuration entries following the same pattern as existing chains (Base, MegaETH, etc).

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)