### PR TITLE
feat(specs): add pause-commit scheme specification for EVM

### DIFF
--- a/specs/schemes/pause-commit/scheme_pause_commit.md
+++ b/specs/schemes/pause-commit/scheme_pause_commit.md
@@ -1,0 +1,87 @@
+# Scheme: `pause-commit`
+
+## Summary
+
+`pause-commit` is a payment scheme for x402 that adds two capabilities missing from existing schemes: **pre-payment address risk scoring** and **payer-controlled cancellation**.
+
+The scheme uses off-chain EIP-712 signatures for payment authorization (zero gas for the client) and on-chain atomic settlement via the PAUSECommit smart contract. Between authorization and settlement, the client can revoke the payment if the server fails to deliver.
+
+## Problem
+
+Existing x402 schemes (`exact`, `upto`) transfer funds before or during resource delivery. The client has no recourse if:
+
+- The `payTo` address has been compromised or is associated with known scams
+- The server fails to deliver the requested resource after payment
+- The `payTo` address changes between requests (V2 dynamic routing)
+
+The 402Bridge incident (October 2025) demonstrated that compromised `payTo` addresses can drain users without any pre-payment check.
+
+## How It Works
+
+The scheme operates in two phases:
+
+**Phase 1 — Intent**: Client scores the `payTo` address against 11 Bayesian risk signals via the PAUSE Risk Engine. If the address passes (score >= 40), the client signs an EIP-712 PaymentIntent off-chain. No gas cost. Funds remain in the client's wallet.
+
+**Phase 2 — Commit**: The server (or facilitator) calls `PAUSECommit.commit()` on-chain to settle the payment atomically. Only the recipient (`to` address) can call commit. If the server never commits, the client can call `revoke()` to permanently cancel the intent.
+
+## Use Cases
+
+- High-value API calls where the client needs cancellation ability
+- First-time interactions with unknown service providers
+- Agent-to-agent payments where neither party has prior trust
+- Regulated environments requiring pre-payment risk assessment
+
+## Comparison with Other Schemes
+
+| Property | exact | pause-commit |
+|----------|-------|--------------|
+| Payment timing | Before delivery | After delivery |
+| Cancellable | No | Yes, before commit |
+| Pre-payment risk scoring | No | 11 Bayesian signals |
+| Client gas cost | ~21k (EIP-3009) | Zero (off-chain EIP-712) |
+| Server gas cost | N/A | ~85k (settlement) |
+| Best for | Micropayments | High-value + safety |
+| Caller restriction | Facilitator | Only recipient can commit |
+
+## Risk Assessment
+
+Before signing a PaymentIntent, the client screens the `payTo` address using the PAUSE Risk Engine. The engine evaluates 11 independent Bayesian signals:
+
+| Signal | Weight | Detection |
+|--------|--------|-----------|
+| Mixer Exposure | 0.45 | Tornado Cash interaction |
+| Draining Pattern | 0.30 | Wallet drainer behavior |
+| Exchange Cluster | 0.25 | Exchange wallet proximity |
+| Sweep Pattern | 0.25 | Funds consolidation |
+| TX Burst Anomaly | 0.20 | Bot-like transaction spikes |
+| Scam Graph | 0.20 | Community-reported scam connections |
+| Dusting Attack | 0.15 | Micro-transaction tracking |
+| ENS Authenticity | 0.15 | Domain ownership verification |
+| Rival Consensus | 0.15 | External scoring cross-reference |
+| Wallet Age | 0.10 | Account age and activity |
+| Balance Volatility | 0.10 | Abnormal balance patterns |
+
+Signals are combined using log-odds scoring with correlation discounting to produce a score from 0-100. Addresses scoring below 40 are blocked before any signature is created.
+
+## Security Properties
+
+1. **Non-custodial**: Funds remain in the client's wallet until atomic settlement
+2. **Recipient-only commit**: Only the `to` address can call `commit()` — prevents front-running
+3. **Sender-only revoke**: Only the `from` address can call `revoke()` — prevents griefing
+4. **Expiry enforcement**: Intents expire automatically after the `expiry` timestamp
+5. **Replay protection**: Each intent uses a unique nonce; committed and revoked intents cannot be reused
+6. **Chain binding**: The `chainId` field prevents cross-chain replay attacks
+
+## Infrastructure
+
+| Component | URL | Status |
+|-----------|-----|--------|
+| Smart Contract (Ethereum) | [`0x604152D82Fd031cCD8D27F26C5792AC2CD328bF4`](https://etherscan.io/address/0x604152D82Fd031cCD8D27F26C5792AC2CD328bF4) | Deployed, verified |
+| Risk Engine API | `https://api.pausescan.com/api/v1/analyze` | Live |
+| Facilitator | `https://facilitator.pausesecure.com` | Live |
+| npm (risk) | [`@pausesecure/x402-risk`](https://www.npmjs.com/package/@pausesecure/x402-risk) | Published |
+| npm (commit) | [`@pausesecure/x402-commit`](https://www.npmjs.com/package/@pausesecure/x402-commit) | Published |
+
+## Network-Specific Implementations
+
+- [`scheme_pause_commit_evm.md`](./scheme_pause_commit_evm.md) — EVM implementation details

--- a/specs/schemes/pause-commit/scheme_pause_commit_evm.md
+++ b/specs/schemes/pause-commit/scheme_pause_commit_evm.md
@@ -1,0 +1,288 @@
+# Scheme: `pause-commit` on `EVM`
+
+## Summary
+
+The `pause-commit` scheme on EVM uses the PAUSECommit smart contract for two-phase payment settlement. Clients sign off-chain EIP-712 payment intents at zero gas cost. Recipients claim payments atomically on-chain. Clients can revoke unclaimed intents.
+
+This document describes the deployed contract interface, EIP-712 signing format, validation requirements, and integration patterns.
+
+## Smart Contract
+
+**Contract**: PAUSECommit V2
+**Ethereum Mainnet**: [`0x604152D82Fd031cCD8D27F26C5792AC2CD328bF4`](https://etherscan.io/address/0x604152D82Fd031cCD8D27F26C5792AC2CD328bF4)
+**Verified**: Yes (Etherscan)
+
+### Functions
+
+```solidity
+// Settle a payment intent on-chain. Only callable by the recipient (to).
+function commit(
+    address from,
+    address to,
+    address token,
+    uint256 amount,
+    uint256 nonce,
+    uint256 expiry,
+    uint256 chainId,
+    bytes calldata signature
+) external;
+
+// Cancel a payment intent. Only callable by the sender (from).
+function revoke(
+    address from,
+    address to,
+    address token,
+    uint256 amount,
+    uint256 nonce,
+    uint256 expiry,
+    uint256 chainId
+) external;
+
+// Check if an intent has been committed
+function isIntentUsed(bytes32 intentHash) external view returns (bool);
+
+// Check if an intent has been revoked
+function isIntentRevoked(bytes32 intentHash) external view returns (bool);
+
+// Get intent status: "committed", "revoked", or "pending"
+function intentStatus(bytes32 intentHash) external view returns (string memory);
+
+// Get the EIP-712 domain separator
+function domainSeparator() external view returns (bytes32);
+```
+
+### Events
+
+```solidity
+event PaymentCommitted(
+    bytes32 indexed intentHash,
+    address indexed from,
+    address indexed to,
+    address token,
+    uint256 amount
+);
+
+event PaymentRevoked(
+    bytes32 indexed intentHash,
+    address indexed from
+);
+```
+
+### Access Control
+
+- `commit()` enforces `require(msg.sender == to)` — only the recipient can settle
+- `revoke()` enforces `require(msg.sender == from)` — only the sender can cancel
+
+## EIP-712 Signing
+
+### Domain Separator
+
+```json
+{
+  "name": "PAUSE Protocol",
+  "version": "1",
+  "chainId": 1,
+  "verifyingContract": "0x604152D82Fd031cCD8D27F26C5792AC2CD328bF4"
+}
+```
+
+The domain is constructed in the contract constructor using `block.chainid`, so it reflects the chain the contract is deployed on.
+
+### PaymentIntent Type
+
+```
+PaymentIntent(address from,address to,address token,uint256 amount,uint256 nonce,uint256 expiry,uint256 chainId)
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `from` | `address` | Sender (payer) address |
+| `to` | `address` | Recipient (payee) address |
+| `token` | `address` | ERC-20 token contract (e.g. USDC) |
+| `amount` | `uint256` | Payment amount in token base units |
+| `nonce` | `uint256` | Unique value to prevent replay |
+| `expiry` | `uint256` | Unix timestamp after which the intent is invalid |
+| `chainId` | `uint256` | Target chain ID (must match `block.chainid`) |
+
+### Intent Hash
+
+The contract computes the intent hash as:
+
+```
+intentHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash))
+```
+
+where `structHash = keccak256(abi.encode(TYPE_HASH, from, to, token, amount, nonce, expiry, chainId))`.
+
+## Payment Flow
+
+### 1. Server Returns 402
+
+```http
+HTTP/1.1 402 Payment Required
+PAYMENT-REQUIRED: <base64-encoded JSON>
+```
+
+```json
+{
+  "x402Version": 2,
+  "resource": {
+    "url": "https://api.example.com/premium-data",
+    "description": "Premium market analysis",
+    "mimeType": "application/json"
+  },
+  "accepts": [{
+    "scheme": "pause-commit",
+    "network": "eip155:1",
+    "amount": "5000000",
+    "asset": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "payTo": "0x742d35Cc6634C0532925a3b8D951D75aC1FDF3fC",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "contractAddress": "0x604152D82Fd031cCD8D27F26C5792AC2CD328bF4",
+      "facilitatorUrl": "https://facilitator.pausesecure.com"
+    }
+  }]
+}
+```
+
+### 2. Client Screens `payTo` Address
+
+Client calls the PAUSE Risk Engine to score the recipient address:
+
+```http
+POST https://api.pausescan.com/api/v1/analyze
+Content-Type: application/json
+
+{"address": "0x742d35Cc6634C0532925a3b8D951D75aC1FDF3fC"}
+```
+
+Response includes a score from 0-100. Addresses scoring below 40 should be blocked.
+
+### 3. Client Signs EIP-712 PaymentIntent
+
+If risk assessment passes, client signs the intent off-chain (zero gas):
+
+```typescript
+const intent = {
+  from: clientAddress,
+  to: "0x742d35Cc6634C0532925a3b8D951D75aC1FDF3fC",
+  token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+  amount: "5000000",
+  nonce: generateUniqueNonce(),
+  expiry: Math.floor(Date.now() / 1000) + 300,
+  chainId: 1
+};
+
+const signature = await signer._signTypedData(domain, types, intent);
+```
+
+### 4. Client Retries with Payment Header
+
+```http
+GET /premium-data HTTP/1.1
+PAYMENT-SIGNATURE: <base64-encoded JSON>
+```
+
+```json
+{
+  "scheme": "pause-commit",
+  "payload": {
+    "signature": "0x...",
+    "intent": {
+      "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      "to": "0x742d35Cc6634C0532925a3b8D951D75aC1FDF3fC",
+      "token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "amount": "5000000",
+      "nonce": "1710000001",
+      "expiry": "1710000300",
+      "chainId": "1"
+    },
+    "riskScore": 85
+  }
+}
+```
+
+### 5. Server Validates Intent
+
+The server (or facilitator) must verify:
+
+1. Recover signer from EIP-712 signature — must match `intent.from`
+2. `intent.to` matches server's own address
+3. `intent.amount` >= required payment amount
+4. `intent.token` matches required asset
+5. `intent.expiry > block.timestamp` (not expired)
+6. `intent.chainId == block.chainid` (correct chain)
+7. Intent not already used or revoked (call `intentStatus()`)
+8. Client has sufficient token balance and has approved the PAUSECommit contract
+
+### 6. Server Commits On-Chain
+
+After delivering the resource, the server calls:
+
+```solidity
+PAUSECommit.commit(from, to, token, amount, nonce, expiry, chainId, signature)
+```
+
+Gas cost: ~85,000. The server or facilitator pays gas.
+
+The contract verifies the signature, checks expiry and chain ID, confirms the intent hasn't been used or revoked, and executes `transferFrom(from, to, amount)` atomically.
+
+### 7. Cancellation
+
+If the server fails to commit before the expiry, the client can revoke:
+
+```solidity
+PAUSECommit.revoke(from, to, token, amount, nonce, expiry, chainId)
+```
+
+Requirements:
+- Caller must be `from` (the original signer)
+- Intent must not be already committed
+- Intent must not be already revoked
+
+After revocation, the intent hash is permanently marked as revoked and can never be committed.
+
+## Gas Costs
+
+| Operation | Gas | Paid By |
+|-----------|-----|---------|
+| EIP-712 signing | 0 | Client (off-chain) |
+| `commit()` | ~85,000 | Server or facilitator |
+| `revoke()` | ~45,000 | Client |
+| `isIntentUsed()` | 0 (view) | — |
+| `isIntentRevoked()` | 0 (view) | — |
+| `intentStatus()` | 0 (view) | — |
+
+## Facilitator Endpoints
+
+The PAUSE facilitator at `https://facilitator.pausesecure.com` provides:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/verify` | POST | Validate intent signature, check on-chain status |
+| `/settle` | POST | Execute `commit()` on-chain, return tx hash |
+| `/health` | GET | Service health check |
+| `/info` | GET | Supported networks, contract addresses, pricing |
+
+## Token Requirements
+
+- The token must be ERC-20 compatible
+- The client must have `balance >= amount`
+- The client must have called `token.approve(PAUSECommitAddress, amount)` before the server can commit
+- USDC on Ethereum Mainnet: `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`
+
+## Network Deployment
+
+| Network | Chain ID | Contract | Status |
+|---------|----------|----------|--------|
+| Ethereum Mainnet | 1 | `0x604152D82Fd031cCD8D27F26C5792AC2CD328bF4` | Deployed |
+| Base | 8453 | TBD | Planned Q2 2026 |
+| Arbitrum | 42161 | TBD | Planned Q2 2026 |
+
+## Reference Implementation
+
+- Risk extension: [`@pausesecure/x402-risk`](https://www.npmjs.com/package/@pausesecure/x402-risk)
+- Commit scheme: [`@pausesecure/x402-commit`](https://www.npmjs.com/package/@pausesecure/x402-commit)
+- Scanner: [pausescan.com](https://pausescan.com)
+- Platform: [pausesecure.com](https://pausesecure.com)


### PR DESCRIPTION
## Summary

Adds formal specification for the `pause-commit` payment scheme on EVM, as proposed in #1594.

This spec is written by the author of the PAUSECommit V2 smart contract. All function signatures, EIP-712 types, domain parameters, and event definitions are verified against the deployed and verified contract source on Etherscan.

## What's in this PR

Two files following the existing scheme spec pattern:

- `specs/schemes/pause-commit/scheme_pause_commit.md` — Scheme overview, problem statement, risk assessment, security properties
- `specs/schemes/pause-commit/scheme_pause_commit_evm.md` — EVM implementation: contract interface, EIP-712 signing, payment flow, facilitator endpoints

## What `pause-commit` does

- Client signs an off-chain EIP-712 PaymentIntent (zero gas)
- Server commits the payment on-chain after delivering the resource (~85k gas)
- Client can revoke the intent if the server never commits
- Every `payTo` address is risk-scored across 11 Bayesian signals before signing

## Deployed infrastructure

- **Contract**: PAUSECommit V2 at `0x604152D82Fd031cCD8D27F26C5792AC2CD328bF4` (Ethereum mainnet, verified)
- **Risk Engine**: https://api.pausescan.com/api/v1/analyze
- **Facilitator**: https://facilitator.pausesecure.com
- **npm**: `@pausesecure/x402-risk`, `@pausesecure/x402-commit`

## Note on PR #1609

A previous spec PR (#1609) was submitted by a third party with several inaccuracies against the deployed contract (wrong EIP-712 domain, wrong field names, wrong function signatures). This PR corrects those issues. See my review comment on #1609 for the full list of differences.

Resolves #1594
