### PR TITLE
feat: run e2e tests in parallel

### DIFF
--- a/e2e/.env-local
+++ b/e2e/.env-local
@@ -8,3 +8,9 @@ CLIENT_STELLAR_PRIVATE_KEY=
 FACILITATOR_EVM_PRIVATE_KEY=
 FACILITATOR_SVM_PRIVATE_KEY=
 FACILITATOR_STELLAR_PRIVATE_KEY=
+
+# Plural keys for within-family parallelism (comma-delimited)
+# Count must match between client and facilitator for each family.
+# Plural takes precedence over singular when both are set.
+# CLIENT_EVM_PRIVATE_KEYS=0xkey1,0xkey2,0xkey3
+# FACILITATOR_EVM_PRIVATE_KEYS=0xfkey1,0xfkey2,0xfkey3

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -41,10 +41,18 @@ bash build.sh
 
 ## Usage
 
-### Interactive Test Mode
+### Run All Tests (Headless, Default)
 
 ```bash
 pnpm test
+```
+
+Runs ALL tests headlessly on testnet. No prompts — suitable for CI and agent invocation.
+
+### Interactive Mode
+
+```bash
+pnpm test -i
 ```
 
 Launches an interactive CLI where you can select:
@@ -52,7 +60,7 @@ Launches an interactive CLI where you can select:
 - **Servers** - Protected endpoints requiring payment (Express, Gin, Hono, Next.js, FastAPI, Flask, etc.)
 - **Clients** - Payment-capable HTTP clients (axios, fetch, httpx, requests, etc.)
 - **Extensions** - Additional features like Bazaar discovery
-- **Protocols** - EVM, SVM, and/or Aptos networks
+- **Protocols** - EVM, SVM, Aptos, and/or Stellar networks
 
 Every valid combination of your selections will be tested. For example, selecting 2 facilitators, 3 servers, and 2 clients will generate and run all compatible test scenarios.
 
@@ -62,7 +70,7 @@ Every valid combination of your selections will be tested. For example, selectin
 pnpm test --min
 ```
 
-Same interactive CLI, but with intelligent test minimization:
+Same as default but with intelligent test minimization:
 - **90% fewer tests** compared to full mode
 - Each selected component is tested at least once across all variations
 - Skips redundant combinations that provide no additional coverage
@@ -79,11 +87,34 @@ pnpm test --min -v
 
 Add the `-v` flag to any command for verbose output:
 - Prints all facilitator logs
-- Prints all server logs  
+- Prints all server logs
 - Prints all client logs
 - Shows detailed information after each test scenario
 
 Useful for debugging test failures or understanding the payment flow.
+
+### Filter Tests (Headless)
+
+Run a subset of tests without entering interactive mode:
+
+```bash
+pnpm test --facilitators=go --servers=express
+pnpm test --testnet --families=evm
+pnpm test --mainnet --facilitators=go --servers=express
+```
+
+### Parallel Execution
+
+```bash
+pnpm test --min --parallel -v
+pnpm test --min --parallel --concurrency=8 -v
+```
+
+With `--parallel`, test combos run concurrently. The scheduler automatically partitions work by protocol family (EVM, SVM, APTOS, STELLAR) so that each family runs in its own independent lane. Different families never block each other.
+
+Within each family, parallelism is controlled by the number of comma-delimited private keys you provide (see [Plural Keys for Parallelism](#plural-keys-for-parallelism) below). One key pair = one sub-lane within that family.
+
+The `--concurrency=<N>` flag sets an overall cap on how many combos execute simultaneously across all families (default: 4).
 
 ## Environment Variables
 
@@ -109,6 +140,37 @@ FACILITATOR_APTOS_PRIVATE_KEY=...   # Aptos private key for facilitator (hex str
 FACILITATOR_STELLAR_PRIVATE_KEY=... # Stellar private key for facilitator
 ```
 
+### Plural Keys for Parallelism
+
+To run multiple tests within a protocol family concurrently without nonce or gas-estimation collisions, provide comma-delimited key lists. Each pair (client key N + facilitator key N) maps to a unique sub-lane that runs independently.
+
+Plural keys are supported for **all** families:
+
+```bash
+# EVM (prevents nonce collisions)
+CLIENT_EVM_PRIVATE_KEYS=0xkey1,0xkey2,0xkey3
+FACILITATOR_EVM_PRIVATE_KEYS=0xfkey1,0xfkey2,0xfkey3
+
+# SVM
+CLIENT_SVM_PRIVATE_KEYS=svmkey1,svmkey2
+FACILITATOR_SVM_PRIVATE_KEYS=svmfkey1,svmfkey2
+
+# APTOS
+CLIENT_APTOS_PRIVATE_KEYS=aptoskey1,aptoskey2
+FACILITATOR_APTOS_PRIVATE_KEYS=aptosfkey1,aptosfkey2
+
+# STELLAR
+CLIENT_STELLAR_PRIVATE_KEYS=stellarkey1,stellarkey2
+FACILITATOR_STELLAR_PRIVATE_KEYS=stellarfkey1,stellarfkey2
+```
+
+Rules:
+- The count of client keys and facilitator keys must be equal for each family.
+- Singular (`CLIENT_EVM_PRIVATE_KEY`) and plural (`CLIENT_EVM_PRIVATE_KEYS`) are supported; plural takes precedence.
+- With N key pairs for a family, up to N tests of that family run concurrently, each using a unique key pair.
+- Different families always run in independent lanes (EVM work never blocks SVM, etc.).
+- The `--parallel` flag is also required to enable concurrent combo execution.
+
 ### Account Setup Instructions
 
 #### Stellar Testnet
