### PR TITLE
Add Fastify framework adapter for x402 payment middleware

### DIFF
--- a/.github/workflows/publish_npm_scoped_x402_fastify.yml
+++ b/.github/workflows/publish_npm_scoped_x402_fastify.yml
@@ -1,0 +1,56 @@
+name: Publish @x402/fastify package to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-npm-x402-fastify:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/main' && 'npm' || '' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061
+        with:
+          version: 10.7.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+          cache-dependency-path: ./typescript
+
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Configure npm for trusted publishing
+        run: npm config delete always-auth 2>/dev/null || true
+
+      - name: Install and build
+        working-directory: ./typescript
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm -r --filter=@x402/core --filter=@x402/extensions --filter=@x402/fastify run build
+
+      - name: Publish @x402/fastify package
+        working-directory: ./typescript/packages/http/fastify
+        run: |
+          # Get package information directly
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          echo "Package: $PACKAGE_NAME@$PACKAGE_VERSION"
+
+          # Check if running on main branch
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "Publishing to NPM (main branch)"
+            pnpm publish --provenance --access public
+          else
+            echo "Dry run only (non-main branch: ${{ github.ref }})"
+            pnpm publish --dry-run --no-git-checks
+          fi

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -290,6 +290,67 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.0)(jiti@1.21.7)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(tsx@4.20.3)(yaml@2.8.1)
 
+  ../typescript/packages/http/fastify:
+    dependencies:
+      '@x402/core':
+        specifier: workspace:~
+        version: link:../../core
+      '@x402/extensions':
+        specifier: workspace:~
+        version: link:../../extensions
+      '@x402/paywall':
+        specifier: workspace:*
+        version: link:../paywall
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.38.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.16.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.48.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.38.0(jiti@1.21.7)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.38.0(jiti@1.21.7))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint@9.38.0(jiti@1.21.7))(prettier@3.5.2)
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.2
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.1)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.3
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.3
+      vite:
+        specifier: ^6.2.6
+        version: 6.4.1(@types/node@22.16.0)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.3)(vite@6.4.1(@types/node@22.16.0)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.0)(jiti@1.21.7)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(tsx@4.20.3)(yaml@2.8.1)
+
   ../typescript/packages/http/fetch:
     dependencies:
       '@x402/core':
@@ -1932,6 +1993,70 @@ importers:
         specifier: ^5.3.0
         version: 5.8.3
 
+  servers/fastify:
+    dependencies:
+      '@x402/aptos':
+        specifier: workspace:*
+        version: link:../../../typescript/packages/mechanisms/aptos
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../typescript/packages/core
+      '@x402/evm':
+        specifier: workspace:*
+        version: link:../../../typescript/packages/mechanisms/evm
+      '@x402/extensions':
+        specifier: workspace:*
+        version: link:../../../typescript/packages/extensions
+      '@x402/fastify':
+        specifier: workspace:*
+        version: link:../../../typescript/packages/http/fastify
+      '@x402/stellar':
+        specifier: workspace:*
+        version: link:../../../typescript/packages/mechanisms/stellar
+      '@x402/svm':
+        specifier: workspace:*
+        version: link:../../../typescript/packages/mechanisms/svm
+      dotenv:
+        specifier: ^16.6.1
+        version: 16.6.1
+      fastify:
+        specifier: ^5.3.3
+        version: 5.8.2
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.38.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.48.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.38.0(jiti@1.21.7)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.38.0(jiti@1.21.7))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.38.0(jiti@1.21.7))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint@9.38.0(jiti@1.21.7))(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^7.2.0
+        version: 7.3.0(postcss@8.5.6)(typescript@5.8.3)
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.3
+      typescript:
+        specifier: ^5.3.0
+        version: 5.8.3
+
   servers/hono:
     dependencies:
       '@hono/node-server':
@@ -3178,6 +3303,24 @@ packages:
     peerDependencies:
       typescript: 5.8.3
 
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
   '@gemini-wallet/core@0.2.0':
     resolution: {integrity: sha512-vv9aozWnKrrPWQ3vIFcWk7yta4hQW1Ie0fsNNPeXnjAxkbXr2hqMagEptLuMxpEP2W3mnRu05VDNKzcvAuuZDw==}
     peerDependencies:
@@ -3647,6 +3790,9 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5789,6 +5935,9 @@ packages:
       zod:
         optional: true
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -5938,6 +6087,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
@@ -6275,6 +6427,10 @@ packages:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   core-js-compat@3.46.0:
     resolution: {integrity: sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==}
 
@@ -6471,6 +6627,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
@@ -6898,6 +7058,9 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -6915,8 +7078,14 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
@@ -6933,6 +7102,9 @@ packages:
 
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
+
+  fastify@5.8.2:
+    resolution: {integrity: sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -6968,6 +7140,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -7261,6 +7437,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -7497,6 +7677,9 @@ packages:
   json-rpc-random-id@1.0.1:
     resolution: {integrity: sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==}
 
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -7553,6 +7736,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -7903,6 +8089,10 @@ packages:
   on-exit-leak-free@0.2.0:
     resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -8098,8 +8288,18 @@ packages:
   pino-abstract-transport@0.5.0:
     resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
   pino-std-serializers@4.0.0:
     resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pino@7.11.0:
     resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
@@ -8239,6 +8439,12 @@ packages:
   process-warning@1.0.0:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -8371,6 +8577,10 @@ packages:
     resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
     engines: {node: '>= 12.13.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -8434,9 +8644,16 @@ packages:
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   ripemd160@2.0.3:
     resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
@@ -8478,6 +8695,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-regex2@5.1.0:
+    resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
+    hasBin: true
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -8491,6 +8712,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -8519,6 +8743,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -8603,6 +8830,9 @@ packages:
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8797,6 +9027,10 @@ packages:
   thread-stream@0.15.2:
     resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
 
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -8833,6 +9067,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -10830,6 +11068,29 @@ snapshots:
       typescript: 5.8.3
       zod: 3.25.71
 
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.1.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
+
   '@gemini-wallet/core@0.2.0(viem@2.31.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
@@ -11357,6 +11618,8 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@paulmillr/qr@0.2.1': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -15538,6 +15801,8 @@ snapshots:
       typescript: 5.8.3
       zod: 4.1.12
 
+  abstract-logging@2.0.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -15701,6 +15966,11 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.19.1
 
   axe-core@4.11.0: {}
 
@@ -16070,6 +16340,8 @@ snapshots:
 
   cookie@0.7.1: {}
 
+  cookie@1.1.1: {}
+
   core-js-compat@3.46.0:
     dependencies:
       browserslist: 4.27.0
@@ -16270,6 +16542,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.2)(react@19.2.0)):
     dependencies:
@@ -17039,6 +17313,8 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -17061,7 +17337,20 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
 
   fast-redact@3.5.0: {}
 
@@ -17072,6 +17361,24 @@ snapshots:
   fast-uri@3.1.0: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
+
+  fastify@5.8.2:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.3
+      toad-cache: 3.7.0
 
   fastq@1.19.1:
     dependencies:
@@ -17117,6 +17424,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.0
 
   find-up@4.1.0:
     dependencies:
@@ -17446,6 +17759,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.3.0: {}
+
   iron-webcrypto@1.2.1: {}
 
   is-arguments@1.2.0:
@@ -17700,6 +18015,10 @@ snapshots:
 
   json-rpc-random-id@1.0.1: {}
 
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -17749,6 +18068,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lilconfig@3.1.3: {}
 
@@ -18063,6 +18388,8 @@ snapshots:
 
   on-exit-leak-free@0.2.0: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -18343,7 +18670,27 @@ snapshots:
       duplexify: 4.1.3
       split2: 4.2.0
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-std-serializers@4.0.0: {}
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
 
   pino@7.11.0:
     dependencies:
@@ -18505,6 +18852,10 @@ snapshots:
 
   process-warning@1.0.0: {}
 
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -18653,6 +19004,8 @@ snapshots:
 
   real-require@0.1.0: {}
 
+  real-require@0.2.0: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -18724,7 +19077,11 @@ snapshots:
     dependencies:
       lowercase-keys: 2.0.0
 
+  ret@0.5.0: {}
+
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   ripemd160@2.0.3:
     dependencies:
@@ -18811,6 +19168,10 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-regex2@5.1.0:
+    dependencies:
+      ret: 0.5.0
+
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
@@ -18820,6 +19181,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
 
@@ -18878,6 +19241,8 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -19015,6 +19380,10 @@ snapshots:
       - supports-color
 
   sonic-boom@2.8.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
 
@@ -19244,6 +19613,10 @@ snapshots:
     dependencies:
       real-require: 0.1.0
 
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -19274,6 +19647,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 

--- a/e2e/servers/fastify/.prettierignore
+++ b/e2e/servers/fastify/.prettierignore
@@ -1,0 +1,8 @@
+docs/
+dist/
+node_modules/
+coverage/
+.github/
+src/client
+**/**/*.json
+*.md

--- a/e2e/servers/fastify/.prettierrc
+++ b/e2e/servers/fastify/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/e2e/servers/fastify/build.sh
+++ b/e2e/servers/fastify/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# TypeScript build handled by pnpm at root level
+# This file is intentionally empty
+exit 0

--- a/e2e/servers/fastify/eslint.config.js
+++ b/e2e/servers/fastify/eslint.config.js
@@ -1,0 +1,73 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        console: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+];

