### PR TITLE
ecosystem: add PathCourse Health — autonomous AI token gateway

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/pathcoursehealth/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/pathcoursehealth/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "PathCourse Health — Autonomous AI Token Gateway",
+  "description": "Autonomous AI token gateway for agent-native LLM inference. Agents deposit USDC on Base, receive an API key, and run inference — no accounts, no signup, no human steps. Wallet is authentication. pch-fast $0.44/M, pch-pro $1.96/M, pch-coder $3.50/M. OpenAI-compatible API. x402 native on Base L2. ERC-8004 certified. A2A ready.",
+  "logoUrl": "/logos/pathcoursehealth.svg",
+  "websiteUrl": "https://pathcoursehealth.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/pathcoursehealth.svg
+++ b/typescript/site/public/logos/pathcoursehealth.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <style>
+    .bg { fill: #0d2e1a; }
+    .hex { fill: none; stroke: #1a5c30; stroke-width: 1.5; opacity: 0.5; }
+    .pch { font-family: Arial, sans-serif; font-size: 42px; font-weight: 700; fill: #2ecc71; letter-spacing: 2px; }
+    .gw { font-family: Arial, sans-serif; font-size: 10px; font-weight: 400; fill: #2ecc71; letter-spacing: 3px; opacity: 0.85; }
+    .div { stroke: #2ecc71; stroke-width: 0.8; opacity: 0.6; }
+  </style>
+  <rect width="200" height="200" rx="8" class="bg"/>
+  <polygon points="100,16 158,49 158,116 100,149 42,116 42,49" class="hex"/>
+  <polygon points="100,30 144,55 144,105 100,130 56,105 56,55" class="hex"/>
+  <text x="100" y="103" text-anchor="middle" class="pch">PCH</text>
+  <line x1="68" y1="112" x2="132" y2="112" class="div"/>
+  <text x="100" y="124" text-anchor="middle" class="gw">GATEWAY</text>
+</svg>


### PR DESCRIPTION
## Add PathCourse Health to the x402 Ecosystem

**Category:** Services/Endpoints

PathCourse Health is an autonomous AI token gateway for agent-native 
LLM inference. Agents deposit USDC on Base, receive an API key, and 
run inference — no accounts, no signup, no human steps. 
Wallet = authentication.

**Features:**
- pch-fast ($0.44/M tokens), pch-pro ($1.96/M tokens), pch-coder ($3.50/M tokens)
- OpenAI-compatible API — drop-in replacement for existing agent stacks
- x402 native — USDC on Base L2 (chain_id 8453)
- ERC-8004 compatible — on-chain portable agent passport
- A2A ready — agent.json at agents.pathcoursehealth.com

**Links:**
- Website: https://pathcoursehealth.com
- Gateway: https://gateway.pathcoursehealth.com/v1
- Agent card: https://gateway.pathcoursehealth.com/.well-known/agent.json
- Docs: https://gateway.pathcoursehealth.com/docs
- Examples: https://github.com/pathcourse-health/pch-integration-examples

**Checklist:**
- [x] x402 protocol implemented natively
- [x] USDC on Base L2 (chain_id 8453)
- [x] OpenAI-compatible API
- [x] Live in production
- [x] Public docs and integration examples available
- [x] agent.json at .well-known/agent.json