### PR TITLE
feat(examples): add EUR settlement example via fiat-capable facilitator

### DIFF
--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -3297,6 +3297,61 @@ importers:
         specifier: ^5.3.0
         version: 5.9.2
 
+  servers/eur-settlement:
+    dependencies:
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/core
+      '@x402/evm':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/mechanisms/evm
+      '@x402/express':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/http/express
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.33.0
+      '@types/express':
+        specifier: ^5.0.1
+        version: 5.0.3
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.33.0(jiti@2.6.1)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.33.0(jiti@2.6.1)))(eslint@9.33.0(jiti@2.6.1))(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^7.2.0
+        version: 7.3.0(postcss@8.5.6)(typescript@5.9.2)
+      tsx:
+        specifier: ^4.7.0
+        version: 4.20.4
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.2
+
   servers/express:
     dependencies:
       '@x402/core':
@@ -8877,6 +8932,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -12217,7 +12273,7 @@ packages:
     engines: {node: '>=6.0.0'}
 
   prettier@3.5.2:
-    resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==, tarball: https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz}
+    resolution: {integrity: sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==}
     engines: {node: '>=14'}
     hasBin: true
 

--- a/examples/typescript/servers/eur-settlement/.env-local
+++ b/examples/typescript/servers/eur-settlement/.env-local
@@ -1,0 +1,2 @@
+EVM_ADDRESS=
+FACILITATOR_URL=https://x402.asterpay.io/v2/x402

--- a/examples/typescript/servers/eur-settlement/.prettierignore
+++ b/examples/typescript/servers/eur-settlement/.prettierignore
@@ -1,0 +1,8 @@
+docs/
+dist/
+node_modules/
+coverage/
+.github/
+src/client
+**/**/*.json
+*.md

