### PR TITLE
feat: add permit2 and gas sponsorship extensions to gitbooks

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -55,33 +55,44 @@ Multiple production-ready facilitators are available supporting various networks
 
 x402 supports tokens on EVM, Solana, Stellar, and Aptos networks:
 
-* **EVM**: Any ERC-20 token that implements the EIP-3009 standard
+* **EVM**: Any ERC-20 token (via EIP-3009 or Permit2)
 * **Solana**: Any SPL or token-2022 token
 * **Stellar**: Any Soroban token implementing SEP-41
 * **Aptos**: Any fungible asset using Aptos's native fungible asset framework
 
-**Important**: Facilitators support networks, not specific tokens — any EIP-3009 compatible token works on EVM networks, any SPL/token-2022 token works on Solana, any SEP-41 token works on Stellar, and any fungible asset works on Aptos, for the facilitators that support those networks.
+**Important**: Facilitators support networks, not specific tokens — any ERC-20 token works on EVM networks (via EIP-3009 or Permit2), any SPL/token-2022 token works on Solana, any SEP-41 token works on Stellar, and any fungible asset works on Aptos, for the facilitators that support those networks.
 
-#### EVM: EIP-3009 Requirement
+#### EVM: Asset Transfer Methods
 
-Tokens must implement the `transferWithAuthorization` function from the EIP-3009 standard. This enables:
+x402 supports two asset transfer methods on EVM, selected automatically based on token capabilities:
+
+| Method | When Used | How It Works |
+|--------|-----------|--------------|
+| **EIP-3009** | Tokens with `transferWithAuthorization` (e.g., USDC) | Single off-chain signature, simplest flow |
+| **Permit2** | Any ERC-20 token | Uses Uniswap's [Permit2](https://docs.uniswap.org/contracts/v4/deployments) contract + `x402ExactPermit2Proxy` |
+
+Both methods provide:
 
 * **Gasless transfers**: The facilitator sponsors gas fees
 * **Signature-based authorization**: Users sign transfer authorizations off-chain
 * **Secure payments**: Transfers are authorized by cryptographic signatures
+
+EIP-3009 is preferred when available (simpler, no approval step). Permit2 serves as the universal fallback, enabling any ERC-20 token to work with x402.
+
+**Permit2 approval**: Permit2 requires a one-time on-chain approval of the Permit2 contract. x402 supports two gas sponsoring extensions that make this step gasless — see [EIP-2612 Gas Sponsoring](/extensions/eip2612-gas-sponsoring) and [ERC-20 Approval Gas Sponsoring](/extensions/erc20-approval-gas-sponsoring).
 
 #### Specifying Payment Amounts
 
 When configuring payment requirements, you have two options:
 
 1. **Price String** (e.g., `"$0.01"`) - The system infers USDC as the token
-2. **TokenAmount** - Specify exact atomic units of any EIP-3009 token
+2. **TokenAmount** - Specify exact atomic units of any ERC-20 token
 
-#### Using Custom EIP-3009 Tokens
+#### Using Custom ERC-20 Tokens
 
-To use a custom EIP-3009 token, you need three key pieces of information:
+To use a custom ERC-20 token, you need three key pieces of information:
 
-1. **Token Address**: The contract address of your EIP-3009 token
+1. **Token Address**: The contract address of your ERC-20 token
 2. **EIP-712 Name**: The token's name for EIP-712 signatures
 3. **EIP-712 Version**: The token's version for EIP-712 signatures
 
@@ -118,16 +129,16 @@ On Aptos, x402 supports all fungible assets using Aptos's native fungible asset 
 #### USDC - The Default Token
 
 * **Status**: Supported by default across all networks
-* **Why**: USDC implements EIP-3009 and is widely available
+* **Why**: USDC implements EIP-3009 (simplest flow) and is widely available
 * **Networks**: Available on `eip155:8453` (Base), `eip155:84532` (Base Sepolia), and all supported networks
 
-#### Why EIP-3009?
+#### Why EIP-3009 + Permit2?
 
-The EIP-3009 standard is essential for x402 because it enables:
+These two transfer methods together give x402 full ERC-20 coverage on EVM:
 
 1. **Gas abstraction**: Buyers don't need native tokens (ETH, MATIC, etc.) for gas
-2. **One-step payments**: No separate approval transactions required
-3. **Universal facilitator support**: Any EIP-3009 token works with any facilitator
+2. **EIP-3009**: One-step payments with no approval needed — ideal for tokens like USDC
+3. **Permit2**: Universal fallback for any ERC-20 token, with optional gas-sponsored approval via [extensions](/extensions/eip2612-gas-sponsoring)
 
 ### Quick Reference
 
