### PR TITLE
feat: add Open Wallet Standard signer adapter

### DIFF
--- a/typescript/packages/signer-ows/package.json
+++ b/typescript/packages/signer-ows/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@x402/signer-ows",
+  "version": "0.1.0",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "keywords": [
+    "x402",
+    "payment",
+    "protocol",
+    "ows",
+    "open-wallet-standard",
+    "wallet"
+  ],
+  "license": "Apache-2.0",
+  "author": "Coinbase Inc.",
+  "repository": "https://github.com/coinbase/x402",
+  "description": "Open Wallet Standard signer adapter for x402 Payment Protocol",
+  "dependencies": {
+    "@open-wallet-standard/core": "^1.0.0"
+  },
+  "peerDependencies": {
+    "@solana/kit": ">=5.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@solana/kit": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@solana/kit": ">=5.1.0",
+    "@types/node": "^22.13.4",
+    "tsup": "^8.4.0",
+    "typescript": "^5.7.3",
+    "vite": "^6.2.6",
+    "vitest": "^3.0.5"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./evm": {
+      "import": {
+        "types": "./dist/esm/evm.d.mts",
+        "default": "./dist/esm/evm.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/evm.d.ts",
+        "default": "./dist/cjs/evm.js"
+      }
+    },
+    "./svm": {
+      "import": {
+        "types": "./dist/esm/svm.d.mts",
+        "default": "./dist/esm/svm.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/svm.d.ts",
+        "default": "./dist/cjs/svm.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/typescript/packages/signer-ows/src/evm.test.ts
+++ b/typescript/packages/signer-ows/src/evm.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  createWallet,
+  deleteWallet,
+  signTypedData as owsSignTypedData,
+} from "@open-wallet-standard/core";
+import { owsToClientEvmSigner } from "./evm";
+
+const VAULT_PATH = "/tmp/ows-x402-evm-test";
+const WALLET_NAME = "evm-test-wallet";
+
+let walletAddress: string;
+
+beforeAll(() => {
+  const wallet = createWallet(WALLET_NAME, undefined, 12, VAULT_PATH);
+  const evmAccount = wallet.accounts.find(a => a.chainId.startsWith("eip155:"));
+  walletAddress = evmAccount!.address;
+});
+
+afterAll(() => {
+  try {
+    deleteWallet(WALLET_NAME, VAULT_PATH);
+  } catch {
+    // ignore cleanup errors
+  }
+});
+
+describe("owsToClientEvmSigner", () => {
+  it("resolves the correct EVM address from the wallet", () => {
+    const signer = owsToClientEvmSigner(WALLET_NAME, { vaultPath: VAULT_PATH });
+    expect(signer.address).toBe(walletAddress);
+    expect(signer.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+  });
+
+  it("signs EIP-712 typed data and returns a valid hex signature", async () => {
+    const signer = owsToClientEvmSigner(WALLET_NAME, {
+      chain: "eip155:1",
+      vaultPath: VAULT_PATH,
+    });
+
+    const signature = await signer.signTypedData({
+      domain: {
+        name: "USD Coin",
+        version: "2",
+        chainId: "84532",
+        verifyingContract: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      },
+      types: {
+        EIP712Domain: [
+          { name: "name", type: "string" },
+          { name: "version", type: "string" },
+          { name: "chainId", type: "uint256" },
+          { name: "verifyingContract", type: "address" },
+        ],
+        TransferWithAuthorization: [
+          { name: "from", type: "address" },
+          { name: "to", type: "address" },
+          { name: "value", type: "uint256" },
+          { name: "validAfter", type: "uint256" },
+          { name: "validBefore", type: "uint256" },
+          { name: "nonce", type: "bytes32" },
+        ],
+      },
+      primaryType: "TransferWithAuthorization",
+      message: {
+        from: signer.address,
+        to: "0x209693Bc600a970C15e3076ae0F1441956630a05",
+        value: "10000",
+        validAfter: "0",
+        validBefore: "1740672154",
+        nonce: "0xf374661300000000000000000000000000000000000000000000000000000001",
+      },
+    });
+
+    // 0x + 130 hex chars = 65-byte ECDSA signature (r + s + v)
+    expect(signature).toMatch(/^0x[0-9a-fA-F]{130}$/);
+  });
+
+  it("produces deterministic signatures for the same input", async () => {
+    const signer = owsToClientEvmSigner(WALLET_NAME, {
+      chain: "eip155:1",
+      vaultPath: VAULT_PATH,
+    });
+
+    const msg = {
+      domain: { name: "Test", version: "1", chainId: "1", verifyingContract: "0x0000000000000000000000000000000000000001" },
+      types: {
+        EIP712Domain: [
+          { name: "name", type: "string" },
+          { name: "version", type: "string" },
+          { name: "chainId", type: "uint256" },
+          { name: "verifyingContract", type: "address" },
+        ],
+        Mail: [{ name: "contents", type: "string" }],
+      },
+      primaryType: "Mail",
+      message: { contents: "Hello" },
+    };
+
+    const sig1 = await signer.signTypedData(msg);
+    const sig2 = await signer.signTypedData(msg);
+    expect(sig1).toBe(sig2);
+  });
+
+  it("produces the same signature as calling OWS SDK directly", async () => {
+    const signer = owsToClientEvmSigner(WALLET_NAME, {
+      chain: "eip155:1",
+      vaultPath: VAULT_PATH,
+    });
+
+    const typedData = {
+      domain: { name: "Test", version: "1", chainId: "1", verifyingContract: "0x0000000000000000000000000000000000000001" },
+      types: {
+        EIP712Domain: [
+          { name: "name", type: "string" },
+          { name: "version", type: "string" },
+          { name: "chainId", type: "uint256" },
+          { name: "verifyingContract", type: "address" },
+        ],
+        Mail: [{ name: "contents", type: "string" }],
+      },
+      primaryType: "Mail",
+      message: { contents: "Hello" },
+    };
+
+    const adapterSig = await signer.signTypedData(typedData);
+
+    // Call OWS SDK directly for comparison
+    const directResult = owsSignTypedData(
+      WALLET_NAME,
+      "eip155:1",
+      JSON.stringify(typedData),
+      undefined,
+      undefined,
+      VAULT_PATH,
+    );
+    const directSig = `0x${directResult.signature}`;
+
+    expect(adapterSig).toBe(directSig);
+  });
+
+  it("throws when wallet does not exist", () => {
+    expect(() =>
+      owsToClientEvmSigner("nonexistent-wallet", { vaultPath: VAULT_PATH }),
+    ).toThrow();
+  });
+
+  it("falls back to any eip155: account when exact chain not found", () => {
+    // The wallet has eip155:1, but we ask for eip155:8453.
+    // Should fallback to the eip155:1 account.
+    const signer = owsToClientEvmSigner(WALLET_NAME, {
+      chain: "eip155:8453",
+      vaultPath: VAULT_PATH,
+    });
+    expect(signer.address).toBe(walletAddress);
+  });
+});

--- a/typescript/packages/signer-ows/src/evm.ts
+++ b/typescript/packages/signer-ows/src/evm.ts
@@ -1,0 +1,100 @@
+import {
+  getWallet,
+  signTypedData as owsSignTypedData,
+} from "@open-wallet-standard/core";
+
+/**
+ * Options for creating an OWS-backed EVM client signer.
+ */
+export interface OwsEvmSignerOptions {
+  /** CAIP-2 chain ID (default: "eip155:8453" for Base mainnet). */
+  chain?: string;
+  /** Vault passphrase. Omit for unlocked/dev mode. */
+  passphrase?: string;
+  /** BIP-44 account index (default: 0). */
+  index?: number;
+  /** Custom vault path (default: ~/.ows). */
+  vaultPath?: string;
+}
+
+/**
+ * Structural match for x402 ClientEvmSigner.
+ * Returned by owsToClientEvmSigner — pass directly to ExactEvmScheme.
+ */
+export interface OwsClientEvmSigner {
+  readonly address: `0x${string}`;
+  signTypedData(message: {
+    domain: Record<string, unknown>;
+    types: Record<string, unknown>;
+    primaryType: string;
+    message: Record<string, unknown>;
+  }): Promise<`0x${string}`>;
+}
+
+/**
+ * Creates a ClientEvmSigner backed by an OWS wallet.
+ *
+ * The returned signer satisfies the x402 ClientEvmSigner interface
+ * and delegates all signing to OWS (keys never leave the vault).
+ *
+ * @param walletName - OWS wallet name or ID
+ * @param options - Optional chain, passphrase, index, vault path
+ * @returns A ClientEvmSigner for use with ExactEvmScheme
+ *
+ * @example
+ * ```ts
+ * import { owsToClientEvmSigner } from "@x402/signer-ows/evm";
+ * import { ExactEvmScheme } from "@x402/evm/exact/client";
+ * import { x402Client } from "@x402/core";
+ *
+ * const signer = owsToClientEvmSigner("agent-treasury");
+ * const client = new x402Client()
+ *   .register("eip155:*", new ExactEvmScheme(signer));
+ * ```
+ */
+export function owsToClientEvmSigner(
+  walletName: string,
+  options?: OwsEvmSignerOptions,
+): OwsClientEvmSigner {
+  const chain = options?.chain ?? "eip155:8453";
+  const wallet = getWallet(walletName, options?.vaultPath);
+
+  const account =
+    wallet.accounts.find(a => a.chainId === chain) ??
+    wallet.accounts.find(a => a.chainId.startsWith("eip155:"));
+
+  if (!account) {
+    throw new Error(
+      `No EVM account found in wallet "${walletName}". ` +
+        `Available chains: ${wallet.accounts.map(a => a.chainId).join(", ")}`,
+    );
+  }
+
+  const address = account.address as `0x${string}`;
+
+  return {
+    address,
+    async signTypedData(message) {
+      const typedData = {
+        types: message.types,
+        primaryType: message.primaryType,
+        domain: message.domain,
+        message: message.message,
+      };
+
+      const result = owsSignTypedData(
+        walletName,
+        chain,
+        JSON.stringify(typedData),
+        options?.passphrase,
+        options?.index,
+        options?.vaultPath,
+      );
+
+      const sig = result.signature.startsWith("0x")
+        ? result.signature
+        : `0x${result.signature}`;
+      return sig as `0x${string}`;
+    },
+  };
+}

--- a/typescript/packages/signer-ows/src/index.ts
+++ b/typescript/packages/signer-ows/src/index.ts
@@ -1,0 +1,5 @@
+export { owsToClientEvmSigner } from "./evm";
+export type { OwsClientEvmSigner, OwsEvmSignerOptions } from "./evm";
+
+export { owsToClientSvmSigner } from "./svm";
+export type { OwsClientSvmSigner, OwsSvmSignerOptions } from "./svm";

--- a/typescript/packages/signer-ows/src/svm.test.ts
+++ b/typescript/packages/signer-ows/src/svm.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  createWallet,
+  deleteWallet,
+  signMessage as owsSignMessage,
+} from "@open-wallet-standard/core";
+import { owsToClientSvmSigner } from "./svm";
+
+const VAULT_PATH = "/tmp/ows-x402-svm-test";
+const WALLET_NAME = "svm-test-wallet";
+
+let solanaAddress: string;
+
+beforeAll(() => {
+  const wallet = createWallet(WALLET_NAME, undefined, 12, VAULT_PATH);
+  const solAccount = wallet.accounts.find(a => a.chainId.startsWith("solana:"));
+  solanaAddress = solAccount!.address;
+});
+
+afterAll(() => {
+  try {
+    deleteWallet(WALLET_NAME, VAULT_PATH);
+  } catch {
+    // ignore cleanup errors
+  }
+});
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+describe("owsToClientSvmSigner", () => {
+  it("resolves the correct Solana address from the wallet", () => {
+    const signer = owsToClientSvmSigner(WALLET_NAME, { vaultPath: VAULT_PATH });
+    expect(signer.address).toBe(solanaAddress);
+  });
+
+  it("signs transaction message bytes and attaches the signature", async () => {
+    const signer = owsToClientSvmSigner(WALLET_NAME, { vaultPath: VAULT_PATH });
+
+    // Simulate a Solana transaction with dummy message bytes
+    const messageBytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const tx = {
+      messageBytes,
+      signatures: {} as Record<string, Uint8Array>,
+    };
+
+    const [signed] = await signer.signTransactions([tx]);
+
+    // Signature should be present at the signer's address key
+    expect(signed.signatures[signer.address]).toBeDefined();
+
+    // Ed25519 signature = 64 bytes
+    const sigBytes = signed.signatures[signer.address];
+    expect(sigBytes.length).toBe(64);
+
+    // Original messageBytes should be preserved
+    expect(signed.messageBytes).toBe(messageBytes);
+  });
+
+  it("produces the same signature as calling OWS SDK directly", async () => {
+    const signer = owsToClientSvmSigner(WALLET_NAME, { vaultPath: VAULT_PATH });
+
+    const messageBytes = new Uint8Array([10, 20, 30, 40, 50]);
+    const tx = {
+      messageBytes,
+      signatures: {} as Record<string, Uint8Array>,
+    };
+
+    const [signed] = await signer.signTransactions([tx]);
+    const adapterSig = bytesToHex(signed.signatures[signer.address]);
+
+    // Call OWS SDK directly
+    const directResult = owsSignMessage(
+      WALLET_NAME,
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      bytesToHex(messageBytes),
+      undefined,
+      "hex",
+      undefined,
+      VAULT_PATH,
+    );
+
+    expect(adapterSig).toBe(directResult.signature);
+  });
+
+  it("signs multiple transactions in a single call", async () => {
+    const signer = owsToClientSvmSigner(WALLET_NAME, { vaultPath: VAULT_PATH });
+
+    const txs = [
+      { messageBytes: new Uint8Array([1, 2, 3]), signatures: {} as Record<string, Uint8Array> },
+      { messageBytes: new Uint8Array([4, 5, 6]), signatures: {} as Record<string, Uint8Array> },
+      { messageBytes: new Uint8Array([7, 8, 9]), signatures: {} as Record<string, Uint8Array> },
+    ];
+
+    const signed = await signer.signTransactions(txs);
+
+    expect(signed).toHaveLength(3);
+    for (const tx of signed) {
+      expect(tx.signatures[signer.address]).toBeDefined();
+      expect(tx.signatures[signer.address].length).toBe(64);
+    }
+
+    // Each tx should have a different signature (different message bytes)
+    const sigs = signed.map(tx => bytesToHex(tx.signatures[signer.address]));
+    expect(new Set(sigs).size).toBe(3);
+  });
+
+  it("preserves existing signatures from other signers", async () => {
+    const signer = owsToClientSvmSigner(WALLET_NAME, { vaultPath: VAULT_PATH });
+
+    const existingSig = new Uint8Array(64).fill(0xab);
+    const tx = {
+      messageBytes: new Uint8Array([1, 2, 3]),
+      signatures: { "SomeOtherSigner1111111111111111111111111111111": existingSig } as Record<string, Uint8Array>,
+    };
+
+    const [signed] = await signer.signTransactions([tx]);
+
+    // Our signature should be added
+    expect(signed.signatures[signer.address]).toBeDefined();
+    // Existing signature should be preserved
+    expect(signed.signatures["SomeOtherSigner1111111111111111111111111111111"]).toBe(existingSig);
+  });
+
+  it("throws when wallet does not exist", () => {
+    expect(() =>
+      owsToClientSvmSigner("nonexistent-wallet", { vaultPath: VAULT_PATH }),
+    ).toThrow();
+  });
+});

--- a/typescript/packages/signer-ows/src/svm.ts
+++ b/typescript/packages/signer-ows/src/svm.ts
@@ -1,0 +1,134 @@
+import {
+  getWallet,
+  signMessage as owsSignMessage,
+} from "@open-wallet-standard/core";
+import type { Address } from "@solana/kit";
+
+/**
+ * Options for creating an OWS-backed SVM client signer.
+ */
+export interface OwsSvmSignerOptions {
+  /** CAIP-2 chain ID (default: Solana mainnet). */
+  chain?: string;
+  /** Vault passphrase. Omit for unlocked/dev mode. */
+  passphrase?: string;
+  /** BIP-44 account index (default: 0). */
+  index?: number;
+  /** Custom vault path (default: ~/.ows). */
+  vaultPath?: string;
+}
+
+/** Solana mainnet CAIP-2 identifier. */
+const SOLANA_MAINNET = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+
+function hexToBytes(hex: string): Uint8Array {
+  const h = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const bytes = new Uint8Array(h.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(h.substring(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array | ReadonlyUint8Array): string {
+  let hex = "";
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+type ReadonlyUint8Array = Readonly<Uint8Array> & { readonly [n: number]: number };
+
+/**
+ * A transaction-like object with messageBytes and signatures.
+ * Matches the @solana/kit Transaction shape.
+ */
+interface SolanaTransaction {
+  readonly messageBytes: ReadonlyUint8Array;
+  readonly signatures: Readonly<Record<string, ReadonlyUint8Array>>;
+}
+
+/**
+ * Structural match for @solana/kit TransactionSigner (= x402 ClientSvmSigner).
+ * Returned by owsToClientSvmSigner — pass directly to ExactSvmScheme.
+ */
+export interface OwsClientSvmSigner {
+  readonly address: Address;
+  signTransactions<T extends SolanaTransaction>(
+    transactions: readonly T[],
+  ): Promise<readonly T[]>;
+}
+
+/**
+ * Creates a ClientSvmSigner (TransactionSigner) backed by an OWS wallet.
+ *
+ * The returned signer satisfies the @solana/kit TransactionSigner interface
+ * and delegates Ed25519 signing to OWS (keys never leave the vault).
+ *
+ * @param walletName - OWS wallet name or ID
+ * @param options - Optional chain, passphrase, index, vault path
+ * @returns A TransactionSigner for use with ExactSvmScheme
+ *
+ * @example
+ * ```ts
+ * import { owsToClientSvmSigner } from "@x402/signer-ows/svm";
+ * import { ExactSvmScheme } from "@x402/svm/exact/client";
+ * import { x402Client } from "@x402/core";
+ *
+ * const signer = owsToClientSvmSigner("agent-treasury");
+ * const client = new x402Client()
+ *   .register("solana:*", new ExactSvmScheme(signer));
+ * ```
+ */
+export function owsToClientSvmSigner(
+  walletName: string,
+  options?: OwsSvmSignerOptions,
+): OwsClientSvmSigner {
+  const chain = options?.chain ?? SOLANA_MAINNET;
+  const wallet = getWallet(walletName, options?.vaultPath);
+
+  const account =
+    wallet.accounts.find(a => a.chainId === chain) ??
+    wallet.accounts.find(a => a.chainId.startsWith("solana:"));
+
+  if (!account) {
+    throw new Error(
+      `No Solana account found in wallet "${walletName}". ` +
+        `Available chains: ${wallet.accounts.map(a => a.chainId).join(", ")}`,
+    );
+  }
+
+  const address = account.address as Address;
+
+  return {
+    address,
+    async signTransactions<T extends SolanaTransaction>(
+      transactions: readonly T[],
+    ): Promise<readonly T[]> {
+      return transactions.map(tx => {
+        const msgHex = bytesToHex(tx.messageBytes);
+
+        const result = owsSignMessage(
+          walletName,
+          chain,
+          msgHex,
+          options?.passphrase,
+          "hex",
+          options?.index,
+          options?.vaultPath,
+        );
+
+        const sigBytes = hexToBytes(result.signature);
+
+        return {
+          ...tx,
+          signatures: Object.freeze({
+            ...tx.signatures,
+            [address]: sigBytes,
+          }),
+        } as T;
+      });
+    },
+  };
+}

--- a/typescript/packages/signer-ows/tsconfig.json
+++ b/typescript/packages/signer-ows/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "allowJs": false,
+    "checkJs": false
+  },
+  "include": ["src"]
+}

--- a/typescript/packages/signer-ows/tsup.config.ts
+++ b/typescript/packages/signer-ows/tsup.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "tsup";
+
+const baseConfig = {
+  entry: {
+    index: "src/index.ts",
+    evm: "src/evm.ts",
+    svm: "src/svm.ts",
+  },
+  dts: {
+    resolve: true,
+  },
+  sourcemap: true,
+  target: "node16" as const,
+};
+
+export default defineConfig([
+  {
+    ...baseConfig,
+    format: "esm",
+    outDir: "dist/esm",
+    clean: true,
+  },
+  {
+    ...baseConfig,
+    format: "cjs",
+    outDir: "dist/cjs",
+    clean: false,
+  },
+]);

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1339,6 +1339,31 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(jiti@2.6.1)(jsdom@27.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
 
+  packages/signer-ows:
+    dependencies:
+      '@open-wallet-standard/core':
+        specifier: ^1.0.0
+        version: 1.0.0
+    devDependencies:
+      '@solana/kit':
+        specifier: '>=5.1.0'
+        version: 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.18.0
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.2
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(jiti@2.6.1)(jsdom@27.4.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
+
   site:
     dependencies:
       '@aptos-labs/ts-sdk':
@@ -2893,6 +2918,30 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@open-wallet-standard/core-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-2mr22VTm+IQ0w1RKyMCY4BHX3+eb+kAOSYbIQrGm30n1ZLIYhcoAo1HiZfa2raSyPVlIpsEsnHs/w1VrA3Fuxw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@open-wallet-standard/core-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-s4Dvu3HxYSTEubUAYsYUNyP2WDzqbEE0C0v/NhP3c48wPq5UKe3JG83aQpZU7Hdxn1rcCNf0TPkuirik74xGtg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@open-wallet-standard/core-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-cdFXgSigycW+lh0orfo12cXZIkiZZ3R2XUVaXrJOn8m6wgaa1bk7kyEIHVQCToRPHqFUm76XxX7CLLmji2kflA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@open-wallet-standard/core-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-8bSkyiIlFSm1SVcbEN1YiSQLvSQMGldJqbCxBlWrMW7esSwXksshIdZ6Jstd3lzrdSSwvU+qFqtzP3Cfa7PZ3g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@open-wallet-standard/core@1.0.0':
+    resolution: {integrity: sha512-fgA/2QOko9d4wMjRl6d/+bC/qYeP8e4YIJzzLPECAP5bjLbST3co50HHU61jI+JshzXe9KvvixC93i9lmRobMw==}
+    hasBin: true
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
@@ -6861,9 +6910,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  magic-string@0.30.18:
-    resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -8222,9 +8268,6 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici-types@7.22.0:
     resolution: {integrity: sha512-RKZvifiL60xdsIuC80UY0dq8Z7DbJUV8/l2hOVbyZAxBzEeQU4Z58+4ZzJ6WN2Lidi9KzT5EbiGX+PI/UGYuRw==}
@@ -10060,7 +10103,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10722,6 +10765,25 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@open-wallet-standard/core-darwin-arm64@1.0.0':
+    optional: true
+
+  '@open-wallet-standard/core-darwin-x64@1.0.0':
+    optional: true
+
+  '@open-wallet-standard/core-linux-arm64-gnu@1.0.0':
+    optional: true
+
+  '@open-wallet-standard/core-linux-x64-gnu@1.0.0':
+    optional: true
+
+  '@open-wallet-standard/core@1.0.0':
+    optionalDependencies:
+      '@open-wallet-standard/core-darwin-arm64': 1.0.0
+      '@open-wallet-standard/core-darwin-x64': 1.0.0
+      '@open-wallet-standard/core-linux-arm64-gnu': 1.0.0
+      '@open-wallet-standard/core-linux-x64-gnu': 1.0.0
 
   '@paulmillr/qr@0.2.1': {}
 
@@ -11690,7 +11752,7 @@ snapshots:
   '@solana/errors@2.3.0(typescript@5.9.2)':
     dependencies:
       chalk: 5.6.2
-      commander: 14.0.2
+      commander: 14.0.3
       typescript: 5.9.2
 
   '@solana/errors@5.0.0(typescript@5.9.2)':
@@ -12534,7 +12596,7 @@ snapshots:
       '@solana/rpc-spec': 2.3.0(typescript@5.9.2)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.2)
       typescript: 5.9.2
-      undici-types: 7.16.0
+      undici-types: 7.22.0
 
   '@solana/rpc-transport-http@5.0.0(typescript@5.9.2)':
     dependencies:
@@ -12542,7 +12604,7 @@ snapshots:
       '@solana/rpc-spec': 5.0.0(typescript@5.9.2)
       '@solana/rpc-spec-types': 5.0.0(typescript@5.9.2)
       typescript: 5.9.2
-      undici-types: 7.16.0
+      undici-types: 7.22.0
 
   '@solana/rpc-transport-http@5.1.0(typescript@5.9.2)':
     dependencies:
@@ -12550,7 +12612,7 @@ snapshots:
       '@solana/rpc-spec': 5.1.0(typescript@5.9.2)
       '@solana/rpc-spec-types': 5.1.0(typescript@5.9.2)
       typescript: 5.9.2
-      undici-types: 7.16.0
+      undici-types: 7.22.0
 
   '@solana/rpc-transport-http@6.1.0(typescript@5.9.2)':
     dependencies:
@@ -13658,7 +13720,7 @@ snapshots:
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.18
+      magic-string: 0.30.21
     optionalDependencies:
       vite: 6.3.5(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
 
@@ -13675,7 +13737,7 @@ snapshots:
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.18
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/spy@3.2.4':
@@ -16009,7 +16071,7 @@ snapshots:
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
-      magic-string: 0.30.18
+      magic-string: 0.30.21
       mlly: 1.8.0
       rollup: 4.50.0
 
@@ -16785,10 +16847,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  magic-string@0.30.18:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
 
   magic-string@0.30.21:
     dependencies:
@@ -17616,7 +17674,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.1
       uuid: 8.3.2
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
@@ -18302,8 +18360,6 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.16.0: {}
-
   undici-types@7.22.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
@@ -18517,7 +18573,7 @@ snapshots:
   vite-node@3.2.4(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.3.5(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)
@@ -18553,7 +18609,7 @@ snapshots:
       picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.50.0
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.18.0
       fsevents: 2.3.3
@@ -18573,15 +18629,15 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.1
+      debug: 4.4.3
       expect-type: 1.2.2
-      magic-string: 0.30.18
+      magic-string: 0.30.21
       pathe: 2.0.3
       picomatch: 4.0.3
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.3.5(@types/node@22.18.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.5)(yaml@2.8.1)

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - packages/core
   - packages/extensions
   - packages/mcp
+  - packages/signer-ows
   - packages/http/*
   - packages/mechanisms/*
   - packages/legacy/*


### PR DESCRIPTION
## Summary
- Adds `@x402/signer-ows`, a new package that adapts [Open Wallet Standard](https://github.com/wallet-standard/wallet-standard) wallets for use with x402
- Supports both EVM and SVM (Solana) chains — any OWS-compatible wallet can sign x402 payments
- Includes unit tests for both EVM and SVM signers

## Test plan
- [ ] `pnpm test` passes in `typescript/packages/signer-ows`
- [ ] `pnpm build` succeeds
- [ ] Verify EVM signer correctly signs EIP-712 typed data via OWS wallet
- [ ] Verify SVM signer correctly signs Solana transactions via OWS wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)