### PR TITLE
Fixed paywall config injection

### DIFF
--- a/go/.changes/unreleased/fixed-20260310-221203.yaml
+++ b/go/.changes/unreleased/fixed-20260310-221203.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Fixed paywall config injection targeting `</body>` causing SVG parse errors in the browser
+time: 2026-03-10T22:12:03.806859+09:00

--- a/go/http/paywall_test.go
+++ b/go/http/paywall_test.go
@@ -277,7 +277,7 @@ func TestRegisterPaywallProvider(t *testing.T) {
 // --- injectPaywallConfig tests ---
 
 func TestInjectPaywallConfig(t *testing.T) {
-	template := "<html><body></body></html>"
+	template := "<html><head></head><body></body></html>"
 	paymentReq := makePaymentRequired("eip155:8453")
 
 	t.Run("injects window.x402 config", func(t *testing.T) {

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -939,7 +939,7 @@ func (s *x402HTTPResourceServer) generatePaywallHTML(paymentRequired x402.Paymen
 
 	// Select template based on network
 	template := s.selectPaywallTemplate(paymentRequired)
-	return strings.Replace(template, "</body>", configScript+"</body>", 1)
+	return strings.Replace(template, "</head>", configScript+"\n</head>", 1)
 }
 
 // selectPaywallTemplate chooses the appropriate paywall template based on the network
@@ -1023,7 +1023,7 @@ func injectPaywallConfig(template string, paymentRequired types.PaymentRequired,
 		html.EscapeString(currentURL),
 	)
 
-	return strings.Replace(template, "</body>", configScript+"</body>", 1)
+	return strings.Replace(template, "</head>", configScript+"\n</head>", 1)
 }
 
 // ============================================================================

--- a/python/x402/changelog.d/1550.bugfix.md
+++ b/python/x402/changelog.d/1550.bugfix.md
@@ -1,0 +1,1 @@
+Fixed paywall config injection targeting </body> causing SVG parse errors in the browser

--- a/python/x402/http/paywall/__init__.py
+++ b/python/x402/http/paywall/__init__.py
@@ -166,7 +166,7 @@ class EvmPaywallHandler:
     window.x402 = {htmlsafe_json_dumps(x402_config)};
   </script>"""
 
-        return template.replace("</head>", f"{config_script}\n</head>")
+        return template.replace("</head>", f"{config_script}\n</head>", 1)
 
     def _fallback_html(
         self,
@@ -243,7 +243,7 @@ class SvmPaywallHandler:
     window.x402 = {htmlsafe_json_dumps(x402_config)};
   </script>"""
 
-        return template.replace("</head>", f"{config_script}\n</head>")
+        return template.replace("</head>", f"{config_script}\n</head>", 1)
 
     def _fallback_html(
         self,

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -749,7 +749,7 @@ class x402HTTPServerBase:
             f"<script>\n    window.x402 = {htmlsafe_json_dumps(x402_config)};\n</script>"
         )
 
-        return template.replace("</body>", config_script + "</body>")
+        return template.replace("</head>", config_script + "\n</head>", 1)
 
     def _generate_fallback_html(
         self,


### PR DESCRIPTION
## Description

- Paywall config injection in Python/Go replaces `</body>` in the template, but the minified JS contains `</body>` inside a template literal breaking the inline `<script>` and causing SVG parse errors in the browser
- Changed injection point to `</head>` (matching the TypeScript paywall) with first-occurrence-only replacement, since the first `</head>` is always the real HTML tag


## Tests

Manually tested go/py paywall UIs

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 