### PR TITLE
Add Rug Scanner to ecosystem — on-chain token risk analysis

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/rug-scanner/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/rug-scanner/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "Rug Scanner",
+  "description": "On-chain token risk analysis API. 7 parallel checks, deterministic rug pull scoring. $0.05 USDC per scan via x402 on Base.",
+  "websiteUrl": "https://rug-scanner-production.up.railway.app",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
Adds Rug Scanner to the Services/Endpoints category. Live x402-gated API for on-chain token rug pull risk analysis. 7 parallel checks, deterministic threshold scoring, $0.05 USDC per scan on Base.

Live: https://rug-scanner-production.up.railway.app
GitHub: https://github.com/LucianoLupo/rug-scanner
Discovery: https://rug-scanner-production.up.railway.app/.well-known/x402.json