### PR TITLE
Claude/add-stellar-support-gjXK7

### DIFF
--- a/go/.changes/1.0.0.
+++ b/go/.changes/1.0.0.
@@ -1,3 +1,0 @@
-## 1.0.0 - 2025-09-12
-### Added
-- Implements x402 v1 for the Go SDK.

--- a/go/.changes/2.0.0.
+++ b/go/.changes/2.0.0.
@@ -1,3 +1,0 @@
-## 2.0.0 - 2025-10-12
-### Added
-- Implements x402 v2 for the Go SDK.

--- a/go/.changes/2.1.0.
+++ b/go/.changes/2.1.0.
@@ -1,4 +1,0 @@
-## 2.1.0 - 2026-01-09
-### Added
-- Fixed interopability bug
-- Added extensions support

--- a/go/.changes/2.2.0.
+++ b/go/.changes/2.2.0.
@@ -1,5 +1,0 @@
-## 2.2.0 - 2026-02-11
-### Added
-- Added MCP transport integration for x402 payment protocol
-- Add MegaETH mainnet (chain ID 4326) support with USDM as the default stablecoin
-- Added memo instruction with random nonce to SVM transactions to ensure uniqueness and prevent duplicate transaction attacks

--- a/go/.changes/unreleased.
+++ b/go/.changes/unreleased.
@@ -1,3 +1,0 @@
-## unreleased
-### Added
-- Implemented EIP-2612 gasless Permit2 approval extension for the exact EVM scheme, enabling clients to sign off-chain permits and facilitators to settle via `settleWithPermit`

--- a/go/.changes/unreleased/changed-20260224-permit2-post-audit.yaml
+++ b/go/.changes/unreleased/changed-20260224-permit2-post-audit.yaml
@@ -1,3 +1,0 @@
-kind: changed
-body: Update Permit2 witness struct (remove extra field), contract addresses, and error names for post-audit x402 proxy contracts on Base Sepolia
-time: 2026-02-24T00:00:00.000000Z

--- a/go/.changes/unreleased/changed-20260225-093142.yaml
+++ b/go/.changes/unreleased/changed-20260225-093142.yaml
@@ -1,3 +1,0 @@
-kind: changed
-body: Pre-compile constant regex patterns in http server for better performance
-time: 2026-02-25T09:31:42.16463+09:00

--- a/go/.changes/unreleased/fixed-20260220-093321.yaml
+++ b/go/.changes/unreleased/fixed-20260220-093321.yaml
@@ -1,3 +1,0 @@
-kind: fixed
-body: preserve query params in paywall redirect
-time: 2026-02-20T09:33:21.369429+01:00

