### PR TITLE
Add http-level beforeSettleHook

### DIFF
--- a/typescript/.changeset/nine-knives-camp.md
+++ b/typescript/.changeset/nine-knives-camp.md
@@ -1,0 +1,8 @@
+---
+'@x402/express': patch
+'@x402/hono': patch
+'@x402/next': patch
+'@x402/core': patch
+---
+
+Added HTTP-level beforeSettleHook

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -190,6 +190,21 @@ export type ProtectedRequestHook = (
 ) => Promise<void | { grantAccess: true } | { abort: true; reason: string }>;
 
 /**
+ * Hook that runs inside before payment settlement.
+ * Can modify the requirements object in place or abort the settlement process.
+ *
+ * @returns
+ * - `void` - Continue to settlement (default behavior)
+ * - `{ abort: true; reason: string; message?: string }` - Abort settlement
+ */
+export type BeforeSettleHook = (
+  paymentPayload: PaymentPayload,
+  requirements: PaymentRequirements,
+  declaredExtensions?: Record<string, unknown>,
+  transportContext?: HTTPTransportContext,
+) => Promise<void | { abort: true; reason: string; message?: string }>;
+
+/**
  * Compiled route for efficient matching
  */
 export interface CompiledRoute {
@@ -216,6 +231,8 @@ export interface HTTPTransportContext {
   request: HTTPRequestContext;
   /** The response body buffer */
   responseBody?: Buffer;
+  /** The response headers */
+  responseHeaders?: Record<string, string>;
 }
 
 /**
@@ -308,6 +325,7 @@ export class x402HTTPResourceServer {
   private routesConfig: RoutesConfig;
   private paywallProvider?: PaywallProvider;
   private protectedRequestHooks: ProtectedRequestHook[] = [];
+  private beforeSettleHooks: BeforeSettleHook[] = [];
 
   /**
    * Creates a new x402HTTPResourceServer instance.
@@ -400,6 +418,18 @@ export class x402HTTPResourceServer {
    */
   onProtectedRequest(hook: ProtectedRequestHook): this {
     this.protectedRequestHooks.push(hook);
+    return this;
+  }
+
+  /**
+   * Register a hook that runs before payment settlement.
+   * Hooks are executed in order of registration.
+   *
+   * @param hook - The beforeSettle hook function
+   * @returns The x402HTTPResourceServer instance for chaining
+   */
+  onBeforeSettle(hook: BeforeSettleHook): this {
+    this.beforeSettleHooks.push(hook);
     return this;
   }
 
@@ -576,6 +606,25 @@ export class x402HTTPResourceServer {
     transportContext?: HTTPTransportContext,
   ): Promise<ProcessSettleResultResponse> {
     try {
+      // Execute before settle hooks
+      for (const hook of this.beforeSettleHooks) {
+        const result = await hook(
+          paymentPayload,
+          requirements,
+          declaredExtensions,
+          transportContext,
+        );
+        if (result && "abort" in result && result.abort) {
+          throw new SettleError(400, {
+            success: false,
+            errorReason: result.reason,
+            errorMessage: result.message,
+            transaction: "",
+            network: requirements.network,
+          });
+        }
+      }
+
       const settleResponse = await this.ResourceServer.settlePayment(
         paymentPayload,
         requirements,

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -24,4 +24,5 @@ export type {
   ProcessSettleSuccessResponse,
   ProcessSettleFailureResponse,
   RouteValidationError,
+  BeforeSettleHook,
 } from "../http/x402HTTPResourceServer";

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceServer.hooks.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceServer.hooks.test.ts
@@ -5,6 +5,8 @@ import {
   HTTPAdapter,
   RouteConfig,
   ProtectedRequestHook,
+  BeforeSettleHook,
+  HTTPTransportContext,
 } from "../../../src/http/x402HTTPResourceServer";
 import { x402ResourceServer } from "../../../src/server/x402ResourceServer";
 import {
@@ -951,6 +953,276 @@ describe("x402HTTPResourceServer Hooks", () => {
 
         expect(hook).not.toHaveBeenCalled();
         expect(result.type).toBe("no-payment-required");
+      });
+    });
+  });
+
+  describe("BeforeSettleHook", () => {
+    let ResourceServer: x402ResourceServer;
+    let mockFacilitator: MockFacilitatorClient;
+    let mockScheme: MockSchemeNetworkServer;
+
+    const testNetwork = "eip155:8453" as Network;
+    const testRoutes = {
+      "/api/test": {
+        accepts: {
+          scheme: "exact",
+          payTo: "0xabc",
+          price: "$1.00" as Price,
+          network: testNetwork,
+        },
+      },
+    };
+
+    beforeEach(async () => {
+      mockFacilitator = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: testNetwork }],
+        }),
+        buildVerifyResponse({ isValid: true }),
+      );
+
+      ResourceServer = new x402ResourceServer(mockFacilitator);
+
+      mockScheme = new MockSchemeNetworkServer("exact", {
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        extra: {},
+      });
+
+      ResourceServer.register(testNetwork, mockScheme);
+      await ResourceServer.initialize();
+    });
+
+    describe("hook registration", () => {
+      it("should return this for chaining", () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook: BeforeSettleHook = async () => {};
+
+        const result = httpServer.onBeforeSettle(hook);
+
+        expect(result).toBe(httpServer);
+      });
+    });
+
+    describe("hook receives correct context", () => {
+      it("should receive paymentPayload, requirements, and transportContext", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        let receivedPayload: unknown;
+        let receivedRequirements: unknown;
+        let receivedTransport: HTTPTransportContext | undefined;
+
+        const hook: BeforeSettleHook = async (
+          paymentPayload,
+          requirements,
+          _declaredExtensions,
+          transportContext,
+        ) => {
+          receivedPayload = paymentPayload;
+          receivedRequirements = requirements;
+          receivedTransport = transportContext;
+        };
+
+        httpServer.onBeforeSettle(hook);
+
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
+          network: testNetwork,
+        });
+
+        mockFacilitator.setSettleResponse(buildSettleResponse({ success: true }));
+
+        const transportContext: HTTPTransportContext = {
+          request: { path: "/api/test", method: "GET" } as HTTPRequestContext,
+          responseBody: Buffer.from('{"data":"test"}'),
+          responseHeaders: { "content-type": "application/json", "upto-amount": "500000" },
+        };
+
+        await httpServer.processSettlement(payload, requirements, undefined, transportContext);
+
+        expect(receivedPayload).toBe(payload);
+        expect(receivedRequirements).toBe(requirements);
+        expect(receivedTransport).toBe(transportContext);
+        expect(receivedTransport?.responseHeaders?.["upto-amount"]).toBe("500000");
+      });
+    });
+
+    describe("hook can mutate requirements", () => {
+      it("should allow hook to mutate requirements.amount and flow to settlePayment", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+
+        const hook: BeforeSettleHook = async (
+          _paymentPayload,
+          requirements,
+          _declaredExtensions,
+          transportContext,
+        ) => {
+          const amount = transportContext?.responseHeaders?.["upto-amount"];
+          if (amount) {
+            requirements.amount = amount;
+          }
+        };
+
+        httpServer.onBeforeSettle(hook);
+
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
+          network: testNetwork,
+          amount: "1000000",
+        });
+
+        mockFacilitator.setSettleResponse(buildSettleResponse({ success: true }));
+
+        const transportContext: HTTPTransportContext = {
+          request: { path: "/api/test", method: "GET" } as HTTPRequestContext,
+          responseBody: Buffer.from("{}"),
+          responseHeaders: { "upto-amount": "500000" },
+        };
+
+        await httpServer.processSettlement(payload, requirements, undefined, transportContext);
+
+        expect(requirements.amount).toBe("500000");
+      });
+    });
+
+    describe("hook returning void", () => {
+      it("should continue to settlement when hook returns void", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook = vi.fn().mockResolvedValue(undefined);
+
+        httpServer.onBeforeSettle(hook);
+
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
+          network: testNetwork,
+        });
+
+        mockFacilitator.setSettleResponse(
+          buildSettleResponse({ success: true, network: testNetwork }),
+        );
+
+        const result = await httpServer.processSettlement(payload, requirements);
+
+        expect(hook).toHaveBeenCalled();
+        expect(result.success).toBe(true);
+      });
+    });
+
+    describe("hook returning abort", () => {
+      it("should produce settlement failure when hook returns abort", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook: BeforeSettleHook = async () => ({
+          abort: true,
+          reason: "Invalid amount",
+          message: "Amount exceeds maximum",
+        });
+
+        httpServer.onBeforeSettle(hook);
+
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
+          network: testNetwork,
+        });
+
+        const result = await httpServer.processSettlement(payload, requirements);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.errorReason).toBe("Invalid amount");
+          expect(result.errorMessage).toContain("Amount exceeds maximum");
+        }
+      });
+    });
+
+    describe("multiple hooks", () => {
+      it("should execute hooks in registration order", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const order: number[] = [];
+
+        httpServer.onBeforeSettle(async () => {
+          order.push(1);
+        });
+        httpServer.onBeforeSettle(async () => {
+          order.push(2);
+        });
+        httpServer.onBeforeSettle(async () => {
+          order.push(3);
+        });
+
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
+          network: testNetwork,
+        });
+
+        mockFacilitator.setSettleResponse(buildSettleResponse({ success: true }));
+
+        await httpServer.processSettlement(payload, requirements);
+
+        expect(order).toEqual([1, 2, 3]);
+      });
+
+      it("should stop execution at first hook to abort", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+        const hook1 = vi.fn().mockResolvedValue(undefined);
+        const hook2 = vi.fn().mockResolvedValue({ abort: true, reason: "Blocked" });
+        const hook3 = vi.fn().mockResolvedValue(undefined);
+
+        httpServer.onBeforeSettle(hook1);
+        httpServer.onBeforeSettle(hook2);
+        httpServer.onBeforeSettle(hook3);
+
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
+          network: testNetwork,
+        });
+
+        const result = await httpServer.processSettlement(payload, requirements);
+
+        expect(hook1).toHaveBeenCalled();
+        expect(hook2).toHaveBeenCalled();
+        expect(hook3).not.toHaveBeenCalled();
+        expect(result.success).toBe(false);
+      });
+    });
+
+    describe("hook can read responseHeaders for upto-amount", () => {
+      it("should read UPTO-AMOUNT header to determine settlement amount", async () => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, testRoutes);
+
+        httpServer.onBeforeSettle(
+          async (_paymentPayload, requirements, _declaredExtensions, transportContext) => {
+            if (!transportContext?.responseHeaders) return;
+            const amount = transportContext.responseHeaders["upto-amount"];
+            if (amount) {
+              requirements.amount = amount;
+            }
+          },
+        );
+
+        const payload = buildPaymentPayload();
+        const requirements = buildPaymentRequirements({
+          scheme: "exact",
+          network: testNetwork,
+          amount: "1000000",
+        });
+
+        mockFacilitator.setSettleResponse(buildSettleResponse({ success: true }));
+
+        const transportContext: HTTPTransportContext = {
+          request: { path: "/api/test", method: "GET" } as HTTPRequestContext,
+          responseBody: Buffer.from('{"weather":"sunny"}'),
+          responseHeaders: { "upto-amount": "350000", "content-type": "application/json" },
+        };
+
+        await httpServer.processSettlement(payload, requirements, undefined, transportContext);
+
+        expect(requirements.amount).toBe("350000");
       });
     });
   });

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -179,6 +179,9 @@ function createMockResponse(): Response & {
       return this;
     }),
     flushHeaders: vi.fn(),
