### PR TITLE
Go: Use X-Forwarded headers for users that are running services behind a proxy/reverse proxy.

### DIFF
--- a/go/http/echo/middleware.go
+++ b/go/http/echo/middleware.go
@@ -53,11 +53,15 @@ func (a *EchoAdapter) GetPath() string {
 func (a *EchoAdapter) GetURL() string {
 	req := a.ctx.Request()
 	scheme := "http"
-	if req.TLS != nil {
+	if xForwardedProto := req.Header.Get("X-Forwarded-Proto"); xForwardedProto != "" {
+		scheme = xForwardedProto
+	} else if req.TLS != nil {
 		scheme = "https"
 	}
 	host := req.Host
-	if host == "" {
+	if xForwardedHost := req.Header.Get("X-Forwarded-Host"); xForwardedHost != "" {
+		host = xForwardedHost
+	} else if host == "" {
 		host = req.Header.Get("Host")
 	}
 	return fmt.Sprintf("%s://%s%s", scheme, host, req.RequestURI)

--- a/go/http/echo/middleware_test.go
+++ b/go/http/echo/middleware_test.go
@@ -212,6 +212,11 @@ func TestEchoAdapter_GetURL(t *testing.T) {
 			target:   "/api/test?id=1&foo=bar",
 			expected: "http://example.com/api/test?id=1&foo=bar",
 		},
+		{
+			name:     "x forwarded for",
+			target:   "/api/test",
+			expected: "https://example.com/api/test",
+		},
 	}
 
 	for _, tt := range tests {
@@ -226,6 +231,10 @@ func TestEchoAdapter_GetURL(t *testing.T) {
 
 			req := httptest.NewRequest("GET", tt.target, nil)
 			req.Host = "example.com"
+			if tt.name == "x forwarded for" {
+				req.Header.Set("X-Forwarded-Proto", "https")
+				req.Header.Set("X-Forwarded-Host", "example.com")
+			}
 			w := httptest.NewRecorder()
 			e.ServeHTTP(w, req)
 

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -52,11 +52,15 @@ func (a *GinAdapter) GetPath() string {
 // GetURL gets the full request URL
 func (a *GinAdapter) GetURL() string {
 	scheme := "http"
-	if a.ctx.Request.TLS != nil {
+	if xForwardedProto := a.ctx.GetHeader("X-Forwarded-Proto"); xForwardedProto != "" {
+		scheme = xForwardedProto
+	} else if a.ctx.Request.TLS != nil {
 		scheme = "https"
 	}
 	host := a.ctx.Request.Host
-	if host == "" {
+	if xForwardedHost := a.ctx.GetHeader("X-Forwarded-Host"); xForwardedHost != "" {
+		host = xForwardedHost
+	} else if host == "" {
 		host = a.ctx.GetHeader("Host")
 	}
 	return fmt.Sprintf("%s://%s%s", scheme, host, a.ctx.Request.URL.RequestURI())

--- a/go/http/gin/middleware_test.go
+++ b/go/http/gin/middleware_test.go
@@ -220,6 +220,11 @@ func TestGinAdapter_GetURL(t *testing.T) {
 			target:   "/api/test?id=1&foo=bar",
 			expected: "http://example.com/api/test?id=1&foo=bar",
 		},
+		{
+			name:     "x forwarded for",
+			target:   "/api/test",
+			expected: "https://example.com/api/test",
+		},
 	}
 
 	for _, tt := range tests {
@@ -233,6 +238,10 @@ func TestGinAdapter_GetURL(t *testing.T) {
 
 			req := httptest.NewRequest("GET", tt.target, nil)
 			req.Host = "example.com"
+			if tt.name == "x forwarded for" {
+				req.Header.Set("X-Forwarded-Proto", "https")
+				req.Header.Set("X-Forwarded-Host", "example.com")
+			}
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
 

--- a/go/http/nethttp/adapter.go
+++ b/go/http/nethttp/adapter.go
@@ -33,11 +33,15 @@ func (a *NetHTTPAdapter) GetPath() string {
 // GetURL gets the full request URL.
 func (a *NetHTTPAdapter) GetURL() string {
 	scheme := "http"
-	if a.r.TLS != nil {
+	if xForwardedProto := a.r.Header.Get("X-Forwarded-Proto"); xForwardedProto != "" {
+		scheme = xForwardedProto
+	} else if a.r.TLS != nil {
 		scheme = "https"
 	}
 	host := a.r.Host
-	if host == "" {
+	if xForwardedHost := a.r.Header.Get("X-Forwarded-Host"); xForwardedHost != "" {
+		host = xForwardedHost
+	} else if host == "" {
 		host = a.r.Header.Get("Host")
 	}
 	return fmt.Sprintf("%s://%s%s", scheme, host, a.r.URL.RequestURI())

--- a/go/http/nethttp/middleware_test.go
+++ b/go/http/nethttp/middleware_test.go
@@ -191,6 +191,11 @@ func TestNetHTTPAdapter_GetURL(t *testing.T) {
 			target:   "/api/test?id=1&foo=bar",
 			expected: "http://example.com/api/test?id=1&foo=bar",
 		},
+		{
+			name:     "x forwarded for",
+			target:   "/api/test",
+			expected: "https://example.com/api/test",
+		},
 	}
 
 	for _, tt := range tests {
@@ -198,6 +203,11 @@ func TestNetHTTPAdapter_GetURL(t *testing.T) {
 			req := httptest.NewRequest("GET", tt.target, nil)
 			req.Host = "example.com"
 			adapter := NewNetHTTPAdapter(req)
+
+			if tt.name == "x forwarded for" {
+				req.Header.Set("X-Forwarded-Proto", "https")
+				req.Header.Set("X-Forwarded-Host", "example.com")
+			}
 
 			if adapter.GetURL() != tt.expected {
 				t.Errorf("Expected URL '%s', got '%s'", tt.expected, adapter.GetURL())


### PR DESCRIPTION
## Description
when running servers in trusted environments such as kubernetes or if just sitting behind a reverse proxy like traefik or nginx the scheme of the resourceURL is incorrectly being set to http. This is due to the adapters looking specifically for a TLS connection state in the request object coming from the http lib/framework. 

This PR aims to resolve this, by using standard proxy X-Forwarded Headers.

It should be said that the adapters assume that the X-Forwarded headers can be trusted. It may be wise to add to documentation that if the app is behind a proxy of some sort it will use X-Forwarded headers, and you should make sure that you are only allowing trusted proxies to hit your server.

## Tests
tests added to ensure that https is handled correctly if no tls connection is present the x-forwarded headers can be used.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

- Go: use X-Forwarded headers (if present) when constructing URL for payment-requried header.