### PR TITLE
perf: precompile regex patterns in http/server.go

### DIFF
--- a/go/.changes/unreleased/changed-20260225-093142.yaml
+++ b/go/.changes/unreleased/changed-20260225-093142.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Pre-compile constant regex patterns in http server for better performance
+time: 2026-02-25T09:31:42.16463+09:00

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -15,6 +15,12 @@ import (
 	"github.com/coinbase/x402/go/types"
 )
 
+// Pre-compiled regex patterns to avoid recompilation on every call.
+var (
+	multiSlashRegex = regexp.MustCompile(`/+`)
+	paramRegex      = regexp.MustCompile(`\\\[([^\]]+)\\\]`)
+)
+
 // ============================================================================
 // HTTP Adapter Interface
 // ============================================================================
@@ -783,7 +789,6 @@ func parseRoutePattern(pattern string) (string, *regexp.Regexp) {
 	regexPattern := "^" + regexp.QuoteMeta(path)
 	regexPattern = strings.ReplaceAll(regexPattern, `\*`, `.*?`)
 	// Handle parameters like [id]
-	paramRegex := regexp.MustCompile(`\\\[([^\]]+)\\\]`)
 	regexPattern = paramRegex.ReplaceAllString(regexPattern, `[^/]+`)
 	regexPattern += "$"
 
@@ -807,8 +812,7 @@ func normalizePath(path string) string {
 	// Normalize slashes
 	path = strings.ReplaceAll(path, `\`, `/`)
 	// Replace multiple slashes with single slash
-	multiSlash := regexp.MustCompile(`/+`)
-	path = multiSlash.ReplaceAllString(path, `/`)
+	path = multiSlashRegex.ReplaceAllString(path, `/`)
 	// Remove trailing slash
 	path = strings.TrimSuffix(path, `/`)
 


### PR DESCRIPTION
## Summary

- Pre-compile constant regex patterns as package-level variables in `go/http/server.go`
- `normalizePath()` called on every HTTP request was recompiling `regexp.MustCompile("/+")` each time
- `parseRoutePattern()` was recompiling a constant param-matching regex on each call

## Changes

Two constant regex patterns moved from function-local to package-level `var`:

```go
  var (
      multiSlashRegex = regexp.MustCompile(`/+`)
      paramRegex      = regexp.MustCompile(`\\\[([^\]]+)\\\]`)
 )
```

| Location | Before | After |
|---|---|---|
| `normalizePath()` (L815) | `regexp.MustCompile("/+")` per Call | Uses `multiSlashRegex` |
| `parseRoutePattern()` (L792) | `regexp.MustCompile(...)` per Call | Uses `paramRegex` |

Not changed
- `regexp.MustCompile(regexPattern)` in `parseRoutePattern()` (L795)
- This compiles a dynamic per-route pattern and is already cached in `CompiledRoute.Regex`.

## Benchmark

Benchmarks were run with `go test -bench -benchmem -count=10` and compared using **benchstat**.

### Benchmark codes

```go
func BenchmarkNormalizePath(b *testing.B) {
    paths := []string{
        "/api/v1/resource",
        "///multiple///slashes///",
        "/path/with?query=string#fragment",
        "/encoded%20path/to%2Fresource",
        "/a/b/c/d/e/f/g/h/i/j",
    }
    b.ResetTimer()
    for i := 0; i < b.N; i++ {
        for _, p := range paths {
            _ = normalizePath(p)
        }
    }
}
```

```go
func BenchmarkParseRoutePattern(b *testing.B) {
    patterns := []string{
        "GET /api/v1/resource",
        "POST /api/v2/[id]/action",
        "/wildcard/*",
        "PUT /users/[userId]/posts/[postId]",
    }
    b.ResetTimer()
    for i := 0; i < b.N; i++ {
        for _, p := range patterns {
            parseRoutePattern(p)
        }
    }
}
```

### Results 

**System Information**

- Apple M3 Air
  - 8-core CPU with 4 performance cores and 4 efficiency cores
  - 10-core GPU
  - 16GB unified memory
- Go 1.24, darwin/arm64

**Summary Table**

| Metric | Before | After | Improvement |
| :--- | :--- | :--- | :--- |
| **NormalizePath (per request)** | | | |
| Speed | 3.761µs | 2.037µs | -45.83% |
| Memory | 4,925 B/op | 443 B/op | -91.01% |
| Allocations | 84 allocs/op | 24 allocs/op | -71.43% |
| **ParseRoutePattern (init only)** | | | |
| Speed | 14.97µs | 10.93µs | -27.01% |
| Memory | 35.77 KiB | 26.00 KiB | -27.33% |
| Allocations | 420 allocs/op | 328 allocs/op | -21.90% |

**Raw Benchmark Results (benchstat)**

| Function | Metric | Before | After | Delta | Confidence (p) |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **NormalizePath-8** | Speed (sec/op) | 3.761µ ± 4% | 2.037µ ± 9% | -45.83% | p=0.000 |
| | Memory (B/op) | 4925.0 ± 0% | 443.0 ± 0% | -91.01% | p=0.000 |
| | Allocs (allocs/op) | 84.00 ± 0% | 24.00 ± 0% | -71.43% | p=0.000 |
| **ParseRoutePattern-8** | Speed (sec/op) | 14.97µ ± 10% | 10.93µ ± 1% | -27.01% | p=0.000 |
| | Memory (B/op) | 35.77Ki ± 0% | 26.00Ki ± 0% | -27.33% | p=0.000 |
| | Allocs (allocs/op) | 420.0 ± 0% | 328.0 ± 0% | -21.90% | p=0.000 |

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)