@@ -137,7 +148,7 @@ The EIP-3009 standard is essential for x402 because it enables:
 | [Production Facilitators](https://www.x402.org/ecosystem?filter=facilitators) | Various (Base, Solana, Polygon, Avalanche, etc.) | Yes | Varies |
 | Self-hosted | Any EVM network (CAIP-2 format) | Yes | Technical setup |
 
-**Note**: On EVM networks, facilitators support any EIP-3009 compatible token; on Solana, facilitators support any SPL/Token-2022 token.
+**Note**: On EVM networks, facilitators support any ERC-20 token (via EIP-3009 or Permit2); on Solana, facilitators support any SPL/Token-2022 token.
 
 ### Adding Support for New Networks
 
@@ -263,7 +274,7 @@ Key takeaways:
 
 * Base (`eip155:8453`), Base Sepolia (`eip155:84532`), Solana (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`), and Solana Devnet (`solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`) have the best out-of-the-box support
 * Any EVM network can be supported with a custom facilitator using CAIP-2 format
-* Any EIP-3009 token (with `transferWithAuthorization`) works on any facilitator
+* Any ERC-20 token works on any facilitator (via EIP-3009 or Permit2)
 * Use price strings for USDC or TokenAmount for custom tokens
 * Network choice affects gas costs and payment economics
 * V2 uses CAIP-2 network identifiers for unambiguous cross-chain support

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,7 +69,9 @@
           "extensions/bazaar",
           "extensions/payment-identifier",
           "extensions/sign-in-with-x",
-          "extensions/offer-receipt"
+          "extensions/offer-receipt",
+          "extensions/eip2612-gas-sponsoring",
+          "extensions/erc20-approval-gas-sponsoring"
         ]
       },
       {

--- a/docs/extensions/eip2612-gas-sponsoring.mdx
+++ b/docs/extensions/eip2612-gas-sponsoring.mdx
@@ -1,0 +1,109 @@
+---
+title: "EIP-2612 Gas Sponsoring"
+description: "Gasless Permit2 approval for ERC-20 tokens that implement EIP-2612. The facilitator submits the permit on-chain, so the client never pays gas for the approval step."
+---
+
+The EIP-2612 gas sponsoring extension enables gasless Permit2 approval for tokens that implement the [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) `permit()` function (e.g., USDC). The client signs an off-chain permit authorizing the Permit2 contract, and the facilitator submits it atomically during settlement via `x402ExactPermit2Proxy.settleWithPermit`.
+
+## Overview
+
+When using the Permit2 asset transfer method, the user must first approve the Permit2 contract to spend their tokens. For tokens that support EIP-2612, this approval can be done entirely off-chain:
+
+* **For Buyers**: No gas needed — sign a permit off-chain and the facilitator handles the rest
+* **For Sellers**: Advertise this extension so clients using EIP-2612 tokens get a seamless experience
+* **For Facilitators**: Accept the permit signature and call `settleWithPermit` to atomically approve + settle in one transaction
+
+## How It Works
+
+1. **Server** advertises `eip2612GasSponsoring` in the `PaymentRequired` response extensions
+2. **Client** checks if Permit2 allowance is insufficient; if so, signs an EIP-2612 permit off-chain
+3. **Client** includes the permit data in the `extensions.eip2612GasSponsoring.info` field of the payment payload
+4. **Facilitator** calls `x402ExactPermit2Proxy.settleWithPermit()`, which atomically submits the EIP-2612 permit and executes the Permit2 transfer in a single transaction
+
+## Server Usage
+
+Advertise support for this extension in your route configuration:
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```typescript
+    import { declareEip2612GasSponsoringExtension } from "@x402/extensions/eip2612-gas-sponsoring";
+
+    const routes = {
+      "GET /api/data": {
+        accepts: [{
+          scheme: "exact",
+          network: "eip155:84532",
+          price: "$0.01",
+          payTo: "0xYourAddress",
+        }],
+        extensions: {
+          ...declareEip2612GasSponsoringExtension(),
+        },
+      },
+    };
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```go
+    import (
+        "github.com/coinbase/x402/go/extensions/eip2612gassponsor"
+    )
+
+    extensions := eip2612gassponsor.DeclareEip2612GasSponsoringExtension()
+    // Include in your route's Extensions field
+    ```
+  </Tab>
+</Tabs>
+
+## Client Usage
+
+The `ExactEvmScheme` handles EIP-2612 gas sponsoring automatically. When the server advertises this extension and the client's Permit2 allowance is insufficient, the scheme signs the EIP-2612 permit and includes it in the payment payload.
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```typescript
+    import { ExactEvmScheme } from "@x402/evm/exact/client";
+
+    // readContract capability is required for EIP-2612 (to check allowance and nonce)
+    const scheme = new ExactEvmScheme(signer);
+    client.register("eip155:*", scheme);
+
+    // The scheme automatically signs an EIP-2612 permit when:
+    // 1. The server advertises eip2612GasSponsoring
+    // 2. The asset transfer method is "permit2"
+    // 3. The client's Permit2 allowance is insufficient
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```go
+    import (
+        evm "github.com/coinbase/x402/go/mechanisms/evm/exact/client"
+    )
+
+    scheme := evm.NewExactEvmScheme(signer)
+    client.Register("eip155:*", scheme)
+
+    // EIP-2612 permit signing is handled automatically
+    // when the server advertises the extension
+    ```
+  </Tab>
+</Tabs>
+
+## When to Use
+
+Use this extension when:
+
+- Your payment token implements EIP-2612 (has a `permit()` function)
+- You want fully gasless Permit2 onboarding for your users
+- You're using the `permit2` asset transfer method
+
+Common EIP-2612 tokens include USDC, DAI, and many modern ERC-20 tokens.
+
+## SDK Support
+
+| SDK | Supported |
+|-----|-----------|
+| TypeScript | ✅ |
+| Go | ✅ |
+| Python | ❌ |

--- a/docs/extensions/erc20-approval-gas-sponsoring.mdx
+++ b/docs/extensions/erc20-approval-gas-sponsoring.mdx
@@ -1,0 +1,115 @@
+---
+title: "ERC-20 Approval Gas Sponsoring"
+description: "Gasless Permit2 approval for any ERC-20 token, including those without EIP-2612. The facilitator sponsors the gas for the approval transaction."
+---
+
+The ERC-20 approval gas sponsoring extension enables gasless Permit2 approval for **any ERC-20 token**, including those that do not implement EIP-2612. The client signs (but does not broadcast) a standard `approve(Permit2, MaxUint256)` transaction, and the facilitator broadcasts it atomically before settling the Permit2 payment.
+
+## Overview
+
+This is the universal fallback for gasless Permit2 onboarding. While [EIP-2612 gas sponsoring](/extensions/eip2612-gas-sponsoring) is preferred for tokens that support it, this extension works with every ERC-20 token:
+
+* **For Buyers**: No gas needed — sign an approval transaction off-chain and the facilitator broadcasts it
+* **For Sellers**: Advertise this extension to support the widest range of ERC-20 tokens
+* **For Facilitators**: Broadcast the pre-signed approval and settle in an atomic batch, optionally funding the client's gas if needed
+
+## How It Works
+
+1. **Server** advertises `erc20ApprovalGasSponsoring` in the `PaymentRequired` response extensions
+2. **Client** checks if Permit2 allowance is insufficient; if so, signs a raw `approve(Permit2, MaxUint256)` transaction without broadcasting it
+3. **Client** includes the signed transaction in `extensions.erc20ApprovalGasSponsoring.info.signedTransaction`
+4. **Facilitator** executes an atomic batch:
+   - Funds the client's wallet with gas (if needed)
+   - Broadcasts the client's signed approval transaction
+   - Calls `x402ExactPermit2Proxy.settle()` to complete the payment
+
+The atomic batch ensures the approval and settlement happen together — there is no window for front-running between the approval and the payment.
+
+## Server Usage
+
+Advertise support for this extension in your route configuration:
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```typescript
+    import { declareErc20ApprovalGasSponsoringExtension } from "@x402/extensions/erc20-approval-gas-sponsoring";
+
+    const routes = {
+      "GET /api/data": {
+        accepts: [{
+          scheme: "exact",
+          network: "eip155:84532",
+          price: "$0.01",
+          payTo: "0xYourAddress",
+        }],
+        extensions: {
+          ...declareErc20ApprovalGasSponsoringExtension(),
+        },
+      },
+    };
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```go
+    import (
+        "github.com/coinbase/x402/go/extensions/erc20approvalgassponsor"
+    )
+
+    extensions := erc20approvalgassponsor.DeclareExtension()
+    // Include in your route's Extensions field
+    ```
+  </Tab>
+</Tabs>
+
+## Client Usage
+
+The `ExactEvmScheme` handles ERC-20 approval gas sponsoring automatically as a fallback when EIP-2612 is not available.
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```typescript
+    import { ExactEvmScheme } from "@x402/evm/exact/client";
+
+    // signTransaction and getTransactionCount capabilities are required
+    const scheme = new ExactEvmScheme(signer);
+    client.register("eip155:*", scheme);
+
+    // The scheme automatically signs an ERC-20 approval when:
+    // 1. The server advertises erc20ApprovalGasSponsoring
+    // 2. The asset transfer method is "permit2"
+    // 3. The client's Permit2 allowance is insufficient
+    // 4. EIP-2612 gas sponsoring is not available or not supported by the token
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```go
+    import (
+        evm "github.com/coinbase/x402/go/mechanisms/evm/exact/client"
+    )
+
+    scheme := evm.NewExactEvmScheme(signer)
+    client.Register("eip155:*", scheme)
+
+    // ERC-20 approval gas sponsoring is handled automatically
+    // as a fallback when EIP-2612 is not available
+    ```
+  </Tab>
+</Tabs>
+
+## When to Use
+
+Use this extension when:
+
+- You want to support any ERC-20 token, not just those with EIP-2612
+- You're using the `permit2` asset transfer method
+- You want fully gasless onboarding for your users regardless of the token
+
+This extension is typically advertised alongside [EIP-2612 gas sponsoring](/extensions/eip2612-gas-sponsoring). The client automatically selects the best option: EIP-2612 if the token supports it, ERC-20 approval otherwise.
+
+## SDK Support
+
+| SDK | Supported |
+|-----|-----------|
+| TypeScript | ✅ |
+| Go | ✅ |
+| Python | ❌ |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,8 +63,8 @@ Yes. x402 handles the _payment execution_. You can still meter usage, aggregate 
 
 | Network        | CAIP-2 ID | Asset | Fees\*   | Status      |
 | -------------- | --------- | ----- | -------- | ----------- |
-| Base           | `eip155:8453` | Any EIP-3009 token  | fee-free | **Mainnet** |
-| Base Sepolia   | `eip155:84532` | Any EIP-3009 token  | fee-free | **Testnet** |
+| Base           | `eip155:8453` | Any ERC-20 token  | fee-free | **Mainnet** |
+| Base Sepolia   | `eip155:84532` | Any ERC-20 token  | fee-free | **Testnet** |
 | Solana         | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` | Any SPL token or Token-2022 token | fee-free | **Mainnet** |
 | Solana Devnet  | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` | Any SPL token or Token-2022 | fee-free | **Testnet** |
 
@@ -119,7 +119,7 @@ Yes. Programmatic wallets (e.g., **CDP Wallet API**, **viem**, **ethers‑v6** H
 Tracked in public GitHub issues + community RFCs. Major themes:
 
 * Multi‑asset support
-* Additional schemes (`upto`, `stream`, `permit2`)
+* Additional schemes (`upto`, `stream`)
 * Discovery layer for service search & reputation
 
 **Why is x402 hosted in the Coinbase GitHub?**

--- a/docs/sdk-features.md
+++ b/docs/sdk-features.md
@@ -36,6 +36,7 @@ This page tracks which features are implemented in each SDK (TypeScript, Go, Pyt
 | Mechanism | TypeScript | Go | Python |
 |-----------|------------|-----|--------|
 | exact/evm (EIP-3009) | ✅ | ✅ | ✅ |
+| exact/evm (Permit2) | ✅ | ✅ | ❌ |
 | exact/svm (SPL) | ✅ | ✅ | ✅ |
 | exact/stellar (Soroban) | ✅ | ❌ | ❌ |
 | exact/aptos (Fungible Assets) | ✅ | ❌ | ❌ |
@@ -49,6 +50,8 @@ This page tracks which features are implemented in each SDK (TypeScript, Go, Pyt
 | sign-in-with-x | ✅ | ❌ | ❌ |
 | payment-identifier | ✅ | ✅ | ✅ |
 | offer-receipt | ✅ | ❌ | ❌ |
+| eip2612-gas-sponsoring | ✅ | ✅ | ❌ |
+| erc20-approval-gas-sponsoring | ✅ | ✅ | ❌ |
 
 ## Client Hooks
 


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Updates the Gitbooks to reference Permit2 support & explain the gas sponsorship extensions

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 