### PR TITLE
chore: handle io.ReadAll error in GetSupported for consistent error handling

### DIFF
--- a/go/http/facilitator_client.go
+++ b/go/http/facilitator_client.go
@@ -149,15 +149,20 @@ func (c *HTTPFacilitatorClient) GetSupported(ctx context.Context) (x402.Supporte
 	}
 	defer resp.Body.Close()
 
+	// Read response body
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return x402.SupportedResponse{}, fmt.Errorf("failed to read response body: %w", err)
+	}
+
 	// Check status
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return x402.SupportedResponse{}, fmt.Errorf("facilitator supported failed (%d): %s", resp.StatusCode, string(body))
+		return x402.SupportedResponse{}, fmt.Errorf("facilitator supported failed (%d): %s", resp.StatusCode, string(responseBody))
 	}
 
 	// Parse response
 	var supportedResponse x402.SupportedResponse
-	if err := json.NewDecoder(resp.Body).Decode(&supportedResponse); err != nil {
+	if err := json.Unmarshal(responseBody, &supportedResponse); err != nil {
 		return x402.SupportedResponse{}, fmt.Errorf("failed to decode supported response: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- Handle `io.ReadAll(resp.Body)` error explicitly in `HTTPFacilitatorClient.GetSupported` instead of discarding it with `_`
- Align with the pattern used by `verifyHTTP` and `settleHTTP` in the same file
- Switch from `json.NewDecoder().Decode()` to `json.Unmarshal()` to match the single-read flow

 ## Motivation

`GetSupported` was the only method in `facilitator_client.go` that ignored the `io.ReadAll` error. 

While unlikely, body reads can fail due to network interruption, context cancellation, or connection resets — resulting in a silent empty error message that makes debugging harder.

## Changelog

No changelog fragment added — this is an internal refactor with no user-facing behavior change (see [CONTRIBUTING.md](https://github.com/coinbase/x402/blob/main/go/CONTRIBUTING.md#when-a-fragment-is-required)).

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)