### PR TITLE
Add Strale metadata for business data APIs

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/strale/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/strale/metadata.json
@@ -1,0 +1,43 @@
+{
+  "name": "Strale",
+  "description": "Business data and compliance APIs for AI agents via x402. IBAN validation, VAT verification, sanctions screening, SSL checks, and paid API pre-flight verification. 225+ quality-scored capabilities across 27 countries. First compliance and regulatory data provider in the x402 ecosystem.",
+  "logoUrl": "/logos/strale.png",
+  "websiteUrl": "https://strale.dev/docs",
+  "category": "Services/Endpoints"
+}
+```
+
+**Step 6:** Click **Commit changes** → commit directly to main → **Commit changes**
+
+**Step 7:** Now you need to add the logo. Navigate to `typescript/site/public/logos/` in your fork.
+
+**Step 8:** Click **Add file** → **Upload files**
+
+**Step 9:** Upload your Strale logo as `strale.png`. Use a square logo, ideally 200x200px or similar. If you don't have one handy as a PNG, let me know and we can sort that out.
+
+**Step 10:** Click **Commit changes**
+
+**Step 11:** Go back to your fork's main page. Click **Contribute** → **Open pull request**
+
+**Step 12:** On the PR form:
+- Title: `Add Strale to ecosystem — business data & compliance APIs`
+- Description:
+```
+Adds Strale as the first business data and compliance provider in the x402 ecosystem.
+
+**Category:** Services/Endpoints
+
+**What Strale provides:**
+- IBAN validation, VAT verification, sanctions screening, SSL checks, paid API pre-flight verification
+- 225+ quality-scored capabilities across 27 countries
+- Every capability independently tested with published quality scores
+- Available via x402 (USDC on Base), MCP server, and REST API
+
+**Live x402 endpoints:**
+- https://api.strale.io/x402/iban-validate
+- https://api.strale.io/x402/vat-format-validate
+- https://api.strale.io/x402/paid-api-preflight
+- https://api.strale.io/x402/ssl-check
+- https://api.strale.io/x402/sanctions-check
+
+Website: https://strale.dev


### PR DESCRIPTION
Adds Strale as the first business data and compliance provider in the x402 ecosystem, including various APIs for validation and verification.

<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 