### PR TITLE
feat(svm): allow injecting RPC client into ExactSvmScheme

### DIFF
--- a/typescript/packages/mechanisms/svm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/client/scheme.ts
@@ -59,7 +59,7 @@ export class ExactSvmScheme implements SchemeNetworkClient {
     x402Version: number,
     paymentRequirements: PaymentRequirements,
   ): Promise<Pick<PaymentPayload, "x402Version" | "payload">> {
-    const rpc = createRpcClient(paymentRequirements.network, this.config?.rpcUrl);
+    const rpc = this.config?.rpc ?? createRpcClient(paymentRequirements.network, this.config?.rpcUrl);
 
     const tokenMint = await fetchMint(rpc, paymentRequirements.asset as Address);
     const tokenProgramAddress = tokenMint.programAddress;

--- a/typescript/packages/mechanisms/svm/src/exact/v1/client/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/client/scheme.ts
@@ -68,7 +68,7 @@ export class ExactSvmSchemeV1 implements SchemeNetworkClient {
     Pick<PaymentPayload, "x402Version" | "payload"> & { scheme: string; network: Network }
   > {
     const selectedV1 = paymentRequirements as unknown as PaymentRequirementsV1;
-    const rpc = createRpcClient(selectedV1.network, this.config?.rpcUrl);
+    const rpc = this.config?.rpc ?? createRpcClient(selectedV1.network, this.config?.rpcUrl);
 
     const tokenMint = await fetchMint(rpc, selectedV1.asset as Address);
     const tokenProgramAddress = tokenMint.programAddress;

--- a/typescript/packages/mechanisms/svm/src/index.ts
+++ b/typescript/packages/mechanisms/svm/src/index.ts
@@ -11,6 +11,7 @@ export { ExactSvmScheme } from "./exact";
 export { toClientSvmSigner, toFacilitatorSvmSigner } from "./signer";
 export type {
   ClientSvmSigner,
+  ClientRpcClient,
   FacilitatorSvmSigner,
   FacilitatorRpcClient,
   FacilitatorRpcConfig,

--- a/typescript/packages/mechanisms/svm/src/signer.ts
+++ b/typescript/packages/mechanisms/svm/src/signer.ts
@@ -19,6 +19,14 @@ import { createRpcClient, decodeTransactionFromPayload } from "./utils";
 export type ClientSvmSigner = TransactionSigner;
 
 /**
+ * RPC client type that can be used for client operations
+ */
+export type ClientRpcClient =
+  | RpcDevnet<SolanaRpcApiDevnet>
+  | RpcTestnet<SolanaRpcApiTestnet>
+  | RpcMainnet<SolanaRpcApiMainnet>;
+
+/**
  * Configuration for client operations
  */
 export type ClientSvmConfig = {
@@ -26,6 +34,13 @@ export type ClientSvmConfig = {
    * Optional custom RPC URL for the client to use
    */
   rpcUrl?: string;
+
+  /**
+   * Optional pre-configured RPC client to use instead of creating one internally.
+   * Useful for custom transports (failover, retry, rate-limit handling).
+   * Takes precedence over rpcUrl when provided.
+   */
+  rpc?: ClientRpcClient;
 };
 
 /**

--- a/typescript/packages/mechanisms/svm/test/unit/clientRpcInjection.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/clientRpcInjection.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ExactSvmScheme } from "../../src/exact";
+import type { ClientSvmSigner, ClientRpcClient } from "../../src/signer";
+
+describe("ExactSvmScheme - RPC Client Injection", () => {
+  let mockSigner: ClientSvmSigner;
+
+  beforeEach(() => {
+    mockSigner = {
+      address: "9xAXssX9j7vuK99c7cFwqbixzL3bFrzPy9PUhCtDPAYJ" as never,
+      signTransactions: vi.fn().mockResolvedValue([
+        {
+          messageBytes: new Uint8Array(10),
+          signatures: {},
+        },
+      ]) as never,
+    };
+  });
+
+  describe("constructor with rpc config", () => {
+    it("should create instance with default config (no rpc)", () => {
+      const client = new ExactSvmScheme(mockSigner);
+      expect(client.scheme).toBe("exact");
+    });
+
+    it("should accept config with rpcUrl only", () => {
+      const client = new ExactSvmScheme(mockSigner, {
+        rpcUrl: "https://custom-rpc.com",
+      });
+      expect(client.scheme).toBe("exact");
+    });
+
+    it("should accept config with custom rpc client", () => {
+      const mockRpc = {
+        getLatestBlockhash: vi.fn(),
+        getBalance: vi.fn(),
+      } as unknown as ClientRpcClient;
+
+      const client = new ExactSvmScheme(mockSigner, { rpc: mockRpc });
+      expect(client.scheme).toBe("exact");
+    });
+
+    it("should accept config with both rpc and rpcUrl (rpc takes precedence)", () => {
+      const mockRpc = {
+        getLatestBlockhash: vi.fn(),
+      } as unknown as ClientRpcClient;
+
+      const client = new ExactSvmScheme(mockSigner, {
+        rpc: mockRpc,
+        rpcUrl: "https://should-be-ignored.com",
+      });
+      expect(client.scheme).toBe("exact");
+    });
+  });
+
+  describe("ClientRpcClient type", () => {
+    it("should be importable and usable as a type", () => {
+      // Type-level test: ClientRpcClient can be used as a variable type
+      const rpc: ClientRpcClient | undefined = undefined;
+      expect(rpc).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds optional `rpc` field to `ClientSvmConfig` so consumers can inject a pre-configured Solana RPC client (with custom transport, failover, retry, rate-limit handling) instead of relying on the internally-created one
- `rpc` takes precedence over `rpcUrl`; when neither is provided, behavior is unchanged
- Applied to both V2 (`ExactSvmScheme`) and V1 (`ExactSvmSchemeV1`) client schemes
- Exports the new `ClientRpcClient` type from `@x402/svm`

## Motivation
Public Solana RPCs rate-limit at ~100 req/10s. Users running concurrent payments need custom transports (failover, retry on 429, request coalescing), but `ExactSvmScheme` creates its RPC client internally with no way to override. This forced consumers to reimplement the entire class just to change transport configuration.

## Usage
```ts
import { createSolanaRpc, mainnet } from "@solana/kit";
import { ExactSvmScheme } from "@x402/svm";

// Custom RPC with failover transport
const rpc = createSolanaRpc(mainnet("https://my-custom-rpc.com"));
const scheme = new ExactSvmScheme(signer, { rpc });
```

## Test plan
- [x] 5 new tests in `clientRpcInjection.test.ts`
- [x] All 130 existing SVM tests still pass
- [x] Full monorepo build (41/41 tasks) passes

Closes #1832