### PR TITLE
docs(spec-exact-evm): clarify extra fields per assetTransferMethod and fix two→three typo

### DIFF
--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -4,7 +4,7 @@
 
 The `exact` scheme on EVM executes a transfer where the Facilitator (server) pays the gas, but the Client (user) controls the exact flow of funds via cryptographic signatures.
 
-This is implemented via one of two asset transfer methods, depending on the token's capabilities:
+This is implemented via one of three asset transfer methods, depending on the token's capabilities:
 
 | AssetTransferMethod | Use Case                                                     | Recommendation                                 | Usage Semantics                     |
 | :------------------ | :----------------------------------------------------------- | :--------------------------------------------- | :---------------------------------- |
@@ -65,6 +65,12 @@ The `payload` field must contain:
   }
 }
 ```
+
+**`extra` field definitions specific to `eip3009`:**
+
+- `extra.assetTransferMethod` (required): MUST be `"eip3009"`.
+- `extra.name` (required): The EIP-712 domain name of the token contract. Used for `transferWithAuthorization` signature construction.
+- `extra.version` (required): The EIP-712 domain version of the token contract. Used for `transferWithAuthorization` signature construction.
 
 ### Phase 2: Verification Logic
 
@@ -156,6 +162,12 @@ The `payload` field must contain:
   },
 }
 ```
+
+**`extra` field definitions specific to `permit2`:**
+
+- `extra.assetTransferMethod` (required): MUST be `"permit2"`.
+- `extra.name` (conditional): The EIP-712 domain name of the token contract. Required when the token supports EIP-2612 for gasless Permit2 approval.
+- `extra.version` (conditional): The EIP-712 domain version of the token contract. Required when the token supports EIP-2612 for gasless Permit2 approval.
 
 ### Phase 3: Verification Logic
 
@@ -262,6 +274,12 @@ The `payload` field must contain:
   }
 }
 ```
+
+**`extra` field definitions specific to `erc7710`:**
+
+- `extra.assetTransferMethod` (required): MUST be `"erc7710"`.
+- `extra.name` (optional): The EIP-712 domain name of the token contract. Not required for ERC-7710 delegation-based transfers.
+- `extra.version` (optional): The EIP-712 domain version of the token contract. Not required for ERC-7710 delegation-based transfers.
 
 **Note:** The structure of `permissionContext` is determined by the specific Delegation Manager implementation. Common implementations (e.g., MetaMask Delegation Framework) use EIP-712 signed delegation chains.
 


### PR DESCRIPTION
## Description

The exact-EVM scheme spec describes three asset transfer methods (`eip3009`, `permit2`, `erc7710`) but documents the `extra` object only by example. Readers can't tell which of the `extra.*` fields are required, conditional, or optional for each method, as they may differ for each.

This PR:

- Fixes a typo related to when `erc7710` was added
- Adds a per-`assetTransferMethod` field-classification block after each method's `PAYMENT-SIGNATURE` example


