### PR TITLE
feat(evm): add shielded payment mechanism (privacy pool unshield)

### DIFF
--- a/specs/schemes/exact/scheme_exact_evm_shielded.md
+++ b/specs/schemes/exact/scheme_exact_evm_shielded.md
@@ -1,0 +1,274 @@
+# Scheme: `exact` on `EVM` — AssetTransferMethod: `shielded`
+
+## Summary
+
+The `shielded` asset transfer method enables privacy-preserving payments on EVM chains via on-chain privacy pools. The client withdraws ("unshields") tokens from a privacy pool directly to the resource server's `payTo` address. The facilitator verifies the payment by checking the ERC-20 `Transfer` event emitted during the unshield — no viewing keys, trial decryption, or off-chain state is required.
+
+This is the first fully private payment option for x402 on EVM. Unlike existing EVM methods (EIP-3009, Permit2, ERC-7710) where the payer's address is publicly visible on-chain, shielded payments hide the sender's identity behind a zero-knowledge proof verified by the privacy pool contract.
+
+### Key Properties
+
+| Property | Value |
+|:---------|:------|
+| Settlement | Client-driven (client unshields on-chain before verification) |
+| Verification | ERC-20 `Transfer` event from registered privacy pool contract |
+| Privacy | Sender hidden (ZK proof); amount visible to facilitator |
+| Gas/Fees | Client pays, or gasless via ERC-4337 account abstraction |
+| Facilitator role | Verify-only (no settlement, no custody) |
+| Token | Any ERC-20 supported by the privacy pool (USDC, USDT, DAI, WETH) |
+
+### Key Differences from Other EVM Methods
+
+| Aspect | EIP-3009 | Permit2 | ERC-7710 | **Shielded** |
+|--------|----------|---------|----------|-------------|
+| Authorization | Off-chain signature | Off-chain signature | Delegation | On-chain ZK proof |
+| Settlement | Facilitator submits | Facilitator submits | Facilitator submits | **Client sends directly** |
+| Verification | Signature recovery | Signature recovery | Delegation check | **Transfer event inspection** |
+| Sender privacy | None (public) | None (public) | None (public) | **Full (ZK hidden)** |
+| Gas | Facilitator sponsors | Facilitator sponsors | Facilitator sponsors | Client pays (or ERC-4337) |
+| Setup | None | One-time approve | One-time delegation | One-time shield |
+
+---
+
+## Protocol Flow
+
+1. **Client** requests a resource from the **Resource Server**.
+2. **Resource Server** responds with `402 Payment Required`. The `accepts` array includes a shielded payment option with `extra.assetTransferMethod: "shielded"`.
+3. **Client** unshields tokens from a privacy pool on-chain, sending them directly to the `payTo` address.
+4. **Client** waits for the transaction to confirm (typically 2–15 seconds depending on chain).
+5. **Client** retries the request with the `PAYMENT-SIGNATURE` header containing the base64-encoded `PaymentPayload` with the unshield transaction hash.
+6. **Resource Server** forwards the payload to the **Facilitator's** `/verify` endpoint.
+7. **Facilitator** fetches the transaction receipt and verifies the ERC-20 `Transfer` event.
+8. **Facilitator** returns a `VerifyResponse`.
+9. **Resource Server** grants access.
+
+```
+Client                    Resource Server              Facilitator
+  │                            │                              │
+  │  GET /api/data             │                              │
+  │───────────────────────────>│                              │
+  │                            │                              │
+  │  402 Payment Required      │                              │
+  │  PAYMENT-REQUIRED: base64  │                              │
+  │  (assetTransferMethod:     │                              │
+  │   "shielded")              │                              │
+  │<───────────────────────────│                              │
+  │                            │                              │
+  │  (unshields tokens from    │                              │
+  │   privacy pool on-chain    │                              │
+  │   to payTo address)        │                              │
+  │                            │                              │
+  │  GET /api/data             │                              │
+  │  PAYMENT-SIGNATURE: base64 │                              │
+  │───────────────────────────>│                              │
+  │                            │  POST /verify                │
+  │                            │  { payload, requirements }   │
+  │                            │─────────────────────────────>│
+  │                            │                              │
+  │                            │  { isValid: true }           │
+  │                            │<─────────────────────────────│
+  │                            │                              │
+  │  200 OK                    │                              │
+  │  PAYMENT-RESPONSE: base64  │                              │
+  │<───────────────────────────│                              │
+```
+
+---
+
+## `PaymentRequirements`
+
+```json
+{
+  "scheme": "exact",
+  "network": "eip155:8453",
+  "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "amount": "1000000",
+  "payTo": "0xMerchantAddress...",
+  "maxTimeoutSeconds": 120,
+  "extra": {
+    "assetTransferMethod": "shielded",
+    "poolContracts": [
+      "0x26111e2379E5fC0A7Cd8728fe52c7b84CA4fbE85"
+    ]
+  }
+}
+```
+
+| Field | Description |
+|:------|:------------|
+| `scheme` | MUST be `"exact"`. |
+| `network` | MUST be a CAIP-2 EVM network identifier (e.g., `"eip155:8453"` for Base). |
+| `asset` | MUST be the ERC-20 token contract address. |
+| `amount` | Payment amount in the token's smallest denomination (e.g., `"1000000"` = 1 USDC). |
+| `payTo` | Recipient address that MUST receive the unshielded tokens. |
+| `maxTimeoutSeconds` | Maximum time to wait for verification. |
+| `extra.assetTransferMethod` | MUST be `"shielded"`. |
+| `extra.poolContracts` | List of privacy pool contract addresses accepted by this resource server. If omitted, the facilitator uses its own allowlist. |
+
+---
+
+## `PAYMENT-SIGNATURE` Header Payload
+
+The `payload` field of the `PaymentPayload` contains:
+
+```json
+{
+  "txHash": "0x4712f6ad727eb4f72a59bf6e23edeb23589da66edc0166a2223252a5be9459c7",
+  "nullifiers": ["0xabc123..."]
+}
+```
+
+| Field | Description |
+|:------|:------------|
+| `txHash` | The transaction hash of the on-chain unshield operation. MUST be a valid 32-byte hex string. |
+| `nullifiers` | OPTIONAL. Array of nullifier hashes from the ZK proof. Provides protocol-level double-spend prevention beyond txHash replay protection. |
+
+Full `PaymentPayload` example:
+
+```json
+{
+  "x402Version": 2,
+  "resource": {
+    "url": "https://api.example.com/premium-data",
+    "description": "Access to premium market data",
+    "mimeType": "application/json"
+  },
+  "accepted": {
+    "scheme": "exact",
+    "network": "eip155:8453",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "amount": "1000000",
+    "payTo": "0xMerchantAddress...",
+    "maxTimeoutSeconds": 120,
+    "extra": {
+      "assetTransferMethod": "shielded",
+      "poolContracts": ["0x26111e2379E5fC0A7Cd8728fe52c7b84CA4fbE85"]
+    }
+  },
+  "payload": {
+    "txHash": "0x4712f6ad727eb4f72a59bf6e23edeb23589da66edc0166a2223252a5be9459c7",
+    "nullifiers": []
+  }
+}
+```
+
+---
+
+## Verification
+
+A facilitator verifying a `shielded` payment MUST enforce all of the following:
+
+### 1. Transaction Existence
+
+The `txHash` MUST reference a confirmed transaction on the target chain. Facilitators MAY accept mempool transactions for low-value payments, but SHOULD require at least 1 confirmation for amounts exceeding a configurable threshold.
+
+### 2. Transfer Event Inspection
+
+The transaction receipt MUST contain an ERC-20 `Transfer(address indexed from, address indexed to, uint256 value)` event for the required `asset` token, where:
+
+- `from` MUST be one of the registered privacy pool contract addresses.
+- `to` MUST match the `payTo` address from `PaymentRequirements`.
+- `value` MUST be greater than or equal to the required `amount`.
+
+### 3. Pool Contract Validation
+
+The `from` address in the Transfer event MUST be a recognized privacy pool contract. The facilitator MUST maintain an allowlist of accepted pool contracts, either:
+
+- From the `extra.poolContracts` array in `PaymentRequirements`, OR
+- From the facilitator's own configuration.
+
+The facilitator MUST NOT accept transfers from arbitrary addresses — only from registered privacy pool contracts.
+
+### 4. Replay Protection
+
+The facilitator MUST prevent the same payment from being used twice. Two mechanisms are supported:
+
+**a. Transaction hash replay protection (REQUIRED)**
+
+The facilitator MUST track used `txHash` values. A `txHash` that has already been used for a successful verification MUST be rejected.
+
+**b. Nullifier replay protection (RECOMMENDED)**
+
+If `nullifiers` are provided in the payload, the facilitator SHOULD verify that each nullifier has not been previously used. Nullifiers provide ZK-level double-spend prevention that is independent of transaction identity.
+
+### 5. Timeout Enforcement
+
+If the facilitator cannot retrieve and verify the transaction within the `maxTimeoutSeconds` window, verification MUST fail.
+
+---
+
+## Settlement
+
+Settlement for shielded payments is **client-driven**:
+
+1. The client unshields tokens from the privacy pool **before** sending the `PaymentPayload`.
+2. The facilitator does **not** submit, co-sign, or broadcast any transaction.
+3. The facilitator exposes only a `/verify` endpoint.
+
+This means:
+- The facilitator never holds or moves funds.
+- The client pays the gas for the unshield transaction (or uses ERC-4337 for gasless execution).
+- Transaction finality is determined by the underlying chain.
+
+### `SettleResponse`
+
+Since settlement is client-driven, the response confirms verification rather than settlement:
+
+```json
+{
+  "success": true,
+  "transaction": "0x4712f6ad727eb4f72a59bf6e23edeb23589da66edc0166a2223252a5be9459c7",
+  "network": "eip155:8453",
+  "payer": "0x26111e2379E5fC0A7Cd8728fe52c7b84CA4fbE85"
+}
+```
+
+The `payer` field contains the privacy pool contract address (the `from` in the Transfer event), not the client's actual address — which is hidden by the ZK proof.
+
+---
+
+## Appendix
+
+### Privacy Guarantees
+
+Shielded EVM payments provide the following privacy properties not available with other x402 EVM methods:
+
+- **Sender privacy**: The payer's wallet address is not visible in the Transfer event. The `from` field shows the privacy pool contract, not the individual.
+- **Unlinkability**: Multiple payments from the same sender cannot be linked by an on-chain observer.
+- **Pattern privacy**: An observer cannot determine which API was paid for or correlate payment timing with API usage.
+
+**Not hidden:**
+- **Amount**: The transfer amount is visible in the Transfer event.
+- **Recipient**: The `payTo` address is visible (the resource server's address is public).
+
+### Supported Privacy Pools
+
+This specification is designed to work with any EVM privacy pool that emits standard ERC-20 `Transfer` events when tokens are withdrawn. Known compatible implementations:
+
+| Protocol | Chains | Contract Addresses |
+|:---------|:-------|:-------------------|
+| Railgun | Base, Ethereum, BSC, Polygon, Arbitrum | [railgun.org/contracts](https://railgun.org) |
+
+Additional privacy pool implementations MAY be added by registering their contract addresses with the facilitator.
+
+### Security Considerations
+
+1. **Pool contract allowlist**: The facilitator MUST only accept transfers from known privacy pool contracts. Accepting transfers from arbitrary addresses would allow non-private payments to masquerade as shielded ones.
+
+2. **Transaction confirmation depth**: For high-value payments, facilitators SHOULD require multiple block confirmations to mitigate reorg risk. For micropayments (< $1), single confirmation is typically sufficient.
+
+3. **Nullifier verification**: When nullifiers are provided, facilitators SHOULD verify them against the privacy pool's on-chain state or a trusted indexer. This prevents a class of double-spend attacks where the same ZK proof is submitted in multiple transactions.
+
+4. **No viewing keys required**: Verification does not require viewing keys or trial decryption. The ERC-20 Transfer event is a public log entry — verification is purely based on event inspection. This simplifies facilitator implementation and eliminates key management concerns.
+
+5. **Client-side proof generation**: The ZK proof is generated entirely on the client side. The privacy pool contract verifies the proof on-chain. The facilitator does not need to understand or verify the ZK proof — it only needs to confirm that the privacy pool contract accepted the transaction (i.e., the transaction was not reverted).
+
+### One-Time Setup: Shielding
+
+Before making shielded payments, the client must deposit ("shield") tokens into the privacy pool. This is a one-time setup:
+
+1. Client approves the privacy pool contract to spend their ERC-20 tokens.
+2. Client calls the pool's shield function, which moves tokens into the shielded pool.
+3. After shielding, the client can make any number of shielded payments (unshields) from the pool.
+
+Shielding breaks the on-chain link between the client's public address and their shielded balance.

--- a/specs/schemes/exact/scheme_exact_evm_shielded.md
+++ b/specs/schemes/exact/scheme_exact_evm_shielded.md
@@ -156,13 +156,29 @@ Full `PaymentPayload` example:
 
 ## Verification
 
-A facilitator verifying a `shielded` payment MUST enforce all of the following:
+Verification happens in two layers: the privacy pool contract handles ZK proof verification and double-spend prevention on-chain, while the facilitator confirms the resulting transfer matches the payment requirements.
 
-### 1. Transaction Existence
+### On-chain layer (handled by the privacy pool contract)
 
-The `txHash` MUST reference a confirmed transaction on the target chain. Facilitators MAY accept mempool transactions for low-value payments, but SHOULD require at least 1 confirmation for amounts exceeding a configurable threshold.
+Before the facilitator is involved, the following has already happened on-chain:
 
-### 2. Transfer Event Inspection
+1. The client generated a groth16 ZK proof proving ownership of a UTXO in the pool's shielded Merkle tree.
+2. The proof includes **nullifiers** — deterministic hashes derived from the UTXO being spent. Each UTXO produces a unique nullifier.
+3. The client submitted the proof to the pool contract.
+4. The pool contract verified the ZK proof, checked that the nullifiers are not in its on-chain spent set (preventing double-spend), added the nullifiers to the spent set, and executed the ERC-20 transfer.
+5. If the transaction was not reverted, all of the above succeeded.
+
+The facilitator does not need to verify the ZK proof or check nullifiers against the pool's on-chain state — the pool contract already did this. A non-reverted transaction is sufficient proof.
+
+### Facilitator layer
+
+The facilitator MUST enforce all of the following:
+
+#### 1. Transaction Existence
+
+The `txHash` MUST reference a non-reverted transaction on the target chain. A reverted transaction means the pool contract rejected the ZK proof or the nullifiers were already spent. Facilitators MAY accept mempool transactions for low-value payments, but SHOULD require at least 1 confirmation for amounts exceeding a configurable threshold.
+
+#### 2. Transfer Event Inspection
 
 The transaction receipt MUST contain an ERC-20 `Transfer(address indexed from, address indexed to, uint256 value)` event for the required `asset` token, where:
 
@@ -170,7 +186,7 @@ The transaction receipt MUST contain an ERC-20 `Transfer(address indexed from, a
 - `to` MUST match the `payTo` address from `PaymentRequirements`.
 - `value` MUST be greater than or equal to the required `amount`.
 
-### 3. Pool Contract Validation
+#### 3. Pool Contract Validation
 
 The `from` address in the Transfer event MUST be a recognized privacy pool contract. The facilitator MUST maintain an allowlist of accepted pool contracts, either:
 
@@ -179,19 +195,15 @@ The `from` address in the Transfer event MUST be a recognized privacy pool contr
 
 The facilitator MUST NOT accept transfers from arbitrary addresses — only from registered privacy pool contracts.
 
-### 4. Replay Protection
+#### 4. Application-Level Replay Protection
 
-The facilitator MUST prevent the same payment from being used twice. Two mechanisms are supported:
-
-**a. Transaction hash replay protection (REQUIRED)**
+The on-chain nullifiers prevent the same UTXO from being spent twice at the protocol level. However, the facilitator MUST also prevent the same **payment transaction** from being used to access multiple resources (application-level replay).
 
 The facilitator MUST track used `txHash` values. A `txHash` that has already been used for a successful verification MUST be rejected.
 
-**b. Nullifier replay protection (RECOMMENDED)**
+If `nullifiers` are provided in the payload, the facilitator MAY additionally track nullifiers for defense-in-depth.
 
-If `nullifiers` are provided in the payload, the facilitator SHOULD verify that each nullifier has not been previously used. Nullifiers provide ZK-level double-spend prevention that is independent of transaction identity.
-
-### 5. Timeout Enforcement
+#### 5. Timeout Enforcement
 
 If the facilitator cannot retrieve and verify the transaction within the `maxTimeoutSeconds` window, verification MUST fail.
 

--- a/typescript/packages/mechanisms/evm/src/shielded/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/client/index.ts
@@ -1,0 +1,2 @@
+export { ShieldedEvmClient } from "./scheme.js";
+export type { ShieldedEvmClientConfig } from "./scheme.js";

--- a/typescript/packages/mechanisms/evm/src/shielded/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/client/scheme.ts
@@ -1,0 +1,38 @@
+import type {
+  PaymentRequirements,
+  PaymentPayloadResult,
+  PaymentPayloadContext,
+} from "@x402/core/types";
+import type { SchemeNetworkClient } from "@x402/core/types/mechanisms";
+import type { UnshieldFn } from "../types.js";
+
+export interface ShieldedEvmClientConfig {
+  unshield: UnshieldFn;
+}
+
+export class ShieldedEvmClient implements SchemeNetworkClient {
+  readonly scheme = "exact";
+  private unshield: UnshieldFn;
+
+  constructor(config: ShieldedEvmClientConfig) {
+    this.unshield = config.unshield;
+  }
+
+  async createPaymentPayload(
+    x402Version: number,
+    paymentRequirements: PaymentRequirements,
+    _context?: PaymentPayloadContext,
+  ): Promise<PaymentPayloadResult> {
+    const { txHash } = await this.unshield(
+      paymentRequirements.asset,
+      paymentRequirements.amount,
+      paymentRequirements.payTo,
+      paymentRequirements.network,
+    );
+
+    return {
+      x402Version,
+      payload: { txHash },
+    };
+  }
+}

--- a/typescript/packages/mechanisms/evm/src/shielded/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * Known privacy pool contract addresses by chain ID.
+ *
+ * These are the default pool contracts accepted by the facilitator.
+ * Resource servers can override with their own list via extra.poolContracts.
+ *
+ * Currently includes Railgun relay contracts. Additional pools can be
+ * registered by passing them in ShieldedFacilitatorConfig.poolContracts.
+ */
+export const DEFAULT_POOL_CONTRACTS: Record<number, string[]> = {
+  // Base
+  8453: ["0x26111e2379E5fC0A7Cd8728fe52c7b84CA4fbE85"],
+  // Ethereum
+  1: ["0xfa7093cdd9ee6932b4eb2c9e1cde7ce00b1fa4b9"],
+  // BSC
+  56: ["0x9dB0eDC77C9047a06Fd6dE82c892630DAa5eF601"],
+  // Polygon
+  137: ["0x19b620929f97b7b990801496c3b361ca5def8c71"],
+  // Arbitrum
+  42161: ["0xfa7093cdd9ee6932b4eb2c9e1cde7ce00b1fa4b9"],
+};
+
+/**
+ * ERC-20 Transfer event topic (keccak256 of "Transfer(address,address,uint256)").
+ */
+export const TRANSFER_EVENT_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";

--- a/typescript/packages/mechanisms/evm/src/shielded/facilitator/errors.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/facilitator/errors.ts
@@ -1,0 +1,5 @@
+export const INVALID_TX_HASH = "invalid_tx_hash";
+export const TRANSACTION_NOT_FOUND = "transaction_not_found";
+export const TRANSACTION_REVERTED = "transaction_reverted";
+export const NO_MATCHING_TRANSFER = "no_matching_transfer";
+export const TX_ALREADY_USED = "tx_already_used";

--- a/typescript/packages/mechanisms/evm/src/shielded/facilitator/index.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/facilitator/index.ts
@@ -1,0 +1,2 @@
+export { ShieldedEvmFacilitator } from "./scheme.js";
+export * from "./errors.js";

--- a/typescript/packages/mechanisms/evm/src/shielded/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/facilitator/scheme.ts
@@ -1,0 +1,175 @@
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+  Network,
+} from "@x402/core/types";
+import type { SchemeNetworkFacilitator } from "@x402/core/types/mechanisms";
+import type { VerifyResponse, SettleResponse } from "@x402/core/types/facilitator";
+import type {
+  ShieldedPayload,
+  ShieldedProvider,
+  ShieldedFacilitatorConfig,
+  ReplayStore,
+} from "../types.js";
+import { TRANSFER_EVENT_TOPIC } from "../constants.js";
+import {
+  INVALID_TX_HASH,
+  TRANSACTION_NOT_FOUND,
+  TRANSACTION_REVERTED,
+  NO_MATCHING_TRANSFER,
+  TX_ALREADY_USED,
+} from "./errors.js";
+
+const TX_HASH_RE = /^0x[0-9a-fA-F]{64}$/;
+
+class MemoryReplayStore implements ReplayStore {
+  private used = new Set<string>();
+  has(key: string) { return this.used.has(key); }
+  add(key: string) { this.used.add(key); }
+}
+
+function getChainId(network: string): number {
+  return parseInt(network.split(":")[1], 10);
+}
+
+export class ShieldedEvmFacilitator implements SchemeNetworkFacilitator {
+  readonly scheme = "exact";
+  readonly caipFamily = "eip155:*";
+
+  private provider: ShieldedProvider;
+  private poolContracts: Record<number, string[]>;
+  private replayStore: ReplayStore;
+
+  constructor(config: ShieldedFacilitatorConfig) {
+    this.provider = config.provider;
+    this.poolContracts = config.poolContracts;
+    this.replayStore = config.replayStore ?? new MemoryReplayStore();
+  }
+
+  getExtra(network: string): Record<string, unknown> | undefined {
+    const chainId = getChainId(network);
+    const pools = this.poolContracts[chainId];
+    if (!pools || pools.length === 0) return undefined;
+    return {
+      assetTransferMethod: "shielded",
+      poolContracts: pools,
+    };
+  }
+
+  getSigners(_network: string): string[] {
+    return [];
+  }
+
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    const raw = payload.payload as ShieldedPayload;
+    const txHash = raw?.txHash ?? "";
+
+    // 1. Validate txHash format
+    if (!TX_HASH_RE.test(txHash)) {
+      return { isValid: false, invalidReason: INVALID_TX_HASH };
+    }
+
+    // 2. Check replay
+    if (await this.replayStore.has(txHash)) {
+      return { isValid: false, invalidReason: TX_ALREADY_USED };
+    }
+
+    // 3. Fetch receipt
+    let receipt;
+    try {
+      receipt = await this.provider.getTransactionReceipt({ hash: txHash as `0x${string}` });
+    } catch {
+      return { isValid: false, invalidReason: TRANSACTION_NOT_FOUND };
+    }
+
+    if (!receipt) {
+      return { isValid: false, invalidReason: TRANSACTION_NOT_FOUND };
+    }
+
+    // 4. Non-reverted = ZK proof was accepted by pool contract
+    if (receipt.status === "reverted") {
+      return { isValid: false, invalidReason: TRANSACTION_REVERTED };
+    }
+
+    // 5. Find matching Transfer event
+    const chainId = getChainId(requirements.network);
+    const pools = (
+      (requirements.extra?.poolContracts as string[]) ??
+      this.poolContracts[chainId] ??
+      []
+    ).map((a) => a.toLowerCase());
+
+    const asset = requirements.asset.toLowerCase();
+    const payTo = requirements.payTo.toLowerCase();
+    const requiredAmount = BigInt(requirements.amount);
+
+    let matchedPool: string | undefined;
+
+    for (const log of receipt.logs) {
+      if (log.address.toLowerCase() !== asset) continue;
+      if (log.topics[0] !== TRANSFER_EVENT_TOPIC) continue;
+      if (log.topics.length < 3) continue;
+
+      const from = "0x" + log.topics[1].slice(26).toLowerCase();
+      const to = "0x" + log.topics[2].slice(26).toLowerCase();
+      const value = BigInt(log.data);
+
+      if (pools.includes(from) && to === payTo && value >= requiredAmount) {
+        matchedPool = from;
+        break;
+      }
+    }
+
+    if (!matchedPool) {
+      return { isValid: false, invalidReason: NO_MATCHING_TRANSFER };
+    }
+
+    // 6. Mark txHash as used
+    await this.replayStore.add(txHash);
+
+    // 7. Track nullifiers if provided (defense-in-depth on top of on-chain nullifier set)
+    const nullifiers = raw.nullifiers ?? [];
+    for (const nullifier of nullifiers) {
+      if (await this.replayStore.has(`nullifier:${nullifier}`)) {
+        return { isValid: false, invalidReason: TX_ALREADY_USED };
+      }
+      await this.replayStore.add(`nullifier:${nullifier}`);
+    }
+
+    return { isValid: true, payer: matchedPool };
+  }
+
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    // Re-verify before settling (follows SVM/EVM exact pattern)
+    const valid = await this.verify(payload, requirements);
+    if (!valid.isValid) {
+      // If re-verify fails with tx_already_used, that's expected — we already
+      // verified this payment. The replay store correctly prevents double-verify,
+      // but for settle we just need to confirm it was previously verified.
+      if (valid.invalidReason !== TX_ALREADY_USED) {
+        return {
+          success: false,
+          transaction: "",
+          network: requirements.network as Network,
+          errorReason: valid.invalidReason,
+          payer: valid.payer ?? "",
+        };
+      }
+    }
+
+    // Client-driven settlement — no on-chain action from facilitator
+    const raw = payload.payload as ShieldedPayload;
+    return {
+      success: true,
+      transaction: raw.txHash,
+      network: requirements.network as Network,
+      payer: valid.payer ?? "",
+    };
+  }
+}

--- a/typescript/packages/mechanisms/evm/src/shielded/index.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/index.ts
@@ -1,0 +1,13 @@
+export { ShieldedEvmClient } from "./client/index.js";
+export type { ShieldedEvmClientConfig } from "./client/index.js";
+export { ShieldedEvmFacilitator } from "./facilitator/index.js";
+export { ShieldedEvmServer } from "./server/index.js";
+export type {
+  ShieldedPayload,
+  UnshieldFn,
+  ShieldedProvider,
+  ShieldedFacilitatorConfig,
+  ShieldedServerConfig,
+  ReplayStore,
+} from "./types.js";
+export { DEFAULT_POOL_CONTRACTS, TRANSFER_EVENT_TOPIC } from "./constants.js";

--- a/typescript/packages/mechanisms/evm/src/shielded/server/index.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/server/index.ts
@@ -1,0 +1,1 @@
+export { ShieldedEvmServer } from "./scheme.js";

--- a/typescript/packages/mechanisms/evm/src/shielded/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/server/scheme.ts
@@ -1,0 +1,83 @@
+import type {
+  PaymentRequirements,
+  Network,
+  Price,
+  AssetAmount,
+} from "@x402/core/types";
+import type { SchemeNetworkServer } from "@x402/core/types/mechanisms";
+import type { ShieldedServerConfig } from "../types.js";
+
+// Default token addresses per chain (USDC)
+const DEFAULT_TOKENS: Record<number, { address: string; decimals: number }> = {
+  8453: { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", decimals: 6 },
+  1: { address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", decimals: 6 },
+  56: { address: "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d", decimals: 18 },
+  137: { address: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", decimals: 6 },
+  42161: { address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", decimals: 6 },
+};
+
+function getChainId(network: string): number {
+  return parseInt(network.split(":")[1], 10);
+}
+
+export class ShieldedEvmServer implements SchemeNetworkServer {
+  readonly scheme = "exact";
+  private poolContracts: Record<number, string[]>;
+  private defaultDecimals: number;
+
+  constructor(config: ShieldedServerConfig) {
+    this.poolContracts = config.poolContracts;
+    this.defaultDecimals = config.defaultDecimals ?? 6;
+  }
+
+  getAssetDecimals(_asset: string, _network: Network): number {
+    return this.defaultDecimals;
+  }
+
+  async parsePrice(price: Price, network: Network): Promise<AssetAmount> {
+    // Pass through AssetAmount objects
+    if (typeof price === "object" && price !== null && "amount" in price) {
+      return price as AssetAmount;
+    }
+
+    const chainId = getChainId(network);
+    const token = DEFAULT_TOKENS[chainId];
+    if (!token) {
+      throw new Error(`No default token for chain ${chainId}`);
+    }
+
+    // Parse dollar string or number
+    let amount: number;
+    if (typeof price === "string") {
+      amount = parseFloat(price.replace(/^\$/, ""));
+    } else {
+      amount = price as number;
+    }
+
+    const atomicAmount = Math.round(amount * 10 ** token.decimals);
+
+    return {
+      amount: atomicAmount.toString(),
+      asset: token.address,
+      extra: {},
+    };
+  }
+
+  async enhancePaymentRequirements(
+    requirements: PaymentRequirements,
+    _supportedKind: { x402Version: number; scheme: string; network: Network },
+    _extensionKeys: string[],
+  ): Promise<PaymentRequirements> {
+    const chainId = getChainId(requirements.network);
+    const pools = this.poolContracts[chainId] ?? [];
+
+    return {
+      ...requirements,
+      extra: {
+        ...requirements.extra,
+        assetTransferMethod: "shielded",
+        poolContracts: pools,
+      },
+    };
+  }
+}

--- a/typescript/packages/mechanisms/evm/src/shielded/types.ts
+++ b/typescript/packages/mechanisms/evm/src/shielded/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Payload for shielded EVM payments.
+ *
+ * The client unshields tokens from a privacy pool directly to the payTo address.
+ * The txHash is the on-chain transaction that the facilitator verifies.
+ */
+export type ShieldedPayload = {
+  txHash: `0x${string}`;
+  nullifiers?: string[];
+};
+
+/**
+ * Function that performs the on-chain unshield operation.
+ * Injected by the client — not tied to any specific privacy pool SDK.
+ */
+export type UnshieldFn = (
+  token: string,
+  amount: string,
+  to: string,
+  network: string,
+) => Promise<{ txHash: `0x${string}` }>;
+
+/**
+ * Minimal provider interface for fetching transaction receipts.
+ * Compatible with viem's PublicClient.
+ */
+export type ShieldedProvider = {
+  getTransactionReceipt(args: {
+    hash: `0x${string}`;
+  }): Promise<TransactionReceipt | null>;
+};
+
+export type TransactionReceipt = {
+  status: "success" | "reverted";
+  logs: Array<{
+    address: string;
+    topics: string[];
+    data: string;
+  }>;
+};
+
+/**
+ * Replay store interface — tracks used txHashes to prevent reuse.
+ */
+export type ReplayStore = {
+  has(key: string): boolean | Promise<boolean>;
+  add(key: string): void | Promise<void>;
+};
+
+/**
+ * Configuration for the shielded facilitator.
+ */
+export type ShieldedFacilitatorConfig = {
+  provider: ShieldedProvider;
+  poolContracts: Record<number, string[]>;
+  replayStore?: ReplayStore;
+};
+
+/**
+ * Configuration for the shielded server.
+ */
+export type ShieldedServerConfig = {
+  poolContracts: Record<number, string[]>;
+  defaultDecimals?: number;
+};

--- a/typescript/packages/mechanisms/evm/test/unit/shielded/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/shielded/client.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { ShieldedEvmClient } from "../../../src/shielded/client/scheme.js";
+import type { PaymentRequirements } from "@x402/core/types";
+import type { UnshieldFn } from "../../../src/shielded/types.js";
+
+const TX_HASH = "0x4712f6ad727eb4f72a59bf6e23edeb23589da66edc0166a2223252a5be9459c7" as const;
+const PAY_TO = "0x0cB634602891d5c200C80052a5047374afcE684A";
+const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+function makeRequirements(): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "eip155:8453" as `${string}:${string}`,
+    asset: USDC,
+    amount: "1000000",
+    payTo: PAY_TO,
+    maxTimeoutSeconds: 120,
+    extra: { assetTransferMethod: "shielded" },
+  };
+}
+
+describe("ShieldedEvmClient", () => {
+  it("calls unshield with correct token, amount, and recipient", async () => {
+    const unshield = vi.fn<UnshieldFn>().mockResolvedValue({ txHash: TX_HASH });
+    const client = new ShieldedEvmClient({ unshield });
+
+    await client.createPaymentPayload(2, makeRequirements());
+
+    expect(unshield).toHaveBeenCalledWith(USDC, "1000000", PAY_TO, "eip155:8453");
+  });
+
+  it("returns txHash in payload", async () => {
+    const unshield = vi.fn<UnshieldFn>().mockResolvedValue({ txHash: TX_HASH });
+    const client = new ShieldedEvmClient({ unshield });
+
+    const result = await client.createPaymentPayload(2, makeRequirements());
+
+    expect(result.x402Version).toBe(2);
+    expect((result.payload as Record<string, unknown>).txHash).toBe(TX_HASH);
+  });
+
+  it("propagates unshield errors", async () => {
+    const unshield = vi.fn<UnshieldFn>().mockRejectedValue(new Error("insufficient shielded balance"));
+    const client = new ShieldedEvmClient({ unshield });
+
+    await expect(client.createPaymentPayload(2, makeRequirements())).rejects.toThrow(
+      "insufficient shielded balance",
+    );
+  });
+
+  it("has scheme set to exact", () => {
+    const unshield = vi.fn<UnshieldFn>().mockResolvedValue({ txHash: TX_HASH });
+    const client = new ShieldedEvmClient({ unshield });
+    expect(client.scheme).toBe("exact");
+  });
+});

--- a/typescript/packages/mechanisms/evm/test/unit/shielded/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/shielded/facilitator.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ShieldedEvmFacilitator } from "../../../src/shielded/facilitator/scheme.js";
+import type {
+  ShieldedProvider,
+  TransactionReceipt,
+  ReplayStore,
+} from "../../../src/shielded/types.js";
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+} from "@x402/core/types";
+
+const POOL_CONTRACT = "0x26111e2379E5fC0A7Cd8728fe52c7b84CA4fbE85";
+const PAY_TO = "0x0cB634602891d5c200C80052a5047374afcE684A";
+const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const TX_HASH = "0x4712f6ad727eb4f72a59bf6e23edeb23589da66edc0166a2223252a5be9459c7";
+
+// ERC-20 Transfer event log from pool contract to payTo
+function makeTransferLog(from: string, to: string, amount: bigint, token: string) {
+  const fromPadded = "0x" + from.slice(2).toLowerCase().padStart(64, "0");
+  const toPadded = "0x" + to.slice(2).toLowerCase().padStart(64, "0");
+  const valuePadded = "0x" + amount.toString(16).padStart(64, "0");
+  return {
+    address: token.toLowerCase(),
+    topics: [
+      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+      fromPadded,
+      toPadded,
+    ],
+    data: valuePadded,
+  };
+}
+
+function makeReceipt(
+  status: "success" | "reverted" = "success",
+  logs: TransactionReceipt["logs"] = [],
+): TransactionReceipt {
+  return { status, logs };
+}
+
+function makeProvider(receipt: TransactionReceipt | null): ShieldedProvider {
+  return {
+    getTransactionReceipt: async () => receipt,
+  };
+}
+
+function makeReplayStore(): ReplayStore & { store: Set<string> } {
+  const store = new Set<string>();
+  return {
+    store,
+    has: (key: string) => store.has(key),
+    add: (key: string) => { store.add(key); },
+  };
+}
+
+function makeRequirements(overrides?: Partial<PaymentRequirements>): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "eip155:8453" as `${string}:${string}`,
+    asset: USDC,
+    amount: "1000000", // 1 USDC
+    payTo: PAY_TO,
+    maxTimeoutSeconds: 120,
+    extra: {
+      assetTransferMethod: "shielded",
+      poolContracts: [POOL_CONTRACT],
+    },
+    ...overrides,
+  };
+}
+
+function makePayload(txHash: string = TX_HASH, nullifiers?: string[]): PaymentPayload {
+  return {
+    x402Version: 2,
+    accepted: makeRequirements(),
+    payload: {
+      txHash,
+      ...(nullifiers ? { nullifiers } : {}),
+    },
+  };
+}
+
+describe("ShieldedEvmFacilitator", () => {
+  let replayStore: ReplayStore & { store: Set<string> };
+
+  beforeEach(() => {
+    replayStore = makeReplayStore();
+  });
+
+  describe("verify", () => {
+    it("accepts valid transfer from pool to payTo", async () => {
+      const log = makeTransferLog(POOL_CONTRACT, PAY_TO, 1000000n, USDC);
+      const provider = makeProvider(makeReceipt("success", [log]));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result.isValid).toBe(true);
+      expect(result.payer).toBe(POOL_CONTRACT.toLowerCase());
+    });
+
+    it("rejects invalid txHash format", async () => {
+      const provider = makeProvider(null);
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.verify(
+        makePayload("not-a-hash"),
+        makeRequirements(),
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("invalid_tx_hash");
+    });
+
+    it("rejects reverted transaction", async () => {
+      const provider = makeProvider(makeReceipt("reverted"));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("transaction_reverted");
+    });
+
+    it("rejects if transaction not found", async () => {
+      const provider = makeProvider(null);
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("transaction_not_found");
+    });
+
+    it("rejects if no Transfer from pool contract", async () => {
+      const log = makeTransferLog(
+        "0x0000000000000000000000000000000000000001", // not the pool
+        PAY_TO,
+        1000000n,
+        USDC,
+      );
+      const provider = makeProvider(makeReceipt("success", [log]));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("no_matching_transfer");
+    });
+
+    it("rejects if Transfer to wrong address", async () => {
+      const log = makeTransferLog(
+        POOL_CONTRACT,
+        "0x0000000000000000000000000000000000000002", // wrong recipient
+        1000000n,
+        USDC,
+      );
+      const provider = makeProvider(makeReceipt("success", [log]));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("no_matching_transfer");
+    });
+
+    it("rejects if Transfer amount too low", async () => {
+      const log = makeTransferLog(POOL_CONTRACT, PAY_TO, 999999n, USDC); // 1 micro short
+      const provider = makeProvider(makeReceipt("success", [log]));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("no_matching_transfer");
+    });
+
+    it("accepts Transfer with amount greater than required", async () => {
+      const log = makeTransferLog(POOL_CONTRACT, PAY_TO, 2000000n, USDC); // 2 USDC > 1 required
+      const provider = makeProvider(makeReceipt("success", [log]));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result.isValid).toBe(true);
+    });
+
+    it("rejects replayed txHash", async () => {
+      const log = makeTransferLog(POOL_CONTRACT, PAY_TO, 1000000n, USDC);
+      const provider = makeProvider(makeReceipt("success", [log]));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      // First call succeeds
+      const result1 = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result1.isValid).toBe(true);
+
+      // Second call with same txHash rejected
+      const result2 = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result2.isValid).toBe(false);
+      expect(result2.invalidReason).toBe("tx_already_used");
+    });
+
+    it("rejects if Transfer event is for wrong token", async () => {
+      const log = makeTransferLog(
+        POOL_CONTRACT,
+        PAY_TO,
+        1000000n,
+        "0x0000000000000000000000000000000000000099", // wrong token
+      );
+      const provider = makeProvider(makeReceipt("success", [log]));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.verify(makePayload(), makeRequirements());
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("no_matching_transfer");
+    });
+
+    it("rejects replayed nullifier", async () => {
+      const log = makeTransferLog(POOL_CONTRACT, PAY_TO, 1000000n, USDC);
+      const provider = makeProvider(makeReceipt("success", [log]));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const TX_HASH_2 = "0x" + "bb".repeat(32);
+      const NULLIFIER = "0x" + "cc".repeat(32);
+
+      // First with nullifier succeeds
+      const result1 = await facilitator.verify(
+        makePayload(TX_HASH, [NULLIFIER]),
+        makeRequirements(),
+      );
+      expect(result1.isValid).toBe(true);
+
+      // Different txHash but same nullifier — rejected
+      const result2 = await facilitator.verify(
+        makePayload(TX_HASH_2, [NULLIFIER]),
+        makeRequirements(),
+      );
+      expect(result2.isValid).toBe(false);
+      expect(result2.invalidReason).toBe("tx_already_used");
+    });
+  });
+
+  describe("settle", () => {
+    it("returns txHash after re-verification (client-driven)", async () => {
+      const log = makeTransferLog(POOL_CONTRACT, PAY_TO, 1000000n, USDC);
+      const provider = makeProvider(makeReceipt("success", [log]));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.settle(makePayload(), makeRequirements());
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe(TX_HASH);
+      expect(result.network).toBe("eip155:8453");
+    });
+
+    it("fails settle if verification fails", async () => {
+      const provider = makeProvider(makeReceipt("reverted"));
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const result = await facilitator.settle(makePayload(), makeRequirements());
+      expect(result.success).toBe(false);
+      expect(result.errorReason).toBe("transaction_reverted");
+    });
+  });
+
+  describe("getExtra", () => {
+    it("returns pool contracts for supported network", () => {
+      const provider = makeProvider(null);
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const extra = facilitator.getExtra("eip155:8453");
+      expect(extra).toEqual({
+        assetTransferMethod: "shielded",
+        poolContracts: [POOL_CONTRACT],
+      });
+    });
+
+    it("returns undefined for unsupported network", () => {
+      const provider = makeProvider(null);
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      const extra = facilitator.getExtra("eip155:999999");
+      expect(extra).toBeUndefined();
+    });
+  });
+
+  describe("getSigners", () => {
+    it("returns empty array (verify-only, no facilitator signers)", () => {
+      const provider = makeProvider(null);
+      const facilitator = new ShieldedEvmFacilitator({
+        provider,
+        poolContracts: { 8453: [POOL_CONTRACT] },
+        replayStore,
+      });
+
+      expect(facilitator.getSigners("eip155:8453")).toEqual([]);
+    });
+  });
+});

--- a/typescript/packages/mechanisms/evm/test/unit/shielded/server.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/shielded/server.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { ShieldedEvmServer } from "../../../src/shielded/server/scheme.js";
+import type { PaymentRequirements, Network } from "@x402/core/types";
+
+const POOL_CONTRACT = "0x26111e2379E5fC0A7Cd8728fe52c7b84CA4fbE85";
+const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+describe("ShieldedEvmServer", () => {
+  const server = new ShieldedEvmServer({
+    poolContracts: { 8453: [POOL_CONTRACT] },
+  });
+
+  describe("parsePrice", () => {
+    it("converts dollar amount to USDC atomic units", async () => {
+      const result = await server.parsePrice("$1.00", "eip155:8453" as Network);
+      expect(result.amount).toBe("1000000");
+      expect(result.asset).toBe(USDC);
+    });
+
+    it("converts numeric price", async () => {
+      const result = await server.parsePrice(0.5, "eip155:8453" as Network);
+      expect(result.amount).toBe("500000");
+    });
+
+    it("passes through AssetAmount objects", async () => {
+      const result = await server.parsePrice(
+        { amount: "2000000", asset: USDC, extra: {} },
+        "eip155:8453" as Network,
+      );
+      expect(result.amount).toBe("2000000");
+      expect(result.asset).toBe(USDC);
+    });
+  });
+
+  describe("getAssetDecimals", () => {
+    it("returns 6 for USDC", () => {
+      expect(server.getAssetDecimals(USDC, "eip155:8453" as Network)).toBe(6);
+    });
+  });
+
+  describe("enhancePaymentRequirements", () => {
+    it("adds shielded method and pool contracts", async () => {
+      const requirements: PaymentRequirements = {
+        scheme: "exact",
+        network: "eip155:8453" as `${string}:${string}`,
+        asset: USDC,
+        amount: "1000000",
+        payTo: "0xSomeAddress",
+        maxTimeoutSeconds: 120,
+        extra: {},
+      };
+
+      const enhanced = await server.enhancePaymentRequirements(
+        requirements,
+        { x402Version: 2, scheme: "exact", network: "eip155:8453" as Network },
+        [],
+      );
+
+      expect(enhanced.extra.assetTransferMethod).toBe("shielded");
+      expect(enhanced.extra.poolContracts).toEqual([POOL_CONTRACT]);
+    });
+  });
+
+  describe("scheme", () => {
+    it("is exact", () => {
+      expect(server.scheme).toBe("exact");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `ShieldedEvmClient`, `ShieldedEvmFacilitator`, and `ShieldedEvmServer` implementing `assetTransferMethod: "shielded"` for the `exact` scheme on EVM.

Agents withdraw tokens from an on-chain privacy pool (e.g., Railgun) directly to the merchant's `payTo` address. The pool contract verifies the ZK proof and checks nullifiers on-chain. The facilitator confirms the resulting ERC-20 Transfer event matches the payment requirements.

Reference implementation uses a deployed privacy pool on Base (Railgun) with on-chain nullifier tracking for double-spend prevention.

## Implementation

**Client** (`ShieldedEvmClient`): Takes an injected `UnshieldFn` — SDK-agnostic, any privacy pool works. Calls unshield and returns `{ txHash }`.

**Facilitator** (`ShieldedEvmFacilitator`):
- Validates txHash format, checks replay store
- Fetches tx receipt — non-reverted means pool accepted the ZK proof
- Parses ERC-20 Transfer events: `from` must be a registered pool contract, `to` must match `payTo`, `value` >= required
- Tracks txHash + nullifiers in replay store
- Settle re-verifies before confirming (matches existing EVM/SVM pattern)
- Client-driven settlement — facilitator is verify-only

**Server** (`ShieldedEvmServer`): Parses prices, enhances requirements with `assetTransferMethod: "shielded"` and `poolContracts`.

## Tests

26 unit tests covering:
- Valid payment verification
- Invalid txHash, reverted tx, wrong pool, wrong recipient, wrong amount, wrong token
- txHash replay prevention
- Nullifier replay prevention (defense-in-depth on top of on-chain nullifier set)
- Settle re-verification and settle failure
- Server price parsing and requirement enhancement
- Client payload creation and error propagation

All 365 existing tests still pass.

## Files

```
typescript/packages/mechanisms/evm/src/shielded/
├── types.ts, constants.ts, index.ts
├── client/scheme.ts
├── facilitator/scheme.ts, errors.ts
└── server/scheme.ts

typescript/packages/mechanisms/evm/test/unit/shielded/
├── client.test.ts
├── facilitator.test.ts
└── server.test.ts
```

Spec: #1951
Closes #1953