### PR TITLE
fix(python): reject malformed PAYMENT-SIGNATURE headers early

### DIFF
--- a/python/x402/changelog.d/2010.bugfix.md
+++ b/python/x402/changelog.d/2010.bugfix.md
@@ -1,0 +1,1 @@
+Reject malformed `PAYMENT-SIGNATURE` headers early in the Python HTTP server with a `400 Invalid payment` response.

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import threading
 from collections.abc import Callable, Iterator
+from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 
 try:
@@ -35,6 +36,15 @@ if TYPE_CHECKING:
 # ============================================================================
 # Extension Auto-Registration
 # ============================================================================
+
+
+def _status_line(status_code: int) -> str:
+    """Build a WSGI status line using the standard HTTP reason phrase when possible."""
+    try:
+        phrase = HTTPStatus(status_code).phrase
+    except ValueError:
+        phrase = "Payment Required"
+    return f"{status_code} {phrase}"
 
 
 def _check_if_bazaar_needed(routes: RoutesConfig) -> bool:
@@ -403,18 +413,21 @@ class PaymentMiddleware:
                     start_response(status, headers)
                     return [body]
 
-                status = f"{response.status} Payment Required"
+                status = _status_line(response.status)
                 headers = list(response.headers.items())
+                has_content_type = any(key.lower() == "content-type" for key, _ in headers)
 
                 if response.is_html:
-                    headers.append(("Content-Type", "text/html; charset=utf-8"))
+                    if not has_content_type:
+                        headers.append(("Content-Type", "text/html; charset=utf-8"))
                     body = (
                         response.body.encode("utf-8")
                         if isinstance(response.body, str)
                         else response.body
                     )
                 else:
-                    headers.append(("Content-Type", "application/json"))
+                    if not has_content_type:
+                        headers.append(("Content-Type", "application/json"))
                     body = json.dumps(response.body or {}).encode("utf-8")
 
                 start_response(status, headers)
@@ -458,7 +471,7 @@ class PaymentMiddleware:
                                 headers = [("Content-Type", "application/json")]
                                 body = json.dumps({}).encode("utf-8")
                             else:
-                                status = f"{response.status} Payment Required"
+                                status = _status_line(response.status)
                                 headers = list(response.headers.items())
                                 if response.is_html:
                                     body = (

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -90,6 +90,10 @@ ProcessPhase = Literal["resolve_options", "verify_payment", "build_requirements"
 ProcessCommand = tuple[ProcessPhase, Any, Any]  # (phase, target, context)
 
 
+class MalformedPaymentHeaderError(ValueError):
+    """Raised when PAYMENT-SIGNATURE cannot be decoded into a payment payload."""
+
+
 # ============================================================================
 # Base HTTP Server Class (Shared Logic)
 # ============================================================================
@@ -286,7 +290,17 @@ class x402HTTPServerBase:
         context = dataclasses.replace(context, route_pattern=route_pattern)
 
         # Extract payment from headers
-        payment_payload = self._extract_payment(context.adapter)
+        try:
+            payment_payload = self._extract_payment(context.adapter)
+        except MalformedPaymentHeaderError:
+            return HTTPProcessResult(
+                type=RESULT_PAYMENT_ERROR,
+                response=HTTPResponseInstructions(
+                    status=400,
+                    headers={"Content-Type": "application/json"},
+                    body={"error": "Invalid payment"},
+                ),
+            )
 
         # Build resource info (Static metadata as per maintainer feedback)
         resource_info = ResourceInfo(
@@ -517,8 +531,8 @@ class x402HTTPServerBase:
         if header:
             try:
                 return decode_payment_signature_header(header)
-            except Exception:
-                return None
+            except Exception as exc:
+                raise MalformedPaymentHeaderError("Invalid payment") from exc
 
         return None
 

--- a/python/x402/tests/integrations/test_http_integration.py
+++ b/python/x402/tests/integrations/test_http_integration.py
@@ -297,6 +297,30 @@ class TestHTTPIntegration:
         result = components.process_http_request(context)
         assert result.type == "no-payment-required"
 
+    def test_malformed_payment_signature_returns_400(
+        self,
+        components: HTTPComponentsFixture,
+    ) -> None:
+        """Malformed PAYMENT-SIGNATURE headers should return 400 instead of 402."""
+        mock_adapter = MockHTTPAdapter(
+            path="/api/protected",
+            method="GET",
+            headers={"PAYMENT-SIGNATURE": "not-valid-base64"},
+        )
+        context = HTTPRequestContext(
+            adapter=mock_adapter,
+            path="/api/protected",
+            method="GET",
+        )
+
+        result = components.process_http_request(context)
+
+        assert result.type == "payment-error"
+        assert result.response is not None
+        assert result.response.status == 400
+        assert result.response.body == {"error": "Invalid payment"}
+        assert result.response.headers == {"Content-Type": "application/json"}
+
 
 class TestDynamicPricing:
     """Tests for dynamic pricing - run against both sync and async implementations."""


### PR DESCRIPTION
## Description

Rejects malformed `PAYMENT-SIGNATURE` headers early in the Python HTTP server instead of treating them as missing payments and returning a 402 challenge.

This makes the Python HTTP flow stricter and more predictable, and brings it closer to the behavior already enforced in other parts of the repo. The PR also adds a regression test that covers both sync and async HTTP server implementations.

## Tests

- `python -m pytest tests/integrations/test_http_integration.py -q` (`22 passed`)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
