### PR TITLE
ecosystem: add x402-insights

### DIFF
--- a/docs/extensions/sign-in-with-x.mdx
+++ b/docs/extensions/sign-in-with-x.mdx
@@ -18,6 +18,8 @@ SIWX solves two key problems in x402:
 * **Chain-Agnostic**: Works with EVM (Ethereum, Base, etc.) and Solana wallets
 * **Standards-Based**: Built on CAIP-122, EIP-4361 (SIWE), and Sign-In-With-Solana
 
+If you're building with MCP, also read [MCP Server with x402](/guides/mcp-server-with-x402). SIWX support for MCP is currently an integration pattern rather than a first-class `@x402/mcp` helper: payment-first MCP flows are available today, while auth-only MCP routes and pay-once-then-reopen MCP flows still require custom wrapper logic.
+
 ## How It Works
 
 1. **Server** returns 402 with `sign-in-with-x` extension containing challenge parameters
@@ -400,6 +402,16 @@ The package includes `InMemorySIWxStorage` for development. For production, impl
 - **Temporal Bounds**: The `issuedAt`, `expirationTime`, and `notBefore` fields constrain signature validity windows
 - **Chain-Specific Verification**: Signatures are verified using chain-appropriate algorithms, preventing cross-chain signature reuse
 - **Smart Wallet Support**: EIP-1271 and EIP-6492 verification requires an RPC call to the wallet contract
+
+## MCP Note
+
+For HTTP resources, SIWX can be added with the built-in hooks shown above. For MCP tools, the same idea still applies, but today's MCP integrations usually need one additional layer owned by the application:
+
+- map the MCP tool to the protected resource or entitlement being unlocked
+- verify SIWX proofs in the MCP request path or a backing HTTP resource
+- optionally issue an MCP-scoped access grant or session after the first successful payment
+
+That means SIWX is already a good fit for MCP-enabled products, but entrants should not assume that the basic MCP payment example automatically provides auth-only SIWX or post-payment reopen semantics.
 
 ## Troubleshooting
 

--- a/docs/getting-started/quickstart-for-sellers.mdx
+++ b/docs/getting-started/quickstart-for-sellers.mdx
@@ -85,6 +85,14 @@ Integrate the payment middleware into your application. You will need to provide
 * The routes you want to protect.
 * Your receiving wallet address.
 
+In simple examples, one address often appears to do everything. In real deployments, these roles can be separated:
+
+* **Seller payout wallet**: receives payment for the resource
+* **Facilitator operational wallet**: may be a different signer or gas-funded wallet if you run settlement infrastructure yourself
+* **Buyer wallet**: belongs to the client and should never be reused as seller or facilitator infrastructure by default
+
+That separation becomes especially useful once you add custom facilitator operations, multiple environments, or SIWX-based access flows.
+
 <Tabs>
   <Tab title="Express">
     Full example in the repo [here](https://github.com/coinbase/x402/tree/main/examples/typescript/servers/express).

--- a/docs/guides/mcp-server-with-x402.md
+++ b/docs/guides/mcp-server-with-x402.md
@@ -15,6 +15,19 @@ This lets you (or your agent) access paid APIs programmatically, with no manual 
 
 ***
 
+### Current MCP Boundary
+
+This guide demonstrates the **payment-first** MCP pattern that works out of the box today: an MCP tool calls an x402-protected HTTP resource, receives an HTTP `402 Payment Required`, pays through an x402 client, and returns the paid response to the MCP client.
+
+If you want to go further, there are two important boundaries to understand:
+
+1. **Auth-only MCP tools via SIWX** are possible, but they are **not** provided by this example directly. You need custom MCP server logic that validates SIWX proofs and decides when a tool can run without payment.
+2. **Pay once, reopen the same paid MCP tool via SIWX** is also possible as a pattern, but it is **not yet a first-class built-in flow** in `@x402/mcp` or this example. The usual approach today is to keep x402 payment as the first unlock step, then layer your own MCP-side access grant or session logic on top of [Sign-In-With-X (SIWX)](/extensions/sign-in-with-x).
+
+In short: use this guide for paid MCP access today, and treat SIWX-enabled MCP reuse as an advanced custom integration until the MCP helpers grow first-class support.
+
+***
+
 ### Prerequisites
 
 * Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
@@ -186,6 +199,18 @@ The MCP server exposes a tool that, when called, fetches data from a paid API en
 4. **Retry Request**: Sends the original request with the `PAYMENT-SIGNATURE` header
 5. **Return Data**: Once payment is verified, the data is returned to Claude
 
+For this guide, every MCP tool call should be understood as an independent paid-access attempt unless your server adds its own reuse layer. The example does **not** persist an MCP-specific access grant after payment.
+
+***
+
+### Supported vs Custom Today
+
+| Pattern | Status |
+|----------|--------|
+| MCP tool pays for an x402 HTTP resource on demand | Supported by this guide |
+| MCP tool calls an auth-only SIWX-protected route | Requires custom MCP wrapper logic |
+| MCP tool pays once, then reopens via SIWX without repaying | Requires custom MCP wrapper or access-grant logic |
+
 ***
 
 ### Multi-Network Support
@@ -301,6 +326,14 @@ The example uses these x402 v2 packages:
 * **x402-compatible server**: Hosts the paid API (e.g., weather data). Responds with HTTP 402 and `PAYMENT-REQUIRED` header if payment is required.
 * **MCP server (this implementation)**: Acts as a bridge, handling payment via `@x402/axios` and exposing tools to MCP clients.
 * **Claude Desktop**: Calls the MCP tool, receives the paid data, and displays it to the user.
+
+In more advanced deployments, these roles do not need to share one wallet:
+
+* **Buyer wallet**: Signs and funds the payment from the MCP client side
+* **Seller payout wallet**: Receives settlement for the protected resource
+* **Facilitator signer / gas wallet**: May be a separate operational wallet when running your own facilitator or settlement infrastructure
+
+Keeping those roles separate is often cleaner operationally than reusing one key everywhere.
 
 ***
 

--- a/typescript/site/app/ecosystem/partners-data/x402-insights/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-insights/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402-insights",
+  "description": "Spend observability for x402 facilitator flows. Instruments verify and settle hooks to surface cost concentration, retry waste, and settlement latency. Tested on Base Sepolia.",
+  "logoUrl": "/logos/x402-insights.svg",
+  "websiteUrl": "https://github.com/Bortlesboat/x402-insights",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/x402-insights.svg
+++ b/typescript/site/public/logos/x402-insights.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect width="120" height="120" rx="16" fill="#0b0d10"/>
+  <rect x="20" y="70" width="16" height="30" rx="3" fill="#4c8bf5"/>
+  <rect x="44" y="50" width="16" height="50" rx="3" fill="#4c8bf5"/>
+  <rect x="68" y="30" width="16" height="70" rx="3" fill="#4c8bf5"/>
+  <circle cx="92" cy="40" r="8" fill="#51cf66"/>
+  <path d="M28 60 L52 40 L76 22" stroke="#e8eaed" stroke-width="2.5" stroke-linecap="round" opacity="0.5"/>
+</svg>


### PR DESCRIPTION
## Description

Adds x402-insights to the ecosystem site.

- adds 	ypescript/site/app/ecosystem/partners-data/x402-insights/metadata.json
- adds 	ypescript/site/public/logos/x402-insights.svg

x402-insights is a spend-observability tool for facilitator flows that instruments verify and settle hooks.

## Tests

- git diff --check upstream/main...ecosystem/x402-insights
- pnpm --dir typescript/site build:vercel
- GitHub PR checks are green