--- a/go/.changes/v2.3.0.
+++ b/go/.changes/v2.3.0.
@@ -1,8 +1,0 @@
-## v2.3.0 - 2026-02-20
-### Added
-- Added payment-identifier extension — Enables idempotent payment requests.
-### Changed
-- Increased EVM validAfter buffer from 30 seconds to 10 minutes for consistency with TypeScript SDK
-- Upgraded facilitator extension registration from string keys to FacilitatorExtension objects. Added FacilitatorContext to SchemeNetworkFacilitator functions
-### Fixed
-- Add validAfter and validBefore timing validation to EIP-3009 verification in the Go facilitator SDK

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -85,8 +85,9 @@ type UnpaidResponseBodyFunc func(ctx context.Context, reqCtx HTTPRequestContext)
 // Represents one way a client can pay for access to the resource
 type PaymentOption struct {
 	Scheme            string                 `json:"scheme"`
-	PayTo             interface{}            `json:"payTo"` // string or DynamicPayToFunc
-	Price             interface{}            `json:"price"` // x402.Price or DynamicPriceFunc
+	PayTo             interface{}            `json:"payTo"`             // string or DynamicPayToFunc
+	Recipient         interface{}            `json:"recipient,omitempty"` // string or DynamicPayToFunc — merchant payout address when using a settlement router
+	Price             interface{}            `json:"price"`             // x402.Price or DynamicPriceFunc
 	Network           x402.Network           `json:"network"`
 	MaxTimeoutSeconds int                    `json:"maxTimeoutSeconds,omitempty"`
 	Extra             map[string]interface{} `json:"extra,omitempty"`
@@ -255,6 +256,22 @@ func (s *x402HTTPResourceServer) BuildPaymentRequirementsFromOptions(ctx context
 			resolvedPrice = option.Price
 		}
 
+		// Resolve Recipient (string or DynamicPayToFunc), if set.
+		var resolvedRecipient string
+		if option.Recipient != nil {
+			if recipientFunc, ok := option.Recipient.(DynamicPayToFunc); ok {
+				r, err := recipientFunc(ctx, reqCtx)
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve dynamic recipient: %w", err)
+				}
+				resolvedRecipient = r
+			} else if recipientStr, ok := option.Recipient.(string); ok {
+				resolvedRecipient = recipientStr
+			} else {
+				return nil, fmt.Errorf("recipient must be string or DynamicPayToFunc, got %T", option.Recipient)
+			}
+		}
+
 		// Build resource config from this option
 		resourceConfig := x402.ResourceConfig{
 			Scheme:            option.Scheme,
@@ -268,6 +285,13 @@ func (s *x402HTTPResourceServer) BuildPaymentRequirementsFromOptions(ctx context
 		requirements, err := s.BuildPaymentRequirementsFromConfig(ctx, resourceConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build requirements for option %s on %s: %w", option.Scheme, option.Network, err)
+		}
+
+		// Stamp recipient onto each requirement if resolved.
+		if resolvedRecipient != "" {
+			for i := range requirements {
+				requirements[i].Recipient = resolvedRecipient
+			}
 		}
 
 		allRequirements = append(allRequirements, requirements...)

--- a/go/mechanisms/stellar/constants.go
+++ b/go/mechanisms/stellar/constants.go
@@ -1,0 +1,76 @@
+package stellar
+
+const (
+	// SchemeExact is the scheme identifier for exact payments
+	SchemeExact = "exact"
+
+	// DefaultDecimals is the default token decimals for Stellar assets (7 decimals)
+	DefaultDecimals = 7
+
+	// Horizon endpoints
+	HorizonTestnet = "https://horizon-testnet.stellar.org"
+	HorizonMainnet = "https://horizon.stellar.org"
+
+	// Network passphrases
+	TestnetPassphrase = "Test SDF Network ; September 2015"
+	MainnetPassphrase = "Public Global Stellar Network ; September 2015"
+
+	// CAIP-2 network identifiers
+	StellarPubnetCAIP2  = "stellar:pubnet"
+	StellarTestnetCAIP2 = "stellar:testnet"
+
+	// USDC issuer addresses
+	USDCIssuerMainnet = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+	USDCIssuerTestnet = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+
+	// USDC asset code
+	USDCCode = "USDC"
+
+	// XLM native asset identifier
+	XLMNative = "native"
+)
+
+// AssetInfo contains information about a Stellar asset
+type AssetInfo struct {
+	Code     string // Asset code (e.g., "USDC", "XLM")
+	Issuer   string // Issuer address (empty for native XLM)
+	Decimals int    // Asset decimals (7 for Stellar)
+	IsNative bool   // Whether this is the native XLM asset
+}
+
+// NetworkConfig contains network-specific configuration
+type NetworkConfig struct {
+	Name         string    // Network name
+	CAIP2        string    // CAIP-2 identifier
+	Passphrase   string    // Network passphrase
+	HorizonURL   string    // Horizon API URL
+	DefaultAsset AssetInfo // Default stablecoin
+}
+
+var (
+	// NetworkConfigs maps CAIP-2 identifiers to network configurations
+	NetworkConfigs = map[string]NetworkConfig{
+		StellarPubnetCAIP2: {
+			Name:       "Stellar Pubnet",
+			CAIP2:      StellarPubnetCAIP2,
+			Passphrase: MainnetPassphrase,
+			HorizonURL: HorizonMainnet,
+			DefaultAsset: AssetInfo{
+				Code:     USDCCode,
+				Issuer:   USDCIssuerMainnet,
+				Decimals: DefaultDecimals,
+			},
+		},
+		StellarTestnetCAIP2: {
+			Name:       "Stellar Testnet",
+			CAIP2:      StellarTestnetCAIP2,
+			Passphrase: TestnetPassphrase,
+			HorizonURL: HorizonTestnet,
+			DefaultAsset: AssetInfo{
+				Code:     USDCCode,
+				Issuer:   USDCIssuerTestnet,
+				Decimals: DefaultDecimals,
+			},
+		},
+	}
+)

--- a/go/mechanisms/stellar/exact/server/errors.go
+++ b/go/mechanisms/stellar/exact/server/errors.go
@@ -1,0 +1,11 @@
+package server
+
+// Server error constants for the exact Stellar scheme (V2)
+const (
+	ErrAmountMustBeString    = "invalid_exact_stellar_server_amount_must_be_string"
+	ErrFailedToParsePrice    = "invalid_exact_stellar_server_failed_to_parse_price"
+	ErrInvalidPriceFormat    = "invalid_exact_stellar_server_invalid_price_format"
+	ErrFailedToConvertAmount = "invalid_exact_stellar_server_failed_to_convert_amount"
+	ErrFailedToParseAmount   = "invalid_exact_stellar_server_failed_to_parse_amount"
+	ErrNoAssetSpecified      = "invalid_exact_stellar_server_no_asset_specified"
+)

--- a/go/mechanisms/stellar/exact/server/scheme.go
+++ b/go/mechanisms/stellar/exact/server/scheme.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	x402 "github.com/coinbase/x402/go"
+	"github.com/coinbase/x402/go/mechanisms/stellar"
+	"github.com/coinbase/x402/go/types"
+)
+
+// ExactStellarScheme implements the SchemeNetworkServer interface for Stellar exact payments (V2)
+type ExactStellarScheme struct {
+	moneyParsers []x402.MoneyParser
+}
+
+// NewExactStellarScheme creates a new ExactStellarScheme
+func NewExactStellarScheme() *ExactStellarScheme {
+	return &ExactStellarScheme{
+		moneyParsers: []x402.MoneyParser{},
+	}
+}
+
+// Scheme returns the scheme identifier
+func (s *ExactStellarScheme) Scheme() string {
+	return stellar.SchemeExact
+}
+
+// RegisterMoneyParser registers a custom money parser in the parser chain.
+// Multiple parsers can be registered - they will be tried in registration order.
+// Each parser receives a decimal amount (e.g., 1.50 for $1.50).
+// If a parser returns nil, the next parser in the chain will be tried.
+// The default parser is always the final fallback.
+func (s *ExactStellarScheme) RegisterMoneyParser(parser x402.MoneyParser) *ExactStellarScheme {
+	s.moneyParsers = append(s.moneyParsers, parser)
+	return s
+}
+
+// ParsePrice parses a price and converts it to an asset amount (V2)
+// If price is already an AssetAmount, returns it directly.
+// If price is Money (string | number), parses to decimal and tries custom parsers.
+// Falls back to default conversion if all custom parsers return nil.
+func (s *ExactStellarScheme) ParsePrice(price x402.Price, network x402.Network) (x402.AssetAmount, error) {
+	networkStr := string(network)
+
+	config, err := stellar.GetNetworkConfig(networkStr)
+	if err != nil {
+		return x402.AssetAmount{}, err
+	}
+
+	// Handle pre-parsed price object (with amount and asset)
+	if priceMap, ok := price.(map[string]interface{}); ok {
+		if amountVal, hasAmount := priceMap["amount"]; hasAmount {
+			amountStr, ok := amountVal.(string)
+			if !ok {
+				return x402.AssetAmount{}, errors.New(ErrAmountMustBeString)
+			}
+
+			// Default to the network's default asset identifier
+			asset := stellar.FormatAssetIdentifier(config.DefaultAsset)
+			if assetVal, hasAsset := priceMap["asset"]; hasAsset {
+				if assetStr, ok := assetVal.(string); ok {
+					asset = assetStr
+				}
+			}
+
+			extra := make(map[string]interface{})
+			if extraVal, hasExtra := priceMap["extra"]; hasExtra {
+				if extraMap, ok := extraVal.(map[string]interface{}); ok {
+					extra = extraMap
+				}
+			}
+
+			return x402.AssetAmount{
+				Amount: amountStr,
+				Asset:  asset,
+				Extra:  extra,
+			}, nil
+		}
+	}
+
+	// Parse Money to decimal number
+	decimalAmount, err := s.parseMoneyToDecimal(price)
+	if err != nil {
+		return x402.AssetAmount{}, err
+	}
+
+	// Try each custom money parser in order
+	for _, parser := range s.moneyParsers {
+		result, err := parser(decimalAmount, network)
+		if err != nil {
+			continue
+		}
+		if result != nil {
+			return *result, nil
+		}
+	}
+
+	// All custom parsers returned nil, use default conversion
+	return s.defaultMoneyConversion(decimalAmount, config)
+}
+
+// parseMoneyToDecimal converts Money (string | number) to decimal amount
+func (s *ExactStellarScheme) parseMoneyToDecimal(price x402.Price) (float64, error) {
+	if priceStr, ok := price.(string); ok {
+		cleanPrice := strings.TrimSpace(priceStr)
+		cleanPrice = strings.TrimPrefix(cleanPrice, "$")
+		cleanPrice = strings.TrimSpace(cleanPrice)
+
+		parts := strings.Fields(cleanPrice)
+		if len(parts) >= 1 {
+			amount, err := strconv.ParseFloat(parts[0], 64)
+			if err != nil {
+				return 0, fmt.Errorf(ErrFailedToParsePrice+": '%s': %w", priceStr, err)
+			}
+			return amount, nil
+		}
+	}
+
+	switch v := price.(type) {
+	case float64:
+		return v, nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	}
+
+	return 0, fmt.Errorf(ErrInvalidPriceFormat+": %v", price)
+}
+
+// defaultMoneyConversion converts decimal amount to USDC AssetAmount on Stellar
+func (s *ExactStellarScheme) defaultMoneyConversion(amount float64, config *stellar.NetworkConfig) (x402.AssetAmount, error) {
+	// Convert decimal to smallest unit (e.g., $1.50 -> 15000000 for USDC with 7 decimals)
+	amountStr := fmt.Sprintf("%.7f", amount)
+	parsedAmount, err := stellar.ParseAmount(amountStr, config.DefaultAsset.Decimals)
+	if err != nil {
+		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
+	}
+
+	return x402.AssetAmount{
+		Amount: strconv.FormatUint(parsedAmount, 10),
+		Asset:  stellar.FormatAssetIdentifier(config.DefaultAsset),
+		Extra:  make(map[string]interface{}),
+	}, nil
+}
+
+// EnhancePaymentRequirements adds Stellar-specific enhancements to V2 payment requirements
+func (s *ExactStellarScheme) EnhancePaymentRequirements(
+	ctx context.Context,
+	requirements types.PaymentRequirements,
+	supportedKind types.SupportedKind,
+	extensionKeys []string,
+) (types.PaymentRequirements, error) {
+	_ = ctx
+
+	networkStr := string(requirements.Network)
+	config, err := stellar.GetNetworkConfig(networkStr)
+	if err != nil {
+		return requirements, err
+	}
+
+	// If no asset specified, use the default
+	if requirements.Asset == "" {
+		requirements.Asset = stellar.FormatAssetIdentifier(config.DefaultAsset)
+	}
+
+	// Ensure amount is in the correct format (smallest unit / stroops)
+	if requirements.Amount != "" && strings.Contains(requirements.Amount, ".") {
+		assetInfo, err := stellar.ParseAssetIdentifier(requirements.Asset)
+		if err != nil {
+			// Fall back to default decimals
+			assetInfo = &config.DefaultAsset
+		}
+		parsedAmount, err := stellar.ParseAmount(requirements.Amount, assetInfo.Decimals)
+		if err != nil {
+			return requirements, fmt.Errorf(ErrFailedToParseAmount+": %w", err)
+		}
+		requirements.Amount = strconv.FormatUint(parsedAmount, 10)
+	}
+
+	// Initialize extra map if needed
+	if requirements.Extra == nil {
+		requirements.Extra = make(map[string]interface{})
+	}
+
+	// Add Stellar-specific fields
+	if _, ok := requirements.Extra["horizonURL"]; !ok {
+		requirements.Extra["horizonURL"] = config.HorizonURL
+	}
+	if _, ok := requirements.Extra["networkPassphrase"]; !ok {
+		requirements.Extra["networkPassphrase"] = config.Passphrase
+	}
+
+	// Indicate fee sponsorship availability from facilitator
+	if supportedKind.Extra != nil {
+		if areFeesSponsored, ok := supportedKind.Extra["areFeesSponsored"]; ok {
+			requirements.Extra["areFeesSponsored"] = areFeesSponsored
+		}
+	}
+
+	// Copy extensions from supportedKind if provided
+	if supportedKind.Extra != nil {
+		for _, key := range extensionKeys {
+			if val, ok := supportedKind.Extra[key]; ok {
+				requirements.Extra[key] = val
+			}
+		}
+	}
+
+	return requirements, nil
+}

--- a/go/mechanisms/stellar/types.go
+++ b/go/mechanisms/stellar/types.go
@@ -1,0 +1,37 @@
+package stellar
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ExactStellarPayload represents a Stellar payment payload
+type ExactStellarPayload struct {
+	Transaction string `json:"transaction"` // Base64 encoded signed XDR envelope
+}
+
+// ToMap converts an ExactStellarPayload to a map for JSON marshaling
+func (p *ExactStellarPayload) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"transaction": p.Transaction,
+	}
+}
+
+// PayloadFromMap creates an ExactStellarPayload from a map
+func PayloadFromMap(data map[string]interface{}) (*ExactStellarPayload, error) {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal payload data: %w", err)
+	}
+
+	var payload ExactStellarPayload
+	if err := json.Unmarshal(jsonBytes, &payload); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+
+	if payload.Transaction == "" {
+		return nil, fmt.Errorf("missing transaction field in payload")
+	}
+
+	return &payload, nil
+}