+    getHeaders: vi.fn(function (this: typeof res) {
+      return { ...this._headers };
+    }),
   };
   return res as unknown as Response & typeof res;
 }
@@ -352,6 +355,7 @@ describe("paymentMiddleware", () => {
           method: "GET",
         }),
         responseBody: expect.any(Buffer),
+        responseHeaders: expect.any(Object),
       }),
     );
     expect(res.setHeader).toHaveBeenCalledWith("PAYMENT-RESPONSE", "settled");

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -293,7 +293,15 @@ export function paymentMiddlewareFromHTTPServer(
             paymentPayload,
             paymentRequirements,
             declaredExtensions,
-            { request: context, responseBody },
+            {
+              request: context,
+              responseBody,
+              responseHeaders: Object.fromEntries(
+                Object.entries(res.getHeaders())
+                  .filter(([, v]) => typeof v === "string")
+                  .map(([k, v]) => [k.toLowerCase(), v as string]),
+              ),
+            },
           );
 
           // If settlement fails, return an error and do not send the buffered response

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -351,6 +351,7 @@ describe("paymentMiddleware", () => {
           method: "GET",
         }),
         responseBody: expect.any(Buffer),
+        responseHeaders: expect.any(Object),
       }),
     );
     expect(responseHeaders.get("PAYMENT-RESPONSE")).toBe("settled");

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -220,7 +220,11 @@ export function paymentMiddlewareFromHTTPServer(
             paymentPayload,
             paymentRequirements,
             declaredExtensions,
-            { request: context, responseBody },
+            {
+              request: context,
+              responseBody,
+              responseHeaders: Object.fromEntries(res.headers.entries()),
+            },
           );
 
           if (!settleResult.success) {

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -305,6 +305,7 @@ describe("handleSettlement", () => {
       expect.objectContaining({
         request: undefined,
         responseBody: expect.any(Buffer),
+        responseHeaders: expect.any(Object),
       }),
     );
   });

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -176,7 +176,11 @@ export async function handleSettlement(
       paymentPayload,
       paymentRequirements,
       declaredExtensions,
-      { request: httpContext, responseBody },
+      {
+        request: httpContext,
+        responseBody,
+        responseHeaders: Object.fromEntries(response.headers.entries()),
+      },
     );
 
     if (!result.success) {

--- a/typescript/packages/mechanisms/stellar/test/unit/shared.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/shared.test.ts
@@ -6,12 +6,22 @@ import {
 } from "@stellar/stellar-sdk";
 import { AssembledTransaction } from "@stellar/stellar-sdk/contract";
 import { Api } from "@stellar/stellar-sdk/rpc";
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { STELLAR_TESTNET_CAIP2 } from "../../src/constants";
 import { ExactStellarScheme } from "../../src/exact/client/scheme";
 import { gatherAuthEntrySignatureStatus, handleSimulationResult } from "../../src/shared";
 import { createEd25519Signer } from "../../src/signer";
+import * as stellarUtils from "../../src/utils";
 import type { PaymentRequirements } from "@x402/core/types";
+
+vi.mock("../../src/utils", async () => {
+  const actual = await vi.importActual<typeof stellarUtils>("../../src/utils");
+  return {
+    ...actual,
+    getEstimatedLedgerCloseTimeSeconds: vi.fn().mockResolvedValue(5),
+    getRpcClient: vi.fn(),
+  };
+});
 
 describe("Stellar Shared Utilities", () => {
   describe("handleSimulationResult", () => {
@@ -85,6 +95,14 @@ describe("Stellar Shared Utilities", () => {
   describe("gatherAuthEntrySignatureStatus", () => {
     const CLIENT_SECRET = "SDV3OZOPGIO6GQAVI7T6ZJ7NSNFB26JX6QZYCI64TBC7BAZY6FQVAXXK";
     const CLIENT_PUBLIC = "GBBO4ZDDZTSM2IUKQYBAST3CFHNPFXECGEFTGWTA2WELR2BIWDK57UVE";
+
+    const mockRpcServer = {
+      getLatestLedger: vi.fn().mockResolvedValue({ sequence: 100000 }),
+    };
+
+    beforeEach(() => {
+      vi.mocked(stellarUtils.getRpcClient).mockReturnValue(mockRpcServer as never);
+    });
 
     // paymenrRequirements is used to create a valid payload for the test
     const paymentRequirements: PaymentRequirements = {


### PR DESCRIPTION
## Description

For the `upto` scheme https://github.com/coinbase/x402/pull/1551, we need a mechanism for the server to declare the amount to be settled. The existing transport-agnostic `BeforeSettleHook` on `x402ResourceServer` receives no context what the route handler did.

This adds a new HTTP-level `BeforeSettleHook` that runs inside `x402HTTPResourceServer::processSettlement()` and receives full transportContext including response body and headers.

The new HTTP-level `BeforeSettleHook` can:
- Mutate requirements in place (e.g., set `requirements.amount` for upto)
- Return void to continue
- Return { abort: true, reason } to cancel settlement (matching core `BeforeSettleHook` behaviour)

## Tests

Modified express example with:

```
httpServer.onBeforeSettle(async (_paymentPayload, requirements, declaredExtensions, transportContext) => {
  if (transportContext?.responseBody) {
    const body = JSON.parse(transportContext.responseBody.toString());
    console.log("[onBeforeSettle] responseBody:", body);
  }
  console.log("[onBeforeSettle] responseHeaders:", transportContext?.responseHeaders);
});

app.use(paymentMiddlewareFromHTTPServer(httpServer));

app.get("/weather", (req, res) => {

  res.set("payment-amount", "500");

  res.send({
    report: {
      weather: "sunny",
      temperature: 70,
    },
  });
});
```

Server log:
```
[onBeforeSettle] responseHeaders: {
  'x-powered-by': 'Express',
  'payment-amount': '500',
  'content-type': 'application/json; charset=utf-8',
}
[onBeforeSettle] responseBody: { report: { weather: 'sunny', temperature: 70 } }
```

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 