--- a/e2e/servers/fastify/index.ts
+++ b/e2e/servers/fastify/index.ts
@@ -1,0 +1,421 @@
+import Fastify from "fastify";
+import { paymentMiddleware } from "@x402/fastify";
+import { x402ResourceServer, HTTPFacilitatorClient } from "@x402/core/server";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { ExactSvmScheme } from "@x402/svm/exact/server";
+import { ExactAptosScheme } from "@x402/aptos/exact/server";
+import { ExactStellarScheme } from "@x402/stellar/exact/server";
+import { bazaarResourceServerExtension, declareDiscoveryExtension } from "@x402/extensions/bazaar";
+import {
+  declareEip2612GasSponsoringExtension,
+  declareErc20ApprovalGasSponsoringExtension,
+} from "@x402/extensions";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+/**
+ * Fastify E2E Test Server with x402 Payment Middleware
+ *
+ * This server demonstrates how to integrate x402 payment middleware
+ * with a Fastify application for end-to-end testing.
+ */
+
+const PORT = process.env.PORT || "4024";
+const EVM_NETWORK = (process.env.EVM_NETWORK || "eip155:84532") as `${string}:${string}`;
+const SVM_NETWORK = (process.env.SVM_NETWORK ||
+  "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1") as `${string}:${string}`;
+const APTOS_NETWORK = (process.env.APTOS_NETWORK || "aptos:2") as `${string}:${string}`;
+const STELLAR_NETWORK = (process.env.STELLAR_NETWORK || "stellar:testnet") as `${string}:${string}`;
+const EVM_PAYEE_ADDRESS = process.env.EVM_PAYEE_ADDRESS as `0x${string}`;
+const SVM_PAYEE_ADDRESS = process.env.SVM_PAYEE_ADDRESS as string;
+const APTOS_PAYEE_ADDRESS = process.env.APTOS_PAYEE_ADDRESS as string;
+const STELLAR_PAYEE_ADDRESS = process.env.STELLAR_PAYEE_ADDRESS as string | undefined;
+const facilitatorUrl = process.env.FACILITATOR_URL;
+
+if (!EVM_PAYEE_ADDRESS) {
+  console.error("❌ EVM_PAYEE_ADDRESS environment variable is required");
+  process.exit(1);
+}
+
+if (!SVM_PAYEE_ADDRESS) {
+  console.error("❌ SVM_PAYEE_ADDRESS environment variable is required");
+  process.exit(1);
+}
+
+if (!facilitatorUrl) {
+  console.error("❌ FACILITATOR_URL environment variable is required");
+  process.exit(1);
+}
+
+// Initialize Fastify app
+const app = Fastify();
+
+// Create HTTP facilitator client
+const facilitatorClient = new HTTPFacilitatorClient({ url: facilitatorUrl });
+
+// Create x402 resource server
+const server = new x402ResourceServer(facilitatorClient);
+
+// Register server schemes
+server.register("eip155:*", new ExactEvmScheme());
+server.register("solana:*", new ExactSvmScheme());
+if (APTOS_PAYEE_ADDRESS) {
+  server.register("aptos:*", new ExactAptosScheme());
+}
+if (STELLAR_PAYEE_ADDRESS) {
+  server.register("stellar:*", new ExactStellarScheme());
+}
+
+// Register Bazaar discovery extension
+server.registerExtension(bazaarResourceServerExtension);
+
+console.log(
+  `Facilitator account: ${process.env.EVM_PRIVATE_KEY ? process.env.EVM_PRIVATE_KEY.substring(0, 10) + "..." : "not configured"}`,
+);
+console.log(`Using remote facilitator at: ${facilitatorUrl}`);
+
+/**
+ * Pre-middleware guard for optional Aptos endpoint
+ * Returns 501 Not Implemented if Aptos is not configured
+ */
+app.addHook("onRequest", async (request, reply) => {
+  if (request.url.split("?")[0] === "/protected-aptos" && !APTOS_PAYEE_ADDRESS) {
+    return reply.status(501).send({
+      error: "Aptos payments not configured",
+      message: "APTOS_PAYEE_ADDRESS environment variable is not set",
+    });
+  }
+});
+
+/**
+ * Pre-middleware guard for optional Stellar endpoint
+ * Returns 501 Not Implemented if Stellar is not configured
+ */
+app.addHook("onRequest", async (request, reply) => {
+  if (request.url.split("?")[0] === "/protected-stellar" && !STELLAR_PAYEE_ADDRESS) {
+    return reply.status(501).send({
+      error: "Stellar payments not configured",
+      message: "STELLAR_PAYEE_ADDRESS environment variable is not set",
+    });
+  }
+});
+
+/**
+ * Configure x402 payment middleware using builder pattern
+ *
+ * This middleware protects endpoints with $0.001 USDC payment requirements
+ * on Base Sepolia, Solana Devnet, Aptos Testnet, and Stellar Testnet with bazaar discovery extension.
+ */
+paymentMiddleware(
+  app,
+  {
+    // Route-specific payment configuration
+    "GET /protected": {
+      accepts: {
+        payTo: EVM_PAYEE_ADDRESS,
+        scheme: "exact",
+        price: "$0.001",
+        network: EVM_NETWORK,
+      },
+      extensions: {
+        ...declareDiscoveryExtension({
+          output: {
+            example: {
+              message: "Protected endpoint accessed successfully",
+              timestamp: "2024-01-01T00:00:00Z",
+            },
+            schema: {
+              properties: {
+                message: { type: "string" },
+                timestamp: { type: "string" },
+              },
+              required: ["message", "timestamp"],
+            },
+          },
+        }),
+      },
+    },
+    "GET /protected-svm": {
+      accepts: {
+        payTo: SVM_PAYEE_ADDRESS,
+        scheme: "exact",
+        price: "$0.001",
+        network: SVM_NETWORK,
+      },
+      extensions: {
+        ...declareDiscoveryExtension({
+          output: {
+            example: {
+              message: "Protected endpoint accessed successfully",
+              timestamp: "2024-01-01T00:00:00Z",
+            },
+            schema: {
+              properties: {
+                message: { type: "string" },
+                timestamp: { type: "string" },
+              },
+              required: ["message", "timestamp"],
+            },
+          },
+        }),
+      },
+    },
+    ...(APTOS_PAYEE_ADDRESS
+      ? {
+          "GET /protected-aptos": {
+            accepts: {
+              payTo: APTOS_PAYEE_ADDRESS,
+              scheme: "exact",
+              price: "$0.001",
+              network: APTOS_NETWORK,
+            },
+            extensions: {
+              ...declareDiscoveryExtension({
+                output: {
+                  example: {
+                    message: "Protected endpoint accessed successfully",
+                    timestamp: "2024-01-01T00:00:00Z",
+                  },
+                  schema: {
+                    properties: {
+                      message: { type: "string" },
+                      timestamp: { type: "string" },
+                    },
+                    required: ["message", "timestamp"],
+                  },
+                },
+              }),
+            },
+          },
+        }
+      : {}),
+    // Permit2 endpoint for generic ERC-20 tokens (no EIP-2612, uses raw approve tx)
+    "GET /protected-permit2-erc20": {
+      accepts: {
+        payTo: EVM_PAYEE_ADDRESS,
+        scheme: "exact",
+        network: EVM_NETWORK,
+        price: {
+          amount: "1000",
+          asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a", // Generic MockERC20 token (no EIP-2612)
+          extra: {
+            assetTransferMethod: "permit2",
+            // No name/version - generic ERC-20 without EIP-2612
+          },
+        },
+      },
+      extensions: {
+        ...declareErc20ApprovalGasSponsoringExtension(),
+      },
+    },
+    // Permit2 endpoint - explicitly requires Permit2 flow instead of EIP-3009
+    "GET /protected-permit2": {
+      accepts: {
+        payTo: EVM_PAYEE_ADDRESS,
+        scheme: "exact",
+        network: EVM_NETWORK,
+        price: "$0.001",
+        // Use pre-parsed price with assetTransferMethod to force Permit2
+        extra: { assetTransferMethod: "permit2" },
+      },
+      extensions: {
+        ...declareDiscoveryExtension({
+          output: {
+            example: {
+              message: "Permit2 endpoint accessed successfully",
+              timestamp: "2024-01-01T00:00:00Z",
+              method: "permit2",
+            },
+            schema: {
+              properties: {
+                message: { type: "string" },
+                timestamp: { type: "string" },
+                method: { type: "string" },
+              },
+              required: ["message", "timestamp", "method"],
+            },
+          },
+        }),
+        ...declareEip2612GasSponsoringExtension(),
+      },
+    },
+    ...(STELLAR_PAYEE_ADDRESS
+      ? {
+          "GET /protected-stellar": {
+            accepts: {
+              payTo: STELLAR_PAYEE_ADDRESS!,
+              scheme: "exact",
+              price: "$0.001",
+              network: STELLAR_NETWORK,
+            },
+            extensions: {
+              ...declareDiscoveryExtension({
+                output: {
+                  example: {
+                    message: "Protected Stellar endpoint accessed successfully",
+                    timestamp: "2024-01-01T00:00:00Z",
+                  },
+                  schema: {
+                    properties: {
+                      message: { type: "string" },
+                      timestamp: { type: "string" },
+                    },
+                    required: ["message", "timestamp"],
+                  },
+                },
+              }),
+            },
+          },
+        }
+      : {}),
+  },
+  server, // Pass pre-configured server instance
+);
+
+/**
+ * Protected endpoint - requires payment to access
+ *
+ * This endpoint demonstrates a resource protected by x402 payment middleware.
+ * Clients must provide a valid payment signature to access this endpoint.
+ */
+app.get("/protected", async () => {
+  return {
+    message: "Protected endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+  };
+});
+
+/**
+ * Protected SVM endpoint - requires payment to access
+ *
+ * This endpoint demonstrates a resource protected by x402 payment middleware for SVM.
+ * Clients must provide a valid payment signature to access this endpoint.
+ */
+app.get("/protected-svm", async () => {
+  return {
+    message: "Protected endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+  };
+});
+
+/**
+ * Protected Aptos endpoint - requires payment to access
+ *
+ * This endpoint demonstrates a resource protected by x402 payment middleware for Aptos.
+ * Clients must provide a valid payment signature to access this endpoint.
+ * Note: 501 check is handled by pre-middleware guard above.
+ */
+app.get("/protected-aptos", async () => {
+  return {
+    message: "Protected endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+  };
+});
+
+/**
+ * Protected Permit2 ERC-20 endpoint - requires payment via Permit2 flow with ERC-20 approval
+ *
+ * This endpoint demonstrates the ERC-20 approval gas sponsoring flow for tokens
+ * that do NOT implement EIP-2612. The facilitator broadcasts the pre-signed
+ * approve() transaction on the client's behalf before settling.
+ */
+app.get("/protected-permit2-erc20", async () => {
+  return {
+    message: "Permit2 ERC-20 approval endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+    method: "permit2-erc20-approval",
+  };
+});
+
+/**
+ * Protected Permit2 endpoint - requires payment via Permit2 flow
+ *
+ * This endpoint demonstrates the Permit2 payment flow.
+ * Clients must have approved Permit2 to spend their USDC before accessing.
+ */
+app.get("/protected-permit2", async () => {
+  return {
+    message: "Permit2 endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+    method: "permit2",
+  };
+});
+
+/**
+ * Protected Stellar endpoint - requires payment to access
+ *
+ * This endpoint demonstrates a resource protected by x402 payment middleware for Stellar.
+ * Clients must provide a valid payment signature to access this endpoint.
+ * Note: 501 check is handled by pre-middleware guard above.
+ */
+if (STELLAR_PAYEE_ADDRESS) {
+  app.get("/protected-stellar", async () => {
+    return {
+      message: "Protected Stellar endpoint accessed successfully",
+      timestamp: new Date().toISOString(),
+    };
+  });
+}
+
+/**
+ * Health check endpoint - no payment required
+ *
+ * Used to verify the server is running and responsive.
+ */
+app.get("/health", async () => {
+  return {
+    status: "ok",
+    network: EVM_NETWORK,
+    payee: EVM_PAYEE_ADDRESS,
+    version: "2.0.0",
+  };
+});
+
+/**
+ * Shutdown endpoint - used by e2e tests
+ *
+ * Allows graceful shutdown of the server during testing.
+ */
+app.post("/close", async (request, reply) => {
+  reply.send({ message: "Server shutting down gracefully" });
+  console.log("Received shutdown request");
+
+  // Give time for response to be sent
+  setTimeout(() => {
+    process.exit(0);
+  }, 100);
+});
+
+// Start the server
+app.listen({ port: parseInt(PORT) }, (err, address) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  console.log(`
+╔════════════════════════════════════════════════════════╗
+║           x402 Fastify E2E Test Server                 ║
+╠════════════════════════════════════════════════════════╣
+║  Server:       ${address}                              ║
+║  EVM Network:  ${EVM_NETWORK}                          ║
+║  SVM Network:  ${SVM_NETWORK}                          ║
+║  Aptos Network: ${APTOS_NETWORK}                       ║
+║  Stellar Network: ${STELLAR_NETWORK}║
+║  EVM Payee:    ${EVM_PAYEE_ADDRESS}                    ║
+║  SVM Payee:    ${SVM_PAYEE_ADDRESS}                    ║
+║  Aptos Payee:  ${APTOS_PAYEE_ADDRESS || "(not configured)"}
+║  Stellar Payee: ${STELLAR_PAYEE_ADDRESS || "(not configured)"}
+║                                                        ║
+║  Endpoints:                                            ║
+║  • GET  /protected             (EIP-3009 payment - EVM)    ║
+║  • GET  /protected-svm         (SVM payment)               ║
+║  • GET  /protected-aptos       (Aptos payment)             ║
+║  • GET  /protected-permit2     (Permit2 payment - EVM)     ║
+║  • GET  /protected-permit2-erc20 (Permit2 + ERC-20 approval) ║
+║  • GET  /protected-stellar     (Stellar payment)           ║
+║  • GET  /health                (no payment required)       ║
+║  • POST /close                 (shutdown server)           ║
+╚════════════════════════════════════════════════════════╝
+  `);
+});

--- a/e2e/servers/fastify/install.sh
+++ b/e2e/servers/fastify/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# TypeScript dependencies handled by pnpm install at root level
+# This file is intentionally empty
+exit 0

--- a/e2e/servers/fastify/package.json
+++ b/e2e/servers/fastify/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@x402/fastify-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx index.ts",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "dependencies": {
+    "@x402/aptos": "workspace:*",
+    "@x402/core": "workspace:*",
+    "@x402/fastify": "workspace:*",
+    "@x402/evm": "workspace:*",
+    "@x402/extensions": "workspace:*",
+    "@x402/stellar": "workspace:*",
+    "@x402/svm": "workspace:*",
+    "dotenv": "^16.6.1",
+    "fastify": "^5.3.3"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsup": "^7.2.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/e2e/servers/fastify/run.sh
+++ b/e2e/servers/fastify/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pnpm dev

--- a/e2e/servers/fastify/test.config.json
+++ b/e2e/servers/fastify/test.config.json
@@ -1,0 +1,71 @@
+{
+  "name": "fastify",
+  "type": "server",
+  "language": "typescript",
+  "x402Version": 2,
+  "extensions": ["bazaar", "eip2612GasSponsoring", "erc20ApprovalGasSponsoring"],
+  "endpoints": [
+    {
+      "path": "/protected",
+      "method": "GET",
+      "description": "Protected endpoint requiring EIP-3009 payment",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "eip3009"
+    },
+    {
+      "path": "/protected-permit2",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2"
+    },
+    {
+      "path": "/protected-permit2-erc20",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment with ERC-20 approval gas sponsoring",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "extensions": ["erc20ApprovalGasSponsoring"]
+    },
+    {
+      "path": "/protected-svm",
+      "method": "GET",
+      "description": "Protected endpoint requiring payment on SVM network",
+      "requiresPayment": true,
+      "protocolFamily": "svm"
+    },
+    {
+      "path": "/protected-aptos",
+      "method": "GET",
+      "description": "Protected endpoint requiring payment on Aptos network",
+      "requiresPayment": true,
+      "protocolFamily": "aptos"
+    },
+    {
+      "path": "/protected-stellar",
+      "method": "GET",
+      "description": "Protected endpoint requiring payment on Stellar network",
+      "requiresPayment": true,
+      "protocolFamily": "stellar"
+    },
+    {
+      "path": "/health",
+      "method": "GET",
+      "description": "Health check endpoint",
+      "health": true
+    },
+    {
+      "path": "/close",
+      "method": "POST",
+      "description": "Graceful shutdown endpoint",
+      "close": true
+    }
+  ],
+  "environment": {
+    "required": ["PORT", "EVM_PAYEE_ADDRESS", "SVM_PAYEE_ADDRESS", "FACILITATOR_URL"],
+    "optional": ["APTOS_PAYEE_ADDRESS", "STELLAR_PAYEE_ADDRESS"]
+  }
+}

--- a/e2e/servers/fastify/tsconfig.json
+++ b/e2e/servers/fastify/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -268,6 +268,67 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.2)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(tsx@4.20.4)(yaml@2.8.1)
 
+  ../../typescript/packages/http/fastify:
+    dependencies:
+      '@x402/core':
+        specifier: workspace:~
+        version: link:../../core
+      '@x402/extensions':
+        specifier: workspace:~
+        version: link:../../extensions
+      '@x402/paywall':
+        specifier: workspace:*
+        version: link:../paywall
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.33.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.17.2
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.33.0(jiti@2.6.1)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))(prettier@3.5.2)
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.2
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.4)(typescript@5.9.2)(yaml@2.8.1)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.4
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.2
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.4)(yaml@2.8.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.2)(vite@6.3.5(@types/node@22.17.2)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.4)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.2)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(tsx@4.20.4)(yaml@2.8.1)
+
   ../../typescript/packages/http/fetch:
     dependencies:
       '@x402/core':
