### PR TITLE
fix stellar e2e config

### DIFF
--- a/e2e/servers/express/test.config.json
+++ b/e2e/servers/express/test.config.json
@@ -45,6 +45,13 @@
       "protocolFamily": "aptos"
     },
     {
+      "path": "/protected-stellar",
+      "method": "GET",
+      "description": "Protected endpoint requiring payment on Stellar network",
+      "requiresPayment": true,
+      "protocolFamily": "stellar"
+    },
+    {
       "path": "/health",
       "method": "GET",
       "description": "Health check endpoint",
@@ -59,6 +66,6 @@
   ],
   "environment": {
     "required": ["PORT", "EVM_PAYEE_ADDRESS", "SVM_PAYEE_ADDRESS", "FACILITATOR_URL"],
-    "optional": ["APTOS_PAYEE_ADDRESS"]
+    "optional": ["APTOS_PAYEE_ADDRESS", "STELLAR_PAYEE_ADDRESS"]
   }
 }

--- a/e2e/servers/hono/test.config.json
+++ b/e2e/servers/hono/test.config.json
@@ -45,6 +45,13 @@
       "protocolFamily": "aptos"
     },
     {
+      "path": "/protected-stellar",
+      "method": "GET",
+      "description": "Protected endpoint requiring payment on Stellar network",
+      "requiresPayment": true,
+      "protocolFamily": "stellar"
+    },
+    {
       "path": "/health",
       "method": "GET",
       "description": "Health check endpoint",
@@ -59,6 +66,6 @@
   ],
   "environment": {
     "required": ["PORT", "EVM_PAYEE_ADDRESS", "SVM_PAYEE_ADDRESS", "FACILITATOR_URL"],
-    "optional": ["APTOS_PAYEE_ADDRESS"]
+    "optional": ["APTOS_PAYEE_ADDRESS", "STELLAR_PAYEE_ADDRESS"]
   }
 }

--- a/e2e/servers/next/proxy.ts
+++ b/e2e/servers/next/proxy.ts
@@ -3,6 +3,7 @@ import { x402ResourceServer, HTTPFacilitatorClient } from "@x402/core/server";
 import { ExactEvmScheme } from "@x402/evm/exact/server";
 import { ExactSvmScheme } from "@x402/svm/exact/server";
 import { ExactAptosScheme } from "@x402/aptos/exact/server";
