### PR TITLE
fix: remove facilitator from exact scheme witness struct

### DIFF
--- a/contracts/evm/README.md
+++ b/contracts/evm/README.md
@@ -24,8 +24,8 @@ Both contracts:
 
 | Contract | Address | Verified |
 |----------|---------|----------|
-| x402ExactPermit2Proxy | [`0x4020cd856c882d5fb903d99ce35316a085bb0001`](https://sepolia.basescan.org/address/0x4020cd856c882d5fb903d99ce35316a085bb0001) | ✓ |
-| x402UptoPermit2Proxy | [`0x40204513ec14919adfd30d77c0a991371b420002`](https://sepolia.basescan.org/address/0x40204513ec14919adfd30d77c0a991371b420002) | ✓ |
+| x402ExactPermit2Proxy | [`0x402085c248EeA27D92E8b30b2C58ed07f9E20001`](https://sepolia.basescan.org/address/0x402085c248EeA27D92E8b30b2C58ed07f9E20001) | ✓ |
+| x402UptoPermit2Proxy | [`0x402039b3d6E6BEC5A02c2C9fd937ac17A6940002`](https://sepolia.basescan.org/address/0x402039b3d6E6BEC5A02c2C9fd937ac17A6940002) | ✓ |
 
 ## Prerequisites
 

--- a/contracts/evm/script/ComputeAddress.s.sol
+++ b/contracts/evm/script/ComputeAddress.s.sol
@@ -28,12 +28,12 @@ contract ComputeAddress is Script {
     address constant CANONICAL_PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
 
     /// @notice Default salt for x402ExactPermit2Proxy
-    /// @dev Vanity mined for address 0x4020cd856c882d5fb903d99ce35316a085bb0001
-    bytes32 constant DEFAULT_EXACT_SALT = 0x0000000000000000000000000000000000000000000000002c00000003c30a30;
+    /// @dev Vanity mined for address 0x402085c248eea27d92e8b30b2c58ed07f9e20001
+    bytes32 constant DEFAULT_EXACT_SALT = 0x0000000000000000000000000000000000000000000000003000000007263b0e;
 
     /// @notice Default salt for x402UptoPermit2Proxy
-    /// @dev Vanity mined for address 0x40204513ec14919adfd30d77c0a991371b420002
-    bytes32 constant DEFAULT_UPTO_SALT = 0x00000000000000000000000000000000000000000000000084000000275d7dbb;
+    /// @dev Vanity mined for address 0x402039b3d6e6bec5a02c2c9fd937ac17a6940002
+    bytes32 constant DEFAULT_UPTO_SALT = 0x0000000000000000000000000000000000000000000000000000000000edb738;
 
     /**
      * @notice Computes the CREATE2 addresses using the default salts

--- a/contracts/evm/script/Deploy.s.sol
+++ b/contracts/evm/script/Deploy.s.sol
@@ -29,12 +29,12 @@ contract DeployX402Proxies is Script {
     address constant CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
 
     /// @notice Salt for x402ExactPermit2Proxy deterministic deployment
-    /// @dev Vanity mined for address 0x4020cd856c882d5fb903d99ce35316a085bb0001
-    bytes32 constant EXACT_SALT = 0x0000000000000000000000000000000000000000000000002c00000003c30a30;
+    /// @dev Vanity mined for address 0x402085c248eea27d92e8b30b2c58ed07f9e20001
+    bytes32 constant EXACT_SALT = 0x0000000000000000000000000000000000000000000000003000000007263b0e;
 
     /// @notice Salt for x402UptoPermit2Proxy deterministic deployment
-    /// @dev Vanity mined for address 0x40204513ec14919adfd30d77c0a991371b420002
-    bytes32 constant UPTO_SALT = 0x00000000000000000000000000000000000000000000000084000000275d7dbb;
+    /// @dev Vanity mined for address 0x402039b3d6e6bec5a02c2c9fd937ac17a6940002
+    bytes32 constant UPTO_SALT = 0x0000000000000000000000000000000000000000000000000000000000edb738;
 
     function run() public {
         // Allow override of Permit2 address for chains with non-canonical deployments

--- a/contracts/evm/src/x402UptoPermit2Proxy.sol
+++ b/contracts/evm/src/x402UptoPermit2Proxy.sol
@@ -12,19 +12,41 @@ import {ISignatureTransfer} from "./interfaces/ISignatureTransfer.sol";
  *      It uses the "witness" pattern to cryptographically bind the payment destination,
  *      preventing facilitators from redirecting funds.
  *
- *      Unlike x402ExactPermit2Proxy, this contract allows the facilitator to specify
- *      how much to transfer (up to the permitted amount), useful for scenarios where
- *      the actual amount is determined at settlement time.
+ *      This contract allows the facilitator to transfer up to the permitted amount.
+ *      The witness includes a facilitator field so only the authorized caller can
+ *      choose the final settlement amount.
  *
  * @author x402 Protocol
  */
 contract x402UptoPermit2Proxy is x402BasePermit2Proxy {
-    constructor(
-        address _permit2
-    ) x402BasePermit2Proxy(_permit2) {}
+    /// @notice EIP-712 type string for witness data
+    string public constant WITNESS_TYPE_STRING =
+        "Witness witness)TokenPermissions(address token,uint256 amount)Witness(address to,address facilitator,uint256 validAfter)";
+
+    /// @notice EIP-712 typehash for witness struct
+    bytes32 public constant WITNESS_TYPEHASH = keccak256("Witness(address to,address facilitator,uint256 validAfter)");
+
+    /// @notice Thrown when msg.sender does not match the facilitator in the witness
+    error UnauthorizedFacilitator();
 
     /// @notice Thrown when requested amount exceeds permitted amount
     error AmountExceedsPermitted();
+
+    /**
+     * @notice Witness data structure for payment authorization
+     * @param to Destination address (immutable once signed)
+     * @param facilitator Address authorized to settle this payment (must be msg.sender)
+     * @param validAfter Earliest timestamp when payment can be settled
+     */
+    struct Witness {
+        address to;
+        address facilitator;
+        uint256 validAfter;
+    }
+
+    constructor(
+        address _permit2
+    ) x402BasePermit2Proxy(_permit2) {}
 
     /**
      * @notice Settles a payment using a Permit2 signature
@@ -43,7 +65,10 @@ contract x402UptoPermit2Proxy is x402BasePermit2Proxy {
         bytes calldata signature
     ) external nonReentrant {
         if (amount > permit.permitted.amount) revert AmountExceedsPermitted();
-        _settle(permit, amount, owner, witness, signature);
+        if (msg.sender != witness.facilitator) revert UnauthorizedFacilitator();
+        bytes32 witnessHash =
+            keccak256(abi.encode(WITNESS_TYPEHASH, witness.to, witness.facilitator, witness.validAfter));
+        _settle(permit, amount, owner, witness.to, witness.validAfter, witnessHash, WITNESS_TYPE_STRING, signature);
         emit Settled();
     }
 
@@ -70,8 +95,11 @@ contract x402UptoPermit2Proxy is x402BasePermit2Proxy {
         bytes calldata signature
     ) external nonReentrant {
         if (amount > permit.permitted.amount) revert AmountExceedsPermitted();
+        if (msg.sender != witness.facilitator) revert UnauthorizedFacilitator();
         _executePermit(permit.permitted.token, owner, permit2612, permit.permitted.amount);
-        _settle(permit, amount, owner, witness, signature);
+        bytes32 witnessHash =
+            keccak256(abi.encode(WITNESS_TYPEHASH, witness.to, witness.facilitator, witness.validAfter));
+        _settle(permit, amount, owner, witness.to, witness.validAfter, witnessHash, WITNESS_TYPE_STRING, signature);
         emit SettledWithPermit();
     }
 }

--- a/contracts/evm/test/invariants/X402ExactInvariants.t.sol
+++ b/contracts/evm/test/invariants/X402ExactInvariants.t.sol
@@ -45,12 +45,11 @@ contract X402ExactHandler is Test {
             deadline: t + 3600
         });
 
-        x402BasePermit2Proxy.Witness memory witness =
-            x402BasePermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t > 60 ? t - 60 : 0});
+        x402ExactPermit2Proxy.Witness memory witness =
+            x402ExactPermit2Proxy.Witness({to: recipient, validAfter: t > 60 ? t - 60 : 0});
 
         bytes memory sig = abi.encodePacked(bytes32(uint256(1)), bytes32(uint256(2)), uint8(27));
 
-        // Exact variant has no amount parameter - always transfers the full permitted amount
         try proxy.settle(permit, payer, witness, sig) {
             totalSettled += amount;
             settleCallCount++;

--- a/contracts/evm/test/invariants/X402UptoInvariants.t.sol
+++ b/contracts/evm/test/invariants/X402UptoInvariants.t.sol
@@ -45,8 +45,8 @@ contract X402UptoHandler is Test {
             deadline: t + 3600
         });
 
-        x402BasePermit2Proxy.Witness memory witness =
-            x402BasePermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t > 60 ? t - 60 : 0});
+        x402UptoPermit2Proxy.Witness memory witness =
+            x402UptoPermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t > 60 ? t - 60 : 0});
 
         bytes memory sig = abi.encodePacked(bytes32(uint256(1)), bytes32(uint256(2)), uint8(27));
 

--- a/contracts/evm/test/mocks/MaliciousReentrantExact.sol
+++ b/contracts/evm/test/mocks/MaliciousReentrantExact.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.20;
 
 import {ISignatureTransfer} from "../../src/interfaces/ISignatureTransfer.sol";
 import {x402ExactPermit2Proxy} from "../../src/x402ExactPermit2Proxy.sol";
-import {x402BasePermit2Proxy} from "../../src/x402BasePermit2Proxy.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract MaliciousReentrantExact is ISignatureTransfer {
@@ -12,7 +11,7 @@ contract MaliciousReentrantExact is ISignatureTransfer {
 
     ISignatureTransfer.PermitTransferFrom public storedPermit;
     address public storedOwner;
-    x402BasePermit2Proxy.Witness public storedWitness;
+    x402ExactPermit2Proxy.Witness public storedWitness;
     bytes public storedSignature;
 
     mapping(address => mapping(uint256 => uint256)) public nonceBitmapStorage;
@@ -32,7 +31,7 @@ contract MaliciousReentrantExact is ISignatureTransfer {
     function setAttackParams(
         ISignatureTransfer.PermitTransferFrom calldata permit,
         address owner,
-        x402BasePermit2Proxy.Witness calldata witness,
+        x402ExactPermit2Proxy.Witness calldata witness,
         bytes calldata signature
     ) external {
         storedPermit = permit;
@@ -67,7 +66,6 @@ contract MaliciousReentrantExact is ISignatureTransfer {
         nonceBitmapStorage[owner][wordPos] |= (1 << bitPos);
 
         if (attemptReentry && address(target) != address(0)) {
-            // Exact variant has no amount parameter
             target.settle(storedPermit, storedOwner, storedWitness, storedSignature);
         }
 

--- a/contracts/evm/test/mocks/MaliciousReentrantUpto.sol
+++ b/contracts/evm/test/mocks/MaliciousReentrantUpto.sol
@@ -13,7 +13,7 @@ contract MaliciousReentrantUpto is ISignatureTransfer {
     ISignatureTransfer.PermitTransferFrom public storedPermit;
     uint256 public storedAmount;
     address public storedOwner;
-    x402BasePermit2Proxy.Witness public storedWitness;
+    x402UptoPermit2Proxy.Witness public storedWitness;
     bytes public storedSignature;
 
     mapping(address => mapping(uint256 => uint256)) public nonceBitmapStorage;
@@ -34,7 +34,7 @@ contract MaliciousReentrantUpto is ISignatureTransfer {
         ISignatureTransfer.PermitTransferFrom calldata permit,
         uint256 amount,
         address owner,
-        x402BasePermit2Proxy.Witness calldata witness,
+        x402UptoPermit2Proxy.Witness calldata witness,
         bytes calldata signature
     ) external {
         storedPermit = permit;

--- a/contracts/evm/test/x402UptoPermit2Proxy.fork.t.sol
+++ b/contracts/evm/test/x402UptoPermit2Proxy.fork.t.sol
@@ -68,7 +68,7 @@ contract X402UptoPermit2ProxyForkTest is Test {
         uint256 amount,
         uint256 nonce,
         uint256 deadline,
-        x402BasePermit2Proxy.Witness memory witness
+        x402UptoPermit2Proxy.Witness memory witness
     ) internal view returns (bytes memory) {
         // Must match contract's witness hash computation order
         bytes32 witnessHash =
@@ -90,8 +90,8 @@ contract X402UptoPermit2ProxyForkTest is Test {
         uint256 nonce = _nonce(1);
         uint256 deadline = t + 3600;
 
-        x402BasePermit2Proxy.Witness memory witness =
-            x402BasePermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
+        x402UptoPermit2Proxy.Witness memory witness =
+            x402UptoPermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
 
         bytes memory sig = _sign(address(token), TRANSFER_AMOUNT, nonce, deadline, witness);
 
@@ -115,8 +115,8 @@ contract X402UptoPermit2ProxyForkTest is Test {
         uint256 t = block.timestamp;
         uint256 nonce = _nonce(2);
 
-        x402BasePermit2Proxy.Witness memory witness =
-            x402BasePermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
+        x402UptoPermit2Proxy.Witness memory witness =
+            x402UptoPermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
 
         ISignatureTransfer.PermitTransferFrom memory permit = ISignatureTransfer.PermitTransferFrom({
             permitted: ISignatureTransfer.TokenPermissions({token: address(token), amount: TRANSFER_AMOUNT}),
@@ -135,8 +135,8 @@ contract X402UptoPermit2ProxyForkTest is Test {
         uint256 nonce = _nonce(3);
         uint256 deadline = t + 3600;
 
-        x402BasePermit2Proxy.Witness memory witness =
-            x402BasePermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
+        x402UptoPermit2Proxy.Witness memory witness =
+            x402UptoPermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
 
         uint256 wrongKey = 0xdeadbeef;
         bytes32 witnessHash =
@@ -163,8 +163,8 @@ contract X402UptoPermit2ProxyForkTest is Test {
         uint256 nonce = _nonce(4);
         uint256 deadline = t + 3600;
 
-        x402BasePermit2Proxy.Witness memory witness =
-            x402BasePermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
+        x402UptoPermit2Proxy.Witness memory witness =
+            x402UptoPermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
 
         bytes memory sig = _sign(address(token), TRANSFER_AMOUNT, nonce, deadline, witness);
 
@@ -185,8 +185,8 @@ contract X402UptoPermit2ProxyForkTest is Test {
         uint256 nonce = _nonce(5);
         uint256 deadline = t - 60; // expired (Permit2's deadline enforces the upper bound)
 
-        x402BasePermit2Proxy.Witness memory witness =
-            x402BasePermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 120});
+        x402UptoPermit2Proxy.Witness memory witness =
+            x402UptoPermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 120});
 
         bytes memory sig = _sign(address(token), TRANSFER_AMOUNT, nonce, deadline, witness);
 
@@ -207,8 +207,8 @@ contract X402UptoPermit2ProxyForkTest is Test {
 
         address attacker = makeAddr("attacker");
 
-        x402BasePermit2Proxy.Witness memory signedWitness =
-            x402BasePermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
+        x402UptoPermit2Proxy.Witness memory signedWitness =
+            x402UptoPermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
 
         bytes memory sig = _sign(address(token), TRANSFER_AMOUNT, nonce, deadline, signedWitness);
 
@@ -218,7 +218,7 @@ contract X402UptoPermit2ProxyForkTest is Test {
             deadline: deadline
         });
 
-        x402BasePermit2Proxy.Witness memory tamperedWitness = x402BasePermit2Proxy.Witness({
+        x402UptoPermit2Proxy.Witness memory tamperedWitness = x402UptoPermit2Proxy.Witness({
             to: attacker,
             facilitator: signedWitness.facilitator,
             validAfter: signedWitness.validAfter
@@ -235,8 +235,8 @@ contract X402UptoPermit2ProxyForkTest is Test {
         uint256 permitted = TRANSFER_AMOUNT;
         uint256 requested = permitted / 2;
 
-        x402BasePermit2Proxy.Witness memory witness =
-            x402BasePermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
+        x402UptoPermit2Proxy.Witness memory witness =
+            x402UptoPermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: t - 60});
 
         bytes memory sig = _sign(address(token), permitted, nonce, deadline, witness);
 

--- a/contracts/evm/test/x402UptoPermit2Proxy.t.sol
+++ b/contracts/evm/test/x402UptoPermit2Proxy.t.sol
@@ -60,8 +60,8 @@ contract X402UptoPermit2ProxyTest is Test {
         address to,
         address facilitator,
         uint256 validAfter
-    ) internal pure returns (x402BasePermit2Proxy.Witness memory) {
-        return x402BasePermit2Proxy.Witness({to: to, facilitator: facilitator, validAfter: validAfter});
+    ) internal pure returns (x402UptoPermit2Proxy.Witness memory) {
+        return x402UptoPermit2Proxy.Witness({to: to, facilitator: facilitator, validAfter: validAfter});
     }
 
     function _sig() internal pure returns (bytes memory) {
@@ -131,7 +131,7 @@ contract X402UptoPermit2ProxyTest is Test {
         uint256 t = block.timestamp;
         address attacker = makeAddr("attacker");
         vm.prank(attacker);
-        vm.expectRevert(x402BasePermit2Proxy.UnauthorizedFacilitator.selector);
+        vm.expectRevert(x402UptoPermit2Proxy.UnauthorizedFacilitator.selector);
         proxy.settle(
             _permit(TRANSFER_AMOUNT, 0, t + 3600),
             TRANSFER_AMOUNT,

--- a/contracts/evm/vanity-miner/src/main.rs
+++ b/contracts/evm/vanity-miner/src/main.rs
@@ -17,10 +17,10 @@ const UPTO_SUFFIX: [u8; 2] = [0x00, 0x02]; // ...0002
 // Run `forge script script/ComputeAddress.s.sol` to verify these match
 // x402ExactPermit2Proxy
 const EXACT_INIT_CODE_HASH: [u8; 32] =
-    hex_literal::hex!("61f007aac96be95995d250c70b750b0c239f3c8cbc28b7b0e89761f84bc0c2bb");
+    hex_literal::hex!("e774d1d5a07218946ab54efe010b300481478b86861bb17d69c98a57f68a604c");
 // x402UptoPermit2Proxy
 const UPTO_INIT_CODE_HASH: [u8; 32] =
-    hex_literal::hex!("6bc5ae76d294a4e82cf7857326e018e5d9cd6e306ccfd1ff1300c08697eed7b2");
+    hex_literal::hex!("b956a3d1d040d7b587f0dc6e8145368a5501bac459a111e73a4954ada577673b");
 
 fn compute_create2_address(salt: &[u8; 32], init_code_hash: &[u8; 32]) -> [u8; 20] {
     let mut hasher = Keccak::v256();

--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -144,7 +144,7 @@ The `payload` field must contain:
         "amount": "10000"
       },
       "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-      "spender": "0x4020CD856C882D5fb903D99CE35316A085Bb0001", // Canonical x402ExactPermit2Proxy address
+      "spender": "0x402085c248EeA27D92E8b30b2C58ed07f9E20001", // Canonical x402ExactPermit2Proxy address
       "nonce": "0xf3746613c2d920b5fdabc0856f2aeb2d4f88ee6037b8cc5d04a71a4462f13480",
       "deadline": "1740672154",
       "witness": {
@@ -219,7 +219,7 @@ This contract acts as the authorized Spender. It validates the Witness data to e
 
 > **Requirement**: This contract will be deployed to the same address across all supported EVM chains using `CREATE2` to ensure consistent behavior and simpler integration.
 
-**Canonical Address:** `0x4020CD856C882D5fb903D99CE35316A085Bb0001`
+**Canonical Address:** `0x402085c248EeA27D92E8b30b2C58ed07f9E20001`
 
 ```solidity
 // SPDX-License-Identifier: MIT


### PR DESCRIPTION
## Description

- Removes the `facilitator` field from the `Witness` struct used by `x402ExactPermit2Proxy`, since the exact scheme always transfers the full permitted amount and has no settlement frontrunning risk
- Keeps the `facilitator` field in `x402UptoPermit2Proxy` where it is needed to prevent amount griefing (as identified in audit finding 3.1.1)
- Refactors `x402BasePermit2Proxy._settle()` to accept decomposed parameters, allowing each child contract to define its own witness format and EIP-712 types

## Motivation

The `facilitator` field was added to the shared `Witness` struct to address audit finding 3.1.1 (signature griefing/frontrunning in `x402UptoPermit2Proxy`). However, it was incorrectly applied to both schemes. For the exact scheme, the amount is always the full permitted amount -- there is no variable amount that can be griefed. Adding `facilitator` to the exact witness introduced unnecessary centralization (only the facilitator can submit the settlement tx) without any security benefit.

## Changes

**Contracts:**
- `x402BasePermit2Proxy`: Removed shared `Witness` struct, `WITNESS_TYPE_STRING`, `WITNESS_TYPEHASH`, and `UnauthorizedFacilitator` error. Refactored `_settle()` to accept decomposed parameters (`to`, `validAfter`, `witnessHash`, `witnessTypeString`).
- `x402ExactPermit2Proxy`: Added `Witness(address to, uint256 validAfter)` -- no facilitator. Anyone can submit the settlement transaction.
- `x402UptoPermit2Proxy`: Added `Witness(address to, address facilitator, uint256 validAfter)` -- keeps facilitator check to prevent amount griefing.

**Cross-mechanism safety:** The different witness type strings produce different EIP-712 type hashes, providing type-level domain separation between exact and upto signatures (in addition to the existing spender-address separation from different proxy contract addresses).

**Deployment:**
- Re-mined vanity salts for both contracts (prefix `0x4020`, suffix `0001`/`0002`)
- Deployed to Base Sepolia: Exact at `0x402085c248EeA27D92E8b30b2C58ed07f9E20001`, Upto at `0x402039b3d6E6BEC5A02c2C9fd937ac17A6940002`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 