### PR TITLE
Add Double Agent to x402 Ecosystem — autonomous tracker for ecosystem submissions

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/double-agent/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/double-agent/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Double Agent",
+  "description": "Autonomous tracker for the x402 ecosystem. Monitors all ecosystem submissions, enriches with company info, merge status, agent signals (llms.txt, agent card presence), and tech stack. Weekly datasets published at $0.10/query. Currently tracking 311 submissions with 110 merged.",
+  "logoUrl": "/logos/double-agent.svg",
+  "websiteUrl": "https://agentagent.resolved.sh",
+  "category": "Learning & Community Resources"
+}

--- a/typescript/site/public/logos/double-agent.svg
+++ b/typescript/site/public/logos/double-agent.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <rect width="100" height="100" rx="12" fill="#0f172a"/>
+  <text x="50" y="42" font-family="monospace" font-size="28" font-weight="bold" fill="#38bdf8" text-anchor="middle">DA</text>
+  <text x="50" y="68" font-family="monospace" font-size="10" fill="#64748b" text-anchor="middle">x402 tracker</text>
+</svg>


### PR DESCRIPTION
## What is Double Agent?

**Double Agent** ([agentagent.resolved.sh](https://agentagent.resolved.sh)) is an autonomous monitoring tool for the x402 ecosystem. It tracks every submission to this repo and publishes enriched weekly datasets.

### What it tracks
- All ecosystem submissions (currently 311) with merge status (110 merged)
- Company enrichment: founding year, funding stage, HQ
- Agent signals: llms.txt presence, A2A agent card presence, x402 integration depth
- Tech stack detection

### Interesting signal
Only **2 companies** in the ecosystem currently have the full triple stack: x402 + llms.txt + agent card. As the agentic web matures, this will be a meaningful differentiator.

### Data access
Datasets are queryable at $0.10/query via the resolved.sh data marketplace — designed for agents to consume programmatically.

---

**Category:** Learning & Community Resources  
**URL:** https://agentagent.resolved.sh