### PR TITLE
feat: validate bazaar config on server startup

### DIFF
--- a/e2e/clients/httpx/uv.lock
+++ b/e2e/clients/httpx/uv.lock
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/facilitators/python/uv.lock
+++ b/e2e/facilitators/python/uv.lock
@@ -2846,7 +2846,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/fastapi/uv.lock
+++ b/e2e/servers/fastapi/uv.lock
@@ -2841,7 +2841,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/go/.changes/unreleased/added-20260311-003154.yaml
+++ b/go/.changes/unreleased/added-20260311-003154.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Added startup-time bazaar extension validation in Gin middleware using JSON-schema validation from the bazaar extension package
+time: 2026-03-11T00:31:54.000000+00:00

--- a/go/extensions/bazaar/bazaar_test.go
+++ b/go/extensions/bazaar/bazaar_test.go
@@ -280,6 +280,133 @@ func TestValidateDiscoveryExtension(t *testing.T) {
 	})
 }
 
+func TestValidateDiscoveryExtensionSpec(t *testing.T) {
+	t.Run("should pass for valid HTTP GET extension", func(t *testing.T) {
+		ext, _ := bazaar.DeclareDiscoveryExtension(
+			bazaar.MethodGET,
+			map[string]interface{}{"q": "test"},
+			bazaar.JSONSchema{"properties": map[string]interface{}{"q": map[string]interface{}{"type": "string"}}},
+			"",
+			nil,
+		)
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.True(t, result.Valid)
+	})
+
+	t.Run("should pass for valid HTTP POST extension", func(t *testing.T) {
+		ext, _ := bazaar.DeclareDiscoveryExtension(
+			bazaar.MethodPOST,
+			map[string]interface{}{"name": "foo"},
+			bazaar.JSONSchema{"properties": map[string]interface{}{"name": map[string]interface{}{"type": "string"}}},
+			bazaar.BodyTypeJSON,
+			nil,
+		)
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.True(t, result.Valid)
+	})
+
+	t.Run("should pass for pre-enrichment HTTP extension (no method)", func(t *testing.T) {
+		ext := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.QueryInput{Type: "http"},
+			},
+			Schema: bazaar.JSONSchema{},
+		}
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.True(t, result.Valid)
+	})
+
+	t.Run("should fail for invalid input.type", func(t *testing.T) {
+		ext := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.QueryInput{Type: "grpc"},
+			},
+			Schema: bazaar.JSONSchema{},
+		}
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.False(t, result.Valid)
+		assert.Contains(t, result.Errors[0], "input.type")
+	})
+
+	t.Run("should fail for invalid HTTP method", func(t *testing.T) {
+		ext := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.QueryInput{Type: "http", Method: "DESTROY"},
+			},
+			Schema: bazaar.JSONSchema{},
+		}
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.False(t, result.Valid)
+		assert.Contains(t, result.Errors[0], "method")
+	})
+
+	t.Run("should fail for invalid bodyType", func(t *testing.T) {
+		ext := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.BodyInput{Type: "http", Method: "POST", BodyType: "xml"},
+			},
+			Schema: bazaar.JSONSchema{},
+		}
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.False(t, result.Valid)
+		assert.Contains(t, result.Errors[0], "bodyType")
+	})
+
+	t.Run("should fail when bodyType set with non-body method", func(t *testing.T) {
+		ext := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.BodyInput{Type: "http", Method: "GET", BodyType: "json"},
+			},
+			Schema: bazaar.JSONSchema{},
+		}
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.False(t, result.Valid)
+		hasBodyMethodErr := false
+		for _, e := range result.Errors {
+			if strings.Contains(e, "not a body method") {
+				hasBodyMethodErr = true
+			}
+		}
+		assert.True(t, hasBodyMethodErr)
+	})
+
+	t.Run("should fail for MCP missing toolName", func(t *testing.T) {
+		ext := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{},
+			Schema: bazaar.JSONSchema{},
+		}
+		extJSON := `{"info":{"input":{"type":"mcp","inputSchema":{"type":"object"}}},"schema":{}}`
+		_ = json.Unmarshal([]byte(extJSON), &ext)
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.False(t, result.Valid)
+		assert.Contains(t, result.Errors[0], "toolName")
+	})
+
+	t.Run("should fail for MCP missing inputSchema", func(t *testing.T) {
+		ext := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{},
+			Schema: bazaar.JSONSchema{},
+		}
+		extJSON := `{"info":{"input":{"type":"mcp","toolName":"t"}},"schema":{}}`
+		_ = json.Unmarshal([]byte(extJSON), &ext)
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.False(t, result.Valid)
+		assert.Contains(t, result.Errors[0], "inputSchema")
+	})
+
+	t.Run("should fail for MCP invalid transport", func(t *testing.T) {
+		ext := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{},
+			Schema: bazaar.JSONSchema{},
+		}
+		extJSON := `{"info":{"input":{"type":"mcp","toolName":"t","inputSchema":{"type":"object"},"transport":"websocket"}},"schema":{}}`
+		_ = json.Unmarshal([]byte(extJSON), &ext)
+		result := bazaar.ValidateDiscoveryExtensionSpec(ext)
+		assert.False(t, result.Valid)
+		assert.Contains(t, result.Errors[0], "transport")
+	})
+}
+
 func TestExtractDiscoveryInfoFromExtension(t *testing.T) {
 	t.Run("should extract info from a valid extension", func(t *testing.T) {
 		extension, _ := bazaar.DeclareDiscoveryExtension(

--- a/go/extensions/bazaar/facilitator.go
+++ b/go/extensions/bazaar/facilitator.go
@@ -86,6 +86,89 @@ func ValidateDiscoveryExtension(extension types.DiscoveryExtension) ValidationRe
 	}
 }
 
+// ValidateDiscoveryExtensionSpec validates a discovery extension against the Bazaar protocol
+// specification. Unlike ValidateDiscoveryExtension which checks internal consistency (info vs
+// schema), this function enforces protocol-level invariants:
+//   - info.input.type must be "http" or "mcp"
+//   - HTTP: if method is present it must be GET/POST/PUT/PATCH/DELETE/HEAD
+//   - HTTP body methods: bodyType must be "json", "form-data", or "text"
+//   - MCP: toolName (string) and inputSchema (object) are required
+//   - MCP: if transport is present it must be "streamable-http" or "sse"
+//
+// Safe for pre-enrichment HTTP extensions where method may be absent.
+func ValidateDiscoveryExtensionSpec(extension types.DiscoveryExtension) ValidationResult {
+	infoJSON, err := json.Marshal(extension.Info)
+	if err != nil {
+		return ValidationResult{Valid: false, Errors: []string{"Failed to marshal info"}}
+	}
+
+	var raw struct {
+		Input map[string]interface{} `json:"input"`
+	}
+	if err := json.Unmarshal(infoJSON, &raw); err != nil || raw.Input == nil {
+		return ValidationResult{Valid: false, Errors: []string{"Missing or invalid 'info.input' field"}}
+	}
+
+	inputType, _ := raw.Input["type"].(string)
+	if inputType != "http" && inputType != "mcp" {
+		return ValidationResult{
+			Valid:  false,
+			Errors: []string{fmt.Sprintf(`info.input.type must be "http" or "mcp", got %q`, inputType)},
+		}
+	}
+
+	var errors []string
+
+	if inputType == "http" {
+		if method, ok := raw.Input["method"]; ok {
+			methodStr, _ := method.(string)
+			if !types.IsQueryMethod(methodStr) && !types.IsBodyMethod(methodStr) {
+				errors = append(errors, fmt.Sprintf(
+					"info.input.method must be one of DELETE, GET, HEAD, PATCH, POST, PUT, got %q", methodStr))
+			}
+		}
+
+		if bt, ok := raw.Input["bodyType"]; ok {
+			btStr, _ := bt.(string)
+			if btStr != "json" && btStr != "form-data" && btStr != "text" {
+				errors = append(errors, fmt.Sprintf(
+					`info.input.bodyType must be one of json, form-data, text, got %q`, btStr))
+			}
+			if method, ok2 := raw.Input["method"]; ok2 {
+				methodStr, _ := method.(string)
+				if !types.IsBodyMethod(methodStr) {
+					errors = append(errors, fmt.Sprintf(
+						`info.input.bodyType is set but method %q is not a body method (POST, PUT, PATCH)`, methodStr))
+				}
+			}
+		}
+	}
+
+	if inputType == "mcp" {
+		toolName, _ := raw.Input["toolName"].(string)
+		if toolName == "" {
+			errors = append(errors, "info.input.toolName is required and must be a non-empty string for MCP extensions")
+		}
+		if is, ok := raw.Input["inputSchema"]; !ok || is == nil {
+			errors = append(errors, "info.input.inputSchema is required and must be an object for MCP extensions")
+		} else if _, isMap := is.(map[string]interface{}); !isMap {
+			errors = append(errors, "info.input.inputSchema is required and must be an object for MCP extensions")
+		}
+		if transport, ok := raw.Input["transport"]; ok {
+			tStr, _ := transport.(string)
+			if tStr != "streamable-http" && tStr != "sse" {
+				errors = append(errors, fmt.Sprintf(
+					`info.input.transport must be one of streamable-http, sse, got %q`, tStr))
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return ValidationResult{Valid: false, Errors: errors}
+	}
+	return ValidationResult{Valid: true}
+}
+
 type DiscoveredResource struct {
 	ResourceURL   string
 	Method        string

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -313,6 +313,12 @@ func validateSingleBazaarExtension(pattern string, extensions map[string]interfa
 	if err := json.Unmarshal(extJSON, &ext); err != nil {
 		return
 	}
+	specResult := bazaar.ValidateDiscoveryExtensionSpec(ext)
+	if !specResult.Valid {
+		fmt.Printf("x402 Warning: Route %q has invalid bazaar extension: %s\n",
+			pattern, strings.Join(specResult.Errors, ", "))
+		return
+	}
 	result := bazaar.ValidateDiscoveryExtension(ext)
 	if !result.Valid {
 		fmt.Printf("x402 Warning: Route %q has invalid bazaar extension: %s\n",

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -3,13 +3,16 @@ package gin
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/extensions/bazaar"
+	extypes "github.com/coinbase/x402/go/extensions/types"
 	x402http "github.com/coinbase/x402/go/http"
 	"github.com/gin-gonic/gin"
 )
@@ -189,6 +192,8 @@ func PaymentMiddleware(routes x402http.RoutesConfig, server *x402.X402ResourceSe
 		}
 	}
 
+	validateBazaarExtensions(routes)
+
 	// Create middleware handler using shared logic
 	return createMiddlewareHandler(httpServer, config)
 }
@@ -227,6 +232,8 @@ func PaymentMiddlewareFromHTTPServer(httpServer *x402http.HTTPServer, opts ...Mi
 			fmt.Printf("Warning: failed to initialize x402 server: %v\n", err)
 		}
 	}
+
+	validateBazaarExtensionsFromServer(httpServer)
 
 	// Create middleware handler using shared logic
 	return createMiddlewareHandler(httpServer, config)
@@ -271,8 +278,46 @@ func PaymentMiddlewareFromConfig(routes x402http.RoutesConfig, opts ...Middlewar
 		}
 	}
 
+	validateBazaarExtensions(config.Routes)
+
 	// Create middleware handler
 	return createMiddlewareHandler(httpServer, config)
+}
+
+// validateBazaarExtensions validates all bazaar extensions declared on routes using
+// the bazaar package's JSON-schema validator. Emits warnings but does not block startup.
+func validateBazaarExtensions(routes x402http.RoutesConfig) {
+	for pattern, config := range routes {
+		validateSingleBazaarExtension(pattern, config.Extensions)
+	}
+}
+
+// validateBazaarExtensionsFromServer validates bazaar extensions from pre-compiled routes.
+func validateBazaarExtensionsFromServer(server *x402http.HTTPServer) {
+	for _, route := range server.GetCompiledRoutes() {
+		pattern := route.Verb + " " + route.Regex.String()
+		validateSingleBazaarExtension(pattern, route.Config.Extensions)
+	}
+}
+
+func validateSingleBazaarExtension(pattern string, extensions map[string]interface{}) {
+	extVal, ok := extensions[extypes.BAZAAR.Key()]
+	if !ok || extVal == nil {
+		return
+	}
+	extJSON, err := json.Marshal(extVal)
+	if err != nil {
+		return
+	}
+	var ext extypes.DiscoveryExtension
+	if err := json.Unmarshal(extJSON, &ext); err != nil {
+		return
+	}
+	result := bazaar.ValidateDiscoveryExtension(ext)
+	if !result.Valid {
+		fmt.Printf("x402 Warning: Route %q has invalid bazaar extension: %s\n",
+			pattern, strings.Join(result.Errors, ", "))
+	}
 }
 
 // createMiddlewareHandler creates the actual Gin handler function.

--- a/go/http/gin/middleware_test.go
+++ b/go/http/gin/middleware_test.go
@@ -6,9 +6,12 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -1402,4 +1405,113 @@ func (m *mockGinResponseWriter) Flush() {
 
 func (m *mockGinResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, nil
+}
+
+// ============================================================================
+// Bazaar Extension Validation Tests
+// ============================================================================
+
+func captureStdout(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+	return buf.String()
+}
+
+func TestValidateBazaarExtensions_NoBazaar(t *testing.T) {
+	routes := x402http.RoutesConfig{
+		"GET /api": {
+			Accepts: x402http.PaymentOptions{
+				{Scheme: "exact", PayTo: "0xtest", Price: "$1.00", Network: "eip155:8453"},
+			},
+		},
+	}
+
+	output := captureStdout(func() {
+		validateBazaarExtensions(routes)
+	})
+
+	if strings.Contains(output, "Warning") || strings.Contains(output, "bazaar") {
+		t.Errorf("Expected no bazaar warning, got: %s", output)
+	}
+}
+
+func TestValidateBazaarExtensions_ValidExtension(t *testing.T) {
+	routes := x402http.RoutesConfig{
+		"GET /api": {
+			Accepts: x402http.PaymentOptions{
+				{Scheme: "exact", PayTo: "0xtest", Price: "$1.00", Network: "eip155:8453"},
+			},
+			Extensions: map[string]interface{}{
+				"bazaar": map[string]interface{}{
+					"info": map[string]interface{}{
+						"input": map[string]interface{}{
+							"type":   "http",
+							"method": "GET",
+						},
+					},
+					"schema": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"input": map[string]interface{}{"type": "object"},
+						},
+						"required": []interface{}{"input"},
+					},
+				},
+			},
+		},
+	}
+
+	output := captureStdout(func() {
+		validateBazaarExtensions(routes)
+	})
+
+	if strings.Contains(output, "Warning") || strings.Contains(output, "invalid") {
+		t.Errorf("Expected no warning for valid bazaar extension, got: %s", output)
+	}
+}
+
+func TestValidateBazaarExtensions_InvalidExtension(t *testing.T) {
+	routes := x402http.RoutesConfig{
+		"GET /api": {
+			Accepts: x402http.PaymentOptions{
+				{Scheme: "exact", PayTo: "0xtest", Price: "$1.00", Network: "eip155:8453"},
+			},
+			Extensions: map[string]interface{}{
+				"bazaar": map[string]interface{}{
+					"info": map[string]interface{}{
+						"input": map[string]interface{}{
+							"type":   "http",
+							"method": "GET",
+						},
+					},
+					"schema": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"input": map[string]interface{}{"type": "object"},
+							"jobs":  map[string]interface{}{"type": "array"},
+							"count": map[string]interface{}{"type": "integer"},
+						},
+						"required": []interface{}{"input", "jobs", "count"},
+					},
+				},
+			},
+		},
+	}
+
+	output := captureStdout(func() {
+		validateBazaarExtensions(routes)
+	})
+
+	if !strings.Contains(output, "Warning") {
+		t.Errorf("Expected warning for invalid bazaar extension, got: %q", output)
+	}
+	if !strings.Contains(output, "bazaar") {
+		t.Errorf("Expected 'bazaar' in warning output, got: %q", output)
+	}
 }

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -269,6 +269,11 @@ func Wrappedx402HTTPResourceServer(routes RoutesConfig, resourceServer *x402.X40
 	return server
 }
 
