### PR TITLE
docs: clarify Bazaar v2 metadata placement

### DIFF
--- a/docs/extensions/bazaar.mdx
+++ b/docs/extensions/bazaar.mdx
@@ -11,9 +11,9 @@ The x402 Bazaar is in early development. While our vision is to build the "Googl
 
 The Bazaar solves a critical problem in the x402 ecosystem: **discoverability**. Without it, x402-compatible endpoints and MCP tools are like hidden stalls in a vast market. The Bazaar provides:
 
-* **For Buyers (API Consumers)**: Programmatically discover available x402-enabled services (HTTP endpoints and MCP tools), understand their capabilities, pricing, and schemas
-* **For Sellers (API Providers)**: Automatic visibility for your x402-enabled services to a global audience of developers and AI agents
-* **For AI Agents**: Dynamic service discovery without pre-baked integrations - query, find, pay, and use
+- **For Buyers (API Consumers)**: Programmatically discover available x402-enabled services (HTTP endpoints and MCP tools), understand their capabilities, pricing, and schemas
+- **For Sellers (API Providers)**: Automatic visibility for your x402-enabled services to a global audience of developers and AI agents
+- **For AI Agents**: Dynamic service discovery without pre-baked integrations - query, find, pay, and use
 
 ### How It Works
 
@@ -29,32 +29,34 @@ After processing a payment that includes the `bazaar` extension, facilitators **
 
 **Header value:** A base64-encoded JSON object keyed by extension name. The `bazaar` key contains the bazaar extension's response:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `bazaar.status` | string | Yes | One of `"success"`, `"processing"`, or `"rejected"` |
-| `bazaar.rejectedReason` | string | No | Human-readable explanation. Only present when `status` is `"rejected"` |
+| Field                   | Type   | Required | Description                                                            |
+| ----------------------- | ------ | -------- | ---------------------------------------------------------------------- |
+| `bazaar.status`         | string | Yes      | One of `"success"`, `"processing"`, or `"rejected"`                    |
+| `bazaar.rejectedReason` | string | No       | Human-readable explanation. Only present when `status` is `"rejected"` |
 
 **Status values:**
 
-| Value | Meaning |
-|-------|---------|
-| `"success"` | The discovery info was validated and successfully cataloged |
-| `"processing"` | The discovery info was accepted and is being cataloged asynchronously |
-| `"rejected"` | The discovery info was rejected (e.g., failed schema validation). See `rejectedReason` for details |
+| Value          | Meaning                                                                                            |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| `"success"`    | The discovery info was validated and successfully cataloged                                        |
+| `"processing"` | The discovery info was accepted and is being cataloged asynchronously                              |
+| `"rejected"`   | The discovery info was rejected (e.g., failed schema validation). See `rejectedReason` for details |
 
 **Example (success):**
 
 ```
 EXTENSION-RESPONSES: eyJiYXphYXIiOnsic3RhdHVzIjoic3VjY2VzcyJ9fQ==
 ```
-*(base64 of `{"bazaar":{"status":"success"}}`)*
+
+_(base64 of `{"bazaar":{"status":"success"}}`)_
 
 **Example (rejected):**
 
 ```
 EXTENSION-RESPONSES: eyJiYXphYXIiOnsic3RhdHVzIjoicmVqZWN0ZWQiLCJyZWplY3RlZFJlYXNvbiI6ImluZm8gZmFpbGVkIHNjaGVtYSB2YWxpZGF0aW9uIn19
 ```
-*(base64 of `{"bazaar":{"status":"rejected","rejectedReason":"info failed schema validation"}}`)*
+
+_(base64 of `{"bazaar":{"status":"rejected","rejectedReason":"info failed schema validation"}}`)_
 
 Clients that understand the `bazaar` extension should read the `bazaar` key of this header to confirm cataloging succeeded and surface any rejection reason for debugging.
 
@@ -72,15 +74,16 @@ Clients that understand the `bazaar` extension should read the `bazaar` key of t
 Retrieve all available x402-compatible endpoints and MCP tools:
 
 ##### Coinbase
+
 ```bash
 GET https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources
 ```
 
 ##### PayAI
+
 ```bash
 GET https://facilitator.payai.network/discovery/resources
 ```
-
 
 **Note**: The recommended way to use this endpoint is to use the `useFacilitator` hook as described below.
 
@@ -90,53 +93,54 @@ Each resource in the list contains the following fields:
 
 ```json
 {
-  "accepts": [
+  "x402Version": 2,
+  "items": [
     {
-      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-      "description": "",
-      "extra": {
-        "name": "USD Coin",
-        "version": "2"
-      },
-      "maxAmountRequired": "200",
-      "maxTimeoutSeconds": 60,
-      "mimeType": "",
-      "network": "eip155:8453",
-      "outputSchema": {
-        "input": {
-          "method": "GET",
-          "type": "http"
-        },
-        "output": null
-      },
-      "payTo": "0xa2477E16dCB42E2AD80f03FE97D7F1a1646cd1c0",
       "resource": "https://api.example.com/x402/weather",
-      "scheme": "exact"
+      "type": "http",
+      "x402Version": 2,
+      "accepts": [
+        {
+          "scheme": "exact",
+          "network": "eip155:8453",
+          "amount": "200",
+          "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          "payTo": "0xa2477E16dCB42E2AD80f03FE97D7F1a1646cd1c0",
+          "maxTimeoutSeconds": 60,
+          "extra": {
+            "name": "USD Coin",
+            "version": "2"
+          }
+        }
+      ],
+      "lastUpdated": "2025-08-09T01:07:04.005Z",
+      "metadata": {}
     }
   ],
-  "lastUpdated": "2025-08-09T01:07:04.005Z",
-  "metadata": {},
-  "resource": "https://api.example.com/x402/weather",
-  "type": "http",
-  "x402Version": 2
+  "pagination": {
+    "limit": 20,
+    "offset": 0,
+    "total": 1
+  }
 }
 ```
 
 **Resource Types**
 
 The `type` field indicates the resource type:
+
 - `"http"` - HTTP endpoints (GET, POST, PUT, PATCH, DELETE, HEAD)
 - `"mcp"` - MCP (Model Context Protocol) tools
 
