### PR TITLE
fix(python): handle invalid facilitator responses

### DIFF
--- a/go/.changeset/facilitator-response-errors.md
+++ b/go/.changeset/facilitator-response-errors.md
@@ -1,0 +1,5 @@
+---
+'github.com/coinbase/x402/go': patch
+---
+
+Treat malformed facilitator success payloads as facilitator boundary errors in the Go HTTP client instead of surfacing them as verification or settlement failures.

--- a/go/http/facilitator_client.go
+++ b/go/http/facilitator_client.go
@@ -180,7 +180,7 @@ func parseSupportedSuccessResponse(body []byte) (x402.SupportedResponse, error) 
 				"getSupported",
 				"data",
 				body,
-				fmt.Errorf("invalid supported kind"),
+				fmt.Errorf("invalid supported response fields"),
 			)
 		}
 		kinds = append(kinds, x402.SupportedKind{
@@ -191,25 +191,21 @@ func parseSupportedSuccessResponse(body []byte) (x402.SupportedResponse, error) 
 		})
 	}
 
+	extensions := response.Extensions
+	if extensions == nil {
+		extensions = []string{}
+	}
+
+	signers := response.Signers
+	if signers == nil {
+		signers = map[string][]string{}
+	}
+
 	return x402.SupportedResponse{
 		Kinds:      kinds,
-		Extensions: nonNilStrings(response.Extensions),
-		Signers:    nonNilSigners(response.Signers),
+		Extensions: extensions,
+		Signers:    signers,
 	}, nil
-}
-
-func nonNilStrings(values []string) []string {
-	if values == nil {
-		return []string{}
-	}
-	return values
-}
-
-func nonNilSigners(signers map[string][]string) map[string][]string {
-	if signers == nil {
-		return map[string][]string{}
-	}
-	return signers
 }
 
 // NewHTTPFacilitatorClient creates a new HTTP facilitator client
@@ -331,7 +327,11 @@ func (c *HTTPFacilitatorClient) GetSupported(ctx context.Context) (x402.Supporte
 			return parseSupportedSuccessResponse(responseBody)
 		}
 
