### PR TITLE
feat(ecosystem): update DJD Agent Score — production URL and expanded description

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/djd-agent-score/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/djd-agent-score/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "DJD Agent Score",
-  "description": "Reputation scoring API for AI agent wallets on Base. Scores agents 0–100 based on on-chain signals and provides x402-agent-score Hono middleware for gating API requests by reputation.",
+  "category": "Services/Endpoints",
   "logoUrl": "/logos/djd-agent-score.png",
-  "websiteUrl": "https://djd-agent-score.fly.dev",
-  "category": "Services/Endpoints"
+  "description": "On-chain reputation scoring for autonomous AI agents on Base. Five-dimension trust scores (0-100) covering reliability, viability, identity, behavior, and capability. Free tier for basic lookups; paid endpoints via x402 USDC micropayments.",
+  "websiteUrl": "https://djdagentscore.dev"
 }


### PR DESCRIPTION
## Summary

Updates the existing DJD Agent Score ecosystem entry (merged in #1303) with:

- **Production URL**: `https://djdagentscore.dev` (was pointing to `djd-agent-score.fly.dev`)
- **Expanded description**: Now mentions five-dimension scoring (reliability, viability, identity, behavior, capability), free tier, and x402 micropayments

## DJD Agent Score

**URL:** https://djdagentscore.dev
**Docs:** https://djdagentscore.dev/docs
**Category:** Services/Endpoints

### What it does

DJD Agent Score is an on-chain reputation API for autonomous AI agents on Base L2. Merchants and services accepting x402 payments from unknown agents can query the API to get a trust score (0-100) before fulfilling a request.

Every paid score query is itself settled via x402 USDC micropayments on Base.

### Scoring dimensions

| Dimension | Weight | What it measures |
|---|---|---|
| Payment Reliability | 30% | Transaction history and consistency on Base |
| Economic Viability | 25% | Financial health signals from USDC activity |
| Identity | 20% | Verifiable identity markers (Basename, GitHub, registration) |
| Behavior | 15% | Transaction timing patterns and anomaly detection |
| Capability | 10% | Demonstrated service delivery and ecosystem participation |

### API (live on Base mainnet)

- Free: 10 basic score lookups/day, no payment needed
- $0.10 USDC via x402: full breakdown with all dimensions
- $0.25 USDC via x402: force live recalculation
- $0.15 USDC via x402: historical scores with trend analysis

### Integrations

- TypeScript SDK: [`djd-agent-score-client`](https://www.npmjs.com/package/djd-agent-score-client)
- Python SDK: [`djd-agent-score`](https://pypi.org/project/djd-agent-score/)
- MCP Server: [`djd-agent-score-mcp`](https://www.npmjs.com/package/djd-agent-score-mcp)
- LangChain + CrewAI tools included