### PR TITLE
Add PayCrow to ecosystem — escrow + trust layer for x402

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/paycrow/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/paycrow/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "PayCrow",
+  "description": "Escrow protection for autonomous agent payments. Trust scoring from 4 on-chain sources + USDC escrow with dispute resolution on Base. 10 MCP tools including safe_pay (trust-informed smart escrow) and trust_gate (go/no-go before payment). PayPal for AI agents.",
+  "logoUrl": "/logos/paycrow.svg",
+  "websiteUrl": "https://github.com/michu5696/paycrow",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/paycrow.svg
+++ b/typescript/site/public/logos/paycrow.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect width="100" height="100" rx="16" fill="#1a1a2e"/>
+  <text x="50" y="42" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="14" fill="#e0e0ff">PAY</text>
+  <text x="50" y="62" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="14" fill="#7c6ef0">CROW</text>
+  <path d="M30 72 L50 78 L70 72" stroke="#7c6ef0" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds [PayCrow](https://github.com/michu5696/paycrow) to the x402 ecosystem directory under **Infrastructure & Tooling**.

PayCrow is the trust and escrow protection layer for x402 agent payments:

- **Trust scoring** from 4 on-chain sources (PayCrow escrow history, ERC-8004 identity, Moltbook karma, Base chain activity)
- **USDC escrow** with the only real dispute resolution on Base/EVM
- **10 MCP tools** including `safe_pay` (trust-informed smart escrow) and `trust_gate` (go/no-go before payment)
- **ERC-8183 Evaluator** for agentic commerce marketplaces
- **Bilateral quality ratings** for buyers and sellers

Live on Base mainnet. npm: `paycrow`. 341 tests passing.

## Files Changed

- `typescript/site/app/ecosystem/partners-data/paycrow/metadata.json` — listing metadata
- `typescript/site/public/logos/paycrow.svg` — logo