### PR TITLE
feat: add Flow EVM (eip155:747) as a supported network

### DIFF
--- a/typescript/packages/legacy/x402/src/types/shared/evm/config.ts
+++ b/typescript/packages/legacy/x402/src/types/shared/evm/config.ts
@@ -64,6 +64,10 @@ export const config: Record<string, ChainConfig> = {
     usdcAddress: "0xF1815bd50389c46847f0Bda824eC8da914045D14",
     usdcName: "Bridged USDC",
   },
+  "747": {
+    usdcAddress: "0xF1815bd50389c46847f0Bda824eC8da914045D14",
+    usdcName: "stgUSDC",
+  },
   "41923": {
     usdcAddress: "0x12a272A581feE5577A5dFa371afEB4b2F3a8C2F8",
     usdcName: "Bridged USDC (Stargate)",

--- a/typescript/packages/legacy/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/legacy/x402/src/types/shared/evm/wallet.ts
@@ -26,6 +26,7 @@ import {
   abstractTestnet,
   story,
   eduChain,
+  flowMainnet,
 } from "viem/chains";
 import { skaleBaseSepolia } from "../custom-chains";
 import { privateKeyToAccount } from "viem/accounts";
@@ -233,6 +234,8 @@ export function getChainFromNetwork(network: string | undefined): Chain {
       return iotex;
     case "iotex-testnet":
       return iotexTestnet;
+    case "flow-evm":
+      return flowMainnet;
     case "skale-base-sepolia":
       return skaleBaseSepolia;
     default:

--- a/typescript/packages/legacy/x402/src/types/shared/network.ts
+++ b/typescript/packages/legacy/x402/src/types/shared/network.ts
@@ -17,6 +17,7 @@ export const NetworkSchema = z.enum([
   "peaq",
   "story",
   "educhain",
+  "flow-evm",
   "skale-base-sepolia",
 ]);
 export type Network = z.infer<typeof NetworkSchema>;
@@ -37,6 +38,7 @@ export const SupportedEVMNetworks: Network[] = [
   "peaq",
   "story",
   "educhain",
+  "flow-evm",
   "skale-base-sepolia",
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
@@ -54,6 +56,7 @@ export const EvmNetworkToChainId = new Map<Network, number>([
   ["peaq", 3338],
   ["story", 1514],
   ["educhain", 41923],
+  ["flow-evm", 747],
   ["skale-base-sepolia", 324705682],
 ]);
 


### PR DESCRIPTION
## Description

Adds Flow EVM mainnet (chain ID `747`) as a supported network in the legacy x402 package, as suggested by @apmcdermott in #550.

### Summary of Changes

- **`config.ts`** — added stgUSDC address for chain `747`
- **`network.ts`** — added `"flow-evm"` to `NetworkSchema`, `SupportedEVMNetworks`, and `EvmNetworkToChainId`
- **`wallet.ts`** — added `flowMainnet` chain mapping from `viem/chains`

## Context

All required infrastructure contracts are deployed and verified on Flow EVM mainnet:

| Contract | Address | Status |
|----------|---------|--------|
| x402ExactPermit2Proxy | [`0x402085c248EeA27D92E8b30b2C58ed07f9E20001`](https://evm.flow.com/address/0x402085c248EeA27D92E8b30b2C58ed07f9E20001) | ✅ Canonical CREATE2 address, verified |
| Permit2 | [`0x000000000022D473030F116dDEE9F6B43aC78BA3`](https://evm.flow.com/address/0x000000000022D473030F116dDEE9F6B43aC78BA3) | ✅ Canonical address, verified |
| USDC (stgUSDC) | [`0xF1815bd50389c46847f0Bda824eC8da914045D14`](https://evm.flow.com/address/0xF1815bd50389c46847f0Bda824eC8da914045D14) | ✅ FiatTokenV2_2, EIP-3009 + EIP-2612 |

Related: #550 (original v1 PR, closed in favor of v2), #1721 (CDP facilitator request)

## Tests

Existing tests should continue to pass as this only adds a new network entry.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)