### PR TITLE
feat(svm): add simulation-based smart wallet verification

### DIFF
--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -37,9 +37,116 @@ import {
   getTokenPayerFromTransaction,
   transactionMessageHash,
 } from "../../utils";
+import { verifySmartWalletTransaction, verifyPostSettlement } from "./smartWalletVerification";
+
+/**
+ * Default allowed smart wallet program addresses.
+ * Only these programs can reach Path 2 (simulation-based verification).
+ * Operators can override via smartWalletAllowedPrograms in options.
+ */
+const DEFAULT_SMART_WALLET_ALLOWED_PROGRAMS = [
+  "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf", // Squads Multisig v4
+  "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG", // Squads Smart Account
+  "SWiGmQedKzMz1tiTqoJCWeGDnGXfNBp2PkXLkpCAtQo", // Swig
+  "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw", // SPL Governance
+  "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d", // Metaplex Core
+  LIGHTHOUSE_PROGRAM_ADDRESS, // Phantom's wallet-protection assertions (see #2097)
+];
+
+/**
+ * Which verification path produced a successful result.
+ * Returned by the internal _verify so settle() knows whether post-settlement
+ * TOCTOU verification is required, without re-deriving it from the transaction.
+ */
+type VerificationPath = "static" | "smartWallet";
+
+/**
+ * Internal verify result that also reports which path succeeded.
+ * verificationPath is null when verification failed.
+ */
+type VerifyResult = {
+  response: VerifyResponse;
+  verificationPath: VerificationPath | null;
+};
+
+/**
+ * Path 1 failure reasons that indicate a transaction layout a standard-wallet
+ * parser could not handle — extra/unknown instructions, unexpected counts, or
+ * a missing positional transfer. These are the only cases where falling through
+ * to Path 2 (simulation) can legitimately recover the payment, because the
+ * transfer may simply be wrapped in a smart-wallet CPI.
+ *
+ * Reasons NOT in this set are semantic rejections (amount/mint/recipient/memo
+ * mismatch, self-spend, failed simulation). Those describe a transaction that
+ * is genuinely invalid for this payment, so Path 2 must not run — doing so would
+ * mask the real reason behind a misleading smart_wallet_* error code.
+ */
+const LAYOUT_RECOVERABLE_REASONS = new Set<string>([
+  "invalid_exact_svm_payload_transaction_instructions_length",
+  "invalid_exact_svm_payload_no_transfer_instruction",
+  "invalid_exact_svm_payload_unknown_fourth_instruction",
+  "invalid_exact_svm_payload_unknown_fifth_instruction",
+  "invalid_exact_svm_payload_unknown_sixth_instruction",
+  "invalid_exact_svm_payload_unknown_optional_instruction",
+  "invalid_exact_svm_payload_transaction_instructions_compute_limit_instruction",
+  "invalid_exact_svm_payload_transaction_instructions_compute_price_instruction",
+]);
+
+/**
+ * Configuration options for ExactSvmScheme.
+ */
+export type ExactSvmSchemeOptions = {
+  /**
+   * Enable simulation-based smart wallet verification.
+   * When enabled, transactions rejected by the static validation path
+   * (unknown programs, wrong instruction count) are re-verified using
+   * simulation inner instruction analysis. Works for any smart wallet
+   * program (Squads, Swig, SPL Governance, etc.) without per-wallet parsers.
+   *
+   * Default: false (only standard wallet transactions are accepted)
+   */
+  enableSmartWalletVerification?: boolean;
+
+  /**
+   * Maximum compute units allowed for smart wallet transactions.
+   * Smart wallet programs need more CU for CPI overhead.
+   * Only applies when enableSmartWalletVerification is true.
+   *
+   * Default: 400,000
+   */
+  smartWalletMaxComputeUnits?: number;
+
+  /**
+   * Maximum priority fee in microlamports for smart wallet transactions.
+   * Only applies when enableSmartWalletVerification is true.
+   *
+   * Default: 50,000
+   */
+  smartWalletMaxPriorityFeeMicroLamports?: number;
+
+  /**
+   * Allowed smart wallet program addresses for Path 2 verification.
+   * Only transactions whose top-level non-ComputeBudget instruction invokes
+   * a program in this list will be accepted through the simulation path.
+   * Prevents unknown/malicious programs from reaching CPI verification.
+   *
+   * Default: Squads Multisig v4, Squads Smart Account, Swig, SPL Governance, Metaplex Core
+   */
+  smartWalletAllowedPrograms?: string[];
+};
 
 /**
  * SVM facilitator implementation for the Exact payment scheme.
+ *
+ * Dual-path verification:
+ *
+ * Path 1 (Static): Strict positional instruction validation for standard wallets.
+ *   Fast, preserves existing behavior.
+ *
+ * Path 2 (Simulation): Outcome-based verification for smart wallets.
+ *   When Path 1 rejects a transaction and smart wallet verification is enabled,
+ *   falls back to simulation-based validation that inspects CPI inner instructions.
+ *   Works for any wallet program that executes TransferChecked via CPI.
  */
 export class ExactSvmScheme implements SchemeNetworkFacilitator {
   readonly scheme = "exact";
@@ -48,17 +155,39 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
   private readonly settlementCache: SettlementCache;
 
   /**
-   * Creates a new ExactSvmFacilitator instance.
+   * Creates a new ExactSvmScheme instance.
    *
-   * @param signer - The SVM RPC client for facilitator operations
+   * @param signer - The SVM signer for facilitator operations
    * @param settlementCache - Optional shared settlement cache (one is created if omitted)
-   * @returns ExactSvmFacilitator instance
+   * @param options - Optional configuration for smart wallet verification
    */
   constructor(
     private readonly signer: FacilitatorSvmSigner,
     settlementCache?: SettlementCache,
+    private readonly options?: ExactSvmSchemeOptions,
   ) {
     this.settlementCache = settlementCache ?? new SettlementCache();
+
+    if (this.options?.enableSmartWalletVerification) {
+      // fetchAddressLookupTables is required too: assertFeePayerIsolated can't
+      // inspect ALT-resolved accounts without it, so an ALT-using wallet would
+      // otherwise fail at verify time rather than at construction.
+      const required = [
+        "simulateTransactionWithInnerInstructions",
+        "getConfirmedTransactionInnerInstructions",
+        "getTokenAccountBalance",
+        "fetchAddressLookupTables",
+      ] as const;
+
+      for (const method of required) {
+        if (typeof (this.signer as Record<string, unknown>)[method] !== "function") {
+          throw new Error(
+            `enableSmartWalletVerification requires ${method} on the signer. ` +
+              `Use toFacilitatorSvmSigner() which provides all required methods.`,
+          );
+        }
+      }
+    }
   }
 
   /**
@@ -74,9 +203,11 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     const addresses = this.signer.getAddresses();
     const randomIndex = Math.floor(Math.random() * addresses.length);
 
-    return {
-      feePayer: addresses[randomIndex],
-    };
+    const extra: Record<string, unknown> = { feePayer: addresses[randomIndex] };
+    if (this.options?.enableSmartWalletVerification) {
+      extra.features = { smartWalletSupported: true };
+    }
+    return extra;
   }
 
   /**
@@ -101,30 +232,191 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     payload: PaymentPayload,
     requirements: PaymentRequirements,
   ): Promise<VerifyResponse> {
+    const { response } = await this._verify(payload, requirements);
+    return response;
+  }
+
+  /**
+   * Settles a payment by submitting the transaction.
+   * Ensures the correct signer is used based on the feePayer specified in requirements.
+   *
+   * @param payload - The payment payload to settle
+   * @param requirements - The payment requirements
+   * @returns Promise resolving to settlement response
+   */
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    const exactSvmPayload = payload.payload as ExactSvmPayloadV2;
+
+    const { response: valid, verificationPath } = await this._verify(payload, requirements);
+    if (!valid.isValid) {
+      return {
+        success: false,
+        network: payload.accepted.network,
+        transaction: "",
+        errorReason: valid.invalidReason ?? "verification_failed",
+        payer: valid.payer || "",
+      };
+    }
+
+    // Decode the transaction to compute the message hash used as the cache key.
+    // Must remain synchronous (before any await) so concurrent settle calls for
+    // the same payment are caught before any async work begins.
+    const decodedTx = decodeTransactionFromPayload(exactSvmPayload);
+
+    // Duplicate settlement check keyed on message hash (immune to mutable fee-payer sig at slot 0).
+    const txKey = transactionMessageHash(decodedTx);
+    if (this.settlementCache.isDuplicate(txKey)) {
+      return {
+        success: false,
+        network: payload.accepted.network,
+        transaction: "",
+        errorReason: "duplicate_settlement",
+        payer: valid.payer || "",
+      };
+    }
+
+    // Settlements verified through Path 2 (smart wallet) require post-settlement
+    // verification to defend against TOCTOU. _verify reports the path directly,
+    // so we no longer re-decode the transaction to infer it.
+    const isSmartWalletSettlement = verificationPath === "smartWallet";
+
+    // For smart wallet settlements: record destination ATA balance before sending.
+    // Used as fallback verification if getTransaction has indexing lag.
+    // Try both SPL Token and Token-2022 programs — the payment may use either.
+    let balanceBefore: bigint | null = null;
+    let balanceBeforeTokenProgram:
+      | typeof TOKEN_PROGRAM_ADDRESS
+      | typeof TOKEN_2022_PROGRAM_ADDRESS
+      | null = null;
+    if (isSmartWalletSettlement && typeof this.signer.getTokenAccountBalance === "function") {
+      for (const tokenProgram of [TOKEN_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS]) {
+        try {
+          const [destinationAta] = await findAssociatedTokenPda({
+            mint: requirements.asset as Address,
+            owner: requirements.payTo as Address,
+            tokenProgram: tokenProgram as unknown as Address,
+          });
+          const balance = await this.signer.getTokenAccountBalance(
+            destinationAta.toString(),
+            requirements.network,
+          );
+          if (balance !== null) {
+            balanceBefore = balance;
+            balanceBeforeTokenProgram = tokenProgram;
+            break; // Use whichever ATA has a balance (exists on-chain)
+          }
+        } catch {
+          // ATA doesn't exist for this token program. Try the other.
+        }
+      }
+    }
+
+    try {
+      // Extract feePayer from requirements (already validated in verify)
+      const feePayer = requirements.extra.feePayer as Address;
+
+      // Sign transaction with the feePayer's signer
+      const fullySignedTransaction = await this.signer.signTransaction(
+        exactSvmPayload.transaction,
+        feePayer,
+        requirements.network,
+      );
+
+      // Send transaction to network
+      const signature = await this.signer.sendTransaction(
+        fullySignedTransaction,
+        requirements.network,
+      );
+
+      // Wait for confirmation
+      await this.signer.confirmTransaction(signature, requirements.network);
+
+      // Post-settlement verification for smart wallet transactions.
+      // Confirms the TransferChecked actually executed on-chain (TOCTOU defense).
+      if (isSmartWalletSettlement) {
+        const signerAddresses = this.signer.getAddresses().map(a => a.toString());
+        const postVerify = await verifyPostSettlement(
+          this.signer,
+          signature,
+          requirements.network,
+          requirements,
+          signerAddresses,
+          balanceBefore,
+          balanceBeforeTokenProgram?.toString() ?? null,
+        );
+
+        if (!postVerify.verified) {
+          return {
+            success: false,
+            errorReason: "post_settlement_transfer_not_confirmed",
+            transaction: signature,
+            network: payload.accepted.network,
+            payer: valid.payer || "",
+          };
+        }
+      }
+
+      return {
+        success: true,
+        transaction: signature,
+        network: payload.accepted.network,
+        payer: valid.payer,
+      };
+    } catch (error) {
+      console.error("Failed to settle transaction:", error);
+      return {
+        success: false,
+        errorReason: "transaction_failed",
+        transaction: "",
+        network: payload.accepted.network,
+        payer: valid.payer || "",
+      };
+    }
+  }
+
+  /**
+   * Internal verification that also reports which path validated the payment.
+   *
+   * settle() consumes verificationPath to decide whether post-settlement TOCTOU
+   * verification is required, instead of re-decoding the transaction and
+   * inferring the path from a missing token payer.
+   *
+   * @param payload - The payment payload to verify
+   * @param requirements - The payment requirements
+   * @returns Verify response plus the path that succeeded (null on failure)
+   */
+  private async _verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResult> {
     const exactSvmPayload = payload.payload as ExactSvmPayloadV2;
 
     // Step 1: Validate Payment Requirements
     if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
       return {
-        isValid: false,
-        invalidReason: "unsupported_scheme",
-        payer: "",
+        response: { isValid: false, invalidReason: "unsupported_scheme", payer: "" },
+        verificationPath: null,
       };
     }
 
     if (payload.accepted.network !== requirements.network) {
       return {
-        isValid: false,
-        invalidReason: "network_mismatch",
-        payer: "",
+        response: { isValid: false, invalidReason: "network_mismatch", payer: "" },
+        verificationPath: null,
       };
     }
 
     if (!requirements.extra?.feePayer || typeof requirements.extra.feePayer !== "string") {
       return {
-        isValid: false,
-        invalidReason: "invalid_exact_svm_payload_missing_fee_payer",
-        payer: "",
+        response: {
+          isValid: false,
+          invalidReason: "invalid_exact_svm_payload_missing_fee_payer",
+          payer: "",
+        },
+        verificationPath: null,
       };
     }
 
@@ -132,9 +424,12 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     const signerAddresses = this.signer.getAddresses().map(addr => addr.toString());
     if (!signerAddresses.includes(requirements.extra.feePayer)) {
       return {
-        isValid: false,
-        invalidReason: "fee_payer_not_managed_by_facilitator",
-        payer: "",
+        response: {
+          isValid: false,
+          invalidReason: "fee_payer_not_managed_by_facilitator",
+          payer: "",
+        },
+        verificationPath: null,
       };
     }
 
@@ -144,23 +439,129 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       transaction = decodeTransactionFromPayload(exactSvmPayload);
     } catch {
       return {
-        isValid: false,
-        invalidReason: "invalid_exact_svm_payload_transaction_could_not_be_decoded",
-        payer: "",
+        response: {
+          isValid: false,
+          invalidReason: "invalid_exact_svm_payload_transaction_could_not_be_decoded",
+          payer: "",
+        },
+        verificationPath: null,
       };
     }
 
+    // ─── Path 1: Static validation (standard wallets) ───────────────────
+    const staticResult = await this.verifyStaticPath(
+      transaction,
+      exactSvmPayload,
+      requirements,
+      signerAddresses,
+    );
+
+    if (staticResult.isValid) {
+      return { response: staticResult, verificationPath: "static" };
+    }
+
+    // ─── Path 2: Simulation-based verification (smart wallets) ──────────
+    // Only fall through to Path 2 when Path 1 failed for a recoverable layout
+    // reason (extra/unknown instructions, unexpected count, missing positional
+    // transfer). A semantic rejection — wrong amount/mint/recipient/memo,
+    // self-spend, or a genuinely failing simulation — describes a transaction
+    // that is invalid for this payment regardless of wallet type, so Path 2 must
+    // not run; doing so would mask the real reason behind a smart_wallet_* code.
+    const staticReasonRecoverable =
+      typeof staticResult.invalidReason === "string" &&
+      LAYOUT_RECOVERABLE_REASONS.has(staticResult.invalidReason);
+
+    if (this.options?.enableSmartWalletVerification && staticReasonRecoverable) {
+      // Program allowlist: only known, audited smart wallet programs can reach Path 2.
+      // This prevents custom malicious programs from exploiting the simulation path.
+      const allowedPrograms = new Set(
+        this.options.smartWalletAllowedPrograms ?? DEFAULT_SMART_WALLET_ALLOWED_PROGRAMS,
+      );
+
+      const compiled = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
+      const decompiledForCheck = decompileTransactionMessage(compiled);
+      // ComputeBudget and Memo are category-exempt: compute budget is validated
+      // by caps, and memo content is verified by Path 2's Step 4a. Neither is a
+      // wallet program, so they must not be subject to the wallet-program
+      // allowlist. Explicit for-loop instead of .map().filter() because strict
+      // TypeScript inference on decompileTransactionMessage's return type is
+      // sensitive to which @solana/kit version resolves across peer deps.
+      const rawInstructions = (decompiledForCheck.instructions ?? []) as ReadonlyArray<{
+        programAddress: { toString(): string };
+      }>;
+      const topLevelPrograms: string[] = [];
+      for (const ix of rawInstructions) {
+        const addr = ix.programAddress.toString();
+        if (addr === COMPUTE_BUDGET_PROGRAM_ADDRESS.toString() || addr === MEMO_PROGRAM_ADDRESS) {
+          continue;
+        }
+        topLevelPrograms.push(addr);
+      }
+
+      const disallowedProgram = topLevelPrograms.find(addr => !allowedPrograms.has(addr));
+      if (disallowedProgram) {
+        return {
+          response: {
+            isValid: false,
+            invalidReason: `smart_wallet_program_not_allowed: ${disallowedProgram}`,
+            payer: "",
+          },
+          verificationPath: null,
+        };
+      }
+
+      const feePayer = requirements.extra.feePayer;
+      const smartWalletResult = await verifySmartWalletTransaction(
+        exactSvmPayload.transaction,
+        requirements,
+        this.signer,
+        feePayer,
+        signerAddresses,
+        {
+          enabled: true,
+          maxComputeUnits: this.options.smartWalletMaxComputeUnits,
+          maxPriorityFeeMicroLamports: this.options.smartWalletMaxPriorityFeeMicroLamports,
+        },
+      );
+      return {
+        response: smartWalletResult,
+        verificationPath: smartWalletResult.isValid ? "smartWallet" : null,
+      };
+    }
+
+    return { response: staticResult, verificationPath: null };
+  }
+
+  /**
+   * Path 1: Static instruction-layout verification for standard wallets.
+   * Validates positional instruction structure, program allowlist, and
+   * transfer details. Unchanged from the original implementation.
+   *
+   * @param transaction - Decoded transaction to verify
+   * @param exactSvmPayload - The raw SVM payload containing the base64 transaction
+   * @param requirements - Payment requirements to verify against
+   * @param signerAddresses - Facilitator signer addresses (for self-spend protection)
+   * @returns Verification result
+   */
+  private async verifyStaticPath(
+    transaction: ReturnType<typeof decodeTransactionFromPayload>,
+    exactSvmPayload: ExactSvmPayloadV2,
+    requirements: PaymentRequirements,
+    signerAddresses: string[],
+  ): Promise<VerifyResponse> {
     const compiled = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
     const decompiled = decompileTransactionMessage(compiled);
     const instructions = decompiled.instructions ?? [];
 
-    // Allow 3-6 instructions:
+    // Allow 3-7 instructions:
     // - 3 instructions: ComputeLimit + ComputePrice + TransferChecked
     // - 4 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse or Memo
     // - 5 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse + Lighthouse or Memo
     // - 6 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse + Lighthouse + Memo
+    // - 7 instructions: + a third wallet-injected Lighthouse (Phantom, see #2097)
     // See: https://github.com/x402-foundation/x402/issues/828
-    if (instructions.length < 3 || instructions.length > 6) {
+    //  and: https://github.com/x402-foundation/x402/issues/2097
+    if (instructions.length < 3 || instructions.length > 7) {
       return {
         isValid: false,
         invalidReason: "invalid_exact_svm_payload_transaction_instructions_length",
@@ -286,6 +687,7 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       "invalid_exact_svm_payload_unknown_fourth_instruction",
       "invalid_exact_svm_payload_unknown_fifth_instruction",
       "invalid_exact_svm_payload_unknown_sixth_instruction",
+      "invalid_exact_svm_payload_unknown_seventh_instruction",
     ];
 
     for (let i = 0; i < optionalInstructions.length; i += 1) {
@@ -332,16 +734,14 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     // Step 6: Sign and Simulate Transaction
     // CRITICAL: Simulation proves transaction will succeed (catches insufficient balance, invalid accounts, etc)
     try {
-      const feePayer = requirements.extra.feePayer as Address;
+      const feePayer = requirements.extra!.feePayer as Address;
 
-      // Sign transaction with the feePayer's signer
       const fullySignedTransaction = await this.signer.signTransaction(
         exactSvmPayload.transaction,
         feePayer,
         requirements.network,
       );
 
-      // Simulate to verify transaction would succeed
       await this.signer.simulateTransaction(fullySignedTransaction, requirements.network);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -358,86 +758,6 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       invalidReason: undefined,
       payer,
     };
-  }
-
-  /**
-   * Settles a payment by submitting the transaction.
-   * Ensures the correct signer is used based on the feePayer specified in requirements.
-   *
-   * @param payload - The payment payload to settle
-   * @param requirements - The payment requirements
-   * @returns Promise resolving to settlement response
-   */
-  async settle(
-    payload: PaymentPayload,
-    requirements: PaymentRequirements,
-  ): Promise<SettleResponse> {
-    const exactSvmPayload = payload.payload as ExactSvmPayloadV2;
-
-    const valid = await this.verify(payload, requirements);
-    if (!valid.isValid) {
-      return {
-        success: false,
-        network: payload.accepted.network,
-        transaction: "",
-        errorReason: valid.invalidReason ?? "verification_failed",
-        payer: valid.payer || "",
-      };
-    }
-
-    // Decode the transaction to compute the message hash used as the cache key.
-    // Must remain synchronous (before any await) so concurrent settle calls for
-    // the same payment are caught before any async work begins.
-    const decodedTx = decodeTransactionFromPayload(exactSvmPayload);
-
-    // Duplicate settlement check keyed on message hash (immune to mutable fee-payer sig at slot 0).
-    const txKey = transactionMessageHash(decodedTx);
-    if (this.settlementCache.isDuplicate(txKey)) {
-      return {
-        success: false,
-        network: payload.accepted.network,
-        transaction: "",
-        errorReason: "duplicate_settlement",
-        payer: valid.payer || "",
-      };
-    }
-
-    try {
-      // Extract feePayer from requirements (already validated in verify)
-      const feePayer = requirements.extra.feePayer as Address;
-
-      // Sign transaction with the feePayer's signer
-      const fullySignedTransaction = await this.signer.signTransaction(
-        exactSvmPayload.transaction,
-        feePayer,
-        requirements.network,
-      );
-
-      // Send transaction to network
-      const signature = await this.signer.sendTransaction(
-        fullySignedTransaction,
-        requirements.network,
-      );
-
-      // Wait for confirmation
-      await this.signer.confirmTransaction(signature, requirements.network);
-
-      return {
-        success: true,
-        transaction: signature,
-        network: payload.accepted.network,
-        payer: valid.payer,
-      };
-    } catch (error) {
-      console.error("Failed to settle transaction:", error);
-      return {
-        success: false,
-        errorReason: "transaction_failed",
-        transaction: "",
-        network: payload.accepted.network,
-        payer: valid.payer || "",
-      };
-    }
   }
 
   /**

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/smartWalletVerification.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/smartWalletVerification.ts
@@ -1,0 +1,612 @@
+/**
+ * Smart wallet verification via simulation-based outcome analysis.
+ *
+ * Instead of parsing proprietary smart wallet instruction formats, this module
+ * verifies payment outcomes by inspecting the CPI trace from transaction simulation.
+ * Works for any smart wallet program (Squads, Swig, SPL Governance, etc.) that
+ * ultimately executes a TransferChecked via CPI.
+ */
+
+import { COMPUTE_BUDGET_PROGRAM_ADDRESS } from "@solana-program/compute-budget";
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import { TOKEN_2022_PROGRAM_ADDRESS, findAssociatedTokenPda } from "@solana-program/token-2022";
+import {
+  decompileTransactionMessage,
+  getBase58Encoder,
+  getCompiledTransactionMessageDecoder,
+  type Address,
+  type Transaction,
+} from "@solana/kit";
+import type { PaymentRequirements, VerifyResponse } from "@x402/core/types";
+import { MEMO_PROGRAM_ADDRESS } from "../../constants";
+import type { FacilitatorSvmSigner, SvmInnerInstructionsResult } from "../../signer";
+import { decodeTransactionFromPayload } from "../../utils";
+
+const DEFAULT_SMART_WALLET_MAX_COMPUTE_UNITS = 400_000;
+const DEFAULT_SMART_WALLET_MAX_PRIORITY_FEE_MICROLAMPORTS = 50_000;
+
+const IX_SET_COMPUTE_UNIT_LIMIT = 2;
+const IX_SET_COMPUTE_UNIT_PRICE = 3;
+const IX_TOKEN_TRANSFER_CHECKED = 12;
+
+const TOKEN_PROGRAMS = new Set([
+  TOKEN_PROGRAM_ADDRESS.toString(),
+  TOKEN_2022_PROGRAM_ADDRESS.toString(),
+]);
+
+export type TransferCheckedInfo = {
+  programId: string;
+  amount: bigint;
+  mint: string;
+  destination: string;
+  authority: string;
+};
+
+/**
+ * Asserts the fee payer does NOT appear in any instruction's accounts or as a
+ * program ID. If the fee payer is never referenced in any instruction, the
+ * Solana runtime cannot authorize it for token transfers, account creation,
+ * approvals, or any operation that requires a signer in the accounts list.
+ * The fee payer only pays the transaction fee automatically.
+ *
+ * @param transaction - Decoded transaction to inspect
+ * @param feePayerAddress - Facilitator fee payer address that must remain isolated
+ * @param signer - Optional facilitator signer for resolving Address Lookup Tables
+ * @param network - Optional CAIP-2 network identifier for ALT resolution RPC calls
+ */
+export async function assertFeePayerIsolated(
+  transaction: Transaction,
+  feePayerAddress: string,
+  signer?: FacilitatorSvmSigner,
+  network?: string,
+): Promise<void> {
+  const compiled = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
+
+  // Check if transaction uses Address Lookup Tables
+  const hasALTs =
+    "addressTableLookups" in compiled &&
+    Array.isArray(compiled.addressTableLookups) &&
+    compiled.addressTableLookups.length > 0;
+
+  let decompiled;
+  if (hasALTs) {
+    // Resolve ALTs before decompiling so all accounts are visible
+    if (!signer || !network || typeof signer.fetchAddressLookupTables !== "function") {
+      throw new Error(
+        "smart_wallet_alt_resolution_not_available: transaction uses Address Lookup Tables " +
+          "but signer does not implement fetchAddressLookupTables",
+      );
+    }
+
+    const altAddresses = (
+      compiled.addressTableLookups as Array<{ lookupTableAddress: string }>
+    ).map(l => l.lookupTableAddress.toString());
+    const resolved = await signer.fetchAddressLookupTables(altAddresses, network);
+
+    // Convert to the format decompileTransactionMessage expects
+    const addressesByLookupTableAddress: Record<string, Array<Address>> = {};
+    for (const [key, addresses] of Object.entries(resolved)) {
+      addressesByLookupTableAddress[key] = addresses.map(a => a as Address);
+    }
+
+    decompiled = decompileTransactionMessage(compiled, { addressesByLookupTableAddress });
+  } else {
+    decompiled = decompileTransactionMessage(compiled);
+  }
+
+  const instructions = decompiled.instructions ?? [];
+
+  for (const ix of instructions) {
+    if (ix.programAddress.toString() === feePayerAddress) {
+      throw new Error(
+        `smart_wallet_fee_payer_not_isolated: fee payer ${feePayerAddress} invoked as program`,
+      );
+    }
+
+    const accounts = ix.accounts ?? [];
+    for (const account of accounts) {
+      if (account.address.toString() === feePayerAddress) {
+        throw new Error(
+          `smart_wallet_fee_payer_not_isolated: fee payer ${feePayerAddress} appears in instruction accounts (program: ${ix.programAddress})`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Validates ComputeBudget instructions without enforcing a program allowlist.
+ * Caps compute units and priority fees to bound the facilitator's fee exposure.
+ *
+ * @param transaction - Decoded transaction to inspect
+ * @param limits - Optional operator-provided overrides for compute budget caps
+ * @param limits.maxComputeUnits - Maximum allowed compute units
+ * @param limits.maxPriorityFeeMicroLamports - Maximum allowed priority fee in microlamports
+ */
+export function validateComputeBudgetLimits(
+  transaction: Transaction,
+  limits?: { maxComputeUnits?: number; maxPriorityFeeMicroLamports?: number },
+): void {
+  const maxCU = limits?.maxComputeUnits ?? DEFAULT_SMART_WALLET_MAX_COMPUTE_UNITS;
+  const maxPriorityFee =
+    limits?.maxPriorityFeeMicroLamports ?? DEFAULT_SMART_WALLET_MAX_PRIORITY_FEE_MICROLAMPORTS;
+
+  const compiled = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
+  const decompiled = decompileTransactionMessage(compiled);
+  const instructions = decompiled.instructions ?? [];
+
+  for (const ix of instructions) {
+    if (ix.programAddress.toString() !== COMPUTE_BUDGET_PROGRAM_ADDRESS.toString()) continue;
+    const data = ix.data;
+    if (!data || data.length === 0) {
+      throw new Error("smart_wallet_malformed_compute_budget: empty instruction data");
+    }
+
+    if (data[0] === IX_SET_COMPUTE_UNIT_LIMIT) {
+      if (data.length < 5) {
+        throw new Error("smart_wallet_malformed_compute_limit");
+      }
+      const units = new DataView(data.buffer, data.byteOffset, data.byteLength).getUint32(1, true);
+      if (units > maxCU) {
+        throw new Error(`smart_wallet_compute_units_too_high: ${units} exceeds max ${maxCU}`);
+      }
+      continue;
+    }
+
+    if (data[0] === IX_SET_COMPUTE_UNIT_PRICE) {
+      if (data.length < 9) {
+        throw new Error("smart_wallet_malformed_compute_price");
+      }
+      const microLamports = new DataView(
+        data.buffer,
+        data.byteOffset,
+        data.byteLength,
+      ).getBigUint64(1, true);
+      if (microLamports > BigInt(maxPriorityFee)) {
+        throw new Error(
+          `smart_wallet_priority_fee_too_high: ${microLamports} exceeds max ${maxPriorityFee}`,
+        );
+      }
+      continue;
+    }
+
+    // Only SetComputeUnitLimit (2) and SetComputeUnitPrice (3) are accepted.
+    // Other ComputeBudget types (RequestHeapFrame, SetLoadedAccountsDataSizeLimit, etc.)
+    // are rejected because they expand execution surface without being necessary
+    // for payment outcome verification.
+    throw new Error(`smart_wallet_unsupported_compute_budget_instruction: type ${data[0]}`);
+  }
+}
+
+/**
+ * Extracts TransferChecked instructions from simulation inner instructions
+ * (CPI trace). Handles both parsed and compiled formats from the Solana RPC.
+ *
+ * @param innerInstructions - Inner instructions from simulation result
+ * @param accountKeys - Static account keys from the compiled transaction message
+ * @returns Array of extracted TransferChecked instructions
+ */
+export function extractTransfersFromInnerInstructions(
+  innerInstructions: SvmInnerInstructionsResult["innerInstructions"],
+  accountKeys: readonly string[],
+): TransferCheckedInfo[] {
+  if (!innerInstructions) return [];
+
+  const transfers: TransferCheckedInfo[] = [];
+
+  for (const group of innerInstructions) {
+    for (const ix of group.instructions) {
+      const ixAny = ix as Record<string, unknown>;
+
+      // Parsed format (jsonParsed encoding)
+      const parsed = ixAny.parsed as { type?: string; info?: Record<string, unknown> } | undefined;
+      if (parsed && parsed.type === "transferChecked" && parsed.info) {
+        const programId = String(ixAny.programId ?? "");
+        if (!TOKEN_PROGRAMS.has(programId)) continue;
+
+        const info = parsed.info;
+        const tokenAmount = info.tokenAmount as { amount?: string } | undefined;
+        const amountStr = tokenAmount?.amount ?? String(info.amount ?? "0");
+
+        transfers.push({
+          programId,
+          amount: BigInt(amountStr),
+          mint: String(info.mint ?? ""),
+          destination: String(info.destination ?? ""),
+          authority: String(info.authority ?? info.owner ?? ""),
+        });
+        continue;
+      }
+
+      // Compiled format (programIdIndex + accounts + data as base58)
+      const programIdIndex = ixAny.programIdIndex as number | undefined;
+      const accounts = ixAny.accounts as number[] | undefined;
+      const dataStr = ixAny.data as string | undefined;
+      if (programIdIndex == null || !accounts || !dataStr) continue;
+
+      const programId = accountKeys[programIdIndex];
+      if (!programId || !TOKEN_PROGRAMS.has(programId)) continue;
+
+      let data: Uint8Array;
+      try {
+        data = getBase58Encoder().encode(dataStr) as Uint8Array;
+      } catch {
+        continue;
+      }
+
+      if (data[0] !== IX_TOKEN_TRANSFER_CHECKED) continue;
+      if (data.length < 9 || accounts.length < 4) continue;
+
+      const amount = new DataView(data.buffer, data.byteOffset, data.byteLength).getBigUint64(
+        1,
+        true,
+      );
+      const mint = accountKeys[accounts[1]];
+      const destination = accountKeys[accounts[2]];
+      const authority = accountKeys[accounts[3]];
+      if (!mint || !destination || !authority) continue;
+
+      transfers.push({ programId, amount, mint, destination, authority });
+    }
+  }
+
+  return transfers;
+}
+
+/**
+ * Operator-configurable options for smart wallet verification.
+ * Passed through from the ExactSvmScheme constructor.
+ */
+export type SmartWalletOptions = {
+  enabled: boolean;
+  maxComputeUnits?: number;
+  maxPriorityFeeMicroLamports?: number;
+};
+
+/**
+ * Full smart wallet verification pipeline.
+ * Called when static verification rejects a transaction due to unknown programs.
+ *
+ * 1. Assert fee payer isolation
+ * 2. Validate compute budget caps
+ * 3. Simulate with inner instructions
+ * 4. Extract and match TransferChecked from CPI trace
+ *
+ * @param transactionBase64 - Base64 encoded transaction
+ * @param requirements - Payment requirements to verify against
+ * @param signer - Facilitator signer (must implement simulateTransactionWithInnerInstructions)
+ * @param feePayerAddress - Facilitator fee payer address
+ * @param signerAddresses - All facilitator signer addresses (for self-spend protection)
+ * @param options - Optional operator-configurable limits
+ * @returns Verification result
+ */
+export async function verifySmartWalletTransaction(
+  transactionBase64: string,
+  requirements: PaymentRequirements,
+  signer: FacilitatorSvmSigner,
+  feePayerAddress: string,
+  signerAddresses: readonly string[],
+  options?: SmartWalletOptions,
+): Promise<VerifyResponse> {
+  const transaction = decodeTransactionFromPayload({ transaction: transactionBase64 });
+
+  // 1. Fee payer must not appear in any instruction's accounts.
+  try {
+    await assertFeePayerIsolated(transaction, feePayerAddress, signer, requirements.network);
+  } catch (error) {
+    return {
+      isValid: false,
+      invalidReason: error instanceof Error ? error.message : "smart_wallet_fee_payer_not_isolated",
+      payer: "",
+    };
+  }
+
+  // 2. Compute budget caps still apply (operator-configurable).
+  try {
+    validateComputeBudgetLimits(transaction, {
+      maxComputeUnits: options?.maxComputeUnits,
+      maxPriorityFeeMicroLamports: options?.maxPriorityFeeMicroLamports,
+    });
+  } catch (error) {
+    return {
+      isValid: false,
+      invalidReason:
+        error instanceof Error ? error.message : "smart_wallet_compute_budget_violation",
+      payer: "",
+    };
+  }
+
+  // 3. Simulate with inner instructions.
+  if (typeof signer.simulateTransactionWithInnerInstructions !== "function") {
+    return {
+      isValid: false,
+      invalidReason: "smart_wallet_verification_not_available",
+      payer: "",
+    };
+  }
+
+  let simResult: SvmInnerInstructionsResult;
+  try {
+    simResult = await signer.simulateTransactionWithInnerInstructions(
+      transactionBase64,
+      feePayerAddress as Address,
+      requirements.network,
+    );
+  } catch (error) {
+    return {
+      isValid: false,
+      invalidReason: `smart_wallet_simulation_failed: ${error instanceof Error ? error.message : String(error)}`,
+      payer: "",
+    };
+  }
+
+  // 4. Extract TransferChecked from top-level instructions and CPI inner instructions.
+  const compiled = getCompiledTransactionMessageDecoder().decode(transaction.messageBytes);
+  const decompiled = decompileTransactionMessage(compiled);
+  const accountKeys = (compiled.staticAccounts ?? []).map(String);
+
+  // 4a. Verify memo content matches extra.memo when present.
+  // Mirrors Path 1's Step 5b enforcement so a seller-required memo cannot be
+  // bypassed by routing through a smart wallet. The memo program is a standalone
+  // top-level instruction in both paths; wallet programs do not wrap it via CPI.
+  const expectedMemo = requirements.extra?.memo as string | undefined;
+  if (expectedMemo) {
+    const memoInstructions = (decompiled.instructions ?? []).filter(
+      ix => ix.programAddress.toString() === MEMO_PROGRAM_ADDRESS,
+    );
+    if (memoInstructions.length !== 1) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_svm_payload_memo_count",
+        payer: "",
+      };
+    }
+    const memoData = memoInstructions[0].data;
+    const actualMemo = memoData ? new TextDecoder().decode(new Uint8Array(memoData)) : "";
+    if (actualMemo !== expectedMemo) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_svm_payload_memo_mismatch",
+        payer: "",
+      };
+    }
+  }
+
+  const allTransfers: TransferCheckedInfo[] = [];
+
+  for (const ix of decompiled.instructions ?? []) {
+    const progId = ix.programAddress.toString();
+    if (!TOKEN_PROGRAMS.has(progId)) continue;
+    const data = ix.data;
+    if (!data || data[0] !== IX_TOKEN_TRANSFER_CHECKED || data.length < 9) continue;
+    const accts = ix.accounts ?? [];
+    if (accts.length < 4) continue;
+    const amount = new DataView(data.buffer, data.byteOffset, data.byteLength).getBigUint64(
+      1,
+      true,
+    );
+    allTransfers.push({
+      programId: progId,
+      amount,
+      mint: accts[1].address.toString(),
+      destination: accts[2].address.toString(),
+      authority: accts[3].address.toString(),
+    });
+  }
+
+  allTransfers.push(
+    ...extractTransfersFromInnerInstructions(simResult.innerInstructions, accountKeys),
+  );
+
+  // Fee payer must not be the authority on any transfer.
+  for (const t of allTransfers) {
+    if (signerAddresses.includes(t.authority)) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_svm_payload_transaction_fee_payer_transferring_funds",
+        payer: t.authority,
+      };
+    }
+  }
+
+  // Derive expected destination ATAs for both token programs.
+  // ATA derivation is a pure local PDA computation (no RPC), so both always succeed.
+  // A transfer matches if its destination equals the ATA for its token program.
+  const expectedATAs = new Set<string>();
+  for (const tokenProgram of [TOKEN_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS]) {
+    try {
+      const [ata] = await findAssociatedTokenPda({
+        mint: requirements.asset as Address,
+        owner: requirements.payTo as Address,
+        tokenProgram: tokenProgram as unknown as Address,
+      });
+      expectedATAs.add(ata.toString());
+    } catch {
+      // Invalid address format — skip this program
+    }
+  }
+
+  if (expectedATAs.size === 0) {
+    return {
+      isValid: false,
+      invalidReason: "smart_wallet_cannot_derive_destination_ata",
+      payer: "",
+    };
+  }
+
+  const requiredAmount = BigInt(requirements.amount);
+  const matchingTransfers = allTransfers.filter(
+    t =>
+      t.mint === requirements.asset &&
+      expectedATAs.has(t.destination) &&
+      t.amount >= requiredAmount,
+  );
+
+  if (matchingTransfers.length === 0) {
+    if (allTransfers.length === 0) {
+      return { isValid: false, invalidReason: "smart_wallet_no_transfer_in_simulation", payer: "" };
+    }
+    return {
+      isValid: false,
+      invalidReason: "smart_wallet_transfer_mismatch",
+      payer: allTransfers[0].authority,
+    };
+  }
+
+  if (matchingTransfers.length > 1) {
+    return {
+      isValid: false,
+      invalidReason: "smart_wallet_multiple_matching_transfers",
+      payer: matchingTransfers[0].authority,
+    };
+  }
+
+  return { isValid: true, payer: matchingTransfers[0].authority };
+}
+
+/**
+ * Post-settlement verification for smart wallet transactions.
+ *
+ * After a transaction confirms on-chain, verifies the TransferChecked actually
+ * executed by inspecting the confirmed transaction's inner instructions.
+ * Falls back to balance-delta checking if the RPC's transaction index has lag.
+ *
+ * This closes the TOCTOU gap where a malicious program could pass simulation
+ * but skip the transfer during on-chain execution.
+ *
+ * @param signer - Facilitator signer with optional getConfirmedTransactionInnerInstructions
+ * @param signature - Confirmed transaction signature
+ * @param network - CAIP-2 network identifier
+ * @param requirements - Payment requirements (asset, payTo, amount)
+ * @param signerAddresses - Facilitator signer addresses
+ * @param balanceBefore - Destination ATA balance before settlement (for fallback)
+ * @param balanceBeforeTokenProgram - Which token program the balanceBefore was captured from (SPL Token or Token-2022)
+ * @returns Whether the transfer was verified on-chain
+ */
+export async function verifyPostSettlement(
+  signer: FacilitatorSvmSigner,
+  signature: string,
+  network: string,
+  requirements: PaymentRequirements,
+  signerAddresses: string[],
+  balanceBefore: bigint | null,
+  balanceBeforeTokenProgram?: string | null,
+): Promise<{ verified: boolean; method: "innerInstructions" | "balanceDelta" | "unverified" }> {
+  const requiredAmount = BigInt(requirements.amount);
+
+  // Primary path: fetch confirmed transaction and inspect inner instructions.
+  // Retry with backoff to handle RPC indexing lag (transaction confirmed but
+  // not yet indexed). Same polling pattern as confirmTransaction in the SVM signer.
+  if (typeof signer.getConfirmedTransactionInnerInstructions === "function") {
+    let confirmed: SvmInnerInstructionsResult | null = null;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        confirmed = await signer.getConfirmedTransactionInnerInstructions(signature, network);
+        if (confirmed?.innerInstructions) break;
+      } catch {
+        // RPC error — retry
+      }
+      if (attempt < 2) {
+        await new Promise(resolve => setTimeout(resolve, 100 * (attempt + 1)));
+      }
+    }
+
+    try {
+      if (confirmed?.innerInstructions) {
+        // Reuse the same extraction logic used for simulation results.
+        // We pass an empty accountKeys array because the confirmed transaction's
+        // inner instructions from jsonParsed encoding are already in parsed format
+        // (programId as string, not index), so index-based resolution isn't needed.
+        const transfers = extractTransfersFromInnerInstructions(confirmed.innerInstructions, []);
+
+        // Derive expected destination ATAs (same logic as in verifySmartWalletTransaction).
+        const expectedATAs = new Set<string>();
+        for (const tokenProgram of [TOKEN_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS]) {
+          try {
+            const [ata] = await findAssociatedTokenPda({
+              mint: requirements.asset as Address,
+              owner: requirements.payTo as Address,
+              tokenProgram: tokenProgram as unknown as Address,
+            });
+            expectedATAs.add(ata.toString());
+          } catch {
+            // Skip invalid address combinations
+          }
+        }
+
+        const matching = transfers.filter(
+          t =>
+            t.mint === requirements.asset &&
+            expectedATAs.has(t.destination) &&
+            t.amount >= requiredAmount &&
+            !signerAddresses.includes(t.authority),
+        );
+
+        if (matching.length >= 1) {
+          return { verified: true, method: "innerInstructions" };
+        }
+
+        // Inner instructions fetched but no matching transfer found.
+        // The malicious program skipped the CPI. TOCTOU caught.
+        return { verified: false, method: "innerInstructions" };
+      }
+    } catch {
+      // getTransaction failed or returned null (indexing lag). Fall through to balance delta.
+    }
+  }
+
+  // Fallback: balance-delta check.
+  // If we recorded balanceBefore and the signer supports getTokenAccountBalance,
+  // check whether the destination ATA balance increased by at least the required amount.
+  // Try both SPL Token and Token-2022 programs — the payment may use either.
+  if (balanceBefore !== null && typeof signer.getTokenAccountBalance === "function") {
+    // If we know which token program was used for balanceBefore, check that one first.
+    // Otherwise try both (SPL Token first, then Token-2022).
+    const tokenProgramsToCheck = balanceBeforeTokenProgram
+      ? [
+          balanceBeforeTokenProgram as Address,
+          ...(balanceBeforeTokenProgram === TOKEN_PROGRAM_ADDRESS.toString()
+            ? [TOKEN_2022_PROGRAM_ADDRESS as unknown as Address]
+            : [TOKEN_PROGRAM_ADDRESS as unknown as Address]),
+        ]
+      : [
+          TOKEN_PROGRAM_ADDRESS as unknown as Address,
+          TOKEN_2022_PROGRAM_ADDRESS as unknown as Address,
+        ];
+
+    let anyBalanceChecked = false;
+    for (const tokenProgram of tokenProgramsToCheck) {
+      try {
+        const [destinationAta] = await findAssociatedTokenPda({
+          mint: requirements.asset as Address,
+          owner: requirements.payTo as Address,
+          tokenProgram,
+        });
+
+        const balanceAfter = await signer.getTokenAccountBalance(
+          destinationAta.toString(),
+          network,
+        );
+
+        if (balanceAfter !== null) {
+          anyBalanceChecked = true;
+          if (balanceAfter - balanceBefore >= requiredAmount) {
+            return { verified: true, method: "balanceDelta" };
+          }
+        }
+      } catch {
+        // ATA doesn't exist or balance check failed for this token program. Try next.
+      }
+    }
+
+    if (anyBalanceChecked) {
+      // We got balance data but it didn't show sufficient increase.
+      return { verified: false, method: "balanceDelta" };
+    }
+    // All balance checks threw — fall through to unverified.
+  }
+
+  // Neither verification method available or both failed.
+  // Return unverified — caller decides policy.
+  return { verified: false, method: "unverified" };
+}

--- a/typescript/packages/mechanisms/svm/src/index.ts
+++ b/typescript/packages/mechanisms/svm/src/index.ts
@@ -6,6 +6,20 @@
 
 // Export V2 implementations (default)
 export { ExactSvmScheme } from "./exact";
+export type { ExactSvmSchemeOptions } from "./exact/facilitator/scheme";
+
+// Export smart wallet verification helpers
+export {
+  assertFeePayerIsolated,
+  validateComputeBudgetLimits,
+  extractTransfersFromInnerInstructions,
+  verifySmartWalletTransaction,
+  verifyPostSettlement,
+} from "./exact/facilitator/smartWalletVerification";
+export type {
+  SmartWalletOptions,
+  TransferCheckedInfo,
+} from "./exact/facilitator/smartWalletVerification";
 
 // Export signer utilities and types
 export { toClientSvmSigner, toFacilitatorSvmSigner } from "./signer";
@@ -15,6 +29,7 @@ export type {
   FacilitatorRpcClient,
   FacilitatorRpcConfig,
   ClientSvmConfig,
+  SvmInnerInstructionsResult,
 } from "./signer";
 
 // Export payload types

--- a/typescript/packages/mechanisms/svm/src/signer.ts
+++ b/typescript/packages/mechanisms/svm/src/signer.ts
@@ -9,7 +9,7 @@ import type {
   SolanaRpcApiMainnet,
   Address,
 } from "@solana/kit";
-import { getBase64EncodedWireTransaction } from "@solana/kit";
+import { fetchAddressesForLookupTables, getBase64EncodedWireTransaction } from "@solana/kit";
 import { createRpcClient, decodeTransactionFromPayload } from "./utils";
 
 /**
@@ -163,6 +163,87 @@ export type FacilitatorSvmSigner = {
    * @throws Error if confirmation fails or times out
    */
   confirmTransaction(signature: string, network: string): Promise<void>;
+
+  /**
+   * Simulate a transaction and return inner instructions (CPI calls).
+   * Used by smart wallet verification to find TransferChecked instructions
+   * executed via CPI by smart wallet programs (Squads, Swig, etc.).
+   *
+   * Optional — if not implemented, smart wallet verification is unavailable.
+   * The default toFacilitatorSvmSigner() factory provides an implementation.
+   *
+   * @param transaction - Base64 encoded transaction (may be partially signed)
+   * @param feePayer - Fee payer address to sign with before simulation
+   * @param network - CAIP-2 network identifier
+   * @returns Inner instructions from simulation, or null if unavailable
+   * @throws Error if simulation fails (transaction would revert on-chain)
+   */
+  simulateTransactionWithInnerInstructions?(
+    transaction: string,
+    feePayer: Address,
+    network: string,
+  ): Promise<SvmInnerInstructionsResult>;
+
+  /**
+   * Fetch inner instructions from a confirmed transaction.
+   * Used for post-settlement verification to confirm that the TransferChecked
+   * actually executed on-chain (defends against TOCTOU in simulation path).
+   *
+   * Optional — if not implemented, post-settlement verification falls back
+   * to balance-delta checking only.
+   *
+   * @param signature - Transaction signature to fetch
+   * @param network - CAIP-2 network identifier
+   * @returns Inner instructions from the confirmed transaction, or null if not yet indexed
+   */
+  getConfirmedTransactionInnerInstructions?(
+    signature: string,
+    network: string,
+  ): Promise<SvmInnerInstructionsResult | null>;
+
+  /**
+   * Get the token balance of a specific token account.
+   * Used for balance-delta fallback in post-settlement verification.
+   *
+   * Optional — if not implemented, balance-delta fallback is unavailable.
+   *
+   * @param tokenAccountAddress - Base58 encoded token account (ATA) address
+   * @param network - CAIP-2 network identifier
+   * @returns Token balance in atomic units, or null if account not found
+   */
+  getTokenAccountBalance?(tokenAccountAddress: string, network: string): Promise<bigint | null>;
+
+  /**
+   * Resolve Address Lookup Tables for v0 transactions.
+   * Returns a map of ALT address to resolved account address arrays.
+   * Used by fee payer isolation check to inspect ALT-resolved accounts.
+   *
+   * Optional — if not implemented, transactions with ALTs are rejected
+   * conservatively (safe, but limits smart wallet coverage for wallets
+   * that use ALTs like Crossmint/Swig).
+   *
+   * @param lookupTableAddresses - Base58 encoded ALT addresses to resolve
+   * @param network - CAIP-2 network identifier
+   * @returns Map of ALT address to ordered array of resolved account addresses
+   */
+  fetchAddressLookupTables?(
+    lookupTableAddresses: string[],
+    network: string,
+  ): Promise<Record<string, string[]>>;
+};
+
+/**
+ * Result from simulation with inner instruction inspection.
+ */
+export type SvmInnerInstructionsResult = {
+  innerInstructions: Array<{
+    index: number;
+    instructions: Array<{
+      programIdIndex: number;
+      accounts: number[];
+      data: string;
+    }>;
+  }> | null;
 };
 
 /**
@@ -396,6 +477,151 @@ export function toFacilitatorSvmSigner(
       const rpc = getRpcForNetwork(network);
       const rpcCapabilities = createRpcCapabilitiesFromRpc(rpc);
       await rpcCapabilities.confirmTransaction(signature);
+    },
+
+    simulateTransactionWithInnerInstructions: async (
+      transaction: string,
+      feePayer: Address,
+      network: string,
+    ) => {
+      if (feePayer !== signer.address) {
+        throw new Error(`No signer for feePayer ${feePayer}. Available: ${signer.address}`);
+      }
+
+      const tx = decodeTransactionFromPayload({ transaction });
+      const signableMessage = {
+        content: tx.messageBytes,
+        signatures: tx.signatures,
+      };
+      const [facilitatorSignatureDictionary] = await signer.signMessages([
+        signableMessage as never,
+      ]);
+      const signedTx = {
+        ...tx,
+        signatures: { ...tx.signatures, ...facilitatorSignatureDictionary },
+      };
+      const signedBase64 = getBase64EncodedWireTransaction(signedTx);
+
+      // Signature and blockhash verification during simulation.
+      //
+      // sigVerify: true — matches the existing Path 1 simulation behavior. Ensures all
+      // transaction signatures are valid, preventing an attacker from passing verify()
+      // with forged signatures and getting free resource access before on-chain failure.
+      //
+      // replaceRecentBlockhash: false — preserves the original blockhash so signatures
+      // remain valid (they cover the full message including blockhash). Also required for
+      // durable nonce transactions (AdvanceNonceAccount), which use a nonce instead of a
+      // recent blockhash and are valid indefinitely until the nonce is advanced.
+      // See RFC #646 for the durable nonce handling specification.
+      //
+      // Blockhash expiry (~60-90s) is not a concern: the x402 flow (payer signs → HTTP
+      // request → facilitator verifies) completes well within this window. If the
+      // blockhash has expired, the transaction can't land on-chain regardless, so
+      // rejecting at verify-time is the correct behavior.
+      const rpc = getRpcForNetwork(network);
+      const result = await rpc
+        .simulateTransaction(
+          signedBase64 as never,
+          {
+            sigVerify: true,
+            replaceRecentBlockhash: false,
+            commitment: "confirmed",
+            encoding: "base64",
+            innerInstructions: true,
+          } as never,
+        )
+        .send();
+
+      const value = result.value as unknown as {
+        err: unknown;
+        innerInstructions?: Array<{
+          index: number;
+          instructions: Array<{ programIdIndex: number; accounts: number[]; data: string }>;
+        }>;
+      };
+
+      if (value.err) {
+        const errorStr = JSON.stringify(value.err, (_, v) =>
+          typeof v === "bigint" ? v.toString() : v,
+        );
+        throw new Error(`Smart wallet simulation failed: ${errorStr}`);
+      }
+
+      return { innerInstructions: value.innerInstructions ?? null };
+    },
+
+    getConfirmedTransactionInnerInstructions: async (
+      signature: string,
+      network: string,
+    ): Promise<SvmInnerInstructionsResult | null> => {
+      const rpc = getRpcForNetwork(network);
+      const result = await rpc
+        .getTransaction(
+          signature as never,
+          {
+            commitment: "confirmed",
+            maxSupportedTransactionVersion: 0,
+            encoding: "jsonParsed",
+          } as never,
+        )
+        .send();
+
+      if (!result) {
+        return null;
+      }
+
+      const meta = (
+        result as unknown as {
+          meta?: { innerInstructions?: SvmInnerInstructionsResult["innerInstructions"] };
+        }
+      ).meta;
+      return { innerInstructions: meta?.innerInstructions ?? null };
+    },
+
+    getTokenAccountBalance: async (
+      tokenAccountAddress: string,
+      network: string,
+    ): Promise<bigint | null> => {
+      const rpc = getRpcForNetwork(network);
+      try {
+        const result = await rpc
+          .getTokenAccountBalance(
+            tokenAccountAddress as never,
+            { commitment: "confirmed" } as never,
+          )
+          .send();
+        const amount = (result as unknown as { value?: { amount?: string } }).value?.amount;
+        return amount ? BigInt(amount) : null;
+      } catch {
+        return null;
+      }
+    },
+
+    fetchAddressLookupTables: async (
+      lookupTableAddresses: string[],
+      network: string,
+    ): Promise<Record<string, string[]>> => {
+      const rpc = getRpcForNetwork(network);
+      try {
+        const resolved = await fetchAddressesForLookupTables(
+          lookupTableAddresses.map(a => a as Address),
+          rpc,
+        );
+        const result: Record<string, string[]> = {};
+        for (const [key, addresses] of Object.entries(resolved)) {
+          result[key] = addresses.map((a: Address) => a.toString());
+        }
+        return result;
+      } catch (error) {
+        // Surface resolution failures rather than returning an empty map.
+        // An empty map would be indistinguishable from "no ALTs", silently
+        // weakening the fee-payer isolation check that depends on resolved
+        // accounts. The caller (assertFeePayerIsolated) converts this into a
+        // verify failure so a transient RPC blip fails the payment safely.
+        throw new Error(
+          `smart_wallet_alt_resolution_failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     },
   };
 }

--- a/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
@@ -379,9 +379,16 @@ describe("ExactSvmScheme", () => {
     };
 
     function setupSettleMocks(facilitator: ExactSvmScheme) {
-      vi.spyOn(facilitator, "verify").mockResolvedValue({
-        isValid: true,
-        payer: "PayerAddress",
+      // settle() calls the internal _verify (which also reports the path), so we
+      // mock that to isolate the duplicate-cache logic from real verification.
+      vi.spyOn(
+        facilitator as unknown as {
+          _verify: (...args: unknown[]) => Promise<unknown>;
+        },
+        "_verify",
+      ).mockResolvedValue({
+        response: { isValid: true, payer: "PayerAddress" },
+        verificationPath: "static",
       });
       (mockSigner as Record<string, unknown>).signTransaction = vi
         .fn()
@@ -446,9 +453,12 @@ describe("ExactSvmScheme", () => {
       const v1 = new ExactSvmSchemeV1(mockSigner, sharedCache);
 
       // Mock V2 settle flow
-      vi.spyOn(v2, "verify").mockResolvedValue({
-        isValid: true,
-        payer: "PayerAddress",
+      vi.spyOn(
+        v2 as unknown as { _verify: (...args: unknown[]) => Promise<unknown> },
+        "_verify",
+      ).mockResolvedValue({
+        response: { isValid: true, payer: "PayerAddress" },
+        verificationPath: "static",
       });
       (mockSigner as Record<string, unknown>).signTransaction = vi
         .fn()

--- a/typescript/packages/mechanisms/svm/test/unit/smartWalletFallback.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/smartWalletFallback.test.ts
@@ -1,0 +1,1024 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  appendTransactionMessageInstruction,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getBase64EncodedWireTransaction,
+  getCompiledTransactionMessageEncoder,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Address,
+  type IInstruction,
+} from "@solana/kit";
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import {
+  LIGHTHOUSE_PROGRAM_ADDRESS,
+  MEMO_PROGRAM_ADDRESS,
+  SOLANA_DEVNET_CAIP2,
+  USDC_DEVNET_ADDRESS,
+} from "../../src/constants";
+
+const COMPUTE_BUDGET_PROGRAM = "ComputeBudget111111111111111111111111111111" as Address;
+const TOKEN_PROGRAM = TOKEN_PROGRAM_ADDRESS.toString();
+
+const FAKE_BLOCKHASH = {
+  blockhash: "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF" as string &
+    import("@solana/kit").Blockhash,
+  lastValidBlockHeight: 1000n,
+};
+
+let mockAtaMap: Record<string, Address> = {};
+
+vi.mock("@solana-program/token-2022", async () => {
+  const actual = await vi.importActual<typeof import("@solana-program/token-2022")>(
+    "@solana-program/token-2022",
+  );
+  return {
+    ...actual,
+    findAssociatedTokenPda: vi.fn().mockImplementation(async (args: { owner: unknown }) => {
+      const owner = String(args.owner);
+      const ata = mockAtaMap[owner];
+      if (!ata) {
+        throw new Error(`Missing ATA mock for owner ${owner}`);
+      }
+      return [ata, 255] as const;
+    }),
+  };
+});
+
+async function buildTransaction(feePayer: Address, instructions: IInstruction[]) {
+  const { compileTransactionMessage } = await import("@solana/kit");
+  let msg = pipe(
+    createTransactionMessage({ version: 0 }),
+    m => setTransactionMessageFeePayer(feePayer, m),
+    m => setTransactionMessageLifetimeUsingBlockhash(FAKE_BLOCKHASH, m),
+  );
+  for (const ix of instructions) {
+    msg = appendTransactionMessageInstruction(ix, msg);
+  }
+  const compiled = compileTransactionMessage(msg);
+  const messageBytes = getCompiledTransactionMessageEncoder().encode(compiled);
+  return { messageBytes, signatures: {} };
+}
+
+async function buildSmartWalletPayload(feePayer: Address, unknownProgram: Address, payer: Address) {
+  const tx = await buildTransaction(feePayer, [
+    { programAddress: COMPUTE_BUDGET_PROGRAM, data: new Uint8Array([2, 160, 134, 1, 0]) },
+    { programAddress: COMPUTE_BUDGET_PROGRAM, data: new Uint8Array([3, 16, 39, 0, 0, 0, 0, 0, 0]) },
+    {
+      programAddress: unknownProgram,
+      accounts: [{ address: payer, role: 1 }],
+      data: new Uint8Array([0]),
+    },
+  ]);
+
+  const txWithSig = {
+    messageBytes: tx.messageBytes,
+    signatures: { [feePayer]: new Uint8Array(64) } as Record<string, Uint8Array>,
+  };
+
+  return getBase64EncodedWireTransaction(txWithSig as never);
+}
+
+async function buildSmartWalletPayloadWithMemos(
+  feePayer: Address,
+  unknownProgram: Address,
+  payer: Address,
+  memos: string[],
+) {
+  const encoder = new TextEncoder();
+  const baseInstructions: IInstruction[] = [
+    { programAddress: COMPUTE_BUDGET_PROGRAM, data: new Uint8Array([2, 160, 134, 1, 0]) },
+    { programAddress: COMPUTE_BUDGET_PROGRAM, data: new Uint8Array([3, 16, 39, 0, 0, 0, 0, 0, 0]) },
+    {
+      programAddress: unknownProgram,
+      accounts: [{ address: payer, role: 1 }],
+      data: new Uint8Array([0]),
+    },
+  ];
+  for (const memo of memos) {
+    baseInstructions.push({
+      programAddress: MEMO_PROGRAM_ADDRESS as Address,
+      data: encoder.encode(memo),
+    });
+  }
+
+  const tx = await buildTransaction(feePayer, baseInstructions);
+
+  const txWithSig = {
+    messageBytes: tx.messageBytes,
+    signatures: { [feePayer]: new Uint8Array(64) } as Record<string, Uint8Array>,
+  };
+
+  return getBase64EncodedWireTransaction(txWithSig as never);
+}
+
+/**
+ * Build a structurally valid Path-1 transaction (ComputeLimit, ComputePrice,
+ * real TransferChecked) so static verification proceeds past layout checks and
+ * reaches the semantic amount/mint/recipient checks. Used to prove that a
+ * semantic failure (e.g. wrong amount) does NOT fall through to Path 2.
+ */
+async function buildStaticTransferPayload(args: {
+  feePayer: Address;
+  source: Address;
+  mint: Address;
+  destination: Address;
+  authority: Address;
+  amount: bigint;
+  trailing?: IInstruction[];
+}) {
+  const data = new Uint8Array(10);
+  data[0] = 12; // TransferChecked discriminator
+  new DataView(data.buffer).setBigUint64(1, args.amount, true);
+  data[9] = 6; // decimals
+
+  const tx = await buildTransaction(args.feePayer, [
+    { programAddress: COMPUTE_BUDGET_PROGRAM, data: new Uint8Array([2, 160, 134, 1, 0]) },
+    { programAddress: COMPUTE_BUDGET_PROGRAM, data: new Uint8Array([3, 16, 39, 0, 0, 0, 0, 0, 0]) },
+    {
+      programAddress: TOKEN_PROGRAM_ADDRESS,
+      accounts: [
+        { address: args.source, role: 1 },
+        { address: args.mint, role: 0 },
+        { address: args.destination, role: 1 },
+        // Authority is a signer (role 3), so the compiled message requires its
+        // signature slot in addition to the fee payer's.
+        { address: args.authority, role: 3 },
+      ],
+      data,
+    },
+    ...(args.trailing ?? []),
+  ]);
+
+  const txWithSig = {
+    messageBytes: tx.messageBytes,
+    signatures: {
+      [args.feePayer]: new Uint8Array(64),
+      [args.authority]: new Uint8Array(64),
+    } as Record<string, Uint8Array>,
+  };
+
+  return getBase64EncodedWireTransaction(txWithSig as never);
+}
+
+function buildMockInnerTransfer(
+  programId: string,
+  mint: string,
+  destination: string,
+  authority: string,
+  amount: string,
+) {
+  return {
+    programId,
+    parsed: {
+      type: "transferChecked",
+      info: { mint, destination, authority, tokenAmount: { amount } },
+    },
+  } as Record<string, unknown>;
+}
+
+describe("ExactSvmScheme smart wallet fallback path", () => {
+  beforeEach(() => {
+    mockAtaMap = {};
+    vi.clearAllMocks();
+  });
+
+  it("verify falls back to simulation when static path rejects unknown program", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const unknownProgram = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    const txBase64 = await buildSmartWalletPayload(
+      feePayer.address,
+      unknownProgram.address,
+      payer.address,
+    );
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                payer.address as string,
+                "100000",
+              ),
+            ],
+          },
+        ],
+      }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+      smartWalletAllowedPrograms: [unknownProgram.address],
+    });
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: payTo.address,
+          maxTimeoutSeconds: 3600,
+          extra: { feePayer: feePayer.address },
+        },
+        payload: { transaction: txBase64 },
+      } as never,
+      {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "100000",
+        payTo: payTo.address,
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: feePayer.address },
+      } as never,
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.payer).toBe(payer.address);
+    expect(mockSigner.simulateTransactionWithInnerInstructions).toHaveBeenCalled();
+  });
+
+  it("verify rejects smart wallet transaction with multiple matching transfers", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const unknownProgram = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    const txBase64 = await buildSmartWalletPayload(
+      feePayer.address,
+      unknownProgram.address,
+      payer.address,
+    );
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                payer.address as string,
+                "100000",
+              ),
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                payer.address as string,
+                "100000",
+              ),
+            ],
+          },
+        ],
+      }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+      smartWalletAllowedPrograms: [unknownProgram.address],
+    });
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: payTo.address,
+          maxTimeoutSeconds: 3600,
+          extra: { feePayer: feePayer.address },
+        },
+        payload: { transaction: txBase64 },
+      } as never,
+      {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "100000",
+        payTo: payTo.address,
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: feePayer.address },
+      } as never,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("smart_wallet_multiple_matching_transfers");
+  });
+
+  it("verify rejects smart wallet transaction when fee payer is transfer authority", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const unknownProgram = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    // Fee payer NOT in instruction accounts (passes isolation check),
+    // but simulation returns fee payer as the transfer authority (caught at step 4)
+    const txBase64 = await buildSmartWalletPayload(
+      feePayer.address,
+      unknownProgram.address,
+      payer.address,
+    );
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                feePayer.address as string,
+                "100000",
+              ),
+            ],
+          },
+        ],
+      }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+      smartWalletAllowedPrograms: [unknownProgram.address],
+    });
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: payTo.address,
+          maxTimeoutSeconds: 3600,
+          extra: { feePayer: feePayer.address },
+        },
+        payload: { transaction: txBase64 },
+      } as never,
+      {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "100000",
+        payTo: payTo.address,
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: feePayer.address },
+      } as never,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe(
+      "invalid_exact_svm_payload_transaction_fee_payer_transferring_funds",
+    );
+  });
+
+  it("verify rejects smart wallet transaction when program is not in allowlist", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const unknownProgram = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const txBase64 = await buildSmartWalletPayload(
+      feePayer.address,
+      unknownProgram.address,
+      payer.address,
+    );
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [],
+      }),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+    };
+
+    // Allowlist does NOT include unknownProgram
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+      smartWalletAllowedPrograms: ["SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf"],
+    });
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: payTo.address,
+          extra: { feePayer: feePayer.address },
+        },
+        payload: { transaction: txBase64 },
+      } as never,
+      {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "100000",
+        payTo: payTo.address,
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: feePayer.address },
+      } as never,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toContain("smart_wallet_program_not_allowed");
+  });
+
+  it("verify accepts smart wallet transaction when required memo is present and matches", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const unknownProgram = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    const txBase64 = await buildSmartWalletPayloadWithMemos(
+      feePayer.address,
+      unknownProgram.address,
+      payer.address,
+      ["order-12345"],
+    );
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                payer.address as string,
+                "100000",
+              ),
+            ],
+          },
+        ],
+      }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+      smartWalletAllowedPrograms: [unknownProgram.address],
+    });
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: payTo.address,
+          extra: { feePayer: feePayer.address, memo: "order-12345" },
+        },
+        payload: { transaction: txBase64 },
+      } as never,
+      {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "100000",
+        payTo: payTo.address,
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: feePayer.address, memo: "order-12345" },
+      } as never,
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.payer).toBe(payer.address);
+  });
+
+  it("verify rejects smart wallet transaction when required memo is missing", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const unknownProgram = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    const txBase64 = await buildSmartWalletPayloadWithMemos(
+      feePayer.address,
+      unknownProgram.address,
+      payer.address,
+      [],
+    );
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                payer.address as string,
+                "100000",
+              ),
+            ],
+          },
+        ],
+      }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+      smartWalletAllowedPrograms: [unknownProgram.address],
+    });
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: payTo.address,
+          extra: { feePayer: feePayer.address, memo: "order-12345" },
+        },
+        payload: { transaction: txBase64 },
+      } as never,
+      {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "100000",
+        payTo: payTo.address,
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: feePayer.address, memo: "order-12345" },
+      } as never,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_exact_svm_payload_memo_count");
+  });
+
+  it("verify rejects smart wallet transaction when required memo content does not match", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const unknownProgram = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    const txBase64 = await buildSmartWalletPayloadWithMemos(
+      feePayer.address,
+      unknownProgram.address,
+      payer.address,
+      ["wrong-order"],
+    );
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                payer.address as string,
+                "100000",
+              ),
+            ],
+          },
+        ],
+      }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+      smartWalletAllowedPrograms: [unknownProgram.address],
+    });
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: payTo.address,
+          extra: { feePayer: feePayer.address, memo: "order-12345" },
+        },
+        payload: { transaction: txBase64 },
+      } as never,
+      {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "100000",
+        payTo: payTo.address,
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: feePayer.address, memo: "order-12345" },
+      } as never,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_exact_svm_payload_memo_mismatch");
+  });
+
+  it("verify rejects smart wallet transaction when multiple memo instructions are present", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const unknownProgram = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    const txBase64 = await buildSmartWalletPayloadWithMemos(
+      feePayer.address,
+      unknownProgram.address,
+      payer.address,
+      ["order-12345", "order-12345"],
+    );
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                payer.address as string,
+                "100000",
+              ),
+            ],
+          },
+        ],
+      }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+      smartWalletAllowedPrograms: [unknownProgram.address],
+    });
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: payTo.address,
+          extra: { feePayer: feePayer.address, memo: "order-12345" },
+        },
+        payload: { transaction: txBase64 },
+      } as never,
+      {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "100000",
+        payTo: payTo.address,
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: feePayer.address, memo: "order-12345" },
+      } as never,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_exact_svm_payload_memo_count");
+  });
+
+  it("verify does NOT fall through to Path 2 on a semantic (amount mismatch) failure", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    // Structurally valid tx, but the on-chain transfer amount (1) does not match
+    // the required amount (100000). Path 1 must reject with amount_mismatch.
+    const txBase64 = await buildStaticTransferPayload({
+      feePayer: feePayer.address,
+      source: source.address,
+      mint: USDC_DEVNET_ADDRESS as Address,
+      destination: expectedAta,
+      authority: payer.address,
+      amount: 1n,
+    });
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi
+        .fn()
+        .mockResolvedValue({ innerInstructions: [] }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+    });
+
+    const accepted = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: feePayer.address },
+    };
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted,
+        payload: { transaction: txBase64 },
+      } as never,
+      accepted as never,
+    );
+
+    // Must surface the real Path-1 reason, NOT a misleading smart_wallet_* code.
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_exact_svm_payload_amount_mismatch");
+    // Path 2 must never have run for a semantic failure.
+    expect(mockSigner.simulateTransactionWithInnerInstructions).not.toHaveBeenCalled();
+  });
+
+  it("verify DOES fall through to Path 2 on a layout (instruction count) failure", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const unknownProgram = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    // 3-instruction tx whose third instruction is an unknown program: Path 1
+    // rejects with a layout reason (no_transfer_instruction), which IS recoverable.
+    const txBase64 = await buildSmartWalletPayload(
+      feePayer.address,
+      unknownProgram.address,
+      payer.address,
+    );
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                payer.address as string,
+                "100000",
+              ),
+            ],
+          },
+        ],
+      }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+      smartWalletAllowedPrograms: [unknownProgram.address],
+    });
+
+    const accepted = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: feePayer.address },
+    };
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted,
+        payload: { transaction: txBase64 },
+      } as never,
+      accepted as never,
+    );
+
+    // Layout failure is recoverable: Path 2 runs and validates via simulation.
+    expect(result.isValid).toBe(true);
+    expect(mockSigner.simulateTransactionWithInnerInstructions).toHaveBeenCalled();
+  });
+
+  it("accepts a 7-instruction Phantom transaction (3 Lighthouse) on Path 1 without Path 2", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    // Phantom shape: the correct positional transfer plus three wallet-injected
+    // Lighthouse assertions in the optional tail = 7 instructions total (see #2097).
+    const lighthouse: IInstruction = {
+      programAddress: LIGHTHOUSE_PROGRAM_ADDRESS as Address,
+      data: new Uint8Array([0]),
+    };
+    const txBase64 = await buildStaticTransferPayload({
+      feePayer: feePayer.address,
+      source: source.address,
+      mint: USDC_DEVNET_ADDRESS as Address,
+      destination: expectedAta,
+      authority: payer.address,
+      amount: 100000n,
+      trailing: [lighthouse, lighthouse, lighthouse],
+    });
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi
+        .fn()
+        .mockResolvedValue({ innerInstructions: [] }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
+    });
+
+    const accepted = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: feePayer.address },
+    };
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted,
+        payload: { transaction: txBase64 },
+      } as never,
+      accepted as never,
+    );
+
+    // Path 1 accepts the raised instruction count; Path 2 simulation is never reached.
+    expect(result.isValid).toBe(true);
+    expect(result.payer).toBe(payer.address);
+    expect(mockSigner.simulateTransactionWithInnerInstructions).not.toHaveBeenCalled();
+  });
+});

--- a/typescript/packages/mechanisms/svm/test/unit/smartWalletVerification.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/smartWalletVerification.test.ts
@@ -1,0 +1,1007 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertFeePayerIsolated,
+  validateComputeBudgetLimits,
+  extractTransfersFromInnerInstructions,
+} from "../../src/exact/facilitator/smartWalletVerification";
+import {
+  appendTransactionMessageInstruction,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getCompiledTransactionMessageEncoder,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Address,
+  type IInstruction,
+} from "@solana/kit";
+
+const COMPUTE_BUDGET_PROGRAM = "ComputeBudget111111111111111111111111111111" as Address;
+const TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" as Address;
+const TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb" as Address;
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const DEST_ATA = "DestATA11111111111111111111111111";
+const AUTHORITY = "Authority111111111111111111111111";
+
+const FAKE_BLOCKHASH = {
+  blockhash: "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF" as string &
+    import("@solana/kit").Blockhash,
+  lastValidBlockHeight: 1000n,
+};
+
+async function buildTransaction(feePayer: Address, instructions: IInstruction[]) {
+  const { compileTransactionMessage } = await import("@solana/kit");
+  let msg = pipe(
+    createTransactionMessage({ version: 0 }),
+    m => setTransactionMessageFeePayer(feePayer, m),
+    m => setTransactionMessageLifetimeUsingBlockhash(FAKE_BLOCKHASH, m),
+  );
+  for (const ix of instructions) {
+    msg = appendTransactionMessageInstruction(ix, msg);
+  }
+  const compiled = compileTransactionMessage(msg);
+  const messageBytes = getCompiledTransactionMessageEncoder().encode(compiled);
+  return { messageBytes, signatures: {} };
+}
+
+// ─── assertFeePayerIsolated ─────────────────────────────────────────────────
+
+describe("assertFeePayerIsolated", () => {
+  it("passes when fee payer is not in any instruction", async () => {
+    const feePayer = await generateKeyPairSigner();
+    const otherAccount = await generateKeyPairSigner();
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        accounts: [{ address: otherAccount.address, role: 1 }],
+        data: new Uint8Array([2, 0, 0, 0, 0]),
+      },
+    ]);
+
+    await expect(assertFeePayerIsolated(tx as never, feePayer.address)).resolves.not.toThrow();
+  });
+
+  it("throws when fee payer appears in instruction accounts", async () => {
+    const feePayer = await generateKeyPairSigner();
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        accounts: [{ address: feePayer.address, role: 1 }],
+        data: new Uint8Array([2, 0, 0, 0, 0]),
+      },
+    ]);
+
+    await expect(assertFeePayerIsolated(tx as never, feePayer.address)).rejects.toThrow(
+      "smart_wallet_fee_payer_not_isolated",
+    );
+  });
+
+  it("throws when fee payer appears in accounts of multiple instructions", async () => {
+    const feePayer = await generateKeyPairSigner();
+    const otherProgram = await generateKeyPairSigner();
+    const otherAccount = await generateKeyPairSigner();
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        data: new Uint8Array([2, 0, 0, 0, 0]),
+      },
+      {
+        programAddress: otherProgram.address,
+        accounts: [
+          { address: otherAccount.address, role: 1 },
+          { address: feePayer.address, role: 0 },
+        ],
+        data: new Uint8Array([]),
+      },
+    ]);
+
+    await expect(assertFeePayerIsolated(tx as never, feePayer.address)).rejects.toThrow(
+      "smart_wallet_fee_payer_not_isolated",
+    );
+  });
+});
+
+// ─── validateComputeBudgetLimits ────────────────────────────────────────────
+
+function buildSetComputeUnitLimit(units: number): Uint8Array {
+  const buf = new Uint8Array(5);
+  buf[0] = 2;
+  new DataView(buf.buffer).setUint32(1, units, true);
+  return buf;
+}
+
+function buildSetComputeUnitPrice(microLamports: bigint): Uint8Array {
+  const buf = new Uint8Array(9);
+  buf[0] = 3;
+  new DataView(buf.buffer).setBigUint64(1, microLamports, true);
+  return buf;
+}
+
+describe("validateComputeBudgetLimits", () => {
+  it("passes when CU and priority fee are within defaults", async () => {
+    const feePayer = await generateKeyPairSigner();
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        data: buildSetComputeUnitLimit(300_000),
+      },
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        data: buildSetComputeUnitPrice(10_000n),
+      },
+    ]);
+
+    expect(() => validateComputeBudgetLimits(tx as never)).not.toThrow();
+  });
+
+  it("throws when CU exceeds default max", async () => {
+    const feePayer = await generateKeyPairSigner();
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        data: buildSetComputeUnitLimit(500_000),
+      },
+    ]);
+
+    expect(() => validateComputeBudgetLimits(tx as never)).toThrow(
+      "smart_wallet_compute_units_too_high",
+    );
+  });
+
+  it("throws when priority fee exceeds default max", async () => {
+    const feePayer = await generateKeyPairSigner();
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        data: buildSetComputeUnitPrice(100_000n),
+      },
+    ]);
+
+    expect(() => validateComputeBudgetLimits(tx as never)).toThrow(
+      "smart_wallet_priority_fee_too_high",
+    );
+  });
+
+  it("respects custom operator-provided limits", async () => {
+    const feePayer = await generateKeyPairSigner();
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        data: buildSetComputeUnitLimit(800_000),
+      },
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        data: buildSetComputeUnitPrice(200_000n),
+      },
+    ]);
+
+    // Should pass with high custom limits
+    expect(() =>
+      validateComputeBudgetLimits(tx as never, {
+        maxComputeUnits: 1_000_000,
+        maxPriorityFeeMicroLamports: 500_000,
+      }),
+    ).not.toThrow();
+
+    // Same transaction should fail with low custom limits
+    expect(() =>
+      validateComputeBudgetLimits(tx as never, {
+        maxComputeUnits: 100_000,
+      }),
+    ).toThrow("smart_wallet_compute_units_too_high");
+  });
+
+  it("rejects unknown ComputeBudget instruction type", async () => {
+    const feePayer = await generateKeyPairSigner();
+
+    // Type 1 = RequestHeapFrame, type 4 = SetLoadedAccountsDataSizeLimit
+    const unknownCBInstruction = new Uint8Array([1, 0, 0, 0, 0]);
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        data: unknownCBInstruction,
+      },
+    ]);
+
+    expect(() => validateComputeBudgetLimits(tx as never)).toThrow(
+      "smart_wallet_unsupported_compute_budget_instruction",
+    );
+  });
+
+  it("rejects ComputeBudget instruction with empty data", async () => {
+    const feePayer = await generateKeyPairSigner();
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        data: new Uint8Array([]),
+      },
+    ]);
+
+    expect(() => validateComputeBudgetLimits(tx as never)).toThrow(
+      "smart_wallet_malformed_compute_budget",
+    );
+  });
+});
+
+// ─── extractTransfersFromInnerInstructions ──────────────────────────────────
+
+describe("extractTransfersFromInnerInstructions", () => {
+  it("returns empty array for null inner instructions", () => {
+    const result = extractTransfersFromInnerInstructions(null, []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for empty inner instructions", () => {
+    const result = extractTransfersFromInnerInstructions([], []);
+    expect(result).toEqual([]);
+  });
+
+  it("extracts TransferChecked from parsed format", () => {
+    const innerInstructions = [
+      {
+        index: 0,
+        instructions: [
+          {
+            programIdIndex: 0,
+            accounts: [],
+            data: "",
+            programId: TOKEN_PROGRAM as string,
+            parsed: {
+              type: "transferChecked",
+              info: {
+                mint: USDC_MINT,
+                destination: DEST_ATA,
+                authority: AUTHORITY,
+                tokenAmount: { amount: "100000" },
+              },
+            },
+          } as Record<string, unknown>,
+        ],
+      },
+    ];
+
+    const result = extractTransfersFromInnerInstructions(innerInstructions, [
+      TOKEN_PROGRAM as string,
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mint).toBe(USDC_MINT);
+    expect(result[0].destination).toBe(DEST_ATA);
+    expect(result[0].authority).toBe(AUTHORITY);
+    expect(result[0].amount).toBe(BigInt(100000));
+    expect(result[0].programId).toBe(TOKEN_PROGRAM);
+  });
+
+  it("extracts TransferChecked from compiled format", async () => {
+    // Build a TransferChecked instruction data: [12, amount(u64 LE), decimals(u8)]
+    const data = new Uint8Array(10);
+    data[0] = 12; // TransferChecked discriminator
+    new DataView(data.buffer).setBigUint64(1, 50000n, true);
+    data[9] = 6; // decimals
+
+    // RPC returns inner instruction data as base58 strings.
+    // getBase58Decoder().decode(bytes) -> base58 string
+    const { getBase58Decoder } = await import("@solana/kit");
+    const dataBase58 = getBase58Decoder().decode(data);
+
+    const accountKeys = [
+      "SourceATA1111111111111111111111111",
+      USDC_MINT,
+      DEST_ATA,
+      AUTHORITY,
+      TOKEN_PROGRAM as string,
+    ];
+
+    const innerInstructions = [
+      {
+        index: 0,
+        instructions: [
+          {
+            programIdIndex: 4,
+            accounts: [0, 1, 2, 3],
+            data: dataBase58,
+          },
+        ],
+      },
+    ];
+
+    const result = extractTransfersFromInnerInstructions(innerInstructions, accountKeys);
+    expect(result).toHaveLength(1);
+    expect(result[0].programId).toBe(TOKEN_PROGRAM);
+    expect(result[0].mint).toBe(USDC_MINT);
+    expect(result[0].destination).toBe(DEST_ATA);
+    expect(result[0].authority).toBe(AUTHORITY);
+    expect(result[0].amount).toBe(50000n);
+  });
+
+  it("ignores non-transferChecked parsed instructions", () => {
+    const innerInstructions = [
+      {
+        index: 0,
+        instructions: [
+          {
+            programId: TOKEN_PROGRAM as string,
+            parsed: { type: "approve", info: { amount: "100000" } },
+          } as Record<string, unknown>,
+        ],
+      },
+    ];
+
+    const result = extractTransfersFromInnerInstructions(innerInstructions, []);
+    expect(result).toHaveLength(0);
+  });
+
+  it("ignores parsed transfers from non-token programs", () => {
+    const innerInstructions = [
+      {
+        index: 0,
+        instructions: [
+          {
+            programId: "SomeOtherProgram11111111111111111",
+            parsed: {
+              type: "transferChecked",
+              info: {
+                mint: USDC_MINT,
+                destination: DEST_ATA,
+                authority: AUTHORITY,
+                tokenAmount: { amount: "100000" },
+              },
+            },
+          } as Record<string, unknown>,
+        ],
+      },
+    ];
+
+    const result = extractTransfersFromInnerInstructions(innerInstructions, []);
+    expect(result).toHaveLength(0);
+  });
+
+  it("extracts from multiple inner instruction groups", () => {
+    const innerInstructions = [
+      {
+        index: 0,
+        instructions: [
+          {
+            programId: TOKEN_PROGRAM as string,
+            parsed: {
+              type: "transferChecked",
+              info: {
+                mint: USDC_MINT,
+                destination: DEST_ATA,
+                authority: AUTHORITY,
+                tokenAmount: { amount: "50000" },
+              },
+            },
+          } as Record<string, unknown>,
+        ],
+      },
+      {
+        index: 1,
+        instructions: [
+          {
+            programId: TOKEN_2022_PROGRAM as string,
+            parsed: {
+              type: "transferChecked",
+              info: {
+                mint: USDC_MINT,
+                destination: "OtherDest1111111111111111111111111",
+                authority: "OtherAuth1111111111111111111111111",
+                tokenAmount: { amount: "25000" },
+              },
+            },
+          } as Record<string, unknown>,
+        ],
+      },
+    ];
+
+    const result = extractTransfersFromInnerInstructions(innerInstructions, []);
+    expect(result).toHaveLength(2);
+    expect(result[0].amount).toBe(BigInt(50000));
+    expect(result[1].amount).toBe(BigInt(25000));
+  });
+});
+
+describe("verifyPostSettlement", () => {
+  const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+  const PAY_TO = "BuyerAddress11111111111111111111111111111111";
+  const DEST_ATA = "DestATA111111111111111111111111111111111111";
+  const AUTHORITY = "AuthAddr111111111111111111111111111111111111";
+
+  const mockRequirements = {
+    scheme: "exact",
+    network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    amount: "10000",
+    asset: USDC_MINT,
+    payTo: PAY_TO,
+    maxTimeoutSeconds: 60,
+    extra: { feePayer: "FeePayer11111111111111111111111111111111111" },
+  };
+
+  it("verifies transfer via inner instructions when getTransaction succeeds", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getConfirmedTransactionInnerInstructions: async () => ({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              {
+                programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                parsed: {
+                  type: "transferChecked",
+                  info: {
+                    mint: USDC_MINT,
+                    destination: DEST_ATA,
+                    authority: AUTHORITY,
+                    tokenAmount: { amount: "10000" },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      null,
+    );
+
+    expect(result.method).toBe("innerInstructions");
+    // Note: verified may be false if ATA derivation doesn't match mock DEST_ATA.
+    // This test primarily validates the code path executes without error.
+  });
+
+  it("catches TOCTOU when inner instructions show no matching transfer", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getConfirmedTransactionInnerInstructions: async () => ({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [], // No transfers — malicious program skipped CPI
+          },
+        ],
+      }),
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      null,
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.method).toBe("innerInstructions");
+  });
+
+  it("falls back to balance delta when getTransaction returns null", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getConfirmedTransactionInnerInstructions: async () => null, // Indexing lag
+      getTokenAccountBalance: async () => BigInt(20000), // Balance increased
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      BigInt(10000), // balanceBefore = 10000, balanceAfter = 20000, delta = 10000 >= required
+    );
+
+    expect(result.verified).toBe(true);
+    expect(result.method).toBe("balanceDelta");
+  });
+
+  it("catches TOCTOU via balance delta when balance unchanged", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getConfirmedTransactionInnerInstructions: async () => null, // Indexing lag
+      getTokenAccountBalance: async () => BigInt(10000), // Balance unchanged
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      BigInt(10000), // balanceBefore = 10000, balanceAfter = 10000, delta = 0 < required
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.method).toBe("balanceDelta");
+  });
+
+  it("returns unverified when neither method is available", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      // No getConfirmedTransactionInnerInstructions
+      // No getTokenAccountBalance
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      null,
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.method).toBe("unverified");
+  });
+
+  it("rejects when both RPC calls fail (double failure)", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getConfirmedTransactionInnerInstructions: async () => {
+        throw new Error("RPC timeout");
+      },
+      getTokenAccountBalance: async () => {
+        throw new Error("RPC timeout");
+      },
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      BigInt(10000),
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.method).toBe("unverified");
+  });
+
+  it("accepts overpayment (amount > required)", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getConfirmedTransactionInnerInstructions: async () => null,
+      getTokenAccountBalance: async () => BigInt(30000), // 30000 - 10000 = 20000 >= 10000 required
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      BigInt(10000),
+    );
+
+    expect(result.verified).toBe(true);
+    expect(result.method).toBe("balanceDelta");
+  });
+
+  it("falls back to Token-2022 ATA when SPL Token ATA shows no delta", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    // Simulate: getTransaction unavailable (indexing lag).
+    // Payment used Token-2022, so SPL Token ATA is unchanged.
+    // The first ATA check (SPL Token) will throw or show no delta.
+    // The second ATA check (Token-2022) will show the correct delta.
+    let callCount = 0;
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getConfirmedTransactionInnerInstructions: async () => null, // Indexing lag
+      getTokenAccountBalance: async (_ata: string) => {
+        callCount++;
+        // First call: SPL Token ATA — no change (returns same as before)
+        if (callCount === 1) return BigInt(10000);
+        // Second call: Token-2022 ATA — balance increased
+        return BigInt(20000);
+      },
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      BigInt(10000), // balanceBefore
+      null, // no specific token program hint — try both
+    );
+
+    expect(result.verified).toBe(true);
+    expect(result.method).toBe("balanceDelta");
+    // Should have checked at least 2 ATAs (SPL Token first, then Token-2022)
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("uses hinted token program first in balance delta fallback", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    let callCount = 0;
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getConfirmedTransactionInnerInstructions: async () => null,
+      getTokenAccountBalance: async () => {
+        callCount++;
+        return BigInt(20000); // Balance increased on first try
+      },
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      BigInt(10000),
+      "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb", // Hint: Token-2022
+    );
+
+    expect(result.verified).toBe(true);
+    expect(result.method).toBe("balanceDelta");
+    // Should succeed on the first ATA check (Token-2022, the hinted program)
+    expect(callCount).toBe(1);
+  });
+});
+
+describe("ExactSvmScheme constructor enforcement", () => {
+  it("throws when signer missing required methods for smart wallet verification", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const incompleteSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+    };
+
+    expect(
+      () =>
+        new ExactSvmScheme(incompleteSigner as never, undefined, {
+          enableSmartWalletVerification: true,
+        }),
+    ).toThrow("enableSmartWalletVerification requires");
+  });
+
+  it("throws when signer has the other methods but lacks fetchAddressLookupTables", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    // All smart-wallet methods present except ALT resolution. Must still throw,
+    // because ALT-using wallets would otherwise fail later at verify time.
+    const signerMissingAlt = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      simulateTransactionWithInnerInstructions: async () => ({ innerInstructions: null }),
+      getConfirmedTransactionInnerInstructions: async () => null,
+      getTokenAccountBalance: async () => null,
+    };
+
+    expect(
+      () =>
+        new ExactSvmScheme(signerMissingAlt as never, undefined, {
+          enableSmartWalletVerification: true,
+        }),
+    ).toThrow("enableSmartWalletVerification requires fetchAddressLookupTables");
+  });
+
+  it("succeeds when signer has all required methods", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const completeSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      simulateTransactionWithInnerInstructions: async () => ({ innerInstructions: null }),
+      getConfirmedTransactionInnerInstructions: async () => null,
+      getTokenAccountBalance: async () => null,
+      fetchAddressLookupTables: async () => ({}),
+    };
+
+    expect(
+      () =>
+        new ExactSvmScheme(completeSigner as never, undefined, {
+          enableSmartWalletVerification: true,
+        }),
+    ).not.toThrow();
+  });
+
+  it("does not throw when smart wallet verification is disabled", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const minimalSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+    };
+
+    expect(() => new ExactSvmScheme(minimalSigner as never)).not.toThrow();
+  });
+});
+
+describe("assertFeePayerIsolated ALT handling", () => {
+  it("passes non-ALT transaction without signer (backward compatible)", async () => {
+    const { assertFeePayerIsolated } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const feePayer = await generateKeyPairSigner();
+    const otherAccount = await generateKeyPairSigner();
+
+    const tx = await buildTransaction(feePayer.address, [
+      {
+        programAddress: COMPUTE_BUDGET_PROGRAM,
+        accounts: [{ address: otherAccount.address, role: 1 }],
+        data: new Uint8Array([2, 0, 0, 0, 0]),
+      },
+    ]);
+
+    await expect(assertFeePayerIsolated(tx as never, feePayer.address)).resolves.not.toThrow();
+  });
+
+  it("rejects ALT transaction when signer lacks fetchAddressLookupTables", async () => {
+    const { assertFeePayerIsolated } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+    const { getCompiledTransactionMessageEncoder } = await import("@solana/kit");
+
+    const feePayer = await generateKeyPairSigner();
+    const altAddr = await generateKeyPairSigner();
+
+    const compiled = {
+      version: 0 as const,
+      header: {
+        numSignerAccounts: 1,
+        numReadonlySignerAccounts: 0,
+        numReadonlyNonSignerAccounts: 1,
+      },
+      staticAccounts: [feePayer.address, COMPUTE_BUDGET_PROGRAM],
+      lifetimeToken: "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi",
+      instructions: [
+        {
+          programAddressIndex: 1,
+          accountIndices: [2],
+          data: new Uint8Array([2, 0, 0, 0, 0]),
+        },
+      ],
+      addressTableLookups: [
+        {
+          lookupTableAddress: altAddr.address,
+          writableIndexes: [0],
+          readonlyIndexes: [],
+        },
+      ],
+    };
+
+    const messageBytes = getCompiledTransactionMessageEncoder().encode(compiled);
+    const tx = { messageBytes, signatures: {} };
+
+    const signerWithoutALT = {
+      getAddresses: () => [feePayer.address],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+    };
+
+    await expect(
+      assertFeePayerIsolated(
+        tx as never,
+        feePayer.address,
+        signerWithoutALT as never,
+        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      ),
+    ).rejects.toThrow("smart_wallet_alt_resolution_not_available");
+  });
+
+  it("catches fee payer hidden in ALT-resolved accounts", async () => {
+    const { assertFeePayerIsolated } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+    const { getCompiledTransactionMessageEncoder } = await import("@solana/kit");
+
+    const feePayer = await generateKeyPairSigner();
+    const altAddr = await generateKeyPairSigner();
+
+    const compiled = {
+      version: 0 as const,
+      header: {
+        numSignerAccounts: 1,
+        numReadonlySignerAccounts: 0,
+        numReadonlyNonSignerAccounts: 1,
+      },
+      staticAccounts: [feePayer.address, COMPUTE_BUDGET_PROGRAM],
+      lifetimeToken: "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi",
+      instructions: [
+        {
+          programAddressIndex: 1,
+          accountIndices: [2],
+          data: new Uint8Array([2, 0, 0, 0, 0]),
+        },
+      ],
+      addressTableLookups: [
+        {
+          lookupTableAddress: altAddr.address,
+          writableIndexes: [0],
+          readonlyIndexes: [],
+        },
+      ],
+    };
+
+    const messageBytes = getCompiledTransactionMessageEncoder().encode(compiled);
+    const tx = { messageBytes, signatures: {} };
+
+    const signerWithALT = {
+      getAddresses: () => [feePayer.address],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      fetchAddressLookupTables: async () => ({
+        [altAddr.address.toString()]: [feePayer.address.toString()],
+      }),
+    };
+
+    await expect(
+      assertFeePayerIsolated(
+        tx as never,
+        feePayer.address,
+        signerWithALT as never,
+        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      ),
+    ).rejects.toThrow("smart_wallet_fee_payer_not_isolated");
+  });
+
+  it("propagates ALT resolution failure instead of treating it as no ALTs", async () => {
+    const { assertFeePayerIsolated } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+    const { getCompiledTransactionMessageEncoder } = await import("@solana/kit");
+
+    const feePayer = await generateKeyPairSigner();
+    const altAddr = await generateKeyPairSigner();
+
+    const compiled = {
+      version: 0 as const,
+      header: {
+        numSignerAccounts: 1,
+        numReadonlySignerAccounts: 0,
+        numReadonlyNonSignerAccounts: 1,
+      },
+      staticAccounts: [feePayer.address, COMPUTE_BUDGET_PROGRAM],
+      lifetimeToken: "4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi",
+      instructions: [
+        {
+          programAddressIndex: 1,
+          accountIndices: [2],
+          data: new Uint8Array([2, 0, 0, 0, 0]),
+        },
+      ],
+      addressTableLookups: [
+        {
+          lookupTableAddress: altAddr.address,
+          writableIndexes: [0],
+          readonlyIndexes: [],
+        },
+      ],
+    };
+
+    const messageBytes = getCompiledTransactionMessageEncoder().encode(compiled);
+    const tx = { messageBytes, signatures: {} };
+
+    // Signer implements fetchAddressLookupTables but the RPC call fails. The
+    // failure must surface (not be swallowed into an empty map), so the fee-payer
+    // isolation check fails closed rather than proceeding with unresolved accounts.
+    const signerWithFailingALT = {
+      getAddresses: () => [feePayer.address],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      fetchAddressLookupTables: async () => {
+        throw new Error("smart_wallet_alt_resolution_failed: rpc unavailable");
+      },
+    };
+
+    await expect(
+      assertFeePayerIsolated(
+        tx as never,
+        feePayer.address,
+        signerWithFailingALT as never,
+        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      ),
+    ).rejects.toThrow("smart_wallet_alt_resolution_failed");
+  });
+});


### PR DESCRIPTION
## Description

Adds wallet-agnostic smart wallet verification to the SVM facilitator (TypeScript). Verifies payment outcomes by inspecting top-level instructions and the CPI trace from transaction simulation, rather than parsing each wallet type's proprietary instruction format.

Works for any smart wallet program (Squads, Swig, SPL Governance, Crossmint, future wallets) that executes `TransferChecked` via CPI. No per-wallet code required. This approach has been running in production at [Dexter](https://dexter.cash) and is the first implementation to verify and settle smart wallet transactions on-chain.

## Motivation

The existing SVM facilitator rejects any transaction that doesn't match the exact 3-6 instruction layout (ComputeLimit + ComputePrice + TransferChecked + optional Lighthouse/Memo). Smart wallet programs wrap transfers inside their own instructions (e.g., Squads `vaultTransactionExecute`, Swig `SignV2`), so the facilitator sees an unknown program at position [2] and rejects with `no_transfer_instruction`.

This is a fundamental limitation of positional instruction validation. Every smart wallet has a different instruction format, but they all do the same thing: execute a `TransferChecked` via CPI.

## Approach

`ExactSvmScheme.verify()` now has two paths:

**Path 1 (Static)**: Existing positional instruction validation for standard wallets. Unchanged. Standard wallets keep this fast path; simulation is only a fallback for transactions the current verifier cannot structurally understand.

**Path 2 (Simulation)**: When Path 1 rejects and `enableSmartWalletVerification` is set:

1. **Fee payer isolation**: the facilitator's fee payer must not appear in any instruction's accounts. If the fee payer is never referenced, the Solana runtime cannot authorize it for SOL transfers, token approvals, ATA creation, account closes, or any other drain vector.
2. **Compute budget caps**: operator-configurable CU limit and priority fee caps on ComputeBudget instructions. Bounds the facilitator's fee exposure.
3. **Simulate with `innerInstructions: true`**: the facilitator already calls `simulateTransaction` as its final verification step. Path 2 uses the same RPC method with `innerInstructions: true` to get the full CPI trace. No additional round-trip.
4. **Match exactly one transfer**: require exactly one `TransferChecked` across top-level instructions and the CPI trace, matching payment requirements (correct mint, destination ATA derived from `payTo`, amount exactly equals required).

```mermaid
flowchart TD
    TX["Transaction arrives"] --> DECODE["Decode"]
    DECODE --> P1{"Path 1: Static layout check"}
    P1 -->|"Layout matches"| SIM1["Sign + Simulate"]
    SIM1 --> PASS1["VERIFIED"]
    P1 -->|"Unknown program / wrong layout"| SW{"Smart wallet enabled?"}
    SW -->|"No"| REJECT["REJECTED"]
    SW -->|"Yes"| FPI{"Fee payer isolated?"}
    FPI -->|"No"| REJECT
    FPI -->|"Yes"| CB{"Compute budget OK?"}
    CB -->|"No"| REJECT
    CB -->|"Yes"| SIM2["Simulate + innerInstructions"]
    SIM2 -->|"Fails"| REJECT
    SIM2 -->|"Succeeds"| EXTRACT["Extract TransferChecked"]
    EXTRACT --> MATCH{"Exactly 1 match?"}
    MATCH -->|"No"| REJECT
    MATCH -->|"Yes"| PASS2["VERIFIED"]
```

## Security model

| Property | How it's enforced |
|---|---|
| Facilitator funds protected | Fee payer isolation: fee payer never appears in any instruction's accounts list |
| Correct payment recipient | Destination ATA derived from `payTo` + mint, matched against observed transfers |
| Correct payment amount | Amount from `TransferChecked` checked against requirements |
| Correct token | Mint from `TransferChecked` checked against requirements |
| Fee exposure bounded | Operator-configurable compute unit and priority fee caps |
| No double-payment | Exactly one matching transfer required; multiple matches rejected |
| Transaction viability | Simulation proves the transaction would succeed on-chain |

## Production data

Tested against ecosystem facilitators using a real Squads multisig vault transaction, both verify and settle. No other facilitator currently passes.

## Changes

| File | Change |
|------|--------|
| `svm/src/signer.ts` | Add optional `simulateTransactionWithInnerInstructions` to `FacilitatorSvmSigner`; implement in default factory |
| `svm/src/exact/facilitator/scheme.ts` | Add `ExactSvmSchemeOptions` with smart wallet config; refactor `verify()` into dual-path (static + simulation) |
| `svm/src/exact/facilitator/smartWalletVerification.ts` | **New**: `assertFeePayerIsolated`, `validateComputeBudgetLimits`, `extractTransfersFromInnerInstructions`, `verifySmartWalletTransaction` |
| `svm/src/index.ts` | Re-export smart wallet helpers and types |
| `svm/test/unit/smartWalletVerification.test.ts` | **New**: 19 unit tests |
| `svm/test/unit/smartWalletFallback.test.ts` | **New**: 3 integration tests (fallback path verify) |

Go and Python implementations are left for follow-up. This PR is intentionally TypeScript-only to validate the upstream architecture first. If maintainers agree with outcome-based verification as the direction, Go/Python parity can follow without replicating wallet-specific parsers across all SDKs. This PR targets non-ALT smart-wallet transaction shapes first; ALT-aware inner instruction resolution can follow with concrete test cases.

## Usage

```typescript
import { ExactSvmScheme } from "@x402/svm";

const scheme = new ExactSvmScheme(signer, undefined, {
  enableSmartWalletVerification: true,
  smartWalletMaxComputeUnits: 400_000,            // optional, default 400k
  smartWalletMaxPriorityFeeMicroLamports: 50_000,  // optional, default 50k
});
```

## Tests

- [x] All existing tests pass
- [x] 19 new smart wallet verification tests pass (security helpers, adversarial cases, extraction, fallback path integration)
- [x] ESM and CJS builds succeed
- [x] No new TypeScript errors introduced

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
