### PR TITLE
fix(mcp): preserve structuredContent in payment wrapper result

### DIFF
--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -267,11 +267,11 @@ export function createPaymentWrapper(
           await config.hooks.onAfterSettlement(settlementContext);
         }
 
-        // Return result with payment response in _meta
+        // Return full result (preserving structuredContent, etc.) with payment response in _meta
         return {
-          content: result.content,
-          isError: result.isError,
+          ...result,
           _meta: {
+            ...result._meta,
             [MCP_PAYMENT_RESPONSE_META_KEY]: settleResult,
           },
         };

--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -270,10 +270,7 @@ export function createPaymentWrapper(
         // Return full result (preserving structuredContent, etc.) with payment response in _meta
         return {
           ...result,
-          _meta: {
-            ...result._meta,
-            [MCP_PAYMENT_RESPONSE_META_KEY]: settleResult,
-          },
+          _meta: { [MCP_PAYMENT_RESPONSE_META_KEY]: settleResult },
         };
       } catch (settleError) {
         // Settlement failed after execution - return 402 error

--- a/typescript/packages/mcp/test/unit/server.test.ts
+++ b/typescript/packages/mcp/test/unit/server.test.ts
@@ -170,6 +170,31 @@ describe("createPaymentWrapper", () => {
       );
     });
 
+    it("should preserve structuredContent from handler result", async () => {
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+        },
+      );
+
+      const structuredData = { query: "test", results: [{ id: 1 }], count: 1 };
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: JSON.stringify(structuredData) }],
+        structuredContent: structuredData,
+      });
+
+      const wrappedHandler = paid(handler);
+      const result = await wrappedHandler(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      expect(result.structuredContent).toEqual(structuredData);
+      expect(result.content).toEqual([{ type: "text", text: JSON.stringify(structuredData) }]);
+      expect(result._meta?.[MCP_PAYMENT_RESPONSE_META_KEY]).toEqual(mockSettleResponse);
+    });
+
     it("should not settle payment if tool returns error", async () => {
       const paid = createPaymentWrapper(
         mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],


### PR DESCRIPTION
## Problem

`createPaymentWrapper` in `@x402/mcp` reconstructs the tool handler result with only `content`, `isError`, and `_meta`, dropping `structuredContent`:

```typescript
return {
  content: result.content,
  isError: result.isError,
  _meta: {
    [MCP_PAYMENT_RESPONSE_META_KEY]: settleResult,
  },
};
```

This causes the MCP SDK (v1.28.0+) to reject all tool calls with output schema validation errors:

> Output validation error: Tool X has an output schema but no structured content was provided

Any tool that defines an `outputSchema` and uses `createPaymentWrapper` will fail at runtime because the SDK expects `structuredContent` in the result when `outputSchema` is present on the tool registration.

## Fix

Spread the full handler result instead of cherry-picking fields:

```typescript
return {
  ...result,
  _meta: {
    ...result._meta,
    [MCP_PAYMENT_RESPONSE_META_KEY]: settleResult,
  },
};
```

This preserves `structuredContent` and any other fields the handler returns (or that the MCP SDK may add in the future), while still layering on the payment response metadata.

## Test

Added a test verifying `structuredContent` survives the payment wrapper round-trip alongside `content` and `_meta`.

All 75 existing tests pass.