### PR TITLE
refactor: deduplicate checkIfBazaarNeeded across HTTP packages

### DIFF
--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -178,6 +178,22 @@ export interface RouteConfig {
 export type RoutesConfig = Record<string, RouteConfig> | RouteConfig;
 
 /**
+ * Check if any routes in the configuration declare bazaar extensions.
+ *
+ * @param routes - Route configuration
+ * @returns True if any route has extensions.bazaar defined
+ */
+export function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
+  if ("accepts" in routes) {
+    return !!(routes.extensions && "bazaar" in routes.extensions);
+  }
+
+  return Object.values(routes).some(routeConfig => {
+    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
+  });
+}
+
+/**
  * Hook that runs on every request to a protected route, before payment processing.
  * Can grant access without payment, deny the request, or continue to payment flow.
  *
@@ -1078,4 +1094,20 @@ export class x402HTTPResourceServer {
     }
     return 0;
   }
+}
+
+/**
+ * Check if any routes in the configuration declare bazaar extensions
+ *
+ * @param routes - Route configuration
+ * @returns True if any route has extensions.bazaar defined
+ */
+export function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
+  if ("accepts" in routes) {
+    return !!(routes.extensions && "bazaar" in routes.extensions);
+  }
+
+  return Object.values(routes).some(routeConfig => {
+    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
+  });
 }

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1095,19 +1095,3 @@ export class x402HTTPResourceServer {
     return 0;
   }
 }
-
-/**
- * Check if any routes in the configuration declare bazaar extensions
- *
- * @param routes - Route configuration
- * @returns True if any route has extensions.bazaar defined
- */
-export function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  if ("accepts" in routes) {
-    return !!(routes.extensions && "bazaar" in routes.extensions);
-  }
-
-  return Object.values(routes).some(routeConfig => {
-    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
-  });
-}

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -25,6 +25,7 @@ export {
   x402HTTPResourceServer,
   RouteConfigurationError,
   SETTLEMENT_OVERRIDES_HEADER,
+  checkIfBazaarNeeded,
 } from "../http/x402HTTPResourceServer";
 export type {
   HTTPRequestContext,

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -81,6 +81,7 @@ vi.mock("@x402/core/server", () => ({
       registerExtension: vi.fn(),
     },
   })),
