### PR TITLE
fix(exact): enforce strict amount equality per spec

### DIFF
--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -290,7 +290,7 @@ The facilitator performs the following verification steps:
 
 1. **Signature Validation**: Verify the EIP-712 signature is valid and properly signed by the payer
 2. **Balance Verification**: Confirm the payer has sufficient token balance for the transfer
-3. **Amount Validation**: Ensure the payment amount meets or exceeds the required amount
+3. **Amount Validation**: Ensure the payment amount exactly matches the required amount
 4. **Time Window Check**: Verify the authorization is within its valid time range
 5. **Parameter Matching**: Confirm authorization parameters match the original payment requirements
 6. **Transaction Simulation**: Simulate the `transferWithAuthorization` transaction to ensure it would succeed
@@ -579,7 +579,7 @@ The x402 protocol defines standard error codes that may be returned by facilitat
 - **`insufficient_funds`**: Client does not have enough tokens to complete the payment
 - **`invalid_exact_evm_payload_authorization_valid_after`**: Payment authorization is not yet valid (before validAfter timestamp)
 - **`invalid_exact_evm_payload_authorization_valid_before`**: Payment authorization has expired (after validBefore timestamp)
-- **`invalid_exact_evm_payload_authorization_value`**: Payment amount is insufficient for the required payment
+- **`invalid_exact_evm_payload_authorization_value_mismatch`**: Payment amount does not exactly match the required amount
 - **`invalid_exact_evm_payload_signature`**: Payment authorization signature is invalid or improperly signed
 - **`invalid_exact_evm_payload_recipient_mismatch`**: Recipient address does not match payment requirements
 - **`invalid_network`**: Specified blockchain network is not supported

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -197,11 +197,11 @@ export async function verifyEIP3009(
     // If we can't check balance, continue with other validations
   }
 
-  // Verify amount is sufficient
-  if (BigInt(eip3009Payload.authorization.value) < BigInt(requirements.amount)) {
+  // Verify amount exactly matches requirements
+  if (BigInt(eip3009Payload.authorization.value) !== BigInt(requirements.amount)) {
     return {
       isValid: false,
-      invalidReason: "invalid_exact_evm_payload_authorization_value",
+      invalidReason: "invalid_exact_evm_payload_authorization_value_mismatch",
       payer,
     };
   }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -117,10 +117,11 @@ export async function verifyPermit2(
     };
   }
 
