### PR TITLE
feat: update e2e tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -85,12 +85,32 @@ Add the `-v` flag to any command for verbose output:
 
 Useful for debugging test failures or understanding the payment flow.
 
+## Wallet Safety Warning
+
+**Use dedicated test wallets only. Do NOT use wallets that hold real funds.**
+
+The test suite moves ETH between the configured wallets during a run. Funds stay
+within the set of wallets defined in `.env`, but individual wallet balances will
+change unpredictably:
+
+- **ETH is transferred** from the facilitator wallet to the client wallet so the
+  client can pay gas for granting and revoking Permit2 approvals between tests.
+- **ETH is swept** from the client wallet back to the facilitator after revocation
+  to create a zero-balance state, which is required to exercise the facilitator's
+  gasless funding step.
+- **Token approvals are granted and revoked** on the client wallet as part of
+  normal test flow.
+
+While no funds leave the configured wallet set, the client wallet's ETH balance
+will be drained to near-zero between tests. Do not rely on any particular wallet
+having a stable balance during or after a run.
+
 ## Environment Variables
 
 Required environment variables (set in `.env` file):
 
 ```bash
-# Client wallets
+# Client wallets (⚠️ TEST WALLETS ONLY — balances will be swept during runs)
 CLIENT_EVM_PRIVATE_KEY=0x...        # EVM private key for client payments
 CLIENT_SVM_PRIVATE_KEY=...          # Solana private key for client payments
 CLIENT_APTOS_PRIVATE_KEY=...        # Aptos private key for client payments (hex string)
@@ -102,7 +122,7 @@ SERVER_SVM_ADDRESS=...              # Where servers receive Solana payments
 SERVER_APTOS_ADDRESS=0x...          # Where servers receive Aptos payments
 SERVER_STELLAR_ADDRESS=...          # Where servers receive Stellar payments
 
-# Facilitator wallets (for payment verification/settlement)
+# Facilitator wallets (⚠️ TEST WALLETS ONLY — used to fund/drain client between tests)
 FACILITATOR_EVM_PRIVATE_KEY=0x...   # EVM private key for facilitator
 FACILITATOR_SVM_PRIVATE_KEY=...     # Solana private key for facilitator
 FACILITATOR_APTOS_PRIVATE_KEY=...   # Aptos private key for facilitator (hex string)

--- a/e2e/servers/express/index.ts
+++ b/e2e/servers/express/index.ts
@@ -222,6 +222,8 @@ app.use(
             asset: EVM_PERMIT2_ASSET,
             extra: {
               assetTransferMethod: "permit2",
+              name: EVM_NETWORK == "eip155:84532" ? "USDC" : "USD Coin",
+              version: "2",
             },
           },
         },

--- a/e2e/servers/gin/main.go
+++ b/e2e/servers/gin/main.go
@@ -178,9 +178,17 @@ func main() {
 				Price: map[string]interface{}{
 					"amount": "1000",
 					"asset":  evmPermit2Asset,
-					"extra": map[string]interface{}{
-						"assetTransferMethod": "permit2",
-					},
+					"extra": func() map[string]interface{} {
+						name := "USD Coin"
+						if evmNetworkStr == "eip155:84532" {
+							name = "USDC"
+						}
+						return map[string]interface{}{
+							"assetTransferMethod": "permit2",
+							"name":               name,
+							"version":            "2",
+						}
+					}(),
 				},
 				},
 			},

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -1,6 +1,9 @@
 import { config } from 'dotenv';
 import { spawn, execSync } from 'child_process';
 import { writeFileSync } from 'fs';
+import { createWalletClient, createPublicClient, http, parseEther, formatEther } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { base, baseSepolia } from 'viem/chains';
 import { TestDiscovery } from './src/discovery';
 import { ClientConfig, ScenarioResult, ServerConfig, TestScenario } from './src/types';
 import { config as loggerConfig, log, verboseLog, errorLog, close as closeLogger, createComboLogger } from './src/logger';
@@ -118,6 +121,123 @@ async function revokePermit2Approval(tokenAddress?: string): Promise<boolean> {
       resolve(false);
     });
   });
+}
+
+/**
+ * Shared EVM clients for the ETH sandwich helpers.
+ * Lazily initialised on first use so that missing env vars don't blow up
+ * non-EVM test runs.
+ */
+function getEvmClients() {
+  const evmNetwork = process.env.EVM_NETWORK || 'eip155:84532';
+  const evmRpcUrl = process.env.EVM_RPC_URL;
+  const evmChain = evmNetwork === 'eip155:8453' ? base : baseSepolia;
+
+  const facilitatorKey = process.env.FACILITATOR_EVM_PRIVATE_KEY;
+  const clientKey = process.env.CLIENT_EVM_PRIVATE_KEY;
+  if (!facilitatorKey || !clientKey) {
+    throw new Error('FACILITATOR_EVM_PRIVATE_KEY and CLIENT_EVM_PRIVATE_KEY must be set');
+  }
+
+  const facilitatorAccount = privateKeyToAccount(facilitatorKey as `0x${string}`);
+  const clientAccount = privateKeyToAccount(clientKey as `0x${string}`);
+
+  const publicClient = createPublicClient({
+    chain: evmChain,
+    transport: http(evmRpcUrl),
+  });
+  const facilitatorWallet = createWalletClient({
+    account: facilitatorAccount,
+    chain: evmChain,
+    transport: http(evmRpcUrl),
+  });
+  const clientWallet = createWalletClient({
+    account: clientAccount,
+    chain: evmChain,
+    transport: http(evmRpcUrl),
+  });
+
+  return { publicClient, facilitatorWallet, clientWallet, facilitatorAccount, clientAccount };
+}
+
+const REVOKE_FUND_AMOUNT = parseEther('0.001');
+
+/**
+ * Send a small amount of ETH from the facilitator wallet to the client wallet
+ * so the client can pay gas for Permit2 revocation transactions.
+ */
+async function fundClientForRevoke(): Promise<boolean> {
+  try {
+    const { publicClient, facilitatorWallet, facilitatorAccount, clientAccount } = getEvmClients();
+
+    const clientBalance = await publicClient.getBalance({ address: clientAccount.address });
+    if (clientBalance >= REVOKE_FUND_AMOUNT) {
+      verboseLog(`  ℹ️  Client already has ${formatEther(clientBalance)} ETH, skipping fund`);
+      return true;
+    }
+
+    const facilitatorBalance = await publicClient.getBalance({ address: facilitatorAccount.address });
+    if (facilitatorBalance < REVOKE_FUND_AMOUNT) {
+      errorLog(`  ❌ Facilitator wallet ${facilitatorAccount.address} has insufficient ETH (${formatEther(facilitatorBalance)}) to fund client for revoke.`);
+      errorLog(`     Please fund the facilitator wallet with testnet ETH (need at least ${formatEther(REVOKE_FUND_AMOUNT)} ETH).`);
+      return false;
+    }
+
+    verboseLog(`  💸 Funding client ${clientAccount.address} with ${formatEther(REVOKE_FUND_AMOUNT)} ETH for revoke...`);
+    const hash = await facilitatorWallet.sendTransaction({
+      to: clientAccount.address,
+      value: REVOKE_FUND_AMOUNT,
+    });
+    await publicClient.waitForTransactionReceipt({ hash });
+    verboseLog(`  ✅ Funded client (tx: ${hash})`);
+    return true;
+  } catch (err) {
+    errorLog(`  ❌ Failed to fund client for revoke: ${err instanceof Error ? err.message : err}`);
+    return false;
+  }
+}
+
+/**
+ * Drain all ETH from the client wallet back to the facilitator wallet,
+ * leaving the client with ~0 ETH so the gas sponsoring funding step is
+ * exercised during the test.
+ */
+async function drainClientETH(): Promise<boolean> {
+  try {
+    const { publicClient, clientWallet, facilitatorAccount, clientAccount } = getEvmClients();
+
+    const balance = await publicClient.getBalance({ address: clientAccount.address });
+    if (balance === 0n) {
+      verboseLog('  ℹ️  Client ETH balance is already 0');
+      return true;
+    }
+
+    // Reserve enough for gas. On L2s getGasPrice() returns a tiny value but
+    // viem's sendTransaction uses a higher maxFeePerGas with safety margin.
+    // Use a generous fixed buffer to avoid "insufficient funds" from the
+    // estimateGas pre-check.
+    const GAS_RESERVE = parseEther('0.0001');
+    const sendAmount = balance - GAS_RESERVE;
+
+    if (sendAmount <= 0n) {
+      verboseLog(`  ℹ️  Client balance (${formatEther(balance)} ETH) too small to drain, leaving as dust`);
+      return true;
+    }
+
+    verboseLog(`  💸 Draining ${formatEther(sendAmount)} ETH from client back to facilitator...`);
+    const hash = await clientWallet.sendTransaction({
+      to: facilitatorAccount.address,
+      value: sendAmount,
+    });
+    await publicClient.waitForTransactionReceipt({ hash });
+
+    const remaining = await publicClient.getBalance({ address: clientAccount.address });
+    verboseLog(`  ✅ Drained client ETH (tx: ${hash}, remaining: ${formatEther(remaining)} ETH)`);
+    return true;
+  } catch (err) {
+    errorLog(`  ❌ Failed to drain client ETH: ${err instanceof Error ? err.message : err}`);
+    return false;
+  }
 }
 
 // Load environment variables
@@ -704,11 +824,14 @@ async function runTest() {
           if (scenario.endpoint.permit2Direct) {
             await approvePermit2Approval(USDC_BASE_SEPOLIA);
           } else {
+            await fundClientForRevoke();
             const token =
               scenario.endpoint.extensions?.includes('erc20ApprovalGasSponsoring')
                 ? MOCK_ERC20_BASE_SEPOLIA
                 : USDC_BASE_SEPOLIA;
             await revokePermit2Approval(token);
+            await new Promise(resolve => setTimeout(resolve, 2000));
+            await drainClientETH();
           }
         }
 

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -833,6 +833,9 @@ async function runTest() {
             await new Promise(resolve => setTimeout(resolve, 2000));
             await drainClientETH();
           }
+          // Wait for RPC nonce propagation across load-balanced nodes before the
+          // test client (which may use a separate RPC connection) queries the nonce.
+          await new Promise(resolve => setTimeout(resolve, 2000));
         }
 
         if (isEvm && facilitatorName && evmLock) {


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

There was a problem with e2e testing permit2 in how we were juggling revoking approval between tests, with the testing requirement that clients have no funds when flowing through the ERC20 gas sponsorship tests.

This test addresses it by sandwiching the revoke in a `Fund client` -> `Revoke approval` -> `Drain client funds` transaction sandwich between tests

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

E2E tested

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 