### PR TITLE
feat: export hook types

### DIFF
--- a/typescript/.changeset/export-hook-types.md
+++ b/typescript/.changeset/export-hook-types.md
@@ -1,0 +1,5 @@
+---
+'@x402/core': patch
+---
+
+Export all hook types and hook context interfaces from the server entry point

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -1,8 +1,20 @@
 export { x402ResourceServer } from "./x402ResourceServer";
 export type {
   ResourceConfig,
+  PaymentRequiredContext,
+  VerifyContext,
+  VerifyResultContext,
+  VerifyFailureContext,
+  SettleContext,
   SettleResultContext,
+  SettleFailureContext,
   SettlementOverrides,
+  BeforeVerifyHook,
+  AfterVerifyHook,
+  OnVerifyFailureHook,
+  BeforeSettleHook,
+  AfterSettleHook,
+  OnSettleFailureHook,
 } from "./x402ResourceServer";
 
 export { HTTPFacilitatorClient } from "../http/httpFacilitatorClient";
@@ -32,4 +44,5 @@ export type {
   ProcessSettleSuccessResponse,
   ProcessSettleFailureResponse,
   RouteValidationError,
+  ProtectedRequestHook,
 } from "../http/x402HTTPResourceServer";


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

1. Export all lifecycle hook types (`BeforeVerifyHook`, `AfterVerifyHook`, `OnVerifyFailureHook`, `BeforeSettleHook`, `AfterSettleHook`, `OnSettleFailureHook`) and their context interfaces (`aymentRequiredContext`, `VerifyContext`, `VerifyResultContext`, `VerifyFailureContext`, `SettleContext`, `SettleFailureContext`) from `@x402/core/server`
2. Export `ProtectedRequestHook` from the HTTP layer                                                                                                                          
                                                                                           

                                                                                                                                                       
### Why

These types were defined and used internally but not re-exported, making it impossible for consumers to type their hook implementations when using `@x402/core/server`.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 