-For MCP tools, the `outputSchema.input` object will contain:
-- `type: "mcp"` - Identifies this as an MCP tool
-- `tool` - The MCP tool name (used in `tools/call` requests)
-- `inputSchema` - JSON Schema for the tool's arguments (follows MCP `Tool.inputSchema` format)
-- `description` - Human-readable description of the tool (optional)
-- `transport` - MCP transport protocol: `"streamable-http"` (default) or `"sse"` (optional)
-- `example` - Example arguments object (optional)
+<Callout type="info">
+  In x402 v2, seller-declared Bazaar metadata lives in
+  `PaymentRequired.resource` plus `PaymentRequired.extensions.bazaar`. The
+  `accepts[]` array remains payment-method data. Facilitators may copy or derive
+  extra Bazaar fields into discovery `metadata`, but that catalog shape is
+  facilitator-specific and not part of the seller-side v2 contract.
+</Callout>
 
-**Note:** For MCP tools, the unique resource identifier is the tuple (`resource`, `input.tool`) since MCP multiplexes multiple tools over a single server endpoint.
+**Note:** For MCP tools, the unique resource identifier is the tuple (`resource`, `input.toolName`) since MCP multiplexes multiple tools over a single server endpoint.
 
 ### Quickstart for Buyers
 
@@ -161,13 +165,21 @@ Fetch the list of available x402 services using the facilitator client:
     const usdcAsset = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
     const maxPrice = 100000; // $0.10 in USDC atomic units (6 decimals)
 
+    const getAtomicAmount = (paymentRequirements: Record<string, unknown>) =>
+      Number(
+        ("amount" in paymentRequirements
+          ? paymentRequirements.amount
+          : paymentRequirements.maxAmountRequired) ?? 0,
+      );
+
     const affordableServices = response.items.filter(item =>
       item.accepts.find(paymentRequirements =>
         paymentRequirements.asset === usdcAsset &&
-        Number(paymentRequirements.maxAmountRequired) < maxPrice
+        getAtomicAmount(paymentRequirements as Record<string, unknown>) < maxPrice
       )
     );
     ```
+
   </Tab>
   <Tab title="Go">
     ```go
