### PR TITLE
Add PayAPI Market to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/payapi-market/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/payapi-market/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "PayAPI Market",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/payapi-market.svg",
+  "description": "Marketplace where AI agents discover and pay for x402-powered APIs via MCP. 10 APIs, 65 endpoints across property, weather, companies, vehicles, and finance domains. Free to list, providers keep 97% on USDC settlement.",
+  "websiteUrl": "https://payapi.market"
+}

--- a/typescript/site/public/logos/payapi-market.svg
+++ b/typescript/site/public/logos/payapi-market.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="none">
+  <rect width="256" height="256" rx="48" fill="#06080D"/>
+  <text x="128" y="116" text-anchor="middle" font-family="ui-monospace, 'Geist Mono', 'SF Mono', Menlo, monospace" font-size="52" font-weight="800" fill="#00D4FF" letter-spacing="-1.5">payapi</text>
+  <text x="128" y="158" text-anchor="middle" font-family="ui-monospace, 'Geist Mono', 'SF Mono', Menlo, monospace" font-size="28" font-weight="400" fill="#8A92A6" letter-spacing="0.5">market</text>
+  <rect x="56" y="182" width="144" height="2" rx="1" fill="#1A1F2A"/>
+  <text x="128" y="214" text-anchor="middle" font-family="ui-monospace, 'Geist Mono', 'SF Mono', Menlo, monospace" font-size="18" font-weight="600" fill="#00D4FF">x402 · MCP · USDC</text>
+</svg>


### PR DESCRIPTION
PayAPI Market is a marketplace for x402-powered APIs. AI agents discover APIs via MCP and pay per request using USDC on Base. 10 APIs live with 65 endpoints across property, weather, companies, vehicles, and finance domains. Free for providers to list, they keep 97% of every payment. Live at https://payapi.market