### PR TITLE
Fix invalid JSON in “Example (Failure)” block

### DIFF
--- a/specs/transports-v2/http.md
+++ b/specs/transports-v2/http.md
@@ -147,7 +147,7 @@ PAYMENT-RESPONSE: eyJzdWNjZXNzIjpmYWxzZSwiZXJyb3JSZWFzb24iOiJpbnN1ZmZpY2llbnRfZn
 
 {
   "x402Version": 2,
-  "error": "Payment failed: insufficient funds"
+  "error": "Payment failed: insufficient funds",
   "accepts": [...]
 }
 ```


### PR DESCRIPTION
## Description

PR description:
In the JSON example in the `“Example (Failure)”` block, the comma between the ‘error’ and “accepts” fields is missing, which makes the JSON invalid and unusable directly.

Fix: a comma has been added after the line with `“error”: “Payment failed: insufficient funds”.` Now the JSON is valid. 

## Tests

No tests are required, as the fix addresses an obvious syntax error in JSON (a comma is missing).

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 