### PR TITLE
[codex] Fix facilitator RNG and settlement response inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ go get github.com/coinbase/x402/go
 - **Trust minimizing:** all payment schemes must not allow for the facilitator or resource server to move funds, other than in accordance with client intentions
 - **Easy to use:** It is the goal of the x402 community to improve ease of use relative to other forms of payment on the Internet. This means abstracting as many details of crypto as possible away from the client and resource server, and into the facilitator. This means the client/server should not need to think about gas, rpc, etc.
 
+## Security Best Practices
+
+- Check counterparty risk before sending payment. x402 verifies payment mechanics, but it does not attest that a service is trustworthy or that the recipient is safe to pay.
+- Consider screening the resource server domain, IP, payout wallet, and operator identity before funding autonomous requests, especially for sanctions compliance and fraud prevention.
+- Treat payment as only one part of trust. Clients should still validate response integrity, reputation, and any application-specific safety signals before continuing automated workflows.
+
 ## Ecosystem
 
 The x402 ecosystem is growing! Check out our [ecosystem page](https://x402.org/ecosystem) to see projects building with x402, including:

--- a/go/.changes/unreleased/fixed-20260329-1845-574.yaml
+++ b/go/.changes/unreleased/fixed-20260329-1845-574.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Harden SVM facilitator fee-payer selection with crypto/rand and omit empty failed-settlement transaction hashes from Go settlement responses
+time: 2026-03-29T12:00:00-07:00

--- a/go/http/server_test.go
+++ b/go/http/server_test.go
@@ -519,6 +519,17 @@ func TestProcessSettlement_Failure(t *testing.T) {
 	if result.Headers == nil || result.Headers["PAYMENT-RESPONSE"] == "" {
 		t.Error("Expected PAYMENT-RESPONSE header on settlement failure")
 	}
+	decodedHeader, err := base64.StdEncoding.DecodeString(result.Headers["PAYMENT-RESPONSE"])
+	if err != nil {
+		t.Fatalf("failed to decode PAYMENT-RESPONSE header: %v", err)
+	}
+	var paymentResponse map[string]interface{}
+	if err := json.Unmarshal(decodedHeader, &paymentResponse); err != nil {
+		t.Fatalf("failed to unmarshal PAYMENT-RESPONSE header: %v", err)
+	}
+	if _, exists := paymentResponse["transaction"]; exists {
+		t.Errorf("expected failed settlement response to omit transaction, got %v", paymentResponse["transaction"])
+	}
 	if result.Response == nil {
 		t.Fatal("Expected Response to be set on settlement failure")
 	}

--- a/go/mechanisms/svm/exact/facilitator/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/facilitator/duplicate_tx_test.go
@@ -1,10 +1,13 @@
 package facilitator
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/mechanisms/svm"
+	solana "github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -85,4 +88,45 @@ func TestDuplicateSettlementCache(t *testing.T) {
 		assert.Same(t, cache, scheme.settlementCache,
 			"scheme should hold the exact cache instance that was injected")
 	})
+}
+
+func TestGetExtraReturnsManagedFeePayer(t *testing.T) {
+	addresses := []solana.PublicKey{
+		solana.MustPublicKeyFromBase58(svm.MemoProgramAddress),
+		solana.MustPublicKeyFromBase58(svm.LighthouseProgramAddress),
+	}
+	scheme := NewExactSvmScheme(mockFacilitatorSvmSigner{addresses: addresses})
+
+	extra := scheme.GetExtra(x402.Network("solana:mainnet"))
+
+	feePayer, ok := extra["feePayer"].(string)
+	if !ok {
+		t.Fatalf("expected feePayer string, got %T", extra["feePayer"])
+	}
+
+	assert.Contains(t, []string{addresses[0].String(), addresses[1].String()}, feePayer)
+}
+
+type mockFacilitatorSvmSigner struct {
+	addresses []solana.PublicKey
+}
+
+func (m mockFacilitatorSvmSigner) GetAddresses(context.Context, string) []solana.PublicKey {
+	return m.addresses
+}
+
+func (mockFacilitatorSvmSigner) SignTransaction(context.Context, *solana.Transaction, solana.PublicKey, string) error {
+	return nil
+}
+
+func (mockFacilitatorSvmSigner) SimulateTransaction(context.Context, *solana.Transaction, string) error {
+	return nil
+}
+
+func (mockFacilitatorSvmSigner) SendTransaction(context.Context, *solana.Transaction, string) (solana.Signature, error) {
+	return solana.Signature{}, nil
+}
+
+func (mockFacilitatorSvmSigner) ConfirmTransaction(context.Context, solana.Signature, string) error {
+	return nil
 }

