### PR TITLE
Monkey-patch fastify's reply.raw write operations and buffere response

### DIFF
--- a/e2e/servers/fastify/index.ts
+++ b/e2e/servers/fastify/index.ts
@@ -29,6 +29,7 @@ const APTOS_NETWORK = (process.env.APTOS_NETWORK || "aptos:2") as `${string}:${s
 const STELLAR_NETWORK = (process.env.STELLAR_NETWORK || "stellar:testnet") as `${string}:${string}`;
 const EVM_PAYEE_ADDRESS = process.env.EVM_PAYEE_ADDRESS as `0x${string}`;
 const SVM_PAYEE_ADDRESS = process.env.SVM_PAYEE_ADDRESS as string;
+const EVM_PERMIT2_ASSET = process.env.EVM_PERMIT2_ASSET as `0x${string}`;
 const APTOS_PAYEE_ADDRESS = process.env.APTOS_PAYEE_ADDRESS as string;
 const STELLAR_PAYEE_ADDRESS = process.env.STELLAR_PAYEE_ADDRESS as string | undefined;
 const facilitatorUrl = process.env.FACILITATOR_URL;
@@ -76,24 +77,18 @@ console.log(
 console.log(`Using remote facilitator at: ${facilitatorUrl}`);
 
 /**
- * Pre-middleware guard for optional Aptos endpoint
- * Returns 501 Not Implemented if Aptos is not configured
+ * Pre-middleware guard for optional Aptos / Stellar endpoints
+ * Returns 501 Not Implemented if not configured
  */
 app.addHook("onRequest", async (request, reply) => {
-  if (request.url.split("?")[0] === "/protected-aptos" && !APTOS_PAYEE_ADDRESS) {
+  const path = request.url.split("?")[0];
+  if (path === "/exact/aptos" && !APTOS_PAYEE_ADDRESS) {
     return reply.status(501).send({
       error: "Aptos payments not configured",
       message: "APTOS_PAYEE_ADDRESS environment variable is not set",
     });
   }
-});
-
-/**
- * Pre-middleware guard for optional Stellar endpoint
- * Returns 501 Not Implemented if Stellar is not configured
- */
-app.addHook("onRequest", async (request, reply) => {
-  if (request.url.split("?")[0] === "/protected-stellar" && !STELLAR_PAYEE_ADDRESS) {
+  if (path.startsWith("/exact/stellar") && !STELLAR_PAYEE_ADDRESS) {
     return reply.status(501).send({
       error: "Stellar payments not configured",
       message: "STELLAR_PAYEE_ADDRESS environment variable is not set",
@@ -111,7 +106,7 @@ paymentMiddleware(
   app,
   {
     // Route-specific payment configuration
-    "GET /protected": {
+    "GET /exact/evm/eip3009": {
       accepts: {
         payTo: EVM_PAYEE_ADDRESS,
         scheme: "exact",
@@ -136,7 +131,7 @@ paymentMiddleware(
         }),
       },
     },
-    "GET /protected-svm": {
+    "GET /exact/svm": {
       accepts: {
         payTo: SVM_PAYEE_ADDRESS,
         scheme: "exact",
@@ -163,7 +158,7 @@ paymentMiddleware(
     },
     ...(APTOS_PAYEE_ADDRESS
       ? {
-          "GET /protected-aptos": {
+          "GET /exact/aptos": {
             accepts: {
               payTo: APTOS_PAYEE_ADDRESS,
               scheme: "exact",
@@ -190,34 +185,21 @@ paymentMiddleware(
           },
         }
       : {}),
-    // Permit2 endpoint for generic ERC-20 tokens (no EIP-2612, uses raw approve tx)
-    "GET /protected-permit2-erc20": {
+    // Permit2 standard/direct endpoint - no gas sponsoring, client must pre-approve Permit2
+    "GET /exact/evm/permit2": {
       accepts: {
         payTo: EVM_PAYEE_ADDRESS,
         scheme: "exact",
         network: EVM_NETWORK,
         price: {
           amount: "1000",
-          asset: "0xeED520980fC7C7B4eB379B96d61CEdea2423005a", // Generic MockERC20 token (no EIP-2612)
+          asset: EVM_PERMIT2_ASSET,
           extra: {
             assetTransferMethod: "permit2",
-            // No name/version - generic ERC-20 without EIP-2612
+            name: EVM_NETWORK == "eip155:84532" ? "USDC" : "USD Coin",
+            version: "2",
           },
         },
-      },
-      extensions: {
-        ...declareErc20ApprovalGasSponsoringExtension(),
-      },
-    },
-    // Permit2 endpoint - explicitly requires Permit2 flow instead of EIP-3009
-    "GET /protected-permit2": {
-      accepts: {
-        payTo: EVM_PAYEE_ADDRESS,
-        scheme: "exact",
-        network: EVM_NETWORK,
-        price: "$0.001",
-        // Use pre-parsed price with assetTransferMethod to force Permit2
-        extra: { assetTransferMethod: "permit2" },
       },
       extensions: {
         ...declareDiscoveryExtension({
@@ -237,12 +219,59 @@ paymentMiddleware(
             },
           },
         }),
+      },
+    },
+    // Permit2 endpoint with EIP-2612 gas sponsoring
+    "GET /exact/evm/permit2-eip2612GasSponsoring": {
+      accepts: {
+        payTo: EVM_PAYEE_ADDRESS,
+        scheme: "exact",
+        network: EVM_NETWORK,
+        price: "$0.001",
+        extra: { assetTransferMethod: "permit2" },
+      },
+      extensions: {
+        ...declareDiscoveryExtension({
+          output: {
+            example: {
+              message: "Permit2 EIP-2612 endpoint accessed successfully",
+              timestamp: "2024-01-01T00:00:00Z",
+              method: "permit2-eip2612",
+            },
+            schema: {
+              properties: {
+                message: { type: "string" },
+                timestamp: { type: "string" },
+                method: { type: "string" },
+              },
+              required: ["message", "timestamp", "method"],
+            },
+          },
+        }),
         ...declareEip2612GasSponsoringExtension(),
+      },
+    },
+    // Permit2 endpoint for ERC-20 approval gas sponsoring (no EIP-2612)
+    "GET /exact/evm/permit2-erc20ApprovalGasSponsoring": {
+      accepts: {
+        payTo: EVM_PAYEE_ADDRESS,
+        scheme: "exact",
+        network: EVM_NETWORK,
+        price: {
+          amount: "1000",
+          asset: EVM_PERMIT2_ASSET,
+          extra: {
+            assetTransferMethod: "permit2",
+          },
+        },
+      },
+      extensions: {
+        ...declareErc20ApprovalGasSponsoringExtension(),
       },
     },
     ...(STELLAR_PAYEE_ADDRESS
       ? {
-          "GET /protected-stellar": {
+          "GET /exact/stellar": {
             accepts: {
               payTo: STELLAR_PAYEE_ADDRESS!,
               scheme: "exact",
@@ -279,7 +308,7 @@ paymentMiddleware(
  * This endpoint demonstrates a resource protected by x402 payment middleware.
  * Clients must provide a valid payment signature to access this endpoint.
  */
-app.get("/protected", async () => {
+app.get("/exact/evm/eip3009", async () => {
   return {
     message: "Protected endpoint accessed successfully",
     timestamp: new Date().toISOString(),
@@ -292,7 +321,7 @@ app.get("/protected", async () => {
  * This endpoint demonstrates a resource protected by x402 payment middleware for SVM.
  * Clients must provide a valid payment signature to access this endpoint.
  */
-app.get("/protected-svm", async () => {
+app.get("/exact/svm", async () => {
   return {
     message: "Protected endpoint accessed successfully",
     timestamp: new Date().toISOString(),
@@ -306,10 +335,32 @@ app.get("/protected-svm", async () => {
  * Clients must provide a valid payment signature to access this endpoint.
  * Note: 501 check is handled by pre-middleware guard above.
  */
-app.get("/protected-aptos", async () => {
+app.get("/exact/aptos", async () => {
   return {
     message: "Protected endpoint accessed successfully",
     timestamp: new Date().toISOString(),
+  };
+});
+
+/**
+ * Protected Permit2 endpoint - standard settle (no gas sponsoring)
+ */
+app.get("/exact/evm/permit2", async () => {
+  return {
+    message: "Permit2 endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+    method: "permit2",
+  };
+});
+
+/**
+ * Protected Permit2 EIP-2612 endpoint - requires Permit2 with gas sponsoring
+ */
+app.get("/exact/evm/permit2-eip2612GasSponsoring", async () => {
+  return {
+    message: "Permit2 EIP-2612 endpoint accessed successfully",
+    timestamp: new Date().toISOString(),
+    method: "permit2-eip2612",
   };
 });
 
@@ -320,25 +371,11 @@ app.get("/protected-aptos", async () => {
  * that do NOT implement EIP-2612. The facilitator broadcasts the pre-signed
  * approve() transaction on the client's behalf before settling.
  */
-app.get("/protected-permit2-erc20", async () => {
+app.get("/exact/evm/permit2-erc20ApprovalGasSponsoring", async () => {
   return {
     message: "Permit2 ERC-20 approval endpoint accessed successfully",
     timestamp: new Date().toISOString(),
     method: "permit2-erc20-approval",
-  };
-});
-
-/**
- * Protected Permit2 endpoint - requires payment via Permit2 flow
- *
- * This endpoint demonstrates the Permit2 payment flow.
- * Clients must have approved Permit2 to spend their USDC before accessing.
- */
-app.get("/protected-permit2", async () => {
-  return {
-    message: "Permit2 endpoint accessed successfully",
-    timestamp: new Date().toISOString(),
-    method: "permit2",
   };
 });
 
@@ -350,7 +387,7 @@ app.get("/protected-permit2", async () => {
  * Note: 501 check is handled by pre-middleware guard above.
  */
 if (STELLAR_PAYEE_ADDRESS) {
-  app.get("/protected-stellar", async () => {
+  app.get("/exact/stellar", async () => {
     return {
       message: "Protected Stellar endpoint accessed successfully",
       timestamp: new Date().toISOString(),
@@ -408,12 +445,13 @@ app.listen({ port: parseInt(PORT) }, (err, address) => {
 ║  Stellar Payee: ${STELLAR_PAYEE_ADDRESS || "(not configured)"}
 ║                                                        ║
 ║  Endpoints:                                            ║
-║  • GET  /protected             (EIP-3009 payment - EVM)    ║
-║  • GET  /protected-svm         (SVM payment)               ║
-║  • GET  /protected-aptos       (Aptos payment)             ║
-║  • GET  /protected-permit2     (Permit2 payment - EVM)     ║
-║  • GET  /protected-permit2-erc20 (Permit2 + ERC-20 approval) ║
-║  • GET  /protected-stellar     (Stellar payment)           ║
+║  • GET  /exact/evm/eip3009                    (EVM EIP-3009)  ║
+║  • GET  /exact/evm/permit2                    (Permit2)       ║
+║  • GET  /exact/evm/permit2-eip2612GasSponsoring               ║
+║  • GET  /exact/evm/permit2-erc20ApprovalGasSponsoring         ║
+║  • GET  /exact/svm                            (SVM)           ║
+║  • GET  /exact/aptos                          (Aptos)         ║
+║  • GET  /exact/stellar                        (Stellar)       ║
 ║  • GET  /health                (no payment required)       ║
 ║  • POST /close                 (shutdown server)           ║
 ╚════════════════════════════════════════════════════════╝

--- a/e2e/servers/fastify/test.config.json
+++ b/e2e/servers/fastify/test.config.json
@@ -6,7 +6,7 @@
   "extensions": ["bazaar", "eip2612GasSponsoring", "erc20ApprovalGasSponsoring"],
   "endpoints": [
     {
-      "path": "/protected",
+      "path": "/exact/evm/eip3009",
       "method": "GET",
       "description": "Protected endpoint requiring EIP-3009 payment",
       "requiresPayment": true,
@@ -14,15 +14,24 @@
       "transferMethod": "eip3009"
     },
     {
-      "path": "/protected-permit2",
+      "path": "/exact/evm/permit2",
       "method": "GET",
-      "description": "Protected endpoint requiring Permit2 payment",
+      "description": "Protected endpoint requiring Permit2 payment (standard settle, no gas sponsoring)",
+      "requiresPayment": true,
+      "protocolFamily": "evm",
+      "transferMethod": "permit2",
+      "permit2Direct": true
+    },
+    {
+      "path": "/exact/evm/permit2-eip2612GasSponsoring",
+      "method": "GET",
+      "description": "Protected endpoint requiring Permit2 payment with EIP-2612 gas sponsoring",
       "requiresPayment": true,
       "protocolFamily": "evm",
       "transferMethod": "permit2"
     },
     {
-      "path": "/protected-permit2-erc20",
+      "path": "/exact/evm/permit2-erc20ApprovalGasSponsoring",
       "method": "GET",
       "description": "Protected endpoint requiring Permit2 payment with ERC-20 approval gas sponsoring",
       "requiresPayment": true,
@@ -31,21 +40,21 @@
       "extensions": ["erc20ApprovalGasSponsoring"]
     },
     {
-      "path": "/protected-svm",
+      "path": "/exact/svm",
       "method": "GET",
       "description": "Protected endpoint requiring payment on SVM network",
       "requiresPayment": true,
       "protocolFamily": "svm"
     },
     {
-      "path": "/protected-aptos",
+      "path": "/exact/aptos",
       "method": "GET",
       "description": "Protected endpoint requiring payment on Aptos network",
       "requiresPayment": true,
       "protocolFamily": "aptos"
     },
     {
-      "path": "/protected-stellar",
+      "path": "/exact/stellar",
       "method": "GET",
       "description": "Protected endpoint requiring payment on Stellar network",
       "requiresPayment": true,

--- a/typescript/.changeset/tall-windows-rescue.md
+++ b/typescript/.changeset/tall-windows-rescue.md
@@ -1,0 +1,5 @@
+---
+'@x402/fastify': patch
+---
+
+Applied monkey-patch on reply.raw write operations and buffered response to prevent content leak from direct raw writes bypassing Fastify's onSend lifecycle

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -84,6 +84,7 @@ function createMockApp(): { app: FastifyInstance; hooks: CapturedHooks } {
       if (name === "onRequest") hooks.onRequest.push(handler);
       if (name === "onSend") hooks.onSend.push(handler);
     }),
+    decorateRequest: vi.fn(),
   } as unknown as FastifyInstance;
 
   return { app, hooks };
@@ -162,6 +163,12 @@ function createMockReply(): FastifyReply & {
     _body: undefined as unknown,
     _type: undefined as string | undefined,
     statusCode: 200,
+    raw: {
+      write: vi.fn(),
+      end: vi.fn(),
+      writeHead: vi.fn(),
+      flushHeaders: vi.fn(),
+    },
     header: vi.fn(function (this: typeof reply, key: string, value: string) {
       this._headers[key] = value;
       return this;
@@ -349,9 +356,8 @@ describe("paymentMiddleware", () => {
     await hooks.onRequest[0](request, reply);
 
     expect(reply.send).not.toHaveBeenCalled();
-    // Payment context should be stashed on the request via symbol
-    const symbols = Object.getOwnPropertySymbols(request);
-    expect(symbols.length).toBe(1);
+    expect(request.x402Context).toBeDefined();
+    expect(request.x402RawGuard).toBeDefined();
   });
 
   it("settles payment and adds headers in onSend for verified payments", async () => {

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -40,6 +40,27 @@ let mockRegisterPaywallProvider: ReturnType<typeof vi.fn>;
 let mockRequiresPayment: ReturnType<typeof vi.fn>;
 
 vi.mock("@x402/core/server", () => ({
+  FacilitatorResponseError: class FacilitatorResponseError extends Error {
+    /**
+     * Mock error class matching @x402/core/server FacilitatorResponseError.
+     *
+     * @param message - Error message passed to the superclass.
+     */
+    constructor(message: string) {
+      super(message);
+      this.name = "FacilitatorResponseError";
+    }
+  },
+  getFacilitatorResponseError: (error: unknown) => {
+    let current = error;
+    while (current instanceof Error) {
+      if (current.name === "FacilitatorResponseError") {
+        return current;
+      }
+      current = (current as Error & { cause?: unknown }).cause;
+    }
+    return null;
+  },
   x402ResourceServer: vi.fn().mockImplementation(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     registerExtension: vi.fn(),

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -7,6 +7,8 @@ import {
   x402ResourceServer,
   RoutesConfig,
   FacilitatorClient,
+  FacilitatorResponseError,
+  getFacilitatorResponseError,
 } from "@x402/core/server";
 import {
   SchemeNetworkServer,
@@ -132,6 +134,9 @@ function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
  *
  * The guard is deactivated at the start of onSend so that Fastify's own
  * internal reply.raw usage (which happens after onSend) is unaffected.
+ *
+ * @param reply - Fastify reply whose raw ServerResponse is wrapped for buffering.
+ * @returns Guard state and buffer used to replay raw writes after settlement.
  */
 function guardReplyRaw(reply: FastifyReply): RawGuard {
   const raw = reply.raw;
@@ -200,6 +205,16 @@ function guardReplyRaw(reply: FastifyReply): RawGuard {
 }
 
 /**
+ * Sends a normalized 502 response for facilitator boundary failures.
+ *
+ * @param reply - The Fastify reply to write to
+ * @param error - The facilitator response error to surface
+ */
+function sendFacilitatorError(reply: FastifyReply, error: FacilitatorResponseError): void {
+  reply.status(502).send({ error: error.message });
+}
+
+/**
  * Configuration for registering a payment scheme with a specific network.
  */
 export interface SchemeRegistration {
@@ -253,6 +268,28 @@ export function paymentMiddlewareFromHTTPServer(
   app.decorateRequest("x402RawGuard", undefined);
 
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
+  let isInitialized = false;
+
+  /**
+   * Ensures facilitator initialization succeeds once, while allowing retries after failures.
+   */
+  async function initializeHttpServer(): Promise<void> {
+    if (!syncFacilitatorOnStart || isInitialized) {
+      return;
+    }
+
+    if (!initPromise) {
+      initPromise = httpServer.initialize();
+    }
+
+    try {
+      await initPromise;
+      isInitialized = true;
+    } catch (error) {
+      initPromise = null;
+      throw error;
+    }
+  }
 
   let bazaarPromise: Promise<void> | null = null;
   if (checkIfBazaarNeeded(httpServer.routes) && !httpServer.server.hasExtension("bazaar")) {
@@ -281,9 +318,16 @@ export function paymentMiddlewareFromHTTPServer(
       return;
     }
 
-    if (initPromise) {
-      await initPromise;
-      initPromise = null;
+    if (syncFacilitatorOnStart && !isInitialized) {
+      try {
+        await initializeHttpServer();
+      } catch (error) {
+        const facilitatorError = getFacilitatorResponseError(error);
+        if (facilitatorError) {
+          return sendFacilitatorError(reply, facilitatorError);
+        }
+        throw error;
+      }
     }
 
     if (bazaarPromise) {
@@ -291,7 +335,15 @@ export function paymentMiddlewareFromHTTPServer(
       bazaarPromise = null;
     }
 
-    const result = await httpServer.processHTTPRequest(context, paywallConfig);
+    let result: Awaited<ReturnType<x402HTTPResourceServer["processHTTPRequest"]>>;
+    try {
+      result = await httpServer.processHTTPRequest(context, paywallConfig);
+    } catch (error) {
+      if (error instanceof FacilitatorResponseError) {
+        return sendFacilitatorError(reply, error);
+      }
+      throw error;
+    }
 
     switch (result.type) {
       case "no-payment-required":
@@ -392,6 +444,11 @@ export function paymentMiddlewareFromHTTPServer(
       }
       return effectivePayload;
     } catch (error) {
+      if (error instanceof FacilitatorResponseError) {
+        reply.status(502);
+        reply.type("application/json");
+        return JSON.stringify({ error: error.message });
+      }
       console.error(error);
       reply.status(402);
       reply.type("application/json");

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -1,3 +1,4 @@
+import type { ServerResponse } from "http";
 import {
   HTTPRequestContext,
   PaywallConfig,
@@ -16,19 +17,46 @@ import {
 import { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import { FastifyAdapter } from "./adapter";
 
-/**
- * Symbol used to store x402 payment context on the request object.
- */
-const kX402Context = Symbol("x402Context");
-
-/**
- * Extended request type with x402 payment context.
- */
 interface X402PaymentContext {
   paymentPayload: PaymentPayload;
   paymentRequirements: PaymentRequirements;
   declaredExtensions?: Record<string, unknown>;
   requestContext: HTTPRequestContext;
+}
+
+interface BufferedWriteHead {
+  method: "writeHead";
+  statusCode: number;
+  headers?: Record<string, unknown>;
+}
+
+interface BufferedWrite {
+  method: "write";
+  data: string | Buffer;
+}
+
+interface BufferedEnd {
+  method: "end";
+  data?: string | Buffer;
+}
+
+interface BufferedFlushHeaders {
+  method: "flushHeaders";
+}
+
+type BufferedRawCall = BufferedWriteHead | BufferedWrite | BufferedEnd | BufferedFlushHeaders;
+
+interface RawGuard {
+  triggered: boolean;
+  buffer: BufferedRawCall[];
+  deactivate: () => void;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    x402Context?: X402PaymentContext;
+    x402RawGuard?: RawGuard;
+  }
 }
 
 /**
@@ -90,6 +118,88 @@ function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
 }
 
 /**
+ * Buffers reply.raw method calls on a protected route so that settlement
+ * can inspect the response body before anything reaches the client.
+ *
+ * Fastify's normal reply flow (return value / reply.send) goes through the
+ * onSend hook where settlement runs before data reaches the client.  However,
+ * reply.raw gives direct access to the underlying Node.js ServerResponse,
+ * allowing data to be flushed without triggering onSend.
+ *
+ * This guard intercepts writeHead/write/end/flushHeaders, stores them in a
+ * buffer, and ensures Fastify's lifecycle still fires (via reply.send on end)
+ * so that onSend can reconstruct the response, settle, then replay the calls.
+ *
+ * The guard is deactivated at the start of onSend so that Fastify's own
+ * internal reply.raw usage (which happens after onSend) is unaffected.
+ */
+function guardReplyRaw(reply: FastifyReply): RawGuard {
+  const raw = reply.raw;
+  const origWrite = raw.write;
+  const origEnd = raw.end;
+  const origWriteHead = raw.writeHead;
+  const origFlushHeaders = raw.flushHeaders;
+
+  let active = true;
+  const guard: RawGuard = {
+    triggered: false,
+    buffer: [],
+    deactivate() {
+      if (!active) return;
+      active = false;
+      raw.write = origWrite;
+      raw.end = origEnd;
+      raw.writeHead = origWriteHead;
+      raw.flushHeaders = origFlushHeaders;
+    },
+  };
+
+  raw.writeHead = function (this: ServerResponse, ...args: unknown[]) {
+    if (active) {
+      guard.triggered = true;
+      const statusCode = args[0] as number;
+      const headers = (typeof args[1] === "string" ? args[2] : args[1]) as
+        | Record<string, unknown>
+        | undefined;
+      guard.buffer.push({ method: "writeHead", statusCode, headers });
+      return this;
+    }
+    return Reflect.apply(origWriteHead, this, args) as ServerResponse;
+  } as ServerResponse["writeHead"];
+
+  raw.write = function (this: ServerResponse, ...args: unknown[]) {
+    if (active) {
+      guard.triggered = true;
+      guard.buffer.push({ method: "write", data: args[0] as string | Buffer });
+      return true;
+    }
+    return Reflect.apply(origWrite, this, args) as boolean;
+  } as ServerResponse["write"];
+
+  raw.end = function (this: ServerResponse, ...args: unknown[]) {
+    if (active) {
+      guard.triggered = true;
+      const data =
+        typeof args[0] === "function" ? undefined : (args[0] as string | Buffer | undefined);
+      guard.buffer.push({ method: "end", data });
+      return this;
+    }
+    return Reflect.apply(origEnd, this, args) as ServerResponse;
+  } as ServerResponse["end"];
+
+  raw.flushHeaders = function (this: ServerResponse) {
+    if (active) {
+      guard.triggered = true;
+      guard.buffer.push({ method: "flushHeaders" });
+    } else {
+      origFlushHeaders.call(this);
+    }
+  };
+
+  return guard;
+}
+
+/**
  * Configuration for registering a payment scheme with a specific network.
  */
 export interface SchemeRegistration {
@@ -138,6 +248,9 @@ export function paymentMiddlewareFromHTTPServer(
   if (paywall) {
     httpServer.registerPaywallProvider(paywall);
   }
+
+  app.decorateRequest("x402Context", undefined);
+  app.decorateRequest("x402RawGuard", undefined);
 
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
 
@@ -197,33 +310,62 @@ export function paymentMiddlewareFromHTTPServer(
       }
 
       case "payment-verified": {
-        const x402Context: X402PaymentContext = {
+        request.x402Context = {
           paymentPayload: result.paymentPayload,
           paymentRequirements: result.paymentRequirements,
           declaredExtensions: result.declaredExtensions,
           requestContext: context,
         };
-        (request as unknown as Record<symbol, unknown>)[kX402Context] = x402Context;
+        request.x402RawGuard = guardReplyRaw(reply);
         return;
       }
     }
   });
 
   app.addHook("onSend", async (request: FastifyRequest, reply: FastifyReply, payload: unknown) => {
-    const x402Context = (request as unknown as Record<symbol, unknown>)[kX402Context] as
-      | X402PaymentContext
-      | undefined;
+    const rawGuard = request.x402RawGuard;
+    if (rawGuard) {
+      rawGuard.deactivate();
+    }
 
+    const x402Context = request.x402Context;
     if (!x402Context) {
       return payload;
     }
 
+    let effectivePayload: unknown = payload;
+    if (rawGuard?.triggered && rawGuard.buffer.length > 0) {
+      const writeHeadCall = rawGuard.buffer.find(
+        (c): c is BufferedWriteHead => c.method === "writeHead",
+      );
+      if (writeHeadCall) {
+        reply.status(writeHeadCall.statusCode);
+        if (writeHeadCall.headers) {
+          for (const [key, value] of Object.entries(writeHeadCall.headers)) {
+            if (value != null) reply.header(key, String(value));
+          }
+        }
+      }
+
+      const bodyChunks: Buffer[] = [];
+      for (const call of rawGuard.buffer) {
+        if (call.method === "write") {
+          bodyChunks.push(Buffer.from(call.data));
+        } else if (call.method === "end" && call.data != null) {
+          bodyChunks.push(Buffer.from(call.data));
+        }
+      }
+      if (bodyChunks.length > 0) {
+        effectivePayload = Buffer.concat(bodyChunks);
+      }
+    }
+
     if (reply.statusCode >= 400) {
-      return payload;
+      return effectivePayload;
     }
 
     try {
-      const responseBody = getResponseBodyBuffer(payload);
+      const responseBody = getResponseBodyBuffer(effectivePayload);
 
       const settleResult = await httpServer.processSettlement(
         x402Context.paymentPayload,
@@ -248,7 +390,7 @@ export function paymentMiddlewareFromHTTPServer(
       for (const [key, value] of Object.entries(settleResult.headers)) {
         reply.header(key, value);
       }
-      return payload;
+      return effectivePayload;
     } catch (error) {
       console.error(error);
       reply.status(402);

--- a/typescript/packages/http/fastify/src/malformedPathBypass.test.ts
+++ b/typescript/packages/http/fastify/src/malformedPathBypass.test.ts
@@ -30,6 +30,7 @@ function createMockApp(): { app: FastifyInstance; hooks: CapturedHooks } {
       if (name === "onRequest") hooks.onRequest.push(handler);
       if (name === "onSend") hooks.onSend.push(handler);
     }),
+    decorateRequest: vi.fn(),
   } as unknown as FastifyInstance;
 
   return { app, hooks };


### PR DESCRIPTION
## Description

- Applied monkey-patch on `reply.raw` write operations and buffered response to prevent content leak from direct raw writes bypassing fastify's `onSend` lifecycle
- handle fastify's invalid facilitator responses as in https://github.com/coinbase/x402/pull/1506
- aligning fastify e2e tests with structure introduced in https://github.com/coinbase/x402/pull/1779

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 