### PR TITLE
Refresh Augur ecosystem listing copy

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/augur/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/augur/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Augur",
-  "description": "Base mainnet smart contract bytecode risk scoring API for agents and the developers building them. Pay $0.10/call via x402 in USDC on Base and get deterministic findings plus a 0-100 score. \"safe\" is not an audit or guarantee.",
+  "description": "Deterministic Base contract admission control for agents. Pay $0.10/call via x402 in USDC on Base to get a default decision, policy recommendation, and supporting findings before your agent buys, routes funds, approves, pays, or interacts with a contract.",
   "logoUrl": "/logos/augur.png",
   "websiteUrl": "https://augurrisk.com/",
   "category": "Services/Endpoints"


### PR DESCRIPTION
This updates the Augur ecosystem card to match the endpoint as it works today.

The old description still framed Augur mainly as a score-first bytecode API. The new copy makes the use case clearer: contract admission control for agents, with a default decision, policy recommendation, and supporting findings before an agent interacts with a contract.