+// GetCompiledRoutes returns the compiled routes for inspection (e.g., extension validation).
+func (s *x402HTTPResourceServer) GetCompiledRoutes() []CompiledRoute {
+	return s.compiledRoutes
+}
+
 // RegisterPaywallProvider registers a custom PaywallProvider for generating paywall HTML.
 // The provider takes precedence over the built-in EVM/SVM templates but is overridden
 // by per-route CustomPaywallHTML. Returns the server for method chaining.
@@ -330,6 +335,7 @@ func (s *x402HTTPResourceServer) validateRouteConfiguration() error {
 				})
 			}
 		}
+
 	}
 
 	if len(errors) > 0 {

--- a/python/x402/changelog.d/671.feature.md
+++ b/python/x402/changelog.d/671.feature.md
@@ -1,0 +1,1 @@
+Added startup-time JSON-schema validation for bazaar discovery extensions in FastAPI and Flask middleware

--- a/python/x402/extensions/bazaar/__init__.py
+++ b/python/x402/extensions/bazaar/__init__.py
@@ -57,6 +57,7 @@ from .facilitator import (
     extract_discovery_info_from_extension,
     validate_and_extract,
     validate_discovery_extension,
+    validate_discovery_extension_spec,
 )
 from .facilitator_client import (
     BazaarClientExtension,
@@ -128,6 +129,7 @@ __all__ = [
     # Functions
     "declare_discovery_extension",
     "validate_discovery_extension",
+    "validate_discovery_extension_spec",
     "extract_discovery_info",
     "extract_discovery_info_from_extension",
     "validate_and_extract",

--- a/python/x402/extensions/bazaar/facilitator.py
+++ b/python/x402/extensions/bazaar/facilitator.py
@@ -114,6 +114,102 @@ def validate_discovery_extension(extension: DiscoveryExtension) -> ValidationRes
         return ValidationResult(valid=False, errors=[f"Schema validation failed: {e!s}"])
 
 
+_VALID_QUERY_METHODS = frozenset({"GET", "HEAD", "DELETE"})
+_VALID_BODY_METHODS = frozenset({"POST", "PUT", "PATCH"})
+_VALID_METHODS = _VALID_QUERY_METHODS | _VALID_BODY_METHODS
+_VALID_BODY_TYPES = frozenset({"json", "form-data", "text"})
+_VALID_MCP_TRANSPORTS = frozenset({"streamable-http", "sse"})
+
+
+def validate_discovery_extension_spec(extension: dict[str, Any] | object) -> ValidationResult:
+    """Validate a discovery extension against the Bazaar protocol specification.
+
+    Unlike ``validate_discovery_extension`` which checks internal consistency
+    (info vs schema), this function enforces protocol-level invariants:
+
+    - ``info.input.type`` must be ``"http"`` or ``"mcp"``
+    - HTTP: if ``method`` is present it must be GET/POST/PUT/PATCH/DELETE/HEAD
+    - HTTP body methods: ``bodyType`` must be ``"json"`` | ``"form-data"`` | ``"text"``
+    - MCP: ``toolName`` (string) and ``inputSchema`` (object) are required
+    - MCP: if ``transport`` is present it must be ``"streamable-http"`` | ``"sse"``
+
+    Safe for pre-enrichment HTTP extensions where ``method`` may be absent.
+
+    Args:
+        extension: The discovery extension to validate (dict or object).
+
+    Returns:
+        ValidationResult with spec-level errors.
+    """
+    errors: list[str] = []
+
+    if isinstance(extension, dict):
+        info = extension.get("info")
+    elif hasattr(extension, "info"):
+        info = extension.info  # type: ignore[union-attr]
+    else:
+        return ValidationResult(valid=False, errors=["Missing or invalid 'info' field"])
+
+    if not info or not isinstance(info, dict | object):
+        return ValidationResult(valid=False, errors=["Missing or invalid 'info' field"])
+
+    if isinstance(info, dict):
+        input_data = info.get("input")
+    elif hasattr(info, "input"):
+        input_data = info.input  # type: ignore[union-attr]
+    else:
+        return ValidationResult(valid=False, errors=["Missing or invalid 'info.input' field"])
+
+    if not input_data:
+        return ValidationResult(valid=False, errors=["Missing or invalid 'info.input' field"])
+
+    if isinstance(input_data, dict):
+        input_type = input_data.get("type")
+    elif hasattr(input_data, "type"):
+        input_type = input_data.type  # type: ignore[union-attr]
+    else:
+        input_type = None
+
+    if input_type not in ("http", "mcp"):
+        errors.append(f'info.input.type must be "http" or "mcp", got "{input_type}"')
+        return ValidationResult(valid=False, errors=errors)
+
+    if input_type == "http":
+        method = input_data.get("method") if isinstance(input_data, dict) else getattr(input_data, "method", None)
+        if method is not None and method not in _VALID_METHODS:
+            errors.append(
+                f"info.input.method must be one of {', '.join(sorted(_VALID_METHODS))}, got \"{method}\""
+            )
+
+        body_type = input_data.get("bodyType") if isinstance(input_data, dict) else getattr(input_data, "body_type", None)
+        if body_type is not None:
+            if body_type not in _VALID_BODY_TYPES:
+                errors.append(
+                    f"info.input.bodyType must be one of {', '.join(sorted(_VALID_BODY_TYPES))}, got \"{body_type}\""
+                )
+            if method is not None and method not in _VALID_BODY_METHODS:
+                errors.append(
+                    f'info.input.bodyType is set but method "{method}" is not a body method (POST, PUT, PATCH)'
+                )
+
+    if input_type == "mcp":
+        tool_name = input_data.get("toolName") if isinstance(input_data, dict) else getattr(input_data, "tool_name", None)
+        if not isinstance(tool_name, str) or len(tool_name) == 0:
+            errors.append("info.input.toolName is required and must be a non-empty string for MCP extensions")
+
+        input_schema = input_data.get("inputSchema") if isinstance(input_data, dict) else getattr(input_data, "input_schema", None)
+        if not input_schema or not isinstance(input_schema, dict):
+            errors.append("info.input.inputSchema is required and must be an object for MCP extensions")
+
+        transport = input_data.get("transport") if isinstance(input_data, dict) else getattr(input_data, "transport", None)
+        if transport is not None and transport not in _VALID_MCP_TRANSPORTS:
+            errors.append(
+                f"info.input.transport must be one of {', '.join(sorted(_VALID_MCP_TRANSPORTS))}, got \"{transport}\""
+            )
+
+    return ValidationResult(valid=True) if not errors else ValidationResult(valid=False, errors=errors)
+
+
 def _get_method_from_info(info: DiscoveryInfo | dict[str, Any]) -> str:
     """Extract HTTP method from discovery info.
 

--- a/python/x402/http/middleware/_bazaar_utils.py
+++ b/python/x402/http/middleware/_bazaar_utils.py
@@ -1,0 +1,117 @@
+"""Shared bazaar extension utilities for middleware packages.
+
+Provides startup-time bazaar extension detection, registration, and validation
+used by both FastAPI and Flask middleware.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+from ..types import RouteConfig, RoutesConfig
+
+
+def check_if_bazaar_needed(routes: RoutesConfig) -> bool:
+    """Check if any routes in the configuration declare bazaar extensions.
+
+    Args:
+        routes: Route configuration.
+
+    Returns:
+        True if any route has extensions.bazaar defined.
+    """
+    if isinstance(routes, RouteConfig):
+        return bool(routes.extensions and "bazaar" in routes.extensions)
+
+    if isinstance(routes, dict):
+        if "accepts" in routes:
+            extensions = routes.get("extensions", {})
+            return bool(extensions and "bazaar" in extensions)
+
+        for route_config in routes.values():
+            if isinstance(route_config, RouteConfig):
+                if route_config.extensions and "bazaar" in route_config.extensions:
+                    return True
+            elif isinstance(route_config, dict):
+                extensions = route_config.get("extensions", {})
+                if extensions and "bazaar" in extensions:
+                    return True
+
+    return False
+
+
+def register_bazaar_extension(server: Any) -> None:
+    """Register bazaar extension with server if available.
+
+    Works with both x402ResourceServer (async) and x402ResourceServerSync.
+
+    Args:
+        server: Resource server to register extension with.
+    """
+    try:
+        from ...extensions.bazaar import bazaar_resource_server_extension
+
+        server.register_extension(bazaar_resource_server_extension)
+    except ImportError:
+        pass
+
+
+def validate_bazaar_extensions(routes: RoutesConfig) -> None:
+    """Validate bazaar extensions on all routes using the extension's JSON-schema validator.
+
+    Emits warnings for invalid extensions but does not block startup.
+
+    Args:
+        routes: Route configuration.
+    """
+    try:
+        from ...extensions.bazaar import validate_discovery_extension, validate_discovery_extension_spec
+    except ImportError:
+        return
+
+    entries: list[tuple[str, Any]] = []
+    if isinstance(routes, RouteConfig):
+        entries = [("*", routes)]
+    elif isinstance(routes, dict):
+        if "accepts" in routes:
+            entries = [("*", routes)]
+        else:
+            entries = list(routes.items())
+
+    for pattern, config in entries:
+        extensions = None
+        if isinstance(config, RouteConfig):
+            extensions = config.extensions
+        elif isinstance(config, dict):
+            extensions = config.get("extensions")
+
+        if not extensions or "bazaar" not in extensions:
+            continue
+
+        bazaar_ext = extensions["bazaar"]
+        if (
+            not isinstance(bazaar_ext, dict)
+            or "info" not in bazaar_ext
+            or "schema" not in bazaar_ext
+        ):
+            continue
+
+        try:
+            spec_result = validate_discovery_extension_spec(bazaar_ext)
+            if not spec_result.valid:
+                warnings.warn(
+                    f'x402: Route "{pattern}" has an invalid bazaar extension: '
+                    f"{', '.join(spec_result.errors)}",
+                    stacklevel=3,
+                )
+                continue
+            result = validate_discovery_extension(bazaar_ext)
+            if not result.valid:
+                warnings.warn(
+                    f'x402: Route "{pattern}" has an invalid bazaar extension: '
+                    f"{', '.join(result.errors)}",
+                    stacklevel=3,
+                )
+        except Exception:
+            pass

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -118,7 +118,11 @@ def _validate_bazaar_extensions(routes: RoutesConfig) -> None:
             continue
 
         bazaar_ext = extensions["bazaar"]
-        if not isinstance(bazaar_ext, dict) or "info" not in bazaar_ext or "schema" not in bazaar_ext:
+        if (
+            not isinstance(bazaar_ext, dict)
+            or "info" not in bazaar_ext
+            or "schema" not in bazaar_ext
+        ):
             continue
 
         try:
@@ -126,7 +130,7 @@ def _validate_bazaar_extensions(routes: RoutesConfig) -> None:
             if not result.valid:
                 _warnings.warn(
                     f'x402: Route "{pattern}" has an invalid bazaar extension: '
-                    f'{", ".join(result.errors)}',
+                    f"{', '.join(result.errors)}",
                     stacklevel=2,
                 )
         except Exception:

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -80,8 +80,57 @@ def _register_bazaar_extension(server: x402ResourceServer) -> None:
 
         server.register_extension(bazaar_resource_server_extension)
     except ImportError:
-        # Bazaar extension not available, skip silently
         pass
+
+
+def _validate_bazaar_extensions(routes: RoutesConfig) -> None:
+    """Validate bazaar extensions on all routes using the extension's JSON-schema validator.
+
+    Emits warnings for invalid extensions but does not block startup.
+
+    Args:
+        routes: Route configuration.
+    """
+    try:
+        from ...extensions.bazaar import validate_discovery_extension
+    except ImportError:
+        return
+
+    import warnings as _warnings
+
+    entries: list[tuple[str, Any]] = []
+    if isinstance(routes, RouteConfig):
+        entries = [("*", routes)]
+    elif isinstance(routes, dict):
+        if "accepts" in routes:
+            entries = [("*", routes)]
+        else:
+            entries = list(routes.items())
+
+    for pattern, config in entries:
+        extensions = None
+        if isinstance(config, RouteConfig):
+            extensions = config.extensions
+        elif isinstance(config, dict):
+            extensions = config.get("extensions")
+
+        if not extensions or "bazaar" not in extensions:
+            continue
+
+        bazaar_ext = extensions["bazaar"]
+        if not isinstance(bazaar_ext, dict) or "info" not in bazaar_ext or "schema" not in bazaar_ext:
+            continue
+
+        try:
+            result = validate_discovery_extension(bazaar_ext)
+            if not result.valid:
+                _warnings.warn(
+                    f'x402: Route "{pattern}" has an invalid bazaar extension: '
+                    f'{", ".join(result.errors)}',
+                    stacklevel=2,
+                )
+        except Exception:
+            pass
 
 
 # ============================================================================
@@ -241,6 +290,7 @@ def payment_middleware(
     # Auto-register bazaar extension if routes declare it
     if _check_if_bazaar_needed(routes):
         _register_bazaar_extension(server)
+        _validate_bazaar_extensions(routes)
 
     # Create HTTP server wrapper
     http_server = x402HTTPResourceServer(server, routes)

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -35,106 +35,11 @@ if TYPE_CHECKING:
 # Extension Auto-Registration
 # ============================================================================
 
-
-def _check_if_bazaar_needed(routes: RoutesConfig) -> bool:
-    """Check if any routes in the configuration declare bazaar extensions.
-
-    Args:
-        routes: Route configuration.
-
-    Returns:
-        True if any route has extensions.bazaar defined.
-    """
-    # Handle single RouteConfig instance
-    if isinstance(routes, RouteConfig):
-        return bool(routes.extensions and "bazaar" in routes.extensions)
-
-    # Handle dict of routes
-    if isinstance(routes, dict):
-        # Check if it's a single route config dict (has "accepts" key)
-        if "accepts" in routes:
-            extensions = routes.get("extensions", {})
-            return bool(extensions and "bazaar" in extensions)
-
-        # Handle multiple routes
-        for route_config in routes.values():
-            if isinstance(route_config, RouteConfig):
-                if route_config.extensions and "bazaar" in route_config.extensions:
-                    return True
-            elif isinstance(route_config, dict):
-                extensions = route_config.get("extensions", {})
-                if extensions and "bazaar" in extensions:
-                    return True
-
-    return False
-
-
-def _register_bazaar_extension(server: x402ResourceServer) -> None:
-    """Register bazaar extension with server if available.
-
-    Args:
-        server: x402ResourceServer to register extension with.
-    """
-    try:
-        from ...extensions.bazaar import bazaar_resource_server_extension
-
-        server.register_extension(bazaar_resource_server_extension)
-    except ImportError:
-        pass
-
-
-def _validate_bazaar_extensions(routes: RoutesConfig) -> None:
-    """Validate bazaar extensions on all routes using the extension's JSON-schema validator.
-
-    Emits warnings for invalid extensions but does not block startup.
-
-    Args:
-        routes: Route configuration.
-    """
-    try:
-        from ...extensions.bazaar import validate_discovery_extension
-    except ImportError:
-        return
-
-    import warnings as _warnings
-
-    entries: list[tuple[str, Any]] = []
-    if isinstance(routes, RouteConfig):
-        entries = [("*", routes)]
-    elif isinstance(routes, dict):
-        if "accepts" in routes:
-            entries = [("*", routes)]
-        else:
-            entries = list(routes.items())
-
-    for pattern, config in entries:
-        extensions = None
-        if isinstance(config, RouteConfig):
-            extensions = config.extensions
-        elif isinstance(config, dict):
-            extensions = config.get("extensions")
-
-        if not extensions or "bazaar" not in extensions:
-            continue
-
-        bazaar_ext = extensions["bazaar"]
-        if (
-            not isinstance(bazaar_ext, dict)
-            or "info" not in bazaar_ext
-            or "schema" not in bazaar_ext
-        ):
-            continue
-
-        try:
-            result = validate_discovery_extension(bazaar_ext)
-            if not result.valid:
-                _warnings.warn(
-                    f'x402: Route "{pattern}" has an invalid bazaar extension: '
-                    f"{', '.join(result.errors)}",
-                    stacklevel=2,
-                )
-        except Exception:
-            pass
+from ._bazaar_utils import (
+    check_if_bazaar_needed as _check_if_bazaar_needed,
+    register_bazaar_extension as _register_bazaar_extension,
+    validate_bazaar_extensions as _validate_bazaar_extensions,
+)
 
 
 # ============================================================================

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -117,7 +117,11 @@ def _validate_bazaar_extensions(routes: RoutesConfig) -> None:
             continue
 
         bazaar_ext = extensions["bazaar"]
-        if not isinstance(bazaar_ext, dict) or "info" not in bazaar_ext or "schema" not in bazaar_ext:
+        if (
+            not isinstance(bazaar_ext, dict)
+            or "info" not in bazaar_ext
+            or "schema" not in bazaar_ext
+        ):
             continue
 
         try:
@@ -125,7 +129,7 @@ def _validate_bazaar_extensions(routes: RoutesConfig) -> None:
             if not result.valid:
                 _warnings.warn(
                     f'x402: Route "{pattern}" has an invalid bazaar extension: '
-                    f'{", ".join(result.errors)}',
+                    f"{', '.join(result.errors)}",
                     stacklevel=2,
                 )
         except Exception:

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -79,8 +79,57 @@ def _register_bazaar_extension(server: x402ResourceServerSync) -> None:
 
         server.register_extension(bazaar_resource_server_extension)
     except ImportError:
-        # Bazaar extension not available, skip silently
         pass
+
+
+def _validate_bazaar_extensions(routes: RoutesConfig) -> None:
+    """Validate bazaar extensions on all routes using the extension's JSON-schema validator.
+
+    Emits warnings for invalid extensions but does not block startup.
+
+    Args:
+        routes: Route configuration.
+    """
+    try:
+        from ...extensions.bazaar import validate_discovery_extension
+    except ImportError:
+        return
+
+    import warnings as _warnings
+
+    entries: list[tuple[str, Any]] = []
+    if isinstance(routes, RouteConfig):
+        entries = [("*", routes)]
+    elif isinstance(routes, dict):
+        if "accepts" in routes:
+            entries = [("*", routes)]
+        else:
+            entries = list(routes.items())
+
+    for pattern, config in entries:
+        extensions = None
+        if isinstance(config, RouteConfig):
+            extensions = config.extensions
+        elif isinstance(config, dict):
+            extensions = config.get("extensions")
+
+        if not extensions or "bazaar" not in extensions:
+            continue
+
+        bazaar_ext = extensions["bazaar"]
+        if not isinstance(bazaar_ext, dict) or "info" not in bazaar_ext or "schema" not in bazaar_ext:
+            continue
+
+        try:
+            result = validate_discovery_extension(bazaar_ext)
+            if not result.valid:
+                _warnings.warn(
+                    f'x402: Route "{pattern}" has an invalid bazaar extension: '
+                    f'{", ".join(result.errors)}',
+                    stacklevel=2,
+                )
+        except Exception:
+            pass
 
 
 # ============================================================================
@@ -314,6 +363,7 @@ class PaymentMiddleware:
         # Auto-register bazaar extension if routes declare it
         if _check_if_bazaar_needed(routes):
             _register_bazaar_extension(server)
+            _validate_bazaar_extensions(routes)
 
         self._app = app
         self._http_server = x402HTTPResourceServerSync(server, routes)

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -34,106 +34,11 @@ if TYPE_CHECKING:
 # Extension Auto-Registration
 # ============================================================================
 
-
-def _check_if_bazaar_needed(routes: RoutesConfig) -> bool:
-    """Check if any routes in the configuration declare bazaar extensions.
-
-    Args:
-        routes: Route configuration.
-
-    Returns:
-        True if any route has extensions.bazaar defined.
-    """
-    # Handle single RouteConfig instance
-    if isinstance(routes, RouteConfig):
-        return bool(routes.extensions and "bazaar" in routes.extensions)
-
-    # Handle dict of routes
-    if isinstance(routes, dict):
-        # Check if it's a single route config dict (has "accepts" key)
-        if "accepts" in routes:
-            extensions = routes.get("extensions", {})
-            return bool(extensions and "bazaar" in extensions)
-
-        # Handle multiple routes
-        for route_config in routes.values():
-            if isinstance(route_config, RouteConfig):
-                if route_config.extensions and "bazaar" in route_config.extensions:
-                    return True
-            elif isinstance(route_config, dict):
-                extensions = route_config.get("extensions", {})
-                if extensions and "bazaar" in extensions:
-                    return True
-
-    return False
-
-
-def _register_bazaar_extension(server: x402ResourceServerSync) -> None:
-    """Register bazaar extension with server if available.
-
-    Args:
-        server: x402ResourceServerSync to register extension with.
-    """
-    try:
-        from ...extensions.bazaar import bazaar_resource_server_extension
-
-        server.register_extension(bazaar_resource_server_extension)
-    except ImportError:
-        pass
-
-
-def _validate_bazaar_extensions(routes: RoutesConfig) -> None:
-    """Validate bazaar extensions on all routes using the extension's JSON-schema validator.
-
-    Emits warnings for invalid extensions but does not block startup.
-
-    Args:
-        routes: Route configuration.
-    """
-    try:
-        from ...extensions.bazaar import validate_discovery_extension
-    except ImportError:
-        return
-
-    import warnings as _warnings
-
-    entries: list[tuple[str, Any]] = []
-    if isinstance(routes, RouteConfig):
-        entries = [("*", routes)]
-    elif isinstance(routes, dict):
-        if "accepts" in routes:
-            entries = [("*", routes)]
-        else:
-            entries = list(routes.items())
-
-    for pattern, config in entries:
-        extensions = None
-        if isinstance(config, RouteConfig):
-            extensions = config.extensions
-        elif isinstance(config, dict):
-            extensions = config.get("extensions")
-
-        if not extensions or "bazaar" not in extensions:
-            continue
-
-        bazaar_ext = extensions["bazaar"]
-        if (
-            not isinstance(bazaar_ext, dict)
-            or "info" not in bazaar_ext
-            or "schema" not in bazaar_ext
-        ):
-            continue
-
-        try:
-            result = validate_discovery_extension(bazaar_ext)
-            if not result.valid:
-                _warnings.warn(
-                    f'x402: Route "{pattern}" has an invalid bazaar extension: '
-                    f"{', '.join(result.errors)}",
-                    stacklevel=2,
-                )
-        except Exception:
-            pass
+from ._bazaar_utils import (
+    check_if_bazaar_needed as _check_if_bazaar_needed,
+    register_bazaar_extension as _register_bazaar_extension,
+    validate_bazaar_extensions as _validate_bazaar_extensions,
+)
 
 
 # ============================================================================

--- a/python/x402/tests/unit/http/test_bazaar_extension_validation.py
+++ b/python/x402/tests/unit/http/test_bazaar_extension_validation.py
@@ -1,0 +1,317 @@
+"""Tests for startup-time bazaar extension validation in middleware packages."""
+
+from __future__ import annotations
+
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from x402.http.types import (
+    PaymentOption,
+    RouteConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_payment_option():
+    return PaymentOption(
+        scheme="exact",
+        pay_to="0x123",
+        price="$0.01",
+        network="eip155:84532",
+    )
+
+
+# ---------------------------------------------------------------------------
+# FastAPI middleware validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestFastAPIBazaarExtensionValidation:
+    """Tests for bazaar extension validation in FastAPI middleware startup."""
+
+    def test_no_extension_no_warning(self):
+        """A route with no extensions should produce no bazaar warning."""
+        from x402.http.middleware.fastapi import _validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions=None,
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0
+
+    def test_valid_extension_no_warning(self):
+        """A route with a valid bazaar extension should produce no warning."""
+        from x402.http.middleware.fastapi import _validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={
+                    "bazaar": {
+                        "info": {
+                            "input": {"type": "http", "method": "GET"},
+                            "output": {"type": "string"},
+                        },
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "input": {"type": "object"},
+                                "output": {"type": "object"},
+                            },
+                            "required": ["input"],
+                        },
+                    }
+                },
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0
+
+    def test_invalid_extension_emits_warning(self):
+        """A route with schema requiring fields absent from info should emit a warning."""
+        from x402.http.middleware.fastapi import _validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={
+                    "bazaar": {
+                        "info": {
+                            "input": {"type": "http", "method": "GET"},
+                        },
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "input": {"type": "object"},
+                                "jobs": {"type": "array"},
+                                "count": {"type": "integer"},
+                            },
+                            "required": ["input", "jobs", "count"],
+                        },
+                    }
+                },
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 1
+        assert "invalid bazaar extension" in str(bazaar_warnings[0].message).lower()
+
+    def test_non_bazaar_extension_not_warned(self):
+        """Non-bazaar extensions should not trigger bazaar warnings."""
+        from x402.http.middleware.fastapi import _validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={
+                    "other-extension": {
+                        "info": {},
+                        "schema": {"required": ["missing_field"]},
+                    }
+                },
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0
+
+    def test_validation_skipped_when_bazaar_unavailable(self):
+        """When bazaar validation is not importable, no exception should be raised."""
+        from x402.http.middleware.fastapi import _validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={
+                    "bazaar": {
+                        "info": {},
+                        "schema": {"required": ["missing_field"]},
+                    }
+                },
+            )
+        }
+
+        with patch(
+            "x402.http.middleware.fastapi._validate_bazaar_extensions.__module__",
+            side_effect=ImportError,
+        ):
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter("always")
+                _validate_bazaar_extensions(routes)
+
+
+# ---------------------------------------------------------------------------
+# Flask middleware validation tests
+# ---------------------------------------------------------------------------
+
+
+try:
+    import flask as _flask  # noqa: F401
+    _HAS_FLASK = True
+except ImportError:
+    _HAS_FLASK = False
+
+
+@pytest.mark.skipif(not _HAS_FLASK, reason="flask not installed")
+class TestFlaskBazaarExtensionValidation:
+    """Tests for bazaar extension validation in Flask middleware startup."""
+
+    def test_no_extension_no_warning(self):
+        """A route with no extensions should produce no bazaar warning."""
+        from x402.http.middleware.flask import _validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions=None,
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0
+
+    def test_valid_extension_no_warning(self):
+        """A route with a valid bazaar extension should produce no warning."""
+        from x402.http.middleware.flask import _validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={
+                    "bazaar": {
+                        "info": {
+                            "input": {"type": "http", "method": "GET"},
+                            "output": {"type": "string"},
+                        },
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "input": {"type": "object"},
+                                "output": {"type": "object"},
+                            },
+                            "required": ["input"],
+                        },
+                    }
+                },
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0
+
+    def test_invalid_extension_emits_warning(self):
+        """A route with an invalid bazaar extension should emit a warning."""
+        from x402.http.middleware.flask import _validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={
+                    "bazaar": {
+                        "info": {
+                            "input": {"type": "http", "method": "GET"},
+                        },
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "input": {"type": "object"},
+                                "jobs": {"type": "array"},
+                                "count": {"type": "integer"},
+                            },
+                            "required": ["input", "jobs", "count"],
+                        },
+                    }
+                },
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 1
+        assert "invalid bazaar extension" in str(bazaar_warnings[0].message).lower()
+
+
+# ---------------------------------------------------------------------------
+# Core server base no longer validates bazaar extensions
+# ---------------------------------------------------------------------------
+
+
+class TestCoreNoLongerValidatesBazaar:
+    """Verify that the core HTTP server base does not emit bazaar warnings."""
+
+    def test_core_does_not_warn_on_invalid_bazaar(self):
+        """Core _validate_route_configuration should not emit bazaar warnings."""
+        from x402.http.x402_http_server_base import x402HTTPServerBase
+
+        mock_server = MagicMock()
+        mock_server.has_registered_scheme.return_value = True
+        mock_server.get_supported_kind.return_value = "exact"
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={
+                    "bazaar": {
+                        "info": {"input": {"type": "http", "method": "GET"}},
+                        "schema": {
+                            "type": "object",
+                            "properties": {"input": {"type": "object"}, "jobs": {"type": "array"}},
+                            "required": ["input", "jobs"],
+                        },
+                    }
+                },
+            )
+        }
+
+        base = x402HTTPServerBase.__new__(x402HTTPServerBase)
+        base._server = mock_server
+        base._routes_config = routes
+        base._compiled_routes = []
+        base._paywall_provider = None
+        base._compile_routes(routes)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            errors = base._validate_route_configuration()
+
+        assert errors == []
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0