+import { ExactStellarScheme } from "@x402/stellar/exact/server";
 import { bazaarResourceServerExtension, declareDiscoveryExtension } from "@x402/extensions/bazaar";
 import {
   declareEip2612GasSponsoringExtension,
@@ -12,10 +13,13 @@ import {
 export const EVM_PAYEE_ADDRESS = process.env.EVM_PAYEE_ADDRESS as `0x${string}`;
 export const SVM_PAYEE_ADDRESS = process.env.SVM_PAYEE_ADDRESS as string;
 export const APTOS_PAYEE_ADDRESS = process.env.APTOS_PAYEE_ADDRESS as string;
+export const STELLAR_PAYEE_ADDRESS = process.env.STELLAR_PAYEE_ADDRESS as string | undefined;
 export const EVM_NETWORK = (process.env.EVM_NETWORK || "eip155:84532") as `${string}:${string}`;
 export const SVM_NETWORK = (process.env.SVM_NETWORK ||
   "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1") as `${string}:${string}`;
 export const APTOS_NETWORK = (process.env.APTOS_NETWORK || "aptos:2") as `${string}:${string}`;
+export const STELLAR_NETWORK = (process.env.STELLAR_NETWORK ||
+  "stellar:testnet") as `${string}:${string}`;
 const facilitatorUrl = process.env.FACILITATOR_URL;
 
 if (!facilitatorUrl) {
@@ -34,6 +38,9 @@ server.register("eip155:*", new ExactEvmScheme());
 server.register("solana:*", new ExactSvmScheme());
 if (APTOS_PAYEE_ADDRESS) {
   server.register("aptos:*", new ExactAptosScheme());
+}
+if (STELLAR_PAYEE_ADDRESS) {
+  server.register("stellar:*", new ExactStellarScheme());
 }
 
 // Register Bazaar discovery extension
@@ -122,6 +129,35 @@ export const proxy = paymentProxy(
           },
         }
       : {}),
+    ...(STELLAR_PAYEE_ADDRESS
+      ? {
+          "/api/protected-stellar-proxy": {
+            accepts: {
+              payTo: STELLAR_PAYEE_ADDRESS,
+              scheme: "exact",
+              price: "$0.001",
+              network: STELLAR_NETWORK,
+            },
+            extensions: {
+              ...declareDiscoveryExtension({
+                output: {
+                  example: {
+                    message: "Protected endpoint accessed successfully",
+                    timestamp: "2024-01-01T00:00:00Z",
+                  },
+                  schema: {
+                    properties: {
+                      message: { type: "string" },
+                      timestamp: { type: "string" },
+                    },
+                    required: ["message", "timestamp"],
+                  },
+                },
+              }),
+            },
+          },
+        }
+      : {}),
     "/api/protected-permit2-proxy": {
       accepts: {
         payTo: EVM_PAYEE_ADDRESS,
@@ -177,6 +213,7 @@ export const config = {
     "/api/protected-proxy",
     "/api/protected-svm-proxy",
     "/api/protected-aptos-proxy",
+    "/api/protected-stellar-proxy",
     "/api/protected-permit2-proxy",
     "/api/protected-permit2-erc20-proxy",
   ],

--- a/e2e/servers/next/test.config.json
+++ b/e2e/servers/next/test.config.json
@@ -45,6 +45,13 @@
       "protocolFamily": "aptos"
     },
     {
+      "path": "/api/protected-stellar-proxy",
+      "method": "GET",
+      "description": "Protected Stellar endpoint using proxy middleware",
+      "requiresPayment": true,
+      "protocolFamily": "stellar"
+    },
+    {
       "path": "/api/protected-withx402",
       "method": "GET",
       "description": "Protected endpoint using withX402 wrapper",
@@ -58,6 +65,13 @@
       "description": "Protected endpoint using withX402 wrapper on SVM",
       "requiresPayment": true,
       "protocolFamily": "svm"
+    },
+    {
+      "path": "/api/protected-stellar-withx402",
+      "method": "GET",
+      "description": "Protected Stellar endpoint using withX402 wrapper",
+      "requiresPayment": true,
+      "protocolFamily": "stellar"
     },
     {
       "path": "/api/health",
@@ -74,6 +88,6 @@
   ],
   "environment": {
     "required": ["PORT", "EVM_PAYEE_ADDRESS", "SVM_PAYEE_ADDRESS", "FACILITATOR_URL"],
-    "optional": ["APTOS_PAYEE_ADDRESS"]
+    "optional": ["APTOS_PAYEE_ADDRESS", "STELLAR_PAYEE_ADDRESS"]
   }
 }

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -648,13 +648,14 @@ async function runTest() {
 
     const facilitatorConfig = facilitatorName ? uniqueFacilitators.get(facilitatorName)?.config : undefined;
     const facilitatorSupportsAptos = facilitatorConfig?.protocolFamilies?.includes('aptos') ?? false;
+    const facilitatorSupportsStellar = facilitatorConfig?.protocolFamilies?.includes('stellar') ?? false;
 
     const serverConfig: ServerConfig = {
       port,
       evmPayTo: serverEvmAddress!,
       svmPayTo: serverSvmAddress!,
       aptosPayTo: facilitatorSupportsAptos ? (serverAptosAddress || '') : '',
-      stellarPayTo: serverStellarAddress || '',
+      stellarPayTo: facilitatorSupportsStellar ? (serverStellarAddress || '') : '',
       networks,
       facilitatorUrl,
     };
@@ -698,230 +699,230 @@ async function runTest() {
         }
       }
     } finally {
-  cLog.verboseLog(`  🛑 Stopping ${serverName} (finished combo)`);
-  await serverProxy.stop();
-}
-
-return results;
-  }
-
-// ── Unified execution: concurrency=1 for sequential, N for parallel ──
-const effectiveConcurrency = parsedArgs.parallel ? parsedArgs.concurrency : 1;
-const evmLock = parsedArgs.parallel ? new FacilitatorLock() : null;
-const semaphore = new Semaphore(effectiveConcurrency);
-
-let globalTestNumber = 0;
-const nextTestNumber = () => ++globalTestNumber;
-
-const comboPromises = serverFacilitatorCombos.map(async (combo) => {
-  const release = await semaphore.acquire();
-  try {
-    return await executeCombo(combo, evmLock, nextTestNumber);
-  } finally {
-    release();
-  }
-});
-
-testResults = (await Promise.all(comboPromises)).flat();
-
-// Run discovery validation before cleanup (while facilitators are still running)
-const facilitatorsWithConfig = Array.from(uniqueFacilitators.values()).map((f: any) => ({
-  proxy: facilitatorManagers.get(f.name)!.getProxy(),
-  config: f.config,
-}));
-
-const serversArray = Array.from(uniqueServers.values());
-
-// Build a serverName→port map for discovery validation (first combo per server).
-const discoveryServerPorts = new Map<string, number>();
-for (const combo of serverFacilitatorCombos) {
-  if (!discoveryServerPorts.has(combo.serverName)) {
-    discoveryServerPorts.set(combo.serverName, combo.port);
-  }
-}
-
-// Run discovery validation if bazaar extension is enabled
-const showBazaarOutput = shouldShowExtensionOutput('bazaar', selectedExtensions);
-if (showBazaarOutput && shouldRunDiscoveryValidation(facilitatorsWithConfig, serversArray)) {
-  log('\n🔍 Running Bazaar Discovery Validation...\n');
-  await handleDiscoveryValidation(
-    facilitatorsWithConfig,
-    serversArray,
-    discoveryServerPorts,
-    facilitatorServerMap
-  );
-}
-
-// Clean up facilitators (servers already stopped in test loop for both modes)
-log('\n🧹 Cleaning up...');
-
-// Stop all facilitators
-const facilitatorStopPromises: Promise<void>[] = [];
-for (const [facilitatorName, manager] of facilitatorManagers) {
-  log(`  🛑 Stopping facilitator: ${facilitatorName}`);
-  facilitatorStopPromises.push(manager.stop());
-}
-await Promise.all(facilitatorStopPromises);
-
-// Calculate totals
-const passed = testResults.filter(r => r.passed).length;
-const failed = testResults.filter(r => !r.passed).length;
-
-// Summary
-log('');
-log('📊 Test Summary');
-log('==============');
-log(`🌐 Network: ${networkMode} (${getNetworkModeDescription(networkMode)})`);
-log(`✅ Passed: ${passed}`);
-log(`❌ Failed: ${failed}`);
-log(`📈 Total: ${passed + failed}`);
-log('');
-
-// Detailed results table
-log('📋 Detailed Test Results');
-log('========================');
-log('');
-
-// Group by status
-const passedTests = testResults.filter(r => r.passed);
-const failedTests = testResults.filter(r => !r.passed);
-
-if (passedTests.length > 0) {
-  log('✅ PASSED TESTS:');
-  log('');
-  passedTests.forEach(test => {
-    log(`  #${test.testNumber.toString().padStart(2, ' ')}: ${test.client} → ${test.server} → ${test.endpoint}`);
-    log(`      Facilitator: ${test.facilitator}`);
-    if (test.network) {
-      log(`      Network: ${test.network}`);
+      cLog.verboseLog(`  🛑 Stopping ${serverName} (finished combo)`);
+      await serverProxy.stop();
     }
-    if (test.transaction) {
-      log(`      Tx: ${test.transaction}`);
+
+    return results;
+  }
+
+  // ── Unified execution: concurrency=1 for sequential, N for parallel ──
+  const effectiveConcurrency = parsedArgs.parallel ? parsedArgs.concurrency : 1;
+  const evmLock = parsedArgs.parallel ? new FacilitatorLock() : null;
+  const semaphore = new Semaphore(effectiveConcurrency);
+
+  let globalTestNumber = 0;
+  const nextTestNumber = () => ++globalTestNumber;
+
+  const comboPromises = serverFacilitatorCombos.map(async (combo) => {
+    const release = await semaphore.acquire();
+    try {
+      return await executeCombo(combo, evmLock, nextTestNumber);
+    } finally {
+      release();
     }
   });
-  log('');
-}
 
-if (failedTests.length > 0) {
-  log('❌ FAILED TESTS:');
-  log('');
-  failedTests.forEach(test => {
-    log(`  #${test.testNumber.toString().padStart(2, ' ')}: ${test.client} → ${test.server} → ${test.endpoint}`);
-    log(`      Facilitator: ${test.facilitator}`);
-    if (test.network) {
-      log(`      Network: ${test.network}`);
+  testResults = (await Promise.all(comboPromises)).flat();
+
+  // Run discovery validation before cleanup (while facilitators are still running)
+  const facilitatorsWithConfig = Array.from(uniqueFacilitators.values()).map((f: any) => ({
+    proxy: facilitatorManagers.get(f.name)!.getProxy(),
+    config: f.config,
+  }));
+
+  const serversArray = Array.from(uniqueServers.values());
+
+  // Build a serverName→port map for discovery validation (first combo per server).
+  const discoveryServerPorts = new Map<string, number>();
+  for (const combo of serverFacilitatorCombos) {
+    if (!discoveryServerPorts.has(combo.serverName)) {
+      discoveryServerPorts.set(combo.serverName, combo.port);
     }
-    log(`      Error: ${test.error || 'Unknown error'}`);
-  });
+  }
+
+  // Run discovery validation if bazaar extension is enabled
+  const showBazaarOutput = shouldShowExtensionOutput('bazaar', selectedExtensions);
+  if (showBazaarOutput && shouldRunDiscoveryValidation(facilitatorsWithConfig, serversArray)) {
+    log('\n🔍 Running Bazaar Discovery Validation...\n');
+    await handleDiscoveryValidation(
+      facilitatorsWithConfig,
+      serversArray,
+      discoveryServerPorts,
+      facilitatorServerMap
+    );
+  }
+
+  // Clean up facilitators (servers already stopped in test loop for both modes)
+  log('\n🧹 Cleaning up...');
+
+  // Stop all facilitators
+  const facilitatorStopPromises: Promise<void>[] = [];
+  for (const [facilitatorName, manager] of facilitatorManagers) {
+    log(`  🛑 Stopping facilitator: ${facilitatorName}`);
+    facilitatorStopPromises.push(manager.stop());
+  }
+  await Promise.all(facilitatorStopPromises);
+
+  // Calculate totals
+  const passed = testResults.filter(r => r.passed).length;
+  const failed = testResults.filter(r => !r.passed).length;
+
+  // Summary
   log('');
-}
+  log('📊 Test Summary');
+  log('==============');
+  log(`🌐 Network: ${networkMode} (${getNetworkModeDescription(networkMode)})`);
+  log(`✅ Passed: ${passed}`);
+  log(`❌ Failed: ${failed}`);
+  log(`📈 Total: ${passed + failed}`);
+  log('');
 
-// Breakdown by facilitator
-const facilitatorBreakdown = testResults.reduce((acc, test) => {
-  const key = test.facilitator;
-  if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
-  if (test.passed) acc[key].passed++;
-  else acc[key].failed++;
-  return acc;
-}, {} as Record<string, { passed: number; failed: number }>);
+  // Detailed results table
+  log('📋 Detailed Test Results');
+  log('========================');
+  log('');
 
-log('📊 Breakdown by Facilitator:');
-Object.entries(facilitatorBreakdown).forEach(([facilitator, stats]) => {
-  const total = stats.passed + stats.failed;
-  const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
-  log(` ${facilitator.padEnd(15)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
-});
-log('');
+  // Group by status
+  const passedTests = testResults.filter(r => r.passed);
+  const failedTests = testResults.filter(r => !r.passed);
 
-// Breakdown by server
-const serverBreakdown = testResults.reduce((acc, test) => {
-  const key = test.server;
-  if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
-  if (test.passed) acc[key].passed++;
-  else acc[key].failed++;
-  return acc;
-}, {} as Record<string, { passed: number; failed: number }>);
+  if (passedTests.length > 0) {
+    log('✅ PASSED TESTS:');
+    log('');
+    passedTests.forEach(test => {
+      log(`  #${test.testNumber.toString().padStart(2, ' ')}: ${test.client} → ${test.server} → ${test.endpoint}`);
+      log(`      Facilitator: ${test.facilitator}`);
+      if (test.network) {
+        log(`      Network: ${test.network}`);
+      }
+      if (test.transaction) {
+        log(`      Tx: ${test.transaction}`);
+      }
+    });
+    log('');
+  }
 
-log('📊 Breakdown by Server:');
-Object.entries(serverBreakdown).forEach(([server, stats]) => {
-  const total = stats.passed + stats.failed;
-  const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
-  log(` ${server.padEnd(20)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
-});
-log('');
+  if (failedTests.length > 0) {
+    log('❌ FAILED TESTS:');
+    log('');
+    failedTests.forEach(test => {
+      log(`  #${test.testNumber.toString().padStart(2, ' ')}: ${test.client} → ${test.server} → ${test.endpoint}`);
+      log(`      Facilitator: ${test.facilitator}`);
+      if (test.network) {
+        log(`      Network: ${test.network}`);
+      }
+      log(`      Error: ${test.error || 'Unknown error'}`);
+    });
+    log('');
+  }
 
-// Breakdown by client
-const clientBreakdown = testResults.reduce((acc, test) => {
-  const key = test.client;
-  if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
-  if (test.passed) acc[key].passed++;
-  else acc[key].failed++;
-  return acc;
-}, {} as Record<string, { passed: number; failed: number }>);
+  // Breakdown by facilitator
+  const facilitatorBreakdown = testResults.reduce((acc, test) => {
+    const key = test.facilitator;
+    if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
+    if (test.passed) acc[key].passed++;
+    else acc[key].failed++;
+    return acc;
+  }, {} as Record<string, { passed: number; failed: number }>);
 
-log('📊 Breakdown by Client:');
-Object.entries(clientBreakdown).forEach(([client, stats]) => {
-  const total = stats.passed + stats.failed;
-  const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
-  log(`   ${client.padEnd(20)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
-});
-log('');
-
-// Protocol family breakdown
-const protocolBreakdown = testResults.reduce((acc, test) => {
-  const key = test.protocolFamily;
-  if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
-  if (test.passed) acc[key].passed++;
-  else acc[key].failed++;
-  return acc;
-}, {} as Record<string, { passed: number; failed: number }>);
-
-if (Object.keys(protocolBreakdown).length > 1) {
-  log('📊 Protocol Family Breakdown:');
-  Object.entries(protocolBreakdown).forEach(([protocol, stats]) => {
+  log('📊 Breakdown by Facilitator:');
+  Object.entries(facilitatorBreakdown).forEach(([facilitator, stats]) => {
     const total = stats.passed + stats.failed;
-    log(` ${protocol.toUpperCase()}: ✅ ${stats.passed} / ❌ ${stats.failed} / 📈 ${total} total`);
+    const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
+    log(` ${facilitator.padEnd(15)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
   });
   log('');
-}
 
-// Write structured JSON output if requested
-if (parsedArgs.outputJson) {
-  const breakdown = (results: DetailedTestResult[], key: keyof DetailedTestResult) =>
-    results.reduce((acc, test) => {
-      const k = String(test[key]);
-      if (!acc[k]) acc[k] = { passed: 0, failed: 0 };
-      if (test.passed) acc[k].passed++;
-      else acc[k].failed++;
-      return acc;
-    }, {} as Record<string, { passed: number; failed: number }>);
+  // Breakdown by server
+  const serverBreakdown = testResults.reduce((acc, test) => {
+    const key = test.server;
+    if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
+    if (test.passed) acc[key].passed++;
+    else acc[key].failed++;
+    return acc;
+  }, {} as Record<string, { passed: number; failed: number }>);
 
-  const jsonOutput = {
-    summary: {
-      total: passed + failed,
-      passed,
-      failed,
-      networkMode,
-    },
-    results: testResults,
-    breakdowns: {
-      byFacilitator: breakdown(testResults, 'facilitator'),
-      byServer: breakdown(testResults, 'server'),
-      byClient: breakdown(testResults, 'client'),
-      byProtocolFamily: breakdown(testResults, 'protocolFamily'),
-    },
-  };
+  log('📊 Breakdown by Server:');
+  Object.entries(serverBreakdown).forEach(([server, stats]) => {
+    const total = stats.passed + stats.failed;
+    const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
+    log(` ${server.padEnd(20)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
+  });
+  log('');
 
-  writeFileSync(parsedArgs.outputJson, JSON.stringify(jsonOutput, null, 2));
-  log(`📄 JSON results written to ${parsedArgs.outputJson}`);
-}
+  // Breakdown by client
+  const clientBreakdown = testResults.reduce((acc, test) => {
+    const key = test.client;
+    if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
+    if (test.passed) acc[key].passed++;
+    else acc[key].failed++;
+    return acc;
+  }, {} as Record<string, { passed: number; failed: number }>);
 
-// Close logger
-closeLogger();
+  log('📊 Breakdown by Client:');
+  Object.entries(clientBreakdown).forEach(([client, stats]) => {
+    const total = stats.passed + stats.failed;
+    const passRate = total > 0 ? Math.round((stats.passed / total) * 100) : 0;
+    log(`   ${client.padEnd(20)} ✅ ${stats.passed} / ❌ ${stats.failed} (${passRate}%)`);
+  });
+  log('');
 
-if (failed > 0) {
-  process.exit(1);
-}
+  // Protocol family breakdown
+  const protocolBreakdown = testResults.reduce((acc, test) => {
+    const key = test.protocolFamily;
+    if (!acc[key]) acc[key] = { passed: 0, failed: 0 };
+    if (test.passed) acc[key].passed++;
+    else acc[key].failed++;
+    return acc;
+  }, {} as Record<string, { passed: number; failed: number }>);
+
+  if (Object.keys(protocolBreakdown).length > 1) {
+    log('📊 Protocol Family Breakdown:');
+    Object.entries(protocolBreakdown).forEach(([protocol, stats]) => {
+      const total = stats.passed + stats.failed;
+      log(` ${protocol.toUpperCase()}: ✅ ${stats.passed} / ❌ ${stats.failed} / 📈 ${total} total`);
+    });
+    log('');
+  }
+
+  // Write structured JSON output if requested
+  if (parsedArgs.outputJson) {
+    const breakdown = (results: DetailedTestResult[], key: keyof DetailedTestResult) =>
+      results.reduce((acc, test) => {
+        const k = String(test[key]);
+        if (!acc[k]) acc[k] = { passed: 0, failed: 0 };
+        if (test.passed) acc[k].passed++;
+        else acc[k].failed++;
+        return acc;
+      }, {} as Record<string, { passed: number; failed: number }>);
+
+    const jsonOutput = {
+      summary: {
+        total: passed + failed,
+        passed,
+        failed,
+        networkMode,
+      },
+      results: testResults,
+      breakdowns: {
+        byFacilitator: breakdown(testResults, 'facilitator'),
+        byServer: breakdown(testResults, 'server'),
+        byClient: breakdown(testResults, 'client'),
+        byProtocolFamily: breakdown(testResults, 'protocolFamily'),
+      },
+    };
+
+    writeFileSync(parsedArgs.outputJson, JSON.stringify(jsonOutput, null, 2));
+    log(`📄 JSON results written to ${parsedArgs.outputJson}`);
+  }
+
+  // Close logger
+  closeLogger();
+
+  if (failed > 0) {
+    process.exit(1);
+  }
 }
 
 // Run the test


### PR DESCRIPTION
## Description

The E2E test gates aptosPayTo on facilitator support but always passes stellarPayTo, causing eg the express server to register /protected-stellar when the facilitator (go/python) doesn't support stellar 

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 