### PR TITLE
Add Hodler DeFi Intelligence to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/hodler-defi-intelligence/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/hodler-defi-intelligence/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Hodler DeFi Intelligence",
+  "description": "Real-time DeFi data for AI agents: stablecoin monitoring (120+ USD stablecoins), redeem arbitrage opportunities with spread% and APR, and cross-chain pair discovery across 10 EVM chains. 6 endpoints at $0.01 USDC on Base via x402.",
+  "logoUrl": "/logos/hodler-defi-intelligence.svg",
+  "websiteUrl": "https://x402.hodle.com.br/.well-known/agent-catalog.json",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/hodler-defi-intelligence.svg
+++ b/typescript/site/public/logos/hodler-defi-intelligence.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect width="120" height="120" rx="24" fill="#0D1117"/>
+  <text x="60" y="68" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="700" font-size="28" fill="#58A6FF">HODL</text>
+  <text x="60" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-weight="500" font-size="11" fill="#8B949E">DeFi Intel</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds **Hodler DeFi Intelligence** to the x402 ecosystem page under Services/Endpoints.

Hodler DeFi Intelligence provides real-time DeFi data for AI agents:
- 120+ USD stablecoins with prices, deviation, redeemability
- Redeem arbitrage opportunities with spread%, net profit, annualized APR
- Cross-chain pair discovery across 10 EVM chains (Ethereum, Base, Arbitrum, Polygon, BSC, Optimism, Avalanche, Linea, Sonic, HyperEVM)
- 6 endpoints at $0.01 USDC on Base via x402 protocol

**Agent catalog:** https://x402.hodle.com.br/.well-known/agent-catalog.json

## Changes

- Added `typescript/site/app/ecosystem/partners-data/hodler-defi-intelligence/metadata.json`
- Added `typescript/site/public/logos/hodler-defi-intelligence.svg`