### PR TITLE
fix(specs,ts): add x402Version to facilitator verify/settle request body

### DIFF
--- a/specs/x402-specification-v1.md
+++ b/specs/x402-specification-v1.md
@@ -280,6 +280,7 @@ Verifies a payment authorization without executing the transaction on the blockc
 
 ```json
 {
+  "x402Version": 1,
   "paymentPayload": {
     /* PaymentPayload schema */
   },
@@ -293,6 +294,7 @@ Example with actual data:
 
 ```json
 {
+  "x402Version": 1,
   "paymentPayload": {
     "x402Version": 1,
     "scheme": "exact",

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -323,6 +323,7 @@ Verifies a payment authorization without executing the transaction on the blockc
 
 ```json
 {
+  "x402Version": 2,
   "paymentPayload": {
     /* PaymentPayload schema */
   },
@@ -336,6 +337,7 @@ Example with actual data:
 
 ```json
 {
+  "x402Version": 2,
   "paymentPayload": {
     "x402Version": 2,
     "resource": {

--- a/typescript/.changeset/add-x402version-to-facilitator-request-types.md
+++ b/typescript/.changeset/add-x402version-to-facilitator-request-types.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Added `x402Version` field to `VerifyRequest`, `SettleRequest`, `VerifyRequestV1`, and `SettleRequestV1` types to match what all SDK implementations already send in facilitator request bodies.

--- a/typescript/packages/core/src/types/facilitator.ts
+++ b/typescript/packages/core/src/types/facilitator.ts
@@ -2,6 +2,7 @@ import { PaymentPayload, PaymentRequirements } from "./payments";
 import { Network } from "./";
 
 export type VerifyRequest = {
+  x402Version: number;
   paymentPayload: PaymentPayload;
   paymentRequirements: PaymentRequirements;
 };
@@ -15,6 +16,7 @@ export type VerifyResponse = {
 };
 
 export type SettleRequest = {
+  x402Version: number;
   paymentPayload: PaymentPayload;
   paymentRequirements: PaymentRequirements;
 };

--- a/typescript/packages/core/src/types/v1/index.ts
+++ b/typescript/packages/core/src/types/v1/index.ts
@@ -30,11 +30,13 @@ export type PaymentPayloadV1 = {
 
 // Facilitator Requests/Responses
 export type VerifyRequestV1 = {
+  x402Version: number;
   paymentPayload: PaymentPayloadV1;
   paymentRequirements: PaymentRequirementsV1;
 };
 
 export type SettleRequestV1 = {
+  x402Version: number;
   paymentPayload: PaymentPayloadV1;
   paymentRequirements: PaymentRequirementsV1;
 };


### PR DESCRIPTION
## Summary

All four SDK implementations (TypeScript, Go, Go legacy, Python) include `x402Version` as a top-level field in the facilitator `/verify` and `/settle` request bodies, but neither the v1/v2 specs nor the TypeScript types document it.

- **TypeScript** `HTTPFacilitatorClient.verify()` sends `x402Version: paymentPayload.x402Version` at line 105
- **Go** `verifyHTTP()` sends `"x402Version": version` at line 182
- **Go legacy** `Verify()` sends `"x402Version": 1` at line 46
- **Python** `_build_request_body()` sends `"x402Version": version` at line 197
- **Go tests** assert `requestBody["x402Version"].(float64) == 2` at line 166

This PR adds the missing field to:
- v2 spec section 7.1 (POST /verify) request schema
- v1 spec section 7.1 (POST /verify) request schema (7.2 /settle references 7.1)
- `VerifyRequest` and `SettleRequest` types in `@x402/core`
- `VerifyRequestV1` and `SettleRequestV1` types in `@x402/core`

Includes a changeset for the `@x402/core` patch.

## Test plan

- [x] `pnpm --filter @x402/core build` passes (no type errors)
- [x] `pnpm --filter @x402/core test` passes (308 tests)
- [x] Spec examples already show `x402Version` in the nested `paymentPayload` — this adds it to the top-level schema to match what SDKs actually send

Closes #1176