@@ -176,6 +188,7 @@ Fetch the list of available x402 services using the facilitator client:
     import (
         "context"
         "fmt"
+        "strconv"
 
         "github.com/x402-foundation/x402/go/extensions/bazaar"
         x402http "github.com/x402-foundation/x402/go/http"
@@ -206,48 +219,56 @@ Fetch the list of available x402 services using the facilitator client:
 
         for _, item := range response.Items {
             for _, paymentReq := range item.Accepts {
-                // Parse asset and maxAmountRequired from payment requirements
+                // Parse asset and amount from payment requirements
                 if asset, ok := paymentReq["asset"].(string); ok && asset == usdcAsset {
-                    if maxAmount, ok := paymentReq["maxAmountRequired"].(string); ok {
-                        // Convert and compare price
-                        fmt.Printf("Found service: %s\n", item.Resource)
+                    amount, ok := paymentReq["amount"].(string)
+                    if !ok {
+                        amount, ok = paymentReq["maxAmountRequired"].(string)
+                    }
+                    if ok {
+                        if amountAtomic, err := strconv.Atoi(amount); err == nil && amountAtomic < maxPrice {
+                            fmt.Printf("Found service: %s\n", item.Resource)
+                        }
                     }
                 }
             }
         }
     }
     ```
+
   </Tab>
   <Tab title="Python">
     ```python
+    from x402.extensions.bazaar import ListDiscoveryResourcesParams, with_bazaar
     from x402.http import FacilitatorConfig, HTTPFacilitatorClient
 
-    facilitator = HTTPFacilitatorClient(
+    facilitator = with_bazaar(HTTPFacilitatorClient(
         FacilitatorConfig(url="https://x402.org/facilitator")
+    ))
+
+    response = facilitator.extensions.discovery.list_resources(
+        ListDiscoveryResourcesParams(type="http", limit=20, offset=0)
     )
 
-    response = await facilitator.list_resources(type="http")
-
-    # Filter services under $0.10
-    usdc_asset = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
-    max_price = 100000  # $0.10 in USDC atomic units (6 decimals)
-
-    affordable_services = [
-        item
-        for item in response.items
-        if any(
-            payment_req.asset == usdc_asset
-            and int(payment_req.max_amount_required) < max_price
-            for payment_req in item.accepts
-        )
-    ]
+    for item in response.resources:
+        print(f"Found service: {item.url}")
     ```
+
   </Tab>
 </Tabs>
 
 #### Step 2: Call a Discovered Service
 
 Once you've found a suitable service, use an x402 client to call it:
+
+<Callout type="info">
+  The stable cross-facilitator discovery fields are `resource`, `type`,
+  `accepts`, and pagination. Some facilitators may expose richer Bazaar
+  invocation details in `metadata`, but that is facilitator-specific. For
+  portable clients, treat discovery as a way to find resources and payment
+  methods, then call the resource with the method and parameters your
+  application expects.
+</Callout>
 
 <Tabs>
   <Tab title="TypeScript">
@@ -271,19 +292,16 @@ Once you've found a suitable service, use an x402 client to call it:
       client
     );
 
-    // Select the payment method of your choice
-    const selectedPaymentRequirements = selectedService.accepts[0];
-    const inputSchema = selectedPaymentRequirements.outputSchema.input;
-
-    // Build the request using the service's schema
+    // Build the request using the discovered resource URL
     const response = await api.request({
-      method: inputSchema.method,
-      url: inputSchema.resource,
-      params: { location: "San Francisco" } // Based on inputSchema
+      method: "GET",
+      url: selectedService.resource,
+      params: { city: "San Francisco" },
     });
 
     console.log("Response data:", response.data);
     ```
+
   </Tab>
   <Tab title="Python">
     ```python
@@ -303,18 +321,14 @@ Once you've found a suitable service, use an x402 client to call it:
         register_exact_evm_client(client, EthAccountSigner(account))
 
         # Select a service from discovery (from Step 1)
-        selected_service = affordable_services[0]
+        selected_service = response.resources[0]
 
-        # Select the payment method of your choice
-        selected_payment_requirements = selected_service.accepts[0]
-        input_schema = selected_payment_requirements.output_schema.input
-
-        # Make the request using httpx client
+        # Make the request using the discovered resource URL
         async with x402HttpxClient(client) as http:
             response = await http.request(
-                method=input_schema.method,
-                url=input_schema.resource,
-                params={"location": "San Francisco"}  # Based on input_schema
+                method="GET",
+                url=selected_service.url,
+                params={"city": "San Francisco"},
             )
             await response.aread()
             print(f"Response data: {response.json()}")
@@ -322,6 +336,7 @@ Once you've found a suitable service, use an x402 client to call it:
 
     asyncio.run(main())
     ```
+
   </Tab>
 </Tabs>
 
@@ -332,6 +347,7 @@ Once you've found a suitable service, use an x402 client to call it:
 Add the bazaar extension to your route configuration to make your API or MCP tools discoverable.
 
 **Supported Resource Types:**
+
 - **HTTP Endpoints** - Standard REST APIs (GET, POST, PUT, PATCH, DELETE, HEAD)
 - **MCP Tools** - Model Context Protocol tools for AI agent integration
 
@@ -358,51 +374,63 @@ To enhance your listing with descriptions and schemas, include them when setting
     import { x402ResourceServer, HTTPFacilitatorClient } from "@x402/core/server";
     import { ExactEvmScheme } from "@x402/evm/exact/server";
     import { bazaarResourceServerExtension } from "@x402/extensions";
+    import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
 
     const facilitatorClient = new HTTPFacilitatorClient({
       url: "https://x402.org/facilitator"
     });
-    const server = new x402ResourceServer(facilitatorClient);
-    server.register("eip155:*", new ExactEvmScheme());
+    const server = new x402ResourceServer(facilitatorClient)
+      .register("eip155:*", new ExactEvmScheme())
+      .registerExtension(bazaarResourceServerExtension);
 
     const routes = {
       "GET /weather": {
-        price: "$0.001",
-        network: "eip155:8453",
-        resource: "0xYourAddress",
+        accepts: [
+          {
+            scheme: "exact",
+            price: "$0.001",
+            network: "eip155:8453",
+            payTo: "0xYourAddress"
+          }
+        ],
         description: "Get current weather data for any location",
+        mimeType: "application/json",
         extensions: {
-          bazaar: {
-            discoverable: true,
+          ...declareDiscoveryExtension({
+            input: {
+              location: "San Francisco"
+            },
             inputSchema: {
-              queryParams: {
+              properties: {
                 location: {
                   type: "string",
-                  description: "City name or coordinates",
-                  required: true
+                  description: "City name or coordinates"
                 }
-              }
+              },
+              required: ["location"]
             },
-            outputSchema: {
-              type: "object",
-              properties: {
-                temperature: { type: "number" },
-                conditions: { type: "string" },
-                humidity: { type: "number" }
+            output: {
+              example: {
+                location: "San Francisco",
+                temperature: 68,
+                conditions: "sunny",
+                humidity: 45
               }
             }
-          }
+          })
         }
       }
     };
 
     app.use(paymentMiddleware(routes, server));
     ```
+
   </Tab>
   <Tab title="Python">
     ```python
     from fastapi import FastAPI
 
+    from x402.extensions.bazaar import OutputConfig, declare_discovery_extension
     from x402.http import FacilitatorConfig, HTTPFacilitatorClient, PaymentOption
     from x402.http.middleware.fastapi import PaymentMiddlewareASGI
     from x402.http.types import RouteConfig
@@ -434,32 +462,33 @@ To enhance your listing with descriptions and schemas, include them when setting
             mime_type="application/json",
             description="Get current weather data for any location",
             extensions={
-                "bazaar": {
-                    "discoverable": True,
-                    "inputSchema": {
-                        "queryParams": {
+                **declare_discovery_extension(
+                    input={"location": "San Francisco"},
+                    input_schema={
+                        "properties": {
                             "location": {
                                 "type": "string",
                                 "description": "City name or coordinates",
-                                "required": True,
                             }
-                        }
-                    },
-                    "outputSchema": {
-                        "type": "object",
-                        "properties": {
-                            "temperature": {"type": "number"},
-                            "conditions": {"type": "string"},
-                            "humidity": {"type": "number"},
                         },
+                        "required": ["location"],
                     },
-                }
+                    output=OutputConfig(
+                        example={
+                            "location": "San Francisco",
+                            "temperature": 68,
+                            "conditions": "sunny",
+                            "humidity": 45,
+                        }
+                    ),
+                )
             },
         ),
     }
 
     app.add_middleware(PaymentMiddlewareASGI, routes=routes, server=server)
     ```
+
   </Tab>
   <Tab title="Go">
     ```go
@@ -544,6 +573,7 @@ To enhance your listing with descriptions and schemas, include them when setting
         r.Run(":4021")
     }
     ```
+
   </Tab>
 </Tabs>
 
@@ -553,8 +583,8 @@ The x402 Bazaar is rapidly evolving, and your feedback helps us prioritize featu
 
 ### Support
 
-* **GitHub**: [github.com/x402-foundation/x402](https://github.com/x402-foundation/x402)
-* **Discord**: [Join #x402 channel](https://discord.com/invite/cdp)
+- **GitHub**: [github.com/x402-foundation/x402](https://github.com/x402-foundation/x402)
+- **Discord**: [Join #x402 channel](https://discord.com/invite/cdp)
 
 ### FAQ
 

--- a/docs/getting-started/quickstart-for-sellers.mdx
+++ b/docs/getting-started/quickstart-for-sellers.mdx
@@ -9,9 +9,9 @@ description: "This guide walks you through integrating with **x402** to enable p
 
 Before you begin, ensure you have:
 
-* A crypto wallet to receive funds (any EVM or SVM compatible wallet)
-* [Node.js](https://nodejs.org/en) and npm, [Go](https://go.dev/), or Python and pip installed
-* An existing API or server
+- A crypto wallet to receive funds (any EVM or SVM compatible wallet)
+- [Node.js](https://nodejs.org/en) and npm, [Go](https://go.dev/), or Python and pip installed
+- An existing API or server
 
 **Note**\
 There are pre-configured examples available in the x402 repo for both [Node.js](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers) and [Go](https://github.com/x402-foundation/x402/tree/main/examples/go/servers). There is also an [advanced example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/advanced) that shows how to use the x402 SDKs to build a more complex payment flow.
@@ -25,6 +25,7 @@ There are pre-configured examples available in the x402 repo for both [Node.js](
     ```bash
     npm install @x402/express @x402/core @x402/evm @x402/svm
     ```
+
   </Tab>
   <Tab title="Next.js">
     Install the [x402 Next.js middleware package](https://www.npmjs.com/package/@x402/next).
@@ -32,6 +33,7 @@ There are pre-configured examples available in the x402 repo for both [Node.js](
     ```bash
     npm install @x402/next @x402/core @x402/evm @x402/svm
     ```
+
   </Tab>
   <Tab title="Hono">
     Install the [x402 Hono middleware package](https://www.npmjs.com/package/@x402/hono).
@@ -39,6 +41,7 @@ There are pre-configured examples available in the x402 repo for both [Node.js](
     ```bash
     npm install @x402/hono @x402/core @x402/evm @x402/svm
     ```
+
   </Tab>
   <Tab title="Fastify">
     Install the [x402 Fastify middleware package](https://www.npmjs.com/package/@x402/fastify).
@@ -46,6 +49,7 @@ There are pre-configured examples available in the x402 repo for both [Node.js](
     ```bash
     npm install @x402/fastify @x402/core @x402/evm @x402/svm
     ```
+
   </Tab>
   <Tab title="Go (Gin)">
     Add the x402 Go module to your project:
@@ -53,6 +57,7 @@ There are pre-configured examples available in the x402 repo for both [Node.js](
     ```bash
     go get github.com/x402-foundation/x402/go
     ```
+
   </Tab>
   <Tab title="Go (Echo)">
     Add the x402 Go module to your project:
@@ -60,6 +65,7 @@ There are pre-configured examples available in the x402 repo for both [Node.js](
     ```bash
     go get github.com/x402-foundation/x402/go
     ```
+
   </Tab>
   <Tab title="FastAPI">
     [Install the x402 Python package](https://pypi.org/project/x402/) with FastAPI support:
@@ -70,6 +76,7 @@ There are pre-configured examples available in the x402 repo for both [Node.js](
     # For Solana support, also add:
     pip install "x402[svm]"
     ```
+
   </Tab>
   <Tab title="Flask">
     [Install the x402 Python package](https://pypi.org/project/x402/) with Flask support:
@@ -80,6 +87,7 @@ There are pre-configured examples available in the x402 repo for both [Node.js](
     # For Solana support, also add:
     pip install "x402[svm]"
     ```
+
   </Tab>
 </Tabs>
 
@@ -87,10 +95,10 @@ There are pre-configured examples available in the x402 repo for both [Node.js](
 
 Integrate the payment middleware into your application. You will need to provide:
 
-* The Facilitator URL or facilitator client. For testing, use `https://x402.org/facilitator` which works on Base Sepolia and Solana devnet.
-  * For mainnet setup, see [Running on Mainnet](#running-on-mainnet)
-* The routes you want to protect.
-* Your receiving wallet address.
+- The Facilitator URL or facilitator client. For testing, use `https://x402.org/facilitator` which works on Base Sepolia and Solana devnet.
+  - For mainnet setup, see [Running on Mainnet](#running-on-mainnet)
+- The routes you want to protect.
+- Your receiving wallet address.
 
 <Tabs>
   <Tab title="Express">
@@ -155,6 +163,7 @@ Integrate the payment middleware into your application. You will need to provide
       console.log(`Server listening at http://localhost:4021`);
     });
     ```
+
   </Tab>
   <Tab title="Next.js">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/fullstack/next).
@@ -253,6 +262,7 @@ Integrate the payment middleware into your application. You will need to provide
       server,
     );
     ```
+
   </Tab>
   <Tab title="Hono">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/hono).
@@ -312,6 +322,7 @@ Integrate the payment middleware into your application. You will need to provide
 
     serve({ fetch: app.fetch, port: 4021 });
     ```
+
   </Tab>
   <Tab title="Fastify">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/fastify).
@@ -369,6 +380,7 @@ Integrate the payment middleware into your application. You will need to provide
 
     app.listen({ port: 4021 });
     ```
+
   </Tab>
   <Tab title="Go (Gin)">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/go/servers/gin).
@@ -442,6 +454,7 @@ Integrate the payment middleware into your application. You will need to provide
         r.Run(":4021")
     }
     ```
+
   </Tab>
   <Tab title="Go (net/http)">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/go/servers/nethttp).
@@ -521,6 +534,7 @@ Integrate the payment middleware into your application. You will need to provide
         http.ListenAndServe(":4021", handler)
     }
     ```
+
   </Tab>
   <Tab title="Go (Echo)">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/go/servers/echo).
@@ -594,6 +608,7 @@ Integrate the payment middleware into your application. You will need to provide
         e.Start(":4021")
     }
     ```
+
   </Tab>
   <Tab title="FastAPI">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/fastapi).
@@ -669,6 +684,7 @@ Integrate the payment middleware into your application. You will need to provide
         import uvicorn
         uvicorn.run(app, host="0.0.0.0", port=4021)
     ```
