### PR TITLE
feat(evm): add Stable mainnet (chain ID 988) network support

### DIFF
--- a/go/.changes/unreleased/stable-support.yaml
+++ b/go/.changes/unreleased/stable-support.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add Stable mainnet (chain ID 988) support with USDT0 as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -72,6 +72,7 @@ var (
 	ChainIDMegaETH     = big.NewInt(4326)
 	ChainIDMonad       = big.NewInt(143)
 	ChainIDMezoTestnet = big.NewInt(31611)
+	ChainIDStable      = big.NewInt(988)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -137,6 +138,16 @@ var (
 				Decimals:            18,
 				AssetTransferMethod: AssetTransferMethodPermit2,
 				SupportsEip2612:     true,
+			},
+		},
+		// Stable Mainnet
+		"eip155:988": {
+			ChainID: ChainIDStable,
+			DefaultAsset: AssetInfo{
+				Address:  "0x779Ded0c9e1022225f8E0630b35a9b54bE713736", // USDT0 on Stable
+				Name:     "USDT0",
+				Version:  "1",
+				Decimals: DefaultDecimals,
 			},
 		},
 	}

--- a/go/mechanisms/evm/v1/network.go
+++ b/go/mechanisms/evm/v1/network.go
@@ -27,6 +27,7 @@ var NetworkChainIDs = map[string]*big.Int{
 	"skale-base-sepolia": big.NewInt(324705682),
 	"megaeth":            big.NewInt(4326),
 	"monad":              big.NewInt(143),
+	"stable":             big.NewInt(988),
 }
 
 // NetworkConfigs maps v1 legacy network names to their full configuration.
@@ -65,6 +66,15 @@ var NetworkConfigs = map[string]evm.NetworkConfig{
 			Address:  "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
 			Name:     "USD Coin",
 			Version:  "2",
+			Decimals: evm.DefaultDecimals,
+		},
+	},
+	"stable": {
+		ChainID: big.NewInt(988),
+		DefaultAsset: evm.AssetInfo{
+			Address:  "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+			Name:     "USDT0",
+			Version:  "1",
 			Decimals: evm.DefaultDecimals,
 		},
 	},

--- a/python/x402/changelog.d/stable-support.feature.md
+++ b/python/x402/changelog.d/stable-support.feature.md
@@ -1,0 +1,1 @@
+Add Stable mainnet (chain ID 988) support with USDT0 as the default stablecoin

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -317,6 +317,24 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "supports_eip2612": True,
         },
     },
+    # Stable Mainnet
+    "eip155:988": {
+        "chain_id": 988,
+        "default_asset": {
+            "address": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+            "name": "USDT0",
+            "version": "1",
+            "decimals": 6,
+        },
+        "supported_assets": {
+            "USDT0": {
+                "address": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+                "name": "USDT0",
+                "version": "1",
+                "decimals": 6,
+            },
+        },
+    },
 }
 
 # V1 legacy constants are in x402.mechanisms.evm.v1.constants

--- a/python/x402/mechanisms/evm/v1/constants.py
+++ b/python/x402/mechanisms/evm/v1/constants.py
@@ -40,6 +40,12 @@ V1_DEFAULT_ASSETS: dict[str, AssetInfo] = {
         "version": "2",
         "decimals": 6,
     },
+    "stable": {
+        "address": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+        "name": "USDT0",
+        "version": "1",
+        "decimals": 6,
+    },
 }
 
 
@@ -62,6 +68,7 @@ V1_NETWORKS = [
     "skale-base-sepolia",
     "megaeth",
     "monad",
+    "stable",
 ]
 
 # V1 network name to chain ID mapping
@@ -84,4 +91,5 @@ V1_NETWORK_CHAIN_IDS: dict[str, int] = {
     "skale-base-sepolia": 1444673419,
     "megaeth": 4326,
     "monad": 143,
+    "stable": 988,
 }

--- a/typescript/.changeset/add-stable-support.md
+++ b/typescript/.changeset/add-stable-support.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": minor
+---
+
+Add Stable mainnet (chain ID 988) support with USDT0 as the default stablecoin

--- a/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
@@ -245,6 +245,12 @@ export class ExactEvmScheme implements SchemeNetworkServer {
         assetTransferMethod: "permit2",
         supportsEip2612: true,
       }, // Mezo Testnet mUSD (no EIP-3009, supports EIP-2612)
+      "eip155:988": {
+        address: "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+        name: "USDT0",
+        version: "1",
+        decimals: 6,
+      }, // Stable mainnet USDT0
     };
 
     const assetInfo = stablecoins[network];

--- a/typescript/packages/mechanisms/evm/src/v1/index.ts
+++ b/typescript/packages/mechanisms/evm/src/v1/index.ts
@@ -20,6 +20,7 @@ export const EVM_NETWORK_CHAIN_ID_MAP = {
   "skale-base-sepolia": 324705682,
   megaeth: 4326,
   monad: 143,
+  stable: 988,
 } as const;
 
 export type EvmNetworkV1 = keyof typeof EVM_NETWORK_CHAIN_ID_MAP;


### PR DESCRIPTION
Add Stable mainnet (chain ID 988) to the EVM network chain ID map across TypeScript, Python, and Go SDKs. Stable uses USDT0 with EIP-3009 (transferWithAuthorization) support.

- TypeScript: add to EVM_NETWORK_CHAIN_ID_MAP and stablecoins map in ExactEvmScheme
- Python: add to NETWORK_CONFIGS, V1_NETWORKS, V1_NETWORK_CHAIN_IDS, and V1_DEFAULT_ASSETS
- Go: add ChainIDStable and NetworkConfigs entry (CAIP-2 format), and v1 NetworkChainIDs/NetworkConfigs entries

USDT0 on Stable: `0x779Ded0c9e1022225f8E0630b35a9b54bE713736`

## Test plan
- Verify USDT0 contract address is correct on Stable mainnet
- Verify EIP-712 domain name ("USDT0") and version ("1") match the on-chain values
- Confirm transferWithAuthorization works with the USDT0 token
- Test USD string pricing (e.g., "$0.10") resolves to USDT0 on eip155:988

## Checklist
- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 