### PR TITLE
Add Addybook to x402 ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/addybook/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/addybook/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Addybook",
+  "description": "Addybook is a DeFi contract registry API with 4,300+ protocols and verified addresses across 88 chains. AI agents pay per-request with x402 to look up contract addresses, ABIs, events, and deployment metadata — no API keys needed.",
+  "logoUrl": "/logos/addybook.svg",
+  "websiteUrl": "https://addybook.xyz",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/addybook.svg
+++ b/typescript/site/public/logos/addybook.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" fill="#000000"/>
+  <text x="16" y="22" font-family="monospace" font-size="20" font-weight="bold" fill="#00ff88" text-anchor="middle">A</text>
+</svg>


### PR DESCRIPTION
## Summary

Adding [Addybook](https://addybook.xyz) to the x402 ecosystem directory.

**Addybook** is a DeFi contract registry API optimized for LLM and AI agent consumption:
- 4,300+ protocols with verified contract addresses across 88 chains
- Lookup by address, event signature, protocol name, chain, or category
- x402 pay-per-request ($0.001/request via USDC on Base) — no API keys needed
- Free tier for metadata, lite search index, and individual protocol lookups

**Category:** Services/Endpoints

**Links:**
- Website: https://addybook.xyz
- API docs: https://addybook.apidocumentation.com/addybook-api
- x402 info: https://addybook.xyz/api/v1/x402-info.json
- GitHub: https://github.com/karelxfi/contracts-registry-llm
- SDK: `npm install @addybook/sdk`
- MCP server: `npx @addybook/mcp-server`

**Files added:**
- `typescript/site/app/ecosystem/partners-data/addybook/metadata.json`
- `typescript/site/public/logos/addybook.svg`