### PR TITLE
Fix extra: null incompatibility between python facilitator and TS zod schema

### DIFF
--- a/e2e/clients/httpx/uv.lock
+++ b/e2e/clients/httpx/uv.lock
@@ -1937,7 +1937,7 @@ svm = [
 [package.metadata]
 requires-dist = [
     { name = "eth-abi", marker = "extra == 'evm'", specifier = ">=5.0.0" },
-    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.12.0" },
+    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.13.0" },
     { name = "eth-keys", marker = "extra == 'evm'", specifier = ">=0.5.0" },
     { name = "eth-utils", marker = "extra == 'evm'", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
@@ -1964,7 +1964,7 @@ provides-extras = ["httpx", "requests", "flask", "fastapi", "evm", "svm", "mcp",
 dev = [
     { name = "black", specifier = ">=23.0.0" },
     { name = "eth-abi", specifier = ">=5.0.0" },
-    { name = "eth-account", specifier = ">=0.12.0" },
+    { name = "eth-account", specifier = ">=0.13.0" },
     { name = "eth-keys", specifier = ">=0.5.0" },
     { name = "eth-utils", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },

--- a/e2e/clients/httpx/uv.lock
+++ b/e2e/clients/httpx/uv.lock
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.3.0"
+version = "2.5.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/mcp-python/uv.lock
+++ b/e2e/clients/mcp-python/uv.lock
@@ -2160,7 +2160,7 @@ mcp = [
 [package.metadata]
 requires-dist = [
     { name = "eth-abi", marker = "extra == 'evm'", specifier = ">=5.0.0" },
-    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.12.0" },
+    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.13.0" },
     { name = "eth-keys", marker = "extra == 'evm'", specifier = ">=0.5.0" },
     { name = "eth-utils", marker = "extra == 'evm'", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
@@ -2187,7 +2187,7 @@ provides-extras = ["httpx", "requests", "flask", "fastapi", "evm", "svm", "mcp",
 dev = [
     { name = "black", specifier = ">=23.0.0" },
     { name = "eth-abi", specifier = ">=5.0.0" },
-    { name = "eth-account", specifier = ">=0.12.0" },
+    { name = "eth-account", specifier = ">=0.13.0" },
     { name = "eth-keys", specifier = ">=0.5.0" },
     { name = "eth-utils", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },

--- a/e2e/clients/mcp-python/uv.lock
+++ b/e2e/clients/mcp-python/uv.lock
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.3.0"
+version = "2.5.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/requests/uv.lock
+++ b/e2e/clients/requests/uv.lock
@@ -1937,7 +1937,7 @@ svm = [
 [package.metadata]
 requires-dist = [
     { name = "eth-abi", marker = "extra == 'evm'", specifier = ">=5.0.0" },
-    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.12.0" },
+    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.13.0" },
     { name = "eth-keys", marker = "extra == 'evm'", specifier = ">=0.5.0" },
     { name = "eth-utils", marker = "extra == 'evm'", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
@@ -1964,7 +1964,7 @@ provides-extras = ["httpx", "requests", "flask", "fastapi", "evm", "svm", "mcp",
 dev = [
     { name = "black", specifier = ">=23.0.0" },
     { name = "eth-abi", specifier = ">=5.0.0" },
-    { name = "eth-account", specifier = ">=0.12.0" },
+    { name = "eth-account", specifier = ">=0.13.0" },
     { name = "eth-keys", specifier = ">=0.5.0" },
     { name = "eth-utils", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },

--- a/e2e/clients/requests/uv.lock
+++ b/e2e/clients/requests/uv.lock
@@ -1907,7 +1907,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.3.0"
+version = "2.5.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/facilitators/python/main.py
+++ b/e2e/facilitators/python/main.py
@@ -319,15 +319,7 @@ async def supported():
         response = facilitator.get_supported()
 
         return {
-            "kinds": [
-                {
-                    "x402Version": k.x402_version,
-                    "scheme": k.scheme,
-                    "network": k.network,
-                    "extra": k.extra,
-                }
-                for k in response.kinds
-            ],
+            "kinds": [k.model_dump(by_alias=True, exclude_none=True) for k in response.kinds],
             "extensions": response.extensions,
             "signers": response.signers,
         }

--- a/e2e/facilitators/python/main.py
+++ b/e2e/facilitators/python/main.py
@@ -243,11 +243,7 @@ async def verify(request: VerifyRequest):
         if not response.is_valid:
             print(f"  ❌ Verify rejected: {response.invalid_reason} (payer={response.payer})")
 
-        return {
-            "isValid": response.is_valid,
-            "payer": response.payer,
-            "invalidReason": response.invalid_reason,
-        }
+        return response.model_dump(by_alias=True, exclude_none=True)
     except Exception as e:
         import traceback
         print(f"Verify error: {e}")
@@ -282,28 +278,23 @@ async def settle(request: SettleRequest):
         # - Clean up tracking (on_after_settle / on_settle_failure)
         response = await facilitator.settle(payload, requirements)
 
-        return {
-            "success": response.success,
-            "transaction": response.transaction,
-            "network": response.network,
-            "payer": response.payer,
-            "errorReason": response.error_reason,
-        }
+        return response.model_dump(by_alias=True, exclude_none=True)
     except Exception as e:
         print(f"Settle error: {e}")
 
         # Check if this was an abort from hook
         if "aborted" in str(e).lower() or "Settlement aborted" in str(e):
-            # Return a proper SettleResponse instead of 500 error
-            return {
-                "success": False,
-                "errorReason": str(e).replace("Settlement aborted: ", ""),
-                "network": request.paymentPayload.get("accepted", {}).get(
+            from x402.schemas import SettleResponse
+
+            abort = SettleResponse(
+                success=False,
+                error_reason=str(e).replace("Settlement aborted: ", ""),
+                network=request.paymentPayload.get("accepted", {}).get(
                     "network", "unknown"
                 ),
-                "transaction": "",
-                "payer": None,
-            }
+                transaction="",
+            )
+            return abort.model_dump(by_alias=True, exclude_none=True)
 
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/e2e/facilitators/python/uv.lock
+++ b/e2e/facilitators/python/uv.lock
@@ -2877,7 +2877,7 @@ svm = [
 [package.metadata]
 requires-dist = [
     { name = "eth-abi", marker = "extra == 'evm'", specifier = ">=5.0.0" },
-    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.12.0" },
+    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.13.0" },
     { name = "eth-keys", marker = "extra == 'evm'", specifier = ">=0.5.0" },
     { name = "eth-utils", marker = "extra == 'evm'", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
@@ -2904,7 +2904,7 @@ provides-extras = ["httpx", "requests", "flask", "fastapi", "evm", "svm", "mcp",
 dev = [
     { name = "black", specifier = ">=23.0.0" },
     { name = "eth-abi", specifier = ">=5.0.0" },
-    { name = "eth-account", specifier = ">=0.12.0" },
+    { name = "eth-account", specifier = ">=0.13.0" },
     { name = "eth-keys", specifier = ">=0.5.0" },
     { name = "eth-utils", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },

--- a/e2e/facilitators/python/uv.lock
+++ b/e2e/facilitators/python/uv.lock
@@ -2846,7 +2846,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.3.0"
+version = "2.5.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/fastapi/uv.lock
+++ b/e2e/servers/fastapi/uv.lock
@@ -2841,7 +2841,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.3.0"
+version = "2.5.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/fastapi/uv.lock
+++ b/e2e/servers/fastapi/uv.lock
@@ -2872,7 +2872,7 @@ svm = [
 [package.metadata]
 requires-dist = [
     { name = "eth-abi", marker = "extra == 'evm'", specifier = ">=5.0.0" },
-    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.12.0" },
+    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.13.0" },
     { name = "eth-keys", marker = "extra == 'evm'", specifier = ">=0.5.0" },
     { name = "eth-utils", marker = "extra == 'evm'", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
@@ -2899,7 +2899,7 @@ provides-extras = ["httpx", "requests", "flask", "fastapi", "evm", "svm", "mcp",
 dev = [
     { name = "black", specifier = ">=23.0.0" },
     { name = "eth-abi", specifier = ">=5.0.0" },
-    { name = "eth-account", specifier = ">=0.12.0" },
+    { name = "eth-account", specifier = ">=0.13.0" },
     { name = "eth-keys", specifier = ">=0.5.0" },
     { name = "eth-utils", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },

--- a/e2e/servers/flask/uv.lock
+++ b/e2e/servers/flask/uv.lock
@@ -2072,7 +2072,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.3.0"
+version = "2.5.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/flask/uv.lock
+++ b/e2e/servers/flask/uv.lock
@@ -2102,7 +2102,7 @@ svm = [
 [package.metadata]
 requires-dist = [
     { name = "eth-abi", marker = "extra == 'evm'", specifier = ">=5.0.0" },
-    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.12.0" },
+    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.13.0" },
     { name = "eth-keys", marker = "extra == 'evm'", specifier = ">=0.5.0" },
     { name = "eth-utils", marker = "extra == 'evm'", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
@@ -2129,7 +2129,7 @@ provides-extras = ["httpx", "requests", "flask", "fastapi", "evm", "svm", "mcp",
 dev = [
     { name = "black", specifier = ">=23.0.0" },
     { name = "eth-abi", specifier = ">=5.0.0" },
-    { name = "eth-account", specifier = ">=0.12.0" },
+    { name = "eth-account", specifier = ">=0.13.0" },
     { name = "eth-keys", specifier = ">=0.5.0" },
     { name = "eth-utils", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },

--- a/e2e/servers/mcp-python/uv.lock
+++ b/e2e/servers/mcp-python/uv.lock
@@ -2160,7 +2160,7 @@ mcp = [
 [package.metadata]
 requires-dist = [
     { name = "eth-abi", marker = "extra == 'evm'", specifier = ">=5.0.0" },
-    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.12.0" },
+    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.13.0" },
     { name = "eth-keys", marker = "extra == 'evm'", specifier = ">=0.5.0" },
     { name = "eth-utils", marker = "extra == 'evm'", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
@@ -2187,7 +2187,7 @@ provides-extras = ["httpx", "requests", "flask", "fastapi", "evm", "svm", "mcp",
 dev = [
     { name = "black", specifier = ">=23.0.0" },
     { name = "eth-abi", specifier = ">=5.0.0" },
-    { name = "eth-account", specifier = ">=0.12.0" },
+    { name = "eth-account", specifier = ">=0.13.0" },
     { name = "eth-keys", specifier = ">=0.5.0" },
     { name = "eth-utils", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },

--- a/e2e/servers/mcp-python/uv.lock
+++ b/e2e/servers/mcp-python/uv.lock
@@ -2137,7 +2137,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.3.0"
+version = "2.5.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/examples/python/facilitator/advanced/all_networks.py
+++ b/examples/python/facilitator/advanced/all_networks.py
@@ -208,15 +208,7 @@ async def supported():
         response = facilitator.get_supported()
 
         return {
-            "kinds": [
-                {
-                    "x402Version": k.x402_version,
-                    "scheme": k.scheme,
-                    "network": k.network,
-                    "extra": k.extra,
-                }
-                for k in response.kinds
-            ],
+            "kinds": [k.model_dump(by_alias=True, exclude_none=True) for k in response.kinds],
             "extensions": response.extensions,
             "signers": response.signers,
         }

--- a/examples/python/facilitator/advanced/all_networks.py
+++ b/examples/python/facilitator/advanced/all_networks.py
@@ -145,11 +145,7 @@ async def verify(request: VerifyRequest):
         # Verify payment (await async method)
         response = await facilitator.verify(payload, requirements)
 
-        return {
-            "isValid": response.is_valid,
-            "payer": response.payer,
-            "invalidReason": response.invalid_reason,
-        }
+        return response.model_dump(by_alias=True, exclude_none=True)
     except Exception as e:
         print(f"Verify error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -175,24 +171,21 @@ async def settle(request: SettleRequest):
         # Settle payment (await async method)
         response = await facilitator.settle(payload, requirements)
 
-        return {
-            "success": response.success,
-            "transaction": response.transaction,
-            "network": response.network,
-            "payer": response.payer,
-            "errorReason": response.error_reason,
-        }
+        return response.model_dump(by_alias=True, exclude_none=True)
     except Exception as e:
         print(f"Settle error: {e}")
 
         # Check if this was an abort from hook
         if "aborted" in str(e).lower():
-            return {
-                "success": False,
-                "errorReason": str(e),
-                "network": request.paymentPayload.get("accepted", {}).get("network", "unknown"),
-                "transaction": "",
-            }
+            from x402.schemas import SettleResponse
+
+            abort = SettleResponse(
+                success=False,
+                error_reason=str(e),
+                network=request.paymentPayload.get("accepted", {}).get("network", "unknown"),
+                transaction="",
+            )
+            return abort.model_dump(by_alias=True, exclude_none=True)
 
         raise HTTPException(status_code=500, detail=str(e)) from e
 

--- a/examples/python/facilitator/advanced/bazaar.py
+++ b/examples/python/facilitator/advanced/bazaar.py
@@ -268,15 +268,7 @@ async def supported():
         response = facilitator.get_supported()
 
         return {
-            "kinds": [
-                {
-                    "x402Version": k.x402_version,
-                    "scheme": k.scheme,
-                    "network": k.network,
-                    "extra": k.extra,
-                }
-                for k in response.kinds
-            ],
+            "kinds": [k.model_dump(by_alias=True, exclude_none=True) for k in response.kinds],
             "extensions": response.extensions,
             "signers": response.signers,
         }

--- a/examples/python/facilitator/advanced/bazaar.py
+++ b/examples/python/facilitator/advanced/bazaar.py
@@ -205,11 +205,7 @@ async def verify(request: VerifyRequest):
         # - Extract and catalog discovery info (on_after_verify)
         response = await facilitator.verify(payload, requirements)
 
-        return {
-            "isValid": response.is_valid,
-            "payer": response.payer,
-            "invalidReason": response.invalid_reason,
-        }
+        return response.model_dump(by_alias=True, exclude_none=True)
     except Exception as e:
         print(f"Verify error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -234,25 +230,21 @@ async def settle(request: SettleRequest):
 
         response = await facilitator.settle(payload, requirements)
 
-        return {
-            "success": response.success,
-            "transaction": response.transaction,
-            "network": response.network,
-            "payer": response.payer,
-            "errorReason": response.error_reason,
-        }
+        return response.model_dump(by_alias=True, exclude_none=True)
     except Exception as e:
         print(f"Settle error: {e}")
 
         # Check if this was an abort from hook
         if "aborted" in str(e).lower() or "Settlement aborted" in str(e):
-            return {
-                "success": False,
-                "errorReason": str(e).replace("Settlement aborted: ", ""),
-                "network": request.paymentPayload.get("accepted", {}).get("network", "unknown"),
-                "transaction": "",
-                "payer": None,
-            }
+            from x402.schemas import SettleResponse
+
+            abort = SettleResponse(
+                success=False,
+                error_reason=str(e).replace("Settlement aborted: ", ""),
+                network=request.paymentPayload.get("accepted", {}).get("network", "unknown"),
+                transaction="",
+            )
+            return abort.model_dump(by_alias=True, exclude_none=True)
 
         raise HTTPException(status_code=500, detail=str(e)) from e
 

--- a/examples/python/facilitator/basic/main.py
+++ b/examples/python/facilitator/basic/main.py
@@ -208,15 +208,7 @@ async def supported():
         response = facilitator.get_supported()
 
         return {
-            "kinds": [
-                {
-                    "x402Version": k.x402_version,
-                    "scheme": k.scheme,
-                    "network": k.network,
-                    "extra": k.extra,
-                }
-                for k in response.kinds
-            ],
+            "kinds": [k.model_dump(by_alias=True, exclude_none=True) for k in response.kinds],
             "extensions": response.extensions,
             "signers": response.signers,
         }

--- a/examples/python/facilitator/basic/main.py
+++ b/examples/python/facilitator/basic/main.py
@@ -145,11 +145,7 @@ async def verify(request: VerifyRequest):
         # Verify payment (await async method)
         response = await facilitator.verify(payload, requirements)
 
-        return {
-            "isValid": response.is_valid,
-            "payer": response.payer,
-            "invalidReason": response.invalid_reason,
-        }
+        return response.model_dump(by_alias=True, exclude_none=True)
     except Exception as e:
         print(f"Verify error: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -175,24 +171,21 @@ async def settle(request: SettleRequest):
         # Settle payment (await async method)
         response = await facilitator.settle(payload, requirements)
 
-        return {
-            "success": response.success,
-            "transaction": response.transaction,
-            "network": response.network,
-            "payer": response.payer,
-            "errorReason": response.error_reason,
-        }
+        return response.model_dump(by_alias=True, exclude_none=True)
     except Exception as e:
         print(f"Settle error: {e}")
 
         # Check if this was an abort from hook
         if "aborted" in str(e).lower():
-            return {
-                "success": False,
-                "errorReason": str(e),
-                "network": request.paymentPayload.get("accepted", {}).get("network", "unknown"),
-                "transaction": "",
-            }
+            from x402.schemas import SettleResponse
+
+            abort = SettleResponse(
+                success=False,
+                error_reason=str(e),
+                network=request.paymentPayload.get("accepted", {}).get("network", "unknown"),
+                transaction="",
+            )
+            return abort.model_dump(by_alias=True, exclude_none=True)
 
         raise HTTPException(status_code=500, detail=str(e)) from e
 

--- a/examples/python/facilitator/basic/uv.lock
+++ b/examples/python/facilitator/basic/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -2976,7 +2976,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.1.0"
+version = "2.5.0"
 source = { editable = "../../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/examples/typescript/clients/fetch/index.ts
+++ b/examples/typescript/clients/fetch/index.ts
@@ -35,7 +35,10 @@ async function main(): Promise<void> {
 
   console.log(`Making request to: ${url}\n`);
   const response = await fetchWithPayment(url, { method: "GET" });
-  const body = await response.json();
+  const contentType = response.headers.get("content-type") ?? "";
+  const body = contentType.includes("application/json")
+    ? await response.json()
+    : await response.text();
   console.log("Response body:", body);
 
   const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(name =>

--- a/python/x402/changelog.d/1762.bugfix.md
+++ b/python/x402/changelog.d/1762.bugfix.md
@@ -1,0 +1,1 @@
+Fix extra: null incompatibility between python facilitator and TS zod schema

--- a/python/x402/extensions/erc20_approval_gas_sponsoring/facilitator.py
+++ b/python/x402/extensions/erc20_approval_gas_sponsoring/facilitator.py
@@ -116,9 +116,10 @@ def _validate_signed_approval_tx(
         return "erc20_approval_tx_signer_mismatch", "recovered signer does not match payer"
 
     try:
-        from eth_account._utils.typed_transactions import TypedTransaction
+        from eth_account.typed_transactions import TypedTransaction
+        from hexbytes import HexBytes
 
-        tx_obj = TypedTransaction.from_bytes(tx_bytes)
+        tx_obj = TypedTransaction.from_bytes(HexBytes(tx_bytes))
         tx_dict = tx_obj.transaction.dictionary
 
         to_addr = tx_dict.get("to", b"")

--- a/python/x402/pyproject.toml
+++ b/python/x402/pyproject.toml
@@ -39,7 +39,7 @@ evm = [
     "eth-abi>=5.0.0",
     "eth-keys>=0.5.0",
     "eth-utils>=4.0.0",
-    "eth-account>=0.12.0",
+    "eth-account>=0.13.0",
     "web3>=7.0.0",
 ]
 svm = [
@@ -77,7 +77,7 @@ dev = [
     "eth-abi>=5.0.0",
     "eth-keys>=0.5.0",
     "eth-utils>=4.0.0",
-    "eth-account>=0.12.0",
+    "eth-account>=0.13.0",
     "web3>=7.0.0",
     # SVM dependencies
     "solders>=0.27.0",

--- a/python/x402/uv.lock
+++ b/python/x402/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -3509,7 +3509,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "eth-abi", marker = "extra == 'evm'", specifier = ">=5.0.0" },
-    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.12.0" },
+    { name = "eth-account", marker = "extra == 'evm'", specifier = ">=0.13.0" },
     { name = "eth-keys", marker = "extra == 'evm'", specifier = ">=0.5.0" },
     { name = "eth-utils", marker = "extra == 'evm'", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'fastapi'", specifier = ">=0.115.0" },
@@ -3536,7 +3536,7 @@ provides-extras = ["httpx", "requests", "flask", "fastapi", "evm", "svm", "mcp",
 dev = [
     { name = "black", specifier = ">=23.0.0" },
     { name = "eth-abi", specifier = ">=5.0.0" },
-    { name = "eth-account", specifier = ">=0.12.0" },
+    { name = "eth-account", specifier = ">=0.13.0" },
     { name = "eth-keys", specifier = ">=0.5.0" },
     { name = "eth-utils", specifier = ">=4.0.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },

--- a/typescript/.changeset/kind-icons-leave.md
+++ b/typescript/.changeset/kind-icons-leave.md
@@ -1,0 +1,5 @@
+---
+'@x402/core': patch
+---
+
+Accept null in extra and extension fields

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -67,7 +67,10 @@ const verifyResponseSchema: z.ZodType<VerifyResponse, z.ZodTypeDef, unknown> = z
   invalidReason: z.string().optional(),
   invalidMessage: z.string().optional(),
   payer: z.string().optional(),
-  extensions: z.record(z.string(), z.unknown()).optional(),
+  extensions: z
+    .record(z.string(), z.unknown())
+    .nullish()
+    .transform(v => v ?? undefined),
 });
 
 const settleResponseSchema: z.ZodType<SettleResponse, z.ZodTypeDef, unknown> = z.object({
@@ -77,7 +80,10 @@ const settleResponseSchema: z.ZodType<SettleResponse, z.ZodTypeDef, unknown> = z
   payer: z.string().optional(),
   transaction: z.string(),
   network: z.custom<SettleResponse["network"]>(value => typeof value === "string"),
-  extensions: z.record(z.string(), z.unknown()).optional(),
+  extensions: z
+    .record(z.string(), z.unknown())
+    .nullish()
+    .transform(v => v ?? undefined),
 });
 
 const supportedKindSchema: z.ZodType<SupportedResponse["kinds"][number], z.ZodTypeDef, unknown> =
@@ -87,7 +93,10 @@ const supportedKindSchema: z.ZodType<SupportedResponse["kinds"][number], z.ZodTy
     network: z.custom<SupportedResponse["kinds"][number]["network"]>(
       value => typeof value === "string",
     ),
-    extra: z.record(z.string(), z.unknown()).optional(),
+    extra: z
+      .record(z.string(), z.unknown())
+      .nullish()
+      .transform(v => v ?? undefined),
   });
 
 const supportedResponseSchema: z.ZodType<SupportedResponse, z.ZodTypeDef, unknown> = z.object({

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -64,9 +64,18 @@ const GET_SUPPORTED_RETRY_DELAY_MS = 1000;
 
 const verifyResponseSchema: z.ZodType<VerifyResponse, z.ZodTypeDef, unknown> = z.object({
   isValid: z.boolean(),
-  invalidReason: z.string().optional(),
-  invalidMessage: z.string().optional(),
-  payer: z.string().optional(),
+  invalidReason: z
+    .string()
+    .nullish()
+    .transform(v => v ?? undefined),
+  invalidMessage: z
+    .string()
+    .nullish()
+    .transform(v => v ?? undefined),
+  payer: z
+    .string()
+    .nullish()
+    .transform(v => v ?? undefined),
   extensions: z
     .record(z.string(), z.unknown())
     .nullish()
@@ -75,9 +84,18 @@ const verifyResponseSchema: z.ZodType<VerifyResponse, z.ZodTypeDef, unknown> = z
 
 const settleResponseSchema: z.ZodType<SettleResponse, z.ZodTypeDef, unknown> = z.object({
   success: z.boolean(),
-  errorReason: z.string().optional(),
-  errorMessage: z.string().optional(),
-  payer: z.string().optional(),
+  errorReason: z
+    .string()
+    .nullish()
+    .transform(v => v ?? undefined),
+  errorMessage: z
+    .string()
+    .nullish()
+    .transform(v => v ?? undefined),
+  payer: z
+    .string()
+    .nullish()
+    .transform(v => v ?? undefined),
   transaction: z.string(),
   network: z.custom<SettleResponse["network"]>(value => typeof value === "string"),
   extensions: z

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -109,4 +109,58 @@ describe("HTTPFacilitatorClient", () => {
 
     await expect(client.settle(paymentPayload, paymentRequirements)).rejects.toThrow(SettleError);
   });
+
+  it("parses verify 200 when optional string fields are JSON null", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            isValid: true,
+            invalidReason: null,
+            invalidMessage: null,
+            payer: null,
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+    const result = await client.verify(paymentPayload, paymentRequirements);
+
+    expect(result.isValid).toBe(true);
+    expect(result.invalidReason).toBeUndefined();
+    expect(result.invalidMessage).toBeUndefined();
+    expect(result.payer).toBeUndefined();
+  });
+
+  it("parses settle 200 when optional string fields are JSON null", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            success: true,
+            transaction: "0xabc",
+            network: "eip155:8453",
+            errorReason: null,
+            errorMessage: null,
+            payer: null,
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+    const result = await client.settle(paymentPayload, paymentRequirements);
+
+    expect(result.success).toBe(true);
+    expect(result.transaction).toBe("0xabc");
+    expect(result.network).toBe("eip155:8453");
+    expect(result.errorReason).toBeUndefined();
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.payer).toBeUndefined();
+  });
 });

--- a/typescript/packages/mechanisms/stellar/test/unit/shared.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/shared.test.ts
@@ -6,12 +6,22 @@ import {
 } from "@stellar/stellar-sdk";
 import { AssembledTransaction } from "@stellar/stellar-sdk/contract";
 import { Api } from "@stellar/stellar-sdk/rpc";
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { STELLAR_TESTNET_CAIP2 } from "../../src/constants";
 import { ExactStellarScheme } from "../../src/exact/client/scheme";
 import { gatherAuthEntrySignatureStatus, handleSimulationResult } from "../../src/shared";
 import { createEd25519Signer } from "../../src/signer";
+import * as stellarUtils from "../../src/utils";
 import type { PaymentRequirements } from "@x402/core/types";
+
+vi.mock("../../src/utils", async () => {
+  const actual = await vi.importActual<typeof stellarUtils>("../../src/utils");
+  return {
+    ...actual,
+    getEstimatedLedgerCloseTimeSeconds: vi.fn().mockResolvedValue(5),
+    getRpcClient: vi.fn(),
+  };
+});
 
 describe("Stellar Shared Utilities", () => {
   describe("handleSimulationResult", () => {
@@ -85,6 +95,14 @@ describe("Stellar Shared Utilities", () => {
   describe("gatherAuthEntrySignatureStatus", () => {
     const CLIENT_SECRET = "SDV3OZOPGIO6GQAVI7T6ZJ7NSNFB26JX6QZYCI64TBC7BAZY6FQVAXXK";
     const CLIENT_PUBLIC = "GBBO4ZDDZTSM2IUKQYBAST3CFHNPFXECGEFTGWTA2WELR2BIWDK57UVE";
+
+    const mockRpcServer = {
+      getLatestLedger: vi.fn().mockResolvedValue({ sequence: 100000 }),
+    };
+
+    beforeEach(() => {
+      vi.mocked(stellarUtils.getRpcClient).mockReturnValue(mockRpcServer as never);
+    });
 
     // paymenrRequirements is used to create a valid payload for the test
     const paymentRequirements: PaymentRequirements = {


### PR DESCRIPTION
## Description

The python facilitator's `/supported `endpoint returns `"extra": null` when there is no `extra` data, unlike TS/go.
The TS zod schema uses .optional() which rejects null, unlike python/go.
-> Failing e2e tests in the ts/python combo

- `exclude_none` in python facilitator as the spec defines `extra` as type `object` (optional) such that the key should be absent, not null.
- Still except `null` in TS scheme (as in go/py) to avoid crashes and improve interop with 3rd party sdks
- fixed outdated `eth_account._utils.typed_transactions` import in v0.13+

## Tests

```
📊 Breakdown by Facilitator:
 python          ✅ 4 / ❌ 0 (100%)

📊 Breakdown by Server:
 express              ✅ 4 / ❌ 0 (100%)

📊 Breakdown by Client:
   axios                ✅ 4 / ❌ 0 (100%)
```

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 