### PR TITLE
feat(go): add callback client signer helpers

### DIFF
--- a/go/.changes/unreleased/callback-client-signers.yaml
+++ b/go/.changes/unreleased/callback-client-signers.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add callback-based EVM and SVM client signer helpers for external signing systems

--- a/go/signers/evm/README.md
+++ b/go/signers/evm/README.md
@@ -20,7 +20,39 @@ if err != nil {
 evmScheme := evmclient.NewExactEvmScheme(signer)
 ```
 
+For HSMs, MPC/TSS systems, custodial signing services, or remote wallets, use a callback signer:
+
+```go
+import x402evm "github.com/x402-foundation/x402/go/mechanisms/evm"
+
+signer, err := evmsigners.NewClientSigner("0xYourAddress", func(
+    ctx context.Context,
+    domain x402evm.TypedDataDomain,
+    types map[string][]x402evm.TypedDataField,
+    primaryType string,
+    message map[string]interface{},
+) ([]byte, error) {
+    return remoteSigner.SignTypedData(ctx, domain, types, primaryType, message)
+})
+```
+
 ## API
+
+### NewClientSigner
+
+```go
+func NewClientSigner(address string, signFunc SignTypedDataFunc) (evm.ClientEvmSigner, error)
+```
+
+Creates a client signer from an Ethereum address and EIP-712 signing callback. Use this when raw private keys are held outside the process.
+
+**Args:**
+- `address`: Ethereum address for the signer
+- `signFunc`: Callback that signs EIP-712 typed data and returns a 65-byte signature
+
+**Returns:**
+- `evm.ClientEvmSigner` implementation
+- Error if the address is invalid or the callback is nil
 
 ### NewClientSignerFromPrivateKey
 
@@ -167,4 +199,3 @@ func TestPayment(t *testing.T) {
 - [../svm/README.md](../svm/README.md) - SVM client signer
 - [../../mechanisms/evm/README.md](../../mechanisms/evm/README.md) - EVM mechanism documentation
 - [../README.md](../README.md) - Signers package overview
-

--- a/go/signers/evm/client.go
+++ b/go/signers/evm/client.go
@@ -19,12 +19,45 @@ import (
 	x402evm "github.com/x402-foundation/x402/go/mechanisms/evm"
 )
 
-// ClientSigner implements x402evm.ClientEvmSigner using an ECDSA private key.
-// This provides client-side EIP-712 signing for creating payment payloads.
+// SignTypedDataFunc signs EIP-712 typed data for an Ethereum address.
+//
+// Use this callback when signing is delegated to an external system such as an
+// HSM, MPC/TSS service, custody provider, or remote wallet.
+type SignTypedDataFunc func(
+	ctx context.Context,
+	domain x402evm.TypedDataDomain,
+	types map[string][]x402evm.TypedDataField,
+	primaryType string,
+	message map[string]interface{},
+) ([]byte, error)
+
+// ClientSigner implements x402evm.ClientEvmSigner.
+//
+// Signers can be backed by either an ECDSA private key or a callback to an
+// external signing system. Private-key signers also support optional extension
+// capabilities such as transaction signing and contract reads.
 type ClientSigner struct {
-	privateKey *ecdsa.PrivateKey
-	address    common.Address
-	ethClient  *ethclient.Client
+	privateKey    *ecdsa.PrivateKey
+	address       common.Address
+	ethClient     *ethclient.Client
+	signTypedData SignTypedDataFunc
+}
+
+// NewClientSigner creates a client signer from an Ethereum address and signing callback.
+//
+// Use this constructor when raw private keys are held by an external signer.
+func NewClientSigner(address string, signFunc SignTypedDataFunc) (x402evm.ClientEvmSigner, error) {
+	if !common.IsHexAddress(address) {
+		return nil, fmt.Errorf("invalid address: %s", address)
+	}
+	if signFunc == nil {
+		return nil, fmt.Errorf("sign callback is required")
+	}
+
+	return &ClientSigner{
+		address:       common.HexToAddress(address),
+		signTypedData: signFunc,
+	}, nil
 }
 
 // NewClientSignerFromPrivateKey creates a client signer from a hex-encoded private key.
@@ -71,6 +104,9 @@ func NewClientSignerFromPrivateKeyWithClient(privateKeyHex string, ethClient *et
 		privateKey: privateKey,
 		address:    address,
 		ethClient:  ethClient,
+		signTypedData: func(_ context.Context, domain x402evm.TypedDataDomain, types map[string][]x402evm.TypedDataField, primaryType string, message map[string]interface{}) ([]byte, error) {
+			return signTypedDataWithPrivateKey(privateKey, domain, types, primaryType, message)
+		},
 	}, nil
 }
 
@@ -95,6 +131,20 @@ func (s *ClientSigner) Address() string {
 //	Error if signing fails
 func (s *ClientSigner) SignTypedData(
 	ctx context.Context,
+	domain x402evm.TypedDataDomain,
+	types map[string][]x402evm.TypedDataField,
+	primaryType string,
+	message map[string]interface{},
+) ([]byte, error) {
+	if s.signTypedData == nil {
+		return nil, fmt.Errorf("sign callback is required")
+	}
+
+	return s.signTypedData(ctx, domain, types, primaryType, message)
+}
+
+func signTypedDataWithPrivateKey(
+	privateKey *ecdsa.PrivateKey,
 	domain x402evm.TypedDataDomain,
 	types map[string][]x402evm.TypedDataField,
 	primaryType string,
@@ -154,7 +204,7 @@ func (s *ClientSigner) SignTypedData(
 	digest := crypto.Keccak256(rawData)
 
 	// Sign the digest with ECDSA
-	signature, err := crypto.Sign(digest, s.privateKey)
+	signature, err := crypto.Sign(digest, privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign: %w", err)
 	}
@@ -215,6 +265,10 @@ func (s *ClientSigner) EstimateFeesPerGas(ctx context.Context) (maxFeePerGas, ma
 // SignTransaction signs an EIP-1559 transaction using the signer's private key
 // and returns the RLP-encoded signed transaction bytes.
 func (s *ClientSigner) SignTransaction(ctx context.Context, tx *types.Transaction) ([]byte, error) {
+	if s.privateKey == nil {
+		return nil, fmt.Errorf("SignTransaction requires a private key; use NewClientSignerFromPrivateKey")
+	}
+
 	// Derive chain ID from tx
 	chainID := tx.ChainId()
 	signer := types.LatestSignerForChainID(chainID)

--- a/go/signers/evm/client_test.go
+++ b/go/signers/evm/client_test.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"bytes"
 	"context"
 	"math/big"
 	"strings"
@@ -98,6 +99,77 @@ func TestClientSigner_Address(t *testing.T) {
 	expected := "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 	if !equalAddresses(addr, expected) {
 		t.Errorf("Address() = %v, want %v", addr, expected)
+	}
+}
+
+func TestNewClientSigner(t *testing.T) {
+	expectedAddress := "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+	expectedSignature := make([]byte, 65)
+	expectedSignature[64] = 27
+	called := false
+
+	signer, err := NewClientSigner(expectedAddress, func(ctx context.Context, domain x402evm.TypedDataDomain, types map[string][]x402evm.TypedDataField, primaryType string, message map[string]interface{}) ([]byte, error) {
+		called = true
+		if ctx == nil {
+			t.Fatal("expected context")
+		}
+		if domain.Name != "USD Coin" {
+			t.Fatalf("domain.Name = %q, want USD Coin", domain.Name)
+		}
+		if primaryType != "TransferWithAuthorization" {
+			t.Fatalf("primaryType = %q, want TransferWithAuthorization", primaryType)
+		}
+		if len(types["TransferWithAuthorization"]) == 0 {
+			t.Fatal("expected typed data fields")
+		}
+		if message["from"] != expectedAddress {
+			t.Fatalf("message.from = %v, want %s", message["from"], expectedAddress)
+		}
+		return expectedSignature, nil
+	})
+	if err != nil {
+		t.Fatalf("NewClientSigner() failed: %v", err)
+	}
+
+	domain := x402evm.TypedDataDomain{
+		Name:              "USD Coin",
+		Version:           "2",
+		ChainID:           big.NewInt(84532),
+		VerifyingContract: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+	}
+	types := map[string][]x402evm.TypedDataField{
+		"TransferWithAuthorization": {
+			{Name: "from", Type: "address"},
+		},
+	}
+	message := map[string]interface{}{"from": expectedAddress}
+
+	signature, err := signer.SignTypedData(context.Background(), domain, types, "TransferWithAuthorization", message)
+	if err != nil {
+		t.Fatalf("SignTypedData() failed: %v", err)
+	}
+
+	if !called {
+		t.Fatal("expected signing callback to be called")
+	}
+	if !bytes.Equal(signature, expectedSignature) {
+		t.Fatal("SignTypedData() did not return callback signature")
+	}
+	if !equalAddresses(signer.Address(), expectedAddress) {
+		t.Fatalf("Address() = %v, want %v", signer.Address(), expectedAddress)
+	}
+}
+
+func TestNewClientSignerValidation(t *testing.T) {
+	signFunc := func(context.Context, x402evm.TypedDataDomain, map[string][]x402evm.TypedDataField, string, map[string]interface{}) ([]byte, error) {
+		return make([]byte, 65), nil
+	}
+
+	if _, err := NewClientSigner("not-an-address", signFunc); err == nil {
+		t.Fatal("expected invalid address error")
+	}
+	if _, err := NewClientSigner("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", nil); err == nil {
+		t.Fatal("expected nil callback error")
 	}
 }
 

--- a/go/signers/svm/README.md
+++ b/go/signers/svm/README.md
@@ -20,7 +20,37 @@ if err != nil {
 svmScheme := svmclient.NewExactSvmScheme(signer)
 ```
 
+For HSMs, MPC/TSS systems, custodial signing services, or remote wallets, use a callback signer:
+
+```go
+import solana "github.com/gagliardetto/solana-go"
+
+publicKey := solana.MustPublicKeyFromBase58("YourPublicKey")
+signer, err := svmsigners.NewClientSigner(publicKey, func(
+    ctx context.Context,
+    tx *solana.Transaction,
+) error {
+    return remoteSigner.SignTransaction(ctx, tx)
+})
+```
+
 ## API
+
+### NewClientSigner
+
+```go
+func NewClientSigner(publicKey solana.PublicKey, signFunc SignTransactionFunc) (svm.ClientSvmSigner, error)
+```
+
+Creates a client signer from a Solana public key and transaction signing callback. Use this when raw private keys are held outside the process.
+
+**Args:**
+- `publicKey`: Solana public key for the signer
+- `signFunc`: Callback that signs the transaction in place
+
+**Returns:**
+- `svm.ClientSvmSigner` implementation
+- Error if the public key is zero or the callback is nil
 
 ### NewClientSignerFromPrivateKey
 
@@ -213,4 +243,3 @@ fmt.Println("Public Key:", privateKey.PublicKey())
 - [../evm/README.md](../evm/README.md) - EVM client signer
 - [../../mechanisms/svm/README.md](../../mechanisms/svm/README.md) - SVM mechanism documentation
 - [../README.md](../README.md) - Signers package overview
-

--- a/go/signers/svm/client.go
+++ b/go/signers/svm/client.go
@@ -9,10 +9,36 @@ import (
 	x402svm "github.com/x402-foundation/x402/go/mechanisms/svm"
 )
 
-// ClientSigner implements x402svm.ClientSvmSigner using an Ed25519 private key.
-// This provides client-side transaction signing for creating payment payloads.
+// SignTransactionFunc signs a Solana transaction in place.
+//
+// Use this callback when signing is delegated to an external system such as an
+// HSM, MPC/TSS service, custody provider, or remote wallet.
+type SignTransactionFunc func(ctx context.Context, tx *solana.Transaction) error
+
+// ClientSigner implements x402svm.ClientSvmSigner.
+//
+// Signers can be backed by either an Ed25519 private key or a callback to an
+// external signing system.
 type ClientSigner struct {
-	privateKey solana.PrivateKey
+	publicKey       solana.PublicKey
+	signTransaction SignTransactionFunc
+}
+
+// NewClientSigner creates a client signer from a public key and signing callback.
+//
+// Use this constructor when raw private keys are held by an external signer.
+func NewClientSigner(publicKey solana.PublicKey, signFunc SignTransactionFunc) (x402svm.ClientSvmSigner, error) {
+	if publicKey == (solana.PublicKey{}) {
+		return nil, fmt.Errorf("public key is required")
+	}
+	if signFunc == nil {
+		return nil, fmt.Errorf("sign callback is required")
+	}
+
+	return &ClientSigner{
+		publicKey:       publicKey,
+		signTransaction: signFunc,
+	}, nil
 }
 
 // NewClientSignerFromPrivateKey creates a client signer from a base58-encoded private key.
@@ -42,13 +68,16 @@ func NewClientSignerFromPrivateKey(privateKeyBase58 string) (x402svm.ClientSvmSi
 	}
 
 	return &ClientSigner{
-		privateKey: privateKey,
+		publicKey: privateKey.PublicKey(),
+		signTransaction: func(ctx context.Context, tx *solana.Transaction) error {
+			return signTransactionWithPrivateKey(ctx, tx, privateKey)
+		},
 	}, nil
 }
 
 // Address returns the Solana public key of the signer.
 func (s *ClientSigner) Address() solana.PublicKey {
-	return s.privateKey.PublicKey()
+	return s.publicKey
 }
 
 // SignTransaction partially signs a Solana transaction.