+
   </Tab>
   <Tab title="Flask">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/python/servers/flask).
@@ -737,6 +753,7 @@ Integrate the payment middleware into your application. You will need to provide
     if __name__ == "__main__":
         app.run(host="0.0.0.0", port=4021)
     ```
+
   </Tab>
 </Tabs>
 
@@ -745,14 +762,14 @@ Integrate the payment middleware into your application. You will need to provide
 ```typescript
 interface RouteConfig {
   accepts: Array<{
-    scheme: string;           // Payment scheme: "exact" or "upto"
-    price: string;            // For "exact": the fixed price. For "upto": the maximum authorized amount.
-    network: string;          // Network in CAIP-2 format (e.g., "eip155:84532" or "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1")
-    payTo: string;            // Your wallet address
+    scheme: string; // Payment scheme: "exact" or "upto"
+    price: string; // For "exact": the fixed price. For "upto": the maximum authorized amount.
+    network: string; // Network in CAIP-2 format (e.g., "eip155:84532" or "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1")
+    payTo: string; // Your wallet address
   }>;
-  description?: string;       // Description of the resource
-  mimeType?: string;          // MIME type of the response
-  extensions?: object;        // Optional extensions (e.g., Bazaar)
+  description?: string; // Description of the resource
+  mimeType?: string; // MIME type of the response
+  extensions?: object; // Optional extensions (e.g., Bazaar)
 }
 ```
 
@@ -830,6 +847,7 @@ The examples in step 2 above all use the `exact` scheme. To use `upto` instead, 
       console.log("Server listening at http://localhost:4021");
     });
     ```
