### PR TITLE
feat: Add local stablecoin support examples (wARS/Peso Argentino)

### DIFF
--- a/docs/guides/local-stablecoins.md
+++ b/docs/guides/local-stablecoins.md
@@ -1,0 +1,128 @@
+# Local Stablecoins with x402
+
+x402 is asset-agnostic by design. While USDC is the default payment token, any ERC-20 can be used as a payment asset. This guide shows how to accept and pay with **local currency stablecoins** — tokens pegged to currencies like the Argentine Peso (ARS), Brazilian Real (BRL), or Colombian Peso (COP).
+
+## Why Local Stablecoins Matter for Agents
+
+When an AI agent operating in Argentina needs to pay for a local API, forcing it through USD creates unnecessary friction:
+
+- **FX conversion costs** eat into every transaction
+- **Price instability** — local services priced in USD must constantly adjust
+- **Regulatory complexity** — some jurisdictions prefer local-currency settlement
+
+Local stablecoins solve this by letting agents pay in the currency the service is naturally priced in. An agent querying Argentine market data pays in wARS. An agent accessing Brazilian logistics APIs pays in wBRL. No conversion, no friction.
+
+## Available Local Stablecoins
+
+| Token | Currency | Chain | Address | Decimals |
+|-------|----------|-------|---------|----------|
+| wARS | Argentine Peso (ARS) | Base | `0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D` | 18 |
+
+*More local stablecoins (wBRL, wCOP, wMXN) are in development.*
+
+## How It Works
+
+x402's `PaymentRequirements` include an `asset` field — the token contract address. When a server specifies wARS as the asset, clients pay in wARS. The protocol doesn't care what the token represents; it just moves ERC-20 tokens from buyer to seller.
+
+### Payment Flow
+
+Most local stablecoins implement [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) (`permit`) rather than [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) (`transferWithAuthorization`). This means they use the **Permit2** flow:
+
+1. Client requests a resource → server responds with `402 Payment Required`
+2. Payment requirements specify the wARS token address and amount
+3. Client signs a [Permit2](https://github.com/Uniswap/permit2) authorization
+4. Facilitator verifies the signature and settles on-chain
+5. Server delivers the resource
+
+The client needs Permit2 approval for the token (a one-time on-chain transaction), after which all payments are gasless signatures.
+
+## Server Setup
+
+Use `registerMoneyParser` to price your API in local currency:
+
+```typescript
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+
+const WARS_BASE = {
+  address: "0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D",
+  symbol: "wARS",
+  decimals: 18,
+};
+
+const evmScheme = new ExactEvmScheme().registerMoneyParser(
+  async (amount, network) => {
+    if (network !== "eip155:8453") return null;
+
+    return {
+      amount: BigInt(Math.round(amount * 10 ** WARS_BASE.decimals)).toString(),
+      asset: WARS_BASE.address,
+      extra: {
+        token: WARS_BASE.symbol,
+        assetTransferMethod: "permit2",
+      },
+    };
+  }
+);
+```
+
+Then price your endpoints in ARS:
+
+```typescript
+app.use(
+  paymentMiddleware(
+    {
+      "GET /cotizacion": {
+        accepts: {
+          scheme: "exact",
+          price: 1500, // 1500 ARS
+          network: "eip155:8453",
+          payTo: evmAddress,
+        },
+        description: "Argentine market data",
+      },
+    },
+    new x402ResourceServer(facilitatorClient).register("eip155:8453", evmScheme),
+  ),
+);
+```
+
+## Client Setup
+
+Clients don't need special configuration for local stablecoins. The standard x402 client handles Permit2 automatically:
+
+```typescript
+import { withX402 } from "@x402/fetch";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+
+const x402Fetch = withX402(fetch, {
+  "eip155:8453": new ExactEvmScheme(signer),
+});
+
+// Just fetch — x402 handles payment in wARS automatically
+const response = await x402Fetch("https://api.example.com/cotizacion");
+```
+
+The client wallet needs:
+1. wARS token balance
+2. One-time Permit2 approval for wARS (or the facilitator can sponsor this via EIP-2612 gas sponsoring)
+
+## Adding Your Own Local Stablecoin
+
+Any ERC-20 token can be used with x402. To add a new local stablecoin:
+
+1. **Deploy your token** as a standard ERC-20 (EIP-2612 permit support recommended)
+2. **Create a money parser** that maps your currency to the token (see server example above)
+3. **Set `assetTransferMethod: "permit2"`** in the `extra` field if your token doesn't support EIP-3009
+
+The x402 protocol handles the rest — verification, settlement, and the client payment flow all work with any ERC-20.
+
+## Full Examples
+
+- [Server example](../../examples/typescript/servers/advanced/local-stablecoin.ts) — Express server accepting wARS
+- [Client example](../../examples/typescript/clients/advanced/local-stablecoin.ts) — Agent paying with wARS
+
+## Related
+
+- [Custom Money Definitions](../../examples/typescript/servers/advanced/custom-money-definition.ts)
+- [EIP-2612 Gas Sponsoring](../../examples/typescript/servers/advanced/eip2612-gas-sponsoring.ts)
+- [x402 Specification](../specs/x402-specification-v2.md)

--- a/docs/guides/local-stablecoins.md
+++ b/docs/guides/local-stablecoins.md
@@ -18,7 +18,7 @@ Local stablecoins solve this by letting agents pay in the currency the service i
 |-------|----------|-------|---------|----------|
 | wARS | Argentine Peso (ARS) | Base | `0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D` | 18 |
 
-*More local stablecoins (wBRL, wCOP, wMXN) are in development.*
+wARS is part of the [latam-stables](https://github.com/ripio/latam-stables) project by [Ripio](https://ripio.com) — Foundry-based contracts with cross-chain bridge infrastructure. More local stablecoins (wBRL, wCOP, wMXN) are in development.
 
 ## How It Works
 

--- a/examples/typescript/clients/advanced/local-stablecoin.ts
+++ b/examples/typescript/clients/advanced/local-stablecoin.ts
@@ -1,0 +1,76 @@
+/**
+ * Local Stablecoin Client Example
+ *
+ * Demonstrates how an AI agent (or any client) pays for API access
+ * using a local currency stablecoin (wARS) via x402.
+ *
+ * The client doesn't need to know anything special about wARS — it just
+ * sends an HTTP request, gets a 402 back with payment requirements, and
+ * pays using the standard x402 flow. The Permit2 mechanism handles
+ * token approval and transfer automatically.
+ *
+ * This is the power of x402: agents can pay for services in any currency
+ * the server accepts, without accounts, API keys, or manual setup.
+ */
+import { config } from "dotenv";
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { base } from "viem/chains";
+import { publicActions } from "viem";
+import { withX402 } from "@x402/fetch";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { toClientEvmSigner } from "@x402/evm";
+config();
+
+const PRIVATE_KEY = process.env.PRIVATE_KEY as `0x${string}`;
+if (!PRIVATE_KEY) {
+  console.error("❌ PRIVATE_KEY environment variable is required");
+  process.exit(1);
+}
+
+// Server URL (the local-stablecoin server example)
+const SERVER_URL = process.env.SERVER_URL ?? "http://localhost:4022";
+
+async function main() {
+  // ─── Setup wallet ───────────────────────────────────────────────────────
+  const account = privateKeyToAccount(PRIVATE_KEY);
+  const walletClient = createWalletClient({
+    account,
+    chain: base,
+    transport: http(),
+  }).extend(publicActions);
+
+  const signer = toClientEvmSigner(walletClient);
+
+  // ─── Create x402-enabled fetch ──────────────────────────────────────────
+  // withX402 wraps the standard fetch function. When a server responds with
+  // HTTP 402, it automatically handles payment and retries the request.
+  const x402Fetch = withX402(fetch, {
+    "eip155:8453": new ExactEvmScheme(signer),
+  });
+
+  // ─── Make paid request ──────────────────────────────────────────────────
+  // The agent just fetches a URL. x402 handles the rest:
+  // 1. Server returns 402 with wARS payment requirements
+  // 2. Client signs Permit2 authorization for wARS
+  // 3. Server verifies and settles payment on Base
+  // 4. Server returns the data
+  console.log("🇦🇷 Fetching Argentine market data (costs 1500 wARS)...\n");
+
+  const response = await x402Fetch(`${SERVER_URL}/cotizacion`);
+  const data = await response.json();
+
+  console.log("Exchange rates:");
+  console.log(JSON.stringify(data, null, 2));
+
+  // ─── Another request ────────────────────────────────────────────────────
+  console.log("\n🌤️  Fetching weather data (costs 100 wARS)...\n");
+
+  const weatherResponse = await x402Fetch(`${SERVER_URL}/clima`);
+  const weatherData = await weatherResponse.json();
+
+  console.log("Weather:");
+  console.log(JSON.stringify(weatherData, null, 2));
+}
+
+main().catch(console.error);

--- a/examples/typescript/servers/advanced/local-stablecoin.ts
+++ b/examples/typescript/servers/advanced/local-stablecoin.ts
@@ -1,0 +1,158 @@
+/**
+ * Local Stablecoin Server Example
+ *
+ * Demonstrates how to accept payments in local currency stablecoins
+ * (e.g., wARS/Peso Argentino, wBRL/Real Brasileiro) using x402.
+ *
+ * x402 is asset-agnostic by design. While USDC is the default, any ERC-20
+ * token can be used as a payment asset. This is especially powerful for
+ * agents operating in local markets — they can pay in local currency
+ * without FX friction.
+ *
+ * This example uses Permit2 (not EIP-3009) because most local stablecoins
+ * implement EIP-2612 permit rather than EIP-3009 transferWithAuthorization.
+ *
+ * Token: wARS (Peso Argentino) on Base
+ * Address: 0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D
+ * Decimals: 18
+ * Standard: ERC-20 with EIP-2612 permit
+ */
+import { config } from "dotenv";
+import express from "express";
+import { paymentMiddleware, x402ResourceServer } from "@x402/express";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+config();
+
+const evmAddress = process.env.EVM_ADDRESS as `0x${string}`;
+if (!evmAddress) {
+  console.error("❌ EVM_ADDRESS environment variable is required");
+  process.exit(1);
+}
+
+const facilitatorUrl = process.env.FACILITATOR_URL;
+if (!facilitatorUrl) {
+  console.error("❌ FACILITATOR_URL environment variable is required");
+  process.exit(1);
+}
+const facilitatorClient = new HTTPFacilitatorClient({ url: facilitatorUrl });
+
+// ─── Local Stablecoin Registry ──────────────────────────────────────────────
+// Add your local stablecoins here. Each entry maps a network to token metadata.
+// This pattern scales to any number of local currencies.
+const LOCAL_STABLECOINS: Record<
+  string,
+  Record<string, { address: string; symbol: string; decimals: number }>
+> = {
+  // wARS - Argentine Peso stablecoin by Ripio
+  ARS: {
+    "eip155:8453": {
+      address: "0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D",
+      symbol: "wARS",
+      decimals: 18,
+    },
+  },
+  // Future local stablecoins can be added here:
+  // BRL: {
+  //   "eip155:8453": { address: "0x...", symbol: "wBRL", decimals: 18 },
+  // },
+  // COP: {
+  //   "eip155:8453": { address: "0x...", symbol: "wCOP", decimals: 18 },
+  // },
+};
+
+// ─── Money Parser for Local Currency ────────────────────────────────────────
+// When a server prices in local currency (e.g., ARS 1500), this parser
+// converts the amount to the correct token units.
+function createLocalCurrencyParser(currencyCode: string) {
+  return async (amount: number, network: string) => {
+    const currencies = LOCAL_STABLECOINS[currencyCode];
+    if (!currencies) return null;
+
+    const token = currencies[network];
+    if (!token) return null;
+
+    // Convert decimal amount to token smallest unit
+    const tokenAmount = BigInt(Math.round(amount * 10 ** token.decimals)).toString();
+
+    return {
+      amount: tokenAmount,
+      asset: token.address,
+      extra: {
+        token: token.symbol,
+        // Use permit2 since wARS supports EIP-2612, not EIP-3009
+        assetTransferMethod: "permit2",
+      },
+    };
+  };
+}
+
+const app = express();
+
+// ─── Payment Middleware ─────────────────────────────────────────────────────
+// Price your API in local currency. Agents pay in wARS on Base.
+// No USD conversion needed — price directly in ARS.
+app.use(
+  paymentMiddleware(
+    {
+      // Price: 1500 ARS per request (about $1.25 USD at typical rates)
+      "GET /cotizacion": {
+        accepts: {
+          scheme: "exact",
+          price: 1500,
+          network: "eip155:8453",
+          payTo: evmAddress,
+        },
+        description: "Argentine market data - real-time exchange rates",
+        mimeType: "application/json",
+      },
+      // Cheaper endpoint: 100 ARS
+      "GET /clima": {
+        accepts: {
+          scheme: "exact",
+          price: 100,
+          network: "eip155:8453",
+          payTo: evmAddress,
+        },
+        description: "Weather data for Argentine cities",
+        mimeType: "application/json",
+      },
+    },
+    new x402ResourceServer(facilitatorClient).register(
+      "eip155:8453",
+      new ExactEvmScheme().registerMoneyParser(createLocalCurrencyParser("ARS")),
+    ),
+  ),
+);
+
+// ─── Endpoints ──────────────────────────────────────────────────────────────
+app.get("/cotizacion", (_req, res) => {
+  res.json({
+    currency: "ARS",
+    rates: {
+      USD: { buy: 1180, sell: 1220 },
+      BRL: { buy: 195, sell: 205 },
+      EUR: { buy: 1280, sell: 1340 },
+    },
+    source: "BCRA + market",
+    timestamp: new Date().toISOString(),
+  });
+});
+
+app.get("/clima", (_req, res) => {
+  res.json({
+    city: "Buenos Aires",
+    temperature: 28,
+    condition: "Partly cloudy",
+    humidity: 65,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+const PORT = 4022;
+app.listen(PORT, () => {
+  console.log(`🇦🇷 Local stablecoin server listening at http://localhost:${PORT}`);
+  console.log(`   Accepting wARS payments on Base`);
+  console.log(`   GET /cotizacion - 1500 ARS`);
+  console.log(`   GET /clima - 100 ARS`);
+});


### PR DESCRIPTION
## Summary

x402 is asset-agnostic by design, but all existing examples use USDC. This PR adds working examples and documentation for accepting payments in **local currency stablecoins**, starting with **wARS (Peso Argentino)** on Base.

### Why this matters

As AI agents expand into emerging markets, they need to transact in local currencies. Forcing USD creates FX friction, regulatory complexity, and pricing instability. Local stablecoins like wARS let agents pay for services in the currency those services are naturally priced in — no conversion needed.

This aligns with x402's mission of making payments work for both humans and AI agents, everywhere.

### What's included

| File | Description |
|------|-------------|
| `examples/typescript/servers/advanced/local-stablecoin.ts` | Express server accepting wARS payments with `registerMoneyParser` for ARS-denominated pricing |
| `examples/typescript/clients/advanced/local-stablecoin.ts` | Agent/client paying for API access with wARS |
| `docs/guides/local-stablecoins.md` | Guide: why local stablecoins matter, how to set them up, how to add new ones |

### Token details

- **Token**: wARS (Peso Argentino)
- **Chain**: Base mainnet (`eip155:8453`)
- **Address**: [`0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D`](https://basescan.org/token/0x0DC4F92879B7670e5f4e4e6e3c801D229129D90D)
- **Standard**: ERC-20 with EIP-2612 permit (uses Permit2 flow)
- **Decimals**: 18
- **Issuer**: [Ripio](https://ripio.com) — 12-year crypto infrastructure company in Latin America
- **Source**: [ripio/latam-stables](https://github.com/ripio/latam-stables) — Foundry-based contracts with cross-chain bridge infrastructure (burn-and-mint)

### Design decisions

- Uses `registerMoneyParser` (no changes to core) — this is the intended extension point
- Uses Permit2 flow since wARS implements EIP-2612 (`permit`) rather than EIP-3009 (`transferWithAuthorization`)
- Examples are structured to be easily extended for other local stablecoins (wBRL, wCOP, wMXN)
- No modifications to existing code — purely additive

### Testing

Examples follow existing patterns in `examples/typescript/`. No new dependencies introduced.