### PR TITLE
feat: add Mezo Testnet mUSD as default stablecoin (Permit2 + EIP-2612)

### DIFF
--- a/go/.changes/unreleased/mezo-testnet-default-asset.yaml
+++ b/go/.changes/unreleased/mezo-testnet-default-asset.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add Mezo Testnet (chain ID 31611) support with mUSD as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -71,6 +71,7 @@ var (
 	ChainIDBaseSepolia = big.NewInt(84532)
 	ChainIDMegaETH     = big.NewInt(4326)
 	ChainIDMonad       = big.NewInt(143)
+	ChainIDMezoTestnet = big.NewInt(31611)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -124,6 +125,18 @@ var (
 				Name:     "USD Coin",
 				Version:  "2",
 				Decimals: DefaultDecimals,
+			},
+		},
+		// Mezo Testnet (uses Permit2 instead of EIP-3009, supports EIP-2612)
+		"eip155:31611": {
+			ChainID: ChainIDMezoTestnet,
+			DefaultAsset: AssetInfo{
+				Address:             "0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503", // mUSD on Mezo Testnet
+				Name:                "Mezo USD",
+				Version:             "1",
+				Decimals:            18,
+				AssetTransferMethod: AssetTransferMethodPermit2,
+				SupportsEip2612:     true,
 			},
 		},
 	}

--- a/python/x402/changelog.d/mezo-testnet-default-asset.feature.md
+++ b/python/x402/changelog.d/mezo-testnet-default-asset.feature.md
@@ -1,0 +1,1 @@
+Add Mezo Testnet (chain ID 31611) support with mUSD as the default stablecoin

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -305,6 +305,18 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "decimals": 6,
         },
     },
+    # Mezo Testnet (uses Permit2 instead of EIP-3009, supports EIP-2612)
+    "eip155:31611": {
+        "chain_id": 31611,
+        "default_asset": {
+            "address": "0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503",
+            "name": "Mezo USD",
+            "version": "1",
+            "decimals": 18,
+            "asset_transfer_method": "permit2",
+            "supports_eip2612": True,
+        },
+    },
 }
 
 # V1 legacy constants are in x402.mechanisms.evm.v1.constants

--- a/typescript/.changeset/add-mezo-testnet-default-asset.md
+++ b/typescript/.changeset/add-mezo-testnet-default-asset.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Add Mezo Testnet (chain ID 31611) support with mUSD as the default stablecoin

--- a/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
@@ -237,6 +237,14 @@ export class ExactEvmScheme implements SchemeNetworkServer {
         version: "2",
         decimals: 6,
       }, // Monad mainnet USDC
+      "eip155:31611": {
+        address: "0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503",
+        name: "Mezo USD",
+        version: "1",
+        decimals: 18,
+        assetTransferMethod: "permit2",
+        supportsEip2612: true,
+      }, // Mezo Testnet mUSD (no EIP-3009, supports EIP-2612)
     };
 
     const assetInfo = stablecoins[network];


### PR DESCRIPTION
## Description

Add [mUSD](https://explorer.test.mezo.org/address/0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503) as the default stablecoin for Mezo Testnet (`eip155:31611`) across all three SDKs, following the [DEFAULT_ASSET.md](https://github.com/coinbase/x402/blob/main/typescript/packages/mechanisms/evm/src/exact/server/DEFAULT_ASSET.md) guide.

[Mezo](https://mezo.org) is a Bitcoin-native EVM L2. mUSD is its CDP-backed stablecoin (Liquity V2 fork, 18 decimals). mUSD does **not** support EIP-3009, so Permit2 is the required transfer method. mUSD **does** support EIP-2612 `permit()` for gasless approval.

| Field | Value |
|-------|-------|
| Network | `eip155:31611` (Mezo Testnet) |
| Asset | `0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503` |
| EIP-712 name | `Mezo USD` |
| EIP-712 version | `1` |
| Decimals | 18 |
| Transfer method | `permit2` |
| EIP-2612 support | `true` |

**Files changed (cross-SDK checklist per DEFAULT_ASSET.md):**
- **TypeScript:** `typescript/packages/mechanisms/evm/src/exact/server/scheme.ts`
- **Go:** `go/mechanisms/evm/constants.go`
- **Python:** `python/x402/mechanisms/evm/constants.py`
- **Changesets:** TS `.changeset`, Go `.changes/unreleased` yaml, Python `changelog.d` feature.md

Verified end-to-end on Mezo Testnet: client pays mUSD via Permit2 → facilitator verifies and settles on-chain → merchant delivers content. Settlement tx: [0xfad973...](https://explorer.test.mezo.org/tx/0xfad9738d0e50b0e9eacca9fd0fb4123158f2a2b0ab50a22913b3050feeb16a2b)

## Tests

- Verified mUSD EIP-712 domain parameters on-chain (`name="Mezo USD"`, `version="1"`)
- End-to-end payment flow tested on Mezo Testnet (chain 31611) with Permit2 settlement
- Canonical `x402ExactPermit2Proxy` deployed and verified at `0x402085c248EeA27D92E8b30b2C58ed07f9E20001` on Mezo Testnet
- No existing tests affected — config-only change appending to existing maps

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes