### PR TITLE
feat: implemented the erc20 gas sponsorship extension in typescript

### DIFF
--- a/e2e/clients/axios/index.ts
+++ b/e2e/clients/axios/index.ts
@@ -25,13 +25,11 @@ const svmSigner = await createKeyPairSignerFromBytes(
   base58.decode(process.env.SVM_PRIVATE_KEY as string),
 );
 
-// Create a public client for on-chain reads (needed for EIP-2612 extension)
 const publicClient = createPublicClient({
   chain: baseSepolia,
   transport: http(),
 });
 
-// Compose account + publicClient into a full ClientEvmSigner
 const evmSigner = toClientEvmSigner(evmAccount, publicClient);
 
 // Initialize Aptos signer if key is provided

--- a/e2e/clients/axios/test.config.json
+++ b/e2e/clients/axios/test.config.json
@@ -18,7 +18,8 @@
     ]
   },
   "extensions": [
-    "eip2612GasSponsoring"
+    "eip2612GasSponsoring",
+    "erc20ApprovalGasSponsoring"
   ],
   "environment": {
     "required": [

--- a/e2e/clients/fetch/index.ts
+++ b/e2e/clients/fetch/index.ts
@@ -22,13 +22,11 @@ const url = `${baseURL}${endpointPath}`;
 const evmAccount = privateKeyToAccount(process.env.EVM_PRIVATE_KEY as `0x${string}`);
 const svmSigner = await createKeyPairSignerFromBytes(base58.decode(process.env.SVM_PRIVATE_KEY as string));
 
-// Create a public client for on-chain reads (needed for EIP-2612 extension)
 const publicClient = createPublicClient({
   chain: baseSepolia,
   transport: http(),
 });
 
-// Compose account + publicClient into a full ClientEvmSigner
 const evmSigner = toClientEvmSigner(evmAccount, publicClient);
 
 // Initialize Aptos signer if key is provided

--- a/e2e/clients/fetch/test.config.json
+++ b/e2e/clients/fetch/test.config.json
@@ -18,7 +18,8 @@
     ]
   },
   "extensions": [
-    "eip2612GasSponsoring"
+    "eip2612GasSponsoring",
+    "erc20ApprovalGasSponsoring"
   ],
   "environment": {
     "required": [

--- a/e2e/facilitators/typescript/index.ts
+++ b/e2e/facilitators/typescript/index.ts
@@ -29,7 +29,11 @@ import { ExactEvmScheme } from "@x402/evm/exact/facilitator";
 import { ExactEvmSchemeV1 } from "@x402/evm/exact/v1/facilitator";
 import { NETWORKS as EVM_V1_NETWORKS } from "@x402/evm/v1";
 import { BAZAAR, extractDiscoveryInfo } from "@x402/extensions/bazaar";
-import { EIP2612_GAS_SPONSORING } from "@x402/extensions";
+import {
+  EIP2612_GAS_SPONSORING,
+  ERC20_APPROVAL_GAS_SPONSORING,
+  type Erc20ApprovalGasSponsoringFacilitatorExtension,
+} from "@x402/extensions";
 import { toFacilitatorSvmSigner } from "@x402/svm";
 import { ExactSvmScheme } from "@x402/svm/exact/facilitator";
 import { ExactSvmSchemeV1 } from "@x402/svm/exact/v1/facilitator";
@@ -177,8 +181,18 @@ if (aptosSigner) {
   facilitator.register(APTOS_NETWORK as Network, new ExactAptosScheme(aptosSigner));
 }
 
+const erc20GasSponsorshipExtension: Erc20ApprovalGasSponsoringFacilitatorExtension = {
+  ...ERC20_APPROVAL_GAS_SPONSORING,
+  signer: {
+    ...evmSigner,
+    sendRawTransaction: (args: { serializedTransaction: `0x${string}` }) =>
+      viemClient.sendRawTransaction(args),
+  },
+};
+
 facilitator.registerExtension(BAZAAR)
   .registerExtension(EIP2612_GAS_SPONSORING)
+  .registerExtension(erc20GasSponsorshipExtension)
   // Lifecycle hooks for payment tracking and discovery
   .onAfterVerify(async (context) => {
     // Hook 1: Track verified payment for verify→settle flow validation

--- a/e2e/facilitators/typescript/test.config.json
+++ b/e2e/facilitators/typescript/test.config.json
@@ -13,7 +13,8 @@
   ],
   "extensions": [
     "bazaar",
-    "eip2612GasSponsoring"
+    "eip2612GasSponsoring",
+    "erc20ApprovalGasSponsoring"
   ],
   "evm": {
     "transferMethods": ["eip3009", "permit2"]

--- a/e2e/servers/express/test.config.json
+++ b/e2e/servers/express/test.config.json
@@ -5,7 +5,8 @@
   "x402Version": 2,
   "extensions": [
     "bazaar",
-    "eip2612GasSponsoring"
+    "eip2612GasSponsoring",
+    "erc20ApprovalGasSponsoring"
   ],
   "endpoints": [
     {
@@ -23,6 +24,15 @@
       "requiresPayment": true,
       "protocolFamily": "evm",
       "transferMethod": "permit2"
+    },
+    {
+      "path": "/protected-permit2-erc20",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment with ERC-20 approval gas sponsoring",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "extensions": ["erc20ApprovalGasSponsoring"]
     },
     {
       "path": "/protected-svm",

--- a/e2e/servers/hono/test.config.json
+++ b/e2e/servers/hono/test.config.json
@@ -5,7 +5,8 @@
   "x402Version": 2,
   "extensions": [
     "bazaar",
-    "eip2612GasSponsoring"
+    "eip2612GasSponsoring",
+    "erc20ApprovalGasSponsoring"
   ],
   "endpoints": [
     {
@@ -23,6 +24,15 @@
       "requiresPayment": true,
       "protocolFamily": "evm",
       "permit2": true
+    },
+    {
+      "path": "/protected-permit2-erc20",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment with ERC-20 approval gas sponsoring",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "extensions": ["erc20ApprovalGasSponsoring"]
     },
     {
       "path": "/protected-svm",

--- a/e2e/servers/next/app/api/protected-permit2-erc20-proxy/route.ts
+++ b/e2e/servers/next/app/api/protected-permit2-erc20-proxy/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Protected Permit2 ERC-20 endpoint requiring payment with ERC-20 approval gas sponsoring (proxy middleware)
+ */
+export const runtime = "nodejs";
+
+export async function GET() {
+  return NextResponse.json({
+    message: "Permit2 ERC-20 approval endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+    method: "permit2-erc20-approval",
+  });
+}

--- a/e2e/servers/next/proxy.ts
+++ b/e2e/servers/next/proxy.ts
@@ -4,7 +4,10 @@ import { ExactEvmScheme } from "@x402/evm/exact/server";
 import { ExactSvmScheme } from "@x402/svm/exact/server";
 import { ExactAptosScheme } from "@x402/aptos/exact/server";
 import { bazaarResourceServerExtension, declareDiscoveryExtension } from "@x402/extensions/bazaar";
-import { declareEip2612GasSponsoringExtension } from "@x402/extensions";
+import {
+  declareEip2612GasSponsoringExtension,
+  declareErc20ApprovalGasSponsoringExtension,
+} from "@x402/extensions";
 
 export const EVM_PAYEE_ADDRESS = process.env.EVM_PAYEE_ADDRESS as `0x${string}`;
 export const SVM_PAYEE_ADDRESS = process.env.SVM_PAYEE_ADDRESS as string;
@@ -154,11 +157,27 @@ export const proxy = paymentProxy(
         ...declareEip2612GasSponsoringExtension(),
       },
     },
+    "/api/protected-permit2-erc20-proxy": {
+      accepts: {
+        payTo: EVM_PAYEE_ADDRESS,
+        scheme: "exact",
+        network: EVM_NETWORK,
+        price: {
+          amount: "1000",
+          asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a",
+          extra: {
+            assetTransferMethod: "permit2",
+          },
+        },
+      },
+      extensions: {
+        ...declareErc20ApprovalGasSponsoringExtension(),
+      },
+    },
   },
   server, // Pass pre-configured server instance
 );
 
-// Configure which paths the middleware should run on
 export const config = {
-  matcher: ["/api/protected-proxy", "/api/protected-svm-proxy", "/api/protected-aptos-proxy", "/api/protected-permit2-proxy"],
+  matcher: ["/api/protected-proxy", "/api/protected-svm-proxy", "/api/protected-aptos-proxy", "/api/protected-permit2-proxy", "/api/protected-permit2-erc20-proxy"],
 };

--- a/e2e/servers/next/test.config.json
+++ b/e2e/servers/next/test.config.json
@@ -5,7 +5,8 @@
   "x402Version": 2,
   "extensions": [
     "bazaar",
-    "eip2612GasSponsoring"
+    "eip2612GasSponsoring",
+    "erc20ApprovalGasSponsoring"
   ],
   "endpoints": [
     {
@@ -23,6 +24,15 @@
       "requiresPayment": true,
       "protocolFamily": "evm",
       "permit2": true
+    },
+    {
+      "path": "/api/protected-permit2-erc20-proxy",
+      "method": "GET",
+      "description": "Protected Permit2 endpoint with ERC-20 approval gas sponsoring using proxy middleware",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "extensions": ["erc20ApprovalGasSponsoring"]
     },
     {
       "path": "/api/protected-svm-proxy",

--- a/typescript/.changeset/hip-candies-hammer.md
+++ b/typescript/.changeset/hip-candies-hammer.md
@@ -1,0 +1,6 @@
+---
+'@x402/evm': minor
+'@x402/extensions': minor
+---
+
+Implemented the erc20 approval gas sponsorship extension

--- a/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/facilitator.ts
+++ b/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/facilitator.ts
@@ -1,0 +1,85 @@
+/**
+ * Facilitator functions for extracting and validating ERC-20 Approval Gas Sponsoring
+ * extension data.
+ *
+ * These functions help facilitators extract the pre-signed approve() transaction
+ * from payment payloads and validate it before broadcasting and settling.
+ */
+
+import type { PaymentPayload } from "@x402/core/types";
+import {
+  ERC20_APPROVAL_GAS_SPONSORING,
+  type Erc20ApprovalGasSponsoringInfo,
+  type Erc20ApprovalGasSponsoringExtension,
+} from "./types";
+
+/**
+ * Extracts the ERC-20 approval gas sponsoring info from a payment payload's extensions.
+ *
+ * Returns the info if the extension is present and contains the required client-populated
+ * fields (from, asset, spender, amount, signedTransaction, version).
+ *
+ * @param paymentPayload - The payment payload to extract from
+ * @returns The ERC-20 approval gas sponsoring info, or null if not present
+ */
+export function extractErc20ApprovalGasSponsoringInfo(
+  paymentPayload: PaymentPayload,
+): Erc20ApprovalGasSponsoringInfo | null {
+  if (!paymentPayload.extensions) {
+    return null;
+  }
+
+  const extension = paymentPayload.extensions[ERC20_APPROVAL_GAS_SPONSORING.key] as
+    | Erc20ApprovalGasSponsoringExtension
+    | undefined;
+
+  if (!extension?.info) {
+    return null;
+  }
+
+  const info = extension.info as Record<string, unknown>;
+
+  // Check that the client has populated the required fields
+  if (
+    !info.from ||
+    !info.asset ||
+    !info.spender ||
+    !info.amount ||
+    !info.signedTransaction ||
+    !info.version
+  ) {
+    return null;
+  }
+
+  return info as unknown as Erc20ApprovalGasSponsoringInfo;
+}
+
+/**
+ * Validates that the ERC-20 approval gas sponsoring info has valid format.
+ *
+ * Performs basic validation on the info fields:
+ * - Addresses are valid hex (0x + 40 hex chars)
+ * - Amount is a numeric string
+ * - signedTransaction is a hex string
+ * - Version is a numeric version string
+ *
+ * @param info - The ERC-20 approval gas sponsoring info to validate
+ * @returns True if the info is valid, false otherwise
+ */
+export function validateErc20ApprovalGasSponsoringInfo(
+  info: Erc20ApprovalGasSponsoringInfo,
+): boolean {
+  const addressPattern = /^0x[a-fA-F0-9]{40}$/;
+  const numericPattern = /^[0-9]+$/;
+  const hexPattern = /^0x[a-fA-F0-9]+$/;
+  const versionPattern = /^[0-9]+(\.[0-9]+)*$/;
+
+  return (
+    addressPattern.test(info.from) &&
+    addressPattern.test(info.asset) &&
+    addressPattern.test(info.spender) &&
+    numericPattern.test(info.amount) &&
+    hexPattern.test(info.signedTransaction) &&
+    versionPattern.test(info.version)
+  );
+}

--- a/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/index.ts
+++ b/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/index.ts
@@ -1,0 +1,58 @@
+/**
+ * ERC-20 Approval Gas Sponsoring Extension for x402
+ *
+ * Enables gasless Permit2 approval for generic ERC-20 tokens that do NOT
+ * implement EIP-2612. The client signs (but does not broadcast) a raw
+ * `approve(Permit2, MaxUint256)` transaction, and the facilitator broadcasts
+ * it atomically before settling the Permit2 payment.
+ *
+ * ## For Resource Servers
+ *
+ * ```typescript
+ * import { declareErc20ApprovalGasSponsoringExtension } from '@x402/extensions';
+ *
+ * const routes = [
+ *   {
+ *     path: "/api/data",
+ *     price: { amount: "1000", asset: "0x...", extra: { assetTransferMethod: "permit2" } },
+ *     extensions: {
+ *       ...declareErc20ApprovalGasSponsoringExtension(),
+ *     },
+ *   },
+ * ];
+ * ```
+ *
+ * ## For Facilitators
+ *
+ * ```typescript
+ * import {
+ *   extractErc20ApprovalGasSponsoringInfo,
+ *   validateErc20ApprovalGasSponsoringInfo,
+ * } from '@x402/extensions';
+ *
+ * const info = extractErc20ApprovalGasSponsoringInfo(paymentPayload);
+ * if (info && validateErc20ApprovalGasSponsoringInfo(info)) {
+ *   // Broadcast the pre-signed approve tx, then call standard settle()
+ * }
+ * ```
+ */
+
+// Export types
+export type {
+  Erc20ApprovalGasSponsoringInfo,
+  Erc20ApprovalGasSponsoringServerInfo,
+  Erc20ApprovalGasSponsoringExtension,
+  Erc20ApprovalGasSponsoringSigner,
+  Erc20ApprovalGasSponsoringFacilitatorExtension,
+} from "./types";
+
+export { ERC20_APPROVAL_GAS_SPONSORING } from "./types";
+
+// Export resource service functions (for servers)
+export { declareErc20ApprovalGasSponsoringExtension } from "./resourceService";
+
+// Export facilitator functions
+export {
+  extractErc20ApprovalGasSponsoringInfo,
+  validateErc20ApprovalGasSponsoringInfo,
+} from "./facilitator";

--- a/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/index.ts
+++ b/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/index.ts
@@ -46,10 +46,13 @@ export type {
   Erc20ApprovalGasSponsoringFacilitatorExtension,
 } from "./types";
 
-export { ERC20_APPROVAL_GAS_SPONSORING } from "./types";
+export { ERC20_APPROVAL_GAS_SPONSORING, ERC20_APPROVAL_GAS_SPONSORING_VERSION } from "./types";
 
 // Export resource service functions (for servers)
-export { declareErc20ApprovalGasSponsoringExtension } from "./resourceService";
+export {
+  declareErc20ApprovalGasSponsoringExtension,
+  erc20ApprovalGasSponsoringSchema,
+} from "./resourceService";
 
 // Export facilitator functions
 export {

--- a/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/resourceService.ts
+++ b/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/resourceService.ts
@@ -6,13 +6,17 @@
  * implement EIP-2612 (generic ERC-20 tokens).
  */
 
-import { ERC20_APPROVAL_GAS_SPONSORING, type Erc20ApprovalGasSponsoringExtension } from "./types";
+import {
+  ERC20_APPROVAL_GAS_SPONSORING,
+  ERC20_APPROVAL_GAS_SPONSORING_VERSION,
+  type Erc20ApprovalGasSponsoringExtension,
+} from "./types";
 
 /**
  * The JSON Schema for the ERC-20 approval gas sponsoring extension info.
  * Matches the schema defined in the spec.
  */
-const erc20ApprovalGasSponsoringSchema: Record<string, unknown> = {
+export const erc20ApprovalGasSponsoringSchema: Record<string, unknown> = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
   type: "object",
   properties: {
@@ -85,7 +89,7 @@ export function declareErc20ApprovalGasSponsoringExtension(): Record<
       info: {
         description:
           "The facilitator broadcasts a pre-signed ERC-20 approve() transaction to grant Permit2 allowance.",
-        version: "1",
+        version: ERC20_APPROVAL_GAS_SPONSORING_VERSION,
       },
       schema: erc20ApprovalGasSponsoringSchema,
     },

--- a/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/resourceService.ts
+++ b/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/resourceService.ts
@@ -1,0 +1,93 @@
+/**
+ * Resource Service functions for declaring the ERC-20 Approval Gas Sponsoring extension.
+ *
+ * These functions help servers declare support for ERC-20 approval gas sponsoring
+ * in the PaymentRequired response extensions. Use this for tokens that do NOT
+ * implement EIP-2612 (generic ERC-20 tokens).
+ */
+
+import { ERC20_APPROVAL_GAS_SPONSORING, type Erc20ApprovalGasSponsoringExtension } from "./types";
+
+/**
+ * The JSON Schema for the ERC-20 approval gas sponsoring extension info.
+ * Matches the schema defined in the spec.
+ */
+const erc20ApprovalGasSponsoringSchema: Record<string, unknown> = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "object",
+  properties: {
+    from: {
+      type: "string",
+      pattern: "^0x[a-fA-F0-9]{40}$",
+      description: "The address of the sender (token owner).",
+    },
+    asset: {
+      type: "string",
+      pattern: "^0x[a-fA-F0-9]{40}$",
+      description: "The address of the ERC-20 token contract.",
+    },
+    spender: {
+      type: "string",
+      pattern: "^0x[a-fA-F0-9]{40}$",
+      description: "The address of the spender (Canonical Permit2).",
+    },
+    amount: {
+      type: "string",
+      pattern: "^[0-9]+$",
+      description: "The amount approved (uint256). Always MaxUint256.",
+    },
+    signedTransaction: {
+      type: "string",
+      pattern: "^0x[a-fA-F0-9]+$",
+      description: "The RLP-encoded signed EIP-1559 transaction as a hex string.",
+    },
+    version: {
+      type: "string",
+      pattern: "^[0-9]+(\\.[0-9]+)*$",
+      description: "Schema version identifier.",
+    },
+  },
+  required: ["from", "asset", "spender", "amount", "signedTransaction", "version"],
+};
+
+/**
+ * Declares the ERC-20 approval gas sponsoring extension for inclusion in
+ * PaymentRequired.extensions.
+ *
+ * The server advertises that it (or its facilitator) supports broadcasting
+ * a pre-signed `approve(Permit2, MaxUint256)` transaction on the client's behalf.
+ * Use this for tokens that do NOT implement EIP-2612.
+ *
+ * @returns An object keyed by the extension identifier containing the extension declaration
+ *
+ * @example
+ * ```typescript
+ * import { declareErc20ApprovalGasSponsoringExtension } from '@x402/extensions';
+ *
+ * const routes = [
+ *   {
+ *     path: "/api/data",
+ *     price: { amount: "1000", asset: "0x...", extra: { assetTransferMethod: "permit2" } },
+ *     extensions: {
+ *       ...declareErc20ApprovalGasSponsoringExtension(),
+ *     },
+ *   },
+ * ];
+ * ```
+ */
+export function declareErc20ApprovalGasSponsoringExtension(): Record<
+  string,
+  Erc20ApprovalGasSponsoringExtension
+> {
+  const key = ERC20_APPROVAL_GAS_SPONSORING.key;
+  return {
+    [key]: {
+      info: {
+        description:
+          "The facilitator broadcasts a pre-signed ERC-20 approve() transaction to grant Permit2 allowance.",
+        version: "1",
+      },
+      schema: erc20ApprovalGasSponsoringSchema,
+    },
+  };
+}

--- a/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/types.ts
+++ b/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/types.ts
@@ -55,6 +55,9 @@ export const ERC20_APPROVAL_GAS_SPONSORING: FacilitatorExtension = {
   key: "erc20ApprovalGasSponsoring",
 };
 
+/** Current schema version for the ERC-20 approval gas sponsoring extension info. */
+export const ERC20_APPROVAL_GAS_SPONSORING_VERSION = "1";
+
 /**
  * Extended extension object registered in a facilitator via registerExtension().
  * Carries the signer that owns the full approve+settle flow for ERC-20 tokens
@@ -92,15 +95,15 @@ export interface Erc20ApprovalGasSponsoringInfo {
   /** Index signature for compatibility with Record<string, unknown> */
   [key: string]: unknown;
   /** The address of the sender (token owner who signed the tx). */
-  from: string;
+  from: `0x${string}`;
   /** The address of the ERC-20 token contract. */
-  asset: string;
+  asset: `0x${string}`;
   /** The address of the spender (Canonical Permit2). */
-  spender: string;
+  spender: `0x${string}`;
   /** The amount approved (uint256 as decimal string). Always MaxUint256. */
   amount: string;
   /** The RLP-encoded signed EIP-1559 transaction as a hex string. */
-  signedTransaction: string;
+  signedTransaction: `0x${string}`;
   /** Schema version identifier. */
   version: string;
 }

--- a/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/types.ts
+++ b/typescript/packages/extensions/src/erc20-approval-gas-sponsoring/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Type definitions for the ERC-20 Approval Gas Sponsoring Extension
+ *
+ * This extension enables gasless Permit2 approval for generic ERC-20 tokens
+ * that do NOT implement EIP-2612. The client signs (but does not broadcast) a
+ * raw `approve(Permit2, MaxUint256)` transaction, and the facilitator broadcasts
+ * it atomically before settling the Permit2 payment.
+ */
+
+import type { FacilitatorExtension } from "@x402/core/types";
+
+/**
+ * Signer capability carried by the ERC-20 approval extension when registered in a facilitator.
+ *
+ * Mirrors FacilitatorEvmSigner (from @x402/evm) plus `sendRawTransaction`.
+ * The extension signer owns the full approve+settle flow: it broadcasts the
+ * pre-signed approval transaction AND executes the Permit2 settle call, enabling
+ * production implementations to bundle both atomically (e.g., Flashbots, multicall).
+ *
+ * The method signatures are duplicated here (rather than extending FacilitatorEvmSigner)
+ * to avoid a circular dependency between @x402/extensions and @x402/evm.
+ */
+export interface Erc20ApprovalGasSponsoringSigner {
+  getAddresses(): readonly `0x${string}`[];
+  readContract(args: {
+    address: `0x${string}`;
+    abi: readonly unknown[];
+    functionName: string;
+    args?: readonly unknown[];
+  }): Promise<unknown>;
+  verifyTypedData(args: {
+    address: `0x${string}`;
+    domain: Record<string, unknown>;
+    types: Record<string, unknown>;
+    primaryType: string;
+    message: Record<string, unknown>;
+    signature: `0x${string}`;
+  }): Promise<boolean>;
+  writeContract(args: {
+    address: `0x${string}`;
+    abi: readonly unknown[];
+    functionName: string;
+    args: readonly unknown[];
+  }): Promise<`0x${string}`>;
+  sendTransaction(args: { to: `0x${string}`; data: `0x${string}` }): Promise<`0x${string}`>;
+  waitForTransactionReceipt(args: { hash: `0x${string}` }): Promise<{ status: string }>;
+  getCode(args: { address: `0x${string}` }): Promise<`0x${string}` | undefined>;
+  sendRawTransaction(args: { serializedTransaction: `0x${string}` }): Promise<`0x${string}`>;
+}
+
+/**
+ * Extension identifier for the ERC-20 approval gas sponsoring extension.
+ */
+export const ERC20_APPROVAL_GAS_SPONSORING: FacilitatorExtension = {
+  key: "erc20ApprovalGasSponsoring",
+};
+
+/**
+ * Extended extension object registered in a facilitator via registerExtension().
+ * Carries the signer that owns the full approve+settle flow for ERC-20 tokens
+ * that lack EIP-2612. The signer must have all FacilitatorEvmSigner capabilities
+ * plus `sendRawTransaction` for broadcasting the pre-signed approval tx.
+ *
+ * @example
+ * ```typescript
+ * const erc20GasSponsorshipExtension: Erc20ApprovalGasSponsoringFacilitatorExtension = {
+ *   ...ERC20_APPROVAL_GAS_SPONSORING,
+ *   signer: {
+ *     ...evmSigner,
+ *     sendRawTransaction: (args) => viemClient.sendRawTransaction(args),
+ *   },
+ * };
+ * facilitator.registerExtension(erc20GasSponsorshipExtension);
+ * ```
+ */
+export interface Erc20ApprovalGasSponsoringFacilitatorExtension extends FacilitatorExtension {
+  key: "erc20ApprovalGasSponsoring";
+  /** Signer with broadcast + settle capability. Optional — settlement fails gracefully if absent. */
+  signer?: Erc20ApprovalGasSponsoringSigner;
+}
+
+/**
+ * ERC-20 approval gas sponsoring info populated by the client.
+ *
+ * Contains the RLP-encoded signed `approve(Permit2, MaxUint256)` transaction
+ * that the facilitator broadcasts before settling the Permit2 payment.
+ *
+ * Note: Unlike EIP-2612, there is no nonce/deadline/signature — instead the
+ * entire signed transaction is included as `signedTransaction`.
+ */
+export interface Erc20ApprovalGasSponsoringInfo {
+  /** Index signature for compatibility with Record<string, unknown> */
+  [key: string]: unknown;
+  /** The address of the sender (token owner who signed the tx). */
+  from: string;
+  /** The address of the ERC-20 token contract. */
+  asset: string;
+  /** The address of the spender (Canonical Permit2). */
+  spender: string;
+  /** The amount approved (uint256 as decimal string). Always MaxUint256. */
+  amount: string;
+  /** The RLP-encoded signed EIP-1559 transaction as a hex string. */
+  signedTransaction: string;
+  /** Schema version identifier. */
+  version: string;
+}
+
+/**
+ * Server-side ERC-20 approval gas sponsoring info included in PaymentRequired.
+ * Contains a description and version; the client populates the rest.
+ */
+export interface Erc20ApprovalGasSponsoringServerInfo {
+  /** Index signature for compatibility with Record<string, unknown> */
+  [key: string]: unknown;
+  /** Human-readable description of the extension. */
+  description: string;
+  /** Schema version identifier. */
+  version: string;
+}
+
+/**
+ * The full extension object as it appears in PaymentRequired.extensions
+ * and PaymentPayload.extensions.
+ */
+export interface Erc20ApprovalGasSponsoringExtension {
+  /** Extension info - server-provided or client-enriched. */
+  info: Erc20ApprovalGasSponsoringServerInfo | Erc20ApprovalGasSponsoringInfo;
+  /** JSON Schema describing the expected structure of info. */
+  schema: Record<string, unknown>;
+}

--- a/typescript/packages/extensions/src/index.ts
+++ b/typescript/packages/extensions/src/index.ts
@@ -14,3 +14,6 @@ export { paymentIdentifierResourceServerExtension } from "./payment-identifier/r
 
 // EIP-2612 Gas Sponsoring extension
 export * from "./eip2612-gas-sponsoring";
+
+// ERC-20 Approval Gas Sponsoring extension
+export * from "./erc20-approval-gas-sponsoring";

--- a/typescript/packages/extensions/test/erc20-approval-gas-sponsoring.test.ts
+++ b/typescript/packages/extensions/test/erc20-approval-gas-sponsoring.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for ERC-20 Approval Gas Sponsoring Extension
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  ERC20_APPROVAL_GAS_SPONSORING,
+  declareErc20ApprovalGasSponsoringExtension,
+  extractErc20ApprovalGasSponsoringInfo,
+  validateErc20ApprovalGasSponsoringInfo,
+} from "../src/erc20-approval-gas-sponsoring/index";
+import type {
+  Erc20ApprovalGasSponsoringInfo,
+  Erc20ApprovalGasSponsoringExtension,
+} from "../src/erc20-approval-gas-sponsoring/types";
+import type { PaymentPayload } from "@x402/core/types";
+
+describe("ERC-20 Approval Gas Sponsoring Extension", () => {
+  describe("ERC20_APPROVAL_GAS_SPONSORING constant", () => {
+    it("should export the correct extension identifier", () => {
+      expect(ERC20_APPROVAL_GAS_SPONSORING.key).toBe("erc20ApprovalGasSponsoring");
+    });
+  });
+
+  describe("declareErc20ApprovalGasSponsoringExtension", () => {
+    it("should create a valid extension declaration", () => {
+      const result = declareErc20ApprovalGasSponsoringExtension();
+
+      expect(result).toHaveProperty("erc20ApprovalGasSponsoring");
+      const extension = result.erc20ApprovalGasSponsoring;
+
+      // Check info contains server-side defaults
+      expect(extension.info).toHaveProperty("description");
+      expect(extension.info).toHaveProperty("version", "1");
+
+      // Check schema has required fields
+      expect(extension.schema).toHaveProperty("$schema");
+      expect(extension.schema).toHaveProperty("type", "object");
+      expect(extension.schema).toHaveProperty("properties");
+      expect(extension.schema).toHaveProperty("required");
+
+      const required = extension.schema.required as string[];
+      expect(required).toContain("from");
+      expect(required).toContain("asset");
+      expect(required).toContain("spender");
+      expect(required).toContain("amount");
+      expect(required).toContain("signedTransaction");
+      expect(required).toContain("version");
+    });
+
+    it("should NOT include nonce, deadline, or signature in required fields", () => {
+      const result = declareErc20ApprovalGasSponsoringExtension();
+      const required = result.erc20ApprovalGasSponsoring.schema.required as string[];
+
+      expect(required).not.toContain("nonce");
+      expect(required).not.toContain("deadline");
+      expect(required).not.toContain("signature");
+    });
+
+    it("should have correct schema properties for signedTransaction", () => {
+      const result = declareErc20ApprovalGasSponsoringExtension();
+      const properties = result.erc20ApprovalGasSponsoring.schema.properties as Record<
+        string,
+        unknown
+      >;
+
+      expect(properties).toHaveProperty("signedTransaction");
+      const signedTxSchema = properties.signedTransaction as Record<string, unknown>;
+      expect(signedTxSchema.type).toBe("string");
+      // signedTransaction uses hex pattern
+      expect(signedTxSchema.pattern).toContain("0x");
+    });
+  });
+
+  describe("extractErc20ApprovalGasSponsoringInfo", () => {
+    const validInfo: Erc20ApprovalGasSponsoringInfo = {
+      from: "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a",
+      spender: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+      amount: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      signedTransaction:
+        "0x02f8708501234567890185012345678901850174876e80082011094eed520980fc7c7b4eb379b96d61cedea2423005a80b844095ea7b3000000000000000000000000000000000022d473030f116ddee9f6b43ac78ba3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      version: "1",
+    };
+
+    it("should extract info from a valid payload", () => {
+      const payload = {
+        x402Version: 2,
+        extensions: {
+          erc20ApprovalGasSponsoring: {
+            info: validInfo,
+            schema: {},
+          } as Erc20ApprovalGasSponsoringExtension,
+        },
+      } as unknown as PaymentPayload;
+
+      const result = extractErc20ApprovalGasSponsoringInfo(payload);
+      expect(result).not.toBeNull();
+      expect(result!.from).toBe(validInfo.from);
+      expect(result!.asset).toBe(validInfo.asset);
+      expect(result!.spender).toBe(validInfo.spender);
+      expect(result!.signedTransaction).toBe(validInfo.signedTransaction);
+    });
+
+    it("should return null when no extensions", () => {
+      const payload = {
+        x402Version: 2,
+      } as unknown as PaymentPayload;
+
+      const result = extractErc20ApprovalGasSponsoringInfo(payload);
+      expect(result).toBeNull();
+    });
+
+    it("should return null when extension is missing", () => {
+      const payload = {
+        x402Version: 2,
+        extensions: {},
+      } as unknown as PaymentPayload;
+
+      const result = extractErc20ApprovalGasSponsoringInfo(payload);
+      expect(result).toBeNull();
+    });
+
+    it("should return null when info is incomplete (only server-side fields)", () => {
+      const payload = {
+        x402Version: 2,
+        extensions: {
+          erc20ApprovalGasSponsoring: {
+            info: {
+              description: "test",
+              version: "1",
+            },
+            schema: {},
+          },
+        },
+      } as unknown as PaymentPayload;
+
+      const result = extractErc20ApprovalGasSponsoringInfo(payload);
+      expect(result).toBeNull();
+    });
+
+    it("should return null when signedTransaction is missing", () => {
+      const payload = {
+        x402Version: 2,
+        extensions: {
+          erc20ApprovalGasSponsoring: {
+            info: {
+              from: validInfo.from,
+              asset: validInfo.asset,
+              spender: validInfo.spender,
+              amount: validInfo.amount,
+              // signedTransaction is missing
+              version: validInfo.version,
+            },
+            schema: {},
+          },
+        },
+      } as unknown as PaymentPayload;
+
+      const result = extractErc20ApprovalGasSponsoringInfo(payload);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("validateErc20ApprovalGasSponsoringInfo", () => {
+    it("should validate correct info", () => {
+      const info: Erc20ApprovalGasSponsoringInfo = {
+        from: "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+        asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a",
+        spender: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+        amount: "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        signedTransaction: "0x02f8ab",
+        version: "1",
+      };
+
+      expect(validateErc20ApprovalGasSponsoringInfo(info)).toBe(true);
+    });
+
+    it("should reject invalid from address format", () => {
+      const info: Erc20ApprovalGasSponsoringInfo = {
+        from: "invalid-address",
+        asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a",
+        spender: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+        amount: "100",
+        signedTransaction: "0x02ab",
+        version: "1",
+      };
+
+      expect(validateErc20ApprovalGasSponsoringInfo(info)).toBe(false);
+    });
+
+    it("should reject non-numeric amount", () => {
+      const info: Erc20ApprovalGasSponsoringInfo = {
+        from: "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+        asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a",
+        spender: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+        amount: "not-a-number",
+        signedTransaction: "0x02ab",
+        version: "1",
+      };
+
+      expect(validateErc20ApprovalGasSponsoringInfo(info)).toBe(false);
+    });
+
+    it("should reject invalid signedTransaction (not hex)", () => {
+      const info: Erc20ApprovalGasSponsoringInfo = {
+        from: "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+        asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a",
+        spender: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+        amount: "100",
+        signedTransaction: "not-a-hex-string",
+        version: "1",
+      };
+
+      expect(validateErc20ApprovalGasSponsoringInfo(info)).toBe(false);
+    });
+
+    it("should reject invalid spender address", () => {
+      const info: Erc20ApprovalGasSponsoringInfo = {
+        from: "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+        asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a",
+        spender: "not-an-address",
+        amount: "100",
+        signedTransaction: "0x02ab",
+        version: "1",
+      };
+
+      expect(validateErc20ApprovalGasSponsoringInfo(info)).toBe(false);
+    });
+
+    it("should reject invalid version format", () => {
+      const info: Erc20ApprovalGasSponsoringInfo = {
+        from: "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+        asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a",
+        spender: "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+        amount: "100",
+        signedTransaction: "0x02ab",
+        version: "not.a.version",
+      };
+
+      expect(validateErc20ApprovalGasSponsoringInfo(info)).toBe(false);
+    });
+  });
+});

--- a/typescript/packages/mechanisms/evm/src/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/constants.ts
@@ -109,6 +109,43 @@ export const eip2612NoncesAbi = [
   },
 ] as const;
 
+/** ERC-20 approve(address,uint256) ABI for encoding/decoding approval calldata. */
+export const erc20ApproveAbi = [
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/** ERC-20 allowance(address,address) ABI for checking spender approval. */
+export const erc20AllowanceAbi = [
+  {
+    type: "function",
+    name: "allowance",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ type: "uint256" }],
+    stateMutability: "view",
+  },
+] as const;
+
+/** Gas limit for a standard ERC-20 approve() transaction. */
+export const ERC20_APPROVE_GAS_LIMIT = 70_000n;
+
+/** Fallback max fee per gas (1 gwei) when fee estimation fails. */
+export const DEFAULT_MAX_FEE_PER_GAS = 1_000_000_000n;
+
+/** Fallback max priority fee per gas (0.1 gwei) when fee estimation fails. */
+export const DEFAULT_MAX_PRIORITY_FEE_PER_GAS = 100_000_000n;
+
 /**
  * Canonical Permit2 contract address.
  * Same address on all EVM chains via CREATE2 deployment.

--- a/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
@@ -3,7 +3,7 @@ import { getAddress } from "viem";
 import { authorizationTypes } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
 import { ExactEIP3009Payload } from "../../types";
-import { createNonce } from "../../utils";
+import { createNonce, getEvmChainId } from "../../utils";
 
 /**
  * Creates an EIP-3009 (transferWithAuthorization) payload.
@@ -56,7 +56,7 @@ async function signEIP3009Authorization(
   authorization: ExactEIP3009Payload["authorization"],
   requirements: PaymentRequirements,
 ): Promise<`0x${string}`> {
-  const chainId = parseInt(requirements.network.split(":")[1]);
+  const chainId = getEvmChainId(requirements.network);
 
   if (!requirements.extra?.name || !requirements.extra?.version) {
     throw new Error(

--- a/typescript/packages/mechanisms/evm/src/exact/client/erc20approval.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/erc20approval.ts
@@ -1,0 +1,84 @@
+import { encodeFunctionData, getAddress, maxUint256 } from "viem";
+import type { Erc20ApprovalGasSponsoringInfo } from "@x402/extensions";
+import { PERMIT2_ADDRESS } from "../../constants";
+import { ClientEvmSigner } from "../../signer";
+
+/** ERC-20 approve ABI for encoding approve(address,uint256) calldata */
+const erc20ApproveAbi = [
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/**
+ * Signs an EIP-1559 `approve(Permit2, MaxUint256)` transaction for the given token.
+ *
+ * The signed transaction is NOT broadcast here — the facilitator broadcasts it
+ * atomically before settling the Permit2 payment. This enables Permit2 payments
+ * for generic ERC-20 tokens that do NOT implement EIP-2612.
+ *
+ * Always approves MaxUint256 regardless of the payment amount.
+ *
+ * @param signer - The client EVM signer (must support signTransaction, getTransactionCount)
+ * @param tokenAddress - The ERC-20 token contract address
+ * @param chainId - The chain ID
+ * @returns The ERC-20 approval gas sponsoring info object
+ */
+export async function signErc20ApprovalTransaction(
+  signer: ClientEvmSigner,
+  tokenAddress: `0x${string}`,
+  chainId: number,
+): Promise<Erc20ApprovalGasSponsoringInfo> {
+  const from = signer.address;
+  const spender = getAddress(PERMIT2_ADDRESS);
+
+  // Encode approve(PERMIT2_ADDRESS, MaxUint256) calldata
+  const data = encodeFunctionData({
+    abi: erc20ApproveAbi,
+    functionName: "approve",
+    args: [spender, maxUint256],
+  });
+
+  // Get current nonce for the sender
+  const nonce = await signer.getTransactionCount!({ address: from });
+
+  // Get current fee estimates, with fallback values
+  let maxFeePerGas: bigint;
+  let maxPriorityFeePerGas: bigint;
+  try {
+    const fees = await signer.estimateFeesPerGas!();
+    maxFeePerGas = fees.maxFeePerGas;
+    maxPriorityFeePerGas = fees.maxPriorityFeePerGas;
+  } catch {
+    // Fallback to 1 gwei base and priority fees
+    maxFeePerGas = 1_000_000_000n;
+    maxPriorityFeePerGas = 100_000_000n;
+  }
+
+  // Sign the EIP-1559 transaction (not broadcast)
+  const signedTransaction = await signer.signTransaction!({
+    to: tokenAddress,
+    data,
+    nonce,
+    gas: 70_000n,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    chainId,
+  });
+
+  return {
+    from,
+    asset: tokenAddress,
+    spender,
+    amount: maxUint256.toString(),
+    signedTransaction,
+    version: "1",
+  };
+}

--- a/typescript/packages/mechanisms/evm/src/exact/client/erc20approval.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/erc20approval.ts
@@ -1,21 +1,16 @@
 import { encodeFunctionData, getAddress, maxUint256 } from "viem";
-import type { Erc20ApprovalGasSponsoringInfo } from "@x402/extensions";
-import { PERMIT2_ADDRESS } from "../../constants";
+import {
+  ERC20_APPROVAL_GAS_SPONSORING_VERSION,
+  type Erc20ApprovalGasSponsoringInfo,
+} from "@x402/extensions";
+import {
+  PERMIT2_ADDRESS,
+  erc20ApproveAbi,
+  ERC20_APPROVE_GAS_LIMIT,
+  DEFAULT_MAX_FEE_PER_GAS,
+  DEFAULT_MAX_PRIORITY_FEE_PER_GAS,
+} from "../../constants";
 import { ClientEvmSigner } from "../../signer";
-
-/** ERC-20 approve ABI for encoding approve(address,uint256) calldata */
-const erc20ApproveAbi = [
-  {
-    type: "function",
-    name: "approve",
-    inputs: [
-      { name: "spender", type: "address" },
-      { name: "amount", type: "uint256" },
-    ],
-    outputs: [{ type: "bool" }],
-    stateMutability: "nonpayable",
-  },
-] as const;
 
 /**
  * Signs an EIP-1559 `approve(Permit2, MaxUint256)` transaction for the given token.
@@ -57,9 +52,8 @@ export async function signErc20ApprovalTransaction(
     maxFeePerGas = fees.maxFeePerGas;
     maxPriorityFeePerGas = fees.maxPriorityFeePerGas;
   } catch {
-    // Fallback to 1 gwei base and priority fees
-    maxFeePerGas = 1_000_000_000n;
-    maxPriorityFeePerGas = 100_000_000n;
+    maxFeePerGas = DEFAULT_MAX_FEE_PER_GAS;
+    maxPriorityFeePerGas = DEFAULT_MAX_PRIORITY_FEE_PER_GAS;
   }
 
   // Sign the EIP-1559 transaction (not broadcast)
@@ -67,7 +61,7 @@ export async function signErc20ApprovalTransaction(
     to: tokenAddress,
     data,
     nonce,
-    gas: 70_000n,
+    gas: ERC20_APPROVE_GAS_LIMIT,
     maxFeePerGas,
     maxPriorityFeePerGas,
     chainId,
@@ -79,6 +73,6 @@ export async function signErc20ApprovalTransaction(
     spender,
     amount: maxUint256.toString(),
     signedTransaction,
-    version: "1",
+    version: ERC20_APPROVAL_GAS_SPONSORING_VERSION,
   };
 }

--- a/typescript/packages/mechanisms/evm/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/index.ts
@@ -4,6 +4,6 @@ export type { EvmClientConfig } from "./register";
 export {
   createPermit2ApprovalTx,
   getPermit2AllowanceReadParams,
-  erc20AllowanceAbi,
   type Permit2AllowanceParams,
 } from "./permit2";
+export { erc20AllowanceAbi } from "../../constants";

--- a/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/permit2.ts
@@ -4,10 +4,12 @@ import {
   permit2WitnessTypes,
   PERMIT2_ADDRESS,
   x402ExactPermit2ProxyAddress,
+  erc20ApproveAbi,
+  erc20AllowanceAbi,
 } from "../../constants";
 import { ClientEvmSigner } from "../../signer";
 import { ExactPermit2Payload } from "../../types";
-import { createPermit2Nonce } from "../../utils";
+import { createPermit2Nonce, getEvmChainId } from "../../utils";
 
 /** Maximum uint256 value for unlimited approval. */
 const MAX_UINT256 = BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -81,7 +83,7 @@ async function signPermit2Authorization(
   permit2Authorization: ExactPermit2Payload["permit2Authorization"],
   requirements: PaymentRequirements,
 ): Promise<`0x${string}`> {
-  const chainId = parseInt(requirements.network.split(":")[1]);
+  const chainId = getEvmChainId(requirements.network);
 
   const domain = {
     name: "Permit2",
@@ -110,38 +112,6 @@ async function signPermit2Authorization(
     message,
   });
 }
-
-/**
- * ERC20 approve ABI for encoding approval transactions.
- */
-const erc20ApproveAbi = [
-  {
-    type: "function",
-    name: "approve",
-    inputs: [
-      { name: "spender", type: "address" },
-      { name: "amount", type: "uint256" },
-    ],
-    outputs: [{ type: "bool" }],
-    stateMutability: "nonpayable",
-  },
-] as const;
-
-/**
- * ERC20 allowance ABI for checking approval status.
- */
-export const erc20AllowanceAbi = [
-  {
-    type: "function",
-    name: "allowance",
-    inputs: [
-      { name: "owner", type: "address" },
-      { name: "spender", type: "address" },
-    ],
-    outputs: [{ type: "uint256" }],
-    stateMutability: "view",
-  },
-] as const;
 
 /**
  * Creates transaction data to approve Permit2 to spend tokens.

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -7,26 +7,13 @@ import {
 import { EIP2612_GAS_SPONSORING, ERC20_APPROVAL_GAS_SPONSORING } from "@x402/extensions";
 import { ClientEvmSigner } from "../../signer";
 import { AssetTransferMethod } from "../../types";
-import { PERMIT2_ADDRESS } from "../../constants";
+import { PERMIT2_ADDRESS, erc20AllowanceAbi } from "../../constants";
 import { getAddress } from "viem";
+import { getEvmChainId } from "../../utils";
 import { createEIP3009Payload } from "./eip3009";
 import { createPermit2Payload } from "./permit2";
 import { signEip2612Permit } from "./eip2612";
 import { signErc20ApprovalTransaction } from "./erc20approval";
-
-/** ERC20 allowance ABI for checking Permit2 approval */
-const erc20AllowanceAbi = [
-  {
-    type: "function",
-    name: "allowance",
-    inputs: [
-      { name: "owner", type: "address" },
-      { name: "spender", type: "address" },
-    ],
-    outputs: [{ type: "uint256" }],
-    stateMutability: "view",
-  },
-] as const;
 
 /**
  * EVM client implementation for the Exact payment scheme.
@@ -137,7 +124,7 @@ export class ExactEvmScheme implements SchemeNetworkClient {
       return undefined;
     }
 
-    const chainId = parseInt(requirements.network.split(":")[1]);
+    const chainId = getEvmChainId(requirements.network);
     const tokenAddress = getAddress(requirements.asset) as `0x${string}`;
 
     // Check if user already has sufficient Permit2 allowance
@@ -213,7 +200,7 @@ export class ExactEvmScheme implements SchemeNetworkClient {
       return undefined;
     }
 
-    const chainId = parseInt(requirements.network.split(":")[1]);
+    const chainId = getEvmChainId(requirements.network);
     const tokenAddress = getAddress(requirements.asset) as `0x${string}`;
 
     // Check if user already has sufficient Permit2 allowance

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -7,6 +7,7 @@ import {
 import { getAddress, Hex, isAddressEqual, parseErc6492Signature, parseSignature } from "viem";
 import { authorizationTypes, eip3009ABI } from "../../constants";
 import { FacilitatorEvmSigner } from "../../signer";
+import { getEvmChainId } from "../../utils";
 import { ExactEIP3009Payload } from "../../types";
 
 export interface EIP3009FacilitatorConfig {
@@ -73,7 +74,7 @@ export async function verifyEIP3009(
     domain: {
       name,
       version,
-      chainId: parseInt(requirements.network.split(":")[1]),
+      chainId: getEvmChainId(requirements.network),
       verifyingContract: erc20Address,
     },
     message: {

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/erc20approval.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/erc20approval.ts
@@ -1,0 +1,113 @@
+import { getAddress, parseTransaction, decodeFunctionData, recoverTransactionAddress } from "viem";
+import {
+  validateErc20ApprovalGasSponsoringInfo,
+  type Erc20ApprovalGasSponsoringInfo,
+} from "@x402/extensions";
+import { PERMIT2_ADDRESS } from "../../constants";
+
+/** ERC-20 approve ABI for decoding approve(address,uint256) calldata */
+const erc20ApproveAbi = [
+  {
+    type: "function",
+    name: "approve",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ type: "bool" }],
+    stateMutability: "nonpayable",
+  },
+] as const;
+
+/** The approve(address,uint256) function selector */
+const APPROVE_SELECTOR = "0x095ea7b3";
+
+/**
+ * Validates ERC-20 approval extension data for a Permit2 payment.
+ *
+ * Performs comprehensive validation:
+ * - Format validation via validateErc20ApprovalGasSponsoringInfo
+ * - `from` matches payer
+ * - `asset` matches token
+ * - `spender` is PERMIT2_ADDRESS
+ * - Transaction `to` matches token address
+ * - Transaction calldata is a valid approve(PERMIT2_ADDRESS, ...) call
+ * - Recovered transaction signer matches `from`
+ *
+ * @param info - The ERC-20 approval gas sponsoring info
+ * @param payer - The expected payer address
+ * @param tokenAddress - The expected token address
+ * @returns Validation result
+ */
+export async function validateErc20ApprovalForPayment(
+  info: Erc20ApprovalGasSponsoringInfo,
+  payer: `0x${string}`,
+  tokenAddress: `0x${string}`,
+): Promise<{ isValid: boolean; invalidReason?: string }> {
+  // Validate format
+  if (!validateErc20ApprovalGasSponsoringInfo(info)) {
+    return { isValid: false, invalidReason: "invalid_erc20_approval_extension_format" };
+  }
+
+  // Verify from matches payer
+  if (getAddress(info.from as `0x${string}`) !== getAddress(payer)) {
+    return { isValid: false, invalidReason: "erc20_approval_from_mismatch" };
+  }
+
+  // Verify asset matches token
+  if (getAddress(info.asset as `0x${string}`) !== tokenAddress) {
+    return { isValid: false, invalidReason: "erc20_approval_asset_mismatch" };
+  }
+
+  // Verify spender field in info is Permit2
+  if (getAddress(info.spender as `0x${string}`) !== getAddress(PERMIT2_ADDRESS)) {
+    return { isValid: false, invalidReason: "erc20_approval_spender_not_permit2" };
+  }
+
+  // Parse and validate the signed transaction
+  try {
+    const serializedTx = info.signedTransaction as `0x${string}`;
+    const tx = parseTransaction(serializedTx);
+
+    // Verify the transaction targets the token contract
+    if (!tx.to || getAddress(tx.to) !== tokenAddress) {
+      return { isValid: false, invalidReason: "erc20_approval_tx_wrong_target" };
+    }
+
+    // Verify the calldata is an approve() call
+    const data = tx.data ?? "0x";
+    if (!data.startsWith(APPROVE_SELECTOR)) {
+      return { isValid: false, invalidReason: "erc20_approval_tx_wrong_selector" };
+    }
+
+    // Decode the calldata to verify the spender argument is PERMIT2_ADDRESS
+    try {
+      const decoded = decodeFunctionData({
+        abi: erc20ApproveAbi,
+        data: data as `0x${string}`,
+      });
+      const calldataSpender = getAddress(decoded.args[0] as `0x${string}`);
+      if (calldataSpender !== getAddress(PERMIT2_ADDRESS)) {
+        return { isValid: false, invalidReason: "erc20_approval_tx_wrong_spender" };
+      }
+    } catch {
+      return { isValid: false, invalidReason: "erc20_approval_tx_invalid_calldata" };
+    }
+
+    // Recover the signer of the transaction and verify it matches from
+    try {
+      const recoveredAddress = await recoverTransactionAddress({
+        serializedTransaction: serializedTx,
+      });
+      if (getAddress(recoveredAddress) !== getAddress(payer)) {
+        return { isValid: false, invalidReason: "erc20_approval_tx_signer_mismatch" };
+      }
+    } catch {
+      return { isValid: false, invalidReason: "erc20_approval_tx_invalid_signature" };
+    }
+  } catch {
+    return { isValid: false, invalidReason: "erc20_approval_tx_parse_failed" };
+  }
+
+  return { isValid: true };
+}

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
@@ -26,3 +26,16 @@ export const ErrPermit2InvalidOwner = "permit2_invalid_owner";
 export const ErrPermit2PaymentTooEarly = "permit2_payment_too_early";
 export const ErrPermit2InvalidNonce = "permit2_invalid_nonce";
 export const ErrPermit2612AmountMismatch = "permit2_2612_amount_mismatch";
+
+// ERC-20 approval gas sponsoring verify errors
+export const ErrErc20ApprovalInvalidFormat = "invalid_erc20_approval_extension_format";
+export const ErrErc20ApprovalFromMismatch = "erc20_approval_from_mismatch";
+export const ErrErc20ApprovalAssetMismatch = "erc20_approval_asset_mismatch";
+export const ErrErc20ApprovalSpenderNotPermit2 = "erc20_approval_spender_not_permit2";
+export const ErrErc20ApprovalTxWrongTarget = "erc20_approval_tx_wrong_target";
+export const ErrErc20ApprovalTxWrongSelector = "erc20_approval_tx_wrong_selector";
+export const ErrErc20ApprovalTxWrongSpender = "erc20_approval_tx_wrong_spender";
+export const ErrErc20ApprovalTxInvalidCalldata = "erc20_approval_tx_invalid_calldata";
+export const ErrErc20ApprovalTxSignerMismatch = "erc20_approval_tx_signer_mismatch";
+export const ErrErc20ApprovalTxInvalidSignature = "erc20_approval_tx_invalid_signature";
+export const ErrErc20ApprovalTxParseFailed = "erc20_approval_tx_parse_failed";

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -1,12 +1,16 @@
 import {
   PaymentPayload,
   PaymentRequirements,
+  FacilitatorContext,
   SettleResponse,
   VerifyResponse,
 } from "@x402/core/types";
 import {
   extractEip2612GasSponsoringInfo,
   validateEip2612GasSponsoringInfo,
+  extractErc20ApprovalGasSponsoringInfo,
+  ERC20_APPROVAL_GAS_SPONSORING,
+  type Erc20ApprovalGasSponsoringFacilitatorExtension,
 } from "@x402/extensions";
 import type { Eip2612GasSponsoringInfo } from "@x402/extensions";
 import { getAddress } from "viem";
@@ -28,8 +32,8 @@ import {
 } from "./errors";
 import { FacilitatorEvmSigner } from "../../signer";
 import { ExactPermit2Payload } from "../../types";
+import { validateErc20ApprovalForPayment } from "./erc20approval";
 
-// ERC20 allowance ABI for checking Permit2 approval
 const erc20AllowanceABI = [
   {
     type: "function",
@@ -46,10 +50,16 @@ const erc20AllowanceABI = [
 /**
  * Verifies a Permit2 payment payload.
  *
+ * Handles all Permit2 verification paths:
+ * - Standard: checks on-chain Permit2 allowance
+ * - EIP-2612: validates the EIP-2612 permit extension when allowance is insufficient
+ * - ERC-20 approval: validates the pre-signed approve tx extension when allowance is insufficient
+ *
  * @param signer - The facilitator signer for contract reads
  * @param payload - The payment payload to verify
  * @param requirements - The payment requirements
  * @param permit2Payload - The Permit2 specific payload
+ * @param context - Optional facilitator context for extension-provided capabilities
  * @returns Promise resolving to verification response
  */
 export async function verifyPermit2(
@@ -57,10 +67,10 @@ export async function verifyPermit2(
   payload: PaymentPayload,
   requirements: PaymentRequirements,
   permit2Payload: ExactPermit2Payload,
+  context?: FacilitatorContext,
 ): Promise<VerifyResponse> {
   const payer = permit2Payload.permit2Authorization.from;
 
-  // Verify scheme matches
   if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
     return {
       isValid: false,
@@ -69,7 +79,6 @@ export async function verifyPermit2(
     };
   }
 
-  // Verify network matches
   if (payload.accepted.network !== requirements.network) {
     return {
       isValid: false,
@@ -81,7 +90,6 @@ export async function verifyPermit2(
   const chainId = parseInt(requirements.network.split(":")[1]);
   const tokenAddress = getAddress(requirements.asset);
 
-  // Verify spender is the x402ExactPermit2Proxy
   if (
     getAddress(permit2Payload.permit2Authorization.spender) !==
     getAddress(x402ExactPermit2ProxyAddress)
@@ -93,7 +101,6 @@ export async function verifyPermit2(
     };
   }
 
-  // Verify witness.to matches payTo
   if (
     getAddress(permit2Payload.permit2Authorization.witness.to) !== getAddress(requirements.payTo)
   ) {
@@ -104,7 +111,6 @@ export async function verifyPermit2(
     };
   }
 
-  // Verify deadline not expired (with 6 second buffer for block time)
   const now = Math.floor(Date.now() / 1000);
   if (BigInt(permit2Payload.permit2Authorization.deadline) < BigInt(now + 6)) {
     return {
@@ -114,7 +120,6 @@ export async function verifyPermit2(
     };
   }
 
-  // Verify validAfter is not in the future
   if (BigInt(permit2Payload.permit2Authorization.witness.validAfter) > BigInt(now)) {
     return {
       isValid: false,
@@ -123,7 +128,6 @@ export async function verifyPermit2(
     };
   }
 
-  // Verify amount is sufficient
   if (BigInt(permit2Payload.permit2Authorization.permitted.amount) < BigInt(requirements.amount)) {
     return {
       isValid: false,
@@ -132,7 +136,6 @@ export async function verifyPermit2(
     };
   }
 
-  // Verify token matches
   if (getAddress(permit2Payload.permit2Authorization.permitted.token) !== tokenAddress) {
     return {
       isValid: false,
@@ -141,7 +144,6 @@ export async function verifyPermit2(
     };
   }
 
-  // Build typed data for Permit2 signature verification
   const permit2TypedData = {
     types: permit2WitnessTypes,
     primaryType: "PermitWitnessTransferFrom" as const,
@@ -165,7 +167,6 @@ export async function verifyPermit2(
     },
   };
 
-  // Verify signature
   try {
     const isValid = await signer.verifyTypedData({
       address: payer,
@@ -188,54 +189,19 @@ export async function verifyPermit2(
     };
   }
 
-  // Check Permit2 allowance
-  try {
-    const allowance = (await signer.readContract({
-      address: tokenAddress,
-      abi: erc20AllowanceABI,
-      functionName: "allowance",
-      args: [payer, PERMIT2_ADDRESS],
-    })) as bigint;
-
-    if (allowance < BigInt(requirements.amount)) {
-      // Allowance insufficient - check for EIP-2612 gas sponsoring extension
-      const eip2612Info = extractEip2612GasSponsoringInfo(payload);
-      if (eip2612Info) {
-        // Validate the EIP-2612 extension data
-        const validationResult = validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress);
-        if (!validationResult.isValid) {
-          return {
-            isValid: false,
-            invalidReason: validationResult.invalidReason!,
-            payer,
-          };
-        }
-        // EIP-2612 extension is valid, allowance will be set during settlement
-      } else {
-        return {
-          isValid: false,
-          invalidReason: "permit2_allowance_required",
-          payer,
-        };
-      }
-    }
-  } catch {
-    // If we can't check allowance, check if EIP-2612 extension is present
-    const eip2612Info = extractEip2612GasSponsoringInfo(payload);
-    if (eip2612Info) {
-      const validationResult = validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress);
-      if (!validationResult.isValid) {
-        return {
-          isValid: false,
-          invalidReason: validationResult.invalidReason!,
-          payer,
-        };
-      }
-      // EIP-2612 extension is valid, allowance will be set during settlement
-    }
+  // Check Permit2 allowance — if insufficient, try gas sponsoring extensions
+  const allowanceResult = await _verifyPermit2Allowance(
+    signer,
+    payload,
+    requirements,
+    payer,
+    tokenAddress,
+    context,
+  );
+  if (allowanceResult) {
+    return allowanceResult;
   }
 
-  // Check balance
   try {
     const balance = (await signer.readContract({
       address: tokenAddress,
@@ -253,7 +219,7 @@ export async function verifyPermit2(
       };
     }
   } catch {
-    // If we can't check balance, continue with other validations
+    // If we can't check balance, continue
   }
 
   return {
@@ -264,12 +230,88 @@ export async function verifyPermit2(
 }
 
 /**
- * Settles a Permit2 payment by calling the x402ExactPermit2Proxy.
+ * Checks Permit2 allowance and validates gas sponsoring extensions if allowance is insufficient.
  *
- * @param signer - The facilitator signer for contract writes
+ * @param signer - The facilitator signer for on-chain reads
+ * @param payload - The payment payload
+ * @param requirements - The payment requirements
+ * @param payer - The payer address
+ * @param tokenAddress - The token contract address
+ * @param context - Optional facilitator context for extension lookup
+ * @returns A VerifyResponse if verification should stop (failure), or null to continue
+ */
+async function _verifyPermit2Allowance(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  requirements: PaymentRequirements,
+  payer: `0x${string}`,
+  tokenAddress: `0x${string}`,
+  context?: FacilitatorContext,
+): Promise<VerifyResponse | null> {
+  try {
+    const allowance = (await signer.readContract({
+      address: tokenAddress,
+      abi: erc20AllowanceABI,
+      functionName: "allowance",
+      args: [payer, PERMIT2_ADDRESS],
+    })) as bigint;
+
+    if (allowance >= BigInt(requirements.amount)) {
+      return null; // Sufficient allowance, continue verification
+    }
+
+    // Allowance insufficient — try EIP-2612 gas sponsoring first
+    const eip2612Info = extractEip2612GasSponsoringInfo(payload);
+    if (eip2612Info) {
+      const result = validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress);
+      if (!result.isValid) {
+        return { isValid: false, invalidReason: result.invalidReason!, payer };
+      }
+      return null; // EIP-2612 is valid, allowance will be set atomically during settlement
+    }
+
+    // Try ERC-20 approval gas sponsoring as fallback
+    const erc20GasSponsorshipExtension =
+      context?.getExtension<Erc20ApprovalGasSponsoringFacilitatorExtension>(
+        ERC20_APPROVAL_GAS_SPONSORING.key,
+      );
+    if (erc20GasSponsorshipExtension) {
+      const erc20Info = extractErc20ApprovalGasSponsoringInfo(payload);
+      if (erc20Info) {
+        const result = await validateErc20ApprovalForPayment(erc20Info, payer, tokenAddress);
+        if (!result.isValid) {
+          return { isValid: false, invalidReason: result.invalidReason!, payer };
+        }
+        return null; // ERC-20 approval is valid, will be broadcast before settlement
+      }
+    }
+
+    return { isValid: false, invalidReason: "permit2_allowance_required", payer };
+  } catch {
+    // If allowance check fails, validate extensions if present; otherwise proceed optimistically
+    const eip2612Info = extractEip2612GasSponsoringInfo(payload);
+    if (eip2612Info) {
+      const result = validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress);
+      if (!result.isValid) {
+        return { isValid: false, invalidReason: result.invalidReason!, payer };
+      }
+    }
+    return null;
+  }
+}
+
+/**
+ * Settles a Permit2 payment. Single entry point for all Permit2 settlement paths:
+ *
+ * 1. EIP-2612 extension present -> settleWithPermit (atomic single tx via contract)
+ * 2. ERC-20 approval extension present + extension signer -> broadcast approval + settle (via extension signer)
+ * 3. Standard -> settle directly (allowance already on-chain)
+ *
+ * @param signer - The base facilitator signer for contract writes
  * @param payload - The payment payload to settle
  * @param requirements - The payment requirements
  * @param permit2Payload - The Permit2 specific payload
+ * @param context - Optional facilitator context for extension-provided capabilities
  * @returns Promise resolving to settlement response
  */
 export async function settlePermit2(
@@ -277,11 +319,11 @@ export async function settlePermit2(
   payload: PaymentPayload,
   requirements: PaymentRequirements,
   permit2Payload: ExactPermit2Payload,
+  context?: FacilitatorContext,
 ): Promise<SettleResponse> {
   const payer = permit2Payload.permit2Authorization.from;
 
-  // Re-verify before settling
-  const valid = await verifyPermit2(signer, payload, requirements, permit2Payload);
+  const valid = await verifyPermit2(signer, payload, requirements, permit2Payload, context);
   if (!valid.isValid) {
     return {
       success: false,
@@ -292,157 +334,303 @@ export async function settlePermit2(
     };
   }
 
-  try {
-    // Check if EIP-2612 gas sponsoring extension is present
-    const eip2612Info = extractEip2612GasSponsoringInfo(payload);
+  // Branch: EIP-2612 gas sponsoring (atomic settleWithPermit via contract)
+  const eip2612Info = extractEip2612GasSponsoringInfo(payload);
+  if (eip2612Info) {
+    return _settlePermit2WithEIP2612(signer, payload, permit2Payload, eip2612Info);
+  }
 
-    let tx: `0x${string}`;
-
-    if (eip2612Info) {
-      // Use settleWithPermit - includes the EIP-2612 permit
-      const { v, r, s } = splitEip2612Signature(eip2612Info.signature);
-
-      tx = await signer.writeContract({
-        address: x402ExactPermit2ProxyAddress,
-        abi: x402ExactPermit2ProxyABI,
-        functionName: "settleWithPermit",
-        args: [
-          {
-            value: BigInt(eip2612Info.amount),
-            deadline: BigInt(eip2612Info.deadline),
-            r,
-            s,
-            v,
-          },
-          {
-            permitted: {
-              token: getAddress(permit2Payload.permit2Authorization.permitted.token),
-              amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
-            },
-            nonce: BigInt(permit2Payload.permit2Authorization.nonce),
-            deadline: BigInt(permit2Payload.permit2Authorization.deadline),
-          },
-          getAddress(payer),
-          {
-            to: getAddress(permit2Payload.permit2Authorization.witness.to),
-            validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
-          },
-          permit2Payload.signature,
-        ],
-      });
-    } else {
-      // Standard settle - no EIP-2612 extension
-      tx = await signer.writeContract({
-        address: x402ExactPermit2ProxyAddress,
-        abi: x402ExactPermit2ProxyABI,
-        functionName: "settle",
-        args: [
-          {
-            permitted: {
-              token: getAddress(permit2Payload.permit2Authorization.permitted.token),
-              amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
-            },
-            nonce: BigInt(permit2Payload.permit2Authorization.nonce),
-            deadline: BigInt(permit2Payload.permit2Authorization.deadline),
-          },
-          getAddress(payer),
-          {
-            to: getAddress(permit2Payload.permit2Authorization.witness.to),
-            validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
-          },
-          permit2Payload.signature,
-        ],
-      });
+  // Branch: ERC-20 approval gas sponsoring (broadcast approval + settle via extension signer)
+  const erc20Info = extractErc20ApprovalGasSponsoringInfo(payload);
+  if (erc20Info) {
+    const erc20GasSponsorshipExtension =
+      context?.getExtension<Erc20ApprovalGasSponsoringFacilitatorExtension>(
+        ERC20_APPROVAL_GAS_SPONSORING.key,
+      );
+    if (erc20GasSponsorshipExtension?.signer) {
+      return _settlePermit2WithERC20Approval(
+        erc20GasSponsorshipExtension.signer,
+        payload,
+        permit2Payload,
+        erc20Info,
+      );
     }
+  }
 
-    // Wait for transaction confirmation
-    const receipt = await signer.waitForTransactionReceipt({ hash: tx });
+  // Branch: standard settle (allowance already on-chain)
+  return _settlePermit2Direct(signer, payload, permit2Payload);
+}
 
-    if (receipt.status !== "success") {
+/**
+ * Settles via settleWithPermit — includes the EIP-2612 permit atomically in one tx.
+ *
+ * @param signer - The base facilitator signer
+ * @param payload - The payment payload
+ * @param permit2Payload - The Permit2 specific payload
+ * @param eip2612Info - The EIP-2612 gas sponsoring info from the payload extension
+ * @returns Promise resolving to settlement response
+ */
+async function _settlePermit2WithEIP2612(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  permit2Payload: ExactPermit2Payload,
+  eip2612Info: Eip2612GasSponsoringInfo,
+): Promise<SettleResponse> {
+  const payer = permit2Payload.permit2Authorization.from;
+  try {
+    const { v, r, s } = splitEip2612Signature(eip2612Info.signature);
+
+    const tx = await signer.writeContract({
+      address: x402ExactPermit2ProxyAddress,
+      abi: x402ExactPermit2ProxyABI,
+      functionName: "settleWithPermit",
+      args: [
+        {
+          value: BigInt(eip2612Info.amount),
+          deadline: BigInt(eip2612Info.deadline),
+          r,
+          s,
+          v,
+        },
+        {
+          permitted: {
+            token: getAddress(permit2Payload.permit2Authorization.permitted.token),
+            amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
+          },
+          nonce: BigInt(permit2Payload.permit2Authorization.nonce),
+          deadline: BigInt(permit2Payload.permit2Authorization.deadline),
+        },
+        getAddress(payer),
+        {
+          to: getAddress(permit2Payload.permit2Authorization.witness.to),
+          validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
+        },
+        permit2Payload.signature,
+      ],
+    });
+
+    return _waitAndReturn(signer, tx, payload, payer);
+  } catch (error) {
+    return _mapSettleError(error, payload, payer);
+  }
+}
+
+/**
+ * Broadcasts the pre-signed ERC-20 approve tx then settles via the extension signer.
+ * Both operations use the extension signer, enabling atomic bundling by production implementations.
+ *
+ * @param extensionSigner - The extension signer with sendRawTransaction + writeContract
+ * @param payload - The payment payload
+ * @param permit2Payload - The Permit2 specific payload
+ * @param erc20Info - Object containing the signed approval transaction
+ * @param erc20Info.signedTransaction - The RLP-encoded signed EIP-1559 approval tx
+ * @returns Promise resolving to settlement response
+ */
+async function _settlePermit2WithERC20Approval(
+  extensionSigner: Erc20ApprovalGasSponsoringFacilitatorExtension["signer"] & {},
+  payload: PaymentPayload,
+  permit2Payload: ExactPermit2Payload,
+  erc20Info: { signedTransaction: string },
+): Promise<SettleResponse> {
+  const payer = permit2Payload.permit2Authorization.from;
+
+  try {
+    const approvalTxHash = await extensionSigner.sendRawTransaction({
+      serializedTransaction: erc20Info.signedTransaction as `0x${string}`,
+    });
+
+    const approvalReceipt = await extensionSigner.waitForTransactionReceipt({
+      hash: approvalTxHash,
+    });
+
+    if (approvalReceipt.status !== "success") {
       return {
         success: false,
-        errorReason: "invalid_transaction_state",
-        transaction: tx,
+        errorReason: "erc20_approval_tx_failed",
+        transaction: approvalTxHash,
         network: payload.accepted.network,
         payer,
       };
     }
 
-    return {
-      success: true,
-      transaction: tx,
-      network: payload.accepted.network,
-      payer,
-    };
+    const tx = await extensionSigner.writeContract({
+      address: x402ExactPermit2ProxyAddress,
+      abi: x402ExactPermit2ProxyABI,
+      functionName: "settle",
+      args: [
+        {
+          permitted: {
+            token: getAddress(permit2Payload.permit2Authorization.permitted.token),
+            amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
+          },
+          nonce: BigInt(permit2Payload.permit2Authorization.nonce),
+          deadline: BigInt(permit2Payload.permit2Authorization.deadline),
+        },
+        getAddress(payer),
+        {
+          to: getAddress(permit2Payload.permit2Authorization.witness.to),
+          validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
+        },
+        permit2Payload.signature,
+      ],
+    });
+
+    return _waitAndReturn(extensionSigner, tx, payload, payer);
   } catch (error) {
-    // Extract meaningful error message from the contract revert
-    let errorReason = "transaction_failed";
-    if (error instanceof Error) {
-      // Check for common contract revert patterns (ordered: more specific first)
-      const message = error.message;
-      if (message.includes("Permit2612AmountMismatch")) {
-        errorReason = ErrPermit2612AmountMismatch;
-      } else if (message.includes("InvalidAmount")) {
-        errorReason = ErrPermit2InvalidAmount;
-      } else if (message.includes("InvalidDestination")) {
-        errorReason = ErrPermit2InvalidDestination;
-      } else if (message.includes("InvalidOwner")) {
-        errorReason = ErrPermit2InvalidOwner;
-      } else if (message.includes("PaymentTooEarly")) {
-        errorReason = ErrPermit2PaymentTooEarly;
-      } else if (message.includes("InvalidSignature") || message.includes("SignatureExpired")) {
-        errorReason = ErrPermit2InvalidSignature;
-      } else if (message.includes("InvalidNonce")) {
-        errorReason = ErrPermit2InvalidNonce;
-      } else {
-        // Include error message for debugging (longer for better visibility)
-        errorReason = `transaction_failed: ${message.slice(0, 500)}`;
-      }
-    }
-    return {
-      success: false,
-      errorReason,
-      transaction: "",
-      network: payload.accepted.network,
-      payer,
-    };
+    return _mapSettleError(error, payload, payer);
   }
 }
 
 /**
- * Validates EIP-2612 permit extension data for a payment.
+ * Standard Permit2 settle — allowance is already on-chain.
+ *
+ * @param signer - The base facilitator signer
+ * @param payload - The payment payload
+ * @param permit2Payload - The Permit2 specific payload
+ * @returns Promise resolving to settlement response
+ */
+async function _settlePermit2Direct(
+  signer: FacilitatorEvmSigner,
+  payload: PaymentPayload,
+  permit2Payload: ExactPermit2Payload,
+): Promise<SettleResponse> {
+  const payer = permit2Payload.permit2Authorization.from;
+  try {
+    const tx = await signer.writeContract({
+      address: x402ExactPermit2ProxyAddress,
+      abi: x402ExactPermit2ProxyABI,
+      functionName: "settle",
+      args: [
+        {
+          permitted: {
+            token: getAddress(permit2Payload.permit2Authorization.permitted.token),
+            amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
+          },
+          nonce: BigInt(permit2Payload.permit2Authorization.nonce),
+          deadline: BigInt(permit2Payload.permit2Authorization.deadline),
+        },
+        getAddress(payer),
+        {
+          to: getAddress(permit2Payload.permit2Authorization.witness.to),
+          validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
+        },
+        permit2Payload.signature,
+      ],
+    });
+
+    return _waitAndReturn(signer, tx, payload, payer);
+  } catch (error) {
+    return _mapSettleError(error, payload, payer);
+  }
+}
+
+/**
+ * Waits for tx receipt and returns the appropriate SettleResponse.
+ *
+ * @param signer - Signer with waitForTransactionReceipt capability
+ * @param tx - The transaction hash to wait for
+ * @param payload - The payment payload (for network info)
+ * @param payer - The payer address
+ * @returns Promise resolving to settlement response
+ */
+async function _waitAndReturn(
+  signer: Pick<FacilitatorEvmSigner, "waitForTransactionReceipt">,
+  tx: `0x${string}`,
+  payload: PaymentPayload,
+  payer: `0x${string}`,
+): Promise<SettleResponse> {
+  const receipt = await signer.waitForTransactionReceipt({ hash: tx });
+
+  if (receipt.status !== "success") {
+    return {
+      success: false,
+      errorReason: "invalid_transaction_state",
+      transaction: tx,
+      network: payload.accepted.network,
+      payer,
+    };
+  }
+
+  return {
+    success: true,
+    transaction: tx,
+    network: payload.accepted.network,
+    payer,
+  };
+}
+
+/**
+ * Maps contract revert errors to structured SettleResponse error reasons.
+ *
+ * @param error - The caught error
+ * @param payload - The payment payload (for network info)
+ * @param payer - The payer address
+ * @returns A failed SettleResponse with mapped error reason
+ */
+function _mapSettleError(
+  error: unknown,
+  payload: PaymentPayload,
+  payer: `0x${string}`,
+): SettleResponse {
+  let errorReason = "transaction_failed";
+  if (error instanceof Error) {
+    const message = error.message;
+    if (message.includes("Permit2612AmountMismatch")) {
+      errorReason = ErrPermit2612AmountMismatch;
+    } else if (message.includes("InvalidAmount")) {
+      errorReason = ErrPermit2InvalidAmount;
+    } else if (message.includes("InvalidDestination")) {
+      errorReason = ErrPermit2InvalidDestination;
+    } else if (message.includes("InvalidOwner")) {
+      errorReason = ErrPermit2InvalidOwner;
+    } else if (message.includes("PaymentTooEarly")) {
+      errorReason = ErrPermit2PaymentTooEarly;
+    } else if (message.includes("InvalidSignature") || message.includes("SignatureExpired")) {
+      errorReason = ErrPermit2InvalidSignature;
+    } else if (message.includes("InvalidNonce")) {
+      errorReason = ErrPermit2InvalidNonce;
+    } else {
+      errorReason = `transaction_failed: ${message.slice(0, 500)}`;
+    }
+  }
+  return {
+    success: false,
+    errorReason,
+    transaction: "",
+    network: payload.accepted.network,
+    payer,
+  };
+}
+
+/**
+ * Validates EIP-2612 permit extension data for a Permit2 payment.
  *
  * @param info - The EIP-2612 gas sponsoring info
  * @param payer - The expected payer address
  * @param tokenAddress - The expected token address
- * @returns Validation result
+ * @returns Validation result with optional invalidReason
  */
 function validateEip2612PermitForPayment(
   info: Eip2612GasSponsoringInfo,
   payer: `0x${string}`,
   tokenAddress: `0x${string}`,
 ): { isValid: boolean; invalidReason?: string } {
-  // Validate format
   if (!validateEip2612GasSponsoringInfo(info)) {
     return { isValid: false, invalidReason: "invalid_eip2612_extension_format" };
   }
 
-  // Verify from matches payer
   if (getAddress(info.from as `0x${string}`) !== getAddress(payer)) {
     return { isValid: false, invalidReason: "eip2612_from_mismatch" };
   }
 
-  // Verify asset matches token
   if (getAddress(info.asset as `0x${string}`) !== tokenAddress) {
     return { isValid: false, invalidReason: "eip2612_asset_mismatch" };
   }
 
-  // Verify spender is Permit2
   if (getAddress(info.spender as `0x${string}`) !== getAddress(PERMIT2_ADDRESS)) {
     return { isValid: false, invalidReason: "eip2612_spender_not_permit2" };
   }
 
-  // Verify deadline not expired (with 6 second buffer, consistent with Permit2 deadline check)
   const now = Math.floor(Date.now() / 1000);
   if (BigInt(info.deadline) < BigInt(now + 6)) {
     return { isValid: false, invalidReason: "eip2612_deadline_expired" };

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -20,6 +20,7 @@ import {
   permit2WitnessTypes,
   x402ExactPermit2ProxyABI,
   x402ExactPermit2ProxyAddress,
+  erc20AllowanceAbi,
 } from "../../constants";
 import {
   ErrPermit2612AmountMismatch,
@@ -32,20 +33,8 @@ import {
 } from "./errors";
 import { FacilitatorEvmSigner } from "../../signer";
 import { ExactPermit2Payload } from "../../types";
+import { getEvmChainId } from "../../utils";
 import { validateErc20ApprovalForPayment } from "./erc20approval";
-
-const erc20AllowanceABI = [
-  {
-    type: "function",
-    name: "allowance",
-    inputs: [
-      { name: "owner", type: "address" },
-      { name: "spender", type: "address" },
-    ],
-    outputs: [{ type: "uint256" }],
-    stateMutability: "view",
-  },
-] as const;
 
 /**
  * Verifies a Permit2 payment payload.
@@ -87,7 +76,7 @@ export async function verifyPermit2(
     };
   }
 
-  const chainId = parseInt(requirements.network.split(":")[1]);
+  const chainId = getEvmChainId(requirements.network);
   const tokenAddress = getAddress(requirements.asset);
 
   if (
@@ -251,7 +240,7 @@ async function _verifyPermit2Allowance(
   try {
     const allowance = (await signer.readContract({
       address: tokenAddress,
-      abi: erc20AllowanceABI,
+      abi: erc20AllowanceAbi,
       functionName: "allowance",
       args: [payer, PERMIT2_ADDRESS],
     })) as bigint;

--- a/typescript/packages/mechanisms/evm/src/utils.ts
+++ b/typescript/packages/mechanisms/evm/src/utils.ts
@@ -2,15 +2,27 @@ import { toHex } from "viem";
 import { EVM_NETWORK_CHAIN_ID_MAP, EvmNetworkV1 } from "./v1";
 
 /**
- * Extract chain ID from network string (e.g., "base-sepolia" -> 84532)
- * Used by v1 implementations
+ * Extract chain ID from a network identifier string.
  *
- * @param network - The network identifier
+ * Supports two formats:
+ * - CAIP-2: "eip155:8453" -> 8453
+ * - Legacy v1 name: "base-sepolia" -> 84532
+ *
+ * @param network - The network identifier (CAIP-2 or legacy name)
  * @returns The numeric chain ID
- * @throws Error if the network is not supported
+ * @throws Error if the network format is invalid or the name is unsupported
  */
-export function getEvmChainId(network: EvmNetworkV1): number {
-  const chainId = EVM_NETWORK_CHAIN_ID_MAP[network];
+export function getEvmChainId(network: string): number {
+  if (network.startsWith("eip155:")) {
+    const idStr = network.split(":")[1];
+    const chainId = parseInt(idStr, 10);
+    if (isNaN(chainId)) {
+      throw new Error(`Invalid CAIP-2 chain ID: ${network}`);
+    }
+    return chainId;
+  }
+
+  const chainId = EVM_NETWORK_CHAIN_ID_MAP[network as EvmNetworkV1];
   if (!chainId) {
     throw new Error(`Unsupported network: ${network}`);
   }


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Implements the ERC20 gas approval sponsorship extension in typescript

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 