### PR TITLE
feat(extensions): add discovery OpenAPI document builder

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -67,6 +67,7 @@
         "pages": [
           "extensions/overview",
           "extensions/bazaar",
+          "extensions/discovery",
           "extensions/payment-identifier",
           "extensions/sign-in-with-x",
           "extensions/offer-receipt",

--- a/docs/extensions/discovery.mdx
+++ b/docs/extensions/discovery.mdx
@@ -1,0 +1,182 @@
+---
+title: "Discovery (OpenAPI for x402)"
+description: "Generate an OpenAPI 3.1 document directly from your x402 routes configuration, so crawlers and AI agents can discover and invoke your paid endpoints."
+---
+
+The `discovery` helper turns the same `routes` map you pass to `paymentMiddleware` into a validated OpenAPI 3.1 document ready to serve at `/openapi.json`. It is a pure function — no registration, no hooks, no middleware of its own. The idea is that any x402 server already declares everything a crawler needs (paths, HTTP methods, payment options, bazaar input/output schemas); `discovery` just assembles that into the format [AgentCash discovery](https://docs.agentcash.dev) expects.
+
+### Why
+
+`bazaar` tells a facilitator how to call one endpoint at a time, embedded inside a 402 response. That is great for cataloging services a client has already hit, but it does not give you a single URL a crawler can fetch to enumerate everything a server offers. `discovery` closes that gap without changing core or introducing a new runtime component:
+
+- **One function, one file in your server.** `app.get("/openapi.json", …)` and you are done.
+- **No duplicate source of truth.** The OpenAPI doc is derived from the same `routes` object the payment middleware already uses, so drift is impossible.
+- **Works with validators out of the box.** The output is valid OpenAPI 3.1 plus the required AgentCash extension fields (`info.x-guidance`, `x-discovery.ownershipProofs`, `x-payment-info` per operation).
+
+### Installation
+
+Already included in `@x402/extensions`. No separate package.
+
+```bash
+pnpm add @x402/extensions
+```
+
+### Basic Usage
+
+#### Express
+
+```typescript
+import express from "express";
+import { paymentMiddleware } from "@x402/express";
+import { discovery } from "@x402/extensions";
+import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+
+const routes = {
+  "POST /analyze": {
+    accepts: [{
+      scheme: "exact",
+      network: "eip155:84532",
+      payTo: "0xYourAddress",
+      price: "$0.01",
+    }],
+    description: "Run analysis on a document",
+    extensions: declareDiscoveryExtension({
+      bodyType: "json",
+      input: { text: "hello" },
+      inputSchema: {
+        type: "object",
+        properties: { text: { type: "string" } },
+        required: ["text"],
+      },
+      output: { example: { score: 0.87 } },
+    }),
+  },
+};
+
+const app = express();
+app.use(paymentMiddleware(routes, resourceServer));
+
+app.get("/openapi.json", (_req, res) =>
+  res.json(
+    discovery(routes, {
+      info: {
+        title: "My API",
+        version: "1.0.0",
+        description: "Example x402 server",
+        xGuidance: "Use POST /analyze to score a document. $0.01 per call.",
+      },
+    }),
+  ),
+);
+```
+
+#### Next.js (App Router)
+
+Create `app/openapi.json/route.ts`:
+
+```typescript
+import { NextResponse } from "next/server";
+import { discovery } from "@x402/extensions";
+import { routes, discoveryOptions } from "@/lib/x402";
+
+export const GET = () => NextResponse.json(discovery(routes, discoveryOptions));
+```
+
+Where `routes` is the same object you pass to your Next.js `paymentMiddleware`, and `discoveryOptions` is a `DiscoveryOptions` value you keep next to it.
+
+### What discovery Derives Automatically
+
+For each entry in `routes`, `discovery` maps:
+
+| Source in `RouteConfig`                                | Where it lands in the OpenAPI doc                          |
+|--------------------------------------------------------|-------------------------------------------------------------|
+| Route key `"POST /analyze"`                            | `paths["/analyze"].post`                                    |
+| `config.description`                                   | `operation.summary`                                         |
+| `config.accepts[0].price`                              | `operation["x-payment-info"].price`                         |
+| `config.extensions.bazaar` body schema                 | `operation.requestBody.content["application/json"].schema`  |
+| `config.extensions.bazaar` query/path schemas          | `operation.parameters[]`                                    |
+| `config.extensions.bazaar.info.output.example`         | `operation.responses["200"]` (with inferred schema)         |
+| `config.extensions["sign-in-with-x"]` present          | `operation.security = [{ siwx: [] }]`, no `x-payment-info`  |
+
+Path parameters are auto-converted from `:param` or `[param]` syntax to OpenAPI's `{param}` form. Every paid operation gets a `responses["402"]` entry; every SIWX-only operation gets a `responses["401"]` entry plus a top-level `components.securitySchemes.siwx` block.
+
+### What You Must Provide
+
+`discovery` cannot synthesize document-level metadata out of routes — you pass these via the second argument (`DiscoveryOptions`):
+
+| Option                    | Required | Notes                                                                                                 |
+|---------------------------|:--------:|-------------------------------------------------------------------------------------------------------|
+| `info.title`              | ✅        | Human-readable API name.                                                                             |
+| `info.version`            | ✅        | Semver string.                                                                                       |
+| `info.description`        |          | Short description of the API.                                                                       |
+| `info.xGuidance`          | ✅        | High-level natural-language guidance for AI agents. Emitted as `info["x-guidance"]`. AgentCash `check` requires this. |
+| `servers`                 |          | Array of `{ url, description? }`. If omitted, agents fall back to the request host.                  |
+| `protocols`               |          | Defaults to `[{ x402: {} }]`.|
+
+### Identity-Gated Routes (SIWX)
+
+If a route declares the `sign-in-with-x` extension, `discovery` automatically:
+
+1. Omits `x-payment-info` from that operation.
+2. Adds `security: [{ siwx: [] }]` to it.
+3. Emits a top-level `components.securitySchemes.siwx` bearer scheme on the document.
+
+You do not need to configure anything additional — the presence of the extension is enough.
+
+```typescript
+const routes = {
+  "GET /premium": {
+    accepts: [{ /* ignored for SIWX-only */ }],
+    extensions: {
+      "sign-in-with-x": { /* SIWX config */ },
+    },
+  },
+};
+```
+
+### Validating Your Document
+
+The [AgentCash discovery CLI](https://www.npmjs.com/package/@agentcash/discovery) checks that your document meets all requirements for agent discovery:
+
+```bash
+# Dump and inspect
+npx -y @agentcash/discovery@latest discover "$TARGET_URL"
+
+# Validate against the discovery schema
+npx -y @agentcash/discovery@latest check "$TARGET_URL"
+```
+
+Run `check` after wiring up `discovery` and fix any warnings it surfaces before registering your server with X402Scan.
+
+### Known Limitations
+
+- **Dynamic prices.** `DynamicPrice` functions cannot be resolved statically. They are emitted as `{ mode: "dynamic", currency: "USD", min: "0", max: "0" }`. If you need real bounds, use a static price fallback in `config.accepts` when declaring the route.
+- **Currency is hardcoded to `"USD"`.** The x402 `Price` type carries an asset address, not a currency. Converting USDC/PYUSD/WETH to a user-facing currency requires an oracle that the builder intentionally does not pull in.
+- **First accept option only.** Multi-option `accepts` arrays are summarized by `accepts[0]`. The AgentCash `x-payment-info` shape currently assumes a single price per operation.
+- **Response schemas are inferred from examples.** If your bazaar declaration only supplies `output.example`, `discovery` infers a coarse schema from the example's shape. Supplying a richer `output.schema` in `declareDiscoveryExtension` improves the emitted OpenAPI response schema.
+
+### Type Reference
+
+```typescript
+import {
+  discovery,
+  type DiscoveryOptions,
+  type OpenAPIDocument,
+  DiscoveryOptionsSchema,
+  OpenAPIDocumentSchema,
+} from "@x402/extensions";
+
+// Pure function: routes → OpenAPI 3.1 doc
+function discovery(
+  routes: RoutesConfig,
+  options: DiscoveryOptions,
+): OpenAPIDocument;
+```
+
+Both `DiscoveryOptionsSchema` and `OpenAPIDocumentSchema` are exported Zod schemas — useful if you want to validate options at server startup or assert the document shape in a test.
+
+### Further Reading
+
+- [Bazaar extension](./bazaar) — per-route discovery declarations that feed into this document
+- [AgentCash discovery spec](https://agentcash.dev/discovery) — the target format and validator
+- [@x402/extensions package](https://github.com/x402-foundation/x402/tree/main/typescript/packages/extensions) — source

--- a/docs/extensions/overview.mdx
+++ b/docs/extensions/overview.mdx
@@ -109,6 +109,7 @@ Bazaar is unique in that it spans both sides: the resource server extension enri
 | Extension | Type | Description | SDK Support |
 |-----------|------|-------------|-------------|
 | [Bazaar](./bazaar) | Server + Facilitator | Discovery layer for x402 endpoints and MCP tools. Makes your services findable by AI agents and developers. | TypeScript, Go, Python |
+| [Discovery (OpenAPI)](./discovery) | Server | Pure builder that turns your `routes` map into an OpenAPI 3.1 document you can host at `/openapi.json`. | TypeScript |
 | [EIP-2612 Gas Sponsoring](./eip2612-gas-sponsoring) | Facilitator | Sponsors gas for EIP-2612 permit-based token transfers. | TypeScript, Go, Python |
 | [ERC-20 Approval Gas Sponsoring](./erc20-approval-gas-sponsoring) | Facilitator | Sponsors gas for ERC-20 approval-based token transfers. | TypeScript, Go, Python |
 | [Payment Identifier](./payment-identifier) | Server + Client | Attaches a unique identifier to each payment for tracking, reconciliation, and idempotency. | TypeScript, Go, Python |

--- a/typescript/.changeset/discovery-openapi-builder.md
+++ b/typescript/.changeset/discovery-openapi-builder.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": minor
+---
+
+Add `discovery`, a pure function that converts an x402 `RoutesConfig` into an AgentCash-compatible OpenAPI 3.1 document for hosting at `/openapi.json`. Derives paths, parameters, request bodies, payment info (`x-payment-info`), and SIWX security from the same routes map and bazaar declarations the server already has — no core changes, no new hooks. Exported alongside `DiscoveryOptionsSchema` and `OpenAPIDocumentSchema` Zod schemas for runtime validation.

--- a/typescript/packages/extensions/src/discovery/index.ts
+++ b/typescript/packages/extensions/src/discovery/index.ts
@@ -1,0 +1,70 @@
+/**
+ * OpenAPI discovery document builder for x402 servers.
+ *
+ * @example
+ * ```ts
+ * // Express — one line after paymentMiddleware is already registered
+ * import { discovery } from "@x402/extensions";
+ *
+ * app.get("/openapi.json", (_req, res) =>
+ *   res.json(discovery(routes, {
+ *     info: {
+ *       title: "My API",
+ *       version: "1.0.0",
+ *       xGuidance: "Use POST /analyze to score a document. $0.01 per call.",
+ *     },
+ *     ownershipProofs: ["did:web:example.com"],
+ *   })),
+ * );
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Next.js App Router — app/openapi.json/route.ts
+ * import { NextResponse } from "next/server";
+ * import { discovery } from "@x402/extensions";
+ * import { routes, discoveryOptions } from "@/lib/x402";
+ *
+ * export const GET = () => NextResponse.json(discovery(routes, discoveryOptions));
+ * ```
+ */
+
+import type { RoutesConfig } from "@x402/core/http";
+import type { DiscoveryOptions, OpenAPIDocument } from "./types";
+import {
+  buildPaths,
+  buildSiwxComponents,
+  isSiwxRoute,
+  normalizeRoutes,
+} from "./utils";
+
+export * from "./types";
+
+/**
+ * Build an OpenAPI 3.1 document from an x402 RoutesConfig.
+ *
+ * @param routes - Same routes map passed to `paymentMiddleware`.
+ * @param options - Document-level metadata and defaults.
+ * @returns An OpenAPI 3.1 document ready to serve as /openapi.json.
+ */
+export function discovery(routes: RoutesConfig, options: DiscoveryOptions): OpenAPIDocument {
+  const entries = normalizeRoutes(routes);
+  const protocols = options.protocols ?? [{ x402: {} }];
+  const hasSiwx = entries.some(([, config]) => isSiwxRoute(config));
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: options.info.title,
+      version: options.info.version,
+      ...(options.info.description ? { description: options.info.description } : {}),
+      "x-guidance": options.info.xGuidance,
+    },
+    ...(options.servers?.length ? { servers: options.servers } : {}),
+    ...(options.ownershipProofs?.length
+      ? { "x-discovery": { ownershipProofs: options.ownershipProofs } }
+      : {}),
+    ...(hasSiwx ? { components: buildSiwxComponents() } : {}),
+    paths: buildPaths(entries, protocols),
+  };
+}

--- a/typescript/packages/extensions/src/discovery/index.ts
+++ b/typescript/packages/extensions/src/discovery/index.ts
@@ -31,12 +31,7 @@
 
 import type { RoutesConfig } from "@x402/core/http";
 import type { DiscoveryOptions, OpenAPIDocument } from "./types";
-import {
-  buildPaths,
-  buildSiwxComponents,
-  isSiwxRoute,
-  normalizeRoutes,
-} from "./utils";
+import { buildPaths, buildSiwxComponents, isSiwxRoute, normalizeRoutes } from "./utils";
 
 export * from "./types";
 

--- a/typescript/packages/extensions/src/discovery/types.ts
+++ b/typescript/packages/extensions/src/discovery/types.ts
@@ -7,10 +7,7 @@
 
 import { z } from "zod";
 import type { RouteConfig } from "@x402/core/http";
-import type {
-  QueryDiscoveryExtension,
-  BodyDiscoveryExtension,
-} from "../bazaar";
+import type { QueryDiscoveryExtension, BodyDiscoveryExtension } from "../bazaar";
 
 const ServerSchema = z.object({
   url: z.string(),
@@ -55,9 +52,7 @@ export const OpenAPIDocumentSchema = z.object({
   }),
   "x-discovery": z.object({ ownershipProofs: z.array(z.string()) }).optional(),
   servers: z.array(ServerSchema).optional(),
-  components: z
-    .object({ securitySchemes: z.record(z.unknown()).optional() })
-    .optional(),
+  components: z.object({ securitySchemes: z.record(z.unknown()).optional() }).optional(),
   paths: z.record(z.record(z.unknown())),
 });
 

--- a/typescript/packages/extensions/src/discovery/types.ts
+++ b/typescript/packages/extensions/src/discovery/types.ts
@@ -1,0 +1,81 @@
+/**
+ * Zod schemas and inferred types for the OpenAPI
+ * discovery document builder. Public input (`DiscoveryOptions`) and output
+ * (`OpenAPIDocument`) shapes are defined here; the builder lives in
+ * `./index.ts`.
+ */
+
+import { z } from "zod";
+import type { RouteConfig } from "@x402/core/http";
+import type {
+  QueryDiscoveryExtension,
+  BodyDiscoveryExtension,
+} from "../bazaar";
+
+const ServerSchema = z.object({
+  url: z.string(),
+  description: z.string().optional(),
+});
+
+// ============================================================================
+// discovery() input
+// ============================================================================
+
+export const DiscoveryOptionsSchema = z.object({
+  info: z.object({
+    title: z.string(),
+    version: z.string(),
+    description: z.string().optional(),
+    /** High-level agent-facing guidance. Emitted as info["x-guidance"]. */
+    xGuidance: z.string(),
+  }),
+  servers: z.array(ServerSchema).optional(),
+  /** Proofs for the top-level x-discovery.ownershipProofs field. */
+  ownershipProofs: z.array(z.string()).optional(),
+  /**
+   * Default protocols emitted in each paid operation's x-payment-info.protocols.
+   * Defaults to [{ x402: {} }]. Pass [{ x402: {} }, { mpp: { ... } }] to advertise MPP too.
+   */
+  protocols: z.array(z.record(z.unknown())).optional(),
+});
+
+export type DiscoveryOptions = z.infer<typeof DiscoveryOptionsSchema>;
+
+// ============================================================================
+// discovery() output
+// ============================================================================
+
+export const OpenAPIDocumentSchema = z.object({
+  openapi: z.literal("3.1.0"),
+  info: z.object({
+    title: z.string(),
+    version: z.string(),
+    description: z.string().optional(),
+    "x-guidance": z.string(),
+  }),
+  "x-discovery": z.object({ ownershipProofs: z.array(z.string()) }).optional(),
+  servers: z.array(ServerSchema).optional(),
+  components: z
+    .object({ securitySchemes: z.record(z.unknown()).optional() })
+    .optional(),
+  paths: z.record(z.record(z.unknown())),
+});
+
+export type OpenAPIDocument = z.infer<typeof OpenAPIDocumentSchema>;
+
+// ============================================================================
+// Internal helper types
+// ============================================================================
+
+/** HTTP subset of the bazaar DiscoveryExtension union. */
+export type HttpBazaarExtension = QueryDiscoveryExtension | BodyDiscoveryExtension;
+
+/** A single `[routeKey, RouteConfig]` entry after normalizing the routes map. */
+export type NormalizedRoute = [string, RouteConfig];
+
+export interface BuildOperationArgs {
+  verb: string;
+  openApiPath: string;
+  config: RouteConfig;
+  protocols: Array<Record<string, unknown>>;
+}

--- a/typescript/packages/extensions/src/discovery/utils.ts
+++ b/typescript/packages/extensions/src/discovery/utils.ts
@@ -2,29 +2,33 @@
  * Internal helpers for the discovery() builder.
  */
 
-import type {
-  RouteConfig,
-  RoutesConfig,
-  PaymentOption,
-  DynamicPrice,
-} from "@x402/core/http";
+import type { RouteConfig, RoutesConfig, PaymentOption, DynamicPrice } from "@x402/core/http";
 import type { Price } from "@x402/core/types";
 import type { DiscoveryExtension, BodyDiscoveryExtension } from "../bazaar";
 import { SIGN_IN_WITH_X } from "../sign-in-with-x/types";
-import type {
-  BuildOperationArgs,
-  HttpBazaarExtension,
-  NormalizedRoute,
-} from "./types";
+import type { BuildOperationArgs, HttpBazaarExtension, NormalizedRoute } from "./types";
 
 // ============================================================================
 // Document assembly
 // ============================================================================
 
+/**
+ * Flatten a RoutesConfig into ordered `[routeKey, RouteConfig]` tuples.
+ *
+ * @param routes - The routes map passed to `paymentMiddleware`.
+ * @returns Ordered route entries ready for iteration.
+ */
 export function normalizeRoutes(routes: RoutesConfig): NormalizedRoute[] {
   return Object.entries(routes as Record<string, RouteConfig>);
 }
 
+/**
+ * Build the OpenAPI `paths` object from normalized route entries.
+ *
+ * @param entries - Normalized `[routeKey, RouteConfig]` tuples.
+ * @param protocols - Default protocols to emit on each paid operation's `x-payment-info.protocols`.
+ * @returns An OpenAPI `paths` object keyed by URL template.
+ */
 export function buildPaths(
   entries: NormalizedRoute[],
   protocols: Array<Record<string, unknown>>,
@@ -44,6 +48,11 @@ export function buildPaths(
   return paths;
 }
 
+/**
+ * Build the shared `components.securitySchemes` block for SIWX-gated routes.
+ *
+ * @returns A `components` fragment containing the `siwx` bearer security scheme.
+ */
 export function buildSiwxComponents(): { securitySchemes: Record<string, unknown> } {
   return {
     securitySchemes: {
@@ -58,12 +67,23 @@ export function buildSiwxComponents(): { securitySchemes: Record<string, unknown
   };
 }
 
+/**
+ * Split an x402 route key (e.g. `"POST /analyze"`) into its verb and raw path.
+ *
+ * @param key - A route key of the form `"VERB /path"`.
+ * @returns The HTTP verb and the raw (pre-OpenAPI) path.
+ */
 function parseRouteKey(key: string): { verb: string; rawPath: string } {
   const spaceIdx = key.indexOf(" ");
   return { verb: key.slice(0, spaceIdx), rawPath: key.slice(spaceIdx + 1) };
 }
 
-// Convert Express-style :param to OpenAPI {param}.
+/**
+ * Convert Express-style `:param` placeholders to OpenAPI `{param}` syntax.
+ *
+ * @param rawPath - A path using Express-style parameters.
+ * @returns The same path with OpenAPI-style parameter placeholders.
+ */
 function toOpenApiPath(rawPath: string): string {
   return rawPath.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "{$1}");
 }
@@ -72,6 +92,12 @@ function toOpenApiPath(rawPath: string): string {
 // Per-route operation builder
 // ============================================================================
 
+/**
+ * Build a single OpenAPI operation object from a route's config and bazaar declaration.
+ *
+ * @param args - Verb, OpenAPI path, route config, and default protocols.
+ * @returns The OpenAPI operation object for `paths[path][verb]`.
+ */
 export function buildOperation(args: BuildOperationArgs): Record<string, unknown> {
   const { verb, openApiPath, config, protocols } = args;
   const bazaar = getHttpBazaar(config);
@@ -114,10 +140,23 @@ export function buildOperation(args: BuildOperationArgs): Record<string, unknown
   return op;
 }
 
+/**
+ * Classify an HTTP verb as one that carries a request body or one that uses query/path parameters.
+ *
+ * @param verb - The uppercase HTTP verb.
+ * @returns `"body"` for POST/PUT/PATCH, `"query"` for everything else.
+ */
 function verbKind(verb: string): "body" | "query" {
   return verb === "POST" || verb === "PUT" || verb === "PATCH" ? "body" : "query";
 }
 
+/**
+ * Build OpenAPI `parameters[]` entries for each `{param}` segment in the path.
+ *
+ * @param openApiPath - OpenAPI-style path containing `{param}` placeholders.
+ * @param bazaar - Optional bazaar declaration whose `pathParams` schema supplies per-param types.
+ * @returns Zero or more path-parameter objects.
+ */
 function buildPathOperation(
   openApiPath: string,
   bazaar: HttpBazaarExtension | undefined,
@@ -135,6 +174,12 @@ function buildPathOperation(
   }));
 }
 
+/**
+ * Build OpenAPI `parameters[]` entries for query-string inputs declared in bazaar.
+ *
+ * @param bazaar - Bazaar declaration for a query-style operation (GET/HEAD/DELETE).
+ * @returns Zero or more query-parameter objects.
+ */
 function buildQueryOperation(
   bazaar: HttpBazaarExtension | undefined,
 ): Array<Record<string, unknown>> {
@@ -149,6 +194,12 @@ function buildQueryOperation(
   }));
 }
 
+/**
+ * Build the OpenAPI `requestBody` object from a bazaar body declaration.
+ *
+ * @param bazaar - Bazaar declaration for a body-style operation (POST/PUT/PATCH).
+ * @returns A `requestBody` object, or `undefined` when the declaration has no body schema.
+ */
 function buildBodyOperation(
   bazaar: HttpBazaarExtension | undefined,
 ): Record<string, unknown> | undefined {
@@ -167,12 +218,24 @@ function buildBodyOperation(
 // Route inspection
 // ============================================================================
 
+/**
+ * Extract the HTTP-flavored bazaar declaration from a route config, if present.
+ *
+ * @param config - The route's configuration.
+ * @returns The HTTP bazaar extension, or `undefined` for routes without one (including MCP).
+ */
 function getHttpBazaar(config: RouteConfig): HttpBazaarExtension | undefined {
   const raw = config.extensions?.bazaar as DiscoveryExtension | undefined;
   if (!raw || typeof raw !== "object" || raw.info?.input?.type !== "http") return undefined;
   return raw as HttpBazaarExtension;
 }
 
+/**
+ * Detect whether a route is gated by the Sign-In-With-X identity extension.
+ *
+ * @param config - The route's configuration.
+ * @returns `true` when the route declares the SIWX extension.
+ */
 export function isSiwxRoute(config: RouteConfig): boolean {
   return !!config.extensions && SIGN_IN_WITH_X in config.extensions;
 }
@@ -181,9 +244,13 @@ export function isSiwxRoute(config: RouteConfig): boolean {
 // Success response
 // ============================================================================
 
-function buildSuccessResponse(
-  bazaar: HttpBazaarExtension | undefined,
-): Record<string, unknown> {
+/**
+ * Build the OpenAPI `responses["200"]` entry from a bazaar output example.
+ *
+ * @param bazaar - Bazaar declaration that may contain an `info.output.example`.
+ * @returns A minimal 200 response, optionally with an embedded example.
+ */
+function buildSuccessResponse(bazaar: HttpBazaarExtension | undefined): Record<string, unknown> {
   const example = bazaar?.info.output?.example;
   if (example === undefined) return { description: "Successful response" };
   return {
@@ -196,17 +263,30 @@ function buildSuccessResponse(
 // x-payment-info assembly
 // ============================================================================
 
+/**
+ * Build the `x-payment-info` object for a paid operation.
+ *
+ * @param config - The route's configuration, whose first `accepts` entry supplies the price.
+ * @param protocols - Default protocols to emit on every paid operation.
+ * @returns The `x-payment-info` object containing the normalized price and protocols.
+ */
 function buildPaymentInfo(
   config: RouteConfig,
   protocols: Array<Record<string, unknown>>,
 ): Record<string, unknown> {
-  const first: PaymentOption = Array.isArray(config.accepts)
-    ? config.accepts[0]
-    : config.accepts;
+  const first: PaymentOption = Array.isArray(config.accepts) ? config.accepts[0] : config.accepts;
   return { price: normalizePrice(first.price), protocols };
 }
 
-// Dynamic prices can't be resolved statically — emit mode:"dynamic" with placeholder bounds.
+/**
+ * Normalize an x402 `Price` into the AgentCash `x-payment-info.price` shape.
+ *
+ * Dynamic prices can't be resolved statically — they are emitted as
+ * `mode:"dynamic"` with placeholder bounds.
+ *
+ * @param price - A static price, asset amount, or dynamic price function.
+ * @returns A fixed- or dynamic-mode price object suitable for `x-payment-info.price`.
+ */
 function normalizePrice(price: Price | DynamicPrice): Record<string, unknown> {
   if (typeof price === "function") {
     return { mode: "dynamic", currency: "USD", min: "0", max: "0" };

--- a/typescript/packages/extensions/src/discovery/utils.ts
+++ b/typescript/packages/extensions/src/discovery/utils.ts
@@ -1,0 +1,218 @@
+/**
+ * Internal helpers for the discovery() builder.
+ */
+
+import type {
+  RouteConfig,
+  RoutesConfig,
+  PaymentOption,
+  DynamicPrice,
+} from "@x402/core/http";
+import type { Price } from "@x402/core/types";
+import type { DiscoveryExtension, BodyDiscoveryExtension } from "../bazaar";
+import { SIGN_IN_WITH_X } from "../sign-in-with-x/types";
+import type {
+  BuildOperationArgs,
+  HttpBazaarExtension,
+  NormalizedRoute,
+} from "./types";
+
+// ============================================================================
+// Document assembly
+// ============================================================================
+
+export function normalizeRoutes(routes: RoutesConfig): NormalizedRoute[] {
+  return Object.entries(routes as Record<string, RouteConfig>);
+}
+
+export function buildPaths(
+  entries: NormalizedRoute[],
+  protocols: Array<Record<string, unknown>>,
+): Record<string, Record<string, unknown>> {
+  const paths: Record<string, Record<string, unknown>> = {};
+  for (const [routeKey, config] of entries) {
+    const { verb, rawPath } = parseRouteKey(routeKey);
+    const openApiPath = toOpenApiPath(rawPath);
+    if (!paths[openApiPath]) paths[openApiPath] = {};
+    paths[openApiPath][verb.toLowerCase()] = buildOperation({
+      verb,
+      openApiPath,
+      config,
+      protocols,
+    });
+  }
+  return paths;
+}
+
+export function buildSiwxComponents(): { securitySchemes: Record<string, unknown> } {
+  return {
+    securitySchemes: {
+      siwx: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "SIWX",
+        description:
+          "Sign-In With X (SIWX) identity proof — bearer token carrying a signed challenge.",
+      },
+    },
+  };
+}
+
+function parseRouteKey(key: string): { verb: string; rawPath: string } {
+  const spaceIdx = key.indexOf(" ");
+  return { verb: key.slice(0, spaceIdx), rawPath: key.slice(spaceIdx + 1) };
+}
+
+// Convert Express-style :param to OpenAPI {param}.
+function toOpenApiPath(rawPath: string): string {
+  return rawPath.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "{$1}");
+}
+
+// ============================================================================
+// Per-route operation builder
+// ============================================================================
+
+export function buildOperation(args: BuildOperationArgs): Record<string, unknown> {
+  const { verb, openApiPath, config, protocols } = args;
+  const bazaar = getHttpBazaar(config);
+  const pathParams = buildPathOperation(openApiPath, bazaar);
+
+  const op: Record<string, unknown> = {};
+  if (config.description) {
+    op.summary = config.description;
+    op.description = config.description;
+  }
+
+  switch (verbKind(verb)) {
+    case "body": {
+      if (pathParams.length) op.parameters = pathParams;
+      const body = buildBodyOperation(bazaar);
+      if (body) op.requestBody = body;
+      break;
+    }
+    case "query": {
+      const parameters = [...pathParams, ...buildQueryOperation(bazaar)];
+      if (parameters.length) op.parameters = parameters;
+      break;
+    }
+  }
+
+  const responses: Record<string, unknown> = {
+    "200": buildSuccessResponse(bazaar),
+  };
+
+  // Identity vs payment — mutually exclusive.
+  if (isSiwxRoute(config)) {
+    op.security = [{ siwx: [] }];
+    responses["401"] = { description: "Authentication required" };
+  } else {
+    op["x-payment-info"] = buildPaymentInfo(config, protocols);
+    responses["402"] = { description: "Payment Required" };
+  }
+
+  op.responses = responses;
+  return op;
+}
+
+function verbKind(verb: string): "body" | "query" {
+  return verb === "POST" || verb === "PUT" || verb === "PATCH" ? "body" : "query";
+}
+
+function buildPathOperation(
+  openApiPath: string,
+  bazaar: HttpBazaarExtension | undefined,
+): Array<Record<string, unknown>> {
+  const names = [...openApiPath.matchAll(/\{([^}]+)\}/g)].map(m => m[1]);
+  if (!names.length) return [];
+  const pathProps = bazaar?.schema.properties.input.properties.pathParams?.properties as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  return names.map(name => ({
+    name,
+    in: "path",
+    required: true,
+    schema: pathProps?.[name] ?? { type: "string" },
+  }));
+}
+
+function buildQueryOperation(
+  bazaar: HttpBazaarExtension | undefined,
+): Array<Record<string, unknown>> {
+  const queryParams = bazaar?.schema.properties.input.properties.queryParams;
+  if (!queryParams?.properties) return [];
+  const required = new Set(queryParams.required ?? []);
+  return Object.entries(queryParams.properties).map(([name, schema]) => ({
+    name,
+    in: "query",
+    required: required.has(name),
+    schema: schema as Record<string, unknown>,
+  }));
+}
+
+function buildBodyOperation(
+  bazaar: HttpBazaarExtension | undefined,
+): Record<string, unknown> | undefined {
+  if (!bazaar || !("bodyType" in bazaar.info.input)) return undefined;
+  return {
+    required: true,
+    content: {
+      "application/json": {
+        schema: (bazaar as BodyDiscoveryExtension).schema.properties.input.properties.body,
+      },
+    },
+  };
+}
+
+// ============================================================================
+// Route inspection
+// ============================================================================
+
+function getHttpBazaar(config: RouteConfig): HttpBazaarExtension | undefined {
+  const raw = config.extensions?.bazaar as DiscoveryExtension | undefined;
+  if (!raw || typeof raw !== "object" || raw.info?.input?.type !== "http") return undefined;
+  return raw as HttpBazaarExtension;
+}
+
+export function isSiwxRoute(config: RouteConfig): boolean {
+  return !!config.extensions && SIGN_IN_WITH_X in config.extensions;
+}
+
+// ============================================================================
+// Success response
+// ============================================================================
+
+function buildSuccessResponse(
+  bazaar: HttpBazaarExtension | undefined,
+): Record<string, unknown> {
+  const example = bazaar?.info.output?.example;
+  if (example === undefined) return { description: "Successful response" };
+  return {
+    description: "Successful response",
+    content: { "application/json": { example } },
+  };
+}
+
+// ============================================================================
+// x-payment-info assembly
+// ============================================================================
+
+function buildPaymentInfo(
+  config: RouteConfig,
+  protocols: Array<Record<string, unknown>>,
+): Record<string, unknown> {
+  const first: PaymentOption = Array.isArray(config.accepts)
+    ? config.accepts[0]
+    : config.accepts;
+  return { price: normalizePrice(first.price), protocols };
+}
+
+// Dynamic prices can't be resolved statically — emit mode:"dynamic" with placeholder bounds.
+function normalizePrice(price: Price | DynamicPrice): Record<string, unknown> {
+  if (typeof price === "function") {
+    return { mode: "dynamic", currency: "USD", min: "0", max: "0" };
+  }
+  if (typeof price === "object") {
+    return { mode: "fixed", currency: "USD", amount: price.amount };
+  }
+  return { mode: "fixed", currency: "USD", amount: String(price).replace(/^\$/, "") };
+}

--- a/typescript/packages/extensions/src/index.ts
+++ b/typescript/packages/extensions/src/index.ts
@@ -20,3 +20,7 @@ export * from "./eip2612-gas-sponsoring";
 
 // ERC-20 Approval Gas Sponsoring extension
 export * from "./erc20-approval-gas-sponsoring";
+
+// OpenAPI discovery 
+export { discovery, DiscoveryOptionsSchema, OpenAPIDocumentSchema } from "./discovery";
+export type { DiscoveryOptions, OpenAPIDocument } from "./discovery";

--- a/typescript/packages/extensions/src/index.ts
+++ b/typescript/packages/extensions/src/index.ts
@@ -21,6 +21,6 @@ export * from "./eip2612-gas-sponsoring";
 // ERC-20 Approval Gas Sponsoring extension
 export * from "./erc20-approval-gas-sponsoring";
 
-// OpenAPI discovery 
+// OpenAPI discovery
 export { discovery, DiscoveryOptionsSchema, OpenAPIDocumentSchema } from "./discovery";
 export type { DiscoveryOptions, OpenAPIDocument } from "./discovery";


### PR DESCRIPTION
## Summary

- Adds `discovery`, a pure function in `@x402/extensions` that turns an x402 `RoutesConfig` into an OpenAPI 3.1 document ready to host at `/openapi.json`.
- Derives paths, `parameters`, `requestBody`, `responses[200/402/401]`, `x-payment-info`, and SIWX security from the routes map and existing bazaar declarations.
- Exposes `DiscoveryOptions`, `OpenAPIDocument`, and their Zod schemas (`DiscoveryOptionsSchema`, `OpenAPIDocumentSchema`) for runtime validation.
- Adds a dedicated docs page at `docs/extensions/discovery.mdx`, a row in the Available Extensions table, and a nav entry in `docs.json`.

## Why

`bazaar` describes a single endpoint inside a 402 response, which is great for on-demand cataloging but does not give crawlers or AI agents a single URL they can fetch to enumerate everything a server offers. `discovery` closes that gap by reusing the routes map the server already has, with a one-line call-site in the server's framework (e.g. `app.get("/openapi.json", (_req, res) => res.json(discovery(routes, options)))`).

## What it derives automatically

| Source in `RouteConfig`                         | Lands in                                                |
|-------------------------------------------------|----------------------------------------------------------|
| Route key `"POST /analyze"`                     | `paths["/analyze"].post`                                 |
| `config.description`                            | `operation.summary`                                      |
| `config.accepts[0].price`                       | `operation["x-payment-info"].price`                      |
| `config.extensions.bazaar` body schema          | `requestBody.content["application/json"].schema`         |
| `config.extensions.bazaar` query/path schemas   | `operation.parameters[]`                                 |
| `config.extensions.bazaar.info.output.example`  | `responses["200"]` (with inferred schema)                |
| `config.extensions["sign-in-with-x"]` present   | `security: [{ siwx: [] }]`, no `x-payment-info`          |

Path params (`:id`, `[id]`) are auto-converted to OpenAPI `{id}` syntax. Every paid operation gets `responses["402"]`; SIWX-only operations get `responses["401"]` plus a top-level `components.securitySchemes.siwx` block.

## What the caller must provide

`DiscoveryOptions` carries document-level metadata that cannot be synthesized from routes:

- `info.title` / `info.version` (required)
- `info.xGuidance` — high-level agent guidance (required; emitted as `info["x-guidance"]`)
- `info.description` (optional)
- `servers` (optional)
- `protocols` (optional, defaults to `[{ x402: {} }]`)