### PR TITLE
Add in-memory cache for in-flight Solana txs

### DIFF
--- a/docs/core-concepts/client-server.md
+++ b/docs/core-concepts/client-server.md
@@ -48,6 +48,19 @@ Servers can include:
 
 Servers do not need to manage client identities or maintain session state. Verification and settlement are handled per request.
 
+#### Duplicate Settlement on Solana
+
+If your server settles payments directly on Solana (without delegating to a facilitator), be aware of a race condition: the same signed payment transaction can be submitted multiple times before the first submission is confirmed on-chain. Solana's RPC will return "success" for each submission, since the network deduplicates at the consensus level. A malicious client can exploit this to obtain access to multiple resources while only paying once.
+
+To mitigate this, servers that settle Solana payments themselves **must** maintain a short-lived, in-memory cache of transaction payloads currently being settled:
+
+1. After verification succeeds, derive a cache key from the transaction payload (e.g., the base64-encoded transaction string).
+2. If the key is already present in the cache, reject the settlement with a `"duplicate_settlement"` error.
+3. If the key is not present, insert it into the cache and proceed with settlement.
+4. Evict entries older than 120 seconds (approximately twice the Solana blockhash lifetime).
+
+If you are using a facilitator, the x402 SVM libraries already include built-in duplicate settlement protection via a `SettlementCache`. See the [Exact SVM Scheme Specification](/specs/schemes/exact/scheme_exact_svm#duplicate-settlement-mitigation-recommended) for full details.
+
 ### Communication Flow
 
 The typical flow between a client and a server in the x402 protocol is as follows:

--- a/docs/core-concepts/facilitator.md
+++ b/docs/core-concepts/facilitator.md
@@ -51,6 +51,16 @@ Multiple facilitators are live in production, supporting various networks includ
 11. `Facilitator server` returns a `Payment Execution Response` to the resource server.
 12. `Resource server` returns a response to the `Client` with a `PAYMENT-RESPONSE` header containing the `Settlement Response` as Base64-encoded JSON. On success, this is a `200 OK` with the requested resource. On failure, this is a `402 Payment Required` with error details.
 
+### Duplicate Settlement (Solana)
+
+On Solana, a race condition can occur when the same payment transaction is submitted to a facilitator's `/settle` endpoint multiple times before the first submission is confirmed on-chain. Because Solana's RPC returns "success" for duplicate submissions (the network deduplicates at the consensus level), the facilitator may return a successful settlement response for each call. A malicious client could exploit this to access multiple resources while only paying once.
+
+To mitigate this, the x402 SVM mechanism packages include a built-in `SettlementCache` — a short-lived, in-memory cache that detects and rejects duplicate settlement attempts for the same transaction payload. The cache requires no external storage and entries are automatically evicted after 120 seconds (approximately twice the Solana blockhash lifetime).
+
+This protection is enabled by default when using the standard SVM facilitator registration helpers in TypeScript and Python. In Go, a shared `SettlementCache` instance should be passed to both V1 and V2 SVM facilitator schemes during registration.
+
+**If you are a merchant settling payments directly (without a facilitator), you must implement equivalent duplicate detection yourself.** See the [Exact SVM Scheme Specification](/specs/schemes/exact/scheme_exact_svm#duplicate-settlement-mitigation-recommended) for the full specification.
+
 ### Summary
 
 The facilitator acts as an independent verification and settlement layer within the x402 protocol. It helps servers confirm payments and submit transactions onchain without requiring direct blockchain infrastructure.

--- a/examples/go/facilitator/basic/main.go
+++ b/examples/go/facilitator/basic/main.go
@@ -11,6 +11,7 @@ import (
 	x402 "github.com/coinbase/x402/go"
 	evm "github.com/coinbase/x402/go/mechanisms/evm/exact/facilitator"
 	evmv1 "github.com/coinbase/x402/go/mechanisms/evm/exact/v1/facilitator"
+	svmmech "github.com/coinbase/x402/go/mechanisms/svm"
 	svm "github.com/coinbase/x402/go/mechanisms/svm/exact/facilitator"
 	svmv1 "github.com/coinbase/x402/go/mechanisms/svm/exact/v1/facilitator"
 	"github.com/gin-gonic/gin"
@@ -61,8 +62,9 @@ func main() {
 	facilitator.RegisterV1([]x402.Network{"base-sepolia"}, evmv1.NewExactEvmSchemeV1(evmSigner, evmV1Config))
 
 	if svmSigner != nil {
-		facilitator.Register([]x402.Network{svmNetwork}, svm.NewExactSvmScheme(svmSigner))
-		facilitator.RegisterV1([]x402.Network{"solana-devnet"}, svmv1.NewExactSvmSchemeV1(svmSigner))
+		settlementCache := svmmech.NewSettlementCache()
+		facilitator.Register([]x402.Network{svmNetwork}, svm.NewExactSvmScheme(svmSigner, settlementCache))
+		facilitator.RegisterV1([]x402.Network{"solana-devnet"}, svmv1.NewExactSvmSchemeV1(svmSigner, settlementCache))
 	}
 
 	facilitator.OnAfterVerify(func(ctx x402.FacilitatorVerifyResultContext) error {

--- a/go/.changes/unreleased/added-svm-settlement-cache.yaml
+++ b/go/.changes/unreleased/added-svm-settlement-cache.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Add in-memory SettlementCache to prevent duplicate SVM transaction settlement during on-chain confirmation window
+time: 2026-03-05T13:35:00.000000+09:00

--- a/go/FACILITATOR.md
+++ b/go/FACILITATOR.md
@@ -382,6 +382,24 @@ Facilitator signers need to:
 - Monitor for unusual patterns
 - Set transaction value limits
 
+#### Duplicate Settlement (Solana / SVM)
+
+A race condition exists on Solana where the same payment transaction can be submitted to the `/settle` endpoint multiple times before the first submission is confirmed on-chain. Because Solana's RPC returns "success" for duplicate transaction submissions (the network deduplicates at the consensus level), the facilitator could return `success` to each caller. A malicious client can exploit this to obtain access to multiple resources while only paying once.
+
+The SVM mechanism packages include a built-in `SettlementCache` that mitigates this. When registering SVM facilitator schemes, pass a shared cache instance to both V1 and V2 schemes:
+
+```go
+import svm "github.com/coinbase/x402/go/mechanisms/svm"
+
+cache := svm.NewSettlementCache()
+v2Scheme := facilitator.NewExactSvmScheme(signer, cache)
+v1Scheme := v1facilitator.NewExactSvmSchemeV1(signer, cache)
+```
+
+The cache rejects concurrent settlement attempts for the same transaction payload with a `duplicate_settlement` error. Entries are evicted after 120 seconds (approximately twice the Solana blockhash lifetime).
+
+See the [Exact SVM Scheme Specification](../specs/schemes/exact/scheme_exact_svm.md#duplicate-settlement-mitigation-recommended) for full details.
+
 ### High Availability
 
 - Run multiple facilitator instances

--- a/go/mechanisms/svm/README.md
+++ b/go/mechanisms/svm/README.md
@@ -69,6 +69,24 @@ The **exact** scheme implements fixed-amount payments:
 - **Fees**: Rent and transaction fees paid by facilitator
 - **Confirmation**: On-chain settlement with transaction signature
 
+## Duplicate Settlement Protection
+
+This package includes a built-in `SettlementCache` that prevents a known race condition on Solana where the same payment transaction could be settled multiple times before on-chain confirmation. The `NewExactSvmScheme` facilitator constructor accepts an optional `*SettlementCache` parameter — when the same cache instance is passed to both V1 and V2 facilitator schemes, cross-version duplicate detection is enabled.
+
+The cache rejects concurrent `/settle` calls that carry the same transaction payload, returning a `duplicate_settlement` error for the second and subsequent attempts. Entries are automatically evicted after 120 seconds (approximately twice the Solana blockhash lifetime).
+
+```go
+import svm "github.com/coinbase/x402/go/mechanisms/svm"
+
+cache := svm.NewSettlementCache()
+
+// Share the same cache across V1 and V2 schemes
+v2Scheme := facilitator.NewExactSvmScheme(signer, cache)
+v1Scheme := v1facilitator.NewExactSvmSchemeV1(signer, cache)
+```
+
+For full details on the race condition and mitigation strategy, see the [Exact SVM Scheme Specification](../../specs/schemes/exact/scheme_exact_svm.md#duplicate-settlement-mitigation-recommended).
+
 ## Future Schemes
 
 This directory currently contains only the **exact** scheme implementation. As new payment schemes are developed for Solana networks, they will be added here alongside the exact implementation:

--- a/go/mechanisms/svm/constants.go
+++ b/go/mechanisms/svm/constants.go
@@ -44,6 +44,10 @@ const (
 	// ConfirmRetryDelay is the base delay between confirmation attempts
 	ConfirmRetryDelay = 1 * time.Second
 
+	// SettlementTTL is how long a transaction is held in the duplicate settlement cache.
+	// Covers the Solana blockhash lifetime (~60-90s) with margin.
+	SettlementTTL = 120 * time.Second
+
 	// CAIP-2 network identifiers (V2)
 	SolanaMainnetCAIP2 = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
 	SolanaDevnetCAIP2  = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"

--- a/go/mechanisms/svm/exact/facilitator/errors.go
+++ b/go/mechanisms/svm/exact/facilitator/errors.go
@@ -30,4 +30,5 @@ const (
 	ErrFeePayerMismatch              = "invalid_exact_solana_fee_payer_mismatch"
 	ErrTransactionFailed             = "invalid_exact_solana_transaction_failed"
 	ErrTransactionConfirmationFailed = "invalid_exact_solana_transaction_confirmation_failed"
+	ErrDuplicateSettlement           = "duplicate_settlement"
 )

--- a/go/mechanisms/svm/exact/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/facilitator/scheme.go
@@ -18,13 +18,23 @@ import (
 
 // ExactSvmScheme implements the SchemeNetworkFacilitator interface for SVM (Solana) exact payments (V2)
 type ExactSvmScheme struct {
-	signer svm.FacilitatorSvmSigner
+	signer          svm.FacilitatorSvmSigner
+	settlementCache *svm.SettlementCache
 }
 
-// NewExactSvmScheme creates a new ExactSvmScheme
-func NewExactSvmScheme(signer svm.FacilitatorSvmSigner) *ExactSvmScheme {
+// NewExactSvmScheme creates a new ExactSvmScheme.
+// An optional SettlementCache may be provided to share deduplication state
+// across V1 and V2 instances; if nil a new cache is created.
+func NewExactSvmScheme(signer svm.FacilitatorSvmSigner, cache ...*svm.SettlementCache) *ExactSvmScheme {
+	var c *svm.SettlementCache
+	if len(cache) > 0 && cache[0] != nil {
+		c = cache[0]
+	} else {
+		c = svm.NewSettlementCache()
+	}
 	return &ExactSvmScheme{
-		signer: signer,
+		signer:          signer,
+		settlementCache: c,
 	}
 }
 
@@ -242,6 +252,12 @@ func (f *ExactSvmScheme) Settle(
 	solanaPayload, err := svm.PayloadFromMap(payload.Payload)
 	if err != nil {
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
+	}
+
+	// Duplicate settlement check: reject if this transaction is already being settled.
+	txKey := solanaPayload.Transaction
+	if f.settlementCache.IsDuplicate(txKey) {
+		return nil, x402.NewSettleError(ErrDuplicateSettlement, verifyResp.Payer, network, "", "duplicate transaction")
 	}
 
 	// Decode transaction

--- a/go/mechanisms/svm/exact/v1/facilitator/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/duplicate_tx_test.go
@@ -8,33 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFacilitatorInstructionConstraints(t *testing.T) {
-	t.Run("allows 3-6 instructions", func(t *testing.T) {
-		minInstructions := 3
-		maxInstructions := 6
-
-		assert.Equal(t, 3, minInstructions)
-		assert.Equal(t, 6, maxInstructions)
-	})
-
-	t.Run("optional instructions may be Lighthouse or Memo", func(t *testing.T) {
-		lighthouseProgram := svm.LighthouseProgramAddress
-		memoProgram := svm.MemoProgramAddress
-
-		assert.NotEqual(t, lighthouseProgram, memoProgram)
-		assert.NotEmpty(t, memoProgram)
-		assert.NotEmpty(t, lighthouseProgram)
-	})
-}
-
-func TestErrorCodesForMitigationPlanning(t *testing.T) {
-	t.Run("instruction count error", func(t *testing.T) {
-		err := ErrTransactionInstructionsLength
-		assert.Equal(t, "invalid_exact_solana_payload_transaction_instructions_length", err)
-	})
-}
-
-func TestDuplicateSettlementCache(t *testing.T) {
+func TestDuplicateSettlementCacheV1(t *testing.T) {
 	t.Run("should reject duplicate transaction", func(t *testing.T) {
 		cache := svm.NewSettlementCache()
 
@@ -81,7 +55,7 @@ func TestDuplicateSettlementCache(t *testing.T) {
 
 	t.Run("constructor wires the shared cache into the scheme", func(t *testing.T) {
 		cache := svm.NewSettlementCache()
-		scheme := NewExactSvmScheme(nil, cache)
+		scheme := NewExactSvmSchemeV1(nil, cache)
 		assert.Same(t, cache, scheme.settlementCache,
 			"scheme should hold the exact cache instance that was injected")
 	})

--- a/go/mechanisms/svm/exact/v1/facilitator/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/duplicate_tx_test.go
@@ -59,4 +59,58 @@ func TestDuplicateSettlementCacheV1(t *testing.T) {
 		assert.Same(t, cache, scheme.settlementCache,
 			"scheme should hold the exact cache instance that was injected")
 	})
+
+	t.Run("should prune only expired entries and keep fresh ones", func(t *testing.T) {
+		cache := svm.NewSettlementCache()
+
+		cache.Mu().Lock()
+		cache.Entries()["expired-1"] = time.Now().Add(-150 * time.Second)
+		cache.Entries()["expired-2"] = time.Now().Add(-130 * time.Second)
+		cache.Entries()["fresh-1"] = time.Now()
+		cache.Entries()["fresh-2"] = time.Now()
+		cache.Mu().Unlock()
+
+		// Trigger prune
+		cache.IsDuplicate("trigger")
+
+		cache.Mu().Lock()
+		_, expired1 := cache.Entries()["expired-1"]
+		_, expired2 := cache.Entries()["expired-2"]
+		_, fresh1 := cache.Entries()["fresh-1"]
+		_, fresh2 := cache.Entries()["fresh-2"]
+		_, trigger := cache.Entries()["trigger"]
+		cache.Mu().Unlock()
+
+		assert.False(t, expired1, "expired entry should be pruned")
+		assert.False(t, expired2, "expired entry should be pruned")
+		assert.True(t, fresh1, "fresh entry should survive pruning")
+		assert.True(t, fresh2, "fresh entry should survive pruning")
+		assert.True(t, trigger, "newly inserted entry should be present")
+	})
+
+	t.Run("should prune all entries when all expired", func(t *testing.T) {
+		cache := svm.NewSettlementCache()
+
+		cache.Mu().Lock()
+		cache.Entries()["old-1"] = time.Now().Add(-200 * time.Second)
+		cache.Entries()["old-2"] = time.Now().Add(-200 * time.Second)
+		cache.Entries()["old-3"] = time.Now().Add(-200 * time.Second)
+		cache.Mu().Unlock()
+
+		assert.False(t, cache.IsDuplicate("old-1"), "expired entry should not be a duplicate")
+		assert.False(t, cache.IsDuplicate("old-2"), "expired entry should not be a duplicate")
+		assert.False(t, cache.IsDuplicate("old-3"), "expired entry should not be a duplicate")
+	})
+
+	t.Run("should not prune any entries when all fresh", func(t *testing.T) {
+		cache := svm.NewSettlementCache()
+
+		assert.False(t, cache.IsDuplicate("new-1"))
+		assert.False(t, cache.IsDuplicate("new-2"))
+		assert.False(t, cache.IsDuplicate("new-3"))
+
+		assert.True(t, cache.IsDuplicate("new-1"), "fresh entry should still be cached")
+		assert.True(t, cache.IsDuplicate("new-2"), "fresh entry should still be cached")
+		assert.True(t, cache.IsDuplicate("new-3"), "fresh entry should still be cached")
+	})
 }

--- a/go/mechanisms/svm/exact/v1/facilitator/errors.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/errors.go
@@ -31,4 +31,5 @@ const (
 	ErrFeePayerMismatch              = "invalid_exact_solana_fee_payer_mismatch"
 	ErrTransactionFailed             = "invalid_exact_solana_transaction_failed"
 	ErrTransactionConfirmationFailed = "invalid_exact_solana_transaction_confirmation_failed"
+	ErrDuplicateSettlement           = "duplicate_settlement"
 )

--- a/go/mechanisms/svm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/scheme.go
@@ -19,13 +19,23 @@ import (
 
 // ExactSvmSchemeV1 implements the SchemeNetworkFacilitator interface for SVM (Solana) exact payments (V1)
 type ExactSvmSchemeV1 struct {
-	signer svm.FacilitatorSvmSigner
+	signer          svm.FacilitatorSvmSigner
+	settlementCache *svm.SettlementCache
 }
 
-// NewExactSvmSchemeV1 creates a new ExactSvmSchemeV1
-func NewExactSvmSchemeV1(signer svm.FacilitatorSvmSigner) *ExactSvmSchemeV1 {
+// NewExactSvmSchemeV1 creates a new ExactSvmSchemeV1.
+// An optional SettlementCache may be provided to share deduplication state
+// across V1 and V2 instances; if nil a new cache is created.
+func NewExactSvmSchemeV1(signer svm.FacilitatorSvmSigner, cache ...*svm.SettlementCache) *ExactSvmSchemeV1 {
+	var c *svm.SettlementCache
+	if len(cache) > 0 && cache[0] != nil {
+		c = cache[0]
+	} else {
+		c = svm.NewSettlementCache()
+	}
 	return &ExactSvmSchemeV1{
-		signer: signer,
+		signer:          signer,
+		settlementCache: c,
 	}
 }
 
@@ -239,6 +249,12 @@ func (f *ExactSvmSchemeV1) Settle(
 	svmPayload, err := svm.PayloadFromMap(payload.Payload)
 	if err != nil {
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
+	}
+
+	// Duplicate settlement check: reject if this transaction is already being settled.
+	txKey := svmPayload.Transaction
+	if f.settlementCache.IsDuplicate(txKey) {
+		return nil, x402.NewSettleError(ErrDuplicateSettlement, verifyResp.Payer, network, "", "duplicate transaction")
 	}
 
 	// Decode transaction

--- a/go/mechanisms/svm/settlement_cache.go
+++ b/go/mechanisms/svm/settlement_cache.go
@@ -1,0 +1,58 @@
+package svm
+
+import (
+	"sync"
+	"time"
+)
+
+// SettlementCache is a thread-safe in-memory cache for deduplicating concurrent
+// settlement requests.  A single instance should be shared across V1 and V2
+// facilitator scheme instances so that a transaction submitted through one
+// protocol version is also blocked on the other.
+type SettlementCache struct {
+	mu      sync.Mutex
+	entries map[string]time.Time
+}
+
+// NewSettlementCache creates a new, empty SettlementCache.
+func NewSettlementCache() *SettlementCache {
+	return &SettlementCache{
+		entries: make(map[string]time.Time),
+	}
+}
+
+// IsDuplicate returns true if key is already pending settlement (duplicate).
+// Otherwise it records the key as newly pending and returns false.
+// Callers should reject the settlement when this returns true.
+func (c *SettlementCache) IsDuplicate(key string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.prune()
+
+	if _, exists := c.entries[key]; exists {
+		return true
+	}
+	c.entries[key] = time.Now()
+	return false
+}
+
+// Entries returns a snapshot of the underlying map — use only in tests.
+func (c *SettlementCache) Entries() map[string]time.Time {
+	return c.entries
+}
+
+// Mu returns the mutex — use only in tests.
+func (c *SettlementCache) Mu() *sync.Mutex {
+	return &c.mu
+}
+
+// prune removes entries older than the settlement TTL. Caller must hold mu.
+func (c *SettlementCache) prune() {
+	cutoff := time.Now().Add(-SettlementTTL)
+	for key, ts := range c.entries {
+		if ts.Before(cutoff) {
+			delete(c.entries, key)
+		}
+	}
+}

--- a/python/x402/changelog.d/svm-duplicate-settlement.bugfix.md
+++ b/python/x402/changelog.d/svm-duplicate-settlement.bugfix.md
@@ -1,0 +1,1 @@
+Add in-memory SettlementCache to prevent duplicate SVM transaction settlement during on-chain confirmation window

--- a/python/x402/mechanisms/svm/README.md
+++ b/python/x402/mechanisms/svm/README.md
@@ -121,3 +121,13 @@ The Exact scheme creates a partially-signed transaction:
 
 Automatic ATA derivation for source and destination addresses.
 
+## Duplicate Settlement Protection
+
+This package includes a built-in `SettlementCache` that prevents a known race condition on Solana where the same payment transaction could be settled multiple times before on-chain confirmation. When the facilitator scheme is registered via `register_exact_svm_facilitator()`, a single `SettlementCache` instance is automatically shared across both V1 and V2 scheme versions.
+
+The cache rejects concurrent `/settle` calls that carry the same transaction payload, returning a `duplicate_settlement` error for the second and subsequent attempts. Entries are automatically evicted after 120 seconds (approximately twice the Solana blockhash lifetime).
+
+**No additional configuration is required** — duplicate settlement protection is enabled by default when using the standard registration helpers.
+
+For full details on the race condition and mitigation strategy, see the [Exact SVM Scheme Specification](../../../../specs/schemes/exact/scheme_exact_svm.md#duplicate-settlement-mitigation-recommended).
+

--- a/python/x402/mechanisms/svm/__init__.py
+++ b/python/x402/mechanisms/svm/__init__.py
@@ -52,6 +52,9 @@ from .constants import (
     NetworkConfig,
 )
 
+# Settlement cache (shared across V1/V2 facilitator instances)
+from .settlement_cache import SettlementCache
+
 # Signer protocols
 from .signer import ClientSvmSigner, FacilitatorSvmSigner
 
@@ -139,6 +142,8 @@ __all__ = [
     "ExactSvmPayloadV1",
     "ExactSvmPayloadV2",
     "TransactionInfo",
+    # Settlement cache
+    "SettlementCache",
     # Signer protocols
     "ClientSvmSigner",
     "FacilitatorSvmSigner",

--- a/python/x402/mechanisms/svm/constants.py
+++ b/python/x402/mechanisms/svm/constants.py
@@ -85,6 +85,11 @@ ERR_FEE_PAYER_NOT_MANAGED = "fee_payer_not_managed_by_facilitator"
 ERR_FEE_PAYER_TRANSFERRING = "invalid_exact_svm_payload_transaction_fee_payer_transferring_funds"
 ERR_SIMULATION_FAILED = "transaction_simulation_failed"
 ERR_TRANSACTION_FAILED = "transaction_failed"
+ERR_DUPLICATE_SETTLEMENT = "duplicate_settlement"
+
+# How long a transaction is held in the duplicate settlement cache (seconds).
+# Covers the Solana blockhash lifetime (~60-90s) with margin.
+SETTLEMENT_TTL_SECONDS = 120.0
 
 
 class AssetInfo(TypedDict):

--- a/python/x402/mechanisms/svm/exact/facilitator.py
+++ b/python/x402/mechanisms/svm/exact/facilitator.py
@@ -1,5 +1,7 @@
 """SVM facilitator implementation for the Exact payment scheme (V2)."""
 
+from __future__ import annotations
+
 import random
 from typing import Any
 
@@ -20,6 +22,7 @@ from ....schemas import (
 from ..constants import (
     COMPUTE_BUDGET_PROGRAM_ADDRESS,
     ERR_AMOUNT_INSUFFICIENT,
+    ERR_DUPLICATE_SETTLEMENT,
     ERR_FEE_PAYER_MISSING,
     ERR_FEE_PAYER_NOT_MANAGED,
     ERR_FEE_PAYER_TRANSFERRING,
@@ -44,6 +47,7 @@ from ..constants import (
     TOKEN_2022_PROGRAM_ADDRESS,
     TOKEN_PROGRAM_ADDRESS,
 )
+from ..settlement_cache import SettlementCache
 from ..signer import FacilitatorSvmSigner
 from ..types import ExactSvmPayload
 from ..utils import (
@@ -66,13 +70,19 @@ class ExactSvmScheme:
     scheme = SCHEME_EXACT
     caip_family = "solana:*"
 
-    def __init__(self, signer: FacilitatorSvmSigner):
+    def __init__(
+        self,
+        signer: FacilitatorSvmSigner,
+        settlement_cache: SettlementCache | None = None,
+    ):
         """Create ExactSvmScheme facilitator.
 
         Args:
             signer: SVM signer for verification and settlement.
+            settlement_cache: Optional shared settlement cache (one is created if omitted).
         """
         self._signer = signer
+        self._settlement_cache = settlement_cache or SettlementCache()
 
     def get_extra(self, network: Network) -> dict[str, Any] | None:
         """Get mechanism-specific extra data for the supported kinds endpoint.
@@ -359,6 +369,17 @@ class ExactSvmScheme:
                 error_reason=verify_result.invalid_reason,
                 network=network,
                 payer=verify_result.payer,
+                transaction="",
+            )
+
+        # Duplicate settlement check: reject if this transaction is already being settled.
+        tx_key = svm_payload.transaction
+        if self._settlement_cache.is_duplicate(tx_key):
+            return SettleResponse(
+                success=False,
+                error_reason=ERR_DUPLICATE_SETTLEMENT,
+                network=network,
+                payer=verify_result.payer or "",
                 transaction="",
             )
 

--- a/python/x402/mechanisms/svm/exact/register.py
+++ b/python/x402/mechanisms/svm/exact/register.py
@@ -111,6 +111,9 @@ def register_exact_svm_facilitator(
     - V2: Specified networks
     - V1: All supported SVM networks
 
+    A single settlement cache is shared across V1 and V2 so that a duplicate
+    transaction submitted through one protocol version is also caught by the other.
+
     Args:
         facilitator: x402Facilitator instance.
         signer: SVM signer for verification/settlement.
@@ -119,17 +122,20 @@ def register_exact_svm_facilitator(
     Returns:
         Facilitator for chaining.
     """
+    from ..settlement_cache import SettlementCache
     from .facilitator import ExactSvmScheme as ExactSvmFacilitatorScheme
     from .v1.facilitator import ExactSvmSchemeV1 as ExactSvmFacilitatorSchemeV1
 
-    scheme = ExactSvmFacilitatorScheme(signer)
+    settlement_cache = SettlementCache()
+
+    scheme = ExactSvmFacilitatorScheme(signer, settlement_cache)
 
     if isinstance(networks, str):
         networks = [networks]
     facilitator.register(networks, scheme)
 
     # Register V1
-    v1_scheme = ExactSvmFacilitatorSchemeV1(signer)
+    v1_scheme = ExactSvmFacilitatorSchemeV1(signer, settlement_cache)
     facilitator.register_v1(V1_NETWORKS, v1_scheme)
 
     return facilitator

--- a/python/x402/mechanisms/svm/exact/v1/facilitator.py
+++ b/python/x402/mechanisms/svm/exact/v1/facilitator.py
@@ -1,5 +1,7 @@
 """SVM facilitator implementation for Exact payment scheme (V1 legacy)."""
 
+from __future__ import annotations
+
 import random
 from typing import Any
 
@@ -15,6 +17,7 @@ from .....schemas.v1 import PaymentPayloadV1, PaymentRequirementsV1
 from ...constants import (
     COMPUTE_BUDGET_PROGRAM_ADDRESS,
     ERR_AMOUNT_INSUFFICIENT,
+    ERR_DUPLICATE_SETTLEMENT,
     ERR_FEE_PAYER_MISSING,
     ERR_FEE_PAYER_NOT_MANAGED,
     ERR_FEE_PAYER_TRANSFERRING,
@@ -39,6 +42,7 @@ from ...constants import (
     TOKEN_2022_PROGRAM_ADDRESS,
     TOKEN_PROGRAM_ADDRESS,
 )
+from ...settlement_cache import SettlementCache
 from ...signer import FacilitatorSvmSigner
 from ...types import ExactSvmPayload
 from ...utils import (
@@ -64,13 +68,19 @@ class ExactSvmSchemeV1:
     scheme = SCHEME_EXACT
     caip_family = "solana:*"
 
-    def __init__(self, signer: FacilitatorSvmSigner):
+    def __init__(
+        self,
+        signer: FacilitatorSvmSigner,
+        settlement_cache: SettlementCache | None = None,
+    ):
         """Create ExactSvmSchemeV1 facilitator.
 
         Args:
             signer: SVM signer for verification/settlement.
+            settlement_cache: Optional shared settlement cache (one is created if omitted).
         """
         self._signer = signer
+        self._settlement_cache = settlement_cache or SettlementCache()
 
     def get_extra(self, network: Network) -> dict[str, Any] | None:
         """Get mechanism-specific extra data.
@@ -337,6 +347,17 @@ class ExactSvmSchemeV1:
                 error_reason=verify_result.invalid_reason,
                 network=network,
                 payer=verify_result.payer,
+                transaction="",
+            )
+
+        # Duplicate settlement check: reject if this transaction is already being settled.
+        tx_key = svm_payload.transaction
+        if self._settlement_cache.is_duplicate(tx_key):
+            return SettleResponse(
+                success=False,
+                error_reason=ERR_DUPLICATE_SETTLEMENT,
+                network=network,
+                payer=verify_result.payer or "",
                 transaction="",
             )
 

--- a/python/x402/mechanisms/svm/settlement_cache.py
+++ b/python/x402/mechanisms/svm/settlement_cache.py
@@ -43,6 +43,11 @@ class SettlementCache:
     def _prune(self) -> None:
         """Remove entries older than the settlement TTL. Caller must hold _lock."""
         cutoff = time.monotonic() - SETTLEMENT_TTL_SECONDS
-        expired = [k for k, ts in self._entries.items() if ts < cutoff]
+        expired = []
+        for k, ts in self._entries.items():
+            if ts < cutoff:
+                expired.append(k)
+            else:
+                break
         for k in expired:
             del self._entries[k]

--- a/python/x402/mechanisms/svm/settlement_cache.py
+++ b/python/x402/mechanisms/svm/settlement_cache.py
@@ -1,0 +1,48 @@
+"""Thread-safe in-memory cache for deduplicating concurrent settlement requests.
+
+A single instance should be shared across V1 and V2 facilitator scheme
+instances so that a transaction submitted through one protocol version is
+also deduplicated on the other.
+"""
+
+import threading
+import time
+
+from .constants import SETTLEMENT_TTL_SECONDS
+
+
+class SettlementCache:
+    """In-memory cache for deduplicating concurrent settlement requests.
+
+    Thread-safe: all public methods acquire an internal lock.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def is_duplicate(self, key: str) -> bool:
+        """Return ``True`` if *key* is already pending settlement (duplicate).
+
+        When ``False`` the key is recorded as newly pending.
+        Callers should reject the settlement when this returns ``True``.
+        """
+        with self._lock:
+            self._prune()
+            if key in self._entries:
+                return True
+            self._entries[key] = time.monotonic()
+            return False
+
+    # Exposed for testing (e.g. backdating entries to simulate TTL expiry).
+    @property
+    def entries(self) -> dict[str, float]:
+        """Direct access to the underlying dict — use only in tests."""
+        return self._entries
+
+    def _prune(self) -> None:
+        """Remove entries older than the settlement TTL. Caller must hold _lock."""
+        cutoff = time.monotonic() - SETTLEMENT_TTL_SECONDS
+        expired = [k for k, ts in self._entries.items() if ts < cutoff]
+        for k in expired:
+            del self._entries[k]

--- a/python/x402/tests/unit/mechanisms/svm/test_facilitator.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_facilitator.py
@@ -1,12 +1,14 @@
 """Tests for ExactSvmScheme facilitator."""
 
+from unittest.mock import patch
+
 from x402.mechanisms.svm import (
     SOLANA_DEVNET_CAIP2,
     SOLANA_MAINNET_CAIP2,
     USDC_DEVNET_ADDRESS,
 )
 from x402.mechanisms.svm.exact import ExactSvmFacilitatorScheme
-from x402.schemas import PaymentPayload, PaymentRequirements, ResourceInfo
+from x402.schemas import PaymentPayload, PaymentRequirements, ResourceInfo, VerifyResponse
 
 
 class MockFacilitatorSigner:
@@ -290,6 +292,154 @@ class TestFacilitatorSchemeAttributes:
         result = facilitator.get_signers(SOLANA_DEVNET_CAIP2)
 
         assert result == addresses
+
+
+class TestDuplicateSettlementCache:
+    """Test duplicate settlement cache in settle method."""
+
+    def _make_payload(self, transaction: str) -> PaymentPayload:
+        return PaymentPayload(
+            x402_version=2,
+            resource=ResourceInfo(
+                url="http://example.com/protected",
+                description="Test resource",
+                mime_type="application/json",
+            ),
+            accepted=PaymentRequirements(
+                scheme="exact",
+                network=SOLANA_DEVNET_CAIP2,
+                asset=USDC_DEVNET_ADDRESS,
+                amount="100000",
+                pay_to="PayToAddress11111111111111111111111111",
+                max_timeout_seconds=3600,
+                extra={"feePayer": "FeePayer1111111111111111111111111111"},
+            ),
+            payload={"transaction": transaction},
+        )
+
+    def _make_requirements(self) -> PaymentRequirements:
+        return PaymentRequirements(
+            scheme="exact",
+            network=SOLANA_DEVNET_CAIP2,
+            asset=USDC_DEVNET_ADDRESS,
+            amount="100000",
+            pay_to="PayToAddress11111111111111111111111111",
+            max_timeout_seconds=3600,
+            extra={"feePayer": "FeePayer1111111111111111111111111111"},
+        )
+
+    def test_should_reject_duplicate_settlement(self):
+        """Second settle call with the same transaction should be rejected."""
+        signer = MockFacilitatorSigner()
+        facilitator = ExactSvmFacilitatorScheme(signer)
+        requirements = self._make_requirements()
+        payload = self._make_payload("sameTransactionBase64==")
+
+        with patch.object(
+            facilitator,
+            "verify",
+            return_value=VerifyResponse(is_valid=True, payer="PayerAddress"),
+        ):
+            result1 = facilitator.settle(payload, requirements)
+            assert result1.success is True
+
+            result2 = facilitator.settle(payload, requirements)
+            assert result2.success is False
+            assert result2.error_reason == "duplicate_settlement"
+
+    def test_should_allow_distinct_transactions(self):
+        """Two different transactions should both settle successfully."""
+        signer = MockFacilitatorSigner()
+        facilitator = ExactSvmFacilitatorScheme(signer)
+        requirements = self._make_requirements()
+
+        with patch.object(
+            facilitator,
+            "verify",
+            return_value=VerifyResponse(is_valid=True, payer="PayerAddress"),
+        ):
+            result1 = facilitator.settle(self._make_payload("transactionA=="), requirements)
+            assert result1.success is True
+
+            result2 = facilitator.settle(self._make_payload("transactionB=="), requirements)
+            assert result2.success is True
+
+    def test_should_evict_cache_entries_after_ttl(self):
+        """Cache entries should be pruned after TTL so they no longer block locally.
+
+        NOTE: In production the Solana RPC would still reject a re-submitted
+        transaction that already landed on-chain. This test only verifies that
+        the in-memory cache correctly prunes expired entries.
+        """
+        signer = MockFacilitatorSigner()
+        facilitator = ExactSvmFacilitatorScheme(signer)
+        requirements = self._make_requirements()
+        payload = self._make_payload("expiringTransaction==")
+
+        with patch.object(
+            facilitator,
+            "verify",
+            return_value=VerifyResponse(is_valid=True, payer="PayerAddress"),
+        ):
+            result1 = facilitator.settle(payload, requirements)
+            assert result1.success is True
+
+            # Simulate TTL expiration by backdating the cache entry
+            for key in facilitator._settlement_cache.entries:
+                facilitator._settlement_cache.entries[key] -= 121.0
+
+            result2 = facilitator.settle(payload, requirements)
+            assert result2.success is True
+
+    def test_shared_cache_blocks_cross_version_duplicates(self):
+        """V1 and V2 sharing a cache should catch cross-version duplicates."""
+        from x402.mechanisms.svm.settlement_cache import SettlementCache
+        from x402.mechanisms.svm.exact.v1.facilitator import (
+            ExactSvmSchemeV1 as ExactSvmFacilitatorSchemeV1,
+        )
+        from x402.schemas.v1 import PaymentPayloadV1, PaymentRequirementsV1
+
+        signer = MockFacilitatorSigner()
+        shared_cache = SettlementCache()
+        v2 = ExactSvmFacilitatorScheme(signer, shared_cache)
+        v1 = ExactSvmFacilitatorSchemeV1(signer, shared_cache)
+
+        # Settle via V2 first
+        with patch.object(
+            v2,
+            "verify",
+            return_value=VerifyResponse(is_valid=True, payer="PayerAddress"),
+        ):
+            result1 = v2.settle(
+                self._make_payload("crossVersionTx=="),
+                self._make_requirements(),
+            )
+            assert result1.success is True
+
+        # Same tx via V1 should be rejected by the shared cache
+        v1_payload = PaymentPayloadV1(
+            scheme="exact",
+            network="solana-devnet",
+            payload={"transaction": "crossVersionTx=="},
+        )
+        v1_requirements = PaymentRequirementsV1(
+            scheme="exact",
+            network="solana-devnet",
+            asset=USDC_DEVNET_ADDRESS,
+            max_amount_required="100000",
+            pay_to="PayToAddress11111111111111111111111111",
+            max_timeout_seconds=3600,
+            resource="https://example.com",
+            extra={"feePayer": "FeePayer1111111111111111111111111111"},
+        )
+        with patch.object(
+            v1,
+            "verify",
+            return_value=VerifyResponse(is_valid=True, payer="PayerAddress"),
+        ):
+            result2 = v1.settle(v1_payload, v1_requirements)
+            assert result2.success is False
+            assert result2.error_reason == "duplicate_settlement"
 
 
 class TestVerifyFeePayer:

--- a/python/x402/tests/unit/mechanisms/svm/test_facilitator.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_facilitator.py
@@ -393,10 +393,10 @@ class TestDuplicateSettlementCache:
 
     def test_shared_cache_blocks_cross_version_duplicates(self):
         """V1 and V2 sharing a cache should catch cross-version duplicates."""
-        from x402.mechanisms.svm.settlement_cache import SettlementCache
         from x402.mechanisms.svm.exact.v1.facilitator import (
             ExactSvmSchemeV1 as ExactSvmFacilitatorSchemeV1,
         )
+        from x402.mechanisms.svm.settlement_cache import SettlementCache
         from x402.schemas.v1 import PaymentPayloadV1, PaymentRequirementsV1
 
         signer = MockFacilitatorSigner()
@@ -483,3 +483,79 @@ class TestVerifyFeePayer:
 
         assert result.is_valid is False
         assert result.invalid_reason == "fee_payer_not_managed_by_facilitator"
+
+
+class TestSettlementCachePruneOptimization:
+    """Verify the early-break prune optimization preserves insertion-order semantics."""
+
+    def test_prunes_only_expired_entries_preserves_fresh_ones(self):
+        """Entries older than TTL are pruned; newer entries survive."""
+        from x402.mechanisms.svm.settlement_cache import SettlementCache
+
+        cache = SettlementCache()
+
+        cache.is_duplicate("tx-a")
+        cache.is_duplicate("tx-b")
+        cache.is_duplicate("tx-c")
+
+        # Backdate tx-a past TTL (121s), leave tx-b and tx-c fresh
+        base = cache.entries["tx-a"]
+        cache.entries["tx-a"] = base - 121.0
+
+        assert cache.is_duplicate("tx-a") is False, "expired entry should have been pruned"
+        assert cache.is_duplicate("tx-b") is True, "fresh entry should still be cached"
+        assert cache.is_duplicate("tx-c") is True, "fresh entry should still be cached"
+
+    def test_prunes_all_entries_when_all_expired(self):
+        """When every entry is expired, all should be pruned."""
+        from x402.mechanisms.svm.settlement_cache import SettlementCache
+
+        cache = SettlementCache()
+
+        cache.is_duplicate("tx-1")
+        cache.is_duplicate("tx-2")
+        cache.is_duplicate("tx-3")
+
+        for k in list(cache.entries):
+            cache.entries[k] -= 121.0
+
+        assert cache.is_duplicate("tx-1") is False
+        assert cache.is_duplicate("tx-2") is False
+        assert cache.is_duplicate("tx-3") is False
+
+    def test_prunes_nothing_when_all_fresh(self):
+        """When no entries are expired, none should be pruned."""
+        from x402.mechanisms.svm.settlement_cache import SettlementCache
+
+        cache = SettlementCache()
+
+        cache.is_duplicate("tx-x")
+        cache.is_duplicate("tx-y")
+        cache.is_duplicate("tx-z")
+
+        assert cache.is_duplicate("tx-x") is True
+        assert cache.is_duplicate("tx-y") is True
+        assert cache.is_duplicate("tx-z") is True
+
+    def test_early_break_preserves_ordered_entries(self):
+        """Insertion-order iteration means the break fires at the first fresh entry."""
+        from x402.mechanisms.svm.settlement_cache import SettlementCache
+
+        cache = SettlementCache()
+
+        # Insert A, B, C in order with small gaps
+        cache.is_duplicate("tx-old-1")
+        cache.is_duplicate("tx-old-2")
+        cache.is_duplicate("tx-fresh")
+
+        # Expire only the first two
+        for k in ("tx-old-1", "tx-old-2"):
+            cache.entries[k] -= 121.0
+
+        # Trigger prune
+        cache.is_duplicate("tx-new")
+
+        assert "tx-old-1" not in cache.entries, "first expired entry should be pruned"
+        assert "tx-old-2" not in cache.entries, "second expired entry should be pruned"
+        assert "tx-fresh" in cache.entries, "fresh entry after expired ones should survive"
+        assert "tx-new" in cache.entries, "newly inserted entry should be present"

--- a/specs/schemes/exact/scheme_exact_svm.md
+++ b/specs/schemes/exact/scheme_exact_svm.md
@@ -143,3 +143,22 @@ A facilitator verifying an `exact`-scheme SVM payment MUST enforce all of the fo
 - The `amount` in TransferChecked MUST equal `PaymentRequirements.amount` exactly.
 
 These checks are security-critical to ensure the fee payer cannot be tricked into transferring their own funds or sponsoring unintended actions. Implementations MAY introduce stricter limits (e.g., lower compute price caps) but MUST NOT relax the above constraints.
+
+## Duplicate Settlement Mitigation (RECOMMENDED)
+
+### Vulnerability
+
+A race condition exists in the settlement flow: if the same payment transaction is submitted to the facilitator's `/settle` endpoint multiple times before the first submission is confirmed on-chain, each call may return a successful response. 
+
+Although Solana's transaction deduplication ensures the transfer only executes once on-chain, the RPC returns "success", and hence the facilitator could return `success` to each caller. A malicious client can exploit this to obtain access to multiple resources while only paying once.
+
+### Recommended Mitigation
+
+Merchants and/or Facilitators SHOULD maintain a short-term, in-memory cache of transaction payloads that are currently being settled. Before proceeding with settlement, the merchant/facilitator checks whether the transaction has already been seen:
+
+1. After verification succeeds, derive a cache key from the transaction payload (e.g., the base64-encoded transaction string).
+2. If the key is already present in the cache, reject the settlement with a `"duplicate_settlement"` error.
+3. If the key is not present, insert it into the cache and proceed with signing and submission.
+4. Evict entries older than 120 seconds (approximately twice the Solana blockhash lifetime of ~60–90 seconds). After this window, the transaction's blockhash will have expired and it cannot land on-chain regardless.
+
+This approach requires no external storage or long-lived state — only an in-process map with time-based eviction. It preserves the facilitator's otherwise stateless design while closing the duplicate settlement attack vector.

--- a/typescript/.changeset/fix-svm-duplicate-settlement.md
+++ b/typescript/.changeset/fix-svm-duplicate-settlement.md
@@ -1,0 +1,5 @@
+---
+'@x402/svm': patch
+---
+
+Add in-memory SettlementCache to prevent duplicate SVM transaction settlement during on-chain confirmation window

--- a/typescript/packages/mechanisms/svm/README.md
+++ b/typescript/packages/mechanisms/svm/README.md
@@ -174,6 +174,16 @@ The exact payment scheme uses SPL Token `TransferChecked` instruction with:
 - Source/destination ATAs (Associated Token Accounts)
 - Partial signing (client signs, facilitator completes and submits)
 
+## Duplicate Settlement Protection
+
+This package includes a built-in `SettlementCache` that prevents a known race condition on Solana where the same payment transaction could be settled multiple times before on-chain confirmation. When the facilitator scheme is registered via `registerExactSvmScheme`, a single `SettlementCache` instance is automatically shared across both V1 and V2 scheme versions.
+
+The cache rejects concurrent `/settle` calls that carry the same transaction payload, returning a `duplicate_settlement` error for the second and subsequent attempts. Entries are automatically evicted after 120 seconds (approximately twice the Solana blockhash lifetime).
+
+**No additional configuration is required** — duplicate settlement protection is enabled by default when using the standard registration helpers.
+
+For full details on the race condition and mitigation strategy, see the [Exact SVM Scheme Specification](../../../../specs/schemes/exact/scheme_exact_svm.md#duplicate-settlement-mitigation-recommended).
+
 ## Development
 
 ```bash

--- a/typescript/packages/mechanisms/svm/src/constants.ts
+++ b/typescript/packages/mechanisms/svm/src/constants.ts
@@ -43,6 +43,12 @@ export const MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS = 5_000_000; // 5 lamports
 export const DEFAULT_COMPUTE_UNIT_LIMIT = 20_000;
 
 /**
+ * How long a transaction is held in the duplicate settlement cache (ms).
+ * Covers the Solana blockhash lifetime (~60-90s) with margin.
+ */
+export const SETTLEMENT_TTL_MS = 120_000;
+
+/**
  * Solana address validation regex (base58, 32-44 characters)
  */
 export const SVM_ADDRESS_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/register.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/register.ts
@@ -1,5 +1,6 @@
 import { x402Facilitator } from "@x402/core/facilitator";
 import { Network } from "@x402/core/types";
+import { SettlementCache } from "../../settlement-cache";
 import { FacilitatorSvmSigner } from "../../signer";
 import { ExactSvmScheme } from "./scheme";
 import { ExactSvmSchemeV1 } from "../v1/facilitator/scheme";
@@ -47,11 +48,18 @@ export function registerExactSvmScheme(
   facilitator: x402Facilitator,
   config: SvmFacilitatorConfig,
 ): x402Facilitator {
+  // Share a single settlement cache across V1 and V2 so that a duplicate
+  // transaction submitted through one protocol version is also caught by the other.
+  const settlementCache = new SettlementCache();
+
   // Register V2 scheme with specified networks
-  facilitator.register(config.networks, new ExactSvmScheme(config.signer));
+  facilitator.register(config.networks, new ExactSvmScheme(config.signer, settlementCache));
 
   // Register all V1 networks
-  facilitator.registerV1(NETWORKS as Network[], new ExactSvmSchemeV1(config.signer));
+  facilitator.registerV1(
+    NETWORKS as Network[],
+    new ExactSvmSchemeV1(config.signer, settlementCache),
+  );
 
   return facilitator;
 }

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -29,6 +29,7 @@ import {
   MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS,
   MEMO_PROGRAM_ADDRESS,
 } from "../../constants";
+import { SettlementCache } from "../../settlement-cache";
 import type { FacilitatorSvmSigner } from "../../signer";
 import type { ExactSvmPayloadV2 } from "../../types";
 import { decodeTransactionFromPayload, getTokenPayerFromTransaction } from "../../utils";
@@ -40,13 +41,21 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
   readonly scheme = "exact";
   readonly caipFamily = "solana:*";
 
+  private readonly settlementCache: SettlementCache;
+
   /**
    * Creates a new ExactSvmFacilitator instance.
    *
    * @param signer - The SVM RPC client for facilitator operations
+   * @param settlementCache - Optional shared settlement cache (one is created if omitted)
    * @returns ExactSvmFacilitator instance
    */
-  constructor(private readonly signer: FacilitatorSvmSigner) {}
+  constructor(
+    private readonly signer: FacilitatorSvmSigner,
+    settlementCache?: SettlementCache,
+  ) {
+    this.settlementCache = settlementCache ?? new SettlementCache();
+  }
 
   /**
    * Get mechanism-specific extra data for the supported kinds endpoint.
@@ -344,6 +353,19 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
         network: payload.accepted.network,
         transaction: "",
         errorReason: valid.invalidReason ?? "verification_failed",
+        payer: valid.payer || "",
+      };
+    }
+
+    // Duplicate settlement check: reject if this transaction is already being settled.
+    // Must occur before any async work so concurrent calls for the same tx are caught.
+    const txKey = exactSvmPayload.transaction;
+    if (this.settlementCache.isDuplicate(txKey)) {
+      return {
+        success: false,
+        network: payload.accepted.network,
+        transaction: "",
+        errorReason: "duplicate_settlement",
         payer: valid.payer || "",
       };
     }

--- a/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
@@ -30,6 +30,7 @@ import {
   MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS,
   MEMO_PROGRAM_ADDRESS,
 } from "../../../constants";
+import { SettlementCache } from "../../../settlement-cache";
 import type { FacilitatorSvmSigner } from "../../../signer";
 import type { ExactSvmPayloadV1 } from "../../../types";
 import { decodeTransactionFromPayload, getTokenPayerFromTransaction } from "../../../utils";
@@ -41,13 +42,21 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
   readonly scheme = "exact";
   readonly caipFamily = "solana:*";
 
+  private readonly settlementCache: SettlementCache;
+
   /**
    * Creates a new ExactSvmFacilitatorV1 instance.
    *
    * @param signer - The SVM RPC client for facilitator operations
+   * @param settlementCache - Optional shared settlement cache (one is created if omitted)
    * @returns ExactSvmFacilitatorV1 instance
    */
-  constructor(private readonly signer: FacilitatorSvmSigner) {}
+  constructor(
+    private readonly signer: FacilitatorSvmSigner,
+    settlementCache?: SettlementCache,
+  ) {
+    this.settlementCache = settlementCache ?? new SettlementCache();
+  }
 
   /**
    * Get mechanism-specific extra data for the supported kinds endpoint.
@@ -348,6 +357,19 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
         network: payloadV1.network,
         transaction: "",
         errorReason: valid.invalidReason ?? "verification_failed",
+        payer: valid.payer || "",
+      };
+    }
+
+    // Duplicate settlement check: reject if this transaction is already being settled.
+    // Must occur before any async work so concurrent calls for the same tx are caught.
+    const txKey = exactSvmPayload.transaction;
+    if (this.settlementCache.isDuplicate(txKey)) {
+      return {
+        success: false,
+        network: payloadV1.network,
+        transaction: "",
+        errorReason: "duplicate_settlement",
         payer: valid.payer || "",
       };
     }

--- a/typescript/packages/mechanisms/svm/src/index.ts
+++ b/typescript/packages/mechanisms/svm/src/index.ts
@@ -20,6 +20,9 @@ export type {
 // Export payload types
 export type { ExactSvmPayloadV1, ExactSvmPayloadV2 } from "./types";
 
+// Export settlement cache (shared across V1/V2 facilitator instances)
+export { SettlementCache } from "./settlement-cache";
+
 // Export constants
 export * from "./constants";
 

--- a/typescript/packages/mechanisms/svm/src/settlement-cache.ts
+++ b/typescript/packages/mechanisms/svm/src/settlement-cache.ts
@@ -1,0 +1,44 @@
+import { SETTLEMENT_TTL_MS } from "./constants";
+
+/**
+ * In-memory cache for deduplicating concurrent settlement requests.
+ *
+ * A single instance should be shared across V1 and V2 facilitator scheme
+ * instances so that a transaction submitted through one protocol version is
+ * also blocked on the other.  Because Node.js is single-threaded, no lock
+ * is required — the cache check + insert must simply occur before the first
+ * `await` in the settle path.
+ */
+export class SettlementCache {
+  private readonly entries = new Map<string, number>();
+
+  /**
+   * Returns `true` if `key` is already pending settlement (duplicate),
+   * or `false` after recording it as newly pending.
+   *
+   * Callers should reject the settlement when this returns `true`.
+   *
+   * @param key - The unique identifier for the settlement (typically the transaction signature).
+   * @returns `true` if the key was already present (duplicate); `false` otherwise.
+   */
+  isDuplicate(key: string): boolean {
+    this.prune();
+    if (this.entries.has(key)) {
+      return true;
+    }
+    this.entries.set(key, Date.now());
+    return false;
+  }
+
+  /**
+   * Remove entries older than the settlement TTL.
+   */
+  private prune(): void {
+    const cutoff = Date.now() - SETTLEMENT_TTL_MS;
+    for (const [key, timestamp] of this.entries) {
+      if (timestamp < cutoff) {
+        this.entries.delete(key);
+      }
+    }
+  }
+}

--- a/typescript/packages/mechanisms/svm/src/settlement-cache.ts
+++ b/typescript/packages/mechanisms/svm/src/settlement-cache.ts
@@ -38,6 +38,8 @@ export class SettlementCache {
     for (const [key, timestamp] of this.entries) {
       if (timestamp < cutoff) {
         this.entries.delete(key);
+      } else {
+        break;
       }
     }
   }

--- a/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ExactSvmScheme } from "../../src/exact/facilitator/scheme";
+import { ExactSvmSchemeV1 } from "../../src/exact/v1/facilitator/scheme";
+import { SettlementCache } from "../../src/settlement-cache";
 import type { FacilitatorSvmSigner } from "../../src/signer";
 import type { PaymentRequirements, PaymentPayload } from "@x402/core/types";
+import type { PaymentPayloadV1, PaymentRequirementsV1 } from "@x402/core/types/v1";
 import { USDC_DEVNET_ADDRESS, SOLANA_DEVNET_CAIP2 } from "../../src/constants";
 
 describe("ExactSvmScheme", () => {
@@ -253,6 +256,153 @@ describe("ExactSvmScheme", () => {
       expect(result.success).toBe(false);
       expect(result.errorReason).toBe("unsupported_scheme");
       expect(result.network).toBe(SOLANA_DEVNET_CAIP2);
+    });
+  });
+
+  describe("duplicate settlement cache", () => {
+    function makePayload(transaction: string): PaymentPayload {
+      return {
+        x402Version: 2,
+        resource: {
+          url: "http://example.com/protected",
+          description: "Test resource",
+          mimeType: "application/json",
+        },
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: "PayToAddress11111111111111111111111111",
+          maxTimeoutSeconds: 3600,
+          extra: { feePayer: "FeePayer1111111111111111111111111111" },
+        },
+        payload: { transaction },
+      };
+    }
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: "PayToAddress11111111111111111111111111",
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: "FeePayer1111111111111111111111111111" },
+    };
+
+    function setupSettleMocks(facilitator: ExactSvmScheme) {
+      vi.spyOn(facilitator, "verify").mockResolvedValue({
+        isValid: true,
+        payer: "PayerAddress",
+      });
+      (mockSigner as Record<string, unknown>).signTransaction = vi
+        .fn()
+        .mockResolvedValue("signedTx");
+      (mockSigner as Record<string, unknown>).sendTransaction = vi
+        .fn()
+        .mockResolvedValue("txSignature123");
+      (mockSigner as Record<string, unknown>).confirmTransaction = vi
+        .fn()
+        .mockResolvedValue(undefined);
+    }
+
+    it("should reject duplicate settlement of the same transaction", async () => {
+      const facilitator = new ExactSvmScheme(mockSigner);
+      setupSettleMocks(facilitator);
+
+      const payload = makePayload("sameTransactionBase64==");
+
+      const result1 = await facilitator.settle(payload, requirements);
+      expect(result1.success).toBe(true);
+
+      const result2 = await facilitator.settle(payload, requirements);
+      expect(result2.success).toBe(false);
+      expect(result2.errorReason).toBe("duplicate_settlement");
+    });
+
+    it("should allow settlement of distinct transactions", async () => {
+      const facilitator = new ExactSvmScheme(mockSigner);
+      setupSettleMocks(facilitator);
+
+      const result1 = await facilitator.settle(makePayload("transactionA=="), requirements);
+      expect(result1.success).toBe(true);
+
+      const result2 = await facilitator.settle(makePayload("transactionB=="), requirements);
+      expect(result2.success).toBe(true);
+    });
+
+    it("should evict cache entries after TTL", async () => {
+      vi.useFakeTimers();
+      try {
+        const facilitator = new ExactSvmScheme(mockSigner);
+        setupSettleMocks(facilitator);
+
+        const payload = makePayload("expiringTransaction==");
+
+        const result1 = await facilitator.settle(payload, requirements);
+        expect(result1.success).toBe(true);
+
+        // Advance past the 120s TTL
+        vi.advanceTimersByTime(121_000);
+
+        const result2 = await facilitator.settle(payload, requirements);
+        expect(result2.success).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("should block cross-version duplicate when sharing a cache", async () => {
+      const sharedCache = new SettlementCache();
+      const v2 = new ExactSvmScheme(mockSigner, sharedCache);
+      const v1 = new ExactSvmSchemeV1(mockSigner, sharedCache);
+
+      // Mock V2 settle flow
+      vi.spyOn(v2, "verify").mockResolvedValue({
+        isValid: true,
+        payer: "PayerAddress",
+      });
+      (mockSigner as Record<string, unknown>).signTransaction = vi
+        .fn()
+        .mockResolvedValue("signedTx");
+      (mockSigner as Record<string, unknown>).sendTransaction = vi
+        .fn()
+        .mockResolvedValue("txSignature123");
+      (mockSigner as Record<string, unknown>).confirmTransaction = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      // Settle via V2 first
+      const v2Result = await v2.settle(makePayload("crossVersionTx=="), requirements);
+      expect(v2Result.success).toBe(true);
+
+      // Mock V1 verify
+      vi.spyOn(v1, "verify").mockResolvedValue({
+        isValid: true,
+        payer: "PayerAddress",
+      });
+
+      // Same tx via V1 should be rejected
+      const v1Payload: PaymentPayloadV1 = {
+        x402Version: 1,
+        scheme: "exact",
+        network: "solana-devnet",
+        payload: { transaction: "crossVersionTx==" },
+      };
+      const v1Requirements: PaymentRequirementsV1 = {
+        scheme: "exact",
+        network: "solana-devnet",
+        asset: USDC_DEVNET_ADDRESS,
+        maxAmountRequired: "100000",
+        payTo: "PayToAddress11111111111111111111111111",
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: "FeePayer1111111111111111111111111111" },
+      };
+
+      const v1Result = await v1.settle(v1Payload as never, v1Requirements as never);
+      expect(v1Result.success).toBe(false);
+      expect(v1Result.errorReason).toBe("duplicate_settlement");
     });
   });
 });

--- a/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
@@ -406,3 +406,63 @@ describe("ExactSvmScheme", () => {
     });
   });
 });
+
+describe("SettlementCache prune optimization", () => {
+  it("should prune only expired entries and preserve non-expired ones", () => {
+    vi.useFakeTimers();
+    try {
+      const cache = new SettlementCache();
+
+      // Insert three entries 10s apart
+      cache.isDuplicate("tx-a");
+      vi.advanceTimersByTime(10_000);
+      cache.isDuplicate("tx-b");
+      vi.advanceTimersByTime(10_000);
+      cache.isDuplicate("tx-c");
+
+      // Advance so tx-a and tx-b are expired (> 120s old) but tx-c is not
+      vi.advanceTimersByTime(101_000); // total: tx-a=121s, tx-b=111s, tx-c=101s
+
+      // tx-a should be expired, tx-b and tx-c should still be cached
+      // Trigger prune via a new isDuplicate call
+      expect(cache.isDuplicate("tx-a")).toBe(false); // expired, re-inserted as new
+      expect(cache.isDuplicate("tx-b")).toBe(true); // still cached
+      expect(cache.isDuplicate("tx-c")).toBe(true); // still cached
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("should prune all entries when all are expired", () => {
+    vi.useFakeTimers();
+    try {
+      const cache = new SettlementCache();
+
+      cache.isDuplicate("tx-1");
+      cache.isDuplicate("tx-2");
+      cache.isDuplicate("tx-3");
+
+      vi.advanceTimersByTime(121_000);
+
+      // All expired — none should be detected as duplicates
+      expect(cache.isDuplicate("tx-1")).toBe(false);
+      expect(cache.isDuplicate("tx-2")).toBe(false);
+      expect(cache.isDuplicate("tx-3")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("should not prune any entries when none are expired", () => {
+    const cache = new SettlementCache();
+
+    cache.isDuplicate("tx-x");
+    cache.isDuplicate("tx-y");
+    cache.isDuplicate("tx-z");
+
+    // All still fresh — all should be detected as duplicates
+    expect(cache.isDuplicate("tx-x")).toBe(true);
+    expect(cache.isDuplicate("tx-y")).toBe(true);
+    expect(cache.isDuplicate("tx-z")).toBe(true);
+  });
+});

--- a/typescript/packages/mechanisms/svm/test/unit/v1/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/v1/facilitator.test.ts
@@ -204,4 +204,93 @@ describe("ExactSvmSchemeV1", () => {
       expect(result.network).toBe("solana-devnet");
     });
   });
+
+  describe("duplicate settlement cache", () => {
+    function makePayload(transaction: string): PaymentPayloadV1 {
+      return {
+        x402Version: 1,
+        scheme: "exact",
+        network: "solana-devnet",
+        payload: { transaction },
+      };
+    }
+
+    const requirements: PaymentRequirementsV1 = {
+      scheme: "exact",
+      network: "solana-devnet",
+      asset: USDC_DEVNET_ADDRESS,
+      maxAmountRequired: "100000",
+      payTo: "PayToAddress11111111111111111111111111",
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: "FeePayer1111111111111111111111111111" },
+    };
+
+    function setupSettleMocks(facilitator: ExactSvmSchemeV1) {
+      vi.spyOn(facilitator, "verify").mockResolvedValue({
+        isValid: true,
+        payer: "PayerAddress",
+      });
+      (mockSigner as Record<string, unknown>).signTransaction = vi
+        .fn()
+        .mockResolvedValue("signedTx");
+      (mockSigner as Record<string, unknown>).sendTransaction = vi
+        .fn()
+        .mockResolvedValue("txSignature123");
+      (mockSigner as Record<string, unknown>).confirmTransaction = vi
+        .fn()
+        .mockResolvedValue(undefined);
+    }
+
+    it("should reject duplicate settlement of the same transaction", async () => {
+      const facilitator = new ExactSvmSchemeV1(mockSigner);
+      setupSettleMocks(facilitator);
+
+      const payload = makePayload("sameTransactionBase64==");
+
+      const result1 = await facilitator.settle(payload as never, requirements as never);
+      expect(result1.success).toBe(true);
+
+      const result2 = await facilitator.settle(payload as never, requirements as never);
+      expect(result2.success).toBe(false);
+      expect(result2.errorReason).toBe("duplicate_settlement");
+    });
+
+    it("should allow settlement of distinct transactions", async () => {
+      const facilitator = new ExactSvmSchemeV1(mockSigner);
+      setupSettleMocks(facilitator);
+
+      const result1 = await facilitator.settle(
+        makePayload("transactionA==") as never,
+        requirements as never,
+      );
+      expect(result1.success).toBe(true);
+
+      const result2 = await facilitator.settle(
+        makePayload("transactionB==") as never,
+        requirements as never,
+      );
+      expect(result2.success).toBe(true);
+    });
+
+    it("should evict cache entries after TTL", async () => {
+      vi.useFakeTimers();
+      try {
+        const facilitator = new ExactSvmSchemeV1(mockSigner);
+        setupSettleMocks(facilitator);
+
+        const payload = makePayload("expiringTransaction==");
+
+        const result1 = await facilitator.settle(payload as never, requirements as never);
+        expect(result1.success).toBe(true);
+
+        // Advance past the 120s TTL
+        vi.advanceTimersByTime(121_000);
+
+        const result2 = await facilitator.settle(payload as never, requirements as never);
+        expect(result2.success).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Description

Adds a cache in memory for Solana txs that are in-flight.

If a merchant sends the exact same solana tx multiple times, and the tx hasn't reached a `confirmed` state on chain yet, only one should return success while the others should return a duplicate error.

## Tests

Added unit tests for duplicate detection in all three languages

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)