### PR TITLE
fix retry in payment-identifier client example 

### DIFF
--- a/examples/typescript/clients/payment-identifier/index.ts
+++ b/examples/typescript/clients/payment-identifier/index.ts
@@ -50,7 +50,22 @@ async function main(): Promise<void> {
     }
   });
 
-  const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+  const httpClient = new x402HTTPClient(client);
+
+  // After the first request is signed, capture the exact encoded payment header.
+  let capturedPaymentHeaders: Record<string, string> | undefined;
+  client.onAfterPaymentCreation(async ({ paymentPayload }) => {
+    capturedPaymentHeaders = httpClient.encodePaymentSignatureHeader(paymentPayload);
+  });
+
+  // On any subsequent 402, replay the captured headers instead of creating a new signature.
+  httpClient.onPaymentRequired(async () => {
+    if (capturedPaymentHeaders) {
+      return { headers: capturedPaymentHeaders };
+    }
+  });
+
+  const fetchWithPayment = wrapFetchWithPayment(fetch, httpClient);
 
   // First request - will process payment
   console.log(`\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);


### PR DESCRIPTION
## Description

The [client example](https://github.com/coinbase/x402/compare/examples/typescript/clients/payment-identifier/index.ts) intends to demonstrate idempotent retries (same id, same payload -> cached response) but actually triggers the 409 Conflict path (same id, different payload)

**Root cause:** Calling fetchWithPayment a second time creates a new signed payload (fresh signature). The server's payloadFingerprint in the [server example](https://github.com/coinbase/x402/compare/examples/typescript/servers/payment-identifier/index.ts) hashes the entire PaymentPayload including the signature, so it sees a fingerprint mismatch and returns 409

**Fix:** capture header in `onAfterPaymentCreation` and replay with `onPaymentRequired` hook

## Tests

Before:
```
🔑 Generated Payment ID: pay_148d1e9716b4400892bc829272d58c13

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
📤 First Request (with payment ID: pay_148d1e9716b4400892bc829272d58c13)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Making request to: http://localhost:4022/weather

Response (2404ms): {
  "report": {
    "weather": "sunny",
    "temperature": 70,
    "cached": false
  }
}

💰 Payment settled on eip155:84532

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
📤 Second Request (SAME payment ID: pay_148d1e9716b4400892bc829272d58c13)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Making request to: http://localhost:4022/weather

💡 Expected: Server returns cached response without payment processing

Response (4ms): {
  "error": "payment identifier already used with different payload",
  "paymentId": "pay_148d1e9716b4400892bc829272d58c13"
}

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
📊 Summary
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Payment ID: pay_148d1e9716b4400892bc829272d58c13
   First request:  2404ms (payment processed)
   Second request: 4ms (cached)
   ⚡ Cached response was 100% faster!
```

After:
```
🔑 Generated Payment ID: pay_02116fb55fbb47e6a0b6a97aa62240d7

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
📤 First Request (with payment ID: pay_02116fb55fbb47e6a0b6a97aa62240d7)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Making request to: http://localhost:4022/weather

Response (2260ms): {
  "report": {
    "weather": "sunny",
    "temperature": 70,
    "cached": false
  }
}

💰 Payment settled on eip155:84532

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
📤 Second Request (SAME payment ID: pay_02116fb55fbb47e6a0b6a97aa62240d7)
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Making request to: http://localhost:4022/weather

💡 Expected: Server returns cached response without payment processing

Response (6ms): {
  "report": {
    "weather": "sunny",
    "temperature": 70,
    "cached": true
  }
}

✅ No payment processed - response served from cache!

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
📊 Summary
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Payment ID: pay_02116fb55fbb47e6a0b6a97aa62240d7
   First request:  2260ms (payment processed)
   Second request: 6ms (cached)
   ⚡ Cached response was 100% faster!
```



## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 