+
   </Tab>
   <Tab title="Go (Gin)">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/go/servers/upto).
@@ -906,14 +924,15 @@ The examples in step 2 above all use the `exact` scheme. To use `upto` instead, 
         r.Run(":4021")
     }
     ```
+
   </Tab>
 </Tabs>
 
 The `setSettlementOverrides` amount supports three formats:
 
-* **Raw atomic units** — e.g., `"1000"` settles exactly 1,000 atomic units of the token (for USDC with 6 decimals, `"1000"` = $0.001)
-* **Percentage of authorized maximum** — e.g., `"50%"` settles 50% of `PaymentRequirements.amount`. Supports up to two decimal places (e.g., `"33.33%"`). The result is floored to the nearest atomic unit.
-* **Dollar price** — e.g., `"$0.05"` converts a USD-denominated price to atomic units. This format works when you configured your route with `$`-prefixed pricing (e.g., `price: "$0.10"`). Token decimals are determined from the registered scheme. The result is rounded to the nearest atomic unit.
+- **Raw atomic units** — e.g., `"1000"` settles exactly 1,000 atomic units of the token (for USDC with 6 decimals, `"1000"` = $0.001)
+- **Percentage of authorized maximum** — e.g., `"50%"` settles 50% of `PaymentRequirements.amount`. Supports up to two decimal places (e.g., `"33.33%"`). The result is floored to the nearest atomic unit.
+- **Dollar price** — e.g., `"$0.05"` converts a USD-denominated price to atomic units. This format works when you configured your route with `$`-prefixed pricing (e.g., `price: "$0.10"`). Token decimals are determined from the registered scheme. The result is rounded to the nearest atomic unit.
 
 The resolved amount must always be &lt;= the authorized maximum. If the amount is `"0"`, no on-chain transaction occurs and the client is not charged.
 
@@ -932,6 +951,8 @@ To verify:
 When using a facilitator that supports the Bazaar extension, your endpoints can be listed in the [x402 Bazaar](/extensions/bazaar), the discovery layer that helps buyers and AI agents find services. To enable discovery:
 
 ```typescript
+import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+
 {
   "GET /weather": {
     accepts: [
@@ -951,22 +972,41 @@ When using a facilitator that supports the Bazaar extension, your endpoints can 
     description: "Get real-time weather data including temperature, conditions, and humidity",
     mimeType: "application/json",
     extensions: {
-      bazaar: {
-        discoverable: true,
-        category: "weather",
-        tags: ["forecast", "real-time"],
-      },
+      ...declareDiscoveryExtension({
+        input: {
+          city: "San Francisco",
+        },
+        inputSchema: {
+          properties: {
+            city: {
+              type: "string",
+              description: "City name or coordinates",
+            },
+          },
+          required: ["city"],
+        },
+        output: {
+          example: {
+            city: "San Francisco",
+            temperature: 68,
+            conditions: "sunny",
+            humidity: 45,
+          },
+        },
+      }),
     },
   },
 }
 ```
 
+For x402 v2, keep payment metadata in `accepts[]`, keep human-readable endpoint metadata in `resource`/route config (`description`, `mimeType`), and put invocation schemas in `extensions.bazaar`. Avoid adding ad hoc Bazaar fields directly to `accepts[]`.
+
 Learn more about the discovery layer in the [Bazaar documentation](/extensions/bazaar).
 
 ### 5. Error Handling
 
-* If you run into trouble, check out the examples in the [repo](https://github.com/x402-foundation/x402/tree/main/examples) for more context and full code.
-* Run `npm install` or `go mod tidy` to install dependencies
+- If you run into trouble, check out the examples in the [repo](https://github.com/x402-foundation/x402/tree/main/examples) for more context and full code.
+- Run `npm install` or `go mod tidy` to install dependencies
 
 ---
 
@@ -1012,6 +1052,7 @@ For mainnet, use a production facilitator. See the [x402 Ecosystem](https://www.
         #FacilitatorConfig(url="https://facilitator.payai.network")  # PayAI Facilitator
     )
     ```
+
   </Tab>
   <Tab title="Python (Flask)">
     ```python
@@ -1022,6 +1063,7 @@ For mainnet, use a production facilitator. See the [x402 Ecosystem](https://www.
         #FacilitatorConfig(url="https://facilitator.payai.network")  # PayAI Facilitator
     )
     ```
+
   </Tab>
 </Tabs>
 
@@ -1044,6 +1086,7 @@ Change from testnet to mainnet network identifiers:
     // For Solana, use a Solana wallet address (base58 format)
     payTo: "YourSolanaWalletAddress",
     ```
+
   </Tab>
   <Tab title="Multi-Network">
     ```typescript
@@ -1085,6 +1128,7 @@ For multi-network support, register both EVM and SVM schemes:
     server.register("eip155:*", new ExactEvmScheme());
     server.register("solana:*", new ExactSvmScheme());
     ```
+
   </Tab>
   <Tab title="Go (Gin)">
     ```go
@@ -1101,6 +1145,7 @@ For multi-network support, register both EVM and SVM schemes:
         },
     }))
     ```
+
   </Tab>
   <Tab title="Go (Echo)">
     ```go
