### PR TITLE
Add DevDrops to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/devdrops/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/devdrops/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "DevDrops",
+  "description": "43 pay-per-query data APIs on Base mainnet — weather, FX, stocks, crypto, SEC filings, sanctions screening, sentiment analysis, IP geolocation, and more. Universal MCP server with 18 tools for AI agents. Prepaid USDC credit bundles. Free tier: 5 queries/day/IP on select endpoints. No API keys, no signups.",
+  "logoUrl": "/logos/devdrops.svg",
+  "websiteUrl": "https://devdrops.run",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/devdrops.svg
+++ b/typescript/site/public/logos/devdrops.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="24" fill="#0a0a0b"/>
+  <text x="100" y="80" font-family="monospace" font-size="48" font-weight="700" fill="#22c55e" text-anchor="middle">dd</text>
+  <text x="100" y="130" font-family="monospace" font-size="18" fill="#9d9b95" text-anchor="middle">devdrops</text>
+  <text x="100" y="158" font-family="monospace" font-size="13" fill="#5c5b57" text-anchor="middle">x402 APIs</text>
+</svg>


### PR DESCRIPTION
## What is DevDrops?

[DevDrops](https://devdrops.run) is a suite of 22+ pay-per-query data APIs built natively on x402, running on Cloudflare Workers (Base mainnet).

AI agents send a standard HTTP request, receive HTTP 402, pay USDC on Base, and get structured JSON — no API keys, no accounts, no subscriptions.

## Endpoints include

- Prediction markets (Polymarket + Manifold)
- Sports odds
- FX rates, crypto prices, stock data
- Regulatory filings (SEC EDGAR + Companies House)
- UK property intelligence (with MCP server)
- Weather, IP geolocation, domain intelligence
- AI-powered sentiment, research briefs, document summarisation
- And more — full catalog at https://api.devdrops.run/catalog

## Links

- Homepage: https://devdrops.run
- API: https://api.devdrops.run
- Catalog: https://api.devdrops.run/catalog
- OpenAPI: https://api.devdrops.run/openapi.json
- GitHub: https://github.com/metamorphosis-sre/devdrops