### PR TITLE
fix(go): use math/rand/v2 instead of math/rand in SVM facilitator

### DIFF
--- a/go/mechanisms/svm/exact/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/facilitator/scheme.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 
 	solana "github.com/gagliardetto/solana-go"
@@ -55,7 +55,7 @@ func (f *ExactSvmScheme) GetExtra(network x402.Network) map[string]interface{} {
 	addresses := f.signer.GetAddresses(context.Background(), string(network))
 
 	// Randomly select from available addresses to distribute load
-	randomIndex := rand.Intn(len(addresses))
+	randomIndex := rand.IntN(len(addresses))
 
 	return map[string]interface{}{
 		"feePayer": addresses[randomIndex].String(),

--- a/go/mechanisms/svm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/scheme.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 
 	solana "github.com/gagliardetto/solana-go"
@@ -56,7 +56,7 @@ func (f *ExactSvmSchemeV1) GetExtra(network x402.Network) map[string]interface{}
 	addresses := f.signer.GetAddresses(context.Background(), string(network))
 
 	// Randomly select from available addresses to distribute load
-	randomIndex := rand.Intn(len(addresses))
+	randomIndex := rand.IntN(len(addresses))
 
 	return map[string]interface{}{
 		"feePayer": addresses[randomIndex].String(),


### PR DESCRIPTION
Fixes #1845

## Summary

Replace `math/rand` with `math/rand/v2` in SVM facilitator fee payer address selection. `math/rand/v2` uses a crypto-quality source by default (Go 1.22+), which is the idiomatic choice for financial infrastructure code. This aligns with the client-side code (`exact/client/scheme.go`, `exact/v1/client/scheme.go`) which already uses `crypto/rand` for memo nonce generation.

## Changes

- `go/mechanisms/svm/exact/facilitator/scheme.go`: `math/rand` → `math/rand/v2`, `rand.Intn` → `rand.IntN`
- `go/mechanisms/svm/exact/v1/facilitator/scheme.go`: same change

Uses Option B from the issue (math/rand/v2) since `go.mod` requires Go 1.24.0.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./mechanisms/svm/...` passes
- [ ] Verify fee payer selection still distributes load across signers