### PR TITLE
Add x402 On-Chain Data API to ecosystem — Services/Endpoints

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-onchain-api/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-onchain-api/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 On-Chain Data API",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/x402-onchain-api.svg",
+  "description": "Pay-per-request blockchain data API powered by the x402 protocol. Serves live on-chain data — wallet risk scores, token metrics, DeFi protocol TVL, and top yield opportunities — all gated by USDC micropayments on Base. No subscriptions, no API keys. Each call costs $0.05–$0.25 USDC.",
+  "websiteUrl": "https://github.com/0xEtherial/x402-onchain-api"
+}

--- a/typescript/site/public/logos/x402-onchain-api.svg
+++ b/typescript/site/public/logos/x402-onchain-api.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="20" fill="#0052FF"/>
+  <text x="100" y="85" font-family="monospace" font-size="36" font-weight="bold" fill="white" text-anchor="middle">x402</text>
+  <text x="100" y="130" font-family="monospace" font-size="16" fill="#A8C4FF" text-anchor="middle">on-chain</text>
+  <text x="100" y="155" font-family="monospace" font-size="16" fill="#A8C4FF" text-anchor="middle">data api</text>
+</svg>


### PR DESCRIPTION
## Project: x402 On-Chain Data API

A pay-per-request blockchain data server built on the x402 protocol.

**What it serves:**
- `GET /wallet/:address/score` — $0.10 USDC — wallet risk scoring (Base + Ethereum RPC)
- `GET /token/:symbol/metrics` — $0.10 USDC — CoinGecko market data
- `GET /protocol/:name/tvl` — $0.05 USDC — DeFiLlama protocol TVL
- `GET /yields/top` — $0.10 USDC — top DeFi yield opportunities
- `POST /wallet/batch` — $0.25 USDC — batch wallet scoring (up to 5 wallets)

**Payment:** USDC on Base Mainnet
**Receiving address:** `0xDA05AB5d0528dC36B70fD9e6f23C763e2B2684fd`
**x402 scheme:** `exact`

**Category:** Services/Endpoints
**GitHub:** https://github.com/0xEtherial/x402-onchain-api

This is a live implementation demonstrating x402 as a machine-native monetization primitive for crypto data APIs. Any x402-compatible client can query it without API keys or subscriptions.

Also includes an MCP server wrapper (`io.github.0xetherial.x402-blockchain-data`) that exposes all five endpoints as MCP tools for Claude and other AI clients.