### PR TITLE
Add terms extension specification

### DIFF
--- a/specs/extensions/terms.md
+++ b/specs/extensions/terms.md
@@ -1,0 +1,90 @@
+# Extension: `terms`
+
+## Summary
+
+The `terms` extension can be used by any network or scheme to communicate the terms of the payment commitment.
+
+## Purpose
+
+Describes the usage rights, obligations, and settlement terms of a payment commitment.
+
+## Extension Definition
+
+```json
+{
+  "terms": {
+    "schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": ["uri", "markdown", "plaintext", "json"],
+          "description": "Format identifier describing how to interpret the terms field"
+        },
+        "terms": {
+          "type": "string",
+          "description": "Terms as a string (URL, markdown, plaintext, or JSON)"
+        },
+        "version": {
+          "type": "string",
+          "description": "Version identifier for change detection"
+        }
+      },
+      "required": ["format", "terms"]
+    },
+    "info": {
+      "format": "uri",
+      "terms": "https://example.com/terms.md",
+      "version": "2026-01-15"
+    }
+  }
+}
+```
+
+## Fields
+
+- **`format`** (required): Format identifier describing how to interpret the `terms` field
+  - `"uri"`: Terms field contains a URL or data URI to the terms document
+  - `"markdown"`: Terms field contains Markdown formatted text
+  - `"plaintext"`: Terms field contains plain text
+  - `"json"`: Terms field contains JSON-stringified structured data
+
+- **`terms`** (required): Terms as a string
+  - If `format` is `"uri"`: An HTTPS URL or data URI pointing to the terms document
+  - If `format` is `"markdown"` or `"plaintext"`: The actual terms text
+  - If `format` is `"json"`: JSON string containing structured terms data
+
+- **`version`** (optional): Identifier for change detection. Allows clients to detect when terms have changed without fetching the full document. Can be a date, semantic version, hash, or any string that changes when terms are updated.
+
+**Schema Omission**: The `schema` field is optional and may be omitted from responses to reduce header size. When omitted, clients should reference this specification for field definitions.
+
+## Examples
+
+```json
+// URI format with version for change detection
+{ "format": "uri", "terms": "https://example.com/terms.md", "version": "2026-01-15" }
+
+// Markdown format
+{ "format": "markdown", "terms": "# Terms of Use\n\nThis content is provided under the following terms..." }
+
+// Plaintext format
+{ "format": "plaintext", "terms": "Licensed for non-commercial use only. Attribution required." }
+```
+
+## Usage
+
+This extension can be used across different payment schemes and networks to communicate:
+
+- **Content licensing**: Rights for LLM training, inference, or redistribution
+- **Subscription agreements**: Terms of service for ongoing access
+- **Usage restrictions**: Limitations on how the resource can be used
+- **Legal obligations**: Compliance requirements or liability terms
+
+Networks may specify terms alongside authentication extensions (like `http-message-signatures`), in order to create a complete framework where the network knows both who is paying and what terms govern the usage of the accessed resource.
+
+## Example Use Cases
+
+- **batch-settlement scheme**: Communicating usage rights for content accessed through batched payment
+- **exact scheme**: Specifying terms for blockchain-settled payments
+- **Any scheme**: Describing legal terms for resource access


### PR DESCRIPTION
## Summary

Adds the `terms` extension, providing a channel for servers to communicate usage rights, obligations, and settlement terms alongside the `PaymentRequired` response.

- Scheme- and network-agnostic — works with `exact`, `batch-settlement`, or any future scheme
- Supports multiple formats: `uri`, `markdown`, `plaintext`, `json`
- Optional `version` field for change detection

Split from #1145 for separate review per discussion with @carsonroscoe.

### A note on scope

This extension defines how terms are **communicated** — not how they are **consented to**. The spec takes the implicit approach: terms are presented, and proceeding with payment implies awareness. Whether a network requires explicit consent (e.g., tying terms acceptance to a signed SIWX message) is a per-network or future-extension concern. The priority is establishing a standard channel for terms to be discoverable and machine-readable.

#### What's Included

| File | Description |
|------|-------------|
| `specs/extensions/terms.md` | Terms extension specification |

## Tests
None — spec-only, no SDK implementation.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [ ] **SKIPPED** added a changelog fragment for user-facing changes (docs-only changes can skip)