### PR TITLE
feat(go): add route configuration validation during initialization

### DIFF
--- a/go/.changes/unreleased/added-20260227-085721.yaml
+++ b/go/.changes/unreleased/added-20260227-085721.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Add route configuration validation during Initialize() to catch scheme/facilitator mismatches at startup
+time: 2026-02-27T08:57:21.873969+09:00

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -169,6 +169,44 @@ type ProcessSettleResult struct {
 }
 
 // ============================================================================
+// Route Validation Types
+// ============================================================================
+
+// RouteValidationError represents a single validation failure for a route's payment option
+type RouteValidationError struct {
+	// RoutePattern is the route pattern (e.g., "GET /api/weather")
+	RoutePattern string
+
+	// Scheme is the payment scheme that failed validation
+	Scheme string
+
+	// Network is the network that failed validation
+	Network x402.Network
+
+	// Reason is the type of validation failure: "missing_scheme" or "missing_facilitator"
+	Reason string
+
+	// Message is a human-readable error message
+	Message string
+}
+
+// RouteConfigurationError collects all route validation errors
+type RouteConfigurationError struct {
+	// Errors contains all validation failures
+	Errors []RouteValidationError
+}
+
+// Error returns a formatted error message listing all validation failures
+func (e *RouteConfigurationError) Error() string {
+	lines := make([]string, 0, len(e.Errors)+1)
+	lines = append(lines, "x402 Route Configuration Errors:")
+	for _, err := range e.Errors {
+		lines = append(lines, "  - "+err.Message)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ============================================================================
 // x402HTTPResourceServer
 // ============================================================================
 
@@ -207,6 +245,59 @@ func Wrappedx402HTTPResourceServer(routes RoutesConfig, resourceServer *x402.X40
 	}
 
 	return server
+}
+
+// Initialize initializes the server by populating facilitator data and validating route configuration.
+// It calls the parent server's Initialize to fetch facilitator support, then validates that all
+// configured routes have matching scheme registrations and facilitator support.
+func (s *x402HTTPResourceServer) Initialize(ctx context.Context) error {
+	// First, initialize the parent (populates facilitatorClients from GetSupported)
+	if err := s.X402ResourceServer.Initialize(ctx); err != nil {
+		return err
+	}
+
+	// Then validate route configuration against registered schemes and facilitator support
+	return s.validateRouteConfiguration()
+}
+
+// validateRouteConfiguration checks that all configured routes have matching scheme registrations
+// and facilitator support. Returns a RouteConfigurationError if any mismatches are found.
+func (s *x402HTTPResourceServer) validateRouteConfiguration() error {
+	var errors []RouteValidationError
+
+	for _, route := range s.compiledRoutes {
+		for _, option := range route.Config.Accepts {
+			// Check 1: Is the scheme registered for this network?
+			if !s.HasRegisteredScheme(option.Network, option.Scheme) {
+				errors = append(errors, RouteValidationError{
+					RoutePattern: route.Verb + " " + route.Regex.String(),
+					Scheme:       option.Scheme,
+					Network:      option.Network,
+					Reason:       "missing_scheme",
+					Message:      fmt.Sprintf("Route %q: No scheme implementation registered for %q on network %q", route.Verb+" "+route.Regex.String(), option.Scheme, option.Network),
+				})
+				// Skip facilitator check if scheme isn't registered
+				continue
+			}
+
+			// Check 2: Does a facilitator support this scheme/network combination?
+			if !s.HasFacilitatorSupport(option.Network, option.Scheme) {
+				errors = append(errors, RouteValidationError{
+					RoutePattern: route.Verb + " " + route.Regex.String(),
+					Scheme:       option.Scheme,
+					Network:      option.Network,
+					Reason:       "missing_facilitator",
+					Message:      fmt.Sprintf("Route %q: Facilitator does not support scheme %q on network %q", route.Verb+" "+route.Regex.String(), option.Scheme, option.Network),
+				})
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return &RouteConfigurationError{Errors: errors}
+	}
+
+	return nil
 }
 
 // BuildPaymentRequirementsFromOptions builds payment requirements from multiple payment options

--- a/go/server.go
+++ b/go/server.go
@@ -149,6 +149,32 @@ func (s *x402ResourceServer) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// HasRegisteredScheme checks if a scheme is registered for a given network
+func (s *x402ResourceServer) HasRegisteredScheme(network Network, scheme string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	networkSchemes, ok := s.schemes[network]
+	if !ok {
+		return false
+	}
+	_, exists := networkSchemes[scheme]
+	return exists
+}
+
+// HasFacilitatorSupport checks if a facilitator client supports a given network/scheme combination
+func (s *x402ResourceServer) HasFacilitatorSupport(network Network, scheme string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	networkClients, ok := s.facilitatorClients[network]
+	if !ok {
+		return false
+	}
+	_, exists := networkClients[scheme]
+	return exists
+}
+
 // Register registers a payment mechanism (V2, default)
 func (s *x402ResourceServer) Register(network Network, schemeServer SchemeNetworkServer) *x402ResourceServer {
 	s.mu.Lock()


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

### Summary

- Add `validateRouteConfiguration()` to Go HTTP server, matching TypeScript's existing implementation
- Server now validates that all route payment options have matching registered schemes and facilitator support during `Initialize()`
- Catches configuration mismatches at startup instead of failing silently at runtime when payment requests arrive

### Changes

- `go/server.go`: Add `HasRegisteredScheme()` and `HasFacilitatorSupport()` helper methods
- `go/http/server.go`: Add `RouteValidationError`, `RouteConfigurationError` types and `validateRouteConfiguration()` / `Initialize()` methods
- `go/http/server_test.go`: Add 6 tests covering success, missing scheme, missing facilitator, multiple errors, empty routes, and error message formatting

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

- [x] All 6 new validation tests pass
- [x] All existing tests pass (no breaking changes)
- [x] Verify `Initialize()` returns clear error when route config doesn't match registered schemes
- [x] Verify `Initialize()` returns clear error when facilitator doesn't support configured network/scheme

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 