-		lastErr = fmt.Errorf("facilitator supported failed (%d): %s", resp.StatusCode, string(responseBody))
+		lastErr = fmt.Errorf(
+			"facilitator supported failed (%d): %s",
+			resp.StatusCode,
+			responseExcerpt(responseBody, 200),
+		)
 
 		// Retry on 429 with exponential backoff, except on the last attempt
 		if resp.StatusCode == http.StatusTooManyRequests && attempt < getSupportedRetries-1 {

--- a/go/http/facilitator_client.go
+++ b/go/http/facilitator_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	x402 "github.com/coinbase/x402/go"
@@ -66,6 +67,145 @@ const getSupportedRetries = 3
 
 // getSupportedRetryBaseDelay is the base delay for exponential backoff on retries
 const getSupportedRetryBaseDelay = 1 * time.Second
+
+// FacilitatorResponseError indicates a facilitator returned malformed success payload data.
+type FacilitatorResponseError struct {
+	message string
+	cause   error
+}
+
+func (e *FacilitatorResponseError) Error() string {
+	return e.message
+}
+
+func (e *FacilitatorResponseError) Unwrap() error {
+	return e.cause
+}
+
+type verifyResponseEnvelope struct {
+	IsValid        *bool  `json:"isValid"`
+	InvalidReason  string `json:"invalidReason,omitempty"`
+	InvalidMessage string `json:"invalidMessage,omitempty"`
+	Payer          string `json:"payer,omitempty"`
+}
+
+type settleResponseEnvelope struct {
+	Success      *bool        `json:"success"`
+	ErrorReason  string       `json:"errorReason,omitempty"`
+	ErrorMessage string       `json:"errorMessage,omitempty"`
+	Payer        string       `json:"payer,omitempty"`
+	Transaction  *string      `json:"transaction"`
+	Network      *x402.Network `json:"network"`
+}
+
+type supportedKindEnvelope struct {
+	X402Version *int                   `json:"x402Version"`
+	Scheme      string                 `json:"scheme"`
+	Network     string                 `json:"network"`
+	Extra       map[string]interface{} `json:"extra,omitempty"`
+}
+
+type supportedResponseEnvelope struct {
+	Kinds      []supportedKindEnvelope `json:"kinds"`
+	Extensions []string                `json:"extensions"`
+	Signers    map[string][]string     `json:"signers"`
+}
+
+func responseExcerpt(body []byte, limit int) string {
+	text := strings.TrimSpace(string(body))
+	if text == "" {
+		return "<empty response>"
+	}
+
+	compact := strings.Join(strings.Fields(text), " ")
+	if len(compact) <= limit {
+		return compact
+	}
+
+	return compact[:limit-3] + "..."
+}
+
+func newFacilitatorResponseError(operation string, kind string, body []byte, cause error) error {
+	return &FacilitatorResponseError{
+		message: fmt.Sprintf("facilitator %s returned invalid %s: %s", operation, kind, responseExcerpt(body, 200)),
+		cause:   cause,
+	}
+}
+
+func parseVerifySuccessResponse(body []byte) (*x402.VerifyResponse, error) {
+	var response verifyResponseEnvelope
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, newFacilitatorResponseError("verify", "JSON", body, err)
+	}
+	if response.IsValid == nil {
+		return nil, newFacilitatorResponseError("verify", "data", body, fmt.Errorf("missing isValid"))
+	}
+
+	return &x402.VerifyResponse{
+		IsValid:        *response.IsValid,
+		InvalidReason:  response.InvalidReason,
+		InvalidMessage: response.InvalidMessage,
+		Payer:          response.Payer,
+	}, nil
+}
+
+func parseSettleSuccessResponse(body []byte) (*x402.SettleResponse, error) {
+	var response settleResponseEnvelope
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, newFacilitatorResponseError("settle", "JSON", body, err)
+	}
+	if response.Success == nil || response.Transaction == nil || response.Network == nil {
+		return nil, newFacilitatorResponseError("settle", "data", body, fmt.Errorf("missing required fields"))
+	}
+
+	return &x402.SettleResponse{
+		Success:      *response.Success,
+		ErrorReason:  response.ErrorReason,
+		ErrorMessage: response.ErrorMessage,
+		Payer:        response.Payer,
+		Transaction:  *response.Transaction,
+		Network:      *response.Network,
+	}, nil
+}
+
+func parseSupportedSuccessResponse(body []byte) (x402.SupportedResponse, error) {
+	var response supportedResponseEnvelope
+	if err := json.Unmarshal(body, &response); err != nil {
+		return x402.SupportedResponse{}, newFacilitatorResponseError("getSupported", "JSON", body, err)
+	}
+	if response.Kinds == nil {
+		return x402.SupportedResponse{}, newFacilitatorResponseError(
+			"getSupported",
+			"data",
+			body,
+			fmt.Errorf("missing kinds"),
+		)
+	}
+
+	kinds := make([]x402.SupportedKind, 0, len(response.Kinds))
+	for _, kind := range response.Kinds {
+		if kind.X402Version == nil || kind.Scheme == "" || kind.Network == "" {
+			return x402.SupportedResponse{}, newFacilitatorResponseError(
+				"getSupported",
+				"data",
+				body,
+				fmt.Errorf("invalid supported kind"),
+			)
+		}
+		kinds = append(kinds, x402.SupportedKind{
+			X402Version: *kind.X402Version,
+			Scheme:      kind.Scheme,
+			Network:     kind.Network,
+			Extra:       kind.Extra,
+		})
+	}
+
+	return x402.SupportedResponse{
+		Kinds:      kinds,
+		Extensions: response.Extensions,
+		Signers:    response.Signers,
+	}, nil
+}
 
 // NewHTTPFacilitatorClient creates a new HTTP facilitator client
 func NewHTTPFacilitatorClient(config *FacilitatorConfig) *HTTPFacilitatorClient {
@@ -183,11 +323,7 @@ func (c *HTTPFacilitatorClient) GetSupported(ctx context.Context) (x402.Supporte
 
 		// Success
 		if resp.StatusCode == http.StatusOK {
-			var supportedResponse x402.SupportedResponse
-			if err := json.Unmarshal(responseBody, &supportedResponse); err != nil {
-				return x402.SupportedResponse{}, fmt.Errorf("failed to decode supported response: %w", err)
-			}
-			return supportedResponse, nil
+			return parseSupportedSuccessResponse(responseBody)
 		}
 
 		lastErr = fmt.Errorf("facilitator supported failed (%d): %s", resp.StatusCode, string(responseBody))
@@ -266,18 +402,9 @@ func (c *HTTPFacilitatorClient) verifyHTTP(ctx context.Context, version int, pay
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	var verifyResponse x402.VerifyResponse
-	if err := json.Unmarshal(responseBody, &verifyResponse); err != nil {
-		return nil, x402.NewVerifyError(
-			x402.ErrInvalidResponse,
-			"",
-			fmt.Sprintf("failed to unmarshal verify response: %s", err.Error()),
-		)
-	}
-
-	// For non-200 responses, return an error with the details from the response
 	if resp.StatusCode != http.StatusOK {
-		if verifyResponse.InvalidReason != "" {
+		var verifyResponse verifyResponseEnvelope
+		if err := json.Unmarshal(responseBody, &verifyResponse); err == nil && verifyResponse.InvalidReason != "" {
 			return nil, x402.NewVerifyError(
 				verifyResponse.InvalidReason,
 				verifyResponse.Payer,
@@ -287,7 +414,7 @@ func (c *HTTPFacilitatorClient) verifyHTTP(ctx context.Context, version int, pay
 		return nil, fmt.Errorf("facilitator verify failed (%d): %s", resp.StatusCode, string(responseBody))
 	}
 
-	return &verifyResponse, nil
+	return parseVerifySuccessResponse(responseBody)
 }
 
 func (c *HTTPFacilitatorClient) settleHTTP(ctx context.Context, version int, payloadBytes, requirementsBytes []byte) (*x402.SettleResponse, error) {
@@ -342,24 +469,27 @@ func (c *HTTPFacilitatorClient) settleHTTP(ctx context.Context, version int, pay
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	var settleResponse x402.SettleResponse
-	if err := json.Unmarshal(responseBody, &settleResponse); err != nil {
-		return nil, fmt.Errorf("facilitator settle failed (%d): %s", resp.StatusCode, string(responseBody))
-	}
-
-	// For non-200 responses, return an error with the details from the response
 	if resp.StatusCode != http.StatusOK {
-		if settleResponse.ErrorReason != "" {
+		var settleResponse settleResponseEnvelope
+		if err := json.Unmarshal(responseBody, &settleResponse); err == nil && settleResponse.ErrorReason != "" {
+			network := x402.Network("")
+			if settleResponse.Network != nil {
+				network = *settleResponse.Network
+			}
+			transaction := ""
+			if settleResponse.Transaction != nil {
+				transaction = *settleResponse.Transaction
+			}
 			return nil, x402.NewSettleError(
 				settleResponse.ErrorReason,
 				settleResponse.Payer,
-				settleResponse.Network,
-				settleResponse.Transaction,
+				network,
+				transaction,
 				fmt.Sprintf("facilitator returned %d", resp.StatusCode),
 			)
 		}
 		return nil, fmt.Errorf("facilitator settle failed (%d): %s", resp.StatusCode, string(responseBody))
 	}
 
-	return &settleResponse, nil
+	return parseSettleSuccessResponse(responseBody)
 }

--- a/go/http/facilitator_client.go
+++ b/go/http/facilitator_client.go
@@ -90,11 +90,11 @@ type verifyResponseEnvelope struct {
 }
 
 type settleResponseEnvelope struct {
-	Success      *bool        `json:"success"`
-	ErrorReason  string       `json:"errorReason,omitempty"`
-	ErrorMessage string       `json:"errorMessage,omitempty"`
-	Payer        string       `json:"payer,omitempty"`
-	Transaction  *string      `json:"transaction"`
+	Success      *bool         `json:"success"`
+	ErrorReason  string        `json:"errorReason,omitempty"`
+	ErrorMessage string        `json:"errorMessage,omitempty"`
+	Payer        string        `json:"payer,omitempty"`
+	Transaction  *string       `json:"transaction"`
 	Network      *x402.Network `json:"network"`
 }
 
@@ -173,15 +173,6 @@ func parseSupportedSuccessResponse(body []byte) (x402.SupportedResponse, error) 
 	if err := json.Unmarshal(body, &response); err != nil {
 		return x402.SupportedResponse{}, newFacilitatorResponseError("getSupported", "JSON", body, err)
 	}
-	if response.Kinds == nil {
-		return x402.SupportedResponse{}, newFacilitatorResponseError(
-			"getSupported",
-			"data",
-			body,
-			fmt.Errorf("missing kinds"),
-		)
-	}
-
 	kinds := make([]x402.SupportedKind, 0, len(response.Kinds))
 	for _, kind := range response.Kinds {
 		if kind.X402Version == nil || kind.Scheme == "" || kind.Network == "" {
@@ -202,9 +193,23 @@ func parseSupportedSuccessResponse(body []byte) (x402.SupportedResponse, error) 
 
 	return x402.SupportedResponse{
 		Kinds:      kinds,
-		Extensions: response.Extensions,
-		Signers:    response.Signers,
+		Extensions: nonNilStrings(response.Extensions),
+		Signers:    nonNilSigners(response.Signers),
 	}, nil
+}
+
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
+}
+
+func nonNilSigners(signers map[string][]string) map[string][]string {
+	if signers == nil {
+		return map[string][]string{}
+	}
+	return signers
 }
 
 // NewHTTPFacilitatorClient creates a new HTTP facilitator client

--- a/go/http/facilitator_client_test.go
+++ b/go/http/facilitator_client_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -249,15 +250,12 @@ func TestHTTPFacilitatorClientVerifyInvalidResponse(t *testing.T) {
 		t.Fatal("Expected error for invalid verify response")
 	}
 
-	var verifyErr *x402.VerifyError
-	if !errors.As(err, &verifyErr) {
-		t.Fatalf("Expected VerifyError, got: %T (%v)", err, err)
+	var responseErr *FacilitatorResponseError
+	if !errors.As(err, &responseErr) {
+		t.Fatalf("Expected FacilitatorResponseError, got: %T (%v)", err, err)
 	}
-	if verifyErr.InvalidReason != x402.ErrInvalidResponse {
-		t.Errorf("Expected InvalidReason %q, got %q", x402.ErrInvalidResponse, verifyErr.InvalidReason)
-	}
-	if verifyErr.InvalidMessage == "" {
-		t.Error("Expected InvalidMessage to be set for invalid response")
+	if !strings.Contains(responseErr.Error(), "facilitator verify returned invalid JSON") {
+		t.Errorf("Expected invalid JSON message, got %q", responseErr.Error())
 	}
 }
 
@@ -317,6 +315,50 @@ func TestHTTPFacilitatorClientSettle(t *testing.T) {
 	}
 }
 
+func TestHTTPFacilitatorClientSettleInvalidResponse(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success": true}`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPFacilitatorClient(&FacilitatorConfig{
+		URL: server.URL,
+	})
+
+	requirements := x402.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:1",
+		Asset:   "USDC",
+		Amount:  "1000000",
+		PayTo:   "0xrecipient",
+	}
+
+	payload := x402.PaymentPayload{
+		X402Version: 2,
+		Accepted:    requirements,
+		Payload:     map[string]interface{}{"sig": "test"},
+	}
+
+	payloadBytes, _ := json.Marshal(payload)
+	requirementsBytes, _ := json.Marshal(requirements)
+
+	_, err := client.Settle(ctx, payloadBytes, requirementsBytes)
+	if err == nil {
+		t.Fatal("Expected error for invalid settle response")
+	}
+
+	var responseErr *FacilitatorResponseError
+	if !errors.As(err, &responseErr) {
+		t.Fatalf("Expected FacilitatorResponseError, got: %T (%v)", err, err)
+	}
+	if !strings.Contains(responseErr.Error(), "facilitator settle returned invalid data") {
+		t.Errorf("Expected invalid data message, got %q", responseErr.Error())
+	}
+}
+
 func TestHTTPFacilitatorClientGetSupported(t *testing.T) {
 	ctx := context.Background()
 
@@ -370,6 +412,33 @@ func TestHTTPFacilitatorClientGetSupported(t *testing.T) {
 	}
 	if response.Extensions[0] != "bazaar" {
 		t.Errorf("Expected 'bazaar' extension, got %s", response.Extensions[0])
+	}
+}
+
+func TestHTTPFacilitatorClientGetSupportedInvalidResponse(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kinds":[{"scheme":"exact"}]}`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPFacilitatorClient(&FacilitatorConfig{
+		URL: server.URL,
+	})
+
+	_, err := client.GetSupported(ctx)
+	if err == nil {
+		t.Fatal("Expected error for invalid supported response")
+	}
+
+	var responseErr *FacilitatorResponseError
+	if !errors.As(err, &responseErr) {
+		t.Fatalf("Expected FacilitatorResponseError, got: %T (%v)", err, err)
+	}
+	if !strings.Contains(responseErr.Error(), "facilitator getSupported returned invalid data") {
+		t.Errorf("Expected invalid data message, got %q", responseErr.Error())
 	}
 }
 

--- a/python/x402/changelog.d/545.bugfix.md
+++ b/python/x402/changelog.d/545.bugfix.md
@@ -1,0 +1,1 @@
+Fixed Python HTTP middleware to return `502` instead of `500` when the facilitator responds with invalid JSON or schema-invalid data.

--- a/python/x402/http/facilitator_client.py
+++ b/python/x402/http/facilitator_client.py
@@ -7,7 +7,9 @@ implementations for communicating with remote facilitator services.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from pydantic import ValidationError
 
 from ..schemas import (
     PaymentPayload,
@@ -24,6 +26,7 @@ from .facilitator_client_base import (
     FacilitatorClient,
     FacilitatorClientSync,
     FacilitatorConfig,
+    FacilitatorResponseError,
     HTTPFacilitatorClientBase,
 )
 
@@ -35,12 +38,53 @@ __all__ = [
     "HTTPFacilitatorClient",
     "HTTPFacilitatorClientSync",
     "FacilitatorConfig",
+    "FacilitatorResponseError",
     "FacilitatorClient",
     "FacilitatorClientSync",
     "AuthProvider",
     "AuthHeaders",
     "CreateHeadersAuthProvider",
 ]
+
+_ResponseModelT = TypeVar(
+    "_ResponseModelT",
+    VerifyResponse,
+    SettleResponse,
+    SupportedResponse,
+)
+
+
+def _response_excerpt(response: Any, limit: int = 200) -> str:
+    """Build a compact response preview for parse errors."""
+    text = str(getattr(response, "text", "") or "").strip()
+    if not text:
+        return "<empty response>"
+
+    compact = " ".join(text.split())
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[: limit - 3]}..."
+
+
+def _parse_facilitator_response(
+    response: Any,
+    model_cls: type[_ResponseModelT],
+    operation: str,
+) -> _ResponseModelT:
+    """Parse facilitator JSON into a validated response model."""
+    try:
+        response_data = response.json()
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        raise FacilitatorResponseError(
+            f"Facilitator {operation} returned invalid JSON: {_response_excerpt(response)}"
+        ) from exc
+
+    try:
+        return model_cls.model_validate(response_data)
+    except (ValidationError, ValueError, TypeError) as exc:
+        raise FacilitatorResponseError(
+            f"Facilitator {operation} returned invalid data: {_response_excerpt(response)}"
+        ) from exc
 
 
 # ============================================================================
@@ -167,7 +211,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
                     f"Facilitator get_supported failed ({response.status_code}): {response.text}"
                 )
 
-            return SupportedResponse.model_validate(response.json())
+            return _parse_facilitator_response(response, SupportedResponse, "supported")
 
     # =========================================================================
     # Bytes-Based Methods (Network Boundary)
@@ -244,7 +288,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
         if response.status_code != 200:
             raise ValueError(f"Facilitator verify failed ({response.status_code}): {response.text}")
 
-        return VerifyResponse.model_validate(response.json())
+        return _parse_facilitator_response(response, VerifyResponse, "verify")
 
     async def _settle_http(
         self,
@@ -265,7 +309,7 @@ class HTTPFacilitatorClient(HTTPFacilitatorClientBase):
         if response.status_code != 200:
             raise ValueError(f"Facilitator settle failed ({response.status_code}): {response.text}")
 
-        return SettleResponse.model_validate(response.json())
+        return _parse_facilitator_response(response, SettleResponse, "settle")
 
 
 # ============================================================================
@@ -383,7 +427,7 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
                 f"Facilitator get_supported failed ({response.status_code}): {response.text}"
             )
 
-        return SupportedResponse.model_validate(response.json())
+        return _parse_facilitator_response(response, SupportedResponse, "supported")
 
     # =========================================================================
     # Bytes-Based Methods (Network Boundary)
@@ -460,7 +504,7 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
         if response.status_code != 200:
             raise ValueError(f"Facilitator verify failed ({response.status_code}): {response.text}")
 
-        return VerifyResponse.model_validate(response.json())
+        return _parse_facilitator_response(response, VerifyResponse, "verify")
 
     def _settle_http(
         self,
@@ -481,4 +525,4 @@ class HTTPFacilitatorClientSync(HTTPFacilitatorClientBase):
         if response.status_code != 200:
             raise ValueError(f"Facilitator settle failed ({response.status_code}): {response.text}")
 
-        return SettleResponse.model_validate(response.json())
+        return _parse_facilitator_response(response, SettleResponse, "settle")

--- a/python/x402/http/facilitator_client_base.py
+++ b/python/x402/http/facilitator_client_base.py
@@ -66,6 +66,10 @@ class CreateHeadersAuthProvider:
         )
 
 
+class FacilitatorResponseError(ValueError):
+    """Facilitator returned malformed or schema-invalid response data."""
+
+
 # ============================================================================
 # FacilitatorClient Protocols
 # ============================================================================

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -18,6 +18,7 @@ except ImportError as e:
         "FastAPI middleware requires fastapi and starlette. Install with: uv add x402[fastapi]"
     ) from e
 
+from ..facilitator_client_base import FacilitatorResponseError
 from ..types import (
     HTTPAdapter,
     HTTPRequestContext,
@@ -187,6 +188,14 @@ class FastAPIAdapter(HTTPAdapter):
 # ============================================================================
 
 
+def _facilitator_error_response(error: FacilitatorResponseError) -> JSONResponse:
+    """Map invalid facilitator responses to a stable HTTP error."""
+    return JSONResponse(
+        content={"error": str(error)},
+        status_code=502,
+    )
+
+
 def payment_middleware(
     routes: RoutesConfig,
     server: x402ResourceServer,
@@ -274,11 +283,17 @@ def payment_middleware(
 
         # Initialize on first protected request
         if sync_facilitator_on_start and not init_done:
-            http_server.initialize()
+            try:
+                http_server.initialize()
+            except FacilitatorResponseError as error:
+                return _facilitator_error_response(error)
             init_done = True
 
         # Process payment request
-        result = await http_server.process_http_request(context, paywall_config)
+        try:
+            result = await http_server.process_http_request(context, paywall_config)
+        except FacilitatorResponseError as error:
+            return _facilitator_error_response(error)
 
         if result.type == "no-payment-required":
             return await call_next(request)
@@ -360,6 +375,8 @@ def payment_middleware(
                     media_type=response.media_type,
                 )
 
+            except FacilitatorResponseError as error:
+                return _facilitator_error_response(error)
             except Exception:
                 return JSONResponse(content={}, status_code=402)
 

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -17,6 +17,7 @@ except ImportError as e:
         "Flask middleware requires the flask package. Install with: uv add x402[flask]"
     ) from e
 
+from ..facilitator_client_base import FacilitatorResponseError
 from ..types import (
     HTTPAdapter,
     HTTPRequestContext,
@@ -184,6 +185,19 @@ class FlaskAdapter(HTTPAdapter):
 # ============================================================================
 # Response Wrapper for Settlement
 # ============================================================================
+
+
+def _facilitator_error_wsgi_response(
+    start_response: Callable[..., Any],
+    error: FacilitatorResponseError,
+) -> list[bytes]:
+    """Map invalid facilitator responses to a stable HTTP error."""
+    body = json.dumps({"error": str(error)}).encode("utf-8")
+    start_response(
+        "502 Bad Gateway",
+        [("Content-Type", "application/json")],
+    )
+    return [body]
 
 
 class ResponseWrapper:
@@ -360,11 +374,17 @@ class PaymentMiddleware:
 
             # Initialize on first protected request
             if self._sync_on_start and not self._init_done:
-                self._http_server.initialize()
+                try:
+                    self._http_server.initialize()
+                except FacilitatorResponseError as error:
+                    return _facilitator_error_wsgi_response(start_response, error)
                 self._init_done = True
 
             # Process payment request synchronously (no asyncio overhead)
-            result = self._http_server.process_http_request(context, self._paywall_config)
+            try:
+                result = self._http_server.process_http_request(context, self._paywall_config)
+            except FacilitatorResponseError as error:
+                return _facilitator_error_wsgi_response(start_response, error)
 
             if result.type == "no-payment-required":
                 return self._original_wsgi(environ, start_response)
@@ -446,6 +466,9 @@ class PaymentMiddleware:
                                     body = json.dumps(response.body or {}).encode("utf-8")
                             start_response(status, headers)
                             return [body]
+
+                    except FacilitatorResponseError as error:
+                        return _facilitator_error_wsgi_response(start_response, error)
 
                     except Exception:
                         # Settlement error - return empty body with 402

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -12,6 +12,7 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from starlette.datastructures import Headers, QueryParams
 
+from x402.http.facilitator_client_base import FacilitatorResponseError
 from x402.http.middleware.fastapi import (
     FastAPIAdapter,
     PaymentMiddlewareASGI,
@@ -446,6 +447,102 @@ class TestFastAPIMiddlewareIntegration:
                 assert response.status_code == 402
                 assert response.json() == {}
                 assert "PAYMENT-RESPONSE" in response.headers
+
+    def test_invalid_facilitator_verify_response_returns_502(self):
+        """Test that invalid facilitator data during verify returns 502 instead of 500."""
+        app = FastAPI()
+
+        @app.get("/api/protected")
+        def protected_route():
+            return {"data": "Protected content"}
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request = AsyncMock(
+                side_effect=FacilitatorResponseError(
+                    "Facilitator verify returned invalid JSON: not-json"
+                )
+            )
+            mock_http_server.return_value = mock_http_server_instance
+
+            @app.middleware("http")
+            async def x402_middleware(request: Request, call_next):
+                return await payment_middleware(
+                    routes, mock_server, sync_facilitator_on_start=False
+                )(request, call_next)
+
+            with TestClient(app) as client:
+                response = client.get("/api/protected")
+                assert response.status_code == 502
+                assert response.json() == {
+                    "error": "Facilitator verify returned invalid JSON: not-json"
+                }
+
+    def test_invalid_facilitator_settlement_response_returns_502(self):
+        """Test that invalid facilitator data during settlement returns 502."""
+        app = FastAPI()
+
+        @app.get("/api/protected")
+        def protected_route():
+            return {"data": "Protected content"}
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request = AsyncMock(
+                return_value=HTTPProcessResult(
+                    type="payment-verified",
+                    payment_payload=payment_payload,
+                    payment_requirements=payment_requirements,
+                )
+            )
+            mock_http_server_instance.process_settlement = AsyncMock(
+                side_effect=FacilitatorResponseError(
+                    "Facilitator settle returned invalid data: {'success': true}"
+                )
+            )
+            mock_http_server.return_value = mock_http_server_instance
+
+            @app.middleware("http")
+            async def x402_middleware(request: Request, call_next):
+                return await payment_middleware(
+                    routes, mock_server, sync_facilitator_on_start=False
+                )(request, call_next)
+
+            with TestClient(app) as client:
+                response = client.get("/api/protected")
+                assert response.status_code == 502
+                assert response.json() == {
+                    "error": "Facilitator settle returned invalid data: {'success': true}"
+                }
 
 
 # =============================================================================

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -13,6 +13,7 @@ pytest.importorskip("flask")
 from flask import Flask
 from werkzeug.datastructures import Headers, ImmutableMultiDict
 
+from x402.http.facilitator_client_base import FacilitatorResponseError
 from x402.http.middleware.flask import (
     FlaskAdapter,
     PaymentMiddleware,
@@ -565,3 +566,85 @@ class TestFlaskMiddlewareIntegration:
                 data = json.loads(response.data)
                 assert data == {}
                 assert "PAYMENT-RESPONSE" in response.headers
+
+    def test_invalid_facilitator_verify_response_returns_502(self):
+        """Test that invalid facilitator data during verify returns 502 instead of 500."""
+        app = Flask(__name__)
+
+        @app.route("/api/protected")
+        def protected_route():
+            return "Protected content"
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request.side_effect = FacilitatorResponseError(
+                "Facilitator verify returned invalid JSON: not-json"
+            )
+            mock_http_server.return_value = mock_http_server_instance
+
+            PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=False)
+
+            with app.test_client() as client:
+                response = client.get("/api/protected")
+                assert response.status_code == 502
+                assert response.get_json() == {
+                    "error": "Facilitator verify returned invalid JSON: not-json"
+                }
+
+    def test_invalid_facilitator_settlement_response_returns_502(self):
+        """Test that invalid facilitator data during settlement returns 502."""
+        app = Flask(__name__)
+
+        @app.route("/api/protected")
+        def protected_route():
+            return "Protected content"
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+            )
+            mock_http_server_instance.process_settlement.side_effect = FacilitatorResponseError(
+                "Facilitator settle returned invalid data: {'success': true}"
+            )
+            mock_http_server.return_value = mock_http_server_instance
+
+            PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=False)
+
+            with app.test_client() as client:
+                response = client.get("/api/protected")
+                assert response.status_code == 502
+                assert response.get_json() == {
+                    "error": "Facilitator settle returned invalid data: {'success': true}"
+                }

--- a/python/x402/tests/unit/http/test_facilitator_client.py
+++ b/python/x402/tests/unit/http/test_facilitator_client.py
@@ -1,0 +1,117 @@
+"""Unit tests for x402.http.facilitator_client."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from x402.http.facilitator_client import (
+    HTTPFacilitatorClient,
+    HTTPFacilitatorClientSync,
+)
+from x402.http.facilitator_client_base import (
+    FacilitatorConfig,
+    FacilitatorResponseError,
+)
+from x402.schemas import PaymentPayload, PaymentRequirements
+
+
+def make_payment_requirements() -> PaymentRequirements:
+    """Helper to create valid PaymentRequirements."""
+    return PaymentRequirements(
+        scheme="exact",
+        network="eip155:8453",
+        asset="0x0000000000000000000000000000000000000000",
+        amount="1000000",
+        pay_to="0x1234567890123456789012345678901234567890",
+        max_timeout_seconds=300,
+    )
+
+
+def make_v2_payload(signature: str = "0xmock") -> PaymentPayload:
+    """Helper to create valid V2 PaymentPayload."""
+    return PaymentPayload(
+        x402_version=2,
+        payload={"signature": signature},
+        accepted=make_payment_requirements(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_verify_raises_facilitator_response_error_for_invalid_json():
+    """Async verify should surface invalid JSON as facilitator boundary error."""
+    response = MagicMock(status_code=200, text="not-json")
+    response.json.side_effect = json.JSONDecodeError("Expecting value", "not-json", 0)
+
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=response)
+
+    client = HTTPFacilitatorClient(
+        FacilitatorConfig(url="https://facilitator.test", http_client=http_client)
+    )
+
+    with pytest.raises(
+        FacilitatorResponseError,
+        match="Facilitator verify returned invalid JSON",
+    ):
+        await client.verify(make_v2_payload(), make_payment_requirements())
+
+
+@pytest.mark.asyncio
+async def test_async_settle_raises_facilitator_response_error_for_invalid_schema():
+    """Async settle should surface schema drift as facilitator boundary error."""
+    response = MagicMock(status_code=200, text='{"success": true}')
+    response.json.return_value = {"success": True}
+
+    http_client = MagicMock()
+    http_client.post = AsyncMock(return_value=response)
+
+    client = HTTPFacilitatorClient(
+        FacilitatorConfig(url="https://facilitator.test", http_client=http_client)
+    )
+
+    with pytest.raises(
+        FacilitatorResponseError,
+        match="Facilitator settle returned invalid data",
+    ):
+        await client.settle(make_v2_payload(), make_payment_requirements())
+
+
+def test_sync_verify_raises_facilitator_response_error_for_invalid_json():
+    """Sync verify should surface invalid JSON as facilitator boundary error."""
+    response = MagicMock(status_code=200, text="not-json")
+    response.json.side_effect = json.JSONDecodeError("Expecting value", "not-json", 0)
+
+    http_client = MagicMock()
+    http_client.post.return_value = response
+
+    client = HTTPFacilitatorClientSync(
+        FacilitatorConfig(url="https://facilitator.test", http_client=http_client)
+    )
+
+    with pytest.raises(
+        FacilitatorResponseError,
+        match="Facilitator verify returned invalid JSON",
+    ):
+        client.verify(make_v2_payload(), make_payment_requirements())
+
+
+def test_sync_settle_raises_facilitator_response_error_for_invalid_schema():
+    """Sync settle should surface schema drift as facilitator boundary error."""
+    response = MagicMock(status_code=200, text='{"success": true}')
+    response.json.return_value = {"success": True}
+
+    http_client = MagicMock()
+    http_client.post.return_value = response
+
+    client = HTTPFacilitatorClientSync(
+        FacilitatorConfig(url="https://facilitator.test", http_client=http_client)
+    )
+
+    with pytest.raises(
+        FacilitatorResponseError,
+        match="Facilitator settle returned invalid data",
+    ):
+        client.settle(make_v2_payload(), make_payment_requirements())

--- a/typescript/.changeset/facilitator-response-errors.md
+++ b/typescript/.changeset/facilitator-response-errors.md
@@ -1,0 +1,8 @@
+---
+'@x402/core': patch
+'@x402/express': patch
+'@x402/hono': patch
+'@x402/next': patch
+---
+
+Treat malformed facilitator success payloads as upstream facilitator errors and return 502 responses from framework middleware instead of flattening them into payment failures.

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -5,7 +5,9 @@ import {
   SupportedResponse,
   VerifyError,
   SettleError,
+  FacilitatorResponseError,
 } from "../types/facilitator";
+import { z } from "../schemas";
 
 const DEFAULT_FACILITATOR_URL = "https://x402.org/facilitator";
 
@@ -60,6 +62,78 @@ const GET_SUPPORTED_RETRIES = 3;
 /** Base delay in ms for exponential backoff on retries */
 const GET_SUPPORTED_RETRY_DELAY_MS = 1000;
 
+const verifyResponseSchema: z.ZodType<VerifyResponse> = z.object({
+  isValid: z.boolean(),
+  invalidReason: z.string().optional(),
+  invalidMessage: z.string().optional(),
+  payer: z.string().optional(),
+  extensions: z.record(z.string(), z.unknown()).optional(),
+});
+
+const settleResponseSchema: z.ZodType<SettleResponse> = z.object({
+  success: z.boolean(),
+  errorReason: z.string().optional(),
+  errorMessage: z.string().optional(),
+  payer: z.string().optional(),
+  transaction: z.string(),
+  network: z.custom<SettleResponse["network"]>(value => typeof value === "string"),
+  extensions: z.record(z.string(), z.unknown()).optional(),
+});
+
+const supportedKindSchema: z.ZodType<SupportedResponse["kinds"][number]> = z.object({
+  x402Version: z.number(),
+  scheme: z.string(),
+  network: z.custom<SupportedResponse["kinds"][number]["network"]>(
+    value => typeof value === "string",
+  ),
+  extra: z.record(z.string(), z.unknown()).optional(),
+});
+
+const supportedResponseSchema: z.ZodType<SupportedResponse> = z.object({
+  kinds: z.array(supportedKindSchema),
+  extensions: z.array(z.string()).default([]),
+  signers: z.record(z.string(), z.array(z.string())).default({}),
+});
+
+function responseExcerpt(text: string, limit: number = 200): string {
+  const compact = text.trim().replace(/\s+/g, " ");
+  if (!compact) {
+    return "<empty response>";
+  }
+
+  if (compact.length <= limit) {
+    return compact;
+  }
+
+  return `${compact.slice(0, limit - 3)}...`;
+}
+
+async function parseSuccessResponse<T>(
+  response: Response,
+  schema: z.ZodType<T>,
+  operation: string,
+): Promise<T> {
+  const text = await response.text();
+
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch (error) {
+    throw new FacilitatorResponseError(
+      `Facilitator ${operation} returned invalid JSON: ${responseExcerpt(text)}`,
+    );
+  }
+
+  const parsed = schema.safeParse(data);
+  if (!parsed.success) {
+    throw new FacilitatorResponseError(
+      `Facilitator ${operation} returned invalid data: ${responseExcerpt(text)}`,
+    );
+  }
+
+  return parsed.data;
+}
+
 /**
  * HTTP-based client for interacting with x402 facilitator services
  * Handles HTTP communication with facilitator endpoints
@@ -108,17 +182,23 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       }),
     });
 
-    const data = await response.json();
-
-    if (typeof data === "object" && data !== null && "isValid" in data) {
-      const verifyResponse = data as VerifyResponse;
-      if (!response.ok) {
-        throw new VerifyError(response.status, verifyResponse);
+    if (!response.ok) {
+      const text = await response.text();
+      let data: unknown;
+      try {
+        data = JSON.parse(text);
+      } catch {
+        throw new Error(`Facilitator verify failed (${response.status}): ${text}`);
       }
-      return verifyResponse;
+
+      if (typeof data === "object" && data !== null && "isValid" in data) {
+        throw new VerifyError(response.status, data as VerifyResponse);
+      }
+
+      throw new Error(`Facilitator verify failed (${response.status}): ${JSON.stringify(data)}`);
     }
 
-    throw new Error(`Facilitator verify failed (${response.status}): ${JSON.stringify(data)}`);
+    return parseSuccessResponse(response, verifyResponseSchema, "verify");
   }
 
   /**
@@ -151,17 +231,23 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       }),
     });
 
-    const data = await response.json();
-
-    if (typeof data === "object" && data !== null && "success" in data) {
-      const settleResponse = data as SettleResponse;
-      if (!response.ok) {
-        throw new SettleError(response.status, settleResponse);
+    if (!response.ok) {
+      const text = await response.text();
+      let data: unknown;
+      try {
+        data = JSON.parse(text);
+      } catch {
+        throw new Error(`Facilitator settle failed (${response.status}): ${text}`);
       }
-      return settleResponse;
+
+      if (typeof data === "object" && data !== null && "success" in data) {
+        throw new SettleError(response.status, data as SettleResponse);
+      }
+
+      throw new Error(`Facilitator settle failed (${response.status}): ${JSON.stringify(data)}`);
     }
 
-    throw new Error(`Facilitator settle failed (${response.status}): ${JSON.stringify(data)}`);
+    return parseSuccessResponse(response, settleResponseSchema, "settle");
   }
 
   /**
@@ -188,7 +274,7 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       });
 
       if (response.ok) {
-        return (await response.json()) as SupportedResponse;
+        return parseSuccessResponse(response, supportedResponseSchema, "supported");
       }
 
       const errorText = await response.text().catch(() => response.statusText);

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -204,14 +204,16 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       try {
         data = JSON.parse(text);
       } catch {
-        throw new Error(`Facilitator verify failed (${response.status}): ${text}`);
+        throw new Error(`Facilitator verify failed (${response.status}): ${responseExcerpt(text)}`);
       }
 
       if (typeof data === "object" && data !== null && "isValid" in data) {
         throw new VerifyError(response.status, data as VerifyResponse);
       }
 
-      throw new Error(`Facilitator verify failed (${response.status}): ${JSON.stringify(data)}`);
+      throw new Error(
+        `Facilitator verify failed (${response.status}): ${responseExcerpt(JSON.stringify(data))}`,
+      );
     }
 
     return parseSuccessResponse(response, verifyResponseSchema, "verify");
@@ -253,14 +255,16 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       try {
         data = JSON.parse(text);
       } catch {
-        throw new Error(`Facilitator settle failed (${response.status}): ${text}`);
+        throw new Error(`Facilitator settle failed (${response.status}): ${responseExcerpt(text)}`);
       }
 
       if (typeof data === "object" && data !== null && "success" in data) {
         throw new SettleError(response.status, data as SettleResponse);
       }
 
-      throw new Error(`Facilitator settle failed (${response.status}): ${JSON.stringify(data)}`);
+      throw new Error(
+        `Facilitator settle failed (${response.status}): ${responseExcerpt(JSON.stringify(data))}`,
+      );
     }
 
     return parseSuccessResponse(response, settleResponseSchema, "settle");
@@ -294,7 +298,9 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       }
 
       const errorText = await response.text().catch(() => response.statusText);
-      lastError = new Error(`Facilitator getSupported failed (${response.status}): ${errorText}`);
+      lastError = new Error(
+        `Facilitator getSupported failed (${response.status}): ${responseExcerpt(errorText)}`,
+      );
 
       // Retry on 429 rate limit errors with exponential backoff
       if (response.status === 429 && attempt < GET_SUPPORTED_RETRIES - 1) {

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -62,7 +62,7 @@ const GET_SUPPORTED_RETRIES = 3;
 /** Base delay in ms for exponential backoff on retries */
 const GET_SUPPORTED_RETRY_DELAY_MS = 1000;
 
-const verifyResponseSchema: z.ZodType<VerifyResponse> = z.object({
+const verifyResponseSchema: z.ZodType<VerifyResponse, z.ZodTypeDef, unknown> = z.object({
   isValid: z.boolean(),
   invalidReason: z.string().optional(),
   invalidMessage: z.string().optional(),
@@ -70,7 +70,7 @@ const verifyResponseSchema: z.ZodType<VerifyResponse> = z.object({
   extensions: z.record(z.string(), z.unknown()).optional(),
 });
 
-const settleResponseSchema: z.ZodType<SettleResponse> = z.object({
+const settleResponseSchema: z.ZodType<SettleResponse, z.ZodTypeDef, unknown> = z.object({
   success: z.boolean(),
   errorReason: z.string().optional(),
   errorMessage: z.string().optional(),
@@ -80,21 +80,29 @@ const settleResponseSchema: z.ZodType<SettleResponse> = z.object({
   extensions: z.record(z.string(), z.unknown()).optional(),
 });
 
-const supportedKindSchema: z.ZodType<SupportedResponse["kinds"][number]> = z.object({
-  x402Version: z.number(),
-  scheme: z.string(),
-  network: z.custom<SupportedResponse["kinds"][number]["network"]>(
-    value => typeof value === "string",
-  ),
-  extra: z.record(z.string(), z.unknown()).optional(),
-});
+const supportedKindSchema: z.ZodType<SupportedResponse["kinds"][number], z.ZodTypeDef, unknown> =
+  z.object({
+    x402Version: z.number(),
+    scheme: z.string(),
+    network: z.custom<SupportedResponse["kinds"][number]["network"]>(
+      value => typeof value === "string",
+    ),
+    extra: z.record(z.string(), z.unknown()).optional(),
+  });
 
-const supportedResponseSchema: z.ZodType<SupportedResponse> = z.object({
+const supportedResponseSchema: z.ZodType<SupportedResponse, z.ZodTypeDef, unknown> = z.object({
   kinds: z.array(supportedKindSchema),
   extensions: z.array(z.string()).default([]),
   signers: z.record(z.string(), z.array(z.string())).default({}),
 });
 
+/**
+ * Produces a compact excerpt of a facilitator response body for error messages.
+ *
+ * @param text - The raw response body text
+ * @param limit - The maximum number of characters to include
+ * @returns A normalized excerpt suitable for logs and thrown errors
+ */
 function responseExcerpt(text: string, limit: number = 200): string {
   const compact = text.trim().replace(/\s+/g, " ");
   if (!compact) {
@@ -108,9 +116,17 @@ function responseExcerpt(text: string, limit: number = 200): string {
   return `${compact.slice(0, limit - 3)}...`;
 }
 
+/**
+ * Parses and validates a successful facilitator response body.
+ *
+ * @param response - The HTTP response returned by the facilitator
+ * @param schema - The schema used to validate the response payload
+ * @param operation - The facilitator operation name for error reporting
+ * @returns The validated facilitator payload
+ */
 async function parseSuccessResponse<T>(
   response: Response,
-  schema: z.ZodType<T>,
+  schema: z.ZodType<T, z.ZodTypeDef, unknown>,
   operation: string,
 ): Promise<T> {
   const text = await response.text();
@@ -118,7 +134,7 @@ async function parseSuccessResponse<T>(
   let data: unknown;
   try {
     data = JSON.parse(text);
-  } catch (error) {
+  } catch {
     throw new FacilitatorResponseError(
       `Facilitator ${operation} returned invalid JSON: ${responseExcerpt(text)}`,
     );

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -108,5 +108,5 @@ export {
   FacilitatorClient,
   FacilitatorConfig,
 } from "./httpFacilitatorClient";
-export { FacilitatorResponseError } from "../types";
+export { FacilitatorResponseError, getFacilitatorResponseError } from "../types";
 export { x402HTTPClient, PaymentRequiredContext, PaymentRequiredHook } from "./x402HTTPClient";

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -108,4 +108,5 @@ export {
   FacilitatorClient,
   FacilitatorConfig,
 } from "./httpFacilitatorClient";
+export { FacilitatorResponseError } from "../types";
 export { x402HTTPClient, PaymentRequiredContext, PaymentRequiredHook } from "./x402HTTPClient";

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -9,6 +9,7 @@ import {
   PaymentRequired,
   SettleResponse,
   SettleError,
+  FacilitatorResponseError,
   Price,
   Network,
   PaymentRequirements,
@@ -542,6 +543,9 @@ export class x402HTTPResourceServer {
         declaredExtensions: routeConfig.extensions,
       };
     } catch (error) {
+      if (error instanceof FacilitatorResponseError) {
+        throw error;
+      }
       const errorResponse = await this.ResourceServer.createPaymentRequiredResponse(
         requirements,
         resourceInfo,
@@ -599,6 +603,9 @@ export class x402HTTPResourceServer {
         requirements,
       };
     } catch (error) {
+      if (error instanceof FacilitatorResponseError) {
+        throw error;
+      }
       if (error instanceof SettleError) {
         const errorReason = error.errorReason || error.message;
         const settleResponse: SettleResponse = {

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -3,7 +3,7 @@ export type { ResourceConfig, SettleResultContext } from "./x402ResourceServer";
 
 export { HTTPFacilitatorClient } from "../http/httpFacilitatorClient";
 export type { FacilitatorClient, FacilitatorConfig } from "../http/httpFacilitatorClient";
-export { FacilitatorResponseError } from "../types";
+export { FacilitatorResponseError, getFacilitatorResponseError } from "../types";
 
 export { x402HTTPResourceServer, RouteConfigurationError } from "../http/x402HTTPResourceServer";
 export type {

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -3,6 +3,7 @@ export type { ResourceConfig, SettleResultContext } from "./x402ResourceServer";
 
 export { HTTPFacilitatorClient } from "../http/httpFacilitatorClient";
 export type { FacilitatorClient, FacilitatorConfig } from "../http/httpFacilitatorClient";
+export { FacilitatorResponseError } from "../types";
 
 export { x402HTTPResourceServer, RouteConfigurationError } from "../http/x402HTTPResourceServer";
 export type {

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -350,10 +350,15 @@ export class x402ResourceServer {
 
     if (this.supportedResponsesMap.size === 0) {
       throw lastError
-        ? new Error("Failed to initialize: no supported payment kinds loaded from any facilitator.", {
-            cause: lastError,
-          })
-        : new Error("Failed to initialize: no supported payment kinds loaded from any facilitator.");
+        ? new Error(
+            "Failed to initialize: no supported payment kinds loaded from any facilitator.",
+            {
+              cause: lastError,
+            },
+          )
+        : new Error(
+            "Failed to initialize: no supported payment kinds loaded from any facilitator.",
+          );
     }
   }
 

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -299,6 +299,7 @@ export class x402ResourceServer {
     // Clear existing mappings
     this.supportedResponsesMap.clear();
     this.facilitatorClientsMap.clear();
+    let lastError: Error | undefined;
 
     // Fetch supported kinds from all facilitator clients
     // Process in order to give precedence to earlier facilitators
@@ -341,15 +342,18 @@ export class x402ResourceServer {
           }
         }
       } catch (error) {
+        lastError = error as Error;
         // Log error but continue with other facilitators
         console.warn(`Failed to fetch supported kinds from facilitator: ${error}`);
       }
     }
 
     if (this.supportedResponsesMap.size === 0) {
-      throw new Error(
-        "Failed to initialize: no supported payment kinds loaded from any facilitator.",
-      );
+      throw lastError
+        ? new Error("Failed to initialize: no supported payment kinds loaded from any facilitator.", {
+            cause: lastError,
+          })
+        : new Error("Failed to initialize: no supported payment kinds loaded from any facilitator.");
     }
   }
 

--- a/typescript/packages/core/src/types/facilitator.ts
+++ b/typescript/packages/core/src/types/facilitator.ts
@@ -101,3 +101,18 @@ export class SettleError extends Error {
     this.network = response.network;
   }
 }
+
+/**
+ * Error thrown when a facilitator returns malformed success payload data.
+ */
+export class FacilitatorResponseError extends Error {
+  /**
+   * Creates a FacilitatorResponseError for malformed facilitator responses.
+   *
+   * @param message - The boundary error message
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = "FacilitatorResponseError";
+  }
+}

--- a/typescript/packages/core/src/types/facilitator.ts
+++ b/typescript/packages/core/src/types/facilitator.ts
@@ -116,3 +116,24 @@ export class FacilitatorResponseError extends Error {
     this.name = "FacilitatorResponseError";
   }
 }
+
+/**
+ * Walks an error cause chain to find the first facilitator response error.
+ *
+ * @param error - The thrown value to inspect
+ * @returns The nested facilitator response error, if present
+ */
+export function getFacilitatorResponseError(
+  error: unknown,
+): FacilitatorResponseError | null {
+  let current = error;
+
+  while (current instanceof Error) {
+    if (current instanceof FacilitatorResponseError) {
+      return current;
+    }
+    current = current.cause;
+  }
+
+  return null;
+}

--- a/typescript/packages/core/src/types/facilitator.ts
+++ b/typescript/packages/core/src/types/facilitator.ts
@@ -123,9 +123,7 @@ export class FacilitatorResponseError extends Error {
  * @param error - The thrown value to inspect
  * @returns The nested facilitator response error, if present
  */
-export function getFacilitatorResponseError(
-  error: unknown,
-): FacilitatorResponseError | null {
+export function getFacilitatorResponseError(error: unknown): FacilitatorResponseError | null {
   let current = error;
 
   while (current instanceof Error) {

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -5,7 +5,12 @@ export type {
   SettleResponse,
   SupportedResponse,
 } from "./facilitator";
-export { VerifyError, SettleError, FacilitatorResponseError } from "./facilitator";
+export {
+  VerifyError,
+  SettleError,
+  FacilitatorResponseError,
+  getFacilitatorResponseError,
+} from "./facilitator";
 export type {
   PaymentRequirements,
   PaymentPayload,

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -5,7 +5,7 @@ export type {
   SettleResponse,
   SupportedResponse,
 } from "./facilitator";
-export { VerifyError, SettleError } from "./facilitator";
+export { VerifyError, SettleError, FacilitatorResponseError } from "./facilitator";
 export type {
   PaymentRequirements,
   PaymentPayload,

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HTTPFacilitatorClient } from "../../../src/http/httpFacilitatorClient";
+import { FacilitatorResponseError, SettleError, VerifyError } from "../../../src/types";
+import { PaymentPayload, PaymentRequirements } from "../../../src/types/payments";
+
+const paymentRequirements: PaymentRequirements = {
+  scheme: "exact",
+  network: "eip155:8453",
+  asset: "0x0000000000000000000000000000000000000000",
+  amount: "1000000",
+  payTo: "0x1234567890123456789012345678901234567890",
+  maxTimeoutSeconds: 300,
+  extra: {},
+};
+
+const paymentPayload: PaymentPayload = {
+  x402Version: 2,
+  accepted: paymentRequirements,
+  payload: { signature: "0xmock" },
+};
+
+describe("HTTPFacilitatorClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("throws FacilitatorResponseError for invalid verify JSON on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("not-json", { status: 200 })),
+    );
+
+    const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+    const error = await client
+      .verify(paymentPayload, paymentRequirements)
+      .catch(caught => caught as Error);
+
+    expect(error).toBeInstanceOf(FacilitatorResponseError);
+    expect(error.message).toContain("Facilitator verify returned invalid JSON");
+  });
+
+  it("throws FacilitatorResponseError for invalid settle data on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 }),
+      ),
+    );
+
+    const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+    const error = await client
+      .settle(paymentPayload, paymentRequirements)
+      .catch(caught => caught as Error);
+
+    expect(error).toBeInstanceOf(FacilitatorResponseError);
+    expect(error.message).toContain("Facilitator settle returned invalid data");
+  });
+
+  it("throws FacilitatorResponseError for invalid supported data on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ kinds: [{ scheme: "exact" }] }), { status: 200 }),
+      ),
+    );
+
+    const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+    const error = await client.getSupported().catch(caught => caught as Error);
+
+    expect(error).toBeInstanceOf(FacilitatorResponseError);
+    expect(error.message).toContain("Facilitator supported returned invalid data");
+  });
+
+  it("preserves VerifyError semantics for valid non-200 verify responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            isValid: false,
+            invalidReason: "invalid_signature",
+            invalidMessage: "signature mismatch",
+          }),
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+
+    await expect(client.verify(paymentPayload, paymentRequirements)).rejects.toThrow(VerifyError);
+  });
+
+  it("preserves SettleError semantics for valid non-200 settle responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            success: false,
+            errorReason: "insufficient_allowance",
+            transaction: "",
+            network: "eip155:8453",
+          }),
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+
+    await expect(client.settle(paymentPayload, paymentRequirements)).rejects.toThrow(SettleError);
+  });
+});

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -26,10 +26,7 @@ describe("HTTPFacilitatorClient", () => {
   });
 
   it("throws FacilitatorResponseError for invalid verify JSON on success", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(new Response("not-json", { status: 200 })),
-    );
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("not-json", { status: 200 })));
 
     const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
     const error = await client
@@ -43,9 +40,7 @@ describe("HTTPFacilitatorClient", () => {
   it("throws FacilitatorResponseError for invalid settle data on success", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ success: true }), { status: 200 }),
-      ),
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 })),
     );
 
     const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
@@ -60,9 +55,11 @@ describe("HTTPFacilitatorClient", () => {
   it("throws FacilitatorResponseError for invalid supported data on success", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ kinds: [{ scheme: "exact" }] }), { status: 200 }),
-      ),
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(JSON.stringify({ kinds: [{ scheme: "exact" }] }), { status: 200 }),
+        ),
     );
 
     const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceServer.errors.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceServer.errors.test.ts
@@ -99,7 +99,7 @@ describe("x402HTTPResourceServer facilitator response errors", () => {
 
   it("rethrows FacilitatorResponseError during settlement", async () => {
     facilitator.setSettleResponse(
-      new FacilitatorResponseError("Facilitator settle returned invalid data: {\"success\":true}"),
+      new FacilitatorResponseError('Facilitator settle returned invalid data: {"success":true}'),
     );
 
     const accepted = buildPaymentRequirements({

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceServer.errors.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceServer.errors.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { x402HTTPResourceServer, HTTPAdapter } from "../../../src/http/x402HTTPResourceServer";
+import { x402ResourceServer } from "../../../src/server/x402ResourceServer";
+import { FacilitatorResponseError, Network } from "../../../src/types";
+import {
+  MockFacilitatorClient,
+  MockSchemeNetworkServer,
+  buildPaymentPayload,
+  buildPaymentRequirements,
+  buildSupportedResponse,
+} from "../../mocks";
+import { encodePaymentSignatureHeader } from "../../../src/http";
+
+class MockHTTPAdapter implements HTTPAdapter {
+  constructor(private readonly headers: Record<string, string> = {}) {}
+
+  getHeader(name: string): string | undefined {
+    return this.headers[name.toLowerCase()];
+  }
+
+  getMethod(): string {
+    return "GET";
+  }
+
+  getPath(): string {
+    return "/api/test";
+  }
+
+  getUrl(): string {
+    return "https://example.com/api/test";
+  }
+
+  getAcceptHeader(): string {
+    return "application/json";
+  }
+
+  getUserAgent(): string {
+    return "Vitest";
+  }
+}
+
+describe("x402HTTPResourceServer facilitator response errors", () => {
+  let resourceServer: x402ResourceServer;
+  let facilitator: MockFacilitatorClient;
+  let httpServer: x402HTTPResourceServer;
+  const network = "eip155:8453" as Network;
+
+  beforeEach(async () => {
+    facilitator = new MockFacilitatorClient(
+      buildSupportedResponse({
+        kinds: [{ x402Version: 2, scheme: "exact", network }],
+      }),
+    );
+
+    resourceServer = new x402ResourceServer(facilitator);
+    resourceServer.register(network, new MockSchemeNetworkServer("exact"));
+    await resourceServer.initialize();
+
+    httpServer = new x402HTTPResourceServer(resourceServer, {
+      "/api/test": {
+        accepts: {
+          scheme: "exact",
+          payTo: "0xabc",
+          price: "$1.00",
+          network,
+        },
+      },
+    });
+  });
+
+  it("rethrows FacilitatorResponseError during verification", async () => {
+    facilitator.setVerifyResponse(
+      new FacilitatorResponseError("Facilitator verify returned invalid JSON: not-json"),
+    );
+
+    const accepted = buildPaymentRequirements({
+      scheme: "exact",
+      network,
+      payTo: "0xabc",
+      asset: "USDC",
+      amount: "1000000",
+    });
+    const payload = buildPaymentPayload({
+      x402Version: 2,
+      accepted,
+    });
+
+    await expect(
+      httpServer.processHTTPRequest({
+        adapter: new MockHTTPAdapter({
+          "payment-signature": encodePaymentSignatureHeader(payload),
+        }),
+        path: "/api/test",
+        method: "GET",
+        paymentHeader: encodePaymentSignatureHeader(payload),
+      }),
+    ).rejects.toThrow(FacilitatorResponseError);
+  });
+
+  it("rethrows FacilitatorResponseError during settlement", async () => {
+    facilitator.setSettleResponse(
+      new FacilitatorResponseError("Facilitator settle returned invalid data: {\"success\":true}"),
+    );
+
+    const accepted = buildPaymentRequirements({
+      scheme: "exact",
+      network,
+      payTo: "0xabc",
+      asset: "USDC",
+      amount: "1000000",
+    });
+    await expect(
+      httpServer.processSettlement(buildPaymentPayload({ x402Version: 2, accepted }), accepted),
+    ).rejects.toThrow(FacilitatorResponseError);
+  });
+});

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -42,10 +42,25 @@ let mockRequiresPayment: ReturnType<typeof vi.fn>;
 
 vi.mock("@x402/core/server", () => ({
   FacilitatorResponseError: class FacilitatorResponseError extends Error {
+    /**
+     * Creates a mock facilitator response error.
+     *
+     * @param message - Error message.
+     */
     constructor(message: string) {
       super(message);
       this.name = "FacilitatorResponseError";
     }
+  },
+  getFacilitatorResponseError: (error: unknown) => {
+    let current = error;
+    while (current instanceof Error) {
+      if (current.name === "FacilitatorResponseError") {
+        return current;
+      }
+      current = (current as Error & { cause?: unknown }).cause;
+    }
+    return null;
   },
   x402ResourceServer: vi.fn().mockImplementation(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
@@ -402,21 +417,18 @@ describe("paymentMiddleware", () => {
   });
 
   it("returns 502 when facilitator init fails during protected request", async () => {
+    const initialize = vi.fn().mockRejectedValue(
+      new Error("Failed to initialize: no supported payment kinds loaded from any facilitator.", {
+        cause: new FacilitatorResponseError(
+          "Facilitator supported returned invalid JSON: not-json",
+        ),
+      }),
+    );
+
     vi.mocked(HTTPResourceServer).mockImplementation(
       (server, routes) =>
         ({
-          initialize: vi
-            .fn()
-            .mockRejectedValue(
-              new Error(
-                "Failed to initialize: no supported payment kinds loaded from any facilitator.",
-                {
-                  cause: new FacilitatorResponseError(
-                    "Facilitator supported returned invalid JSON: not-json",
-                  ),
-                },
-              ),
-            ),
+          initialize,
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
           registerPaywallProvider: mockRegisterPaywallProvider,
@@ -441,6 +453,49 @@ describe("paymentMiddleware", () => {
     expect(res.json).toHaveBeenCalledWith({
       error: "Facilitator supported returned invalid JSON: not-json",
     });
+  });
+
+  it("retries initialization after a facilitator init failure", async () => {
+    const initialize = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Failed to initialize: no supported payment kinds loaded from any facilitator.", {
+          cause: new FacilitatorResponseError(
+            "Facilitator supported returned invalid JSON: not-json",
+          ),
+        }),
+      )
+      .mockResolvedValueOnce(undefined);
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize,
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+    mockProcessHTTPRequest.mockResolvedValue({ type: "no-payment-required" });
+
+    const middleware = paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer);
+    const firstRes = createMockResponse();
+    const secondRes = createMockResponse();
+    const next = vi.fn();
+
+    await middleware(createMockRequest(), firstRes, next);
+    await middleware(createMockRequest(), secondRes, next);
+
+    expect(firstRes.status).toHaveBeenCalledWith(502);
+    expect(initialize).toHaveBeenCalledTimes(2);
+    expect(mockProcessHTTPRequest).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it("returns 502 when processHTTPRequest surfaces FacilitatorResponseError", async () => {
@@ -475,7 +530,7 @@ describe("paymentMiddleware", () => {
       paymentRequirements: mockPaymentRequirements,
     });
     mockProcessSettlement.mockRejectedValue(
-      new FacilitatorResponseError("Facilitator settle returned invalid data: {\"success\":true}"),
+      new FacilitatorResponseError('Facilitator settle returned invalid data: {"success":true}'),
     );
 
     const middleware = paymentMiddleware(
@@ -496,7 +551,7 @@ describe("paymentMiddleware", () => {
 
     expect(res.status).toHaveBeenCalledWith(502);
     expect(res.json).toHaveBeenCalledWith({
-      error: "Facilitator settle returned invalid data: {\"success\":true}",
+      error: 'Facilitator settle returned invalid data: {"success":true}',
     });
   });
 

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -7,6 +7,7 @@ import type {
   FacilitatorClient,
 } from "@x402/core/server";
 import {
+  FacilitatorResponseError,
   x402ResourceServer,
   x402HTTPResourceServer as HTTPResourceServer,
 } from "@x402/core/server";
@@ -40,6 +41,12 @@ let mockRegisterPaywallProvider: ReturnType<typeof vi.fn>;
 let mockRequiresPayment: ReturnType<typeof vi.fn>;
 
 vi.mock("@x402/core/server", () => ({
+  FacilitatorResponseError: class FacilitatorResponseError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "FacilitatorResponseError";
+    }
+  },
   x402ResourceServer: vi.fn().mockImplementation(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     registerExtension: vi.fn(),
@@ -392,6 +399,105 @@ describe("paymentMiddleware", () => {
 
     expect(res.status).toHaveBeenCalledWith(402);
     expect(res.json).toHaveBeenCalledWith({});
+  });
+
+  it("returns 502 when facilitator init fails during protected request", async () => {
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize: vi
+            .fn()
+            .mockRejectedValue(
+              new Error(
+                "Failed to initialize: no supported payment kinds loaded from any facilitator.",
+                {
+                  cause: new FacilitatorResponseError(
+                    "Facilitator supported returned invalid JSON: not-json",
+                  ),
+                },
+              ),
+            ),
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+
+    const middleware = paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer);
+    const req = createMockRequest();
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(mockProcessHTTPRequest).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Facilitator supported returned invalid JSON: not-json",
+    });
+  });
+
+  it("returns 502 when processHTTPRequest surfaces FacilitatorResponseError", async () => {
+    mockProcessHTTPRequest.mockRejectedValue(
+      new FacilitatorResponseError("Facilitator verify returned invalid JSON: not-json"),
+    );
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest();
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Facilitator verify returned invalid JSON: not-json",
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when settlement surfaces FacilitatorResponseError", async () => {
+    setupMockHttpServer({
+      type: "payment-verified",
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+    });
+    mockProcessSettlement.mockRejectedValue(
+      new FacilitatorResponseError("Facilitator settle returned invalid data: {\"success\":true}"),
+    );
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest();
+    const res = createMockResponse();
+    const next = vi.fn(() => {
+      res.statusCode = 200;
+      res.end();
+    });
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Facilitator settle returned invalid data: {\"success\":true}",
+    });
   });
 
   it("returns 402 when settlement returns success: false", async () => {

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -7,6 +7,7 @@ import {
   RoutesConfig,
   FacilitatorClient,
   FacilitatorResponseError,
+  getFacilitatorResponseError,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { NextFunction, Request, Response } from "express";
@@ -45,19 +46,12 @@ export interface SchemeRegistration {
   server: SchemeNetworkServer;
 }
 
-function getFacilitatorResponseError(error: unknown): FacilitatorResponseError | null {
-  let current = error;
-
-  while (current instanceof Error) {
-    if (current instanceof FacilitatorResponseError) {
-      return current;
-    }
-    current = current.cause;
-  }
-
-  return null;
-}
-
+/**
+ * Sends a normalized 502 response for facilitator boundary failures.
+ *
+ * @param res - The Express response to write to
+ * @param error - The facilitator response error to surface
+ */
 function sendFacilitatorError(res: Response, error: FacilitatorResponseError): void {
   res.status(502).json({ error: error.message });
 }
@@ -100,6 +94,28 @@ export function paymentMiddlewareFromHTTPServer(
   // Store initialization promise (not the result)
   // httpServer.initialize() fetches facilitator support and validates routes
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
+  let isInitialized = false;
+
+  /**
+   * Ensures facilitator initialization succeeds once, while allowing retries after failures.
+   */
+  async function initializeHttpServer(): Promise<void> {
+    if (!syncFacilitatorOnStart || isInitialized) {
+      return;
+    }
+
+    if (!initPromise) {
+      initPromise = httpServer.initialize();
+    }
+
+    try {
+      await initPromise;
+      isInitialized = true;
+    } catch (error) {
+      initPromise = null;
+      throw error;
+    }
+  }
 
   // Dynamically register bazaar extension if routes declare it and not already registered
   // Skip if pre-registered (e.g., in serverless environments where static imports are used)
@@ -130,9 +146,9 @@ export function paymentMiddlewareFromHTTPServer(
     }
 
     // Only initialize when processing a protected route
-    if (initPromise) {
+    if (syncFacilitatorOnStart && !isInitialized) {
       try {
-        await initPromise;
+        await initializeHttpServer();
       } catch (error) {
         const facilitatorError = getFacilitatorResponseError(error);
         if (facilitatorError) {
@@ -141,7 +157,6 @@ export function paymentMiddlewareFromHTTPServer(
         }
         return next(error);
       }
-      initPromise = null; // Clear after first await
     }
 
     // Await bazaar extension loading if needed

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -6,6 +6,7 @@ import {
   x402ResourceServer,
   RoutesConfig,
   FacilitatorClient,
+  FacilitatorResponseError,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { NextFunction, Request, Response } from "express";
@@ -42,6 +43,23 @@ export interface SchemeRegistration {
    * The scheme server implementation for this network
    */
   server: SchemeNetworkServer;
+}
+
+function getFacilitatorResponseError(error: unknown): FacilitatorResponseError | null {
+  let current = error;
+
+  while (current instanceof Error) {
+    if (current instanceof FacilitatorResponseError) {
+      return current;
+    }
+    current = current.cause;
+  }
+
+  return null;
+}
+
+function sendFacilitatorError(res: Response, error: FacilitatorResponseError): void {
+  res.status(502).json({ error: error.message });
 }
 
 /**
@@ -113,7 +131,16 @@ export function paymentMiddlewareFromHTTPServer(
 
     // Only initialize when processing a protected route
     if (initPromise) {
-      await initPromise;
+      try {
+        await initPromise;
+      } catch (error) {
+        const facilitatorError = getFacilitatorResponseError(error);
+        if (facilitatorError) {
+          sendFacilitatorError(res, facilitatorError);
+          return;
+        }
+        return next(error);
+      }
       initPromise = null; // Clear after first await
     }
 
@@ -124,7 +151,16 @@ export function paymentMiddlewareFromHTTPServer(
     }
 
     // Process payment requirement check
-    const result = await httpServer.processHTTPRequest(context, paywallConfig);
+    let result: Awaited<ReturnType<x402HTTPResourceServer["processHTTPRequest"]>>;
+    try {
+      result = await httpServer.processHTTPRequest(context, paywallConfig);
+    } catch (error) {
+      if (error instanceof FacilitatorResponseError) {
+        sendFacilitatorError(res, error);
+        return;
+      }
+      return next(error);
+    }
 
     // Handle the different result types
     switch (result.type) {
@@ -265,6 +301,11 @@ export function paymentMiddlewareFromHTTPServer(
             res.setHeader(key, value);
           });
         } catch (error) {
+          if (error instanceof FacilitatorResponseError) {
+            bufferedCalls = [];
+            sendFacilitatorError(res, error);
+            return;
+          }
           console.error(error);
           // If settlement fails, don't send the buffered response
           bufferedCalls = [];

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -7,6 +7,7 @@ import type {
   FacilitatorClient,
 } from "@x402/core/server";
 import {
+  FacilitatorResponseError,
   x402ResourceServer,
   x402HTTPResourceServer as HTTPResourceServer,
 } from "@x402/core/server";
@@ -41,10 +42,25 @@ let mockRequiresPayment: ReturnType<typeof vi.fn>;
 
 vi.mock("@x402/core/server", () => ({
   FacilitatorResponseError: class FacilitatorResponseError extends Error {
+    /**
+     * Creates a mock facilitator response error.
+     *
+     * @param message - Error message.
+     */
     constructor(message: string) {
       super(message);
       this.name = "FacilitatorResponseError";
     }
+  },
+  getFacilitatorResponseError: (error: unknown) => {
+    let current = error;
+    while (current instanceof Error) {
+      if (current.name === "FacilitatorResponseError") {
+        return current;
+      }
+      current = (current as Error & { cause?: unknown }).cause;
+    }
+    return null;
   },
   x402ResourceServer: vi.fn().mockImplementation(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
@@ -400,6 +416,46 @@ describe("paymentMiddleware", () => {
     await middleware(context, next);
 
     expect(context.json).toHaveBeenCalledWith({}, 402);
+  });
+
+  it("retries initialization after a facilitator init failure", async () => {
+    const initialize = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Failed to initialize: no supported payment kinds loaded from any facilitator.", {
+          cause: new FacilitatorResponseError(
+            "Facilitator supported returned invalid JSON: not-json",
+          ),
+        }),
+      )
+      .mockResolvedValueOnce(undefined);
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize,
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+    mockProcessHTTPRequest.mockResolvedValue({ type: "no-payment-required" });
+
+    const middleware = paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer);
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await middleware(createMockContext(), next);
+    await middleware(createMockContext(), next);
+
+    expect(initialize).toHaveBeenCalledTimes(2);
+    expect(mockProcessHTTPRequest).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it("returns 402 when settlement returns success: false", async () => {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -40,6 +40,12 @@ let mockRegisterPaywallProvider: ReturnType<typeof vi.fn>;
 let mockRequiresPayment: ReturnType<typeof vi.fn>;
 
 vi.mock("@x402/core/server", () => ({
+  FacilitatorResponseError: class FacilitatorResponseError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "FacilitatorResponseError";
+    }
+  },
   x402ResourceServer: vi.fn().mockImplementation(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     registerExtension: vi.fn(),

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -6,6 +6,7 @@ import {
   x402ResourceServer,
   RoutesConfig,
   FacilitatorClient,
+  FacilitatorResponseError,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { Context, MiddlewareHandler } from "hono";
@@ -42,6 +43,23 @@ export interface SchemeRegistration {
    * The scheme server implementation for this network
    */
   server: SchemeNetworkServer;
+}
+
+function getFacilitatorResponseError(error: unknown): FacilitatorResponseError | null {
+  let current = error;
+
+  while (current instanceof Error) {
+    if (current instanceof FacilitatorResponseError) {
+      return current;
+    }
+    current = current.cause;
+  }
+
+  return null;
+}
+
+function facilitatorErrorResponse(c: Context, error: FacilitatorResponseError): Response {
+  return c.json({ error: error.message }, 502);
 }
 
 /**
@@ -113,7 +131,15 @@ export function paymentMiddlewareFromHTTPServer(
 
     // Only initialize when processing a protected route
     if (initPromise) {
-      await initPromise;
+      try {
+        await initPromise;
+      } catch (error) {
+        const facilitatorError = getFacilitatorResponseError(error);
+        if (facilitatorError) {
+          return facilitatorErrorResponse(c, facilitatorError);
+        }
+        throw error;
+      }
       initPromise = null; // Clear after first await
     }
 
@@ -124,7 +150,15 @@ export function paymentMiddlewareFromHTTPServer(
     }
 
     // Process payment requirement check
-    const result = await httpServer.processHTTPRequest(context, paywallConfig);
+    let result: Awaited<ReturnType<x402HTTPResourceServer["processHTTPRequest"]>>;
+    try {
+      result = await httpServer.processHTTPRequest(context, paywallConfig);
+    } catch (error) {
+      if (error instanceof FacilitatorResponseError) {
+        return facilitatorErrorResponse(c, error);
+      }
+      throw error;
+    }
 
     // Handle the different result types
     switch (result.type) {
@@ -190,6 +224,11 @@ export function paymentMiddlewareFromHTTPServer(
             });
           }
         } catch (error) {
+          if (error instanceof FacilitatorResponseError) {
+            res = facilitatorErrorResponse(c, error);
+            c.res = res;
+            return;
+          }
           console.error(error);
           // If settlement fails, return an error response
           res = c.json({}, 402);

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -7,6 +7,7 @@ import {
   RoutesConfig,
   FacilitatorClient,
   FacilitatorResponseError,
+  getFacilitatorResponseError,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { Context, MiddlewareHandler } from "hono";
@@ -45,19 +46,13 @@ export interface SchemeRegistration {
   server: SchemeNetworkServer;
 }
 
-function getFacilitatorResponseError(error: unknown): FacilitatorResponseError | null {
-  let current = error;
-
-  while (current instanceof Error) {
-    if (current instanceof FacilitatorResponseError) {
-      return current;
-    }
-    current = current.cause;
-  }
-
-  return null;
-}
-
+/**
+ * Builds a normalized 502 response for facilitator boundary failures.
+ *
+ * @param c - The current Hono context
+ * @param error - The facilitator response error to surface
+ * @returns A JSON 502 response
+ */
 function facilitatorErrorResponse(c: Context, error: FacilitatorResponseError): Response {
   return c.json({ error: error.message }, 502);
 }
@@ -100,6 +95,28 @@ export function paymentMiddlewareFromHTTPServer(
   // Store initialization promise (not the result)
   // httpServer.initialize() fetches facilitator support and validates routes
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
+  let isInitialized = false;
+
+  /**
+   * Ensures facilitator initialization succeeds once, while allowing retries after failures.
+   */
+  async function initializeHttpServer(): Promise<void> {
+    if (!syncFacilitatorOnStart || isInitialized) {
+      return;
+    }
+
+    if (!initPromise) {
+      initPromise = httpServer.initialize();
+    }
+
+    try {
+      await initPromise;
+      isInitialized = true;
+    } catch (error) {
+      initPromise = null;
+      throw error;
+    }
+  }
 
   // Dynamically register bazaar extension if routes declare it and not already registered
   // Skip if pre-registered (e.g., in serverless environments where static imports are used)
@@ -130,9 +147,9 @@ export function paymentMiddlewareFromHTTPServer(
     }
 
     // Only initialize when processing a protected route
-    if (initPromise) {
+    if (syncFacilitatorOnStart && !isInitialized) {
       try {
-        await initPromise;
+        await initializeHttpServer();
       } catch (error) {
         const facilitatorError = getFacilitatorResponseError(error);
         if (facilitatorError) {
@@ -140,7 +157,6 @@ export function paymentMiddlewareFromHTTPServer(
         }
         throw error;
       }
-      initPromise = null; // Clear after first await
     }
 
     // Await bazaar extension loading if needed

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -36,6 +36,16 @@ vi.mock("@x402/core/server", () => ({
       this.name = "FacilitatorResponseError";
     }
   },
+  getFacilitatorResponseError: (error: unknown) => {
+    let current = error;
+    while (current instanceof Error) {
+      if (current.name === "FacilitatorResponseError") {
+        return current;
+      }
+      current = (current as Error & { cause?: unknown }).cause;
+    }
+    return null;
+  },
   x402ResourceServer: vi.fn().mockImplementation(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     registerExtension: vi.fn(),

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -31,6 +31,11 @@ const mockFunctions = {
 // Mock @x402/core/server
 vi.mock("@x402/core/server", () => ({
   FacilitatorResponseError: class FacilitatorResponseError extends Error {
+    /**
+     * Creates a mock facilitator response error.
+     *
+     * @param message - Error message.
+     */
     constructor(message: string) {
       super(message);
       this.name = "FacilitatorResponseError";

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -30,6 +30,12 @@ const mockFunctions = {
 
 // Mock @x402/core/server
 vi.mock("@x402/core/server", () => ({
+  FacilitatorResponseError: class FacilitatorResponseError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "FacilitatorResponseError";
+    }
+  },
   x402ResourceServer: vi.fn().mockImplementation(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     registerExtension: vi.fn(),

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -5,6 +5,7 @@ import {
   RoutesConfig,
   RouteConfig,
   FacilitatorClient,
+  FacilitatorResponseError,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { NextRequest, NextResponse } from "next/server";
@@ -13,6 +14,8 @@ import {
   createRequestContext,
   handlePaymentError,
   handleSettlement,
+  createFacilitatorErrorResponse,
+  getFacilitatorResponseError,
 } from "./utils";
 import { x402HTTPResourceServer } from "@x402/core/server";
 
@@ -85,7 +88,15 @@ export function paymentProxyFromHTTPServer(
     }
 
     // Only initialize when processing a protected route
-    await init();
+    try {
+      await init();
+    } catch (error) {
+      const facilitatorError = getFacilitatorResponseError(error);
+      if (facilitatorError) {
+        return createFacilitatorErrorResponse(facilitatorError);
+      }
+      throw error;
+    }
 
     // Await bazaar extension loading if needed
     if (bazaarPromise) {
@@ -94,7 +105,15 @@ export function paymentProxyFromHTTPServer(
     }
 
     // Process payment requirement check
-    const result = await httpServer.processHTTPRequest(context, paywallConfig);
+    let result: Awaited<ReturnType<x402HTTPResourceServer["processHTTPRequest"]>>;
+    try {
+      result = await httpServer.processHTTPRequest(context, paywallConfig);
+    } catch (error) {
+      if (error instanceof FacilitatorResponseError) {
+        return createFacilitatorErrorResponse(error);
+      }
+      throw error;
+    }
 
     // Handle the different result types
     switch (result.type) {

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -22,6 +22,12 @@ vi.mock("@x402/core/server", () => {
     requiresPayment: vi.fn().mockReturnValue(true),
   }));
   return {
+    FacilitatorResponseError: class FacilitatorResponseError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "FacilitatorResponseError";
+      }
+    },
     x402HTTPResourceServer: MockHTTPResourceServer,
     x402ResourceServer: vi.fn(),
   };

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -13,20 +13,37 @@ import {
   handleSettlement,
 } from "./utils";
 
+let mockInitialize: ReturnType<typeof vi.fn>;
+
 // Mock @x402/core/server
 vi.mock("@x402/core/server", () => {
   const MockHTTPResourceServer = vi.fn().mockImplementation(() => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
+    initialize: mockInitialize,
     registerPaywallProvider: vi.fn(),
     processSettlement: vi.fn(),
     requiresPayment: vi.fn().mockReturnValue(true),
   }));
   return {
     FacilitatorResponseError: class FacilitatorResponseError extends Error {
+      /**
+       * Creates a mock facilitator response error.
+       *
+       * @param message - Error message.
+       */
       constructor(message: string) {
         super(message);
         this.name = "FacilitatorResponseError";
       }
+    },
+    getFacilitatorResponseError: (error: unknown) => {
+      let current = error;
+      while (current instanceof Error) {
+        if (current.name === "FacilitatorResponseError") {
+          return current;
+        }
+        current = (current as Error & { cause?: unknown }).cause;
+      }
+      return null;
     },
     x402HTTPResourceServer: MockHTTPResourceServer,
     x402ResourceServer: vi.fn(),
@@ -68,6 +85,10 @@ function createMockResourceServer(): x402ResourceServer {
 }
 
 describe("createHttpServer", () => {
+  beforeEach(() => {
+    mockInitialize = vi.fn().mockResolvedValue(undefined);
+  });
+
   it("creates server and initializes on start by default", async () => {
     const routes = {
       "/api/*": {
@@ -112,6 +133,25 @@ describe("createHttpServer", () => {
     // Wait for initialization to complete to avoid warnings
     await init();
     expect(httpServer.registerPaywallProvider).toHaveBeenCalledWith(paywall);
+  });
+
+  it("retries initialization after a facilitator init failure", async () => {
+    mockInitialize = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("not-json"))
+      .mockResolvedValueOnce(undefined);
+    const routes = {
+      "/api/*": {
+        accepts: { scheme: "exact", payTo: "0x123", price: "$0.01", network: "eip155:84532" },
+      },
+    } as const;
+    const server = createMockResourceServer();
+
+    const { init } = createHttpServer(routes, server);
+
+    await expect(init()).rejects.toThrow("not-json");
+    await expect(init()).resolves.toBeUndefined();
+    expect(mockInitialize).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -7,6 +7,7 @@ import {
   x402ResourceServer,
   RoutesConfig,
   FacilitatorResponseError,
+  getFacilitatorResponseError as getCoreFacilitatorResponseError,
 } from "@x402/core/server";
 import { PaymentPayload, PaymentRequirements } from "@x402/core/types";
 import { NextAdapter } from "./adapter";
@@ -19,19 +20,14 @@ export interface HttpServerInstance {
   init: () => Promise<void>;
 }
 
-export function getFacilitatorResponseError(error: unknown): FacilitatorResponseError | null {
-  let current = error;
+export const getFacilitatorResponseError = getCoreFacilitatorResponseError;
 
-  while (current instanceof Error) {
-    if (current instanceof FacilitatorResponseError) {
-      return current;
-    }
-    current = current.cause;
-  }
-
-  return null;
-}
-
+/**
+ * Builds a normalized 502 response for facilitator boundary failures.
+ *
+ * @param error - The facilitator response error to surface
+ * @returns A JSON 502 response
+ */
 export function createFacilitatorErrorResponse(error: FacilitatorResponseError): NextResponse {
   return new NextResponse(JSON.stringify({ error: error.message }), {
     status: 502,
@@ -60,14 +56,28 @@ export function prepareHttpServer(
   // Store initialization promise (not the result)
   // httpServer.initialize() fetches facilitator support and validates routes
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
+  let isInitialized = false;
 
   return {
     httpServer,
+    /**
+     * Ensures facilitator initialization succeeds once, while allowing retries after failures.
+     */
     async init() {
-      // Ensure initialization completes before processing
-      if (initPromise) {
+      if (!syncFacilitatorOnStart || isInitialized) {
+        return;
+      }
+
+      if (!initPromise) {
+        initPromise = httpServer.initialize();
+      }
+
+      try {
         await initPromise;
-        initPromise = null; // Clear after first await
+        isInitialized = true;
+      } catch (error) {
+        initPromise = null;
+        throw error;
       }
     },
   };

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -6,6 +6,7 @@ import {
   x402HTTPResourceServer,
   x402ResourceServer,
   RoutesConfig,
+  FacilitatorResponseError,
 } from "@x402/core/server";
 import { PaymentPayload, PaymentRequirements } from "@x402/core/types";
 import { NextAdapter } from "./adapter";
@@ -16,6 +17,26 @@ import { NextAdapter } from "./adapter";
 export interface HttpServerInstance {
   httpServer: x402HTTPResourceServer;
   init: () => Promise<void>;
+}
+
+export function getFacilitatorResponseError(error: unknown): FacilitatorResponseError | null {
+  let current = error;
+
+  while (current instanceof Error) {
+    if (current instanceof FacilitatorResponseError) {
+      return current;
+    }
+    current = current.cause;
+  }
+
+  return null;
+}
+
+export function createFacilitatorErrorResponse(error: FacilitatorResponseError): NextResponse {
+  return new NextResponse(JSON.stringify({ error: error.message }), {
+    status: 502,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 /**
@@ -165,6 +186,9 @@ export async function handleSettlement(
 
     return response;
   } catch (error) {
+    if (error instanceof FacilitatorResponseError) {
+      return createFacilitatorErrorResponse(error);
+    }
     console.error("Settlement failed:", error);
     // If settlement fails, return an error response
     return new NextResponse(JSON.stringify({}), {

--- a/typescript/packages/mechanisms/aptos/.prettierignore
+++ b/typescript/packages/mechanisms/aptos/.prettierignore
@@ -1,0 +1,3 @@
+# build output
+dist/
+node_modules/

--- a/typescript/tsconfig.base.json
+++ b/typescript/tsconfig.base.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "ES2020",
     "lib": [
-      "ES2020"
+      "ES2022"
     ],
     "moduleResolution": "bundler",
     "declaration": true,


### PR DESCRIPTION
## Description

Closes #545.

Handle malformed facilitator responses in the Python HTTP client and middleware so they return a stable `502` instead of surfacing as `500`.

This change:
- adds a dedicated `FacilitatorResponseError` for invalid facilitator JSON and schema-invalid responses
- wraps facilitator response parsing in the Python HTTP client for `verify`, `settle`, and `get_supported`
- maps facilitator boundary errors to `502 Bad Gateway` in both FastAPI and Flask middleware
- adds regression coverage for invalid JSON and schema-invalid facilitator responses

## Tests

- `uv run --project python/x402 ruff check python/x402/http/facilitator_client.py python/x402/http/facilitator_client_base.py python/x402/http/middleware/fastapi.py python/x402/http/middleware/flask.py python/x402/tests/unit/http/test_facilitator_client.py python/x402/tests/unit/http/middleware/test_fastapi.py python/x402/tests/unit/http/middleware/test_flask.py`
- `uv run --project python/x402 pytest python/x402/tests/unit/http/test_facilitator_client.py python/x402/tests/unit/http/middleware/test_fastapi.py python/x402/tests/unit/http/middleware/test_flask.py`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes