### PR TITLE
Add Octomil to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/octomil/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/octomil/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Octomil",
+  "description": "On-device ML inference as an x402-gated MCP server. Agents pay per tool call to run LLMs locally — code generation, code review, inference, model benchmarking, and more. Payments are accumulated and batch-settled via settle402.",
+  "logoUrl": "/logos/octomil.svg",
+  "websiteUrl": "https://octomil.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/octomil.svg
+++ b/typescript/site/public/logos/octomil.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="24" fill="#0a0a0a"/>
+  <text x="100" y="115" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="40" font-weight="700" fill="#ffffff">octomil</text>
+</svg>


### PR DESCRIPTION
## Summary

- Adds Octomil as a service in the x402 ecosystem
- Octomil is an on-device ML inference platform exposed as an x402-gated MCP server
- Agents pay per tool call (code generation, code review, inference, benchmarking)
- Payments are batch-settled on-chain via settle402

## Details

- **Website:** https://octomil.com
- **Category:** Services/Endpoints
- **How agents use it:** `octomil mcp serve --x402` starts an HTTP agent server with x402 payment gating
- **Tools available:** run_inference, generate_code, review_code, explain_code, write_tests, benchmark_model, and more
- **60+ models:** Gemma, Llama, Phi, Qwen, DeepSeek, Mistral — auto engine selection (MLX, llama.cpp, ONNX)

## Files

- `typescript/site/app/ecosystem/partners-data/octomil/metadata.json` — service metadata
- `typescript/site/public/logos/octomil.svg` — logo