### PR TITLE
docs(examples): clarify facilitator key separation

### DIFF
--- a/examples/go/facilitator/basic/README.md
+++ b/examples/go/facilitator/basic/README.md
@@ -73,7 +73,7 @@ EVM_PRIVATE_KEY=<your-evm-private-key>
 SVM_PRIVATE_KEY=<your-svm-private-key>
 ```
 
-**⚠️ Security Note:** The facilitator private key needs ETH/SOL for gas fees. Use a dedicated testnet account.
+**⚠️ Security Note:** The facilitator private key needs ETH/SOL for gas fees. Use a dedicated facilitator account for settlement, and keep it separate from your seller `payTo` wallet and buyer test wallets.
 
 2. Install dependencies and run:
 

--- a/examples/python/facilitator/basic/README.md
+++ b/examples/python/facilitator/basic/README.md
@@ -6,8 +6,8 @@ FastAPI-based facilitator service that verifies and settles payments on-chain fo
 
 - Python 3.10+ (install via [pyenv](https://github.com/pyenv/pyenv) or [uv](https://docs.astral.sh/uv/))
 - uv package manager (install via [uv installation](https://docs.astral.sh/uv/getting-started/installation/))
-- EVM private key with Base Sepolia ETH for transaction fees
-- SVM private key with Solana Devnet SOL for transaction fees
+- Dedicated EVM facilitator private key with Base Sepolia ETH for transaction fees
+- Dedicated SVM facilitator private key with Solana Devnet SOL for transaction fees
 
 ## Setup
 
@@ -19,10 +19,12 @@ cp .env-local .env
 
 and fill required environment variables:
 
-- `EVM_PRIVATE_KEY` - Ethereum private key (hex with 0x prefix)
-- `SVM_PRIVATE_KEY` - Solana private key (base58 encoded)
+- `EVM_PRIVATE_KEY` - Ethereum facilitator private key (hex with 0x prefix)
+- `SVM_PRIVATE_KEY` - Solana facilitator private key (base58 encoded)
 - `PORT` - Server port (optional, defaults to 4022)
 - `EVM_RPC_URL` - Custom EVM RPC URL (optional, defaults to Base Sepolia)
+
+**⚠️ Security Note:** The facilitator key is the signer used to settle payments on-chain. Keep it separate from your seller `payTo` wallet and buyer test wallets, and make sure it is funded only for facilitator gas/fees.
 
 2. Install dependencies:
 

--- a/examples/typescript/facilitator/basic/README.md
+++ b/examples/typescript/facilitator/basic/README.md
@@ -6,8 +6,8 @@ Express.js facilitator service that verifies and settles payments on-chain for t
 
 - Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
 - pnpm v10 (install via [pnpm.io/installation](https://pnpm.io/installation))
-- EVM private key with Base Sepolia ETH for transaction fees
-- SVM private key with Solana Devnet SOL for transaction fees
+- Dedicated EVM facilitator private key with Base Sepolia ETH for transaction fees
+- Dedicated SVM facilitator private key with Solana Devnet SOL for transaction fees
 
 ## Setup
 
@@ -19,9 +19,11 @@ cp .env-local .env
 
 and fill required environment variables:
 
-- `EVM_PRIVATE_KEY` - Ethereum private key
-- `SVM_PRIVATE_KEY` - Solana private key
+- `EVM_PRIVATE_KEY` - Ethereum facilitator private key
+- `SVM_PRIVATE_KEY` - Solana facilitator private key
 - `PORT` - Server port (optional, defaults to 4022)
+
+**⚠️ Security Note:** The facilitator key is the signer used to settle payments on-chain. Keep it separate from your seller `payTo` wallet and buyer test wallets, and make sure it is funded only for facilitator gas/fees.
 
 2. Install and build all packages from the typescript examples root:
 


### PR DESCRIPTION
## Description

This docs-only PR clarifies the basic facilitator example READMEs around wallet separation.

- calls out that the facilitator signer should be a dedicated funded key
- makes it explicit that it should stay separate from seller `payTo` wallets and buyer test wallets
- aligns the Python and TypeScript wording with the stronger Go guidance already present in the examples

## Tests

- `git diff --check upstream/main...codex/facilitator-docs-role-separation`
- manual review of the three touched README files
- GitHub PR checks are green