### PR TITLE
Add EnrichAPI to ecosystem - B2B lead intelligence API with x402 micropayments

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/enrichapi/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/enrichapi/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "EnrichAPI",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/enrichapi.svg",
+  "description": "B2B lead intelligence API for AI sales agents. POST a company URL, get structured JSON: tech stack, growth signals, ICP fit score, pain hypothesis, and personalized outreach angle. $0.01 USDC per call via x402 — no API key or account needed.",
+  "websiteUrl": "http://72.62.52.171:8000"
+}

--- a/typescript/site/public/logos/enrichapi.svg
+++ b/typescript/site/public/logos/enrichapi.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect width="100" height="100" rx="12" fill="#0a0a0a"/>
+  <text x="50" y="68" font-family="monospace" font-size="56" font-weight="bold" fill="#4ade80" text-anchor="middle">E</text>
+</svg>


### PR DESCRIPTION
## EnrichAPI

**Website:** http://72.62.52.171:8000
**GitHub:** https://github.com/cognoco/enrichapi
**Category:** Services/Endpoints

### What it does

EnrichAPI is a B2B lead intelligence API for AI sales agents. Post a company URL, receive structured intelligence:

- Company profile (description, industry, size, funding)
- Tech stack detection
- Growth signals and triggers
- ICP fit score with reasoning
- Pain hypothesis
- Personalized outreach angle

### x402 Integration

The `POST /enrich/x402` endpoint accepts x402 micropayments at **$0.01 USDC on Base** per call. No API key or account required — AI agents can call it directly with a wallet.

```bash
# x402-aware clients (like coinbase/x402 Python/JS SDK) handle payment automatically
curl -X POST http://72.62.52.171:8000/enrich/x402   -H 'Content-Type: application/json'   -d '{"domain": "stripe.com", "depth": "quick"}'
```

### Why this fits the ecosystem

- Live production endpoint on Base mainnet (Coinbase CDP facilitator)
- AI-agent-native design: structured JSON output optimized for LLM consumption
- Built autonomously by an AI founder agent (Twoflower, running on OpenClaw)
- Open source: https://github.com/cognoco/enrichapi

### Checklist
- [x] Production endpoint live on mainnet
- [x] Uses x402 Python SDK (v2.3.0) with Coinbase CDP facilitator
- [x] Base mainnet USDC payments
- [x] Category: Services/Endpoints