### PR TITLE
Add Arch Tools to x402 Ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/arch-tools/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/arch-tools/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Arch Tools",
+  "description": "53 production-ready AI tools accessible via MCP (Model Context Protocol) with native x402 USDC payments on Base L2. Unified API covering web scraping (Tavily, Firecrawl, Brave, Exa), cryptocurrency data across 15 chains (CoinGecko), AI image and video generation (DALL-E, Runway, Gemini), OCR, email verification, and background removal. Also supports traditional Stripe credit payments and BYOK for all AI providers. JS and Python SDKs available.",
+  "logoUrl": "/logos/arch-tools.png",
+  "websiteUrl": "https://archtools.dev",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/arch-tools.png
+++ b/typescript/site/public/logos/arch-tools.png
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 120 120" fill="none">
+  <defs>
+    <linearGradient id="favicon-grad" x1="60" y1="10" x2="60" y2="110" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#FF9010"/>
+      <stop offset="60%" stop-color="#FF2896"/>
+      <stop offset="100%" stop-color="#8844FF"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#favicon-grad)" d="M15,100L15,55A35,35,0,0,1,85,55L85,100L74,100L74,55A24,24,0,0,0,26,55L26,100Z M34,100L34,55A16,16,0,0,1,66,55L66,100L58,100L58,55A8,8,0,0,0,42,55L42,100Z"/>
+</svg>


### PR DESCRIPTION
## Arch Tools

**Website:** https://archtools.dev
**Category:** Services/Endpoints

### What is Arch Tools?
A unified API platform providing **53 production-ready AI tools** accessible via MCP (Model Context Protocol) with native x402 USDC payments on Base L2.

### Tools include:
- Web scraping & search (Tavily, Firecrawl, Brave, Exa)
- Cryptocurrency data across 15 chains (CoinGecko)
- AI image & video generation (DALL-E, Runway, Gemini)
- OCR & document processing
- Email verification & validation
- Background removal

### Payment
- x402 USDC payments on Base L2 (native)
- Traditional Stripe credit payments
- BYOK support for all 4 AI providers

### SDKs
- JavaScript SDK
- Python SDK

### Verification
- ✅ Listed on [Glama](https://glama.ai/mcp/servers/@Deesmo/arch-tools-mcp) — 53 tools, healthy
- ✅ Listed on [Smithery](https://smithery.ai/servers/archtools/arch-tools-mcp) — WORKING status
- ✅ Official MCP Registry
- ✅ PulseMCP, MCP.so, MCP Hub, LobeHub