### PR TITLE
feat(go/http): add pluggable PaywallProvider for custom paywall HTML generation

### DIFF
--- a/go/.changes/unreleased/changed-20260227-153504.yaml
+++ b/go/.changes/unreleased/changed-20260227-153504.yaml
@@ -1,0 +1,3 @@
+kind: changed
+body: Add pluggable PaywallProvider interface for custom paywall HTML generation with PaywallBuilder pattern
+time: 2026-02-27T15:35:04.609332+09:00

--- a/go/http/paywall.go
+++ b/go/http/paywall.go
@@ -1,0 +1,126 @@
+package http
+
+import (
+	"strings"
+
+	"github.com/coinbase/x402/go/types"
+)
+
+// ============================================================================
+// Paywall Provider Interfaces
+// ============================================================================
+
+// PaywallProvider generates HTML for browser-facing 402 responses.
+// Register a custom implementation via RegisterPaywallProvider to override
+// the built-in EVM/SVM templates.
+type PaywallProvider interface {
+	GenerateHTML(paymentRequired types.PaymentRequired, config *PaywallConfig) string
+}
+
+// PaywallNetworkHandler handles paywall HTML generation for a specific network family.
+// Used with PaywallBuilder to compose network-specific handlers into a single PaywallProvider.
+type PaywallNetworkHandler interface {
+	// Supports returns true if this handler can generate HTML for the given payment requirement.
+	Supports(requirement types.PaymentRequirements) bool
+
+	// GenerateHTML generates the paywall HTML for the given requirement.
+	GenerateHTML(requirement types.PaymentRequirements, paymentRequired types.PaymentRequired, config *PaywallConfig) string
+}
+
+// ============================================================================
+// Built-in Network Handlers
+// ============================================================================
+
+// EVMPaywallHandler generates paywall HTML for EVM-compatible networks (eip155:*).
+type EVMPaywallHandler struct{}
+
+// Supports returns true for EVM networks (eip155:* CAIP-2 identifiers).
+func (h *EVMPaywallHandler) Supports(requirement types.PaymentRequirements) bool {
+	return strings.HasPrefix(requirement.Network, "eip155:")
+}
+
+// GenerateHTML generates paywall HTML using the built-in EVM template.
+func (h *EVMPaywallHandler) GenerateHTML(_ types.PaymentRequirements, paymentRequired types.PaymentRequired, config *PaywallConfig) string {
+	return injectPaywallConfig(EVMPaywallTemplate, paymentRequired, config)
+}
+
+// SVMPaywallHandler generates paywall HTML for Solana networks (solana:*).
+type SVMPaywallHandler struct{}
+
+// Supports returns true for Solana networks (solana:* CAIP-2 identifiers).
+func (h *SVMPaywallHandler) Supports(requirement types.PaymentRequirements) bool {
+	return strings.HasPrefix(requirement.Network, "solana:")
+}
+
+// GenerateHTML generates paywall HTML using the built-in SVM template.
+func (h *SVMPaywallHandler) GenerateHTML(_ types.PaymentRequirements, paymentRequired types.PaymentRequired, config *PaywallConfig) string {
+	return injectPaywallConfig(SVMPaywallTemplate, paymentRequired, config)
+}
+
+// ============================================================================
+// Paywall Builder
+// ============================================================================
+
+// PaywallBuilder composes multiple PaywallNetworkHandlers into a single PaywallProvider.
+// Use NewPaywallBuilder to create a builder, add network handlers, and call Build.
+type PaywallBuilder struct {
+	handlers []PaywallNetworkHandler
+	config   *PaywallConfig
+}
+
+// NewPaywallBuilder creates a new PaywallBuilder.
+func NewPaywallBuilder() *PaywallBuilder {
+	return &PaywallBuilder{}
+}
+
+// WithNetwork adds a network handler to the builder.
+func (b *PaywallBuilder) WithNetwork(handler PaywallNetworkHandler) *PaywallBuilder {
+	b.handlers = append(b.handlers, handler)
+	return b
+}
+
+// WithConfig sets default paywall configuration for the builder.
+func (b *PaywallBuilder) WithConfig(config *PaywallConfig) *PaywallBuilder {
+	b.config = config
+	return b
+}
+
+// Build creates a PaywallProvider that dispatches to the first matching network handler.
+func (b *PaywallBuilder) Build() PaywallProvider {
+	return &compositePaywallProvider{
+		handlers: b.handlers,
+		config:   b.config,
+	}
+}
+
+// compositePaywallProvider dispatches to the first handler that supports the payment requirement.
+type compositePaywallProvider struct {
+	handlers []PaywallNetworkHandler
+	config   *PaywallConfig
+}
+
+func (p *compositePaywallProvider) GenerateHTML(paymentRequired types.PaymentRequired, config *PaywallConfig) string {
+	// Use builder config as fallback if no per-call config provided
+	effectiveConfig := config
+	if effectiveConfig == nil {
+		effectiveConfig = p.config
+	}
+
+	for _, req := range paymentRequired.Accepts {
+		for _, handler := range p.handlers {
+			if handler.Supports(req) {
+				return handler.GenerateHTML(req, paymentRequired, effectiveConfig)
+			}
+		}
+	}
+
+	return ""
+}
+
+// DefaultPaywallProvider creates a PaywallProvider with built-in EVM and SVM handlers.
+func DefaultPaywallProvider() PaywallProvider {
+	return NewPaywallBuilder().
+		WithNetwork(&EVMPaywallHandler{}).
+		WithNetwork(&SVMPaywallHandler{}).
+		Build()
+}

