### PR TITLE
feat(go): add Health() method to resource server

### DIFF
--- a/go/server.go
+++ b/go/server.go
@@ -243,6 +243,51 @@ func (s *x402ResourceServer) OnSettleFailure(hook OnSettleFailureHook) *x402Reso
 }
 
 // ============================================================================
+// Health / Diagnostics
+// ============================================================================
+
+// HealthScheme describes a registered scheme for a given network.
+type HealthScheme struct {
+	Network string `json:"network"`
+	Scheme  string `json:"scheme"`
+}
+
+// HealthResponse contains diagnostic information about the resource server's
+// current configuration, including registered schemes and extensions.
+type HealthResponse struct {
+	Status     string         `json:"status"`
+	Schemes    []HealthScheme `json:"schemes"`
+	Extensions []string       `json:"extensions"`
+}
+
+// Health returns diagnostic information about the server's configuration.
+func (s *x402ResourceServer) Health() HealthResponse {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	schemes := make([]HealthScheme, 0)
+	for network, schemeMap := range s.schemes {
+		for schemeName := range schemeMap {
+			schemes = append(schemes, HealthScheme{
+				Network: string(network),
+				Scheme:  schemeName,
+			})
+		}
+	}
+
+	extensions := make([]string, 0, len(s.registeredExtensions))
+	for key := range s.registeredExtensions {
+		extensions = append(extensions, key)
+	}
+
+	return HealthResponse{
+		Status:     "ok",
+		Schemes:    schemes,
+		Extensions: extensions,
+	}
+}
+
+// ============================================================================
 // Core Payment Methods (V2 Only)
 // ============================================================================
 

--- a/go/server_test.go
+++ b/go/server_test.go
@@ -607,3 +607,58 @@ func TestSupportedCache(t *testing.T) {
 	}
 }
 */
+
+type mockExtension struct {
+	key string
+}
+
+func (m *mockExtension) Key() string { return m.key }
+func (m *mockExtension) EnrichDeclaration(declaration interface{}, transportContext interface{}) interface{} {
+	return declaration
+}
+
+func TestHealth_Empty(t *testing.T) {
+	server := Newx402ResourceServer()
+	health := server.Health()
+
+	if health.Status != "ok" {
+		t.Fatalf("expected status ok, got %s", health.Status)
+	}
+	if len(health.Schemes) != 0 {
+		t.Fatalf("expected 0 schemes, got %d", len(health.Schemes))
+	}
+	if len(health.Extensions) != 0 {
+		t.Fatalf("expected 0 extensions, got %d", len(health.Extensions))
+	}
+}
+
+func TestHealth_WithSchemesAndExtensions(t *testing.T) {
+	mock := &mockSchemeNetworkServer{scheme: "exact"}
+	mockExt := &mockExtension{key: "paymentidentifier"}
+
+	server := Newx402ResourceServer(
+		WithSchemeServer("eip155:8453", mock),
+	)
+	server.RegisterExtension(mockExt)
+
+	health := server.Health()
+
+	if health.Status != "ok" {
+		t.Fatalf("expected status ok, got %s", health.Status)
+	}
+	if len(health.Schemes) != 1 {
+		t.Fatalf("expected 1 scheme, got %d", len(health.Schemes))
+	}
+	if health.Schemes[0].Network != "eip155:8453" {
+		t.Fatalf("expected network eip155:8453, got %s", health.Schemes[0].Network)
+	}
+	if health.Schemes[0].Scheme != "exact" {
+		t.Fatalf("expected scheme exact, got %s", health.Schemes[0].Scheme)
+	}
+	if len(health.Extensions) != 1 {
+		t.Fatalf("expected 1 extension, got %d", len(health.Extensions))
+	}
+	if health.Extensions[0] != "paymentidentifier" {
+		t.Fatalf("expected extension paymentidentifier, got %s", health.Extensions[0])
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `Health()` method to `x402ResourceServer` that returns registered schemes (with network info) and loaded extensions. Gives operators a programmatic way to verify server configuration without making payment requests.

## Why this matters

The Go resource server tracks registered schemes and extensions internally but doesn't expose this state. Operators deploying x402 servers can't verify their configuration is correct without attempting real payments. The existing `DiagnosePermit2SimulationFailure` in `go/mechanisms/evm/exact/facilitator/permit2_helpers.go` shows the codebase already values diagnostic capabilities for specific mechanisms - this extends that pattern to the server level.

## Changes

- Added `HealthResponse` and `HealthScheme` types in `go/server.go`
- Added `Health()` method on `x402ResourceServer` that iterates registered schemes and extensions under read lock
- Added tests for empty server and server with schemes + extensions

## Testing

```
go test -run "TestHealth" -v .
=== RUN   TestHealth_Empty
--- PASS: TestHealth_Empty (0.00s)
=== RUN   TestHealth_WithSchemesAndExtensions
--- PASS: TestHealth_WithSchemesAndExtensions (0.00s)
PASS
```

`go vet ./...` and `go build ./...` clean.

This contribution was developed with AI assistance (Claude Code).