@@ -1117,6 +1162,7 @@ For multi-network support, register both EVM and SVM schemes:
         },
     }))
     ```
+
   </Tab>
   <Tab title="Python">
     ```python
@@ -1128,6 +1174,7 @@ For multi-network support, register both EVM and SVM schemes:
     server.register("eip155:8453", ExactEvmServerScheme())  # Base mainnet
     server.register("solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", ExactSvmServerScheme())  # Solana mainnet
     ```
+
   </Tab>
 </Tabs>
 
@@ -1138,6 +1185,7 @@ Make sure your receiving wallet address is a real mainnet address where you want
 ### 5. Test with Real Payments
 
 Before going live:
+
 1. Test with small amounts first
 2. Verify payments are arriving in your wallet
 3. Monitor the facilitator for any issues
@@ -1150,12 +1198,12 @@ Before going live:
 
 x402 v2 uses [CAIP-2](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md) format for network identifiers:
 
-| Network | CAIP-2 Identifier |
-|---------|-------------------|
-| Base Mainnet | `eip155:8453` |
-| Base Sepolia | `eip155:84532` |
+| Network        | CAIP-2 Identifier                         |
+| -------------- | ----------------------------------------- |
+| Base Mainnet   | `eip155:8453`                             |
+| Base Sepolia   | `eip155:84532`                            |
 | Solana Mainnet | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` |
-| Solana Devnet | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` |
+| Solana Devnet  | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` |
 
 See [Network Support](/core-concepts/network-and-token-support) for the full list.
 
@@ -1163,10 +1211,10 @@ See [Network Support](/core-concepts/network-and-token-support) for the full lis
 
 ### Next Steps
 