-  if (BigInt(permit2Payload.permit2Authorization.permitted.amount) < BigInt(requirements.amount)) {
+  // Verify amount exactly matches requirements
+  if (BigInt(permit2Payload.permit2Authorization.permitted.amount) !== BigInt(requirements.amount)) {
     return {
       isValid: false,
-      invalidReason: "permit2_insufficient_amount",
+      invalidReason: "permit2_amount_mismatch",
       payer,
     };
   }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -118,7 +118,9 @@ export async function verifyPermit2(
   }
 
   // Verify amount exactly matches requirements
-  if (BigInt(permit2Payload.permit2Authorization.permitted.amount) !== BigInt(requirements.amount)) {
+  if (
+    BigInt(permit2Payload.permit2Authorization.permitted.amount) !== BigInt(requirements.amount)
+  ) {
     return {
       isValid: false,
       invalidReason: "permit2_amount_mismatch",

--- a/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
@@ -258,11 +258,11 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
       // If we can't check balance, continue with other validations
     }
 
-    // Verify amount is sufficient
-    if (BigInt(exactEvmPayload.authorization.value) < BigInt(requirementsV1.maxAmountRequired)) {
+    // Verify amount exactly matches requirements
+    if (BigInt(exactEvmPayload.authorization.value) !== BigInt(requirementsV1.maxAmountRequired)) {
       return {
         isValid: false,
-        invalidReason: "invalid_exact_evm_payload_authorization_value",
+        invalidReason: "invalid_exact_evm_payload_authorization_value_mismatch",
         payer: exactEvmPayload.authorization.from,
       };
     }

--- a/typescript/packages/mechanisms/evm/test/unit/v1/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/v1/facilitator.test.ts
@@ -169,7 +169,7 @@ describe("ExactEvmSchemeV1", () => {
       const result = await facilitator.verify(payload as never, requirements as never);
 
       expect(result.isValid).toBe(false);
-      expect(result.invalidReason).toBe("invalid_exact_evm_payload_authorization_value");
+      expect(result.invalidReason).toBe("invalid_exact_evm_payload_authorization_value_mismatch");
     });
 
     it("should reject if balance is insufficient", async () => {

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -258,10 +258,10 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
 
     // Verify transfer amount meets requirements
     const amount = parsedTransfer.data.amount;
-    if (amount < BigInt(requirements.amount)) {
+    if (amount !== BigInt(requirements.amount)) {
       return {
         isValid: false,
-        invalidReason: "invalid_exact_svm_payload_amount_insufficient",
+        invalidReason: "invalid_exact_svm_payload_amount_mismatch",
         payer,
       };
     }

--- a/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
@@ -259,12 +259,12 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
       };
     }
 
-    // Verify transfer amount meets requirements
+    // Verify transfer amount exactly matches requirements
     const amount = parsedTransfer.data.amount;
-    if (amount < BigInt(requirementsV1.maxAmountRequired)) {
+    if (amount !== BigInt(requirementsV1.maxAmountRequired)) {
       return {
         isValid: false,
-        invalidReason: "invalid_exact_svm_payload_amount_insufficient",
+        invalidReason: "invalid_exact_svm_payload_amount_mismatch",
         payer,
       };
     }


### PR DESCRIPTION
## Problem

The exact scheme spec requires strict amount equality, but all five TypeScript exact scheme facilitators use a \`<\` comparison, silently accepting any amount **≥** the requirement (including overpayments).

**Abstract scheme contract** (\`specs/schemes/exact/scheme_exact.md\` L24):
> Amount exactness: the transferred amount **MUST equal** \`maxAmountRequired\`.

**SVM scheme spec** (\`specs/schemes/exact/scheme_exact_svm.md\` L143):
> The \`amount\` in TransferChecked **MUST equal** \`PaymentRequirements.amount\` exactly.

**Before (all five facilitators)**:
\`\`\`ts
if (amount < BigInt(requirements.amount)) { // accepts overpayment
\`\`\`

**After**:
\`\`\`ts
if (amount !== BigInt(requirements.amount)) { // strict equality
\`\`\`

## Changes

### Code (5 facilitators)

| File | Change |
|------|--------|
| `typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts` | `<` → `!==`, reason: `..._value_mismatch` |
| `typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts` | `<` → `!==`, reason: `permit2_amount_mismatch` |
| `typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts` | `<` → `!==`, reason: `..._value_mismatch` |
| `typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts` | `<` → `!==`, reason: `..._amount_mismatch` |
| `typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts` | `<` → `!==`, reason: `..._amount_mismatch` |

Error reason strings renamed from `_insufficient` / `_authorization_value` to `_mismatch` variants to cover both directions (underpayment and overpayment).

### Spec corrections (`specs/x402-specification-v2.md`)

Two entries in the general spec contradicted the authoritative scheme-layer documents:

1. **§6.1.2 step 3**: `"meets or exceeds"` → `"exactly matches"` — this section describes the EVM implementation of the *exact* scheme; the abstract scheme contract in `scheme_exact.md` is unambiguous about strict equality.

2. **§9 error table**: `invalid_exact_evm_payload_authorization_value` renamed to `invalid_exact_evm_payload_authorization_value_mismatch`, description updated from "insufficient" to "does not exactly match." These are EVM-scheme-layer error codes; the table is corrected to reflect the implementation.

The scheme-specific documents (`scheme_exact.md`, `scheme_exact_evm.md`, `scheme_exact_svm.md`) are the authoritative layer and are unchanged — this PR corrects the general spec to agree with them.

## Scope

TypeScript only. Go and Python facilitators have the same `<` comparison and will be addressed in follow-up PRs using this as the reference.

## Related

- Closes #1378
- Related: #142 (prior discussion of `maxAmountRequired` naming and overpayment behavior)