### PR TITLE
feat(go): add WithBazaar facilitator client for discovery resource queries

### DIFF
--- a/go/.changes/unreleased/added-20260302-103254.yaml
+++ b/go/.changes/unreleased/added-20260302-103254.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Add WithBazaar facilitator client decorator for querying /discovery/resources endpoint from bazaar in go
+time: 2026-03-02T10:32:54.304235+09:00

--- a/go/extensions/bazaar/facilitator_client.go
+++ b/go/extensions/bazaar/facilitator_client.go
@@ -1,0 +1,181 @@
+package bazaar
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	x402http "github.com/coinbase/x402/go/http"
+)
+
+// ListDiscoveryResourcesParams contains optional filtering and pagination parameters
+// for listing discovery resources from a facilitator's bazaar.
+type ListDiscoveryResourcesParams struct {
+	// Type filters by protocol type (e.g., "http", "mcp").
+	Type string
+
+	// Limit is the number of discovered x402 resources to return per page.
+	Limit int
+
+	// Offset is the offset of the first discovered x402 resource to return.
+	Offset int
+}
+
+// DiscoveryResource represents a discovered x402 resource from the bazaar.
+type DiscoveryResource struct {
+	// Resource is the URL or identifier of the discovered resource.
+	Resource string `json:"resource"`
+
+	// Type is the protocol type of the resource (e.g., "http").
+	Type string `json:"type"`
+
+	// X402Version is the x402 protocol version supported by this resource.
+	X402Version int `json:"x402Version"`
+
+	// Accepts is an array of accepted payment methods for this resource.
+	Accepts []json.RawMessage `json:"accepts"`
+
+	// LastUpdated is an ISO 8601 timestamp of when the resource was last updated.
+	LastUpdated string `json:"lastUpdated"`
+
+	// Metadata contains additional metadata about the resource.
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// Pagination contains pagination information for a discovery resources response.
+type Pagination struct {
+	// Limit is the maximum number of results returned.
+	Limit int `json:"limit"`
+
+	// Offset is the number of results skipped.
+	Offset int `json:"offset"`
+
+	// Total is the total count of resources matching the query.
+	Total int `json:"total"`
+}
+
+// DiscoveryResourcesResponse is the response from listing discovery resources.
+type DiscoveryResourcesResponse struct {
+	// X402Version is the x402 protocol version of this response.
+	X402Version int `json:"x402Version"`
+
+	// Items is the list of discovered resources.
+	Items []DiscoveryResource `json:"items"`
+
+	// Pagination contains pagination information for the response.
+	Pagination Pagination `json:"pagination"`
+}
+
+// BazaarFacilitatorClient wraps an HTTPFacilitatorClient with bazaar discovery
+// query functionality. It preserves all original facilitator client capabilities
+// (Verify, Settle, GetSupported) and adds the ability to list discovered x402
+// resources from the facilitator's bazaar.
+type BazaarFacilitatorClient struct {
+	*x402http.HTTPFacilitatorClient
+}
+
+// WithBazaar extends a facilitator client with bazaar discovery query functionality.
+//
+// Example:
+//
+//	client := bazaar.WithBazaar(http.NewHTTPFacilitatorClient(nil))
+//	resources, err := client.ListDiscoveryResources(ctx, &bazaar.ListDiscoveryResourcesParams{
+//	    Type: "http",
+//	    Limit: 20,
+//	})
+func WithBazaar(client *x402http.HTTPFacilitatorClient) *BazaarFacilitatorClient {
+	return &BazaarFacilitatorClient{HTTPFacilitatorClient: client}
+}
+
+// ListDiscoveryResources queries the facilitator's /discovery/resources endpoint
+// to list x402 discovery resources from the bazaar.
+//
+// Params may be nil to list all resources without filtering.
+func (c *BazaarFacilitatorClient) ListDiscoveryResources(
+	ctx context.Context,
+	params *ListDiscoveryResourcesParams,
+) (*DiscoveryResourcesResponse, error) {
+	// Build URL with query parameters
+	endpoint, err := c.buildDiscoveryURL(params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build discovery URL: %w", err)
+	}
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create discovery request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	// Add auth headers if available
+	authProvider := c.GetAuthProvider()
+	if authProvider != nil {
+		authHeaders, err := authProvider.GetAuthHeaders(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get auth headers: %w", err)
+		}
+		for k, v := range authHeaders.Discovery {
+			req.Header.Set(k, v)
+		}
+	}
+
+	// Make request
+	resp, err := c.HTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("discovery request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Check for error response
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("facilitator listDiscoveryResources failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	// Parse response
+	var result DiscoveryResourcesResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode discovery response: %w", err)
+	}
+
+	return &result, nil
+}
+
+// buildDiscoveryURL constructs the full /discovery/resources URL with query parameters.
+func (c *BazaarFacilitatorClient) buildDiscoveryURL(params *ListDiscoveryResourcesParams) (string, error) {
+	base := c.URL() + "/discovery/resources"
+
+	if params == nil {
+		return base, nil
+	}
+
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	if params.Type != "" {
+		q.Set("type", params.Type)
+	}
+	if params.Limit > 0 {
+		q.Set("limit", strconv.Itoa(params.Limit))
+	}
+	if params.Offset > 0 {
+		q.Set("offset", strconv.Itoa(params.Offset))
+	}
+
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/go/extensions/bazaar/facilitator_client_test.go
+++ b/go/extensions/bazaar/facilitator_client_test.go
@@ -1,0 +1,491 @@
+package bazaar
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	x402http "github.com/coinbase/x402/go/http"
+)
+
+// testAuthProvider is a test helper that returns fixed auth headers.
+type testAuthProvider struct {
+	headers x402http.AuthHeaders
+	err     error
+}
+
+func (p *testAuthProvider) GetAuthHeaders(_ context.Context) (x402http.AuthHeaders, error) {
+	return p.headers, p.err
+}
+
+func TestWithBazaar(t *testing.T) {
+	client := x402http.NewHTTPFacilitatorClient(nil)
+	bazaarClient := WithBazaar(client)
+
+	if bazaarClient == nil {
+		t.Fatal("Expected non-nil bazaar client")
+	}
+	if bazaarClient.HTTPFacilitatorClient != client {
+		t.Error("Expected embedded client to match original")
+	}
+}
+
+func TestWithBazaar_PreservesOriginalMethods(t *testing.T) {
+	client := x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: "https://example.com/facilitator",
+	})
+	bazaarClient := WithBazaar(client)
+
+	// Verify the wrapped client preserves the URL
+	if bazaarClient.URL() != "https://example.com/facilitator" {
+		t.Errorf("Expected URL https://example.com/facilitator, got %s", bazaarClient.URL())
+	}
+}
+
+func TestListDiscoveryResources_Success(t *testing.T) {
+	ctx := context.Background()
+
+	expectedResponse := DiscoveryResourcesResponse{
+		X402Version: 2,
+		Items: []DiscoveryResource{
+			{
+				Resource:    "https://api.example.com/data",
+				Type:        "http",
+				X402Version: 2,
+				Accepts:     []json.RawMessage{json.RawMessage(`{"scheme":"exact","network":"eip155:1"}`)},
+				LastUpdated: "2026-03-01T00:00:00Z",
+				Metadata:    map[string]any{"category": "data"},
+			},
+		},
+		Pagination: Pagination{
+			Limit:  20,
+			Offset: 0,
+			Total:  1,
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/discovery/resources" {
+			t.Errorf("Expected path /discovery/resources, got %s", r.URL.Path)
+		}
+		if r.Method != "GET" {
+			t.Errorf("Expected GET method, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expectedResponse)
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	result, err := client.ListDiscoveryResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if result.X402Version != 2 {
+		t.Errorf("Expected x402Version 2, got %d", result.X402Version)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("Expected 1 item, got %d", len(result.Items))
+	}
+	if result.Items[0].Resource != "https://api.example.com/data" {
+		t.Errorf("Expected resource URL https://api.example.com/data, got %s", result.Items[0].Resource)
+	}
+	if result.Items[0].Type != "http" {
+		t.Errorf("Expected type http, got %s", result.Items[0].Type)
+	}
+	if result.Items[0].X402Version != 2 {
+		t.Errorf("Expected item x402Version 2, got %d", result.Items[0].X402Version)
+	}
+	if result.Items[0].LastUpdated != "2026-03-01T00:00:00Z" {
+		t.Errorf("Expected lastUpdated 2026-03-01T00:00:00Z, got %s", result.Items[0].LastUpdated)
+	}
+	if result.Items[0].Metadata["category"] != "data" {
+		t.Errorf("Expected metadata category=data, got %v", result.Items[0].Metadata["category"])
+	}
+	if result.Pagination.Limit != 20 {
+		t.Errorf("Expected pagination limit 20, got %d", result.Pagination.Limit)
+	}
+	if result.Pagination.Total != 1 {
+		t.Errorf("Expected pagination total 1, got %d", result.Pagination.Total)
+	}
+}
+
+func TestListDiscoveryResources_WithParams(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+
+		if query.Get("type") != "http" {
+			t.Errorf("Expected type=http, got %s", query.Get("type"))
+		}
+		if query.Get("limit") != "10" {
+			t.Errorf("Expected limit=10, got %s", query.Get("limit"))
+		}
+		if query.Get("offset") != "5" {
+			t.Errorf("Expected offset=5, got %s", query.Get("offset"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DiscoveryResourcesResponse{
+			X402Version: 2,
+			Items:       []DiscoveryResource{},
+			Pagination:  Pagination{Limit: 10, Offset: 5, Total: 0},
+		})
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	result, err := client.ListDiscoveryResources(ctx, &ListDiscoveryResourcesParams{
+		Type:   "http",
+		Limit:  10,
+		Offset: 5,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result.Pagination.Limit != 10 {
+		t.Errorf("Expected pagination limit 10, got %d", result.Pagination.Limit)
+	}
+	if result.Pagination.Offset != 5 {
+		t.Errorf("Expected pagination offset 5, got %d", result.Pagination.Offset)
+	}
+}
+
+func TestListDiscoveryResources_NoParams(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != "" {
+			t.Errorf("Expected no query params, got %s", r.URL.RawQuery)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DiscoveryResourcesResponse{
+			X402Version: 2,
+			Items:       []DiscoveryResource{},
+			Pagination:  Pagination{Limit: 20, Offset: 0, Total: 0},
+		})
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestListDiscoveryResources_PartialParams(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+
+		if query.Get("type") != "mcp" {
+			t.Errorf("Expected type=mcp, got %s", query.Get("type"))
+		}
+		// limit and offset should not be set when zero
+		if query.Has("limit") {
+			t.Errorf("Expected no limit param, got %s", query.Get("limit"))
+		}
+		if query.Has("offset") {
+			t.Errorf("Expected no offset param, got %s", query.Get("offset"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DiscoveryResourcesResponse{
+			X402Version: 2,
+			Items:       []DiscoveryResource{},
+			Pagination:  Pagination{Limit: 20, Offset: 0, Total: 0},
+		})
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, &ListDiscoveryResourcesParams{
+		Type: "mcp",
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestListDiscoveryResources_ErrorResponse(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, nil)
+	if err == nil {
+		t.Fatal("Expected error for 500 response")
+	}
+
+	expected := "facilitator listDiscoveryResources failed (500): internal server error"
+	if err.Error() != expected {
+		t.Errorf("Expected error message %q, got %q", expected, err.Error())
+	}
+}
+
+func TestListDiscoveryResources_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, nil)
+	if err == nil {
+		t.Fatal("Expected error for 404 response")
+	}
+
+	expected := "facilitator listDiscoveryResources failed (404): not found"
+	if err.Error() != expected {
+		t.Errorf("Expected error message %q, got %q", expected, err.Error())
+	}
+}
+
+func TestListDiscoveryResources_InvalidJSON(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"x402Version":`))
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, nil)
+	if err == nil {
+		t.Fatal("Expected error for invalid JSON response")
+	}
+}
+
+func TestListDiscoveryResources_WithAuthHeaders(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-token" {
+			t.Errorf("Expected Authorization header 'Bearer test-token', got %q", auth)
+		}
+
+		apiKey := r.Header.Get("X-Api-Key")
+		if apiKey != "my-key" {
+			t.Errorf("Expected X-Api-Key header 'my-key', got %q", apiKey)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DiscoveryResourcesResponse{
+			X402Version: 2,
+			Items:       []DiscoveryResource{},
+			Pagination:  Pagination{Limit: 20, Offset: 0, Total: 0},
+		})
+	}))
+	defer server.Close()
+
+	authProvider := &testAuthProvider{
+		headers: x402http.AuthHeaders{
+			Discovery: map[string]string{
+				"Authorization": "Bearer test-token",
+				"X-Api-Key":     "my-key",
+			},
+		},
+	}
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL:          server.URL,
+		AuthProvider: authProvider,
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestListDiscoveryResources_NoAuthProvider(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Should not have Authorization header when no auth provider
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("Expected no Authorization header, got %q", r.Header.Get("Authorization"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(DiscoveryResourcesResponse{
+			X402Version: 2,
+			Items:       []DiscoveryResource{},
+			Pagination:  Pagination{Limit: 20, Offset: 0, Total: 0},
+		})
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestListDiscoveryResources_AuthProviderError(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("Request should not have been made when auth provider fails")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	authProvider := &testAuthProvider{
+		err: http.ErrAbortHandler,
+	}
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL:          server.URL,
+		AuthProvider: authProvider,
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, nil)
+	if err == nil {
+		t.Fatal("Expected error when auth provider fails")
+	}
+}
+
+func TestListDiscoveryResources_MultipleItems(t *testing.T) {
+	ctx := context.Background()
+
+	expectedResponse := DiscoveryResourcesResponse{
+		X402Version: 2,
+		Items: []DiscoveryResource{
+			{
+				Resource:    "https://api.example.com/endpoint1",
+				Type:        "http",
+				X402Version: 2,
+				Accepts:     []json.RawMessage{json.RawMessage(`{"scheme":"exact"}`)},
+				LastUpdated: "2026-03-01T00:00:00Z",
+			},
+			{
+				Resource:    "https://api.example.com/endpoint2",
+				Type:        "http",
+				X402Version: 1,
+				Accepts:     []json.RawMessage{json.RawMessage(`{"scheme":"exact"}`)},
+				LastUpdated: "2026-02-28T00:00:00Z",
+			},
+			{
+				Resource:    "mcp://tools/search",
+				Type:        "mcp",
+				X402Version: 2,
+				Accepts:     []json.RawMessage{json.RawMessage(`{"scheme":"exact"}`)},
+				LastUpdated: "2026-03-01T12:00:00Z",
+			},
+		},
+		Pagination: Pagination{
+			Limit:  20,
+			Offset: 0,
+			Total:  3,
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(expectedResponse)
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	result, err := client.ListDiscoveryResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(result.Items) != 3 {
+		t.Fatalf("Expected 3 items, got %d", len(result.Items))
+	}
+	if result.Items[0].Resource != "https://api.example.com/endpoint1" {
+		t.Errorf("Expected first resource https://api.example.com/endpoint1, got %s", result.Items[0].Resource)
+	}
+	if result.Items[2].Type != "mcp" {
+		t.Errorf("Expected third resource type mcp, got %s", result.Items[2].Type)
+	}
+	if result.Pagination.Total != 3 {
+		t.Errorf("Expected total 3, got %d", result.Pagination.Total)
+	}
+}
+
+func TestListDiscoveryResources_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("Request should not have been made with cancelled context")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: server.URL,
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, nil)
+	if err == nil {
+		t.Fatal("Expected error with cancelled context")
+	}
+}
+
+func TestListDiscoveryResources_ConnectionError(t *testing.T) {
+	ctx := context.Background()
+
+	// Use a URL that will fail to connect
+	client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+		URL: "http://127.0.0.1:1", // Port 1 should fail
+	}))
+
+	_, err := client.ListDiscoveryResources(ctx, nil)
+	if err == nil {
+		t.Fatal("Expected error for connection failure")
+	}
+}

--- a/go/http/facilitator_client.go
+++ b/go/http/facilitator_client.go
@@ -37,6 +37,7 @@ type AuthHeaders struct {
 	Verify    map[string]string
 	Settle    map[string]string
 	Supported map[string]string
+	Discovery map[string]string
 }
 
 // FacilitatorConfig configures the HTTP facilitator client
@@ -99,6 +100,21 @@ func NewHTTPFacilitatorClient(config *FacilitatorConfig) *HTTPFacilitatorClient 
 		authProvider: config.AuthProvider,
 		identifier:   identifier,
 	}
+}
+
+// URL returns the base URL of the facilitator service.
+func (c *HTTPFacilitatorClient) URL() string {
+	return c.url
+}
+
+// HTTPClient returns the underlying HTTP client.
+func (c *HTTPFacilitatorClient) HTTPClient() *http.Client {
+	return c.httpClient
+}
+
+// GetAuthProvider returns the authentication provider, or nil if not configured.
+func (c *HTTPFacilitatorClient) GetAuthProvider() AuthProvider {
+	return c.authProvider
 }
 
 // ============================================================================


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

### Summary

- Add `WithBazaar()` decorator that wraps `HTTPFacilitatorClient` with bazaar discovery query functionality, achieving parity with the TypeScript `withBazaar()` implementation
- Add `ListDiscoveryResources()` method to query the facilitator's `GET /discovery/resources` endpoint with optional filtering (`type`) and pagination (`limit`, `offset`)
- Add getter methods (`URL()`, `HTTPClient()`, `GetAuthProvider()`) to `HTTPFacilitatorClient` for cross-package access
- Add `Discovery` field to `AuthHeaders` for discovery endpoint authentication

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

- [x] `TestWithBazaar` - wrapper creation and embedded client preservation
- [x] `TestListDiscoveryResources_Success` - full response parsing with all fields
- [x] `TestListDiscoveryResources_WithParams` - query parameter forwarding (type, limit, offset)
- [x] `TestListDiscoveryResources_NoParams` / `_PartialParams` - zero-value param handling
- [x] `TestListDiscoveryResources_ErrorResponse` / `_NotFound` - HTTP error status handling
- [x] `TestListDiscoveryResources_InvalidJSON` - malformed response handling
- [x] `TestListDiscoveryResources_WithAuthHeaders` / `_NoAuthProvider` / `_AuthProviderError` - auth integration
- [x] `TestListDiscoveryResources_MultipleItems` - multiple resources with mixed types
- [x] `TestListDiscoveryResources_ContextCancellation` / `_ConnectionError` - failure scenarios

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 