### PR TITLE
chore: add scoped viem dependabot updates for /typescript

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/typescript"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    allow:
+      - dependency-name: "viem"
+    ignore:
+      - dependency-name: "viem"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      viem:
+        patterns:
+          - "viem"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- add a Dependabot config at the repo root for the `/typescript` workspace
- scope updates to `viem` only so chain additions land without broad dependency churn
- keep the PR volume low with one weekly update and major versions ignored

## Testing
- `python -c "import pathlib; import yaml; p=pathlib.Path('.github/dependabot.yml'); data=yaml.safe_load(p.read_text()); print(data[''version'']); print(data[''updates''][0][''allow''][0][''dependency-name''])"`

Closes #1971