--- a/examples/typescript/servers/eur-settlement/.prettierrc
+++ b/examples/typescript/servers/eur-settlement/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/examples/typescript/servers/eur-settlement/README.md
+++ b/examples/typescript/servers/eur-settlement/README.md
@@ -1,0 +1,126 @@
+# EUR Settlement Example
+
+Express.js server showing how to accept x402 payments and receive EUR via SEPA Instant instead of USDC. The server code is identical to the [standard Express example](../express/) — the only change is the `FACILITATOR_URL` in `.env`.
+
+```typescript
+import express from "express";
+import { paymentMiddleware, x402ResourceServer } from "@x402/express";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+
+const app = express();
+
+app.use(
+  paymentMiddleware(
+    {
+      "GET /weather": {
+        accepts: { scheme: "exact", price: "$0.001", network: "eip155:84532", payTo: evmAddress },
+        description: "European weather data",
+        mimeType: "application/json",
+      },
+    },
+    new x402ResourceServer(new HTTPFacilitatorClient({ url: facilitatorUrl }))
+      .register("eip155:84532", new ExactEvmScheme()),
+  ),
+);
+
+app.get("/weather", (_, res) => res.json({ city: "Berlin", weather: "partly cloudy" }));
+```
+
+Buyers pay USDC as usual. The facilitator settles to the seller's bank account in EUR via SEPA Instant. No changes to client code or SDK.
+
+## Prerequisites
+
+- Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
+- pnpm v10 (install via [pnpm.io/installation](https://pnpm.io/installation))
+- EVM address for receiving payments
+- A EUR-capable facilitator URL (see below)
+
+## Setup
+
+1. Copy `.env-local` to `.env`:
+
+```bash
+cp .env-local .env
+```
+
+and set the required variables:
+
+- `EVM_ADDRESS` — your Ethereum address
+- `FACILITATOR_URL` — endpoint of a facilitator that supports EUR settlement
+
+2. Install and build from the typescript examples root:
+```bash
+cd ../../
+pnpm install && pnpm build
+cd servers/eur-settlement
+```
+
+3. Run the server:
+```bash
+pnpm dev
+```
+
+## Facilitator
+
+The difference between standard USDC settlement and EUR settlement is one environment variable:
+
+```bash
+# Standard (USDC stays as USDC):
+FACILITATOR_URL=https://x402.org/facilitator
+
+# EUR settlement (USDC converted to EUR, sent via SEPA Instant):
+FACILITATOR_URL=https://x402.asterpay.io/v2/x402
+```
+
+[AsterPay](https://asterpay.io) is used here as an example of a EUR-capable facilitator. Any facilitator that implements the same x402 HTTP interface and supports EUR conversion will work.
+
+## How it works
+
+The `price` field (e.g. `"$0.001"`) is the on-chain USDC amount the buyer pays — same as any other x402 server. The facilitator handles the USDC-to-EUR conversion and initiates a SEPA Instant transfer to the seller's linked bank account.
+
+From the buyer's perspective, nothing changes. From the seller's perspective, EUR arrives in their bank account instead of USDC in their wallet.
+
+## Testing
+
+You can test using any of the example clients:
+
+```bash
+cd ../clients/fetch
+# Ensure .env is set up
+pnpm dev
+```
+
+Both endpoints require payment:
+- `GET /weather` — 0.001 USDC
+- `GET /market-data` — 0.01 USDC
+
+## Example Endpoints
+
+### `/weather`
+```json
+{
+  "report": {
+    "city": "Berlin",
+    "weather": "partly cloudy",
+    "temperature": 18,
+    "unit": "celsius"
+  }
+}
+```
+
+### `/market-data`
+```json
+{
+  "market": "EU",
+  "indices": {
+    "EURO STOXX 50": { "value": 5142.3, "change": "+0.8%" },
+    "DAX": { "value": 18654.7, "change": "+1.1%" },
+    "CAC40": { "value": 7832.1, "change": "+0.5%" }
+  }
+}
+```
+
+## Network
+
+This example uses Base Sepolia (`eip155:84532`). For testnet USDC, see the [x402 quickstart](https://docs.x402.org/getting-started/quickstart-for-sellers).

--- a/examples/typescript/servers/eur-settlement/eslint.config.js
+++ b/examples/typescript/servers/eur-settlement/eslint.config.js
@@ -1,0 +1,73 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        console: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+];

--- a/examples/typescript/servers/eur-settlement/index.ts
+++ b/examples/typescript/servers/eur-settlement/index.ts
@@ -1,0 +1,80 @@
+import { config } from "dotenv";
+import express from "express";
+import { paymentMiddleware, x402ResourceServer } from "@x402/express";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+config();
+
+const evmAddress = process.env.EVM_ADDRESS as `0x${string}`;
+if (!evmAddress) {
+  console.error("Missing required environment variables");
+  process.exit(1);
+}
+
+const facilitatorUrl = process.env.FACILITATOR_URL;
+if (!facilitatorUrl) {
+  console.error("❌ FACILITATOR_URL environment variable is required");
+  process.exit(1);
+}
+const facilitatorClient = new HTTPFacilitatorClient({ url: facilitatorUrl });
+
+const app = express();
+
+app.use(
+  paymentMiddleware(
+    {
+      "GET /weather": {
+        accepts: [
+          {
+            scheme: "exact",
+            price: "$0.001",
+            network: "eip155:84532",
+            payTo: evmAddress,
+          },
+        ],
+        description: "European weather data",
+        mimeType: "application/json",
+      },
+      "GET /market-data": {
+        accepts: [
+          {
+            scheme: "exact",
+            price: "$0.01",
+            network: "eip155:84532",
+            payTo: evmAddress,
+          },
+        ],
+        description: "European market indices",
+        mimeType: "application/json",
+      },
+    },
+    new x402ResourceServer(facilitatorClient).register("eip155:84532", new ExactEvmScheme()),
+  ),
+);
+
+app.get("/weather", (_, res) => {
+  res.send({
+    report: {
+      city: "Berlin",
+      weather: "partly cloudy",
+      temperature: 18,
+      unit: "celsius",
+    },
+  });
+});
+
+app.get("/market-data", (_, res) => {
+  res.send({
+    market: "EU",
+    indices: {
+      "EURO STOXX 50": { value: 5142.3, change: "+0.8%" },
+      DAX: { value: 18654.7, change: "+1.1%" },
+      CAC40: { value: 7832.1, change: "+0.5%" },
+    },
+    timestamp: new Date().toISOString(),
+  });
+});
+
+app.listen(4021, () => {
+  console.log(`Server listening at http://localhost:${4021}`);
+});

--- a/examples/typescript/servers/eur-settlement/package.json
+++ b/examples/typescript/servers/eur-settlement/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@x402/eur-settlement-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx index.ts",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "dependencies": {
+    "@x402/core": "workspace:*",
+    "@x402/evm": "workspace:*",
+    "@x402/express": "workspace:*",
+    "dotenv": "^16.4.7",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@types/express": "^5.0.1",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsup": "^7.2.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/examples/typescript/servers/eur-settlement/tsconfig.json
+++ b/examples/typescript/servers/eur-settlement/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary

Adds an Express server example showing how to accept x402 payments and receive EUR via SEPA Instant. The server code is identical to the standard Express example — the only difference is the `FACILITATOR_URL` pointing to a facilitator that handles USDC-to-EUR conversion.

## What this enables

- European sellers receive EUR in their bank account instead of USDC
- Buyers/agents pay USDC as normal — no change to client code
- Standard `exact` scheme, no new packages or types needed
- One env var change from an existing x402 integration

## Changes

- New example: `examples/typescript/servers/eur-settlement/`
- Express server with two paid endpoints (`/weather`, `/market-data`)
- README explaining the facilitator swap pattern
- `.env-local` with `FACILITATOR_URL` template

No changes to existing examples, packages, or types.

## Design notes

- `FACILITATOR_URL` is an environment variable, not hardcoded — any fiat-capable facilitator works
- In this example, [AsterPay](https://asterpay.io) is used as one possible EUR settlement facilitator. Other facilitators can implement the same capability by supporting the same HTTP interface.

## Test plan

- [x] `pnpm install` resolves without errors
- [x] `pnpm dev` starts the server on port 4021
- [x] `GET /weather` returns 402 Payment Required
- [x] `GET /market-data` returns 402 Payment Required
- [x] Config files match `express/` example conventions
- [ ] Payment flow works with x402 client SDK