### PR TITLE
feat: Add Swarmrails Bittensor x402 gateway to ecosystem"

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/mcp-example/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/mcp-example/metadata.json
@@ -4,4 +4,11 @@
   "logoUrl": "/logos/mcp-example.png",
   "description": "A reference implementation MCP server and wallet to call x402 endpoints. Explore the code and run your own server.",
   "websiteUrl": "https://github.com/coinbase/x402/tree/main/examples/typescript/mcp"
+},
+{
+  "name": "Swarmrails",
+  "description": "x402 gateway for Bittensor subnets (USDC pay-per-call). Access Text Prompting, Image Gen, Code, TTS & more via one endpoint.",
+  "logoUrl": "https://github.com/wizerai1111/swarmrails-bittensor/raw/main/logo.png",
+  "websiteUrl": "https://github.com/wizerai1111/swarmrails-bittensor",
+  "category": "Services/Endpoints"
 }


### PR DESCRIPTION
Adds Swarmrails x402 gateway for Bittensor subnets.

- Pay-per-call USDC on Base ($0.005+)
- 13+ subnets: Text, Image Gen, Code, TTS, etc.
- No keys/subs needed

Docs: https://github.com/wizerai1111/swarmrails-bittensor


