### PR TITLE
Simulate permit2

### DIFF
--- a/e2e/clients/httpx/uv.lock
+++ b/e2e/clients/httpx/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/mcp-python/uv.lock
+++ b/e2e/clients/mcp-python/uv.lock
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/requests/uv.lock
+++ b/e2e/clients/requests/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/facilitators/python/uv.lock
+++ b/e2e/facilitators/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -2846,7 +2846,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -792,10 +792,10 @@ importers:
     dependencies:
       '@coinbase/cdp-sdk':
         specifier: ^1.22.0
-        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/kit':
         specifier: ^5.0.0
-        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       express:
         specifier: ^4.18.2
         version: 4.21.2
@@ -1539,145 +1539,6 @@ importers:
         version: 4.20.3
       typescript:
         specifier: ^5.3.0
-        version: 5.8.3
-
-  facilitators/external-proxies/cdp:
-    dependencies:
-      '@coinbase/x402':
-        specifier: ^0.7.3
-        version: 0.7.3(@solana/sysvars@6.1.0(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-
-  facilitators/external-proxies/cdp-dev:
-    dependencies:
-      '@coinbase/cdp-sdk':
-        specifier: ^1.22.0
-        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-      x402:
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/legacy/x402
-
-  facilitators/external-proxies/cdp-local:
-    dependencies:
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-      x402:
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/legacy/x402
-
-  facilitators/external-proxies/x402.org:
-    dependencies:
-      '@coinbase/x402':
-        specifier: ^0.7.3
-        version: 0.7.3(@solana/sysvars@6.1.0(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.20.3
-      typescript:
-        specifier: ^5.7.2
         version: 5.8.3
 
   facilitators/typescript:
@@ -2897,9 +2758,6 @@ packages:
 
   '@coinbase/wallet-sdk@4.3.6':
     resolution: {integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==}
-
-  '@coinbase/x402@0.7.3':
-    resolution: {integrity: sha512-mSxxbPnDCvSLfq6ZZAB5P1HyYQfQNSdWyY01Cn7yjzTuGUFFgZ7onDkbZnZ1Yry0UnG467aqrmjs6AgoYgpzCQ==}
 
   '@craftamap/esbuild-plugin-html@0.9.0':
     resolution: {integrity: sha512-V5LFrcGXQWU1SSzYPwxEFjF8IjeXW0oTKh5c0xyhGuTNoEnjgJRNSX83HnZ5TTAutJfo/MAyWA4Z9/fIwbMhUQ==}
@@ -9579,9 +9437,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  x402@0.7.3:
-    resolution: {integrity: sha512-8CIZsdMTOn52PjMH/ErVke9ebeZ7ErwiZ5FL3tN3Wny7Ynxs3LkuB/0q7IoccRLdVXA7f2lueYBJ2iDrElhXnA==}
-
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -10505,26 +10360,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@base-org/account@1.1.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@3.25.71)
-      preact: 10.24.2
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zustand: 5.0.3(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
   '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
@@ -10553,29 +10388,6 @@ snapshots:
       '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      abitype: 1.0.6(typescript@5.8.3)(zod@3.25.71)
-      axios: 1.13.4
-      axios-retry: 4.5.0(axios@1.13.4)
-      jose: 6.1.3
-      md5: 2.3.0
-      uncrypto: 0.1.3
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zod: 3.25.71
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
-      - ws
-
-  '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana/kit': 3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       abitype: 1.0.6(typescript@5.8.3)(zod@3.25.71)
       axios: 1.13.4
@@ -10694,67 +10506,6 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
-
-  '@coinbase/wallet-sdk@4.3.6(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@3.25.71)
-      preact: 10.24.2
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zustand: 5.0.3(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
-  '@coinbase/x402@0.7.3(@solana/sysvars@6.1.0(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@coinbase/cdp-sdk': 1.38.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      x402: 0.7.3(@solana/sysvars@6.1.0(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      zod: 3.25.71
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - ws
 
   '@craftamap/esbuild-plugin-html@0.9.0(bufferutil@4.0.9)(esbuild@0.25.5)(utf-8-validate@5.0.10)':
     dependencies:
@@ -11707,41 +11458,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      valtio: 1.13.2(react@19.2.3)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-pay@1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
@@ -11786,42 +11502,6 @@ snapshots:
       '@reown/appkit-utils': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.2)(react@19.2.1))(zod@3.25.71)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-pay@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
-      lit: 3.3.0
-      valtio: 1.13.2(react@19.2.3)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11928,43 +11608,6 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-scaffold-ui@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - valtio
-      - zod
-
   '@reown/appkit-ui@1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
@@ -12004,41 +11647,6 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@reown/appkit-controllers': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-      qrcode: 1.5.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-ui@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -12146,44 +11754,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      valtio: 1.13.2(react@19.2.3)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-wallet@1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -12252,49 +11822,6 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit@1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-pay': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.3))(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      bs58: 6.0.0
-      valtio: 1.13.2(react@19.2.3)
       viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -12465,10 +11992,6 @@ snapshots:
     dependencies:
       '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/compute-budget@0.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-
   '@solana-program/compute-budget@0.8.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -12480,10 +12003,6 @@ snapshots:
   '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-
-  '@solana-program/system@0.8.1(@solana/kit@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
-    dependencies:
-      '@solana/kit': 3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/token-2022@0.4.2(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))':
     dependencies:
@@ -12500,11 +12019,6 @@ snapshots:
       '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/sysvars': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
 
-  '@solana-program/token-2022@0.6.1(@solana/kit@5.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(typescript@5.8.3))':
-    dependencies:
-      '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/sysvars': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-
   '@solana-program/token@0.5.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -12517,19 +12031,11 @@ snapshots:
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
-  '@solana-program/token@0.6.0(@solana/kit@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
-    dependencies:
-      '@solana/kit': 3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-
   '@solana-program/token@0.9.0(@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/token@0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-
-  '@solana-program/token@0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
 
@@ -13105,27 +12611,27 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/kit@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/kit@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/codecs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/functional': 3.0.3(typescript@5.8.3)
-      '@solana/instruction-plans': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/instructions': 3.0.3(typescript@5.8.3)
-      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/programs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-parsed-types': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-spec-types': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/signers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/sysvars': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transaction-confirmation': 3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/accounts': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/functional': 5.0.0(typescript@5.8.3)
+      '@solana/instruction-plans': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/instructions': 5.0.0(typescript@5.8.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/programs': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-parsed-types': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/signers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/sysvars': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-confirmation': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -13646,15 +13152,6 @@ snapshots:
       typescript: 5.8.3
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
-  '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/functional': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.8.3)
-      '@solana/subscribable': 3.0.3(typescript@5.8.3)
-      typescript: 5.8.3
-      ws: 8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-
   '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.8.3)
@@ -13663,6 +13160,15 @@ snapshots:
       '@solana/subscribable': 3.0.3(typescript@5.8.3)
       typescript: 5.8.3
       ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
+  '@solana/rpc-subscriptions-channel-websocket@5.0.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/functional': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-subscriptions-spec': 5.0.0(typescript@5.8.3)
+      '@solana/subscribable': 5.0.0(typescript@5.8.3)
+      typescript: 5.8.3
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   '@solana/rpc-subscriptions-channel-websocket@5.0.0(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
@@ -13793,19 +13299,19 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/rpc-subscriptions@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/fast-stable-stringify': 3.0.3(typescript@5.8.3)
-      '@solana/functional': 3.0.3(typescript@5.8.3)
-      '@solana/promises': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-spec-types': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-subscriptions-api': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions-channel-websocket': 3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-transformers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/subscribable': 3.0.3(typescript@5.8.3)
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/fast-stable-stringify': 5.0.0(typescript@5.8.3)
+      '@solana/functional': 5.0.0(typescript@5.8.3)
+      '@solana/promises': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-spec-types': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-subscriptions-api': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions-channel-websocket': 5.0.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-spec': 5.0.0(typescript@5.8.3)
+      '@solana/rpc-transformers': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/subscribable': 5.0.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -14279,18 +13785,18 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/transaction-confirmation@3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/transaction-confirmation@5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/promises': 3.0.3(typescript@5.8.3)
-      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 3.0.3(typescript@5.8.3)(ws@8.18.2(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/addresses': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/codecs-strings': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/errors': 5.0.0(typescript@5.8.3)
+      '@solana/keys': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/promises': 5.0.0(typescript@5.8.3)
+      '@solana/rpc': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/rpc-subscriptions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-types': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transaction-messages': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      '@solana/transactions': 5.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -14706,11 +14212,6 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.8
       react: 19.2.1
-
-  '@tanstack/react-query@5.90.8(react@19.2.3)':
-    dependencies:
-      '@tanstack/query-core': 5.90.8
-      react: 19.2.3
 
   '@trysound/sax@0.2.0': {}
 
@@ -15372,53 +14873,6 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/connectors@6.1.0(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))(zod@3.25.71)':
-    dependencies:
-      '@base-org/account': 1.1.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@coinbase/wallet-sdk': 4.3.6(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@gemini-wallet/core': 0.2.0(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@wagmi/core': 2.22.1(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      '@walletconnect/ethereum-provider': 2.21.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.19(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - uploadthing
-      - use-sync-external-store
-      - utf-8-validate
-      - wagmi
-      - zod
-
   '@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(@types/react@19.2.2)(react@19.2.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.40.3(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
     dependencies:
       eventemitter3: 5.0.1
@@ -15457,20 +14911,6 @@ snapshots:
       zustand: 5.0.0(@types/react@19.2.2)(react@19.2.1)(use-sync-external-store@1.4.0(react@19.2.1))
     optionalDependencies:
       '@tanstack/query-core': 5.90.8
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@2.22.1(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.8.3)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zustand: 5.0.0(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
-    optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - '@types/react'
@@ -15624,47 +15064,6 @@ snapshots:
   '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@walletconnect/jsonrpc-http-connection': 1.0.8
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/ethereum-provider@2.21.1(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit': 1.7.8(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
@@ -16882,10 +16281,6 @@ snapshots:
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.2)(react@19.2.1)):
     dependencies:
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
-
-  derive-valtio@0.1.0(valtio@1.13.2(react@19.2.3)):
-    dependencies:
-      valtio: 1.13.2(react@19.2.3)
 
   des.js@1.1.0:
     dependencies:
@@ -19041,26 +18436,6 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  porto@0.2.19(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)):
-    dependencies:
-      '@wagmi/core': 2.22.1(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      hono: 4.10.2
-      idb-keyval: 6.2.2
-      mipd: 0.0.7(typescript@5.8.3)
-      ox: 0.9.12(typescript@5.8.3)(zod@4.1.12)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zod: 4.1.12
-      zustand: 5.0.8(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
-    optionalDependencies:
-      '@tanstack/react-query': 5.90.8(react@19.2.3)
-      react: 19.2.3
-      typescript: 5.8.3
-      wagmi: 2.18.2(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - use-sync-external-store
-
   poseidon-lite@0.2.1: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -19405,7 +18780,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.1
       uuid: 8.3.2
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
@@ -20160,10 +19535,6 @@ snapshots:
     dependencies:
       react: 19.2.1
 
-  use-sync-external-store@1.2.0(react@19.2.3):
-    dependencies:
-      react: 19.2.3
-
   use-sync-external-store@1.4.0(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -20171,10 +19542,6 @@ snapshots:
   use-sync-external-store@1.4.0(react@19.2.1):
     dependencies:
       react: 19.2.1
-
-  use-sync-external-store@1.4.0(react@19.2.3):
-    dependencies:
-      react: 19.2.3
 
   utf-8-validate@5.0.10:
     dependencies:
@@ -20215,14 +19582,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       react: 19.2.1
-
-  valtio@1.13.2(react@19.2.3):
-    dependencies:
-      derive-valtio: 0.1.0(valtio@1.13.2(react@19.2.3))
-      proxy-compare: 2.6.0
-      use-sync-external-store: 1.2.0(react@19.2.3)
-    optionalDependencies:
-      react: 19.2.3
 
   vary@1.1.2: {}
 
@@ -20573,45 +19932,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71):
-    dependencies:
-      '@tanstack/react-query': 5.90.8(react@19.2.3)
-      '@wagmi/connectors': 6.1.0(@tanstack/react-query@5.90.8(react@19.2.3))(@wagmi/core@2.22.1(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))(zod@3.25.71)
-      '@wagmi/core': 2.22.1(react@19.2.3)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      react: 19.2.3
-      use-sync-external-store: 1.4.0(react@19.2.3)
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - immer
-      - ioredis
-      - supports-color
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   webextension-polyfill@0.10.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -20746,54 +20066,6 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
-  x402@0.7.3(@solana/sysvars@6.1.0(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10):
-    dependencies:
-      '@scure/base': 1.2.6
-      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana-program/token': 0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana-program/token-2022': 0.6.1(@solana/kit@5.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(typescript@5.8.3))
-      '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/transaction-confirmation': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/wallet-standard-features': 1.3.0
-      '@wallet-standard/app': 1.1.0
-      '@wallet-standard/base': 1.1.0
-      '@wallet-standard/features': 1.1.0
-      viem: 2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      wagmi: 2.18.2(@tanstack/react-query@5.90.8(react@19.2.3))(bufferutil@4.0.9)(react@19.2.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.45.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)
-      zod: 3.25.71
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -20859,11 +20131,6 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
 
-  zustand@5.0.0(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
-    optionalDependencies:
-      react: 19.2.3
-      use-sync-external-store: 1.4.0(react@19.2.3)
-
   zustand@5.0.3(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0)):
     optionalDependencies:
       '@types/react': 19.2.2
@@ -20876,11 +20143,6 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
 
-  zustand@5.0.3(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
-    optionalDependencies:
-      react: 19.2.3
-      use-sync-external-store: 1.4.0(react@19.2.3)
-
   zustand@5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0)):
     optionalDependencies:
       '@types/react': 19.2.2
@@ -20892,8 +20154,3 @@ snapshots:
       '@types/react': 19.2.2
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
-
-  zustand@5.0.8(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3)):
-    optionalDependencies:
-      react: 19.2.3
-      use-sync-external-store: 1.4.0(react@19.2.3)

--- a/e2e/scripts/permit2-approval.ts
+++ b/e2e/scripts/permit2-approval.ts
@@ -8,7 +8,7 @@
  *   pnpm tsx scripts/permit2-approval.ts approve [tokenAddress]
  *   pnpm tsx scripts/permit2-approval.ts revoke  [tokenAddress]
  *
- * If tokenAddress is not provided, defaults to Base Sepolia USDC.
+ * If tokenAddress is not provided, processes all known tokens.
  *
  * Environment variables required:
  *   CLIENT_EVM_PRIVATE_KEY - Private key of the client wallet
@@ -43,6 +43,11 @@ const TOKENS_BY_NETWORK: Record<string, Record<string, { address: `0x${string}`;
       decimals: 6,
       name: 'USDC',
     },
+    MockERC20: {
+      address: '0xeED520980fC7C7B4eB379B96d61CEdea2423005a',
+      decimals: 6,
+      name: 'MockERC20',
+    },
   },
   'eip155:8453': {
     USDC: {
@@ -67,6 +72,8 @@ const erc20Abi = parseAbi([
 
 async function main() {
   const action = process.argv[2];
+  const tokenAddressArg = process.argv[3];
+  const filterAddress = tokenAddressArg ? (getAddress(tokenAddressArg) as `0x${string}`) : undefined;
 
   if (!action || (action !== 'approve' && action !== 'revoke')) {
     console.log(`
@@ -76,7 +83,7 @@ Usage:
   pnpm tsx scripts/permit2-approval.ts approve [tokenAddress]
   pnpm tsx scripts/permit2-approval.ts revoke  [tokenAddress]
 
-If tokenAddress is not provided, defaults to Base Sepolia USDC.
+If tokenAddress is not provided, processes all known tokens (USDC and MockERC20).
 
 Environment variables required:
   CLIENT_EVM_PRIVATE_KEY - Private key of the client wallet
@@ -139,8 +146,20 @@ Environment variables required:
   }
   console.log();
 
+  const tokensToProcess = filterAddress
+    ? tokenStates.filter((t) => getAddress(t.address) === filterAddress)
+    : tokenStates;
+
+  if (tokensToProcess.length === 0) {
+    const addr = filterAddress ?? 'none';
+    console.error(`❌ No matching token found for address ${addr}`);
+    process.exit(1);
+  }
+
+  let nonce = await publicClient.getTransactionCount({ address: account.address });
+
   if (action === 'revoke') {
-    for (const token of tokenStates) {
+    for (const token of tokensToProcess) {
       if (token.allowance === 0n) {
         console.log(`✅ ${token.name}: Permit2 approval already revoked (allowance is 0)`);
         continue;
@@ -153,6 +172,7 @@ Environment variables required:
         abi: erc20Abi,
         functionName: 'approve',
         args: [PERMIT2_ADDRESS, 0n],
+        nonce: nonce++,
       });
 
       console.log(`   📝 Transaction: ${hash}`);
@@ -169,7 +189,7 @@ Environment variables required:
   }
 
   // action === 'approve'
-  for (const token of tokenStates) {
+  for (const token of tokensToProcess) {
     if (token.allowance === MAX_UINT256) {
       console.log(`✅ ${token.name}: Permit2 already has unlimited approval`);
       continue;
@@ -182,6 +202,7 @@ Environment variables required:
       abi: erc20Abi,
       functionName: 'approve',
       args: [PERMIT2_ADDRESS, MAX_UINT256],
+      nonce: nonce++,
     });
 
     console.log(`   📝 Transaction: ${hash}`);

--- a/e2e/servers/express/index.ts
+++ b/e2e/servers/express/index.ts
@@ -166,32 +166,32 @@ app.use(
       },
       ...(APTOS_PAYEE_ADDRESS
         ? {
-            "GET /protected-aptos": {
-              accepts: {
-                payTo: APTOS_PAYEE_ADDRESS,
-                scheme: "exact",
-                price: "$0.001",
-                network: APTOS_NETWORK,
-              },
-              extensions: {
-                ...declareDiscoveryExtension({
-                  output: {
-                    example: {
-                      message: "Protected endpoint accessed successfully",
-                      timestamp: "2024-01-01T00:00:00Z",
-                    },
-                    schema: {
-                      properties: {
-                        message: { type: "string" },
-                        timestamp: { type: "string" },
-                      },
-                      required: ["message", "timestamp"],
-                    },
-                  },
-                }),
-              },
+          "GET /protected-aptos": {
+            accepts: {
+              payTo: APTOS_PAYEE_ADDRESS,
+              scheme: "exact",
+              price: "$0.001",
+              network: APTOS_NETWORK,
             },
-          }
+            extensions: {
+              ...declareDiscoveryExtension({
+                output: {
+                  example: {
+                    message: "Protected endpoint accessed successfully",
+                    timestamp: "2024-01-01T00:00:00Z",
+                  },
+                  schema: {
+                    properties: {
+                      message: { type: "string" },
+                      timestamp: { type: "string" },
+                    },
+                    required: ["message", "timestamp"],
+                  },
+                },
+              }),
+            },
+          },
+        }
         : {}),
       // Permit2 endpoint for ERC-20 approval gas sponsoring (no EIP-2612)
       "GET /protected-permit2-erc20": {
@@ -211,7 +211,7 @@ app.use(
           ...declareErc20ApprovalGasSponsoringExtension(),
         },
       },
-      // Permit2 endpoint - explicitly requires Permit2 flow instead of EIP-3009
+      // Permit2 standard/direct endpoint - no gas sponsoring, client must pre-approve Permit2
       "GET /protected-permit2": {
         accepts: {
           payTo: EVM_PAYEE_ADDRESS,
@@ -243,37 +243,66 @@ app.use(
               },
             },
           }),
+        },
+      },
+      // Permit2 endpoint with EIP-2612 gas sponsoring
+      "GET /protected-permit2-eip2612": {
+        accepts: {
+          payTo: EVM_PAYEE_ADDRESS,
+          scheme: "exact",
+          network: EVM_NETWORK,
+          price: "$0.001",
+          extra: { assetTransferMethod: "permit2" },
+        },
+        extensions: {
+          ...declareDiscoveryExtension({
+            output: {
+              example: {
+                message: "Permit2 EIP-2612 endpoint accessed successfully",
+                timestamp: "2024-01-01T00:00:00Z",
+                method: "permit2-eip2612",
+              },
+              schema: {
+                properties: {
+                  message: { type: "string" },
+                  timestamp: { type: "string" },
+                  method: { type: "string" },
+                },
+                required: ["message", "timestamp", "method"],
+              },
+            },
+          }),
           ...declareEip2612GasSponsoringExtension(),
         },
       },
       ...(STELLAR_PAYEE_ADDRESS
         ? {
-            "GET /protected-stellar": {
-              accepts: {
-                payTo: STELLAR_PAYEE_ADDRESS!,
-                scheme: "exact",
-                price: "$0.001",
-                network: STELLAR_NETWORK,
-              },
-              extensions: {
-                ...declareDiscoveryExtension({
-                  output: {
-                    example: {
-                      message: "Protected Stellar endpoint accessed successfully",
-                      timestamp: "2024-01-01T00:00:00Z",
-                    },
-                    schema: {
-                      properties: {
-                        message: { type: "string" },
-                        timestamp: { type: "string" },
-                      },
-                      required: ["message", "timestamp"],
-                    },
-                  },
-                }),
-              },
+          "GET /protected-stellar": {
+            accepts: {
+              payTo: STELLAR_PAYEE_ADDRESS!,
+              scheme: "exact",
+              price: "$0.001",
+              network: STELLAR_NETWORK,
             },
-          }
+            extensions: {
+              ...declareDiscoveryExtension({
+                output: {
+                  example: {
+                    message: "Protected Stellar endpoint accessed successfully",
+                    timestamp: "2024-01-01T00:00:00Z",
+                  },
+                  schema: {
+                    properties: {
+                      message: { type: "string" },
+                      timestamp: { type: "string" },
+                    },
+                    required: ["message", "timestamp"],
+                  },
+                },
+              }),
+            },
+          },
+        }
         : {}),
     },
     server, // Pass pre-configured server instance
@@ -350,6 +379,19 @@ app.get("/protected-permit2", (req, res) => {
 });
 
 /**
+ * Protected Permit2 EIP-2612 endpoint - requires payment via Permit2 with gas sponsoring
+ *
+ * Uses EIP-2612 permit atomically in settleWithPermit. No pre-approval needed.
+ */
+app.get("/protected-permit2-eip2612", (req, res) => {
+  res.json({
+    message: "Permit2 EIP-2612 endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+    method: "permit2-eip2612",
+  });
+});
+
+/**
  * Protected Stellar endpoint - requires payment to access
  *
  * This endpoint demonstrates a resource protected by x402 payment middleware for Stellar.
@@ -414,7 +456,8 @@ app.listen(parseInt(PORT), () => {
 ║  • GET  /protected             (EIP-3009 payment - EVM)    ║
 ║  • GET  /protected-svm         (SVM payment)               ║
 ║  • GET  /protected-aptos       (Aptos payment)             ║
-║  • GET  /protected-permit2     (Permit2 payment - EVM)     ║
+║  • GET  /protected-permit2     (Permit2 direct - EVM)       ║
+║  • GET  /protected-permit2-eip2612 (Permit2 + EIP-2612)    ║
 ║  • GET  /protected-permit2-erc20 (Permit2 + ERC-20 approval) ║
 ║  • GET  /protected-stellar     (Stellar payment)           ║
 ║  • GET  /health                (no payment required)       ║

--- a/e2e/servers/express/test.config.json
+++ b/e2e/servers/express/test.config.json
@@ -16,7 +16,16 @@
     {
       "path": "/protected-permit2",
       "method": "GET",
-      "description": "Protected endpoint requiring Permit2 payment",
+      "description": "Protected endpoint requiring Permit2 payment (standard settle, no gas sponsoring)",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "permit2Direct": true
+    },
+    {
+      "path": "/protected-permit2-eip2612",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment with EIP-2612 gas sponsoring",
       "requiresPayment": true,
       "protocolFamily": "evm",
       "transferMethod": "permit2"

--- a/e2e/servers/fastapi/uv.lock
+++ b/e2e/servers/fastapi/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -2841,7 +2841,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/flask/uv.lock
+++ b/e2e/servers/flask/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -2072,7 +2072,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/gin/main.go
+++ b/e2e/servers/gin/main.go
@@ -148,8 +148,28 @@ func main() {
 			types.BAZAAR.Key(): discoveryExtension,
 		},
 	},
+	// Permit2 direct endpoint - standard settle, no gas sponsoring (client must pre-approve Permit2)
+	"GET /protected-permit2": {
+		Accepts: x402http.PaymentOptions{
+			{
+				Scheme:  "exact",
+				PayTo:   evmPayeeAddress,
+				Network: evmNetwork,
+				Price: map[string]interface{}{
+					"amount": "1000",
+					"asset":  "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+					"extra": map[string]interface{}{
+						"assetTransferMethod": "permit2",
+					},
+				},
+			},
+		},
+		Extensions: map[string]interface{}{
+			types.BAZAAR.Key(): discoveryExtension,
+		},
+	},
 	// Permit2 endpoint - explicitly requires Permit2 flow instead of EIP-3009
-		"GET /protected-permit2": {
+		"GET /protected-permit2-eip2612": {
 			Accepts: x402http.PaymentOptions{
 				{
 					Scheme:  "exact",
@@ -280,10 +300,7 @@ func main() {
 	})
 
 	/**
-	 * Protected Permit2 endpoint - requires payment via Permit2 flow
-	 *
-	 * This endpoint demonstrates the Permit2 payment flow.
-	 * Clients must have approved Permit2 to spend their USDC before accessing.
+	 * Protected Permit2 direct endpoint - standard settle (no gas sponsoring)
 	 */
 	r.GET("/protected-permit2", func(c *ginfw.Context) {
 		if shutdownRequested {
@@ -297,6 +314,25 @@ func main() {
 			"message":   "Permit2 endpoint accessed successfully",
 			"timestamp": time.Now().Format(time.RFC3339),
 			"method":    "permit2",
+		})
+	})
+
+	/**
+	 * Protected Permit2 EIP-2612 endpoint - requires payment via Permit2 with gas sponsoring.
+	 * Uses EIP-2612 permit atomically in settleWithPermit. No pre-approval needed.
+	 */
+	r.GET("/protected-permit2-eip2612", func(c *ginfw.Context) {
+		if shutdownRequested {
+			c.JSON(http.StatusServiceUnavailable, ginfw.H{
+				"error": "Server shutting down",
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, ginfw.H{
+			"message":   "Permit2 EIP-2612 endpoint accessed successfully",
+			"timestamp": time.Now().Format(time.RFC3339),
+			"method":    "permit2-eip2612",
 		})
 	})
 
@@ -380,7 +416,8 @@ func main() {
 ║  Endpoints:                                            ║
 ║  • GET  /protected              (EIP-3009 payment)    ║
 ║  • GET  /protected-svm          (SVM payment)         ║
-║  • GET  /protected-permit2      (Permit2 payment)     ║
+║  • GET  /protected-permit2     (Permit2 - EVM)        ║
+║  • GET  /protected-permit2-eip2612 (Permit2 + EIP-2612)║
 ║  • GET  /protected-permit2-erc20 (Permit2 ERC-20)     ║
 ║  • GET  /health                 (no payment required)  ║
 ║  • POST /close                  (shutdown server)      ║

--- a/e2e/servers/gin/test.config.json
+++ b/e2e/servers/gin/test.config.json
@@ -21,7 +21,16 @@
     {
       "path": "/protected-permit2",
       "method": "GET",
-      "description": "Protected endpoint requiring Permit2 payment",
+      "description": "Protected endpoint requiring Permit2 payment (standard settle, no gas sponsoring)",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "permit2Direct": true
+    },
+    {
+      "path": "/protected-permit2-eip2612",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment with EIP-2612 gas sponsoring",
       "requiresPayment": true,
       "protocolFamily": "evm",
       "transferMethod": "permit2"

--- a/e2e/servers/hono/index.ts
+++ b/e2e/servers/hono/index.ts
@@ -171,32 +171,32 @@ app.use(
       },
       ...(APTOS_PAYEE_ADDRESS
         ? {
-            "GET /protected-aptos": {
-              accepts: {
-                payTo: APTOS_PAYEE_ADDRESS,
-                scheme: "exact",
-                price: "$0.001",
-                network: APTOS_NETWORK,
-              },
-              extensions: {
-                ...declareDiscoveryExtension({
-                  output: {
-                    example: {
-                      message: "Protected endpoint accessed successfully",
-                      timestamp: "2024-01-01T00:00:00Z",
-                    },
-                    schema: {
-                      properties: {
-                        message: { type: "string" },
-                        timestamp: { type: "string" },
-                      },
-                      required: ["message", "timestamp"],
-                    },
-                  },
-                }),
-              },
+          "GET /protected-aptos": {
+            accepts: {
+              payTo: APTOS_PAYEE_ADDRESS,
+              scheme: "exact",
+              price: "$0.001",
+              network: APTOS_NETWORK,
             },
-          }
+            extensions: {
+              ...declareDiscoveryExtension({
+                output: {
+                  example: {
+                    message: "Protected endpoint accessed successfully",
+                    timestamp: "2024-01-01T00:00:00Z",
+                  },
+                  schema: {
+                    properties: {
+                      message: { type: "string" },
+                      timestamp: { type: "string" },
+                    },
+                    required: ["message", "timestamp"],
+                  },
+                },
+              }),
+            },
+          },
+        }
         : {}),
       "GET /protected-permit2": {
         accepts: {
@@ -218,6 +218,35 @@ app.use(
                 message: "Permit2 endpoint accessed successfully",
                 timestamp: "2024-01-01T00:00:00Z",
                 method: "permit2",
+              },
+              schema: {
+                properties: {
+                  message: { type: "string" },
+                  timestamp: { type: "string" },
+                  method: { type: "string" },
+                },
+                required: ["message", "timestamp", "method"],
+              },
+            },
+          }),
+        },
+      },
+      "GET /protected-permit2-eip2612": {
+        accepts: {
+          payTo: EVM_PAYEE_ADDRESS,
+          scheme: "exact",
+          network: EVM_NETWORK,
+          price: "$0.001",
+          // Use pre-parsed price with assetTransferMethod to force Permit2
+          extra: { assetTransferMethod: "permit2" },
+        },
+        extensions: {
+          ...declareDiscoveryExtension({
+            output: {
+              example: {
+                message: "Permit2 EIP-2612 endpoint accessed successfully",
+                timestamp: "2024-01-01T00:00:00Z",
+                method: "permit2-eip2612",
               },
               schema: {
                 properties: {
@@ -251,32 +280,32 @@ app.use(
       },
       ...(STELLAR_PAYEE_ADDRESS
         ? {
-            "GET /protected-stellar": {
-              accepts: {
-                payTo: STELLAR_PAYEE_ADDRESS!,
-                scheme: "exact",
-                price: "$0.001",
-                network: STELLAR_NETWORK,
-              },
-              extensions: {
-                ...declareDiscoveryExtension({
-                  output: {
-                    example: {
-                      message: "Protected Stellar endpoint accessed successfully",
-                      timestamp: "2024-01-01T00:00:00Z",
-                    },
-                    schema: {
-                      properties: {
-                        message: { type: "string" },
-                        timestamp: { type: "string" },
-                      },
-                      required: ["message", "timestamp"],
-                    },
-                  },
-                }),
-              },
+          "GET /protected-stellar": {
+            accepts: {
+              payTo: STELLAR_PAYEE_ADDRESS!,
+              scheme: "exact",
+              price: "$0.001",
+              network: STELLAR_NETWORK,
             },
-          }
+            extensions: {
+              ...declareDiscoveryExtension({
+                output: {
+                  example: {
+                    message: "Protected Stellar endpoint accessed successfully",
+                    timestamp: "2024-01-01T00:00:00Z",
+                  },
+                  schema: {
+                    properties: {
+                      message: { type: "string" },
+                      timestamp: { type: "string" },
+                    },
+                    required: ["message", "timestamp"],
+                  },
+                },
+              }),
+            },
+          },
+        }
         : {}),
     },
     x402Server, // Pass pre-configured server instance
@@ -324,7 +353,7 @@ app.get("/protected-aptos", c => {
 });
 
 /**
- * Protected Permit2 endpoint - requires Permit2 payment with EIP-2612 gas sponsoring
+ * Protected Permit2 endpoint - standard settle (no gas sponsoring)
  */
 app.get("/protected-permit2", c => {
   return c.json({
@@ -335,6 +364,16 @@ app.get("/protected-permit2", c => {
 });
 
 /**
+ * Protected Permit2 EIP-2612 endpoint - requires Permit2 with gas sponsoring
+ */
+app.get("/protected-permit2-eip2612", c => {
+  return c.json({
+    message: "Permit2 EIP-2612 endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+    method: "permit2-eip2612",
+  });
+});
+
 /**
  * Protected Permit2 ERC-20 endpoint - requires Permit2 payment with ERC-20 approval gas sponsoring
  */
@@ -414,7 +453,8 @@ console.log(`
 ║                                                        ║
 ║  Endpoints:                                            ║
 ║  • GET  /protected               (EIP-3009 payment)        ║
-║  • GET  /protected-permit2       (Permit2 + EIP-2612)      ║
+║  • GET  /protected-permit2     (Permit2 - EVM)             ║
+║  • GET  /protected-permit2-eip2612 (Permit2 + EIP-2612)    ║
 ║  • GET  /protected-permit2-erc20 (Permit2 + ERC-20 approval)║
 ║  • GET  /protected-svm           (SVM payment)             ║
 ║  • GET  /protected-aptos         (Aptos payment)           ║

--- a/e2e/servers/hono/test.config.json
+++ b/e2e/servers/hono/test.config.json
@@ -16,7 +16,16 @@
     {
       "path": "/protected-permit2",
       "method": "GET",
-      "description": "Protected endpoint requiring Permit2 payment",
+      "description": "Protected endpoint requiring Permit2 payment (standard settle, no gas sponsoring)",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "permit2Direct": true
+    },
+    {
+      "path": "/protected-permit2-eip2612",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment with EIP-2612 gas sponsoring",
       "requiresPayment": true,
       "protocolFamily": "evm",
       "transferMethod": "permit2"

--- a/e2e/servers/mcp-python/uv.lock
+++ b/e2e/servers/mcp-python/uv.lock
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/next/app/api/protected-permit2-eip2612-proxy/route.ts
+++ b/e2e/servers/next/app/api/protected-permit2-eip2612-proxy/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Protected Permit2 EIP-2612 endpoint requiring payment (proxy middleware)
+ */
+export const runtime = "nodejs";
+
+export async function GET() {
+  return NextResponse.json({
+    message: "Permit2 EIP-2612 endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+    method: "permit2-eip2612",
+  });
+}

--- a/e2e/servers/next/proxy.ts
+++ b/e2e/servers/next/proxy.ts
@@ -190,6 +190,34 @@ export const proxy = paymentProxy(
             },
           },
         }),
+      },
+    },
+    "/api/protected-permit2-eip2612-proxy": {
+      accepts: {
+        payTo: EVM_PAYEE_ADDRESS,
+        scheme: "exact",
+        network: EVM_NETWORK,
+        price: "$0.001",
+        extra: { assetTransferMethod: "permit2" },
+      },
+      extensions: {
+        ...declareDiscoveryExtension({
+          output: {
+            example: {
+              message: "Permit2 EIP-2612 endpoint accessed successfully",
+              timestamp: "2024-01-01T00:00:00Z",
+              method: "permit2-eip2612",
+            },
+            schema: {
+              properties: {
+                message: { type: "string" },
+                timestamp: { type: "string" },
+                method: { type: "string" },
+              },
+              required: ["message", "timestamp", "method"],
+            },
+          },
+        }),
         ...declareEip2612GasSponsoringExtension(),
       },
     },
@@ -221,6 +249,7 @@ export const config = {
     "/api/protected-aptos-proxy",
     "/api/protected-stellar-proxy",
     "/api/protected-permit2-proxy",
+    "/api/protected-permit2-eip2612-proxy",
     "/api/protected-permit2-erc20-proxy",
   ],
 };

--- a/e2e/servers/next/test.config.json
+++ b/e2e/servers/next/test.config.json
@@ -16,7 +16,16 @@
     {
       "path": "/api/protected-permit2-proxy",
       "method": "GET",
-      "description": "Protected Permit2 endpoint using proxy middleware",
+      "description": "Protected Permit2 direct endpoint (standard settle, no gas sponsoring)",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "permit2Direct": true
+    },
+    {
+      "path": "/api/protected-permit2-eip2612-proxy",
+      "method": "GET",
+      "description": "Protected Permit2 EIP-2612 endpoint using proxy middleware",
       "requiresPayment": true,
       "protocolFamily": "evm",
       "transferMethod": "permit2"

--- a/e2e/src/types.ts
+++ b/e2e/src/types.ts
@@ -53,6 +53,8 @@ export interface TestEndpoint {
   protocolFamily?: ProtocolFamily;
   transferMethod?: TransferMethod;
   extensions?: string[];
+  /** True for Permit2 standard/direct settle - requires pre-approval (approve before test, not revoke) */
+  permit2Direct?: boolean;
   health?: boolean;
   close?: boolean;
 }

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -15,6 +15,10 @@ import { Semaphore, FacilitatorLock } from './src/concurrency';
 import { FacilitatorManager } from './src/facilitators/facilitator-manager';
 import { waitForHealth } from './src/health';
 
+// Base Sepolia token addresses used by permit2 E2E tests
+const USDC_BASE_SEPOLIA = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
+const MOCK_ERC20_BASE_SEPOLIA = '0xeED520980fC7C7B4eB379B96d61CEdea2423005a';
+
 /**
  * Approve Permit2 so that the standard/direct settle path can be exercised.
  * Grants unlimited Permit2 allowance for the given token (or USDC by default).
@@ -698,10 +702,13 @@ async function runTest() {
 
         if (scenario.endpoint.transferMethod === 'permit2') {
           if (scenario.endpoint.permit2Direct) {
-            await approvePermit2Approval();
+            await approvePermit2Approval(USDC_BASE_SEPOLIA);
           } else {
-            await revokePermit2Approval();
-            await revokePermit2Approval('0xeED520980fC7C7B4eB379B96d61CEdea2423005a');
+            const token =
+              scenario.endpoint.extensions?.includes('erc20ApprovalGasSponsoring')
+                ? MOCK_ERC20_BASE_SEPOLIA
+                : USDC_BASE_SEPOLIA;
+            await revokePermit2Approval(token);
           }
         }
 

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -16,6 +16,56 @@ import { FacilitatorManager } from './src/facilitators/facilitator-manager';
 import { waitForHealth } from './src/health';
 
 /**
+ * Approve Permit2 so that the standard/direct settle path can be exercised.
+ * Grants unlimited Permit2 allowance for the given token (or USDC by default).
+ */
+async function approvePermit2Approval(tokenAddress?: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const label = tokenAddress ? `token ${tokenAddress}` : 'USDC (default)';
+    verboseLog(`  🔓 Approving Permit2 for ${label}...`);
+
+    const args = ['scripts/permit2-approval.ts', 'approve'];
+    if (tokenAddress) {
+      args.push(tokenAddress);
+    }
+    const child = spawn('tsx', args, {
+      cwd: process.cwd(),
+      stdio: 'pipe',
+      shell: true,
+    });
+
+    let stderr = '';
+
+    child.stdout?.on('data', (data) => {
+      verboseLog(data.toString().trim());
+    });
+
+    child.stderr?.on('data', (data) => {
+      stderr += data.toString();
+      verboseLog(data.toString().trim());
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        verboseLog('  ✅ Permit2 approval granted');
+        resolve(true);
+      } else {
+        errorLog(`  ❌ Permit2 approve failed (exit code ${code})`);
+        if (stderr) {
+          errorLog(`  Error: ${stderr}`);
+        }
+        resolve(false);
+      }
+    });
+
+    child.on('error', (error) => {
+      errorLog(`  ❌ Failed to run Permit2 approve: ${error.message}`);
+      resolve(false);
+    });
+  });
+}
+
+/**
  * Revoke Permit2 approval so that gas sponsoring extensions are exercised.
  * Sets the Permit2 allowance to 0 for the given token (or USDC by default),
  * forcing the client into the EIP-2612 or ERC-20 approval extension path.
@@ -323,12 +373,14 @@ async function runTest() {
   if (evmScenarios.length > 0) {
     const hasEip3009 = evmScenarios.some(s => (s.endpoint.transferMethod || 'eip3009') === 'eip3009');
     const hasPermit2 = evmScenarios.some(s => s.endpoint.transferMethod === 'permit2');
-    const hasPermit2Eip2612 = evmScenarios.some(s => s.endpoint.transferMethod === 'permit2' && !s.endpoint.extensions?.includes('erc20ApprovalGasSponsoring'));
+    const hasPermit2Direct = evmScenarios.some(s => s.endpoint.transferMethod === 'permit2' && s.endpoint.permit2Direct === true);
+    const hasPermit2Eip2612 = evmScenarios.some(s => s.endpoint.transferMethod === 'permit2' && !s.endpoint.extensions?.includes('erc20ApprovalGasSponsoring') && !s.endpoint.permit2Direct);
     const hasPermit2Erc20 = evmScenarios.some(s => s.endpoint.transferMethod === 'permit2' && s.endpoint.extensions?.includes('erc20ApprovalGasSponsoring'));
 
     log('🔍 EVM Branch Coverage Check:');
     log(`   EIP-3009 route:          ${hasEip3009 ? '✅' : '❌ MISSING'}`);
     log(`   Permit2 route:           ${hasPermit2 ? '✅' : '❌ MISSING'}`);
+    log(`   Permit2+direct settle:   ${hasPermit2Direct ? '✅' : '⚠️  not found'}`);
     log(`   Permit2+EIP2612 route:   ${hasPermit2Eip2612 ? '✅' : '⚠️  not found (may be covered by permit2 route if eip2612 extension enabled)'}`);
     log(`   Permit2+ERC20 route:     ${hasPermit2Erc20 ? '✅' : '⚠️  not found'}`);
     log('');
@@ -340,7 +392,7 @@ async function runTest() {
   );
 
   if (hasPermit2Scenarios) {
-    log('🔐 Permit2 scenarios detected — approval will be revoked before each test to exercise extension paths');
+    log('🔐 Permit2 scenarios detected — revoke before gas-sponsored tests, approve before permit2-direct tests');
   }
 
   // Collect unique facilitators and servers
@@ -645,8 +697,12 @@ async function runTest() {
         const isEvm = scenario.protocolFamily === 'evm';
 
         if (scenario.endpoint.transferMethod === 'permit2') {
-          await revokePermit2Approval();
-          await revokePermit2Approval('0xeED520980fC7C7B4eB379B96d61CEdea2423005a');
+          if (scenario.endpoint.permit2Direct) {
+            await approvePermit2Approval();
+          } else {
+            await revokePermit2Approval();
+            await revokePermit2Approval('0xeED520980fC7C7B4eB379B96d61CEdea2423005a');
+          }
         }
 
         if (isEvm && facilitatorName && evmLock) {

--- a/go/.changes/unreleased/added-20260313-141700.yaml
+++ b/go/.changes/unreleased/added-20260313-141700.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Added simulation to permit2 verify and (optional) settle
+time: 2026-03-13T14:17:00.280905+09:00

--- a/go/extensions/erc20approvalgassponsor/types.go
+++ b/go/extensions/erc20approvalgassponsor/types.go
@@ -78,6 +78,13 @@ type Erc20ApprovalGasSponsoringSigner interface {
 	SendTransactions(ctx context.Context, transactions []TransactionRequest) ([]string, error)
 }
 
+// Erc20ApprovalGasSponsoringSimulator is an optional extension of Erc20ApprovalGasSponsoringSigner with multi-transaction simulation.
+// The signer owns the simulation strategy.
+type Erc20ApprovalGasSponsoringSimulator interface {
+	Erc20ApprovalGasSponsoringSigner
+	SimulateTransactions(ctx context.Context, transactions []TransactionRequest) (bool, error)
+}
+
 // Erc20ApprovalFacilitatorExtension carries the signer; registered with the facilitator.
 // It implements x402.FacilitatorExtension so it can be registered and retrieved via FacilitatorContext.
 type Erc20ApprovalFacilitatorExtension struct {

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -60,6 +60,9 @@ const (
 
 	// ERC20ApproveGasLimit is the gas limit for a standard ERC-20 approve() transaction.
 	ERC20ApproveGasLimit = 70000
+
+	// DefaultMaxFeePerGas is the fallback max fee per gas (1 gwei) for gas cost estimation.
+	DefaultMaxFeePerGas = 1_000_000_000
 )
 
 var (
@@ -309,6 +312,30 @@ var (
 			],
 			"outputs": [],
 			"stateMutability": "nonpayable"
+		}
+	]`)
+
+	// X402ExactPermit2ProxyPermit2ABI for verifying proxy deployment
+	X402ExactPermit2ProxyPermit2ABI = []byte(`[
+		{
+			"inputs": [],
+			"name": "PERMIT2",
+			"outputs": [{"name": "", "type": "address"}],
+			"stateMutability": "view",
+			"type": "function"
+		}
+	]`)
+
+	// Multicall3GetEthBalanceABI for querying native ETH balance via Multicall3.
+	Multicall3GetEthBalanceABI = []byte(`[
+		{
+			"inputs": [
+				{"name": "addr", "type": "address"}
+			],
+			"name": "getEthBalance",
+			"outputs": [{"name": "balance", "type": "uint256"}],
+			"stateMutability": "view",
+			"type": "function"
 		}
 	]`)
 

--- a/go/mechanisms/evm/exact/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/facilitator/errors.go
@@ -58,6 +58,13 @@ const (
 	ErrPermit2InvalidNonce       = "permit2_invalid_nonce"
 	ErrPermit2612AmountMismatch  = "permit2_2612_amount_mismatch"
 
+	// Permit2 simulation errors
+	ErrPermit2SimulationFailed      = "permit2_simulation_failed"
+	ErrPermit2InsufficientBalance   = "permit2_insufficient_balance"
+	ErrPermit2ProxyNotDeployed      = "permit2_proxy_not_deployed"
+	ErrErc20ApprovalInsufficientEth = "erc20_approval_insufficient_eth_for_gas"
+	ErrErc20ApprovalTxFailed        = "erc20_approval_tx_failed"
+
 	// ERC-20 approval gas sponsoring errors
 	ErrErc20ApprovalInvalidFormat   = "invalid_erc20_approval_extension_format"
 	ErrErc20ApprovalFromMismatch    = "erc20_approval_from_mismatch"

--- a/go/mechanisms/evm/exact/facilitator/permit2.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2.go
@@ -7,14 +7,25 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
-
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/extensions/eip2612gassponsor"
 	"github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
 	"github.com/coinbase/x402/go/mechanisms/evm"
 	"github.com/coinbase/x402/go/types"
 )
+
+// VerifyPermit2Options controls optional behaviour for VerifyPermit2.
+type VerifyPermit2Options struct {
+	// Simulate enables onchain simulation. Defaults to true when zero-value.
+	Simulate *bool
+}
+
+func (o *VerifyPermit2Options) shouldSimulate() bool {
+	if o == nil || o.Simulate == nil {
+		return true
+	}
+	return *o.Simulate
+}
 
 // VerifyPermit2 verifies a Permit2 payment payload.
 func VerifyPermit2(
@@ -24,6 +35,7 @@ func VerifyPermit2(
 	requirements types.PaymentRequirements,
 	permit2Payload *evm.ExactPermit2Payload,
 	facilCtx *x402.FacilitatorContext,
+	opts *VerifyPermit2Options,
 ) (*x402.VerifyResponse, error) {
 	payer := permit2Payload.Permit2Authorization.From
 
@@ -60,8 +72,7 @@ func VerifyPermit2(
 	if !ok {
 		return nil, x402.NewVerifyError(ErrInvalidPayload, payer, "invalid deadline format")
 	}
-	deadlineThreshold := big.NewInt(now + evm.Permit2DeadlineBuffer)
-	if deadline.Cmp(deadlineThreshold) < 0 {
+	if deadline.Cmp(big.NewInt(now+evm.Permit2DeadlineBuffer)) < 0 {
 		return nil, x402.NewVerifyError(ErrPermit2DeadlineExpired, payer, "deadline expired")
 	}
 
@@ -70,8 +81,7 @@ func VerifyPermit2(
 	if !ok {
 		return nil, x402.NewVerifyError(ErrInvalidPayload, payer, "invalid validAfter format")
 	}
-	nowBig := big.NewInt(now)
-	if validAfter.Cmp(nowBig) > 0 {
+	if validAfter.Cmp(big.NewInt(now)) > 0 {
 		return nil, x402.NewVerifyError(ErrPermit2NotYetValid, payer, "not yet valid")
 	}
 
@@ -99,55 +109,38 @@ func VerifyPermit2(
 		return nil, x402.NewVerifyError(ErrInvalidSignatureFormat, payer, err.Error())
 	}
 
-	valid, err := verifyPermit2Signature(ctx, signer, permit2Payload.Permit2Authorization, signatureBytes, chainID)
-	if err != nil || !valid {
-		return nil, x402.NewVerifyError(ErrPermit2InvalidSignature, payer, "invalid signature")
-	}
-
-	needsExtension := true
-	allowance, allowanceErr := signer.ReadContract(ctx, tokenAddress, evm.ERC20AllowanceABI, "allowance",
-		common.HexToAddress(payer), common.HexToAddress(evm.PERMIT2Address))
-	if allowanceErr == nil {
-		if allowanceBig, ok := allowance.(*big.Int); ok && allowanceBig.Cmp(requiredAmount) >= 0 {
-			needsExtension = false
+	sigValid, sigErr := verifyPermit2Signature(ctx, signer, permit2Payload.Permit2Authorization, signatureBytes, chainID)
+	if sigErr != nil || !sigValid {
+		// Check if payer is a deployed smart contract
+		// ERC-1271 signatures may not be verifiable by all signer implementations
+		code, codeErr := signer.GetCode(ctx, payer)
+		if codeErr != nil || len(code) == 0 {
+			return nil, x402.NewVerifyError(ErrPermit2InvalidSignature, payer, "invalid signature")
 		}
+		// Deployed smart contract: fall through to simulation
 	}
 
-	if needsExtension {
-		if extErr := verifyPermit2Extensions(payload, payer, tokenAddress, facilCtx); extErr != nil {
-			return nil, extErr
-		}
+	// Early return when simulation is disabled
+	if !opts.shouldSimulate() {
+		return &x402.VerifyResponse{IsValid: true, Payer: payer}, nil
 	}
 
-	// Check balance
-	balance, err := signer.GetBalance(ctx, payer, tokenAddress)
-	if err == nil && balance.Cmp(requiredAmount) < 0 {
-		return nil, x402.NewVerifyError(ErrInsufficientBalance, payer, "insufficient balance")
-	}
-
-	return &x402.VerifyResponse{
-		IsValid: true,
-		Payer:   payer,
-	}, nil
-}
-
-// verifyPermit2Extensions validates gas-sponsoring extensions when Permit2 allowance
-// is insufficient or could not be read. Returns nil if a valid extension is found,
-// or a VerifyError if none are present/valid.
-func verifyPermit2Extensions(
-	payload types.PaymentPayload,
-	payer string,
-	tokenAddress string,
-	facilCtx *x402.FacilitatorContext,
-) error {
+	// EIP-2612 gas sponsoring (atomic settleWithPermit via contract)
 	eip2612Info, _ := eip2612gassponsor.ExtractEip2612GasSponsoringInfo(payload.Extensions)
 	if eip2612Info != nil {
 		if validErr := validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress); validErr != "" {
-			return x402.NewVerifyError(validErr, payer, "eip2612 validation failed")
+			return nil, x402.NewVerifyError(validErr, payer, "eip2612 validation failed")
 		}
-		return nil
+
+		simOk, simErr := SimulatePermit2SettleWithPermit(ctx, signer, permit2Payload, eip2612Info.Signature, eip2612Info.Amount, eip2612Info.Deadline)
+		if simErr != nil || !simOk {
+			resp := DiagnosePermit2SimulationFailure(ctx, signer, tokenAddress, permit2Payload, requirements.Amount)
+			return nil, x402.NewVerifyError(resp.InvalidReason, payer, "simulation failed")
+		}
+		return &x402.VerifyResponse{IsValid: true, Payer: payer}, nil
 	}
 
+	// ERC-20 approval gas sponsoring
 	erc20Info, _ := erc20approvalgassponsor.ExtractInfo(payload.Extensions)
 	if erc20Info != nil && facilCtx != nil {
 		ext, ok := facilCtx.GetExtension(erc20approvalgassponsor.ERC20ApprovalGasSponsoring.Key()).(*erc20approvalgassponsor.Erc20ApprovalFacilitatorExtension)
@@ -155,15 +148,57 @@ func verifyPermit2Extensions(
 		if ok && ext != nil {
 			extensionSigner = ext.ResolveSigner(payload.Accepted.Network)
 		}
+
 		if extensionSigner != nil {
 			if reason, msg := ValidateErc20ApprovalForPayment(erc20Info, payer, tokenAddress); reason != "" {
-				return x402.NewVerifyError(reason, payer, msg)
+				return nil, x402.NewVerifyError(reason, payer, msg)
 			}
-			return nil
+
+			// If the signer supports SimulateTransactions, use it for the approve+settle bundle
+			if simulator, ok := extensionSigner.(erc20approvalgassponsor.Erc20ApprovalGasSponsoringSimulator); ok {
+				simArgs, buildErr := BuildPermit2SettleArgs(permit2Payload)
+				if buildErr == nil {
+					simOk, simErr := simulator.SimulateTransactions(ctx, []erc20approvalgassponsor.TransactionRequest{
+						{Serialized: erc20Info.SignedTransaction},
+						{Call: &erc20approvalgassponsor.WriteContractCall{
+							Address:  evm.X402ExactPermit2ProxyAddress,
+							ABI:      evm.X402ExactPermit2ProxySettleABI,
+							Function: evm.FunctionSettle,
+							Args:     []interface{}{simArgs.permitStruct(), simArgs.Owner, simArgs.witnessStruct(), simArgs.Signature},
+						}},
+					})
+					if simErr == nil && simOk {
+						return &x402.VerifyResponse{IsValid: true, Payer: payer}, nil
+					}
+				}
+				resp := DiagnosePermit2SimulationFailure(ctx, signer, tokenAddress, permit2Payload, requirements.Amount)
+				return nil, x402.NewVerifyError(resp.InvalidReason, payer, "simulation failed")
+			}
+
+			// Fallback: signer does not support simulation; check prerequisites only
+			prereqResp := CheckPermit2Prerequisites(ctx, signer, tokenAddress, payer, requirements.Amount)
+			if !prereqResp.IsValid {
+				return nil, x402.NewVerifyError(prereqResp.InvalidReason, payer, "prerequisites check failed")
+			}
+			return &x402.VerifyResponse{IsValid: true, Payer: payer}, nil
 		}
 	}
 
-	return x402.NewVerifyError(ErrPermit2AllowanceRequired, payer, "permit2 allowance required")
+	// Standard settle (allowance already on-chain)
+	simOk, simErr := SimulatePermit2Settle(ctx, signer, permit2Payload)
+	if simErr != nil || !simOk {
+		resp := DiagnosePermit2SimulationFailure(ctx, signer, tokenAddress, permit2Payload, requirements.Amount)
+		return nil, x402.NewVerifyError(resp.InvalidReason, payer, "simulation failed")
+	}
+
+	return &x402.VerifyResponse{IsValid: true, Payer: payer}, nil
+}
+
+// Permit2FacilitatorConfig holds optional settlement-time configuration.
+type Permit2FacilitatorConfig struct {
+	// SimulateInSettle re-runs simulation during settle
+	// When false (default), the settle path skips simulation since verify already ran it
+	SimulateInSettle bool
 }
 
 // SettlePermit2 settles a Permit2 payment by calling x402ExactPermit2Proxy.settle().
@@ -174,12 +209,17 @@ func SettlePermit2(
 	requirements types.PaymentRequirements,
 	permit2Payload *evm.ExactPermit2Payload,
 	facilCtx *x402.FacilitatorContext,
+	config *Permit2FacilitatorConfig,
 ) (*x402.SettleResponse, error) {
 	network := x402.Network(payload.Accepted.Network)
 	payer := permit2Payload.Permit2Authorization.From
 
-	// Re-verify before settling
-	verifyResp, err := VerifyPermit2(ctx, signer, payload, requirements, permit2Payload, facilCtx)
+	simulate := false
+	if config != nil {
+		simulate = config.SimulateInSettle
+	}
+
+	verifyResp, err := VerifyPermit2(ctx, signer, payload, requirements, permit2Payload, facilCtx, &VerifyPermit2Options{Simulate: &simulate})
 	if err != nil {
 		ve := &x402.VerifyError{}
 		if errors.As(err, &ve) {
@@ -188,56 +228,13 @@ func SettlePermit2(
 		return nil, x402.NewSettleError(ErrVerificationFailed, payer, network, "", err.Error())
 	}
 
-	// Parse values for contract call (validated during verify, but check again for safety)
-	amount, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Permitted.Amount, 10)
-	if !ok {
-		return nil, x402.NewSettleError(ErrInvalidPayload, payer, network, "", "invalid permitted amount")
-	}
-	nonce, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Nonce, 10)
-	if !ok {
-		return nil, x402.NewSettleError(ErrInvalidPayload, payer, network, "", "invalid nonce")
-	}
-	deadline, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Deadline, 10)
-	if !ok {
-		return nil, x402.NewSettleError(ErrInvalidPayload, payer, network, "", "invalid deadline")
-	}
-	validAfter, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Witness.ValidAfter, 10)
-	if !ok {
-		return nil, x402.NewSettleError(ErrInvalidPayload, payer, network, "", "invalid validAfter")
-	}
-	signatureBytes, err := evm.HexToBytes(permit2Payload.Signature)
-	if err != nil {
-		return nil, x402.NewSettleError(ErrInvalidSignatureFormat, payer, network, "", "invalid signature format")
+	args, buildErr := BuildPermit2SettleArgs(permit2Payload)
+	if buildErr != nil {
+		return nil, x402.NewSettleError(ErrInvalidPayload, payer, network, "", buildErr.Error())
 	}
 
-	// Create struct args for the settle call
-	// The ABI expects: settle(permit, owner, witness, signature)
-	permitStruct := struct {
-		Permitted struct {
-			Token  common.Address
-			Amount *big.Int
-		}
-		Nonce    *big.Int
-		Deadline *big.Int
-	}{
-		Permitted: struct {
-			Token  common.Address
-			Amount *big.Int
-		}{
-			Token:  common.HexToAddress(permit2Payload.Permit2Authorization.Permitted.Token),
-			Amount: amount,
-		},
-		Nonce:    nonce,
-		Deadline: deadline,
-	}
-
-	witnessStruct := struct {
-		To         common.Address
-		ValidAfter *big.Int
-	}{
-		To:         common.HexToAddress(permit2Payload.Permit2Authorization.Witness.To),
-		ValidAfter: validAfter,
-	}
+	permitStruct := args.permitStruct()
+	witnessStruct := args.witnessStruct()
 
 	eip2612Info, _ := eip2612gassponsor.ExtractEip2612GasSponsoringInfo(payload.Extensions)
 	erc20Info, _ := erc20approvalgassponsor.ExtractInfo(payload.Extensions)
@@ -282,10 +279,11 @@ func SettlePermit2(
 			evm.FunctionSettleWithPermit,
 			permit2612Struct,
 			permitStruct,
-			common.HexToAddress(payer),
+			args.Owner,
 			witnessStruct,
-			signatureBytes,
+			args.Signature,
 		)
+
 	case erc20Info != nil && facilCtx != nil:
 		// Branch: ERC-20 approval gas sponsoring (broadcast approval + settle via extension signer)
 		ext, ok := facilCtx.GetExtension(erc20approvalgassponsor.ERC20ApprovalGasSponsoring.Key()).(*erc20approvalgassponsor.Erc20ApprovalFacilitatorExtension)
@@ -298,7 +296,7 @@ func SettlePermit2(
 				Address:  evm.X402ExactPermit2ProxyAddress,
 				ABI:      evm.X402ExactPermit2ProxySettleABI,
 				Function: evm.FunctionSettle,
-				Args:     []interface{}{permitStruct, common.HexToAddress(payer), witnessStruct, signatureBytes},
+				Args:     []interface{}{permitStruct, args.Owner, witnessStruct, args.Signature},
 			}
 			txHashes, sendErr := extensionSigner.SendTransactions(ctx, []erc20approvalgassponsor.TransactionRequest{
 				{Serialized: erc20Info.SignedTransaction},
@@ -316,11 +314,12 @@ func SettlePermit2(
 				evm.X402ExactPermit2ProxySettleABI,
 				evm.FunctionSettle,
 				permitStruct,
-				common.HexToAddress(payer),
+				args.Owner,
 				witnessStruct,
-				signatureBytes,
+				args.Signature,
 			)
 		}
+
 	default:
 		txHash, err = signer.WriteContract(
 			ctx,
@@ -328,9 +327,9 @@ func SettlePermit2(
 			evm.X402ExactPermit2ProxySettleABI,
 			evm.FunctionSettle,
 			permitStruct,
-			common.HexToAddress(payer),
+			args.Owner,
 			witnessStruct,
-			signatureBytes,
+			args.Signature,
 		)
 	}
 

--- a/go/mechanisms/evm/exact/facilitator/permit2_helpers.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2_helpers.go
@@ -1,0 +1,317 @@
+package facilitator
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	x402 "github.com/coinbase/x402/go"
+	"github.com/coinbase/x402/go/mechanisms/evm"
+)
+
+// Permit2SettleArgs holds the parsed and typed arguments for settle() / settleWithPermit().
+type Permit2SettleArgs struct {
+	Permit struct {
+		Permitted struct {
+			Token  common.Address
+			Amount *big.Int
+		}
+		Nonce    *big.Int
+		Deadline *big.Int
+	}
+	Owner   common.Address
+	Witness struct {
+		To         common.Address
+		ValidAfter *big.Int
+	}
+	Signature []byte
+}
+
+// BuildPermit2SettleArgs converts a raw ExactPermit2Payload into typed contract-call
+// arguments, deduplicating the struct construction shared by verify simulation and settle.
+func BuildPermit2SettleArgs(permit2Payload *evm.ExactPermit2Payload) (*Permit2SettleArgs, error) {
+	amount, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Permitted.Amount, 10)
+	if !ok {
+		return nil, errParse("permitted amount")
+	}
+	nonce, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Nonce, 10)
+	if !ok {
+		return nil, errParse("nonce")
+	}
+	deadline, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Deadline, 10)
+	if !ok {
+		return nil, errParse("deadline")
+	}
+	validAfter, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Witness.ValidAfter, 10)
+	if !ok {
+		return nil, errParse("validAfter")
+	}
+	signatureBytes, err := evm.HexToBytes(permit2Payload.Signature)
+	if err != nil {
+		return nil, err
+	}
+
+	args := &Permit2SettleArgs{}
+	args.Permit.Permitted.Token = common.HexToAddress(permit2Payload.Permit2Authorization.Permitted.Token)
+	args.Permit.Permitted.Amount = amount
+	args.Permit.Nonce = nonce
+	args.Permit.Deadline = deadline
+	args.Owner = common.HexToAddress(permit2Payload.Permit2Authorization.From)
+	args.Witness.To = common.HexToAddress(permit2Payload.Permit2Authorization.Witness.To)
+	args.Witness.ValidAfter = validAfter
+	args.Signature = signatureBytes
+	return args, nil
+}
+
+// SimulatePermit2Settle runs settle() via eth_call (ReadContract).
+// Returns true if the simulation succeeded.
+func SimulatePermit2Settle(
+	ctx context.Context,
+	signer evm.FacilitatorEvmSigner,
+	permit2Payload *evm.ExactPermit2Payload,
+) (bool, error) {
+	args, err := BuildPermit2SettleArgs(permit2Payload)
+	if err != nil {
+		return false, err
+	}
+
+	permitStruct := args.permitStruct()
+	witnessStruct := args.witnessStruct()
+
+	_, err = signer.ReadContract(
+		ctx,
+		evm.X402ExactPermit2ProxyAddress,
+		evm.X402ExactPermit2ProxySettleABI,
+		evm.FunctionSettle,
+		permitStruct,
+		args.Owner,
+		witnessStruct,
+		args.Signature,
+	)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SimulatePermit2SettleWithPermit runs settleWithPermit() via eth_call.
+// The contract atomically calls token.permit() then PERMIT2.permitTransferFrom(),
+// so simulation covers allowance + balance + nonces.
+func SimulatePermit2SettleWithPermit(
+	ctx context.Context,
+	signer evm.FacilitatorEvmSigner,
+	permit2Payload *evm.ExactPermit2Payload,
+	eip2612Signature, eip2612Amount, eip2612DeadlineStr string,
+) (bool, error) {
+	args, err := BuildPermit2SettleArgs(permit2Payload)
+	if err != nil {
+		return false, err
+	}
+
+	v, r, s, splitErr := splitEip2612Signature(eip2612Signature)
+	if splitErr != nil {
+		return false, splitErr
+	}
+
+	eip2612Value, ok := new(big.Int).SetString(eip2612Amount, 10)
+	if !ok {
+		return false, errParse("eip2612 amount")
+	}
+	eip2612Deadline, ok := new(big.Int).SetString(eip2612DeadlineStr, 10)
+	if !ok {
+		return false, errParse("eip2612 deadline")
+	}
+
+	permit2612Struct := struct {
+		Value    *big.Int
+		Deadline *big.Int
+		R        [32]byte
+		S        [32]byte
+		V        uint8
+	}{
+		Value:    eip2612Value,
+		Deadline: eip2612Deadline,
+		R:        r,
+		S:        s,
+		V:        v,
+	}
+
+	permitStruct := args.permitStruct()
+	witnessStruct := args.witnessStruct()
+
+	_, err = signer.ReadContract(
+		ctx,
+		evm.X402ExactPermit2ProxyAddress,
+		evm.X402ExactPermit2ProxySettleWithPermitABI,
+		evm.FunctionSettleWithPermit,
+		permit2612Struct,
+		permitStruct,
+		args.Owner,
+		witnessStruct,
+		args.Signature,
+	)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// DiagnosePermit2SimulationFailure runs a multicall diagnostic to return the most
+// specific error reason after a simulation failure.
+func DiagnosePermit2SimulationFailure(
+	ctx context.Context,
+	signer evm.FacilitatorEvmSigner,
+	tokenAddress string,
+	permit2Payload *evm.ExactPermit2Payload,
+	amountRequired string,
+) *x402.VerifyResponse {
+	payer := permit2Payload.Permit2Authorization.From
+
+	results, err := evm.Multicall(ctx, signer, []evm.MulticallCall{
+		{
+			Address:      evm.X402ExactPermit2ProxyAddress,
+			ABI:          evm.X402ExactPermit2ProxyPermit2ABI,
+			FunctionName: "PERMIT2",
+		},
+		{
+			Address:      tokenAddress,
+			ABI:          evm.ERC20BalanceOfABI,
+			FunctionName: "balanceOf",
+			Args:         []interface{}{common.HexToAddress(payer)},
+		},
+		{
+			Address:      tokenAddress,
+			ABI:          evm.ERC20AllowanceABI,
+			FunctionName: "allowance",
+			Args:         []interface{}{common.HexToAddress(payer), common.HexToAddress(evm.PERMIT2Address)},
+		},
+	})
+	if err != nil || len(results) < 3 {
+		return &x402.VerifyResponse{IsValid: false, InvalidReason: ErrPermit2SimulationFailed, Payer: payer}
+	}
+
+	if !results[0].Success() {
+		return &x402.VerifyResponse{IsValid: false, InvalidReason: ErrPermit2ProxyNotDeployed, Payer: payer}
+	}
+
+	reqAmount, ok := new(big.Int).SetString(amountRequired, 10)
+	if !ok {
+		return &x402.VerifyResponse{IsValid: false, InvalidReason: ErrPermit2SimulationFailed, Payer: payer}
+	}
+
+	if results[1].Success() {
+		if balance := asBigInt(results[1].Result); balance != nil && balance.Cmp(reqAmount) < 0 {
+			return &x402.VerifyResponse{IsValid: false, InvalidReason: ErrPermit2InsufficientBalance, Payer: payer}
+		}
+	}
+
+	if results[2].Success() {
+		if allowance := asBigInt(results[2].Result); allowance != nil && allowance.Cmp(reqAmount) < 0 {
+			return &x402.VerifyResponse{IsValid: false, InvalidReason: ErrPermit2AllowanceRequired, Payer: payer}
+		}
+	}
+
+	return &x402.VerifyResponse{IsValid: false, InvalidReason: ErrPermit2SimulationFailed, Payer: payer}
+}
+
+// CheckPermit2Prerequisites checks proxy deployment, payer token balance and payer ETH balance for gas.
+func CheckPermit2Prerequisites(
+	ctx context.Context,
+	signer evm.FacilitatorEvmSigner,
+	tokenAddress string,
+	payer string,
+	amountRequired string,
+) *x402.VerifyResponse {
+	results, err := evm.Multicall(ctx, signer, []evm.MulticallCall{
+		{
+			Address:      evm.X402ExactPermit2ProxyAddress,
+			ABI:          evm.X402ExactPermit2ProxyPermit2ABI,
+			FunctionName: "PERMIT2",
+		},
+		{
+			Address:      tokenAddress,
+			ABI:          evm.ERC20BalanceOfABI,
+			FunctionName: "balanceOf",
+			Args:         []interface{}{common.HexToAddress(payer)},
+		},
+		{
+			Address:      evm.MULTICALL3Address,
+			ABI:          evm.Multicall3GetEthBalanceABI,
+			FunctionName: "getEthBalance",
+			Args:         []interface{}{common.HexToAddress(payer)},
+		},
+	})
+	if err != nil || len(results) < 3 {
+		// Fail open for prerequisites-only check
+		return &x402.VerifyResponse{IsValid: true, Payer: payer}
+	}
+
+	if !results[0].Success() {
+		return &x402.VerifyResponse{IsValid: false, InvalidReason: ErrPermit2ProxyNotDeployed, Payer: payer}
+	}
+
+	reqAmount, ok := new(big.Int).SetString(amountRequired, 10)
+	if ok && results[1].Success() {
+		if balance := asBigInt(results[1].Result); balance != nil && balance.Cmp(reqAmount) < 0 {
+			return &x402.VerifyResponse{IsValid: false, InvalidReason: ErrPermit2InsufficientBalance, Payer: payer}
+		}
+	}
+
+	if results[2].Success() {
+		minEthForGas := new(big.Int).Mul(
+			big.NewInt(int64(evm.ERC20ApproveGasLimit)),
+			big.NewInt(int64(evm.DefaultMaxFeePerGas)),
+		)
+		if ethBalance := asBigInt(results[2].Result); ethBalance != nil && ethBalance.Cmp(minEthForGas) < 0 {
+			return &x402.VerifyResponse{IsValid: false, InvalidReason: ErrErc20ApprovalInsufficientEth, Payer: payer}
+		}
+	}
+
+	return &x402.VerifyResponse{IsValid: true, Payer: payer}
+}
+
+// permitStruct returns the ABI-compatible tuple for the permit parameter.
+func (a *Permit2SettleArgs) permitStruct() interface{} {
+	return struct {
+		Permitted struct {
+			Token  common.Address
+			Amount *big.Int
+		}
+		Nonce    *big.Int
+		Deadline *big.Int
+	}{
+		Permitted: struct {
+			Token  common.Address
+			Amount *big.Int
+		}{
+			Token:  a.Permit.Permitted.Token,
+			Amount: a.Permit.Permitted.Amount,
+		},
+		Nonce:    a.Permit.Nonce,
+		Deadline: a.Permit.Deadline,
+	}
+}
+
+// witnessStruct returns the ABI-compatible tuple for the witness parameter.
+func (a *Permit2SettleArgs) witnessStruct() interface{} {
+	return struct {
+		To         common.Address
+		ValidAfter *big.Int
+	}{
+		To:         a.Witness.To,
+		ValidAfter: a.Witness.ValidAfter,
+	}
+}
+
+func errParse(field string) error {
+	return &parseError{field: field}
+}
+
+type parseError struct {
+	field string
+}
+
+func (e *parseError) Error() string {
+	return "invalid " + e.field
+}

--- a/go/mechanisms/evm/exact/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/facilitator/scheme.go
@@ -81,7 +81,7 @@ func (f *ExactEvmScheme) Verify(
 		if err != nil {
 			return nil, x402.NewVerifyError(ErrInvalidPayload, "", fmt.Sprintf("failed to parse Permit2 payload: %s", err.Error()))
 		}
-		return VerifyPermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx)
+		return VerifyPermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx, nil)
 	}
 
 	return f.verifyEIP3009(ctx, payload, requirements, true)
@@ -103,7 +103,9 @@ func (f *ExactEvmScheme) Settle(
 			network := x402.Network(payload.Accepted.Network)
 			return nil, x402.NewSettleError(ErrInvalidPayload, "", network, "", fmt.Sprintf("failed to parse Permit2 payload: %s", err.Error()))
 		}
-		return SettlePermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx)
+		return SettlePermit2(ctx, f.signer, payload, requirements, permit2Payload, fctx, &Permit2FacilitatorConfig{
+			SimulateInSettle: f.config.SimulateInSettle,
+		})
 	}
 
 	return f.settleEIP3009(ctx, payload, requirements)

--- a/go/test/unit/evm_client_facilitator_test.go
+++ b/go/test/unit/evm_client_facilitator_test.go
@@ -654,7 +654,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil, nil)
 		if err == nil {
 			t.Error("Expected error for invalid spender")
 		}
@@ -679,7 +679,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil, nil)
 		if err == nil {
 			t.Error("Expected error for recipient mismatch")
 		}
@@ -701,7 +701,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil, nil)
 		if err == nil {
 			t.Error("Expected error for expired deadline")
 		}
@@ -726,7 +726,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil, nil)
 		if err == nil {
 			t.Error("Expected error for not-yet-valid payment")
 		}
@@ -748,7 +748,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil, nil)
 		if err == nil {
 			t.Error("Expected error for insufficient amount")
 		}
@@ -770,7 +770,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil, nil)
 		if err == nil {
 			t.Error("Expected error for token mismatch")
 		}
@@ -792,7 +792,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, validPayload, validRequirements, permit2Payload, nil, nil)
 		if err == nil {
 			t.Error("Expected error for invalid deadline format")
 		}
@@ -822,7 +822,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongSchemePayload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongSchemePayload, validRequirements, permit2Payload, nil, nil)
 		if err == nil {
 			t.Error("Expected error for scheme mismatch")
 		}
@@ -852,7 +852,7 @@ func TestVerifyPermit2InvalidInputs(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongNetworkPayload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.VerifyPermit2(ctx, signer, wrongNetworkPayload, validRequirements, permit2Payload, nil, nil)
 		if err == nil {
 			t.Error("Expected error for network mismatch")
 		}
@@ -1467,7 +1467,7 @@ func TestSettlePermit2_EIP2612Routing(t *testing.T) {
 			},
 		}
 
-		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1501,7 +1501,7 @@ func TestSettlePermit2_EIP2612Routing(t *testing.T) {
 			// No extensions
 		}
 
-		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil)
+		_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -1595,7 +1595,7 @@ func TestSettlePermit2_ContractRevertErrors(t *testing.T) {
 				},
 			}
 
-			_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil)
+			_, err := evmfacilitator.SettlePermit2(ctx, signer, payload, validRequirements, permit2Payload, nil, nil)
 			if err == nil {
 				t.Fatal("Expected error from SettlePermit2")
 			}

--- a/typescript/.changeset/fifty-doodles-strive.md
+++ b/typescript/.changeset/fifty-doodles-strive.md
@@ -1,0 +1,5 @@
+---
+'@x402/evm': patch
+---
+
+Added simulation to permit2 verify and (optional) settle

--- a/typescript/packages/mechanisms/evm/src/exact/extensions.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/extensions.ts
@@ -38,6 +38,7 @@ export type TransactionRequest =
 
 export type Erc20ApprovalGasSponsoringSigner = FacilitatorEvmSigner & {
   sendTransactions(transactions: TransactionRequest[]): Promise<`0x${string}`[]>;
+  simulateTransactions?(transactions: TransactionRequest[]): Promise<boolean>;
 };
 
 export interface Erc20ApprovalGasSponsoringFacilitatorExtension {

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
@@ -33,6 +33,9 @@ export const ErrPermit2AmountMismatch = "permit2_amount_mismatch";
 export const ErrPermit2TokenMismatch = "permit2_token_mismatch";
 export const ErrPermit2InvalidSignature = "invalid_permit2_signature";
 export const ErrPermit2AllowanceRequired = "permit2_allowance_required";
+export const ErrPermit2SimulationFailed = "permit2_simulation_failed";
+export const ErrPermit2InsufficientBalance = "permit2_insufficient_balance";
+export const ErrPermit2ProxyNotDeployed = "permit2_proxy_not_deployed";
 
 // Permit2 settle errors (from contract reverts)
 export const ErrPermit2InvalidAmount = "permit2_invalid_amount";
@@ -43,6 +46,7 @@ export const ErrPermit2InvalidNonce = "permit2_invalid_nonce";
 export const ErrPermit2612AmountMismatch = "permit2_2612_amount_mismatch";
 
 // ERC-20 approval gas sponsoring verify errors
+export const ErrErc20ApprovalInsufficientEthForGas = "erc20_approval_insufficient_eth_for_gas";
 export const ErrErc20ApprovalInvalidFormat = "invalid_erc20_approval_extension_format";
 export const ErrErc20ApprovalFromMismatch = "erc20_approval_from_mismatch";
 export const ErrErc20ApprovalAssetMismatch = "erc20_approval_asset_mismatch";
@@ -54,3 +58,15 @@ export const ErrErc20ApprovalTxInvalidCalldata = "erc20_approval_tx_invalid_call
 export const ErrErc20ApprovalTxSignerMismatch = "erc20_approval_tx_signer_mismatch";
 export const ErrErc20ApprovalTxInvalidSignature = "erc20_approval_tx_invalid_signature";
 export const ErrErc20ApprovalTxParseFailed = "erc20_approval_tx_parse_failed";
+export const ErrErc20ApprovalTxFailed = "erc20_approval_tx_failed";
+
+// EIP-2612 gas sponsoring verify errors
+export const ErrInvalidEip2612ExtensionFormat = "invalid_eip2612_extension_format";
+export const ErrEip2612FromMismatch = "eip2612_from_mismatch";
+export const ErrEip2612AssetMismatch = "eip2612_asset_mismatch";
+export const ErrEip2612SpenderNotPermit2 = "eip2612_spender_not_permit2";
+export const ErrEip2612DeadlineExpired = "eip2612_deadline_expired";
+
+// Shared settle errors
+export const ErrUnsupportedPayloadType = "unsupported_payload_type";
+export const ErrInvalidTransactionState = "invalid_transaction_state";

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2-utils.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2-utils.ts
@@ -1,0 +1,442 @@
+import { PaymentPayload, SettleResponse, VerifyResponse } from "@x402/core/types";
+import { encodeFunctionData, getAddress } from "viem";
+import {
+  eip3009ABI,
+  erc20AllowanceAbi,
+  ERC20_APPROVE_GAS_LIMIT,
+  DEFAULT_MAX_FEE_PER_GAS,
+  PERMIT2_ADDRESS,
+  x402ExactPermit2ProxyABI,
+  x402ExactPermit2ProxyAddress,
+} from "../../constants";
+import {
+  multicall,
+  ContractCall,
+  MULTICALL3_ADDRESS,
+  multicall3GetEthBalanceAbi,
+} from "../../multicall";
+import { FacilitatorEvmSigner } from "../../signer";
+import { ExactPermit2Payload } from "../../types";
+import {
+  validateEip2612GasSponsoringInfo,
+  type Eip2612GasSponsoringInfo,
+  type Erc20ApprovalGasSponsoringSigner,
+} from "../extensions";
+import * as Errors from "./errors";
+
+/**
+ * Simulates settle() via eth_call (readContract).
+ * Returns true if simulation succeeded, false if it failed.
+ *
+ * @param signer - EVM signer for contract reads
+ * @param permit2Payload - Permit2 payload with authorization and signature
+ * @returns true if simulation succeeded, false if it failed
+ */
+export async function simulatePermit2Settle(
+  signer: FacilitatorEvmSigner,
+  permit2Payload: ExactPermit2Payload,
+): Promise<boolean> {
+  try {
+    await signer.readContract({
+      address: x402ExactPermit2ProxyAddress,
+      abi: x402ExactPermit2ProxyABI,
+      functionName: "settle",
+      args: buildPermit2SettleArgs(permit2Payload),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Splits a 65-byte EIP-2612 signature into v, r, s components for contract calls.
+ * Validates length and throws if invalid.
+ *
+ * @param signature - The hex-encoded 65-byte signature
+ * @returns Object with v (uint8), r (bytes32), s (bytes32)
+ */
+export function splitEip2612Signature(signature: string): {
+  v: number;
+  r: `0x${string}`;
+  s: `0x${string}`;
+} {
+  const sig = signature.startsWith("0x") ? signature.slice(2) : signature;
+
+  if (sig.length !== 130) {
+    throw new Error(
+      `invalid EIP-2612 signature length: expected 65 bytes (130 hex chars), got ${sig.length / 2} bytes`,
+    );
+  }
+
+  const r = `0x${sig.slice(0, 64)}` as `0x${string}`;
+  const s = `0x${sig.slice(64, 128)}` as `0x${string}`;
+  const v = parseInt(sig.slice(128, 130), 16);
+
+  return { v, r, s };
+}
+
+/**
+ * Builds the args array for settle() and settleWithPermit() Permit2 calls.
+ * Shared by simulation and settlement to keep contract ABI shape in one place.
+ *
+ * @param permit2Payload - The Permit2 authorization payload
+ * @returns The args tuple for settle(permit, owner, witness, signature)
+ */
+export function buildPermit2SettleArgs(permit2Payload: ExactPermit2Payload) {
+  return [
+    {
+      permitted: {
+        token: getAddress(permit2Payload.permit2Authorization.permitted.token),
+        amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
+      },
+      nonce: BigInt(permit2Payload.permit2Authorization.nonce),
+      deadline: BigInt(permit2Payload.permit2Authorization.deadline),
+    },
+    getAddress(permit2Payload.permit2Authorization.from),
+    {
+      to: getAddress(permit2Payload.permit2Authorization.witness.to),
+      validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
+    },
+    permit2Payload.signature,
+  ] as const;
+}
+
+/**
+ * Encodes settle() calldata for the x402 Exact Permit2 proxy.
+ * Used when bundling approve + settle (e.g. ERC-20 approval gas sponsoring).
+ *
+ * @param permit2Payload - The Permit2 authorization payload
+ * @returns Hex-encoded settle calldata
+ */
+export function encodePermit2SettleCalldata(permit2Payload: ExactPermit2Payload): `0x${string}` {
+  return encodeFunctionData({
+    abi: x402ExactPermit2ProxyABI,
+    functionName: "settle",
+    args: buildPermit2SettleArgs(permit2Payload),
+  });
+}
+
+/**
+ * Simulates settleWithPermit() via eth_call (readContract).
+ * The contract atomically calls token.permit() then PERMIT2.permitTransferFrom(),
+ * so simulation covers allowance + balance + nonces.
+ *
+ * @param signer - EVM signer for contract reads
+ * @param permit2Payload - Permit2 payload with authorization and signature
+ * @param eip2612Info - EIP-2612 gas sponsoring info from the payload extension
+ * @returns true if simulation succeeded, false if it failed
+ */
+export async function simulatePermit2SettleWithPermit(
+  signer: FacilitatorEvmSigner,
+  permit2Payload: ExactPermit2Payload,
+  eip2612Info: Eip2612GasSponsoringInfo,
+): Promise<boolean> {
+  try {
+    const { v, r, s } = splitEip2612Signature(eip2612Info.signature);
+
+    await signer.readContract({
+      address: x402ExactPermit2ProxyAddress,
+      abi: x402ExactPermit2ProxyABI,
+      functionName: "settleWithPermit",
+      args: [
+        {
+          value: BigInt(eip2612Info.amount),
+          deadline: BigInt(eip2612Info.deadline),
+          r,
+          s,
+          v,
+        },
+        ...buildPermit2SettleArgs(permit2Payload),
+      ],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Diagnoses a Permit2 simulation failure by performing a multicall to check the proxy deployment, balance and allowance.
+ *
+ * @param signer - EVM signer for contract reads
+ * @param tokenAddress - ERC-20 token contract address
+ * @param permit2Payload - The Permit2 authorization payload
+ * @param amountRequired - Required payment amount (as string)
+ * @returns VerifyResponse with the most specific failure reason
+ */
+export async function diagnosePermit2SimulationFailure(
+  signer: FacilitatorEvmSigner,
+  tokenAddress: `0x${string}`,
+  permit2Payload: ExactPermit2Payload,
+  amountRequired: string,
+): Promise<VerifyResponse> {
+  const payer = permit2Payload.permit2Authorization.from;
+
+  const diagnosticCalls: ContractCall[] = [
+    {
+      address: x402ExactPermit2ProxyAddress,
+      abi: x402ExactPermit2ProxyABI,
+      functionName: "PERMIT2",
+    },
+    {
+      address: tokenAddress,
+      abi: eip3009ABI,
+      functionName: "balanceOf",
+      args: [payer],
+    },
+    {
+      address: tokenAddress,
+      abi: erc20AllowanceAbi,
+      functionName: "allowance",
+      args: [payer, PERMIT2_ADDRESS],
+    },
+  ];
+
+  try {
+    const results = await multicall(signer.readContract.bind(signer), diagnosticCalls);
+
+    const [proxyResult, balanceResult, allowanceResult] = results;
+
+    if (proxyResult.status === "failure") {
+      return { isValid: false, invalidReason: Errors.ErrPermit2ProxyNotDeployed, payer };
+    }
+
+    if (balanceResult.status === "success") {
+      const balance = balanceResult.result as bigint;
+      if (balance < BigInt(amountRequired)) {
+        return { isValid: false, invalidReason: Errors.ErrPermit2InsufficientBalance, payer };
+      }
+    }
+
+    if (allowanceResult.status === "success") {
+      const allowance = allowanceResult.result as bigint;
+      if (allowance < BigInt(amountRequired)) {
+        return { isValid: false, invalidReason: Errors.ErrPermit2AllowanceRequired, payer };
+      }
+    }
+  } catch {
+    // Diagnostic multicall itself failed — fall through to generic error
+  }
+
+  return { isValid: false, invalidReason: Errors.ErrPermit2SimulationFailed, payer };
+}
+
+/**
+ * Targeted multicall for the ERC-20 approval path where simulation cannot be used
+ * (the approval hasn't been broadcast yet, so settle() would fail for expected reasons).
+ * Checks proxy deployment, payer token balance and payer ETH balance for gas.
+ *
+ * @param signer - EVM signer for contract reads
+ * @param tokenAddress - ERC-20 token contract address
+ * @param payer - The payer address
+ * @param amountRequired - Required payment amount (as string)
+ * @returns VerifyResponse — valid if checks pass, otherwise the most specific failure
+ */
+export async function checkPermit2Prerequisites(
+  signer: FacilitatorEvmSigner,
+  tokenAddress: `0x${string}`,
+  payer: `0x${string}`,
+  amountRequired: string,
+): Promise<VerifyResponse> {
+  const diagnosticCalls: ContractCall[] = [
+    {
+      address: x402ExactPermit2ProxyAddress,
+      abi: x402ExactPermit2ProxyABI,
+      functionName: "PERMIT2",
+    },
+    {
+      address: tokenAddress,
+      abi: eip3009ABI,
+      functionName: "balanceOf",
+      args: [payer],
+    },
+    {
+      address: MULTICALL3_ADDRESS,
+      abi: multicall3GetEthBalanceAbi,
+      functionName: "getEthBalance",
+      args: [payer],
+    },
+  ];
+
+  try {
+    const results = await multicall(signer.readContract.bind(signer), diagnosticCalls);
+
+    const [proxyResult, balanceResult, ethBalanceResult] = results;
+
+    if (proxyResult.status === "failure") {
+      return { isValid: false, invalidReason: Errors.ErrPermit2ProxyNotDeployed, payer };
+    }
+
+    if (balanceResult.status === "success") {
+      const balance = balanceResult.result as bigint;
+      if (balance < BigInt(amountRequired)) {
+        return { isValid: false, invalidReason: Errors.ErrPermit2InsufficientBalance, payer };
+      }
+    }
+
+    if (ethBalanceResult.status === "success") {
+      const minEthForApprovalGas = ERC20_APPROVE_GAS_LIMIT * DEFAULT_MAX_FEE_PER_GAS;
+      const ethBalance = ethBalanceResult.result as bigint;
+      if (ethBalance < minEthForApprovalGas) {
+        return {
+          isValid: false,
+          invalidReason: Errors.ErrErc20ApprovalInsufficientEthForGas,
+          payer,
+        };
+      }
+    }
+  } catch {
+    // Multicall failed — fall through to valid (fail open for prerequisites-only check)
+  }
+
+  return { isValid: true, invalidReason: undefined, payer };
+}
+
+/**
+ * Delegates the full approve+settle simulation flow to the extension signer via simulateTransactions.
+ * The signer owns execution strategy.
+ *
+ * @param extensionSigner - The extension signer with simulateTransactions capability
+ * @param permit2Payload - The Permit2 specific payload
+ * @param erc20Info - Object containing the signed approval transaction
+ * @param erc20Info.signedTransaction - The RLP-encoded signed ERC-20 approve transaction
+ * @returns true if the bundle simulation succeeded, false otherwise
+ */
+export async function simulatePermit2SettleWithErc20Approval(
+  extensionSigner: Erc20ApprovalGasSponsoringSigner,
+  permit2Payload: ExactPermit2Payload,
+  erc20Info: { signedTransaction: string },
+): Promise<boolean> {
+  if (!extensionSigner.simulateTransactions) {
+    return false;
+  }
+
+  try {
+    const settleData = encodePermit2SettleCalldata(permit2Payload);
+
+    return await extensionSigner.simulateTransactions([
+      erc20Info.signedTransaction as `0x${string}`,
+      { to: x402ExactPermit2ProxyAddress, data: settleData, gas: BigInt(300_000) },
+    ]);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Waits for tx receipt and returns the appropriate SettleResponse.
+ *
+ * @param signer - Signer with waitForTransactionReceipt capability
+ * @param tx - The transaction hash to wait for
+ * @param payload - The payment payload (for network info)
+ * @param payer - The payer address
+ * @returns Promise resolving to settlement response
+ */
+export async function waitAndReturn(
+  signer: Pick<FacilitatorEvmSigner, "waitForTransactionReceipt">,
+  tx: `0x${string}`,
+  payload: PaymentPayload,
+  payer: `0x${string}`,
+): Promise<SettleResponse> {
+  const receipt = await signer.waitForTransactionReceipt({ hash: tx });
+
+  if (receipt.status !== "success") {
+    return {
+      success: false,
+      errorReason: Errors.ErrInvalidTransactionState,
+      transaction: tx,
+      network: payload.accepted.network,
+      payer,
+    };
+  }
+
+  return {
+    success: true,
+    transaction: tx,
+    network: payload.accepted.network,
+    payer,
+  };
+}
+
+/**
+ * Maps contract revert errors to structured SettleResponse error reasons.
+ *
+ * @param error - The caught error
+ * @param payload - The payment payload (for network info)
+ * @param payer - The payer address
+ * @returns A failed SettleResponse with mapped error reason
+ */
+export function mapSettleError(
+  error: unknown,
+  payload: PaymentPayload,
+  payer: `0x${string}`,
+): SettleResponse {
+  let errorReason = Errors.ErrTransactionFailed;
+  if (error instanceof Error) {
+    const message = error.message;
+    if (message.includes("Permit2612AmountMismatch")) {
+      errorReason = Errors.ErrPermit2612AmountMismatch;
+    } else if (message.includes("InvalidAmount")) {
+      errorReason = Errors.ErrPermit2InvalidAmount;
+    } else if (message.includes("InvalidDestination")) {
+      errorReason = Errors.ErrPermit2InvalidDestination;
+    } else if (message.includes("InvalidOwner")) {
+      errorReason = Errors.ErrPermit2InvalidOwner;
+    } else if (message.includes("PaymentTooEarly")) {
+      errorReason = Errors.ErrPermit2PaymentTooEarly;
+    } else if (message.includes("InvalidSignature") || message.includes("SignatureExpired")) {
+      errorReason = Errors.ErrPermit2InvalidSignature;
+    } else if (message.includes("InvalidNonce")) {
+      errorReason = Errors.ErrPermit2InvalidNonce;
+    } else if (message.includes("erc20_approval_tx_failed")) {
+      errorReason = Errors.ErrErc20ApprovalTxFailed;
+    } else {
+      errorReason = `${Errors.ErrTransactionFailed}: ${message.slice(0, 500)}`;
+    }
+  }
+  return {
+    success: false,
+    errorReason,
+    transaction: "",
+    network: payload.accepted.network,
+    payer,
+  };
+}
+
+/**
+ * Validates EIP-2612 permit extension data for a Permit2 payment.
+ *
+ * @param info - The EIP-2612 gas sponsoring info
+ * @param payer - The expected payer address
+ * @param tokenAddress - The expected token address
+ * @returns Validation result with optional invalidReason
+ */
+export function validateEip2612PermitForPayment(
+  info: Eip2612GasSponsoringInfo,
+  payer: `0x${string}`,
+  tokenAddress: `0x${string}`,
+): { isValid: boolean; invalidReason?: string } {
+  if (!validateEip2612GasSponsoringInfo(info)) {
+    return { isValid: false, invalidReason: Errors.ErrInvalidEip2612ExtensionFormat };
+  }
+
+  if (getAddress(info.from as `0x${string}`) !== getAddress(payer)) {
+    return { isValid: false, invalidReason: Errors.ErrEip2612FromMismatch };
+  }
+
+  if (getAddress(info.asset as `0x${string}`) !== tokenAddress) {
+    return { isValid: false, invalidReason: Errors.ErrEip2612AssetMismatch };
+  }
+
+  if (getAddress(info.spender as `0x${string}`) !== getAddress(PERMIT2_ADDRESS)) {
+    return { isValid: false, invalidReason: Errors.ErrEip2612SpenderNotPermit2 };
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (BigInt(info.deadline) < BigInt(now + 6)) {
+    return { isValid: false, invalidReason: Errors.ErrEip2612DeadlineExpired };
+  }
+
+  return { isValid: true };
+}

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -7,7 +7,6 @@ import {
 } from "@x402/core/types";
 import {
   extractEip2612GasSponsoringInfo,
-  validateEip2612GasSponsoringInfo,
   extractErc20ApprovalGasSponsoringInfo,
   ERC20_APPROVAL_GAS_SPONSORING_KEY,
   resolveErc20ApprovalExtensionSigner,
@@ -15,29 +14,46 @@ import {
   type Erc20ApprovalGasSponsoringFacilitatorExtension,
   type Erc20ApprovalGasSponsoringSigner,
 } from "../extensions";
-import { getAddress, encodeFunctionData } from "viem";
+import { getAddress } from "viem";
 import {
-  eip3009ABI,
   PERMIT2_ADDRESS,
   permit2WitnessTypes,
   x402ExactPermit2ProxyABI,
   x402ExactPermit2ProxyAddress,
-  erc20AllowanceAbi,
 } from "../../constants";
-import {
-  ErrPermit2612AmountMismatch,
-  ErrPermit2AmountMismatch,
-  ErrPermit2InvalidAmount,
-  ErrPermit2InvalidDestination,
-  ErrPermit2InvalidNonce,
-  ErrPermit2InvalidOwner,
-  ErrPermit2InvalidSignature,
-  ErrPermit2PaymentTooEarly,
-} from "./errors";
+import * as Errors from "./errors";
 import { FacilitatorEvmSigner } from "../../signer";
 import { ExactPermit2Payload } from "../../types";
 import { getEvmChainId } from "../../utils";
 import { validateErc20ApprovalForPayment } from "./erc20approval";
+import {
+  simulatePermit2Settle,
+  simulatePermit2SettleWithPermit,
+  simulatePermit2SettleWithErc20Approval,
+  diagnosePermit2SimulationFailure,
+  checkPermit2Prerequisites,
+  splitEip2612Signature,
+  buildPermit2SettleArgs,
+  encodePermit2SettleCalldata,
+  waitAndReturn,
+  mapSettleError,
+  validateEip2612PermitForPayment,
+} from "./permit2-utils";
+
+export interface VerifyPermit2Options {
+  /** Run onchain simulation. Defaults to true. */
+  simulate?: boolean;
+}
+
+export interface Permit2FacilitatorConfig {
+  /**
+   * If enabled, simulates transaction before settling. Defaults to false,
+   * i.e. only simulate during verify.
+   *
+   * @default false
+   */
+  simulateInSettle?: boolean;
+}
 
 /**
  * Verifies a Permit2 payment payload.
@@ -52,6 +68,7 @@ import { validateErc20ApprovalForPayment } from "./erc20approval";
  * @param requirements - The payment requirements
  * @param permit2Payload - The Permit2 specific payload
  * @param context - Optional facilitator context for extension-provided capabilities
+ * @param options - Optional verification options (e.g. simulate)
  * @returns Promise resolving to verification response
  */
 export async function verifyPermit2(
@@ -60,13 +77,14 @@ export async function verifyPermit2(
   requirements: PaymentRequirements,
   permit2Payload: ExactPermit2Payload,
   context?: FacilitatorContext,
+  options?: VerifyPermit2Options,
 ): Promise<VerifyResponse> {
   const payer = permit2Payload.permit2Authorization.from;
 
   if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
     return {
       isValid: false,
-      invalidReason: "unsupported_scheme",
+      invalidReason: Errors.ErrUnsupportedPayloadType,
       payer,
     };
   }
@@ -74,7 +92,7 @@ export async function verifyPermit2(
   if (payload.accepted.network !== requirements.network) {
     return {
       isValid: false,
-      invalidReason: "network_mismatch",
+      invalidReason: Errors.ErrNetworkMismatch,
       payer,
     };
   }
@@ -88,7 +106,7 @@ export async function verifyPermit2(
   ) {
     return {
       isValid: false,
-      invalidReason: "invalid_permit2_spender",
+      invalidReason: Errors.ErrPermit2InvalidSpender,
       payer,
     };
   }
@@ -98,7 +116,7 @@ export async function verifyPermit2(
   ) {
     return {
       isValid: false,
-      invalidReason: "invalid_permit2_recipient_mismatch",
+      invalidReason: Errors.ErrPermit2RecipientMismatch,
       payer,
     };
   }
@@ -107,7 +125,7 @@ export async function verifyPermit2(
   if (BigInt(permit2Payload.permit2Authorization.deadline) < BigInt(now + 6)) {
     return {
       isValid: false,
-      invalidReason: "permit2_deadline_expired",
+      invalidReason: Errors.ErrPermit2DeadlineExpired,
       payer,
     };
   }
@@ -115,7 +133,7 @@ export async function verifyPermit2(
   if (BigInt(permit2Payload.permit2Authorization.witness.validAfter) > BigInt(now)) {
     return {
       isValid: false,
-      invalidReason: "permit2_not_yet_valid",
+      invalidReason: Errors.ErrPermit2NotYetValid,
       payer,
     };
   }
@@ -126,7 +144,7 @@ export async function verifyPermit2(
   ) {
     return {
       isValid: false,
-      invalidReason: ErrPermit2AmountMismatch,
+      invalidReason: Errors.ErrPermit2AmountMismatch,
       payer,
     };
   }
@@ -134,7 +152,7 @@ export async function verifyPermit2(
   if (getAddress(permit2Payload.permit2Authorization.permitted.token) !== tokenAddress) {
     return {
       isValid: false,
-      invalidReason: "permit2_token_mismatch",
+      invalidReason: Errors.ErrPermit2TokenMismatch,
       payer,
     };
   }
@@ -172,144 +190,96 @@ export async function verifyPermit2(
     if (!isValid) {
       return {
         isValid: false,
-        invalidReason: "invalid_permit2_signature",
+        invalidReason: Errors.ErrPermit2InvalidSignature,
         payer,
       };
     }
   } catch {
     return {
       isValid: false,
-      invalidReason: "invalid_permit2_signature",
+      invalidReason: Errors.ErrPermit2InvalidSignature,
       payer,
     };
   }
 
-  // Check Permit2 allowance — if insufficient, try gas sponsoring extensions
-  const allowanceResult = await _verifyPermit2Allowance(
-    signer,
-    payload,
-    requirements,
-    payer,
-    tokenAddress,
-    context,
-  );
-  if (allowanceResult) {
-    return allowanceResult;
+  // If simulation is disabled, return early
+  if (options?.simulate === false) {
+    return { isValid: true, invalidReason: undefined, payer };
   }
 
-  try {
-    const balance = (await signer.readContract({
-      address: tokenAddress,
-      abi: eip3009ABI,
-      functionName: "balanceOf",
-      args: [payer],
-    })) as bigint;
-
-    if (balance < BigInt(requirements.amount)) {
-      return {
-        isValid: false,
-        invalidReason: "insufficient_funds",
-        invalidMessage: `Insufficient funds to complete the payment. Required: ${requirements.amount} ${requirements.asset}, Available: ${balance.toString()} ${requirements.asset}. Please add funds to your wallet and try again.`,
-        payer,
-      };
-    }
-  } catch {
-    // If we can't check balance, continue
-  }
-
-  return {
-    isValid: true,
-    invalidReason: undefined,
-    payer,
-  };
-}
-
-/**
- * Checks Permit2 allowance and validates gas sponsoring extensions if allowance is insufficient.
- *
- * @param signer - The facilitator signer for on-chain reads
- * @param payload - The payment payload
- * @param requirements - The payment requirements
- * @param payer - The payer address
- * @param tokenAddress - The token contract address
- * @param context - Optional facilitator context for extension lookup
- * @returns A VerifyResponse if verification should stop (failure), or null to continue
- */
-async function _verifyPermit2Allowance(
-  signer: FacilitatorEvmSigner,
-  payload: PaymentPayload,
-  requirements: PaymentRequirements,
-  payer: `0x${string}`,
-  tokenAddress: `0x${string}`,
-  context?: FacilitatorContext,
-): Promise<VerifyResponse | null> {
-  try {
-    const allowance = (await signer.readContract({
-      address: tokenAddress,
-      abi: erc20AllowanceAbi,
-      functionName: "allowance",
-      args: [payer, PERMIT2_ADDRESS],
-    })) as bigint;
-
-    if (allowance >= BigInt(requirements.amount)) {
-      return null; // Sufficient allowance, continue verification
+  // Branch: EIP-2612 gas sponsoring (atomic settleWithPermit via contract)
+  const eip2612Info = extractEip2612GasSponsoringInfo(payload);
+  if (eip2612Info) {
+    const fieldResult = validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress);
+    if (!fieldResult.isValid) {
+      return { isValid: false, invalidReason: fieldResult.invalidReason!, payer };
     }
 
-    // Allowance insufficient — try EIP-2612 gas sponsoring first
-    const eip2612Info = extractEip2612GasSponsoringInfo(payload);
-    if (eip2612Info) {
-      const result = validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress);
-      if (!result.isValid) {
-        return { isValid: false, invalidReason: result.invalidReason!, payer };
-      }
-      return null; // EIP-2612 is valid, allowance will be set atomically during settlement
-    }
-
-    // Try ERC-20 approval gas sponsoring as fallback
-    const erc20GasSponsorshipExtension =
-      context?.getExtension<Erc20ApprovalGasSponsoringFacilitatorExtension>(
-        ERC20_APPROVAL_GAS_SPONSORING_KEY,
+    const simOk = await simulatePermit2SettleWithPermit(signer, permit2Payload, eip2612Info);
+    if (!simOk) {
+      return diagnosePermit2SimulationFailure(
+        signer,
+        tokenAddress,
+        permit2Payload,
+        requirements.amount,
       );
-    if (erc20GasSponsorshipExtension) {
-      const erc20Info = extractErc20ApprovalGasSponsoringInfo(payload);
-      if (erc20Info) {
-        const result = await validateErc20ApprovalForPayment(erc20Info, payer, tokenAddress);
-        if (!result.isValid) {
-          return { isValid: false, invalidReason: result.invalidReason!, payer };
-        }
-        return null; // ERC-20 approval is valid, will be broadcast before settlement
-      }
     }
 
-    return { isValid: false, invalidReason: "permit2_allowance_required", payer };
-  } catch {
-    // Allowance check failed — validate extensions if present; fail closed if none valid
-    const eip2612Info = extractEip2612GasSponsoringInfo(payload);
-    if (eip2612Info) {
-      const result = validateEip2612PermitForPayment(eip2612Info, payer, tokenAddress);
-      if (!result.isValid) {
-        return { isValid: false, invalidReason: result.invalidReason!, payer };
-      }
-      return null;
-    }
-
-    const erc20GasSponsorshipExtension =
-      context?.getExtension<Erc20ApprovalGasSponsoringFacilitatorExtension>(
-        ERC20_APPROVAL_GAS_SPONSORING_KEY,
-      );
-    if (erc20GasSponsorshipExtension) {
-      const erc20Info = extractErc20ApprovalGasSponsoringInfo(payload);
-      if (erc20Info) {
-        const result = await validateErc20ApprovalForPayment(erc20Info, payer, tokenAddress);
-        if (!result.isValid) {
-          return { isValid: false, invalidReason: result.invalidReason!, payer };
-        }
-        return null;
-      }
-    }
-
-    return { isValid: false, invalidReason: "permit2_allowance_required", payer };
+    return { isValid: true, invalidReason: undefined, payer };
   }
+
+  // Branch: ERC-20 approval gas sponsoring (broadcast approval + settle via extension signer)
+  const erc20GasSponsorshipExtension =
+    context?.getExtension<Erc20ApprovalGasSponsoringFacilitatorExtension>(
+      ERC20_APPROVAL_GAS_SPONSORING_KEY,
+    );
+  if (erc20GasSponsorshipExtension) {
+    const erc20Info = extractErc20ApprovalGasSponsoringInfo(payload);
+    if (erc20Info) {
+      const fieldResult = await validateErc20ApprovalForPayment(erc20Info, payer, tokenAddress);
+      if (!fieldResult.isValid) {
+        return { isValid: false, invalidReason: fieldResult.invalidReason!, payer };
+      }
+
+      const extensionSigner = resolveErc20ApprovalExtensionSigner(
+        erc20GasSponsorshipExtension,
+        requirements.network,
+      );
+
+      if (extensionSigner?.simulateTransactions) {
+        const simOk = await simulatePermit2SettleWithErc20Approval(
+          extensionSigner,
+          permit2Payload,
+          erc20Info,
+        );
+        if (!simOk) {
+          return diagnosePermit2SimulationFailure(
+            signer,
+            tokenAddress,
+            permit2Payload,
+            requirements.amount,
+          );
+        }
+        return { isValid: true, invalidReason: undefined, payer };
+      }
+
+      // Fallback to prerequisite-only check if simulateTransactions is not available
+      return checkPermit2Prerequisites(signer, tokenAddress, payer, requirements.amount);
+    }
+  }
+
+  // Branch: standard settle (allowance already on-chain)
+  const simOk = await simulatePermit2Settle(signer, permit2Payload);
+  if (!simOk) {
+    return diagnosePermit2SimulationFailure(
+      signer,
+      tokenAddress,
+      permit2Payload,
+      requirements.amount,
+    );
+  }
+
+  return { isValid: true, invalidReason: undefined, payer };
 }
 
 /**
@@ -324,6 +294,7 @@ async function _verifyPermit2Allowance(
  * @param requirements - The payment requirements
  * @param permit2Payload - The Permit2 specific payload
  * @param context - Optional facilitator context for extension-provided capabilities
+ * @param config - Optional facilitator config (simulateInSettle)
  * @returns Promise resolving to settlement response
  */
 export async function settlePermit2(
@@ -332,16 +303,19 @@ export async function settlePermit2(
   requirements: PaymentRequirements,
   permit2Payload: ExactPermit2Payload,
   context?: FacilitatorContext,
+  config?: Permit2FacilitatorConfig,
 ): Promise<SettleResponse> {
   const payer = permit2Payload.permit2Authorization.from;
 
-  const valid = await verifyPermit2(signer, payload, requirements, permit2Payload, context);
+  const valid = await verifyPermit2(signer, payload, requirements, permit2Payload, context, {
+    simulate: config?.simulateInSettle ?? false,
+  });
   if (!valid.isValid) {
     return {
       success: false,
       network: payload.accepted.network,
       transaction: "",
-      errorReason: valid.invalidReason ?? "invalid_scheme",
+      errorReason: valid.invalidReason ?? Errors.ErrInvalidScheme,
       payer,
     };
   }
@@ -403,26 +377,13 @@ async function _settlePermit2WithEIP2612(
           s,
           v,
         },
-        {
-          permitted: {
-            token: getAddress(permit2Payload.permit2Authorization.permitted.token),
-            amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
-          },
-          nonce: BigInt(permit2Payload.permit2Authorization.nonce),
-          deadline: BigInt(permit2Payload.permit2Authorization.deadline),
-        },
-        getAddress(payer),
-        {
-          to: getAddress(permit2Payload.permit2Authorization.witness.to),
-          validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
-        },
-        permit2Payload.signature,
+        ...buildPermit2SettleArgs(permit2Payload),
       ],
     });
 
-    return _waitAndReturn(signer, tx, payload, payer);
+    return waitAndReturn(signer, tx, payload, payer);
   } catch (error) {
-    return _mapSettleError(error, payload, payer);
+    return mapSettleError(error, payload, payer);
   }
 }
 
@@ -446,26 +407,7 @@ async function _settlePermit2WithERC20Approval(
   const payer = permit2Payload.permit2Authorization.from;
 
   try {
-    const settleData = encodeFunctionData({
-      abi: x402ExactPermit2ProxyABI,
-      functionName: "settle",
-      args: [
-        {
-          permitted: {
-            token: getAddress(permit2Payload.permit2Authorization.permitted.token),
-            amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
-          },
-          nonce: BigInt(permit2Payload.permit2Authorization.nonce),
-          deadline: BigInt(permit2Payload.permit2Authorization.deadline),
-        },
-        getAddress(payer),
-        {
-          to: getAddress(permit2Payload.permit2Authorization.witness.to),
-          validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
-        },
-        permit2Payload.signature,
-      ],
-    });
+    const settleData = encodePermit2SettleCalldata(permit2Payload);
 
     const txHashes = await extensionSigner.sendTransactions([
       erc20Info.signedTransaction as `0x${string}`,
@@ -473,9 +415,9 @@ async function _settlePermit2WithERC20Approval(
     ]);
 
     const settleTxHash = txHashes[txHashes.length - 1];
-    return _waitAndReturn(extensionSigner, settleTxHash, payload, payer);
+    return waitAndReturn(extensionSigner, settleTxHash, payload, payer);
   } catch (error) {
-    return _mapSettleError(error, payload, payer);
+    return mapSettleError(error, payload, payer);
   }
 }
 
@@ -498,169 +440,11 @@ async function _settlePermit2Direct(
       address: x402ExactPermit2ProxyAddress,
       abi: x402ExactPermit2ProxyABI,
       functionName: "settle",
-      args: [
-        {
-          permitted: {
-            token: getAddress(permit2Payload.permit2Authorization.permitted.token),
-            amount: BigInt(permit2Payload.permit2Authorization.permitted.amount),
-          },
-          nonce: BigInt(permit2Payload.permit2Authorization.nonce),
-          deadline: BigInt(permit2Payload.permit2Authorization.deadline),
-        },
-        getAddress(payer),
-        {
-          to: getAddress(permit2Payload.permit2Authorization.witness.to),
-          validAfter: BigInt(permit2Payload.permit2Authorization.witness.validAfter),
-        },
-        permit2Payload.signature,
-      ],
+      args: buildPermit2SettleArgs(permit2Payload),
     });
 
-    return _waitAndReturn(signer, tx, payload, payer);
+    return waitAndReturn(signer, tx, payload, payer);
   } catch (error) {
-    return _mapSettleError(error, payload, payer);
+    return mapSettleError(error, payload, payer);
   }
-}
-
-/**
- * Waits for tx receipt and returns the appropriate SettleResponse.
- *
- * @param signer - Signer with waitForTransactionReceipt capability
- * @param tx - The transaction hash to wait for
- * @param payload - The payment payload (for network info)
- * @param payer - The payer address
- * @returns Promise resolving to settlement response
- */
-async function _waitAndReturn(
-  signer: Pick<FacilitatorEvmSigner, "waitForTransactionReceipt">,
-  tx: `0x${string}`,
-  payload: PaymentPayload,
-  payer: `0x${string}`,
-): Promise<SettleResponse> {
-  const receipt = await signer.waitForTransactionReceipt({ hash: tx });
-
-  if (receipt.status !== "success") {
-    return {
-      success: false,
-      errorReason: "invalid_transaction_state",
-      transaction: tx,
-      network: payload.accepted.network,
-      payer,
-    };
-  }
-
-  return {
-    success: true,
-    transaction: tx,
-    network: payload.accepted.network,
-    payer,
-  };
-}
-
-/**
- * Maps contract revert errors to structured SettleResponse error reasons.
- *
- * @param error - The caught error
- * @param payload - The payment payload (for network info)
- * @param payer - The payer address
- * @returns A failed SettleResponse with mapped error reason
- */
-function _mapSettleError(
-  error: unknown,
-  payload: PaymentPayload,
-  payer: `0x${string}`,
-): SettleResponse {
-  let errorReason = "transaction_failed";
-  if (error instanceof Error) {
-    const message = error.message;
-    if (message.includes("Permit2612AmountMismatch")) {
-      errorReason = ErrPermit2612AmountMismatch;
-    } else if (message.includes("InvalidAmount")) {
-      errorReason = ErrPermit2InvalidAmount;
-    } else if (message.includes("InvalidDestination")) {
-      errorReason = ErrPermit2InvalidDestination;
-    } else if (message.includes("InvalidOwner")) {
-      errorReason = ErrPermit2InvalidOwner;
-    } else if (message.includes("PaymentTooEarly")) {
-      errorReason = ErrPermit2PaymentTooEarly;
-    } else if (message.includes("InvalidSignature") || message.includes("SignatureExpired")) {
-      errorReason = ErrPermit2InvalidSignature;
-    } else if (message.includes("InvalidNonce")) {
-      errorReason = ErrPermit2InvalidNonce;
-    } else if (message.includes("erc20_approval_tx_failed")) {
-      errorReason = "erc20_approval_tx_failed";
-    } else {
-      errorReason = `transaction_failed: ${message.slice(0, 500)}`;
-    }
-  }
-  return {
-    success: false,
-    errorReason,
-    transaction: "",
-    network: payload.accepted.network,
-    payer,
-  };
-}
-
-/**
- * Validates EIP-2612 permit extension data for a Permit2 payment.
- *
- * @param info - The EIP-2612 gas sponsoring info
- * @param payer - The expected payer address
- * @param tokenAddress - The expected token address
- * @returns Validation result with optional invalidReason
- */
-function validateEip2612PermitForPayment(
-  info: Eip2612GasSponsoringInfo,
-  payer: `0x${string}`,
-  tokenAddress: `0x${string}`,
-): { isValid: boolean; invalidReason?: string } {
-  if (!validateEip2612GasSponsoringInfo(info)) {
-    return { isValid: false, invalidReason: "invalid_eip2612_extension_format" };
-  }
-
-  if (getAddress(info.from as `0x${string}`) !== getAddress(payer)) {
-    return { isValid: false, invalidReason: "eip2612_from_mismatch" };
-  }
-
-  if (getAddress(info.asset as `0x${string}`) !== tokenAddress) {
-    return { isValid: false, invalidReason: "eip2612_asset_mismatch" };
-  }
-
-  if (getAddress(info.spender as `0x${string}`) !== getAddress(PERMIT2_ADDRESS)) {
-    return { isValid: false, invalidReason: "eip2612_spender_not_permit2" };
-  }
-
-  const now = Math.floor(Date.now() / 1000);
-  if (BigInt(info.deadline) < BigInt(now + 6)) {
-    return { isValid: false, invalidReason: "eip2612_deadline_expired" };
-  }
-
-  return { isValid: true };
-}
-
-/**
- * Splits a 65-byte EIP-2612 signature into v, r, s components.
- *
- * @param signature - The hex-encoded 65-byte signature
- * @returns Object with v (uint8), r (bytes32), s (bytes32)
- */
-function splitEip2612Signature(signature: string): {
-  v: number;
-  r: `0x${string}`;
-  s: `0x${string}`;
-} {
-  const sig = signature.startsWith("0x") ? signature.slice(2) : signature;
-
-  if (sig.length !== 130) {
-    throw new Error(
-      `invalid EIP-2612 signature length: expected 65 bytes (130 hex chars), got ${sig.length / 2} bytes`,
-    );
-  }
-
-  const r = `0x${sig.slice(0, 64)}` as `0x${string}`;
-  const s = `0x${sig.slice(64, 128)}` as `0x${string}`;
-  const v = parseInt(sig.slice(128, 130), 16);
-
-  return { v, r, s };
 }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -180,26 +180,34 @@ export async function verifyPermit2(
     },
   };
 
+  // Verify signature
+  // Note: verifyTypedData is implementation-dependent and pluggable on FacilitatorEvmSigner
+  // Some implementations only do EOA-style ECDSA recovery (e.g. viem/utils verifyTypedData, ethers.verifyTypedData)
+  // Viem's publicClient.verifyTypedData supports EOA and Smart Contract Account (ERC-1271 / ERC-6492) signature verification
+  let signatureValid = false;
   try {
-    const isValid = await signer.verifyTypedData({
+    signatureValid = await signer.verifyTypedData({
       address: payer,
       ...permit2TypedData,
       signature: permit2Payload.signature,
     });
+  } catch {
+    signatureValid = false;
+  }
 
-    if (!isValid) {
+  if (!signatureValid) {
+    // Check if the payer is a deployed smart contract
+    const bytecode = await signer.getCode({ address: payer });
+    const isDeployedContract = bytecode && bytecode !== "0x";
+
+    if (!isDeployedContract) {
       return {
         isValid: false,
         invalidReason: Errors.ErrPermit2InvalidSignature,
         payer,
       };
     }
-  } catch {
-    return {
-      isValid: false,
-      invalidReason: Errors.ErrPermit2InvalidSignature,
-      payer,
-    };
+    // Deployed smart contract: fall through to simulation
   }
 
   // If simulation is disabled, return early

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
@@ -115,7 +115,9 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
     const isPermit2 = isPermit2Payload(rawPayload);
 
     if (isPermit2) {
-      return settlePermit2(this.signer, payload, requirements, rawPayload, context);
+      return settlePermit2(this.signer, payload, requirements, rawPayload, context, {
+        simulateInSettle: this.config.simulateInSettle,
+      });
     }
 
     const eip3009Payload: ExactEIP3009Payload = rawPayload;

--- a/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
@@ -262,7 +262,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
   });
 
   describe("Permit2 payload verification", () => {
-    it("should verify Permit2 payloads with valid signature and allowance", async () => {
+    it("should verify Permit2 payloads with valid signature and simulation success", async () => {
       const requirements: PaymentRequirements = {
         scheme: "exact",
         network: "eip155:84532",
@@ -273,8 +273,8 @@ describe("ExactEvmScheme (Facilitator)", () => {
         extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
       };
 
-      // Mock readContract to return sufficient allowance and balance
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt("10000000000"));
+      // Simulation of settle() on the proxy succeeds (readContract doesn't throw)
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const permit2Payload: PaymentPayload = {
         x402Version: 2,
@@ -305,7 +305,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
       expect(result.payer).toBe(mockClientSigner.address);
     });
 
-    it("should reject Permit2 payloads with insufficient allowance", async () => {
+    it("should reject Permit2 payloads when simulation fails and allowance is insufficient", async () => {
       const requirements: PaymentRequirements = {
         scheme: "exact",
         network: "eip155:84532",
@@ -316,8 +316,31 @@ describe("ExactEvmScheme (Facilitator)", () => {
         extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
       };
 
-      // Mock readContract to return zero allowance
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt(0));
+      // Simulation fails (settle throws), diagnostic multicall returns proxy OK, balance OK, allowance 0
+      mockFacilitatorSigner.readContract = vi
+        .fn()
+        .mockImplementation(({ address }: { address: string }) => {
+          if (address === x402ExactPermit2ProxyAddress) {
+            return Promise.reject(new Error("execution reverted"));
+          }
+          if (address === MULTICALL3_ADDRESS) {
+            return Promise.resolve([
+              {
+                success: true,
+                returnData: "0x000000000000000000000000000000000022D473030F116dDEE9F6B43aC78BA3",
+              },
+              {
+                success: true,
+                returnData: "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              },
+              {
+                success: true,
+                returnData: "0x0000000000000000000000000000000000000000000000000000000000000000",
+              },
+            ]);
+          }
+          return Promise.resolve(BigInt(0));
+        });
 
       const permit2Payload: PaymentPayload = {
         x402Version: 2,
@@ -485,8 +508,8 @@ describe("ExactEvmScheme (Facilitator)", () => {
         extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
       };
 
-      // Mock readContract to return sufficient allowance and balance
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt("10000000000"));
+      // settle's re-verify has simulate=false (default), so no simulation readContract needed
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const permit2Payload: PaymentPayload = {
         x402Version: 2,
@@ -519,7 +542,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
       expect(mockFacilitatorSigner.writeContract).toHaveBeenCalled();
     });
 
-    it("should fail Permit2 settlement when verification fails", async () => {
+    it("should fail Permit2 settlement when signature verification fails", async () => {
       const requirements: PaymentRequirements = {
         scheme: "exact",
         network: "eip155:84532",
@@ -530,8 +553,8 @@ describe("ExactEvmScheme (Facilitator)", () => {
         extra: { name: "USDC", version: "2", assetTransferMethod: "permit2" },
       };
 
-      // Mock readContract to return zero allowance
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt(0));
+      // Signature verification fails
+      mockFacilitatorSigner.verifyTypedData = vi.fn().mockResolvedValue(false);
 
       const permit2Payload: PaymentPayload = {
         x402Version: 2,
@@ -559,7 +582,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
       const result = await facilitator.settle(permit2Payload, requirements);
 
       expect(result.success).toBe(false);
-      expect(result.errorReason).toBe("permit2_allowance_required");
+      expect(result.errorReason).toBe("invalid_permit2_signature");
       expect(result.payer).toBe(mockClientSigner.address);
     });
   });
@@ -630,12 +653,9 @@ describe("ExactEvmScheme (Facilitator)", () => {
   });
 
   describe("EIP-2612 Gas Sponsoring - Verify", () => {
-    it("should accept valid EIP-2612 extension when Permit2 allowance is 0", async () => {
-      // Mock: allowance returns 0, then balance returns sufficient
-      mockFacilitatorSigner.readContract = vi
-        .fn()
-        .mockResolvedValueOnce(0n) // allowance check = 0
-        .mockResolvedValueOnce(BigInt("10000000")); // balance check
+    it("should accept valid EIP-2612 extension when settleWithPermit simulation succeeds", async () => {
+      // Simulation of settleWithPermit on proxy succeeds
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const permit2Requirements: PaymentRequirements = {
         scheme: "exact",
@@ -647,7 +667,6 @@ describe("ExactEvmScheme (Facilitator)", () => {
         extra: { assetTransferMethod: "permit2", name: "USDC", version: "2" },
       };
 
-      // Create a Permit2 payload
       const permit2ClientSigner: ClientEvmSigner = {
         address: "0x1234567890123456789012345678901234567890",
         signTypedData: vi.fn().mockResolvedValue("0x" + "ab".repeat(32) + "cd".repeat(32) + "1b"),
@@ -656,7 +675,6 @@ describe("ExactEvmScheme (Facilitator)", () => {
       const permit2Client = new ClientExactEvmScheme(permit2ClientSigner);
       const paymentPayload = await permit2Client.createPaymentPayload(2, permit2Requirements);
 
-      // Add EIP-2612 extension data
       const now = Math.floor(Date.now() / 1000);
       const fullPayload: PaymentPayload = {
         ...paymentPayload,
@@ -681,17 +699,38 @@ describe("ExactEvmScheme (Facilitator)", () => {
       };
 
       const result = await facilitator.verify(fullPayload, permit2Requirements);
-      // Should pass verify (EIP-2612 extension provides the permit)
       expect(result).toBeDefined();
-      // It may still fail on signature verification (mock), but should NOT fail with permit2_allowance_required
       if (!result.isValid) {
         expect(result.invalidReason).not.toBe("permit2_allowance_required");
       }
     });
 
-    it("should reject when allowance is 0 and no EIP-2612 extension", async () => {
-      // Mock: allowance returns 0
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValueOnce(0n); // allowance check = 0
+    it("should reject when simulation fails and no extension present (allowance insufficient)", async () => {
+      // Simulation fails, diagnostic multicall returns low allowance
+      mockFacilitatorSigner.readContract = vi
+        .fn()
+        .mockImplementation(({ address }: { address: string }) => {
+          if (address === x402ExactPermit2ProxyAddress) {
+            return Promise.reject(new Error("execution reverted"));
+          }
+          if (address === MULTICALL3_ADDRESS) {
+            return Promise.resolve([
+              {
+                success: true,
+                returnData: "0x000000000000000000000000000000000022D473030F116dDEE9F6B43aC78BA3",
+              },
+              {
+                success: true,
+                returnData: "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              },
+              {
+                success: true,
+                returnData: "0x0000000000000000000000000000000000000000000000000000000000000000",
+              },
+            ]);
+          }
+          return Promise.resolve(BigInt(0));
+        });
 
       const permit2Requirements: PaymentRequirements = {
         scheme: "exact",
@@ -715,20 +754,15 @@ describe("ExactEvmScheme (Facilitator)", () => {
         ...paymentPayload,
         accepted: permit2Requirements,
         resource: { url: "https://test.com", description: "", mimeType: "" },
-        // NO eip2612GasSponsoring extension
       };
 
       const result = await facilitator.verify(fullPayload, permit2Requirements);
-      // Should fail with permit2_allowance_required since there's no EIP-2612 extension
       expect(result.isValid).toBe(false);
       expect(result.invalidReason).toBe("permit2_allowance_required");
     });
 
     it("should reject EIP-2612 extension with wrong spender", async () => {
-      mockFacilitatorSigner.readContract = vi
-        .fn()
-        .mockResolvedValueOnce(0n) // allowance = 0
-        .mockResolvedValueOnce(BigInt("10000000")); // balance
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const permit2Requirements: PaymentRequirements = {
         scheme: "exact",
@@ -1064,14 +1098,8 @@ describe("ExactEvmScheme (Facilitator)", () => {
     }
 
     it("should call settleWithPermit when EIP-2612 extension is present", async () => {
-      // Mock: allowance=0 (verify), balance=sufficient, allowance=0 (settle re-verify), balance=sufficient
-      mockFacilitatorSigner.readContract = vi
-        .fn()
-        .mockImplementation(({ functionName }: { functionName: string }) => {
-          if (functionName === "allowance") return Promise.resolve(0n);
-          if (functionName === "balanceOf") return Promise.resolve(BigInt("10000000"));
-          return Promise.resolve(0n);
-        });
+      // settle's re-verify has simulate=false, so readContract is not called for simulation
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const payload = makePermit2Payload(makeEip2612Extension());
       const result = await facilitator.settle(payload, permit2Requirements);
@@ -1079,15 +1107,14 @@ describe("ExactEvmScheme (Facilitator)", () => {
       expect(result.success).toBe(true);
       expect(result.transaction).toBe("0xtxhash");
 
-      // Verify writeContract was called with settleWithPermit
       const writeCall = (mockFacilitatorSigner.writeContract as ReturnType<typeof vi.fn>).mock
         .calls[0][0];
       expect(writeCall.functionName).toBe("settleWithPermit");
     });
 
     it("should call settle (not settleWithPermit) when no EIP-2612 extension", async () => {
-      // Mock: allowance=sufficient, balance=sufficient
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt("10000000000"));
+      // settle's re-verify has simulate=false
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const payload = makePermit2Payload();
       const result = await facilitator.settle(payload, permit2Requirements);
@@ -1095,14 +1122,13 @@ describe("ExactEvmScheme (Facilitator)", () => {
       expect(result.success).toBe(true);
       expect(result.transaction).toBe("0xtxhash");
 
-      // Verify writeContract was called with settle (not settleWithPermit)
       const writeCall = (mockFacilitatorSigner.writeContract as ReturnType<typeof vi.fn>).mock
         .calls[0][0];
       expect(writeCall.functionName).toBe("settle");
     });
 
     it("should map Permit2612AmountMismatch contract revert to permit2_2612_amount_mismatch", async () => {
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt("10000000000"));
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
       mockFacilitatorSigner.writeContract = vi
         .fn()
         .mockRejectedValue(new Error("execution reverted: Permit2612AmountMismatch()"));
@@ -1115,7 +1141,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
     });
 
     it("should map InvalidAmount contract revert to permit2_invalid_amount", async () => {
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt("10000000000"));
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
       mockFacilitatorSigner.writeContract = vi
         .fn()
         .mockRejectedValue(new Error("execution reverted: InvalidAmount()"));
@@ -1128,7 +1154,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
     });
 
     it("should map InvalidNonce contract revert to permit2_invalid_nonce", async () => {
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(BigInt("10000000000"));
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
       mockFacilitatorSigner.writeContract = vi
         .fn()
         .mockRejectedValue(new Error("execution reverted: InvalidNonce()"));
@@ -1141,13 +1167,8 @@ describe("ExactEvmScheme (Facilitator)", () => {
     });
 
     it("should pass correct EIP-2612 permit struct to settleWithPermit", async () => {
-      mockFacilitatorSigner.readContract = vi
-        .fn()
-        .mockImplementation(({ functionName }: { functionName: string }) => {
-          if (functionName === "allowance") return Promise.resolve(0n);
-          if (functionName === "balanceOf") return Promise.resolve(BigInt("10000000"));
-          return Promise.resolve(0n);
-        });
+      // settle's re-verify has simulate=false
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const extensions = makeEip2612Extension();
       const payload = makePermit2Payload(extensions);
@@ -1157,14 +1178,12 @@ describe("ExactEvmScheme (Facilitator)", () => {
         .calls[0][0];
       expect(writeCall.functionName).toBe("settleWithPermit");
 
-      // First arg to settleWithPermit is the EIP-2612 permit struct (value, deadline, r, s, v)
       const permit2612Struct = writeCall.args[0];
       expect(permit2612Struct.value).toBeDefined();
       expect(permit2612Struct.deadline).toBeDefined();
       expect(permit2612Struct.r).toBeDefined();
       expect(permit2612Struct.s).toBeDefined();
       expect(permit2612Struct.v).toBeDefined();
-      // v should be a number (27 or 28)
       expect(typeof permit2612Struct.v).toBe("number");
     });
   });
@@ -1245,8 +1264,32 @@ describe("ExactEvmScheme (Facilitator)", () => {
       };
     }
 
-    it("should reject when allowance is 0 and no ERC-20 extension (no context)", async () => {
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValueOnce(0n);
+    it("should reject when simulation fails and no ERC-20 extension (no context)", async () => {
+      // Simulation of settle() fails, diagnostic multicall shows low allowance
+      mockFacilitatorSigner.readContract = vi
+        .fn()
+        .mockImplementation(({ address }: { address: string }) => {
+          if (address === x402ExactPermit2ProxyAddress) {
+            return Promise.reject(new Error("execution reverted"));
+          }
+          if (address === MULTICALL3_ADDRESS) {
+            return Promise.resolve([
+              {
+                success: true,
+                returnData: "0x000000000000000000000000000000000022D473030F116dDEE9F6B43aC78BA3",
+              },
+              {
+                success: true,
+                returnData: "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              },
+              {
+                success: true,
+                returnData: "0x0000000000000000000000000000000000000000000000000000000000000000",
+              },
+            ]);
+          }
+          return Promise.resolve(BigInt(0));
+        });
 
       const payload = makeErc20Permit2Payload();
       const result = await facilitator.verify(payload, erc20Requirements);
@@ -1256,7 +1299,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
     });
 
     it("should reject when ERC-20 extension has invalid format (bad address)", async () => {
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValueOnce(0n);
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const payload = makeErc20Permit2Payload({
         erc20ApprovalGasSponsoring: {
@@ -1279,7 +1322,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
     });
 
     it("should reject when ERC-20 extension `from` doesn't match payer", async () => {
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValueOnce(0n);
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const payload = makeErc20Permit2Payload({
         erc20ApprovalGasSponsoring: {
@@ -1302,7 +1345,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
     });
 
     it("should reject when ERC-20 extension `asset` doesn't match token", async () => {
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValueOnce(0n);
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const payload = makeErc20Permit2Payload({
         erc20ApprovalGasSponsoring: {
@@ -1325,7 +1368,7 @@ describe("ExactEvmScheme (Facilitator)", () => {
     });
 
     it("should reject when ERC-20 extension spender is not PERMIT2_ADDRESS", async () => {
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValueOnce(0n);
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const payload = makeErc20Permit2Payload({
         erc20ApprovalGasSponsoring: {
@@ -1347,11 +1390,31 @@ describe("ExactEvmScheme (Facilitator)", () => {
       expect(result.invalidReason).toBe("erc20_approval_spender_not_permit2");
     });
 
-    it("should accept when allowance insufficient but valid ERC-20 extension present", async () => {
-      // allowance=0 (verifyPermit2 returns permit2_allowance_required, scheme handles it)
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValueOnce(0n);
+    it("should accept when valid ERC-20 extension present and prerequisites pass", async () => {
+      // checkPermit2Prerequisites multicall: proxy deployed + sufficient token balance + sufficient ETH for gas
+      mockFacilitatorSigner.readContract = vi
+        .fn()
+        .mockImplementation(({ address }: { address: string }) => {
+          if (address === MULTICALL3_ADDRESS) {
+            return Promise.resolve([
+              {
+                success: true,
+                returnData: "0x000000000000000000000000000000000022D473030F116dDEE9F6B43aC78BA3",
+              },
+              {
+                success: true,
+                returnData: "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              },
+              // ETH balance: 0.001 ETH (well above the gas floor of 70_000 * 1 gwei)
+              {
+                success: true,
+                returnData: "0x00000000000000000000000000000000000000000000000000038D7EA4C68000",
+              },
+            ]);
+          }
+          return Promise.resolve(undefined);
+        });
 
-      // Mock viem functions used in validateErc20ApprovalForPayment
       const { parseTransaction, recoverTransactionAddress } = await import("viem");
       vi.mocked(parseTransaction).mockReturnValue({
         to: TOKEN_ADDRESS,
@@ -1362,14 +1425,13 @@ describe("ExactEvmScheme (Facilitator)", () => {
       const payload = makeErc20Permit2Payload(makeValidErc20Extension());
       const result = await facilitator.verify(payload, erc20Requirements, makeErc20Context());
 
-      // Should NOT fail with permit2_allowance_required
       if (!result.isValid) {
         expect(result.invalidReason).not.toBe("permit2_allowance_required");
       }
     });
 
     it("should reject when calldata targets wrong address (not PERMIT2_ADDRESS)", async () => {
-      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValueOnce(0n);
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const wrongSpenderCalldata =
         "0x095ea7b3" +
@@ -1388,6 +1450,155 @@ describe("ExactEvmScheme (Facilitator)", () => {
 
       expect(result.isValid).toBe(false);
       expect(result.invalidReason).toBe("erc20_approval_tx_wrong_spender");
+    });
+
+    it("Path 2 simulation: should accept when extension signer simulateTransactions returns true", async () => {
+      const { parseTransaction, recoverTransactionAddress } = await import("viem");
+      vi.mocked(parseTransaction).mockReturnValue({
+        to: TOKEN_ADDRESS,
+        data: APPROVE_CALLDATA as `0x${string}`,
+      } as any);
+      vi.mocked(recoverTransactionAddress).mockResolvedValue(PAYER);
+
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
+
+      const mockSimulateTransactions = vi.fn().mockResolvedValue(true);
+
+      const mockContext = {
+        getExtension: vi.fn().mockImplementation((key: string) => {
+          if (key === ERC20_APPROVAL_GAS_SPONSORING_KEY) {
+            return {
+              key: ERC20_APPROVAL_GAS_SPONSORING_KEY,
+              signer: {
+                ...mockFacilitatorSigner,
+                sendTransactions: vi.fn(),
+                simulateTransactions: mockSimulateTransactions,
+              },
+            };
+          }
+          return undefined;
+        }),
+      };
+
+      const payload = makeErc20Permit2Payload(makeValidErc20Extension());
+      const result = await facilitator.verify(payload, erc20Requirements, mockContext);
+
+      expect(mockSimulateTransactions).toHaveBeenCalledOnce();
+      const bundle = mockSimulateTransactions.mock.calls[0][0];
+      expect(bundle[0]).toBe(MOCK_SIGNED_TX);
+      expect(bundle[1]).toHaveProperty("to");
+      expect(bundle[1]).toHaveProperty("data");
+      expect(result.isValid).toBe(true);
+    });
+
+    it("Path 2 simulation: should reject with diagnostic reason when simulateTransactions returns false", async () => {
+      const { parseTransaction, recoverTransactionAddress } = await import("viem");
+      vi.mocked(parseTransaction).mockReturnValue({
+        to: TOKEN_ADDRESS,
+        data: APPROVE_CALLDATA as `0x${string}`,
+      } as any);
+      vi.mocked(recoverTransactionAddress).mockResolvedValue(PAYER);
+
+      mockFacilitatorSigner.readContract = vi
+        .fn()
+        .mockImplementation(({ address }: { address: string }) => {
+          if (address === MULTICALL3_ADDRESS) {
+            // diagnostic multicall: proxy deployed, balance insufficient
+            return Promise.resolve([
+              {
+                success: true,
+                returnData: "0x000000000000000000000000000000000022D473030F116dDEE9F6B43aC78BA3",
+              },
+              {
+                success: true,
+                returnData: "0x0000000000000000000000000000000000000000000000000000000000000001",
+              },
+              {
+                success: true,
+                returnData: "0x0000000000000000000000000000000000000000000000000000000000000000",
+              },
+            ]);
+          }
+          return Promise.resolve(undefined);
+        });
+
+      const mockSimulateTransactions = vi.fn().mockResolvedValue(false);
+
+      const mockContext = {
+        getExtension: vi.fn().mockImplementation((key: string) => {
+          if (key === ERC20_APPROVAL_GAS_SPONSORING_KEY) {
+            return {
+              key: ERC20_APPROVAL_GAS_SPONSORING_KEY,
+              signer: {
+                ...mockFacilitatorSigner,
+                sendTransactions: vi.fn(),
+                simulateTransactions: mockSimulateTransactions,
+              },
+            };
+          }
+          return undefined;
+        }),
+      };
+
+      const payload = makeErc20Permit2Payload(makeValidErc20Extension());
+      const result = await facilitator.verify(payload, erc20Requirements, mockContext);
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe(Errors.ErrPermit2InsufficientBalance);
+    });
+
+    it("Path 2 simulation: should fall back to checkPermit2Prerequisites when simulateTransactions is absent", async () => {
+      const { parseTransaction, recoverTransactionAddress } = await import("viem");
+      vi.mocked(parseTransaction).mockReturnValue({
+        to: TOKEN_ADDRESS,
+        data: APPROVE_CALLDATA as `0x${string}`,
+      } as any);
+      vi.mocked(recoverTransactionAddress).mockResolvedValue(PAYER);
+
+      // prerequisites pass: proxy deployed + sufficient token balance + sufficient ETH for gas
+      mockFacilitatorSigner.readContract = vi
+        .fn()
+        .mockImplementation(({ address }: { address: string }) => {
+          if (address === MULTICALL3_ADDRESS) {
+            return Promise.resolve([
+              {
+                success: true,
+                returnData: "0x000000000000000000000000000000000022D473030F116dDEE9F6B43aC78BA3",
+              },
+              {
+                success: true,
+                returnData: "0x00000000000000000000000000000000000000000000000000000000000f4240",
+              },
+              // ETH balance: 0.001 ETH (well above the gas floor of 70_000 * 1 gwei)
+              {
+                success: true,
+                returnData: "0x00000000000000000000000000000000000000000000000000038D7EA4C68000",
+              },
+            ]);
+          }
+          return Promise.resolve(undefined);
+        });
+
+      // signer has sendTransactions but no simulateTransactions (legacy)
+      const mockContext = {
+        getExtension: vi.fn().mockImplementation((key: string) => {
+          if (key === ERC20_APPROVAL_GAS_SPONSORING_KEY) {
+            return {
+              key: ERC20_APPROVAL_GAS_SPONSORING_KEY,
+              signer: {
+                ...mockFacilitatorSigner,
+                sendTransactions: vi.fn(),
+              },
+            };
+          }
+          return undefined;
+        }),
+      };
+
+      const payload = makeErc20Permit2Payload(makeValidErc20Extension());
+      const result = await facilitator.verify(payload, erc20Requirements, mockContext);
+
+      expect(result.isValid).toBe(true);
     });
   });
 
@@ -1462,14 +1673,8 @@ describe("ExactEvmScheme (Facilitator)", () => {
       } as any);
       vi.mocked(recoverTransactionAddress).mockResolvedValue(PAYER);
 
-      // Base signer: allowance=0 (re-verify sees ERC-20 extension in context and accepts it)
-      mockFacilitatorSigner.readContract = vi
-        .fn()
-        .mockImplementation(({ functionName }: { functionName: string }) => {
-          if (functionName === "allowance") return Promise.resolve(0n);
-          if (functionName === "balanceOf") return Promise.resolve(BigInt("10000000"));
-          return Promise.resolve(0n);
-        });
+      // settle's re-verify has simulate=false, so no simulation calls
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const SETTLE_TX_HASH = "0xsettle_tx_hash_mock" as `0x${string}`;
       const mockSendTransactions = vi.fn().mockResolvedValue([SETTLE_TX_HASH]);
@@ -1521,13 +1726,8 @@ describe("ExactEvmScheme (Facilitator)", () => {
       } as any);
       vi.mocked(recoverTransactionAddress).mockResolvedValue(PAYER);
 
-      mockFacilitatorSigner.readContract = vi
-        .fn()
-        .mockImplementation(({ functionName }: { functionName: string }) => {
-          if (functionName === "allowance") return Promise.resolve(0n);
-          if (functionName === "balanceOf") return Promise.resolve(BigInt("10000000"));
-          return Promise.resolve(0n);
-        });
+      // settle's re-verify has simulate=false
+      mockFacilitatorSigner.readContract = vi.fn().mockResolvedValue(undefined);
 
       const selectedSignerSendTransactions = vi
         .fn()


### PR DESCRIPTION
## Description

- Adds simulation to permit2 `verify/ `and optional `settle/ `, analogous to https://github.com/coinbase/x402/pull/1474 for 3009
- Introduces optional `simulateTransactions` to extension signer interface, analogous to `sendTransactions` introduced in https://github.com/coinbase/x402/pull/1487
- If verifyTypedData fails, check if bytecode exists and if thats the case proceed to simulation as authoritative check for deployed smart wallets (see https://github.com/coinbase/x402/pull/1474)
- Adds missing e2e test for permit2 branch without gas sponsoring extension
- Improve nonce handling in `permit2-approval.ts` e2e script and avoid unnecessary approval/revoke calls based on route

## Tests

```
📋 Detailed Test Results
========================

✅ PASSED TESTS:

  # 1: axios → express → /protected
      Facilitator: go
      Network: eip155:84532
      Tx: 0x58ffaedc59bf2698fa097c02469da00a90dcfa89663c3603ac3a8d901399eb61
  # 2: axios → express → /protected-permit2
      Facilitator: go
      Network: eip155:84532
      Tx: 0x792bbc003f1b7db9f0d94bc0858368d96e501c98607e2d49bda578f8d079eb79
  # 3: axios → express → /protected-permit2-eip2612
      Facilitator: go
      Network: eip155:84532
      Tx: 0x6d827fb3f2f59361d6fbeb827627ac6f18e5d1d3cf118cd0f4c539432aea33ec
  # 4: axios → express → /protected-permit2-erc20
      Facilitator: go
      Network: eip155:84532
      Tx: 0x1d3d70c1fb95fce06071a1b0a281638a20e25aad085e8170b34448016b4b664b
  # 5: go-http → express → /protected
      Facilitator: go
      Network: eip155:84532
      Tx: 0xd949ea0a99c2668578f843e96026cf73e9ad1f1048f68d7de64ae9de6876da27
  # 6: axios → express → /protected
      Facilitator: typescript
      Network: eip155:84532
      Tx: 0xe0baad661794cd8ecaea470dedebbb6ec81326665933ea7f6948f204ce99a6a1
  # 7: axios → gin → /protected
      Facilitator: go
      Network: eip155:84532
      Tx: 0xd28ce53824ecf6b63b184deac59d9cc64cef88fbfb596ee54e783b6b808fe15c
  # 8: axios → gin → /protected-permit2
      Facilitator: go
      Network: eip155:84532
      Tx: 0x3b49f1f1ff553e261688e07d2e78038497fea0562f543d6ab4fbb1460b9052d8
  # 9: axios → gin → /protected-permit2-eip2612
      Facilitator: go
      Network: eip155:84532
      Tx: 0x518ea38529dd20e9284c2bb6b5dfefe37edf29a2898c3cdc6613db98bc672fc0
  #10: axios → gin → /protected-permit2-erc20
      Facilitator: go
      Network: eip155:84532
      Tx: 0x33cc100e678ad0a7d7bb5bc7bacefadc16ccf1e47f9751b19667c5450c4fda17

📊 Breakdown by Facilitator:
 go              ✅ 9 / ❌ 0 (100%)
 typescript      ✅ 1 / ❌ 0 (100%)

📊 Breakdown by Server:
 express              ✅ 6 / ❌ 0 (100%)
 gin                  ✅ 4 / ❌ 0 (100%)

📊 Breakdown by Client:
   axios                ✅ 9 / ❌ 0 (100%)
   go-http              ✅ 1 / ❌ 0 (100%)
```


## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 