### PR TITLE
Add ActionGate to x402 Ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/actiongate/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/actiongate/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "ActionGate",
+  "description": "Pre-execution decision API for autonomous agents with paid risk scoring, simulation, and policy-gate endpoints using x402 V2.",
+  "logoUrl": "/logos/actiongate.svg",
+  "websiteUrl": "https://api.actiongate.xyz/docs",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/actiongate.svg
+++ b/typescript/site/public/logos/actiongate.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="ActionGate logo">
+  <rect width="256" height="256" rx="36" fill="#0f172a"/>
+  <path d="M52 188L102 68h20l50 120h-24l-11-28H87l-11 28H52zm43-49h34l-17-44-17 44z" fill="#22d3ee"/>
+  <path d="M152 122h52v20h-52z" fill="#f8fafc"/>
+  <path d="M179 95l27 37-27 37z" fill="#f8fafc"/>
+</svg>


### PR DESCRIPTION
## Description

Adds ActionGate to the x402 ecosystem under `Services/Endpoints`.

Files added:
- `typescript/site/app/ecosystem/partners-data/actiongate/metadata.json`
- `typescript/site/public/logos/actiongate.svg`

ActionGate is a paid safety layer for agent wallets with live x402-gated endpoints for:
- risk scoring
- simulation
- policy gating

Public docs:
- `https://api.actiongate.xyz/docs`

OpenAPI:
- `https://api.actiongate.xyz/docs/openapi-v1.yaml`

## Tests

Validated the public ActionGate integration endpoints and discovery surfaces:

- `curl https://api.actiongate.xyz/.well-known/agent.json`
- `curl https://api.actiongate.xyz/docs/openapi-v1.yaml`
- `curl -X POST https://api.actiongate.xyz/v1/risk-score` returns `402`
- `curl -X POST https://api.actiongate.xyz/v1/simulate` returns `402`
- `curl -X POST https://api.actiongate.xyz/v1/policy-gate` returns `402`

Confirmed:
- metadata schema matches existing ecosystem entry structure
- logo is SVG and served publicly
- category is `Services/Endpoints`

This PR only adds ecosystem site metadata and a logo asset. No x402 library code is changed.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
