### PR TITLE
feat: updated pypi workflow to use trusted publishing

### DIFF
--- a/.github/workflows/publish_pypi_x402.yml
+++ b/.github/workflows/publish_pypi_x402.yml
@@ -14,6 +14,7 @@ jobs:
       url: https://pypi.org/p/x402
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -45,4 +46,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           packages-dir: python/x402/dist/
-          password: ${{ secrets.PYPI_X402_TOKEN }}


### PR DESCRIPTION
The x402 pypi package is moving towards using trusted publishing

Two changes made:

1. **Added `id-token: write`** to permissions — required for the GitHub Actions OIDC token that PyPI trusted publishing uses.
2. **Removed the `password: ${{ secrets.PYPI_X402_TOKEN }}`** line — when no password is provided, `pypa/gh-action-pypi-publish` automatically falls back to OIDC trusted publishing.

This assumes we've already configured the trusted publisher on PyPI for the `x402` package to trust the `x402-foundation/x402` repo, the `publish_pypi_x402.yml` workflow, and the `pypi` environment.
