### PR TITLE
fix(http): align settlement failure body with v2 spec format

### DIFF
--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -387,8 +387,9 @@ describe("paymentMiddleware", () => {
 
     expect(res.status).toHaveBeenCalledWith(402);
     expect(res.json).toHaveBeenCalledWith({
-      error: "Settlement failed",
-      details: "Settlement rejected",
+      x402Version: 2,
+      error: "Settlement failed: Settlement rejected",
+      accepts: [mockPaymentRequirements],
     });
   });
 
@@ -425,8 +426,9 @@ describe("paymentMiddleware", () => {
     expect(res.setHeader).toHaveBeenCalledWith("PAYMENT-RESPONSE", "settlement-failed-encoded");
     expect(res.status).toHaveBeenCalledWith(402);
     expect(res.json).toHaveBeenCalledWith({
-      error: "Settlement failed",
-      details: "Insufficient funds",
+      x402Version: 2,
+      error: "Settlement failed: Insufficient funds",
+      accepts: [mockPaymentRequirements],
     });
   });
 

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -252,8 +252,9 @@ export function paymentMiddlewareFromHTTPServer(
               res.setHeader(key, value);
             });
             res.status(402).json({
-              error: "Settlement failed",
-              details: settleResult.errorReason,
+              x402Version: 2,
+              error: `Settlement failed: ${settleResult.errorReason}`,
+              accepts: [paymentRequirements],
             });
             return;
           }
