### PR TITLE
fix: randomize facilitator signer selection

### DIFF
--- a/go/mechanisms/evm/upto/facilitator/permit2_test.go
+++ b/go/mechanisms/evm/upto/facilitator/permit2_test.go
@@ -788,13 +788,15 @@ func TestUptoEvmScheme_GetExtra_NoAddresses(t *testing.T) {
 	}
 }
 
-func TestUptoEvmScheme_GetExtra_MultipleAddresses_UsesFirst(t *testing.T) {
+func TestUptoEvmScheme_GetExtra_MultipleAddresses_UsesOneFromPool(t *testing.T) {
 	addr1 := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	addr2 := "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	pool := map[string]bool{addr1: true, addr2: true}
 	s := NewUptoEvmScheme(newMockSigner(addr1, addr2), nil)
 	extra := s.GetExtra(x402.Network(testNetwork))
-	if extra["facilitatorAddress"] != addr1 {
-		t.Errorf("expected first address %s, got %v", addr1, extra["facilitatorAddress"])
+	got, ok := extra["facilitatorAddress"].(string)
+	if !ok || !pool[got] {
+		t.Errorf("expected one of pool addresses, got %v", extra["facilitatorAddress"])
 	}
 }
 

--- a/go/mechanisms/evm/upto/facilitator/scheme.go
+++ b/go/mechanisms/evm/upto/facilitator/scheme.go
@@ -42,8 +42,7 @@ func (f *UptoEvmScheme) CaipFamily() string {
 }
 
 // GetExtra returns mechanism-specific extra data for the supported kinds endpoint.
-// For upto, returns a randomly selected facilitatorAddress so clients include it in
-// their signed witness. Randomizing distributes settlement load across the signer pool.
+// For upto, returns the facilitatorAddress so clients include it in their signed witness.
 func (f *UptoEvmScheme) GetExtra(_ x402.Network) map[string]interface{} {
 	addresses := f.signer.GetAddresses()
 	if len(addresses) == 0 {

--- a/go/mechanisms/evm/upto/facilitator/scheme.go
+++ b/go/mechanisms/evm/upto/facilitator/scheme.go
@@ -3,6 +3,7 @@ package facilitator
 import (
 	"context"
 	"fmt"
+	"math/rand"
 
 	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/mechanisms/evm"
@@ -41,14 +42,15 @@ func (f *UptoEvmScheme) CaipFamily() string {
 }
 
 // GetExtra returns mechanism-specific extra data for the supported kinds endpoint.
-// For upto, returns the facilitatorAddress so clients include it in their signed witness.
+// For upto, returns a randomly selected facilitatorAddress so clients include it in
+// their signed witness. Randomizing distributes settlement load across the signer pool.
 func (f *UptoEvmScheme) GetExtra(_ x402.Network) map[string]interface{} {
 	addresses := f.signer.GetAddresses()
 	if len(addresses) == 0 {
 		return nil
 	}
 	return map[string]interface{}{
-		"facilitatorAddress": addresses[0],
+		"facilitatorAddress": addresses[rand.Intn(len(addresses))],
 	}
 }
 

--- a/typescript/packages/mechanisms/evm/src/upto/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/facilitator/scheme.ts
@@ -36,7 +36,7 @@ export class UptoEvmScheme implements SchemeNetworkFacilitator {
     if (addresses.length === 0) {
       return undefined;
     }
-    return { facilitatorAddress: addresses[0] };
+    return { facilitatorAddress: addresses[Math.floor(Math.random() * addresses.length)] };
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Fixed an oversight where `addresses[0]` was used as the signing address for `upto`, rather than distributing `upto` transactions between addresses via randomizing th eindex
