### PR TITLE
Add PayCrow to ecosystem listings

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/paycrow/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/paycrow/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "PayCrow",
+  "description": "Escrow protection for autonomous agent payments. Trust scoring + USDC escrow + dispute resolution on Base. The trust layer for x402.",
+  "logoUrl": "/logos/paycrow.svg",
+  "websiteUrl": "https://github.com/michu5696/paycrow",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/paycrow.svg
+++ b/typescript/site/public/logos/paycrow.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <rect width="120" height="120" rx="20" fill="#0052FF"/>
+  <text x="60" y="52" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="16" fill="white">PAY</text>
+  <text x="60" y="78" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="16" fill="white">CROW</text>
+  <path d="M40 88 L60 95 L80 88" stroke="white" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add PayCrow as a Services/Endpoints ecosystem entry
- Include a PayCrow logo asset (SVG) for the site listing

## What is PayCrow?
PayCrow provides escrow protection for autonomous agent payments on Base:
- **Trust scoring** — on-chain reputation system for agents and services
- **USDC escrow** — funds held in escrow until service delivery is confirmed
- **Dispute resolution** — automated and manual dispute handling for failed deliveries

It serves as the trust layer for x402, adding payment protection on top of the x402 payment protocol.

**Website**: https://github.com/michu5696/paycrow
**Tags**: escrow, trust, dispute-resolution, reputation, payment-protection

## Testing
- Metadata-only ecosystem partner addition (no code changes)
- Verified metadata.json follows the existing partner format

🤖 Generated with [Claude Code](https://claude.com/claude-code)