### PR TITLE
spec(exact-evm): add optional `decimals` field to `extra` in PaymentRequirements

### DIFF
--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -72,7 +72,7 @@ The `payload` field must contain:
 - `extra.assetTransferMethod` (required): MUST be `"eip3009"`.
 - `extra.name` (required): The EIP-712 domain name of the token contract. Used for `transferWithAuthorization` signature construction.
 - `extra.version` (required): The EIP-712 domain version of the token contract. Used for `transferWithAuthorization` signature construction.
-- `extra.decimals` (required): The token's decimal precision (integer, same semantics as ERC-20 `decimals()`). Informational for display rendering only. MUST NOT affect payment verification or settlement.
+- `extra.decimals` (optional): The token's decimal precision (integer, same semantics as ERC-20 `decimals()`). Informational for display rendering only. MUST NOT affect payment verification or settlement. Servers SHOULD include this field to save clients an on-chain RPC round trip. Clients MUST fall back to querying the token's ERC-20 `decimals()` function when the field is absent, and SHOULD cross-check server-asserted values against a trusted token registry before rendering amounts.
 
 ### Phase 2: Verification Logic
 
@@ -171,7 +171,7 @@ The `payload` field must contain:
 - `extra.assetTransferMethod` (required): MUST be `"permit2"`.
 - `extra.name` (conditional): The EIP-712 domain name of the token contract. Required when the token supports EIP-2612 for gasless Permit2 approval.
 - `extra.version` (conditional): The EIP-712 domain version of the token contract. Required when the token supports EIP-2612 for gasless Permit2 approval.
-- `extra.decimals` (required): The token's decimal precision (integer, same semantics as ERC-20 `decimals()`). Informational for display rendering only, MUST NOT affect payment verification or settlement.
+- `extra.decimals` (optional): The token's decimal precision (integer, same semantics as ERC-20 `decimals()`). Informational for display rendering only. MUST NOT affect payment verification or settlement. Servers SHOULD include this field to save clients an on-chain RPC round trip. Clients MUST fall back to querying the token's ERC-20 `decimals()` function when the field is absent, and SHOULD cross-check server-asserted values against a trusted token registry before rendering amounts.
 
 ### Phase 3: Verification Logic
 
@@ -285,7 +285,7 @@ The `payload` field must contain:
 - `extra.assetTransferMethod` (required): MUST be `"erc7710"`.
 - `extra.name` (optional): The EIP-712 domain name of the token contract. Not required for ERC-7710 delegation-based transfers.
 - `extra.version` (optional): The EIP-712 domain version of the token contract. Not required for ERC-7710 delegation-based transfers.
-- `extra.decimals` (required): The token's decimal precision (integer, same semantics as ERC-20 `decimals()`). Informational for display rendering only, MUST NOT affect payment verification or settlement.
+- `extra.decimals` (optional): The token's decimal precision (integer, same semantics as ERC-20 `decimals()`). Informational for display rendering only. MUST NOT affect payment verification or settlement. Servers SHOULD include this field to save clients an on-chain RPC round trip. Clients MUST fall back to querying the token's ERC-20 `decimals()` function when the field is absent, and SHOULD cross-check server-asserted values against a trusted token registry before rendering amounts.
 
 **Note:** The structure of `permissionContext` is determined by the specific Delegation Manager implementation. Common implementations (e.g., MetaMask Delegation Framework) use EIP-712 signed delegation chains.
 

--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -4,7 +4,7 @@
 
 The `exact` scheme on EVM executes a transfer where the Facilitator (server) pays the gas, but the Client (user) controls the exact flow of funds via cryptographic signatures.
 
-This is implemented via one of two asset transfer methods, depending on the token's capabilities:
+This is implemented via one of three asset transfer methods, depending on the token's capabilities:
 
 | AssetTransferMethod | Use Case                                                     | Recommendation                                 | Usage Semantics                     |
 | :------------------ | :----------------------------------------------------------- | :--------------------------------------------- | :---------------------------------- |