@@ -3169,6 +3230,64 @@ importers:
         specifier: ^5.3.0
         version: 5.9.2
 
+  servers/fastify:
+    dependencies:
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/core
+      '@x402/evm':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/mechanisms/evm
+      '@x402/extensions':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/extensions
+      '@x402/fastify':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/http/fastify
+      '@x402/svm':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/mechanisms/svm
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.2
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.33.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.33.0(jiti@2.6.1)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^7.2.0
+        version: 7.3.0(postcss@8.5.6)(typescript@5.9.2)
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.4
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.2
+
   servers/hono:
     dependencies:
       '@hono/node-server':
@@ -4628,6 +4747,24 @@ packages:
     peerDependencies:
       typescript: 5.8.3
 
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
@@ -5292,6 +5429,9 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -8422,6 +8562,9 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -8458,6 +8601,14 @@ packages:
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -8610,6 +8761,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
@@ -9067,6 +9221,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   core-js-compat@3.45.1:
     resolution: {integrity: sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==}
 
@@ -9281,6 +9439,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
@@ -9821,6 +9983,9 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -9838,8 +10003,14 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
@@ -9859,6 +10030,9 @@ packages:
 
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
+
+  fastify@5.8.2:
+    resolution: {integrity: sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -9914,6 +10088,10 @@ packages:
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
+
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -10301,6 +10479,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -10595,6 +10777,9 @@ packages:
   json-rpc-random-id@1.0.1:
     resolution: {integrity: sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==}
 
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -10679,6 +10864,9 @@ packages:
 
   libphonenumber-js@1.12.13:
     resolution: {integrity: sha512-QZXnR/OGiDcBjF4hGk0wwVrPcZvbSSyzlvkjXv5LFfktj7O2VZDrt4Xs8SgR/vOFco+qk1i8J43ikMXZoTrtPw==}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -11229,6 +11417,10 @@ packages:
   on-exit-leak-free@0.2.0:
     resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -11496,8 +11688,18 @@ packages:
   pino-abstract-transport@0.5.0:
     resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
   pino-std-serializers@4.0.0:
     resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pino@7.11.0:
     resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
@@ -11666,6 +11868,12 @@ packages:
 
   process-warning@1.0.0:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
+
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -11883,6 +12091,10 @@ packages:
     resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
     engines: {node: '>= 12.13.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   redaxios@0.5.1:
     resolution: {integrity: sha512-FSD2AmfdbkYwl7KDExYQlVvIrFz6Yd83pGfaGjBzM9F6rpq8g652Q4Yq5QD4c+nf4g2AgeElv1y+8ajUPiOYMg==}
 
@@ -11966,6 +12178,10 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
@@ -11977,6 +12193,9 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
@@ -12034,6 +12253,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-regex2@5.1.0:
+    resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
+    hasBin: true
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -12063,6 +12286,9 @@ packages:
   secp256k1@5.0.1:
     resolution: {integrity: sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==}
     engines: {node: '>=18.0.0'}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -12110,6 +12336,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -12221,6 +12450,9 @@ packages:
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -12478,6 +12710,10 @@ packages:
   thread-stream@0.15.2:
     resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
 
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
+
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
 
@@ -12528,6 +12764,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -15487,6 +15727,29 @@ snapshots:
       typescript: 5.9.2
       zod: 3.25.76
 
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.0.6
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
+
   '@floating-ui/core@1.7.3':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -16269,6 +16532,8 @@ snapshots:
       - utf-8-validate
 
   '@paulmillr/qr@0.2.1': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -23679,6 +23944,8 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  abstract-logging@2.0.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -23713,6 +23980,10 @@ snapshots:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
@@ -23788,7 +24059,7 @@ snapshots:
       minimatch: 10.0.3
       plist: 3.1.0
       resedit: 1.7.2
-      semver: 7.7.2
+      semver: 7.7.3
       tar: 6.2.1
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
@@ -23908,6 +24179,11 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.19.1
 
   axe-core@4.10.3: {}
 
@@ -24427,6 +24703,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   core-js-compat@3.45.1:
     dependencies:
       browserslist: 4.25.3
@@ -24621,6 +24899,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.1.10)(react@19.1.1)):
     dependencies:
@@ -25186,7 +25466,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.40.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -25752,6 +26032,8 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -25774,7 +26056,20 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.0.6
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
 
   fast-redact@3.5.0: {}
 
@@ -25787,6 +26082,24 @@ snapshots:
   fast-uri@3.0.6: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
+
+  fastify@5.8.2:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.3
+      toad-cache: 3.7.0
 
   fastq@1.19.1:
     dependencies:
@@ -25853,6 +26166,12 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.0
 
   find-up@4.1.0:
     dependencies:
@@ -26300,6 +26619,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.3.0: {}
+
   iron-webcrypto@1.2.1: {}
 
   is-arguments@1.2.0:
@@ -26587,6 +26908,10 @@ snapshots:
 
   json-rpc-random-id@1.0.1: {}
 
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -26662,6 +26987,12 @@ snapshots:
       type-check: 0.4.0
 
   libphonenumber-js@1.12.13: {}
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -27186,6 +27517,8 @@ snapshots:
 
   on-exit-leak-free@0.2.0: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -27591,7 +27924,27 @@ snapshots:
       duplexify: 4.1.3
       split2: 4.2.0
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-std-serializers@4.0.0: {}
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
 
   pino@7.11.0:
     dependencies:
@@ -27867,6 +28220,10 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@1.0.0: {}
+
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
 
   progress@2.0.3: {}
 
@@ -28158,6 +28515,8 @@ snapshots:
 
   real-require@0.1.0: {}
 
+  real-require@0.2.0: {}
+
   redaxios@0.5.1: {}
 
   reflect-metadata@0.2.2: {}
@@ -28248,11 +28607,15 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  ret@0.5.0: {}
+
   retry@0.12.0: {}
 
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rimraf@2.6.3:
     dependencies:
@@ -28359,6 +28722,10 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-regex2@5.1.0:
+    dependencies:
+      ret: 0.5.0
+
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
@@ -28386,6 +28753,8 @@ snapshots:
       elliptic: 6.6.1
       node-addon-api: 5.1.0
       node-gyp-build: 4.8.4
+
+  secure-json-parse@4.1.0: {}
 
   selderee@0.11.0:
     dependencies:
@@ -28460,6 +28829,8 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -28571,7 +28942,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.3
 
   simple-wcswidth@1.1.2: {}
 
@@ -28631,6 +29002,10 @@ snapshots:
       smart-buffer: 4.2.0
 
   sonic-boom@2.8.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
 
@@ -28924,6 +29299,10 @@ snapshots:
     dependencies:
       real-require: 0.1.0
 
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
@@ -28969,6 +29348,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 

--- a/examples/typescript/servers/fastify/.env-local
+++ b/examples/typescript/servers/fastify/.env-local
@@ -1,0 +1,3 @@
+EVM_ADDRESS=
+SVM_ADDRESS=
+FACILITATOR_URL=https://x402.org/facilitator

--- a/examples/typescript/servers/fastify/.prettierignore
+++ b/examples/typescript/servers/fastify/.prettierignore
@@ -1,0 +1,8 @@
+docs/
+dist/
+node_modules/
+coverage/
+.github/
+src/client
+**/**/*.json
+*.md