@@ -267,8 +268,9 @@ export function paymentMiddlewareFromHTTPServer(
           // If settlement fails, don't send the buffered response
           bufferedCalls = [];
           res.status(402).json({
-            error: "Settlement failed",
-            details: error instanceof Error ? error.message : "Unknown error",
+            x402Version: 2,
+            error: `Settlement failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+            accepts: [paymentRequirements],
           });
           return;
         } finally {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -390,8 +390,9 @@ describe("paymentMiddleware", () => {
 
     expect(context.json).toHaveBeenCalledWith(
       {
-        error: "Settlement failed",
-        details: "Settlement rejected",
+        x402Version: 2,
+        error: "Settlement failed: Settlement rejected",
+        accepts: [mockPaymentRequirements],
       },
       402,
     );
@@ -435,8 +436,9 @@ describe("paymentMiddleware", () => {
 
     expect(context.json).toHaveBeenCalledWith(
       {
-        error: "Settlement failed",
-        details: "Insufficient funds",
+        x402Version: 2,
+        error: "Settlement failed: Insufficient funds",
+        accepts: [mockPaymentRequirements],
       },
       402,
     );

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -177,8 +177,9 @@ export function paymentMiddlewareFromHTTPServer(
             // Settlement failed - do not return the protected resource
             res = c.json(
               {
-                error: "Settlement failed",
-                details: settleResult.errorReason,
+                x402Version: 2,
+                error: `Settlement failed: ${settleResult.errorReason}`,
+                accepts: [paymentRequirements],
               },
               402,
             );
@@ -196,8 +197,9 @@ export function paymentMiddlewareFromHTTPServer(
           // If settlement fails, return an error response
           res = c.json(
             {
-              error: "Settlement failed",
-              details: error instanceof Error ? error.message : "Unknown error",
+              x402Version: 2,
+              error: `Settlement failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+              accepts: [paymentRequirements],
             },
             402,
           );

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -274,7 +274,9 @@ describe("paymentProxy", () => {
 
     expect(response.status).toBe(402);
     const body = await response.json();
-    expect(body.error).toBe("Settlement failed");
+    expect(body.x402Version).toBe(2);
+    expect(body.error).toBe("Settlement failed: Settlement rejected");
+    expect(body.accepts).toEqual([mockPaymentRequirements]);
   });
 
   it("returns 402 when settlement returns success: false, not the resource", async () => {
@@ -297,8 +299,9 @@ describe("paymentProxy", () => {
 
     expect(response.status).toBe(402);
     const body = await response.json();
-    expect(body.error).toBe("Settlement failed");
-    expect(body.details).toBe("Insufficient funds");
+    expect(body.x402Version).toBe(2);
+    expect(body.error).toBe("Settlement failed: Insufficient funds");
+    expect(body.accepts).toEqual([mockPaymentRequirements]);
     expect(response.headers.get("PAYMENT-RESPONSE")).toBe("settlement-failed-encoded");
   });
 });
@@ -397,7 +400,8 @@ describe("withX402", () => {
     expect(handler).toHaveBeenCalled();
     expect(response.status).toBe(402);
     const body = await response.json();
-    expect(body.error).toBe("Settlement failed");
+    expect(body.x402Version).toBe(2);
+    expect(body.error).toBe("Settlement failed: Settlement rejected");
   });
 
   it("returns 402 when settlement returns success: false, not the handler response", async () => {
@@ -422,8 +426,8 @@ describe("withX402", () => {
     expect(handler).toHaveBeenCalled();
     expect(response.status).toBe(402);
     const body = await response.json();
-    expect(body.error).toBe("Settlement failed");
-    expect(body.details).toBe("Insufficient funds");
+    expect(body.x402Version).toBe(2);
+    expect(body.error).toBe("Settlement failed: Insufficient funds");
     expect(response.headers.get("PAYMENT-RESPONSE")).toBe("settlement-failed-encoded");
   });
 });

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -281,7 +281,11 @@ describe("handleSettlement", () => {
     );
 
     expect(result.status).toBe(402);
-    const body = (await result.json()) as { x402Version: number; error: string; accepts: unknown[] };
+    const body = (await result.json()) as {
+      x402Version: number;
+      error: string;
+      accepts: unknown[];
+    };
     expect(body.x402Version).toBe(2);
     expect(body.error).toBe("Settlement failed: Insufficient funds");
     expect(body.accepts).toEqual([mockRequirements]);
@@ -300,7 +304,11 @@ describe("handleSettlement", () => {
     );
 
     expect(result.status).toBe(402);
-    const body = (await result.json()) as { x402Version: number; error: string; accepts: unknown[] };
+    const body = (await result.json()) as {
+      x402Version: number;
+      error: string;
+      accepts: unknown[];
+    };
     expect(body.x402Version).toBe(2);
     expect(body.error).toBe("Settlement failed: Settlement rejected");
     expect(body.accepts).toEqual([mockRequirements]);

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -281,9 +281,10 @@ describe("handleSettlement", () => {
     );
 
     expect(result.status).toBe(402);
-    const body = (await result.json()) as { error: string; details: string };
-    expect(body.error).toBe("Settlement failed");
-    expect(body.details).toBe("Insufficient funds");
+    const body = (await result.json()) as { x402Version: number; error: string; accepts: unknown[] };
+    expect(body.x402Version).toBe(2);
+    expect(body.error).toBe("Settlement failed: Insufficient funds");
+    expect(body.accepts).toEqual([mockRequirements]);
     expect(result.headers.get("PAYMENT-RESPONSE")).toBe("settlement-failed-encoded");
   });
 
@@ -299,8 +300,9 @@ describe("handleSettlement", () => {
     );
 
     expect(result.status).toBe(402);
-    const body = (await result.json()) as { error: string; details: string };
-    expect(body.error).toBe("Settlement failed");
-    expect(body.details).toBe("Settlement rejected");
+    const body = (await result.json()) as { x402Version: number; error: string; accepts: unknown[] };
+    expect(body.x402Version).toBe(2);
+    expect(body.error).toBe("Settlement failed: Settlement rejected");
+    expect(body.accepts).toEqual([mockRequirements]);
   });
 });

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -152,8 +152,9 @@ export async function handleSettlement(
       // Settlement failed - do not return the protected resource
       return new NextResponse(
         JSON.stringify({
-          error: "Settlement failed",
-          details: result.errorReason,
+          x402Version: 2,
+          error: `Settlement failed: ${result.errorReason}`,
+          accepts: [paymentRequirements],
         }),
         {
           status: 402,
@@ -173,8 +174,9 @@ export async function handleSettlement(
     // If settlement fails, return an error response
     return new NextResponse(
       JSON.stringify({
-        error: "Settlement failed",
-        details: error instanceof Error ? error.message : "Unknown error",
+        x402Version: 2,
+        error: `Settlement failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        accepts: [paymentRequirements],
       }),
       {
         status: 402,


### PR DESCRIPTION
## Problem

When payment settlement fails, all three middleware packages return a response body with the shape `{ error, details }`. The v2 HTTP transport spec requires a different format:

**Spec** (`specs/transports-v2/http.md`, settlement failure example):
```json
{
  "x402Version": 2,
  "error": "Payment failed: insufficient funds",
  "accepts": [...]
}
```

**Actual (before this PR)**:
```json
{
  "error": "Settlement failed",
  "details": "<reason from facilitator>"
}
```

### Why this matters

The `accepts` array in the spec body enables client retry — the client already paid and got a settlement failure, so giving them current payment requirements lets them construct a new payment immediately. The `PAYMENT-RESPONSE` header (added in #1128) carries settlement result details, but not retry information. The response body is also the only structured data a cross-origin browser client can read without explicit `Access-Control-Expose-Headers` configuration.

## Changes

All three middleware packages (Express, Hono, Next.js), both the `!settleResult.success` path and the `catch` path:

| Field | Before | After |
|-------|--------|-------|
| `x402Version` | missing | `2` |
| `error` | `"Settlement failed"` (generic) | `"Settlement failed: <specific reason>"` |
| `accepts` | missing | `[paymentRequirements]` |
| `details` | present (non-spec) | removed |

Test assertions updated accordingly.

## Scope

TypeScript middleware only. Go and Python middleware have the same issue and will be addressed in follow-up PRs, using this as the reference implementation.

## Related

- Closes #1376
- Related: #1128 (adds `PAYMENT-RESPONSE` header on settlement failure)
- Related: #575 (spec example has a syntax error — missing comma)