### PR TITLE
feat(e2e): add multi-mechanism /protected-multi endpoint to Express server

### DIFF
--- a/e2e/servers/express/index.ts
+++ b/e2e/servers/express/index.ts
@@ -19,6 +19,11 @@ dotenv.config();
  *
  * This server demonstrates how to integrate x402 payment middleware
  * with an Express application for end-to-end testing.
+ *
+ * Includes a multi-mechanism /protected-multi endpoint that offers multiple
+ * payment options (EIP-3009 and Permit2) on a single route via an accepts array.
+ * This is the recommended pattern for production resource servers — clients
+ * select their preferred payment method from the available options.
  */
 
 const PORT = process.env.PORT || "4021";
@@ -211,6 +216,97 @@ app.use(
           ...declareErc20ApprovalGasSponsoringExtension(),
         },
       },
+      // Multi-mechanism endpoint: a single route offering multiple payment methods.
+      // The accepts array lets clients choose their preferred payment method from
+      // four options spanning two chains and three transfer mechanisms.
+      // Array order expresses server preference; the client makes the final choice.
+      //
+      // Gas sponsoring: both flavors are declared on this route.
+      // - erc20ApprovalGasSponsoring: for WETH (option 2), a plain ERC-20 needing
+      //   a separate approve() tx broadcast by the facilitator.
+      // - eip2612GasSponsoring: for USDC-via-Permit2 (option 4), enabling atomic
+      //   permit() + transfer in a single settleWithPermit() transaction.
+      // The client SDK handles per-option relevance — options that don't need
+      // gas sponsoring (EIP-3009, SVM) simply ignore the extension data.
+      "GET /protected-multi": {
+        accepts: [
+          // Option 1: USDC via EIP-3009 on Base Sepolia (most widely supported)
+          {
+            payTo: EVM_PAYEE_ADDRESS,
+            scheme: "exact",
+            price: "$0.001",
+            network: EVM_NETWORK,
+          },
+          // Option 2: WETH via Permit2 on Base Sepolia (distinct asset, different mechanism)
+          // WETH is a plain ERC-20 (no EIP-3009, no EIP-2612), so Permit2 is required.
+          // The erc20ApprovalGasSponsoring extension covers the initial approve() gas.
+          // Using a different asset from option 1 ensures each option is independently
+          // reachable by default client behavior based on the client's token holdings —
+          // no custom PaymentPolicy needed to exercise this path.
+          {
+            payTo: EVM_PAYEE_ADDRESS,
+            scheme: "exact",
+            network: EVM_NETWORK,
+            price: {
+              amount: "1000000000000", // 0.000001 WETH (18 decimals)
+              asset: "0x4200000000000000000000000000000000000006", // WETH on Base Sepolia (OP Stack predeploy)
+              extra: {
+                assetTransferMethod: "permit2",
+              },
+            },
+          },
+          // Option 3: USDC on Solana Devnet (cross-chain alternative)
+          {
+            payTo: SVM_PAYEE_ADDRESS,
+            scheme: "exact",
+            price: "$0.001",
+            network: SVM_NETWORK,
+          },
+          // Option 4: USDC via Permit2 on Base Sepolia (EIP-2612 gas sponsoring demo)
+          // Same USDC as option 1, but forces Permit2 path via assetTransferMethod.
+          // Demonstrates the atomic settleWithPermit() flow where the facilitator
+          // calls permit() + permitWitnessTransferFrom() in a single transaction.
+          // NOT auto-reachable when option 1 exists (same asset) — requires a custom
+          // PaymentPolicy to exercise. Covered in the follow-up PR.
+          {
+            payTo: EVM_PAYEE_ADDRESS,
+            scheme: "exact",
+            network: EVM_NETWORK,
+            price: {
+              amount: "1000", // 0.001 USDC (6 decimals)
+              asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e", // Base Sepolia USDC
+              extra: {
+                assetTransferMethod: "permit2",
+                name: "USDC",
+                version: "2",
+              },
+            },
+          },
+        ],
+        extensions: {
+          // Gas sponsoring: both flavors declared for full mechanism coverage.
+          // - erc20ApprovalGasSponsoring: for WETH (option 2, plain ERC-20)
+          // - eip2612GasSponsoring: for USDC-via-Permit2 (option 4, has permit())
+          // Irrelevant for option 1 (EIP-3009 is gasless) and option 3 (SVM).
+          ...declareErc20ApprovalGasSponsoringExtension(),
+          ...declareEip2612GasSponsoringExtension(),
+          ...declareDiscoveryExtension({
+            output: {
+              example: {
+                message: "Multi-mechanism endpoint accessed successfully",
+                timestamp: "2024-01-01T00:00:00Z",
+              },
+              schema: {
+                properties: {
+                  message: { type: "string" },
+                  timestamp: { type: "string" },
+                },
+                required: ["message", "timestamp"],
+              },
+            },
+          }),
+        },
+      },
       // Permit2 standard/direct endpoint - no gas sponsoring, client must pre-approve Permit2
       "GET /protected-permit2": {
         accepts: {
@@ -352,6 +448,24 @@ app.get("/protected-aptos", (req, res) => {
 });
 
 /**
+ * Multi-mechanism endpoint - accepts multiple payment methods across chains
+ *
+ * This endpoint demonstrates the recommended production pattern: a single resource
+ * offering multiple payment methods via an accepts array. Clients select the
+ * method they support or prefer. The server's ordering expresses preference
+ * (EIP-3009 first), but the client makes the final choice.
+ *
+ * Accepts: USDC via EIP-3009 (EVM), WETH via Permit2 (EVM), USDC (SVM),
+ * and USDC via Permit2 with EIP-2612 gas sponsoring (EVM).
+ */
+app.get("/protected-multi", (req, res) => {
+  res.json({
+    message: "Multi-mechanism endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+  });
+});
+
+/**
  * Protected Permit2 ERC-20 endpoint - requires payment via Permit2 flow with ERC-20 approval
  *
  * This endpoint demonstrates the ERC-20 approval gas sponsoring flow for tokens
@@ -456,6 +570,7 @@ app.listen(parseInt(PORT), () => {
 ║                                                        ║
 ║  Endpoints:                                            ║
 ║  • GET  /protected             (EIP-3009 payment - EVM)    ║
+║  • GET  /protected-multi       (EIP-3009+Permit2+SVM+EIP2612) ║
 ║  • GET  /protected-svm         (SVM payment)               ║
 ║  • GET  /protected-aptos       (Aptos payment)             ║
 ║  • GET  /protected-permit2     (Permit2 direct - EVM)       ║

--- a/e2e/servers/express/test.config.json
+++ b/e2e/servers/express/test.config.json
@@ -40,6 +40,15 @@
       "extensions": ["erc20ApprovalGasSponsoring"]
     },
     {
+      "path": "/protected-multi",
+      "method": "GET",
+      "description": "Multi-mechanism endpoint: USDC (EIP-3009), WETH (Permit2 + ERC-20 gas sponsoring), SVM, and USDC (Permit2 + EIP-2612 gas sponsoring)",
+      "requiresPayment": true,
+      "protocolFamily": ["evm", "svm"],
+      "transferMethod": ["eip3009", "permit2"],
+      "extensions": ["erc20ApprovalGasSponsoring", "eip2612GasSponsoring", "bazaar"]
+    },
+    {
       "path": "/protected-svm",
       "method": "GET",
       "description": "Protected endpoint requiring payment on SVM network",

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceServer.initialize.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceServer.initialize.test.ts
@@ -226,6 +226,66 @@ describe("x402HTTPResourceServer.initialize", () => {
       await expect(httpServer.initialize()).resolves.not.toThrow();
     });
 
+    it("should initialize with multi-mechanism accepts spanning chains and transfer methods", async () => {
+      const routes: RoutesConfig = {
+        "GET /protected-multi": {
+          accepts: [
+            {
+              scheme: testScheme,
+              payTo: "0x123",
+              price: "$0.001",
+              network: testNetwork,
+            },
+            {
+              scheme: testScheme,
+              payTo: "0x123",
+              price: { amount: "1000", asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e" },
+              network: testNetwork,
+            },
+            {
+              scheme: "exact",
+              payTo: "solana_address",
+              price: "$0.001",
+              network: solanaNetwork,
+            },
+          ],
+          description: "Multi-mechanism endpoint with EIP-3009, Permit2, and SVM options",
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(server, routes);
+
+      await expect(httpServer.initialize()).resolves.not.toThrow();
+    });
+
+    it("should reject multi-mechanism route when one option uses unsupported network", async () => {
+      const unsupportedNetwork = "aptos:2" as Network;
+
+      const routes: RoutesConfig = {
+        "GET /protected-multi": {
+          accepts: [
+            {
+              scheme: testScheme,
+              payTo: "0x123",
+              price: "$0.001",
+              network: testNetwork,
+            },
+            {
+              scheme: "exact",
+              payTo: "aptos_address",
+              price: "$0.001",
+              network: unsupportedNetwork,
+            },
+          ],
+          description: "Multi-mechanism with unsupported option",
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(server, routes);
+
+      await expect(httpServer.initialize()).rejects.toThrow(RouteConfigurationError);
+    });
+
     it("should collect errors from multiple routes", async () => {
       const unsupportedNetwork = "unsupported:network" as Network;
 

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -628,6 +628,242 @@ describe("paymentMiddleware", () => {
   });
 });
 
+describe("paymentMiddleware with multi-mechanism accepts array", () => {
+  const multiMechanismRoutes = {
+    "GET /protected-multi": {
+      accepts: [
+        { scheme: "exact", payTo: "0x123", price: "$0.001", network: "eip155:84532" },
+        {
+          scheme: "exact",
+          payTo: "0x123",
+          network: "eip155:84532",
+          price: {
+            amount: "1000000000000",
+            asset: "0x4200000000000000000000000000000000000006",
+            extra: { assetTransferMethod: "permit2" },
+          },
+        },
+        {
+          scheme: "exact",
+          payTo: "SVM_ADDRESS",
+          price: "$0.001",
+          network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+        },
+        {
+          scheme: "exact",
+          payTo: "0x123",
+          network: "eip155:84532",
+          price: {
+            amount: "1000",
+            asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+            extra: { assetTransferMethod: "permit2", name: "USDC", version: "2" },
+          },
+        },
+      ],
+    },
+  } as const;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcessHTTPRequest = vi.fn();
+    mockProcessSettlement = vi.fn();
+    mockRegisterPaywallProvider = vi.fn();
+    mockRequiresPayment = vi.fn().mockReturnValue(true);
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+  });
+
+  it("creates middleware with multi-element accepts array", async () => {
+    setupMockHttpServer({ type: "no-payment-required" });
+
+    const middleware = paymentMiddleware(
+      multiMechanismRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest({ path: "/protected-multi", method: "GET" });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockProcessHTTPRequest).toHaveBeenCalled();
+  });
+
+  it("returns 402 for multi-mechanism route without payment", async () => {
+    setupMockHttpServer({
+      type: "payment-error",
+      response: {
+        status: 402,
+        body: {
+          x402Version: 2,
+          accepts: [
+            { scheme: "exact", payTo: "0x123", network: "eip155:84532" },
+            { scheme: "exact", payTo: "0x123", network: "eip155:84532" },
+            {
+              scheme: "exact",
+              payTo: "SVM_ADDRESS",
+              network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+            },
+            { scheme: "exact", payTo: "0x123", network: "eip155:84532" },
+          ],
+        },
+        headers: { "PAYMENT-REQUIRED": "encoded-requirements" },
+        isHtml: false,
+      },
+    });
+
+    const middleware = paymentMiddleware(
+      multiMechanismRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest({ path: "/protected-multi", method: "GET" });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(402);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        x402Version: 2,
+        accepts: expect.arrayContaining([
+          expect.objectContaining({ network: "eip155:84532" }),
+          expect.objectContaining({ network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1" }),
+        ]),
+      }),
+    );
+    // Verify all four options are present (not just a subset)
+    const body = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(body.accepts).toHaveLength(4);
+  });
+
+  it("includes both gas sponsoring extensions in 402 response", async () => {
+    setupMockHttpServer({
+      type: "payment-error",
+      response: {
+        status: 402,
+        body: {
+          x402Version: 2,
+          accepts: [{ scheme: "exact", payTo: "0x123", network: "eip155:84532" }],
+          extensions: {
+            erc20ApprovalGasSponsoring: { enabled: true },
+            eip2612GasSponsoring: { enabled: true },
+          },
+        },
+        headers: { "PAYMENT-REQUIRED": "encoded-requirements" },
+        isHtml: false,
+      },
+    });
+
+    const middleware = paymentMiddleware(
+      multiMechanismRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest({ path: "/protected-multi", method: "GET" });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    const body = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(body.extensions).toBeDefined();
+    expect(body.extensions).toHaveProperty("erc20ApprovalGasSponsoring");
+    expect(body.extensions).toHaveProperty("eip2612GasSponsoring");
+  });
+
+  it("sets PAYMENT-REQUIRED header for multi-mechanism route", async () => {
+    setupMockHttpServer({
+      type: "payment-error",
+      response: {
+        status: 402,
+        body: { x402Version: 2, accepts: [] },
+        headers: { "PAYMENT-REQUIRED": "base64-encoded-requirements" },
+        isHtml: false,
+      },
+    });
+
+    const middleware = paymentMiddleware(
+      multiMechanismRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest({ path: "/protected-multi", method: "GET" });
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("PAYMENT-REQUIRED", "base64-encoded-requirements");
+  });
+
+  it("settles payment for multi-mechanism route with verified payment", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const middleware = paymentMiddleware(
+      multiMechanismRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest({ path: "/protected-multi", method: "GET" });
+    const res = createMockResponse();
+    const next = vi.fn(() => {
+      res.statusCode = 200;
+      res.end();
+    });
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockProcessSettlement).toHaveBeenCalledWith(
+      mockPaymentPayload,
+      mockPaymentRequirements,
+      undefined,
+      expect.objectContaining({
+        request: expect.objectContaining({
+          path: "/protected-multi",
+          method: "GET",
+        }),
+      }),
+    );
+    expect(res.setHeader).toHaveBeenCalledWith("PAYMENT-RESPONSE", "settled");
+  });
+});
+
 describe("paymentMiddlewareFromConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
### Summary

Adds a `/protected-multi` endpoint to the Express e2e server — the first reference implementation of a multi-element `accepts` array. The endpoint offers four payment options spanning two chains, three transfer mechanisms, and both gas sponsoring flavors.

Closes #1449

### Design

The `accepts` array has four options covering the full range of x402 payment mechanisms:

| # | Asset | Mechanism | Network | Gas Sponsoring | Selection |
|---|-------|-----------|---------|---------------|-----------|
| 1 | USDC | EIP-3009 | Base Sepolia | N/A (gasless natively) | Default for USDC holders |
| 2 | WETH | Permit2 | Base Sepolia | `erc20ApprovalGasSponsoring` | Default for WETH holders |
| 3 | USDC | Native transfer | Solana Devnet | N/A (SVM) | Default for SOL-USDC holders |
| 4 | USDC | Permit2 | Base Sepolia | `eip2612GasSponsoring` | Requires custom `PaymentPolicy` |

**Why WETH for option 2?** The default client selector picks the first compatible option. If options 1 and 2 both used USDC on the same network, a client with USDC would always match option 1 — making option 2 unreachable without a custom `PaymentPolicy`. WETH (`0x4200000000000000000000000000000000000006`, OP Stack predeploy) is a distinct asset, so each option is independently exercisable based on what the client holds. WETH is a plain ERC-20 with no EIP-3009 or EIP-2612, making Permit2 the only valid transfer method.

**Why option 4 shares USDC with option 1?** Option 4 demonstrates the atomic `settleWithPermit()` flow — the facilitator calls `permit()` + `permitWitnessTransferFrom()` in a single transaction. USDC is the only widely available token on Base Sepolia with EIP-2612 `permit()` support. Since option 1 also uses USDC (via EIP-3009), option 4 is not auto-reachable by default client behavior — it requires a custom `PaymentPolicy` to exercise, which is expected to be covered in a follow-up PR focused on this aspect, so we consider it out of scope in this PR.

**Gas sponsoring:** Both flavors are declared on this route:
- `erc20ApprovalGasSponsoring` — for WETH (option 2). Facilitator broadcasts the client's signed `approve()` tx, paying gas. Two on-chain transactions.
- `eip2612GasSponsoring` — for USDC-via-Permit2 (option 4). Facilitator calls `permit()` + transfer atomically via `settleWithPermit()`. Single transaction.

Extensions are per-route (not per-option) in the current spec. The client SDK handles this correctly — options that don't need gas sponsoring (EIP-3009, SVM) simply ignore the extension data. The client also checks existing `allowance(owner, Permit2)` before signing any gas sponsoring artifact, skipping it if already approved.

### Changes

- `/protected-multi` endpoint configuration with four-option `accepts` array
- Both gas sponsoring extensions (`erc20ApprovalGasSponsoring` + `eip2612GasSponsoring`)
- Route handler and server banner updates
- Updated `test.config.json` for e2e discovery
- 6 new unit tests:
  - 4 Express middleware tests (multi-element accepts creation, 402 response, PAYMENT-REQUIRED header, settlement)
  - 2 core initialize tests (multi-chain + multi-mechanism validation, unsupported network rejection)

### Test plan

- [x] Express middleware tests pass (41/41)
- [x] Core initialize tests pass (10/10)
- [x] Manual verification: `GET /protected-multi` returns 402 with four `accepts` entries
- [x] Manual verification: both gas sponsoring extensions appear in `PAYMENT-REQUIRED` response

### Future work (separate PR)

Client-side `PaymentPolicy` / `registerPolicy()` tests:
- Client overrides server preference (selects WETH over USDC)
- Client selects option 4 (USDC-via-Permit2) over option 1 (USDC-via-EIP-3009)
- Client prefers cross-chain SVM
- Balance-aware fallback selection