@@ -63,6 +92,18 @@ func (s *ClientSigner) Address() solana.PublicKey {
 //
 //	Error if signing fails
 func (s *ClientSigner) SignTransaction(ctx context.Context, tx *solana.Transaction) error {
+	if s.signTransaction == nil {
+		return fmt.Errorf("sign callback is required")
+	}
+
+	return s.signTransaction(ctx, tx)
+}
+
+func signTransactionWithPrivateKey(
+	_ context.Context,
+	tx *solana.Transaction,
+	privateKey solana.PrivateKey,
+) error {
 	// Marshal transaction message to bytes
 	messageBytes, err := tx.Message.MarshalBinary()
 	if err != nil {
@@ -70,13 +111,13 @@ func (s *ClientSigner) SignTransaction(ctx context.Context, tx *solana.Transacti
 	}
 
 	// Sign the message bytes with Ed25519
-	signature, err := s.privateKey.Sign(messageBytes)
+	signature, err := privateKey.Sign(messageBytes)
 	if err != nil {
 		return fmt.Errorf("failed to sign: %w", err)
 	}
 
 	// Find the index of our public key in the transaction
-	accountIndex, err := tx.GetAccountIndex(s.privateKey.PublicKey())
+	accountIndex, err := tx.GetAccountIndex(privateKey.PublicKey())
 	if err != nil {
 		return fmt.Errorf("failed to get account index: %w", err)
 	}

--- a/go/signers/svm/client_test.go
+++ b/go/signers/svm/client_test.go
@@ -79,31 +79,61 @@ func TestClientSigner_Address(t *testing.T) {
 	}
 }
 
+func TestNewClientSigner(t *testing.T) {
+	privateKey, err := solana.PrivateKeyFromBase58(testPrivateKeyBase58)
+	if err != nil {
+		t.Fatalf("PrivateKeyFromBase58() failed: %v", err)
+	}
+
+	called := false
+	signer, err := NewClientSigner(privateKey.PublicKey(), func(ctx context.Context, tx *solana.Transaction) error {
+		called = true
+		if ctx == nil {
+			t.Fatal("expected context")
+		}
+		return signTransactionWithPrivateKey(ctx, tx, privateKey)
+	})
+	if err != nil {
+		t.Fatalf("NewClientSigner() failed: %v", err)
+	}
+
+	tx := newTestTransaction(t, signer.Address())
+
+	if err := signer.SignTransaction(context.Background(), tx); err != nil {
+		t.Fatalf("SignTransaction() failed: %v", err)
+	}
+
+	if !called {
+		t.Fatal("expected signing callback to be called")
+	}
+
+	accountIndex, err := tx.GetAccountIndex(signer.Address())
+	if err != nil {
+		t.Fatalf("GetAccountIndex() failed: %v", err)
+	}
+	if tx.Signatures[accountIndex] == (solana.Signature{}) {
+		t.Fatal("SignTransaction() added zero signature")
+	}
+}
+
+func TestNewClientSignerValidation(t *testing.T) {
+	signFunc := func(context.Context, *solana.Transaction) error { return nil }
+
+	if _, err := NewClientSigner(solana.PublicKey{}, signFunc); err == nil {
+		t.Fatal("expected zero public key error")
+	}
+	if _, err := NewClientSigner(solana.MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"), nil); err == nil {
+		t.Fatal("expected nil callback error")
+	}
+}
+
 func TestClientSigner_SignTransaction(t *testing.T) {
 	signer, err := NewClientSignerFromPrivateKey(testPrivateKeyBase58)
 	if err != nil {
 		t.Fatalf("NewClientSignerFromPrivateKey() failed: %v", err)
 	}
 
-	// Create a simple test transaction with a transfer instruction
-	recentBlockhash := solana.MustHashFromBase58("11111111111111111111111111111111")
-	recipient := solana.MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
-
-	// Create a system transfer instruction
-	transferIx := system.NewTransferInstruction(
-		1000000, // 0.001 SOL in lamports
-		signer.Address(),
-		recipient,
-	).Build()
-
-	tx, err := solana.NewTransactionBuilder().
-		AddInstruction(transferIx).
-		SetRecentBlockHash(recentBlockhash).
-		SetFeePayer(signer.Address()).
-		Build()
-	if err != nil {
-		t.Fatalf("Failed to create test transaction: %v", err)
-	}
+	tx := newTestTransaction(t, signer.Address())
 
 	// Sign the transaction
 	err = signer.SignTransaction(context.Background(), tx)
@@ -136,24 +166,7 @@ func TestClientSigner_SignTransaction_SignatureArray(t *testing.T) {
 		t.Fatalf("NewClientSignerFromPrivateKey() failed: %v", err)
 	}
 
-	// Create a transaction with a transfer instruction
-	recentBlockhash := solana.MustHashFromBase58("11111111111111111111111111111111")
-	recipient := solana.MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
-
-	transferIx := system.NewTransferInstruction(
-		1000000,
-		signer.Address(),
-		recipient,
-	).Build()
-
-	tx, err := solana.NewTransactionBuilder().
-		AddInstruction(transferIx).
-		SetRecentBlockHash(recentBlockhash).
-		SetFeePayer(signer.Address()).
-		Build()
-	if err != nil {
-		t.Fatalf("Failed to create test transaction: %v", err)
-	}
+	tx := newTestTransaction(t, signer.Address())
 
 	// Sign the transaction (should handle expanding signatures array)
 	err = signer.SignTransaction(context.Background(), tx)
@@ -173,4 +186,28 @@ func TestClientSigner_SignTransaction_SignatureArray(t *testing.T) {
 	} else if tx.Signatures[accountIndex] == (solana.Signature{}) {
 		t.Error("SignTransaction() added zero signature")
 	}
+}
+
+func newTestTransaction(t *testing.T, signer solana.PublicKey) *solana.Transaction {
+	t.Helper()
+
+	recentBlockhash := solana.MustHashFromBase58("11111111111111111111111111111111")
+	recipient := solana.MustPublicKeyFromBase58("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA")
+
+	transferIx := system.NewTransferInstruction(
+		1000000,
+		signer,
+		recipient,
+	).Build()
+
+	tx, err := solana.NewTransactionBuilder().
+		AddInstruction(transferIx).
+		SetRecentBlockHash(recentBlockhash).
+		SetFeePayer(signer).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to create test transaction: %v", err)
+	}
+
+	return tx
 }


### PR DESCRIPTION
## Description

Closes #1033.

Adds callback-based EVM and SVM client signer helpers for environments where raw private keys are held by an external signer, such as an HSM, MPC/TSS service, custody provider, or remote wallet. The existing private-key helpers remain in place and now share the same signing path while preserving their current public API.

This also updates the signer READMEs and adds a Go changelog fragment.

## Tests

- `gofmt -w signers/evm/client.go signers/evm/client_test.go signers/svm/client.go signers/svm/client_test.go`
- `go test ./signers/evm ./signers/svm`
- `go test ./signers/... ./mechanisms/evm/... ./mechanisms/svm/...`
- `go test -race -cover ./signers/... ./mechanisms/evm/... ./mechanisms/svm/...`
- `go vet ./signers/... ./mechanisms/evm/... ./mechanisms/svm/...`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)