-* Check out the [Advanced Example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/advanced) for a more complex payment flow
-* Explore [Advanced Concepts](/advanced-concepts/lifecycle-hooks) like lifecycle hooks for custom logic before/after verification/settlement
-* Explore [Extensions](/extensions/bazaar) like Bazaar for service discovery
-* Get started as a [buyer](/getting-started/quickstart-for-buyers)
+- Check out the [Advanced Example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/advanced) for a more complex payment flow
+- Explore [Advanced Concepts](/advanced-concepts/lifecycle-hooks) like lifecycle hooks for custom logic before/after verification/settlement
+- Explore [Extensions](/extensions/bazaar) like Bazaar for service discovery
+- Get started as a [buyer](/getting-started/quickstart-for-buyers)
 
 For questions or support, join our [Discord](https://discord.gg/cdp).
 
@@ -1174,10 +1222,10 @@ For questions or support, join our [Discord](https://discord.gg/cdp).
 
 This quickstart covered:
 
-* Installing the x402 SDK and relevant middleware
-* Adding payment middleware to your API and configuring it
-* Choosing between `exact` (fixed-price) and `upto` (usage-based) payment schemes
-* Testing your integration
-* Deploying to mainnet with CAIP-2 network identifiers
+- Installing the x402 SDK and relevant middleware
+- Adding payment middleware to your API and configuring it
+- Choosing between `exact` (fixed-price) and `upto` (usage-based) payment schemes
+- Testing your integration
+- Deploying to mainnet with CAIP-2 network identifiers
 
 Your API is now ready to accept crypto payments through x402.

--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -11,10 +11,12 @@ The `bazaar` extension enables **resource discovery and cataloging** for x402-en
 A resource server advertises its endpoint specification by including the `bazaar` extension in the `extensions` object of the **402 Payment Required** response.
 
 The extension follows the standard v2 pattern:
+
 - **`info`**: Contains the actual discovery data (HTTP method or MCP tool name, input parameters, and output format)
 - **`schema`**: JSON Schema that validates the structure of `info`
 
 The `info.input` object uses a discriminated union type, distinguished by the `type` field:
+
 - `input.type: "http"` — HTTP endpoints (further discriminated by `method` into query parameter methods vs body methods)
 - `input.type: "mcp"` — MCP (Model Context Protocol) tools
 
@@ -181,7 +183,7 @@ The `info.input` object uses a discriminated union type, distinguished by the `t
       "info": {
         "input": {
           "type": "mcp",
-          "tool": "financial_analysis",
+          "toolName": "financial_analysis",
           "description": "Advanced AI-powered financial analysis",
           "inputSchema": {
             "type": "object",
@@ -212,13 +214,13 @@ The `info.input` object uses a discriminated union type, distinguished by the `t
             "type": "object",
             "properties": {
               "type": { "type": "string", "const": "mcp" },
-              "tool": { "type": "string" },
+              "toolName": { "type": "string" },
               "description": { "type": "string" },
               "transport": { "type": "string", "enum": ["streamable-http", "sse"] },
               "inputSchema": { "type": "object" },
               "example": { "type": "object" }
             },
-            "required": ["type", "tool", "inputSchema"],
+            "required": ["type", "toolName", "inputSchema"],
             "additionalProperties": false
           },
           "output": {
@@ -247,46 +249,46 @@ The `info.input` object describes how to call the endpoint or tool.
 
 #### Query Parameter Methods (GET, HEAD, DELETE)
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | Yes | Always `"http"` |
-| `method` | string | Yes | One of `"GET"`, `"HEAD"`, `"DELETE"` |
-| `queryParams` | object | No | Query parameter examples |
-| `headers` | object | No | Custom header examples |
+| Field         | Type   | Required | Description                          |
+| ------------- | ------ | -------- | ------------------------------------ |
+| `type`        | string | Yes      | Always `"http"`                      |
+| `method`      | string | Yes      | One of `"GET"`, `"HEAD"`, `"DELETE"` |
+| `queryParams` | object | No       | Query parameter examples             |
+| `headers`     | object | No       | Custom header examples               |
 
 #### Body Methods (POST, PUT, PATCH)
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | Yes | Always `"http"` |
-| `method` | string | Yes | One of `"POST"`, `"PUT"`, `"PATCH"` |
-| `bodyType` | string | Yes | One of `"json"`, `"form-data"`, `"text"` |
-| `body` | object/string | Yes | Request body example |
-| `queryParams` | object | No | Query parameter examples |
-| `headers` | object | No | Custom header examples |
+| Field         | Type          | Required | Description                              |
+| ------------- | ------------- | -------- | ---------------------------------------- |
+| `type`        | string        | Yes      | Always `"http"`                          |
+| `method`      | string        | Yes      | One of `"POST"`, `"PUT"`, `"PATCH"`      |
+| `bodyType`    | string        | Yes      | One of `"json"`, `"form-data"`, `"text"` |
+| `body`        | object/string | Yes      | Request body example                     |
+| `queryParams` | object        | No       | Query parameter examples                 |
+| `headers`     | object        | No       | Custom header examples                   |
 
 #### MCP Tools
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | Yes | Always `"mcp"` |
-| `tool` | string | Yes | MCP tool name (matches what's passed to `tools/call`) |
-| `description` | string | No | Human-readable description of the tool |
-| `inputSchema` | object | Yes | JSON Schema for the tool's `arguments`, following the MCP [`Tool.inputSchema`](https://spec.modelcontextprotocol.io/) format (a JSON Schema subset with `type: "object"`, `properties`, and `required`). Servers should reuse the same schema their MCP tool already declares. |
-| `transport` | string | No | MCP transport protocol. One of `"streamable-http"` or `"sse"`. Defaults to `"streamable-http"` if omitted. |
-| `example` | object | No | Example `arguments` object |
+| Field         | Type   | Required | Description                                                                                                                                                                                                                                                                    |
+| ------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `type`        | string | Yes      | Always `"mcp"`                                                                                                                                                                                                                                                                 |
+| `toolName`    | string | Yes      | MCP tool name (matches what's passed to `tools/call`)                                                                                                                                                                                                                          |
+| `description` | string | No       | Human-readable description of the tool                                                                                                                                                                                                                                         |
+| `inputSchema` | object | Yes      | JSON Schema for the tool's `arguments`, following the MCP [`Tool.inputSchema`](https://spec.modelcontextprotocol.io/) format (a JSON Schema subset with `type: "object"`, `properties`, and `required`). Servers should reuse the same schema their MCP tool already declares. |
+| `transport`   | string | No       | MCP transport protocol. One of `"streamable-http"` or `"sse"`. Defaults to `"streamable-http"` if omitted.                                                                                                                                                                     |
+| `example`     | object | No       | Example `arguments` object                                                                                                                                                                                                                                                     |
 
-> **Note:** For MCP tools, the unique resource identifier is the tuple (`resource.url`, `input.tool`). Since MCP multiplexes multiple tools over a single server endpoint, `resource.url` alone may not be unique. Facilitators **must** use both fields when cataloging MCP tools.
+> **Note:** For MCP tools, the unique resource identifier is the tuple (`resource.url`, `input.toolName`). Since MCP multiplexes multiple tools over a single server endpoint, `resource.url` alone may not be unique. Facilitators **must** use both fields when cataloging MCP tools.
 
 ### Output Types
 
 The `info.output` object (optional) describes the expected response format:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `type` | string | Yes | Response content type (e.g., `"json"`, `"text"`) |
-| `format` | string | No | Additional format information |
-| `example` | any | No | Example response value |
+| Field     | Type   | Required | Description                                      |
+| --------- | ------ | -------- | ------------------------------------------------ |
+| `type`    | string | Yes      | Response content type (e.g., `"json"`, `"text"`) |
+| `format`  | string | No       | Additional format information                    |
+| `example` | any    | No       | Example response value                           |
 
 > **Note:** For MCP tools, if `output` is omitted, facilitators should assume arbitrary text content (MCP's default response type).
 
@@ -294,11 +296,11 @@ The `info.output` object (optional) describes the expected response format:
 
 The `input.type` field acts as a discriminator for the discovery info structure:
 
-| `input.type` | Structure | Description |
-|--------------|-----------|-------------|
-| `"http"` | QueryDiscoveryInfo | HTTP GET/HEAD/DELETE with query parameters |
-| `"http"` | BodyDiscoveryInfo | HTTP POST/PUT/PATCH with request body (has `bodyType`) |
-| `"mcp"` | MCPDiscoveryInfo | MCP tool invocation |
+| `input.type` | Structure          | Description                                            |
+| ------------ | ------------------ | ------------------------------------------------------ |
+| `"http"`     | QueryDiscoveryInfo | HTTP GET/HEAD/DELETE with query parameters             |
+| `"http"`     | BodyDiscoveryInfo  | HTTP POST/PUT/PATCH with request body (has `bodyType`) |
+| `"mcp"`      | MCPDiscoveryInfo   | MCP tool invocation                                    |
 
 Facilitators should use `input.type` to determine which validation rules apply. For HTTP inputs, the presence of `bodyType` further distinguishes between query and body methods.
 
@@ -309,12 +311,13 @@ Facilitators should use `input.type` to determine which validation rules apply. 
 The `schema` field contains a JSON Schema (Draft 2020-12) that validates the structure of `info`.
 
 **Requirements:**
+
 - Must use JSON Schema Draft 2020-12
 - Must define an `input` property (required)
 - May define an `output` property (optional)
 - Must validate that `input.type` equals `"http"` (for HTTP endpoints) or `"mcp"` (for MCP tools)
 - For HTTP endpoints: Must validate the appropriate `method` enum based on operation type
-- For MCP tools: Must require `tool` and `inputSchema` fields
+- For MCP tools: Must require `toolName` and `inputSchema` fields
 
 Facilitators **must** validate `info` against `schema` before cataloging.
 
@@ -329,13 +332,13 @@ Facilitators **must** validate `info` against `schema` before cataloging.
       "type": "object",
       "properties": {
         "type": { "type": "string", "const": "mcp" },
-        "tool": { "type": "string" },
+        "toolName": { "type": "string" },
         "description": { "type": "string" },
         "transport": { "type": "string", "enum": ["streamable-http", "sse"] },
         "inputSchema": { "type": "object" },
         "example": { "type": "object" }
       },
-      "required": ["type", "tool", "inputSchema"],
+      "required": ["type", "toolName", "inputSchema"],
       "additionalProperties": false
     },
     "output": {
@@ -370,32 +373,34 @@ After processing a `PaymentPayload`, a facilitator **MAY** append an `EXTENSION-
 
 **Header value:** A base64-encoded JSON object keyed by extension name. The `bazaar` key contains the bazaar extension's response:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `bazaar.status` | string | Yes | One of `"success"`, `"processing"`, or `"rejected"` |
-| `bazaar.rejectedReason` | string | No | Human-readable explanation. Only present when `status` is `"rejected"` |
+| Field                   | Type   | Required | Description                                                            |
+| ----------------------- | ------ | -------- | ---------------------------------------------------------------------- |
+| `bazaar.status`         | string | Yes      | One of `"success"`, `"processing"`, or `"rejected"`                    |
+| `bazaar.rejectedReason` | string | No       | Human-readable explanation. Only present when `status` is `"rejected"` |
 
 **Status values:**
 
-| Value | Meaning |
-|-------|---------|
-| `"success"` | The discovery info was validated and successfully cataloged |
-| `"processing"` | The discovery info was accepted and is being cataloged asynchronously |
-| `"rejected"` | The discovery info was rejected (e.g., failed schema validation). See `rejectedReason` for details |
+| Value          | Meaning                                                                                            |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| `"success"`    | The discovery info was validated and successfully cataloged                                        |
+| `"processing"` | The discovery info was accepted and is being cataloged asynchronously                              |
+| `"rejected"`   | The discovery info was rejected (e.g., failed schema validation). See `rejectedReason` for details |
 
 **Example (success):**
 
 ```
 EXTENSION-RESPONSES: eyJiYXphYXIiOnsic3RhdHVzIjoic3VjY2VzcyJ9fQ==
 ```
-*(base64 of `{"bazaar":{"status":"success"}}`)*
+
+_(base64 of `{"bazaar":{"status":"success"}}`)_
 
 **Example (rejected):**
 
 ```
 EXTENSION-RESPONSES: eyJiYXphYXIiOnsic3RhdHVzIjoicmVqZWN0ZWQiLCJyZWplY3RlZFJlYXNvbiI6ImluZm8gZmFpbGVkIHNjaGVtYSB2YWxpZGF0aW9uIn19
 ```
-*(base64 of `{"bazaar":{"status":"rejected","rejectedReason":"info failed schema validation"}}`)*
+
+_(base64 of `{"bazaar":{"status":"rejected","rejectedReason":"info failed schema validation"}}`)_
 
 Clients that understand the `bazaar` extension SHOULD read the `bazaar` key of this header to confirm cataloging succeeded and surface any rejection reason for debugging.
 
@@ -449,13 +454,13 @@ All SDK implementations use the function `isValidRouteTemplate` (TypeScript, Go)
 `_is_valid_route_template` (Python) which applies the following rules identically.
 **All three copies must stay in sync.**
 
-| Rule | Reason |
-|------|--------|
-| Must be a non-empty string | Empty/absent means "no template" |
-| Must start with `/` | Prevents relative paths and external URLs |
+| Rule                                 | Reason                                                        |
+| ------------------------------------ | ------------------------------------------------------------- |
+| Must be a non-empty string           | Empty/absent means "no template"                              |
+| Must start with `/`                  | Prevents relative paths and external URLs                     |
 | Must match `^/[a-zA-Z0-9_/:.\-~%]+$` | Only allows safe URL path characters and `:param` identifiers |
-| Must not contain `..` | Prevents path traversal (`/users/../admin`) |
-| Must not contain `://` | Prevents URL injection (`http://evil.com`) |
+| Must not contain `..`                | Prevents path traversal (`/users/../admin`)                   |
+| Must not contain `://`               | Prevents URL injection (`http://evil.com`)                    |
 
 All implementations decode percent-encoding (e.g. `%2e%2e` -> `..`) before applying the traversal
 and scheme checks. A value that fails any rule is discarded; the facilitator falls back to the
@@ -472,11 +477,16 @@ The `bazaar` extension was formalized in x402 v2. Discovery functionality unoffi
 
 Facilitators are **not expected** to support v1. If v1 support is desired:
 
-| V1 Location | V2 Location |
-|-------------|-------------|
-| `accepts[0].outputSchema` | `extensions.bazaar` |
-| `accepts[0].resource` | `resource.url` |
-| `accepts[0].description` | `description` (top-level) |
-| `accepts[0].mimeType` | `mimeType` (top-level) |
+| V1 Location               | V2 Location            |
+| ------------------------- | ---------------------- |
+| `accepts[0].outputSchema` | `extensions.bazaar`    |
+| `accepts[0].resource`     | `resource.url`         |
+| `accepts[0].description`  | `resource.description` |
+| `accepts[0].mimeType`     | `resource.mimeType`    |
 
 V1 had no formal schema validation.
+
+For x402 v2, servers SHOULD keep `accepts[]` limited to payment requirements. Human-readable
+resource metadata belongs in `resource`, and Bazaar invocation metadata belongs in
+`extensions.bazaar`. If a facilitator later exposes enriched catalog fields derived from that
+data, treat that as facilitator output rather than part of the seller-side v2 wire contract.


### PR DESCRIPTION
## Summary

This tightens the Bazaar v2 docs/spec around where seller-declared metadata actually lives.

- update Bazaar docs and the seller quickstart to show v2 metadata in `resource` plus `extensions.bazaar`
- remove or reframe examples that implied sellers should put Bazaar metadata directly in `accepts[]`
- align the MCP examples in the Bazaar spec with the live `toolName` field used by the SDKs

## Why

Issue #1945 points at a real source of confusion: the repo currently mixed v1-style enriched `accepts[]` examples with the v2 wire contract. That makes it hard to tell which fields are seller-declared versus facilitator-enriched catalog output.

This PR is docs/spec only. It does not change facilitator behavior or the public catalog shape.

Refs #1945

## Verification

- `npx --yes prettier --check docs/extensions/bazaar.mdx docs/getting-started/quickstart-for-sellers.mdx specs/extensions/bazaar.md`
- `git diff --check`
