### PR TITLE
Add Run402 to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/run402/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/run402/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Run402",
+  "description": "AI-native Postgres databases, REST API, auth, storage, static sites, and serverless functions — all payable via x402. No signups.",
+  "logoUrl": "/logos/run402.svg",
+  "websiteUrl": "https://run402.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/run402.svg
+++ b/typescript/site/public/logos/run402.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect width="120" height="120" rx="16" fill="#000000"/>
+  <text x="50%" y="55%" dominant-baseline="central" text-anchor="middle"
+        font-family="monospace" font-weight="bold" font-size="48" fill="#00FF9F">&gt;$</text>
+</svg>


### PR DESCRIPTION
## Run402

AI-native Postgres databases, REST API, auth, storage, static sites, and serverless functions — all payable via x402. No signups.

**Website:** https://run402.com  
**Category:** Services/Endpoints

Run402 provisions instant Postgres databases with auto-generated REST APIs, authentication, S3-backed storage, static site hosting, and serverless functions. Provisioning and renewals are gated by x402 — agents pay with USDC on Base.

### Files added
- `typescript/site/app/ecosystem/partners-data/run402/metadata.json`
- `typescript/site/public/logos/run402.svg`