### PR TITLE
feat(go): add settlement receipt verification for EVM

### DIFF
--- a/go/mechanisms/evm/verify_settlement.go
+++ b/go/mechanisms/evm/verify_settlement.go
@@ -1,0 +1,72 @@
+package evm
+
+import (
+	"context"
+	"fmt"
+)
+
+// ReceiptProvider can retrieve a transaction receipt from the blockchain.
+// FacilitatorEvmSigner satisfies this interface.
+type ReceiptProvider interface {
+	WaitForTransactionReceipt(ctx context.Context, txHash string) (*TransactionReceipt, error)
+}
+
+// SettlementVerification contains the result of verifying a settlement
+// transaction on-chain.
+type SettlementVerification struct {
+	// Confirmed is true if the transaction was mined and succeeded.
+	Confirmed bool `json:"confirmed"`
+
+	// BlockNumber is the block in which the transaction was included.
+	// Zero when the transaction is unconfirmed or failed.
+	BlockNumber uint64 `json:"blockNumber,omitempty"`
+
+	// TxHash is the transaction hash that was verified.
+	TxHash string `json:"txHash"`
+
+	// Network is the CAIP-2 network identifier where verification was performed.
+	Network string `json:"network"`
+
+	// FailureReason describes why verification failed, if applicable.
+	FailureReason string `json:"failureReason,omitempty"`
+}
+
+// VerifySettlement confirms that a settlement transaction was included in a
+// block and succeeded. It queries the blockchain for the transaction receipt
+// using the provided signer's WaitForTransactionReceipt method.
+//
+// Returns a SettlementVerification with Confirmed=true if the transaction
+// was mined with a success status. Returns Confirmed=false with a
+// FailureReason if the transaction failed or could not be found.
+func VerifySettlement(ctx context.Context, provider ReceiptProvider, txHash string, network string) (*SettlementVerification, error) {
+	if txHash == "" {
+		return &SettlementVerification{
+			Confirmed:     false,
+			TxHash:        txHash,
+			Network:       network,
+			FailureReason: "empty transaction hash",
+		}, nil
+	}
+
+	receipt, err := provider.WaitForTransactionReceipt(ctx, txHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get transaction receipt for %s: %w", txHash, err)
+	}
+
+	if receipt.Status != TxStatusSuccess {
+		return &SettlementVerification{
+			Confirmed:     false,
+			BlockNumber:   receipt.BlockNumber,
+			TxHash:        receipt.TxHash,
+			Network:       network,
+			FailureReason: fmt.Sprintf("transaction reverted with status %d", receipt.Status),
+		}, nil
+	}
+
+	return &SettlementVerification{
+		Confirmed:   true,
+		BlockNumber: receipt.BlockNumber,
+		TxHash:      receipt.TxHash,
+		Network:     network,
+	}, nil
+}

--- a/go/mechanisms/evm/verify_settlement_test.go
+++ b/go/mechanisms/evm/verify_settlement_test.go
@@ -1,0 +1,88 @@
+package evm
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// mockReceiptProvider implements ReceiptProvider for tests.
+type mockReceiptProvider struct {
+	receipt *TransactionReceipt
+	err     error
+}
+
+func (m *mockReceiptProvider) WaitForTransactionReceipt(ctx context.Context, txHash string) (*TransactionReceipt, error) {
+	return m.receipt, m.err
+}
+
+func TestVerifySettlement_Confirmed(t *testing.T) {
+	signer := &mockReceiptProvider{
+		receipt: &TransactionReceipt{
+			Status:      TxStatusSuccess,
+			BlockNumber: 12345,
+			TxHash:      "0xabc",
+		},
+	}
+
+	result, err := VerifySettlement(context.Background(), signer, "0xabc", "eip155:8453")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Confirmed {
+		t.Fatal("expected confirmed")
+	}
+	if result.BlockNumber != 12345 {
+		t.Fatalf("expected block 12345, got %d", result.BlockNumber)
+	}
+	if result.Network != "eip155:8453" {
+		t.Fatalf("expected network eip155:8453, got %s", result.Network)
+	}
+}
+
+func TestVerifySettlement_Reverted(t *testing.T) {
+	signer := &mockReceiptProvider{
+		receipt: &TransactionReceipt{
+			Status:      0,
+			BlockNumber: 12345,
+			TxHash:      "0xdef",
+		},
+	}
+
+	result, err := VerifySettlement(context.Background(), signer, "0xdef", "eip155:8453")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Confirmed {
+		t.Fatal("expected not confirmed")
+	}
+	if result.FailureReason == "" {
+		t.Fatal("expected failure reason")
+	}
+}
+
+func TestVerifySettlement_RPCError(t *testing.T) {
+	signer := &mockReceiptProvider{
+		err: errors.New("rpc connection refused"),
+	}
+
+	_, err := VerifySettlement(context.Background(), signer, "0xghi", "eip155:8453")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestVerifySettlement_EmptyTxHash(t *testing.T) {
+	signer := &mockReceiptProvider{}
+
+	result, err := VerifySettlement(context.Background(), signer, "", "eip155:8453")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Confirmed {
+		t.Fatal("expected not confirmed for empty hash")
+	}
+	if result.FailureReason == "" {
+		t.Fatal("expected failure reason for empty hash")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `VerifySettlement()` utility in `go/mechanisms/evm` that confirms a payment transaction was included in a block and succeeded on-chain.

## Why this matters

After a payment settles, Go server operators receive a `SettleResponse` with a transaction hash but no built-in way to confirm the transaction actually landed. The existing `WaitForTransactionReceipt` is used internally during settlement but isn't exposed as a standalone verification tool. This closes the trust gap for operators who want independent confirmation, in line with x402's trust-minimizing principle.

The implementation uses a narrow `ReceiptProvider` interface (satisfied by `FacilitatorEvmSigner`) rather than requiring the full signer, keeping it testable and composable.

## Changes

- `go/mechanisms/evm/verify_settlement.go`: `VerifySettlement()` function, `ReceiptProvider` interface, `SettlementVerification` result type
- `go/mechanisms/evm/verify_settlement_test.go`: 4 test cases covering confirmed, reverted, RPC error, and empty transaction hash

## Testing

```
go test -run "TestVerifySettlement" -v ./mechanisms/evm/
=== RUN   TestVerifySettlement_Confirmed
--- PASS: TestVerifySettlement_Confirmed (0.00s)
=== RUN   TestVerifySettlement_Reverted
--- PASS: TestVerifySettlement_Reverted (0.00s)
=== RUN   TestVerifySettlement_RPCError
--- PASS: TestVerifySettlement_RPCError (0.00s)
=== RUN   TestVerifySettlement_EmptyTxHash
--- PASS: TestVerifySettlement_EmptyTxHash (0.00s)
PASS
```

`go vet ./...` and `go build ./...` clean. No new dependencies.

SVM verification is out of scope for this PR and can follow separately.

This contribution was developed with AI assistance (Claude Code).