--- a/go/mechanisms/stellar/utils.go
+++ b/go/mechanisms/stellar/utils.go
@@ -1,0 +1,151 @@
+package stellar
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	// Stellar address regex: G or C followed by 55 uppercase alphanumeric characters
+	stellarAddressRegex = regexp.MustCompile(`^[GC][A-Z2-7]{55}$`)
+)
+
+// ValidateStellarAddress checks if a string is a valid Stellar address (G... or C... format)
+func ValidateStellarAddress(address string) bool {
+	return stellarAddressRegex.MatchString(address)
+}
+
+// IsValidNetwork checks if the network is a supported Stellar network
+func IsValidNetwork(network string) bool {
+	_, ok := NetworkConfigs[network]
+	return ok
+}
+
+// GetNetworkConfig returns the configuration for a network
+func GetNetworkConfig(network string) (*NetworkConfig, error) {
+	config, ok := NetworkConfigs[network]
+	if !ok {
+		return nil, fmt.Errorf("unsupported Stellar network: %s", network)
+	}
+	return &config, nil
+}
+
+// GetAssetInfo returns information about an asset on a network
+func GetAssetInfo(network string, assetCodeOrIdentifier string) (*AssetInfo, error) {
+	config, err := GetNetworkConfig(network)
+	if err != nil {
+		return nil, err
+	}
+
+	// If empty or matches default, return default
+	if assetCodeOrIdentifier == "" || assetCodeOrIdentifier == config.DefaultAsset.Code {
+		return &config.DefaultAsset, nil
+	}
+
+	// Check for native XLM
+	if assetCodeOrIdentifier == XLMNative || strings.EqualFold(assetCodeOrIdentifier, "XLM") {
+		return &AssetInfo{
+			Code:     "XLM",
+			Issuer:   "",
+			Decimals: DefaultDecimals,
+			IsNative: true,
+		}, nil
+	}
+
+	// For known USDC issuers, return USDC info
+	if assetCodeOrIdentifier == USDCIssuerMainnet || assetCodeOrIdentifier == USDCIssuerTestnet {
+		return &config.DefaultAsset, nil
+	}
+
+	// Default to the network's default asset
+	return &config.DefaultAsset, nil
+}
+
+// FormatAssetIdentifier formats an asset as "CODE:ISSUER" or "native" for XLM
+func FormatAssetIdentifier(asset AssetInfo) string {
+	if asset.IsNative {
+		return XLMNative
+	}
+	return asset.Code + ":" + asset.Issuer
+}
+
+// ParseAssetIdentifier parses "CODE:ISSUER" or "native" into an AssetInfo
+func ParseAssetIdentifier(identifier string) (*AssetInfo, error) {
+	if identifier == XLMNative {
+		return &AssetInfo{
+			Code:     "XLM",
+			Issuer:   "",
+			Decimals: DefaultDecimals,
+			IsNative: true,
+		}, nil
+	}
+
+	parts := strings.SplitN(identifier, ":", 2)
+	if len(parts) == 2 && len(parts[0]) > 0 && ValidateStellarAddress(parts[1]) {
+		return &AssetInfo{
+			Code:     parts[0],
+			Issuer:   parts[1],
+			Decimals: DefaultDecimals,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("invalid asset identifier: %s (expected CODE:ISSUER or native)", identifier)
+}
+
+// ParseAmount converts a decimal string amount to Stellar stroops (7 decimal places)
+func ParseAmount(amount string, decimals int) (uint64, error) {
+	amount = strings.TrimSpace(amount)
+
+	parts := strings.Split(amount, ".")
+	if len(parts) > 2 {
+		return 0, fmt.Errorf("invalid amount format: %s", amount)
+	}
+
+	intPart, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer part: %s", parts[0])
+	}
+
+	decPart := uint64(0)
+	if len(parts) == 2 && parts[1] != "" {
+		decStr := parts[1]
+		if len(decStr) > decimals {
+			decStr = decStr[:decimals]
+		} else {
+			decStr += strings.Repeat("0", decimals-len(decStr))
+		}
+
+		decPart, err = strconv.ParseUint(decStr, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid decimal part: %s", parts[1])
+		}
+	}
+
+	multiplier := uint64(math.Pow10(decimals))
+	result := intPart*multiplier + decPart
+
+	return result, nil
+}
+
+// FormatAmount converts an amount in stroops to a decimal string
+func FormatAmount(amount uint64, decimals int) string {
+	if amount == 0 {
+		return "0"
+	}
+
+	divisor := uint64(math.Pow10(decimals))
+	quotient := amount / divisor
+	remainder := amount % divisor
+
+	decStr := fmt.Sprintf("%0*d", decimals, remainder)
+	decStr = strings.TrimRight(decStr, "0")
+
+	if decStr == "" {
+		return fmt.Sprintf("%d", quotient)
+	}
+
+	return fmt.Sprintf("%d.%s", quotient, decStr)
+}

--- a/go/types/v2.go
+++ b/go/types/v2.go
@@ -27,6 +27,7 @@ type PaymentRequirements struct {
 	Asset             string                 `json:"asset"`
 	Amount            string                 `json:"amount"`
 	PayTo             string                 `json:"payTo"`
+	Recipient         string                 `json:"recipient,omitempty"`
 	MaxTimeoutSeconds int                    `json:"maxTimeoutSeconds"`
 	Extra             map[string]interface{} `json:"extra,omitempty"`
 }


### PR DESCRIPTION
Add server-side SchemeNetworkServer implementation for Stellar exact
payments, following the same patterns as EVM and SVM mechanisms.

New packages:
- mechanisms/stellar: Constants, types, and utils for Stellar networks
  (stellar:pubnet, stellar:testnet), USDC asset info, address validation,
  and amount parsing (7-decimal Stellar format)
- mechanisms/stellar/exact/server: ExactStellarScheme implementing
  SchemeNetworkServer with ParsePrice and EnhancePaymentRequirements

Supports both native Stellar assets and issued tokens (e.g., USDC)
using CODE:ISSUER asset identifiers.

https://claude.ai/code/session_0197snLHGwY8ZTriRiYiahVM

<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 