### PR TITLE
fix(go): include registered schemes in facilitator error messages

### DIFF
--- a/go/facilitator.go
+++ b/go/facilitator.go
@@ -435,7 +435,8 @@ func (f *x402Facilitator) verifyV1(ctx context.Context, payload types.PaymentPay
 		}
 	}
 
-	return nil, NewVerifyError(ErrNoFacilitatorForNetwork, "", fmt.Sprintf("no facilitator for scheme %s on network %s", scheme, network))
+	registered := f.registeredV1Summary()
+	return nil, NewVerifyError(ErrNoFacilitatorForNetwork, "", fmt.Sprintf("no facilitator for scheme %q on network %q; registered: %s", scheme, network, registered))
 }
 
 // verifyV2 verifies a V2 payment (internal, typed)
@@ -460,7 +461,8 @@ func (f *x402Facilitator) verifyV2(ctx context.Context, payload types.PaymentPay
 		}
 	}
 
-	return nil, NewVerifyError(ErrNoFacilitatorForNetwork, "", fmt.Sprintf("no facilitator for scheme %s on network %s", scheme, network))
+	registered := f.registeredV2Summary()
+	return nil, NewVerifyError(ErrNoFacilitatorForNetwork, "", fmt.Sprintf("no facilitator for scheme %q on network %q; registered: %s", scheme, network, registered))
 }
 
 // settleV1 settles a V1 payment (internal, typed)
@@ -485,7 +487,8 @@ func (f *x402Facilitator) settleV1(ctx context.Context, payload types.PaymentPay
 		}
 	}
 
-	return nil, NewSettleError(ErrNoFacilitatorForNetwork, "", network, "", fmt.Sprintf("no facilitator for scheme %s on network %s", scheme, network))
+	registered := f.registeredV1Summary()
+	return nil, NewSettleError(ErrNoFacilitatorForNetwork, "", network, "", fmt.Sprintf("no facilitator for scheme %q on network %q; registered: %s", scheme, network, registered))
 }
 
 // settleV2 settles a V2 payment (internal, typed)
@@ -510,7 +513,38 @@ func (f *x402Facilitator) settleV2(ctx context.Context, payload types.PaymentPay
 		}
 	}
 
-	return nil, NewSettleError(ErrNoFacilitatorForNetwork, "", network, "", fmt.Sprintf("no facilitator for scheme %s on network %s", scheme, network))
+	registered := f.registeredV2Summary()
+	return nil, NewSettleError(ErrNoFacilitatorForNetwork, "", network, "", fmt.Sprintf("no facilitator for scheme %q on network %q; registered: %s", scheme, network, registered))
+}
+
+// registeredV1Summary returns a human-readable list of registered V1 scheme/network pairs.
+func (f *x402Facilitator) registeredV1Summary() string {
+	if len(f.schemesV1) == 0 {
+		return "(none)"
+	}
+	var parts []string
+	for _, data := range f.schemesV1 {
+		facilitator := data.facilitator.(SchemeNetworkFacilitatorV1)
+		for network := range data.networks {
+			parts = append(parts, fmt.Sprintf("%s@%s", facilitator.Scheme(), network))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// registeredV2Summary returns a human-readable list of registered V2 scheme/network pairs.
+func (f *x402Facilitator) registeredV2Summary() string {
+	if len(f.schemes) == 0 {
+		return "(none)"
+	}
+	var parts []string
+	for _, data := range f.schemes {
+		facilitator := data.facilitator.(SchemeNetworkFacilitator)
+		for network := range data.networks {
+			parts = append(parts, fmt.Sprintf("%s@%s", facilitator.Scheme(), network))
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 // GetSupported returns supported payment kinds


### PR DESCRIPTION
## Description

When `Verify()` or `Settle()` fails to find a matching facilitator for a scheme/network pair, the error message now includes all registered scheme/network combinations. This helps users identify misconfiguration without inspecting the facilitator setup code.

**Before:**
```
no_facilitator_for_network: no facilitator for scheme exact on network eip155:1
```

**After:**
```
no_facilitator_for_network: no facilitator for scheme "exact" on network "eip155:1"; registered: exact@eip155:8453, exact@eip155:84532
```

The change is limited to 4 error return sites in `go/facilitator.go` (verifyV1, verifyV2, settleV1, settleV2) plus two helper methods that format the registered pairs. No behavior changes - only message improvements.

Relates to #959

## Tests

All existing facilitator tests pass, including scheme/network mismatch tests:

```
go test -run "TestFacilitator" -v -count=1 .
--- PASS: TestFacilitatorRegisterExtension (0.00s)
--- PASS: TestFacilitatorVerify (0.00s)
--- PASS: TestFacilitatorVerifyValidation (0.00s)
--- PASS: TestFacilitatorVerifySchemeMismatch (0.00s)
--- PASS: TestFacilitatorVerifyNetworkMismatch (0.00s)
--- PASS: TestFacilitatorSettle (0.00s)
--- PASS: TestFacilitatorSettleVerifiesFirst (0.00s)
--- PASS: TestFacilitatorGetSupported (0.00s)
--- PASS: TestFacilitatorNetworkPatternMatching (0.00s)
PASS
```

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

This contribution was developed with AI assistance (Claude Code).