### PR TITLE
fix(core): reject malformed payment signature headers early

### DIFF
--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -1,12 +1,28 @@
 import { SettleResponse } from "../types";
 import { PaymentPayload, PaymentRequired } from "../types/payments";
 import { Base64EncodedRegex, safeBase64Decode, safeBase64Encode } from "../utils";
+import { validatePaymentPayload } from "../schemas";
 
 // HTTP Methods that typically use query parameters
 export type QueryParamMethods = "GET" | "HEAD" | "DELETE";
 
 // HTTP Methods that typically use request body
 export type BodyMethods = "POST" | "PUT" | "PATCH";
+
+/**
+ * Error thrown when an incoming PAYMENT-SIGNATURE header cannot be decoded or validated.
+ */
+export class InvalidPaymentHeaderError extends Error {
+  /**
+   * Creates a new invalid payment header error.
+   *
+   * @param message - Human-readable error message for the invalid header
+   */
+  constructor(message: string = "Invalid PAYMENT-SIGNATURE header") {
+    super(message);
+    this.name = "InvalidPaymentHeaderError";
+  }
+}
 
 /**
  * Encodes a payment payload as a base64 header value.
@@ -26,9 +42,13 @@ export function encodePaymentSignatureHeader(paymentPayload: PaymentPayload): st
  */
 export function decodePaymentSignatureHeader(paymentSignatureHeader: string): PaymentPayload {
   if (!Base64EncodedRegex.test(paymentSignatureHeader)) {
-    throw new Error("Invalid payment signature header");
+    throw new InvalidPaymentHeaderError();
   }
-  return JSON.parse(safeBase64Decode(paymentSignatureHeader)) as PaymentPayload;
+  try {
+    return validatePaymentPayload(JSON.parse(safeBase64Decode(paymentSignatureHeader)));
+  } catch {
+    throw new InvalidPaymentHeaderError();
+  }
 }
 
 /**

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -1,7 +1,7 @@
 import { SettleResponse } from "../types";
 import { PaymentPayload, PaymentRequired } from "../types/payments";
 import { Base64EncodedRegex, safeBase64Decode, safeBase64Encode } from "../utils";
-import { validatePaymentPayload } from "../schemas";
+import { isPaymentPayloadV2, validatePaymentPayload } from "../schemas";
 
 // HTTP Methods that typically use query parameters
 export type QueryParamMethods = "GET" | "HEAD" | "DELETE";
@@ -45,7 +45,13 @@ export function decodePaymentSignatureHeader(paymentSignatureHeader: string): Pa
     throw new InvalidPaymentHeaderError();
   }
   try {
-    return validatePaymentPayload(JSON.parse(safeBase64Decode(paymentSignatureHeader)));
+    const paymentPayload = validatePaymentPayload(
+      JSON.parse(safeBase64Decode(paymentSignatureHeader)),
+    );
+    if (!isPaymentPayloadV2(paymentPayload)) {
+      throw new InvalidPaymentHeaderError();
+    }
+    return paymentPayload;
   } catch {
     throw new InvalidPaymentHeaderError();
   }

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -1,7 +1,7 @@
 import { SettleResponse } from "../types";
 import { PaymentPayload, PaymentRequired } from "../types/payments";
 import { Base64EncodedRegex, safeBase64Decode, safeBase64Encode } from "../utils";
-import { isPaymentPayloadV2, validatePaymentPayload } from "../schemas";
+import { validatePaymentPayload } from "../schemas";
 
 // HTTP Methods that typically use query parameters
 export type QueryParamMethods = "GET" | "HEAD" | "DELETE";
@@ -48,10 +48,10 @@ export function decodePaymentSignatureHeader(paymentSignatureHeader: string): Pa
     const paymentPayload = validatePaymentPayload(
       JSON.parse(safeBase64Decode(paymentSignatureHeader)),
     );
-    if (!isPaymentPayloadV2(paymentPayload)) {
+    if (paymentPayload.x402Version !== 2) {
       throw new InvalidPaymentHeaderError();
     }
-    return paymentPayload;
+    return paymentPayload as PaymentPayload;
   } catch {
     throw new InvalidPaymentHeaderError();
   }

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -3,6 +3,7 @@ import {
   decodePaymentSignatureHeader,
   encodePaymentRequiredHeader,
   encodePaymentResponseHeader,
+  InvalidPaymentHeaderError,
 } from ".";
 import {
   PaymentPayload,
@@ -452,11 +453,26 @@ export class x402HTTPResourceServer {
       }
     }
 
+    // Check for payment header (v1 or v2)
+    let paymentPayload: PaymentPayload | null;
+    try {
+      paymentPayload = this.extractPayment(adapter);
+    } catch (error) {
+      if (error instanceof InvalidPaymentHeaderError) {
+        return {
+          type: "payment-error",
+          response: {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+            body: { error: error.message },
+          },
+        };
+      }
+      throw error;
+    }
+
     // Normalize accepts field to array of payment options
     const paymentOptions = this.normalizePaymentOptions(routeConfig);
-
-    // Check for payment header (v1 or v2)
-    const paymentPayload = this.extractPayment(adapter);
 
     // Create resource info, using config override if provided
     const resourceInfo = {
@@ -843,11 +859,7 @@ export class x402HTTPResourceServer {
     const header = adapter.getHeader("payment-signature") || adapter.getHeader("PAYMENT-SIGNATURE");
 
     if (header) {
-      try {
-        return decodePaymentSignatureHeader(header);
-      } catch (error) {
-        console.warn("Failed to decode PAYMENT-SIGNATURE header:", error);
-      }
+      return decodePaymentSignatureHeader(header);
     }
 
     return null;

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -633,6 +633,86 @@ describe("x402HTTPResourceServer", () => {
   });
 
   describe("Payment processing", () => {
+    it("should return 400 and skip payment processing for malformed PAYMENT-SIGNATURE headers", async () => {
+      let priceResolved = false;
+
+      const routes = {
+        "/api/test": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: async () => {
+              priceResolved = true;
+              return "$1.00" as Price;
+            },
+            network: "eip155:8453" as Network,
+          },
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+      const adapter = new MockHTTPAdapter({
+        "payment-signature": "not-base64!",
+      });
+      const context: HTTPRequestContext = {
+        adapter,
+        path: "/api/test",
+        method: "GET",
+      };
+
+      const result = await httpServer.processHTTPRequest(context);
+
+      expect(priceResolved).toBe(false);
+      expect(mockFacilitator.verifyCalls.length).toBe(0);
+      expect(result.type).toBe("payment-error");
+      if (result.type === "payment-error") {
+        expect(result.response.status).toBe(400);
+        expect(result.response.headers["Content-Type"]).toBe("application/json");
+        expect(result.response.headers["PAYMENT-REQUIRED"]).toBeUndefined();
+        expect(result.response.body).toEqual({ error: "Invalid PAYMENT-SIGNATURE header" });
+      }
+    });
+
+    it("should return 400 for decoded payment headers that fail schema validation", async () => {
+      const routes = {
+        "/api/test": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00" as Price,
+            network: "eip155:8453" as Network,
+          },
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+      const invalidPaymentHeader = Buffer.from(
+        JSON.stringify({
+          x402Version: 2,
+          payload: {},
+        }),
+        "utf8",
+      ).toString("base64");
+
+      const adapter = new MockHTTPAdapter({
+        "payment-signature": invalidPaymentHeader,
+      });
+      const context: HTTPRequestContext = {
+        adapter,
+        path: "/api/test",
+        method: "GET",
+      };
+
+      const result = await httpServer.processHTTPRequest(context);
+
+      expect(mockFacilitator.verifyCalls.length).toBe(0);
+      expect(result.type).toBe("payment-error");
+      if (result.type === "payment-error") {
+        expect(result.response.status).toBe(400);
+        expect(result.response.body).toEqual({ error: "Invalid PAYMENT-SIGNATURE header" });
+      }
+    });
+
     it("should return payment-error if no payment provided", async () => {
       const routes = {
         "/api/test": {

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -713,6 +713,47 @@ describe("x402HTTPResourceServer", () => {
       }
     });
 
+    it("should return 400 for PAYMENT-SIGNATURE headers with a v1 payload", async () => {
+      const routes = {
+        "/api/test": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00" as Price,
+            network: "eip155:8453" as Network,
+          },
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+      const v1PaymentHeader = Buffer.from(
+        JSON.stringify({
+          x402Version: 1,
+          scheme: "exact",
+          network: "base",
+          payload: { signature: "0x123" },
+        }),
+      ).toString("base64");
+
+      const adapter = new MockHTTPAdapter({
+        "payment-signature": v1PaymentHeader,
+      });
+      const context: HTTPRequestContext = {
+        adapter,
+        path: "/api/test",
+        method: "GET",
+      };
+
+      const result = await httpServer.processHTTPRequest(context);
+
+      expect(mockFacilitator.verifyCalls.length).toBe(0);
+      expect(result.type).toBe("payment-error");
+      if (result.type === "payment-error") {
+        expect(result.response.status).toBe(400);
+        expect(result.response.body).toEqual({ error: "Invalid PAYMENT-SIGNATURE header" });
+      }
+    });
+
     it("should return payment-error if no payment provided", async () => {
       const routes = {
         "/api/test": {


### PR DESCRIPTION
Fixes #800.

## Summary
- validate decoded PAYMENT-SIGNATURE payloads up front with the existing schema
- return a 400 payment error for malformed base64, JSON, or payload shapes before route pricing runs
- add focused HTTP resource server coverage to prove malformed headers never reach verification

## Verification
- pnpm --dir typescript/packages/core test -- test/unit/http/x402HTTPResourceService.test.ts
- pnpm --dir typescript/packages/core test -- test/unit/http
- pnpm --dir typescript/packages/core exec prettier --check src/http/index.ts src/http/x402HTTPResourceServer.ts test/unit/http/x402HTTPResourceService.test.ts
- pnpm --dir typescript/packages/core exec eslint src/http/index.ts src/http/x402HTTPResourceServer.ts test/unit/http/x402HTTPResourceService.test.ts