@@ -49,7 +49,8 @@ The `payload` field must contain:
     "extra": {
       "assetTransferMethod": "eip3009",
       "name": "USDC",
-      "version": "2"
+      "version": "2",
+      "decimals": 6
     }
   },
   "payload": {
@@ -65,6 +66,13 @@ The `payload` field must contain:
   }
 }
 ```
+
+**`extra` Field Definitions specific to eip3009:**
+
+- `extra.assetTransferMethod` (required): MUST be `"eip3009"`.
+- `extra.name` (required): The EIP-712 domain name of the token contract. Used for `transferWithAuthorization` signature construction.
+- `extra.version` (required): The EIP-712 domain version of the token contract. Used for `transferWithAuthorization` signature construction.
+- `extra.decimals` (required): The token's decimal precision (integer, same semantics as ERC-20 `decimals()`). Informational for display rendering only. MUST NOT affect payment verification or settlement.
 
 ### Phase 2: Verification Logic
 
@@ -134,7 +142,8 @@ The `payload` field must contain:
     "extra": {
       "assetTransferMethod": "permit2",
       "name": "USDC",
-      "version": "2"
+      "version": "2",
+      "decimals": 6
     }
   }
   "payload": {
@@ -156,6 +165,13 @@ The `payload` field must contain:
   },
 }
 ```
+
+**`extra` Field Definitions specific to permit2:**
+
+- `extra.assetTransferMethod` (required): MUST be `"permit2"`.
+- `extra.name` (conditional): The EIP-712 domain name of the token contract. Required when the token supports EIP-2612 for gasless Permit2 approval.
+- `extra.version` (conditional): The EIP-712 domain version of the token contract. Required when the token supports EIP-2612 for gasless Permit2 approval.
+- `extra.decimals` (required): The token's decimal precision (integer, same semantics as ERC-20 `decimals()`). Informational for display rendering only, MUST NOT affect payment verification or settlement.
 
 ### Phase 3: Verification Logic
 
