### PR TITLE
Add AI Site Scorer to x402 ecosystem — pay-per-use AI/LLM readiness analyzer

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/ai-site-scorer/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/ai-site-scorer/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AI Site Scorer",
+  "description": "x402-paid MCP server and REST API for AI readiness analysis. Analyzes any website across 14 checks (Schema.org, llms.txt, robots.txt, content quality) and returns a 0-100 score with fix recommendations. AI agents pay $0.01/analysis, $0.05 for LLM deep analysis, $0.02 for IDE fix prompts — no API keys or registration required.",
+  "logoUrl": "/logos/ai-site-scorer.svg",
+  "websiteUrl": "https://ai-readiness.mingles.ai/docs",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/ai-site-scorer.svg
+++ b/typescript/site/public/logos/ai-site-scorer.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="14" fill="#6366F1"/>
+  <text x="32" y="26" font-family="system-ui,sans-serif" font-size="12" font-weight="700" fill="white" text-anchor="middle">AI</text>
+  <text x="32" y="44" font-family="system-ui,sans-serif" font-size="9" font-weight="600" fill="rgba(255,255,255,0.85)" text-anchor="middle">SCORER</text>
+</svg>


### PR DESCRIPTION
## New Ecosystem Partner: AI Site Scorer

### What it is
**AI Site Scorer** is a pay-per-use REST API + MCP server that analyzes any website for AI/LLM readiness using 18 automated checks.

🌐 **Live:** https://ai-readiness.mingles.ai
📦 **MCP endpoint:** https://ai-readiness.mingles.ai/api/mcp/
💻 **GitHub:** https://github.com/MinglesAI/ai-site-scorer

### x402 Integration
- Anonymous users pay via x402 micropayments on **Base Sepolia** (migrating to Base mainnet)
- **Pricing:** $0.01/analyze, $0.05/LLM enhance, $0.02/Cursor fix prompt
- No registration required — just send x402 payment in X-PAYMENT header
- EIP-3009 transferWithAuthorization (USDC on Base)

### MCP + x402 Combined Flow
Users can call the MCP server from Cursor/Claude Desktop and pay per analysis via x402 — making it a fully autonomous, agent-native pay-per-use tool.

### Category
**Services/Endpoints** — pay-per-analysis API with x402 anonymous access

### Files changed
- Added 
- Added 