### PR TITLE
fix(core): isolate afterVerify and afterSettle hook errors from payment outcomes

### DIFF
--- a/typescript/packages/core/src/facilitator/x402Facilitator.ts
+++ b/typescript/packages/core/src/facilitator/x402Facilitator.ts
@@ -372,7 +372,11 @@ export class x402Facilitator {
       };
 
       for (const hook of this.afterVerifyHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (hookError) {
+          console.error("afterVerify hook threw an error (payment succeeded):", hookError);
+        }
       }
 
       return verifyResult;
@@ -464,7 +468,11 @@ export class x402Facilitator {
       };
 
       for (const hook of this.afterSettleHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (hookError) {
+          console.error("afterSettle hook threw an error (settlement succeeded):", hookError);
+        }
       }
 
       return settleResult;

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -744,7 +744,11 @@ export class x402ResourceServer {
       };
 
       for (const hook of this.afterVerifyHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (hookError) {
+          console.error("afterVerify hook threw an error (payment succeeded):", hookError);
+        }
       }
 
       return verifyResult;
@@ -875,7 +879,11 @@ export class x402ResourceServer {
       };
 
       for (const hook of this.afterSettleHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (hookError) {
+          console.error("afterSettle hook threw an error (settlement succeeded):", hookError);
+        }
       }
 
       // Let declared extensions add data to settlement response

--- a/typescript/packages/core/test/unit/facilitator/x402Facilitator.hooks.test.ts
+++ b/typescript/packages/core/test/unit/facilitator/x402Facilitator.hooks.test.ts
@@ -331,4 +331,51 @@ describe("x402Facilitator - Lifecycle Hooks", () => {
       expect(result).toBe(facilitator);
     });
   });
+
+  describe("hook error isolation", () => {
+    it("should not treat payment as failed when afterVerify hook throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      facilitator.onAfterVerify(async () => {
+        throw new Error("Hook side-effect failed");
+      });
+
+      // Payment verification succeeded — hook error must not surface as a verify failure
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+      expect(result.isValid).toBe(true);
+    });
+
+    it("should not treat settlement as failed when afterSettle hook throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      facilitator.onAfterSettle(async () => {
+        throw new Error("Hook side-effect failed");
+      });
+
+      // Settlement succeeded — hook error must not surface as a settle failure
+      const result = await facilitator.settle(buildPaymentPayload(), buildPaymentRequirements());
+      expect(result.success).toBe(true);
+    });
+
+    it("should continue remaining afterVerify hooks after one throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      let secondHookCalled = false;
+
+      facilitator
+        .onAfterVerify(async () => {
+          throw new Error("First hook fails");
+        })
+        .onAfterVerify(async () => {
+          secondHookCalled = true;
+        });
+
+      await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+      expect(secondHookCalled).toBe(true);
+    });
+  });
+
 });

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -545,6 +545,43 @@ describe("x402ResourceServer", () => {
       });
     });
 
+    describe("hook error isolation", () => {
+      it("should not treat payment as failed when afterVerify hook throws", async () => {
+        server.onAfterVerify(async () => {
+          throw new Error("Hook side-effect failed");
+        });
+
+        // Hook error must not surface as a verify failure
+        const result = await server.verifyPayment(buildPaymentPayload(), buildPaymentRequirements());
+        expect(result.isValid).toBe(true);
+      });
+
+      it("should continue remaining afterVerify hooks after one throws", async () => {
+        let secondHookCalled = false;
+
+        server
+          .onAfterVerify(async () => {
+            throw new Error("First hook fails");
+          })
+          .onAfterVerify(async () => {
+            secondHookCalled = true;
+          });
+
+        await server.verifyPayment(buildPaymentPayload(), buildPaymentRequirements());
+        expect(secondHookCalled).toBe(true);
+      });
+
+      it("should not treat settlement as failed when afterSettle hook throws", async () => {
+        server.onAfterSettle(async () => {
+          throw new Error("Hook side-effect failed");
+        });
+
+        // Hook error must not surface as a settle failure
+        const result = await server.settlePayment(buildPaymentPayload(), buildPaymentRequirements());
+        expect(result.success).toBe(true);
+      });
+    });
+
     describe("onVerifyFailure", () => {
       it("should execute when verification fails", async () => {
         let hookExecuted = false;


### PR DESCRIPTION
## Summary

Fixes #1826.

Lifecycle hooks (`afterVerify`, `afterSettle`) ran inside the main `try` block in both `x402ResourceServer` and `x402Facilitator`. If a hook threw, the error fell into the `onVerifyFailure` / `onSettleFailure` catch path, incorrectly treating a **successful** payment as a failure.

### Root cause

```typescript
// Before: hook error falls into the catch block
for (const hook of this.afterVerifyHooks) {
  await hook(resultContext); // throws → caught as verify failure
}
```

### Fix

Wrap each hook invocation in its own `try/catch` and log the error so hook side-effects (logging, metrics, notifications) cannot corrupt payment state:

```typescript
for (const hook of this.afterVerifyHooks) {
  try {
    await hook(resultContext);
  } catch (hookError) {
    console.error("afterVerify hook threw an error (payment succeeded):", hookError);
  }
}
```

### Files changed

- `packages/core/src/server/x402ResourceServer.ts` — `afterVerify` and `afterSettle` hook isolation
- `packages/core/src/facilitator/x402Facilitator.ts` — same fix for facilitator hooks

### Tests added

- Hook throws → verify/settle result is still returned as success
- Second hook still executes after first throws
- Settlement hook throws → settlement result still returned as success

All 97 existing tests continue to pass.