### PR TITLE
Update x402engine ecosystem description

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402engine/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402engine/metadata.json
@@ -2,6 +2,6 @@
   "name": "x402engine",
   "category": "Services/Endpoints",
   "logoUrl": "/logos/x402engine.png",
-  "description": "28 pay-per-call APIs for AI agents — image generation, LLM inference, code execution, audio transcription, crypto market data, blockchain analytics, ENS resolution, IPFS storage, and travel search. Supports USDC on Base/Solana and USDm on MegaETH.",
+  "description": "70+ pay-per-call APIs for AI agents — 44 LLMs, image/video generation, crypto data, wallet analytics, web search, code execution, TTS, IPFS, and travel. Supports USDC on Base/Solana and USDm on MegaETH.",
   "websiteUrl": "https://x402engine.app"
 }


### PR DESCRIPTION
## Summary
- updates the x402engine ecosystem entry description from `28 pay-per-call APIs` to `70+ pay-per-call APIs`
- refreshes the category summary to match the current product surface
- keeps the change scoped to the existing metadata entry only

## Why
The live ecosystem entry on `main` still says `28 pay-per-call APIs`, which is outdated.

This PR intentionally supersedes #1738 with a clean one-file edit based on current `main`, so it can merge without the stale branch conflicts in that PR.