### PR TITLE
feat: add Polygon mainnet to CDP Facilitator ecosystem entry on x402.org

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/cdp/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/cdp/metadata.json
@@ -6,7 +6,7 @@
   "category": "Facilitators",
   "facilitator": {
       "baseUrl": "https://api.cdp.coinbase.com/platform/v2/x402",
-      "networks": ["base", "base-sepolia", "solana", "solana-devnet"],
+      "networks": ["base", "base-sepolia", "solana", "solana-devnet", "polygon"],
       "schemes": ["exact"],
       "assets": ["EIP-3009", "SPL"],
       "supports": { "verify": true, "settle": true, "supported": true, "list": true }


### PR DESCRIPTION
## Summary

- Adds `polygon` to the supported networks list for the CDP Facilitator entry on x402.org

## Test plan

- [ ] Verify the x402.org ecosystem page correctly displays Polygon as a supported network for the CDP Facilitator

Made with [Cursor](https://cursor.com)