### PR TITLE
Add the402.ai to ecosystem partners

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/the402/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/the402/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "the402.ai",
+  "description": "Open marketplace where AI agents discover and purchase services via x402 micropayments (USDC on Base).",
+  "logoUrl": "/logos/the402.svg",
+  "websiteUrl": "https://the402.ai",
+  "category": "services-endpoints"
+}

--- a/typescript/site/public/logos/the402.svg
+++ b/typescript/site/public/logos/the402.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="16" fill="#111827"/>
+  <text x="64" y="92" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="72" font-weight="800" fill="#4ade80">402</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds [the402.ai](https://the402.ai) to the x402 ecosystem page.

**the402.ai** is an open marketplace where AI agents discover and purchase services from third-party providers via x402 micropayments (USDC on Base). 

- MCP server published as [`@the402/mcp-server`](https://www.npmjs.com/package/@the402/mcp-server) on npm with native x402 signing
- 30+ MCP tools for agent workflows (catalog browsing, purchasing, threads, subscriptions)
- Full x402 402 challenge/response flow with EIP-3009 gasless USDC transfers
- Live at [api.the402.ai](https://api.the402.ai/health)

### Files added
- `typescript/site/app/ecosystem/partners-data/the402/metadata.json` — partner metadata
- `typescript/site/public/logos/the402.svg` — logo