### PR TITLE
feat: implemented the erc20 gas sponsorship extension in go

### DIFF
--- a/e2e/clients/go-http/test.config.json
+++ b/e2e/clients/go-http/test.config.json
@@ -17,7 +17,8 @@
     ]
   },
   "extensions": [
-    "eip2612GasSponsoring"
+    "eip2612GasSponsoring",
+    "erc20ApprovalGasSponsoring"
   ],
   "environment": {
     "required": [

--- a/e2e/facilitators/go/test.config.json
+++ b/e2e/facilitators/go/test.config.json
@@ -12,7 +12,8 @@
   ],
   "extensions": [
     "bazaar",
-    "eip2612GasSponsoring"
+    "eip2612GasSponsoring",
+    "erc20ApprovalGasSponsoring"
   ],
   "evm": {
     "transferMethods": ["eip3009", "permit2"]

--- a/e2e/servers/gin/main.go
+++ b/e2e/servers/gin/main.go
@@ -11,6 +11,7 @@ import (
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/extensions/bazaar"
 	"github.com/coinbase/x402/go/extensions/eip2612gassponsor"
+	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
 	"github.com/coinbase/x402/go/extensions/types"
 	x402http "github.com/coinbase/x402/go/http"
 	ginmw "github.com/coinbase/x402/go/http/gin"
@@ -170,7 +171,35 @@ func main() {
 				return ext
 			}(),
 		},
-	}
+	// Permit2 ERC-20 approval endpoint - requires Permit2 flow with a generic ERC-20 token (no EIP-2612)
+	"GET /protected-permit2-erc20": {
+		Accepts: x402http.PaymentOptions{
+			{
+				Scheme:  "exact",
+				PayTo:   evmPayeeAddress,
+				Network: evmNetwork,
+				// Use MockGenericERC20 token that does NOT implement EIP-2612
+				Price: map[string]interface{}{
+					"amount": "1000", // smallest unit
+					"asset":  "0xeED520980fC7C7B4eB379B96d61CEdea2423005a", // MockGenericERC20 on Base Sepolia
+					"extra": map[string]interface{}{
+						"assetTransferMethod": "permit2",
+					},
+				},
+			},
+		},
+		Extensions: func() map[string]interface{} {
+			ext := map[string]interface{}{
+				types.BAZAAR.Key(): discoveryExtension,
+			}
+			// Advertise ERC-20 approval gas sponsoring (for tokens without EIP-2612)
+			for k, v := range erc20approvalgassponsor.DeclareExtension() {
+				ext[k] = v
+			}
+			return ext
+		}(),
+	},
+}
 
 	// Apply payment middleware with detailed error logging
 	r.Use(ginmw.X402Payment(ginmw.Config{
@@ -269,6 +298,26 @@ func main() {
 	})
 
 	/**
+	 * Protected Permit2 ERC-20 approval endpoint - requires payment via Permit2 flow
+	 * using a generic ERC-20 token that does NOT support EIP-2612.
+	 * The facilitator sponsors the approve(Permit2, MaxUint256) transaction.
+	 */
+	r.GET("/protected-permit2-erc20", func(c *ginfw.Context) {
+		if shutdownRequested {
+			c.JSON(http.StatusServiceUnavailable, ginfw.H{
+				"error": "Server shutting down",
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, ginfw.H{
+			"message":   "Permit2 ERC-20 approval endpoint accessed successfully",
+			"timestamp": time.Now().Format(time.RFC3339),
+			"method":    "permit2-erc20-approval",
+		})
+	})
+
+	/**
 	 * Health check endpoint - no payment required
 	 *
 	 * Used to verify the server is running and responsive.
@@ -326,11 +375,12 @@ func main() {
 ║  SVM Payee:   %-40s ║
 ║                                                        ║
 ║  Endpoints:                                            ║
-║  • GET  /protected         (EIP-3009 payment)         ║
-║  • GET  /protected-svm     (SVM payment)              ║
-║  • GET  /protected-permit2 (Permit2 payment)          ║
-║  • GET  /health            (no payment required)      ║
-║  • POST /close             (shutdown server)          ║
+║  • GET  /protected              (EIP-3009 payment)    ║
+║  • GET  /protected-svm          (SVM payment)         ║
+║  • GET  /protected-permit2      (Permit2 payment)     ║
+║  • GET  /protected-permit2-erc20 (Permit2 ERC-20)     ║
+║  • GET  /health                 (no payment required)  ║
+║  • POST /close                  (shutdown server)      ║
 ╚════════════════════════════════════════════════════════╝
 `, port, evmNetwork, evmPayeeAddress, svmNetwork, svmPayeeAddress)
 

--- a/e2e/servers/gin/test.config.json
+++ b/e2e/servers/gin/test.config.json
@@ -5,7 +5,8 @@
   "x402Version": 2,
   "extensions": [
     "bazaar",
-    "eip2612GasSponsoring"
+    "eip2612GasSponsoring",
+    "erc20ApprovalGasSponsoring"
   ],
   "description": "Go Gin server with x402 v2 payment middleware",
   "endpoints": [
@@ -24,6 +25,15 @@
       "requiresPayment": true,
       "protocolFamily": "evm",
       "transferMethod": "permit2"
+    },
+    {
+      "path": "/protected-permit2-erc20",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment with ERC-20 approval gas sponsoring",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "extension": "erc20ApprovalGasSponsoring"
     },
     {
       "path": "/protected-svm",

--- a/go/.changeset/go-erc20-approval-gas-sponsoring.md
+++ b/go/.changeset/go-erc20-approval-gas-sponsoring.md
@@ -1,0 +1,5 @@
+---
+'github.com/coinbase/x402/go': minor
+---
+
+Implemented the erc20 approval gas sponsoring extension in the Go SDK, achieving parity with the TypeScript implementation. Enables Permit2 payments for any ERC-20 token, even those without EIP-2612 support.

--- a/go/extensions/erc20approvalgassponsor/declare.go
+++ b/go/extensions/erc20approvalgassponsor/declare.go
@@ -1,0 +1,67 @@
+package erc20approvalgassponsor
+
+// DeclareExtension creates the extension declaration for inclusion in PaymentRequired.extensions.
+//
+// The server advertises that it (or its facilitator) supports ERC-20 approval gas sponsoring.
+// The client will sign and attach the approve transaction data.
+//
+// Returns a map keyed by the extension identifier.
+//
+// Example:
+//
+//	extensions := erc20approvalgassponsor.DeclareExtension()
+//	// Include in PaymentRequired.Extensions
+func DeclareExtension() map[string]interface{} {
+	return map[string]interface{}{
+		ERC20ApprovalGasSponsoring.Key(): Extension{
+			Info: ServerInfo{
+				Description: "The facilitator accepts a pre-signed ERC-20 approve(Permit2, MaxUint256) transaction for tokens without EIP-2612.",
+				Version:     ERC20ApprovalGasSponsoringVersion,
+			},
+			Schema: erc20ApprovalGasSponsoringSchema(),
+		},
+	}
+}
+
+// erc20ApprovalGasSponsoringSchema returns the JSON Schema for the extension info.
+func erc20ApprovalGasSponsoringSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type":    "object",
+		"properties": map[string]interface{}{
+			"from": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^0x[a-fA-F0-9]{40}$",
+				"description": "The address of the sender (token owner).",
+			},
+			"asset": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^0x[a-fA-F0-9]{40}$",
+				"description": "The address of the ERC-20 token contract.",
+			},
+			"spender": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^0x[a-fA-F0-9]{40}$",
+				"description": "The address being approved (Canonical Permit2).",
+			},
+			"amount": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^[0-9]+$",
+				"description": "The approval amount (uint256 as decimal string). Typically MaxUint256.",
+			},
+			"signedTransaction": map[string]interface{}{
+				"type":        "string",
+				"pattern":     "^0x[a-fA-F0-9]+$",
+				"description": "The RLP-encoded signed approve transaction as a hex string.",
+			},
+			"version": map[string]interface{}{
+				"type":        "string",
+				"pattern":     `^[0-9]+(\.[0-9]+)*$`,
+				"description": "Schema version identifier.",
+			},
+		},
+		"required": []string{
+			"from", "asset", "spender", "amount", "signedTransaction", "version",
+		},
+	}
+}

--- a/go/extensions/erc20approvalgassponsor/extract.go
+++ b/go/extensions/erc20approvalgassponsor/extract.go
@@ -1,0 +1,70 @@
+package erc20approvalgassponsor
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+var (
+	addressPattern = regexp.MustCompile(`^0x[a-fA-F0-9]{40}$`)
+	numericPattern = regexp.MustCompile(`^[0-9]+$`)
+	hexPattern     = regexp.MustCompile(`^0x[a-fA-F0-9]+$`)
+	versionPattern = regexp.MustCompile(`^[0-9]+(\.[0-9]+)*$`)
+)
+
+// ExtractInfo extracts the ERC-20 approval gas sponsoring info from a payment
+// payload's extensions map.
+//
+// Returns the info if the extension is present and contains the required
+// client-populated fields, or nil if not present or incomplete.
+func ExtractInfo(extensions map[string]interface{}) (*Info, error) {
+	if extensions == nil {
+		return nil, nil
+	}
+
+	extRaw, ok := extensions[ERC20ApprovalGasSponsoring.Key()]
+	if !ok {
+		return nil, nil
+	}
+
+	// Marshal and unmarshal to get the extension structure
+	extJSON, err := json.Marshal(extRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal erc20ApprovalGasSponsoring extension: %w", err)
+	}
+
+	var ext Extension
+	if err := json.Unmarshal(extJSON, &ext); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal erc20ApprovalGasSponsoring extension: %w", err)
+	}
+
+	// Marshal and unmarshal info to get the typed struct
+	infoJSON, err := json.Marshal(ext.Info)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal erc20ApprovalGasSponsoring info: %w", err)
+	}
+
+	var info Info
+	if err := json.Unmarshal(infoJSON, &info); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal erc20ApprovalGasSponsoring info: %w", err)
+	}
+
+	// Check that the client has populated the required fields
+	if info.From == "" || info.Asset == "" || info.Spender == "" ||
+		info.Amount == "" || info.SignedTransaction == "" || info.Version == "" {
+		return nil, nil
+	}
+
+	return &info, nil
+}
+
+// ValidateInfo validates that the ERC-20 approval gas sponsoring info has valid format.
+func ValidateInfo(info *Info) bool {
+	return addressPattern.MatchString(info.From) &&
+		addressPattern.MatchString(info.Asset) &&
+		addressPattern.MatchString(info.Spender) &&
+		numericPattern.MatchString(info.Amount) &&
+		hexPattern.MatchString(info.SignedTransaction) &&
+		versionPattern.MatchString(info.Version)
+}

--- a/go/extensions/erc20approvalgassponsor/extract_test.go
+++ b/go/extensions/erc20approvalgassponsor/extract_test.go
@@ -1,0 +1,142 @@
+package erc20approvalgassponsor
+
+import (
+	"testing"
+)
+
+func TestExtractInfo(t *testing.T) {
+	validInfo := map[string]interface{}{
+		"from":              "0x1234567890123456789012345678901234567890",
+		"asset":             "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+		"spender":           "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+		"amount":            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+		"signedTransaction": "0x02f8a48201f4808459682f0085174876e800830111708080b844095ea7b3000000000000000000000000000000000022d473030f116ddee9f6b43ac78ba3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		"version":           "1",
+	}
+
+	t.Run("valid full info", func(t *testing.T) {
+		extensions := map[string]interface{}{
+			"erc20ApprovalGasSponsoring": map[string]interface{}{
+				"info":   validInfo,
+				"schema": map[string]interface{}{},
+			},
+		}
+		info, err := ExtractInfo(extensions)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if info == nil {
+			t.Fatal("expected info, got nil")
+		}
+		if info.From != validInfo["from"] {
+			t.Errorf("expected From=%s, got %s", validInfo["from"], info.From)
+		}
+		if info.SignedTransaction != validInfo["signedTransaction"] {
+			t.Errorf("expected SignedTransaction=%s, got %s", validInfo["signedTransaction"], info.SignedTransaction)
+		}
+	})
+
+	t.Run("nil extensions", func(t *testing.T) {
+		info, err := ExtractInfo(nil)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if info != nil {
+			t.Fatalf("expected nil, got: %+v", info)
+		}
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		extensions := map[string]interface{}{
+			"someOtherExtension": map[string]interface{}{},
+		}
+		info, err := ExtractInfo(extensions)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if info != nil {
+			t.Fatalf("expected nil, got: %+v", info)
+		}
+	})
+
+	t.Run("incomplete fields - missing signedTransaction", func(t *testing.T) {
+		incompleteInfo := map[string]interface{}{
+			"from":    "0x1234567890123456789012345678901234567890",
+			"asset":   "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+			"spender": "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+			"amount":  "12345",
+			"version": "1",
+			// signedTransaction is missing
+		}
+		extensions := map[string]interface{}{
+			"erc20ApprovalGasSponsoring": map[string]interface{}{
+				"info":   incompleteInfo,
+				"schema": map[string]interface{}{},
+			},
+		}
+		info, err := ExtractInfo(extensions)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if info != nil {
+			t.Fatalf("expected nil for incomplete fields, got: %+v", info)
+		}
+	})
+}
+
+func TestValidateInfo(t *testing.T) {
+	validInfo := &Info{
+		From:              "0x1234567890123456789012345678901234567890",
+		Asset:             "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+		Spender:           "0x000000000022D473030F116dDEE9F6B43aC78BA3",
+		Amount:            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+		SignedTransaction: "0x02f8a4",
+		Version:           "1",
+	}
+
+	t.Run("valid info", func(t *testing.T) {
+		if !ValidateInfo(validInfo) {
+			t.Error("expected valid info to pass validation")
+		}
+	})
+
+	t.Run("bad from address", func(t *testing.T) {
+		info := *validInfo
+		info.From = "not-an-address"
+		if ValidateInfo(&info) {
+			t.Error("expected validation to fail for bad from address")
+		}
+	})
+
+	t.Run("bad signedTransaction - not hex", func(t *testing.T) {
+		info := *validInfo
+		info.SignedTransaction = "not-hex-data"
+		if ValidateInfo(&info) {
+			t.Error("expected validation to fail for non-hex signedTransaction")
+		}
+	})
+
+	t.Run("bad amount - non-numeric", func(t *testing.T) {
+		info := *validInfo
+		info.Amount = "not-a-number"
+		if ValidateInfo(&info) {
+			t.Error("expected validation to fail for non-numeric amount")
+		}
+	})
+
+	t.Run("bad version", func(t *testing.T) {
+		info := *validInfo
+		info.Version = "not-a-version"
+		if ValidateInfo(&info) {
+			t.Error("expected validation to fail for bad version")
+		}
+	})
+
+	t.Run("valid version with minor", func(t *testing.T) {
+		info := *validInfo
+		info.Version = "1.0"
+		if !ValidateInfo(&info) {
+			t.Error("expected version '1.0' to pass validation")
+		}
+	})
+}

--- a/go/extensions/erc20approvalgassponsor/types.go
+++ b/go/extensions/erc20approvalgassponsor/types.go
@@ -1,0 +1,68 @@
+// Package erc20approvalgassponsor provides types and helpers for the ERC-20 Approval Gas Sponsoring extension.
+//
+// This extension enables gasless approval of the Permit2 contract for ERC-20 tokens
+// that do NOT implement EIP-2612. Instead of an off-chain signature, the client
+// creates a signed (but unbroadcast) approve(Permit2, MaxUint256) transaction.
+// The facilitator broadcasts it before calling settle().
+package erc20approvalgassponsor
+
+import (
+	"context"
+
+	x402 "github.com/coinbase/x402/go"
+	evm "github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// ERC20ApprovalGasSponsoring is the extension identifier for the ERC-20 approval gas sponsoring extension.
+var ERC20ApprovalGasSponsoring = x402.NewFacilitatorExtension("erc20ApprovalGasSponsoring")
+
+// ERC20ApprovalGasSponsoringVersion is the current schema version for the extension info.
+const ERC20ApprovalGasSponsoringVersion = "1"
+
+// Info contains the signed approve transaction data populated by the client.
+// The facilitator broadcasts this transaction before calling settle().
+type Info struct {
+	// From is the address of the sender (token owner).
+	From string `json:"from"`
+	// Asset is the address of the ERC-20 token contract.
+	Asset string `json:"asset"`
+	// Spender is the address being approved (Canonical Permit2).
+	Spender string `json:"spender"`
+	// Amount is the approval amount (uint256 as decimal string). Typically MaxUint256.
+	Amount string `json:"amount"`
+	// SignedTransaction is the RLP-encoded signed approve transaction as a hex string (0x-prefixed).
+	SignedTransaction string `json:"signedTransaction"`
+	// Version is the schema version identifier.
+	Version string `json:"version"`
+}
+
+// ServerInfo is the server-side info included in PaymentRequired.
+// Contains a description and version; the client populates the rest.
+type ServerInfo struct {
+	Description string `json:"description"`
+	Version     string `json:"version"`
+}
+
+// Extension represents the full extension object as it appears in
+// PaymentRequired.extensions and PaymentPayload.extensions.
+type Extension struct {
+	Info   interface{}            `json:"info"`
+	Schema map[string]interface{} `json:"schema"`
+}
+
+// Erc20ApprovalGasSponsoringSigner extends FacilitatorEvmSigner with raw transaction broadcasting.
+type Erc20ApprovalGasSponsoringSigner interface {
+	evm.FacilitatorEvmSigner
+	SendRawTransaction(ctx context.Context, signedTx string) (string, error)
+}
+
+// Erc20ApprovalFacilitatorExtension carries the signer; registered with the facilitator.
+// It implements x402.FacilitatorExtension so it can be registered and retrieved via FacilitatorContext.
+type Erc20ApprovalFacilitatorExtension struct {
+	Signer Erc20ApprovalGasSponsoringSigner
+}
+
+// Key returns the extension identifier.
+func (e *Erc20ApprovalFacilitatorExtension) Key() string {
+	return ERC20ApprovalGasSponsoring.Key()
+}

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -52,6 +52,9 @@ const (
 	// Permit2DeadlineBuffer is the time buffer (in seconds) added when checking
 	// deadline expiration to account for block propagation time.
 	Permit2DeadlineBuffer = 6
+
+	// ERC20ApproveGasLimit is the gas limit for a standard ERC-20 approve() transaction.
+	ERC20ApproveGasLimit = 70000
 )
 
 var (

--- a/go/mechanisms/evm/exact/client/erc20_approval.go
+++ b/go/mechanisms/evm/exact/client/erc20_approval.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// SignErc20ApprovalTransaction creates a signed (but unbroadcast) EIP-1559 transaction
+// that calls approve(Permit2, MaxUint256) on the given ERC-20 token.
+//
+// The returned Info contains the RLP-encoded signed transaction which the facilitator
+// will broadcast before calling settle().
+func SignErc20ApprovalTransaction(
+	ctx context.Context,
+	signer evm.ClientEvmSignerWithTxSigning,
+	tokenAddress string,
+	chainID *big.Int,
+) (*erc20approvalgassponsor.Info, error) {
+	owner := signer.Address()
+	normalizedToken := evm.NormalizeAddress(tokenAddress)
+	spender := evm.PERMIT2Address
+
+	// Encode calldata: approve(spender, MaxUint256)
+	contractABI, err := abi.JSON(strings.NewReader(string(evm.ERC20ApproveABI)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse approve ABI: %w", err)
+	}
+	maxUint256 := evm.MaxUint256()
+	calldata, err := contractABI.Pack("approve", common.HexToAddress(spender), maxUint256)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode approve calldata: %w", err)
+	}
+
+	// Get nonce
+	nonce, err := signer.GetTransactionCount(ctx, owner)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get transaction count: %w", err)
+	}
+
+	// Get fee estimates
+	maxFeePerGas, maxPriorityFeePerGas, _ := signer.EstimateFeesPerGas(ctx)
+
+	// Build EIP-1559 transaction
+	toAddr := common.HexToAddress(normalizedToken)
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: maxPriorityFeePerGas,
+		GasFeeCap: maxFeePerGas,
+		Gas:       evm.ERC20ApproveGasLimit,
+		To:        &toAddr,
+		Value:     big.NewInt(0),
+		Data:      calldata,
+	})
+
+	// Sign the transaction
+	rlpBytes, err := signer.SignTransaction(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign approve transaction: %w", err)
+	}
+
+	signedTxHex := "0x" + hex.EncodeToString(rlpBytes)
+
+	return &erc20approvalgassponsor.Info{
+		From:              owner,
+		Asset:             normalizedToken,
+		Spender:           spender,
+		Amount:            maxUint256.String(),
+		SignedTransaction: signedTxHex,
+		Version:           erc20approvalgassponsor.ERC20ApprovalGasSponsoringVersion,
+	}, nil
+}

--- a/go/mechanisms/evm/exact/facilitator/erc20_approval.go
+++ b/go/mechanisms/evm/exact/facilitator/erc20_approval.go
@@ -1,0 +1,87 @@
+package facilitator
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// approveSelector is the 4-byte function selector for ERC-20 approve(address,uint256).
+// keccak256("approve(address,uint256)") = 0x095ea7b3...
+var approveSelector = []byte{0x09, 0x5e, 0xa7, 0xb3}
+
+// ValidateErc20ApprovalForPayment validates the ERC-20 approval extension data.
+// Returns ("", "") if valid, or (reason, message) on failure where reason is the
+// error constant and message is a human-readable contextual description.
+func ValidateErc20ApprovalForPayment(info *erc20approvalgassponsor.Info, payer, tokenAddress string) (reason, message string) {
+	if !erc20approvalgassponsor.ValidateInfo(info) {
+		return ErrErc20ApprovalInvalidFormat, "ERC-20 approval extension info failed format validation"
+	}
+
+	if !strings.EqualFold(info.From, payer) {
+		return ErrErc20ApprovalFromMismatch, fmt.Sprintf("expected from=%s, got %s", payer, info.From)
+	}
+
+	if !strings.EqualFold(info.Asset, tokenAddress) {
+		return ErrErc20ApprovalAssetMismatch, fmt.Sprintf("expected asset=%s, got %s", tokenAddress, info.Asset)
+	}
+
+	if !strings.EqualFold(info.Spender, evm.PERMIT2Address) {
+		return ErrErc20ApprovalWrongSpender, fmt.Sprintf("expected spender=%s, got %s", evm.PERMIT2Address, info.Spender)
+	}
+
+	txHex := strings.TrimPrefix(info.SignedTransaction, "0x")
+	txBytes, err := hex.DecodeString(txHex)
+	if err != nil {
+		return ErrErc20ApprovalTxParseFailed, "failed to hex-decode signed transaction"
+	}
+
+	tx := new(types.Transaction)
+	if err := tx.UnmarshalBinary(txBytes); err != nil {
+		return ErrErc20ApprovalTxParseFailed, "failed to RLP-decode signed transaction"
+	}
+
+	txTo := ""
+	if tx.To() != nil {
+		txTo = tx.To().Hex()
+	}
+	if tx.To() == nil || !strings.EqualFold(txTo, tokenAddress) {
+		return ErrErc20ApprovalWrongTarget, fmt.Sprintf("transaction targets %s, expected %s", txTo, tokenAddress)
+	}
+
+	data := tx.Data()
+	if len(data) < 4 {
+		return ErrErc20ApprovalWrongSelector, "transaction calldata too short for approve() selector"
+	}
+	for i, b := range approveSelector {
+		if data[i] != b {
+			return ErrErc20ApprovalWrongSelector, "transaction calldata does not start with approve() selector 0x095ea7b3"
+		}
+	}
+
+	if len(data) < 36 {
+		return ErrErc20ApprovalWrongCalldata, "transaction calldata too short to contain spender parameter"
+	}
+	calldataSpender := common.BytesToAddress(data[4:36])
+	if !strings.EqualFold(calldataSpender.Hex(), evm.PERMIT2Address) {
+		return ErrErc20ApprovalWrongCalldata, fmt.Sprintf("approve() spender is %s, expected Permit2 %s", calldataSpender.Hex(), evm.PERMIT2Address)
+	}
+
+	chainID := tx.ChainId()
+	signer := types.LatestSignerForChainID(chainID)
+	from, err := types.Sender(signer, tx)
+	if err != nil {
+		return ErrErc20ApprovalInvalidSig, "failed to recover signer from the signed transaction"
+	}
+	if !strings.EqualFold(from.Hex(), payer) {
+		return ErrErc20ApprovalSignerMismatch, fmt.Sprintf("transaction signed by %s, expected payer %s", from.Hex(), payer)
+	}
+
+	return "", ""
+}

--- a/go/mechanisms/evm/exact/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/facilitator/errors.go
@@ -53,4 +53,17 @@ const (
 	ErrPermit2PaymentTooEarly    = "permit2_payment_too_early"
 	ErrPermit2InvalidNonce       = "permit2_invalid_nonce"
 	ErrPermit2612AmountMismatch  = "permit2_2612_amount_mismatch"
+
+	// ERC-20 approval gas sponsoring errors
+	ErrErc20ApprovalInvalidFormat   = "invalid_erc20_approval_extension_format"
+	ErrErc20ApprovalFromMismatch    = "erc20_approval_from_mismatch"
+	ErrErc20ApprovalAssetMismatch   = "erc20_approval_asset_mismatch"
+	ErrErc20ApprovalWrongSpender    = "erc20_approval_spender_not_permit2"
+	ErrErc20ApprovalTxParseFailed   = "erc20_approval_tx_parse_failed"
+	ErrErc20ApprovalWrongTarget     = "erc20_approval_tx_wrong_target"
+	ErrErc20ApprovalWrongSelector   = "erc20_approval_tx_wrong_selector"
+	ErrErc20ApprovalWrongCalldata   = "erc20_approval_tx_wrong_spender"
+	ErrErc20ApprovalSignerMismatch  = "erc20_approval_tx_signer_mismatch"
+	ErrErc20ApprovalInvalidSig      = "erc20_approval_tx_invalid_signature"
+	ErrErc20ApprovalBroadcastFailed = "erc20_approval_broadcast_failed"
 )

--- a/go/mechanisms/evm/exact/facilitator/permit2.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2.go
@@ -11,6 +11,7 @@ import (
 
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/extensions/eip2612gassponsor"
+	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
 	"github.com/coinbase/x402/go/mechanisms/evm"
 	"github.com/coinbase/x402/go/types"
 )
@@ -22,6 +23,7 @@ func VerifyPermit2(
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
 	permit2Payload *evm.ExactPermit2Payload,
+	facilCtx *x402.FacilitatorContext,
 ) (*x402.VerifyResponse, error) {
 	payer := permit2Payload.Permit2Authorization.From
 
@@ -107,17 +109,31 @@ func VerifyPermit2(
 		common.HexToAddress(payer), common.HexToAddress(evm.PERMIT2Address))
 	if err == nil {
 		if allowanceBig, ok := allowance.(*big.Int); ok && allowanceBig.Cmp(requiredAmount) < 0 {
-			// Allowance insufficient - check for EIP-2612 gas sponsoring extension
-			eip2612Info, extErr := eip2612gassponsor.ExtractEip2612GasSponsoringInfo(payload.Extensions)
-			if extErr != nil || eip2612Info == nil {
-				return nil, x402.NewVerifyError(ErrPermit2AllowanceRequired, payer, "permit2 allowance required")
+			// Allowance insufficient - try EIP-2612 first, then ERC-20 approval extension
+			eip2612Info, _ := eip2612gassponsor.ExtractEip2612GasSponsoringInfo(payload.Extensions)
+			if eip2612Info != nil {
+				// Validate the EIP-2612 extension data
+				if validErr := validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress); validErr != "" {
+					return nil, x402.NewVerifyError(validErr, payer, "eip2612 validation failed")
+				}
+				// EIP-2612 extension is valid, allowance will be set during settlement
+			} else {
+				// Try ERC-20 approval extension
+				erc20Info, _ := erc20approvalgassponsor.ExtractInfo(payload.Extensions)
+				if erc20Info != nil && facilCtx != nil {
+					ext, ok := facilCtx.GetExtension(erc20approvalgassponsor.ERC20ApprovalGasSponsoring.Key()).(*erc20approvalgassponsor.Erc20ApprovalFacilitatorExtension)
+					if ok && ext != nil && ext.Signer != nil {
+						if reason, msg := ValidateErc20ApprovalForPayment(erc20Info, payer, tokenAddress); reason != "" {
+							return nil, x402.NewVerifyError(reason, payer, msg)
+						}
+						// ERC-20 approval valid, tx will be broadcast during settlement
+					} else {
+						return nil, x402.NewVerifyError(ErrPermit2AllowanceRequired, payer, "permit2 allowance required")
+					}
+				} else {
+					return nil, x402.NewVerifyError(ErrPermit2AllowanceRequired, payer, "permit2 allowance required")
+				}
 			}
-
-			// Validate the EIP-2612 extension data
-			if validErr := validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress); validErr != "" {
-				return nil, x402.NewVerifyError(validErr, payer, "eip2612 validation failed")
-			}
-			// EIP-2612 extension is valid, allowance will be set during settlement
 		}
 	}
 
@@ -140,12 +156,13 @@ func SettlePermit2(
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
 	permit2Payload *evm.ExactPermit2Payload,
+	facilCtx *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	network := x402.Network(payload.Accepted.Network)
 	payer := permit2Payload.Permit2Authorization.From
 
 	// Re-verify before settling
-	verifyResp, err := VerifyPermit2(ctx, signer, payload, requirements, permit2Payload)
+	verifyResp, err := VerifyPermit2(ctx, signer, payload, requirements, permit2Payload, facilCtx)
 	if err != nil {
 		ve := &x402.VerifyError{}
 		if errors.As(err, &ve) {
@@ -207,10 +224,12 @@ func SettlePermit2(
 
 	// Check for EIP-2612 gas sponsoring extension
 	eip2612Info, _ := eip2612gassponsor.ExtractEip2612GasSponsoringInfo(payload.Extensions)
+	erc20Info, _ := erc20approvalgassponsor.ExtractInfo(payload.Extensions)
 
 	var txHash string
 
-	if eip2612Info != nil {
+	switch {
+	case eip2612Info != nil:
 		// Use settleWithPermit - includes the EIP-2612 permit
 		v, r, s, splitErr := splitEip2612Signature(eip2612Info.Signature)
 		if splitErr != nil {
@@ -251,8 +270,52 @@ func SettlePermit2(
 			witnessStruct,
 			signatureBytes,
 		)
-	} else {
-		// Standard settle - no EIP-2612 extension
+	case erc20Info != nil && facilCtx != nil:
+		// ERC-20 approval path: broadcast pre-signed approve tx, then settle
+		ext, ok := facilCtx.GetExtension(erc20approvalgassponsor.ERC20ApprovalGasSponsoring.Key()).(*erc20approvalgassponsor.Erc20ApprovalFacilitatorExtension)
+		if ok && ext != nil && ext.Signer != nil {
+			// 1. Broadcast the pre-signed approve transaction
+			approveTxHash, broadcastErr := ext.Signer.SendRawTransaction(ctx, erc20Info.SignedTransaction)
+			if broadcastErr != nil {
+				return nil, x402.NewSettleError(ErrErc20ApprovalBroadcastFailed, payer, network, "", broadcastErr.Error())
+			}
+
+			// 2. Wait for approve tx confirmation
+			approveReceipt, receiptErr := ext.Signer.WaitForTransactionReceipt(ctx, approveTxHash)
+			if receiptErr != nil || approveReceipt.Status != evm.TxStatusSuccess {
+				msg := "approve tx failed"
+				if receiptErr != nil {
+					msg = receiptErr.Error()
+				}
+				return nil, x402.NewSettleError(ErrErc20ApprovalBroadcastFailed, payer, network, approveTxHash, msg)
+			}
+
+			// 3. Call settle via extension signer
+			txHash, err = ext.Signer.WriteContract(
+				ctx,
+				evm.X402ExactPermit2ProxyAddress,
+				evm.X402ExactPermit2ProxySettleABI,
+				evm.FunctionSettle,
+				permitStruct,
+				common.HexToAddress(payer),
+				witnessStruct,
+				signatureBytes,
+			)
+		} else {
+			// Extension not properly configured, fall through to standard settle
+			txHash, err = signer.WriteContract(
+				ctx,
+				evm.X402ExactPermit2ProxyAddress,
+				evm.X402ExactPermit2ProxySettleABI,
+				evm.FunctionSettle,
+				permitStruct,
+				common.HexToAddress(payer),
+				witnessStruct,
+				signatureBytes,
+			)
+		}
+	default:
+		// Standard settle - no gas sponsoring extension
 		txHash, err = signer.WriteContract(
 			ctx,
 			evm.X402ExactPermit2ProxyAddress,

--- a/go/mechanisms/evm/exact/facilitator/permit2_erc20_test.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2_erc20_test.go
@@ -1,0 +1,283 @@
+package facilitator
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// buildSignedApproveTransaction creates a signed approve(Permit2, MaxUint256) transaction
+// for use in tests. Uses a well-known test private key.
+func buildSignedApproveTransaction(t *testing.T, privateKeyHex string, tokenAddress string, chainID *big.Int) (string, string) {
+	t.Helper()
+
+	privateKeyHex = strings.TrimPrefix(privateKeyHex, "0x")
+	privateKey, err := crypto.HexToECDSA(privateKeyHex)
+	if err != nil {
+		t.Fatalf("failed to parse private key: %v", err)
+	}
+	from := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	// Encode approve(Permit2, MaxUint256) calldata
+	// selector: 0x095ea7b3
+	// param 1 (spender): left-padded Permit2 address
+	// param 2 (amount): MaxUint256
+	spenderAddr := common.HexToAddress(evm.PERMIT2Address)
+	maxUint256 := evm.MaxUint256()
+
+	calldata := make([]byte, 4+32+32)
+	copy(calldata[0:4], []byte{0x09, 0x5e, 0xa7, 0xb3})
+	spenderBytes := spenderAddr.Bytes()
+	copy(calldata[4+12:4+32], spenderBytes) // right-align address in 32 bytes
+	maxBytes := maxUint256.Bytes()
+	copy(calldata[4+32+(32-len(maxBytes)):], maxBytes) // right-align in 32 bytes
+
+	toAddr := common.HexToAddress(tokenAddress)
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     0,
+		GasTipCap: big.NewInt(1000000000), // 1 gwei
+		GasFeeCap: big.NewInt(2000000000), // 2 gwei
+		Gas:       evm.ERC20ApproveGasLimit,
+		To:        &toAddr,
+		Value:     big.NewInt(0),
+		Data:      calldata,
+	})
+
+	signer := types.LatestSignerForChainID(chainID)
+	signedTx, err := types.SignTx(tx, signer, privateKey)
+	if err != nil {
+		t.Fatalf("failed to sign tx: %v", err)
+	}
+
+	rlpBytes, err := signedTx.MarshalBinary()
+	if err != nil {
+		t.Fatalf("failed to marshal tx: %v", err)
+	}
+
+	return "0x" + hex.EncodeToString(rlpBytes), from.Hex()
+}
+
+func TestValidateErc20ApprovalForPayment(t *testing.T) {
+	// Use a deterministic test private key (DO NOT use in production)
+	testPrivKey := "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+	tokenAddress := "0xeED520980fC7C7B4eB379B96d61CEdea2423005a"
+	chainID := big.NewInt(84532) // Base Sepolia
+
+	signedTx, payer := buildSignedApproveTransaction(t, testPrivKey, tokenAddress, chainID)
+
+	t.Run("valid approval", func(t *testing.T) {
+		info := &erc20approvalgassponsor.Info{
+			From:              payer,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction: signedTx,
+			Version:           "1",
+		}
+		reason, msg := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != "" {
+			t.Errorf("expected valid, got error: %s (%s)", reason, msg)
+		}
+	})
+
+	t.Run("invalid format - bad from address", func(t *testing.T) {
+		info := &erc20approvalgassponsor.Info{
+			From:              "not-an-address",
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            "12345",
+			SignedTransaction: signedTx,
+			Version:           "1",
+		}
+		reason, _ := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != ErrErc20ApprovalInvalidFormat {
+			t.Errorf("expected %s, got: %s", ErrErc20ApprovalInvalidFormat, reason)
+		}
+	})
+
+	t.Run("from mismatch", func(t *testing.T) {
+		otherAddr := "0x0000000000000000000000000000000000000001"
+		info := &erc20approvalgassponsor.Info{
+			From:              otherAddr,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction: signedTx,
+			Version:           "1",
+		}
+		reason, _ := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != ErrErc20ApprovalFromMismatch {
+			t.Errorf("expected %s, got: %s", ErrErc20ApprovalFromMismatch, reason)
+		}
+	})
+
+	t.Run("asset mismatch", func(t *testing.T) {
+		info := &erc20approvalgassponsor.Info{
+			From:              payer,
+			Asset:             "0x0000000000000000000000000000000000000001",
+			Spender:           evm.PERMIT2Address,
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction: signedTx,
+			Version:           "1",
+		}
+		reason, _ := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != ErrErc20ApprovalAssetMismatch {
+			t.Errorf("expected %s, got: %s", ErrErc20ApprovalAssetMismatch, reason)
+		}
+	})
+
+	t.Run("wrong spender in info (not Permit2)", func(t *testing.T) {
+		info := &erc20approvalgassponsor.Info{
+			From:              payer,
+			Asset:             tokenAddress,
+			Spender:           "0x0000000000000000000000000000000000000001",
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction: signedTx,
+			Version:           "1",
+		}
+		reason, _ := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != ErrErc20ApprovalWrongSpender {
+			t.Errorf("expected %s, got: %s", ErrErc20ApprovalWrongSpender, reason)
+		}
+	})
+
+	t.Run("tx parse failed - not valid RLP", func(t *testing.T) {
+		info := &erc20approvalgassponsor.Info{
+			From:              payer,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction: "0xdeadbeef1234",
+			Version:           "1",
+		}
+		reason, _ := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != ErrErc20ApprovalTxParseFailed {
+			t.Errorf("expected %s, got: %s", ErrErc20ApprovalTxParseFailed, reason)
+		}
+	})
+
+	t.Run("tx target mismatch", func(t *testing.T) {
+		// Build tx targeting a different token
+		wrongToken := "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+		wrongSignedTx, _ := buildSignedApproveTransaction(t, testPrivKey, wrongToken, chainID)
+		info := &erc20approvalgassponsor.Info{
+			From:              payer,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction: wrongSignedTx,
+			Version:           "1",
+		}
+		reason, _ := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != ErrErc20ApprovalWrongTarget {
+			t.Errorf("expected %s, got: %s", ErrErc20ApprovalWrongTarget, reason)
+		}
+	})
+
+	t.Run("wrong calldata selector", func(t *testing.T) {
+		privateKey, _ := crypto.HexToECDSA(strings.TrimPrefix(testPrivKey, "0x"))
+		toAddr := common.HexToAddress(tokenAddress)
+
+		// Use wrong selector (transfer instead of approve)
+		wrongCalldata := []byte{0xa9, 0x05, 0x9c, 0xbb} // transfer(address,uint256) selector
+		wrongCalldata = append(wrongCalldata, make([]byte, 64)...)
+
+		tx := types.NewTx(&types.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     1,
+			GasTipCap: big.NewInt(1000000000),
+			GasFeeCap: big.NewInt(2000000000),
+			Gas:       evm.ERC20ApproveGasLimit,
+			To:        &toAddr,
+			Value:     big.NewInt(0),
+			Data:      wrongCalldata,
+		})
+		signer := types.LatestSignerForChainID(chainID)
+		signedTxObj, _ := types.SignTx(tx, signer, privateKey)
+		rlpBytes, _ := signedTxObj.MarshalBinary()
+		wrongSignedTxHex := "0x" + hex.EncodeToString(rlpBytes)
+
+		info := &erc20approvalgassponsor.Info{
+			From:              payer,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction: wrongSignedTxHex,
+			Version:           "1",
+		}
+		reason, _ := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != ErrErc20ApprovalWrongSelector {
+			t.Errorf("expected %s, got: %s", ErrErc20ApprovalWrongSelector, reason)
+		}
+	})
+
+	t.Run("wrong calldata spender", func(t *testing.T) {
+		privateKey, _ := crypto.HexToECDSA(strings.TrimPrefix(testPrivKey, "0x"))
+		toAddr := common.HexToAddress(tokenAddress)
+
+		// Approve a wrong spender (not Permit2)
+		wrongSpender := common.HexToAddress("0x0000000000000000000000000000000000000001")
+		calldata := make([]byte, 4+32+32)
+		copy(calldata[0:4], []byte{0x09, 0x5e, 0xa7, 0xb3})
+		copy(calldata[4+12:4+32], wrongSpender.Bytes())
+		maxUint256 := evm.MaxUint256()
+		maxBytes := maxUint256.Bytes()
+		copy(calldata[4+32+(32-len(maxBytes)):], maxBytes)
+
+		tx := types.NewTx(&types.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     1,
+			GasTipCap: big.NewInt(1000000000),
+			GasFeeCap: big.NewInt(2000000000),
+			Gas:       evm.ERC20ApproveGasLimit,
+			To:        &toAddr,
+			Value:     big.NewInt(0),
+			Data:      calldata,
+		})
+		signer := types.LatestSignerForChainID(chainID)
+		signedTxObj, _ := types.SignTx(tx, signer, privateKey)
+		rlpBytes, _ := signedTxObj.MarshalBinary()
+		wrongSignedTxHex := "0x" + hex.EncodeToString(rlpBytes)
+
+		info := &erc20approvalgassponsor.Info{
+			From:              payer,
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction: wrongSignedTxHex,
+			Version:           "1",
+		}
+		reason, _ := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != ErrErc20ApprovalWrongCalldata {
+			t.Errorf("expected %s, got: %s", ErrErc20ApprovalWrongCalldata, reason)
+		}
+	})
+
+	t.Run("signer mismatch - signed by different key", func(t *testing.T) {
+		// Sign with a different private key
+		differentPrivKey := "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+		differentSignedTx, _ := buildSignedApproveTransaction(t, differentPrivKey, tokenAddress, chainID)
+
+		info := &erc20approvalgassponsor.Info{
+			From:              payer, // claims to be payer, but tx is signed by different key
+			Asset:             tokenAddress,
+			Spender:           evm.PERMIT2Address,
+			Amount:            evm.MaxUint256().String(),
+			SignedTransaction: differentSignedTx,
+			Version:           "1",
+		}
+		reason, _ := ValidateErc20ApprovalForPayment(info, payer, tokenAddress)
+		if reason != ErrErc20ApprovalSignerMismatch {
+			t.Errorf("expected %s, got: %s", ErrErc20ApprovalSignerMismatch, reason)
+		}
+	})
+}

--- a/go/mechanisms/evm/exact/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/facilitator/scheme.go
@@ -76,7 +76,7 @@ func (f *ExactEvmScheme) Verify(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
-	_ *x402.FacilitatorContext,
+	fctx *x402.FacilitatorContext,
 ) (*x402.VerifyResponse, error) {
 	// Check if this is a Permit2 payload and route accordingly
 	if evm.IsPermit2Payload(payload.Payload) {
@@ -84,7 +84,7 @@ func (f *ExactEvmScheme) Verify(
 		if err != nil {
 			return nil, x402.NewVerifyError(ErrInvalidPayload, "", fmt.Sprintf("failed to parse Permit2 payload: %s", err.Error()))
 		}
-		return VerifyPermit2(ctx, f.signer, payload, requirements, permit2Payload)
+		return VerifyPermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx)
 	}
 
 	// Default to EIP-3009 verification
@@ -228,7 +228,7 @@ func (f *ExactEvmScheme) Settle(
 	ctx context.Context,
 	payload types.PaymentPayload,
 	requirements types.PaymentRequirements,
-	_ *x402.FacilitatorContext,
+	fctx *x402.FacilitatorContext,
 ) (*x402.SettleResponse, error) {
 	// Check if this is a Permit2 payload and route accordingly
 	if evm.IsPermit2Payload(payload.Payload) {
@@ -237,7 +237,7 @@ func (f *ExactEvmScheme) Settle(
 			network := x402.Network(payload.Accepted.Network)
 			return nil, x402.NewSettleError(ErrInvalidPayload, "", network, "", fmt.Sprintf("failed to parse Permit2 payload: %s", err.Error()))
 		}
-		return SettlePermit2(ctx, f.signer, payload, requirements, permit2Payload)
+		return SettlePermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx)
 	}
 
 	// Default to EIP-3009 settlement

--- a/go/mechanisms/evm/types.go
+++ b/go/mechanisms/evm/types.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+
+	goethtypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 // ExactEIP3009Authorization represents the EIP-3009 TransferWithAuthorization data
@@ -181,6 +183,22 @@ func IsPermit2Payload(data map[string]interface{}) bool {
 func IsEIP3009Payload(data map[string]interface{}) bool {
 	_, ok := data["authorization"]
 	return ok
+}
+
+// ClientEvmSignerWithTxSigning extends ClientEvmSigner with raw transaction signing capabilities.
+// Required for the ERC-20 approval gas sponsoring extension, where the client signs
+// (but does not broadcast) an approve(Permit2, MaxUint256) transaction.
+type ClientEvmSignerWithTxSigning interface {
+	ClientEvmSigner
+
+	// SignTransaction signs an EIP-1559 transaction and returns the RLP-encoded bytes.
+	SignTransaction(ctx context.Context, tx *goethtypes.Transaction) ([]byte, error)
+
+	// GetTransactionCount returns the pending nonce for an address.
+	GetTransactionCount(ctx context.Context, address string) (uint64, error)
+
+	// EstimateFeesPerGas returns the EIP-1559 maxFeePerGas and maxPriorityFeePerGas.
+	EstimateFeesPerGas(ctx context.Context) (maxFeePerGas, maxPriorityFeePerGas *big.Int, err error)
 }
 
 // ClientEvmSigner defines the interface for client-side EVM signing operations.

--- a/go/signers/evm/client.go
+++ b/go/signers/evm/client.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
@@ -161,6 +163,73 @@ func (s *ClientSigner) SignTypedData(
 	signature[64] += 27
 
 	return signature, nil
+}
+
+// GetTransactionCount returns the pending nonce for the given address.
+// Requires an ethclient to be provided via NewClientSignerFromPrivateKeyWithClient.
+func (s *ClientSigner) GetTransactionCount(ctx context.Context, address string) (uint64, error) {
+	if s.ethClient == nil {
+		return 0, fmt.Errorf("GetTransactionCount requires an ethclient; use NewClientSignerFromPrivateKeyWithClient")
+	}
+	nonce, err := s.ethClient.PendingNonceAt(ctx, common.HexToAddress(address))
+	if err != nil {
+		return 0, fmt.Errorf("failed to get pending nonce: %w", err)
+	}
+	return nonce, nil
+}
+
+// EstimateFeesPerGas returns EIP-1559 fee parameters by querying the connected node.
+// Returns maxFeePerGas and maxPriorityFeePerGas. Falls back to 1 gwei / 0.1 gwei on error.
+// Requires an ethclient to be provided via NewClientSignerFromPrivateKeyWithClient.
+func (s *ClientSigner) EstimateFeesPerGas(ctx context.Context) (maxFeePerGas, maxPriorityFeePerGas *big.Int, err error) {
+	gwei := big.NewInt(1_000_000_000)
+	fallbackMax := new(big.Int).Mul(big.NewInt(1), gwei)  // 1 gwei
+	fallbackTip := new(big.Int).Div(gwei, big.NewInt(10)) // 0.1 gwei
+
+	if s.ethClient == nil {
+		return fallbackMax, fallbackTip, nil
+	}
+
+	tip, err := s.ethClient.SuggestGasTipCap(ctx)
+	if err != nil {
+		return fallbackMax, fallbackTip, err
+	}
+
+	// Get base fee from the latest block header
+	header, err := s.ethClient.HeaderByNumber(ctx, nil)
+	if err != nil {
+		// Use tip + 1 gwei as maxFee
+		maxFee := new(big.Int).Add(tip, gwei)
+		return maxFee, tip, err
+	}
+
+	// maxFeePerGas = 2 * baseFee + tip (EIP-1559 convention)
+	baseFee := header.BaseFee
+	if baseFee == nil {
+		baseFee = gwei // fallback to 1 gwei
+	}
+	maxFee := new(big.Int).Add(new(big.Int).Mul(big.NewInt(2), baseFee), tip)
+	return maxFee, tip, nil
+}
+
+// SignTransaction signs an EIP-1559 transaction using the signer's private key
+// and returns the RLP-encoded signed transaction bytes.
+func (s *ClientSigner) SignTransaction(ctx context.Context, tx *types.Transaction) ([]byte, error) {
+	// Derive chain ID from tx
+	chainID := tx.ChainId()
+	signer := types.LatestSignerForChainID(chainID)
+
+	signedTx, err := types.SignTx(tx, signer, s.privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign transaction: %w", err)
+	}
+
+	rlpBytes, err := signedTx.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("failed to RLP-encode transaction: %w", err)
+	}
+
+	return rlpBytes, nil
 }
 
 // ReadContract reads data from a smart contract.

--- a/go/test/integration/evm_test.go
+++ b/go/test/integration/evm_test.go
@@ -499,25 +499,26 @@ func TestEVMIntegrationV2Permit2(t *testing.T) {
 
 	t.Run("EVM V2 Permit2 Flow - x402Client / x402ResourceServer / x402Facilitator", func(t *testing.T) {
 		ctx := context.Background()
+		rpcURL := "https://sepolia.base.org"
 
 		// Wait for any pending transactions from previous tests (shared facilitator wallet)
-		waitForPendingTransactions(t, ctx, facilitatorPrivateKey, "https://sepolia.base.org")
+		waitForPendingTransactions(t, ctx, facilitatorPrivateKey, rpcURL)
 
 		// Revoke Permit2 approval so the test exercises the settleWithPermit path
 		// via EIP-2612 gas sponsoring (instead of hiding behind pre-existing allowance)
 		revokePermit2Approval(t, ctx, clientPrivateKey,
 			"0x036CbD53842c5426634e7929541eC2318f3dCF7e", // USDC on Base Sepolia
-			"https://sepolia.base.org",
+			rpcURL,
 		)
 
-		// Create real client signer with RPC connectivity
-		// (required for EIP-2612 nonce reads when signing the gasless approval permit)
-		clientEthClient, err := ethclient.Dial("https://sepolia.base.org")
+		// Create real client signer with RPC connectivity so it can:
+		// - Read Permit2 allowance before deciding whether to sign EIP-2612 permit
+		// - Query the EIP-2612 nonce from the token contract
+		clientEthClient, err := ethclient.Dial(rpcURL)
 		if err != nil {
-			t.Fatalf("Failed to connect to RPC for client signer: %v", err)
+			t.Fatalf("Failed to connect to Base Sepolia: %v", err)
 		}
 		defer clientEthClient.Close()
-
 		clientSigner, err := evmsigners.NewClientSignerFromPrivateKeyWithClient(clientPrivateKey, clientEthClient)
 		if err != nil {
 			t.Fatalf("Failed to create client signer: %v", err)

--- a/go/test/unit/evm_client_facilitator_test.go
+++ b/go/test/unit/evm_client_facilitator_test.go
@@ -525,7 +525,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for invalid spender")
 		}
@@ -550,7 +550,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for recipient mismatch")
 		}
@@ -572,7 +572,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for expired deadline")
 		}
@@ -597,7 +597,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for not-yet-valid payment")
 		}
@@ -619,7 +619,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for insufficient amount")
 		}
@@ -641,7 +641,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for token mismatch")
 		}
@@ -663,7 +663,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for invalid deadline format")
 		}
@@ -693,7 +693,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongSchemePayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongSchemePayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for scheme mismatch")
 		}
@@ -723,7 +723,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongNetworkPayload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongNetworkPayload, validRequirements, permit2Payload, nil)
 		if err == nil {
 			t.Error("Expected error for network mismatch")
 		}
@@ -1035,7 +1035,7 @@ func TestSettlePermit2_EIP2612Routing(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1069,7 +1069,7 @@ func TestSettlePermit2_EIP2612Routing(t *testing.T) {
 			// No extensions
 		}
 
-		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload)
+		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1163,7 +1163,7 @@ func TestSettlePermit2_ContractRevertErrors(t *testing.T) {
 				},
 			}
 
-			_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload)
+			_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil)
 			if err == nil {
 				t.Fatal("Expected error from SettlePermit2")
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Implements the ERC20 gas approval sponsorship extension in go

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

Passes unit tests, integration tests & e2e tests

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 