### PR TITLE
feat: improved working of adding new default assets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,18 @@ x402 aims to be chain-agnostic. New chain implementations are welcome.
 
 Because different chains have different best practices, a scheme may have a different mechanism on a new chain than it does on EVM. If the scheme mechanism varies from the reference implementation, the x402 Foundation will re-audit the scheme for that chain before accepting.
 
+### Adding a Default Asset for an EVM Chain
+
+If your chain is EVM-compatible and you want to add a default stablecoin for
+dollar-string pricing (`"$0.10"`), you don't need the full 3-PR workflow below. See:
+
+- [Go: DEFAULT_ASSET.md](go/mechanisms/evm/DEFAULT_ASSET.md)
+- [TypeScript: DEFAULT_ASSET.md](typescript/packages/mechanisms/evm/src/exact/server/DEFAULT_ASSET.md)
+
+These guides include a cross-SDK checklist of every file to update.
+
+### Adding a New Chain Family
+
 ### PR 1: Specification Only
 
 Open a PR with specs for one payment scheme implementation.

--- a/go/mechanisms/evm/DEFAULT_ASSET.md
+++ b/go/mechanisms/evm/DEFAULT_ASSET.md
@@ -13,7 +13,7 @@ To add support for a new EVM chain, add an entry to the `NetworkConfigs` map in 
 ```go
 NetworkConfigs = map[string]NetworkConfig{
     // ... existing chains ...
-    
+
     // Your New Chain
     "eip155:YOUR_CHAIN_ID": {
         ChainID: big.NewInt(YOUR_CHAIN_ID),
@@ -22,6 +22,8 @@ NetworkConfigs = map[string]NetworkConfig{
             Name:     "Token Name",  // Must match EIP-712 domain name
             Version:  "1",           // Must match EIP-712 domain version
             Decimals: 6,             // Token decimals (e.g. 6 for USDC)
+            // AssetTransferMethod: AssetTransferMethodPermit2,  // Uncomment if token doesn't support EIP-3009
+            // SupportsEip2612:     true,                        // Set if permit2 token implements EIP-2612 permit()
         },
     },
 }
@@ -36,12 +38,21 @@ NetworkConfigs = map[string]NetworkConfig{
 | `Name` | EIP-712 domain name (must match the token's domain separator) |
 | `Version` | EIP-712 domain version (must match the token's domain separator) |
 | `Decimals` | Token decimal places (typically 6 for USDC) |
+| `AssetTransferMethod` | *(Optional)* Transfer method override: set to `AssetTransferMethodPermit2` for tokens that don't support EIP-3009. Omit for EIP-3009 tokens (default behavior). |
+| `SupportsEip2612` | *(Optional)* Set to `true` for Permit2 tokens that implement EIP-2612 `permit()`. When true, clients can use gasless EIP-2612 permits for Permit2 approval. When false/absent on a Permit2 token, clients fall back to ERC-20 approval gas sponsoring. Ignored for EIP-3009 tokens. |
 
-## Current Limitation
+## Asset Transfer Methods
 
-> ⚠️ **EIP-3009 Required**: Currently, only stablecoins implementing [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009) (`transferWithAuthorization`) are supported.
->
-> Generic ERC-20 support via EIP-2612/Permit2 is planned but not yet implemented.
+x402 supports two methods for transferring assets:
+
+| Method | Use Case | Recommendation |
+|--------|----------|----------------|
+| **EIP-3009** | Tokens with native `transferWithAuthorization` (e.g., USDC) | **Recommended** (Simplest, truly gasless) |
+| **Permit2** | Any ERC-20 token | **Universal Fallback** (Requires one-time approval) |
+
+### Default Behavior
+
+If no `AssetTransferMethod` is specified, the system defaults to **EIP-3009**. This maintains backward compatibility with existing deployments.
 
 ## Asset Selection Policy
 
@@ -52,7 +63,6 @@ The default asset is chosen **per chain** based on the following guidelines:
 2. **No official stance**: If the chain team has not taken a public position on a preferred stablecoin, we encourage the team behind that chain to make the selection and submit a PR.
 
 3. **Community PRs welcome**: Chain teams and community members may submit PRs to add their chain's default asset, provided:
-   - The stablecoin implements EIP-3009
    - The selection aligns with the chain's ecosystem preferences
    - The EIP-712 domain parameters are correctly specified
 
@@ -60,7 +70,29 @@ The default asset is chosen **per chain** based on the following guidelines:
 
 To add a new chain's default asset:
 
-1. Verify the stablecoin implements EIP-3009
-2. Obtain the correct EIP-712 domain `name` and `version` from the token contract
-3. Add the entry to `NetworkConfigs` in `constants.go`
-4. Submit a PR with the chain name and rationale for the asset selection
+1. Obtain the correct EIP-712 domain `name` and `version` from the token contract
+2. Check whether the token supports EIP-3009 (`transferWithAuthorization`):
+   - If yes: omit `AssetTransferMethod` (EIP-3009 is the default)
+   - If no: set `AssetTransferMethod: AssetTransferMethodPermit2`
+3. For Permit2 tokens, check whether the token supports EIP-2612 (`permit()`):
+   - If yes: set `SupportsEip2612: true` so clients can use gasless EIP-2612 permits for Permit2 approval
+   - If no: omit `SupportsEip2612` — clients will fall back to ERC-20 approval gas sponsoring
+4. Add the entry to `NetworkConfigs` in `constants.go`
+5. Submit a PR with the chain name and rationale for the asset selection
+
+## Cross-SDK Checklist
+
+When adding a new chain's default asset, update all three SDKs to maintain parity:
+
+| SDK | File to edit | What to add |
+|-----|-------------|-------------|
+| **Go** | `go/mechanisms/evm/constants.go` | Entry in `NetworkConfigs` map |
+| **TypeScript** | `typescript/packages/mechanisms/evm/src/exact/server/scheme.ts` | Entry in `stablecoins` map inside `getDefaultAsset()` |
+| **Python** | `python/x402/mechanisms/evm/constants.py` | Entry in `NETWORK_CONFIGS` dict |
+
+All three must use:
+- The same CAIP-2 network key (e.g., `eip155:YOUR_CHAIN_ID`)
+- The same token contract address
+- The same EIP-712 domain `name` and `version`
+- The same `decimals` value
+- The same asset transfer method (EIP-3009 default, or Permit2 if specified)

--- a/go/mechanisms/evm/README.md
+++ b/go/mechanisms/evm/README.md
@@ -8,7 +8,7 @@ This package provides scheme implementations for EVM-based blockchains (Ethereum
 
 ## Exact Payment Scheme
 
-The **exact** scheme implementation enables fixed-amount payments using EIP-3009 `transferWithAuthorization` for USDC and compatible tokens.
+The **exact** scheme implementation enables fixed-amount payments using EIP-3009 `transferWithAuthorization` or Permit2 for USDC and compatible tokens.
 
 ### Export Paths
 
@@ -65,6 +65,8 @@ Networks with default assets configured:
 
 - **Base Mainnet**: `eip155:8453` (USDC)
 - **Base Sepolia**: `eip155:84532` (USDC)
+- **MegaETH Mainnet**: `eip155:4326` (MegaUSD, Permit2)
+- **Monad Mainnet**: `eip155:143` (USDC)
 
 To add default asset support for additional chains, see [DEFAULT_ASSET.md](./DEFAULT_ASSET.md).
 
@@ -72,8 +74,8 @@ To add default asset support for additional chains, see [DEFAULT_ASSET.md](./DEF
 
 The **exact** scheme implements fixed-amount payments:
 
-- **Standard**: EIP-3009 `transferWithAuthorization`
-- **Token**: USDC and EIP-3009 compatible tokens
+- **Standard**: EIP-3009 `transferWithAuthorization` or Permit2 (per-asset configuration)
+- **Token**: USDC and other stablecoins (EIP-3009 or any ERC-20 via Permit2)
 - **Gas**: Paid by facilitator
 - **Confirmation**: On-chain settlement with transaction hash
 

--- a/go/mechanisms/evm/README.md
+++ b/go/mechanisms/evm/README.md
@@ -65,7 +65,7 @@ Networks with default assets configured:
 
 - **Base Mainnet**: `eip155:8453` (USDC)
 - **Base Sepolia**: `eip155:84532` (USDC)
-- **MegaETH Mainnet**: `eip155:4326` (MegaUSD, Permit2)
+- **MegaETH Mainnet**: `eip155:4326` (MegaUSD)
 - **Monad Mainnet**: `eip155:143` (USDC)
 
 To add default asset support for additional chains, see [DEFAULT_ASSET.md](./DEFAULT_ASSET.md).

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -80,8 +80,9 @@ var (
 	// - If the chain has officially endorsed a stablecoin, that asset should be used
 	// - If no official stance exists, the chain team should make the selection
 	//
-	// NOTE: Currently only EIP-3009 supporting stablecoins can be used.
-	// Generic ERC-20 support via EIP-2612/Permit2 is planned but not yet implemented.
+	// Both EIP-3009 (transferWithAuthorization) and Permit2 asset transfer methods are supported.
+	// EIP-3009 is the default. Set AssetTransferMethod to AssetTransferMethodPermit2 for tokens
+	// that don't support EIP-3009. See DEFAULT_ASSET.md for details.
 	NetworkConfigs = map[string]NetworkConfig{
 		// Base Mainnet
 		"eip155:8453": {

--- a/typescript/packages/mechanisms/evm/README.md
+++ b/typescript/packages/mechanisms/evm/README.md
@@ -178,10 +178,11 @@ See `NETWORKS` constant in `@x402/evm/v1`
 
 ## Asset Support
 
-Supports any ERC-3009 compatible token:
-- USDC (primary)
-- EURC
-- Any token implementing `transferWithAuthorization()`
+Supports two asset transfer methods:
+- **EIP-3009**: Tokens with native `transferWithAuthorization()` (e.g., USDC, EURC) — simplest, truly gasless
+- **Permit2**: Any ERC-20 token — universal fallback, requires one-time approval
+
+See [DEFAULT_ASSET.md](src/exact/server/DEFAULT_ASSET.md) for the current list of configured chains and how to add new ones.
 
 ## Development
 

--- a/typescript/packages/mechanisms/evm/src/exact/server/DEFAULT_ASSET.md
+++ b/typescript/packages/mechanisms/evm/src/exact/server/DEFAULT_ASSET.md
@@ -144,3 +144,20 @@ To add a new chain's default asset:
 4. Add the entry to `getDefaultAsset()` in `scheme.ts`
 5. Submit a PR with the chain name and rationale for the asset selection
 
+## Cross-SDK Checklist
+
+When adding a new chain's default asset, update all three SDKs to maintain parity:
+
+| SDK | File to edit | What to add |
+|-----|-------------|-------------|
+| **Go** | `go/mechanisms/evm/constants.go` | Entry in `NetworkConfigs` map |
+| **TypeScript** | `typescript/packages/mechanisms/evm/src/exact/server/scheme.ts` | Entry in `stablecoins` map inside `getDefaultAsset()` |
+| **Python** | `python/x402/mechanisms/evm/constants.py` | Entry in `NETWORK_CONFIGS` dict |
+
+All three must use:
+- The same CAIP-2 network key (e.g., `eip155:YOUR_CHAIN_ID`)
+- The same token contract address
+- The same EIP-712 domain `name` and `version`
+- The same `decimals` value
+- The same asset transfer method (EIP-3009 default, or Permit2 if specified)
+


### PR DESCRIPTION
 ## Description                             

  - Fix outdated documentation claiming Permit2 is "planned but not yet implemented" — it's been in
  production since MegaETH launched
  - Add cross-SDK checklist so EVM chain teams can self-serve a single PR to add their default
  stablecoin across Go, TypeScript, and Python
  - Add a lightweight "Adding a Default Asset for an EVM Chain" shortcut in CONTRIBUTING.md so chain
  teams aren't directed to the heavy 3-PR new-chain-family workflow

  ## Changes

  | File | What changed |
  |------|-------------|
  | `go/mechanisms/evm/DEFAULT_ASSET.md` | Major rewrite: removed false "EIP-3009 Required"
  limitation, added Permit2 fields/docs, added cross-SDK checklist |
  | `go/mechanisms/evm/constants.go` | Fixed comment that contradicted MegaETH's Permit2 config 20
  lines below it |
  | `go/mechanisms/evm/README.md` | Added MegaETH + Monad to default-asset list, updated scheme
  description for both transfer methods |
  | `typescript/.../evm/README.md` | Updated Asset Support section to cover both EIP-3009 and Permit2
   |
  | `typescript/.../DEFAULT_ASSET.md` | Appended cross-SDK checklist |
  | `CONTRIBUTING.md` | Added EVM default-asset shortcut section before the 3-PR chain-family
  workflow |

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