--- a/go/http/paywall_test.go
+++ b/go/http/paywall_test.go
@@ -1,0 +1,325 @@
+package http
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coinbase/x402/go/types"
+)
+
+// mockPaywallProvider is a test PaywallProvider that returns configurable HTML.
+type mockPaywallProvider struct {
+	html string
+}
+
+func (m *mockPaywallProvider) GenerateHTML(_ types.PaymentRequired, _ *PaywallConfig) string {
+	return m.html
+}
+
+// mockNetworkHandler is a test PaywallNetworkHandler for a configurable network prefix.
+type mockNetworkHandler struct {
+	prefix string
+	html   string
+}
+
+func (m *mockNetworkHandler) Supports(req types.PaymentRequirements) bool {
+	return strings.HasPrefix(req.Network, m.prefix)
+}
+
+func (m *mockNetworkHandler) GenerateHTML(_ types.PaymentRequirements, _ types.PaymentRequired, _ *PaywallConfig) string {
+	return m.html
+}
+
+func makePaymentRequired(network string) types.PaymentRequired {
+	return types.PaymentRequired{
+		X402Version: 2,
+		Accepts: []types.PaymentRequirements{
+			{
+				Scheme:  "exact",
+				Network: network,
+				Asset:   "USDC",
+				Amount:  "1000000",
+				PayTo:   "0xtest",
+			},
+		},
+		Resource: &types.ResourceInfo{
+			URL:         "/api/test",
+			Description: "Test API",
+		},
+	}
+}
+
+// --- EVMPaywallHandler tests ---
+
+func TestEVMPaywallHandler_Supports(t *testing.T) {
+	handler := &EVMPaywallHandler{}
+
+	tests := []struct {
+		network string
+		want    bool
+	}{
+		{"eip155:1", true},
+		{"eip155:8453", true},
+		{"eip155:84532", true},
+		{"solana:mainnet", false},
+		{"solana:devnet", false},
+		{"aptos:mainnet", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.network, func(t *testing.T) {
+			req := types.PaymentRequirements{Network: tt.network}
+			got := handler.Supports(req)
+			if got != tt.want {
+				t.Errorf("EVMPaywallHandler.Supports(%q) = %v, want %v", tt.network, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- SVMPaywallHandler tests ---
+
+func TestSVMPaywallHandler_Supports(t *testing.T) {
+	handler := &SVMPaywallHandler{}
+
+	tests := []struct {
+		network string
+		want    bool
+	}{
+		{"solana:mainnet", true},
+		{"solana:devnet", true},
+		{"eip155:1", false},
+		{"eip155:8453", false},
+		{"aptos:mainnet", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.network, func(t *testing.T) {
+			req := types.PaymentRequirements{Network: tt.network}
+			got := handler.Supports(req)
+			if got != tt.want {
+				t.Errorf("SVMPaywallHandler.Supports(%q) = %v, want %v", tt.network, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- PaywallBuilder tests ---
+
+func TestPaywallBuilder_Build(t *testing.T) {
+	provider := NewPaywallBuilder().
+		WithNetwork(&mockNetworkHandler{prefix: "eip155:", html: "<evm-html>"}).
+		WithNetwork(&mockNetworkHandler{prefix: "solana:", html: "<svm-html>"}).
+		Build()
+
+	t.Run("matches EVM network", func(t *testing.T) {
+		got := provider.GenerateHTML(makePaymentRequired("eip155:8453"), nil)
+		if got != "<evm-html>" {
+			t.Errorf("expected <evm-html>, got %q", got)
+		}
+	})
+
+	t.Run("matches Solana network", func(t *testing.T) {
+		got := provider.GenerateHTML(makePaymentRequired("solana:mainnet"), nil)
+		if got != "<svm-html>" {
+			t.Errorf("expected <svm-html>, got %q", got)
+		}
+	})
+
+	t.Run("no match returns empty string", func(t *testing.T) {
+		got := provider.GenerateHTML(makePaymentRequired("aptos:mainnet"), nil)
+		if got != "" {
+			t.Errorf("expected empty string for unsupported network, got %q", got)
+		}
+	})
+}
+
+func TestPaywallBuilder_WithConfig(t *testing.T) {
+	var capturedConfig *PaywallConfig
+
+	handler := &configCapturingHandler{
+		prefix: "eip155:",
+		onGenerate: func(config *PaywallConfig) {
+			capturedConfig = config
+		},
+	}
+
+	builderConfig := &PaywallConfig{AppName: "TestApp", Testnet: true}
+	provider := NewPaywallBuilder().
+		WithNetwork(handler).
+		WithConfig(builderConfig).
+		Build()
+
+	t.Run("uses builder config when no per-call config", func(t *testing.T) {
+		provider.GenerateHTML(makePaymentRequired("eip155:1"), nil)
+		if capturedConfig == nil || capturedConfig.AppName != "TestApp" {
+			t.Errorf("expected builder config to be used, got %+v", capturedConfig)
+		}
+	})
+
+	t.Run("per-call config overrides builder config", func(t *testing.T) {
+		callConfig := &PaywallConfig{AppName: "CallApp"}
+		provider.GenerateHTML(makePaymentRequired("eip155:1"), callConfig)
+		if capturedConfig == nil || capturedConfig.AppName != "CallApp" {
+			t.Errorf("expected per-call config to override, got %+v", capturedConfig)
+		}
+	})
+}
+
+type configCapturingHandler struct {
+	prefix     string
+	onGenerate func(config *PaywallConfig)
+}
+
+func (h *configCapturingHandler) Supports(req types.PaymentRequirements) bool {
+	return strings.HasPrefix(req.Network, h.prefix)
+}
+
+func (h *configCapturingHandler) GenerateHTML(_ types.PaymentRequirements, _ types.PaymentRequired, config *PaywallConfig) string {
+	if h.onGenerate != nil {
+		h.onGenerate(config)
+	}
+	return "<captured>"
+}
+
+// --- DefaultPaywallProvider tests ---
+
+func TestDefaultPaywallProvider(t *testing.T) {
+	provider := DefaultPaywallProvider()
+
+	t.Run("EVM network returns non-empty HTML", func(t *testing.T) {
+		got := provider.GenerateHTML(makePaymentRequired("eip155:8453"), nil)
+		if got == "" {
+			t.Error("expected non-empty HTML for EVM network")
+		}
+		if !strings.Contains(got, "window.x402") {
+			t.Error("expected window.x402 config injection in HTML")
+		}
+	})
+
+	t.Run("Solana network returns non-empty HTML", func(t *testing.T) {
+		got := provider.GenerateHTML(makePaymentRequired("solana:mainnet"), nil)
+		if got == "" {
+			t.Error("expected non-empty HTML for Solana network")
+		}
+		if !strings.Contains(got, "window.x402") {
+			t.Error("expected window.x402 config injection in HTML")
+		}
+	})
+
+	t.Run("unsupported network returns empty", func(t *testing.T) {
+		got := provider.GenerateHTML(makePaymentRequired("aptos:mainnet"), nil)
+		if got != "" {
+			t.Errorf("expected empty string for unsupported network, got length %d", len(got))
+		}
+	})
+}
+
+// --- RegisterPaywallProvider integration tests ---
+
+func TestRegisterPaywallProvider(t *testing.T) {
+	routes := RoutesConfig{
+		"GET /api/test": {
+			Accepts: PaymentOptions{
+				{
+					Scheme:  "exact",
+					PayTo:   "0xtest",
+					Price:   "$1.00",
+					Network: "eip155:8453",
+				},
+			},
+		},
+	}
+
+	t.Run("returns server for chaining", func(t *testing.T) {
+		server := Newx402HTTPResourceServer(routes)
+		result := server.RegisterPaywallProvider(&mockPaywallProvider{html: "<custom>"})
+		if result != server {
+			t.Error("expected RegisterPaywallProvider to return the same server instance")
+		}
+	})
+
+	t.Run("registered provider is used in generatePaywallHTMLV2", func(t *testing.T) {
+		server := Newx402HTTPResourceServer(routes)
+		server.RegisterPaywallProvider(&mockPaywallProvider{html: "<custom-paywall>"})
+
+		got := server.generatePaywallHTMLV2(makePaymentRequired("eip155:8453"), nil, "")
+		if got != "<custom-paywall>" {
+			t.Errorf("expected <custom-paywall>, got %q", got)
+		}
+	})
+
+	t.Run("CustomPaywallHTML takes priority over provider", func(t *testing.T) {
+		server := Newx402HTTPResourceServer(routes)
+		server.RegisterPaywallProvider(&mockPaywallProvider{html: "<custom-paywall>"})
+
+		got := server.generatePaywallHTMLV2(makePaymentRequired("eip155:8453"), nil, "<route-custom>")
+		if got != "<route-custom>" {
+			t.Errorf("expected <route-custom>, got %q", got)
+		}
+	})
+
+	t.Run("no provider falls back to built-in template", func(t *testing.T) {
+		server := Newx402HTTPResourceServer(routes)
+
+		got := server.generatePaywallHTMLV2(makePaymentRequired("eip155:8453"), nil, "")
+		if got == "" {
+			t.Error("expected non-empty HTML from built-in template")
+		}
+		if !strings.Contains(got, "window.x402") {
+			t.Error("expected built-in template with window.x402 injection")
+		}
+	})
+}
+
+// --- injectPaywallConfig tests ---
+
+func TestInjectPaywallConfig(t *testing.T) {
+	template := "<html><body></body></html>"
+	paymentReq := makePaymentRequired("eip155:8453")
+
+	t.Run("injects window.x402 config", func(t *testing.T) {
+		got := injectPaywallConfig(template, paymentReq, nil)
+		if !strings.Contains(got, "window.x402") {
+			t.Error("expected window.x402 in output")
+		}
+		if !strings.Contains(got, "</body>") {
+			t.Error("expected </body> to remain in output")
+		}
+	})
+
+	t.Run("includes PaywallConfig values", func(t *testing.T) {
+		config := &PaywallConfig{
+			AppName: "TestApp",
+			AppLogo: "https://example.com/logo.png",
+			Testnet: true,
+		}
+		got := injectPaywallConfig(template, paymentReq, config)
+		if !strings.Contains(got, "TestApp") {
+			t.Error("expected appName in output")
+		}
+		if !strings.Contains(got, "https://example.com/logo.png") {
+			t.Error("expected appLogo in output")
+		}
+		if !strings.Contains(got, "testnet: true") {
+			t.Error("expected testnet: true in output")
+		}
+	})
+
+	t.Run("escapes HTML in config values", func(t *testing.T) {
+		config := &PaywallConfig{AppName: `<script>alert("xss")</script>`}
+		got := injectPaywallConfig(template, paymentReq, config)
+		if strings.Contains(got, `<script>alert("xss")</script>`) {
+			t.Error("expected HTML-escaped appName, got raw script tag")
+		}
+	})
+
+	t.Run("uses resource URL as currentUrl fallback", func(t *testing.T) {
+		got := injectPaywallConfig(template, paymentReq, nil)
+		if !strings.Contains(got, "/api/test") {
+			t.Error("expected resource URL as currentUrl fallback")
+		}
+	})
+}


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

### Summary

- Add `PaywallProvider` and `PaywallNetworkHandler` interfaces for pluggable paywall HTML generation
- Add `RegisterPaywallProvider()` method on `x402HTTPResourceServer` for runtime registration
- Add `PaywallBuilder` for composing network-specific handlers (matching TypeScript's `createPaywall().withNetwork().build()` pattern)
- Provide built-in `EVMPaywallHandler` and `SVMPaywallHandler` implementations
- Extract `injectPaywallConfig` helper for template hydration

### Motivation

The TypeScript SDK supports `registerPaywallProvider()` for custom paywall HTML generation, enabling dynamic branding, network-specific wallet UIs, and reusable templates across routes. 
The Go SDK only had hardcoded EVM/SVM templates with a static `CustomPaywallHTML` string as the sole override — no way to register a dynamic generator at runtime.

### Paywall generation fallback chain (after this change)

1. Per-route `CustomPaywallHTML` (static string, highest priority)
2. **Registered `PaywallProvider`** (new — dynamic, pluggable)
3. Built-in EVM/SVM templates (existing default fallback)

Fully backward-compatible — if no provider is registered, behavior is identical to before.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

- [x] `EVMPaywallHandler.Supports` correctly matches `eip155:*` networks
- [x] `SVMPaywallHandler.Supports` correctly matches `solana:*` networks
- [x] `PaywallBuilder` dispatches to correct network handler
- [x] Builder config used as fallback, per-call config takes priority
- [x] `DefaultPaywallProvider` generates HTML for EVM and SVM networks
- [x] `RegisterPaywallProvider` returns server for method chaining
- [x] Registered provider is used in `generatePaywallHTMLV2`
- [x] `CustomPaywallHTML` takes priority over registered provider
- [x] No provider falls back to built-in templates
- [x] `injectPaywallConfig` correctly injects and HTML-escapes config values
- [x] All existing tests pass (no regressions)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 