### PR TITLE
Fix race condition in lazy facilitator initialization

### DIFF
--- a/python/x402/changelog.d/1584.bugfix.md
+++ b/python/x402/changelog.d/1584.bugfix.md
@@ -1,0 +1,1 @@
+Fixed race condition in lazy facilitator initialization for FastAPI and Flask middleware under concurrent requests.

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -5,6 +5,7 @@ Provides payment-gated route protection for FastAPI applications.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -257,8 +258,9 @@ def payment_middleware(
     if paywall_provider:
         http_server.register_paywall_provider(paywall_provider)
 
-    # Lazy initialization state
+    # Lazy initialization state with async lock for concurrency safety
     init_done = False
+    init_lock = asyncio.Lock()
 
     async def middleware(
         request: Request,
@@ -281,13 +283,15 @@ def payment_middleware(
         if not http_server.requires_payment(context):
             return await call_next(request)
 
-        # Initialize on first protected request
+        # Initialize on first protected request (double-checked locking)
         if sync_facilitator_on_start and not init_done:
-            try:
-                http_server.initialize()
-            except FacilitatorResponseError as error:
-                return _facilitator_error_response(error)
-            init_done = True
+            async with init_lock:
+                if not init_done:
+                    try:
+                        http_server.initialize()
+                    except FacilitatorResponseError as error:
+                        return _facilitator_error_response(error)
+                    init_done = True
 
         # Process payment request
         try:

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -7,6 +7,7 @@ Uses x402HTTPResourceServerSync for synchronous request processing without async
 from __future__ import annotations
 
 import json
+import threading
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Any
 
@@ -334,6 +335,7 @@ class PaymentMiddleware:
         self._paywall_config = paywall_config
         self._sync_on_start = sync_facilitator_on_start
         self._init_done = False
+        self._init_lock = threading.Lock()
         self._original_wsgi = app.wsgi_app
 
         if paywall_provider:
@@ -372,13 +374,15 @@ class PaymentMiddleware:
             if not self._http_server.requires_payment(context):
                 return self._original_wsgi(environ, start_response)
 
-            # Initialize on first protected request
+            # Initialize on first protected request (double-checked locking)
             if self._sync_on_start and not self._init_done:
-                try:
-                    self._http_server.initialize()
-                except FacilitatorResponseError as error:
-                    return _facilitator_error_wsgi_response(start_response, error)
-                self._init_done = True
+                with self._init_lock:
+                    if not self._init_done:
+                        try:
+                            self._http_server.initialize()
+                        except FacilitatorResponseError as error:
+                            return _facilitator_error_wsgi_response(start_response, error)
+                        self._init_done = True
 
             # Process payment request synchronously (no asyncio overhead)
             try:

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -577,7 +577,6 @@ class TestFastAPIMiddlewareConcurrency:
         }
 
         init_call_count = 0
-        init_event = asyncio.Event()
 
         with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
             mock_http_server_instance = MagicMock()
@@ -609,7 +608,7 @@ class TestFastAPIMiddlewareConcurrency:
             async def call_next(req):
                 return MagicMock()
 
-            results = await asyncio.gather(
+            await asyncio.gather(
                 mw(request1, call_next),
                 mw(request2, call_next),
                 mw(request3, call_next),

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -546,6 +546,126 @@ class TestFastAPIMiddlewareIntegration:
 
 
 # =============================================================================
+# Concurrency Tests
+# =============================================================================
+
+
+class TestFastAPIMiddlewareConcurrency:
+    """Tests for concurrency-safe lazy facilitator initialization."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_initialize_only_once(self):
+        """Test that concurrent requests only trigger one initialization call."""
+        import asyncio
+
+        app = FastAPI()
+
+        @app.get("/api/protected")
+        def protected_route():
+            return {"data": "Protected content"}
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        init_call_count = 0
+        init_event = asyncio.Event()
+
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request = AsyncMock(
+                return_value=HTTPProcessResult(
+                    type="payment-error",
+                    response=HTTPResponseInstructions(
+                        status=402,
+                        headers={"PAYMENT-REQUIRED": "encoded"},
+                        body={"error": "Payment required"},
+                    ),
+                )
+            )
+
+            def slow_initialize():
+                nonlocal init_call_count
+                init_call_count += 1
+
+            mock_http_server_instance.initialize.side_effect = slow_initialize
+            mock_http_server.return_value = mock_http_server_instance
+
+            mw = payment_middleware(routes, mock_server, sync_facilitator_on_start=True)
+
+            request1 = make_mock_fastapi_request(path="/api/protected")
+            request2 = make_mock_fastapi_request(path="/api/protected")
+            request3 = make_mock_fastapi_request(path="/api/protected")
+
+            async def call_next(req):
+                return MagicMock()
+
+            results = await asyncio.gather(
+                mw(request1, call_next),
+                mw(request2, call_next),
+                mw(request3, call_next),
+            )
+
+            assert init_call_count == 1, (
+                f"Expected initialize() to be called exactly once, got {init_call_count}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_init_error_does_not_block_subsequent_requests(self):
+        """Test that a failed init allows subsequent requests to retry."""
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        call_count = 0
+
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+
+            def failing_initialize():
+                nonlocal call_count
+                call_count += 1
+                raise FacilitatorResponseError("Connection refused")
+
+            mock_http_server_instance.initialize.side_effect = failing_initialize
+            mock_http_server.return_value = mock_http_server_instance
+
+            mw = payment_middleware(routes, mock_server, sync_facilitator_on_start=True)
+
+            request = make_mock_fastapi_request(path="/api/protected")
+
+            async def call_next(req):
+                return MagicMock()
+
+            # First request fails
+            response1 = await mw(request, call_next)
+            assert response1.status_code == 502
+
+            # Second request should also attempt init since first failed
+            response2 = await mw(request, call_next)
+            assert response2.status_code == 502
+            assert call_count == 2
+
+
+# =============================================================================
 # ASGI Middleware Class Tests
 # =============================================================================
 

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -357,6 +358,117 @@ class TestPaymentMiddleware:
         middleware = PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=False)
 
         assert middleware._original_wsgi == original_wsgi
+
+
+class TestFlaskMiddlewareConcurrency:
+    """Tests for concurrency-safe lazy facilitator initialization."""
+
+    def test_concurrent_threads_initialize_only_once(self):
+        """Test that concurrent threads only trigger one initialization call."""
+        import concurrent.futures
+
+        app = Flask(__name__)
+
+        @app.route("/api/protected")
+        def protected_route():
+            return "Protected content"
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        init_call_count = 0
+        count_lock = threading.Lock()
+
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-error",
+                response=HTTPResponseInstructions(
+                    status=402,
+                    headers={"PAYMENT-REQUIRED": "encoded"},
+                    body={"error": "Payment required"},
+                ),
+            )
+
+            def counting_initialize():
+                nonlocal init_call_count
+                with count_lock:
+                    init_call_count += 1
+
+            mock_http_server_instance.initialize.side_effect = counting_initialize
+            mock_http_server.return_value = mock_http_server_instance
+
+            PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=True)
+
+            def make_request():
+                with app.test_client() as client:
+                    return client.get("/api/protected")
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+                futures = [executor.submit(make_request) for _ in range(5)]
+                responses = [f.result() for f in futures]
+
+            assert init_call_count == 1, (
+                f"Expected initialize() to be called exactly once, got {init_call_count}"
+            )
+            for resp in responses:
+                assert resp.status_code == 402
+
+    def test_init_error_does_not_block_subsequent_requests(self):
+        """Test that a failed init allows subsequent requests to retry."""
+        app = Flask(__name__)
+
+        @app.route("/api/protected")
+        def protected_route():
+            return "Protected content"
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        call_count = 0
+
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+
+            def failing_initialize():
+                nonlocal call_count
+                call_count += 1
+                raise FacilitatorResponseError("Connection refused")
+
+            mock_http_server_instance.initialize.side_effect = failing_initialize
+            mock_http_server.return_value = mock_http_server_instance
+
+            PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=True)
+
+            with app.test_client() as client:
+                # First request fails
+                response1 = client.get("/api/protected")
+                assert response1.status_code == 502
+
+                # Second request retries init since first failed
+                response2 = client.get("/api/protected")
+                assert response2.status_code == 502
+                assert call_count == 2
 
 
 class TestPaymentMiddlewareFunction:


### PR DESCRIPTION
## Summary

Fixes #1584

- **FastAPI middleware**: concurrent async requests could race on `init_done` flag, causing multiple simultaneous `http_server.initialize()` calls. Added `asyncio.Lock` with double-checked locking to ensure single-flight initialization.
- **Flask middleware**: concurrent threads could race on `self._init_done` flag under threaded WSGI servers. Added `threading.Lock` with double-checked locking for thread-safe initialization.
- Failed initialization does not permanently set `init_done = True`, so subsequent requests can retry.

## Changes

| File | Change |
|------|--------|
| `python/x402/http/middleware/fastapi.py` | Added `asyncio.Lock` guard around lazy init |
| `python/x402/http/middleware/flask.py` | Added `threading.Lock` guard around lazy init |
| `python/x402/tests/unit/http/middleware/test_fastapi.py` | Added concurrency + retry tests |
| `python/x402/tests/unit/http/middleware/test_flask.py` | Added concurrency + retry tests |
| `python/x402/changelog.d/1584.bugfix.md` | Towncrier fragment |

## Test plan

- [x] `test_concurrent_requests_initialize_only_once` — fires 3 concurrent async requests at FastAPI middleware, asserts `initialize()` called exactly once
- [x] `test_concurrent_threads_initialize_only_once` — fires 5 concurrent threads at Flask middleware, asserts `initialize()` called exactly once
- [x] `test_init_error_does_not_block_subsequent_requests` — verifies failed init allows retry on next request (both frameworks)
- [x] All 66 existing + new middleware tests pass

cc @ethanoroshiba @CarsonRoscoe