### PR TITLE
Add x402-proxy to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-proxy/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-proxy/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402-proxy",
+  "description": "curl for x402 paid APIs. CLI and library that auto-pays HTTP 402 responses with USDC on Base and Solana, with MCP stdio proxy for AI agents. npx x402-proxy.",
+  "logoUrl": "/logos/cascade.png",
+  "websiteUrl": "https://github.com/cascade-protocol/x402-proxy",
+  "category": "Client-Side Integrations"
+}


### PR DESCRIPTION
Adds x402-proxy to the ecosystem page.

**x402-proxy** is `curl` for x402 paid APIs - a CLI and library that auto-pays HTTP 402 responses with USDC on Base and Solana, with an MCP stdio proxy for AI agents. `npx x402-proxy`.

- **Category:** Client-Side Integrations
- **Website:** https://github.com/cascade-protocol/x402-proxy
- **Logo:** Reuses existing Cascade logo (`/logos/cascade.png`)

Published on npm as [`x402-proxy`](https://www.npmjs.com/package/x402-proxy).