--- a/python/x402/tests/unit/http/test_bazaar_extension_validation.py
+++ b/python/x402/tests/unit/http/test_bazaar_extension_validation.py
@@ -316,3 +316,229 @@ class TestCoreNoLongerValidatesBazaar:
         assert errors == []
         bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
         assert len(bazaar_warnings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Spec-level validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDiscoveryExtensionSpec:
+    """Tests for validate_discovery_extension_spec protocol-level validation."""
+
+    def test_valid_http_get_extension(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {
+            "info": {"input": {"type": "http", "method": "GET"}},
+            "schema": {},
+        }
+        result = validate_discovery_extension_spec(ext)
+        assert result.valid
+
+    def test_valid_http_post_extension(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {
+            "info": {"input": {"type": "http", "method": "POST", "bodyType": "json", "body": {}}},
+            "schema": {},
+        }
+        result = validate_discovery_extension_spec(ext)
+        assert result.valid
+
+    def test_valid_mcp_extension(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {
+            "info": {
+                "input": {
+                    "type": "mcp",
+                    "toolName": "my_tool",
+                    "inputSchema": {"type": "object"},
+                }
+            },
+            "schema": {},
+        }
+        result = validate_discovery_extension_spec(ext)
+        assert result.valid
+
+    def test_pre_enrichment_http_no_method(self):
+        """Pre-enrichment HTTP extensions omit method and should pass."""
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {"info": {"input": {"type": "http"}}, "schema": {}}
+        result = validate_discovery_extension_spec(ext)
+        assert result.valid
+
+    def test_invalid_input_type(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {"info": {"input": {"type": "grpc"}}, "schema": {}}
+        result = validate_discovery_extension_spec(ext)
+        assert not result.valid
+        assert any("input.type" in e for e in result.errors)
+
+    def test_invalid_http_method(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {"info": {"input": {"type": "http", "method": "DESTROY"}}, "schema": {}}
+        result = validate_discovery_extension_spec(ext)
+        assert not result.valid
+        assert any("method" in e for e in result.errors)
+
+    def test_invalid_body_type(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {
+            "info": {"input": {"type": "http", "method": "POST", "bodyType": "xml"}},
+            "schema": {},
+        }
+        result = validate_discovery_extension_spec(ext)
+        assert not result.valid
+        assert any("bodyType" in e for e in result.errors)
+
+    def test_body_type_with_non_body_method(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {
+            "info": {"input": {"type": "http", "method": "GET", "bodyType": "json"}},
+            "schema": {},
+        }
+        result = validate_discovery_extension_spec(ext)
+        assert not result.valid
+        assert any("not a body method" in e for e in result.errors)
+
+    def test_mcp_missing_tool_name(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {
+            "info": {"input": {"type": "mcp", "inputSchema": {"type": "object"}}},
+            "schema": {},
+        }
+        result = validate_discovery_extension_spec(ext)
+        assert not result.valid
+        assert any("toolName" in e for e in result.errors)
+
+    def test_mcp_missing_input_schema(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {"info": {"input": {"type": "mcp", "toolName": "t"}}, "schema": {}}
+        result = validate_discovery_extension_spec(ext)
+        assert not result.valid
+        assert any("inputSchema" in e for e in result.errors)
+
+    def test_mcp_invalid_transport(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        ext = {
+            "info": {
+                "input": {
+                    "type": "mcp",
+                    "toolName": "t",
+                    "inputSchema": {"type": "object"},
+                    "transport": "websocket",
+                }
+            },
+            "schema": {},
+        }
+        result = validate_discovery_extension_spec(ext)
+        assert not result.valid
+        assert any("transport" in e for e in result.errors)
+
+    def test_missing_info(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        result = validate_discovery_extension_spec({"schema": {}})
+        assert not result.valid
+
+    def test_missing_input(self):
+        from x402.extensions.bazaar import validate_discovery_extension_spec
+
+        result = validate_discovery_extension_spec({"info": {}, "schema": {}})
+        assert not result.valid
+
+
+# ---------------------------------------------------------------------------
+# Shared middleware utilities tests
+# ---------------------------------------------------------------------------
+
+
+class TestSharedBazaarUtils:
+    """Tests for the shared _bazaar_utils module."""
+
+    def test_check_if_bazaar_needed_with_bazaar(self):
+        from x402.http.middleware._bazaar_utils import check_if_bazaar_needed
+
+        routes = {
+            "GET /api": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={"bazaar": {}},
+            )
+        }
+        assert check_if_bazaar_needed(routes) is True
+
+    def test_check_if_bazaar_needed_without_bazaar(self):
+        from x402.http.middleware._bazaar_utils import check_if_bazaar_needed
+
+        routes = {
+            "GET /api": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions=None,
+            )
+        }
+        assert check_if_bazaar_needed(routes) is False
+
+    def test_validate_no_warning_on_valid(self):
+        from x402.http.middleware._bazaar_utils import validate_bazaar_extensions
+
+        routes = {
+            "GET /api": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={
+                    "bazaar": {
+                        "info": {
+                            "input": {"type": "http", "method": "GET"},
+                            "output": {"type": "string"},
+                        },
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "input": {"type": "object"},
+                                "output": {"type": "object"},
+                            },
+                            "required": ["input"],
+                        },
+                    }
+                },
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0
+
+    def test_validate_warns_on_spec_violation(self):
+        from x402.http.middleware._bazaar_utils import validate_bazaar_extensions
+
+        routes = {
+            "GET /api": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions={
+                    "bazaar": {
+                        "info": {"input": {"type": "grpc"}},
+                        "schema": {"type": "object"},
+                    }
+                },
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 1
+        assert "invalid bazaar extension" in str(bazaar_warnings[0].message).lower()

--- a/python/x402/tests/unit/http/test_bazaar_extension_validation.py
+++ b/python/x402/tests/unit/http/test_bazaar_extension_validation.py
@@ -174,6 +174,7 @@ class TestFastAPIBazaarExtensionValidation:
 
 try:
     import flask as _flask  # noqa: F401
+
     _HAS_FLASK = True
 except ImportError:
     _HAS_FLASK = False

--- a/typescript/.changeset/validate-bazaar-startup.md
+++ b/typescript/.changeset/validate-bazaar-startup.md
@@ -1,0 +1,8 @@
+---
+'@x402/express': patch
+'@x402/hono': patch
+'@x402/next': patch
+'@x402/core': patch
+---
+
+Added startup-time JSON-schema validation for bazaar discovery extensions in middleware packages; Removed shallow bazaar validation from core in favor of full schema validation using the extensions package validator

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -72,6 +72,92 @@ export function validateDiscoveryExtension(extension: DiscoveryExtension): Valid
   }
 }
 
+const VALID_QUERY_METHODS = new Set(["GET", "HEAD", "DELETE"]);
+const VALID_BODY_METHODS = new Set(["POST", "PUT", "PATCH"]);
+const VALID_METHODS = new Set([...VALID_QUERY_METHODS, ...VALID_BODY_METHODS]);
+const VALID_BODY_TYPES = new Set(["json", "form-data", "text"]);
+const VALID_MCP_TRANSPORTS = new Set(["streamable-http", "sse"]);
+
+/**
+ * Validates a discovery extension against the Bazaar protocol specification.
+ *
+ * Unlike `validateDiscoveryExtension` which checks internal consistency (info vs schema),
+ * this function enforces protocol-level invariants:
+ *   - `info.input.type` must be "http" or "mcp"
+ *   - HTTP: if `method` is present it must be GET/POST/PUT/PATCH/DELETE/HEAD
+ *   - HTTP body methods: `bodyType` must be "json" | "form-data" | "text"
+ *   - MCP: `toolName` (string) and `inputSchema` (object) are required
+ *   - MCP: if `transport` is present it must be "streamable-http" | "sse"
+ *
+ * Designed to be safe for pre-enrichment HTTP extensions where `method` may be absent.
+ *
+ * @param extension - The discovery extension to validate
+ * @returns Validation result with spec-level errors
+ */
+export function validateDiscoveryExtensionSpec(
+  extension: Record<string, unknown>,
+): ValidationResult {
+  const errors: string[] = [];
+
+  const info = extension.info;
+  if (!info || typeof info !== "object") {
+    return { valid: false, errors: ["Missing or invalid 'info' field"] };
+  }
+
+  const input = (info as Record<string, unknown>).input;
+  if (!input || typeof input !== "object") {
+    return { valid: false, errors: ["Missing or invalid 'info.input' field"] };
+  }
+
+  const inputObj = input as Record<string, unknown>;
+  const inputType = inputObj.type;
+
+  if (inputType !== "http" && inputType !== "mcp") {
+    errors.push(`info.input.type must be "http" or "mcp", got "${String(inputType)}"`);
+    return { valid: false, errors };
+  }
+
+  if (inputType === "http") {
+    const method = inputObj.method;
+    if (method !== undefined && !VALID_METHODS.has(method as string)) {
+      errors.push(
+        `info.input.method must be one of ${[...VALID_METHODS].join(", ")}, got "${String(method)}"`,
+      );
+    }
+
+    const bodyType = inputObj.bodyType;
+    if (bodyType !== undefined) {
+      if (!VALID_BODY_TYPES.has(bodyType as string)) {
+        errors.push(
+          `info.input.bodyType must be one of ${[...VALID_BODY_TYPES].join(", ")}, got "${String(bodyType)}"`,
+        );
+      }
+      if (method !== undefined && !VALID_BODY_METHODS.has(method as string)) {
+        errors.push(
+          `info.input.bodyType is set but method "${String(method)}" is not a body method (POST, PUT, PATCH)`,
+        );
+      }
+    }
+  }
+
+  if (inputType === "mcp") {
+    if (typeof inputObj.toolName !== "string" || inputObj.toolName.length === 0) {
+      errors.push("info.input.toolName is required and must be a non-empty string for MCP extensions");
+    }
+    if (!inputObj.inputSchema || typeof inputObj.inputSchema !== "object") {
+      errors.push("info.input.inputSchema is required and must be an object for MCP extensions");
+    }
+    const transport = inputObj.transport;
+    if (transport !== undefined && !VALID_MCP_TRANSPORTS.has(transport as string)) {
+      errors.push(
+        `info.input.transport must be one of ${[...VALID_MCP_TRANSPORTS].join(", ")}, got "${String(transport)}"`,
+      );
+    }
+  }
+
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}
+
 /**
  * Extracts the discovery info from payment payload and requirements
  *

--- a/typescript/packages/extensions/src/bazaar/index.ts
+++ b/typescript/packages/extensions/src/bazaar/index.ts
@@ -112,6 +112,7 @@ export { bazaarResourceServerExtension } from "./server";
 // Export facilitator functions (for facilitators)
 export {
   validateDiscoveryExtension,
+  validateDiscoveryExtensionSpec,
   extractDiscoveryInfo,
   extractDiscoveryInfoFromExtension,
   validateAndExtract,
@@ -123,6 +124,9 @@ export {
 
 // Export v1 functions (v1 data is transformed to v2 DiscoveryInfo format)
 export { extractDiscoveryInfoV1, isDiscoverableV1, extractResourceMetadataV1 } from "./v1";
+
+// Export startup validation helpers (for middleware packages)
+export { checkIfBazaarNeeded, validateBazaarRouteExtensions } from "./startupValidation";
 
 // Export client extension (for facilitator clients querying discovery)
 export {

--- a/typescript/packages/extensions/src/bazaar/startupValidation.ts
+++ b/typescript/packages/extensions/src/bazaar/startupValidation.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared startup-time validation utilities for bazaar extensions in route configs.
+ *
+ * Used by middleware packages (Express, Hono, Next) to validate bazaar extensions
+ * at server startup without duplicating the iteration and warning logic.
+ */
+
+import type { RoutesConfig } from "@x402/core/server";
+import type { DiscoveryExtension } from "./types";
+import { validateDiscoveryExtension, validateDiscoveryExtensionSpec } from "./facilitator";
+
+/**
+ * Check if any routes in the configuration declare bazaar extensions.
+ *
+ * @param routes - Route configuration
+ * @returns True if any route has extensions.bazaar defined
+ */
+export function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
+  if ("accepts" in routes) {
+    return !!(routes.extensions && "bazaar" in routes.extensions);
+  }
+
+  return Object.values(routes).some(routeConfig => {
+    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
+  });
+}
+
+/**
+ * Validate bazaar extensions on all routes using JSON-schema validation.
+ * Emits console warnings for invalid extensions but does not throw.
+ *
+ * @param routes - Route configuration to scan for bazaar extensions
+ */
+export function validateBazaarRouteExtensions(routes: RoutesConfig): void {
+  const entries: [string, { extensions?: Record<string, unknown> }][] =
+    "accepts" in routes ? [["*", routes]] : Object.entries(routes);
+
+  for (const [pattern, config] of entries) {
+    const bazaarExt = config.extensions?.["bazaar"];
+    if (
+      bazaarExt &&
+      typeof bazaarExt === "object" &&
+      "info" in (bazaarExt as Record<string, unknown>) &&
+      "schema" in (bazaarExt as Record<string, unknown>)
+    ) {
+      const specResult = validateDiscoveryExtensionSpec(bazaarExt as Record<string, unknown>);
+      if (!specResult.valid) {
+        console.warn(
+          `x402: Route "${pattern}" has an invalid bazaar extension: ${specResult.errors?.join(", ")}`,
+        );
+        continue;
+      }
+      const schemaResult = validateDiscoveryExtension(bazaarExt as DiscoveryExtension);
+      if (!schemaResult.valid) {
+        console.warn(
+          `x402: Route "${pattern}" has an invalid bazaar extension: ${schemaResult.errors?.join(", ")}`,
+        );
+      }
+    }
+  }
+}

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -2,16 +2,19 @@
  * Tests for Bazaar Discovery Extension
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   BAZAAR,
   declareDiscoveryExtension,
   validateDiscoveryExtension,
+  validateDiscoveryExtensionSpec,
   extractDiscoveryInfo,
   extractDiscoveryInfoFromExtension,
   extractDiscoveryInfoV1,
   validateAndExtract,
   bazaarResourceServerExtension,
+  checkIfBazaarNeeded,
+  validateBazaarRouteExtensions,
 } from "../src/bazaar/index";
 import type { BodyDiscoveryInfo, McpDiscoveryInfo, DiscoveryExtension } from "../src/bazaar/types";
 import type { DiscoveredMCPResource } from "../src/bazaar/facilitator";
@@ -1588,6 +1591,206 @@ describe("Bazaar Discovery Extension", () => {
       // MCP extension should remain unchanged
       expect(enriched.info.input.type).toBe("mcp");
       expect((enriched.info as McpDiscoveryInfo).input.toolName).toBe("my_tool");
+    });
+  });
+
+  describe("validateDiscoveryExtensionSpec", () => {
+    it("should pass for a valid HTTP GET extension", () => {
+      const ext = declareDiscoveryExtension({
+        input: { q: "test" },
+        inputSchema: { properties: { q: { type: "string" } } },
+      });
+      const result = validateDiscoveryExtensionSpec(ext.bazaar as unknown as Record<string, unknown>);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should pass for a valid HTTP POST extension", () => {
+      const ext = declareDiscoveryExtension({
+        input: { name: "foo" },
+        inputSchema: { properties: { name: { type: "string" } } },
+        bodyType: "json",
+      });
+      const result = validateDiscoveryExtensionSpec(ext.bazaar as unknown as Record<string, unknown>);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should pass for a valid MCP extension", () => {
+      const ext = declareDiscoveryExtension({
+        toolName: "my_tool",
+        inputSchema: { type: "object", properties: { q: { type: "string" } } },
+      });
+      const result = validateDiscoveryExtensionSpec(ext.bazaar as unknown as Record<string, unknown>);
+      expect(result.valid).toBe(true);
+    });
+
+    it("should pass for a pre-enrichment HTTP extension (no method)", () => {
+      const result = validateDiscoveryExtensionSpec({
+        info: { input: { type: "http" } },
+        schema: {},
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("should fail for invalid input.type", () => {
+      const result = validateDiscoveryExtensionSpec({
+        info: { input: { type: "grpc" } },
+        schema: {},
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain("input.type");
+    });
+
+    it("should fail for invalid HTTP method", () => {
+      const result = validateDiscoveryExtensionSpec({
+        info: { input: { type: "http", method: "DESTROY" } },
+        schema: {},
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain("method");
+    });
+
+    it("should fail for invalid bodyType", () => {
+      const result = validateDiscoveryExtensionSpec({
+        info: { input: { type: "http", method: "POST", bodyType: "xml" } },
+        schema: {},
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain("bodyType");
+    });
+
+    it("should fail when bodyType is set with a non-body method", () => {
+      const result = validateDiscoveryExtensionSpec({
+        info: { input: { type: "http", method: "GET", bodyType: "json" } },
+        schema: {},
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors?.some(e => e.includes("not a body method"))).toBe(true);
+    });
+
+    it("should fail for MCP extension missing toolName", () => {
+      const result = validateDiscoveryExtensionSpec({
+        info: { input: { type: "mcp", inputSchema: { type: "object" } } },
+        schema: {},
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain("toolName");
+    });
+
+    it("should fail for MCP extension missing inputSchema", () => {
+      const result = validateDiscoveryExtensionSpec({
+        info: { input: { type: "mcp", toolName: "t" } },
+        schema: {},
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain("inputSchema");
+    });
+
+    it("should fail for MCP extension with invalid transport", () => {
+      const result = validateDiscoveryExtensionSpec({
+        info: {
+          input: {
+            type: "mcp",
+            toolName: "t",
+            inputSchema: { type: "object" },
+            transport: "websocket",
+          },
+        },
+        schema: {},
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain("transport");
+    });
+
+    it("should fail when info is missing", () => {
+      const result = validateDiscoveryExtensionSpec({ schema: {} });
+      expect(result.valid).toBe(false);
+    });
+
+    it("should fail when info.input is missing", () => {
+      const result = validateDiscoveryExtensionSpec({ info: {}, schema: {} });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("checkIfBazaarNeeded", () => {
+    it("should return true when single route config has bazaar extension", () => {
+      const routes = {
+        accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+        extensions: { bazaar: {} },
+      };
+      expect(checkIfBazaarNeeded(routes)).toBe(true);
+    });
+
+    it("should return false when no routes have bazaar extensions", () => {
+      const routes = {
+        "/api": {
+          accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+        },
+      };
+      expect(checkIfBazaarNeeded(routes)).toBe(false);
+    });
+
+    it("should return true when any route in multi-route config has bazaar", () => {
+      const routes = {
+        "/a": {
+          accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+        },
+        "/b": {
+          accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+          extensions: { bazaar: {} },
+        },
+      };
+      expect(checkIfBazaarNeeded(routes)).toBe(true);
+    });
+  });
+
+  describe("validateBazaarRouteExtensions", () => {
+    it("should not warn for routes without bazaar extensions", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const routes = {
+        "/api": {
+          accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+        },
+      };
+      validateBazaarRouteExtensions(routes);
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it("should not warn for a valid bazaar extension", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const ext = declareDiscoveryExtension({
+        input: { q: "test" },
+        inputSchema: { properties: { q: { type: "string" } } },
+      });
+      const routes = {
+        "/api": {
+          accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+          extensions: ext,
+        },
+      };
+      validateBazaarRouteExtensions(routes);
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it("should warn for an extension with invalid input.type", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const routes = {
+        "/api": {
+          accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+          extensions: {
+            bazaar: {
+              info: { input: { type: "grpc" } },
+              schema: {},
+            },
+          },
+        },
+      };
+      validateBazaarRouteExtensions(routes);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0]).toContain("invalid bazaar extension");
+      spy.mockRestore();
     });
   });
 });

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -11,57 +11,11 @@ import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { NextFunction, Request, Response } from "express";
 import { ExpressAdapter } from "./adapter";
 
-/**
- * Check if any routes in the configuration declare bazaar extensions
- *
- * @param routes - Route configuration
- * @returns True if any route has extensions.bazaar defined
- */
 function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  // Handle single route config
   if ("accepts" in routes) {
     return !!(routes.extensions && "bazaar" in routes.extensions);
   }
-
-  // Handle multiple routes
-  return Object.values(routes).some(routeConfig => {
-    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
-  });
-}
-
-type ValidateFn = (ext: unknown) => { valid: boolean; errors?: string[] };
-
-/**
- *
- * @param routes
- * @param validate
- */
-/**
- * Validate bazaar extensions on all routes using the extension's JSON-schema validator.
- *
- * @param routes - Route configuration to scan for bazaar extensions
- * @param validate - Validation function from the bazaar extension package
- */
-function validateBazaarExtensions(routes: RoutesConfig, validate: ValidateFn): void {
-  const entries: [string, { extensions?: Record<string, unknown> }][] =
-    "accepts" in routes ? [["*", routes]] : Object.entries(routes);
-
-  for (const [pattern, config] of entries) {
-    const bazaarExt = config.extensions?.["bazaar"];
-    if (
-      bazaarExt &&
-      typeof bazaarExt === "object" &&
-      "info" in (bazaarExt as Record<string, unknown>) &&
-      "schema" in (bazaarExt as Record<string, unknown>)
-    ) {
-      const result = validate(bazaarExt);
-      if (!result.valid) {
-        console.warn(
-          `x402: Route "${pattern}" has an invalid bazaar extension: ${result.errors?.join(", ")}`,
-        );
-      }
-    }
-  }
+  return Object.values(routes).some(r => !!(r.extensions && "bazaar" in r.extensions));
 }
 
 /**
@@ -123,11 +77,9 @@ export function paymentMiddlewareFromHTTPServer(
   let bazaarPromise: Promise<void> | null = null;
   if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import("@x402/extensions/bazaar")
-      .then(({ bazaarResourceServerExtension, validateDiscoveryExtension }) => {
+      .then(({ bazaarResourceServerExtension, validateBazaarRouteExtensions }) => {
         httpServer.server.registerExtension(bazaarResourceServerExtension);
-        validateBazaarExtensions(httpServer.routes, (ext: unknown) =>
-          validateDiscoveryExtension(ext as Parameters<typeof validateDiscoveryExtension>[0]),
-        );
+        validateBazaarRouteExtensions(httpServer.routes);
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -29,6 +29,41 @@ function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
   });
 }
 
+type ValidateFn = (ext: unknown) => { valid: boolean; errors?: string[] };
+
+/**
+ *
+ * @param routes
+ * @param validate
+ */
+/**
+ * Validate bazaar extensions on all routes using the extension's JSON-schema validator.
+ *
+ * @param routes - Route configuration to scan for bazaar extensions
+ * @param validate - Validation function from the bazaar extension package
+ */
+function validateBazaarExtensions(routes: RoutesConfig, validate: ValidateFn): void {
+  const entries: [string, { extensions?: Record<string, unknown> }][] =
+    "accepts" in routes ? [["*", routes]] : Object.entries(routes);
+
+  for (const [pattern, config] of entries) {
+    const bazaarExt = config.extensions?.["bazaar"];
+    if (
+      bazaarExt &&
+      typeof bazaarExt === "object" &&
+      "info" in (bazaarExt as Record<string, unknown>) &&
+      "schema" in (bazaarExt as Record<string, unknown>)
+    ) {
+      const result = validate(bazaarExt);
+      if (!result.valid) {
+        console.warn(
+          `x402: Route "${pattern}" has an invalid bazaar extension: ${result.errors?.join(", ")}`,
+        );
+      }
+    }
+  }
+}
+
 /**
  * Configuration for registering a payment scheme with a specific network
  */
@@ -88,8 +123,11 @@ export function paymentMiddlewareFromHTTPServer(
   let bazaarPromise: Promise<void> | null = null;
   if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import("@x402/extensions/bazaar")
-      .then(({ bazaarResourceServerExtension }) => {
+      .then(({ bazaarResourceServerExtension, validateDiscoveryExtension }) => {
         httpServer.server.registerExtension(bazaarResourceServerExtension);
+        validateBazaarExtensions(httpServer.routes, (ext: unknown) =>
+          validateDiscoveryExtension(ext as Parameters<typeof validateDiscoveryExtension>[0]),
+        );
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -11,57 +11,11 @@ import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { Context, MiddlewareHandler } from "hono";
 import { HonoAdapter } from "./adapter";
 
-/**
- * Check if any routes in the configuration declare bazaar extensions
- *
- * @param routes - Route configuration
- * @returns True if any route has extensions.bazaar defined
- */
 function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  // Handle single route config
   if ("accepts" in routes) {
     return !!(routes.extensions && "bazaar" in routes.extensions);
   }
-
-  // Handle multiple routes
-  return Object.values(routes).some(routeConfig => {
-    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
-  });
-}
-
-type ValidateFn = (ext: unknown) => { valid: boolean; errors?: string[] };
-
-/**
- *
- * @param routes
- * @param validate
- */
-/**
- * Validate bazaar extensions on all routes using the extension's JSON-schema validator.
- *
- * @param routes - Route configuration to scan for bazaar extensions
- * @param validate - Validation function from the bazaar extension package
- */
-function validateBazaarExtensions(routes: RoutesConfig, validate: ValidateFn): void {
-  const entries: [string, { extensions?: Record<string, unknown> }][] =
-    "accepts" in routes ? [["*", routes]] : Object.entries(routes);
-
-  for (const [pattern, config] of entries) {
-    const bazaarExt = config.extensions?.["bazaar"];
-    if (
-      bazaarExt &&
-      typeof bazaarExt === "object" &&
-      "info" in (bazaarExt as Record<string, unknown>) &&
-      "schema" in (bazaarExt as Record<string, unknown>)
-    ) {
-      const result = validate(bazaarExt);
-      if (!result.valid) {
-        console.warn(
-          `x402: Route "${pattern}" has an invalid bazaar extension: ${result.errors?.join(", ")}`,
-        );
-      }
-    }
-  }
+  return Object.values(routes).some(r => !!(r.extensions && "bazaar" in r.extensions));
 }
 
 /**
@@ -123,11 +77,9 @@ export function paymentMiddlewareFromHTTPServer(
   let bazaarPromise: Promise<void> | null = null;
   if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import("@x402/extensions/bazaar")
-      .then(({ bazaarResourceServerExtension, validateDiscoveryExtension }) => {
+      .then(({ bazaarResourceServerExtension, validateBazaarRouteExtensions }) => {
         httpServer.server.registerExtension(bazaarResourceServerExtension);
-        validateBazaarExtensions(httpServer.routes, (ext: unknown) =>
-          validateDiscoveryExtension(ext as Parameters<typeof validateDiscoveryExtension>[0]),
-        );
+        validateBazaarRouteExtensions(httpServer.routes);
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -29,6 +29,41 @@ function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
   });
 }
 
+type ValidateFn = (ext: unknown) => { valid: boolean; errors?: string[] };
+
+/**
+ *
+ * @param routes
+ * @param validate
+ */
+/**
+ * Validate bazaar extensions on all routes using the extension's JSON-schema validator.
+ *
+ * @param routes - Route configuration to scan for bazaar extensions
+ * @param validate - Validation function from the bazaar extension package
+ */
+function validateBazaarExtensions(routes: RoutesConfig, validate: ValidateFn): void {
+  const entries: [string, { extensions?: Record<string, unknown> }][] =
+    "accepts" in routes ? [["*", routes]] : Object.entries(routes);
+
+  for (const [pattern, config] of entries) {
+    const bazaarExt = config.extensions?.["bazaar"];
+    if (
+      bazaarExt &&
+      typeof bazaarExt === "object" &&
+      "info" in (bazaarExt as Record<string, unknown>) &&
+      "schema" in (bazaarExt as Record<string, unknown>)
+    ) {
+      const result = validate(bazaarExt);
+      if (!result.valid) {
+        console.warn(
+          `x402: Route "${pattern}" has an invalid bazaar extension: ${result.errors?.join(", ")}`,
+        );
+      }
+    }
+  }
+}
+
 /**
  * Configuration for registering a payment scheme with a specific network
  */
@@ -88,8 +123,11 @@ export function paymentMiddlewareFromHTTPServer(
   let bazaarPromise: Promise<void> | null = null;
   if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import("@x402/extensions/bazaar")
-      .then(({ bazaarResourceServerExtension }) => {
+      .then(({ bazaarResourceServerExtension, validateDiscoveryExtension }) => {
         httpServer.server.registerExtension(bazaarResourceServerExtension);
+        validateBazaarExtensions(httpServer.routes, (ext: unknown) =>
+          validateDiscoveryExtension(ext as Parameters<typeof validateDiscoveryExtension>[0]),
+        );
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -16,6 +16,13 @@ import {
 } from "./utils";
 import { x402HTTPResourceServer } from "@x402/core/server";
 
+function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
+  if ("accepts" in routes) {
+    return !!(routes.extensions && "bazaar" in routes.extensions);
+  }
+  return Object.values(routes).some(r => !!(r.extensions && "bazaar" in r.extensions));
+}
+
 /**
  * Configuration for registering a payment scheme with a specific network
  */
@@ -68,11 +75,9 @@ export function paymentProxyFromHTTPServer(
   let bazaarPromise: Promise<void> | null = null;
   if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import(/* webpackIgnore: true */ "@x402/extensions/bazaar")
-      .then(({ bazaarResourceServerExtension, validateDiscoveryExtension }) => {
+      .then(({ bazaarResourceServerExtension, validateBazaarRouteExtensions }) => {
         httpServer.server.registerExtension(bazaarResourceServerExtension);
-        validateBazaarExtensions(httpServer.routes, (ext: unknown) =>
-          validateDiscoveryExtension(ext as Parameters<typeof validateDiscoveryExtension>[0]),
-        );
+        validateBazaarRouteExtensions(httpServer.routes);
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);
@@ -253,11 +258,9 @@ export function withX402FromHTTPServer<T = unknown>(
   let bazaarPromise: Promise<void> | null = null;
   if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import(/* webpackIgnore: true */ "@x402/extensions/bazaar")
-      .then(({ bazaarResourceServerExtension, validateDiscoveryExtension }) => {
+      .then(({ bazaarResourceServerExtension, validateBazaarRouteExtensions }) => {
         httpServer.server.registerExtension(bazaarResourceServerExtension);
-        validateBazaarExtensions(httpServer.routes, (ext: unknown) =>
-          validateDiscoveryExtension(ext as Parameters<typeof validateDiscoveryExtension>[0]),
-        );
+        validateBazaarRouteExtensions(httpServer.routes);
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);
@@ -366,59 +369,6 @@ export function withX402<T = unknown>(
     paywall,
     syncFacilitatorOnStart,
   );
-}
-
-/**
- * Check if any routes in the configuration declare bazaar extensions
- *
- * @param routes - Route configuration
- * @returns True if any route has extensions.bazaar defined
- */
-function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  // Handle single route config
-  if ("accepts" in routes) {
-    return !!(routes.extensions && "bazaar" in routes.extensions);
-  }
-
-  // Handle multiple routes
-  return Object.values(routes).some(routeConfig => {
-    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
-  });
-}
-
-type ValidateFn = (ext: unknown) => { valid: boolean; errors?: string[] };
-
-/**
- *
- * @param routes
- * @param validate
- */
-/**
- * Validate bazaar extensions on all routes using the extension's JSON-schema validator.
- *
- * @param routes - Route configuration to scan for bazaar extensions
- * @param validate - Validation function from the bazaar extension package
- */
-function validateBazaarExtensions(routes: RoutesConfig, validate: ValidateFn): void {
-  const entries: [string, { extensions?: Record<string, unknown> }][] =
-    "accepts" in routes ? [["*", routes]] : Object.entries(routes);
-
-  for (const [pattern, config] of entries) {
-    const bazaarExt = config.extensions?.["bazaar"];
-    if (
-      bazaarExt &&
-      typeof bazaarExt === "object" &&
-      "info" in (bazaarExt as Record<string, unknown>) &&
-      "schema" in (bazaarExt as Record<string, unknown>)
-    ) {
-      const result = validate(bazaarExt);
-      if (!result.valid) {
-        console.warn(
-          `x402: Route "${pattern}" has an invalid bazaar extension: ${result.errors?.join(", ")}`,
-        );
-      }
-    }
-  }
 }
 
 export type {

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -68,8 +68,11 @@ export function paymentProxyFromHTTPServer(
   let bazaarPromise: Promise<void> | null = null;
   if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import(/* webpackIgnore: true */ "@x402/extensions/bazaar")
-      .then(({ bazaarResourceServerExtension }) => {
+      .then(({ bazaarResourceServerExtension, validateDiscoveryExtension }) => {
         httpServer.server.registerExtension(bazaarResourceServerExtension);
+        validateBazaarExtensions(httpServer.routes, (ext: unknown) =>
+          validateDiscoveryExtension(ext as Parameters<typeof validateDiscoveryExtension>[0]),
+        );
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);
@@ -247,13 +250,14 @@ export function withX402FromHTTPServer<T = unknown>(
 ): (request: NextRequest) => Promise<NextResponse<T>> {
   const { init } = prepareHttpServer(httpServer, paywall, syncFacilitatorOnStart);
 
-  // Dynamically register bazaar extension if route declares it and not already registered
-  // Skip if pre-registered (e.g., in serverless environments where static imports are used)
   let bazaarPromise: Promise<void> | null = null;
   if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
     bazaarPromise = import(/* webpackIgnore: true */ "@x402/extensions/bazaar")
-      .then(({ bazaarResourceServerExtension }) => {
+      .then(({ bazaarResourceServerExtension, validateDiscoveryExtension }) => {
         httpServer.server.registerExtension(bazaarResourceServerExtension);
+        validateBazaarExtensions(httpServer.routes, (ext: unknown) =>
+          validateDiscoveryExtension(ext as Parameters<typeof validateDiscoveryExtension>[0]),
+        );
       })
       .catch(err => {
         console.error("Failed to load bazaar extension:", err);
@@ -380,6 +384,41 @@ function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
   return Object.values(routes).some(routeConfig => {
     return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
   });
+}
+
+type ValidateFn = (ext: unknown) => { valid: boolean; errors?: string[] };
+
+/**
+ *
+ * @param routes
+ * @param validate
+ */
+/**
+ * Validate bazaar extensions on all routes using the extension's JSON-schema validator.
+ *
+ * @param routes - Route configuration to scan for bazaar extensions
+ * @param validate - Validation function from the bazaar extension package
+ */
+function validateBazaarExtensions(routes: RoutesConfig, validate: ValidateFn): void {
+  const entries: [string, { extensions?: Record<string, unknown> }][] =
+    "accepts" in routes ? [["*", routes]] : Object.entries(routes);
+
+  for (const [pattern, config] of entries) {
+    const bazaarExt = config.extensions?.["bazaar"];
+    if (
+      bazaarExt &&
+      typeof bazaarExt === "object" &&
+      "info" in (bazaarExt as Record<string, unknown>) &&
+      "schema" in (bazaarExt as Record<string, unknown>)
+    ) {
+      const result = validate(bazaarExt);
+      if (!result.valid) {
+        console.warn(
+          `x402: Route "${pattern}" has an invalid bazaar extension: ${result.errors?.join(", ")}`,
+        );
+      }
+    }
+  }
 }
 
 export type {


### PR DESCRIPTION
## Description

- Adds startup-time JSON-schema validation for bazaar discovery extensions across all three SDK languages (TypeScript, Python, Go)
- Validation runs in the extension-aware middleware packages (express/hono/next, FastAPI/Flask, Gin) rather than in core, since only these packages have the `@x402/extensions` / bazaar dependency
- Invalid bazaar extensions emit a console warning but do not block server startup, catching misconfiguration (e.g., `schema.required` listing fields absent from `info`) early without breaking the startup contract

## Tests

- [x] New unit tests for bazaar validation in Go Gin middleware (valid, invalid, no-extension cases)
- [x] New unit tests for FastAPI and Flask middleware validation helpers
- [x] Negative test confirming core HTTP server base no longer validates bazaar (ownership moved to middleware)
- [x] All existing tests pass: TS (build/format/lint/test/integration), Go (lint/test/integration), Python (ruff/pytest 718 passed)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
