### PR TITLE
Add SkillMint to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/skillmint/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/skillmint/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "SkillMint",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/skillmint.png",
+  "description": "Pay-per-call AI skills marketplace with 51 skills across 7 categories. No API keys, no subscriptions — just USDC on Base.",
+  "websiteUrl": "https://skillmint.sagasu.art"
+}


### PR DESCRIPTION
## Summary
Adds SkillMint to the x402 ecosystem directory under Services/Endpoints.

## About SkillMint
SkillMint is a pay-per-call AI skills marketplace powered by x402 on Base mainnet.

- **Live:** https://skillmint.sagasu.art
- **GitHub:** https://github.com/s87343472/skillmint
- **51 AI skills** across 7 categories: developer tools, creative design, research, writing, SEO, business, document generation
- **Price range:** $0.01–$0.50 USDC per call
- **Stack:** Cloudflare Workers (Hono) + x402 middleware + OpenRouter LLM
- **No API keys, no subscriptions** — agents discover, pay, and use skills autonomously via x402

## Note
Logo file (`skillmint.png`) needs to be added to the logos directory. Happy to provide one in the required format.