### PR TITLE
Populate 402 response body with payment info for agent discovery

### DIFF
--- a/python/x402/changelog.d/1677.bugfix.md
+++ b/python/x402/changelog.d/1677.bugfix.md
@@ -1,0 +1,1 @@
+Populated 402 response body with structured payment information instead of empty object, enabling agents to act on payment-required responses without decoding headers.

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -546,13 +546,34 @@ class x402HTTPServerBase:
                 is_html=True,
             )
 
-        # API response
+        # API response — populate body with payment info so agents and programmatic
+        # clients can act on 402 responses without decoding headers
         content_type = "application/json"
-        body: Any = {}
 
         if unpaid_response:
             content_type = unpaid_response.content_type
-            body = unpaid_response.body
+            body: Any = unpaid_response.body
+        else:
+            body = {
+                "x402Version": payment_required.x402_version,
+                "error": "Payment required",
+                "accepts": [
+                    {
+                        "scheme": req.scheme,
+                        "network": req.network,
+                        "asset": req.asset,
+                        "amount": req.amount,
+                        "payTo": req.pay_to,
+                        "maxTimeoutSeconds": req.max_timeout_seconds,
+                    }
+                    for req in payment_required.accepts
+                ],
+                "resource": {
+                    "url": payment_required.resource.url,
+                    "description": payment_required.resource.description or "",
+                    "mimeType": payment_required.resource.mime_type or "",
+                },
+            }
 
         return HTTPResponseInstructions(
             status=402,
@@ -592,7 +613,10 @@ class x402HTTPServerBase:
             custom_body = route_config.settlement_failed_response_body(context, failure)
 
         content_type = custom_body.content_type if custom_body else "application/json"
-        body = custom_body.body if custom_body else {}
+        if custom_body:
+            body = custom_body.body
+        else:
+            body = {"error": failure.error_reason or "Settlement failed"}
 
         return HTTPResponseInstructions(
             status=402,

--- a/python/x402/tests/integrations/test_http_integration.py
+++ b/python/x402/tests/integrations/test_http_integration.py
@@ -227,7 +227,10 @@ class TestHTTPIntegration:
         assert result.response.status == 402
         assert "PAYMENT-REQUIRED" in result.response.headers
         assert result.response.is_html is False
-        assert result.response.body == {}
+        assert "x402Version" in result.response.body
+        assert result.response.body["error"] == "Payment required"
+        assert "accepts" in result.response.body
+        assert "resource" in result.response.body
 
         # Client parses 402 and creates payment
         payment_required = components.http_client.get_payment_required_response(
@@ -639,7 +642,7 @@ class TestSettlementFailureWithContext:
         response = components.http_server._build_settlement_failure_response(failure, context)
 
         assert response.status == 402
-        assert response.body == {}
+        assert response.body["error"] == "test failure"
         assert "PAYMENT-RESPONSE" in response.headers
 
 

--- a/typescript/.changeset/populate-402-response-body.md
+++ b/typescript/.changeset/populate-402-response-body.md
@@ -1,0 +1,5 @@
+---
+'@x402/core': minor
+---
+
+Populated 402 response body with structured payment information (x402Version, accepts, resource) instead of empty object, enabling agents and programmatic clients to act on payment-required responses without decoding headers. Settlement failure responses now include error context.

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -681,7 +681,12 @@ export class x402HTTPResourceServer {
       : undefined;
 
     const contentType = customBody ? customBody.contentType : "application/json";
-    const body = customBody ? customBody.body : {};
+    const body = customBody
+      ? customBody.body
+      : {
+          error: failure.errorReason || "Settlement failed",
+          ...(failure.errorMessage && { message: failure.errorMessage }),
+        };
 
     return {
       status: 402,
@@ -863,9 +868,24 @@ export class x402HTTPResourceServer {
 
     const response = this.createHTTPPaymentRequiredResponse(paymentRequired);
 
-    // Use callback result if provided, otherwise default to JSON with empty object
+    // Use callback result if provided, otherwise populate body with payment info
+    // so agents and programmatic clients can act on 402 responses without decoding headers
     const contentType = unpaidResponse ? unpaidResponse.contentType : "application/json";
-    const body = unpaidResponse ? unpaidResponse.body : {};
+    const body = unpaidResponse
+      ? unpaidResponse.body
+      : {
+          x402Version: paymentRequired.x402Version,
+          error: paymentRequired.error || "Payment required",
+          accepts: paymentRequired.accepts.map(req => ({
+            scheme: req.scheme,
+            network: req.network,
+            asset: req.asset,
+            amount: req.amount,
+            payTo: req.payTo,
+            maxTimeoutSeconds: req.maxTimeoutSeconds,
+          })),
+          resource: paymentRequired.resource,
+        };
 
     return {
       status,

--- a/typescript/packages/core/test/integrations/core.test.ts
+++ b/typescript/packages/core/test/integrations/core.test.ts
@@ -138,7 +138,10 @@ describe("Core Integration Tests", () => {
       expect(initial402Response.headers).toBeDefined();
       expect(initial402Response.headers["PAYMENT-REQUIRED"]).toBeDefined();
       expect(initial402Response.isHtml).toBeFalsy();
-      expect(initial402Response.body).toEqual({});
+      expect(initial402Response.body).toHaveProperty("x402Version");
+      expect(initial402Response.body).toHaveProperty("error", "Payment required");
+      expect(initial402Response.body).toHaveProperty("accepts");
+      expect(initial402Response.body).toHaveProperty("resource");
 
       // Client responds to PaymentRequired and submits a request with a PaymentPayload
       const paymentRequired = client.getPaymentRequiredResponse(


### PR DESCRIPTION
## Summary

Fixes #1677

The 402 response body was empty (`{}`) — payment instructions were only available in the base64-encoded `PAYMENT-REQUIRED` header. Agents parsing the body got nothing to work with, breaking autonomous discovery and payment recovery flows.

### Before
```json
{}
```

### After
```json
{
  "x402Version": 2,
  "error": "Payment required",
  "accepts": [
    {
      "scheme": "exact",
      "network": "eip155:8453",
      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
      "amount": "1000",
      "payTo": "0x...",
      "maxTimeoutSeconds": 300
    }
  ],
  "resource": {
    "url": "https://example.com/api/data",
    "description": "Protected API endpoint",
    "mimeType": "application/json"
  }
}
```

Settlement failure responses now also include error context:
```json
{
  "error": "insufficient_balance",
  "message": "Wallet has insufficient USDC"
}
```

## Changes

| File | Change |
|------|--------|
| `typescript/.../x402HTTPResourceServer.ts` | Populate default 402 body with payment info from `PaymentRequired`; populate settlement failure body with error context |
| `python/.../x402_http_server_base.py` | Same changes for Python SDK |
| Integration tests (both SDKs) | Updated assertions to expect new body structure |
| Changeset + Towncrier fragments | Added |

Custom `unpaidResponseBody` and `settlementFailedResponseBody` callbacks are still respected — the new body is only the default when no callback is configured.

## Test plan

- [x] TypeScript: 326 tests pass (15 test files)
- [x] Python: 82 tests pass (integration + middleware)
- [x] Existing custom response body callbacks unaffected
- [x] Browser paywall HTML responses unaffected

cc @CarsonRoscoe @JayeHarrill