### PR TITLE
chore: added MockGenericERC20 for testing generic erc20 cases with permit2 in e2e

### DIFF
--- a/contracts/evm/script/DeployMockGenericERC20.s.sol
+++ b/contracts/evm/script/DeployMockGenericERC20.s.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {MockGenericERC20} from "../src/mocks/MockGenericERC20.sol";
+
+/**
+ * @title DeployMockGenericERC20
+ * @notice Deterministic CREATE2 deployment for MockGenericERC20
+ * @dev Run with: forge script script/DeployMockGenericERC20.s.sol --rpc-url $BASE_SEPOLIA_RPC_URL --broadcast --verify
+ *
+ *      Because MockGenericERC20 has no constructor arguments, initCode == creationCode,
+ *      giving a single deterministic address across all EVM chains.
+ */
+contract DeployMockGenericERC20 is Script {
+    /// @notice Arachnid's deterministic CREATE2 deployer (same on all EVM chains)
+    address constant CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+    /// @notice Salt for deterministic deployment
+    bytes32 constant SALT = 0x0000000000000000000000000000000000000000000000000000000000000402;
+
+    function run() public {
+        console2.log("");
+        console2.log("============================================================");
+        console2.log("  MockGenericERC20 Deterministic Deployment (CREATE2)");
+        console2.log("============================================================");
+        console2.log("");
+
+        console2.log("Network: chainId", block.chainid);
+        console2.log("CREATE2 Deployer:", CREATE2_DEPLOYER);
+        console2.log("Salt:", vm.toString(SALT));
+        console2.log("");
+
+        bytes memory initCode = type(MockGenericERC20).creationCode;
+        bytes32 initCodeHash = keccak256(initCode);
+        address expectedAddress = _computeCreate2Addr(SALT, initCodeHash, CREATE2_DEPLOYER);
+
+        console2.log("Expected address:", expectedAddress);
+        console2.log("Init code hash:", vm.toString(initCodeHash));
+
+        if (expectedAddress.code.length > 0) {
+            console2.log("Contract already deployed at", expectedAddress);
+            return;
+        }
+
+        if (block.chainid != 31_337 && block.chainid != 1337) {
+            require(CREATE2_DEPLOYER.code.length > 0, "CREATE2 deployer not found on this network");
+            console2.log("CREATE2 deployer verified");
+        }
+
+        vm.startBroadcast();
+
+        address deployedAddress;
+        if (block.chainid == 31_337 || block.chainid == 1337) {
+            console2.log("(Using regular deployment for local network)");
+            MockGenericERC20 token = new MockGenericERC20();
+            deployedAddress = address(token);
+        } else {
+            bytes memory deploymentData = abi.encodePacked(SALT, initCode);
+            (bool success,) = CREATE2_DEPLOYER.call(deploymentData);
+            require(success, "CREATE2 deployment failed for MockGenericERC20");
+            deployedAddress = expectedAddress;
+            require(deployedAddress.code.length > 0, "No bytecode at expected address");
+        }
+
+        vm.stopBroadcast();
+
+        console2.log("Deployed to:", deployedAddress);
+        console2.log("");
+    }
+
+    function _computeCreate2Addr(
+        bytes32 salt,
+        bytes32 initCodeHash,
+        address deployer
+    ) internal pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, initCodeHash)))));
+    }
+}

--- a/contracts/evm/src/mocks/MockGenericERC20.sol
+++ b/contracts/evm/src/mocks/MockGenericERC20.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title MockGenericERC20
+ * @notice Minimal ERC20 mock with no constructor arguments for deterministic CREATE2 deployment.
+ * @dev No EIP-2612 / EIP-3009 extensions — pure vanilla ERC20.
+ *      All metadata is hardcoded so that initCode == creationCode (no constructor args),
+ *      which keeps the deterministic address independent of encoding.
+ */
+contract MockGenericERC20 is ERC20 {
+    constructor() ERC20("Mock Generic ERC20", "MOCK") {}
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+    function mint(address to, uint256 amount) public {
+        _mint(to, amount);
+    }
+}


### PR DESCRIPTION
* Deterministically deploys using the salt `0x0000...402`, which resolves to the address `0xeED520980fC7C7B4eB379B96d61CEdea2423005a`. This ensures e2e tests can be run on any EVM network without changing hardcoded constants
* Deployed to `base-sepolia` to start https://sepolia.basescan.org/address/0xeED520980fC7C7B4eB379B96d61CEdea2423005a
* Anyone can mint the token via the [mint function](https://sepolia.basescan.org/address/0xeED520980fC7C7B4eB379B96d61CEdea2423005a#writeContract#F2) to ensure the contract can be reused by any tester

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/coinbase-5dac824f/coinbase-5dac824f/editor/chore%2Fgeneric-20-deploy-for-e2e-testing?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->