### PR TITLE
Add WalletIQ to x402 ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/walletiq/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/walletiq/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "WalletIQ",
+  "description": "Wallet intelligence API for EVM addresses. One call returns a full profile: wallet age, activity, DeFi footprint, labels, and risk score. Native x402 integration — pay $0.005 USDC per lookup on Base or Avalanche C-Chain, no API key needed.",
+  "logoUrl": "/logos/walletiq.svg",
+  "websiteUrl": "https://walletiq-zeta.vercel.app/api/v1/x402/profile/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/walletiq.svg
+++ b/typescript/site/public/logos/walletiq.svg
@@ -1,0 +1,12 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="64" y1="64" x2="448" y2="448" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EA5E9"/>
+      <stop offset="1" stop-color="#8B5CF6"/>
+    </linearGradient>
+  </defs>
+  <rect x="32" y="32" width="448" height="448" rx="112" fill="#0B1220"/>
+  <rect x="48" y="48" width="416" height="416" rx="96" fill="url(#g)" fill-opacity="0.15" stroke="url(#g)" stroke-width="10"/>
+  <path d="M156 176H196L228 308L260 208L292 308L324 176H356L306 348H274L244 254L214 348H182L156 176Z" fill="white"/>
+  <rect x="164" y="372" width="184" height="20" rx="10" fill="url(#g)"/>
+</svg>


### PR DESCRIPTION
## Summary
Add WalletIQ to the x402 ecosystem page under `Services/Endpoints`.

WalletIQ is a wallet intelligence API for EVM addresses, protected end-to-end with x402.

## What it does
`GET /api/v1/x402/profile/{address}` returns a full wallet profile:
- wallet age
- activity
- DeFi footprint
- labels
- risk score

Pricing: **$0.005 USDC per lookup**

## x402 integration details
- **Scheme:** `exact`
- **Networks:** Base mainnet (`eip155:8453`) and Avalanche C-Chain (`eip155:43114`)
- **Asset:** USDC
- **Facilitators:** AutoIncentive (Base), PayAI (Avalanche)

## Try it
```bash
curl -sD - https://walletiq-zeta.vercel.app/api/v1/x402/profile/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
```

This returns a 402 with payment requirements; any x402-compatible client can pay and retrieve the profile.

## Files added
- `typescript/site/app/ecosystem/partners-data/walletiq/metadata.json`
- `typescript/site/public/logos/walletiq.svg`
