### PR TITLE
feat(extensions): add cold-start mitigation patterns scaffold

### DIFF
--- a/specs/extensions/cold_start_mitigation_patterns.md
+++ b/specs/extensions/cold_start_mitigation_patterns.md
@@ -320,3 +320,14 @@ Possible follow-on work:
 - support for additional signature algorithms and key-distribution helpers
 - optional vocabulary for trust tiers or minimum signal counts
 - tighter linkage with registry-specific schemas once the surrounding discovery work settles
+
+## Acknowledgements
+
+The design of the `coldStartSignals` schema and the patterns in this document emerged from the community discussion in [#1375](https://github.com/coinbase/x402/issues/1375). Key contributions include:
+
+- **@douglasborthwick-crypto** — the three-category signal taxonomy (`onChainCredentials`, `onChainActivity`, `offChainAttestations`), the inline `sig`/`kid`/`jwks` verification pattern, the freshness/TTL model, and detailed EAS attestation and wallet trust schemas
+- **@ruhil6789** — DID/Verifiable Credentials integration design, the `did:pkh` recommendation for EVM agents, and the category-based extensible schema structure
+- **@rplryan** — `discoveryAttestations` as a fourth category, the behavioral trust dimension, service health attestation schemas, and the first signed attestation prototype
+- **@ThoughtProof** — reasoning attestation concept for payment-decision integrity verification
+- **@INJprotocol** — compliance attestation schema for AML/CFT signals
+- **@0xtus** — concrete implementation notes from the Azeth smart account + ERC-8004 integration

--- a/specs/extensions/cold_start_mitigation_patterns.md
+++ b/specs/extensions/cold_start_mitigation_patterns.md
@@ -1,0 +1,322 @@
+# Cold-Start Mitigation Patterns for `8004-reputation`
+
+## Status
+
+Informative draft.
+
+This document describes pre-payment trust signals that can complement the in-flight `8004-reputation` work during a service or agent's cold-start phase. It does **not** modify the `8004-reputation` protocol flow, define mandatory trust policy, or replace post-payment reputation.
+
+## Motivation
+
+`8004-reputation` is strongest after a client has already:
+
+1. discovered a service
+2. paid through x402
+3. received the service
+4. submitted feedback into the reputation system
+
+That feedback loop is exactly what should remain authoritative over time. The gap is earlier:
+
+- a new service may have no feedback yet
+- a service moving to a new market may have thin local history
+- a client may want independently verifiable signals before the first paid request
+
+Without a shared shape for those signals, every client invents a different bootstrap policy and every provider has to satisfy one-off integrations.
+
+## Design Goals
+
+Cold-start signal patterns should be:
+
+- **complementary** to `8004-reputation`, not a replacement for it
+- **optional**, so clients can ignore them and apply local policy
+- **provider-agnostic**, so new providers do not need bespoke client integrations
+- **independently verifiable**, so clients can validate what they trust
+- **forward-compatible**, so unknown categories and signal types do not break older clients
+
+## Data Model
+
+A registration record or discovered resource MAY expose a `coldStartSignals` object directly, or nest it under `metadata.coldStartSignals`. This draft standardizes the inner object only.
+
+```json
+{
+  "coldStartSignals": {
+    "onChainCredentials": [],
+    "onChainActivity": [],
+    "offChainAttestations": [],
+    "discoveryAttestations": []
+  }
+}
+```
+
+### Known Categories
+
+| Category | Purpose | Example signal families |
+| --- | --- | --- |
+| `onChainCredentials` | Third-party credentials anchored on chain | EAS attestations, registry entries, non-transferable credentials, compliance attestations |
+| `onChainActivity` | Observed wallet or economic behavior | stablecoin balances, staking participation, long-lived activity, wallet trust profiles |
+| `offChainAttestations` | Signed claims not anchored directly in chain state | DIDs, verifiable credentials, domain or organization proofs, reasoning attestations |
+| `discoveryAttestations` | Signed observations about service behavior | uptime, compatibility checks, availability probes, registry health JWTs |
+
+Clients MUST ignore unknown categories.
+
+### Generic Signal Shape
+
+Each signal entry SHOULD include a provider-defined `type`. Unknown `type` values MUST be ignored unless a client has explicit policy for them.
+
+```json
+{
+  "type": "serviceHealth",
+  "provider": "discovery-service",
+  "checkedAt": "2026-03-11T12:00:00Z",
+  "ttlSeconds": 300,
+  "sig": "base64url-signature",
+  "kid": "provider-key-1",
+  "jwks": "https://provider.example/.well-known/jwks.json",
+  "alg": "EdDSA"
+}
+```
+
+### Common Fields
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `type` | `string` | Provider-defined signal type |
+| `provider` | `string` | Optional provider identifier |
+| `checkedAt` | `string` | Optional ISO-8601 timestamp for when the signal was checked or issued |
+| `ttlSeconds` | `number` | Optional freshness window in seconds |
+| `sig` | `string` | Optional detached signature over the signal payload |
+| `kid` | `string` | Optional key identifier for the signing key |
+| `jwks` | `string` | Optional HTTPS JWKS hint |
+| `alg` | `string` | Optional signature algorithm hint |
+
+Signed signals SHOULD provide at least `sig` and `kid`. `jwks` is a useful distribution hint, but clients remain free to resolve trusted keys through pinned configuration, cached JWKS, or any other local policy.
+
+This draft is intentionally **algorithm-agnostic**. Providers MAY use RSA, P-256 ECDSA, Ed25519, or other JWK-expressible schemes. Clients should determine the concrete verification path from local trust policy plus the signal's `alg` hint and the resolved JWK metadata (for example `kty`, `alg`, and `crv`).
+
+## Category Guidance
+
+### `onChainCredentials`
+
+Use this category for third-party credentials that are anchored in on-chain data and attributable to an issuer.
+
+```json
+{
+  "type": "eas",
+  "chainId": 8453,
+  "schemaId": "0x...",
+  "attester": "0x...",
+  "result": true,
+  "checkedAt": "2026-03-11T12:00:00Z",
+  "ttlSeconds": 300,
+  "sig": "base64url-signature",
+  "kid": "provider-key-1",
+  "jwks": "https://provider.example/.well-known/jwks.json",
+  "alg": "ES256"
+}
+```
+
+Other valid examples in this category include:
+
+- `type: "compliance-attestation"` for AML/CFT or sanctions screening receipts
+- provider-signed ERC-8004 registration or validation snapshots
+- non-transferable credential checks such as SBT presence
+
+### `onChainActivity`
+
+Use this category for observed wallet behavior or economic participation signals derived from chain state.
+
+```json
+{
+  "type": "walletTrust",
+  "provider": "example-provider",
+  "compositeScore": 0.65,
+  "dimensions": {
+    "stablecoins": { "score": 0.8 },
+    "governance": { "score": 0.6 },
+    "staking": { "score": 0.5 }
+  },
+  "checkedAt": "2026-03-11T12:00:00Z",
+  "ttlSeconds": 300,
+  "sig": "base64url-signature",
+  "kid": "provider-key-1",
+  "jwks": "https://provider.example/.well-known/jwks.json",
+  "alg": "ES256"
+}
+```
+
+Clients SHOULD prefer dimension-aware evaluation over a single composite score when task-specific context matters.
+
+### `offChainAttestations`
+
+Use this category for signed claims that are portable but not directly anchored in chain state.
+
+```json
+{
+  "type": "did",
+  "id": "did:pkh:eip155:8453:0x1234...",
+  "alternateIds": [
+    "did:key:z6Mk...",
+    "did:web:agent.example.com"
+  ],
+  "verifiableCredentials": [
+    {
+      "type": "HumannessCredential",
+      "issuer": "did:web:issuer.example"
+    }
+  ]
+}
+```
+
+The current issue discussion treats `did:pkh`, `did:key`, and `did:web` as all in-bounds. For EVM-native agents, `did:pkh` is a natural default because it reuses the existing wallet identity with minimal extra setup.
+
+Other valid examples in this category include:
+
+- domain verification proofs
+- code audit or organization credentials
+- `type: "reasoningAttestation"` or equivalent verifier receipts for payment-decision integrity
+
+### `discoveryAttestations`
+
+Use this category for signed observations about service behavior or availability.
+
+```json
+{
+  "type": "serviceHealth",
+  "provider": "x402-discovery",
+  "serviceId": "legacy/cf-pay-per-crawl",
+  "uptimePct": 98.2,
+  "avgLatencyMs": 340,
+  "facilitatorCompatible": true,
+  "chainVerifications": {
+    "erc8004Registered": true,
+    "operatorWalletTrust": {
+      "provider": "trust-provider",
+      "trustId": "TRST-XXXXX"
+    }
+  },
+  "checkedAt": "2026-03-11T12:00:00Z",
+  "ttlSeconds": 300,
+  "sig": "base64url-signature",
+  "kid": "discovery-key-1",
+  "jwks": "https://discovery.example/.well-known/jwks.json",
+  "alg": "EdDSA"
+}
+```
+
+This category answers a different question than identity-oriented categories:
+
+- identity categories ask: **who is this actor?**
+- discovery attestations ask: **does this service appear to work as advertised?**
+
+Providers MAY also package discovery attestations as signed JWTs or equivalent signed envelopes, as long as the payload shape and verification metadata are documented.
+
+## Client Processing Model
+
+Recommended high-level flow:
+
+1. discover the service or registration record
+2. inspect available `8004-reputation` history
+3. if reputation is thin, inspect `coldStartSignals`
+4. ignore unknown categories and unknown signal `type` values
+5. apply freshness checks using `checkedAt` and `ttlSeconds`
+6. verify any signed signals the client trusts
+7. combine the remaining signals with local payment policy
+8. after real interactions, increasingly defer to accumulated `8004-reputation`
+
+This document does **not** standardize thresholds or score cutoffs. It also does not mandate a universal trust-tier table. However, tiered local policy is an expected use of these signals, and implementers may reasonably map combinations of cold-start signals to payment tiers such as trial, standard, or high-trust access.
+
+## TypeScript Reference Scaffold
+
+The repository includes a minimal TypeScript scaffold in `@x402/extensions/cold-start` for parsing, freshness checks, and detached signature verification.
+
+```ts
+import {
+  extractColdStartSignals,
+  getFreshColdStartSignals,
+  verifyColdStartSignalSignature,
+} from "@x402/extensions/cold-start";
+
+const signals = extractColdStartSignals(discoveredResource);
+
+if (!signals) {
+  return { proceed: false, reason: "no-cold-start-signals" };
+}
+
+const usableSignals = [];
+
+for (const { category, signal } of getFreshColdStartSignals(signals)) {
+  if (signal.sig) {
+    const verification = await verifyColdStartSignalSignature(signal, {
+      resolveJwk: ({ kid }) => trustedKeyStore.lookup(kid),
+    });
+
+    if (!verification.valid) {
+      continue;
+    }
+  }
+
+  usableSignals.push({ category, type: signal.type });
+}
+
+const proceed = usableSignals.length > 0 || hasSufficient8004Reputation(discoveredResource);
+```
+
+Current scaffold notes:
+
+- parsing helpers ignore unknown categories by default
+- unknown signal `type` values are preserved for local policy
+- freshness checks are generic and signal-type agnostic
+- detached signature verification is real, but intentionally small
+- the current reference verifier supports caller-supplied JWK resolution and a small multi-algorithm set (`RS256`, `ES256`, and `Ed25519` / `EdDSA`)
+- providers can override canonicalization or payload construction when they sign JWTs or other envelopes instead of the default canonical JSON object
+
+## Freshness and Replay
+
+Cold-start signals often depend on changing state. Clients SHOULD scale freshness requirements with payment risk.
+
+- low-value payments may accept cached signals
+- medium-value payments should prefer recent signed signals
+- high-value payments may require direct provider refresh or direct verification
+
+Signals missing either `checkedAt` or `ttlSeconds` are harder to evaluate consistently. Clients should treat partial freshness metadata conservatively.
+
+Some signal families are especially time-sensitive:
+
+- compliance receipts may need shorter TTLs because sanctions lists can change quickly
+- discovery attestations may need tighter windows for high-value routing decisions
+- reasoning or verification attestations may be tied to a single payment or request and should not be reused broadly
+
+## Security Considerations
+
+### Provider compromise
+
+Signed signals are only as trustworthy as their signing keys, issuance controls, and verification policy. Clients SHOULD pin or otherwise trust-manage key material for high-value flows.
+
+### Temporary or manipulated positions
+
+On-chain activity can be inflated temporarily. Clients SHOULD avoid treating activity-only signals as equivalent to long-lived reputation.
+
+### Category concentration
+
+Relying on a single category creates a single failure mode. Higher-value interactions SHOULD prefer signals from multiple categories when available.
+
+### Canonical payload ambiguity
+
+This draft does not standardize a canonical payload for every possible signal type. Providers should document what they sign. The reference TypeScript helper uses canonical JSON without `sig`, `kid`, `jwks`, or `alg` as a pragmatic default.
+
+## Relationship to `8004-reputation`
+
+These patterns are intentionally complementary:
+
+- `coldStartSignals` help when there is little or no interaction history
+- `8004-reputation` becomes the stronger signal after real usage accumulates
+- clients MAY keep both as defense-in-depth, but cold-start signals should not redefine the `8004-reputation` flow
+
+## Future Work
+
+Possible follow-on work:
+
+- standard canonical payload definitions for common signal types
+- support for additional signature algorithms and key-distribution helpers
+- optional vocabulary for trust tiers or minimum signal counts
+- tighter linkage with registry-specific schemas once the surrounding discovery work settles

--- a/typescript/packages/extensions/package.json
+++ b/typescript/packages/extensions/package.json
@@ -62,6 +62,16 @@
         "default": "./dist/cjs/index.js"
       }
     },
