### PR TITLE
docs(sellers): replace legacy Go import path in Echo example

### DIFF
--- a/docs/getting-started/quickstart-for-sellers.mdx
+++ b/docs/getting-started/quickstart-for-sellers.mdx
@@ -1105,8 +1105,8 @@ For multi-network support, register both EVM and SVM schemes:
   <Tab title="Go (Echo)">
     ```go
     import (
-        evm "github.com/coinbase/x402/go/mechanisms/evm/exact/server"
-        svm "github.com/coinbase/x402/go/mechanisms/svm/exact/server"
+        evm "github.com/x402-foundation/x402/go/mechanisms/evm/exact/server"
+        svm "github.com/x402-foundation/x402/go/mechanisms/svm/exact/server"
     )
 
     e.Use(echomw.X402Payment(echomw.Config{


### PR DESCRIPTION
## Description

Replaces the remaining legacy `github.com/coinbase/x402/...` Go imports in the seller quickstart Echo example with the current `github.com/x402-foundation/x402/...` module path.

This aligns the snippet with the canonical Go module path already used across the repo and avoids confusion for users copying the example.

## Tests

- Not run; docs-only change.

