### PR TITLE
fix: settlement overrides for upto in typescript sdk

### DIFF
--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -600,13 +600,17 @@ export class x402HTTPResourceServer {
     try {
       // Resolve overrides: explicit param takes precedence, fall back to response header
       let resolvedOverrides = settlementOverrides;
-      if (!resolvedOverrides && transportContext?.responseHeaders?.[SETTLEMENT_OVERRIDES_HEADER]) {
-        try {
-          resolvedOverrides = JSON.parse(
-            transportContext.responseHeaders[SETTLEMENT_OVERRIDES_HEADER],
-          );
-        } catch {
-          // Ignore malformed header
+      if (!resolvedOverrides && transportContext?.responseHeaders) {
+        const overridesKey = SETTLEMENT_OVERRIDES_HEADER.toLowerCase();
+        const rawValue = Object.entries(transportContext.responseHeaders).find(
+          ([key]) => key.toLowerCase() === overridesKey,
+        )?.[1];
+        if (rawValue) {
+          try {
+            resolvedOverrides = JSON.parse(rawValue);
+          } catch {
+            // Ignore malformed header
+          }
         }
       }
 


### PR DESCRIPTION
## Description

Fix a bug with the Typescript SDK where `upto` could not properly have its amount/price values overridden due to header case sensitivity issues

## Tests

Manually tested via examples

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)