### PR TITLE
Add ag402 and token-rugcheck to x402 ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/ag402/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/ag402/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "ag402",
+  "description": "Payment layer for AI agents using Coinbase x402 protocol. Wrap any API or MCP server with a USDC paywall in one command. Solana USDC, ~0.5s settlement, non-custodial, 648+ tests. Works with Claude Code, Cursor, OpenClaw, LangChain, AutoGen.",
+  "logoUrl": "",
+  "websiteUrl": "https://github.com/AetherCore-Dev/ag402",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/app/ecosystem/partners-data/token-rugcheck/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/token-rugcheck/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "token-rugcheck",
+  "description": "Solana token safety audit MCP server for AI agents. Three-layer risk analysis (machine verdict + LLM analysis + raw on-chain evidence) from RugCheck.xyz, DexScreener, and GoPlus Security. Live on mainnet with USDC micropayments ($0.02/audit).",
+  "logoUrl": "",
+  "websiteUrl": "https://github.com/AetherCore-Dev/token-rugcheck",
+  "category": "DeFi & Finance"
+}


### PR DESCRIPTION
Adding two production-ready x402 implementations to the ecosystem:

**ag402** - Payment layer for AI agents
- Category: Infrastructure & Tooling
- Description: Payment layer for AI agents using Coinbase x402 protocol
- URL: https://github.com/AetherCore-Dev/ag402
- Features: Solana USDC, ~0.5s settlement, non-custodial, 648+ tests

**token-rugcheck** - Solana token safety audit MCP server
- Category: DeFi & Finance
- Description: Three-layer risk analysis from RugCheck.xyz, DexScreener, GoPlus Security
- URL: https://github.com/AetherCore-Dev/token-rugcheck
- Price: /bin/zsh.02 USDC/audit on Solana mainnet

Both are MIT licensed and live on mainnet.