### PR TITLE
fix(go): remove stale TODO in facilitator hooks test

### DIFF
--- a/go/facilitator_hooks_test.go
+++ b/go/facilitator_hooks_test.go
@@ -23,8 +23,6 @@ func TestFacilitatorBeforeVerifyHook_Abort(t *testing.T) {
 	})
 
 	// Try to verify (should be aborted by hook)
-	// Note: Hooks are not fully integrated yet - this test validates hook registration works
-	// TODO: Integrate hooks into Verify execution
 	payload := types.PaymentPayload{X402Version: 2, Payload: map[string]interface{}{}}
 	requirements := types.PaymentRequirements{Scheme: "exact", Network: "eip155:8453"}
 


### PR DESCRIPTION
## Description

Remove stale TODO comment in `go/facilitator_hooks_test.go` (lines 26-27) that incorrectly states hooks are "not fully integrated" into Verify/Settle execution.

Since [#1125](https://github.com/coinbase/x402/issues/1125) was filed, hooks have been fully integrated. All 7 hook tests in this file exercise hooks through the complete Verify and Settle execution paths:

- `TestFacilitatorBeforeVerifyHook_Abort` - BeforeVerify hook aborts verification
- `TestFacilitatorAfterVerifyHook` - AfterVerify hook captures result (payer = "0xTestPayer")
- `TestFacilitatorOnVerifyFailureHook_Recover` - failure hook recovers from verify errors
- `TestFacilitatorBeforeSettleHook_Abort` - BeforeSettle hook aborts settlement
- `TestFacilitatorAfterSettleHook` - AfterSettle hook captures transaction
- `TestFacilitatorOnSettleFailureHook_Recover` - failure hook recovers from settle errors
- `TestFacilitatorMultipleHooks_ExecutionOrder` - hooks execute in registration order

The comment is the only thing that's stale - the code works correctly.

Fixes #1125

## Tests

All 7 hook tests pass unchanged:
```
go test -run "TestFacilitator.*Hook" -v -count=1 .
--- PASS: TestFacilitatorBeforeVerifyHook_Abort (0.00s)
--- PASS: TestFacilitatorAfterVerifyHook (0.00s)
--- PASS: TestFacilitatorOnVerifyFailureHook_Recover (0.00s)
--- PASS: TestFacilitatorBeforeSettleHook_Abort (0.00s)
--- PASS: TestFacilitatorAfterSettleHook (0.00s)
--- PASS: TestFacilitatorOnSettleFailureHook_Recover (0.00s)
--- PASS: TestFacilitatorMultipleHooks_ExecutionOrder (0.00s)
PASS
```

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

No changelog fragment needed - this is a test comment cleanup with no user-facing behavior change.

This contribution was developed with AI assistance (Claude Code).