### PR TITLE
ecosystem: add KYA — consumer-side spending controls for x402 agents

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/kya/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/kya/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "KYA — Know Your Agent",
+  "description": "Consumer-side spending control proxy for AI agents making x402 payments. Enforces per-session budgets, tool allowlists, rate limits, and audit trails between agents and paid MCP tools. Manages agent wallets on Base/USDC with automatic 402→pay→retry flow.",
+  "logoUrl": "/logos/kya.svg",
+  "websiteUrl": "https://github.com/sm11t/KYA",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/kya.svg
+++ b/typescript/site/public/logos/kya.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <rect width="400" height="400" rx="48" fill="#0d1117"/>
+  <text x="200" y="220" text-anchor="middle" font-family="monospace" font-weight="bold" font-size="120" fill="#58a6ff">KYA</text>
+  <text x="200" y="290" text-anchor="middle" font-family="monospace" font-size="28" fill="#8b949e">Know Your Agent</text>
+  <rect x="60" y="320" width="280" height="4" rx="2" fill="#21262d"/>
+  <rect x="60" y="320" width="180" height="4" rx="2" fill="#3fb950"/>
+</svg>


### PR DESCRIPTION
## What is KYA?

**KYA (Know Your Agent)** is an open-source MCP proxy that adds budget enforcement, policies, and audit trails on the **agent-owner side** of x402 payments.

### The gap it fills

| Layer | Who's Building | Example |
|-------|---------------|---------|
| Payment rails | Protocol teams | x402, Stripe MPP |
| Tool monetization | Tool providers | AgentPay, Nevermined |
| **Agent spending control** | **KYA** | Budget enforcement, audit, identity |

x402 solves how agents pay. KYA solves **how agent owners control what their agents spend** — the corporate card for AI agents.

### Features
- MCP proxy enforcing per-session budgets, tool allowlists/blocklists, rate limits via JSON policies
- x402 `402→pay→retry` flow with policy checks before any payment
- Agent wallets on Base/USDC (via viem)
- Full audit ledger (SQLite) + real-time dashboard
- JWT-based agent identity
- CLI tool (`kya init`, `kya start`, `kya wallet`, etc.)
- 112 tests, MIT licensed, built on Bun with zero external frameworks

### Links
- **GitHub:** https://github.com/sm11t/KYA
- **Live Demo:** https://www.asmit.space/kya

### Category
**Infrastructure & Tooling** — KYA sits between agents and x402-enabled MCP tools as a control plane.

### Checklist
- [x] Working integration with x402 (handles HTTP 402 challenges, parses payment headers, manages wallet debits, retries with proof)
- [x] Link to code/documentation (GitHub README with full API reference, policy reference, architecture docs)
- [x] Actively maintained
- [x] Clear setup instructions (`bun install && kya init && kya start --x402`)
- [x] Demonstrates practical use case (agent spending controls — budget enforcement, audit trails, policy engine)
- [x] Logo added to `public/logos/kya.svg`
- [x] Metadata added to `app/ecosystem/partners-data/kya/metadata.json`