--- a/examples/typescript/servers/fastify/.prettierrc
+++ b/examples/typescript/servers/fastify/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/examples/typescript/servers/fastify/README.md
+++ b/examples/typescript/servers/fastify/README.md
@@ -1,0 +1,252 @@
+# @x402/fastify Example Server
+
+Fastify server demonstrating how to protect API endpoints with a paywall using the `@x402/fastify` middleware.
+
+```typescript
+import Fastify from "fastify";
+import { paymentMiddleware, x402ResourceServer } from "@x402/fastify";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+
+const app = Fastify();
+
+paymentMiddleware(
+  app,
+  {
+    "GET /weather": {
+      accepts: { scheme: "exact", price: "$0.001", network: "eip155:84532", payTo: evmAddress },
+      description: "Weather data",
+      mimeType: "application/json",
+    },
+  },
+  new x402ResourceServer(new HTTPFacilitatorClient({ url: facilitatorUrl }))
+    .register("eip155:84532", new ExactEvmScheme()),
+);
+
+app.get("/weather", async () => ({ weather: "sunny", temperature: 70 }));
+```
+
+## Prerequisites
+
+- Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
+- pnpm v10 (install via [pnpm.io/installation](https://pnpm.io/installation))
+- Valid EVM and SVM addresses for receiving payments
+- URL of a facilitator supporting the desired payment network, see [facilitator list](https://www.x402.org/ecosystem?category=facilitators)
+
+## Setup
+
+1. Copy `.env-local` to `.env`:
+
+```bash
+cp .env-local .env
+```
+
+and fill required environment variables:
+
+- `FACILITATOR_URL` - Facilitator endpoint URL
+- `EVM_ADDRESS` - Ethereum address to receive payments
+- `SVM_ADDRESS` - Solana address to receive payments
+
+2. Install and build all packages from the typescript examples root:
+
+```bash
+cd ../../
+pnpm install && pnpm build
+cd servers/fastify
+```
+
+3. Run the server
+
+```bash
+pnpm dev
+```
+
+## Testing the Server
+
+You can test the server using one of the example clients:
+
+### Using the Fetch Client
+
+```bash
+cd ../clients/fetch
+# Ensure .env is setup
+pnpm dev
+```
+
+### Using the Axios Client
+
+```bash
+cd ../clients/axios
+# Ensure .env is setup
+pnpm dev
+```
+
+These clients will demonstrate how to:
+
+1. Make an initial request to get payment requirements
+2. Process the payment requirements
+3. Make a second request with the payment token
+
+## Example Endpoint
+
+The server includes a single example endpoint at `/weather` that requires a payment of 0.001 USDC on Base Sepolia or Solana Devnet to access. The endpoint returns a simple weather report.
+
+## Response Format
+
+### Payment Required (402)
+
+```
+HTTP/1.1 402 Payment Required
+Content-Type: application/json; charset=utf-8
+PAYMENT-REQUIRED: <base64-encoded JSON>
+
+{}
+```
+
+The `PAYMENT-REQUIRED` header contains base64-encoded JSON with the payment requirements.
+Note: `amount` is in atomic units (e.g., 1000 = 0.001 USDC, since USDC has 6 decimals):
+
+```json
+{
+  "x402Version": 2,
+  "error": "Payment required",
+  "resource": {
+    "url": "http://localhost:4021/weather",
+    "description": "Weather data",
+    "mimeType": "application/json"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:84532",
+      "amount": "1000",
+      "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "payTo": "0x1c47E9C085c2B7458F5b6C16cCBD65A65255a9f6",
+      "maxTimeoutSeconds": 300,
+      "extra": {
+        "name": "USDC",
+        "version": "2",
+        "resourceUrl": "http://localhost:4021/weather"
+      }
+    },
+    {
+      "scheme": "exact",
+      "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+      "amount": "1000",
+      "asset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+      "payTo": "FV6JPj6Fy12HG8SYStyHdcecXYmV1oeWERAokrh4GQ1n",
+      "maxTimeoutSeconds": 300,
+      "extra": {
+        "feePayer": "...",
+        "resourceUrl": "http://localhost:4021/weather"
+      }
+    }
+  ]
+}
+```
+
+### Successful Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+PAYMENT-RESPONSE: <base64-encoded JSON>
+
+{"report":{"weather":"sunny","temperature":70}}
+```
+
+The `PAYMENT-RESPONSE` header contains base64-encoded JSON with the settlement details:
+
+```json
+{
+  "success": true,
+  "transaction": "0x...",
+  "network": "eip155:84532",
+  "payer": "0x...",
+  "requirements": {
+    "scheme": "exact",
+    "network": "eip155:84532",
+    "amount": "1000",
+    "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    "payTo": "0x...",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "name": "USDC",
+      "version": "2",
+      "resourceUrl": "http://localhost:4021/weather"
+    }
+  }
+}
+```
+
+## Extending the Example
+
+To add more paid endpoints, follow this pattern:
+
+```typescript
+// First, configure the payment middleware with your routes
+paymentMiddleware(
+  app,
+  {
+    "GET /your-endpoint": {
+      accepts: {
+        scheme: "exact",
+        price: "$0.10",
+        network: "eip155:84532",
+        payTo: evmAddress,
+      },
+      description: "Your endpoint description",
+      mimeType: "application/json",
+    },
+  },
+  resourceServer,
+);
+
+// Then define your routes as normal
+app.get("/your-endpoint", async () => {
+  return {
+    // Your response data
+  };
+});
+```
+
+**Network identifiers** use [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) format, for example:
+
+- `eip155:84532` — Base Sepolia
+- `eip155:8453` — Base Mainnet
+- `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` — Solana Devnet
+- `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` — Solana Mainnet
+
+## x402ResourceServer Config
+
+The `x402ResourceServer` uses a builder pattern to register payment schemes that declare how payments for each network should be processed:
+
+```typescript
+const resourceServer = new x402ResourceServer(facilitatorClient)
+  .register("eip155:*", new ExactEvmScheme()) // All EVM chains
+  .register("solana:*", new ExactSvmScheme()); // All SVM chains
+```
+
+## Facilitator Config
+
+The `HTTPFacilitatorClient` connects to a facilitator service that verifies and settles payments on-chain:
+
+```typescript
+const facilitatorClient = new HTTPFacilitatorClient({ url: facilitatorUrl });
+
+// Or use multiple facilitators for redundancy
+const facilitatorClient = [
+  new HTTPFacilitatorClient({ url: primaryFacilitatorUrl }),
+  new HTTPFacilitatorClient({ url: backupFacilitatorUrl }),
+];
+```
+
+## Next Steps
+
+See [Advanced Examples](../advanced/) for:
+
+- **Bazaar discovery** — make your API discoverable
+- **Dynamic pricing** — price based on request context
+- **Dynamic payTo** — route payments to different recipients
+- **Lifecycle hooks** — custom logic on verify/settle
+- **Custom tokens** — accept payments in custom tokens

--- a/examples/typescript/servers/fastify/eslint.config.js
+++ b/examples/typescript/servers/fastify/eslint.config.js
@@ -1,0 +1,73 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        console: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+];

--- a/examples/typescript/servers/fastify/index.ts
+++ b/examples/typescript/servers/fastify/index.ts
@@ -1,0 +1,67 @@
+import { config } from "dotenv";
+import Fastify from "fastify";
+import { paymentMiddleware, x402ResourceServer } from "@x402/fastify";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { ExactSvmScheme } from "@x402/svm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+config();
+
+const evmAddress = process.env.EVM_ADDRESS as `0x${string}`;
+const svmAddress = process.env.SVM_ADDRESS;
+if (!evmAddress || !svmAddress) {
+  console.error("Missing required environment variables");
+  process.exit(1);
+}
+
+const facilitatorUrl = process.env.FACILITATOR_URL;
+if (!facilitatorUrl) {
+  console.error("❌ FACILITATOR_URL environment variable is required");
+  process.exit(1);
+}
+const facilitatorClient = new HTTPFacilitatorClient({ url: facilitatorUrl });
+
+const app = Fastify();
+
+paymentMiddleware(
+  app,
+  {
+    "GET /weather": {
+      accepts: [
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "eip155:84532",
+          payTo: evmAddress,
+        },
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+          payTo: svmAddress,
+        },
+      ],
+      description: "Weather data",
+      mimeType: "application/json",
+    },
+  },
+  new x402ResourceServer(facilitatorClient)
+    .register("eip155:84532", new ExactEvmScheme())
+    .register("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", new ExactSvmScheme()),
+);
+
+app.get("/weather", async () => {
+  return {
+    report: {
+      weather: "sunny",
+      temperature: 70,
+    },
+  };
+});
+
+app.listen({ port: 4021 }, (err, address) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  console.log(`Server listening at ${address}`);
+});

--- a/examples/typescript/servers/fastify/package.json
+++ b/examples/typescript/servers/fastify/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@x402/fastify-server-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx index.ts",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "dependencies": {
+    "@x402/core": "workspace:*",
+    "@x402/evm": "workspace:*",
+    "@x402/fastify": "workspace:*",
+    "@x402/extensions": "workspace:*",
+    "@x402/svm": "workspace:*",
+    "dotenv": "^16.4.7",
+    "fastify": "^5.0.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsup": "^7.2.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/examples/typescript/servers/fastify/tsconfig.json
+++ b/examples/typescript/servers/fastify/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}

--- a/typescript/.changeset/add-fastify-adapter.md
+++ b/typescript/.changeset/add-fastify-adapter.md
@@ -1,0 +1,5 @@
+---
+"@x402/fastify": minor
+---
+
+Added Fastify framework adapter for x402 payment middleware

--- a/typescript/packages/http/fastify/.prettierignore
+++ b/typescript/packages/http/fastify/.prettierignore
@@ -1,0 +1,8 @@
+docs/
+dist/
+node_modules/
+coverage/
+.github/
+src/client
+**/**/*.json
+*.md

--- a/typescript/packages/http/fastify/.prettierrc
+++ b/typescript/packages/http/fastify/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/typescript/packages/http/fastify/README.md
+++ b/typescript/packages/http/fastify/README.md
@@ -1,0 +1,254 @@
+# @x402/fastify
+
+Fastify middleware integration for the x402 Payment Protocol. This package provides payment middleware for adding x402 payment requirements to your Fastify applications.
+
+## Installation
+
+```bash
+pnpm install @x402/fastify
+```
+
+## Quick Start
+
+```typescript
+import Fastify from "fastify";
+import { paymentMiddleware, x402ResourceServer } from "@x402/fastify";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+
+const app = Fastify();
+
+const facilitatorClient = new HTTPFacilitatorClient({ url: "https://facilitator.x402.org" });
+const resourceServer = new x402ResourceServer(facilitatorClient)
+  .register("eip155:84532", new ExactEvmScheme());
+
+// Apply the payment middleware with your configuration
+paymentMiddleware(
+  app,
+  {
+    "GET /protected-route": {
+      accepts: {
+        scheme: "exact",
+        price: "$0.10",
+        network: "eip155:84532",
+        payTo: "0xYourAddress",
+      },
+      description: "Access to premium content",
+    },
+  },
+  resourceServer,
+);
+
+// Implement your protected route
+app.get("/protected-route", async () => {
+  return { message: "This content is behind a paywall" };
+});
+
+app.listen({ port: 3000 });
+```
+
+## Configuration
+
+The `paymentMiddleware` function accepts the following parameters:
+
+```typescript
+paymentMiddleware(
+  app: FastifyInstance,
+  routes: RoutesConfig,
+  server: x402ResourceServer,
+  paywallConfig?: PaywallConfig,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart?: boolean
+)
+```
+
+### Parameters
+
+1. **`app`** (required): The Fastify instance to register hooks on
+2. **`routes`** (required): Route configurations for protected endpoints
+3. **`server`** (required): Pre-configured x402ResourceServer instance
+4. **`paywallConfig`** (optional): Configuration for the built-in paywall UI
+5. **`paywall`** (optional): Custom paywall provider
+6. **`syncFacilitatorOnStart`** (optional): Whether to sync with facilitator on startup (defaults to true)
+
+## API Reference
+
+### FastifyAdapter
+
+The `FastifyAdapter` class implements the `HTTPAdapter` interface from `@x402/core`, providing Fastify-specific request handling:
+
+```typescript
+class FastifyAdapter implements HTTPAdapter {
+  getHeader(name: string): string | undefined;
+  getMethod(): string;
+  getPath(): string;
+  getUrl(): string;
+  getAcceptHeader(): string;
+  getUserAgent(): string;
+}
+```
+
+### Middleware Function
+
+```typescript
+function paymentMiddleware(
+  app: FastifyInstance,
+  routes: RoutesConfig,
+  server: x402ResourceServer,
+  paywallConfig?: PaywallConfig,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart?: boolean,
+): void;
+```
+
+Registers Fastify hooks (`onRequest` and `onSend`) that:
+
+1. Use the provided x402ResourceServer for payment processing
+2. Check if the incoming request matches a protected route
+3. Validate payment headers if required
+4. Return payment instructions (402 status) if payment is missing or invalid
+5. Process the request if payment is valid
+6. Handle settlement after successful response
+
+### Route Configuration
+
+Routes are passed as the second parameter to `paymentMiddleware`:
+
+```typescript
+const routes: RoutesConfig = {
+  "GET /api/protected": {
+    accepts: {
+      scheme: "exact",
+      price: "$0.10",
+      network: "eip155:84532",
+      payTo: "0xYourAddress",
+      maxTimeoutSeconds: 60,
+    },
+    description: "Premium API access",
+  },
+};
+
+paymentMiddleware(app, routes, resourceServer);
+```
+
+### Paywall Configuration
+
+The middleware automatically displays a paywall UI when browsers request protected endpoints.
+
+**Option 1: Full Paywall UI (Recommended)**
+
+Install the optional `@x402/paywall` package for a complete wallet connection and payment UI:
+
+```bash
+pnpm add @x402/paywall
+```
+
+Then configure it:
+
+```typescript
+const paywallConfig: PaywallConfig = {
+  appName: "Your App Name",
+  appLogo: "/path/to/logo.svg",
+  testnet: true,
+};
+
+paymentMiddleware(app, routes, resourceServer, paywallConfig);
+```
+
+**Option 2: Basic Paywall (No Installation)**
+
+Without `@x402/paywall` installed, the middleware returns a basic HTML page with payment instructions.
+
+**Option 3: Custom Paywall Provider**
+
+Provide your own paywall provider:
+
+```typescript
+paymentMiddleware(app, routes, resourceServer, paywallConfig, customPaywallProvider);
+```
+
+## Advanced Usage
+
+### Multiple Protected Routes
+
+```typescript
+paymentMiddleware(
+  app,
+  {
+    "GET /api/premium/*": {
+      accepts: {
+        scheme: "exact",
+        price: "$1.00",
+        network: "eip155:8453",
+        payTo: "0xYourAddress",
+      },
+      description: "Premium API access",
+    },
+    "GET /api/data": {
+      accepts: {
+        scheme: "exact",
+        price: "$0.50",
+        network: "eip155:84532",
+        payTo: "0xYourAddress",
+        maxTimeoutSeconds: 120,
+      },
+      description: "Data endpoint access",
+    },
+  },
+  resourceServer,
+);
+```
+
+### Multiple Payment Networks
+
+```typescript
+paymentMiddleware(
+  app,
+  {
+    "GET /weather": {
+      accepts: [
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "eip155:84532",
+          payTo: evmAddress,
+        },
+        {
+          scheme: "exact",
+          price: "$0.001",
+          network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+          payTo: svmAddress,
+        },
+      ],
+      description: "Weather data",
+      mimeType: "application/json",
+    },
+  },
+  new x402ResourceServer(facilitatorClient)
+    .register("eip155:84532", new ExactEvmScheme())
+    .register("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", new ExactSvmScheme()),
+);
+```
+
+### Custom Facilitator Client
+
+If you need to use a custom facilitator server, configure it when creating the x402ResourceServer:
+
+```typescript
+import { HTTPFacilitatorClient } from "@x402/core/server";
+import { x402ResourceServer } from "@x402/fastify";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+
+const customFacilitator = new HTTPFacilitatorClient({
+  url: "https://your-facilitator.com",
+  createAuthHeaders: async () => ({
+    verify: { Authorization: "Bearer your-token" },
+    settle: { Authorization: "Bearer your-token" },
+  }),
+});
+
+const resourceServer = new x402ResourceServer(customFacilitator)
+  .register("eip155:84532", new ExactEvmScheme());
+
+paymentMiddleware(app, routes, resourceServer, paywallConfig);
+```

--- a/typescript/packages/http/fastify/eslint.config.js
+++ b/typescript/packages/http/fastify/eslint.config.js
@@ -1,0 +1,73 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        Headers: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+];

--- a/typescript/packages/http/fastify/package.json
+++ b/typescript/packages/http/fastify/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@x402/fastify",
+  "version": "0.1.0",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "start": "tsx --env-file=.env index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "build": "tsup",
+    "watch": "tsc --watch",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "keywords": [],
+  "license": "Apache-2.0",
+  "author": "Coinbase Inc.",
+  "repository": "https://github.com/coinbase/x402",
+  "description": "x402 Payment Protocol - Fastify middleware",
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@types/node": "^22.13.4",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "fastify": "^5.0.0",
+    "prettier": "3.5.2",
+    "tsup": "^8.4.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3",
+    "vite": "^6.2.6",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.0.5"
+  },
+  "dependencies": {
+    "@x402/core": "workspace:~",
+    "@x402/extensions": "workspace:~"
+  },
+  "peerDependencies": {
+    "fastify": "^5.0.0",
+    "@x402/paywall": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@x402/paywall": {
+      "optional": true
+    }
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/typescript/packages/http/fastify/src/adapter.test.ts
+++ b/typescript/packages/http/fastify/src/adapter.test.ts
@@ -13,6 +13,7 @@ import { FastifyAdapter } from "./adapter";
  * @param options.body - Request body.
  * @param options.protocol - The request protocol.
  * @param options.hostname - The request hostname.
+ * @param options.host - The request host header, including port if present.
  * @returns A mock Fastify request.
  */
 function createMockRequest(
@@ -24,6 +25,7 @@ function createMockRequest(
     body?: unknown;
     protocol?: string;
     hostname?: string;
+    host?: string;
   } = {},
 ): FastifyRequest {
   return {
@@ -34,6 +36,7 @@ function createMockRequest(
     body: options.body,
     protocol: options.protocol || "https",
     hostname: options.hostname || "example.com",
+    host: options.host || options.hostname || "example.com",
   } as unknown as FastifyRequest;
 }
 
@@ -86,9 +89,10 @@ describe("FastifyAdapter", () => {
         url: "/api/test?foo=bar",
         protocol: "https",
         hostname: "example.com",
+        host: "example.com:3000",
       });
       const adapter = new FastifyAdapter(req);
-      expect(adapter.getUrl()).toBe("https://example.com/api/test?foo=bar");
+      expect(adapter.getUrl()).toBe("https://example.com:3000/api/test?foo=bar");
     });
   });
 

--- a/typescript/packages/http/fastify/src/adapter.test.ts
+++ b/typescript/packages/http/fastify/src/adapter.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { FastifyRequest } from "fastify";
+import { FastifyAdapter } from "./adapter";
+
+/**
+ * Factory for creating mock Fastify requests.
+ *
+ * @param options - Configuration options for the mock request.
+ * @param options.url - The request URL path with optional query string.
+ * @param options.method - The HTTP method.
+ * @param options.headers - Request headers.
+ * @param options.query - Query parameters.
+ * @param options.body - Request body.
+ * @param options.protocol - The request protocol.
+ * @param options.hostname - The request hostname.
+ * @returns A mock Fastify request.
+ */
+function createMockRequest(
+  options: {
+    url?: string;
+    method?: string;
+    headers?: Record<string, string | string[]>;
+    query?: Record<string, string | string[]>;
+    body?: unknown;
+    protocol?: string;
+    hostname?: string;
+  } = {},
+): FastifyRequest {
+  return {
+    url: options.url || "/api/test",
+    method: options.method || "GET",
+    headers: options.headers || {},
+    query: options.query || {},
+    body: options.body,
+    protocol: options.protocol || "https",
+    hostname: options.hostname || "example.com",
+  } as unknown as FastifyRequest;
+}
+
+describe("FastifyAdapter", () => {
+  describe("getHeader", () => {
+    it("returns header value when present", () => {
+      const req = createMockRequest({ headers: { "x-payment": "test-payment" } });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getHeader("X-Payment")).toBe("test-payment");
+    });
+
+    it("returns first value for array headers", () => {
+      const req = createMockRequest({ headers: { "x-payment": ["first", "second"] } });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getHeader("X-Payment")).toBe("first");
+    });
+
+    it("returns undefined for missing headers", () => {
+      const req = createMockRequest();
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getHeader("X-Missing")).toBeUndefined();
+    });
+  });
+
+  describe("getMethod", () => {
+    it("returns the HTTP method", () => {
+      const req = createMockRequest({ method: "POST" });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getMethod()).toBe("POST");
+    });
+  });
+
+  describe("getPath", () => {
+    it("returns the pathname without query string", () => {
+      const req = createMockRequest({ url: "/api/weather?city=NYC" });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getPath()).toBe("/api/weather");
+    });
+
+    it("returns the pathname when no query string", () => {
+      const req = createMockRequest({ url: "/api/test" });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getPath()).toBe("/api/test");
+    });
+  });
+
+  describe("getUrl", () => {
+    it("returns the full URL", () => {
+      const req = createMockRequest({
+        url: "/api/test?foo=bar",
+        protocol: "https",
+        hostname: "example.com",
+      });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getUrl()).toBe("https://example.com/api/test?foo=bar");
+    });
+  });
+
+  describe("getAcceptHeader", () => {
+    it("returns Accept header when present", () => {
+      const req = createMockRequest({ headers: { accept: "text/html" } });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getAcceptHeader()).toBe("text/html");
+    });
+
+    it("returns empty string when missing", () => {
+      const req = createMockRequest();
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getAcceptHeader()).toBe("");
+    });
+  });
+
+  describe("getUserAgent", () => {
+    it("returns User-Agent header when present", () => {
+      const req = createMockRequest({ headers: { "user-agent": "Mozilla/5.0" } });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getUserAgent()).toBe("Mozilla/5.0");
+    });
+
+    it("returns empty string when missing", () => {
+      const req = createMockRequest();
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getUserAgent()).toBe("");
+    });
+  });
+
+  describe("getQueryParams", () => {
+    it("returns all query parameters", () => {
+      const req = createMockRequest({ query: { foo: "bar", baz: "qux" } });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getQueryParams()).toEqual({ foo: "bar", baz: "qux" });
+    });
+
+    it("returns empty object when no query params", () => {
+      const req = createMockRequest({ query: {} });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getQueryParams()).toEqual({});
+    });
+  });
+
+  describe("getQueryParam", () => {
+    it("returns single value for single param", () => {
+      const req = createMockRequest({ query: { city: "NYC" } });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getQueryParam("city")).toBe("NYC");
+    });
+
+    it("returns undefined for missing param", () => {
+      const req = createMockRequest({ query: {} });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getQueryParam("missing")).toBeUndefined();
+    });
+  });
+
+  describe("getBody", () => {
+    it("returns parsed body", () => {
+      const body = { data: "test" };
+      const req = createMockRequest({ body });
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getBody()).toEqual(body);
+    });
+
+    it("returns undefined when no body", () => {
+      const req = createMockRequest();
+      const adapter = new FastifyAdapter(req);
+      expect(adapter.getBody()).toBeUndefined();
+    });
+  });
+});

--- a/typescript/packages/http/fastify/src/adapter.ts
+++ b/typescript/packages/http/fastify/src/adapter.ts
@@ -47,7 +47,7 @@ export class FastifyAdapter implements HTTPAdapter {
    * @returns The full request URL
    */
   getUrl(): string {
-    return `${this.request.protocol}://${this.request.hostname}${this.request.url}`;
+    return `${this.request.protocol}://${this.request.host || this.request.hostname}${this.request.url}`;
   }
 
   /**

--- a/typescript/packages/http/fastify/src/adapter.ts
+++ b/typescript/packages/http/fastify/src/adapter.ts
@@ -1,0 +1,99 @@
+import { HTTPAdapter } from "@x402/core/server";
+import { FastifyRequest } from "fastify";
+
+/**
+ * Fastify adapter implementation for the x402 HTTP protocol.
+ */
+export class FastifyAdapter implements HTTPAdapter {
+  /**
+   * Creates a new FastifyAdapter instance.
+   *
+   * @param request - The Fastify request object
+   */
+  constructor(private request: FastifyRequest) {}
+
+  /**
+   * Gets a header value from the request.
+   *
+   * @param name - The header name
+   * @returns The header value or undefined
+   */
+  getHeader(name: string): string | undefined {
+    const value = this.request.headers[name.toLowerCase()];
+    return Array.isArray(value) ? value[0] : value;
+  }
+
+  /**
+   * Gets the HTTP method of the request.
+   *
+   * @returns The HTTP method
+   */
+  getMethod(): string {
+    return this.request.method;
+  }
+
+  /**
+   * Gets the path of the request.
+   *
+   * @returns The request path without query string
+   */
+  getPath(): string {
+    return this.request.url.split("?")[0];
+  }
+
+  /**
+   * Gets the full URL of the request.
+   *
+   * @returns The full request URL
+   */
+  getUrl(): string {
+    return `${this.request.protocol}://${this.request.hostname}${this.request.url}`;
+  }
+
+  /**
+   * Gets the Accept header from the request.
+   *
+   * @returns The Accept header value or empty string
+   */
+  getAcceptHeader(): string {
+    return this.getHeader("accept") || "";
+  }
+
+  /**
+   * Gets the User-Agent header from the request.
+   *
+   * @returns The User-Agent header value or empty string
+   */
+  getUserAgent(): string {
+    return this.getHeader("user-agent") || "";
+  }
+
+  /**
+   * Gets all query parameters from the request URL.
+   *
+   * @returns Record of query parameter key-value pairs
+   */
+  getQueryParams(): Record<string, string | string[]> {
+    return (this.request.query as Record<string, string | string[]>) || {};
+  }
+
+  /**
+   * Gets a specific query parameter by name.
+   *
+   * @param name - The query parameter name
+   * @returns The query parameter value(s) or undefined
+   */
+  getQueryParam(name: string): string | string[] | undefined {
+    return this.getQueryParams()[name];
+  }
+
+  /**
+   * Gets the parsed request body.
+   * Fastify automatically parses JSON bodies.
+   *
+   * @returns The parsed request body
+   */
+  getBody(): unknown {
+    return this.request.body;
+  }
+}

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -1,0 +1,812 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import type {
+  HTTPProcessResult,
+  x402HTTPResourceServer,
+  PaywallProvider,
+  FacilitatorClient,
+} from "@x402/core/server";
+import {
+  x402ResourceServer,
+  x402HTTPResourceServer as HTTPResourceServer,
+} from "@x402/core/server";
+import type { PaymentPayload, PaymentRequirements, SchemeNetworkServer } from "@x402/core/types";
+import { paymentMiddleware, paymentMiddlewareFromConfig, type SchemeRegistration } from "./index";
+
+// --- Test Fixtures ---
+const mockRoutes = {
+  "/api/*": {
+    accepts: { scheme: "exact", payTo: "0x123", price: "$0.01", network: "eip155:84532" },
+  },
+} as const;
+
+const mockPaymentPayload = {
+  scheme: "exact",
+  network: "eip155:84532",
+  payload: { signature: "0xabc" },
+} as unknown as PaymentPayload;
+
+const mockPaymentRequirements = {
+  scheme: "exact",
+  network: "eip155:84532",
+  maxAmountRequired: "1000",
+  payTo: "0x123",
+} as unknown as PaymentRequirements;
+
+// --- Mock setup ---
+let mockProcessHTTPRequest: ReturnType<typeof vi.fn>;
+let mockProcessSettlement: ReturnType<typeof vi.fn>;
+let mockRegisterPaywallProvider: ReturnType<typeof vi.fn>;
+let mockRequiresPayment: ReturnType<typeof vi.fn>;
+
+vi.mock("@x402/core/server", () => ({
+  x402ResourceServer: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    registerExtension: vi.fn(),
+    register: vi.fn(),
+    hasExtension: vi.fn().mockReturnValue(false),
+  })),
+  x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    processHTTPRequest: mockProcessHTTPRequest,
+    processSettlement: mockProcessSettlement,
+    registerPaywallProvider: mockRegisterPaywallProvider,
+    requiresPayment: mockRequiresPayment,
+    routes: routes,
+    server: server || {
+      hasExtension: vi.fn().mockReturnValue(false),
+      registerExtension: vi.fn(),
+    },
+  })),
+}));
+
+// --- Hook Capture ---
+type HookHandler = (...args: unknown[]) => Promise<unknown>;
+
+/**
+ * Captured hooks from a mock Fastify instance.
+ */
+interface CapturedHooks {
+  onRequest: HookHandler[];
+  onSend: HookHandler[];
+}
+
+/**
+ * Creates a mock Fastify instance that captures registered hooks.
+ *
+ * @returns Object containing the mock app and captured hooks.
+ */
+function createMockApp(): { app: FastifyInstance; hooks: CapturedHooks } {
+  const hooks: CapturedHooks = { onRequest: [], onSend: [] };
+
+  const app = {
+    addHook: vi.fn((name: string, handler: HookHandler) => {
+      if (name === "onRequest") hooks.onRequest.push(handler);
+      if (name === "onSend") hooks.onSend.push(handler);
+    }),
+  } as unknown as FastifyInstance;
+
+  return { app, hooks };
+}
+
+/**
+ * Sets up the mock HTTP server to return specified results.
+ *
+ * @param processResult - The result to return from processHTTPRequest.
+ * @param settlementResult - Result to return from processSettlement.
+ */
+function setupMockHttpServer(
+  processResult: HTTPProcessResult,
+  settlementResult:
+    | { success: true; headers: Record<string, string> }
+    | {
+        success: false;
+        errorReason: string;
+        headers: Record<string, string>;
+        response: {
+          status: number;
+          headers: Record<string, string>;
+          body?: unknown;
+          isHtml?: boolean;
+        };
+      } = {
+    success: true,
+    headers: {},
+  },
+): void {
+  mockProcessHTTPRequest.mockResolvedValue(processResult);
+  mockProcessSettlement.mockResolvedValue(settlementResult);
+}
+
+/**
+ * Creates a mock Fastify request for testing.
+ *
+ * @param options - Configuration options for the mock request.
+ * @param options.url - The request URL path.
+ * @param options.method - The HTTP method.
+ * @param options.headers - Request headers.
+ * @returns A mock Fastify request.
+ */
+function createMockRequest(
+  options: {
+    url?: string;
+    method?: string;
+    headers?: Record<string, string>;
+  } = {},
+): FastifyRequest {
+  return {
+    url: options.url || "/api/test",
+    method: options.method || "GET",
+    headers: options.headers || {},
+    query: {},
+    body: undefined,
+    protocol: "https",
+    hostname: "example.com",
+  } as unknown as FastifyRequest;
+}
+
+/**
+ * Creates a mock Fastify reply for testing.
+ *
+ * @returns A mock Fastify reply with tracking properties.
+ */
+function createMockReply(): FastifyReply & {
+  _status: number;
+  _headers: Record<string, string>;
+  _body: unknown;
+  _type: string | undefined;
+} {
+  const reply = {
+    _status: 200,
+    _headers: {} as Record<string, string>,
+    _body: undefined as unknown,
+    _type: undefined as string | undefined,
+    statusCode: 200,
+    header: vi.fn(function (this: typeof reply, key: string, value: string) {
+      this._headers[key] = value;
+      return this;
+    }),
+    status: vi.fn(function (this: typeof reply, code: number) {
+      this._status = code;
+      this.statusCode = code;
+      return this;
+    }),
+    type: vi.fn(function (this: typeof reply, contentType: string) {
+      this._type = contentType;
+      return this;
+    }),
+    send: vi.fn(function (this: typeof reply, body: unknown) {
+      this._body = body;
+      return this;
+    }),
+  };
+
+  return reply as unknown as typeof reply;
+}
+
+// --- Tests ---
+describe("paymentMiddleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcessHTTPRequest = vi.fn();
+    mockProcessSettlement = vi.fn();
+    mockRegisterPaywallProvider = vi.fn();
+    mockRequiresPayment = vi.fn().mockReturnValue(true);
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize: vi.fn().mockResolvedValue(undefined),
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+  });
+
+  it("registers onRequest and onSend hooks", () => {
+    const { app } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    expect(app.addHook).toHaveBeenCalledWith("onRequest", expect.any(Function));
+    expect(app.addHook).toHaveBeenCalledWith("onSend", expect.any(Function));
+  });
+
+  it("proceeds when no-payment-required", async () => {
+    setupMockHttpServer({ type: "no-payment-required" });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(mockProcessHTTPRequest).toHaveBeenCalled();
+    expect(reply.send).not.toHaveBeenCalled();
+  });
+
+  it("skips payment check for non-protected routes", async () => {
+    mockRequiresPayment.mockReturnValue(false);
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest({ url: "/health" });
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(mockProcessHTTPRequest).not.toHaveBeenCalled();
+    expect(reply.send).not.toHaveBeenCalled();
+  });
+
+  it("returns 402 HTML for payment-error with isHtml", async () => {
+    setupMockHttpServer({
+      type: "payment-error",
+      response: {
+        status: 402,
+        body: "<html>Paywall</html>",
+        headers: { "PAYMENT-REQUIRED": "encoded-data" },
+        isHtml: true,
+      },
+    });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(402);
+    expect(reply.type).toHaveBeenCalledWith("text/html");
+    expect(reply.send).toHaveBeenCalledWith("<html>Paywall</html>");
+    expect(reply.header).toHaveBeenCalledWith("PAYMENT-REQUIRED", "encoded-data");
+  });
+
+  it("returns 402 JSON for payment-error", async () => {
+    setupMockHttpServer({
+      type: "payment-error",
+      response: {
+        status: 402,
+        body: { error: "Payment required" },
+        headers: {},
+        isHtml: false,
+      },
+    });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(402);
+    expect(reply.send).toHaveBeenCalledWith({ error: "Payment required" });
+  });
+
+  it("stashes payment context on request for payment-verified", async () => {
+    setupMockHttpServer({
+      type: "payment-verified",
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+    });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(reply.send).not.toHaveBeenCalled();
+    // Payment context should be stashed on the request via symbol
+    const symbols = Object.getOwnPropertySymbols(request);
+    expect(symbols.length).toBe(1);
+  });
+
+  it("settles payment and adds headers in onSend for verified payments", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+
+    // Step 1: onRequest stashes payment context
+    await hooks.onRequest[0](request, reply);
+
+    // Step 2: onSend settles payment
+    const payload = JSON.stringify({ data: "premium content" });
+    const result = await hooks.onSend[0](request, reply, payload);
+
+    expect(mockProcessSettlement).toHaveBeenCalledWith(
+      mockPaymentPayload,
+      mockPaymentRequirements,
+      undefined,
+      expect.objectContaining({
+        request: expect.objectContaining({
+          path: "/api/test",
+          method: "GET",
+        }),
+        responseBody: expect.any(Buffer),
+      }),
+    );
+    expect(reply.header).toHaveBeenCalledWith("PAYMENT-RESPONSE", "settled");
+    expect(result).toBe(payload);
+  });
+
+  it("skips settlement for non-payment requests in onSend", async () => {
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+    const payload = JSON.stringify({ data: "free content" });
+
+    const result = await hooks.onSend[0](request, reply, payload);
+
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(result).toBe(payload);
+  });
+
+  it("skips settlement when handler returns >= 400", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: {} },
+    );
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+
+    await hooks.onRequest[0](request, reply);
+
+    reply.statusCode = 500;
+    const payload = JSON.stringify({ error: "Server error" });
+    const result = await hooks.onSend[0](request, reply, payload);
+
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(result).toBe(payload);
+  });
+
+  it("returns 402 when settlement fails", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      {
+        success: false,
+        errorReason: "Insufficient funds",
+        headers: {},
+        response: {
+          status: 402,
+          headers: { "PAYMENT-RESPONSE": "failed" },
+          body: { error: "Settlement failed" },
+        },
+      },
+    );
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+
+    await hooks.onRequest[0](request, reply);
+
+    const payload = JSON.stringify({ data: "premium content" });
+    const result = await hooks.onSend[0](request, reply, payload);
+
+    expect(reply.status).toHaveBeenCalledWith(402);
+    expect(reply.header).toHaveBeenCalledWith("PAYMENT-RESPONSE", "failed");
+    expect(result).toBe(JSON.stringify({ error: "Settlement failed" }));
+  });
+
+  it("returns 402 when settlement throws error", async () => {
+    setupMockHttpServer({
+      type: "payment-verified",
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+    });
+    mockProcessSettlement.mockRejectedValue(new Error("Settlement rejected"));
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+
+    await hooks.onRequest[0](request, reply);
+
+    const payload = JSON.stringify({ data: "premium content" });
+    const result = await hooks.onSend[0](request, reply, payload);
+
+    expect(reply.status).toHaveBeenCalledWith(402);
+    expect(result).toBe(JSON.stringify({}));
+  });
+
+  it("passes paywallConfig to processHTTPRequest", async () => {
+    setupMockHttpServer({ type: "no-payment-required" });
+    const paywallConfig = { appName: "test-app" };
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      paywallConfig,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(mockProcessHTTPRequest).toHaveBeenCalledWith(expect.anything(), paywallConfig);
+  });
+
+  it("registers custom paywall provider", () => {
+    const { app } = createMockApp();
+    const paywall: PaywallProvider = { generateHtml: vi.fn() };
+
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      paywall,
+      false,
+    );
+
+    expect(mockRegisterPaywallProvider).toHaveBeenCalledWith(paywall);
+  });
+});
+
+describe("paymentMiddlewareFromConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcessHTTPRequest = vi.fn();
+    mockProcessSettlement = vi.fn();
+    mockRegisterPaywallProvider = vi.fn();
+    mockRequiresPayment = vi.fn().mockReturnValue(true);
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize: vi.fn().mockResolvedValue(undefined),
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+
+    vi.mocked(x402ResourceServer).mockImplementation(
+      () =>
+        ({
+          initialize: vi.fn().mockResolvedValue(undefined),
+          registerExtension: vi.fn(),
+          register: vi.fn(),
+        }) as unknown as x402ResourceServer,
+    );
+  });
+
+  it("creates x402ResourceServer with facilitator clients", () => {
+    const { app } = createMockApp();
+    const facilitator = { verify: vi.fn(), settle: vi.fn() } as unknown as FacilitatorClient;
+
+    paymentMiddlewareFromConfig(app, mockRoutes, facilitator);
+
+    expect(x402ResourceServer).toHaveBeenCalledWith(facilitator);
+  });
+
+  it("registers scheme servers for each network", () => {
+    const { app } = createMockApp();
+    const schemeServer = { verify: vi.fn(), settle: vi.fn() } as unknown as SchemeNetworkServer;
+    const schemes: SchemeRegistration[] = [
+      { network: "eip155:84532", server: schemeServer },
+      { network: "eip155:8453", server: schemeServer },
+    ];
+
+    paymentMiddlewareFromConfig(app, mockRoutes, undefined, schemes);
+
+    const serverInstance = vi.mocked(x402ResourceServer).mock.results[0].value;
+    expect(serverInstance.register).toHaveBeenCalledTimes(2);
+    expect(serverInstance.register).toHaveBeenCalledWith("eip155:84532", schemeServer);
+    expect(serverInstance.register).toHaveBeenCalledWith("eip155:8453", schemeServer);
+  });
+
+  it("registers hooks on the Fastify instance", () => {
+    const { app } = createMockApp();
+    paymentMiddlewareFromConfig(app, mockRoutes);
+
+    expect(app.addHook).toHaveBeenCalledWith("onRequest", expect.any(Function));
+    expect(app.addHook).toHaveBeenCalledWith("onSend", expect.any(Function));
+  });
+});
+
+describe("FastifyAdapter integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProcessHTTPRequest = vi.fn();
+    mockProcessSettlement = vi.fn();
+    mockRegisterPaywallProvider = vi.fn();
+    mockRequiresPayment = vi.fn().mockReturnValue(true);
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize: vi.fn().mockResolvedValue(undefined),
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes: routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+  });
+
+  it("extracts path and method from request", async () => {
+    setupMockHttpServer({ type: "no-payment-required" });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest({ url: "/api/weather", method: "POST" });
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(mockProcessHTTPRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/weather",
+        method: "POST",
+      }),
+      undefined,
+    );
+  });
+
+  it("strips query string from path", async () => {
+    setupMockHttpServer({ type: "no-payment-required" });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest({ url: "/api/weather?city=NYC" });
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(mockProcessHTTPRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/weather",
+      }),
+      undefined,
+    );
+  });
+
+  it("extracts payment-signature header", async () => {
+    setupMockHttpServer({ type: "no-payment-required" });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest({ headers: { "payment-signature": "sig-data" } });
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(mockProcessHTTPRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentHeader: "sig-data",
+      }),
+      undefined,
+    );
+  });
+
+  it("extracts x-payment header", async () => {
+    setupMockHttpServer({ type: "no-payment-required" });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest({ headers: { "x-payment": "payment-data" } });
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(mockProcessHTTPRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentHeader: "payment-data",
+      }),
+      undefined,
+    );
+  });
+
+  it("prefers payment-signature over x-payment", async () => {
+    setupMockHttpServer({ type: "no-payment-required" });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest({
+      headers: { "payment-signature": "sig-data", "x-payment": "x-payment-data" },
+    });
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(mockProcessHTTPRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentHeader: "sig-data",
+      }),
+      undefined,
+    );
+  });
+
+  it("returns undefined paymentHeader when no payment headers present", async () => {
+    setupMockHttpServer({ type: "no-payment-required" });
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+    await hooks.onRequest[0](request, reply);
+
+    expect(mockProcessHTTPRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentHeader: undefined,
+      }),
+      undefined,
+    );
+  });
+});

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -400,6 +400,40 @@ describe("paymentMiddleware", () => {
     expect(result).toBe(payload);
   });
 