+  checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
 }));
 
 // --- Mock Factories ---

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -10,6 +10,7 @@ import {
   getFacilitatorResponseError,
   SETTLEMENT_OVERRIDES_HEADER,
   SettlementOverrides,
+  checkIfBazaarNeeded,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { NextFunction, Request, Response } from "express";
@@ -24,24 +25,6 @@ import { ExpressAdapter } from "./adapter";
  */
 export function setSettlementOverrides(res: Response, overrides: SettlementOverrides): void {
   res.setHeader(SETTLEMENT_OVERRIDES_HEADER, JSON.stringify(overrides));
-}
-
-/**
- * Check if any routes in the configuration declare bazaar extensions
- *
- * @param routes - Route configuration
- * @returns True if any route has extensions.bazaar defined
- */
-function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  // Handle single route config
-  if ("accepts" in routes) {
-    return !!(routes.extensions && "bazaar" in routes.extensions);
-  }
-
-  // Handle multiple routes
-  return Object.values(routes).some(routeConfig => {
-    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
-  });
 }
 
 /**

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -80,6 +80,7 @@ vi.mock("@x402/core/server", () => ({
       registerExtension: vi.fn(),
     },
   })),
+  checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
 }));
 
 // --- Hook Capture ---

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -11,6 +11,7 @@ import {
   getFacilitatorResponseError,
   SETTLEMENT_OVERRIDES_HEADER,
   SettlementOverrides,
+  checkIfBazaarNeeded,
 } from "@x402/core/server";
 import {
   SchemeNetworkServer,
@@ -114,22 +115,6 @@ function getResponseBodyBuffer(payload: unknown): Buffer | undefined {
   }
 
   return Buffer.from(JSON.stringify(payload ?? {}));
-}
-
-/**
- * Check if any routes in the configuration declare bazaar extensions.
- *
- * @param routes - Route configuration
- * @returns True if any route has extensions.bazaar defined
- */
-function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  if ("accepts" in routes) {
-    return !!(routes.extensions && "bazaar" in routes.extensions);
-  }
-
-  return Object.values(routes).some(routeConfig => {
-    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
-  });
 }
 
 /**

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -81,6 +81,7 @@ vi.mock("@x402/core/server", () => ({
       registerExtension: vi.fn(),
     },
   })),
+  checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
 }));
 
 // --- Mock Factories ---

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -10,6 +10,7 @@ import {
   getFacilitatorResponseError,
   SETTLEMENT_OVERRIDES_HEADER,
   SettlementOverrides,
+  checkIfBazaarNeeded,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { Context, MiddlewareHandler } from "hono";
@@ -24,24 +25,6 @@ import { HonoAdapter } from "./adapter";
  */
 export function setSettlementOverrides(c: Context, overrides: SettlementOverrides): void {
   c.header(SETTLEMENT_OVERRIDES_HEADER, JSON.stringify(overrides));
-}
-
-/**
- * Check if any routes in the configuration declare bazaar extensions
- *
- * @param routes - Route configuration
- * @returns True if any route has extensions.bazaar defined
- */
-function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  // Handle single route config
-  if ("accepts" in routes) {
-    return !!(routes.extensions && "bazaar" in routes.extensions);
-  }
-
-  // Handle multiple routes
-  return Object.values(routes).some(routeConfig => {
-    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
-  });
 }
 
 /**

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -69,6 +69,7 @@ vi.mock("@x402/core/server", () => ({
       registerExtension: vi.fn(),
     },
   })),
+  checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
 }));
 
 // --- Test Fixtures ---

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -6,6 +6,7 @@ import {
   RouteConfig,
   FacilitatorClient,
   FacilitatorResponseError,
+  checkIfBazaarNeeded,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { NextRequest, NextResponse } from "next/server";
@@ -381,24 +382,6 @@ export function withX402<T = unknown>(
     paywall,
     syncFacilitatorOnStart,
   );
-}
-
-/**
- * Check if any routes in the configuration declare bazaar extensions
- *
- * @param routes - Route configuration
- * @returns True if any route has extensions.bazaar defined
- */
-function checkIfBazaarNeeded(routes: RoutesConfig): boolean {
-  // Handle single route config
-  if ("accepts" in routes) {
-    return !!(routes.extensions && "bazaar" in routes.extensions);
-  }
-
-  // Handle multiple routes
-  return Object.values(routes).some(routeConfig => {
-    return !!(routeConfig.extensions && "bazaar" in routeConfig.extensions);
-  });
 }
 
 export type {

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -47,6 +47,7 @@ vi.mock("@x402/core/server", () => {
     },
     x402HTTPResourceServer: MockHTTPResourceServer,
     x402ResourceServer: vi.fn(),
+    checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
   };
 });
 


### PR DESCRIPTION
## Summary

`checkIfBazaarNeeded` was duplicated identically across 4 HTTP middleware packages (Express, Hono, Fastify, Next.js). This PR extracts it into `@x402/core` and replaces the local copies with a shared import.

### Changes
- Added `checkIfBazaarNeeded` to `x402HTTPResourceServer.ts` as an exported function
- Added re-export from `@x402/core/server`
- Removed identical local implementations from `@x402/http-express`, `@x402/http-hono`, `@x402/http-fastify`, `@x402/http-next`

### Motivation
Reduces maintenance burden — any future changes to bazaar detection logic only need to happen in one place.

## Test plan
- [x] Full monorepo build passes (`pnpm run build`)
- [x] All existing tests pass (`pnpm run test`)
- [ ] Verify bazaar extension detection still works in each framework