@@ -252,7 +268,8 @@ The `payload` field must contain:
     "extra": {
       "assetTransferMethod": "erc7710",
       "name": "USDC",
-      "version": "2"
+      "version": "2",
+      "decimals": 6
     }
   },
   "payload": {
@@ -262,6 +279,13 @@ The `payload` field must contain:
   }
 }
 ```
+
+**`extra` Field Definitions specific to erc7710:**
+
+- `extra.assetTransferMethod` (required): MUST be `"erc7710"`.
+- `extra.name` (optional): The EIP-712 domain name of the token contract. Not required for ERC-7710 delegation-based transfers.
+- `extra.version` (optional): The EIP-712 domain version of the token contract. Not required for ERC-7710 delegation-based transfers.
+- `extra.decimals` (required): The token's decimal precision (integer, same semantics as ERC-20 `decimals()`). Informational for display rendering only, MUST NOT affect payment verification or settlement.
 
 **Note:** The structure of `permissionContext` is determined by the specific Delegation Manager implementation. Common implementations (e.g., MetaMask Delegation Framework) use EIP-712 signed delegation chains.
 

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -90,7 +90,8 @@ When a resource server requires payment, it responds with a payment required sig
       "maxTimeoutSeconds": 60,
       "extra": {
         "name": "USDC",
-        "version": "2"
+        "version": "2",
+        "decimals": 6
       }
     }
   ],
@@ -162,7 +163,8 @@ The client includes payment authorization as JSON in the payment payload field:
     "maxTimeoutSeconds": 60,
     "extra": {
       "name": "USDC",
-      "version": "2"
+      "version": "2",
+      "decimals": 6
     }
   },
   "payload": {
@@ -355,7 +357,8 @@ Example with actual data:
       "maxTimeoutSeconds": 60,
       "extra": {
         "name": "USDC",
-        "version": "2"
+        "version": "2",
+        "decimals": 6
       }
     },
     "payload": {
@@ -379,7 +382,8 @@ Example with actual data:
     "maxTimeoutSeconds": 60,
     "extra": {
       "name": "USDC",
-      "version": "2"
+      "version": "2",
+      "decimals": 6
     }
   }
 }
@@ -528,7 +532,8 @@ List discoverable x402 resources from the Bazaar.
           "maxTimeoutSeconds": 60,
           "extra": {
             "name": "USDC",
-            "version": "2"
+            "version": "2",
+            "decimals": 6
           }
         }
       ],

--- a/typescript/.changeset/spec-exact-evm-decimals-optional.md
+++ b/typescript/.changeset/spec-exact-evm-decimals-optional.md
@@ -1,0 +1,7 @@
+---
+"@x402/evm": patch
+---
+
+spec(exact-evm): add optional `extra.decimals` field to `PaymentRequirements` across eip3009, permit2, and erc7710 sections
+
+Informational display-metadata hint for client amount rendering. Servers SHOULD include to save clients an on-chain RPC round trip. Clients MUST fall back to querying ERC-20 `decimals()` when absent, and SHOULD cross-check server-asserted values against a trusted token registry before rendering amounts. MUST NOT affect payment verification or settlement.


### PR DESCRIPTION
> **Update (softened):** This PR now proposes `decimals` as **optional** with server-SHOULD / client-MUST-fallback semantics, not required. See [this comment](https://github.com/x402-foundation/x402/pull/1976#issuecomment-4247030525) for rationale. Strikethrough below reflects the original proposal.

## Proposal

Add a `decimals` field to the `extra` object in the exact EVM scheme's `PaymentRequirements`. This provides the token's decimal precision to clients without requiring an on-chain RPC call, as an **optional hint** that clients MUST be prepared to resolve from the canonical on-chain source when absent.

## Motivation

Currently, when the server constructs `PaymentRequirements`, it calls `getDefaultAsset(network)` which returns `DefaultAssetInfo` including `address`, `name`, `version`, and `decimals`. However, `decimals` is currently not included within `PaymentRequirements`.

Without `decimals` in `PaymentRequirements`, clients have no way to correctly render human-readable token amounts from the raw atomic values in `amount` **without an extra RPC round trip**. Including `decimals` in `extra` gives any client — paywall, wallet, dashboard, or third-party integration — the correct precision as an optional hint.

## Changes Required

- Add `decimals` as an **optional** field in `extra` for the exact EVM scheme's `PaymentRequirements` (eip3009, permit2, erc7710)
- Document all `extra` fields (`assetTransferMethod`, `name`, `version`, `decimals`) per `assetTransferMethod` section, following the pattern established by the SVM, Aptos, Hedera, and Stellar scheme specs
- Servers **SHOULD** include `decimals` to save clients an on-chain RPC round trip
- Clients **MUST** fall back to querying ERC-20 `decimals()` when absent, and **SHOULD** cross-check server-asserted values against a trusted token registry before rendering
- `decimals` is informational only and MUST NOT affect payment verification or settlement
- Update core spec examples in `x402-specification-v2.md` to illustrate the SHOULD case (`"decimals": 6` included in examples)
- Fix typo: "two" to "three" asset transfer methods (ERC-7710 was added)

## Implementation

The server-side implementation is a single line addition in `exact/server/scheme.ts`, adding `decimals: assetInfo.decimals` alongside the existing `name` and `version`.

---

## ~~Original proposal (required) — superseded~~

> ~~**Changes Required:**~~
>
> - ~~Add `decimals` as a **required** field in `extra` for the exact EVM scheme's `PaymentRequirements`~~
> - ~~Document all `extra` fields (`assetTransferMethod`, `name`, `version`, `decimals`) per `assetTransferMethod` section, following the pattern established by the SVM, Aptos, Hedera, and Stellar scheme specs~~
> - ~~Update core spec examples in `x402-specification-v2.md` to include `decimals`~~
> - ~~Fix typo: "two" to "three" asset transfer methods (ERC-7710 was added)~~
>
> ~~**Implementation**~~
> ~~The server-side implementation is a single line addition in `exact/server/scheme.ts`, adding `decimals: assetInfo.decimals` alongside the existing `name` and `version`.~~
>
> ~~**Breaking change note:** Adding `decimals` as a required field is technically a spec-level breaking change — existing server implementations do not currently include it. However, no client code reads `extra.decimals` today (clients currently ignore decimals, hard code the value, or make an RPC call on-chain), and the server-side change is minimal. Clients encountering a server that does not yet include `decimals` should fall back to querying ERC-20 `decimals()` on-chain. The practical impact is that server implementations should include `decimals` when they next release, not that any running system will break.~~

See [softening comment](https://github.com/x402-foundation/x402/pull/1976#issuecomment-4247030525) for why the required approach was withdrawn.