### PR TITLE
ecosystem: add Vealth x402 cloud functions

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/vealth/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/vealth/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Vealth",
+  "description": "Four x402 pay-per-call cloud functions for trading agents and ecological data: Kelly position sizing ($0.001), portfolio risk gate ($0.002), Regen Ledger credit oracle ($0.005), and AI prediction market edge scoring ($0.01). USDC on Base.",
+  "logoUrl": "/logos/vealth.svg",
+  "websiteUrl": "https://vealth.net",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/vealth.svg
+++ b/typescript/site/public/logos/vealth.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <rect width="120" height="120" rx="16" fill="#1a1a2e"/>
+  <text x="60" y="72" font-family="system-ui, sans-serif" font-size="48" font-weight="700" fill="#e8a0bf" text-anchor="middle">V</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds **Vealth** to the x402 ecosystem directory under **Services/Endpoints**.

Vealth exposes four pay-per-call x402 cloud functions for trading agents and ecological data, settled in USDC on Base:

| Function | Price | What it does |
|---|---|---|
| **Kelly position sizing** | $0.001 | Optimal bet size given edge, bankroll, and Kelly fraction |
| **Portfolio risk gate** | $0.002 | Pre-trade risk check across open positions (max drawdown, correlation, concentration) |
| **Regen Ledger credit oracle** | $0.005 | Real-time ecological credit pricing and availability from Regen Network |
| **AI prediction market edge scoring** | $0.01 | LLM-scored divergence between model probability and market odds |

**Settlement wallet:** USDC on Base  
**Website:** https://vealth.net

## Files added

- `typescript/site/app/ecosystem/partners-data/vealth/metadata.json` — partner metadata
- `typescript/site/public/logos/vealth.svg` — logo (minimal SVG)

## Test plan

- [ ] Verify `metadata.json` parses correctly and partner appears on ecosystem page
- [ ] Verify SVG logo renders at expected sizes (28px sidebar, 56px card)
- [ ] Confirm category "Services/Endpoints" groups correctly with other service partners