--- a/go/mechanisms/svm/exact/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/facilitator/scheme.go
@@ -2,9 +2,10 @@ package facilitator
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"strconv"
 
 	solana "github.com/gagliardetto/solana-go"
@@ -53,13 +54,29 @@ func (f *ExactSvmScheme) CaipFamily() string {
 // Random selection distributes load across multiple signers.
 func (f *ExactSvmScheme) GetExtra(network x402.Network) map[string]interface{} {
 	addresses := f.signer.GetAddresses(context.Background(), string(network))
+	if len(addresses) == 0 {
+		return map[string]interface{}{}
+	}
 
 	// Randomly select from available addresses to distribute load
-	randomIndex := rand.Intn(len(addresses))
+	randomIndex := randomAddressIndex(len(addresses))
 
 	return map[string]interface{}{
 		"feePayer": addresses[randomIndex].String(),
 	}
+}
+
+func randomAddressIndex(addressCount int) int {
+	if addressCount <= 1 {
+		return 0
+	}
+
+	randomValue, err := rand.Int(rand.Reader, big.NewInt(int64(addressCount)))
+	if err != nil {
+		return 0
+	}
+
+	return int(randomValue.Int64())
 }
 
 // GetSigners returns signer addresses used by this facilitator.

--- a/go/mechanisms/svm/exact/v1/facilitator/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/duplicate_tx_test.go
@@ -1,10 +1,13 @@
 package facilitator
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	x402 "github.com/coinbase/x402/go"
 	"github.com/coinbase/x402/go/mechanisms/svm"
+	solana "github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -113,4 +116,45 @@ func TestDuplicateSettlementCacheV1(t *testing.T) {
 		assert.True(t, cache.IsDuplicate("new-2"), "fresh entry should still be cached")
 		assert.True(t, cache.IsDuplicate("new-3"), "fresh entry should still be cached")
 	})
+}
+
+func TestGetExtraReturnsManagedFeePayerV1(t *testing.T) {
+	addresses := []solana.PublicKey{
+		solana.MustPublicKeyFromBase58(svm.MemoProgramAddress),
+		solana.MustPublicKeyFromBase58(svm.LighthouseProgramAddress),
+	}
+	scheme := NewExactSvmSchemeV1(mockFacilitatorSvmSignerV1{addresses: addresses})
+
+	extra := scheme.GetExtra(x402.Network("solana:mainnet"))
+
+	feePayer, ok := extra["feePayer"].(string)
+	if !ok {
+		t.Fatalf("expected feePayer string, got %T", extra["feePayer"])
+	}
+
+	assert.Contains(t, []string{addresses[0].String(), addresses[1].String()}, feePayer)
+}
+
+type mockFacilitatorSvmSignerV1 struct {
+	addresses []solana.PublicKey
+}
+
+func (m mockFacilitatorSvmSignerV1) GetAddresses(context.Context, string) []solana.PublicKey {
+	return m.addresses
+}
+
+func (mockFacilitatorSvmSignerV1) SignTransaction(context.Context, *solana.Transaction, solana.PublicKey, string) error {
+	return nil
+}
+
+func (mockFacilitatorSvmSignerV1) SimulateTransaction(context.Context, *solana.Transaction, string) error {
+	return nil
+}
+
+func (mockFacilitatorSvmSignerV1) SendTransaction(context.Context, *solana.Transaction, string) (solana.Signature, error) {
+	return solana.Signature{}, nil
+}
+
+func (mockFacilitatorSvmSignerV1) ConfirmTransaction(context.Context, solana.Signature, string) error {
+	return nil
 }

