### PR TITLE
feat: add retry with exponential backoff for GetSupported on 429

### DIFF
--- a/go/.changes/unreleased/changed-20260226-175344.yaml
+++ b/go/.changes/unreleased/changed-20260226-175344.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: GetSupported retries up to 3 times with exponential backoff on 429 rate limit responses
+time: 2026-02-26T17:53:44.305222+09:00

--- a/go/http/facilitator_client.go
+++ b/go/http/facilitator_client.go
@@ -60,6 +60,12 @@ type FacilitatorConfig struct {
 // DefaultFacilitatorURL is the default public facilitator
 const DefaultFacilitatorURL = "https://x402.org/facilitator"
 
+// getSupportedRetries is the number of retry attempts for GetSupported on 429 rate limit errors
+const getSupportedRetries = 3
+
+// getSupportedRetryBaseDelay is the base delay for exponential backoff on retries
+const getSupportedRetryBaseDelay = 1 * time.Second
+
 // NewHTTPFacilitatorClient creates a new HTTP facilitator client
 func NewHTTPFacilitatorClient(config *FacilitatorConfig) *HTTPFacilitatorClient {
 	if config == nil {
@@ -121,52 +127,71 @@ func (c *HTTPFacilitatorClient) Settle(ctx context.Context, payloadBytes []byte,
 	return c.settleHTTP(ctx, version, payloadBytes, requirementsBytes)
 }
 
-// GetSupported gets supported payment kinds (shared by both V1 and V2)
+// GetSupported gets supported payment kinds (shared by both V1 and V2).
+// Retries up to 3 times with exponential backoff on 429 rate limit errors.
 func (c *HTTPFacilitatorClient) GetSupported(ctx context.Context) (x402.SupportedResponse, error) {
-	// Create request
-	req, err := http.NewRequestWithContext(ctx, "GET", c.url+"/supported", nil)
-	if err != nil {
-		return x402.SupportedResponse{}, fmt.Errorf("failed to create supported request: %w", err)
-	}
+	var lastErr error
 
-	req.Header.Set("Content-Type", "application/json")
-
-	// Add auth headers if available
-	if c.authProvider != nil {
-		authHeaders, err := c.authProvider.GetAuthHeaders(ctx)
+	for attempt := range getSupportedRetries {
+		// Create request
+		req, err := http.NewRequestWithContext(ctx, "GET", c.url+"/supported", nil)
 		if err != nil {
-			return x402.SupportedResponse{}, fmt.Errorf("failed to get auth headers: %w", err)
+			return x402.SupportedResponse{}, fmt.Errorf("failed to create supported request: %w", err)
 		}
-		for k, v := range authHeaders.Supported {
-			req.Header.Set(k, v)
+
+		req.Header.Set("Content-Type", "application/json")
+
+		// Add auth headers if available
+		if c.authProvider != nil {
+			authHeaders, err := c.authProvider.GetAuthHeaders(ctx)
+			if err != nil {
+				return x402.SupportedResponse{}, fmt.Errorf("failed to get auth headers: %w", err)
+			}
+			for k, v := range authHeaders.Supported {
+				req.Header.Set(k, v)
+			}
 		}
+
+		// Make request
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return x402.SupportedResponse{}, fmt.Errorf("supported request failed: %w", err)
+		}
+
+		// Read response body
+		responseBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return x402.SupportedResponse{}, fmt.Errorf("failed to read response body: %w", err)
+		}
+
+		// Success
+		if resp.StatusCode == http.StatusOK {
+			var supportedResponse x402.SupportedResponse
+			if err := json.Unmarshal(responseBody, &supportedResponse); err != nil {
+				return x402.SupportedResponse{}, fmt.Errorf("failed to decode supported response: %w", err)
+			}
+			return supportedResponse, nil
+		}
+
+		lastErr = fmt.Errorf("facilitator supported failed (%d): %s", resp.StatusCode, string(responseBody))
+
+		// Retry on 429 with exponential backoff, except on the last attempt
+		if resp.StatusCode == http.StatusTooManyRequests && attempt < getSupportedRetries-1 {
+			delay := getSupportedRetryBaseDelay * time.Duration(1<<uint(attempt))
+			select {
+			case <-time.After(delay):
+				continue
+			case <-ctx.Done():
+				return x402.SupportedResponse{}, ctx.Err()
+			}
+		}
+
+		// Non-429 errors or last attempt: return immediately
+		return x402.SupportedResponse{}, lastErr
 	}
 
-	// Make request
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return x402.SupportedResponse{}, fmt.Errorf("supported request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Read response body
-	responseBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return x402.SupportedResponse{}, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	// Check status
-	if resp.StatusCode != http.StatusOK {
-		return x402.SupportedResponse{}, fmt.Errorf("facilitator supported failed (%d): %s", resp.StatusCode, string(responseBody))
-	}
-
-	// Parse response
-	var supportedResponse x402.SupportedResponse
-	if err := json.Unmarshal(responseBody, &supportedResponse); err != nil {
-		return x402.SupportedResponse{}, fmt.Errorf("failed to decode supported response: %w", err)
-	}
-
-	return supportedResponse, nil
+	return x402.SupportedResponse{}, lastErr
 }
 
 // ============================================================================


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

### Summary

- Add retry logic with exponential backoff to `HTTPFacilitatorClient.GetSupported()` for 429 (Too Many Requests) responses
- Matches existing TypeScript behavior in `HTTPFacilitatorClient.getSupported()`

### Details

The Go `GetSupported()` previously made a single HTTP call and returned immediately on any non-200 response. The TypeScript implementation already retries on 429 with exponential backoff (3 attempts, 1s base delay).

```typescript
// typescript/packages/core/src/http/httpFacilitatorClient.ts
async getSupported(): Promise<SupportedResponse> {
  let headers: Record<string, string> = {
    "Content-Type": "application/json",
  };

  if (this._createAuthHeaders) {
    const authHeaders = await this.createAuthHeaders("supported");
    headers = { ...headers, ...authHeaders.headers };
  }

  let lastError: Error | null = null;
  for (let attempt = 0; attempt < GET_SUPPORTED_RETRIES; attempt++) {
    const response = await fetch(`${this.url}/supported`, {
      method: "GET",
      headers,
    });

    if (response.ok) {
      return (await response.json()) as SupportedResponse;
    }

    const errorText = await response.text().catch(() => response.statusText);
    lastError = new Error(`Facilitator getSupported failed (${response.status}): ${errorText}`);

    // Retry on 429 rate limit errors with exponential backoff
    if (response.status === 429 && attempt < GET_SUPPORTED_RETRIES - 1) {
      const delay = GET_SUPPORTED_RETRY_DELAY_MS * Math.pow(2, attempt);
      await new Promise(resolve => setTimeout(resolve, delay));
      continue;
    }

    throw lastError;
  }

  throw lastError ?? new Error("Facilitator getSupported failed after retries");
}
```

This change brings Go to parity:

- **3 retry attempts** on 429 responses
- **Exponential backoff**: 1s → 2s → 4s
- **Context cancellation** respected during backoff wait
- Non-429 errors return immediately (no retry)

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

- [x] `TestGetSupportedRetryOn429ThenSuccess` — 429 twice, then 200 → succeeds on 3rd attempt
- [x] `TestGetSupportedRetryExhausted` — 429 on all 3 attempts → returns error
- [x] `TestGetSupportedNoRetryOnNon429Error` — 500 → returns error immediately, no retry
- [x] `TestGetSupportedRetryRespectsContextCancellation` — context timeout during backoff → returns ctx.Err()
- [x] `TestGetSupportedSuccessOnFirstAttempt` — 200 on first call → no retry, returns immediately
- [x] All 36 existing http package tests pass

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 