+  it("passes Buffer payload bytes to settlement without JSON stringifying them", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+    const payload = Buffer.from([0, 1, 2, 255]);
+
+    await hooks.onRequest[0](request, reply);
+    const result = await hooks.onSend[0](request, reply, payload);
+
+    expect(result).toBe(payload);
+    expect(mockProcessSettlement).toHaveBeenCalledTimes(1);
+    expect(
+      (mockProcessSettlement.mock.calls[0]?.[3] as { responseBody?: Buffer }).responseBody,
+    ).toEqual(payload);
+  });
+
   it("skips settlement for non-payment requests in onSend", async () => {
     const { app, hooks } = createMockApp();
     paymentMiddleware(
@@ -467,7 +501,10 @@ describe("paymentMiddleware", () => {
         headers: {},
         response: {
           status: 402,
-          headers: { "PAYMENT-RESPONSE": "failed" },
+          headers: {
+            "PAYMENT-RESPONSE": "failed",
+            "Content-Type": "application/json",
+          },
           body: { error: "Settlement failed" },
         },
       },
@@ -488,11 +525,13 @@ describe("paymentMiddleware", () => {
 
     await hooks.onRequest[0](request, reply);
 
+    reply.type("application/octet-stream");
     const payload = JSON.stringify({ data: "premium content" });
     const result = await hooks.onSend[0](request, reply, payload);
 
     expect(reply.status).toHaveBeenCalledWith(402);
     expect(reply.header).toHaveBeenCalledWith("PAYMENT-RESPONSE", "failed");
+    expect(reply.type).toHaveBeenCalledWith("application/json");
     expect(result).toBe(JSON.stringify({ error: "Settlement failed" }));
   });
 
@@ -523,6 +562,7 @@ describe("paymentMiddleware", () => {
     const result = await hooks.onSend[0](request, reply, payload);
 
     expect(reply.status).toHaveBeenCalledWith(402);
+    expect(reply.type).toHaveBeenCalledWith("application/json");
     expect(result).toBe(JSON.stringify({}));
   });
 

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -1,0 +1,316 @@
+import {
+  HTTPRequestContext,
+  PaywallConfig,
+  PaywallProvider,
+  x402HTTPResourceServer,
+  x402ResourceServer,
+  RoutesConfig,
+  FacilitatorClient,
+} from "@x402/core/server";
+import {
+  SchemeNetworkServer,
+  Network,
+  PaymentPayload,
+  PaymentRequirements,
+} from "@x402/core/types";
+import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { FastifyAdapter } from "./adapter";
+
+/**
+ * Symbol used to store x402 payment context on the request object.
+ */
+const kX402Context = Symbol("x402Context");
+
+/**
+ * Extended request type with x402 payment context.
+ */
+interface X402PaymentContext {
+  paymentPayload: PaymentPayload;
+  paymentRequirements: PaymentRequirements;
+  declaredExtensions?: Record<string, unknown>;
+  requestContext: HTTPRequestContext;
+}
+
+/**
+ * Check if any routes in the configuration declare bazaar extensions.
+ *
+ * @param routes - Route configuration
+ * @returns True if any route has extensions.bazaar defined
+ */
+function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
+  if ("accepts" in routes) {
+    return !!(routes.extensions && "bazaar" in routes.extensions);
+  }
+
+  return Object.values(routes).some(routeConfig => {
+    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
+  });
+}
+
+/**
+ * Configuration for registering a payment scheme with a specific network.
+ */
+export interface SchemeRegistration {
+  /**
+   * The network identifier (e.g., 'eip155:84532', 'solana:mainnet')
+   */
+  network: Network;
+
+  /**
+   * The scheme server implementation for this network
+   */
+  server: SchemeNetworkServer;
+}
+
+/**
+ * Registers x402 payment middleware on a Fastify instance using a pre-configured HTTP server.
+ *
+ * Use this when you need to configure HTTP-level hooks.
+ *
+ * @param app - The Fastify instance
+ * @param httpServer - Pre-configured x402HTTPResourceServer instance
+ * @param paywallConfig - Optional configuration for the built-in paywall UI
+ * @param paywall - Optional custom paywall provider (overrides default)
+ * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
+ *
+ * @example
+ * ```typescript
+ * import { paymentMiddlewareFromHTTPServer, x402ResourceServer, x402HTTPResourceServer } from "@x402/fastify";
+ *
+ * const resourceServer = new x402ResourceServer(facilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme());
+ *
+ * const httpServer = new x402HTTPResourceServer(resourceServer, routes)
+ *   .onProtectedRequest(requestHook);
+ *
+ * paymentMiddlewareFromHTTPServer(app, httpServer);
+ * ```
+ */
+export function paymentMiddlewareFromHTTPServer(
+  app: FastifyInstance,
+  httpServer: x402HTTPResourceServer,
+  paywallConfig?: PaywallConfig,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart: boolean = true,
+): void {
+  if (paywall) {
+    httpServer.registerPaywallProvider(paywall);
+  }
+
+  let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
+
+  let bazaarPromise: Promise<void> | null = null;
+  if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
+    bazaarPromise = import("@x402/extensions/bazaar")
+      .then(({ bazaarResourceServerExtension }) => {
+        httpServer.server.registerExtension(bazaarResourceServerExtension);
+      })
+      .catch(err => {
+        console.error("Failed to load bazaar extension:", err);
+      });
+  }
+
+  app.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
+    const path = request.url.split("?")[0];
+    const adapter = new FastifyAdapter(request);
+    const context: HTTPRequestContext = {
+      adapter,
+      path,
+      method: request.method,
+      paymentHeader:
+        (request.headers["payment-signature"] as string | undefined) ||
+        (request.headers["x-payment"] as string | undefined),
+    };
+
+    if (!httpServer.requiresPayment(context)) {
+      return;
+    }
+
+    if (initPromise) {
+      await initPromise;
+      initPromise = null;
+    }
+
+    if (bazaarPromise) {
+      await bazaarPromise;
+      bazaarPromise = null;
+    }
+
+    const result = await httpServer.processHTTPRequest(context, paywallConfig);
+
+    switch (result.type) {
+      case "no-payment-required":
+        return;
+
+      case "payment-error": {
+        const { response } = result;
+        for (const [key, value] of Object.entries(response.headers)) {
+          reply.header(key, value);
+        }
+        if (response.isHtml) {
+          return reply.status(response.status).type("text/html").send(response.body);
+        } else {
+          return reply.status(response.status).send(response.body || {});
+        }
+      }
+
+      case "payment-verified": {
+        const x402Context: X402PaymentContext = {
+          paymentPayload: result.paymentPayload,
+          paymentRequirements: result.paymentRequirements,
+          declaredExtensions: result.declaredExtensions,
+          requestContext: context,
+        };
+        (request as unknown as Record<symbol, unknown>)[kX402Context] = x402Context;
+        return;
+      }
+    }
+  });
+
+  app.addHook("onSend", async (request: FastifyRequest, reply: FastifyReply, payload: unknown) => {
+    const x402Context = (request as unknown as Record<symbol, unknown>)[kX402Context] as
+      | X402PaymentContext
+      | undefined;
+
+    if (!x402Context) {
+      return payload;
+    }
+
+    if (reply.statusCode >= 400) {
+      return payload;
+    }
+
+    try {
+      const responseBody = Buffer.from(
+        typeof payload === "string" ? payload : JSON.stringify(payload ?? {}),
+      );
+
+      const settleResult = await httpServer.processSettlement(
+        x402Context.paymentPayload,
+        x402Context.paymentRequirements,
+        x402Context.declaredExtensions,
+        { request: x402Context.requestContext, responseBody },
+      );
+
+      if (!settleResult.success) {
+        const { response } = settleResult;
+        for (const [key, value] of Object.entries(response.headers)) {
+          reply.header(key, value);
+        }
+        reply.status(response.status);
+        return response.isHtml ? String(response.body ?? "") : JSON.stringify(response.body ?? {});
+      }
+
+      for (const [key, value] of Object.entries(settleResult.headers)) {
+        reply.header(key, value);
+      }
+      return payload;
+    } catch (error) {
+      console.error(error);
+      reply.status(402);
+      return JSON.stringify({});
+    }
+  });
+}
+
+/**
+ * Registers x402 payment middleware on a Fastify instance using a pre-configured resource server.
+ *
+ * Use this when you want to pass a pre-configured x402ResourceServer instance.
+ * This provides more flexibility for testing, custom configuration, and reusing
+ * server instances across multiple middlewares.
+ *
+ * @param app - The Fastify instance
+ * @param routes - Route configurations for protected endpoints
+ * @param server - Pre-configured x402ResourceServer instance
+ * @param paywallConfig - Optional configuration for the built-in paywall UI
+ * @param paywall - Optional custom paywall provider (overrides default)
+ * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
+ *
+ * @example
+ * ```typescript
+ * import { paymentMiddleware } from "@x402/fastify";
+ *
+ * const server = new x402ResourceServer(myFacilitatorClient)
+ *   .register(NETWORK, new ExactEvmScheme());
+ *
+ * paymentMiddleware(app, routes, server, paywallConfig);
+ * ```
+ */
+export function paymentMiddleware(
+  app: FastifyInstance,
+  routes: RoutesConfig,
+  server: x402ResourceServer,
+  paywallConfig?: PaywallConfig,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart: boolean = true,
+): void {
+  const httpServer = new x402HTTPResourceServer(server, routes);
+
+  paymentMiddlewareFromHTTPServer(app, httpServer, paywallConfig, paywall, syncFacilitatorOnStart);
+}
+
+/**
+ * Registers x402 payment middleware on a Fastify instance using configuration.
+ *
+ * Use this when you want to quickly set up middleware with simple configuration.
+ * This function creates and configures the x402ResourceServer internally.
+ *
+ * @param app - The Fastify instance
+ * @param routes - Route configurations for protected endpoints
+ * @param facilitatorClients - Optional facilitator client(s) for payment processing
+ * @param schemes - Optional array of scheme registrations for server-side payment processing
+ * @param paywallConfig - Optional configuration for the built-in paywall UI
+ * @param paywall - Optional custom paywall provider (overrides default)
+ * @param syncFacilitatorOnStart - Whether to sync with the facilitator on startup (defaults to true)
+ *
+ * @example
+ * ```typescript
+ * import { paymentMiddlewareFromConfig } from "@x402/fastify";
+ *
+ * paymentMiddlewareFromConfig(
+ *   app,
+ *   routes,
+ *   myFacilitatorClient,
+ *   [{ network: "eip155:8453", server: evmSchemeServer }],
+ *   paywallConfig
+ * );
+ * ```
+ */
+export function paymentMiddlewareFromConfig(
+  app: FastifyInstance,
+  routes: RoutesConfig,
+  facilitatorClients?: FacilitatorClient | FacilitatorClient[],
+  schemes?: SchemeRegistration[],
+  paywallConfig?: PaywallConfig,
+  paywall?: PaywallProvider,
+  syncFacilitatorOnStart: boolean = true,
+): void {
+  const ResourceServer = new x402ResourceServer(facilitatorClients);
+
+  if (schemes) {
+    for (const { network, server: schemeServer } of schemes) {
+      ResourceServer.register(network, schemeServer);
+    }
+  }
+
+  paymentMiddleware(app, routes, ResourceServer, paywallConfig, paywall, syncFacilitatorOnStart);
+}
+
+export { x402ResourceServer, x402HTTPResourceServer } from "@x402/core/server";
+
+export type {
+  PaymentRequired,
+  PaymentRequirements,
+  PaymentPayload,
+  Network,
+  SchemeNetworkServer,
+} from "@x402/core/types";
+
+export type { PaywallProvider, PaywallConfig } from "@x402/core/server";
+
+export { RouteConfigurationError } from "@x402/core/server";
+
+export type { RouteValidationError } from "@x402/core/server";
+
+export { FastifyAdapter } from "./adapter";

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -32,6 +32,48 @@ interface X402PaymentContext {
 }
 
 /**
+ * Gets a header value from a plain header record using a case-insensitive lookup.
+ *
+ * @param headers - Headers to search
+ * @param headerName - Header name to find
+ * @returns Matching header value or undefined
+ */
+function getHeaderValue(headers: Record<string, string>, headerName: string): string | undefined {
+  const target = headerName.toLowerCase();
+  return Object.entries(headers).find(([key]) => key.toLowerCase() === target)?.[1];
+}
+
+/**
+ * Converts a Fastify onSend payload into the byte representation used for settlement.
+ *
+ * @param payload - Fastify payload
+ * @returns Buffer when the payload can be represented eagerly, otherwise undefined
+ */
+function getResponseBodyBuffer(payload: unknown): Buffer | undefined {
+  if (typeof payload === "string") {
+    return Buffer.from(payload);
+  }
+
+  if (Buffer.isBuffer(payload)) {
+    return payload;
+  }
+
+  if (payload instanceof Uint8Array) {
+    return Buffer.from(payload);
+  }
+
+  if (payload instanceof ArrayBuffer) {
+    return Buffer.from(new Uint8Array(payload));
+  }
+
+  if (payload && typeof payload === "object" && "pipe" in payload) {
+    return undefined;
+  }
+
+  return Buffer.from(JSON.stringify(payload ?? {}));
+}
+
+/**
  * Check if any routes in the configuration declare bazaar extensions.
  *
  * @param routes - Route configuration
@@ -181,9 +223,7 @@ export function paymentMiddlewareFromHTTPServer(
     }
 
     try {
-      const responseBody = Buffer.from(
-        typeof payload === "string" ? payload : JSON.stringify(payload ?? {}),
-      );
+      const responseBody = getResponseBodyBuffer(payload);
 
       const settleResult = await httpServer.processSettlement(
         x402Context.paymentPayload,
@@ -198,6 +238,10 @@ export function paymentMiddlewareFromHTTPServer(
           reply.header(key, value);
         }
         reply.status(response.status);
+        reply.type(
+          getHeaderValue(response.headers, "content-type") ||
+            (response.isHtml ? "text/html" : "application/json"),
+        );
         return response.isHtml ? String(response.body ?? "") : JSON.stringify(response.body ?? {});
       }
 
@@ -208,6 +252,7 @@ export function paymentMiddlewareFromHTTPServer(
     } catch (error) {
       console.error(error);
       reply.status(402);
+      reply.type("application/json");
       return JSON.stringify({});
     }
   });

--- a/typescript/packages/http/fastify/src/malformedPathBypass.test.ts
+++ b/typescript/packages/http/fastify/src/malformedPathBypass.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+import { paymentMiddleware } from "./index";
+import {
+  x402HTTPResourceServer,
+  x402ResourceServer,
+  type HTTPRequestContext,
+} from "@x402/core/server";
+
+type HookHandler = (...args: unknown[]) => Promise<unknown>;
+
+/**
+ * Captured hooks from a mock Fastify instance.
+ */
+interface CapturedHooks {
+  onRequest: HookHandler[];
+  onSend: HookHandler[];
+}
+
+/**
+ * Creates a mock Fastify instance that captures registered hooks.
+ *
+ * @returns Object containing the mock app and captured hooks.
+ */
+function createMockApp(): { app: FastifyInstance; hooks: CapturedHooks } {
+  const hooks: CapturedHooks = { onRequest: [], onSend: [] };
+
+  const app = {
+    addHook: vi.fn((name: string, handler: HookHandler) => {
+      if (name === "onRequest") hooks.onRequest.push(handler);
+      if (name === "onSend") hooks.onSend.push(handler);
+    }),
+  } as unknown as FastifyInstance;
+
+  return { app, hooks };
+}
+
+/**
+ * Creates a mock Fastify request for testing.
+ *
+ * @param options - Configuration options for the mock request.
+ * @param options.url - The request URL path.
+ * @param options.method - The HTTP method.
+ * @param options.headers - Request headers.
+ * @returns A mock Fastify request.
+ */
+function createMockRequest(
+  options: {
+    url?: string;
+    method?: string;
+    headers?: Record<string, string>;
+  } = {},
+): FastifyRequest {
+  return {
+    url: options.url || "/api/test",
+    method: options.method || "GET",
+    headers: options.headers || {},
+    query: {},
+    body: undefined,
+    protocol: "https",
+    hostname: "example.com",
+  } as unknown as FastifyRequest;
+}
+
+/**
+ * Creates a mock Fastify reply for testing.
+ *
+ * @returns A mock Fastify reply with tracking properties.
+ */
+function createMockReply(): FastifyReply & {
+  _status: number;
+  _headers: Record<string, string>;
+  _body: unknown;
+  _type: string | undefined;
+} {
+  const reply = {
+    _status: 200,
+    _headers: {} as Record<string, string>,
+    _body: undefined as unknown,
+    _type: undefined as string | undefined,
+    statusCode: 200,
+    header: vi.fn(function (this: typeof reply, key: string, value: string) {
+      this._headers[key] = value;
+      return this;
+    }),
+    status: vi.fn(function (this: typeof reply, code: number) {
+      this._status = code;
+      this.statusCode = code;
+      return this;
+    }),
+    type: vi.fn(function (this: typeof reply, contentType: string) {
+      this._type = contentType;
+      return this;
+    }),
+    send: vi.fn(function (this: typeof reply, body: unknown) {
+      this._body = body;
+      return this;
+    }),
+  };
+
+  return reply as unknown as typeof reply;
+}
+
+describe("paymentMiddleware malformed path bypass", () => {
+  let processSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    processSpy = vi
+      .spyOn(x402HTTPResourceServer.prototype, "processHTTPRequest")
+      .mockImplementation(async (context: HTTPRequestContext) => {
+        return {
+          type: "payment-error",
+          response: {
+            status: 402,
+            body: { error: "Payment required", path: context.path },
+            headers: {},
+            isHtml: false,
+          },
+        };
+      });
+  });
+
+  afterEach(() => {
+    processSpy.mockRestore();
+  });
+
+  it.each(["/paywall/some-param%", "/paywall/some-param%c0"])(
+    "does not skip payment check and returns 402 for %s",
+    async path => {
+      const routes = {
+        "/paywall/*": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00",
+            network: "eip155:8453",
+          },
+        },
+      };
+
+      const server = new x402ResourceServer();
+
+      const { app, hooks } = createMockApp();
+      paymentMiddleware(app, routes, server, undefined, undefined, false);
+
+      const request = createMockRequest({ url: path });
+      const reply = createMockReply();
+
+      await hooks.onRequest[0](request, reply);
+
+      expect(processSpy).toHaveBeenCalled();
+      expect(processSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ path }));
+      expect(reply._status).toBe(402);
+    },
+  );
+});