@@ -125,6 +187,18 @@ You need **three separate Stellar accounts** for e2e tests (client, server, faci
 
 ```bash
 $ pnpm test --min
+
+🤖 Programmatic Mode
+===================
+
+✅ 18 scenarios selected
+
+✅ Passed: 18
+❌ Failed: 0
+```
+
+```bash
+$ pnpm test -i --min
 
 🎯 Interactive Mode
 ==================

--- a/e2e/clients/httpx/uv.lock
+++ b/e2e/clients/httpx/uv.lock
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/mcp-python/uv.lock
+++ b/e2e/clients/mcp-python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/requests/uv.lock
+++ b/e2e/clients/requests/uv.lock
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/facilitators/python/uv.lock
+++ b/e2e/facilitators/python/uv.lock
@@ -2846,7 +2846,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -786,10 +786,10 @@ importers:
     dependencies:
       '@coinbase/cdp-sdk':
         specifier: ^1.22.0
-        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/kit':
         specifier: ^5.0.0
-        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       express:
         specifier: ^4.18.2
         version: 4.21.2
@@ -1533,148 +1533,6 @@ importers:
         version: 4.20.3
       typescript:
         specifier: ^5.3.0
-        version: 5.8.3
-
-  facilitators/external-proxies/cdp:
-    dependencies:
-      '@coinbase/x402':
-        specifier: ^0.7.3
-        version: 0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-
-  facilitators/external-proxies/cdp-dev:
-    dependencies:
-      '@coinbase/cdp-sdk':
-        specifier: ^1.22.0
-        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-      x402:
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/legacy/x402
-
-  facilitators/external-proxies/cdp-dev-new:
-    dependencies:
-      '@coinbase/cdp-sdk':
-        specifier: ^1.22.0
-        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-      x402:
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/legacy/x402
-
-  facilitators/external-proxies/x402.org:
-    dependencies:
-      '@coinbase/x402':
-        specifier: ^0.7.3
-        version: 0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
-      typescript:
-        specifier: ^5.7.2
         version: 5.8.3
 
   facilitators/typescript:
@@ -2894,9 +2752,6 @@ packages:
 
   '@coinbase/wallet-sdk@4.3.6':
     resolution: {integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==}
-
-  '@coinbase/x402@0.7.3':
-    resolution: {integrity: sha512-mSxxbPnDCvSLfq6ZZAB5P1HyYQfQNSdWyY01Cn7yjzTuGUFFgZ7onDkbZnZ1Yry0UnG467aqrmjs6AgoYgpzCQ==}
 
   '@craftamap/esbuild-plugin-html@0.9.0':
     resolution: {integrity: sha512-V5LFrcGXQWU1SSzYPwxEFjF8IjeXW0oTKh5c0xyhGuTNoEnjgJRNSX83HnZ5TTAutJfo/MAyWA4Z9/fIwbMhUQ==}
@@ -9576,9 +9431,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  x402@0.7.3:
-    resolution: {integrity: sha512-8CIZsdMTOn52PjMH/ErVke9ebeZ7ErwiZ5FL3tN3Wny7Ynxs3LkuB/0q7IoccRLdVXA7f2lueYBJ2iDrElhXnA==}
-
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -10502,54 +10354,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@base-org/account@1.1.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@3.25.71)
-      preact: 10.24.2
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zustand: 5.0.3(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
   '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      abitype: 1.0.6(typescript@5.8.3)(zod@3.25.71)
-      axios: 1.13.4
-      axios-retry: 4.5.0(axios@1.13.4)
-      jose: 6.1.3
-      md5: 2.3.0
-      uncrypto: 0.1.3
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zod: 3.25.71
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
-      - ws
-
-  '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.8.3)(zod@3.25.71)
       axios: 1.13.4
@@ -10691,67 +10500,6 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
-
-  '@coinbase/wallet-sdk@4.3.6(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@3.25.71)
-      preact: 10.24.2
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zustand: 5.0.3(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
-  '@coinbase/x402@0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@coinbase/cdp-sdk': 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      x402: 0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      zod: 3.25.71
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - ws
 
   '@craftamap/esbuild-plugin-html@0.9.0(bufferutil@4.0.9)(esbuild@0.25.5)(utf-8-validate@5.0.10)':
     dependencies:
@@ -11704,41 +11452,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      valtio: 1.13.2(react@19.2.3)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-pay@1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
@@ -11783,42 +11496,6 @@ snapshots:
       '@reown/appkit-utils': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.2)(react@19.2.1))(zod@3.25.71)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-pay@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
-      lit: 3.3.0
-      valtio: 1.13.2(react@19.2.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11925,43 +11602,6 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-scaffold-ui@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - valtio
-      - zod
-
   '@reown/appkit-ui@1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
@@ -12001,41 +11641,6 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@reown/appkit-controllers': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-      qrcode: 1.5.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-ui@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -12143,44 +11748,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      valtio: 1.13.2(react@19.2.3)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-wallet@1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -12249,49 +11816,6 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-pay': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      bs58: 6.0.0
-      valtio: 1.13.2(react@19.2.3)
       viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -12470,10 +11994,6 @@ snapshots:
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
-    dependencies:
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-
   '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -12500,10 +12020,6 @@ snapshots:
   '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-
-  '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
-    dependencies:
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
@@ -13063,32 +12579,6 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/codecs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/functional': 3.0.3(typescript@5.8.3)
-      '@solana/instruction-plans': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/instructions': 3.0.3(typescript@5.8.3)
-      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/programs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-parsed-types': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-spec-types': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/signers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/sysvars': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
   '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -13110,6 +12600,32 @@ snapshots:
       '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/accounts': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/functional': 5.0.0(typescript@5.8.3)
+      '@solana/instruction-plans': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/instructions': 5.0.0(typescript@5.8.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/programs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-parsed-types': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/signers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/sysvars': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-confirmation': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -13630,15 +13146,6 @@ snapshots:
       typescript: 5.8.3
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
-  '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/functional': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.8.3)
-      '@solana/subscribable': 3.0.3(typescript@5.8.3)
-      typescript: 5.8.3
-      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-
   '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.8.3)
@@ -13647,6 +13154,15 @@ snapshots:
       '@solana/subscribable': 3.0.3(typescript@5.8.3)
       typescript: 5.8.3
       ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
+  '@solana/rpc-subscriptions-channel-websocket@5.0.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/functional': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-subscriptions-spec': 5.0.0(typescript@5.8.3)
+      '@solana/subscribable': 5.0.0(typescript@5.8.3)
+      typescript: 5.8.3
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   '@solana/rpc-subscriptions-channel-websocket@5.0.0(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
@@ -13759,24 +13275,6 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/fast-stable-stringify': 3.0.3(typescript@5.8.3)
-      '@solana/functional': 3.0.3(typescript@5.8.3)
-      '@solana/promises': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-spec-types': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-subscriptions-api': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions-channel-websocket': 3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-transformers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/subscribable': 3.0.3(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
   '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.8.3)
@@ -13790,6 +13288,24 @@ snapshots:
       '@solana/rpc-transformers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/subscribable': 3.0.3(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/rpc-subscriptions@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/fast-stable-stringify': 5.0.0(typescript@5.8.3)
+      '@solana/functional': 5.0.0(typescript@5.8.3)
+      '@solana/promises': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-subscriptions-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions-channel-websocket': 5.0.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-spec': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/subscribable': 5.0.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -14246,23 +13762,6 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/promises': 3.0.3(typescript@5.8.3)
-      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
   '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -14275,6 +13774,23 @@ snapshots:
       '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - ws
+
+  '@solana/transaction-confirmation@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/promises': 5.0.0(typescript@5.8.3)
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -14690,11 +14206,6 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.8
       react: 19.2.1
-
-  '@tanstack/react-query@5.90.8(react@19.2.3)':
-    dependencies:
-      '@tanstack/query-core': 5.90.8
-      react: 19.2.3
 
   '@trysound/sax@0.2.0': {}
 
@@ -15356,53 +14867,6 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/connectors@6.1.0(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))(zod@3.25.71)':
-    dependencies:
-      '@base-org/account': 1.1.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@coinbase/wallet-sdk': 4.3.6(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@gemini-wallet/core': 0.2.0(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      '@walletconnect/ethereum-provider': 2.21.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.19(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - uploadthing
-      - use-sync-external-store
-      - utf-8-validate
-      - wagmi
-      - zod
-
   '@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(@types/react@19.2.2)(react@19.2.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
     dependencies:
       eventemitter3: 5.0.1
@@ -15439,21 +14903,6 @@ snapshots:
       mipd: 0.0.7(typescript@5.8.3)
       viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       zustand: 5.0.0(@types/react@19.2.2)(react@19.2.1)(use-sync-external-store@1.4.0(react@19.2.1))
-    optionalDependencies:
-      '@tanstack/query-core': 5.90.8
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.8.3)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zustand: 5.0.0(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
     optionalDependencies:
       '@tanstack/query-core': 5.90.8
       typescript: 5.8.3
@@ -15609,47 +15058,6 @@ snapshots:
   '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@walletconnect/jsonrpc-http-connection': 1.0.8
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/ethereum-provider@2.21.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
@@ -16867,10 +16275,6 @@ snapshots:
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.2)(react@19.2.1)):
     dependencies:
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
-
-  derive-valtio@0.1.0(valtio@1.13.2(react@19.2.3)):
-    dependencies:
-      valtio: 1.13.2(react@19.2.3)
 
   des.js@1.1.0:
     dependencies:
@@ -19026,26 +18430,6 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  porto@0.2.19(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)):
-    dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      hono: 4.10.2
-      idb-keyval: 6.2.2
-      mipd: 0.0.7(typescript@5.8.3)
-      ox: 0.9.12(typescript@5.8.3)(zod@4.1.12)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zod: 4.1.12
-      zustand: 5.0.8(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
-    optionalDependencies:
-      '@tanstack/react-query': 5.90.8(react@19.2.3)
-      react: 19.2.3
-      typescript: 5.8.3
-      wagmi: 2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - use-sync-external-store
-
   poseidon-lite@0.2.1: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -20145,10 +19529,6 @@ snapshots:
     dependencies:
       react: 19.2.1
 
-  use-sync-external-store@1.2.0(react@19.2.3):
-    dependencies:
-      react: 19.2.3
-
   use-sync-external-store@1.4.0(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -20156,10 +19536,6 @@ snapshots:
   use-sync-external-store@1.4.0(react@19.2.1):
     dependencies:
       react: 19.2.1
-
-  use-sync-external-store@1.4.0(react@19.2.3):
-    dependencies:
-      react: 19.2.3
 
   utf-8-validate@5.0.10:
     dependencies:
@@ -20200,14 +19576,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       react: 19.2.1
-
-  valtio@1.13.2(react@19.2.3):
-    dependencies:
-      derive-valtio: 0.1.0(valtio@1.13.2(react@19.2.3))
-      proxy-compare: 2.6.0
-      use-sync-external-store: 1.2.0(react@19.2.3)
-    optionalDependencies:
-      react: 19.2.3
 
   vary@1.1.2: {}
 
@@ -20558,45 +19926,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71):
-    dependencies:
-      '@tanstack/react-query': 5.90.8(react@19.2.3)
-      '@wagmi/connectors': 6.1.0(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))(zod@3.25.71)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.8)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      react: 19.2.3
-      use-sync-external-store: 1.4.0(react@19.2.3)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - immer
-      - ioredis
-      - supports-color
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   webextension-polyfill@0.10.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -20731,54 +20060,6 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
-  x402@0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10):
-    dependencies:
-      '@scure/base': 1.2.6
-      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana-program/token': 0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana-program/token-2022': 0.6.1(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/transaction-confirmation': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/wallet-standard-features': 1.3.0
-      '@wallet-standard/app': 1.1.0
-      '@wallet-standard/base': 1.1.0
-      '@wallet-standard/features': 1.1.0
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      wagmi: 2.18.2(@tanstack/query-core@5.90.8)(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)
-      zod: 3.25.71
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -20844,11 +20125,6 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
 
-  zustand@5.0.0(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
-    optionalDependencies:
-      react: 19.2.3
-      use-sync-external-store: 1.4.0(react@19.2.3)
-
   zustand@5.0.3(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0)):
     optionalDependencies:
       '@types/react': 19.2.2
@@ -20861,11 +20137,6 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
 
-  zustand@5.0.3(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
-    optionalDependencies:
-      react: 19.2.3
-      use-sync-external-store: 1.4.0(react@19.2.3)
-
   zustand@5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0)):
     optionalDependencies:
       '@types/react': 19.2.2
@@ -20877,8 +20148,3 @@ snapshots:
       '@types/react': 19.2.2
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
-
-  zustand@5.0.8(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
-    optionalDependencies:
-      react: 19.2.3
-      use-sync-external-store: 1.4.0(react@19.2.3)

--- a/e2e/servers/fastapi/uv.lock
+++ b/e2e/servers/fastapi/uv.lock
@@ -2841,7 +2841,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/flask/uv.lock
+++ b/e2e/servers/flask/uv.lock
@@ -2072,7 +2072,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/mcp-python/uv.lock
+++ b/e2e/servers/mcp-python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [[package]]
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/src/cli/args.ts
+++ b/e2e/src/cli/args.ts
@@ -34,18 +34,9 @@ export function parseArgs(): ParsedArgs {
     };
   }
 
-  // Check if any filter args present -> programmatic mode
-  const hasFilterArgs = args.some(arg => 
-    arg.startsWith('--transport=') ||
-    arg.startsWith('--facilitators=') ||
-    arg.startsWith('--servers=') ||
-    arg.startsWith('--clients=') ||
-    arg.startsWith('--extensions=') ||
-    arg.startsWith('--versions=') ||
-    arg.startsWith('--families=')
-  );
-
-  const mode: 'interactive' | 'programmatic' = hasFilterArgs ? 'programmatic' : 'interactive';
+  // If -i/--interactive is passed, enter interactive mode; otherwise default to programmatic
+  const interactive = args.includes('-i') || args.includes('--interactive');
+  const mode: 'interactive' | 'programmatic' = interactive ? 'interactive' : 'programmatic';
 
   // Parse verbose
   const verbose = args.includes('-v') || args.includes('--verbose');
@@ -113,16 +104,19 @@ function parseListArg(args: string[], argName: string): string[] | undefined {
 export function printHelp(): void {
   console.log('Usage: pnpm test [options]');
   console.log('');
-  console.log('Interactive Mode (default):');
-  console.log('  pnpm test                  Launch interactive prompt mode');
-  console.log('  pnpm test -v               Interactive with verbose logging');
+  console.log('Default (headless, runs all tests):');
+  console.log('  pnpm test                  Run ALL tests headlessly on testnet');
+  console.log('  pnpm test -v               Run all tests with verbose logging');
+  console.log('');
+  console.log('Interactive Mode:');
+  console.log('  pnpm test -i               Launch interactive prompt mode');
+  console.log('  pnpm test --interactive    Launch interactive prompt mode');
   console.log('');
   console.log('Network Selection:');
-  console.log('  --testnet                  Use testnet networks (Base Sepolia + Solana Devnet)');
+  console.log('  --testnet                  Use testnet networks (Base Sepolia + Solana Devnet) [default]');
   console.log('  --mainnet                  Use mainnet networks (Base + Solana) ⚠️  Real funds!');
-  console.log('  (If not specified, will prompt in interactive mode)');
   console.log('');
-  console.log('Programmatic Mode (for CI/workflows):');
+  console.log('Filters (headless mode):');
   console.log('  --transport=<list>         Comma-separated transports (e.g., http,mcp)');
   console.log('  --facilitators=<list>      Comma-separated facilitator names');
   console.log('  --servers=<list>           Comma-separated server names');
@@ -132,23 +126,31 @@ export function printHelp(): void {
   console.log('  --families=<list>          Comma-separated protocol families (e.g., evm,svm)');
   console.log('');
   console.log('Options:');
+  console.log('  -i, --interactive          Launch interactive prompt mode');
   console.log('  -v, --verbose              Enable verbose logging');
   console.log('  --log-file=<path>          Save verbose output to file');
   console.log('  --output-json=<path>       Write structured JSON results to file');
   console.log('  --min                      Minimize tests (coverage-based skipping)');
-  console.log('  --parallel                 Run server+facilitator combos concurrently');
+  console.log('  --parallel                 Run combos concurrently (per-family lanes)');
   console.log('  --concurrency=<N>          Max concurrent combos (default: 4, requires --parallel)');
   console.log('  -h, --help                 Show this help message');
   console.log('');
+  console.log('Parallelism:');
+  console.log('  EVM, SVM, APTOS, and STELLAR run in independent lanes automatically.');
+  console.log('  Within each family, provide comma-delimited plural keys to add sub-lanes:');
+  console.log('    CLIENT_EVM_PRIVATE_KEYS=0xkey1,0xkey2');
+  console.log('    FACILITATOR_EVM_PRIVATE_KEYS=0xfkey1,0xfkey2');
+  console.log('  Client and facilitator key counts must match per family.');
+  console.log('');
   console.log('Examples:');
-  console.log('  pnpm test                                           # Interactive mode (testnet)');
-  console.log('  pnpm test --testnet                                 # Skip network prompt');
+  console.log('  pnpm test                                           # Run all tests headlessly (testnet)');
+  console.log('  pnpm test -i                                        # Interactive mode');
   console.log('  pnpm test --mainnet                                 # Use mainnet (real funds!)');
   console.log('  pnpm test --min -v                                  # Minimize with verbose');
-  console.log('  pnpm test --transport=mcp                                # MCP transport only');
-  console.log('  pnpm test --mainnet --facilitators=go --servers=express  # Mainnet programmatic');
-  console.log('  pnpm test --testnet --min --parallel -v                   # Parallel mode');
-  console.log('  pnpm test --testnet --min --parallel --concurrency=2 -v   # Limited concurrency');
+  console.log('  pnpm test --transport=mcp                           # MCP transport only');
+  console.log('  pnpm test --mainnet --facilitators=go --servers=express  # Mainnet with filters');
+  console.log('  pnpm test --min --parallel -v                       # Parallel mode');
+  console.log('  pnpm test --min --parallel --concurrency=8 -v       # Higher concurrency');
   console.log('');
   console.log('Note: --mainnet requires funded wallets with real tokens!');
   console.log('');

--- a/e2e/src/concurrency.ts
+++ b/e2e/src/concurrency.ts
@@ -2,9 +2,14 @@
  * Concurrency utilities for parallel E2E test execution.
  *
  * - Semaphore: bounds how many combos run at once.
- * - FacilitatorLock: async mutex keyed by facilitator name, used to serialize
- *   EVM tests through the same facilitator (prevents nonce collisions).
+ * - SlotPool: manages N numbered key-pair slots so up to N tests of the same
+ *   protocol family can run concurrently without nonce collisions (each slot
+ *   maps to a unique key pair).
+ * - FamilyLanePool: maintains one SlotPool per protocol family so EVM, SVM,
+ *   APTOS and STELLAR work can proceed independently.
  */
+
+import type { ProtocolFamily } from './types';
 
 /**
  * Counting semaphore that limits concurrent async operations.
@@ -41,38 +46,62 @@ export class Semaphore {
 }
 
 /**
- * Per-facilitator async mutex for EVM tests.
+ * Pool of numbered key-pair slots. Each slot has a unique index that maps
+ * to a specific client key and facilitator instance. Callers acquire a slot
+ * before running a test combo and release it when done.
  *
- * EVM transactions use `PendingNonceAt()` — two concurrent EVM tests routed
- * through the same facilitator will get the same nonce and one will fail.
- * This lock serializes EVM tests per facilitator while allowing SVM tests
- * (which use blockhash + random memo) to proceed freely.
+ * With N slots, up to N combos can run concurrently.
+ * With 1 slot (default / no plural keys), behaviour is fully sequential.
  */
-export class FacilitatorLock {
-  private locks = new Map<string, Promise<void>>();
+export class SlotPool {
+  private available: number[];
+  private waiters: Array<(slot: number) => void> = [];
 
-  /**
-   * Acquire the EVM lock for a facilitator. Returns a release function.
-   * Only call this for EVM tests — SVM tests should skip locking entirely.
-   */
-  async acquire(facilitatorName: string): Promise<() => void> {
-    const key = `evm:${facilitatorName}`;
+  constructor(slotCount: number) {
+    this.available = Array.from({ length: slotCount }, (_, i) => i);
+  }
 
-    // Wait for the current holder (if any) to finish
-    while (this.locks.has(key)) {
-      await this.locks.get(key);
+  async acquire(): Promise<{ slotIndex: number; release: () => void }> {
+    if (this.available.length > 0) {
+      const slotIndex = this.available.shift()!;
+      return { slotIndex, release: () => this.releaseSlot(slotIndex) };
     }
-
-    // Set up our own lock
-    let releaseFn: () => void;
-    const lockPromise = new Promise<void>((resolve) => {
-      releaseFn = resolve;
+    return new Promise((resolve) => {
+      this.waiters.push((slot) => {
+        resolve({ slotIndex: slot, release: () => this.releaseSlot(slot) });
+      });
     });
-    this.locks.set(key, lockPromise);
+  }
 
-    return () => {
-      this.locks.delete(key);
-      releaseFn!();
-    };
+  private releaseSlot(slotIndex: number): void {
+    const next = this.waiters.shift();
+    if (next) {
+      next(slotIndex);
+    } else {
+      this.available.push(slotIndex);
+    }
+  }
+}
+
+/**
+ * Per-family lane pool: each protocol family gets its own SlotPool sized
+ * by that family's key count, so EVM/SVM/APTOS/STELLAR run independently.
+ */
+export class FamilyLanePool {
+  private pools: Map<ProtocolFamily, SlotPool>;
+
+  constructor(laneCounts: Record<ProtocolFamily, number>) {
+    this.pools = new Map();
+    for (const [family, count] of Object.entries(laneCounts) as [ProtocolFamily, number][]) {
+      this.pools.set(family, new SlotPool(Math.max(count, 1)));
+    }
+  }
+
+  async acquire(family: ProtocolFamily): Promise<{ slotIndex: number; release: () => void }> {
+    const pool = this.pools.get(family);
+    if (!pool) {
+      return { slotIndex: 0, release: () => {} };
+    }
+    return pool.acquire();
   }
 }

--- a/e2e/src/facilitators/facilitator-manager.ts
+++ b/e2e/src/facilitators/facilitator-manager.ts
@@ -10,6 +10,13 @@ interface Facilitator {
   stop: () => Promise<void>;
 }
 
+export interface FacilitatorKeys {
+  evmPrivateKey?: string;
+  svmPrivateKey?: string;
+  aptosPrivateKey?: string;
+  stellarPrivateKey?: string;
+}
+
 /**
  * Manages the async lifecycle of a facilitator process: start, health-check,
  * ready-gate, and stop.
@@ -20,29 +27,29 @@ export class FacilitatorManager {
   private readyPromise: Promise<string | null>;
   private url: string | null = null;
 
-  constructor(facilitator: Facilitator, port: number, networks: NetworkSet) {
+  constructor(facilitator: Facilitator, port: number, networks: NetworkSet, keys?: FacilitatorKeys) {
     this.facilitator = facilitator;
     this.port = port;
 
     // Start facilitator and health checks asynchronously
-    this.readyPromise = this.startAndWaitForHealth(networks);
+    this.readyPromise = this.startAndWaitForHealth(networks, keys);
   }
 
-  private async startAndWaitForHealth(networks: NetworkSet): Promise<string | null> {
+  private async startAndWaitForHealth(networks: NetworkSet, keys?: FacilitatorKeys): Promise<string | null> {
     verboseLog(`  🏛️ Starting facilitator on port ${this.port}...`);
 
     await this.facilitator.start({
       port: this.port,
-      evmPrivateKey: process.env.FACILITATOR_EVM_PRIVATE_KEY,
-      svmPrivateKey: process.env.FACILITATOR_SVM_PRIVATE_KEY,
-      aptosPrivateKey: process.env.FACILITATOR_APTOS_PRIVATE_KEY,
-      stellarPrivateKey: process.env.FACILITATOR_STELLAR_PRIVATE_KEY,
+      evmPrivateKey: keys?.evmPrivateKey ?? process.env.FACILITATOR_EVM_PRIVATE_KEY,
+      svmPrivateKey: keys?.svmPrivateKey ?? process.env.FACILITATOR_SVM_PRIVATE_KEY,
+      aptosPrivateKey: keys?.aptosPrivateKey ?? process.env.FACILITATOR_APTOS_PRIVATE_KEY,
+      stellarPrivateKey: keys?.stellarPrivateKey ?? process.env.FACILITATOR_STELLAR_PRIVATE_KEY,
       networks,
     });
 
     const healthy = await waitForHealth(
       () => this.facilitator.health(),
-      { label: 'Facilitator' },
+      { label: 'Facilitator', initialDelayMs: 500 },
     );
 
     if (healthy) {

--- a/e2e/src/health.ts
+++ b/e2e/src/health.ts
@@ -12,7 +12,7 @@ export interface WaitForHealthOptions {
  * exhausted. Returns true when healthy, false on timeout.
  */
 export async function waitForHealth(
-  healthCheck: () => Promise<{ success: boolean }>,
+  healthCheck: () => Promise<{ success: boolean; error?: string }>,
   options?: WaitForHealthOptions,
 ): Promise<boolean> {
   const maxAttempts = options?.maxAttempts ?? 10;
@@ -26,7 +26,8 @@ export async function waitForHealth(
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const result = await healthCheck();
-    verboseLog(` 🔍 ${label} health check ${attempt}/${maxAttempts}: ${result.success ? '✅' : '❌'}`);
+    const errorSuffix = !result.success && result.error ? ` (${result.error})` : '';
+    verboseLog(` 🔍 ${label} health check ${attempt}/${maxAttempts}: ${result.success ? '✅' : '❌'}${errorSuffix}`);
 
     if (result.success) {
       verboseLog(`  ✅ ${label} is healthy`);

--- a/e2e/src/proxy-base.ts
+++ b/e2e/src/proxy-base.ts
@@ -75,7 +75,8 @@ export abstract class BaseProxy {
       this.process = spawn(command[0], command.slice(1), {
         env,
         stdio: 'pipe',
-        cwd: this.directory
+        cwd: this.directory,
+        detached: true,
       });
 
       let output = '';
@@ -94,6 +95,10 @@ export abstract class BaseProxy {
       this.process.stderr?.on('data', (data) => {
         stderr += data.toString();
         verboseLog(`[${this.directory}] stderr: ${data.toString()}`);
+        if (stderr.includes(this.readyLog) && !resolved) {
+          resolved = true;
+          resolve();
+        }
       });
 
       this.process.on('error', (error) => {
@@ -130,17 +135,31 @@ export abstract class BaseProxy {
   protected async stopProcess(): Promise<void> {
     if (this.process) {
       return new Promise((resolve) => {
-        const process = this.process!;
-        process.kill('SIGTERM');
+        const child = this.process!;
+        const pid = child.pid;
+
+        // Kill the entire process group (pnpm -> tsx -> node) via negative PID
+        if (pid) {
+          try {
+            process.kill(-pid, 'SIGTERM');
+          } catch {
+            child.kill('SIGTERM');
+          }
+        } else {
+          child.kill('SIGTERM');
+        }
 
         // Force kill after 5 seconds
         const forceKillTimeout = setTimeout(() => {
-          if (process && !process.killed) {
-            process.kill('SIGKILL');
+          if (pid) {
+            try { process.kill(-pid, 'SIGKILL'); } catch { /* already dead */ }
+          }
+          if (child && !child.killed) {
+            child.kill('SIGKILL');
           }
         }, 5000);
 
-        process.on('exit', () => {
+        child.on('exit', () => {
           clearTimeout(forceKillTimeout);
           this.process = null;
           resolve();

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -2,7 +2,7 @@ import { config } from 'dotenv';
 import { spawn, execSync } from 'child_process';
 import { writeFileSync } from 'fs';
 import { TestDiscovery } from './src/discovery';
-import { ClientConfig, ScenarioResult, ServerConfig, TestScenario } from './src/types';
+import { ClientConfig, ProtocolFamily, ScenarioResult, ServerConfig, TestScenario } from './src/types';
 import { config as loggerConfig, log, verboseLog, errorLog, close as closeLogger, createComboLogger } from './src/logger';
 import { handleDiscoveryValidation, shouldRunDiscoveryValidation } from './extensions/bazaar';
 import { parseArgs, printHelp } from './src/cli/args';
@@ -11,7 +11,7 @@ import { filterScenarios, TestFilters, shouldShowExtensionOutput } from './src/c
 import { minimizeScenarios } from './src/sampling';
 import { getNetworkSet, NetworkMode, NetworkSet, getNetworkModeDescription } from './src/networks/networks';
 import { GenericServerProxy } from './src/servers/generic-server';
-import { Semaphore, FacilitatorLock } from './src/concurrency';
+import { Semaphore, FamilyLanePool } from './src/concurrency';
 import { FacilitatorManager } from './src/facilitators/facilitator-manager';
 import { waitForHealth } from './src/health';
 
@@ -182,6 +182,13 @@ async function runClientTest(
   }
 }
 
+// ── Per-family key configuration ──────────────────────────────────────
+interface FamilyKeyConfig {
+  clientKeys: string[];
+  facilitatorKeys: string[];
+  laneCount: number;
+}
+
 async function runTest() {
   // Show help if requested
   if (parsedArgs.showHelp) {
@@ -200,19 +207,64 @@ async function runTest() {
   const serverSvmAddress = process.env.SERVER_SVM_ADDRESS;
   const serverAptosAddress = process.env.SERVER_APTOS_ADDRESS;
   const serverStellarAddress = process.env.SERVER_STELLAR_ADDRESS;
-  const clientEvmPrivateKey = process.env.CLIENT_EVM_PRIVATE_KEY;
-  const clientSvmPrivateKey = process.env.CLIENT_SVM_PRIVATE_KEY;
-  const clientAptosPrivateKey = process.env.CLIENT_APTOS_PRIVATE_KEY;
-  const clientStellarPrivateKey = process.env.CLIENT_STELLAR_PRIVATE_KEY;
-  const facilitatorEvmPrivateKey = process.env.FACILITATOR_EVM_PRIVATE_KEY;
-  const facilitatorSvmPrivateKey = process.env.FACILITATOR_SVM_PRIVATE_KEY;
-  const facilitatorAptosPrivateKey = process.env.FACILITATOR_APTOS_PRIVATE_KEY;
-  const facilitatorStellarPrivateKey = process.env.FACILITATOR_STELLAR_PRIVATE_KEY;
-  if (!serverEvmAddress || !serverSvmAddress || !clientEvmPrivateKey || !clientSvmPrivateKey || !facilitatorEvmPrivateKey || !facilitatorSvmPrivateKey) {
+
+  // Parse plural (comma-delimited) or singular key env vars per family
+  function parseKeyArray(pluralVar: string, singularVar: string): string[] {
+    const plural = process.env[pluralVar];
+    if (plural) {
+      return plural.split(',').map(k => k.trim()).filter(k => k.length > 0);
+    }
+    const singular = process.env[singularVar];
+    return singular ? [singular] : [];
+  }
+
+  // Build per-family key config: each family gets its own lane count
+  const familyKeys: Record<ProtocolFamily, FamilyKeyConfig> = {
+    evm: {
+      clientKeys: parseKeyArray('CLIENT_EVM_PRIVATE_KEYS', 'CLIENT_EVM_PRIVATE_KEY'),
+      facilitatorKeys: parseKeyArray('FACILITATOR_EVM_PRIVATE_KEYS', 'FACILITATOR_EVM_PRIVATE_KEY'),
+      laneCount: 1,
+    },
+    svm: {
+      clientKeys: parseKeyArray('CLIENT_SVM_PRIVATE_KEYS', 'CLIENT_SVM_PRIVATE_KEY'),
+      facilitatorKeys: parseKeyArray('FACILITATOR_SVM_PRIVATE_KEYS', 'FACILITATOR_SVM_PRIVATE_KEY'),
+      laneCount: 1,
+    },
+    aptos: {
+      clientKeys: parseKeyArray('CLIENT_APTOS_PRIVATE_KEYS', 'CLIENT_APTOS_PRIVATE_KEY'),
+      facilitatorKeys: parseKeyArray('FACILITATOR_APTOS_PRIVATE_KEYS', 'FACILITATOR_APTOS_PRIVATE_KEY'),
+      laneCount: 1,
+    },
+    stellar: {
+      clientKeys: parseKeyArray('CLIENT_STELLAR_PRIVATE_KEYS', 'CLIENT_STELLAR_PRIVATE_KEY'),
+      facilitatorKeys: parseKeyArray('FACILITATOR_STELLAR_PRIVATE_KEYS', 'FACILITATOR_STELLAR_PRIVATE_KEY'),
+      laneCount: 1,
+    },
+  };
+
+  // Baseline required check: EVM + SVM must be present
+  if (!serverEvmAddress || !serverSvmAddress ||
+      familyKeys.evm.clientKeys.length === 0 || familyKeys.evm.facilitatorKeys.length === 0 ||
+      familyKeys.svm.clientKeys.length === 0 || familyKeys.svm.facilitatorKeys.length === 0) {
     errorLog('❌ Missing required environment variables:');
     errorLog(' SERVER_EVM_ADDRESS, SERVER_SVM_ADDRESS, CLIENT_EVM_PRIVATE_KEY, CLIENT_SVM_PRIVATE_KEY, FACILITATOR_EVM_PRIVATE_KEY, and FACILITATOR_SVM_PRIVATE_KEY must be set');
     process.exit(1);
   }
+
+  // Validate per-family key counts and derive lane counts
+  for (const [family, cfg] of Object.entries(familyKeys) as [ProtocolFamily, FamilyKeyConfig][]) {
+    if (cfg.clientKeys.length > 0 && cfg.facilitatorKeys.length > 0 &&
+        cfg.clientKeys.length !== cfg.facilitatorKeys.length) {
+      errorLog(`❌ Key count mismatch for ${family}: ${cfg.clientKeys.length} client keys vs ${cfg.facilitatorKeys.length} facilitator keys`);
+      process.exit(1);
+    }
+    cfg.laneCount = Math.max(cfg.clientKeys.length, cfg.facilitatorKeys.length, 1);
+  }
+
+  // The maximum number of facilitator instances needed per facilitator name
+  // is the highest lane count across all families (since each facilitator
+  // process serves all families simultaneously).
+  const maxLaneCount = Math.max(...Object.values(familyKeys).map(c => c.laneCount));
 
   // Discover all servers, clients, and facilitators (always include legacy)
   const discovery = new TestDiscovery('.', true); // Always discover legacy
@@ -432,27 +484,40 @@ async function runTest() {
   let testResults: DetailedTestResult[] = [];
   let currentPort = 4022;
 
-  // Assign ports and start all facilitators
-  const facilitatorManagers = new Map<string, FacilitatorManager>();
+  // Node's fetch follows the WHATWG blocked-port list and rejects some
+  // localhost ports (for example 4045) with "bad port". Skip them when
+  // assigning ephemeral test ports because the harness uses fetch for
+  // server/facilitator health checks and local HTTP calls.
+  const fetchBlockedPorts = new Set([1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669, 6697, 10080]);
 
-  // Group scenarios by server + facilitator combination
-  // This ensures we restart servers when switching facilitators
+  function allocatePort(): number {
+    while (fetchBlockedPorts.has(currentPort)) {
+      currentPort++;
+    }
+
+    return currentPort++;
+  }
+
+  // ── Group scenarios by server + facilitator + protocolFamily ─────────
+  // This ensures each combo contains only one protocol family so that
+  // different families can run independently in their own lanes.
   interface ServerFacilitatorCombo {
     serverName: string;
     facilitatorName: string | undefined;
+    protocolFamily: ProtocolFamily;
     scenarios: typeof filteredScenarios;
     comboIndex: number;
     port: number;
   }
 
   const serverFacilitatorCombos: ServerFacilitatorCombo[] = [];
-  const groupKey = (serverName: string, facilitatorName: string | undefined) =>
-    `${serverName}::${facilitatorName || 'none'}`;
+  const comboGroupKey = (serverName: string, facilitatorName: string | undefined, family: ProtocolFamily) =>
+    `${serverName}::${facilitatorName || 'none'}::${family}`;
 
   const comboMap = new Map<string, typeof filteredScenarios>();
 
   for (const scenario of filteredScenarios) {
-    const key = groupKey(scenario.server.name, scenario.facilitator?.name);
+    const key = comboGroupKey(scenario.server.name, scenario.facilitator?.name, scenario.protocolFamily);
     if (!comboMap.has(key)) {
       comboMap.set(key, []);
     }
@@ -466,45 +531,67 @@ async function runTest() {
     serverFacilitatorCombos.push({
       serverName: firstScenario.server.name,
       facilitatorName: firstScenario.facilitator?.name,
+      protocolFamily: firstScenario.protocolFamily,
       scenarios,
       comboIndex,
-      port: currentPort++,
+      port: allocatePort(),
     });
     comboIndex++;
   }
 
-  // Start all facilitators with unique ports
-  for (const [facilitatorName, facilitator] of uniqueFacilitators) {
-    const port = currentPort++;
-    log(`\n🏛️ Starting facilitator: ${facilitatorName} on port ${port}`);
+  // ── Start facilitator instances ─────────────────────────────────────
+  // Each facilitator process serves all families, but we start enough
+  // instances to cover the highest per-family lane count.
+  const facilitatorInstanceManagers = new Map<string, FacilitatorManager>();
 
-    const manager = new FacilitatorManager(
-      facilitator.proxy,
-      port,
-      networks
-    );
-    facilitatorManagers.set(facilitatorName, manager);
+  for (const [facilitatorName, facilitator] of uniqueFacilitators) {
+    for (let i = 0; i < maxLaneCount; i++) {
+      const port = allocatePort();
+      log(`\n🏛️ Starting facilitator: ${facilitatorName} (slot ${i}) on port ${port}`);
+      const keys = {
+        evmPrivateKey: familyKeys.evm.facilitatorKeys[i] ?? familyKeys.evm.facilitatorKeys[0],
+        svmPrivateKey: familyKeys.svm.facilitatorKeys[i] ?? familyKeys.svm.facilitatorKeys[0],
+        aptosPrivateKey: familyKeys.aptos.facilitatorKeys[i] ?? familyKeys.aptos.facilitatorKeys[0],
+        stellarPrivateKey: familyKeys.stellar.facilitatorKeys[i] ?? familyKeys.stellar.facilitatorKeys[0],
+      };
+      const manager = new FacilitatorManager(facilitator.proxy, port, networks, keys);
+      facilitatorInstanceManagers.set(`${facilitatorName}::${i}`, manager);
+    }
   }
 
-  // Wait for all facilitators to be ready
+  // Wait for all facilitator instances to be ready
   log('\n⏳ Waiting for all facilitators to be ready...');
-  const facilitatorUrls = new Map<string, string>();
+  const facilitatorInstanceUrls = new Map<string, string>();
 
-  for (const [facilitatorName, manager] of facilitatorManagers) {
+  for (const [instanceKey, manager] of facilitatorInstanceManagers) {
     const url = await manager.ready();
     if (!url) {
-      log(`❌ Failed to start facilitator ${facilitatorName}`);
+      errorLog(`❌ Failed to start facilitator instance ${instanceKey}`);
+      for (const [, m] of facilitatorInstanceManagers) {
+        await m.stop().catch(() => {});
+      }
       process.exit(1);
     }
-    facilitatorUrls.set(facilitatorName, url);
-    log(`  ✅ Facilitator ${facilitatorName} ready at ${url}`);
+    facilitatorInstanceUrls.set(instanceKey, url);
+    log(`  ✅ Facilitator ${instanceKey} ready at ${url}`);
   }
 
-  log('\n✅ All facilitators are ready! Servers will be started/restarted as needed per test scenario.\n');
+  // For discovery validation: keep a map of facilitatorName -> first slot manager
+  const facilitatorManagers = new Map<string, FacilitatorManager>();
+  for (const [facilitatorName] of uniqueFacilitators) {
+    const firstSlot = facilitatorInstanceManagers.get(`${facilitatorName}::0`);
+    if (firstSlot) facilitatorManagers.set(facilitatorName, firstSlot);
+  }
 
-  log(`🔧 Server/Facilitator combinations: ${serverFacilitatorCombos.length}`);
+  // Print lane configuration summary
+  const activeFamilies = [...new Set(filteredScenarios.map(s => s.protocolFamily))];
+  const laneDesc = activeFamilies.map(f => `${f.toUpperCase()}:${familyKeys[f].laneCount}`).join(', ');
+  log(`\n✅ All facilitator instances are ready! Lanes: ${laneDesc}`);
+  log(`   Servers will be started/restarted as needed per test scenario.\n`);
+
+  log(`🔧 Server/Facilitator/Family combinations: ${serverFacilitatorCombos.length}`);
   serverFacilitatorCombos.forEach(combo => {
-    log(`   • ${combo.serverName} + ${combo.facilitatorName || 'none'}: ${combo.scenarios.length} test(s)`);
+    log(`   • ${combo.serverName} + ${combo.facilitatorName || 'none'} [${combo.protocolFamily}]: ${combo.scenarios.length} test(s)`);
   });
   if (parsedArgs.parallel) {
     log(`\n⚡ Parallel mode enabled (concurrency: ${parsedArgs.concurrency})`);
@@ -519,16 +606,17 @@ async function runTest() {
     scenario: TestScenario,
     port: number,
     localTestNumber: number,
+    clientKeys: { evm: string; svm: string; aptos: string; stellar: string },
     cLog: { log: typeof log; verboseLog: typeof verboseLog; errorLog: typeof errorLog },
   ): Promise<DetailedTestResult> {
     const facilitatorLabel = scenario.facilitator ? ` via ${scenario.facilitator.name}` : '';
     const testName = `${scenario.client.name} → ${scenario.server.name} → ${scenario.endpoint.path}${facilitatorLabel}`;
 
     const clientConfig: ClientConfig = {
-      evmPrivateKey: clientEvmPrivateKey!,
-      svmPrivateKey: clientSvmPrivateKey!,
-      aptosPrivateKey: clientAptosPrivateKey || '',
-      stellarPrivateKey: clientStellarPrivateKey || '',
+      evmPrivateKey: clientKeys.evm,
+      svmPrivateKey: clientKeys.svm,
+      aptosPrivateKey: clientKeys.aptos,
+      stellarPrivateKey: clientKeys.stellar,
       serverUrl: `http://localhost:${port}`,
       endpointPath: scenario.endpoint.path,
     };
@@ -579,10 +667,12 @@ async function runTest() {
     }
   }
 
-  // ── Execute a single server+facilitator combo ─────────────────────────
+  // ── Execute a single server+facilitator+family combo ─────────────────
   async function executeCombo(
     combo: ServerFacilitatorCombo,
-    evmLock: FacilitatorLock | null,
+    slotIndex: number,
+    facilitatorUrl: string | undefined,
+    clientKeys: { evm: string; svm: string; aptos: string; stellar: string },
     nextTestNumber: () => number,
   ): Promise<DetailedTestResult[]> {
     const { serverName, facilitatorName, scenarios, port } = combo;
@@ -600,11 +690,7 @@ async function runTest() {
     // Create a fresh server instance for this combo (own port, own process)
     const serverProxy = new GenericServerProxy(server.directory);
 
-    const facilitatorUrl = facilitatorName
-      ? facilitatorUrls.get(facilitatorName)
-      : undefined;
-
-    cLog.log(`🚀 Starting server: ${serverName} (port ${port}) with facilitator: ${facilitatorName || 'none'}`);
+    cLog.log(`🚀 Starting server: ${serverName} (port ${port}) with facilitator: ${facilitatorName || 'none'} [${combo.protocolFamily}] (slot ${slotIndex})`);
 
     const facilitatorConfig = facilitatorName ? uniqueFacilitators.get(facilitatorName)?.config : undefined;
     const facilitatorSupportsAptos = facilitatorConfig?.protocolFamilies?.includes('aptos') ?? false;
@@ -640,24 +726,13 @@ async function runTest() {
     try {
       for (const scenario of scenarios) {
         const tn = nextTestNumber();
-        const isEvm = scenario.protocolFamily === 'evm';
 
         if (scenario.endpoint.transferMethod === 'permit2') {
           await revokePermit2Approval();
           await revokePermit2Approval('0xeED520980fC7C7B4eB379B96d61CEdea2423005a');
         }
 
-        if (isEvm && facilitatorName && evmLock) {
-          const releaseLock = await evmLock.acquire(facilitatorName);
-          try {
-            results.push(await runSingleTest(scenario, port, tn, cLog));
-            await new Promise(resolve => setTimeout(resolve, 2000));
-          } finally {
-            releaseLock();
-          }
-        } else {
-          results.push(await runSingleTest(scenario, port, tn, cLog));
-        }
+        results.push(await runSingleTest(scenario, port, tn, clientKeys, cLog));
       }
     } finally {
       cLog.verboseLog(`  🛑 Stopping ${serverName} (finished combo)`);
@@ -667,19 +742,37 @@ async function runTest() {
     return results;
   }
 
-  // ── Unified execution: concurrency=1 for sequential, N for parallel ──
+  // ── Unified execution: per-family lanes + global concurrency cap ─────
   const effectiveConcurrency = parsedArgs.parallel ? parsedArgs.concurrency : 1;
-  const evmLock = parsedArgs.parallel ? new FacilitatorLock() : null;
   const semaphore = new Semaphore(effectiveConcurrency);
+  const familyLanePool = new FamilyLanePool({
+    evm: familyKeys.evm.laneCount,
+    svm: familyKeys.svm.laneCount,
+    aptos: familyKeys.aptos.laneCount,
+    stellar: familyKeys.stellar.laneCount,
+  });
 
   let globalTestNumber = 0;
   const nextTestNumber = () => ++globalTestNumber;
 
   const comboPromises = serverFacilitatorCombos.map(async (combo) => {
-    const release = await semaphore.acquire();
+    // Acquire a lane slot for this combo's protocol family
+    const { slotIndex, release } = await familyLanePool.acquire(combo.protocolFamily);
+    // Also respect global --concurrency cap
+    const semRelease = await semaphore.acquire();
     try {
-      return await executeCombo(combo, evmLock, nextTestNumber);
+      const facilitatorUrl = combo.facilitatorName
+        ? facilitatorInstanceUrls.get(`${combo.facilitatorName}::${slotIndex}`)
+        : undefined;
+      const comboClientKeys = {
+        evm: familyKeys.evm.clientKeys[slotIndex] ?? familyKeys.evm.clientKeys[0] ?? '',
+        svm: familyKeys.svm.clientKeys[slotIndex] ?? familyKeys.svm.clientKeys[0] ?? '',
+        aptos: familyKeys.aptos.clientKeys[slotIndex] ?? familyKeys.aptos.clientKeys[0] ?? '',
+        stellar: familyKeys.stellar.clientKeys[slotIndex] ?? familyKeys.stellar.clientKeys[0] ?? '',
+      };
+      return await executeCombo(combo, slotIndex, facilitatorUrl, comboClientKeys, nextTestNumber);
     } finally {
+      semRelease();
       release();
     }
   });
@@ -717,10 +810,10 @@ async function runTest() {
   // Clean up facilitators (servers already stopped in test loop for both modes)
   log('\n🧹 Cleaning up...');
 
-  // Stop all facilitators
+  // Stop all facilitator instances
   const facilitatorStopPromises: Promise<void>[] = [];
-  for (const [facilitatorName, manager] of facilitatorManagers) {
-    log(`  🛑 Stopping facilitator: ${facilitatorName}`);
+  for (const [instanceKey, manager] of facilitatorInstanceManagers) {
+    log(`  🛑 Stopping facilitator: ${instanceKey}`);
     facilitatorStopPromises.push(manager.stop());
   }
   await Promise.all(facilitatorStopPromises);


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

- Each protocol family (EVM, SVM, APTOS, STELLAR) now runs in its own independent scheduling lane, so different mechanisms never block each other.
- Within each family, concurrency scales with the number of comma-delimited client/facilitator private keys provided via env vars (e.g. `CLIENT_EVM_PRIVATE_KEYS=0xA,0xB,0xC`). Each key pair maps to a unique sub-lane that runs independently, preventing nonce collisions.
- Combos are now grouped by `server + facilitator + protocolFamily` instead of just `server + facilitator`, so an EVM-heavy workload cannot serialize SVM/APTOS/STELLAR work behind it.
- Fixed a startup bug where Node's built-in `fetch` rejects WHATWG-forbidden ports (like 4045) with "bad port", causing facilitator health checks to fail silently. Port allocation now skips blocked ports.
- Improved process lifecycle: child processes are spawned with `detached: true` and stopped via process-group kill (`kill(-pid)`), preventing orphaned facilitator processes after early exits.
- Health check logging now includes the specific error message on failure (e.g. `fetch failed`, `ECONNREFUSED`) instead of just a boolean, making startup failures diagnosable.
- Ready detection in `BaseProxy` now watches both stdout and stderr for the `"Facilitator listening"` message, fixing a 30-second timeout for Go/Python facilitators that log to stderr.

### Test plan

- [x] `pnpm test --min --parallel -v` from `e2e/` starts all facilitators, runs 75 minimized scenarios across EVM/SVM/APTOS/STELLAR, and completes with no failures
- [x] Headless default mode (`pnpm test`) still works without `-i`
- [x] Interactive mode (`pnpm test -i`) still enters prompt selection
- [x] Single-key-per-family config (current `.env`) works correctly with 4 independent lanes
- [x] No orphaned processes left after test completion or early abort

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 