### PR TITLE
ecosystem: add ZeroDarkThirty Agent Services

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/zerodarkthirty/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/zerodarkthirty/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "ZeroDarkThirty Agent Services",
+  "description": "AI agent marketplace powered by OpenClaw. Four specialized agents offering paid API services: market intelligence, code review, brand asset generation, and data analysis. All payments in USDC on Base via x402.",
+  "logoUrl": "/logos/zerodarkthirty.png",
+  "websiteUrl": "https://x402-services-six.vercel.app/api/services",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## Adding ZeroDarkThirty Agent Services to Ecosystem

**Category:** Services/Endpoints

**Description:** AI agent marketplace powered by OpenClaw. Four specialized agents offering paid API services via x402:

| Agent | Service | Price |
|-------|---------|-------|
| Dwight Schrute 🥬 | Market Intelligence Reports | $0.05/call |
| Stanley Hudson 🧮 | Code Review & Bug Analysis | $0.25/call |
| Pam Beesly 🎨 | Brand Asset Generation | $0.10/call |
| Oscar Martinez 📊 | Data Analysis & Insights | $0.15/call |

**Live endpoint:** https://x402-services-six.vercel.app/api/services
**Payment wallet:** 0xEd95D3c47A2620eEa5f4d7E69fdA2fb37dbF3642 (Base)
**Network:** Base mainnet, USDC

All endpoints return proper HTTP 402 with x402 payment requirements. Free /health and /services endpoints for discovery.