### PR TITLE
feat: add brandontan.app to ecosystem (6 x402 APIs)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/brandontan-app/data.json
+++ b/typescript/site/app/ecosystem/partners-data/brandontan-app/data.json
@@ -1,0 +1,7 @@
+{
+    "name": "brandontan.app APIs",
+    "description": "Six pay-per-call APIs on Base mainnet via x402: weather forecast (Open-Meteo), currency exchange rates (ECB), timezone conversion, IP geolocation, real-time crypto prices (CoinGecko), and heartfelt message generation. $0.001–$0.02 USDC per call. No signup, no API keys — just pay per use.",
+    "logoUrl": "/logos/brandontan-app.png",
+    "websiteUrl": "https://brandontan.app/agentic-services",
+    "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## Description

Adding brandontan.app to the x402 ecosystem under **Services/Endpoints**.

Six pay-per-call APIs live on Base mainnet via x402 v2:

- **Weather Forecast** — current conditions + 7-day forecast for any city or lat/lon (Open-Meteo, free)
- **FX Rates** — real-time currency conversion for 170+ currencies (ECB data)
- **Timezone** — datetime conversion across any IANA timezone pair
- **IP Geolocation** — country, city, region, lat/lon, ISP for any IPv4/IPv6
- **Crypto Prices** — live price, 24h change, market cap, volume for 10,000+ coins (CoinGecko, free)
- **Heartfelt Messages** — AI-generated warm messages for any occasion

All endpoints: $0.001–$0.02 USDC per call. Discovery at brandontan.app/.well-known/x402. OpenAPI at brandontan.app/openapi.json.

Note: logo file can be added if reviewers specify preferred format/size.