### PR TITLE
Include payment info in 402 response body for agent discoverability

### DIFF
--- a/go/http/server.go
+++ b/go/http/server.go
@@ -799,9 +799,9 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 		}, nil
 	}
 
-	// Use custom unpaid response if provided, otherwise default to JSON with no body
+	// Use custom unpaid response if provided, otherwise include payment info in body for agent discoverability
 	contentType := "application/json"
-	var body interface{}
+	var body interface{} = paymentRequired
 
 	if unpaidResponse != nil {
 		contentType = unpaidResponse.ContentType

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -536,9 +536,9 @@ class x402HTTPServerBase:
                 is_html=True,
             )
 
-        # API response
+        # API response — include payment info in body for agent discoverability
         content_type = "application/json"
-        body: Any = {}
+        body: Any = payment_required.model_dump(by_alias=True, exclude_none=True)
 
         if unpaid_response:
             content_type = unpaid_response.content_type

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -840,9 +840,9 @@ export class x402HTTPResourceServer {
 
     const response = this.createHTTPPaymentRequiredResponse(paymentRequired);
 
-    // Use callback result if provided, otherwise default to JSON with empty object
+    // Use callback result if provided, otherwise include payment info in body for agent discoverability
     const contentType = unpaidResponse ? unpaidResponse.contentType : "application/json";
-    const body = unpaidResponse ? unpaidResponse.body : {};
+    const body = unpaidResponse ? unpaidResponse.body : paymentRequired;
 
     return {
       status,


### PR DESCRIPTION
## Summary

- Default 402 response body now includes the decoded `PaymentRequired` object instead of `{}`
- Applies to TypeScript, Go, and Python implementations (Java already does this)
- Custom `unpaidResponseBody` callbacks are unaffected — they still override the default
- `PAYMENT-REQUIRED` header is unchanged for backwards compatibility

## Motivation

Autonomous AI agents discovering x402-enabled services parse the response body first. An empty `{}` gives them nothing to work with — they don't know to look for a custom base64-encoded header. Including the payment info in the body enables agent-led discovery and self-recovery without breaking existing clients.

Fixes #1677

## Test plan

- [ ] Verify 402 response body contains payment info when no custom `unpaidResponseBody` is set
- [ ] Verify custom `unpaidResponseBody` callbacks still override the default
- [ ] Verify `PAYMENT-REQUIRED` header is still present and unchanged
- [ ] Verify browser paywall flow is unaffected