### PR TITLE
fix: v1 chain context leaking v2 sdk

### DIFF
--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -619,19 +619,19 @@ importers:
         version: 1.2.6
       '@solana-program/compute-budget':
         specifier: ^0.11.0
-        version: 0.11.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+        version: 0.11.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token':
         specifier: ^0.9.0
-        version: 0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+        version: 0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token-2022':
         specifier: ^0.6.1
-        version: 0.6.1(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+        version: 0.6.1(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
       '@solana/kit':
         specifier: ^5.0.0
-        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-confirmation':
         specifier: ^5.0.0
-        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/wallet-standard-features':
         specifier: ^1.3.0
         version: 1.3.0
@@ -1484,6 +1484,148 @@ importers:
         version: 4.20.3
       typescript:
         specifier: ^5.3.0
+        version: 5.8.3
+
+  facilitators/external-proxies/cdp:
+    dependencies:
+      '@coinbase/x402':
+        specifier: ^0.7.3
+        version: 0.7.3(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/core
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      express:
+        specifier: ^4.19.2
+        version: 4.21.2
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.23
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.16.0
+      eslint:
+        specifier: ^9.15.0
+        version: 9.38.0(jiti@1.21.7)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.5.2
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.3
+      typescript:
+        specifier: ^5.7.2
+        version: 5.8.3
+
+  facilitators/external-proxies/cdp-dev:
+    dependencies:
+      '@coinbase/cdp-sdk':
+        specifier: ^1.22.0
+        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/core
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      express:
+        specifier: ^4.19.2
+        version: 4.21.2
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.23
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.16.0
+      eslint:
+        specifier: ^9.15.0
+        version: 9.38.0(jiti@1.21.7)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.5.2
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.3
+      typescript:
+        specifier: ^5.7.2
+        version: 5.8.3
+      x402:
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/legacy/x402
+
+  facilitators/external-proxies/cdp-dev-new:
+    dependencies:
+      '@coinbase/cdp-sdk':
+        specifier: ^1.22.0
+        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/core
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      express:
+        specifier: ^4.19.2
+        version: 4.21.2
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.23
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.16.0
+      eslint:
+        specifier: ^9.15.0
+        version: 9.38.0(jiti@1.21.7)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.5.2
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.3
+      typescript:
+        specifier: ^5.7.2
+        version: 5.8.3
+      x402:
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/legacy/x402
+
+  facilitators/external-proxies/x402.org:
+    dependencies:
+      '@coinbase/x402':
+        specifier: ^0.7.3
+        version: 0.7.3(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/core
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      express:
+        specifier: ^4.19.2
+        version: 4.21.2
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.23
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.16.0
+      eslint:
+        specifier: ^9.15.0
+        version: 9.38.0(jiti@1.21.7)
+      prettier:
+        specifier: ^3.3.3
+        version: 3.5.2
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.3
+      typescript:
+        specifier: ^5.7.2
         version: 5.8.3
 
   facilitators/typescript:
@@ -2691,6 +2833,9 @@ packages:
 
   '@coinbase/wallet-sdk@4.3.6':
     resolution: {integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==}
+
+  '@coinbase/x402@0.7.3':
+    resolution: {integrity: sha512-mSxxbPnDCvSLfq6ZZAB5P1HyYQfQNSdWyY01Cn7yjzTuGUFFgZ7onDkbZnZ1Yry0UnG467aqrmjs6AgoYgpzCQ==}
 
   '@craftamap/esbuild-plugin-html@0.9.0':
     resolution: {integrity: sha512-V5LFrcGXQWU1SSzYPwxEFjF8IjeXW0oTKh5c0xyhGuTNoEnjgJRNSX83HnZ5TTAutJfo/MAyWA4Z9/fIwbMhUQ==}
@@ -8981,6 +9126,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  x402@0.7.3:
+    resolution: {integrity: sha512-8CIZsdMTOn52PjMH/ErVke9ebeZ7ErwiZ5FL3tN3Wny7Ynxs3LkuB/0q7IoccRLdVXA7f2lueYBJ2iDrElhXnA==}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -9904,6 +10052,49 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@base-org/account@1.1.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.8.3)(zod@3.25.71)
+      preact: 10.24.2
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      zustand: 5.0.3(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
+  '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      abitype: 1.0.6(typescript@5.8.3)(zod@3.25.71)
+      axios: 1.12.2
+      axios-retry: 4.5.0(axios@1.12.2)
+      jose: 6.1.3
+      md5: 2.3.0
+      uncrypto: 0.1.3
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      zod: 3.25.71
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+      - ws
+
   '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
@@ -10027,6 +10218,67 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
+
+  '@coinbase/wallet-sdk@4.3.6(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.8.3)(zod@3.25.71)
+      preact: 10.24.2
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      zustand: 5.0.3(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
+  '@coinbase/x402@0.7.3(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@coinbase/cdp-sdk': 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      x402: 0.7.3(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      zod: 3.25.71
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - ws
 
   '@craftamap/esbuild-plugin-html@0.9.0(bufferutil@4.0.9)(esbuild@0.25.5)(utf-8-validate@5.0.10)':
     dependencies:
@@ -10979,6 +11231,41 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@reown/appkit-controllers@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      valtio: 1.13.2(react@19.2.3)
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@reown/appkit-pay@1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
@@ -11023,6 +11310,42 @@ snapshots:
       '@reown/appkit-utils': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.2)(react@19.2.1))(zod@3.25.71)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-pay@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
+      lit: 3.3.0
+      valtio: 1.13.2(react@19.2.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11129,6 +11452,43 @@ snapshots:
       - valtio
       - zod
 
+  '@reown/appkit-scaffold-ui@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      lit: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - valtio
+      - zod
+
   '@reown/appkit-ui@1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
@@ -11168,6 +11528,41 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@reown/appkit-controllers': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      lit: 3.3.0
+      qrcode: 1.5.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit-ui@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -11275,6 +11670,44 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@reown/appkit-utils@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-polyfills': 1.7.8
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      valtio: 1.13.2(react@19.2.3)
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@reown/appkit-wallet@1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -11343,6 +11776,49 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@reown/appkit@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-pay': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-polyfills': 1.7.8
+      '@reown/appkit-scaffold-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
+      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@walletconnect/types': 2.21.0
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      bs58: 6.0.0
+      valtio: 1.13.2(react@19.2.3)
       viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -11505,9 +11981,9 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@solana-program/compute-budget@0.11.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/compute-budget@0.11.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/compute-budget@0.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -11516,6 +11992,10 @@ snapshots:
   '@solana-program/compute-budget@0.8.0(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+
+  '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+    dependencies:
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
@@ -11526,9 +12006,9 @@ snapshots:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/sysvars': 5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
 
-  '@solana-program/token-2022@0.6.1(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))':
+  '@solana-program/token-2022@0.6.1(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))':
     dependencies:
-      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/sysvars': 5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
 
   '@solana-program/token-2022@0.6.1(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))':
@@ -11540,13 +12020,17 @@ snapshots:
     dependencies:
       '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
+  '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+    dependencies:
+      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+
   '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/token@0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/token@0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
-      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/token@0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -12025,6 +12509,32 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
+  '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 3.0.3(typescript@5.8.3)
+      '@solana/functional': 3.0.3(typescript@5.8.3)
+      '@solana/instruction-plans': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/instructions': 3.0.3(typescript@5.8.3)
+      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/programs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-parsed-types': 3.0.3(typescript@5.8.3)
+      '@solana/rpc-spec-types': 3.0.3(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/signers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/sysvars': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
   '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -12046,6 +12556,32 @@ snapshots:
       '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/accounts': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/functional': 5.0.0(typescript@5.8.3)
+      '@solana/instruction-plans': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/instructions': 5.0.0(typescript@5.8.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/programs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-parsed-types': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/signers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/sysvars': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-confirmation': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -12427,6 +12963,15 @@ snapshots:
       typescript: 5.8.3
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
+  '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/errors': 3.0.3(typescript@5.8.3)
+      '@solana/functional': 3.0.3(typescript@5.8.3)
+      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.8.3)
+      '@solana/subscribable': 3.0.3(typescript@5.8.3)
+      typescript: 5.8.3
+      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
   '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.8.3)
@@ -12435,6 +12980,15 @@ snapshots:
       '@solana/subscribable': 3.0.3(typescript@5.8.3)
       typescript: 5.8.3
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
+  '@solana/rpc-subscriptions-channel-websocket@5.0.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/functional': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-subscriptions-spec': 5.0.0(typescript@5.8.3)
+      '@solana/subscribable': 5.0.0(typescript@5.8.3)
+      typescript: 5.8.3
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   '@solana/rpc-subscriptions-channel-websocket@5.0.0(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
@@ -12525,6 +13079,24 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
+  '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/errors': 3.0.3(typescript@5.8.3)
+      '@solana/fast-stable-stringify': 3.0.3(typescript@5.8.3)
+      '@solana/functional': 3.0.3(typescript@5.8.3)
+      '@solana/promises': 3.0.3(typescript@5.8.3)
+      '@solana/rpc-spec-types': 3.0.3(typescript@5.8.3)
+      '@solana/rpc-subscriptions-api': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions-channel-websocket': 3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.8.3)
+      '@solana/rpc-transformers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/subscribable': 3.0.3(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
   '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.8.3)
@@ -12538,6 +13110,24 @@ snapshots:
       '@solana/rpc-transformers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/subscribable': 3.0.3(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/rpc-subscriptions@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/fast-stable-stringify': 5.0.0(typescript@5.8.3)
+      '@solana/functional': 5.0.0(typescript@5.8.3)
+      '@solana/promises': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-subscriptions-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions-channel-websocket': 5.0.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-spec': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/subscribable': 5.0.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -12915,6 +13505,23 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
+  '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 3.0.3(typescript@5.8.3)
+      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/promises': 3.0.3(typescript@5.8.3)
+      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
   '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -12927,6 +13534,23 @@ snapshots:
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/transaction-confirmation@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/promises': 5.0.0(typescript@5.8.3)
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -13263,6 +13887,11 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.8
       react: 19.2.1
+
+  '@tanstack/react-query@5.90.8(react@19.2.3)':
+    dependencies:
+      '@tanstack/query-core': 5.90.8
+      react: 19.2.3
 
   '@trysound/sax@0.2.0': {}
 
@@ -13924,6 +14553,53 @@ snapshots:
       - wagmi
       - zod
 
+  '@wagmi/connectors@6.1.0(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))(zod@3.25.71)':
+    dependencies:
+      '@base-org/account': 1.1.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@coinbase/wallet-sdk': 4.3.6(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@gemini-wallet/core': 0.2.0(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
+      '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
+      '@walletconnect/ethereum-provider': 2.21.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
+      porto: 0.2.19(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - wagmi
+      - zod
+
   '@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(@types/react@19.2.2)(react@19.2.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
     dependencies:
       eventemitter3: 5.0.1
@@ -13960,6 +14636,21 @@ snapshots:
       mipd: 0.0.7(typescript@5.8.3)
       viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       zustand: 5.0.0(@types/react@19.2.2)(react@19.2.1)(use-sync-external-store@1.4.0(react@19.2.1))
+    optionalDependencies:
+      '@tanstack/query-core': 5.90.8
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.8.3)
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      zustand: 5.0.0(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
     optionalDependencies:
       '@tanstack/query-core': 5.90.8
       typescript: 5.8.3
@@ -14115,6 +14806,47 @@ snapshots:
   '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@walletconnect/types': 2.21.1
+      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/ethereum-provider@2.21.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
+    dependencies:
+      '@reown/appkit': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
@@ -15318,6 +16050,10 @@ snapshots:
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.2)(react@19.2.1)):
     dependencies:
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
+
+  derive-valtio@0.1.0(valtio@1.13.2(react@19.2.3)):
+    dependencies:
+      valtio: 1.13.2(react@19.2.3)
 
   des.js@1.1.0:
     dependencies:
@@ -17465,6 +18201,26 @@ snapshots:
       - immer
       - use-sync-external-store
 
+  porto@0.2.19(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)):
+    dependencies:
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
+      hono: 4.10.2
+      idb-keyval: 6.2.2
+      mipd: 0.0.7(typescript@5.8.3)
+      ox: 0.9.12(typescript@5.8.3)(zod@4.1.12)
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      zod: 4.1.12
+      zustand: 5.0.8(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
+    optionalDependencies:
+      '@tanstack/react-query': 5.90.8(react@19.2.3)
+      react: 19.2.3
+      typescript: 5.8.3
+      wagmi: 2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - use-sync-external-store
+
   poseidon-lite@0.2.1: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -18558,6 +19314,10 @@ snapshots:
     dependencies:
       react: 19.2.1
 
+  use-sync-external-store@1.2.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   use-sync-external-store@1.4.0(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -18565,6 +19325,10 @@ snapshots:
   use-sync-external-store@1.4.0(react@19.2.1):
     dependencies:
       react: 19.2.1
+
+  use-sync-external-store@1.4.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   utf-8-validate@5.0.10:
     dependencies:
@@ -18605,6 +19369,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       react: 19.2.1
+
+  valtio@1.13.2(react@19.2.3):
+    dependencies:
+      derive-valtio: 0.1.0(valtio@1.13.2(react@19.2.3))
+      proxy-compare: 2.6.0
+      use-sync-external-store: 1.2.0(react@19.2.3)
+    optionalDependencies:
+      react: 19.2.3
 
   vary@1.1.2: {}
 
@@ -18955,6 +19727,45 @@ snapshots:
       - utf-8-validate
       - zod
 
+  wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71):
+    dependencies:
+      '@tanstack/react-query': 5.90.8(react@19.2.3)
+      '@wagmi/connectors': 6.1.0(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))(zod@3.25.71)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
+      react: 19.2.3
+      use-sync-external-store: 1.4.0(react@19.2.3)
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - immer
+      - ioredis
+      - supports-color
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   webextension-polyfill@0.10.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -19084,6 +19895,54 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
+  x402@0.7.3(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10):
+    dependencies:
+      '@scure/base': 1.2.6
+      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana-program/token': 0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/transaction-confirmation': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/wallet-standard-features': 1.3.0
+      '@wallet-standard/app': 1.1.0
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/features': 1.1.0
+      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
+      wagmi: 2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)
+      zod: 3.25.71
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@solana/sysvars'
+      - '@tanstack/query-core'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - supports-color
+      - typescript
+      - uploadthing
+      - utf-8-validate
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -19149,6 +20008,11 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
 
+  zustand@5.0.0(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
+    optionalDependencies:
+      react: 19.2.3
+      use-sync-external-store: 1.4.0(react@19.2.3)
+
   zustand@5.0.3(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0)):
     optionalDependencies:
       '@types/react': 19.2.2
@@ -19161,6 +20025,11 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
 
+  zustand@5.0.3(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
+    optionalDependencies:
+      react: 19.2.3
+      use-sync-external-store: 1.4.0(react@19.2.3)
+
   zustand@5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0)):
     optionalDependencies:
       '@types/react': 19.2.2
@@ -19172,3 +20041,8 @@ snapshots:
       '@types/react': 19.2.2
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
+
+  zustand@5.0.8(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
+    optionalDependencies:
+      react: 19.2.3
+      use-sync-external-store: 1.4.0(react@19.2.3)

--- a/go/.changes/unreleased/changed-20260225-174750.yaml
+++ b/go/.changes/unreleased/changed-20260225-174750.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Separated v1 legacy network name resolution from v2 CAIP-2 resolution; v1 code now uses evm/v1 package, shared utils only accept eip155:CHAIN_ID format
+time: 2026-02-25T17:47:50.706805-08:00

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -82,31 +82,11 @@ var (
 				Decimals: DefaultDecimals,
 			},
 		},
-		// Base Mainnet (legacy v1 format)
-		"base": {
-			ChainID: ChainIDBase,
-			DefaultAsset: AssetInfo{
-				Address:  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-				Name:     "USD Coin",
-				Version:  "2",
-				Decimals: DefaultDecimals,
-			},
-		},
 		// Base Sepolia Testnet
 		"eip155:84532": {
 			ChainID: ChainIDBaseSepolia,
 			DefaultAsset: AssetInfo{
 				Address:  "0x036CbD53842c5426634e7929541eC2318f3dCF7e", // USDC on Base Sepolia
-				Name:     "USDC",
-				Version:  "2",
-				Decimals: DefaultDecimals,
-			},
-		},
-		// Base Sepolia Testnet (legacy v1 format)
-		"base-sepolia": {
-			ChainID: ChainIDBaseSepolia,
-			DefaultAsset: AssetInfo{
-				Address:  "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
 				Name:     "USDC",
 				Version:  "2",
 				Decimals: DefaultDecimals,
@@ -122,31 +102,11 @@ var (
 				Decimals: 18,
 			},
 		},
-		// MegaETH Mainnet (legacy v1 format)
-		"megaeth": {
-			ChainID: ChainIDMegaETH,
-			DefaultAsset: AssetInfo{
-				Address:  "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
-				Name:     "MegaUSD",
-				Version:  "1",
-				Decimals: 18,
-			},
-		},
 		// Monad Mainnet
 		"eip155:143": {
 			ChainID: ChainIDMonad,
 			DefaultAsset: AssetInfo{
 				Address:  "0x754704Bc059F8C67012fEd69BC8A327a5aafb603", // USDC on Monad
-				Name:     "USD Coin",
-				Version:  "2",
-				Decimals: DefaultDecimals,
-			},
-		},
-		// Monad Mainnet (legacy v1 format)
-		"monad": {
-			ChainID: ChainIDMonad,
-			DefaultAsset: AssetInfo{
-				Address:  "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
 				Name:     "USD Coin",
 				Version:  "2",
 				Decimals: DefaultDecimals,

--- a/go/mechanisms/evm/exact/v1/client/scheme.go
+++ b/go/mechanisms/evm/exact/v1/client/scheme.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/coinbase/x402/go/mechanisms/evm"
+	evmv1 "github.com/coinbase/x402/go/mechanisms/evm/v1"
 	"github.com/coinbase/x402/go/types"
 )
 
@@ -35,14 +36,14 @@ func (c *ExactEvmSchemeV1) CreatePaymentPayload(
 ) (types.PaymentPayloadV1, error) {
 	networkStr := requirements.Network
 
-	// Get chain ID - works for any EIP-155 network (eip155:CHAIN_ID)
-	chainID, err := evm.GetEvmChainId(networkStr)
+	// Get chain ID from v1 network name
+	chainID, err := evmv1.GetEvmChainId(networkStr)
 	if err != nil {
 		return types.PaymentPayloadV1{}, err
 	}
 
-	// Get asset info - works for any explicit address, or uses default if configured
-	assetInfo, err := evm.GetAssetInfo(networkStr, requirements.Asset)
+	// Get asset info from v1 network config
+	assetInfo, err := evmv1.GetAssetInfo(networkStr, requirements.Asset)
 	if err != nil {
 		return types.PaymentPayloadV1{}, err
 	}

--- a/go/mechanisms/evm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/v1/facilitator/scheme.go
@@ -13,6 +13,7 @@ import (
 
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/mechanisms/evm"
+	evmv1 "github.com/coinbase/x402/go/mechanisms/evm/v1"
 	"github.com/coinbase/x402/go/types"
 )
 
@@ -107,8 +108,8 @@ func (f *ExactEvmSchemeV1) Verify(
 		return nil, x402.NewVerifyError(ErrMissingSignature, "", "missing signature")
 	}
 
-	// Parse chain ID from network identifier
-	chainID, err := evm.GetEvmChainId(string(requirements.Network))
+	// Parse chain ID from v1 network name
+	chainID, err := evmv1.GetEvmChainId(string(requirements.Network))
 	if err != nil {
 		return nil, x402.NewVerifyError(ErrFailedToGetNetworkConfig, "", err.Error())
 	}

--- a/go/mechanisms/evm/v1/network.go
+++ b/go/mechanisms/evm/v1/network.go
@@ -1,0 +1,81 @@
+package v1
+
+import (
+	"math/big"
+
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// NetworkChainIDs maps v1 legacy network names to their chain IDs.
+var NetworkChainIDs = map[string]*big.Int{
+	"ethereum":           big.NewInt(1),
+	"sepolia":            big.NewInt(11155111),
+	"abstract":           big.NewInt(2741),
+	"abstract-testnet":   big.NewInt(11124),
+	"base-sepolia":       big.NewInt(84532),
+	"base":               big.NewInt(8453),
+	"avalanche-fuji":     big.NewInt(43113),
+	"avalanche":          big.NewInt(43114),
+	"iotex":              big.NewInt(4689),
+	"sei":                big.NewInt(1329),
+	"sei-testnet":        big.NewInt(1328),
+	"polygon":            big.NewInt(137),
+	"polygon-amoy":       big.NewInt(80002),
+	"peaq":               big.NewInt(3338),
+	"story":              big.NewInt(1514),
+	"educhain":           big.NewInt(41923),
+	"skale-base-sepolia": big.NewInt(324705682),
+	"megaeth":            big.NewInt(4326),
+	"monad":              big.NewInt(143),
+}
+
+// NetworkConfigs maps v1 legacy network names to their full configuration.
+// Only networks that have a known default asset are included here.
+var NetworkConfigs = map[string]evm.NetworkConfig{
+	"base": {
+		ChainID: big.NewInt(8453),
+		DefaultAsset: evm.AssetInfo{
+			Address:  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+			Name:     "USD Coin",
+			Version:  "2",
+			Decimals: evm.DefaultDecimals,
+		},
+	},
+	"base-sepolia": {
+		ChainID: big.NewInt(84532),
+		DefaultAsset: evm.AssetInfo{
+			Address:  "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			Name:     "USDC",
+			Version:  "2",
+			Decimals: evm.DefaultDecimals,
+		},
+	},
+	"megaeth": {
+		ChainID: big.NewInt(4326),
+		DefaultAsset: evm.AssetInfo{
+			Address:  "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+			Name:     "MegaUSD",
+			Version:  "1",
+			Decimals: 18,
+		},
+	},
+	"monad": {
+		ChainID: big.NewInt(143),
+		DefaultAsset: evm.AssetInfo{
+			Address:  "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+			Name:     "USD Coin",
+			Version:  "2",
+			Decimals: evm.DefaultDecimals,
+		},
+	},
+}
+
+// Networks is the list of all v1 network names.
+var Networks []string
+
+func init() {
+	Networks = make([]string, 0, len(NetworkChainIDs))
+	for name := range NetworkChainIDs {
+		Networks = append(Networks, name)
+	}
+}

--- a/go/mechanisms/evm/v1/utils.go
+++ b/go/mechanisms/evm/v1/utils.go
@@ -1,0 +1,58 @@
+package v1
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// GetEvmChainId returns the chain ID for a v1 legacy network name.
+func GetEvmChainId(network string) (*big.Int, error) {
+	if chainID, ok := NetworkChainIDs[network]; ok {
+		return chainID, nil
+	}
+	return nil, fmt.Errorf("unsupported v1 network: %s", network)
+}
+
+// GetNetworkConfig returns the full configuration for a v1 legacy network name.
+func GetNetworkConfig(network string) (*evm.NetworkConfig, error) {
+	if config, ok := NetworkConfigs[network]; ok {
+		return &config, nil
+	}
+	return nil, fmt.Errorf("no configuration for v1 network: %s", network)
+}
+
+// GetAssetInfo returns information about an asset on a v1 network.
+// If assetSymbolOrAddress is a valid address, returns info for that specific token.
+// If assetSymbolOrAddress is empty or a symbol, attempts to use the network's default asset.
+func GetAssetInfo(network string, assetSymbolOrAddress string) (*evm.AssetInfo, error) {
+	if evm.IsValidAddress(assetSymbolOrAddress) {
+		normalizedAddr := evm.NormalizeAddress(assetSymbolOrAddress)
+
+		config, err := GetNetworkConfig(network)
+		if err == nil && config.DefaultAsset.Address != "" {
+			if normalizedAddr == evm.NormalizeAddress(config.DefaultAsset.Address) {
+				return &config.DefaultAsset, nil
+			}
+		}
+
+		return &evm.AssetInfo{
+			Address:  normalizedAddr,
+			Name:     "Unknown Token",
+			Version:  "1",
+			Decimals: 18,
+		}, nil
+	}
+
+	config, err := GetNetworkConfig(network)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.DefaultAsset.Address == "" {
+		return nil, fmt.Errorf("no default asset configured for v1 network %s; specify an explicit asset address", network)
+	}
+
+	return &config.DefaultAsset, nil
+}

--- a/go/test/integration/evm_test.go
+++ b/go/test/integration/evm_test.go
@@ -510,8 +510,15 @@ func TestEVMIntegrationV2Permit2(t *testing.T) {
 			"https://sepolia.base.org",
 		)
 
-		// Create real client signer
-		clientSigner, err := newRealClientEvmSigner(clientPrivateKey)
+		// Create real client signer with RPC connectivity
+		// (required for EIP-2612 nonce reads when signing the gasless approval permit)
+		clientEthClient, err := ethclient.Dial("https://sepolia.base.org")
+		if err != nil {
+			t.Fatalf("Failed to connect to RPC for client signer: %v", err)
+		}
+		defer clientEthClient.Close()
+
+		clientSigner, err := evmsigners.NewClientSignerFromPrivateKeyWithClient(clientPrivateKey, clientEthClient)
 		if err != nil {
 			t.Fatalf("Failed to create client signer: %v", err)
 		}

--- a/go/test/unit/evm_test.go
+++ b/go/test/unit/evm_test.go
@@ -53,17 +53,17 @@ func TestEVMVersionMismatch(t *testing.T) {
 	t.Run("V1 Client with V2 Requirements Should Fail", func(t *testing.T) {
 		ctx := context.Background()
 
-		// Setup V1 client
+		// Setup V1 client with legacy network name
 		clientSigner := &mockClientEvmSigner{}
 		client := x402.Newx402Client()
 		evmClientV1 := evmv1client.NewExactEvmSchemeV1(clientSigner)
-		client.RegisterV1("eip155:8453", evmClientV1)
+		client.RegisterV1("base", evmClientV1)
 
-		// V1 client should succeed
+		// V1 client should succeed with legacy network name
 		v1Requirements := types.PaymentRequirementsV1{
 			Scheme:            evm.SchemeExact,
-			Network:           "eip155:8453",
-			Asset:             "erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+			Network:           "base",
+			Asset:             "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
 			MaxAmountRequired: "1000000",
 			PayTo:             "0x9876543210987654321098765432109876543210",
 		}
@@ -124,19 +124,19 @@ func TestEVMDualVersionSupport(t *testing.T) {
 		clientSigner := &mockClientEvmSigner{}
 		client := x402.Newx402Client()
 
-		// Register V1 implementation
+		// Register V1 implementation with legacy network name
 		evmClientV1 := evmv1client.NewExactEvmSchemeV1(clientSigner)
-		client.RegisterV1("eip155:8453", evmClientV1)
+		client.RegisterV1("base", evmClientV1)
 
-		// Register V2 implementation
+		// Register V2 implementation with CAIP-2
 		evmClient := evmclient.NewExactEvmScheme(clientSigner)
 		client.Register("eip155:8453", evmClient)
 
-		// V1 requirements (typed)
+		// V1 requirements use legacy network name
 		v1Requirements := types.PaymentRequirementsV1{
 			Scheme:            evm.SchemeExact,
-			Network:           "eip155:8453",
-			Asset:             "erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+			Network:           "base",
+			Asset:             "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
 			MaxAmountRequired: "1000000",
 			PayTo:             "0x9876543210987654321098765432109876543210",
 		}
@@ -156,11 +156,11 @@ func TestEVMDualVersionSupport(t *testing.T) {
 			t.Error("Expected V1 payload to have top-level Scheme")
 		}
 
-		// V2 requirements (typed, uses Amount)
+		// V2 requirements use CAIP-2
 		v2Requirements := types.PaymentRequirements{
 			Scheme:  evm.SchemeExact,
 			Network: "eip155:8453",
-			Asset:   "erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+			Asset:   "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
 			Amount:  "1000000",
 			PayTo:   "0x9876543210987654321098765432109876543210",
 			Extra: map[string]interface{}{
@@ -190,19 +190,19 @@ func TestEVMDualVersionSupport(t *testing.T) {
 		clientSigner := &mockClientEvmSigner{}
 		client := x402.Newx402Client()
 
-		// Register V1 implementation
+		// Register V1 implementation with legacy name
 		evmClientV1 := evmv1client.NewExactEvmSchemeV1(clientSigner)
-		client.RegisterV1("eip155:8453", evmClientV1)
+		client.RegisterV1("base", evmClientV1)
 
-		// Register V2 implementation
+		// Register V2 implementation with CAIP-2
 		evmClient := evmclient.NewExactEvmScheme(clientSigner)
 		client.Register("eip155:8453", evmClient)
 
-		// V2 requirements (typed)
+		// V2 requirements use CAIP-2
 		requirements := types.PaymentRequirements{
 			Scheme:  evm.SchemeExact,
 			Network: "eip155:8453",
-			Asset:   "erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+			Asset:   "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
 			Amount:  "1000000",
 			PayTo:   "0x9876543210987654321098765432109876543210",
 		}

--- a/go/test/unit/evm_utils_test.go
+++ b/go/test/unit/evm_utils_test.go
@@ -24,10 +24,9 @@ func TestGetEvmChainId(t *testing.T) {
 		{"Polygon CAIP-2", "eip155:137", 137, false},
 		{"Arbitrum CAIP-2", "eip155:42161", 42161, false},
 
-		// Legacy names
-		{"Base legacy", "base", 8453, false},
-		{"Base mainnet legacy", "base-mainnet", 8453, false},
-		{"Base Sepolia legacy", "base-sepolia", 84532, false},
+		// Legacy names should now fail (use evm/v1.GetEvmChainId for v1 networks)
+		{"Legacy name rejected", "base", 0, true},
+		{"Legacy name rejected 2", "base-sepolia", 0, true},
 
 		// Invalid formats
 		{"Invalid prefix", "ethereum:1", 0, true},
@@ -467,14 +466,10 @@ func TestGetNetworkConfig(t *testing.T) {
 		}
 	})
 
-	t.Run("Legacy names work", func(t *testing.T) {
-		config, err := evm.GetNetworkConfig("base")
-		if err != nil {
-			t.Fatalf("Failed to get config: %v", err)
-		}
-
-		if config.ChainID.Int64() != 8453 {
-			t.Errorf("Expected chain ID 8453, got %d", config.ChainID.Int64())
+	t.Run("Legacy names rejected", func(t *testing.T) {
+		_, err := evm.GetNetworkConfig("base")
+		if err == nil {
+			t.Error("Expected error for legacy network name; use evm/v1 package for v1 networks")
 		}
 	})
 

--- a/go/test/unit/evm_v1_utils_test.go
+++ b/go/test/unit/evm_v1_utils_test.go
@@ -1,0 +1,143 @@
+package unit_test
+
+import (
+	"testing"
+
+	evmv1 "github.com/coinbase/x402/go/mechanisms/evm/v1"
+)
+
+func TestV1GetEvmChainId(t *testing.T) {
+	tests := []struct {
+		name          string
+		network       string
+		expectedChain int64
+		expectError   bool
+	}{
+		{"base", "base", 8453, false},
+		{"base-sepolia", "base-sepolia", 84532, false},
+		{"ethereum", "ethereum", 1, false},
+		{"polygon", "polygon", 137, false},
+		{"megaeth", "megaeth", 4326, false},
+		{"monad", "monad", 143, false},
+		{"avalanche", "avalanche", 43114, false},
+		{"sei", "sei", 1329, false},
+
+		// CAIP-2 format should NOT work in v1
+		{"CAIP-2 rejected", "eip155:8453", 0, true},
+		{"Unknown network", "unknown-chain", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chainID, err := evmv1.GetEvmChainId(tt.network)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for network %s, got nil", tt.network)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error for network %s: %v", tt.network, err)
+				return
+			}
+
+			if chainID.Int64() != tt.expectedChain {
+				t.Errorf("Expected chain ID %d, got %d", tt.expectedChain, chainID.Int64())
+			}
+		})
+	}
+}
+
+func TestV1GetNetworkConfig(t *testing.T) {
+	t.Run("base has default asset", func(t *testing.T) {
+		config, err := evmv1.GetNetworkConfig("base")
+		if err != nil {
+			t.Fatalf("Failed to get config: %v", err)
+		}
+
+		if config.ChainID.Int64() != 8453 {
+			t.Errorf("Expected chain ID 8453, got %d", config.ChainID.Int64())
+		}
+
+		if config.DefaultAsset.Address == "" {
+			t.Error("Expected default asset to be configured")
+		}
+
+		if config.DefaultAsset.Decimals != 6 {
+			t.Errorf("Expected 6 decimals, got %d", config.DefaultAsset.Decimals)
+		}
+	})
+
+	t.Run("base-sepolia has default asset", func(t *testing.T) {
+		config, err := evmv1.GetNetworkConfig("base-sepolia")
+		if err != nil {
+			t.Fatalf("Failed to get config: %v", err)
+		}
+
+		if config.ChainID.Int64() != 84532 {
+			t.Errorf("Expected chain ID 84532, got %d", config.ChainID.Int64())
+		}
+	})
+
+	t.Run("network without config returns error", func(t *testing.T) {
+		_, err := evmv1.GetNetworkConfig("polygon")
+		if err == nil {
+			t.Error("Expected error for network without configured default asset")
+		}
+	})
+
+	t.Run("CAIP-2 format rejected", func(t *testing.T) {
+		_, err := evmv1.GetNetworkConfig("eip155:8453")
+		if err == nil {
+			t.Error("Expected error for CAIP-2 format in v1")
+		}
+	})
+}
+
+func TestV1GetAssetInfo(t *testing.T) {
+	t.Run("explicit address returns info", func(t *testing.T) {
+		info, err := evmv1.GetAssetInfo("base", "0x1234567890123456789012345678901234567890")
+		if err != nil {
+			t.Fatalf("Failed to get asset info: %v", err)
+		}
+
+		if info.Address != "0x1234567890123456789012345678901234567890" {
+			t.Errorf("Address mismatch: %s", info.Address)
+		}
+
+		if info.Decimals != 18 {
+			t.Errorf("Expected 18 decimals for unknown token, got %d", info.Decimals)
+		}
+	})
+
+	t.Run("empty asset uses network default", func(t *testing.T) {
+		info, err := evmv1.GetAssetInfo("base-sepolia", "")
+		if err != nil {
+			t.Fatalf("Failed to get asset info: %v", err)
+		}
+
+		if info.Address == "" {
+			t.Error("Expected default asset address")
+		}
+	})
+
+	t.Run("network without config fails for empty asset", func(t *testing.T) {
+		_, err := evmv1.GetAssetInfo("polygon", "")
+		if err == nil {
+			t.Error("Expected error for network without default asset")
+		}
+	})
+}
+
+func TestV1NetworksListPopulated(t *testing.T) {
+	if len(evmv1.Networks) == 0 {
+		t.Error("Networks list should not be empty")
+	}
+
+	if len(evmv1.Networks) != len(evmv1.NetworkChainIDs) {
+		t.Errorf("Networks list length %d should match NetworkChainIDs length %d",
+			len(evmv1.Networks), len(evmv1.NetworkChainIDs))
+	}
+}

--- a/python/x402/changelog.d/split-v1-v2-networks.feature.md
+++ b/python/x402/changelog.d/split-v1-v2-networks.feature.md
@@ -1,0 +1,1 @@
+Separated v1 legacy network name resolution from v2 CAIP-2 resolution; get_evm_chain_id now only accepts eip155:CHAIN_ID format, v1 code uses evm.v1.utils

--- a/python/x402/mechanisms/evm/__init__.py
+++ b/python/x402/mechanisms/evm/__init__.py
@@ -25,17 +25,21 @@ from .constants import (
     ERR_VALID_AFTER_FUTURE,
     ERR_VALID_BEFORE_EXPIRED,
     IS_VALID_SIGNATURE_ABI,
-    NETWORK_ALIASES,
     NETWORK_CONFIGS,
     SCHEME_EXACT,
     TRANSFER_WITH_AUTHORIZATION_BYTES_ABI,
     TRANSFER_WITH_AUTHORIZATION_VRS_ABI,
     TX_STATUS_FAILED,
     TX_STATUS_SUCCESS,
-    V1_NETWORK_CHAIN_IDS,
-    V1_NETWORKS,
     AssetInfo,
     NetworkConfig,
+)
+
+# V1 legacy constants (re-exported for backward compatibility)
+from .v1.constants import (
+    NETWORK_ALIASES,
+    V1_NETWORK_CHAIN_IDS,
+    V1_NETWORKS,
 )
 
 # EIP-712

--- a/python/x402/mechanisms/evm/__init__.py
+++ b/python/x402/mechanisms/evm/__init__.py
@@ -35,13 +35,6 @@ from .constants import (
     NetworkConfig,
 )
 
-# V1 legacy constants (re-exported for backward compatibility)
-from .v1.constants import (
-    NETWORK_ALIASES,
-    V1_NETWORK_CHAIN_IDS,
-    V1_NETWORKS,
-)
-
 # EIP-712
 from .eip712 import (
     build_typed_data_for_signing,
@@ -94,6 +87,13 @@ from .utils import (
     normalize_address,
     parse_amount,
     parse_money_to_decimal,
+)
+
+# V1 legacy constants (re-exported for backward compatibility)
+from .v1.constants import (
+    NETWORK_ALIASES,
+    V1_NETWORK_CHAIN_IDS,
+    V1_NETWORKS,
 )
 
 # Verification

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -197,61 +197,8 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
     },
 }
 
-# Network aliases (legacy names to CAIP-2)
-NETWORK_ALIASES: dict[str, str] = {
-    "base": "eip155:8453",
-    "base-mainnet": "eip155:8453",
-    "base-sepolia": "eip155:84532",
-    "ethereum": "eip155:1",
-    "mainnet": "eip155:1",
-    "polygon": "eip155:137",
-    "avalanche": "eip155:43114",
-    "megaeth": "eip155:4326",
-    "monad": "eip155:143",
-}
-
-# V1 supported networks (legacy name-based)
-V1_NETWORKS = [
-    "abstract",
-    "abstract-testnet",
-    "base-sepolia",
-    "base",
-    "avalanche-fuji",
-    "avalanche",
-    "iotex",
-    "sei",
-    "sei-testnet",
-    "polygon",
-    "polygon-amoy",
-    "peaq",
-    "story",
-    "educhain",
-    "skale-base-sepolia",
-    "megaeth",
-    "monad",
-]
-
-# V1 network name to chain ID mapping
-V1_NETWORK_CHAIN_IDS: dict[str, int] = {
-    "base": 8453,
-    "base-sepolia": 84532,
-    "ethereum": 1,
-    "polygon": 137,
-    "polygon-amoy": 80002,
-    "avalanche": 43114,
-    "avalanche-fuji": 43113,
-    "abstract": 2741,
-    "abstract-testnet": 11124,
-    "iotex": 4689,
-    "sei": 1329,
-    "sei-testnet": 713715,
-    "peaq": 3338,
-    "story": 1513,
-    "educhain": 656476,
-    "skale-base-sepolia": 1444673419,
-    "megaeth": 4326,
-    "monad": 143,
-}
+# V1 legacy constants are in x402.mechanisms.evm.v1.constants
+# (NETWORK_ALIASES, V1_NETWORKS, V1_NETWORK_CHAIN_IDS)
 
 # EIP-3009 ABIs
 TRANSFER_WITH_AUTHORIZATION_VRS_ABI = [

--- a/python/x402/mechanisms/evm/exact/register.py
+++ b/python/x402/mechanisms/evm/exact/register.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING, TypeVar
 
-from ..constants import V1_NETWORKS
+from ..v1.constants import V1_NETWORKS
 
 if TYPE_CHECKING:
     from x402 import (

--- a/python/x402/mechanisms/evm/exact/v1/client.py
+++ b/python/x402/mechanisms/evm/exact/v1/client.py
@@ -9,7 +9,8 @@ from ...constants import SCHEME_EXACT
 from ...eip712 import build_typed_data_for_signing
 from ...signer import ClientEvmSigner
 from ...types import ExactEIP3009Authorization, ExactEIP3009Payload, TypedDataField
-from ...utils import create_nonce, get_asset_info, get_evm_chain_id
+from ...utils import create_nonce
+from ...v1.utils import get_asset_info, get_evm_chain_id
 
 
 class ExactEvmSchemeV1:

--- a/python/x402/mechanisms/evm/exact/v1/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/v1/facilitator.py
@@ -31,7 +31,8 @@ from ...eip712 import hash_eip3009_authorization
 from ...erc6492 import has_deployment_info, parse_erc6492_signature
 from ...signer import FacilitatorEvmSigner
 from ...types import ERC6492SignatureData, ExactEIP3009Payload
-from ...utils import bytes_to_hex, get_evm_chain_id, hex_to_bytes, normalize_address
+from ...utils import bytes_to_hex, hex_to_bytes, normalize_address
+from ...v1.utils import get_evm_chain_id
 from ...verify import verify_universal_signature
 
 

--- a/python/x402/mechanisms/evm/utils.py
+++ b/python/x402/mechanisms/evm/utils.py
@@ -15,52 +15,38 @@ except ImportError as e:
 from .constants import (
     DEFAULT_VALIDITY_BUFFER,
     DEFAULT_VALIDITY_PERIOD,
-    NETWORK_ALIASES,
     NETWORK_CONFIGS,
-    V1_NETWORK_CHAIN_IDS,
     AssetInfo,
     NetworkConfig,
 )
 
 
 def get_evm_chain_id(network: str) -> int:
-    """Extract chain ID from network string.
-
-    Handles both CAIP-2 format (eip155:8453) and legacy names (base-sepolia).
+    """Extract chain ID from a CAIP-2 network identifier (eip155:CHAIN_ID).
 
     Args:
-        network: Network identifier.
+        network: Network identifier in CAIP-2 format (e.g., "eip155:8453").
 
     Returns:
         Numeric chain ID.
 
     Raises:
-        ValueError: If network format is unrecognized.
+        ValueError: If network format is invalid.
     """
-    # Handle CAIP-2 format
     if network.startswith("eip155:"):
         try:
             return int(network.split(":")[1])
         except (IndexError, ValueError) as e:
             raise ValueError(f"Invalid CAIP-2 network format: {network}") from e
 
-    # Check aliases
-    if network in NETWORK_ALIASES:
-        caip2 = NETWORK_ALIASES[network]
-        return int(caip2.split(":")[1])
-
-    # Check V1 legacy names
-    if network in V1_NETWORK_CHAIN_IDS:
-        return V1_NETWORK_CHAIN_IDS[network]
-
-    raise ValueError(f"Unknown network: {network}")
+    raise ValueError(f"Unsupported network format: {network} (expected eip155:CHAIN_ID)")
 
 
 def get_network_config(network: str) -> NetworkConfig:
-    """Get configuration for a network.
+    """Get configuration for a CAIP-2 network identifier (eip155:CHAIN_ID).
 
     Args:
-        network: Network identifier (CAIP-2 or legacy name).
+        network: Network identifier in CAIP-2 format.
 
     Returns:
         Network configuration.
@@ -68,18 +54,10 @@ def get_network_config(network: str) -> NetworkConfig:
     Raises:
         ValueError: If network is not configured.
     """
-    # Normalize to CAIP-2
-    if network in NETWORK_ALIASES:
-        network = NETWORK_ALIASES[network]
-    elif not network.startswith("eip155:"):
-        # Try to convert legacy name
-        if network in V1_NETWORK_CHAIN_IDS:
-            network = f"eip155:{V1_NETWORK_CHAIN_IDS[network]}"
-
     if network in NETWORK_CONFIGS:
         return NETWORK_CONFIGS[network]
 
-    raise ValueError(f"No configuration for network: {network}")
+    raise ValueError(f"No configuration for network: {network} (expected eip155:CHAIN_ID)")
 
 
 def get_asset_info(network: str, asset_symbol_or_address: str) -> AssetInfo:

--- a/python/x402/mechanisms/evm/v1/__init__.py
+++ b/python/x402/mechanisms/evm/v1/__init__.py
@@ -1,0 +1,1 @@
+"""V1 legacy network utilities for EVM mechanisms."""

--- a/python/x402/mechanisms/evm/v1/constants.py
+++ b/python/x402/mechanisms/evm/v1/constants.py
@@ -1,0 +1,57 @@
+"""V1 legacy network constants for EVM mechanisms."""
+
+# Network aliases (legacy names to CAIP-2)
+NETWORK_ALIASES: dict[str, str] = {
+    "base": "eip155:8453",
+    "base-mainnet": "eip155:8453",
+    "base-sepolia": "eip155:84532",
+    "ethereum": "eip155:1",
+    "mainnet": "eip155:1",
+    "polygon": "eip155:137",
+    "avalanche": "eip155:43114",
+    "megaeth": "eip155:4326",
+    "monad": "eip155:143",
+}
+
+# V1 supported networks (legacy name-based)
+V1_NETWORKS = [
+    "abstract",
+    "abstract-testnet",
+    "base-sepolia",
+    "base",
+    "avalanche-fuji",
+    "avalanche",
+    "iotex",
+    "sei",
+    "sei-testnet",
+    "polygon",
+    "polygon-amoy",
+    "peaq",
+    "story",
+    "educhain",
+    "skale-base-sepolia",
+    "megaeth",
+    "monad",
+]
+
+# V1 network name to chain ID mapping
+V1_NETWORK_CHAIN_IDS: dict[str, int] = {
+    "base": 8453,
+    "base-sepolia": 84532,
+    "ethereum": 1,
+    "polygon": 137,
+    "polygon-amoy": 80002,
+    "avalanche": 43114,
+    "avalanche-fuji": 43113,
+    "abstract": 2741,
+    "abstract-testnet": 11124,
+    "iotex": 4689,
+    "sei": 1329,
+    "sei-testnet": 713715,
+    "peaq": 3338,
+    "story": 1513,
+    "educhain": 656476,
+    "skale-base-sepolia": 1444673419,
+    "megaeth": 4326,
+    "monad": 143,
+}

--- a/python/x402/mechanisms/evm/v1/utils.py
+++ b/python/x402/mechanisms/evm/v1/utils.py
@@ -1,0 +1,77 @@
+"""V1 legacy network utilities for EVM mechanisms."""
+
+from ..constants import NETWORK_CONFIGS, AssetInfo
+from .constants import NETWORK_ALIASES, V1_NETWORK_CHAIN_IDS
+
+
+def get_evm_chain_id(network: str) -> int:
+    """Extract chain ID from a v1 legacy network name.
+
+    Args:
+        network: V1 network name (e.g., "base-sepolia", "polygon").
+
+    Returns:
+        Numeric chain ID.
+
+    Raises:
+        ValueError: If network is not a known v1 network.
+    """
+    if network in NETWORK_ALIASES:
+        caip2 = NETWORK_ALIASES[network]
+        return int(caip2.split(":")[1])
+
+    if network in V1_NETWORK_CHAIN_IDS:
+        return V1_NETWORK_CHAIN_IDS[network]
+
+    raise ValueError(f"Unknown v1 network: {network}")
+
+
+def get_asset_info(network: str, asset_symbol_or_address: str) -> AssetInfo:
+    """Get asset info for a v1 network.
+
+    Normalizes the v1 network name to CAIP-2 and looks up in shared NETWORK_CONFIGS.
+
+    Args:
+        network: V1 network name.
+        asset_symbol_or_address: Asset symbol (e.g., "USDC") or address.
+
+    Returns:
+        Asset information.
+
+    Raises:
+        ValueError: If asset is not found.
+    """
+    caip2_network = _normalize_to_caip2(network)
+
+    if caip2_network not in NETWORK_CONFIGS:
+        raise ValueError(f"No configuration for v1 network: {network}")
+
+    config = NETWORK_CONFIGS[caip2_network]
+
+    if asset_symbol_or_address.startswith("0x"):
+        for asset in config["supported_assets"].values():
+            if asset["address"].lower() == asset_symbol_or_address.lower():
+                return asset
+        return {
+            "address": asset_symbol_or_address,
+            "name": config["default_asset"]["name"],
+            "version": config["default_asset"]["version"],
+            "decimals": config["default_asset"]["decimals"],
+        }
+
+    symbol = asset_symbol_or_address.upper()
+    if symbol and symbol in config["supported_assets"]:
+        return config["supported_assets"][symbol]
+
+    return config["default_asset"]
+
+
+def _normalize_to_caip2(network: str) -> str:
+    """Convert a v1 network name to CAIP-2 format."""
+    if network in NETWORK_ALIASES:
+        return NETWORK_ALIASES[network]
+
+    if network in V1_NETWORK_CHAIN_IDS:
+        return f"eip155:{V1_NETWORK_CHAIN_IDS[network]}"
+
+    raise ValueError(f"Unknown v1 network: {network}")

--- a/python/x402/tests/integrations/test_mcp_evm.py
+++ b/python/x402/tests/integrations/test_mcp_evm.py
@@ -20,11 +20,12 @@ import threading
 import time
 
 import pytest
-from mcp.client.streamable_http import streamable_http_client
-from mcp.server.fastmcp import FastMCP
 
-from mcp import ClientSession
-from mcp.types import TextContent
+mcp = pytest.importorskip("mcp", reason="mcp package not available")
+from mcp.client.streamable_http import streamable_http_client  # noqa: E402
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp import ClientSession  # noqa: E402
+from mcp.types import TextContent  # noqa: E402
 from x402 import x402ClientSync, x402FacilitatorSync, x402ResourceServerSync
 from x402.mcp import create_payment_wrapper, x402MCPClientSync
 from x402.mechanisms.evm.exact import (

--- a/python/x402/tests/integrations/test_mcp_evm.py
+++ b/python/x402/tests/integrations/test_mcp_evm.py
@@ -24,18 +24,19 @@ import pytest
 mcp = pytest.importorskip("mcp", reason="mcp package not available")
 from mcp.client.streamable_http import streamable_http_client  # noqa: E402
 from mcp.server.fastmcp import FastMCP  # noqa: E402
+
 from mcp import ClientSession  # noqa: E402
 from mcp.types import TextContent  # noqa: E402
-from x402 import x402ClientSync, x402FacilitatorSync, x402ResourceServerSync
-from x402.mcp import create_payment_wrapper, x402MCPClientSync
-from x402.mechanisms.evm.exact import (
+from x402 import x402ClientSync, x402FacilitatorSync, x402ResourceServerSync  # noqa: E402
+from x402.mcp import create_payment_wrapper, x402MCPClientSync  # noqa: E402
+from x402.mechanisms.evm.exact import (  # noqa: E402
     ExactEvmClientScheme,
     ExactEvmFacilitatorScheme,
     ExactEvmSchemeConfig,
     ExactEvmServerScheme,
 )
-from x402.mechanisms.evm.signers import EthAccountSigner, FacilitatorWeb3Signer
-from x402.schemas import ResourceConfig, ResourceInfo
+from x402.mechanisms.evm.signers import EthAccountSigner, FacilitatorWeb3Signer  # noqa: E402
+from x402.schemas import ResourceConfig, ResourceInfo  # noqa: E402
 
 # Environment variables
 CLIENT_PRIVATE_KEY = os.environ.get("EVM_CLIENT_PRIVATE_KEY")

--- a/python/x402/tests/unit/mechanisms/evm/test_v1_utils.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_v1_utils.py
@@ -1,0 +1,59 @@
+"""Tests for EVM v1 legacy network utility functions."""
+
+import pytest
+
+from x402.mechanisms.evm.v1.utils import get_asset_info, get_evm_chain_id
+
+
+class TestV1GetEvmChainId:
+    """Test v1 get_evm_chain_id function (legacy names)."""
+
+    def test_should_resolve_base(self):
+        assert get_evm_chain_id("base") == 8453
+
+    def test_should_resolve_base_sepolia(self):
+        assert get_evm_chain_id("base-sepolia") == 84532
+
+    def test_should_resolve_ethereum(self):
+        assert get_evm_chain_id("ethereum") == 1
+
+    def test_should_resolve_polygon(self):
+        assert get_evm_chain_id("polygon") == 137
+
+    def test_should_resolve_megaeth(self):
+        assert get_evm_chain_id("megaeth") == 4326
+
+    def test_should_resolve_monad(self):
+        assert get_evm_chain_id("monad") == 143
+
+    def test_should_resolve_avalanche(self):
+        assert get_evm_chain_id("avalanche") == 43114
+
+    def test_should_resolve_aliases(self):
+        assert get_evm_chain_id("base-mainnet") == 8453
+        assert get_evm_chain_id("mainnet") == 1
+
+    def test_should_reject_caip2_format(self):
+        with pytest.raises(ValueError, match="Unknown v1 network"):
+            get_evm_chain_id("eip155:8453")
+
+    def test_should_reject_unknown_network(self):
+        with pytest.raises(ValueError, match="Unknown v1 network"):
+            get_evm_chain_id("unknown-chain")
+
+
+class TestV1GetAssetInfo:
+    """Test v1 get_asset_info function."""
+
+    def test_should_return_default_asset_for_base(self):
+        info = get_asset_info("base", "USDC")
+        assert info["address"].startswith("0x")
+        assert info["decimals"] == 6
+
+    def test_should_return_asset_by_address(self):
+        info = get_asset_info("base-sepolia", "0x036CbD53842c5426634e7929541eC2318f3dCF7e")
+        assert info["decimals"] == 6
+
+    def test_should_raise_for_unknown_v1_network(self):
+        with pytest.raises(ValueError, match="Unknown v1 network"):
+            get_asset_info("eip155:8453", "USDC")

--- a/python/x402/uv.lock
+++ b/python/x402/uv.lock
@@ -3407,7 +3407,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "nest-asyncio" },

--- a/typescript/.changeset/split-v1-v2-network-utils.md
+++ b/typescript/.changeset/split-v1-v2-network-utils.md
@@ -1,0 +1,5 @@
+---
+'@x402/evm': patch
+---
+
+Separated v1 legacy network name resolution from v2 CAIP-2 resolution; getEvmChainId now only accepts eip155:CHAIN_ID format, v1 code uses getEvmChainIdV1 from v1/index

--- a/typescript/packages/mechanisms/evm/src/exact/v1/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/client/scheme.ts
@@ -9,8 +9,8 @@ import { getAddress } from "viem";
 import { authorizationTypes } from "../../../constants";
 import { ClientEvmSigner } from "../../../signer";
 import { ExactEvmPayloadV1 } from "../../../types";
-import { createNonce, getEvmChainId } from "../../../utils";
-import { EvmNetworkV1 } from "../../../v1";
+import { createNonce } from "../../../utils";
+import { EvmNetworkV1, getEvmChainIdV1 } from "../../../v1";
 
 /**
  * EVM client implementation for the Exact payment scheme (V1).
@@ -78,7 +78,7 @@ export class ExactEvmSchemeV1 implements SchemeNetworkClient {
     authorization: ExactEvmPayloadV1["authorization"],
     requirements: PaymentRequirementsV1,
   ): Promise<`0x${string}`> {
-    const chainId = getEvmChainId(requirements.network as EvmNetworkV1);
+    const chainId = getEvmChainIdV1(requirements.network as EvmNetworkV1);
 
     if (!requirements.extra?.name || !requirements.extra?.version) {
       throw new Error(

--- a/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
@@ -11,8 +11,7 @@ import { getAddress, Hex, isAddressEqual, parseErc6492Signature, parseSignature 
 import { authorizationTypes, eip3009ABI } from "../../../constants";
 import { FacilitatorEvmSigner } from "../../../signer";
 import { ExactEvmPayloadV1 } from "../../../types";
-import { getEvmChainId } from "../../../utils";
-import { EvmNetworkV1 } from "../../../v1";
+import { EvmNetworkV1, getEvmChainIdV1 } from "../../../v1";
 
 export interface ExactEvmSchemeV1Config {
   /**
@@ -96,7 +95,7 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
     // Get chain configuration
     let chainId: number;
     try {
-      chainId = getEvmChainId(payloadV1.network as EvmNetworkV1);
+      chainId = getEvmChainIdV1(payloadV1.network as EvmNetworkV1);
     } catch {
       return {
         isValid: false,

--- a/typescript/packages/mechanisms/evm/src/utils.ts
+++ b/typescript/packages/mechanisms/evm/src/utils.ts
@@ -1,16 +1,11 @@
 import { toHex } from "viem";
-import { EVM_NETWORK_CHAIN_ID_MAP, EvmNetworkV1 } from "./v1";
 
 /**
- * Extract chain ID from a network identifier string.
+ * Extract chain ID from a CAIP-2 network identifier (eip155:CHAIN_ID).
  *
- * Supports two formats:
- * - CAIP-2: "eip155:8453" -> 8453
- * - Legacy v1 name: "base-sepolia" -> 84532
- *
- * @param network - The network identifier (CAIP-2 or legacy name)
+ * @param network - The network identifier in CAIP-2 format (e.g., "eip155:8453")
  * @returns The numeric chain ID
- * @throws Error if the network format is invalid or the name is unsupported
+ * @throws Error if the network format is invalid
  */
 export function getEvmChainId(network: string): number {
   if (network.startsWith("eip155:")) {
@@ -22,11 +17,7 @@ export function getEvmChainId(network: string): number {
     return chainId;
   }
 
-  const chainId = EVM_NETWORK_CHAIN_ID_MAP[network as EvmNetworkV1];
-  if (!chainId) {
-    throw new Error(`Unsupported network: ${network}`);
-  }
-  return chainId;
+  throw new Error(`Unsupported network format: ${network} (expected eip155:CHAIN_ID)`);
 }
 
 /**

--- a/typescript/packages/mechanisms/evm/src/v1/index.ts
+++ b/typescript/packages/mechanisms/evm/src/v1/index.ts
@@ -25,3 +25,18 @@ export const EVM_NETWORK_CHAIN_ID_MAP = {
 export type EvmNetworkV1 = keyof typeof EVM_NETWORK_CHAIN_ID_MAP;
 
 export const NETWORKS: string[] = Object.keys(EVM_NETWORK_CHAIN_ID_MAP);
+
+/**
+ * Extract chain ID from a v1 legacy network name.
+ *
+ * @param network - The v1 network name (e.g., "base-sepolia", "polygon")
+ * @returns The numeric chain ID
+ * @throws Error if the network name is not a known v1 network
+ */
+export function getEvmChainIdV1(network: string): number {
+  const chainId = EVM_NETWORK_CHAIN_ID_MAP[network as EvmNetworkV1];
+  if (!chainId) {
+    throw new Error(`Unsupported v1 network: ${network}`);
+  }
+  return chainId;
+}

--- a/typescript/packages/mechanisms/evm/test/unit/utils.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/utils.test.ts
@@ -1,81 +1,85 @@
 import { describe, it, expect } from "vitest";
 import { getEvmChainId, createNonce } from "../../src/utils";
-import { EvmNetworkV1 } from "../../src/v1";
+import { getEvmChainIdV1 } from "../../src/v1";
 
 describe("EVM Utils", () => {
-  describe("getEvmChainId", () => {
+  describe("getEvmChainId (CAIP-2 only)", () => {
+    it("should return correct chain ID for CAIP-2 Base", () => {
+      expect(getEvmChainId("eip155:8453")).toBe(8453);
+    });
+
+    it("should return correct chain ID for CAIP-2 Base Sepolia", () => {
+      expect(getEvmChainId("eip155:84532")).toBe(84532);
+    });
+
+    it("should return correct chain ID for CAIP-2 Ethereum", () => {
+      expect(getEvmChainId("eip155:1")).toBe(1);
+    });
+
+    it("should return correct chain ID for CAIP-2 Polygon", () => {
+      expect(getEvmChainId("eip155:137")).toBe(137);
+    });
+
+    it("should return correct chain ID for arbitrary CAIP-2 chain", () => {
+      expect(getEvmChainId("eip155:999999")).toBe(999999);
+    });
+
+    it("should throw for legacy network names", () => {
+      expect(() => getEvmChainId("base")).toThrow();
+    });
+
+    it("should throw for unsupported format", () => {
+      expect(() => getEvmChainId("unknown-network")).toThrow();
+    });
+
+    it("should throw for invalid CAIP-2 chain ID", () => {
+      expect(() => getEvmChainId("eip155:abc")).toThrow("Invalid CAIP-2 chain ID");
+    });
+  });
+
+  describe("getEvmChainIdV1 (legacy names)", () => {
     it("should return correct chain ID for Base", () => {
-      expect(getEvmChainId("base")).toBe(8453);
+      expect(getEvmChainIdV1("base")).toBe(8453);
     });
 
     it("should return correct chain ID for Base Sepolia", () => {
-      expect(getEvmChainId("base-sepolia")).toBe(84532);
+      expect(getEvmChainIdV1("base-sepolia")).toBe(84532);
     });
 
-    it("should return correct chain ID for Ethereum mainnet", () => {
-      expect(getEvmChainId("ethereum")).toBe(1);
-    });
-
-    it("should return correct chain ID for Sepolia", () => {
-      expect(getEvmChainId("sepolia")).toBe(11155111);
+    it("should return correct chain ID for Ethereum", () => {
+      expect(getEvmChainIdV1("ethereum")).toBe(1);
     });
 
     it("should return correct chain ID for Polygon", () => {
-      expect(getEvmChainId("polygon")).toBe(137);
+      expect(getEvmChainIdV1("polygon")).toBe(137);
     });
 
     it("should return correct chain ID for Polygon Amoy", () => {
-      expect(getEvmChainId("polygon-amoy")).toBe(80002);
+      expect(getEvmChainIdV1("polygon-amoy")).toBe(80002);
     });
 
     it("should return correct chain ID for Abstract", () => {
-      expect(getEvmChainId("abstract")).toBe(2741);
-    });
-
-    it("should return correct chain ID for Abstract Testnet", () => {
-      expect(getEvmChainId("abstract-testnet")).toBe(11124);
-    });
-
-    it("should return correct chain ID for Avalanche Fuji", () => {
-      expect(getEvmChainId("avalanche-fuji")).toBe(43113);
+      expect(getEvmChainIdV1("abstract")).toBe(2741);
     });
 
     it("should return correct chain ID for Avalanche", () => {
-      expect(getEvmChainId("avalanche")).toBe(43114);
+      expect(getEvmChainIdV1("avalanche")).toBe(43114);
     });
 
-    it("should return correct chain ID for IoTeX", () => {
-      expect(getEvmChainId("iotex")).toBe(4689);
+    it("should return correct chain ID for MegaETH", () => {
+      expect(getEvmChainIdV1("megaeth")).toBe(4326);
     });
 
-    it("should return correct chain ID for Sei", () => {
-      expect(getEvmChainId("sei")).toBe(1329);
+    it("should return correct chain ID for Monad", () => {
+      expect(getEvmChainIdV1("monad")).toBe(143);
     });
 
-    it("should return correct chain ID for Sei Testnet", () => {
-      expect(getEvmChainId("sei-testnet")).toBe(1328);
+    it("should throw for CAIP-2 format", () => {
+      expect(() => getEvmChainIdV1("eip155:8453")).toThrow("Unsupported v1 network");
     });
 
-    it("should return correct chain ID for Peaq", () => {
-      expect(getEvmChainId("peaq")).toBe(3338);
-    });
-
-    it("should return correct chain ID for Story", () => {
-      expect(getEvmChainId("story")).toBe(1514);
-    });
-
-    it("should return correct chain ID for Educhain", () => {
-      expect(getEvmChainId("educhain")).toBe(41923);
-    });
-
-    it("should return correct chain ID for Skale Base Sepolia", () => {
-      expect(getEvmChainId("skale-base-sepolia")).toBe(324705682);
-    });
-
-    it("should throw for unsupported network", () => {
-      expect(() => getEvmChainId("unknown-network" as EvmNetworkV1)).toThrow(
-        "Unsupported network: unknown-network",
-      );
+    it("should throw for unknown network", () => {
+      expect(() => getEvmChainIdV1("unknown-network")).toThrow("Unsupported v1 network");
     });
   });
 

--- a/typescript/packages/mechanisms/evm/test/unit/v1/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/v1/client.test.ts
@@ -202,7 +202,7 @@ describe("ExactEvmSchemeV1", () => {
       };
 
       await expect(client.createPaymentPayload(1, requirements as never)).rejects.toThrow(
-        "Unsupported network: unknown-network",
+        "Unsupported v1 network: unknown-network",
       );
     });
   });


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

The v1 network info was in a shared util that v2 code was using. This was leading to issues when trying to add new chains such as Polygon to the new SDK when declaring support for v1 networks

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 