### PR TITLE
feat(go/http): add onProtectedRequest hook for pre-payment request interception

### DIFF
--- a/go/.changes/unreleased/added-20260227-175046.yaml
+++ b/go/.changes/unreleased/added-20260227-175046.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Added `onProtectedRequest` hook to HTTP resource server
+time: 2026-02-27T17:50:46.051464+09:00

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -193,6 +193,45 @@ func PaymentMiddleware(routes x402http.RoutesConfig, server *x402.X402ResourceSe
 	return createMiddlewareHandler(httpServer, config)
 }
 
+// PaymentMiddlewareFromHTTPServer creates Gin middleware using a pre-configured HTTPServer.
+// This allows registering hooks (e.g., OnProtectedRequest) on the server before attaching to the router.
+//
+// Example:
+//
+//	resourceServer := x402.Newx402ResourceServer(
+//	    x402.WithFacilitatorClient(facilitator),
+//	).Register("eip155:*", evm.NewExactEvmScheme())
+//
+//	httpServer := x402http.Wrappedx402HTTPResourceServer(routes, resourceServer).
+//	    OnProtectedRequest(requestHook)
+//
+//	r.Use(ginmw.PaymentMiddlewareFromHTTPServer(httpServer))
+func PaymentMiddlewareFromHTTPServer(httpServer *x402http.HTTPServer, opts ...MiddlewareOption) gin.HandlerFunc {
+	config := &MiddlewareConfig{
+		SyncFacilitatorOnStart: true,
+		Timeout:                30 * time.Second,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	httpServer.RegisterExtension(bazaar.BazaarResourceServerExtension)
+
+	// Initialize if requested - queries facilitator /supported to populate facilitatorClients map
+	if config.SyncFacilitatorOnStart {
+		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+		defer cancel()
+		if err := httpServer.Initialize(ctx); err != nil {
+			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
+		}
+	}
+
+	// Create middleware handler using shared logic
+	return createMiddlewareHandler(httpServer, config)
+}
+
 // PaymentMiddlewareFromConfig creates Gin middleware for x402 payment handling.
 // This creates the server internally from the provided options.
 func PaymentMiddlewareFromConfig(routes x402http.RoutesConfig, opts ...MiddlewareOption) gin.HandlerFunc {

--- a/go/http/gin/middleware_test.go
+++ b/go/http/gin/middleware_test.go
@@ -883,6 +883,213 @@ func TestPaymentMiddleware_WithTimeout(t *testing.T) {
 }
 
 // ============================================================================
+// PaymentMiddlewareFromHTTPServer Tests
+// ============================================================================
+
+func TestPaymentMiddlewareFromHTTPServer_Returns402ForProtectedRoute(t *testing.T) {
+	mockClient := &mockFacilitatorClient{
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	routes := x402http.RoutesConfig{
+		"GET /api": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{
+					Scheme:  "exact",
+					PayTo:   "0xtest",
+					Price:   "$1.00",
+					Network: "eip155:1",
+				},
+			},
+		},
+	}
+
+	// Build the resource server externally
+	resourceServer := x402.Newx402ResourceServer(
+		x402.WithFacilitatorClient(mockClient),
+	)
+	resourceServer.Register("eip155:1", &mockSchemeServer{scheme: "exact"})
+
+	// Wrap with HTTP server
+	httpServer := x402http.Wrappedx402HTTPResourceServer(routes, resourceServer)
+
+	// Use PaymentMiddlewareFromHTTPServer
+	router := createTestRouter()
+	router.Use(PaymentMiddlewareFromHTTPServer(httpServer, WithTimeout(5*time.Second)))
+
+	router.GET("/api", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"data": "protected"})
+	})
+
+	req := httptest.NewRequest("GET", "/api", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("Expected status 402, got %d", w.Code)
+	}
+}
+
+func TestPaymentMiddlewareFromHTTPServer_PassesThroughNonProtectedRoute(t *testing.T) {
+	routes := x402http.RoutesConfig{
+		"GET /api": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{
+					Scheme:  "exact",
+					PayTo:   "0xtest",
+					Price:   "$1.00",
+					Network: "eip155:1",
+				},
+			},
+		},
+	}
+
+	resourceServer := x402.Newx402ResourceServer()
+	httpServer := x402http.Wrappedx402HTTPResourceServer(routes, resourceServer)
+
+	router := createTestRouter()
+	router.Use(PaymentMiddlewareFromHTTPServer(httpServer, WithSyncFacilitatorOnStart(false)))
+
+	nextCalled := false
+	router.GET("/public", func(c *gin.Context) {
+		nextCalled = true
+		c.JSON(http.StatusOK, gin.H{"message": "public"})
+	})
+
+	req := httptest.NewRequest("GET", "/public", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if !nextCalled {
+		t.Error("Expected next() to be called for non-protected route")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestPaymentMiddlewareFromHTTPServer_HookGrantsAccess(t *testing.T) {
+	mockClient := &mockFacilitatorClient{
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	routes := x402http.RoutesConfig{
+		"GET /api": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{
+					Scheme:  "exact",
+					PayTo:   "0xtest",
+					Price:   "$1.00",
+					Network: "eip155:1",
+				},
+			},
+		},
+	}
+
+	resourceServer := x402.Newx402ResourceServer(
+		x402.WithFacilitatorClient(mockClient),
+	)
+	resourceServer.Register("eip155:1", &mockSchemeServer{scheme: "exact"})
+
+	// Register a hook that grants free access
+	httpServer := x402http.Wrappedx402HTTPResourceServer(routes, resourceServer).
+		OnProtectedRequest(func(ctx context.Context, reqCtx x402http.HTTPRequestContext, routeConfig x402http.RouteConfig) (*x402http.ProtectedRequestHookResult, error) {
+			return &x402http.ProtectedRequestHookResult{GrantAccess: true}, nil
+		})
+
+	router := createTestRouter()
+	router.Use(PaymentMiddlewareFromHTTPServer(httpServer, WithTimeout(5*time.Second)))
+
+	nextCalled := false
+	router.GET("/api", func(c *gin.Context) {
+		nextCalled = true
+		c.JSON(http.StatusOK, gin.H{"data": "free-access"})
+	})
+
+	// Request without payment header - hook should grant access
+	req := httptest.NewRequest("GET", "/api", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200 (hook granted access), got %d. Body: %s", w.Code, w.Body.String())
+	}
+	if !nextCalled {
+		t.Error("Expected next handler to be called when hook grants access")
+	}
+}
+
+func TestPaymentMiddlewareFromHTTPServer_HookAbortsRequest(t *testing.T) {
+	mockClient := &mockFacilitatorClient{
+		supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	routes := x402http.RoutesConfig{
+		"GET /api": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{
+					Scheme:  "exact",
+					PayTo:   "0xtest",
+					Price:   "$1.00",
+					Network: "eip155:1",
+				},
+			},
+		},
+	}
+
+	resourceServer := x402.Newx402ResourceServer(
+		x402.WithFacilitatorClient(mockClient),
+	)
+	resourceServer.Register("eip155:1", &mockSchemeServer{scheme: "exact"})
+
+	// Register a hook that aborts the request
+	httpServer := x402http.Wrappedx402HTTPResourceServer(routes, resourceServer).
+		OnProtectedRequest(func(ctx context.Context, reqCtx x402http.HTTPRequestContext, routeConfig x402http.RouteConfig) (*x402http.ProtectedRequestHookResult, error) {
+			return &x402http.ProtectedRequestHookResult{Abort: true, Reason: "IP blocked"}, nil
+		})
+
+	router := createTestRouter()
+	router.Use(PaymentMiddlewareFromHTTPServer(httpServer, WithTimeout(5*time.Second)))
+
+	router.GET("/api", func(c *gin.Context) {
+		t.Error("Handler should not be called when hook aborts")
+	})
+
+	req := httptest.NewRequest("GET", "/api", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("Expected status 403 (hook aborted), got %d", w.Code)
+	}
+}
+
+// ============================================================================
 // X402Payment (Builder Pattern) Tests
 // ============================================================================
 

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -127,6 +127,23 @@ type CompiledRoute struct {
 // Request/Response Types
 // ============================================================================
 
+// ProtectedRequestHookResult represents the result of a protected request hook.
+// A nil result means the hook has no opinion and the next hook (or payment flow) should proceed.
+type ProtectedRequestHookResult struct {
+	// GrantAccess bypasses payment and grants free access to the resource.
+	GrantAccess bool
+	// Abort denies the request with a 403 status and the provided Reason.
+	Abort  bool
+	Reason string
+}
+
+// ProtectedRequestHook is called on every request to a protected route, before payment processing.
+// It receives the request context and the matched route configuration.
+// Return nil to continue to the next hook or payment flow.
+// Return a result with GrantAccess=true to bypass payment.
+// Return a result with Abort=true to deny the request with a 403 status.
+type ProtectedRequestHook func(ctx context.Context, reqCtx HTTPRequestContext, routeConfig RouteConfig) (*ProtectedRequestHookResult, error)
+
 // HTTPRequestContext encapsulates an HTTP request
 type HTTPRequestContext struct {
 	Adapter       HTTPAdapter
@@ -213,8 +230,9 @@ func (e *RouteConfigurationError) Error() string {
 // x402HTTPResourceServer provides HTTP-specific payment handling
 type x402HTTPResourceServer struct {
 	*x402.X402ResourceServer
-	compiledRoutes  []CompiledRoute
-	paywallProvider PaywallProvider
+	compiledRoutes        []CompiledRoute
+	paywallProvider       PaywallProvider
+	protectedRequestHooks []ProtectedRequestHook
 }
 
 // Newx402HTTPResourceServer creates a new HTTP resource server
@@ -253,6 +271,15 @@ func Wrappedx402HTTPResourceServer(routes RoutesConfig, resourceServer *x402.X40
 // by per-route CustomPaywallHTML. Returns the server for method chaining.
 func (s *x402HTTPResourceServer) RegisterPaywallProvider(provider PaywallProvider) *x402HTTPResourceServer {
 	s.paywallProvider = provider
+	return s
+}
+
+// OnProtectedRequest registers a hook that runs on every request to a protected route,
+// before payment processing. Hooks are executed in registration order; the first hook
+// to return a non-nil result determines the outcome.
+// Returns the server instance for method chaining.
+func (s *x402HTTPResourceServer) OnProtectedRequest(hook ProtectedRequestHook) *x402HTTPResourceServer {
+	s.protectedRequestHooks = append(s.protectedRequestHooks, hook)
 	return s
 }
 
@@ -382,6 +409,36 @@ func (s *x402HTTPResourceServer) ProcessHTTPRequest(ctx context.Context, reqCtx 
 	routeConfig := s.getRouteConfig(reqCtx.Path, reqCtx.Method)
 	if routeConfig == nil {
 		return HTTPProcessResult{Type: ResultNoPaymentRequired}
+	}
+
+	// Execute protected request hooks before any payment processing
+	for _, hook := range s.protectedRequestHooks {
+		result, err := hook(ctx, reqCtx, *routeConfig)
+		if err != nil {
+			return HTTPProcessResult{
+				Type: ResultPaymentError,
+				Response: &HTTPResponseInstructions{
+					Status:  500,
+					Headers: map[string]string{"Content-Type": "application/json"},
+					Body:    map[string]string{"error": fmt.Sprintf("protected request hook error: %v", err)},
+				},
+			}
+		}
+		if result != nil {
+			if result.GrantAccess {
+				return HTTPProcessResult{Type: ResultNoPaymentRequired}
+			}
+			if result.Abort {
+				return HTTPProcessResult{
+					Type: ResultPaymentError,
+					Response: &HTTPResponseInstructions{
+						Status:  403,
+						Headers: map[string]string{"Content-Type": "application/json"},
+						Body:    map[string]string{"error": result.Reason},
+					},
+				}
+			}
+		}
 	}
 
 	// Get payment options from route config


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

### Summary

- Add `ProtectedRequestHook` type and `OnProtectedRequest()` registration method to `x402HTTPResourceServer`
- Hooks execute in registration order before payment processing; first non-nil result wins
- Three outcomes: `GrantAccess` (bypass payment), `Abort` (403 deny), or `nil` (continue to payment flow)
- Fully backward-compatible — no changes required for existing users

### Motivation

The TypeScript SDK has `onProtectedRequest` ([PR #1010](https://github.com/coinbase/x402/pull/1010)) which is required for extensions like SIWx (Sign-In With X). 

The Go SDK was the only one missing this hook, as tracked in [sdk-features.md](https://github.com/coinbase/x402/blob/main/docs/sdk-features.md#resource-server-hooks).

### Changes

| File | Change |
|------|--------|
| `go/http/server.go` | Add `ProtectedRequestHook` type, `ProtectedRequestHookResult` struct, hook storage field, `OnProtectedRequest()` method, and execution loop in `ProcessHTTPRequest` |
| `go/http/server_test.go` | Add 7 test cases covering all hook behaviors |

### Usage

```go
server := http.Newx402HTTPResourceServer(routes, opts...).
   OnProtectedRequest(func(ctx context.Context, reqCtx http.HTTPRequestContext, route http.RouteConfig) (*http.ProtectedRequestHookResult, error) {
      if hasValidSession(reqCtx) {
         return &http.ProtectedRequestHookResult{GrantAccess: true}, nil
      }
      return nil, nil // continue to payment flow
   })
```

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

- TestOnProtectedRequest_GrantAccess — hook grants free access
- TestOnProtectedRequest_Abort — hook denies with 403
- TestOnProtectedRequest_Continue — hook returns nil, payment flow continues
- TestOnProtectedRequest_MultipleHooks_FirstNonNilWins — chaining behavior
- TestOnProtectedRequest_HookError — error returns 500
- TestOnProtectedRequest_ContextPassing — correct context/route delivered to hook
- TestOnProtectedRequest_UnmatchedRoute_HookNotCalled — hook skipped for non-protected routes

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 