### PR TITLE
feat: added EXTENSION-RESPONSES header to spec

### DIFF
--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -364,16 +364,16 @@ How a facilitator stores, indexes, and exposes discovered resources is an implem
 
 ### Settlement Response Header
 
-After processing a `PaymentPayload`, a facilitator **MAY** append a `BAZAAR-RESPONSE` HTTP header to the settlement response to communicate the cataloging outcome to the client.
+After processing a `PaymentPayload`, a facilitator **MAY** append an `EXTENSION-RESPONSES` HTTP header to the settlement response to communicate extension-specific outcomes to the client.
 
-**Header name:** `BAZAAR-RESPONSE`
+**Header name:** `EXTENSION-RESPONSES`
 
-**Header value:** A base64-encoded JSON object with the following structure:
+**Header value:** A base64-encoded JSON object keyed by extension name. The `bazaar` key contains the bazaar extension's response:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `status` | string | Yes | One of `"success"`, `"processing"`, or `"rejected"` |
-| `rejectedReason` | string | No | Human-readable explanation. Only present when `status` is `"rejected"` |
+| `bazaar.status` | string | Yes | One of `"success"`, `"processing"`, or `"rejected"` |
+| `bazaar.rejectedReason` | string | No | Human-readable explanation. Only present when `status` is `"rejected"` |
 
 **Status values:**
 
@@ -386,18 +386,18 @@ After processing a `PaymentPayload`, a facilitator **MAY** append a `BAZAAR-RESP
 **Example (success):**
 
 ```
-BAZAAR-RESPONSE: eyJzdGF0dXMiOiJzdWNjZXNzIn0=
+EXTENSION-RESPONSES: eyJiYXphYXIiOnsic3RhdHVzIjoic3VjY2VzcyJ9fQ==
 ```
-*(base64 of `{"status":"success"}`)*
+*(base64 of `{"bazaar":{"status":"success"}}`)*
 
 **Example (rejected):**
 
 ```
-BAZAAR-RESPONSE: eyJzdGF0dXMiOiJyZWplY3RlZCIsInJlamVjdGVkUmVhc29uIjoiaW5mbyBmYWlsZWQgc2NoZW1hIHZhbGlkYXRpb24ifQ==
+EXTENSION-RESPONSES: eyJiYXphYXIiOnsic3RhdHVzIjoicmVqZWN0ZWQiLCJyZWplY3RlZFJlYXNvbiI6ImluZm8gZmFpbGVkIHNjaGVtYSB2YWxpZGF0aW9uIn19
 ```
-*(base64 of `{"status":"rejected","rejectedReason":"info failed schema validation"}`)*
+*(base64 of `{"bazaar":{"status":"rejected","rejectedReason":"info failed schema validation"}}`)*
 
-Clients that understand the `bazaar` extension SHOULD read this header to confirm cataloging succeeded and surface any rejection reason for debugging.
+Clients that understand the `bazaar` extension SHOULD read the `bazaar` key of this header to confirm cataloging succeeded and surface any rejection reason for debugging.
 
 ---
 

--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -362,6 +362,43 @@ When a facilitator receives a `PaymentPayload` containing the `bazaar` extension
 
 How a facilitator stores, indexes, and exposes discovered resources is an implementation detail. Facilitators may choose to catalog resources in a database, expose them via a discovery API, or process them in any manner they see fit.
 
+### Settlement Response Header
+
+After processing a `PaymentPayload`, a facilitator **MAY** append a `BAZAAR-RESPONSE` HTTP header to the settlement response to communicate the cataloging outcome to the client.
+
+**Header name:** `BAZAAR-RESPONSE`
+
+**Header value:** A base64-encoded JSON object with the following structure:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `status` | string | Yes | One of `"success"`, `"processing"`, or `"rejected"` |
+| `rejectedReason` | string | No | Human-readable explanation. Only present when `status` is `"rejected"` |
+
+**Status values:**
+
+| Value | Meaning |
+|-------|---------|
+| `"success"` | The discovery info was validated and successfully cataloged |
+| `"processing"` | The discovery info was accepted and is being cataloged asynchronously |
+| `"rejected"` | The discovery info was rejected (e.g., failed schema validation). See `rejectedReason` for details |
+
+**Example (success):**
+
+```
+BAZAAR-RESPONSE: eyJzdGF0dXMiOiJzdWNjZXNzIn0=
+```
+*(base64 of `{"status":"success"}`)*
+
+**Example (rejected):**
+
+```
+BAZAAR-RESPONSE: eyJzdGF0dXMiOiJyZWplY3RlZCIsInJlamVjdGVkUmVhc29uIjoiaW5mbyBmYWlsZWQgc2NoZW1hIHZhbGlkYXRpb24ifQ==
+```
+*(base64 of `{"status":"rejected","rejectedReason":"info failed schema validation"}`)*
+
+Clients that understand the `bazaar` extension SHOULD read this header to confirm cataloging succeeded and surface any rejection reason for debugging.
+
 ---
 
 ## Client Behavior


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Currently, there is no way in-spec for facilitators to communicate bazaar issues with discovery. The only touchpoint they have is `SettlementResponse` in the `PAYMENT-RESPONSE` header, which only communicates payment mechanism results.

This PR addresses this by adding a new header `EXTENSION-RESPONSES` facilitators may include in their response, and prescribes how the `bazaar` key would be populated