### PR TITLE
fix: decouple extraneous chain info from facilitator SDKs in go and python

### DIFF
--- a/e2e/clients/httpx/uv.lock
+++ b/e2e/clients/httpx/uv.lock
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/requests/uv.lock
+++ b/e2e/clients/requests/uv.lock
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/facilitators/python/uv.lock
+++ b/e2e/facilitators/python/uv.lock
@@ -2846,7 +2846,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/fastapi/uv.lock
+++ b/e2e/servers/fastapi/uv.lock
@@ -2841,7 +2841,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/flask/uv.lock
+++ b/e2e/servers/flask/uv.lock
@@ -2072,7 +2072,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/go/mechanisms/evm/exact/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/facilitator/errors.go
@@ -8,7 +8,7 @@ const (
 	ErrInvalidPayload            = "invalid_exact_evm_payload"
 	ErrMissingSignature          = "invalid_exact_evm_payload_missing_signature"
 	ErrFailedToGetNetworkConfig  = "invalid_exact_evm_failed_to_get_network_config"
-	ErrFailedToGetAssetInfo      = "invalid_exact_evm_failed_to_get_asset_info"
+	ErrMissingEip712Domain       = "invalid_exact_evm_missing_eip712_domain"
 	ErrRecipientMismatch         = "invalid_exact_evm_recipient_mismatch"
 	ErrInvalidAuthorizationValue = "invalid_exact_evm_authorization_value"
 	ErrInvalidRequiredAmount     = "invalid_exact_evm_required_amount"

--- a/go/mechanisms/evm/exact/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/facilitator/scheme.go
@@ -118,18 +118,13 @@ func (f *ExactEvmScheme) verifyEIP3009(
 		return nil, x402.NewVerifyError(ErrMissingSignature, "", "missing signature")
 	}
 
-	// Get network configuration
-	networkStr := string(requirements.Network)
-	config, err := evm.GetNetworkConfig(networkStr)
+	// Parse chain ID from network identifier
+	chainID, err := evm.GetEvmChainId(string(requirements.Network))
 	if err != nil {
 		return nil, x402.NewVerifyError(ErrFailedToGetNetworkConfig, "", err.Error())
 	}
 
-	// Get asset info
-	assetInfo, err := evm.GetAssetInfo(networkStr, requirements.Asset)
-	if err != nil {
-		return nil, x402.NewVerifyError(ErrFailedToGetAssetInfo, "", err.Error())
-	}
+	tokenAddress := evm.NormalizeAddress(requirements.Asset)
 
 	// Validate authorization matches requirements
 	if !strings.EqualFold(evmPayload.Authorization.To, requirements.PayTo) {
@@ -174,7 +169,7 @@ func (f *ExactEvmScheme) verifyEIP3009(
 	}
 
 	// Check if nonce has been used
-	nonceUsed, err := f.checkNonceUsed(ctx, evmPayload.Authorization.From, evmPayload.Authorization.Nonce, assetInfo.Address)
+	nonceUsed, err := f.checkNonceUsed(ctx, evmPayload.Authorization.From, evmPayload.Authorization.Nonce, tokenAddress)
 	if err != nil {
 		return nil, x402.NewVerifyError(ErrFailedToCheckNonce, evmPayload.Authorization.From, err.Error())
 	}
@@ -183,7 +178,7 @@ func (f *ExactEvmScheme) verifyEIP3009(
 	}
 
 	// Check balance
-	balance, err := f.signer.GetBalance(ctx, evmPayload.Authorization.From, assetInfo.Address)
+	balance, err := f.signer.GetBalance(ctx, evmPayload.Authorization.From, tokenAddress)
 	if err != nil {
 		return nil, x402.NewVerifyError(ErrFailedToGetBalance, evmPayload.Authorization.From, err.Error())
 	}
@@ -191,16 +186,11 @@ func (f *ExactEvmScheme) verifyEIP3009(
 		return nil, x402.NewVerifyError(ErrInsufficientBalance, evmPayload.Authorization.From, fmt.Sprintf("insufficient balance: %s < %s", balance.String(), authValue.String()))
 	}
 
-	// Extract token info from requirements
-	tokenName := assetInfo.Name
-	tokenVersion := assetInfo.Version
-	if requirements.Extra != nil {
-		if name, ok := requirements.Extra["name"].(string); ok {
-			tokenName = name
-		}
-		if version, ok := requirements.Extra["version"].(string); ok {
-			tokenVersion = version
-		}
+	// Extract EIP-712 domain parameters from requirements
+	tokenName, _ := requirements.Extra["name"].(string)
+	tokenVersion, _ := requirements.Extra["version"].(string)
+	if tokenName == "" || tokenVersion == "" {
+		return nil, x402.NewVerifyError(ErrMissingEip712Domain, evmPayload.Authorization.From, "missing EIP-712 domain name/version in requirements.extra")
 	}
 
 	// Verify signature
@@ -213,8 +203,8 @@ func (f *ExactEvmScheme) verifyEIP3009(
 		ctx,
 		evmPayload.Authorization,
 		signatureBytes,
-		config.ChainID,
-		assetInfo.Address,
+		chainID,
+		tokenAddress,
 		tokenName,
 		tokenVersion,
 	)
@@ -279,12 +269,7 @@ func (f *ExactEvmScheme) settleEIP3009(
 		return nil, x402.NewSettleError(ErrInvalidPayload, verifyResp.Payer, network, "", err.Error())
 	}
 
-	// Get asset info
-	networkStr := string(requirements.Network)
-	assetInfo, err := evm.GetAssetInfo(networkStr, requirements.Asset)
-	if err != nil {
-		return nil, x402.NewSettleError(ErrFailedToGetAssetInfo, verifyResp.Payer, network, "", err.Error())
-	}
+	tokenAddress := evm.NormalizeAddress(requirements.Asset)
 
 	// Parse signature
 	signatureBytes, err := evm.HexToBytes(evmPayload.Signature)
@@ -357,7 +342,7 @@ func (f *ExactEvmScheme) settleEIP3009(
 
 		txHash, err = f.signer.WriteContract(
 			ctx,
-			assetInfo.Address,
+			tokenAddress,
 			evm.TransferWithAuthorizationVRSABI,
 			evm.FunctionTransferWithAuthorization,
 			common.HexToAddress(evmPayload.Authorization.From),
@@ -374,7 +359,7 @@ func (f *ExactEvmScheme) settleEIP3009(
 		// For smart wallets, use bytes signature overload
 		txHash, err = f.signer.WriteContract(
 			ctx,
-			assetInfo.Address,
+			tokenAddress,
 			evm.TransferWithAuthorizationBytesABI,
 			evm.FunctionTransferWithAuthorization,
 			common.HexToAddress(evmPayload.Authorization.From),

--- a/go/mechanisms/evm/exact/v1/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/v1/facilitator/errors.go
@@ -8,7 +8,6 @@ const (
 	ErrInvalidPayload                  = "invalid_exact_evm_payload"
 	ErrMissingSignature                = "invalid_exact_evm_payload_missing_signature"
 	ErrFailedToGetNetworkConfig        = "invalid_exact_evm_failed_to_get_network_config"
-	ErrFailedToGetAssetInfo            = "invalid_exact_evm_failed_to_get_asset_info"
 	ErrInvalidExtraField               = "invalid_exact_evm_extra_field"
 	ErrMissingEip712Domain             = "invalid_exact_evm_missing_eip712_domain"
 	ErrRecipientMismatch               = "invalid_exact_evm_payload_recipient_mismatch"

--- a/python/x402/mechanisms/evm/exact/v1/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/v1/facilitator.py
@@ -8,7 +8,6 @@ from typing import Any
 from .....schemas import Network, SettleResponse, VerifyResponse
 from .....schemas.v1 import PaymentPayloadV1, PaymentRequirementsV1
 from ...constants import (
-    ERR_FAILED_TO_GET_ASSET_INFO,
     ERR_FAILED_TO_GET_NETWORK_CONFIG,
     ERR_FAILED_TO_VERIFY_SIGNATURE,
     ERR_INSUFFICIENT_AMOUNT,
@@ -32,7 +31,7 @@ from ...eip712 import hash_eip3009_authorization
 from ...erc6492 import has_deployment_info, parse_erc6492_signature
 from ...signer import FacilitatorEvmSigner
 from ...types import ERC6492SignatureData, ExactEIP3009Payload
-from ...utils import bytes_to_hex, get_asset_info, get_evm_chain_id, hex_to_bytes
+from ...utils import bytes_to_hex, get_evm_chain_id, hex_to_bytes, normalize_address
 from ...verify import verify_universal_signature
 
 
@@ -142,15 +141,7 @@ class ExactEvmSchemeV1:
                 payer=payer,
             )
 
-        try:
-            asset_info = get_asset_info(network, requirements.asset)
-        except ValueError as e:
-            return VerifyResponse(
-                is_valid=False,
-                invalid_reason=ERR_FAILED_TO_GET_ASSET_INFO,
-                invalid_message=str(e),
-                payer=payer,
-            )
+        token_address = normalize_address(requirements.asset)
 
         # V1: Parse JSON-encoded extra
         extra = requirements.extra or {}
@@ -189,7 +180,7 @@ class ExactEvmSchemeV1:
 
         # Check balance
         try:
-            balance = self._signer.get_balance(payer, asset_info["address"])
+            balance = self._signer.get_balance(payer, token_address)
             if balance < int(requirements.max_amount_required):
                 return VerifyResponse(
                     is_valid=False, invalid_reason=ERR_INSUFFICIENT_BALANCE, payer=payer
@@ -205,7 +196,7 @@ class ExactEvmSchemeV1:
         hash_bytes = hash_eip3009_authorization(
             evm_payload.authorization,
             chain_id,
-            asset_info["address"],
+            token_address,
             extra["name"],
             extra["version"],
         )
@@ -259,7 +250,7 @@ class ExactEvmSchemeV1:
         evm_payload = ExactEIP3009Payload.from_dict(payload.payload)
         payer = evm_payload.authorization.from_address
         network = requirements.network
-        asset_info = get_asset_info(network, requirements.asset)
+        token_address = normalize_address(requirements.asset)
 
         signature = hex_to_bytes(evm_payload.signature)
         sig_data = parse_erc6492_signature(signature)
@@ -296,7 +287,7 @@ class ExactEvmSchemeV1:
             if is_ecdsa:
                 r, s, v = inner_sig[:32], inner_sig[32:64], inner_sig[64]
                 tx_hash = self._signer.write_contract(
-                    asset_info["address"],
+                    token_address,
                     TRANSFER_WITH_AUTHORIZATION_VRS_ABI,
                     "transferWithAuthorization",
                     payer,
@@ -311,7 +302,7 @@ class ExactEvmSchemeV1:
                 )
             else:
                 tx_hash = self._signer.write_contract(
-                    asset_info["address"],
+                    token_address,
                     TRANSFER_WITH_AUTHORIZATION_BYTES_ABI,
                     "transferWithAuthorization",
                     payer,


### PR DESCRIPTION
The `chainInfo` concept should only be referenced by server's who wish to express their amounts in terms of USD strings such as `"$0.01"`. By the time the server responds with a 402 response to the client, it should already be transformed into the `TokenAmount` format, and thus by the time the client sends it to the facilitator it should remain in the `TokenAmount` format.

This means that the clients and facilitators should NOT depend on chain info being registered, only servers.

This PR corrects a bug where facilitator EVM implementations in Go and Python were incorrectly depending on this chainInfo concept, before immediately overwriting these values with the correct ones from `PaymentRequirements`