### PR TITLE
ecosystem: add ClawPay MCP — non-custodial x402 payment layer for AI agents

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/clawpay-mcp/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/clawpay-mcp/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "ClawPay MCP",
+  "description": "Open-source, non-custodial x402 MCP payment layer for AI agents. Agents sign transactions locally with no custodial infrastructure required. Supports x402 V2 sessions, spend limits, and multi-chain payments.",
+  "logoUrl": "/logos/clawpay-mcp.svg",
+  "websiteUrl": "https://www.npmjs.com/package/clawpay-mcp",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/clawpay-mcp.svg
+++ b/typescript/site/public/logos/clawpay-mcp.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#0f172a"/>
+  <text x="256" y="220" text-anchor="middle" font-family="Arial,sans-serif" font-weight="bold" font-size="120" fill="#60a5fa">Claw</text>
+  <text x="256" y="340" text-anchor="middle" font-family="Arial,sans-serif" font-weight="bold" font-size="120" fill="#10b981">Pay</text>
+  <text x="256" y="420" text-anchor="middle" font-family="Arial,sans-serif" font-size="48" fill="#94a3b8">MCP</text>
+</svg>


### PR DESCRIPTION
## ClawPay MCP

**Category:** Infrastructure & Tooling

Open-source, non-custodial x402 MCP payment layer for AI agents.

### Key Features
- **Non-custodial:** Agents sign locally — no custodial infrastructure required
- **x402 V2 Sessions:** First non-custodial x402 V2 session payment implementation
- **Spend Limits:** Built-in per-transaction and daily caps
- **Multi-chain:** Base mainnet with extensible chain support

### Links
- npm: [clawpay-mcp](https://www.npmjs.com/package/clawpay-mcp)
- GitHub: [up2itnow0822/clawpay-mcp](https://github.com/up2itnow0822)
- MIT Licensed

### Changes
- Added `typescript/site/app/ecosystem/partners-data/clawpay-mcp/metadata.json`
- Added `typescript/site/public/logos/clawpay-mcp.svg`

Commit is signed. cc @Must-be-Ash