### PR TITLE
fix(evm): restore Mezo Testnet default asset dropped in v2.9.0 refactor

### DIFF
--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -97,6 +97,14 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     version: "2",
     decimals: 6,
   }, // Arbitrum Sepolia USDC
+  "eip155:31611": {
+    address: "0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503",
+    name: "Mezo USD",
+    version: "1",
+    decimals: 18,
+    assetTransferMethod: "permit2",
+    supportsEip2612: true,
+  }, // Mezo Testnet mUSD (no EIP-3009, supports EIP-2612)
 };
 
 /**


### PR DESCRIPTION
Fixes #1919

## Summary

Re-adds Mezo Testnet mUSD (chain ID 31611) to `DEFAULT_STABLECOINS` in `shared/defaultAssets.ts`. This entry was originally added in #1774 but lost during the upto refactor in #1773 which extracted default assets to a shared module.

## Changes

- Add `eip155:31611` entry to `DEFAULT_STABLECOINS` in `typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts`

Requesting a patch release (v2.9.1) to align the TypeScript SDK with Go and Python, and to correct the v2.9.0 CHANGELOG discrepancy.