### PR TITLE
fix(python): add follow_redirects=True to httpx client retry request

### DIFF
--- a/python/x402/src/x402/clients/httpx.py
+++ b/python/x402/src/x402/clients/httpx.py
@@ -59,7 +59,7 @@ class HttpxHooks:
             request.headers["Access-Control-Expose-Headers"] = "X-Payment-Response"
 
             # Retry the request
-            async with AsyncClient() as client:
+            async with AsyncClient(follow_redirects=True) as client:
                 retry_response = await client.send(request)
 
                 # Copy the retry response data to the original response


### PR DESCRIPTION
## Summary

- The `AsyncClient()` used for retrying 402 payment requests in `x402/clients/httpx.py` does not follow HTTP redirects by default (`httpx` defaults `follow_redirects` to `False`)
- This causes failures when the payment-protected server responds with a redirect after successful payment
- The facilitator client (`x402/facilitator.py`) already has `follow_redirects=True` on all its requests, but the httpx payment client was missing it

## Changes

- Added `follow_redirects=True` to the `AsyncClient()` constructor in `HttpxHooks.on_response()` retry logic

## Test plan

- [ ] Verify existing Python httpx client tests still pass
- [ ] Test with a server that issues redirects after payment to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)