### PR TITLE
feat(spec): document Memo instruction and add seller-defined memo for SVM scheme

### DIFF
--- a/specs/schemes/exact/scheme_exact_svm.md
+++ b/specs/schemes/exact/scheme_exact_svm.md
@@ -40,13 +40,15 @@ In addition to the standard x402 `PaymentRequirements` fields, the `exact` schem
   "payTo": "2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4",
   "maxTimeoutSeconds": 60,
   "extra": {
-    "feePayer": "EwWqGE4ZFKLofuestmU4LDdK7XM1N4ALgdZccwYugwGd"
+    "feePayer": "EwWqGE4ZFKLofuestmU4LDdK7XM1N4ALgdZccwYugwGd",
+    "memo": "pi_3abc123def456"
   }
 }
 ```
 
 - `asset`: The public key of the token mint.
 - `extra.feePayer`: The public key of the account that will pay for the transaction fees. This is typically the facilitator's public key.
+- `extra.memo` (optional): A seller-defined UTF-8 string to include in the transaction's Memo instruction. When present, the client MUST use this value as the Memo instruction data instead of a random nonce. Maximum 256 bytes. This enables sellers to attach payment references (e.g., invoice IDs) to on-chain transactions for reconciliation without requiring unique deposit addresses.
 
 ## PaymentPayload `payload` Field
 
@@ -78,7 +80,8 @@ Full `PaymentPayload` object:
     "payTo": "2wKupLR9q6wXYppw8Gr2NvWxKBUqm4PPJKkQfoxHDBg4",
     "maxTimeoutSeconds": 60,
     "extra": {
-      "feePayer": "EwWqGE4ZFKLofuestmU4LDdK7XM1N4ALgdZccwYugwGd"
+      "feePayer": "EwWqGE4ZFKLofuestmU4LDdK7XM1N4ALgdZccwYugwGd",
+      "memo": "pi_3abc123def456"
     }
   },
   "payload": {
@@ -106,16 +109,18 @@ A facilitator verifying an `exact`-scheme SVM payment MUST enforce all of the fo
 
 1. Instruction layout
 
-- The decompiled transaction MUST contain 3 to 5 instructions in this order:
+- The decompiled transaction MUST contain 3 to 6 instructions in this order:
   1. Compute Budget: Set Compute Unit Limit
   2. Compute Budget: Set Compute Unit Price
   3. SPL Token or Token-2022 TransferChecked
-  4. (Optional) Lighthouse program instruction (Phantom wallet protection)
-  5. (Optional) Lighthouse program instruction (Solflare wallet protection)
+  4. (Optional) Lighthouse or Memo program instruction
+  5. (Optional) Lighthouse or Memo program instruction
+  6. (Optional) Memo program instruction
 
-- If a 4th or 5th instruction is present, the program MUST be the Lighthouse program (`L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`).
-- Phantom wallet injects 1 Lighthouse instruction; Solflare injects 2.
-- These Lighthouse instructions are wallet-injected user protection mechanisms and MUST be allowed to support these wallets.
+- Allowed optional programs: Lighthouse (`L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`) and SPL Memo (`MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr`).
+- Phantom wallet injects 1 Lighthouse instruction; Solflare injects 2. These are wallet-injected user protection mechanisms and MUST be allowed.
+- The Memo instruction ensures transaction uniqueness across concurrent payments with identical parameters. Clients MUST include a Memo instruction containing either the value of `extra.memo` (when present) or a random nonce (at least 16 bytes, hex-encoded for UTF-8 compliance).
+- If `extra.memo` is present in `PaymentRequirements`, the facilitator MUST verify that exactly one Memo instruction exists and that its data matches the value of `extra.memo` encoded as UTF-8.
 
 2. Fee payer (facilitator) safety
 


### PR DESCRIPTION
## Description

The SVM exact scheme spec is out of date with the implementation. PR #1048 added Memo instruction support to all three SDKs (TypeScript, Go, Python) without updating the spec. This PR addresses that gap and extends it with seller-defined memo content.

### Changes

**1. Document existing Memo instruction (spec catch-up)**
- Updates instruction layout from 3-5 to 3-6 instructions
- Documents SPL Memo (`MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr`) as an allowed optional program alongside Lighthouse
- Specifies random nonce behavior (at least 16 bytes, hex-encoded) for transaction uniqueness

**2. Add optional `extra.memo` field**
- When present, the client MUST use this value as Memo instruction data instead of a random nonce
- The facilitator MUST verify the Memo instruction data matches `extra.memo`
- Maximum 256 bytes, UTF-8

### Motivation

Stripe's x402 integration on Solana ([docs](https://docs.stripe.com/payments/machine/x402)) currently creates a unique deposit address (ATA) per payment for reconciliation. Each ATA costs ~0.002 SOL in rent, which adds up for high-volume micropayments.

With `extra.memo`, sellers can attach a payment reference (e.g., a PaymentIntent ID) to the on-chain transaction, enabling reconciliation on a single `payTo` address without creating unique ATAs per payment. This is a well-established pattern on Solana (exchange deposits use the same approach).

### Spec-only change

This PR only modifies `specs/schemes/exact/scheme_exact_svm.md`. SDK implementation changes (TypeScript, Go, Python) will follow in a separate PR once the spec is reviewed.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)