### PR TITLE
docs: clarify MCP and SIWX integration boundaries

### DIFF
--- a/docs/extensions/sign-in-with-x.mdx
+++ b/docs/extensions/sign-in-with-x.mdx
@@ -18,6 +18,8 @@ SIWX solves two key problems in x402:
 * **Chain-Agnostic**: Works with EVM (Ethereum, Base, etc.) and Solana wallets
 * **Standards-Based**: Built on CAIP-122, EIP-4361 (SIWE), and Sign-In-With-Solana
 
+If you're building with MCP, also read [MCP Server with x402](/guides/mcp-server-with-x402). SIWX support for MCP is currently an integration pattern rather than a first-class `@x402/mcp` helper: payment-first MCP flows are available today, while auth-only MCP routes and pay-once-then-reopen MCP flows still require custom wrapper logic.
+
 ## How It Works
 
 1. **Server** returns 402 with `sign-in-with-x` extension containing challenge parameters
@@ -400,6 +402,16 @@ The package includes `InMemorySIWxStorage` for development. For production, impl
 - **Temporal Bounds**: The `issuedAt`, `expirationTime`, and `notBefore` fields constrain signature validity windows
 - **Chain-Specific Verification**: Signatures are verified using chain-appropriate algorithms, preventing cross-chain signature reuse
 - **Smart Wallet Support**: EIP-1271 and EIP-6492 verification requires an RPC call to the wallet contract
+
+## MCP Note
+
+For HTTP resources, SIWX can be added with the built-in hooks shown above. For MCP tools, the same idea still applies, but today's MCP integrations usually need one additional layer owned by the application:
+
+- map the MCP tool to the protected resource or entitlement being unlocked
+- verify SIWX proofs in the MCP request path or a backing HTTP resource
+- optionally issue an MCP-scoped access grant or session after the first successful payment
+
+That means SIWX is already a good fit for MCP-enabled products, but entrants should not assume that the basic MCP payment example automatically provides auth-only SIWX or post-payment reopen semantics.
 
 ## Troubleshooting
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -55,6 +55,8 @@ There is no single answer, but common patterns are:
 
 #### Can I integrate x402 with a usage / plan manager like Metronome?
 
+**Status note:** `upto` is already specified and available today for EVM in the TypeScript and Go SDKs. Python support is still in progress. See [SDK Features](/sdk-features) for the current implementation matrix.
+
 Yes. x402 handles the _payment execution_. You can still meter usage, aggregate calls, or issue prepaid credits in Metronome and only charge when limits are exceeded. Example glue code is coming soon.
 
 ### Assets, Networks & Fees

--- a/docs/getting-started/quickstart-for-sellers.mdx
+++ b/docs/getting-started/quickstart-for-sellers.mdx
@@ -85,6 +85,14 @@ Integrate the payment middleware into your application. You will need to provide
 * The routes you want to protect.
 * Your receiving wallet address.
 
+In simple examples, one address often appears to do everything. In real deployments, these roles can be separated:
+
+* **Seller payout wallet**: receives payment for the resource
+* **Facilitator operational wallet**: may be a different signer or gas-funded wallet if you run settlement infrastructure yourself
+* **Buyer wallet**: belongs to the client and should never be reused as seller or facilitator infrastructure by default
+
+That separation becomes especially useful once you add custom facilitator operations, multiple environments, or SIWX-based access flows.
+
 <Tabs>
   <Tab title="Express">
     Full example in the repo [here](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/express).

--- a/docs/guides/mcp-server-with-x402.md
+++ b/docs/guides/mcp-server-with-x402.md
@@ -15,6 +15,19 @@ This lets you (or your agent) access paid APIs programmatically, with no manual 
 
 ***
 
+### Current MCP Boundary
+
+This guide demonstrates the **payment-first** MCP pattern that works out of the box today: an MCP tool calls an x402-protected HTTP resource, receives an HTTP `402 Payment Required`, pays through an x402 client, and returns the paid response to the MCP client.
+
+If you want to go further, there are two important boundaries to understand:
+
+1. **Auth-only MCP tools via SIWX** are possible, but they are **not** provided by this example directly. You need custom MCP server logic that validates SIWX proofs and decides when a tool can run without payment.
+2. **Pay once, reopen the same paid MCP tool via SIWX** is also possible as a pattern, but it is **not yet a first-class built-in flow** in `@x402/mcp` or this example. The usual approach today is to keep x402 payment as the first unlock step, then layer your own MCP-side access grant or session logic on top of [Sign-In-With-X (SIWX)](/extensions/sign-in-with-x).
+
+In short: use this guide for paid MCP access today, and treat SIWX-enabled MCP reuse as an advanced custom integration until the MCP helpers grow first-class support.
+
+***
+
 ### Prerequisites
 
 * Node.js v20+ (install via [nvm](https://github.com/nvm-sh/nvm))
@@ -186,6 +199,18 @@ The MCP server exposes a tool that, when called, fetches data from a paid API en
 4. **Retry Request**: Sends the original request with the `PAYMENT-SIGNATURE` header
 5. **Return Data**: Once payment is verified, the data is returned to Claude
 
+For this guide, every MCP tool call should be understood as an independent paid-access attempt unless your server adds its own reuse layer. The example does **not** persist an MCP-specific access grant after payment.
+
+***
+
+### Supported vs Custom Today
+
+| Pattern | Status |
+|----------|--------|
+| MCP tool pays for an x402 HTTP resource on demand | Supported by this guide |
+| MCP tool calls an auth-only SIWX-protected route | Requires custom MCP wrapper logic |
+| MCP tool pays once, then reopens via SIWX without repaying | Requires custom MCP wrapper or access-grant logic |
+
 ***
 
 ### Multi-Network Support
@@ -301,6 +326,14 @@ The example uses these x402 v2 packages:
 * **x402-compatible server**: Hosts the paid API (e.g., weather data). Responds with HTTP 402 and `PAYMENT-REQUIRED` header if payment is required.
 * **MCP server (this implementation)**: Acts as a bridge, handling payment via `@x402/axios` and exposing tools to MCP clients.
 * **Claude Desktop**: Calls the MCP tool, receives the paid data, and displays it to the user.
+
+In more advanced deployments, these roles do not need to share one wallet:
+
+* **Buyer wallet**: Signs and funds the payment from the MCP client side
+* **Seller payout wallet**: Receives settlement for the protected resource
+* **Facilitator signer / gas wallet**: May be a separate operational wallet when running your own facilitator or settlement infrastructure
+
+Keeping those roles separate is often cleaner operationally than reusing one key everywhere.
 
 ***
 


### PR DESCRIPTION
## Summary
- clarify that the current MCP guide documents the payment-first flow that works today
- explain that auth-only SIWX MCP routes and pay-once-then-reopen MCP flows still require custom wrapper logic
- add wallet role separation guidance for sellers and operators

## Why
Entrants can currently read the MCP and SIWX docs independently and over-infer first-class MCP SIWX support that is not in the basic example yet. This patch makes the current boundary explicit while still pointing builders at the right extension path.

## Testing
- reviewed the docs diff locally
- no code changes