--- a/typescript/packages/http/fastify/tsconfig.json
+++ b/typescript/packages/http/fastify/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false
+  },
+  "include": ["src"]
+}

--- a/typescript/packages/http/fastify/tsup.config.ts
+++ b/typescript/packages/http/fastify/tsup.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "tsup";
+
+const baseConfig = {
+  entry: {
+    index: "src/index.ts",
+  },
+  dts: {
+    resolve: true,
+  },
+  sourcemap: true,
+  target: "node16",
+};
+
+export default defineConfig([
+  {
+    ...baseConfig,
+    format: "esm",
+    outDir: "dist/esm",
+    clean: true,
+  },
+  {
+    ...baseConfig,
+    format: "cjs",
+    outDir: "dist/cjs",
+    clean: false,
+  },
+]);

--- a/typescript/packages/http/fastify/vitest.config.ts
+++ b/typescript/packages/http/fastify/vitest.config.ts
@@ -1,0 +1,10 @@
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig(({ mode }) => ({
+  test: {
+    env: loadEnv(mode, process.cwd(), ""),
+  },
+  plugins: [tsconfigPaths({ projects: ["."] })],
+}));

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -277,6 +277,70 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(jiti@2.6.1)(jsdom@27.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
 
+  packages/http/fastify:
+    dependencies:
+      '@x402/core':
+        specifier: workspace:~
+        version: link:../../core
+      '@x402/extensions':
+        specifier: workspace:~
+        version: link:../../extensions
+      '@x402/paywall':
+        specifier: workspace:*
+        version: link:../paywall
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.34.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.18.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.49.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.34.0(jiti@2.6.1)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint@9.34.0(jiti@2.6.1))(prettier@3.5.2)
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.2
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.20.5
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.2
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.2)(vite@6.3.5(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(jiti@2.6.1)(jsdom@27.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
+
   packages/http/fetch:
     dependencies:
       '@x402/core':
@@ -2437,6 +2501,24 @@ packages:
     peerDependencies:
       typescript: 5.8.3
 
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
   '@gemini-wallet/core@0.2.0':
     resolution: {integrity: sha512-vv9aozWnKrrPWQ3vIFcWk7yta4hQW1Ie0fsNNPeXnjAxkbXr2hqMagEptLuMxpEP2W3mnRu05VDNKzcvAuuZDw==}
     peerDependencies:
@@ -2894,6 +2976,9 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4956,6 +5041,9 @@ packages:
       zod:
         optional: true
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -5106,6 +5194,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
 
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
@@ -5405,6 +5496,10 @@ packages:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   core-js-compat@3.45.1:
     resolution: {integrity: sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==}
 
@@ -5612,6 +5707,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
@@ -6013,6 +6112,9 @@ packages:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
     engines: {node: '> 0.1.90'}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -6030,8 +6132,14 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
@@ -6048,6 +6156,9 @@ packages:
 
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
+
+  fastify@5.8.2:
+    resolution: {integrity: sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -6086,6 +6197,10 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -6391,6 +6506,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -6656,6 +6775,9 @@ packages:
   json-rpc-random-id@1.0.1:
     resolution: {integrity: sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==}
 
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -6711,6 +6833,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -7128,6 +7253,10 @@ packages:
   on-exit-leak-free@0.2.0:
     resolution: {integrity: sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -7328,8 +7457,18 @@ packages:
   pino-abstract-transport@0.5.0:
     resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
   pino-std-serializers@4.0.0:
     resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pino@7.11.0:
     resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
@@ -7449,6 +7588,12 @@ packages:
   process-warning@1.0.0:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -7562,6 +7707,10 @@ packages:
     resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
     engines: {node: '>= 12.13.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -7625,9 +7774,16 @@ packages:
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rollup@4.50.0:
     resolution: {integrity: sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==}
@@ -7665,6 +7821,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-regex2@5.0.0:
+    resolution: {integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==}
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -7678,6 +7837,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -7711,6 +7873,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -7789,6 +7954,9 @@ packages:
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -7988,6 +8156,10 @@ packages:
   thread-stream@0.15.2:
     resolution: {integrity: sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==}
 
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -8035,6 +8207,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -8842,7 +9018,7 @@ snapshots:
       '@babel/traverse': 7.28.3
       '@babel/types': 7.28.2
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -9964,7 +10140,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.50.2':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.42.0
+      '@typescript-eslint/types': 8.49.0
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.1.0
@@ -10057,7 +10233,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10164,6 +10340,29 @@ snapshots:
       jose: 5.10.0
       typescript: 5.9.2
       zod: 3.25.76
+
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.1.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
 
   '@gemini-wallet/core@0.2.0(viem@2.37.3(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
@@ -10508,7 +10707,7 @@ snapshots:
       '@paulmillr/qr': 0.2.1
       bowser: 2.12.1
       cross-fetch: 4.1.0
-      debug: 4.4.1
+      debug: 4.4.3
       eciesjs: 0.4.15
       eth-rpc-errors: 4.0.3
       eventemitter2: 6.4.9
@@ -10721,6 +10920,8 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@paulmillr/qr@0.2.1': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -13489,7 +13690,7 @@ snapshots:
       '@typescript-eslint/types': 8.42.0
       '@typescript-eslint/typescript-estree': 8.42.0(typescript@5.9.2)
       '@typescript-eslint/utils': 8.42.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.34.0(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.9.2)
       typescript: 5.9.2
@@ -13655,7 +13856,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.18
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 6.3.5(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
 
@@ -13672,7 +13873,7 @@ snapshots:
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.18
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/spy@3.2.4':
@@ -14572,6 +14773,8 @@ snapshots:
       typescript: 5.9.2
       zod: 3.25.76
 
+  abstract-logging@2.0.1: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -14733,6 +14936,11 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.19.1
 
   axe-core@4.10.3: {}
 
@@ -15037,6 +15245,8 @@ snapshots:
 
   cookie@0.7.1: {}
 
+  cookie@1.1.1: {}
+
   core-js-compat@3.45.1:
     dependencies:
       browserslist: 4.25.4
@@ -15221,6 +15431,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.1.12)(react@19.2.1)):
     dependencies:
@@ -15524,12 +15736,12 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.34.0(jiti@2.6.1)
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.42.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.34.0(jiti@2.6.1))
@@ -15620,13 +15832,13 @@ snapshots:
       '@es-joy/jsdoccomment': 0.50.2
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.1
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint: 9.34.0(jiti@2.6.1)
       espree: 10.4.0
       esquery: 1.6.0
       parse-imports-exports: 0.2.4
-      semver: 7.7.2
+      semver: 7.7.3
       spdx-expression-parse: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -15717,7 +15929,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.3
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -15913,6 +16125,8 @@ snapshots:
 
   eyes@0.1.8: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -15935,7 +16149,20 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
 
   fast-redact@3.5.0: {}
 
@@ -15946,6 +16173,24 @@ snapshots:
   fast-uri@3.1.0: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
+
+  fastify@5.8.2:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.3
+      toad-cache: 3.7.0
 
   fastq@1.19.1:
     dependencies:
@@ -15993,6 +16238,12 @@ snapshots:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.0.0
 
   find-up@4.1.0:
     dependencies:
@@ -16321,6 +16572,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.3.0: {}
+
   iron-webcrypto@1.2.1: {}
 
   is-arguments@1.2.0:
@@ -16614,6 +16867,10 @@ snapshots:
 
   json-rpc-random-id@1.0.1: {}
 
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -16665,6 +16922,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -17013,6 +17276,8 @@ snapshots:
 
   on-exit-leak-free@0.2.0: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -17259,7 +17524,27 @@ snapshots:
       duplexify: 4.1.3
       split2: 4.2.0
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-std-serializers@4.0.0: {}
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
 
   pino@7.11.0:
     dependencies:
@@ -17371,6 +17656,10 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@1.0.0: {}
+
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -17495,6 +17784,8 @@ snapshots:
 
   real-require@0.1.0: {}
 
+  real-require@0.2.0: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.8
@@ -17566,7 +17857,11 @@ snapshots:
     dependencies:
       lowercase-keys: 2.0.0
 
+  ret@0.5.0: {}
+
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rollup@4.50.0:
     dependencies:
@@ -17647,6 +17942,10 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-regex2@5.0.0:
+    dependencies:
+      ret: 0.5.0
+
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
@@ -17656,6 +17955,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
 
@@ -17716,6 +18017,8 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -17851,6 +18154,10 @@ snapshots:
       - supports-color
 
   sonic-boom@2.8.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
 
@@ -18058,6 +18365,10 @@ snapshots:
     dependencies:
       real-require: 0.1.0
 
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -18101,6 +18412,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
 
@@ -18514,7 +18827,7 @@ snapshots:
   vite-node@3.2.4(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.5(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
@@ -18550,7 +18863,7 @@ snapshots:
       picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.50.0
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.18.0
       fsevents: 2.3.3
@@ -18570,15 +18883,15 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.1
+      debug: 4.4.3
       expect-type: 1.2.2
-      magic-string: 0.30.18
+      magic-string: 0.30.21
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.3.5(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -288,9 +288,6 @@ importers:
       '@x402/paywall':
         specifier: workspace:*
         version: link:../paywall
-      zod:
-        specifier: ^3.24.2
-        version: 3.25.76
     devDependencies:
       '@eslint/js':
         specifier: ^9.24.0


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->
## Description

  Adds `@x402/fastify`, a Fastify framework adapter for the x402 payment protocol.

  This package integrates x402 payment verification and settlement with Fastify using `onRequest` and
  `onSend`, following the same overall adapter model as the existing Express and Hono packages.

  It includes:
  - `FastifyAdapter` implementing the `HTTPAdapter` interface
  - `paymentMiddleware`, `paymentMiddlewareFromHTTPServer`, and `paymentMiddlewareFromConfig`
  - a Fastify example app under `examples/typescript/servers/fastify/`

  This branch also includes follow-up fixes for Fastify response handling:
  - preserve raw response bytes during settlement for binary payloads
  - reset `Content-Type` when settlement replaces the response body
  - preserve host ports in generated resource URLs

  ## Tests

  Unit tests cover:
  - `FastifyAdapter`
  - payment middleware hook behavior (`onRequest` / `onSend`)
  - settlement success and failure flows
  - error handling
  - malformed path bypass
  - binary payload settlement regression coverage
  - host-with-port URL reconstruction

  ```bash
  pnpm --filter @x402/fastify test
  pnpm --filter @x402/fastify lint:check
  pnpm --filter @x402/fastify build
```

  ## Checklist

  - [x] I have formatted and linted my code
  - [x] All new and existing tests pass
  - [x] My commits are signed
  - [x] I added a changelog fragment for user-facing changes