### PR TITLE
fix(paywall): use token name from payment requirements instead of hardcoded USDC

### DIFF
--- a/typescript/packages/http/paywall/src/evm/EvmPaywall.tsx
+++ b/typescript/packages/http/paywall/src/evm/EvmPaywall.tsx
@@ -51,6 +51,7 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
   const network = firstRequirement.network;
   const chainName = getNetworkDisplayName(network);
   const testnet = isTestnetNetwork(network);
+  const tokenName = (firstRequirement.extra as Record<string, unknown>)?.name as string || "USDC";
 
   const chainId = parseInt(network.split(":")[1]);
 
@@ -138,11 +139,11 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
     setIsPaying(true);
 
     try {
-      setStatus("Checking USDC balance...");
+      setStatus(`Checking ${tokenName} balance...`);
       const balance = await getUSDCBalance(publicClient, address);
 
       if (balance === 0n) {
-        throw new Error(`Insufficient balance. Make sure you have USDC on ${chainName}`);
+        throw new Error(`Insufficient balance. Make sure you have ${tokenName} on ${chainName}`);
       }
 
       setStatus("Creating payment signature...");
@@ -196,11 +197,11 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
         <h1 className="title">Payment Required</h1>
         <p>
           {paymentRequired.resource?.description && `${paymentRequired.resource.description}.`} To
-          access this content, please pay ${amount} {chainName} USDC.
+          access this content, please pay ${amount} {chainName} {tokenName}.
         </p>
         {testnet && (
           <p className="instructions">
-            Need {chainName} USDC?{" "}
+            Need {chainName} {tokenName}?{" "}
             <a href="https://faucet.circle.com/" target="_blank" rel="noopener noreferrer">
               Get some <u>here</u>.
             </a>
@@ -259,14 +260,14 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
                 <span className="payment-value">
                   <button className="balance-button" onClick={() => setHideBalance(prev => !prev)}>
                     {formattedUsdcBalance && !hideBalance
-                      ? `$${formattedUsdcBalance} USDC`
-                      : "••••• USDC"}
+                      ? `$${formattedUsdcBalance} ${tokenName}`
+                      : `••••• ${tokenName}`}
                   </button>
                 </span>
               </div>
               <div className="payment-row">
                 <span className="payment-label">Amount:</span>
-                <span className="payment-value">${amount} USDC</span>
+                <span className="payment-value">${amount} {tokenName}</span>
               </div>
               <div className="payment-row">
                 <span className="payment-label">Network:</span>
@@ -296,3 +297,4 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary

The EVM paywall currently hardcodes "USDC" as the token label in all user-facing strings. This is incorrect for chains whose default stablecoin is not named USDC (e.g. MegaETH uses MegaUSD, Stable uses USDT0).

This PR reads the token name from `firstRequirement.extra.name` (set by the server from the default asset registry) and falls back to "USDC" when the field is absent, maintaining backward compatibility.

## Changes

- Extract `tokenName` from `firstRequirement.extra.name` with `"USDC"` fallback
- Replace 7 hardcoded `"USDC"` display strings in `EvmPaywall.tsx`:
  - Status messages ("Checking balance...", "Insufficient balance...")
  - Payment description text
  - Balance display
  - Amount display

## Testing

- For USDC chains: `extra.name` is `"USDC"`, behavior is identical to before
- For MegaETH: `extra.name` is `"MegaUSD"`, paywall now correctly shows "MegaUSD" instead of "USDC"
- When `extra.name` is absent: falls back to "USDC" (backward compatible)

Closes #1972