### PR TITLE
feat(ecosystem): add EruditePay

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/eruditepay/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/eruditepay/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "EruditePay",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/eruditepay.png",
+  "description": "Cross-chain payment facilitator and Tron analytics API by Erudite Intelligence LLC. Self-hosted x402 settlement on Base mainnet with on-chain fee splitting. Paid endpoints for Tron gas analysis, energy estimates, wallet profiling, USDT flow tracking, and DEX quotes — all gated by real USDC micropayments.",
+  "websiteUrl": "https://x402.eruditepay.com"
+}


### PR DESCRIPTION
## Summary

Adds **EruditePay** by [Erudite Intelligence LLC](https://eruditeintelligence.com) to the x402 ecosystem partners directory.

**Category:** Services/Endpoints

### What EruditePay does

- **Self-hosted x402 facilitator** on Base mainnet with direct on-chain EIP-3009 `transferWithAuthorization` settlement
- **On-chain fee splitting:** 1% facilitator + 0.25% wrapper → 98.75% forwarded to merchant via `USDC.transfer`
- **5 paid Tron analytics endpoints** gated by x402 micropayments (gas status, energy estimates, wallet profiling, USDT flow tracking, DEX quotes)
- **MCP server** with 18 paid tools for AI agent consumption (Tron analytics, sanctions check, stablecoin spread)
- **A2A agent card** at `/.well-known/agent-card.json` for agent-to-agent discovery
- **Bazaar discovery extension** declared on all paid routes

### Proof of mainnet settlement

First mainnet x402 payment settled through our self-hosted facilitator:

- **TX:** [`0x742ebc35fbf1a9181c2f175d09f2a3f3922b90ceba52b247e531512754c89033`](https://basescan.org/tx/0x742ebc35fbf1a9181c2f175d09f2a3f3922b90ceba52b247e531512754c89033)
- **Block:** 42,760,482
- **Network:** Base Mainnet (eip155:8453)
- **Amount:** $0.01 USDC

### Live endpoints

- Facilitator: https://x402.eruditepay.com
- Agent card: https://x402.eruditepay.com/.well-known/agent-card.json
- x402 info: https://x402.eruditepay.com/.well-known/x402
- Health: https://x402.eruditepay.com/health

### Note

Logo file (`/logos/eruditepay.png`) is not included in this PR. Happy to provide one in the format/dimensions you prefer — just let us know.