+    "./cold-start": {
+      "import": {
+        "types": "./dist/esm/cold-start/index.d.mts",
+        "default": "./dist/esm/cold-start/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/cold-start/index.d.ts",
+        "default": "./dist/cjs/cold-start/index.js"
+      }
+    },
     "./bazaar": {
       "import": {
         "types": "./dist/esm/bazaar/index.d.mts",

--- a/typescript/packages/extensions/src/cold-start/index.ts
+++ b/typescript/packages/extensions/src/cold-start/index.ts
@@ -52,9 +52,9 @@ export {
   listColdStartSignals,
   isColdStartSignalFresh,
   getFreshColdStartSignals,
-} from "./parse";
+} from './parse'
 
-export { canonicalizeColdStartSignal, verifyColdStartSignalSignature } from "./verify";
+export { canonicalizeColdStartSignal, verifyColdStartSignalSignature } from './verify'
 
 export {
   COLD_START_SIGNAL_CATEGORIES,
@@ -74,4 +74,4 @@ export {
   type ColdStartSignalJwkResolver,
   type VerifyColdStartSignalOptions,
   type VerifyColdStartSignalResult,
-} from "./types";
+} from './types'

--- a/typescript/packages/extensions/src/cold-start/index.ts
+++ b/typescript/packages/extensions/src/cold-start/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Cold-start signal helpers for x402 discovery and registration metadata.
+ *
+ * These utilities intentionally stay provider-agnostic and stop at:
+ * - typed signal/category definitions
+ * - parsing and extraction
+ * - freshness checks
+ * - detached signature verification with caller-supplied JWK resolution
+ *
+ * They do not define trust policy and they do not modify the ERC-8004
+ * reputation flow.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   extractColdStartSignals,
+ *   getFreshColdStartSignals,
+ *   verifyColdStartSignalSignature,
+ * } from "@x402/extensions/cold-start";
+ *
+ * const signals = extractColdStartSignals(discoveredResource);
+ *
+ * if (!signals) {
+ *   return;
+ * }
+ *
+ * for (const { signal } of getFreshColdStartSignals(signals)) {
+ *   if (!signal.sig) {
+ *     continue;
+ *   }
+ *
+ *   const verification = await verifyColdStartSignalSignature(signal, {
+ *     resolveJwk: ({ kid }) => trustedKeyStore.lookup(kid),
+ *   });
+ *
+ *   if (verification.valid) {
+ *     // Treat as one usable pre-payment signal in local policy.
+ *   }
+ * }
+ * ```
+ */
+
+export {
+  ColdStartSignalSchema,
+  ColdStartSignalsSchema,
+  parseColdStartSignals,
+  safeParseColdStartSignals,
+  extractColdStartSignals,
+  isColdStartSignal,
+  isColdStartSignals,
+  isSignedColdStartSignal,
+  listColdStartSignals,
+  isColdStartSignalFresh,
+  getFreshColdStartSignals,
+} from "./parse";
+
+export { canonicalizeColdStartSignal, verifyColdStartSignalSignature } from "./verify";
+
+export {
+  COLD_START_SIGNAL_CATEGORIES,
+  type ColdStartSignalCategory,
+  type ColdStartSignalSignatureFields,
+  type ColdStartSignal,
+  type OnChainCredentialSignal,
+  type OnChainActivitySignal,
+  type OffChainAttestationSignal,
+  type DiscoveryAttestationSignal,
+  type ColdStartSignals,
+  type ColdStartSignalEnvelope,
+  type CategorizedColdStartSignal,
+  type SignedColdStartSignal,
+  type SupportedColdStartSignalAlgorithm,
+  type ResolveColdStartSignalJwkOptions,
+  type ColdStartSignalJwkResolver,
+  type VerifyColdStartSignalOptions,
+  type VerifyColdStartSignalResult,
+} from "./types";

--- a/typescript/packages/extensions/src/cold-start/parse.ts
+++ b/typescript/packages/extensions/src/cold-start/parse.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from 'zod'
 import {
   COLD_START_SIGNAL_CATEGORIES,
   type ColdStartSignal,
@@ -6,7 +6,7 @@ import {
   type ColdStartSignals,
   type CategorizedColdStartSignal,
   type SignedColdStartSignal,
-} from "./types";
+} from './types'
 
 export const ColdStartSignalSchema = z
   .object({
@@ -19,18 +19,18 @@ export const ColdStartSignalSchema = z
     jwks: z.string().url().optional(),
     alg: z.string().min(1).optional(),
   })
-  .passthrough();
+  .passthrough()
 
 export const ColdStartSignalsSchema = z.object({
   onChainCredentials: z.array(ColdStartSignalSchema).optional(),
   onChainActivity: z.array(ColdStartSignalSchema).optional(),
   offChainAttestations: z.array(ColdStartSignalSchema).optional(),
   discoveryAttestations: z.array(ColdStartSignalSchema).optional(),
-});
+})
 
 type ColdStartSignalsParseResult =
   | { success: true; data: ColdStartSignals }
-  | { success: false; error: string };
+  | { success: false; error: string }
 
 /**
  * Parse and normalize a `coldStartSignals` object.
@@ -39,13 +39,13 @@ type ColdStartSignalsParseResult =
  * over time without breaking older SDK versions.
  */
 export function parseColdStartSignals(value: unknown): ColdStartSignals {
-  const result = safeParseColdStartSignals(value);
+  const result = safeParseColdStartSignals(value)
 
-  if ("data" in result) {
-    return result.data;
+  if ('data' in result) {
+    return result.data
   }
 
-  throw new Error(result.error);
+  throw new Error(result.error)
 }
 
 /**
@@ -55,24 +55,24 @@ export function safeParseColdStartSignals(value: unknown): ColdStartSignalsParse
   if (!isRecord(value)) {
     return {
       success: false,
-      error: "Invalid coldStartSignals: expected an object",
-    };
+      error: 'Invalid coldStartSignals: expected an object',
+    }
   }
 
-  const projected = projectKnownCategories(value);
-  const parsed = ColdStartSignalsSchema.safeParse(projected);
+  const projected = projectKnownCategories(value)
+  const parsed = ColdStartSignalsSchema.safeParse(projected)
 
   if (!parsed.success) {
     return {
       success: false,
       error: `Invalid coldStartSignals: ${formatZodIssues(parsed.error.issues)}`,
-    };
+    }
   }
 
   return {
     success: true,
     data: parsed.data as ColdStartSignals,
-  };
+  }
 }
 
 /**
@@ -81,62 +81,62 @@ export function safeParseColdStartSignals(value: unknown): ColdStartSignalsParse
  */
 export function extractColdStartSignals(value: unknown): ColdStartSignals | undefined {
   if (!isRecord(value)) {
-    return undefined;
+    return undefined
   }
 
-  if ("coldStartSignals" in value) {
+  if ('coldStartSignals' in value) {
     if (value.coldStartSignals === undefined) {
-      return undefined;
+      return undefined
     }
 
-    return parseColdStartSignals(value.coldStartSignals);
+    return parseColdStartSignals(value.coldStartSignals)
   }
 
-  if ("metadata" in value && isRecord(value.metadata) && "coldStartSignals" in value.metadata) {
+  if ('metadata' in value && isRecord(value.metadata) && 'coldStartSignals' in value.metadata) {
     if (value.metadata.coldStartSignals === undefined) {
-      return undefined;
+      return undefined
     }
 
-    return parseColdStartSignals(value.metadata.coldStartSignals);
+    return parseColdStartSignals(value.metadata.coldStartSignals)
   }
 
   if (hasKnownCategory(value)) {
-    return parseColdStartSignals(value);
+    return parseColdStartSignals(value)
   }
 
-  return undefined;
+  return undefined
 }
 
 export function isColdStartSignal(value: unknown): value is ColdStartSignal {
-  return ColdStartSignalSchema.safeParse(value).success;
+  return ColdStartSignalSchema.safeParse(value).success
 }
 
 export function isColdStartSignals(value: unknown): value is ColdStartSignals {
-  return safeParseColdStartSignals(value).success;
+  return safeParseColdStartSignals(value).success
 }
 
 export function isSignedColdStartSignal(value: ColdStartSignal): value is SignedColdStartSignal {
   return (
-    typeof value.sig === "string" &&
+    typeof value.sig === 'string' &&
     value.sig.length > 0 &&
-    typeof value.kid === "string" &&
+    typeof value.kid === 'string' &&
     value.kid.length > 0
-  );
+  )
 }
 
 /**
  * Flatten signals across categories for simple client-side iteration.
  */
 export function listColdStartSignals(signals: ColdStartSignals): CategorizedColdStartSignal[] {
-  const entries: CategorizedColdStartSignal[] = [];
+  const entries: CategorizedColdStartSignal[] = []
 
   for (const category of COLD_START_SIGNAL_CATEGORIES) {
     for (const signal of signals[category] ?? []) {
-      entries.push({ category, signal });
+      entries.push({ category, signal })
     }
   }
 
-  return entries;
+  return entries
 }
 
 /**
@@ -146,28 +146,28 @@ export function listColdStartSignals(signals: ColdStartSignals): CategorizedCold
  * - Signals with only one freshness field are treated as malformed/stale.
  */
 export function isColdStartSignalFresh(
-  signal: Pick<ColdStartSignal, "checkedAt" | "ttlSeconds">,
+  signal: Pick<ColdStartSignal, 'checkedAt' | 'ttlSeconds'>,
   now: Date = new Date(),
 ): boolean {
-  const { checkedAt, ttlSeconds } = signal;
-  const hasCheckedAt = typeof checkedAt === "string";
-  const hasTtlSeconds = typeof ttlSeconds === "number";
+  const { checkedAt, ttlSeconds } = signal
+  const hasCheckedAt = typeof checkedAt === 'string'
+  const hasTtlSeconds = typeof ttlSeconds === 'number'
 
   if (!hasCheckedAt && !hasTtlSeconds) {
-    return true;
+    return true
   }
 
   if (!hasCheckedAt || !hasTtlSeconds) {
-    return false;
+    return false
   }
 
-  const checkedAtMs = Date.parse(checkedAt);
+  const checkedAtMs = Date.parse(checkedAt)
 
   if (Number.isNaN(checkedAtMs)) {
-    return false;
+    return false
   }
 
-  return checkedAtMs + ttlSeconds * 1000 >= now.getTime();
+  return checkedAtMs + ttlSeconds * 1000 >= now.getTime()
 }
 
 /**
@@ -177,34 +177,36 @@ export function getFreshColdStartSignals(
   signals: ColdStartSignals,
   now: Date = new Date(),
 ): CategorizedColdStartSignal[] {
-  return listColdStartSignals(signals).filter(entry => isColdStartSignalFresh(entry.signal, now));
+  return listColdStartSignals(signals).filter((entry) => isColdStartSignalFresh(entry.signal, now))
 }
 
-function projectKnownCategories(value: Record<string, unknown>): Partial<Record<ColdStartSignalCategory, unknown>> {
-  const projected: Partial<Record<ColdStartSignalCategory, unknown>> = {};
+function projectKnownCategories(
+  value: Record<string, unknown>,
+): Partial<Record<ColdStartSignalCategory, unknown>> {
+  const projected: Partial<Record<ColdStartSignalCategory, unknown>> = {}
 
   for (const category of COLD_START_SIGNAL_CATEGORIES) {
     if (category in value) {
-      projected[category] = value[category];
+      projected[category] = value[category]
     }
   }
 
-  return projected;
+  return projected
 }
 
 function hasKnownCategory(value: Record<string, unknown>): boolean {
-  return COLD_START_SIGNAL_CATEGORIES.some(category => category in value);
+  return COLD_START_SIGNAL_CATEGORIES.some((category) => category in value)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function formatZodIssues(issues: z.ZodIssue[]): string {
   return issues
-    .map(issue => {
-      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
-      return `${path}: ${issue.message}`;
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+      return `${path}: ${issue.message}`
     })
-    .join(", ");
+    .join(', ')
 }

--- a/typescript/packages/extensions/src/cold-start/parse.ts
+++ b/typescript/packages/extensions/src/cold-start/parse.ts
@@ -1,0 +1,210 @@
+import { z } from "zod";
+import {
+  COLD_START_SIGNAL_CATEGORIES,
+  type ColdStartSignal,
+  type ColdStartSignalCategory,
+  type ColdStartSignals,
+  type CategorizedColdStartSignal,
+  type SignedColdStartSignal,
+} from "./types";
+
+export const ColdStartSignalSchema = z
+  .object({
+    type: z.string().min(1),
+    provider: z.string().min(1).optional(),
+    checkedAt: z.string().optional(),
+    ttlSeconds: z.number().int().nonnegative().optional(),
+    sig: z.string().min(1).optional(),
+    kid: z.string().min(1).optional(),
+    jwks: z.string().url().optional(),
+    alg: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+export const ColdStartSignalsSchema = z.object({
+  onChainCredentials: z.array(ColdStartSignalSchema).optional(),
+  onChainActivity: z.array(ColdStartSignalSchema).optional(),
+  offChainAttestations: z.array(ColdStartSignalSchema).optional(),
+  discoveryAttestations: z.array(ColdStartSignalSchema).optional(),
+});
+
+type ColdStartSignalsParseResult =
+  | { success: true; data: ColdStartSignals }
+  | { success: false; error: string };
+
+/**
+ * Parse and normalize a `coldStartSignals` object.
+ *
+ * Unknown categories are ignored so clients can safely adopt newer categories
+ * over time without breaking older SDK versions.
+ */
+export function parseColdStartSignals(value: unknown): ColdStartSignals {
+  const result = safeParseColdStartSignals(value);
+
+  if ("data" in result) {
+    return result.data;
+  }
+
+  throw new Error(result.error);
+}
+
+/**
+ * Safe variant of `parseColdStartSignals`.
+ */
+export function safeParseColdStartSignals(value: unknown): ColdStartSignalsParseResult {
+  if (!isRecord(value)) {
+    return {
+      success: false,
+      error: "Invalid coldStartSignals: expected an object",
+    };
+  }
+
+  const projected = projectKnownCategories(value);
+  const parsed = ColdStartSignalsSchema.safeParse(projected);
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: `Invalid coldStartSignals: ${formatZodIssues(parsed.error.issues)}`,
+    };
+  }
+
+  return {
+    success: true,
+    data: parsed.data as ColdStartSignals,
+  };
+}
+
+/**
+ * Extract cold-start signals from a direct `coldStartSignals` object, an
+ * envelope with `coldStartSignals`, or a discovery-style `metadata` object.
+ */
+export function extractColdStartSignals(value: unknown): ColdStartSignals | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if ("coldStartSignals" in value) {
+    if (value.coldStartSignals === undefined) {
+      return undefined;
+    }
+
+    return parseColdStartSignals(value.coldStartSignals);
+  }
+
+  if ("metadata" in value && isRecord(value.metadata) && "coldStartSignals" in value.metadata) {
+    if (value.metadata.coldStartSignals === undefined) {
+      return undefined;
+    }
+
+    return parseColdStartSignals(value.metadata.coldStartSignals);
+  }
+
+  if (hasKnownCategory(value)) {
+    return parseColdStartSignals(value);
+  }
+
+  return undefined;
+}
+
+export function isColdStartSignal(value: unknown): value is ColdStartSignal {
+  return ColdStartSignalSchema.safeParse(value).success;
+}
+
+export function isColdStartSignals(value: unknown): value is ColdStartSignals {
+  return safeParseColdStartSignals(value).success;
+}
+
+export function isSignedColdStartSignal(value: ColdStartSignal): value is SignedColdStartSignal {
+  return (
+    typeof value.sig === "string" &&
+    value.sig.length > 0 &&
+    typeof value.kid === "string" &&
+    value.kid.length > 0
+  );
+}
+
+/**
+ * Flatten signals across categories for simple client-side iteration.
+ */
+export function listColdStartSignals(signals: ColdStartSignals): CategorizedColdStartSignal[] {
+  const entries: CategorizedColdStartSignal[] = [];
+
+  for (const category of COLD_START_SIGNAL_CATEGORIES) {
+    for (const signal of signals[category] ?? []) {
+      entries.push({ category, signal });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Freshness helper for pre-payment evaluation.
+ *
+ * - Signals without freshness metadata are treated as usable by this helper.
+ * - Signals with only one freshness field are treated as malformed/stale.
+ */
+export function isColdStartSignalFresh(
+  signal: Pick<ColdStartSignal, "checkedAt" | "ttlSeconds">,
+  now: Date = new Date(),
+): boolean {
+  const { checkedAt, ttlSeconds } = signal;
+  const hasCheckedAt = typeof checkedAt === "string";
+  const hasTtlSeconds = typeof ttlSeconds === "number";
+
+  if (!hasCheckedAt && !hasTtlSeconds) {
+    return true;
+  }
+
+  if (!hasCheckedAt || !hasTtlSeconds) {
+    return false;
+  }
+
+  const checkedAtMs = Date.parse(checkedAt);
+
+  if (Number.isNaN(checkedAtMs)) {
+    return false;
+  }
+
+  return checkedAtMs + ttlSeconds * 1000 >= now.getTime();
+}
+
+/**
+ * Flatten and retain only signals that are still within their freshness window.
+ */
+export function getFreshColdStartSignals(
+  signals: ColdStartSignals,
+  now: Date = new Date(),
+): CategorizedColdStartSignal[] {
+  return listColdStartSignals(signals).filter(entry => isColdStartSignalFresh(entry.signal, now));
+}
+
+function projectKnownCategories(value: Record<string, unknown>): Partial<Record<ColdStartSignalCategory, unknown>> {
+  const projected: Partial<Record<ColdStartSignalCategory, unknown>> = {};
+
+  for (const category of COLD_START_SIGNAL_CATEGORIES) {
+    if (category in value) {
+      projected[category] = value[category];
+    }
+  }
+
+  return projected;
+}
+
+function hasKnownCategory(value: Record<string, unknown>): boolean {
+  return COLD_START_SIGNAL_CATEGORIES.some(category => category in value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatZodIssues(issues: z.ZodIssue[]): string {
+  return issues
+    .map(issue => {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      return `${path}: ${issue.message}`;
+    })
+    .join(", ");
+}

--- a/typescript/packages/extensions/src/cold-start/types.ts
+++ b/typescript/packages/extensions/src/cold-start/types.ts
@@ -9,13 +9,13 @@
  * Known cold-start signal categories from the draft specification.
  */
 export const COLD_START_SIGNAL_CATEGORIES = [
-  "onChainCredentials",
-  "onChainActivity",
-  "offChainAttestations",
-  "discoveryAttestations",
-] as const;
+  'onChainCredentials',
+  'onChainActivity',
+  'offChainAttestations',
+  'discoveryAttestations',
+] as const
 
-export type ColdStartSignalCategory = (typeof COLD_START_SIGNAL_CATEGORIES)[number];
+export type ColdStartSignalCategory = (typeof COLD_START_SIGNAL_CATEGORIES)[number]
 
 /**
  * Signature metadata that may accompany a cold-start signal.
@@ -24,19 +24,19 @@ export interface ColdStartSignalSignatureFields {
   /**
    * Detached signature over the canonical signal payload.
    */
-  sig?: string;
+  sig?: string
   /**
    * Key identifier for the signing key.
    */
-  kid?: string;
+  kid?: string
   /**
    * Optional JWKS endpoint hint for the signing key.
    */
-  jwks?: string;
+  jwks?: string
   /**
    * Signature algorithm hint. The verifier also accepts `jwk.alg`.
    */
-  alg?: string;
+  alg?: string
 }
 
 /**
@@ -49,19 +49,19 @@ export interface ColdStartSignal extends Record<string, unknown>, ColdStartSigna
   /**
    * Provider-defined signal type.
    */
-  type: string;
+  type: string
   /**
    * Optional provider identifier.
    */
-  provider?: string;
+  provider?: string
   /**
    * ISO-8601 timestamp for when the signal was checked or issued.
    */
-  checkedAt?: string;
+  checkedAt?: string
   /**
    * Freshness window in seconds.
    */
-  ttlSeconds?: number;
+  ttlSeconds?: number
 }
 
 export interface OnChainCredentialSignal extends ColdStartSignal {}
@@ -76,33 +76,33 @@ export interface DiscoveryAttestationSignal extends ColdStartSignal {}
  * Typed container for known cold-start signal categories.
  */
 export interface ColdStartSignals {
-  onChainCredentials?: OnChainCredentialSignal[];
-  onChainActivity?: OnChainActivitySignal[];
-  offChainAttestations?: OffChainAttestationSignal[];
-  discoveryAttestations?: DiscoveryAttestationSignal[];
+  onChainCredentials?: OnChainCredentialSignal[]
+  onChainActivity?: OnChainActivitySignal[]
+  offChainAttestations?: OffChainAttestationSignal[]
+  discoveryAttestations?: DiscoveryAttestationSignal[]
 }
 
 /**
  * Common envelope shape used by discovery metadata or registration payloads.
  */
 export interface ColdStartSignalEnvelope {
-  coldStartSignals?: ColdStartSignals;
+  coldStartSignals?: ColdStartSignals
 }
 
 /**
  * Flattened signal paired with its category for client-side iteration.
  */
 export interface CategorizedColdStartSignal<T extends ColdStartSignal = ColdStartSignal> {
-  category: ColdStartSignalCategory;
-  signal: T;
+  category: ColdStartSignalCategory
+  signal: T
 }
 
 /**
  * Signal with enough metadata to attempt detached signature verification.
  */
 export interface SignedColdStartSignal extends ColdStartSignal {
-  sig: string;
-  kid: string;
+  sig: string
+  kid: string
 }
 
 /**
@@ -111,46 +111,46 @@ export interface SignedColdStartSignal extends ColdStartSignal {
  * The broader draft is intentionally algorithm-agnostic. This union only
  * reflects the helper's currently implemented WebCrypto paths.
  */
-export type SupportedColdStartSignalAlgorithm = "RS256" | "ES256" | "EdDSA" | "Ed25519";
+export type SupportedColdStartSignalAlgorithm = 'RS256' | 'ES256' | 'EdDSA' | 'Ed25519'
 
 export interface ResolveColdStartSignalJwkOptions {
-  signal: SignedColdStartSignal;
-  kid: string;
-  jwks?: string;
+  signal: SignedColdStartSignal
+  kid: string
+  jwks?: string
 }
 
 export type ColdStartSignalJwkResolver = (
   options: ResolveColdStartSignalJwkOptions,
-) => Promise<JsonWebKey | null | undefined> | JsonWebKey | null | undefined;
+) => Promise<JsonWebKey | null | undefined> | JsonWebKey | null | undefined
 
 export interface VerifyColdStartSignalOptions {
   /**
    * Override the signature algorithm instead of reading `signal.alg` or `jwk.alg`.
    */
-  algorithm?: string;
+  algorithm?: string
   /**
    * Provide a JWK directly when key resolution is already handled by the caller.
    */
-  jwk?: JsonWebKey;
+  jwk?: JsonWebKey
   /**
    * Resolve a JWK for the signal without embedding network access in this helper.
    */
-  resolveJwk?: ColdStartSignalJwkResolver;
+  resolveJwk?: ColdStartSignalJwkResolver
   /**
    * Override the payload that should be verified.
    *
    * If omitted, `canonicalizeColdStartSignal(signal)` is used.
    */
-  payload?: string | Uint8Array;
+  payload?: string | Uint8Array
   /**
    * Provide custom canonicalization when the provider signs a non-default payload.
    */
-  canonicalize?: (signal: ColdStartSignal) => string | Uint8Array;
+  canonicalize?: (signal: ColdStartSignal) => string | Uint8Array
 }
 
 export interface VerifyColdStartSignalResult {
-  valid: boolean;
-  error?: string;
-  algorithm?: string;
-  keyId?: string;
+  valid: boolean
+  error?: string
+  algorithm?: string
+  keyId?: string
 }

--- a/typescript/packages/extensions/src/cold-start/types.ts
+++ b/typescript/packages/extensions/src/cold-start/types.ts
@@ -1,0 +1,156 @@
+/**
+ * Type definitions for cold-start trust signals.
+ *
+ * These helpers are intended for discovery and registration metadata, not for
+ * modifying the core x402 payment flow.
+ */
+
+/**
+ * Known cold-start signal categories from the draft specification.
+ */
+export const COLD_START_SIGNAL_CATEGORIES = [
+  "onChainCredentials",
+  "onChainActivity",
+  "offChainAttestations",
+  "discoveryAttestations",
+] as const;
+
+export type ColdStartSignalCategory = (typeof COLD_START_SIGNAL_CATEGORIES)[number];
+
+/**
+ * Signature metadata that may accompany a cold-start signal.
+ */
+export interface ColdStartSignalSignatureFields {
+  /**
+   * Detached signature over the canonical signal payload.
+   */
+  sig?: string;
+  /**
+   * Key identifier for the signing key.
+   */
+  kid?: string;
+  /**
+   * Optional JWKS endpoint hint for the signing key.
+   */
+  jwks?: string;
+  /**
+   * Signature algorithm hint. The verifier also accepts `jwk.alg`.
+   */
+  alg?: string;
+}
+
+/**
+ * Generic cold-start signal shape.
+ *
+ * Signal-specific fields are intentionally left open so providers can add
+ * category-specific payloads without waiting on SDK updates.
+ */
+export interface ColdStartSignal extends Record<string, unknown>, ColdStartSignalSignatureFields {
+  /**
+   * Provider-defined signal type.
+   */
+  type: string;
+  /**
+   * Optional provider identifier.
+   */
+  provider?: string;
+  /**
+   * ISO-8601 timestamp for when the signal was checked or issued.
+   */
+  checkedAt?: string;
+  /**
+   * Freshness window in seconds.
+   */
+  ttlSeconds?: number;
+}
+
+export interface OnChainCredentialSignal extends ColdStartSignal {}
+
+export interface OnChainActivitySignal extends ColdStartSignal {}
+
+export interface OffChainAttestationSignal extends ColdStartSignal {}
+
+export interface DiscoveryAttestationSignal extends ColdStartSignal {}
+
+/**
+ * Typed container for known cold-start signal categories.
+ */
+export interface ColdStartSignals {
+  onChainCredentials?: OnChainCredentialSignal[];
+  onChainActivity?: OnChainActivitySignal[];
+  offChainAttestations?: OffChainAttestationSignal[];
+  discoveryAttestations?: DiscoveryAttestationSignal[];
+}
+
+/**
+ * Common envelope shape used by discovery metadata or registration payloads.
+ */
+export interface ColdStartSignalEnvelope {
+  coldStartSignals?: ColdStartSignals;
+}
+
+/**
+ * Flattened signal paired with its category for client-side iteration.
+ */
+export interface CategorizedColdStartSignal<T extends ColdStartSignal = ColdStartSignal> {
+  category: ColdStartSignalCategory;
+  signal: T;
+}
+
+/**
+ * Signal with enough metadata to attempt detached signature verification.
+ */
+export interface SignedColdStartSignal extends ColdStartSignal {
+  sig: string;
+  kid: string;
+}
+
+/**
+ * Algorithm identifiers currently supported by the reference verifier.
+ *
+ * The broader draft is intentionally algorithm-agnostic. This union only
+ * reflects the helper's currently implemented WebCrypto paths.
+ */
+export type SupportedColdStartSignalAlgorithm = "RS256" | "ES256" | "EdDSA" | "Ed25519";
+
+export interface ResolveColdStartSignalJwkOptions {
+  signal: SignedColdStartSignal;
+  kid: string;
+  jwks?: string;
+}
+
+export type ColdStartSignalJwkResolver = (
+  options: ResolveColdStartSignalJwkOptions,
+) => Promise<JsonWebKey | null | undefined> | JsonWebKey | null | undefined;
+
+export interface VerifyColdStartSignalOptions {
+  /**
+   * Override the signature algorithm instead of reading `signal.alg` or `jwk.alg`.
+   */
+  algorithm?: string;
+  /**
+   * Provide a JWK directly when key resolution is already handled by the caller.
+   */
+  jwk?: JsonWebKey;
+  /**
+   * Resolve a JWK for the signal without embedding network access in this helper.
+   */
+  resolveJwk?: ColdStartSignalJwkResolver;
+  /**
+   * Override the payload that should be verified.
+   *
+   * If omitted, `canonicalizeColdStartSignal(signal)` is used.
+   */
+  payload?: string | Uint8Array;
+  /**
+   * Provide custom canonicalization when the provider signs a non-default payload.
+   */
+  canonicalize?: (signal: ColdStartSignal) => string | Uint8Array;
+}
+
+export interface VerifyColdStartSignalResult {
+  valid: boolean;
+  error?: string;
+  algorithm?: string;
+  keyId?: string;
+}

--- a/typescript/packages/extensions/src/cold-start/verify.ts
+++ b/typescript/packages/extensions/src/cold-start/verify.ts
@@ -2,10 +2,10 @@ import type {
   ColdStartSignal,
   VerifyColdStartSignalOptions,
   VerifyColdStartSignalResult,
-} from "./types";
-import { isSignedColdStartSignal } from "./parse";
+} from './types'
+import { isSignedColdStartSignal } from './parse'
 
-const SIGNATURE_METADATA_FIELDS = new Set(["sig", "kid", "jwks", "alg"]);
+const SIGNATURE_METADATA_FIELDS = new Set(['sig', 'kid', 'jwks', 'alg'])
 
 /**
  * Build the default canonical payload for detached signal verification.
@@ -14,15 +14,15 @@ const SIGNATURE_METADATA_FIELDS = new Set(["sig", "kid", "jwks", "alg"]);
  * without including transport-specific verification hints.
  */
 export function canonicalizeColdStartSignal(signal: ColdStartSignal): string {
-  const payload: Record<string, unknown> = {};
+  const payload: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(signal)) {
     if (!SIGNATURE_METADATA_FIELDS.has(key) && value !== undefined) {
-      payload[key] = value;
+      payload[key] = value
     }
   }
 
-  return JSON.stringify(sortJsonValue(payload));
+  return JSON.stringify(sortJsonValue(payload))
 }
 
 /**
@@ -38,21 +38,21 @@ export async function verifyColdStartSignalSignature(
   if (!isSignedColdStartSignal(signal)) {
     return {
       valid: false,
-      error: "Signal is missing the required sig and kid fields",
-    };
+      error: 'Signal is missing the required sig and kid fields',
+    }
   }
 
-  const algorithm = options.algorithm ?? signal.alg;
-  let resolvedAlgorithm = algorithm;
-  const subtle = globalThis.crypto?.subtle;
+  const algorithm = options.algorithm ?? signal.alg
+  let resolvedAlgorithm = algorithm
+  const subtle = globalThis.crypto?.subtle
 
   if (!subtle) {
     return {
       valid: false,
-      error: "WebCrypto subtle API is not available in this runtime",
+      error: 'WebCrypto subtle API is not available in this runtime',
       keyId: signal.kid,
       algorithm,
-    };
+    }
   }
 
   try {
@@ -62,36 +62,34 @@ export async function verifyColdStartSignalSignature(
         signal,
         kid: signal.kid,
         jwks: signal.jwks,
-      }));
+      }))
 
     if (!jwk) {
       return {
         valid: false,
-        error: "No JWK was provided for signal verification",
+        error: 'No JWK was provided for signal verification',
         keyId: signal.kid,
         algorithm,
-      };
+      }
     }
 
-    resolvedAlgorithm = normalizeAlgorithm(algorithm ?? jwk.alg, jwk);
+    resolvedAlgorithm = normalizeAlgorithm(algorithm ?? jwk.alg, jwk)
 
     if (!resolvedAlgorithm) {
       return {
         valid: false,
-        error: "Unable to determine a signature algorithm for the signal",
+        error: 'Unable to determine a signature algorithm for the signal',
         keyId: signal.kid,
-      };
+      }
     }
 
-    const imported = await importVerificationKey(subtle, jwk, resolvedAlgorithm);
+    const imported = await importVerificationKey(subtle, jwk, resolvedAlgorithm)
     const payload = toArrayBuffer(
-      options.payload ??
-        options.canonicalize?.(signal) ??
-        canonicalizeColdStartSignal(signal),
-    );
+      options.payload ?? options.canonicalize?.(signal) ?? canonicalizeColdStartSignal(signal),
+    )
 
-    const signature = decodeBase64Url(signal.sig);
-    const valid = await subtle.verify(imported.verifyAlgorithm, imported.key, signature, payload);
+    const signature = decodeBase64Url(signal.sig)
+    const valid = await subtle.verify(imported.verifyAlgorithm, imported.key, signature, payload)
 
     return valid
       ? {
@@ -101,30 +99,30 @@ export async function verifyColdStartSignalSignature(
         }
       : {
           valid: false,
-          error: "Signal signature verification failed",
+          error: 'Signal signature verification failed',
           keyId: signal.kid,
           algorithm: resolvedAlgorithm,
-        };
+        }
   } catch (error) {
     return {
       valid: false,
-      error: error instanceof Error ? error.message : "Signal signature verification failed",
+      error: error instanceof Error ? error.message : 'Signal signature verification failed',
       keyId: signal.kid,
       algorithm: resolvedAlgorithm,
-    };
+    }
   }
 }
 
 function normalizeAlgorithm(algorithm: string | undefined, jwk: JsonWebKey): string | undefined {
   if (!algorithm) {
-    return jwk.kty === "OKP" && jwk.crv === "Ed25519" ? "EdDSA" : undefined;
+    return jwk.kty === 'OKP' && jwk.crv === 'Ed25519' ? 'EdDSA' : undefined
   }
 
-  if (algorithm === "Ed25519") {
-    return "EdDSA";
+  if (algorithm === 'Ed25519') {
+    return 'EdDSA'
   }
 
-  return algorithm;
+  return algorithm
 }
 
 async function importVerificationKey(
@@ -132,96 +130,93 @@ async function importVerificationKey(
   jwk: JsonWebKey,
   algorithm: string,
 ): Promise<{
-  key: CryptoKey;
-  verifyAlgorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams;
+  key: CryptoKey
+  verifyAlgorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams
 }> {
   switch (algorithm) {
-    case "RS256": {
+    case 'RS256': {
       return {
         key: await subtle.importKey(
-          "jwk",
+          'jwk',
           jwk,
-          { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+          { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
           false,
-          ["verify"],
+          ['verify'],
         ),
-        verifyAlgorithm: "RSASSA-PKCS1-v1_5",
-      };
+        verifyAlgorithm: 'RSASSA-PKCS1-v1_5',
+      }
     }
-    case "ES256": {
-      if (jwk.crv && jwk.crv !== "P-256") {
-        throw new Error(`ES256 requires a P-256 key, received curve: ${jwk.crv}`);
+    case 'ES256': {
+      if (jwk.crv && jwk.crv !== 'P-256') {
+        throw new Error(`ES256 requires a P-256 key, received curve: ${jwk.crv}`)
       }
 
       return {
-        key: await subtle.importKey(
-          "jwk",
-          jwk,
-          { name: "ECDSA", namedCurve: "P-256" },
-          false,
-          ["verify"],
-        ),
-        verifyAlgorithm: { name: "ECDSA", hash: "SHA-256" },
-      };
+        key: await subtle.importKey('jwk', jwk, { name: 'ECDSA', namedCurve: 'P-256' }, false, [
+          'verify',
+        ]),
+        verifyAlgorithm: { name: 'ECDSA', hash: 'SHA-256' },
+      }
     }
-    case "EdDSA": {
-      if (jwk.crv && jwk.crv !== "Ed25519") {
-        throw new Error(`EdDSA requires an Ed25519 key, received curve: ${jwk.crv}`);
+    case 'EdDSA': {
+      if (jwk.crv && jwk.crv !== 'Ed25519') {
+        throw new Error(`EdDSA requires an Ed25519 key, received curve: ${jwk.crv}`)
       }
 
       return {
-        key: await subtle.importKey("jwk", jwk, { name: "Ed25519" }, false, ["verify"]),
-        verifyAlgorithm: "Ed25519",
-      };
+        key: await subtle.importKey('jwk', jwk, { name: 'Ed25519' }, false, ['verify']),
+        verifyAlgorithm: 'Ed25519',
+      }
     }
     default:
       throw new Error(
         `Unsupported signature algorithm: ${algorithm}. Supported algorithms: RS256, ES256, EdDSA`,
-      );
+      )
   }
 }
 
 function sortJsonValue(value: unknown): unknown {
   if (Array.isArray(value)) {
-    return value.map(sortJsonValue);
+    return value.map(sortJsonValue)
   }
 
-  if (value && typeof value === "object") {
+  if (value && typeof value === 'object') {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
         .filter(([, nestedValue]) => nestedValue !== undefined)
         .sort(([left], [right]) => left.localeCompare(right))
         .map(([key, nestedValue]) => [key, sortJsonValue(nestedValue)]),
-    );
+    )
   }
 
-  return value;
+  return value
 }
 
 function toArrayBuffer(value: string | Uint8Array): ArrayBuffer {
-  const bytes = value instanceof Uint8Array ? Uint8Array.from(value) : new TextEncoder().encode(value);
-  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  const bytes =
+    value instanceof Uint8Array ? Uint8Array.from(value) : new TextEncoder().encode(value)
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
 }
 
 function decodeBase64Url(value: string): ArrayBuffer {
   if (!/^[A-Za-z0-9_-]+=*$/.test(value)) {
-    throw new Error("Signal signature is not valid base64url");
+    throw new Error('Signal signature is not valid base64url')
   }
 
-  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
-  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=')
 
-  if (typeof Buffer !== "undefined") {
-    const bytes = Uint8Array.from(Buffer.from(padded, "base64"));
-    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  if (typeof Buffer !== 'undefined') {
+    const bytes = Uint8Array.from(Buffer.from(padded, 'base64'))
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
   }
 
-  const binary = globalThis.atob(padded);
-  const bytes = new Uint8Array(binary.length);
+  const binary = globalThis.atob(padded)
+  const bytes = new Uint8Array(binary.length)
 
   for (let index = 0; index < binary.length; index += 1) {
-    bytes[index] = binary.charCodeAt(index);
+    bytes[index] = binary.charCodeAt(index)
   }
 
-  return bytes.buffer;
+  return bytes.buffer
 }

--- a/typescript/packages/extensions/src/cold-start/verify.ts
+++ b/typescript/packages/extensions/src/cold-start/verify.ts
@@ -1,0 +1,227 @@
+import type {
+  ColdStartSignal,
+  VerifyColdStartSignalOptions,
+  VerifyColdStartSignalResult,
+} from "./types";
+import { isSignedColdStartSignal } from "./parse";
+
+const SIGNATURE_METADATA_FIELDS = new Set(["sig", "kid", "jwks", "alg"]);
+
+/**
+ * Build the default canonical payload for detached signal verification.
+ *
+ * The signature metadata is excluded so callers can sign the semantic payload
+ * without including transport-specific verification hints.
+ */
+export function canonicalizeColdStartSignal(signal: ColdStartSignal): string {
+  const payload: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(signal)) {
+    if (!SIGNATURE_METADATA_FIELDS.has(key) && value !== undefined) {
+      payload[key] = value;
+    }
+  }
+
+  return JSON.stringify(sortJsonValue(payload));
+}
+
+/**
+ * Verify a detached cold-start signal signature.
+ *
+ * This scaffold intentionally keeps key resolution outside the helper so
+ * callers can decide how to fetch, cache, or pin JWKS documents.
+ */
+export async function verifyColdStartSignalSignature(
+  signal: ColdStartSignal,
+  options: VerifyColdStartSignalOptions = {},
+): Promise<VerifyColdStartSignalResult> {
+  if (!isSignedColdStartSignal(signal)) {
+    return {
+      valid: false,
+      error: "Signal is missing the required sig and kid fields",
+    };
+  }
+
+  const algorithm = options.algorithm ?? signal.alg;
+  let resolvedAlgorithm = algorithm;
+  const subtle = globalThis.crypto?.subtle;
+
+  if (!subtle) {
+    return {
+      valid: false,
+      error: "WebCrypto subtle API is not available in this runtime",
+      keyId: signal.kid,
+      algorithm,
+    };
+  }
+
+  try {
+    const jwk =
+      options.jwk ??
+      (await options.resolveJwk?.({
+        signal,
+        kid: signal.kid,
+        jwks: signal.jwks,
+      }));
+
+    if (!jwk) {
+      return {
+        valid: false,
+        error: "No JWK was provided for signal verification",
+        keyId: signal.kid,
+        algorithm,
+      };
+    }
+
+    resolvedAlgorithm = normalizeAlgorithm(algorithm ?? jwk.alg, jwk);
+
+    if (!resolvedAlgorithm) {
+      return {
+        valid: false,
+        error: "Unable to determine a signature algorithm for the signal",
+        keyId: signal.kid,
+      };
+    }
+
+    const imported = await importVerificationKey(subtle, jwk, resolvedAlgorithm);
+    const payload = toArrayBuffer(
+      options.payload ??
+        options.canonicalize?.(signal) ??
+        canonicalizeColdStartSignal(signal),
+    );
+
+    const signature = decodeBase64Url(signal.sig);
+    const valid = await subtle.verify(imported.verifyAlgorithm, imported.key, signature, payload);
+
+    return valid
+      ? {
+          valid: true,
+          keyId: signal.kid,
+          algorithm: resolvedAlgorithm,
+        }
+      : {
+          valid: false,
+          error: "Signal signature verification failed",
+          keyId: signal.kid,
+          algorithm: resolvedAlgorithm,
+        };
+  } catch (error) {
+    return {
+      valid: false,
+      error: error instanceof Error ? error.message : "Signal signature verification failed",
+      keyId: signal.kid,
+      algorithm: resolvedAlgorithm,
+    };
+  }
+}
+
+function normalizeAlgorithm(algorithm: string | undefined, jwk: JsonWebKey): string | undefined {
+  if (!algorithm) {
+    return jwk.kty === "OKP" && jwk.crv === "Ed25519" ? "EdDSA" : undefined;
+  }
+
+  if (algorithm === "Ed25519") {
+    return "EdDSA";
+  }
+
+  return algorithm;
+}
+
+async function importVerificationKey(
+  subtle: SubtleCrypto,
+  jwk: JsonWebKey,
+  algorithm: string,
+): Promise<{
+  key: CryptoKey;
+  verifyAlgorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams;
+}> {
+  switch (algorithm) {
+    case "RS256": {
+      return {
+        key: await subtle.importKey(
+          "jwk",
+          jwk,
+          { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+          false,
+          ["verify"],
+        ),
+        verifyAlgorithm: "RSASSA-PKCS1-v1_5",
+      };
+    }
+    case "ES256": {
+      if (jwk.crv && jwk.crv !== "P-256") {
+        throw new Error(`ES256 requires a P-256 key, received curve: ${jwk.crv}`);
+      }
+
+      return {
+        key: await subtle.importKey(
+          "jwk",
+          jwk,
+          { name: "ECDSA", namedCurve: "P-256" },
+          false,
+          ["verify"],
+        ),
+        verifyAlgorithm: { name: "ECDSA", hash: "SHA-256" },
+      };
+    }
+    case "EdDSA": {
+      if (jwk.crv && jwk.crv !== "Ed25519") {
+        throw new Error(`EdDSA requires an Ed25519 key, received curve: ${jwk.crv}`);
+      }
+
+      return {
+        key: await subtle.importKey("jwk", jwk, { name: "Ed25519" }, false, ["verify"]),
+        verifyAlgorithm: "Ed25519",
+      };
+    }
+    default:
+      throw new Error(
+        `Unsupported signature algorithm: ${algorithm}. Supported algorithms: RS256, ES256, EdDSA`,
+      );
+  }
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, nestedValue]) => nestedValue !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nestedValue]) => [key, sortJsonValue(nestedValue)]),
+    );
+  }
+
+  return value;
+}
+
+function toArrayBuffer(value: string | Uint8Array): ArrayBuffer {
+  const bytes = value instanceof Uint8Array ? Uint8Array.from(value) : new TextEncoder().encode(value);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+}
+
+function decodeBase64Url(value: string): ArrayBuffer {
+  if (!/^[A-Za-z0-9_-]+=*$/.test(value)) {
+    throw new Error("Signal signature is not valid base64url");
+  }
+
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+
+  if (typeof Buffer !== "undefined") {
+    const bytes = Uint8Array.from(Buffer.from(padded, "base64"));
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  }
+
+  const binary = globalThis.atob(padded);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return bytes.buffer;
+}

--- a/typescript/packages/extensions/src/index.ts
+++ b/typescript/packages/extensions/src/index.ts
@@ -12,6 +12,9 @@ export * from "./sign-in-with-x";
 export * from "./payment-identifier";
 export { paymentIdentifierResourceServerExtension } from "./payment-identifier/resourceServer";
 
+// Cold-start signal helpers
+export * from "./cold-start";
+
 // EIP-2612 Gas Sponsoring extension
 export * from "./eip2612-gas-sponsoring";
 

--- a/typescript/packages/extensions/test/cold-start.test.ts
+++ b/typescript/packages/extensions/test/cold-start.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { generateKeyPairSync, sign as signBuffer } from "crypto";
+import { describe, expect, it } from 'vitest'
+import { generateKeyPairSync, sign as signBuffer } from 'crypto'
 import {
   canonicalizeColdStartSignal,
   extractColdStartSignals,
@@ -10,405 +10,407 @@ import {
   safeParseColdStartSignals,
   verifyColdStartSignalSignature,
   type ColdStartSignals,
-} from "../src/cold-start";
+} from '../src/cold-start'
 
-describe("Cold-start signal helpers", () => {
-  describe("parseColdStartSignals", () => {
-    it("ignores unknown categories while preserving known signals", () => {
+describe('Cold-start signal helpers', () => {
+  describe('parseColdStartSignals', () => {
+    it('ignores unknown categories while preserving known signals', () => {
       const parsed = parseColdStartSignals({
         onChainCredentials: [
           {
-            type: "customCredential",
-            issuer: "did:web:issuer.example",
+            type: 'customCredential',
+            issuer: 'did:web:issuer.example',
           },
         ],
         unknownCategory: [
           {
-            type: "ignore-me",
+            type: 'ignore-me',
           },
         ],
-      });
+      })
 
-      expect(parsed.onChainCredentials).toHaveLength(1);
-      expect(parsed.onChainCredentials?.[0].type).toBe("customCredential");
-      expect("unknownCategory" in parsed).toBe(false);
-    });
+      expect(parsed.onChainCredentials).toHaveLength(1)
+      expect(parsed.onChainCredentials?.[0].type).toBe('customCredential')
+      expect('unknownCategory' in parsed).toBe(false)
+    })
 
-    it("accepts unknown signal types inside known categories", () => {
+    it('accepts unknown signal types inside known categories', () => {
       const parsed = parseColdStartSignals({
         discoveryAttestations: [
           {
-            type: "providerDefinedHealthProbe",
-            provider: "monitoring.example",
+            type: 'providerDefinedHealthProbe',
+            provider: 'monitoring.example',
             successRate: 0.99,
           },
         ],
-      });
+      })
 
-      expect(parsed.discoveryAttestations?.[0].type).toBe("providerDefinedHealthProbe");
-      expect(parsed.discoveryAttestations?.[0].successRate).toBe(0.99);
-    });
+      expect(parsed.discoveryAttestations?.[0].type).toBe('providerDefinedHealthProbe')
+      expect(parsed.discoveryAttestations?.[0].successRate).toBe(0.99)
+    })
 
-    it("returns a safe parse error for malformed known categories", () => {
+    it('returns a safe parse error for malformed known categories', () => {
       const result = safeParseColdStartSignals({
         onChainCredentials: {
-          type: "not-an-array",
+          type: 'not-an-array',
         },
-      });
+      })
 
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(false)
       if (!result.success) {
-        expect(result.error).toContain("onChainCredentials");
+        expect(result.error).toContain('onChainCredentials')
       }
-    });
-  });
+    })
+  })
 
-  describe("extractColdStartSignals", () => {
-    it("extracts from discovery-style metadata", () => {
+  describe('extractColdStartSignals', () => {
+    it('extracts from discovery-style metadata', () => {
       const parsed = extractColdStartSignals({
         metadata: {
           coldStartSignals: {
             offChainAttestations: [
               {
-                type: "did",
-                id: "did:web:agent.example.com",
+                type: 'did',
+                id: 'did:web:agent.example.com',
               },
             ],
           },
         },
-      });
+      })
 
-      expect(parsed?.offChainAttestations?.[0].type).toBe("did");
-    });
+      expect(parsed?.offChainAttestations?.[0].type).toBe('did')
+    })
 
-    it("extracts from a direct coldStartSignals envelope", () => {
+    it('extracts from a direct coldStartSignals envelope', () => {
       const parsed = extractColdStartSignals({
         coldStartSignals: {
           discoveryAttestations: [
             {
-              type: "serviceHealth",
+              type: 'serviceHealth',
               uptimePct: 99.9,
             },
           ],
         },
-      });
+      })
 
-      expect(parsed?.discoveryAttestations?.[0].type).toBe("serviceHealth");
-    });
-  });
+      expect(parsed?.discoveryAttestations?.[0].type).toBe('serviceHealth')
+    })
+  })
 
-  describe("freshness helpers", () => {
-    it("filters stale signals for pre-payment evaluation", () => {
+  describe('freshness helpers', () => {
+    it('filters stale signals for pre-payment evaluation', () => {
       const signals: ColdStartSignals = {
         onChainActivity: [
           {
-            type: "walletTrust",
-            checkedAt: "2026-03-11T12:00:00Z",
+            type: 'walletTrust',
+            checkedAt: '2026-03-11T12:00:00Z',
             ttlSeconds: 120,
           },
         ],
         discoveryAttestations: [
           {
-            type: "serviceHealth",
-            checkedAt: "2026-03-11T12:00:00Z",
+            type: 'serviceHealth',
+            checkedAt: '2026-03-11T12:00:00Z',
             ttlSeconds: 10,
           },
         ],
-      };
+      }
 
-      const allSignals = listColdStartSignals(signals);
-      const freshSignals = getFreshColdStartSignals(signals, new Date("2026-03-11T12:01:00Z"));
+      const allSignals = listColdStartSignals(signals)
+      const freshSignals = getFreshColdStartSignals(signals, new Date('2026-03-11T12:01:00Z'))
 
-      expect(allSignals).toHaveLength(2);
-      expect(freshSignals).toHaveLength(1);
-      expect(freshSignals[0].signal.type).toBe("walletTrust");
-    });
+      expect(allSignals).toHaveLength(2)
+      expect(freshSignals).toHaveLength(1)
+      expect(freshSignals[0].signal.type).toBe('walletTrust')
+    })
 
-    it("treats malformed freshness metadata as stale", () => {
+    it('treats malformed freshness metadata as stale', () => {
       expect(
         isColdStartSignalFresh({
-          checkedAt: "not-a-date",
+          checkedAt: 'not-a-date',
           ttlSeconds: 60,
         }),
-      ).toBe(false);
+      ).toBe(false)
 
       expect(
         isColdStartSignalFresh({
-          checkedAt: "2026-03-11T12:00:00Z",
+          checkedAt: '2026-03-11T12:00:00Z',
         }),
-      ).toBe(false);
-    });
-  });
+      ).toBe(false)
+    })
+  })
 
-  describe("verifyColdStartSignalSignature", () => {
-    it("verifies a real RS256 detached signature with a resolver-supplied JWK", async () => {
-      const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+  describe('verifyColdStartSignalSignature', () => {
+    it('verifies a real RS256 detached signature with a resolver-supplied JWK', async () => {
+      const { publicKey, privateKey } = generateKeyPairSync('rsa', {
         modulusLength: 2048,
-      });
+      })
 
       const unsignedSignal = {
-        type: "serviceHealth",
-        provider: "discovery-service",
-        checkedAt: "2026-03-11T12:00:00Z",
+        type: 'serviceHealth',
+        provider: 'discovery-service',
+        checkedAt: '2026-03-11T12:00:00Z',
         ttlSeconds: 300,
         uptimePct: 99.5,
-      };
+      }
 
       const signature = signBuffer(
-        "RSA-SHA256",
-        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        'RSA-SHA256',
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), 'utf8'),
         privateKey,
-      ).toString("base64url");
+      ).toString('base64url')
 
       const signedSignal = {
         ...unsignedSignal,
         sig: signature,
-        kid: "provider-key-1",
-        jwks: "https://provider.example/.well-known/jwks.json",
-        alg: "RS256",
-      };
+        kid: 'provider-key-1',
+        jwks: 'https://provider.example/.well-known/jwks.json',
+        alg: 'RS256',
+      }
 
-      const jwk = publicKey.export({ format: "jwk" }) as JsonWebKey;
+      const jwk = publicKey.export({ format: 'jwk' }) as JsonWebKey
 
       const result = await verifyColdStartSignalSignature(signedSignal, {
         resolveJwk: async ({ kid, jwks }) => {
-          expect(kid).toBe("provider-key-1");
-          expect(jwks).toBe("https://provider.example/.well-known/jwks.json");
-          return jwk;
+          expect(kid).toBe('provider-key-1')
+          expect(jwks).toBe('https://provider.example/.well-known/jwks.json')
+          return jwk
         },
-      });
+      })
 
       expect(result).toEqual({
         valid: true,
-        algorithm: "RS256",
-        keyId: "provider-key-1",
-      });
-    });
+        algorithm: 'RS256',
+        keyId: 'provider-key-1',
+      })
+    })
 
-    it("verifies a real ES256 detached signature", async () => {
-      const { publicKey, privateKey } = generateKeyPairSync("ec", {
-        namedCurve: "prime256v1",
-      });
+    it('verifies a real ES256 detached signature', async () => {
+      const { publicKey, privateKey } = generateKeyPairSync('ec', {
+        namedCurve: 'prime256v1',
+      })
 
       const unsignedSignal = {
-        type: "walletTrust",
-        provider: "example-provider",
-        checkedAt: "2026-03-11T12:00:00Z",
+        type: 'walletTrust',
+        provider: 'example-provider',
+        checkedAt: '2026-03-11T12:00:00Z',
         ttlSeconds: 300,
         compositeScore: 0.72,
-      };
+      }
 
       const signature = signBuffer(
-        "sha256",
-        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        'sha256',
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), 'utf8'),
         {
           key: privateKey,
-          dsaEncoding: "ieee-p1363",
+          dsaEncoding: 'ieee-p1363',
         },
-      ).toString("base64url");
+      ).toString('base64url')
 
       const result = await verifyColdStartSignalSignature(
         {
           ...unsignedSignal,
           sig: signature,
-          kid: "p256-key-1",
-          alg: "ES256",
+          kid: 'p256-key-1',
+          alg: 'ES256',
         },
         {
-          jwk: publicKey.export({ format: "jwk" }) as JsonWebKey,
+          jwk: publicKey.export({ format: 'jwk' }) as JsonWebKey,
         },
-      );
+      )
 
       expect(result).toEqual({
         valid: true,
-        algorithm: "ES256",
-        keyId: "p256-key-1",
-      });
-    });
+        algorithm: 'ES256',
+        keyId: 'p256-key-1',
+      })
+    })
 
-    it("verifies a real Ed25519 detached signature via EdDSA", async () => {
-      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    it('verifies a real Ed25519 detached signature via EdDSA', async () => {
+      const { publicKey, privateKey } = generateKeyPairSync('ed25519')
 
       const unsignedSignal = {
-        type: "discoveryAttestation",
-        provider: "x402-discovery",
-        checkedAt: "2026-03-11T12:00:00Z",
+        type: 'discoveryAttestation',
+        provider: 'x402-discovery',
+        checkedAt: '2026-03-11T12:00:00Z',
         ttlSeconds: 300,
-        serviceId: "legacy/cf-pay-per-crawl",
-      };
+        serviceId: 'legacy/cf-pay-per-crawl',
+      }
 
       const signature = signBuffer(
         null,
-        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), 'utf8'),
         privateKey,
-      ).toString("base64url");
+      ).toString('base64url')
 
-      const jwk = publicKey.export({ format: "jwk" }) as JsonWebKey;
+      const jwk = publicKey.export({ format: 'jwk' }) as JsonWebKey
 
       const result = await verifyColdStartSignalSignature(
         {
           ...unsignedSignal,
           sig: signature,
-          kid: "ed25519-key-1",
-          alg: "EdDSA",
+          kid: 'ed25519-key-1',
+          alg: 'EdDSA',
         },
         {
           jwk,
         },
-      );
+      )
 
       expect(result).toEqual({
         valid: true,
-        algorithm: "EdDSA",
-        keyId: "ed25519-key-1",
-      });
-    });
+        algorithm: 'EdDSA',
+        keyId: 'ed25519-key-1',
+      })
+    })
 
-    it("infers EdDSA when the JWK curve is Ed25519", async () => {
-      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    it('infers EdDSA when the JWK curve is Ed25519', async () => {
+      const { publicKey, privateKey } = generateKeyPairSync('ed25519')
 
       const unsignedSignal = {
-        type: "reasoningAttestation",
-        provider: "thoughtproof",
-        checkedAt: "2026-03-11T12:00:00Z",
+        type: 'reasoningAttestation',
+        provider: 'thoughtproof',
+        checkedAt: '2026-03-11T12:00:00Z',
         ttlSeconds: 300,
-        verdict: "PASS",
-      };
+        verdict: 'PASS',
+      }
 
       const signature = signBuffer(
         null,
-        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), 'utf8'),
         privateKey,
-      ).toString("base64url");
+      ).toString('base64url')
 
       const result = await verifyColdStartSignalSignature(
         {
           ...unsignedSignal,
           sig: signature,
-          kid: "ed25519-key-2",
+          kid: 'ed25519-key-2',
         },
         {
-          jwk: publicKey.export({ format: "jwk" }) as JsonWebKey,
+          jwk: publicKey.export({ format: 'jwk' }) as JsonWebKey,
         },
-      );
+      )
 
       expect(result).toEqual({
         valid: true,
-        algorithm: "EdDSA",
-        keyId: "ed25519-key-2",
-      });
-    });
+        algorithm: 'EdDSA',
+        keyId: 'ed25519-key-2',
+      })
+    })
 
-    it("accepts the Ed25519 alias and normalizes it to EdDSA", async () => {
-      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    it('accepts the Ed25519 alias and normalizes it to EdDSA', async () => {
+      const { publicKey, privateKey } = generateKeyPairSync('ed25519')
 
       const unsignedSignal = {
-        type: "reasoningAttestation",
-        provider: "thoughtproof",
-        checkedAt: "2026-03-11T12:00:00Z",
+        type: 'reasoningAttestation',
+        provider: 'thoughtproof',
+        checkedAt: '2026-03-11T12:00:00Z',
         ttlSeconds: 300,
-        verdict: "PASS",
-      };
+        verdict: 'PASS',
+      }
 
       const signature = signBuffer(
         null,
-        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), 'utf8'),
         privateKey,
-      ).toString("base64url");
+      ).toString('base64url')
 
       const result = await verifyColdStartSignalSignature(
         {
           ...unsignedSignal,
           sig: signature,
-          kid: "ed25519-key-3",
-          alg: "Ed25519",
+          kid: 'ed25519-key-3',
+          alg: 'Ed25519',
         },
         {
-          jwk: publicKey.export({ format: "jwk" }) as JsonWebKey,
+          jwk: publicKey.export({ format: 'jwk' }) as JsonWebKey,
         },
-      );
+      )
 
       expect(result).toEqual({
         valid: true,
-        algorithm: "EdDSA",
-        keyId: "ed25519-key-3",
-      });
-    });
+        algorithm: 'EdDSA',
+        keyId: 'ed25519-key-3',
+      })
+    })
 
-    it("verifies a caller-supplied canonical payload override", async () => {
-      const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+    it('verifies a caller-supplied canonical payload override', async () => {
+      const { publicKey, privateKey } = generateKeyPairSync('rsa', {
         modulusLength: 2048,
-      });
+      })
 
       const signal = {
-        type: "serviceHealth",
-        provider: "discovery-service",
-        checkedAt: "2026-03-11T12:00:00Z",
+        type: 'serviceHealth',
+        provider: 'discovery-service',
+        checkedAt: '2026-03-11T12:00:00Z',
         ttlSeconds: 300,
         uptimePct: 99.5,
-      };
+      }
 
       const customPayload = JSON.stringify({
         provider: signal.provider,
         type: signal.type,
-      });
+      })
 
-      const signature = signBuffer("RSA-SHA256", Buffer.from(customPayload, "utf8"), privateKey).toString(
-        "base64url",
-      );
+      const signature = signBuffer(
+        'RSA-SHA256',
+        Buffer.from(customPayload, 'utf8'),
+        privateKey,
+      ).toString('base64url')
 
       const result = await verifyColdStartSignalSignature(
         {
           ...signal,
           sig: signature,
-          kid: "provider-key-custom-payload",
-          alg: "RS256",
+          kid: 'provider-key-custom-payload',
+          alg: 'RS256',
         },
         {
-          jwk: publicKey.export({ format: "jwk" }) as JsonWebKey,
-          canonicalize: current =>
+          jwk: publicKey.export({ format: 'jwk' }) as JsonWebKey,
+          canonicalize: (current) =>
             JSON.stringify({
               provider: current.provider,
               type: current.type,
             }),
         },
-      );
+      )
 
       expect(result).toEqual({
         valid: true,
-        algorithm: "RS256",
-        keyId: "provider-key-custom-payload",
-      });
-    });
+        algorithm: 'RS256',
+        keyId: 'provider-key-custom-payload',
+      })
+    })
 
-    it("returns an error for unsupported algorithms", async () => {
+    it('returns an error for unsupported algorithms', async () => {
       const result = await verifyColdStartSignalSignature(
         {
-          type: "serviceHealth",
-          sig: "ZmFrZQ",
-          kid: "provider-key-1",
-          alg: "HS256",
+          type: 'serviceHealth',
+          sig: 'ZmFrZQ',
+          kid: 'provider-key-1',
+          alg: 'HS256',
         },
         {
           jwk: {
-            kty: "oct",
-            alg: "HS256",
-            k: "ZmFrZQ",
+            kty: 'oct',
+            alg: 'HS256',
+            k: 'ZmFrZQ',
           },
         },
-      );
+      )
 
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("Unsupported signature algorithm");
-    });
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain('Unsupported signature algorithm')
+    })
 
-    it("returns an error when the signal is not signed", async () => {
+    it('returns an error when the signal is not signed', async () => {
       const result = await verifyColdStartSignalSignature({
-        type: "serviceHealth",
-      });
+        type: 'serviceHealth',
+      })
 
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("sig and kid");
-    });
-  });
-});
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain('sig and kid')
+    })
+  })
+})

--- a/typescript/packages/extensions/test/cold-start.test.ts
+++ b/typescript/packages/extensions/test/cold-start.test.ts
@@ -299,6 +299,88 @@ describe("Cold-start signal helpers", () => {
       });
     });
 
+    it("accepts the Ed25519 alias and normalizes it to EdDSA", async () => {
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+
+      const unsignedSignal = {
+        type: "reasoningAttestation",
+        provider: "thoughtproof",
+        checkedAt: "2026-03-11T12:00:00Z",
+        ttlSeconds: 300,
+        verdict: "PASS",
+      };
+
+      const signature = signBuffer(
+        null,
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        privateKey,
+      ).toString("base64url");
+
+      const result = await verifyColdStartSignalSignature(
+        {
+          ...unsignedSignal,
+          sig: signature,
+          kid: "ed25519-key-3",
+          alg: "Ed25519",
+        },
+        {
+          jwk: publicKey.export({ format: "jwk" }) as JsonWebKey,
+        },
+      );
+
+      expect(result).toEqual({
+        valid: true,
+        algorithm: "EdDSA",
+        keyId: "ed25519-key-3",
+      });
+    });
+
+    it("verifies a caller-supplied canonical payload override", async () => {
+      const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+      });
+
+      const signal = {
+        type: "serviceHealth",
+        provider: "discovery-service",
+        checkedAt: "2026-03-11T12:00:00Z",
+        ttlSeconds: 300,
+        uptimePct: 99.5,
+      };
+
+      const customPayload = JSON.stringify({
+        provider: signal.provider,
+        type: signal.type,
+      });
+
+      const signature = signBuffer("RSA-SHA256", Buffer.from(customPayload, "utf8"), privateKey).toString(
+        "base64url",
+      );
+
+      const result = await verifyColdStartSignalSignature(
+        {
+          ...signal,
+          sig: signature,
+          kid: "provider-key-custom-payload",
+          alg: "RS256",
+        },
+        {
+          jwk: publicKey.export({ format: "jwk" }) as JsonWebKey,
+          canonicalize: current =>
+            JSON.stringify({
+              provider: current.provider,
+              type: current.type,
+            }),
+        },
+      );
+
+      expect(result).toEqual({
+        valid: true,
+        algorithm: "RS256",
+        keyId: "provider-key-custom-payload",
+      });
+    });
+
     it("returns an error for unsupported algorithms", async () => {
       const result = await verifyColdStartSignalSignature(
         {

--- a/typescript/packages/extensions/test/cold-start.test.ts
+++ b/typescript/packages/extensions/test/cold-start.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+import { generateKeyPairSync, sign as signBuffer } from "crypto";
+import {
+  canonicalizeColdStartSignal,
+  extractColdStartSignals,
+  getFreshColdStartSignals,
+  isColdStartSignalFresh,
+  listColdStartSignals,
+  parseColdStartSignals,
+  safeParseColdStartSignals,
+  verifyColdStartSignalSignature,
+  type ColdStartSignals,
+} from "../src/cold-start";
+
+describe("Cold-start signal helpers", () => {
+  describe("parseColdStartSignals", () => {
+    it("ignores unknown categories while preserving known signals", () => {
+      const parsed = parseColdStartSignals({
+        onChainCredentials: [
+          {
+            type: "customCredential",
+            issuer: "did:web:issuer.example",
+          },
+        ],
+        unknownCategory: [
+          {
+            type: "ignore-me",
+          },
+        ],
+      });
+
+      expect(parsed.onChainCredentials).toHaveLength(1);
+      expect(parsed.onChainCredentials?.[0].type).toBe("customCredential");
+      expect("unknownCategory" in parsed).toBe(false);
+    });
+
+    it("accepts unknown signal types inside known categories", () => {
+      const parsed = parseColdStartSignals({
+        discoveryAttestations: [
+          {
+            type: "providerDefinedHealthProbe",
+            provider: "monitoring.example",
+            successRate: 0.99,
+          },
+        ],
+      });
+
+      expect(parsed.discoveryAttestations?.[0].type).toBe("providerDefinedHealthProbe");
+      expect(parsed.discoveryAttestations?.[0].successRate).toBe(0.99);
+    });
+
+    it("returns a safe parse error for malformed known categories", () => {
+      const result = safeParseColdStartSignals({
+        onChainCredentials: {
+          type: "not-an-array",
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("onChainCredentials");
+      }
+    });
+  });
+
+  describe("extractColdStartSignals", () => {
+    it("extracts from discovery-style metadata", () => {
+      const parsed = extractColdStartSignals({
+        metadata: {
+          coldStartSignals: {
+            offChainAttestations: [
+              {
+                type: "did",
+                id: "did:web:agent.example.com",
+              },
+            ],
+          },
+        },
+      });
+
+      expect(parsed?.offChainAttestations?.[0].type).toBe("did");
+    });
+
+    it("extracts from a direct coldStartSignals envelope", () => {
+      const parsed = extractColdStartSignals({
+        coldStartSignals: {
+          discoveryAttestations: [
+            {
+              type: "serviceHealth",
+              uptimePct: 99.9,
+            },
+          ],
+        },
+      });
+
+      expect(parsed?.discoveryAttestations?.[0].type).toBe("serviceHealth");
+    });
+  });
+
+  describe("freshness helpers", () => {
+    it("filters stale signals for pre-payment evaluation", () => {
+      const signals: ColdStartSignals = {
+        onChainActivity: [
+          {
+            type: "walletTrust",
+            checkedAt: "2026-03-11T12:00:00Z",
+            ttlSeconds: 120,
+          },
+        ],
+        discoveryAttestations: [
+          {
+            type: "serviceHealth",
+            checkedAt: "2026-03-11T12:00:00Z",
+            ttlSeconds: 10,
+          },
+        ],
+      };
+
+      const allSignals = listColdStartSignals(signals);
+      const freshSignals = getFreshColdStartSignals(signals, new Date("2026-03-11T12:01:00Z"));
+
+      expect(allSignals).toHaveLength(2);
+      expect(freshSignals).toHaveLength(1);
+      expect(freshSignals[0].signal.type).toBe("walletTrust");
+    });
+
+    it("treats malformed freshness metadata as stale", () => {
+      expect(
+        isColdStartSignalFresh({
+          checkedAt: "not-a-date",
+          ttlSeconds: 60,
+        }),
+      ).toBe(false);
+
+      expect(
+        isColdStartSignalFresh({
+          checkedAt: "2026-03-11T12:00:00Z",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("verifyColdStartSignalSignature", () => {
+    it("verifies a real RS256 detached signature with a resolver-supplied JWK", async () => {
+      const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+      });
+
+      const unsignedSignal = {
+        type: "serviceHealth",
+        provider: "discovery-service",
+        checkedAt: "2026-03-11T12:00:00Z",
+        ttlSeconds: 300,
+        uptimePct: 99.5,
+      };
+
+      const signature = signBuffer(
+        "RSA-SHA256",
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        privateKey,
+      ).toString("base64url");
+
+      const signedSignal = {
+        ...unsignedSignal,
+        sig: signature,
+        kid: "provider-key-1",
+        jwks: "https://provider.example/.well-known/jwks.json",
+        alg: "RS256",
+      };
+
+      const jwk = publicKey.export({ format: "jwk" }) as JsonWebKey;
+
+      const result = await verifyColdStartSignalSignature(signedSignal, {
+        resolveJwk: async ({ kid, jwks }) => {
+          expect(kid).toBe("provider-key-1");
+          expect(jwks).toBe("https://provider.example/.well-known/jwks.json");
+          return jwk;
+        },
+      });
+
+      expect(result).toEqual({
+        valid: true,
+        algorithm: "RS256",
+        keyId: "provider-key-1",
+      });
+    });
+
+    it("verifies a real ES256 detached signature", async () => {
+      const { publicKey, privateKey } = generateKeyPairSync("ec", {
+        namedCurve: "prime256v1",
+      });
+
+      const unsignedSignal = {
+        type: "walletTrust",
+        provider: "example-provider",
+        checkedAt: "2026-03-11T12:00:00Z",
+        ttlSeconds: 300,
+        compositeScore: 0.72,
+      };
+
+      const signature = signBuffer(
+        "sha256",
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        {
+          key: privateKey,
+          dsaEncoding: "ieee-p1363",
+        },
+      ).toString("base64url");
+
+      const result = await verifyColdStartSignalSignature(
+        {
+          ...unsignedSignal,
+          sig: signature,
+          kid: "p256-key-1",
+          alg: "ES256",
+        },
+        {
+          jwk: publicKey.export({ format: "jwk" }) as JsonWebKey,
+        },
+      );
+
+      expect(result).toEqual({
+        valid: true,
+        algorithm: "ES256",
+        keyId: "p256-key-1",
+      });
+    });
+
+    it("verifies a real Ed25519 detached signature via EdDSA", async () => {
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+
+      const unsignedSignal = {
+        type: "discoveryAttestation",
+        provider: "x402-discovery",
+        checkedAt: "2026-03-11T12:00:00Z",
+        ttlSeconds: 300,
+        serviceId: "legacy/cf-pay-per-crawl",
+      };
+
+      const signature = signBuffer(
+        null,
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        privateKey,
+      ).toString("base64url");
+
+      const jwk = publicKey.export({ format: "jwk" }) as JsonWebKey;
+
+      const result = await verifyColdStartSignalSignature(
+        {
+          ...unsignedSignal,
+          sig: signature,
+          kid: "ed25519-key-1",
+          alg: "EdDSA",
+        },
+        {
+          jwk,
+        },
+      );
+
+      expect(result).toEqual({
+        valid: true,
+        algorithm: "EdDSA",
+        keyId: "ed25519-key-1",
+      });
+    });
+
+    it("infers EdDSA when the JWK curve is Ed25519", async () => {
+      const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+
+      const unsignedSignal = {
+        type: "reasoningAttestation",
+        provider: "thoughtproof",
+        checkedAt: "2026-03-11T12:00:00Z",
+        ttlSeconds: 300,
+        verdict: "PASS",
+      };
+
+      const signature = signBuffer(
+        null,
+        Buffer.from(canonicalizeColdStartSignal(unsignedSignal), "utf8"),
+        privateKey,
+      ).toString("base64url");
+
+      const result = await verifyColdStartSignalSignature(
+        {
+          ...unsignedSignal,
+          sig: signature,
+          kid: "ed25519-key-2",
+        },
+        {
+          jwk: publicKey.export({ format: "jwk" }) as JsonWebKey,
+        },
+      );
+
+      expect(result).toEqual({
+        valid: true,
+        algorithm: "EdDSA",
+        keyId: "ed25519-key-2",
+      });
+    });
+
+    it("returns an error for unsupported algorithms", async () => {
+      const result = await verifyColdStartSignalSignature(
+        {
+          type: "serviceHealth",
+          sig: "ZmFrZQ",
+          kid: "provider-key-1",
+          alg: "HS256",
+        },
+        {
+          jwk: {
+            kty: "oct",
+            alg: "HS256",
+            k: "ZmFrZQ",
+          },
+        },
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("Unsupported signature algorithm");
+    });
+
+    it("returns an error when the signal is not signed", async () => {
+      const result = await verifyColdStartSignalSignature({
+        type: "serviceHealth",
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("sig and kid");
+    });
+  });
+});

--- a/typescript/packages/extensions/tsup.config.ts
+++ b/typescript/packages/extensions/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsup";
 const baseConfig = {
   entry: {
     index: "src/index.ts",
+    "cold-start/index": "src/cold-start/index.ts",
     "bazaar/index": "src/bazaar/index.ts",
     "sign-in-with-x/index": "src/sign-in-with-x/index.ts",
     "payment-identifier/index": "src/payment-identifier/index.ts",


### PR DESCRIPTION
## Summary
- add a cold-start mitigation patterns draft aligned with the latest discussion in #1375
- add `@x402/extensions/cold-start` helpers for parsing, extraction, freshness checks, and detached signature verification
- cover RS256, ES256, and Ed25519/EdDSA verification paths with regression tests

## Validation
- pnpm exec vitest run test/cold-start.test.ts
- pnpm run build
- TDD review: PASS (257 tests passed; no blocking changes before PR)

Closes #1375