--- a/go/mechanisms/svm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/scheme.go
@@ -2,10 +2,11 @@ package facilitator
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"strconv"
 
 	solana "github.com/gagliardetto/solana-go"
@@ -54,13 +55,29 @@ func (f *ExactSvmSchemeV1) CaipFamily() string {
 // Random selection distributes load across multiple signers.
 func (f *ExactSvmSchemeV1) GetExtra(network x402.Network) map[string]interface{} {
 	addresses := f.signer.GetAddresses(context.Background(), string(network))
+	if len(addresses) == 0 {
+		return map[string]interface{}{}
+	}
 
 	// Randomly select from available addresses to distribute load
-	randomIndex := rand.Intn(len(addresses))
+	randomIndex := randomAddressIndex(len(addresses))
 
 	return map[string]interface{}{
 		"feePayer": addresses[randomIndex].String(),
 	}
+}
+
+func randomAddressIndex(addressCount int) int {
+	if addressCount <= 1 {
+		return 0
+	}
+
+	randomValue, err := rand.Int(rand.Reader, big.NewInt(int64(addressCount)))
+	if err != nil {
+		return 0
+	}
+
+	return int(randomValue.Int64())
 }
 
 // GetSigners returns signer addresses used by this facilitator.

--- a/go/types.go
+++ b/go/types.go
@@ -94,7 +94,7 @@ type SettleResponse struct {
 	ErrorReason  string  `json:"errorReason,omitempty"`
 	ErrorMessage string  `json:"errorMessage,omitempty"`
 	Payer        string  `json:"payer,omitempty"`
-	Transaction  string  `json:"transaction"`
+	Transaction  string  `json:"transaction,omitempty"`
 	Network      Network `json:"network"`
 }
 

--- a/python/x402/changelog.d/574.bugfix.md
+++ b/python/x402/changelog.d/574.bugfix.md
@@ -1,0 +1,1 @@
+Normalize failed settlement responses to omit unavailable transaction hashes instead of serializing empty strings.

--- a/python/x402/schemas/responses.py
+++ b/python/x402/schemas/responses.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from .base import BaseX402Model, Network
 from .payments import PaymentPayload, PaymentRequirements
@@ -60,7 +60,7 @@ class SettleResponse(BaseX402Model):
         error_reason: Reason for failure (if success is False).
         error_message: Human-readable message for failure.
         payer: The payer's address.
-        transaction: Transaction hash/identifier.
+        transaction: Transaction hash/identifier when settlement succeeds.
         network: Network where settlement occurred.
     """
 
@@ -68,8 +68,15 @@ class SettleResponse(BaseX402Model):
     error_reason: str | None = None
     error_message: str | None = None
     payer: str | None = None
-    transaction: str
+    transaction: str | None = None
     network: Network
+
+    @field_validator("payer", "transaction", mode="before")
+    @classmethod
+    def normalize_optional_strings(cls, value: str | None) -> str | None:
+        if value == "":
+            return None
+        return value
 
 
 class SupportedKind(BaseX402Model):

--- a/python/x402/tests/unit/http/test_utils.py
+++ b/python/x402/tests/unit/http/test_utils.py
@@ -266,14 +266,17 @@ class TestPaymentResponseHeader:
         settle = SettleResponse(
             success=False,
             error_reason="Insufficient funds",
-            transaction="",
             network="eip155:8453",
         )
         encoded = encode_payment_response_header(settle)
+        data = json.loads(safe_base64_decode(encoded))
         decoded = decode_payment_response_header(encoded)
 
         assert decoded.success is False
         assert decoded.error_reason == "Insufficient funds"
+        assert decoded.transaction is None
+        assert "transaction" not in data
+        assert "payer" not in data
 
 
 class TestDetectPaymentRequiredVersion:

--- a/specs/transports-v1/http.md
+++ b/specs/transports-v1/http.md
@@ -118,7 +118,7 @@ The base64 response header decodes to:
 ```http
 HTTP/1.1 402 Payment Required
 Content-Type: application/json
-X-PAYMENT-RESPONSE: eyJzdWNjZXNzIjpmYWxzZSwiZXJyb3JSZWFzb24iOiJpbnN1ZmZpY2llbnRfZnVuZHMiLCJ0cmFuc2FjdGlvbiI6IiIsIm5ldHdvcmsiOiJiYXNlLXNlcG9saWEiLCJwYXllciI6IjB4ODU3YjA2NTE5RTkxZTNBNTQ1Mzg3OTFiRGJiMEUyMjM3M2UzNmI2NiJ9
+X-PAYMENT-RESPONSE: eyJzdWNjZXNzIjpmYWxzZSwiZXJyb3JSZWFzb24iOiJpbnN1ZmZpY2llbnRfZnVuZHMiLCJuZXR3b3JrIjoiYmFzZS1zZXBvbGlhIn0=
 
 {
   "x402Version": 1,

--- a/specs/transports-v2/http.md
+++ b/specs/transports-v2/http.md
@@ -141,7 +141,7 @@ The base64 response header decodes to:
 ```http
 HTTP/1.1 402 Payment Required
 Content-Type: application/json
-PAYMENT-RESPONSE: eyJzdWNjZXNzIjpmYWxzZSwiZXJyb3JSZWFzb24iOiJpbnN1ZmZpY2llbnRfZnVuZHMiLCJ0cmFuc2FjdGlvbiI6IiIsIm5ldHdvcmsiOiJlaXAxNTU6ODQ1MzIiLCJwYXllciI6IjB4ODU3YjA2NTE5RTkxZTNBNTQ1Mzg3OTFiRGJiMEUyMjM3M2UzNmI2NiJ9
+PAYMENT-RESPONSE: eyJzdWNjZXNzIjpmYWxzZSwiZXJyb3JSZWFzb24iOiJpbnN1ZmZpY2llbnRfZnVuZHMiLCJuZXR3b3JrIjoiZWlwMTU1Ojg0NTMyIn0=
 
 {}
 ```
@@ -152,9 +152,7 @@ The base64 response header decodes to:
 {
   "success": false,
   "errorReason": "insufficient_funds",
-  "transaction": "",
-  "network": "eip155:84532",
-  "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66"
+  "network": "eip155:84532"
 }
 ```
 

--- a/specs/x402-specification-v1.md
+++ b/specs/x402-specification-v1.md
@@ -206,9 +206,9 @@ The `SettlementResponse` schema contains the following fields:
 | ------------- | --------- | -------- | --------------------------------------------------------------- |
 | `success`     | `boolean` | Required | Indicates whether the payment settlement was successful         |
 | `errorReason` | `string`  | Optional | Error reason if settlement failed (omitted if successful)       |
-| `transaction` | `string`  | Required | Blockchain transaction hash (empty string if settlement failed) |
+| `transaction` | `string`  | Optional | Blockchain transaction hash when settlement succeeds            |
 | `network`     | `string`  | Required | Blockchain network identifier                                   |
-| `payer`       | `string`  | Required | Address of the payer's wallet                                   |
+| `payer`       | `string`  | Optional | Address of the payer's wallet when it can be determined         |
 
 **6. Payment Schemes (The Logic)**
 
@@ -371,8 +371,6 @@ Executes a verified payment by broadcasting the transaction to the blockchain.
 {
   "success": false,
   "errorReason": "insufficient_funds",
-  "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-  "transaction": "",
   "network": "base-sepolia"
 }
 ```

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -235,8 +235,8 @@ The `SettleResponse` schema contains the following fields:
 | ------------- | --------- | -------- | --------------------------------------------------------------------- |
 | `success`     | `boolean` | Required | Indicates whether the payment settlement was successful               |
 | `errorReason` | `string`  | Optional | Error reason if settlement failed (omitted if successful)             |
-| `payer`       | `string`  | Optional | Address of the payer's wallet                                         |
-| `transaction` | `string`  | Required | Blockchain transaction hash (empty string if settlement failed)       |
+| `payer`       | `string`  | Optional | Address of the payer's wallet when it can be determined               |
+| `transaction` | `string`  | Optional | Blockchain transaction hash when settlement succeeds                  |
 | `network`     | `string`  | Required | Blockchain network identifier in CAIP-2 format                        |
 | `extensions`  | `object`  | Optional | Protocol extensions data          |
 
@@ -428,8 +428,6 @@ Executes a verified payment by broadcasting the transaction to the blockchain.
 {
   "success": false,
   "errorReason": "insufficient_funds",
-  "payer": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
-  "transaction": "",
   "network": "eip155:84532"
 }
 ```

--- a/typescript/.changeset/settlement-response-and-paywall-regression.md
+++ b/typescript/.changeset/settlement-response-and-paywall-regression.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Normalize failed settlement responses to omit unavailable transaction hashes and preserve paywall current URLs with query parameters

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -95,8 +95,11 @@ const settleResponseSchema: z.ZodType<SettleResponse, z.ZodTypeDef, unknown> = z
   payer: z
     .string()
     .nullish()
-    .transform(v => v ?? undefined),
-  transaction: z.string(),
+    .transform(v => (v && v.length > 0 ? v : undefined)),
+  transaction: z
+    .string()
+    .nullish()
+    .transform(v => (v && v.length > 0 ? v : undefined)),
   network: z.custom<SettleResponse["network"]>(value => typeof value === "string"),
   extensions: z
     .record(z.string(), z.unknown())

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -1,4 +1,4 @@
-import { SettleResponse } from "../types";
+import { normalizeSettleResponse, SettleResponse } from "../types";
 import { PaymentPayload, PaymentRequired } from "../types/payments";
 import { Base64EncodedRegex, safeBase64Decode, safeBase64Encode } from "../utils";
 
@@ -61,7 +61,7 @@ export function decodePaymentRequiredHeader(paymentRequiredHeader: string): Paym
  * @returns Base64 encoded string representation of the payment response
  */
 export function encodePaymentResponseHeader(paymentResponse: SettleResponse): string {
-  return safeBase64Encode(JSON.stringify(paymentResponse));
+  return safeBase64Encode(JSON.stringify(normalizeSettleResponse(paymentResponse)));
 }
 
 /**
@@ -74,7 +74,9 @@ export function decodePaymentResponseHeader(paymentResponseHeader: string): Sett
   if (!Base64EncodedRegex.test(paymentResponseHeader)) {
     throw new Error("Invalid payment response header");
   }
-  return JSON.parse(safeBase64Decode(paymentResponseHeader)) as SettleResponse;
+  return normalizeSettleResponse(
+    JSON.parse(safeBase64Decode(paymentResponseHeader)) as SettleResponse,
+  );
 }
 
 // Export HTTP service and types

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -13,6 +13,7 @@ import {
   Price,
   Network,
   PaymentRequirements,
+  normalizeSettleResponse,
 } from "../types";
 import { x402Version } from "..";
 
@@ -610,12 +611,14 @@ export class x402HTTPResourceServer {
         }
       }
 
-      const settleResponse = await this.ResourceServer.settlePayment(
-        paymentPayload,
-        requirements,
-        declaredExtensions,
-        transportContext,
-        resolvedOverrides,
+      const settleResponse = normalizeSettleResponse(
+        await this.ResourceServer.settlePayment(
+          paymentPayload,
+          requirements,
+          declaredExtensions,
+          transportContext,
+          resolvedOverrides,
+        ),
       );
 
       if (!settleResponse.success) {
@@ -643,14 +646,14 @@ export class x402HTTPResourceServer {
       }
       if (error instanceof SettleError) {
         const errorReason = error.errorReason || error.message;
-        const settleResponse: SettleResponse = {
+        const settleResponse = normalizeSettleResponse({
           success: false,
           errorReason,
           errorMessage: error.errorMessage || errorReason,
           payer: error.payer,
           network: error.network,
           transaction: error.transaction,
-        };
+        });
         const failure = {
           ...settleResponse,
           success: false as const,
@@ -661,13 +664,12 @@ export class x402HTTPResourceServer {
         return { ...failure, response };
       }
       const errorReason = error instanceof Error ? error.message : "Settlement failed";
-      const settleResponse: SettleResponse = {
+      const settleResponse = normalizeSettleResponse({
         success: false,
         errorReason,
         errorMessage: errorReason,
         network: requirements.network as Network,
-        transaction: "",
-      };
+      });
       const failure = {
         ...settleResponse,
         success: false as const,

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -4,6 +4,7 @@ import {
   VerifyResponse,
   SupportedResponse,
   SupportedKind,
+  normalizeSettleResponse,
 } from "../types/facilitator";
 import {
   PaymentPayload,
@@ -802,25 +803,29 @@ export class x402ResourceServer {
       try {
         const result = await hook(context);
         if (result && "abort" in result && result.abort) {
-          throw new SettleError(400, {
-            success: false,
-            errorReason: result.reason,
-            errorMessage: result.message,
-            transaction: "",
-            network: requirements.network,
-          });
+          throw new SettleError(
+            400,
+            normalizeSettleResponse({
+              success: false,
+              errorReason: result.reason,
+              errorMessage: result.message,
+              network: requirements.network,
+            }),
+          );
         }
       } catch (error) {
         if (error instanceof SettleError) {
           throw error;
         }
-        throw new SettleError(400, {
-          success: false,
-          errorReason: "before_settle_hook_error",
-          errorMessage: error instanceof Error ? error.message : "",
-          transaction: "",
-          network: requirements.network,
-        });
+        throw new SettleError(
+          400,
+          normalizeSettleResponse({
+            success: false,
+            errorReason: "before_settle_hook_error",
+            errorMessage: error instanceof Error ? error.message : "",
+            network: requirements.network,
+          }),
+        );
       }
     }
 

--- a/typescript/packages/core/src/types/facilitator.ts
+++ b/typescript/packages/core/src/types/facilitator.ts
@@ -26,12 +26,28 @@ export type SettleResponse = {
   errorReason?: string;
   errorMessage?: string;
   payer?: string;
-  transaction: string;
+  transaction?: string;
   network: Network;
   /** Actual amount settled in atomic token units. Present for schemes like `upto` where settlement amount may differ from the authorized maximum. */
   amount?: string;
   extensions?: Record<string, unknown>;
 };
+
+function normalizeOptionalSettleField(value?: string | null): string | undefined {
+  if (typeof value !== "string" || value.length === 0) {
+    return undefined;
+  }
+
+  return value;
+}
+
+export function normalizeSettleResponse(response: SettleResponse): SettleResponse {
+  return {
+    ...response,
+    payer: normalizeOptionalSettleField(response.payer),
+    transaction: normalizeOptionalSettleField(response.transaction),
+  };
+}
 
 export type SupportedKind = {
   x402Version: number;
@@ -80,7 +96,7 @@ export class SettleError extends Error {
   readonly errorReason?: string;
   readonly errorMessage?: string;
   readonly payer?: string;
-  readonly transaction: string;
+  readonly transaction?: string;
   readonly network: Network;
   readonly statusCode: number;
 
@@ -98,8 +114,8 @@ export class SettleError extends Error {
     this.statusCode = statusCode;
     this.errorReason = response.errorReason;
     this.errorMessage = response.errorMessage;
-    this.payer = response.payer;
-    this.transaction = response.transaction;
+    this.payer = normalizeOptionalSettleField(response.payer);
+    this.transaction = normalizeOptionalSettleField(response.transaction);
     this.network = response.network;
   }
 }

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -10,6 +10,7 @@ export {
   SettleError,
   FacilitatorResponseError,
   getFacilitatorResponseError,
+  normalizeSettleResponse,
 } from "./facilitator";
 export type {
   PaymentRequirements,

--- a/typescript/packages/core/src/types/v1/index.ts
+++ b/typescript/packages/core/src/types/v1/index.ts
@@ -46,7 +46,7 @@ export type SettleResponseV1 = {
   errorReason?: string;
   errorMessage?: string;
   payer?: string;
-  transaction: string;
+  transaction?: string;
   network: Network;
 };
 

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -97,7 +97,6 @@ describe("HTTPFacilitatorClient", () => {
           JSON.stringify({
             success: false,
             errorReason: "insufficient_allowance",
-            transaction: "",
             network: "eip155:8453",
           }),
           { status: 400 },
@@ -107,7 +106,11 @@ describe("HTTPFacilitatorClient", () => {
 
     const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
 
-    await expect(client.settle(paymentPayload, paymentRequirements)).rejects.toThrow(SettleError);
+    await expect(client.settle(paymentPayload, paymentRequirements)).rejects.toMatchObject({
+      name: "SettleError",
+      errorReason: "insufficient_allowance",
+      transaction: undefined,
+    });
   });
 
   it("parses verify 200 when optional string fields are JSON null", async () => {

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -4,6 +4,7 @@ import {
   HTTPRequestContext,
   HTTPAdapter,
 } from "../../../src/http/x402HTTPResourceServer";
+import { decodePaymentResponseHeader } from "../../../src/http";
 import { x402ResourceServer } from "../../../src/server/x402ResourceServer";
 import {
   MockFacilitatorClient,
@@ -824,6 +825,10 @@ describe("x402HTTPResourceServer", () => {
         expect(result.errorReason).toBe("Insufficient funds");
         expect(result.headers).toBeDefined();
         expect(result.headers["PAYMENT-RESPONSE"]).toBeDefined();
+        expect(result.transaction).toBeUndefined();
+        expect(
+          decodePaymentResponseHeader(result.headers["PAYMENT-RESPONSE"]).transaction,
+        ).toBeUndefined();
       }
     });
 

--- a/typescript/packages/http/paywall/src/builder.test.ts
+++ b/typescript/packages/http/paywall/src/builder.test.ts
@@ -131,11 +131,17 @@ describe("PaywallBuilder", () => {
       expect(html).toContain("0.1");
     });
 
-    it("uses resource URL as currentUrl when not provided", () => {
+    it("preserves query params when using the resource URL as currentUrl", () => {
       const paywall = createPaywall().withNetwork(evmPaywall).build();
-      const html = paywall.generateHtml(mockPaymentRequired);
+      const html = paywall.generateHtml({
+        ...mockPaymentRequired,
+        resource: {
+          ...mockPaymentRequired.resource,
+          url: "https://example.com/api/data?city=sf&units=metric",
+        },
+      });
 
-      expect(html).toContain("https://example.com/api/data");
+      expect(html).toContain("https://example.com/api/data?city=sf&units=metric");
     });
 
     it("defaults to testnet when not specified", () => {


### PR DESCRIPTION
## Summary
- switch Go SVM facilitator fee-payer selection from `math/rand` to `crypto/rand` and add focused coverage for managed fee-payer selection (#1845)
- add a README security best-practices section that recommends counterparty risk checks before autonomous payments (#1817)
- normalize failed settlement responses across Go, TypeScript, Python, and the shared specs so unavailable `transaction` and `payer` values are omitted instead of serialized as placeholders (#574)
- add a paywall regression test that preserves query parameters in `currentUrl`, complementing the already-landed Express adapter fix related to query-string stripping (#894)

## Root Cause
- the Go SVM facilitator still used `math/rand` for fee-payer selection in financial infrastructure code
- settlement response types and examples treated missing failure data as required empty strings, which drifted across SDKs and docs
- the Express query-param bug was fixed at the adapter layer, but there was no higher-level regression coverage guarding the paywall URL flow

## Impact
- Go SVM fee-payer selection now uses cryptographic randomness
- failed settlement responses no longer need empty-string transaction hashes and can omit payer information when unknown
- client, server, and spec behavior is aligned across the reference SDKs
- paywall generation keeps full resource URLs, including query strings

## Validation
- `go test ./mechanisms/svm/exact/facilitator ./mechanisms/svm/exact/v1/facilitator ./http`
- `uv run pytest tests/unit/http/test_utils.py`
- `pnpm --filter @x402/core exec vitest run test/unit/http/httpFacilitatorClient.test.ts test/unit/http/x402HTTPResourceService.test.ts`
- `pnpm --filter @x402/paywall exec vitest run src/builder.test.ts`
