### PR TITLE
add upto facilitator examples

### DIFF
--- a/examples/go/clients/http/README.md
+++ b/examples/go/clients/http/README.md
@@ -25,6 +25,9 @@ Required environment variables:
 - `SVM_PRIVATE_KEY` - Solana private key for SVM payments (optional)
 - `SERVER_URL` - Server endpoint (defaults to `http://localhost:4021/weather`)
 
+Optional environment variables:
+- `EVM_RPC_URL` - JSON-RPC endpoint for on-chain reads. Enables gas sponsoring extensions (EIP-2612 and ERC-20 approval). Example: `https://sepolia.base.org`
+
 **⚠️ Security Warning:** Never use mainnet keys in `.env` files! Use testnet keys only.
 
 3. Run the client:

--- a/examples/go/clients/http/builder_pattern.go
+++ b/examples/go/clients/http/builder_pattern.go
@@ -19,19 +19,25 @@ import (
  * which signers and schemes.
  */
 
-func createBuilderPatternClient(evmPrivateKey, svmPrivateKey string) (*x402.X402Client, error) {
+func createBuilderPatternClient(evmPrivateKey, svmPrivateKey, evmRpcURL string) (*x402.X402Client, error) {
 	// Create signers from private keys
 	evmSigner, err := evmsigners.NewClientSignerFromPrivateKey(evmPrivateKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Optional RPC config enables gas sponsoring extensions (EIP-2612 / ERC-20 approval)
+	var rpcConfig *exactevm.ExactEvmSchemeConfig
+	if evmRpcURL != "" {
+		rpcConfig = &exactevm.ExactEvmSchemeConfig{RPCURL: evmRpcURL}
+	}
+
 	// Create client and register schemes using builder pattern
 	client := x402.Newx402Client()
 
 	// Register EVM schemes for all EVM networks
-	client.Register("eip155:*", exactevm.NewExactEvmScheme(evmSigner, nil))
-	client.Register("eip155:*", uptoevm.NewUptoEvmScheme(evmSigner, nil))
+	client.Register("eip155:*", exactevm.NewExactEvmScheme(evmSigner, rpcConfig))
+	client.Register("eip155:*", uptoevm.NewUptoEvmScheme(evmSigner, rpcConfig))
 
 	// You can also register specific networks for fine-grained control
 	// For example, use a different signer for Ethereum mainnet:

--- a/examples/go/clients/http/main.go
+++ b/examples/go/clients/http/main.go
@@ -48,6 +48,7 @@ func main() {
 	}
 
 	svmPrivateKey := os.Getenv("SVM_PRIVATE_KEY")
+	evmRpcURL := os.Getenv("EVM_RPC_URL")
 
 	url := os.Getenv("SERVER_URL")
 	if url == "" {
@@ -60,9 +61,9 @@ func main() {
 
 	switch pattern {
 	case "builder-pattern":
-		client, err = createBuilderPatternClient(evmPrivateKey, svmPrivateKey)
+		client, err = createBuilderPatternClient(evmPrivateKey, svmPrivateKey, evmRpcURL)
 	case "mechanism-helper-registration":
-		client, err = createMechanismHelperRegistrationClient(evmPrivateKey, svmPrivateKey)
+		client, err = createMechanismHelperRegistrationClient(evmPrivateKey, svmPrivateKey, evmRpcURL)
 	default:
 		fmt.Printf("❌ Unknown pattern: %s\n", pattern)
 		fmt.Println("Available patterns: builder-pattern, mechanism-helper-registration")

--- a/examples/go/clients/http/mechanism_helper_registration.go
+++ b/examples/go/clients/http/mechanism_helper_registration.go
@@ -19,19 +19,25 @@ import (
  * all networks of a particular type with the same signer.
  */
 
-func createMechanismHelperRegistrationClient(evmPrivateKey, svmPrivateKey string) (*x402.X402Client, error) {
+func createMechanismHelperRegistrationClient(evmPrivateKey, svmPrivateKey, evmRpcURL string) (*x402.X402Client, error) {
 	// Create signers from private keys
 	evmSigner, err := evmsigners.NewClientSignerFromPrivateKey(evmPrivateKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Optional RPC config enables gas sponsoring extensions (EIP-2612 / ERC-20 approval)
+	var rpcConfig *exactevm.ExactEvmSchemeConfig
+	if evmRpcURL != "" {
+		rpcConfig = &exactevm.ExactEvmSchemeConfig{RPCURL: evmRpcURL}
+	}
+
 	// Start with a new client
 	client := x402.Newx402Client()
 
 	// Register EVM schemes for all EVM networks using wildcard
-	client.Register("eip155:*", exactevm.NewExactEvmScheme(evmSigner, nil))
-	client.Register("eip155:*", uptoevm.NewUptoEvmScheme(evmSigner, nil))
+	client.Register("eip155:*", exactevm.NewExactEvmScheme(evmSigner, rpcConfig))
+	client.Register("eip155:*", uptoevm.NewUptoEvmScheme(evmSigner, rpcConfig))
 
 	// Register SVM scheme if key is provided
 	if svmPrivateKey != "" {

--- a/examples/go/facilitator/advanced/bazaar.go
+++ b/examples/go/facilitator/advanced/bazaar.go
@@ -13,6 +13,7 @@ import (
 	"github.com/x402-foundation/x402/go/extensions/bazaar"
 	exttypes "github.com/x402-foundation/x402/go/extensions/types"
 	evm "github.com/x402-foundation/x402/go/mechanisms/evm/exact/facilitator"
+	uptoevm "github.com/x402-foundation/x402/go/mechanisms/evm/upto/facilitator"
 	svm "github.com/x402-foundation/x402/go/mechanisms/svm/exact/facilitator"
 )
 
@@ -96,6 +97,7 @@ func runBazaarExample(evmPrivateKey, svmPrivateKey string) error {
 			DeployERC4337WithEIP6492: true,
 		}
 		facilitator.Register([]x402.Network{evmNetwork}, evm.NewExactEvmScheme(evmSigner, evmConfig))
+		facilitator.Register([]x402.Network{evmNetwork}, uptoevm.NewUptoEvmScheme(evmSigner, nil))
 	}
 
 	// Register SVM scheme if signer is available

--- a/examples/go/facilitator/advanced/gas_extensions.go
+++ b/examples/go/facilitator/advanced/gas_extensions.go
@@ -9,67 +9,43 @@ import (
 
 	"github.com/gin-gonic/gin"
 	x402 "github.com/x402-foundation/x402/go"
+	eip2612gassponsor "github.com/x402-foundation/x402/go/extensions/eip2612gassponsor"
+	"github.com/x402-foundation/x402/go/extensions/erc20approvalgassponsor"
 	evm "github.com/x402-foundation/x402/go/mechanisms/evm/exact/facilitator"
 	uptoevm "github.com/x402-foundation/x402/go/mechanisms/evm/upto/facilitator"
-	svm "github.com/x402-foundation/x402/go/mechanisms/svm/exact/facilitator"
 )
 
 /**
- * All Networks Facilitator Example
+ * Gas extensions facilitator example (exact + upto)
  *
- * Demonstrates how to create a facilitator that supports all available networks with
- * optional chain configuration via environment variables.
+ * Registers `exact` and `upto` on Base Sepolia and advertises both Permit2 gas-sponsoring
+ * extensions: EIP-2612 and ERC-20 approve (tokens without EIP-2612).
  *
- * New chain support should be added here in alphabetic order by network prefix
- * (e.g., "eip155" before "solana").
+ * Requires EVM_PRIVATE_KEY with Base Sepolia ETH for settlement and for broadcasting
+ * client-supplied approval transactions when those extensions are used.
  */
 
-const (
-	defaultPort = "4022"
-)
+func runGasExtensionsExample(evmPrivateKey string) error {
+	evmNetwork := x402.Network("eip155:84532")
 
-func runAllNetworksExample(evmPrivateKey, svmPrivateKey string) error {
-	// Network configuration
-	evmNetwork := x402.Network("eip155:84532")                            // Base Sepolia
-	svmNetwork := x402.Network("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1") // Solana Devnet
-
-	// Initialize signers based on available keys
-	var evmSigner *facilitatorEvmSigner
-	var svmSigner *facilitatorSvmSigner
-	var err error
-
-	if evmPrivateKey != "" {
-		evmSigner, err = newFacilitatorEvmSigner(evmPrivateKey, DefaultEvmRPC)
-		if err != nil {
-			return fmt.Errorf("failed to create EVM signer: %w", err)
-		}
+	evmSigner, err := newFacilitatorEvmSigner(evmPrivateKey, DefaultEvmRPC)
+	if err != nil {
+		return fmt.Errorf("failed to create EVM signer: %w", err)
 	}
 
-	if svmPrivateKey != "" {
-		svmSigner, err = newFacilitatorSvmSigner(svmPrivateKey, DefaultSvmRPC)
-		if err != nil {
-			return fmt.Errorf("failed to create SVM signer: %w", err)
-		}
-	}
-
-	// Create facilitator
 	facilitator := x402.Newx402Facilitator()
 
-	// Register EVM scheme if signer is available (only explicitly specified networks)
-	if evmSigner != nil {
-		evmConfig := &evm.ExactEvmSchemeConfig{
-			DeployERC4337WithEIP6492: true,
-		}
-		facilitator.Register([]x402.Network{evmNetwork}, evm.NewExactEvmScheme(evmSigner, evmConfig))
-		facilitator.Register([]x402.Network{evmNetwork}, uptoevm.NewUptoEvmScheme(evmSigner, nil))
+	evmConfig := &evm.ExactEvmSchemeConfig{
+		DeployERC4337WithEIP6492: true,
 	}
+	facilitator.Register([]x402.Network{evmNetwork}, evm.NewExactEvmScheme(evmSigner, evmConfig))
+	facilitator.Register([]x402.Network{evmNetwork}, uptoevm.NewUptoEvmScheme(evmSigner, nil))
 
-	// Register SVM scheme if signer is available (only explicitly specified networks)
-	if svmSigner != nil {
-		facilitator.Register([]x402.Network{svmNetwork}, svm.NewExactSvmScheme(svmSigner))
-	}
+	facilitator.RegisterExtension(eip2612gassponsor.EIP2612GasSponsoring)
+	facilitator.RegisterExtension(&erc20approvalgassponsor.Erc20ApprovalFacilitatorExtension{
+		Signer: newErc20ApprovalGasSponsorSigner(evmSigner),
+	})
 
-	// Add lifecycle hooks
 	facilitator.OnAfterVerify(func(ctx x402.FacilitatorVerifyResultContext) error {
 		fmt.Printf("✅ Payment verified\n")
 		return nil
@@ -80,23 +56,19 @@ func runAllNetworksExample(evmPrivateKey, svmPrivateKey string) error {
 		return nil
 	})
 
-	// Setup Gin router
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.Use(gin.Recovery())
 
-	// Supported endpoint
 	r.GET("/supported", func(c *gin.Context) {
 		supported := facilitator.GetSupported()
 		c.JSON(http.StatusOK, supported)
 	})
 
-	// Health endpoint
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 
-	// Verify endpoint
 	r.POST("/verify", func(c *gin.Context) {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 		defer cancel()
@@ -120,7 +92,6 @@ func runAllNetworksExample(evmPrivateKey, svmPrivateKey string) error {
 		c.JSON(http.StatusOK, result)
 	})
 
-	// Settle endpoint
 	r.POST("/settle", func(c *gin.Context) {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 60*time.Second)
 		defer cancel()
@@ -144,14 +115,9 @@ func runAllNetworksExample(evmPrivateKey, svmPrivateKey string) error {
 		c.JSON(http.StatusOK, result)
 	})
 
-	// Print startup info
-	fmt.Printf("🚀 All Networks Facilitator listening on http://localhost:%s\n", defaultPort)
-	if evmSigner != nil {
-		fmt.Printf("   EVM: %s on %s\n", evmSigner.GetAddresses()[0], evmNetwork)
-	}
-	if svmSigner != nil {
-		fmt.Printf("   SVM: %s on %s\n", svmSigner.GetAddresses(context.Background(), string(svmNetwork))[0], svmNetwork)
-	}
+	fmt.Printf("🚀 Gas extensions facilitator (exact + upto) listening on http://localhost:%s\n", defaultPort)
+	fmt.Printf("   Extensions: eip2612GasSponsoring, erc20ApprovalGasSponsoring\n")
+	fmt.Printf("   EVM: %s on %s\n", evmSigner.GetAddresses()[0], evmNetwork)
 	fmt.Println()
 
 	return r.Run(":" + defaultPort)

--- a/examples/go/facilitator/advanced/main.go
+++ b/examples/go/facilitator/advanced/main.go
@@ -15,11 +15,13 @@ import (
  * - all-networks: Facilitator with all supported networks
  * - bazaar: Facilitator with bazaar discovery extension
  * - payment-identifier: Facilitator with payment identifier idempotency
+ * - gas-extensions: Base Sepolia exact + upto with EIP-2612 and ERC-20 approval gas sponsoring
  *
  * Usage:
  *   go run . all-networks
  *   go run . bazaar
  *   go run . payment-identifier
+ *   go run . gas-extensions
  */
 
 func main() {
@@ -38,6 +40,18 @@ func main() {
 	// Get configuration
 	evmPrivateKey := os.Getenv("EVM_PRIVATE_KEY")
 	svmPrivateKey := os.Getenv("SVM_PRIVATE_KEY")
+
+	if pattern == "gas-extensions" {
+		if evmPrivateKey == "" {
+			fmt.Println("❌ EVM_PRIVATE_KEY environment variable is required for gas-extensions")
+			os.Exit(1)
+		}
+		if err := runGasExtensionsExample(evmPrivateKey); err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	// Validate at least one private key is provided
 	if evmPrivateKey == "" && svmPrivateKey == "" {
@@ -67,7 +81,7 @@ func main() {
 
 	default:
 		fmt.Printf("❌ Unknown pattern: %s\n", pattern)
-		fmt.Println("Available patterns: all-networks, bazaar, payment-identifier")
+		fmt.Println("Available patterns: all-networks, bazaar, payment-identifier, gas-extensions")
 		os.Exit(1)
 	}
 }

--- a/examples/go/facilitator/advanced/signer.go
+++ b/examples/go/facilitator/advanced/signer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	solana "github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/x402-foundation/x402/go/extensions/erc20approvalgassponsor"
 	evmmech "github.com/x402-foundation/x402/go/mechanisms/evm"
 	svmmech "github.com/x402-foundation/x402/go/mechanisms/svm"
 )
@@ -382,6 +383,53 @@ func (s *facilitatorEvmSigner) GetCode(ctx context.Context, address string) ([]b
 		return nil, fmt.Errorf("failed to get code: %w", err)
 	}
 	return code, nil
+}
+
+// erc20ApprovalGasSponsorSigner wraps facilitatorEvmSigner with SendTransactions for the
+// erc20ApprovalGasSponsoring facilitator extension (see gas_extensions example).
+type erc20ApprovalGasSponsorSigner struct {
+	*facilitatorEvmSigner
+}
+
+func newErc20ApprovalGasSponsorSigner(base *facilitatorEvmSigner) *erc20ApprovalGasSponsorSigner {
+	return &erc20ApprovalGasSponsorSigner{facilitatorEvmSigner: base}
+}
+
+// SendTransactions implements erc20approvalgassponsor.Erc20ApprovalGasSponsoringSigner.
+func (s *erc20ApprovalGasSponsorSigner) SendTransactions(ctx context.Context, txs []erc20approvalgassponsor.TransactionRequest) ([]string, error) {
+	hashes := make([]string, 0, len(txs))
+	for _, req := range txs {
+		var txHash string
+		switch {
+		case req.Serialized != "":
+			raw := common.FromHex(strings.TrimPrefix(req.Serialized, "0x"))
+			var tx types.Transaction
+			if err := tx.UnmarshalBinary(raw); err != nil {
+				return nil, fmt.Errorf("decode signed transaction: %w", err)
+			}
+			if err := s.client.SendTransaction(ctx, &tx); err != nil {
+				return nil, fmt.Errorf("send raw transaction: %w", err)
+			}
+			txHash = tx.Hash().Hex()
+		case req.Call != nil:
+			h, err := s.WriteContract(ctx, req.Call.Address, req.Call.ABI, req.Call.Function, req.Call.Args...)
+			if err != nil {
+				return nil, err
+			}
+			txHash = h
+		default:
+			return nil, fmt.Errorf("empty transaction request")
+		}
+		rec, err := s.WaitForTransactionReceipt(ctx, txHash)
+		if err != nil {
+			return nil, err
+		}
+		if rec.Status != evmmech.TxStatusSuccess {
+			return nil, fmt.Errorf("transaction failed: %s", txHash)
+		}
+		hashes = append(hashes, txHash)
+	}
+	return hashes, nil
 }
 
 // ============================================================================

--- a/examples/go/facilitator/basic/main.go
+++ b/examples/go/facilitator/basic/main.go
@@ -13,6 +13,7 @@ import (
 	x402 "github.com/x402-foundation/x402/go"
 	evm "github.com/x402-foundation/x402/go/mechanisms/evm/exact/facilitator"
 	evmv1 "github.com/x402-foundation/x402/go/mechanisms/evm/exact/v1/facilitator"
+	uptoevm "github.com/x402-foundation/x402/go/mechanisms/evm/upto/facilitator"
 	svmmech "github.com/x402-foundation/x402/go/mechanisms/svm"
 	svm "github.com/x402-foundation/x402/go/mechanisms/svm/exact/facilitator"
 	svmv1 "github.com/x402-foundation/x402/go/mechanisms/svm/exact/v1/facilitator"
@@ -54,6 +55,7 @@ func main() {
 		DeployERC4337WithEIP6492: true,
 	}
 	facilitator.Register([]x402.Network{evmNetwork}, evm.NewExactEvmScheme(evmSigner, evmConfig))
+	facilitator.Register([]x402.Network{evmNetwork}, uptoevm.NewUptoEvmScheme(evmSigner, nil))
 
 	// Register V1 EVM scheme with smart wallet deployment enabled
 	evmV1Config := &evmv1.ExactEvmSchemeV1Config{

--- a/examples/typescript/clients/axios/README.md
+++ b/examples/typescript/clients/axios/README.md
@@ -45,6 +45,10 @@ Required environment variables:
 - `EVM_PRIVATE_KEY` - Ethereum private key for EVM payments
 - `SVM_PRIVATE_KEY` - Solana private key for SVM payments
 
+Optional environment variables:
+
+- `EVM_RPC_URL` - JSON-RPC endpoint for on-chain reads. Enables gas sponsoring extensions (EIP-2612 and ERC-20 approval). Example: `https://sepolia.base.org`
+
 3. Run the client:
 
 ```bash

--- a/examples/typescript/clients/axios/index.ts
+++ b/examples/typescript/clients/axios/index.ts
@@ -12,6 +12,7 @@ config();
 
 const evmPrivateKey = process.env.EVM_PRIVATE_KEY as `0x${string}`;
 const svmPrivateKey = process.env.SVM_PRIVATE_KEY as string;
+const evmRpcUrl = process.env.EVM_RPC_URL;
 const baseURL = process.env.RESOURCE_SERVER_URL || "http://localhost:4021";
 const endpointPath = process.env.ENDPOINT_PATH || "/weather";
 const url = `${baseURL}${endpointPath}`;
@@ -24,14 +25,18 @@ const url = `${baseURL}${endpointPath}`;
  * Required environment variables:
  * - EVM_PRIVATE_KEY: The private key of the EVM signer
  * - SVM_PRIVATE_KEY: The private key of the SVM signer
+ *
+ * Optional environment variables:
+ * - EVM_RPC_URL: JSON-RPC endpoint for on-chain reads (enables gas sponsoring extensions)
  */
 async function main(): Promise<void> {
   const evmSigner = privateKeyToAccount(evmPrivateKey);
   const svmSigner = await createKeyPairSignerFromBytes(base58.decode(svmPrivateKey));
+  const rpcOptions = evmRpcUrl ? { rpcUrl: evmRpcUrl } : undefined;
 
   const client = new x402Client();
-  client.register("eip155:*", new ExactEvmScheme(evmSigner));
-  client.register("eip155:*", new UptoEvmScheme(evmSigner));
+  client.register("eip155:*", new ExactEvmScheme(evmSigner, rpcOptions));
+  client.register("eip155:*", new UptoEvmScheme(evmSigner, rpcOptions));
   client.register("solana:*", new ExactSvmScheme(svmSigner));
 
   const api = wrapAxiosWithPayment(axios.create(), client);

--- a/examples/typescript/clients/fetch/README.md
+++ b/examples/typescript/clients/fetch/README.md
@@ -48,6 +48,10 @@ Required environment variables:
 - `EVM_PRIVATE_KEY` - Ethereum private key for EVM payments
 - `SVM_PRIVATE_KEY` - Solana private key for SVM payments
 
+Optional environment variables:
+
+- `EVM_RPC_URL` - JSON-RPC endpoint for on-chain reads. Enables gas sponsoring extensions (EIP-2612 and ERC-20 approval). Example: `https://sepolia.base.org`
+
 3. Run the client:
 
 ```bash

--- a/examples/typescript/clients/fetch/index.ts
+++ b/examples/typescript/clients/fetch/index.ts
@@ -11,6 +11,7 @@ config();
 
 const evmPrivateKey = process.env.EVM_PRIVATE_KEY as `0x${string}`;
 const svmPrivateKey = process.env.SVM_PRIVATE_KEY as string;
+const evmRpcUrl = process.env.EVM_RPC_URL;
 const baseURL = process.env.RESOURCE_SERVER_URL || "http://localhost:4021";
 const endpointPath = process.env.ENDPOINT_PATH || "/weather";
 const url = `${baseURL}${endpointPath}`;
@@ -23,14 +24,18 @@ const url = `${baseURL}${endpointPath}`;
  * Required environment variables:
  * - EVM_PRIVATE_KEY: The private key of the EVM signer
  * - SVM_PRIVATE_KEY: The private key of the SVM signer
+ *
+ * Optional environment variables:
+ * - EVM_RPC_URL: JSON-RPC endpoint for onchain reads (enables gas sponsoring extensions)
  */
 async function main(): Promise<void> {
   const evmSigner = privateKeyToAccount(evmPrivateKey);
   const svmSigner = await createKeyPairSignerFromBytes(base58.decode(svmPrivateKey));
+  const rpcOptions = evmRpcUrl ? { rpcUrl: evmRpcUrl } : undefined;
 
   const client = new x402Client();
-  client.register("eip155:*", new ExactEvmScheme(evmSigner));
-  client.register("eip155:*", new UptoEvmScheme(evmSigner));
+  client.register("eip155:*", new ExactEvmScheme(evmSigner, rpcOptions));
+  client.register("eip155:*", new UptoEvmScheme(evmSigner, rpcOptions));
   client.register("solana:*", new ExactSvmScheme(svmSigner));
 
   const fetchWithPayment = wrapFetchWithPayment(fetch, client);

--- a/examples/typescript/facilitator/advanced/README.md
+++ b/examples/typescript/facilitator/advanced/README.md
@@ -1,6 +1,6 @@
 # x402 Advanced Facilitator Examples
 
-Express.js facilitator service demonstrating advanced x402 patterns including all-networks support, bazaar discovery, and lifecycle hooks.
+Express.js facilitator service demonstrating advanced x402 patterns including all-networks support, bazaar discovery, Permit2 gas-sponsoring extensions (`gas_extensions`), and lifecycle hooks.
 
 ## Prerequisites
 
@@ -38,6 +38,7 @@ cd facilitator/advanced
 ```bash
 pnpm dev:all-networks   # All supported networks
 pnpm dev:bazaar         # Bazaar discovery extension
+pnpm dev:gas-extensions # exact + upto with EIP-2612 and ERC-20 approval gas sponsoring
 ```
 
 ## Available Examples
@@ -48,6 +49,7 @@ Each example demonstrates a specific advanced pattern:
 | -------------- | ----------------------- | -------------------------------------------------------- |
 | `all-networks` | `pnpm dev:all-networks` | All supported networks with optional chain configuration |
 | `bazaar`       | `pnpm dev:bazaar`       | Bazaar discovery extension for cataloging x402 resources |
+| `gas_extensions` | `pnpm dev:gas-extensions` | Base Sepolia `exact` + `upto` with both Permit2 gas-sponsoring extensions |
 
 ## API Endpoints
 

--- a/examples/typescript/facilitator/advanced/all_networks.ts
+++ b/examples/typescript/facilitator/advanced/all_networks.ts
@@ -19,6 +19,7 @@ import {
 } from "@x402/core/types";
 import { toFacilitatorEvmSigner } from "@x402/evm";
 import { ExactEvmScheme } from "@x402/evm/exact/facilitator";
+import { UptoEvmScheme } from "@x402/evm/upto/facilitator";
 import { toFacilitatorSvmSigner } from "@x402/svm";
 import { ExactSvmScheme } from "@x402/svm/exact/facilitator";
 import { base58 } from "@scure/base";
@@ -138,6 +139,7 @@ if (evmPrivateKey) {
     EVM_NETWORK,
     new ExactEvmScheme(evmSigner, { deployERC4337WithEIP6492: true }),
   );
+  facilitator.register(EVM_NETWORK, new UptoEvmScheme(evmSigner));
 }
 
 // Register SVM scheme if private key is provided

--- a/examples/typescript/facilitator/advanced/bazaar.ts
+++ b/examples/typescript/facilitator/advanced/bazaar.ts
@@ -16,6 +16,7 @@ import {
 } from "@x402/core/types";
 import { toFacilitatorEvmSigner } from "@x402/evm";
 import { ExactEvmScheme } from "@x402/evm/exact/facilitator";
+import { UptoEvmScheme } from "@x402/evm/upto/facilitator";
 import { toFacilitatorSvmSigner } from "@x402/svm";
 import { ExactSvmScheme } from "@x402/svm/exact/facilitator";
 import { extractDiscoveryInfo, DiscoveryInfo } from "@x402/extensions/bazaar";
@@ -196,6 +197,7 @@ if (evmPrivateKey) {
     EVM_NETWORK,
     new ExactEvmScheme(evmSigner, { deployERC4337WithEIP6492: true }),
   );
+  facilitator.register(EVM_NETWORK, new UptoEvmScheme(evmSigner));
 }
 
 // Register SVM scheme if private key is provided

--- a/examples/typescript/facilitator/advanced/gas_extensions.ts
+++ b/examples/typescript/facilitator/advanced/gas_extensions.ts
@@ -1,5 +1,14 @@
-import { base58 } from "@scure/base";
-import { createKeyPairSignerFromBytes } from "@solana/kit";
+/**
+ * Permit2 gas sponsorship facilitator example (`exact` + `upto`)
+ *
+ * Registers both `exact` and `upto` EVM schemes on Base Sepolia and advertises the two
+ * gas-sponsoring extensions: EIP-2612 permits and ERC-20 `approve` transactions (tokens
+ * without EIP-2612). Both schemes use Permit2 paths that can pair with these extensions.
+ *
+ * Requires `EVM_PRIVATE_KEY` with Base Sepolia ETH for settlement and for broadcasting
+ * client-supplied approval transactions when those extensions are used.
+ */
+
 import { x402Facilitator } from "@x402/core/facilitator";
 import {
   PaymentPayload,
@@ -10,8 +19,10 @@ import {
 import { toFacilitatorEvmSigner } from "@x402/evm";
 import { ExactEvmScheme } from "@x402/evm/exact/facilitator";
 import { UptoEvmScheme } from "@x402/evm/upto/facilitator";
-import { toFacilitatorSvmSigner } from "@x402/svm";
-import { ExactSvmScheme } from "@x402/svm/exact/facilitator";
+import {
+  EIP2612_GAS_SPONSORING,
+  createErc20ApprovalGasSponsoringExtension,
+} from "@x402/extensions";
 import dotenv from "dotenv";
 import express from "express";
 import { createWalletClient, http, publicActions } from "viem";
@@ -20,40 +31,24 @@ import { baseSepolia } from "viem/chains";
 
 dotenv.config();
 
-// Configuration
 const PORT = process.env.PORT || "4022";
+const EVM_NETWORK = "eip155:84532";
 
-// Validate required environment variables
 if (!process.env.EVM_PRIVATE_KEY) {
   console.error("❌ EVM_PRIVATE_KEY environment variable is required");
   process.exit(1);
 }
 
-if (!process.env.SVM_PRIVATE_KEY) {
-  console.error("❌ SVM_PRIVATE_KEY environment variable is required");
-  process.exit(1);
-}
-
-// Initialize the EVM account from private key
 const evmAccount = privateKeyToAccount(
   process.env.EVM_PRIVATE_KEY as `0x${string}`,
 );
 console.info(`EVM Facilitator account: ${evmAccount.address}`);
 
-// Initialize the SVM account from private key
-const svmAccount = await createKeyPairSignerFromBytes(
-  base58.decode(process.env.SVM_PRIVATE_KEY as string),
-);
-console.info(`SVM Facilitator account: ${svmAccount.address}`);
-
-// Create a Viem client with both wallet and public capabilities
 const viemClient = createWalletClient({
   account: evmAccount,
   chain: baseSepolia,
   transport: http(),
 }).extend(publicActions);
-
-// Initialize the x402 Facilitator with EVM and SVM support
 
 const evmSigner = toFacilitatorEvmSigner({
   getCode: (args: { address: `0x${string}` }) => viemClient.getCode(args),
@@ -93,9 +88,6 @@ const evmSigner = toFacilitatorEvmSigner({
     viemClient.waitForTransactionReceipt(args),
 });
 
-// Facilitator can now handle all Solana networks with automatic RPC creation
-const svmSigner = toFacilitatorSvmSigner(svmAccount);
-
 const facilitator = new x402Facilitator()
   .onBeforeVerify(async (context) => {
     console.log("Before verify", context);
@@ -116,27 +108,43 @@ const facilitator = new x402Facilitator()
     console.log("Settle failure", context);
   });
 
-// Register EVM and SVM schemes
 facilitator.register(
-  "eip155:84532",
+  EVM_NETWORK,
   new ExactEvmScheme(evmSigner, { deployERC4337WithEIP6492: true }),
-); // Base Sepolia
-facilitator.register("eip155:84532", new UptoEvmScheme(evmSigner));
-facilitator.register(
-  "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
-  new ExactSvmScheme(svmSigner),
-); // Devnet
+);
+facilitator.register(EVM_NETWORK, new UptoEvmScheme(evmSigner));
 
-// Initialize Express app
+const erc20ApprovalSigner = {
+  ...evmSigner,
+  sendTransactions: async (
+    transactions: (`0x${string}` | { to: `0x${string}`; data: `0x${string}`; gas?: bigint })[],
+  ): Promise<`0x${string}`[]> => {
+    const hashes: `0x${string}`[] = [];
+    for (const tx of transactions) {
+      let hash: `0x${string}`;
+      if (typeof tx === "string") {
+        hash = await viemClient.sendRawTransaction({ serializedTransaction: tx });
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        hash = await viemClient.sendTransaction(tx as any);
+      }
+      const receipt = await viemClient.waitForTransactionReceipt({ hash });
+      if (receipt.status !== "success") {
+        throw new Error(`transaction_failed: ${hash}`);
+      }
+      hashes.push(hash);
+    }
+    return hashes;
+  },
+};
+
+facilitator
+  .registerExtension(EIP2612_GAS_SPONSORING)
+  .registerExtension(createErc20ApprovalGasSponsoringExtension(erc20ApprovalSigner));
+
 const app = express();
 app.use(express.json());
 
-/**
- * POST /verify
- * Verify a payment against requirements
- *
- * Note: Payment tracking and bazaar discovery are handled by lifecycle hooks
- */
 app.post("/verify", async (req, res) => {
   try {
     const { paymentPayload, paymentRequirements } = req.body as {
@@ -150,9 +158,6 @@ app.post("/verify", async (req, res) => {
       });
     }
 
-    // Hooks will automatically:
-    // - Track verified payment (onAfterVerify)
-    // - Extract and catalog discovery info (onAfterVerify)
     const response: VerifyResponse = await facilitator.verify(
       paymentPayload,
       paymentRequirements,
@@ -167,12 +172,6 @@ app.post("/verify", async (req, res) => {
   }
 });
 
-/**
- * POST /settle
- * Settle a payment on-chain
- *
- * Note: Verification validation and cleanup are handled by lifecycle hooks
- */
 app.post("/settle", async (req, res) => {
   try {
     const { paymentPayload, paymentRequirements } = req.body;
@@ -183,10 +182,6 @@ app.post("/settle", async (req, res) => {
       });
     }
 
-    // Hooks will automatically:
-    // - Validate payment was verified (onBeforeSettle - will abort if not)
-    // - Check verification timeout (onBeforeSettle)
-    // - Clean up tracking (onAfterSettle / onSettleFailure)
     const response: SettleResponse = await facilitator.settle(
       paymentPayload as PaymentPayload,
       paymentRequirements as PaymentRequirements,
@@ -196,12 +191,10 @@ app.post("/settle", async (req, res) => {
   } catch (error) {
     console.error("Settle error:", error);
 
-    // Check if this was an abort from hook
     if (
       error instanceof Error &&
       error.message.includes("Settlement aborted:")
     ) {
-      // Return a proper SettleResponse instead of 500 error
       return res.json({
         success: false,
         errorReason: error.message.replace("Settlement aborted: ", ""),
@@ -215,10 +208,6 @@ app.post("/settle", async (req, res) => {
   }
 });
 
-/**
- * GET /supported
- * Get supported payment kinds and extensions
- */
 app.get("/supported", async (req, res) => {
   try {
     const response = facilitator.getSupported();
@@ -231,8 +220,16 @@ app.get("/supported", async (req, res) => {
   }
 });
 
-// Start the server
+app.get("/health", (req, res) => {
+  res.json({ status: "ok" });
+});
+
 app.listen(parseInt(PORT), () => {
-  console.log(`🚀 Facilitator listening on http://localhost:${PORT}`);
+  console.log(
+    `🚀 Gas extensions facilitator (exact + upto) listening on http://localhost:${PORT}`,
+  );
+  console.log(
+    `   Extensions: eip2612GasSponsoring, erc20ApprovalGasSponsoring`,
+  );
   console.log();
 });

--- a/examples/typescript/facilitator/advanced/package.json
+++ b/examples/typescript/facilitator/advanced/package.json
@@ -8,6 +8,7 @@
     "dev": "tsx all_networks.ts",
     "dev:all-networks": "tsx all_networks.ts",
     "dev:bazaar": "tsx bazaar.ts",
+    "dev:gas-extensions": "tsx gas_extensions.ts",
     "build": "tsc",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/examples/typescript/facilitator/basic/package.json
+++ b/examples/typescript/facilitator/basic/package.json
@@ -16,7 +16,6 @@
     "@solana/kit": "^6.1.0",
     "@x402/core": "workspace:*",
     "@x402/evm": "workspace:*",
-    "@x402/extensions": "workspace:*",
     "@x402/svm": "workspace:*",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -1629,9 +1629,6 @@ importers:
       '@x402/evm':
         specifier: workspace:*
         version: link:../../../../typescript/packages/mechanisms/evm
-      '@x402/extensions':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/extensions
       '@x402/svm':
         specifier: workspace:*
         version: link:../../../../typescript/packages/mechanisms/svm

--- a/typescript/site/app/facilitator/index.ts
+++ b/typescript/site/app/facilitator/index.ts
@@ -8,6 +8,7 @@ import { Network } from "@x402/core/types";
 import { toFacilitatorEvmSigner } from "@x402/evm";
 import { ExactEvmScheme } from "@x402/evm/exact/facilitator";
 import { ExactEvmSchemeV1 } from "@x402/evm/exact/v1/facilitator";
+import { UptoEvmScheme } from "@x402/evm/upto/facilitator";
 import {
   EIP2612_GAS_SPONSORING,
   createErc20ApprovalGasSponsoringExtension,
@@ -105,6 +106,7 @@ async function createFacilitator(): Promise<x402Facilitator> {
   const facilitator = new x402Facilitator()
     .register("eip155:84532", new ExactEvmScheme(evmSigner))
     .registerV1("base-sepolia" as Network, new ExactEvmSchemeV1(evmSigner))
+    .register("eip155:84532", new UptoEvmScheme(evmSigner))
     .register("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", new ExactSvmScheme(svmSigner))
     .registerV1("solana-devnet" as Network, new ExactSvmSchemeV1(svmSigner));
 


### PR DESCRIPTION
## Description

- Add upto facilitator examples: basic examples without gas sponsorship extensions, new dedicated examples for gas sponsorship extensions
- Add upto to testnet facilitator
- Add optional rpc to client examples, so they may make use of gas sponsorship extensions

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 