### PR TITLE
Batch-settlement scheme specification for EVM

### DIFF
--- a/specs/schemes/batch-settlement/scheme_batch_settlement.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement.md
@@ -4,13 +4,15 @@
 
 `batch-settlement` is a payment scheme in which the client provides a cryptographic payment commitment at request time, but the transfer of value is not executed synchronously during that request. The commitment is accepted, access is granted immediately, and financial settlement occurs later through a process defined by the network binding.
 
-Per-request on-chain settlement may not be ideal for some real-world use cases. `batch-settlement` exists to serve situations where gas fees exceed the value of individual requests, block confirmation time is incompatible with HTTP response latency, request volume requires batched settlement, or settlement happens through infrastructure that operates asynchronously from HTTP (payment channels, fiat billing systems, stablecoin invoices).
+Per-request onchain settlement may not be ideal for some real-world use cases. `batch-settlement` exists to serve situations where gas fees exceed the value of individual requests, block confirmation time is incompatible with HTTP response latency, request volume requires batched settlement, or settlement happens through infrastructure that operates asynchronously from HTTP (payment channels, fiat billing systems, stablecoin invoices).
 
 The model of how a commitment is formed, what backs it, and how it is eventually redeemed,is defined entirely by the network binding.
 
+The `batch-settlement` scheme supports **dynamic pricing**: the client commits up to the maximum per-request price (`PaymentRequirements.amount`), but the server may charge a lower actual price after executing the request. The actual charge is communicated via the `PAYMENT-RESPONSE`.
+
 ## Protocol behavior
 
-For `exact` and `upto`, verification and settlement happen in a single pass: the commitment is validated, a transaction is broadcast, and value has moved. The settlement result contains an on-chain transaction hash.
+For `exact` and `upto`, verification and settlement happen in a single pass: the commitment is validated, a transaction is broadcast, and value has moved. The settlement result contains an onchain transaction hash.
 
 For `batch-settlement`, verification confirms the commitment is valid, but settlement stores it rather than executing a transfer. The settlement result contains a commitment identifier, but value moves later, through the network binding's redemption process.
 
@@ -24,21 +26,21 @@ Network bindings may choose one of two trust models for backing the client's com
 
 ### Capital-backed
 
-The client's commitment is backed by on-chain capital committed before or during the session such as pre-funded escrow, a payment channel, or a delegated authorization against a wallet balance. The trust anchor is the client's own funds. No network intermediary is required to underwrite access.
+The client's commitment is backed by onchain capital committed before or during the session such as pre-funded escrow, a payment channel, or a delegated authorization against a wallet balance. The trust anchor is the client's own funds. No network intermediary is required to underwrite access.
 
 ### Credit-backed
 
-The client's commitment is backed by a verified identity associated with a billing account managed by a trusted network intermediary. No on-chain capital is required from the client. The network authenticates the identity, underwrites the access obligation, and settles with the resource server through off-chain infrastructure on a defined schedule.
+The client's commitment is backed by a verified identity associated with a billing account managed by a trusted network intermediary. No onchain capital is required from the client. The network authenticates the identity, underwrites the access obligation, and settles with the resource server through off-chain infrastructure on a defined schedule.
 
 ## Use cases
 
-**Escrow-backed micropayments.** An AI agent pre-funds an on-chain escrow at session start. Each sub-cent API call produces a signed voucher drawn against that balance. The provider accumulates vouchers and redeems them in a single on-chain transaction at session end, keeping per-request gas cost to zero.
+**Escrow-backed micropayments.** An AI agent pre-funds an onchain escrow at session start. Each sub-cent API call produces a signed voucher drawn against that balance. The provider accumulates vouchers and redeems them in a single onchain transaction at session end, keeping per-request gas cost to zero.
 
 **Payment channel streaming.** A client and provider open a payment channel once. Each request increments a signed running total (a receipt). The provider closes the channel periodically, collecting accumulated value in one settlement regardless of how many individual requests were made.
 
 **Delegated authorization.** A client delegates spending authority to an operator against their wallet balance. The operator signs commitments per request on the client's behalf. The provider collects authorizations and settles them through the delegation contract.
 
-**Credit-backed content licensing.** A content publisher monetizes AI crawler access. Crawlers authenticate via a network-registered identity backed by a billing account. The network verifies each request, accumulates usage, and invoices the crawler operator on a billing cycle with no wallet or on-chain interaction required from the client.
+**Credit-backed content licensing.** A content publisher monetizes AI crawler access. Crawlers authenticate via a network-registered identity backed by a billing account. The network verifies each request, accumulates usage, and invoices the crawler operator on a billing cycle with no wallet or onchain interaction required from the client.
 
 ## Settlement lifecycle
 
@@ -48,7 +50,7 @@ All `batch-settlement` network bindings share this abstract lifecycle. The netwo
 
 2. **Accumulate.** The network retains the commitment in a voucher store, channel state, account ledger, or billing system. The network binding defines who stores commitments, where, and for how long.
 
-3. **Redeem.** Value is transferred out of band through an on-chain contract call, a channel close, a fiat batch invoice, or any rail the network defines. The trigger, timing, and mechanism are network-defined.
+3. **Redeem.** Value is transferred out of band through an onchain contract call, a channel close, a fiat batch invoice, or any rail the network defines. The trigger, timing, and mechanism are network-defined.
 
 ## Appendix
 
@@ -62,7 +64,7 @@ Every `batch-settlement` network binding MUST specify:
 4. **Double-spend prevention** — how the network ensures the same commitment cannot be accepted or redeemed more than once.
 5. **Commitment expiry** — when commitments become invalid and what happens to unaccepted commitments after expiry.
 6. **Redemption** — who triggers redemption, when, and through what rail.
-7. **Trust model** — whether the trust anchor is the client's on-chain capital (capital-backed) or a network intermediary (credit-backed), and what guarantee the seller has of eventual settlement.
+7. **Trust model** — whether the trust anchor is the client's onchain capital (capital-backed) or a network intermediary (credit-backed), and what guarantee the seller has of eventual settlement.
 
 ### Extensions
 

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_cloudflare.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_cloudflare.md
@@ -239,7 +239,7 @@ Upon successful verification, the server includes a PAYMENT-RESPONSE header (bas
 ```http
 HTTP/2 200 OK
 Content-Type: text/html
-PAYMENT-RESPONSE: eyJhbW91bnQiOiAiNSIsICJhc3NldCI6ICJVU0QiLCAibmV0d29yayI6ICJjbG91ZGZsYXJlOjQwMiIsICJ0aW1lc3RhbXAiOiAxNzMwODcyOTY4LCAiZXh0ZW5zaW9ucyI6IHsidGVybXMiOiB7ImluZm8iOiB7ImZvcm1hdCI6ICJ1cmkiLCAidGVybXMiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9wcGMvdGVybXMubWQifX19fQ==
+PAYMENT-RESPONSE: eyJzdWNjZXNzIjp0cnVlLCJ0cmFuc2FjdGlvbiI6IiIsIm5ldHdvcmsiOiJjbG91ZGZsYXJlOjQwMiIsInBheWVyIjoibXljcmF3bGVyLmNvbSIsImFtb3VudCI6IjUiLCJhc3NldCI6IlVTRCIsImV4dHJhIjp7InRpbWVzdGFtcCI6MTczMDg3Mjk2OH19
 
 <!DOCTYPE html>
 <html>
@@ -252,11 +252,17 @@ PAYMENT-RESPONSE: eyJhbW91bnQiOiAiNSIsICJhc3NldCI6ICJVU0QiLCAibmV0d29yayI6ICJjbG
 
 ```json
 {
+  "success": true,
+  "transaction": "",
+  "network": "cloudflare:402",
+  "payer": "mycrawler.com",
   "amount": "5",
   "asset": "USD",
-  "network": "cloudflare:402",
-  "timestamp": 1730872968
+  "extra": {
+    "timestamp": 1730872968
+  }
 }
+```
 
 ## Appendix
 

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
@@ -86,7 +86,8 @@ The 402 response contains pricing terms and the server's channel parameters. The
 | `extra.assetTransferMethod` | `string` | optional | `"eip3009"` (default) or `"permit2"`                   |
 | `extra.name`                | `string` | yes      | EIP-712 domain name of the token contract              |
 | `extra.version`             | `string` | yes      | EIP-712 domain version of the token contract           |
-| `extra.ChannelState`        | `object` | optional | Corrective-only server state for cumulative amount resynchronization |
+| `extra.channelState`        | `object` | optional | Corrective-only server channel snapshot for cumulative amount resynchronization |
+| `extra.voucherState`        | `object` | optional | Corrective-only signed voucher proof for cumulative amount resynchronization |
 
 ---
 
@@ -225,6 +226,7 @@ The server must maintain per-channel state, keyed by channel ID:
 | `totalClaimed`            | `uint128`       | Total claimed onchain (mirrored from onchain)                                              |
 | `withdrawRequestedAt`     | `uint64`        | Unix timestamp when timed withdrawal was initiated, or 0 if none (mirrored from onchain)   |
 | `refundNonce`             | `uint256`       | Next nonce required for `refundWithSignature` (mirrored from onchain)                      |
+| `onchainSyncedAt`         | `uint64`        | Local timestamp when mirrored onchain fields were refreshed                                |
 | `lastRequestTimestamp`    | `uint64`        | Timestamp of the last paid request                                                         |
 
 ### Request Processing
@@ -234,12 +236,42 @@ The server must serialize request processing per channel and must not update vou
 1. **Verify**:
    - For `voucher` and `deposit` payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount + paymentRequirements.amount`. If this fails, reject with `batch_settlement_cumulative_amount_mismatch` and return a corrective 402.
    - For refund payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount` and skip the resource handler after facilitator verification.
-   - Call facilitator `/verify`.
+   - Always call facilitator `/verify` for `deposit` and `refund` payloads, as well as `voucher` payloads with EIP-1271 vouchers.
+   - A plain EOA-authorized `voucher` may be verified locally when the server's mirrored onchain state is fresh. 
 2. **Execute**: Run the resource handler
 3. **On success** — commit state:
    - `chargedCumulativeAmount += actualPrice` (where `actualPrice <= PaymentRequirements.amount`)
    - Mirror `balance`, `totalClaimed`, `withdrawRequestedAt`, and `refundNonce` from the facilitator response
 4. **On failure**: State unchanged, client can retry the same voucher.
+
+### Payment Response Contract
+
+Successful paid responses distinguish onchain transfers from offchain charges:
+
+- Voucher-only response: `transaction` is `""`, top-level `amount` is `""`, `extra.chargedAmount` is the request charge, and `extra.channelState` carries the channel snapshot.
+- Deposit response: `transaction` is the deposit transaction hash, top-level `amount` is the deposited amount, `extra.chargedAmount` is the request charge, and `extra.channelState` carries the channel snapshot.
+- Refund response: `transaction` is the refund transaction hash, top-level `amount` is the refunded amount, `extra.channelState` carries the post-refund channel snapshot and `extra.chargedAmount` is omitted.
+
+```json
+{
+  "success": true,
+  "transaction": "",
+  "network": "eip155:8453",
+  "payer": "0xClientAddress",
+  "amount": "",
+  "extra": {
+    "chargedAmount": "700",
+    "channelState": {
+      "channelId": "0xabc123...channelId",
+      "balance": "100000",
+      "totalClaimed": "3200",
+      "withdrawRequestedAt": 0,
+      "refundNonce": "1",
+      "chargedCumulativeAmount": "3900"
+    }
+  }
+}
+```
 
 ### Cooperative refund flow
 
@@ -252,7 +284,7 @@ When the server receives a `type: "refund"` payload:
 5. **Update channel state**:
    - **Full refund** (refunded amount equals the remainder): delete the channel record.
    - **Partial refund**: keep the channel record, mirror the returned `balance`, `totalClaimed`, `withdrawRequestedAt`, and `refundNonce`.
-6. Return the settle response in the standard `PAYMENT-RESPONSE` header. The response `amount` is the actual refunded amount; `extra` carries the updated channel snapshot plus `chargedCumulativeAmount`.
+6. Return the settle response in the standard `PAYMENT-RESPONSE` header.
 
 After the server completes the refund payload, the facilitator receives:
 
@@ -346,7 +378,33 @@ Server-authored claim and settle payloads use the same `type` discriminator:
 }
 ```
 
-Response:
+Example facilitator response for a claim:
+
+```json
+{
+  "success": true,
+  "transaction": "0x...transactionHash",
+  "network": "eip155:8453",
+  "amount": ""
+}
+```
+
+`amount` is empty because claim only updates accounting; no funds move.
+
+Example facilitator response for a settle:
+
+```json
+{
+  "success": true,
+  "transaction": "0x...transactionHash",
+  "network": "eip155:8453",
+  "amount": "5000"
+}
+```
+
+`amount` is the amount transferred to the receiver; if settlement is a no-op, it is `"0"`.
+
+Example facilitator response for a deposit:
 
 ```json
 {
@@ -354,18 +412,42 @@ Response:
   "transaction": "0x...transactionHash",
   "network": "eip155:8453",
   "payer": "0xPayerAddress",
-  "amount": "700",
+  "amount": "100000",
   "asset": "0xAssetAddress",
   "extra": {
-    "channelId": "0xabc123...",
-    "balance": "100000",
-    "totalClaimed": "3200",
-    "withdrawRequestedAt": 0,
-    "refundNonce": "1",
-    "chargedCumulativeAmount": "3200"
+    "channelState": {
+      "channelId": "0xabc123...",
+      "balance": "100000",
+      "totalClaimed": "3200",
+      "withdrawRequestedAt": 0,
+      "refundNonce": "1"
+    }
   }
 }
 ```
+
+Example facilitator response for a refund:
+
+```json
+{
+  "success": true,
+  "transaction": "0x...transactionHash",
+  "network": "eip155:8453",
+  "payer": "0xPayerAddress",
+  "amount": "1500",
+  "extra": {
+    "channelState": {
+      "channelId": "0xabc123...",
+      "balance": "98500",
+      "totalClaimed": "3200",
+      "withdrawRequestedAt": 0,
+      "refundNonce": "2"
+    }
+  }
+}
+```
+
+`amount` is the amount returned to the payer.
 
 ### GET /supported
 
@@ -409,7 +491,7 @@ A facilitator must enforce:
 10. **Not below claimed**: `maxClaimableAmount` must exceed onchain `totalClaimed`. For refund payloads (`payload.type == "refund"`), this rule is relaxed to `maxClaimableAmount >= totalClaimed`, since refund vouchers are zero-charge and may match the already-claimed total exactly.
 11. **Signed refunds**: the refund nonce must equal the onchain refund nonce; the EIP-712 refund digest must bind the same amount submitted in the transaction.
 
-The facilitator must return the channel snapshot (`balance`, `totalClaimed`, `withdrawRequestedAt`, `refundNonce`) in every `/verify` and `/settle` response `extra` field. If `withdrawRequestedAt` is non-zero, the server should claim outstanding vouchers promptly before the withdraw delay elapses.
+The facilitator must return the channel snapshot (`balance`, `totalClaimed`, `withdrawRequestedAt`, `refundNonce`) in every `/verify` response `extra` field and in every `/settle` response under `extra.channelState`. If `withdrawRequestedAt` is non-zero, the server should claim outstanding vouchers promptly before the withdraw delay elapses.
 
 ---
 
@@ -435,10 +517,10 @@ The server must claim all outstanding vouchers before the withdraw delay elapses
 
 Before signing the next voucher, the client must verify from the payment response:
 
-1. `amount <= PaymentRequirements.amount`
-2. `chargedCumulativeAmount == previous + amount`
-3. `balance` is consistent with the client's expectation
-4. `channelId` matches
+1. `extra.chargedAmount <= PaymentRequirements.amount`
+2. `extra.channelState.chargedCumulativeAmount == previous + extra.chargedAmount`
+3. `extra.channelState.balance` is consistent with the client's expectation
+4. `extra.channelState.channelId` matches
 
 If any check fails, the client must not sign further vouchers and should initiate withdrawal.
 
@@ -455,7 +537,7 @@ The recovery baseline is:
 
 **Server state loss.** If the server has no local channel record, it sets `chargedCumulativeAmount = totalClaimed` as the baseline. If the server lost unclaimed vouchers, those unclaimed charges are forfeited by the server.
 
-**Corrective 402.** If the server has local channel state and rejects a paid payload (`deposit` or `voucher`) because the client's cumulative amount does not match the server's channel state, it returns `batch_settlement_cumulative_amount_mismatch` with `accepts[].extra.ChannelState` containing `channelId`, `chargedCumulativeAmount`, `signedMaxClaimable`, and `signature`.  The client verifies the voucher signature before adopting `chargedCumulativeAmount` and retrying.
+**Corrective 402.** If the server has local channel state and rejects a paid payload (`deposit` or `voucher`) because the client's cumulative amount does not match the server's channel state, it returns `batch_settlement_cumulative_amount_mismatch` with `accepts[].extra.channelState` containing the channel snapshot and `accepts[].extra.voucherState` containing `signedMaxClaimable` and `signature`.  The client verifies the voucher signature before adopting `chargedCumulativeAmount` and retrying.
 
 ```json
 {
@@ -469,9 +551,15 @@ The recovery baseline is:
         "withdrawDelay": 900,
         "name": "USDC",
         "version": "2",
-        "ChannelState": {
+        "channelState": {
           "channelId": "0xabc123...channelId",
-          "chargedCumulativeAmount": "3200",
+          "balance": "100000",
+          "totalClaimed": "500",
+          "withdrawRequestedAt": 0,
+          "refundNonce": "1",
+          "chargedCumulativeAmount": "3200"
+        },
+        "voucherState": {
           "signedMaxClaimable": "3200",
           "signature": "0x...last voucher signature"
         }

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
@@ -1,0 +1,409 @@
+# Scheme: `batch-settlement` on `EVM`
+
+## Summary
+
+The `batch-settlement` scheme on EVM is a **capital-backed** network binding using stateless unidirectional payment channels for high-throughput, low-cost payments. Clients deposit funds into onchain channels once and sign off-chain **cumulative vouchers** per request. Servers verify vouchers with fast signature checks and claim them onchain periodically in batches, reducing both latency and gas costs drastically. A single claim transaction can cover many channels at once and only updates onchain accounting; claimed funds are later transferred to the receiver via a separate settle operation that sweeps many claims into one token transfer.
+
+The scheme supports **dynamic pricing**: the client authorizes a maximum per-request, and the server charges the actual cost within that ceiling.
+
+---
+
+## Channel Lifecycle
+
+### Channel creation and deposits
+
+A channel is created implicitly on the first deposit. The client deposits funds from the `payer` address into an onchain escrow via one of two asset transfer methods: `eip3009` for tokens that support `receiveWithAuthorization` (e.g. USDC) or `permit2` as a universal fallback for any ERC-20. Deposits are sponsored by the facilitator (gasless for the client).
+
+Channel identity is derived from an immutable config struct:
+```solidity
+struct ChannelConfig {
+    address payer;              // Client wallet (EOA or smart wallet)
+    address payerAuthorizer;    // EOA for voucher signing, or address(0) for EIP-1271 via payer
+    address receiver;           // Server's payment destination (EOA or routing contract)
+    address receiverAuthorizer; // Authorizes claims and refunds via EIP-712 signatures
+    address token;              // ERC-20 payment token
+    uint40  withdrawDelay;      // Seconds before timed withdrawal completes (15 min – 30 days)
+    bytes32 salt;               // Differentiates channels with identical parameters
+}
+```
+with `channelId = keccak256(abi.encode(channelConfig))`.
+
+### Requests and vouchers
+
+The channel tracks two values: `balance` (total deposited minus withdrawals and refunds) and `totalClaimed` (cumulative amount claimed by the server). Each voucher the client signs carries a cumulative ceiling (`maxClaimableAmount`). The server can claim up to that ceiling. Because vouchers are monotonically increasing, old vouchers with lower ceilings are naturally superseded.
+
+The server tracks a running total of actual charges per channel (`chargedCumulativeAmount`). For each subsequent request, the client sets the voucher's `maxClaimableAmount` to `chargedCumulativeAmount + amount`, where `amount` is the per-request maximum. 
+
+### Claim and settle
+
+The server claims the latest voucher per channel onchain at its discretion. `claimWithSignature(claims, signature)` allows aggregating claims from multiple channels in one call. Claiming updates `totalClaimed` per channel; no token transfer occurs.
+
+`settle` sweeps all claimed-but-unsettled funds to the `receiver` in one transfer. 
+
+### Refund and withdrawal
+
+**Cooperative refund** (`refundWithSignature`): instant, authorized by the receiver side, returns up to `balance - totalClaimed` to the payer. The refund amount is explicit (partial or full). 
+
+**Timed withdrawal** (escape hatch): the `payer` calls `initiateWithdraw` to start a grace period, during which the server can claim outstanding vouchers. After the withdrawal delay elapses, `finalizeWithdraw` completes the withdrawal. 
+
+### Authorizer roles
+
+**Payer authorizer** (`payerAuthorizer`): if set to a non-zero address (an EOA), vouchers are verified via ECDSA recovery against that committed key ( fast, no RPC required). If set to zero, vouchers are verified against the payer address, supporting EIP-1271 smart wallets at the cost of an RPC call.
+
+**Receiver authorizer** (`receiverAuthorizer`): authorizes claim and refund operations via EIP-712 signatures. The server chooses this address: a server-owned EOA or smart contract (eg for key rotation), or a facilitator-provided address when the server delegates authorization. Must not be zero. Anyone can relay a `claimWithSignature` or `refundWithSignature` transaction with a valid authorization signature from the `receiverAuthorizer`.
+
+### Channel reuse and parameter changes
+
+Channels are long-lived. After a refund, the client can top up and reuse the same channel. However, the channel config is immutable. If any parameter needs to change, a new channel is required. If delegating `receiverAuthorizer` to a facilitator, the server should claim all outstanding vouchers and refund remaining balances on old channels before switching to another facilitator. 
+
+---
+
+## 402 Response (PaymentRequirements)
+
+The 402 response contains pricing terms and the server's channel parameters. The client maps `payTo` → `ChannelConfig.receiver`, `extra.receiverAuthorizer` → `ChannelConfig.receiverAuthorizer`, `asset` → `ChannelConfig.token`, and `extra.withdrawDelay` → `ChannelConfig.withdrawDelay`, then fills in its own `payer`, `payerAuthorizer`, and `salt` to construct the full config.
+
+```json
+{
+  "scheme": "batch-settlement",
+  "network": "eip155:8453",
+  "amount": "100000",
+  "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  "payTo": "0xServerReceiverAddress",
+  "maxTimeoutSeconds": 3600,
+  "extra": {
+    "receiverAuthorizer": "0xReceiverAuthorizerAddress",
+    "withdrawDelay": 900,
+    "name": "USDC",
+    "version": "2"
+  }
+}
+```
+
+| Field                       | Type     | Required | Description                                            |
+| --------------------------- | -------- | -------- | ------------------------------------------------------ |
+| `extra.receiverAuthorizer`  | `string` | yes      | Address that will authorize claims/refunds              |
+| `extra.withdrawDelay`       | `number` | yes      | Withdrawal delay in seconds (15 min – 30 days)         |
+| `extra.assetTransferMethod` | `string` | optional | `"eip3009"` (default) or `"permit2"`                   |
+| `extra.name`                | `string` | yes      | EIP-712 domain name of the token contract              |
+| `extra.version`             | `string` | yes      | EIP-712 domain version of the token contract           |
+
+---
+
+## Client: Payment Construction
+
+The client constructs a payment payload whose type depends on channel state:
+
+- `deposit`: No channel exists or balance is exhausted — client signs a token authorization and voucher
+- `voucher`: Channel has sufficient balance — client signs a new cumulative voucher
+
+### Deposit Payload
+
+The `deposit.authorization` field contains the token transfer authorization — exactly one of `erc3009Authorization` or `permit2Authorization` must be present.
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "batch-settlement",
+    "network": "eip155:8453",
+    "amount": "1000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "0xServerReceiverAddress",
+    "maxTimeoutSeconds": 3600,
+    "extra": {
+      "receiverAuthorizer": "0xReceiverAuthorizerAddress",
+      "withdrawDelay": 900,
+      "name": "USDC",
+      "version": "2"
+    }
+  },
+  "payload": {
+    "type": "deposit",
+    "deposit": {
+      "channelConfig": {
+        "payer": "0xClientAddress",
+        "payerAuthorizer": "0xClientPayerAuthorizerEOA",
+        "receiver": "0xServerReceiverAddress",
+        "receiverAuthorizer": "0xReceiverAuthorizerAddress",
+        "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        "withdrawDelay": 900,
+        "salt": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      "amount": "100000",
+      "authorization": "<erc3009Authorization | permit2Authorization>"
+    },
+    "voucher": {
+      "channelId": "0xabc123...channelId",
+      "maxClaimableAmount": "1000",
+      "signature": "0x...EIP-712 voucher signature"
+    }
+  }
+}
+```
+
+### Voucher Payload
+
+```json
+{
+  "x402Version": 2,
+  "accepted": { "..." : "..." },
+  "payload": {
+    "type": "voucher",
+    "channelConfig": {
+      "payer": "0xClientAddress",
+      "payerAuthorizer": "0xClientPayerAuthorizerEOA",
+      "receiver": "0xServerReceiverAddress",
+      "receiverAuthorizer": "0xReceiverAuthorizerAddress",
+      "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "withdrawDelay": 900,
+      "salt": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "channelId": "0xabc123...channelId",
+    "maxClaimableAmount": "5000",
+    "signature": "0x...EIP-712 voucher signature",
+    "refund": true
+  }
+}
+```
+
+The optional `refund` flag signals a cooperative refund request. The server will bring onchain claims in line via `claimWithSignature`, then execute `refundWithSignature`.
+
+---
+
+## Server: State & Forwarding
+
+The server is the sole owner of per-channel session state.
+
+### Per-Channel State
+
+The server must maintain per-channel state, keyed by channel ID:
+
+| State Field               | Type            | Description                                                                                |
+| ------------------------- | --------------- | ------------------------------------------------------------------------------------------ |
+| `channelConfig`           | `ChannelConfig` | Full channel configuration object                                                          |
+| `chargedCumulativeAmount` | `uint128`       | Actual accumulated cost for this channel                                                   |
+| `signedMaxClaimable`      | `uint128`       | `maxClaimableAmount` from the latest client-signed voucher                                 |
+| `signature`               | `bytes`         | Client's voucher signature for the latest `signedMaxClaimable`                             |
+| `balance`                 | `uint128`       | Current channel balance (mirrored from onchain)                                            |
+| `totalClaimed`            | `uint128`       | Total claimed onchain (mirrored from onchain)                                              |
+| `withdrawRequestedAt`     | `uint64`        | Unix timestamp when timed withdrawal was initiated, or 0 if none (mirrored from onchain)   |
+| `refundNonce`             | `uint256`       | Next nonce required for `refundWithSignature` (mirrored from onchain)                      |
+| `lastRequestTimestamp`    | `uint64`        | Timestamp of the last paid request                                                         |
+
+### Request Processing
+
+The server must serialize request processing per channel and must not update voucher state until the resource handler has succeeded.
+
+1. **Verify**:
+   - Check that `payload.maxClaimableAmount == chargedCumulativeAmount + paymentRequirements.amount`. If this fails, reject with `batch_settlement_stale_cumulative_amount` and return a corrective 402.
+   - Call facilitator `/verify`.
+2. **Execute**: Run the resource handler
+3. **On success** — commit state:
+   - `chargedCumulativeAmount += actualPrice` (where `actualPrice <= PaymentRequirements.amount`)
+   - Mirror `balance`, `totalClaimed`, `withdrawRequestedAt`, and `refundNonce` from the facilitator response
+4. **On failure**: State unchanged, client can retry the same voucher.
+
+### Cooperative refund flow
+
+When the server receives a voucher with `refund: true`:
+
+1. Update `chargedCumulativeAmount` as with a normal voucher.
+2. Build claim entries for outstanding channels; sign the claim batch as the receiver authorizer.
+3. Sign a refund message with the current onchain refund nonce and an amount up to `balance - totalClaimed` after claims.
+4. Submit `claimWithSignature(claims, claimSig)` then `refundWithSignature(config, amount, nonce, refundSig)` (order matters: claims first if they increase `totalClaimed`).
+5. On success, the chain increments the refund nonce; mirror it in server state and reset session fields as needed.
+
+---
+
+## Facilitator Interface
+
+Uses the standard x402 facilitator interface (`/verify`, `/settle`, `/supported`).
+
+### POST /verify
+
+Verifies a payment payload. Returns the onchain channel snapshot:
+
+```json
+{
+  "isValid": true,
+  "payer": "0xPayerAddress",
+  "extra": {
+    "channelId": "0xabc123...",
+    "balance": "1000000",
+    "totalClaimed": "500000",
+    "withdrawRequestedAt": 0,
+    "refundNonce": "0"
+  }
+}
+```
+
+### POST /settle
+
+| `settleAction`          | When Used                        | Onchain Effect                                                     |
+| ----------------------- | -------------------------------- | ------------------------------------------------------------------ |
+| `"deposit"`             | First request or top-up          | Deposit via pluggable collector (EIP-3009 or Permit2)              |
+| `"claimWithSignature"`  | Server batches voucher claims    | Validate vouchers, update accounting (no transfer)                 |
+| `"settle"`              | Server transfers earned funds    | Transfer unsettled amount to receiver                              |
+| `"refundWithSignature"` | Cooperative refund               | Return specified amount to payer, increment refund nonce           |
+
+Response:
+
+```json
+{
+  "success": true,
+  "transaction": "0x...transactionHash",
+  "network": "eip155:8453",
+  "payer": "0xPayerAddress",
+  "amount": "700",
+  "asset": "0xAssetAddress",
+  "extra": {
+    "channelId": "0xabc123...",
+    "chargedCumulativeAmount": "3200",
+    "balance": "100000",
+    "totalClaimed": "3200",
+    "withdrawRequestedAt": 0,
+    "refundNonce": "1"
+  }
+}
+```
+
+### GET /supported
+
+The facilitator declares a receiver authorizer whose role is to produce EIP-712 signatures for claims and refunds. The server may delegate to this address as its channel's `receiverAuthorizer`, or supply its own. Any address in `signers` may relay the resulting transactions.
+
+```json
+{
+  "kinds": [
+    {
+      "x402Version": 2,
+      "scheme": "batch-settlement",
+      "network": "eip155:8453",
+      "extra": {
+        "receiverAuthorizer": "0xReceiverAuthorizerAddress"
+      }
+    }
+  ],
+  "extensions": [],
+  "signers": {
+    "eip155:*": [
+      "0xSignerAddress1",
+      "0xSignerAddress2"
+    ]
+  }
+}
+```
+
+### Verification Rules
+
+A facilitator must enforce:
+
+1. **Channel config consistency** (deposit and voucher): the config must hash to the claimed channel ID.
+2. **Token match**: the channel token must match the payment requirements asset.
+3. **Receiver match**: the channel receiver must equal the payment requirements `payTo`.
+4. **Receiver authorizer match**: the channel receiver authorizer must equal `extra.receiverAuthorizer`.
+5. **Withdraw delay match**: the channel withdraw delay must equal `extra.withdrawDelay`.
+6. **Signature validity**: recover the signer from the EIP-712 voucher digest. If the payer authorizer is set, the signer must match it (ECDSA only). If the payer authorizer is zero, validate via `SignatureChecker` against the payer.
+7. **Channel existence**: the channel must have a positive balance.
+8. **Balance check** (deposit only): the client must have sufficient token balance.
+9. **Deposit sufficiency**: `maxClaimableAmount` must be at most `balance` (or `balance + depositAmount` for deposit payloads).
+10. **Not below claimed**: `maxClaimableAmount` must exceed onchain `totalClaimed`.
+11. **Signed refunds**: the refund nonce must equal the onchain refund nonce; the EIP-712 refund digest must bind the same amount submitted in the transaction.
+
+The facilitator must return the channel snapshot (`balance`, `totalClaimed`, `withdrawRequestedAt`, `refundNonce`) in every `/verify` and `/settle` response `extra` field. If `withdrawRequestedAt` is non-zero, the server should claim outstanding vouchers promptly before the withdraw delay elapses.
+
+---
+
+## Claim & Settlement Strategy
+
+`claimWithSignature(claims, signature)` validates payer voucher signatures and updates accounting across multiple channels in a single transaction. No token transfer occurs. The committed cumulative total per channel is `totalClaimed`, which the receiver authorizer determines up to `maxClaimableAmount`. All channels in a single call must share the same receiver authorizer. Anyone can submit the transaction.
+
+`settle(receiver, token)` transfers all claimed-but-unsettled funds for a receiver+token pair to the receiver in one transfer. Permissionless.
+
+| Strategy          | Description                                    | Trade-off                        |
+| ----------------- | ---------------------------------------------- | -------------------------------- |
+| **Periodic**      | Claim + settle every N minutes                 | Predictable gas costs            |
+| **Threshold**     | Claim + settle when unclaimed amount exceeds T | Bounds server's risk exposure    |
+| **On withdrawal** | Claim + settle when withdrawal is initiated    | Minimum gas, maximum risk window |
+
+The server must claim all outstanding vouchers before the withdraw delay elapses. Unclaimed vouchers become unclaimable after `finalizeWithdraw()` reduces the channel balance.
+
+---
+
+## Client Verification Rules
+
+### In-Session
+
+Before signing the next voucher, the client must verify from the payment response:
+
+1. `amount <= PaymentRequirements.amount`
+2. `chargedCumulativeAmount == previous + amount`
+3. `balance` is consistent with the client's expectation
+4. `channelId` matches
+
+If any check fails, the client must not sign further vouchers and should initiate withdrawal.
+
+### Recovery After State Loss
+
+Channel identity is deterministic and fully reconstructible from the 402 response together with the client's own parameters (`payer`, `payerAuthorizer`, `salt`). A single `channels(channelId)` RPC read returns the onchain `balance` and `totalClaimed`.
+
+Recovery occurs in two scenarios:
+
+**Cold start — no local session.** When the client has no stored state for a channel, it recomputes the channel ID from the 402 response and its own parameters, then reads the onchain channel. If `balance == 0`, the channel does not yet exist and the next payment must be a deposit. Otherwise the channel already has funds from a previous session; the client adopts onchain `totalClaimed` as its `chargedCumulativeAmount` baseline and proceeds to sign the next voucher. This is an optimistic guess: if the server has charged beyond `totalClaimed` (it holds an outstanding unclaimed voucher), it will return a corrective 402, handled below.
+
+**Corrective 402 — in-session desync.** When the client's voucher is rejected because its cumulative base is out of sync, the server returns a 402 carrying its view of the channel in `accepts[].extra`. The client recovers from whatever the server can provide:
+
+- **Server holds the last voucher**: `extra` contains `chargedCumulativeAmount`, `signedMaxClaimable`, and `signature`. The client verifies the EIP-712 `Voucher` signature over `(channelId, signedMaxClaimable)` recovers to its own `payerAuthorizer` (or `payer`), then adopts `chargedCumulativeAmount` as the new base and retries.
+- **Server does not hold the last voucher** (e.g. its session was evicted after a cooperative refund): `extra` carries no signature fields. The client falls back to onchain state, setting `chargedCumulativeAmount = totalClaimed`, and retries.
+
+---
+
+## Error Codes
+
+| Error Code                                                     | Description                                                                  |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `batch_settlement_stale_cumulative_amount`                     | Client voucher base doesn't match server state; corrective 402               |
+| `batch_settlement_evm_channel_not_found`                       | No channel with positive balance for the given channel ID                    |
+| `batch_settlement_evm_cumulative_exceeds_balance`              | Voucher `maxClaimableAmount` exceeds onchain balance                         |
+| `batch_settlement_evm_cumulative_below_claimed`                | Voucher `maxClaimableAmount` is at or below onchain `totalClaimed`           |
+| `batch_settlement_evm_insufficient_balance`                    | Client token balance is insufficient for the deposit                         |
+| `batch_settlement_evm_invalid_voucher_signature`               | EIP-712 voucher signature does not recover to the expected signer            |
+| `batch_settlement_evm_invalid_scheme`                          | `scheme` is not `batch-settlement`                                           |
+| `batch_settlement_evm_network_mismatch`                        | `network` does not match the facilitator's chain                             |
+| `batch_settlement_evm_token_mismatch`                          | Channel token does not match the payment requirements asset                  |
+| `batch_settlement_evm_channel_id_mismatch`                     | Channel config does not hash to the claimed channel ID                       |
+| `batch_settlement_evm_receiver_mismatch`                       | Channel receiver does not match `payTo`                                      |
+| `batch_settlement_evm_receiver_authorizer_mismatch`            | Channel receiver authorizer does not match `extra.receiverAuthorizer`        |
+| `batch_settlement_evm_withdraw_delay_mismatch`                 | Channel withdraw delay does not match `extra.withdrawDelay`                  |
+| `batch_settlement_evm_withdraw_delay_out_of_range`             | Withdraw delay is outside the 15 min – 30 day bounds                         |
+| `batch_settlement_evm_deposit_voucher_mismatch`                | Deposit payload config does not match the voucher's channel ID               |
+| `batch_settlement_evm_missing_eip712_domain`                   | Token EIP-712 domain (`name`, `version`) could not be read                   |
+| `batch_settlement_evm_payload_authorization_valid_before`      | ERC-3009 authorization `validBefore` has already passed                      |
+| `batch_settlement_evm_payload_authorization_valid_after`       | ERC-3009 authorization `validAfter` is still in the future                   |
+| `batch_settlement_evm_invalid_receive_authorization_signature` | ERC-3009 `receiveWithAuthorization` signature is invalid                     |
+| `batch_settlement_evm_erc3009_authorization_required`          | Deposit payload is missing the required `erc3009Authorization`               |
+| `batch_settlement_evm_invalid_payload_type`                    | Payload `type` is neither `"deposit"` nor `"voucher"`                        |
+| `batch_settlement_evm_refund_not_supported`                    | Server cannot produce `refundWithSignature` (e.g. no signing key)            |
+| `batch_settlement_evm_deposit_transaction_failed`              | Onchain deposit transaction reverted                                         |
+| `batch_settlement_evm_claim_transaction_failed`                | Onchain claim transaction reverted                                           |
+| `batch_settlement_evm_settle_transaction_failed`               | Onchain settle (transfer) transaction reverted                               |
+| `batch_settlement_evm_refund_transaction_failed`               | Onchain refund transaction reverted                                          |
+
+---
+
+## Security and Trust
+
+1. **Capital risk and cumulative replay protection**: Clients bear risk up to the signed `maxClaimableAmount`; the receiver authorizer determines actual `totalClaimed` onchain within that bound. Over-claiming is a trust violation, not a protocol violation. The cumulative model makes nonces unnecessary. As `totalClaimed` only increases, and old vouchers are naturally superseded.
+
+2. **Withdrawal delay as escape hatch**: The 15 min – 30 day bounds prevent a server from indefinitely trapping client funds while giving the server a fair window to claim outstanding vouchers. Cooperative refund returns unclaimed balance immediately when the server cooperates; timed withdrawal is the unilateral fallback. Servers bear the risk of vouchers left unclaimed when `finalizeWithdraw` completes.
+
+3. **Cross-function replay prevention**: `Voucher`, `Refund`, and `ClaimBatch` use distinct EIP-712 type hashes so a signature for one cannot be replayed as another. Refunds additionally carry a per-channel nonce.
+
+4. **Voucher expiry via escrow depletion**: Vouchers carry no expiry field. A voucher remains claimable as long as `balance - totalClaimed > 0`; `finalizeWithdraw` and `refundWithSignature` close the claim window by draining available escrow. The ERC-3009 `validBefore`/`validAfter` fields bound only the deposit authorization, not the voucher.
+
+---
+
+## Version History
+
+| Version | Date       | Changes       | Authors                 |
+| ------- | ---------- | ------------- | ----------------------- |
+| v1.0    | 2025-04-16 | Initial draft | @phdargen @CarsonRoscoe |

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
@@ -242,7 +242,7 @@ The server must maintain per-channel state, keyed by channel ID:
 The server must serialize request processing per channel and must not update voucher state until the resource handler has succeeded.
 
 1. **Verify**:
-   - For `voucher` and `deposit` payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount + paymentRequirements.amount`. If this fails, reject with `batch_settlement_cumulative_amount_mismatch` and return a corrective 402.
+   - For `voucher` and `deposit` payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount + paymentRequirements.amount`. If this fails, reject with `invalid_batch_settlement_evm_cumulative_amount_mismatch` and return a corrective 402.
    - For refund payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount` and skip the resource handler after facilitator verification.
    - Always call facilitator `/verify` for `deposit` and `refund` payloads, as well as `voucher` payloads with EIP-1271 vouchers.
    - A plain EOA-authorized `voucher` may be verified locally when the server's mirrored onchain state is fresh. 
@@ -545,12 +545,12 @@ The recovery baseline is:
 
 **Server state loss.** If the server has no local channel record, it sets `chargedCumulativeAmount = totalClaimed` as the baseline. If the server lost unclaimed vouchers, those unclaimed charges are forfeited by the server.
 
-**Corrective 402.** If the server has local channel state and rejects a paid payload (`deposit` or `voucher`) because the client's cumulative amount does not match the server's channel state, it returns `batch_settlement_cumulative_amount_mismatch` with `accepts[].extra.channelState` containing the channel snapshot and `accepts[].extra.voucherState` containing `signedMaxClaimable` and `signature`.  The client verifies the voucher signature before adopting `chargedCumulativeAmount` and retrying.
+**Corrective 402.** If the server has local channel state and rejects a paid payload (`deposit` or `voucher`) because the client's cumulative amount does not match the server's channel state, it returns `invalid_batch_settlement_evm_cumulative_amount_mismatch` with `accepts[].extra.channelState` containing the channel snapshot and `accepts[].extra.voucherState` containing `signedMaxClaimable` and `signature`.  The client verifies the voucher signature before adopting `chargedCumulativeAmount` and retrying.
 
 ```json
 {
   "x402Version": 2,
-  "error": "batch_settlement_cumulative_amount_mismatch",
+  "error": "invalid_batch_settlement_evm_cumulative_amount_mismatch",
   "accepts": [
     {
       "scheme": "batch-settlement",
@@ -581,34 +581,71 @@ The recovery baseline is:
 
 ## Error Codes
 
-| Error Code                                                     | Description                                                                  |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `batch_settlement_cumulative_amount_mismatch`                  | Client cumulative amount does not match server channel state; corrective 402 |
-| `batch_settlement_evm_channel_not_found`                       | No channel with positive balance for the given channel ID                    |
-| `batch_settlement_evm_cumulative_exceeds_balance`              | Voucher `maxClaimableAmount` exceeds onchain balance                         |
-| `batch_settlement_evm_cumulative_below_claimed`                | Voucher `maxClaimableAmount` is at or below onchain `totalClaimed`           |
-| `batch_settlement_evm_insufficient_balance`                    | Client token balance is insufficient for the deposit                         |
-| `batch_settlement_evm_invalid_voucher_signature`               | EIP-712 voucher signature does not recover to the expected signer            |
-| `batch_settlement_evm_invalid_scheme`                          | `scheme` is not `batch-settlement`                                           |
-| `batch_settlement_evm_network_mismatch`                        | `network` does not match the facilitator's chain                             |
-| `batch_settlement_evm_token_mismatch`                          | Channel token does not match the payment requirements asset                  |
-| `batch_settlement_evm_channel_id_mismatch`                     | Channel config does not hash to the claimed channel ID                       |
-| `batch_settlement_evm_receiver_mismatch`                       | Channel receiver does not match `payTo`                                      |
-| `batch_settlement_evm_receiver_authorizer_mismatch`            | Channel receiver authorizer does not match `extra.receiverAuthorizer`        |
-| `batch_settlement_evm_withdraw_delay_mismatch`                 | Channel withdraw delay does not match `extra.withdrawDelay`                  |
-| `batch_settlement_evm_withdraw_delay_out_of_range`             | Withdraw delay is outside the 15 min – 30 day bounds                         |
-| `batch_settlement_evm_deposit_voucher_mismatch`                | Deposit payload config does not match the voucher's channel ID               |
-| `batch_settlement_evm_missing_eip712_domain`                   | Token EIP-712 domain (`name`, `version`) could not be read                   |
-| `batch_settlement_evm_payload_authorization_valid_before`      | ERC-3009 authorization `validBefore` has already passed                      |
-| `batch_settlement_evm_payload_authorization_valid_after`       | ERC-3009 authorization `validAfter` is still in the future                   |
-| `batch_settlement_evm_invalid_receive_authorization_signature` | ERC-3009 `receiveWithAuthorization` signature is invalid                     |
-| `batch_settlement_evm_erc3009_authorization_required`          | Deposit payload is missing the required `erc3009Authorization`               |
-| `batch_settlement_evm_invalid_payload_type`                    | Payload `type` is not valid for the current verify/settle operation          |
-| `batch_settlement_evm_refund_not_supported`                    | Server cannot produce `refundWithSignature` (e.g. no signing key)            |
-| `batch_settlement_evm_deposit_transaction_failed`              | Onchain deposit transaction reverted                                         |
-| `batch_settlement_evm_claim_transaction_failed`                | Onchain claim transaction reverted                                           |
-| `batch_settlement_evm_settle_transaction_failed`               | Onchain settle (transfer) transaction reverted                               |
-| `batch_settlement_evm_refund_transaction_failed`               | Onchain refund transaction reverted                                          |
+| Error Code                                                               | Description                                                                  |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `invalid_batch_settlement_evm_authorizer_address_mismatch`               | Authorizer address does not match the expected receiver authorizer           |
+| `invalid_batch_settlement_evm_channel_busy`                              | Another request holds the per-channel lock; client should retry shortly      |
+| `invalid_batch_settlement_evm_channel_id_mismatch`                       | Channel config does not hash to the claimed channel ID                       |
+| `invalid_batch_settlement_evm_channel_not_found`                         | No channel with positive balance for the given channel ID                    |
+| `invalid_batch_settlement_evm_channel_state_read_failed`                 | Facilitator failed to read onchain channel state                             |
+| `invalid_batch_settlement_evm_charge_exceeds_signed_cumulative`          | Committing the charge would exceed the voucher's signed `maxClaimableAmount` |
+| `invalid_batch_settlement_evm_claim_payload`                             | Claim payload is malformed                                                   |
+| `invalid_batch_settlement_evm_claim_simulation_failed`                   | Claim simulation failed                                                      |
+| `invalid_batch_settlement_evm_claim_transaction_failed`                  | Onchain claim transaction failed                                             |
+| `invalid_batch_settlement_evm_cumulative_amount_mismatch`               | Corrective 402: client's cumulative voucher ceiling does not match the server's tracked `chargedCumulativeAmount` |
+| `invalid_batch_settlement_evm_cumulative_below_claimed`                  | Voucher `maxClaimableAmount` violates monotonicity vs onchain `totalClaimed` (non-refund: must be greater than `totalClaimed`; refund: must not be strictly below `totalClaimed`; deposit verify: must not be strictly below `totalClaimed`) |
+| `invalid_batch_settlement_evm_cumulative_exceeds_balance`                | Voucher `maxClaimableAmount` exceeds effective onchain balance               |
+| `invalid_batch_settlement_evm_deposit_payload`                           | Deposit payload is malformed                                                 |
+| `invalid_batch_settlement_evm_deposit_simulation_failed`                 | Deposit simulation failed                                                    |
+| `invalid_batch_settlement_evm_deposit_transaction_failed`                | Onchain deposit transaction failed                                           |
+| `invalid_batch_settlement_evm_eip2612_amount_mismatch`                   | EIP-2612 permit amount does not match the requested authorization          |
+| `invalid_batch_settlement_evm_eip2612_asset_mismatch`                    | EIP-2612 permit asset does not match the payment asset                       |
+| `invalid_batch_settlement_evm_eip2612_deadline_expired`                  | EIP-2612 permit deadline has expired                                         |
+| `invalid_batch_settlement_evm_eip2612_invalid_format`                    | EIP-2612 permit segment is malformed                                         |
+| `invalid_batch_settlement_evm_eip2612_invalid_signature`                 | EIP-2612 permit signature is invalid                                         |
+| `invalid_batch_settlement_evm_eip2612_owner_mismatch`                    | EIP-2612 permit owner does not match the payer                               |
+| `invalid_batch_settlement_evm_eip2612_spender_mismatch`                  | EIP-2612 permit spender does not match the expected spender                  |
+| `invalid_batch_settlement_evm_erc20_approval_asset_mismatch`             | ERC-20 approval asset does not match the payment asset                       |
+| `invalid_batch_settlement_evm_erc20_approval_broadcast_failed`           | Facilitator failed to broadcast the pre-signed ERC-20 approval transaction   |
+| `invalid_batch_settlement_evm_erc20_approval_from_mismatch`              | ERC-20 approval signer does not match the payer                              |
+| `invalid_batch_settlement_evm_erc20_approval_invalid_format`             | ERC-20 approval segment is malformed                                         |
+| `invalid_batch_settlement_evm_erc20_approval_unavailable`                | ERC-20 approval gas sponsorship is unavailable                               |
+| `invalid_batch_settlement_evm_erc20_approval_wrong_spender`              | ERC-20 approval spender is not Permit2                                       |
+| `invalid_batch_settlement_evm_erc3009_authorization_required`            | Deposit payload is missing the required `erc3009Authorization`               |
+| `invalid_batch_settlement_evm_insufficient_balance`                    | Client token balance is insufficient for the deposit                         |
+| `invalid_batch_settlement_evm_missing_channel`                           | Resource server has no channel session for the payload's channel ID          |
+| `invalid_batch_settlement_evm_missing_eip712_domain`                     | Token EIP-712 domain (`name`, `version`) is missing from payment requirements |
+| `invalid_batch_settlement_evm_network_mismatch`                          | Payment payload `accepted.network` does not match `paymentRequirements.network` on the verify request |
+| `invalid_batch_settlement_evm_payload_authorization_valid_after`         | ERC-3009 authorization `validAfter` is still in the future                   |
+| `invalid_batch_settlement_evm_payload_authorization_valid_before`        | ERC-3009 authorization `validBefore` has already passed                    |
+| `invalid_batch_settlement_evm_payload_type`                              | Payload `type` is not valid for the current verify/settle operation          |
+| `invalid_batch_settlement_evm_permit2_allowance_required`                | Permit2 allowance is required before deposit                                 |
+| `invalid_batch_settlement_evm_permit2_amount_mismatch`                   | Permit2 authorization amount does not match the requested deposit amount   |
+| `invalid_batch_settlement_evm_permit2_authorization_required`            | Deposit payload is missing the required Permit2 authorization              |
+| `invalid_batch_settlement_evm_permit2_deadline_expired`                  | Permit2 authorization deadline has expired                                   |
+| `invalid_batch_settlement_evm_permit2_invalid_signature`                 | Permit2 authorization signature is invalid                                   |
+| `invalid_batch_settlement_evm_permit2_invalid_spender`                   | Permit2 authorization spender is not the expected spender                  |
+| `invalid_batch_settlement_evm_receive_authorization_signature`           | ERC-3009 `receiveWithAuthorization` signature is invalid                     |
+| `invalid_batch_settlement_evm_receiver_authorizer_mismatch`              | Channel receiver authorizer does not match `extra.receiverAuthorizer`        |
+| `invalid_batch_settlement_evm_receiver_mismatch`                         | Channel receiver does not match `payTo`                                      |                         |
+| `invalid_batch_settlement_evm_refund_amount_invalid`                     | Refund `amount` is non-numeric or non-positive                               |
+| `invalid_batch_settlement_evm_refund_no_balance`                         | Cooperative refund requested but no refundable balance remains             |
+| `invalid_batch_settlement_evm_refund_payload`                            | Refund payload is malformed                                                  |
+| `invalid_batch_settlement_evm_refund_simulation_failed`                  | Refund simulation failed                                                     |
+| `invalid_batch_settlement_evm_refund_transaction_failed`                 | Onchain refund transaction failed                                            |
+| `invalid_batch_settlement_evm_rpc_read_failed`                           | Facilitator failed to read required onchain data                             |
+| `invalid_batch_settlement_evm_scheme`                                    | `scheme` is not `batch-settlement`                                           |
+| `invalid_batch_settlement_evm_settle_payload`                            | Settle payload is malformed                                                  |
+| `invalid_batch_settlement_evm_settle_simulation_failed`                  | Settle simulation failed                                                     |
+| `invalid_batch_settlement_evm_settle_transaction_failed`                 | Onchain settle transaction failed                                            |
+| `invalid_batch_settlement_evm_token_mismatch`                            | Channel token does not match the payment requirements asset                  |
+| `invalid_batch_settlement_evm_transaction_reverted`                      | Submitted transaction reverted                                               |
+| `invalid_batch_settlement_evm_unknown_settle_action`                     | Settle payload requested an unknown action                                   |
+| `invalid_batch_settlement_evm_voucher_payload`                           | Voucher payload is malformed                                                 |
+| `invalid_batch_settlement_evm_voucher_signature`                         | EIP-712 voucher signature does not recover to the expected signer          |
+| `invalid_batch_settlement_evm_wait_for_receipt_failed`                   | Facilitator failed while waiting for the transaction receipt                 |
+| `invalid_batch_settlement_evm_withdraw_delay_mismatch`                   | Channel withdraw delay does not match `extra.withdrawDelay`                  |
+| `invalid_batch_settlement_evm_withdraw_delay_out_of_range`               | Withdraw delay is outside the 15 min - 30 day bounds                         |
 
 ---
 

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
@@ -6,8 +6,6 @@ The `batch-settlement` scheme on EVM is a **capital-backed** network binding usi
 
 The scheme supports **dynamic pricing**: the client authorizes a maximum per-request, and the server charges the actual cost within that ceiling.
 
-The `x402BatchSettlement` contract uses `ReentrancyGuardTransient` (EIP-1153 transient storage) and must only be deployed on chains where that opcode is supported.
-
 ---
 
 ## Channel Lifecycle
@@ -354,7 +352,7 @@ Verifies a deposit, voucher, or refund payment payload. Returns the onchain chan
 
 | `payload.type` | When Used                     | Onchain Effect                                        |
 | -------------- | ----------------------------- | ----------------------------------------------------- |
-| `"deposit"`    | First request or top-up       | Deposit via the EIP-3009 collector                    |
+| `"deposit"`    | First request or top-up       | Deposit via the canonical ERC-3009 or Permit2 collector |
 | `"claim"`      | Server batches voucher claims | Validate vouchers, update accounting (no transfer)    |
 | `"settle"`     | Server transfers earned funds | Transfer unsettled amount to receiver                 |
 | `"refund"`     | Cooperative refund            | Return specified amount to payer, increment refund nonce |
@@ -628,10 +626,15 @@ The recovery baseline is:
 
 ## Reference Implementation: `x402BatchSettlement`
 
-The `batch-settlement` scheme is implemented by the `x402BatchSettlement` contract, deployed to the same address across all supported EVM chains via CREATE2.
+The `batch-settlement` scheme is implemented by the `x402BatchSettlement` contract alongside the `ERC3009DepositCollector` and `Permit2DepositCollector` deposit collector contracts. Each contract is deployed to a deterministic address across all supported EVM chains via CREATE2.
 
-**Canonical Address:** `0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003`
+| Contract | Canonical Address |
+| -------- | ------- |
+| `x402BatchSettlement` | `0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003` |
+| `ERC3009DepositCollector` | `0x4020806089470a89826cB9fB1f4059150b550004` |
+| `Permit2DepositCollector` | `0x4020425FAf3B746C082C2f942b4E5159887B0005` |
 
+The `x402BatchSettlement` contract uses `ReentrancyGuardTransient` (EIP-1153 transient storage) and must only be deployed on chains where that opcode is supported.
 ---
 
 ## Version History

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
@@ -26,7 +26,7 @@ struct ChannelConfig {
     bytes32 salt;               // Differentiates channels with identical parameters
 }
 ```
-with `channelId = keccak256(abi.encode(channelConfig))`.
+with `channelId = EIP712Hash(ChannelConfig)` under the `x402 Batch Settlement` domain. The hash binds the immutable config to the EVM `chainId` and deployed `x402BatchSettlement` address, so the same config produces different IDs across chains or deployments.
 
 ### Requests and vouchers
 
@@ -81,11 +81,12 @@ The 402 response contains pricing terms and the server's channel parameters. The
 
 | Field                       | Type     | Required | Description                                            |
 | --------------------------- | -------- | -------- | ------------------------------------------------------ |
-| `extra.receiverAuthorizer`  | `string` | yes      | Address that will authorize claims/refunds              |
+| `extra.receiverAuthorizer`  | `string` | yes      | Address that will authorize claims/refunds             |
 | `extra.withdrawDelay`       | `number` | yes      | Withdrawal delay in seconds (15 min – 30 days)         |
 | `extra.assetTransferMethod` | `string` | optional | `"eip3009"` (default) or `"permit2"`                   |
 | `extra.name`                | `string` | yes      | EIP-712 domain name of the token contract              |
 | `extra.version`             | `string` | yes      | EIP-712 domain version of the token contract           |
+| `extra.ChannelState`        | `object` | optional | Corrective-only server state for cumulative amount resynchronization |
 
 ---
 
@@ -231,7 +232,7 @@ The server must maintain per-channel state, keyed by channel ID:
 The server must serialize request processing per channel and must not update voucher state until the resource handler has succeeded.
 
 1. **Verify**:
-   - For voucher payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount + paymentRequirements.amount`. If this fails, reject with `batch_settlement_stale_cumulative_amount` and return a corrective 402.
+   - For `voucher` and `deposit` payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount + paymentRequirements.amount`. If this fails, reject with `batch_settlement_cumulative_amount_mismatch` and return a corrective 402.
    - For refund payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount` and skip the resource handler after facilitator verification.
    - Call facilitator `/verify`.
 2. **Execute**: Run the resource handler
@@ -250,7 +251,7 @@ When the server receives a `type: "refund"` payload:
 4. **Submit onchain**: `claimWithSignature(claims, claimSig)` (no-op when `maxClaimableAmount == totalClaimed`) followed by `refundWithSignature(config, amount, nonce, refundSig)`.
 5. **Update channel state**:
    - **Full refund** (refunded amount equals the remainder): delete the channel record.
-   - **Partial refund**: keep the channel record, decrement `balance` by the refunded amount, and increment `refundNonce`.
+   - **Partial refund**: keep the channel record, mirror the returned `balance`, `totalClaimed`, `withdrawRequestedAt`, and `refundNonce`.
 6. Return the settle response in the standard `PAYMENT-RESPONSE` header. The response `amount` is the actual refunded amount; `extra` carries the updated channel snapshot plus `chargedCumulativeAmount`.
 
 After the server completes the refund payload, the facilitator receives:
@@ -396,7 +397,7 @@ The facilitator declares a receiver authorizer whose role is to produce EIP-712 
 
 A facilitator must enforce:
 
-1. **Channel config consistency** (deposit, voucher, and refund): the config must hash to the claimed channel ID.
+1. **Channel config consistency** (deposit, voucher, and refund): the config's chain-bound EIP-712 hash must equal the claimed channel ID.
 2. **Token match**: the channel token must match the payment requirements asset.
 3. **Receiver match**: the channel receiver must equal the payment requirements `payTo`.
 4. **Receiver authorizer match**: the channel receiver authorizer must equal `extra.receiverAuthorizer`.
@@ -454,22 +455,29 @@ The recovery baseline is:
 
 **Server state loss.** If the server has no local channel record, it sets `chargedCumulativeAmount = totalClaimed` as the baseline. If the server lost unclaimed vouchers, those unclaimed charges are forfeited by the server.
 
-**Corrective 402.** If the server has local channel state and rejects a voucher because the client's cumulative base is stale, it returns `batch_settlement_stale_cumulative_amount` with top-level `errorDetails.recoverable: true` and `errorDetails.data` containing `channelId`, `chargedCumulativeAmount`, `signedMaxClaimable`, and `signature`. The client verifies the voucher signature, adopts `chargedCumulativeAmount` and retries. 
+**Corrective 402.** If the server has local channel state and rejects a paid payload (`deposit` or `voucher`) because the client's cumulative amount does not match the server's channel state, it returns `batch_settlement_cumulative_amount_mismatch` with `accepts[].extra.ChannelState` containing `channelId`, `chargedCumulativeAmount`, `signedMaxClaimable`, and `signature`.  The client verifies the voucher signature before adopting `chargedCumulativeAmount` and retrying.
 
 ```json
 {
   "x402Version": 2,
-  "error": "batch_settlement_stale_cumulative_amount",
-  "errorDetails": {
-    "recoverable": true,
-    "data": {
-      "channelId": "0xabc123...channelId",
-      "chargedCumulativeAmount": "3200",
-      "signedMaxClaimable": "3200",
-      "signature": "0x...last voucher signature"
+  "error": "batch_settlement_cumulative_amount_mismatch",
+  "accepts": [
+    {
+      "scheme": "batch-settlement",
+      "extra": {
+        "receiverAuthorizer": "0xReceiverAuthorizerAddress",
+        "withdrawDelay": 900,
+        "name": "USDC",
+        "version": "2",
+        "ChannelState": {
+          "channelId": "0xabc123...channelId",
+          "chargedCumulativeAmount": "3200",
+          "signedMaxClaimable": "3200",
+          "signature": "0x...last voucher signature"
+        }
+      }
     }
-  },
-  "accepts": [{ "scheme": "batch-settlement", "..." : "..." }]
+  ]
 }
 ```
 
@@ -479,7 +487,7 @@ The recovery baseline is:
 
 | Error Code                                                     | Description                                                                  |
 | -------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `batch_settlement_stale_cumulative_amount`                     | Client voucher base doesn't match server state; corrective 402               |
+| `batch_settlement_cumulative_amount_mismatch`                  | Client cumulative amount does not match server channel state; corrective 402 |
 | `batch_settlement_evm_channel_not_found`                       | No channel with positive balance for the given channel ID                    |
 | `batch_settlement_evm_cumulative_exceeds_balance`              | Voucher `maxClaimableAmount` exceeds onchain balance                         |
 | `batch_settlement_evm_cumulative_below_claimed`                | Voucher `maxClaimableAmount` is at or below onchain `totalClaimed`           |

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
@@ -42,7 +42,7 @@ The server claims the latest voucher per channel onchain at its discretion. `cla
 
 ### Refund and withdrawal
 
-**Cooperative refund** (`refundWithSignature`): instant, authorized by the receiver side, returns up to `balance - totalClaimed` to the payer. The refund amount is explicit (partial or full). 
+**Cooperative refund** (`refundWithSignature`): instant, authorized by the receiver side, returns up to `balance - totalClaimed` to the payer.
 
 **Timed withdrawal** (escape hatch): the `payer` calls `initiateWithdraw` to start a grace period, during which the server can claim outstanding vouchers. After the withdrawal delay elapses, `finalizeWithdraw` completes the withdrawal. 
 
@@ -95,6 +95,7 @@ The client constructs a payment payload whose type depends on channel state:
 
 - `deposit`: No channel exists or balance is exhausted — client signs a token authorization and voucher
 - `voucher`: Channel has sufficient balance — client signs a new cumulative voucher
+- `refund`: Client requests a cooperative refund — client signs a zero-charge voucher and optionally includes a refund amount
 
 ### Deposit Payload
 
@@ -119,23 +120,30 @@ The `deposit.authorization` field contains the token transfer authorization — 
   },
   "payload": {
     "type": "deposit",
-    "deposit": {
-      "channelConfig": {
-        "payer": "0xClientAddress",
-        "payerAuthorizer": "0xClientPayerAuthorizerEOA",
-        "receiver": "0xServerReceiverAddress",
-        "receiverAuthorizer": "0xReceiverAuthorizerAddress",
-        "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-        "withdrawDelay": 900,
-        "salt": "0x0000000000000000000000000000000000000000000000000000000000000000"
-      },
-      "amount": "100000",
-      "authorization": "<erc3009Authorization | permit2Authorization>"
+    "channelConfig": {
+      "payer": "0xClientAddress",
+      "payerAuthorizer": "0xClientPayerAuthorizerEOA",
+      "receiver": "0xServerReceiverAddress",
+      "receiverAuthorizer": "0xReceiverAuthorizerAddress",
+      "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "withdrawDelay": 900,
+      "salt": "0x0000000000000000000000000000000000000000000000000000000000000000"
     },
     "voucher": {
       "channelId": "0xabc123...channelId",
       "maxClaimableAmount": "1000",
       "signature": "0x...EIP-712 voucher signature"
+    },
+    "deposit": {
+      "amount": "100000",
+      "authorization": {
+        "erc3009Authorization": {
+          "validAfter": "0",
+          "validBefore": "1770000000",
+          "salt": "0x...authorization salt",
+          "signature": "0x...ERC-3009 signature"
+        }
+      }
     }
   }
 }
@@ -158,21 +166,49 @@ The `deposit.authorization` field contains the token transfer authorization — 
       "withdrawDelay": 900,
       "salt": "0x0000000000000000000000000000000000000000000000000000000000000000"
     },
-    "channelId": "0xabc123...channelId",
-    "maxClaimableAmount": "5000",
-    "signature": "0x...EIP-712 voucher signature",
-    "refund": true
+    "voucher": {
+      "channelId": "0xabc123...channelId",
+      "maxClaimableAmount": "5000",
+      "signature": "0x...EIP-712 voucher signature"
+    }
   }
 }
 ```
 
-The optional `refund` flag signals a cooperative refund request. The server will bring onchain claims in line via `claimWithSignature`, then execute `refundWithSignature`.
+### Refund Payload
+
+The optional `amount` requests a partial refund; omit it for a full refund. The voucher is zero-charge: `voucher.maxClaimableAmount` MUST equal the channel's current `chargedCumulativeAmount`. Before settlement, the server completes the payload with the refund nonce, claim data, and any receiver-authorizer signatures it is responsible for.
+
+```json
+{
+  "x402Version": 2,
+  "accepted": { "..." : "..." },
+  "payload": {
+    "type": "refund",
+    "channelConfig": {
+      "payer": "0xClientAddress",
+      "payerAuthorizer": "0xClientPayerAuthorizerEOA",
+      "receiver": "0xServerReceiverAddress",
+      "receiverAuthorizer": "0xReceiverAuthorizerAddress",
+      "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "withdrawDelay": 900,
+      "salt": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "voucher": {
+      "channelId": "0xabc123...channelId",
+      "maxClaimableAmount": "3200",
+      "signature": "0x...EIP-712 zero-charge voucher signature"
+    },
+    "amount": "1500"
+  }
+}
+```
 
 ---
 
 ## Server: State & Forwarding
 
-The server is the sole owner of per-channel session state.
+The server is the sole owner of per-channel state.
 
 ### Per-Channel State
 
@@ -195,7 +231,8 @@ The server must maintain per-channel state, keyed by channel ID:
 The server must serialize request processing per channel and must not update voucher state until the resource handler has succeeded.
 
 1. **Verify**:
-   - Check that `payload.maxClaimableAmount == chargedCumulativeAmount + paymentRequirements.amount`. If this fails, reject with `batch_settlement_stale_cumulative_amount` and return a corrective 402.
+   - For voucher payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount + paymentRequirements.amount`. If this fails, reject with `batch_settlement_stale_cumulative_amount` and return a corrective 402.
+   - For refund payloads, check that `payload.voucher.maxClaimableAmount == chargedCumulativeAmount` and skip the resource handler after facilitator verification.
    - Call facilitator `/verify`.
 2. **Execute**: Run the resource handler
 3. **On success** — commit state:
@@ -205,13 +242,46 @@ The server must serialize request processing per channel and must not update vou
 
 ### Cooperative refund flow
 
-When the server receives a voucher with `refund: true`:
+When the server receives a `type: "refund"` payload:
 
-1. Update `chargedCumulativeAmount` as with a normal voucher.
-2. Build claim entries for outstanding channels; sign the claim batch as the receiver authorizer.
-3. Sign a refund message with the current onchain refund nonce and an amount up to `balance - totalClaimed` after claims.
-4. Submit `claimWithSignature(claims, claimSig)` then `refundWithSignature(config, amount, nonce, refundSig)` (order matters: claims first if they increase `totalClaimed`).
-5. On success, the chain increments the refund nonce; mirror it in server state and reset session fields as needed.
+1. **Verify (zero-charge)**: enforce `payload.voucher.maxClaimableAmount == chargedCumulativeAmount` (no increment from `paymentRequirements.amount`). If local state is stale, emit a corrective 402 so the client can recover and retry.
+2. **Bypass the protected resource.** Refund payloads are payment operations, not paid requests; the application route is not invoked.
+3. **Complete the settlement payload**: resolve omitted `amount` to a full refund, validate any partial `amount`, add `refundNonce`, build `claims`, and add receiver-authorizer signatures when the server owns that key.
+4. **Submit onchain**: `claimWithSignature(claims, claimSig)` (no-op when `maxClaimableAmount == totalClaimed`) followed by `refundWithSignature(config, amount, nonce, refundSig)`.
+5. **Update channel state**:
+   - **Full refund** (refunded amount equals the remainder): delete the channel record.
+   - **Partial refund**: keep the channel record, decrement `balance` by the refunded amount, and increment `refundNonce`.
+6. Return the settle response in the standard `PAYMENT-RESPONSE` header. The response `amount` is the actual refunded amount; `extra` carries the updated channel snapshot plus `chargedCumulativeAmount`.
+
+After the server completes the refund payload, the facilitator receives:
+
+```json
+{
+  "type": "refund",
+  "channelConfig": { "..." : "..." },
+  "voucher": {
+    "channelId": "0xabc123...channelId",
+    "maxClaimableAmount": "3200",
+    "signature": "0x...EIP-712 zero-charge voucher signature"
+  },
+  "amount": "1500",
+  "refundNonce": "1",
+  "claims": [
+    {
+      "voucher": {
+        "channel": { "..." : "..." },
+        "maxClaimableAmount": "3200"
+      },
+      "signature": "0x...EIP-712 zero-charge voucher signature",
+      "totalClaimed": "3200"
+    }
+  ],
+  "refundAuthorizerSignature": "0x...refund authorization",
+  "claimAuthorizerSignature": "0x...claim authorization"
+}
+```
+
+`refundAuthorizerSignature` and `claimAuthorizerSignature` are included when the server owns the receiver-authorizer key. If the channel delegates receiver authorization to the facilitator, the server omits them and the facilitator signs before submitting the transaction.
 
 ---
 
@@ -221,7 +291,7 @@ Uses the standard x402 facilitator interface (`/verify`, `/settle`, `/supported`
 
 ### POST /verify
 
-Verifies a payment payload. Returns the onchain channel snapshot:
+Verifies a deposit, voucher, or refund payment payload. Returns the onchain channel snapshot:
 
 ```json
 {
@@ -239,12 +309,41 @@ Verifies a payment payload. Returns the onchain channel snapshot:
 
 ### POST /settle
 
-| `settleAction`          | When Used                        | Onchain Effect                                                     |
-| ----------------------- | -------------------------------- | ------------------------------------------------------------------ |
-| `"deposit"`             | First request or top-up          | Deposit via pluggable collector (EIP-3009 or Permit2)              |
-| `"claimWithSignature"`  | Server batches voucher claims    | Validate vouchers, update accounting (no transfer)                 |
-| `"settle"`              | Server transfers earned funds    | Transfer unsettled amount to receiver                              |
-| `"refundWithSignature"` | Cooperative refund               | Return specified amount to payer, increment refund nonce           |
+| `payload.type` | When Used                     | Onchain Effect                                        |
+| -------------- | ----------------------------- | ----------------------------------------------------- |
+| `"deposit"`    | First request or top-up       | Deposit via the EIP-3009 collector                    |
+| `"claim"`      | Server batches voucher claims | Validate vouchers, update accounting (no transfer)    |
+| `"settle"`     | Server transfers earned funds | Transfer unsettled amount to receiver                 |
+| `"refund"`     | Cooperative refund            | Return specified amount to payer, increment refund nonce |
+
+Server-authored claim and settle payloads use the same `type` discriminator:
+
+```json
+{
+  "type": "claim",
+  "claims": [
+    {
+      "voucher": {
+        "channel": { "..." : "..." },
+        "maxClaimableAmount": "5000"
+      },
+      "signature": "0x...voucher signature",
+      "totalClaimed": "5000"
+    }
+  ],
+  "claimAuthorizerSignature": "0x...claim authorization"
+}
+```
+
+`claimAuthorizerSignature` is included when the server owns the receiver-authorizer key. If receiver authorization is delegated to the facilitator, the server omits it and the facilitator signs before submitting the transaction.
+
+```json
+{
+  "type": "settle",
+  "receiver": "0xServerReceiverAddress",
+  "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+}
+```
 
 Response:
 
@@ -258,11 +357,11 @@ Response:
   "asset": "0xAssetAddress",
   "extra": {
     "channelId": "0xabc123...",
-    "chargedCumulativeAmount": "3200",
     "balance": "100000",
     "totalClaimed": "3200",
     "withdrawRequestedAt": 0,
-    "refundNonce": "1"
+    "refundNonce": "1",
+    "chargedCumulativeAmount": "3200"
   }
 }
 ```
@@ -297,7 +396,7 @@ The facilitator declares a receiver authorizer whose role is to produce EIP-712 
 
 A facilitator must enforce:
 
-1. **Channel config consistency** (deposit and voucher): the config must hash to the claimed channel ID.
+1. **Channel config consistency** (deposit, voucher, and refund): the config must hash to the claimed channel ID.
 2. **Token match**: the channel token must match the payment requirements asset.
 3. **Receiver match**: the channel receiver must equal the payment requirements `payTo`.
 4. **Receiver authorizer match**: the channel receiver authorizer must equal `extra.receiverAuthorizer`.
@@ -306,7 +405,7 @@ A facilitator must enforce:
 7. **Channel existence**: the channel must have a positive balance.
 8. **Balance check** (deposit only): the client must have sufficient token balance.
 9. **Deposit sufficiency**: `maxClaimableAmount` must be at most `balance` (or `balance + depositAmount` for deposit payloads).
-10. **Not below claimed**: `maxClaimableAmount` must exceed onchain `totalClaimed`.
+10. **Not below claimed**: `maxClaimableAmount` must exceed onchain `totalClaimed`. For refund payloads (`payload.type == "refund"`), this rule is relaxed to `maxClaimableAmount >= totalClaimed`, since refund vouchers are zero-charge and may match the already-claimed total exactly.
 11. **Signed refunds**: the refund nonce must equal the onchain refund nonce; the EIP-712 refund digest must bind the same amount submitted in the transaction.
 
 The facilitator must return the channel snapshot (`balance`, `totalClaimed`, `withdrawRequestedAt`, `refundNonce`) in every `/verify` and `/settle` response `extra` field. If `withdrawRequestedAt` is non-zero, the server should claim outstanding vouchers promptly before the withdraw delay elapses.
@@ -331,7 +430,7 @@ The server must claim all outstanding vouchers before the withdraw delay elapses
 
 ## Client Verification Rules
 
-### In-Session
+### Steady State
 
 Before signing the next voucher, the client must verify from the payment response:
 
@@ -344,16 +443,35 @@ If any check fails, the client must not sign further vouchers and should initiat
 
 ### Recovery After State Loss
 
-Channel identity is deterministic and fully reconstructible from the 402 response together with the client's own parameters (`payer`, `payerAuthorizer`, `salt`). A single `channels(channelId)` RPC read returns the onchain `balance` and `totalClaimed`.
+Channel identity is deterministic. The client can recompute `channelId` from the 402 response plus its own channel parameters (`payer`, `payerAuthorizer`, `salt`), then read `channels(channelId)` to recover the onchain `balance` and `totalClaimed`.
 
-Recovery occurs in two scenarios:
+The recovery baseline is:
 
-**Cold start — no local session.** When the client has no stored state for a channel, it recomputes the channel ID from the 402 response and its own parameters, then reads the onchain channel. If `balance == 0`, the channel does not yet exist and the next payment must be a deposit. Otherwise the channel already has funds from a previous session; the client adopts onchain `totalClaimed` as its `chargedCumulativeAmount` baseline and proceeds to sign the next voucher. This is an optimistic guess: if the server has charged beyond `totalClaimed` (it holds an outstanding unclaimed voucher), it will return a corrective 402, handled below.
+- Use onchain `totalClaimed` when no trusted offchain state is available.
+- Use server-provided `chargedCumulativeAmount` only when the server also returns the last signed voucher (`signedMaxClaimable` and `signature`) and the client verifies that signature against its own voucher signer.
 
-**Corrective 402 — in-session desync.** When the client's voucher is rejected because its cumulative base is out of sync, the server returns a 402 carrying its view of the channel in `accepts[].extra`. The client recovers from whatever the server can provide:
+**Client cold start.** When the client has no local channel record, it reads onchain state and sets `chargedCumulativeAmount = totalClaimed`. If the next request would exceed the recovered `balance`, the client sends a deposit/top-up payload. Otherwise it signs a voucher for `totalClaimed + amount`.
 
-- **Server holds the last voucher**: `extra` contains `chargedCumulativeAmount`, `signedMaxClaimable`, and `signature`. The client verifies the EIP-712 `Voucher` signature over `(channelId, signedMaxClaimable)` recovers to its own `payerAuthorizer` (or `payer`), then adopts `chargedCumulativeAmount` as the new base and retries.
-- **Server does not hold the last voucher** (e.g. its session was evicted after a cooperative refund): `extra` carries no signature fields. The client falls back to onchain state, setting `chargedCumulativeAmount = totalClaimed`, and retries.
+**Server state loss.** If the server has no local channel record, it sets `chargedCumulativeAmount = totalClaimed` as the baseline. If the server lost unclaimed vouchers, those unclaimed charges are forfeited by the server.
+
+**Corrective 402.** If the server has local channel state and rejects a voucher because the client's cumulative base is stale, it returns `batch_settlement_stale_cumulative_amount` with top-level `errorDetails.recoverable: true` and `errorDetails.data` containing `channelId`, `chargedCumulativeAmount`, `signedMaxClaimable`, and `signature`. The client verifies the voucher signature, adopts `chargedCumulativeAmount` and retries. 
+
+```json
+{
+  "x402Version": 2,
+  "error": "batch_settlement_stale_cumulative_amount",
+  "errorDetails": {
+    "recoverable": true,
+    "data": {
+      "channelId": "0xabc123...channelId",
+      "chargedCumulativeAmount": "3200",
+      "signedMaxClaimable": "3200",
+      "signature": "0x...last voucher signature"
+    }
+  },
+  "accepts": [{ "scheme": "batch-settlement", "..." : "..." }]
+}
+```
 
 ---
 
@@ -381,7 +499,7 @@ Recovery occurs in two scenarios:
 | `batch_settlement_evm_payload_authorization_valid_after`       | ERC-3009 authorization `validAfter` is still in the future                   |
 | `batch_settlement_evm_invalid_receive_authorization_signature` | ERC-3009 `receiveWithAuthorization` signature is invalid                     |
 | `batch_settlement_evm_erc3009_authorization_required`          | Deposit payload is missing the required `erc3009Authorization`               |
-| `batch_settlement_evm_invalid_payload_type`                    | Payload `type` is neither `"deposit"` nor `"voucher"`                        |
+| `batch_settlement_evm_invalid_payload_type`                    | Payload `type` is not valid for the current verify/settle operation          |
 | `batch_settlement_evm_refund_not_supported`                    | Server cannot produce `refundWithSignature` (e.g. no signing key)            |
 | `batch_settlement_evm_deposit_transaction_failed`              | Onchain deposit transaction reverted                                         |
 | `batch_settlement_evm_claim_transaction_failed`                | Onchain claim transaction reverted                                           |
@@ -406,4 +524,4 @@ Recovery occurs in two scenarios:
 
 | Version | Date       | Changes       | Authors                 |
 | ------- | ---------- | ------------- | ----------------------- |
-| v1.0    | 2025-04-16 | Initial draft | @phdargen @CarsonRoscoe |
+| v1.0    | 2025-04-28 | Initial draft | @phdargen @CarsonRoscoen @ilikesymmetry |

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
@@ -6,6 +6,8 @@ The `batch-settlement` scheme on EVM is a **capital-backed** network binding usi
 
 The scheme supports **dynamic pricing**: the client authorizes a maximum per-request, and the server charges the actual cost within that ceiling.
 
+The `x402BatchSettlement` contract uses `ReentrancyGuardTransient` (EIP-1153 transient storage) and must only be deployed on chains where that opcode is supported.
+
 ---
 
 ## Channel Lifecycle
@@ -42,9 +44,13 @@ The server claims the latest voucher per channel onchain at its discretion. `cla
 
 ### Refund and withdrawal
 
-**Cooperative refund** (`refundWithSignature`): instant, authorized by the receiver side, returns up to `balance - totalClaimed` to the payer.
+**Cooperative refund**: the receiver side can return up to `balance - totalClaimed` to the payer via two paths:
+- `refund(config, amount)`: direct call by `receiver` or `receiverAuthorizer`, no signature required.
+- `refundWithSignature(config, amount, nonce, sig)`: relay-friendly; anyone submits an EIP-712 `Refund` signature from `receiverAuthorizer`.
 
-**Timed withdrawal** (escape hatch): the `payer` calls `initiateWithdraw` to start a grace period, during which the server can claim outstanding vouchers. After the withdrawal delay elapses, `finalizeWithdraw` completes the withdrawal. 
+Both paths share the same internal execution: `refundNonce` is incremented **first** (before the amount cap is applied and before any token transfer), so a no-op refund (`amount > 0` but no unclaimed escrow available) still advances the nonce without emitting `Refunded` or moving tokens. A direct `refund` call therefore invalidates any pre-signed `refundWithSignature` digest for the previous nonce. If a timed withdrawal is pending, a cooperative refund **reduces** its recorded amount proportionally; it is only cancelled entirely when the refund amount meets or exceeds the pending withdrawal amount.
+
+**Timed withdrawal** (escape hatch): the `payer` or `payerAuthorizer` calls `initiateWithdraw(config, amount)` to start a grace period. The requested `amount` must not exceed `balance - totalClaimed` at initiation time; the call reverts otherwise. During the grace period the server can claim outstanding vouchers. After the withdrawal delay elapses, `finalizeWithdraw` (also callable by `payerAuthorizer`) completes the withdrawal, capping the transferred amount to whatever unclaimed escrow remains at that point.
 
 ### Authorizer roles
 
@@ -52,9 +58,13 @@ The server claims the latest voucher per channel onchain at its discretion. `cla
 
 **Receiver authorizer** (`receiverAuthorizer`): authorizes claim and refund operations via EIP-712 signatures. The server chooses this address: a server-owned EOA or smart contract (eg for key rotation), or a facilitator-provided address when the server delegates authorization. Must not be zero. Anyone can relay a `claimWithSignature` or `refundWithSignature` transaction with a valid authorization signature from the `receiverAuthorizer`.
 
+### Channel lifecycle events
+
+The contract emits `ChannelCreated(channelId, config)` on the first deposit into a channel (when `balance` transitions from zero with `totalClaimed == 0`). It emits `ChannelClosed(channelId, config)` when unclaimed escrow returns to zero with `totalClaimed == 0` — triggered by either a full cooperative refund or a timed withdrawal that drains all escrow. Indexers must handle `ChannelCreated` firing more than once on the same `channelId` if the channel is re-funded after being fully drained.
+
 ### Channel reuse and parameter changes
 
-Channels are long-lived. After a refund, the client can top up and reuse the same channel. However, the channel config is immutable. If any parameter needs to change, a new channel is required. If delegating `receiverAuthorizer` to a facilitator, the server should claim all outstanding vouchers and refund remaining balances on old channels before switching to another facilitator. 
+Channels are long-lived. After a refund, the client can top up and reuse the same channel. However, the channel config is immutable. If any parameter needs to change, a new channel is required. If delegating `receiverAuthorizer` to a facilitator, the server should claim all outstanding vouchers and refund remaining balances on old channels before switching to another facilitator.
 
 ---
 
@@ -280,10 +290,10 @@ When the server receives a `type: "refund"` payload:
 1. **Verify (zero-charge)**: enforce `payload.voucher.maxClaimableAmount == chargedCumulativeAmount` (no increment from `paymentRequirements.amount`). If local state is stale, emit a corrective 402 so the client can recover and retry.
 2. **Bypass the protected resource.** Refund payloads are payment operations, not paid requests; the application route is not invoked.
 3. **Complete the settlement payload**: resolve omitted `amount` to a full refund, validate any partial `amount`, add `refundNonce`, build `claims`, and add receiver-authorizer signatures when the server owns that key.
-4. **Submit onchain**: `claimWithSignature(claims, claimSig)` (no-op when `maxClaimableAmount == totalClaimed`) followed by `refundWithSignature(config, amount, nonce, refundSig)`.
+4. **Submit onchain**: `claimWithSignature(claims, claimSig)` (no-op when `maxClaimableAmount == totalClaimed`) followed by `refundWithSignature(config, amount, nonce, refundSig)`. The contract increments `refundNonce` before applying the amount cap; even if no tokens move (zero available escrow), the nonce advances.
 5. **Update channel state**:
    - **Full refund** (refunded amount equals the remainder): delete the channel record.
-   - **Partial refund**: keep the channel record, mirror the returned `balance`, `totalClaimed`, `withdrawRequestedAt`, and `refundNonce`.
+   - **Partial refund**: keep the channel record, mirror the returned `balance`, `totalClaimed`, `withdrawRequestedAt`, and `refundNonce`. If a timed withdrawal was pending, its recorded amount is reduced proportionally (or cancelled if the refund covers it entirely).
 6. Return the settle response in the standard `PAYMENT-RESPONSE` header.
 
 After the server completes the refund payload, the facilitator receives:
@@ -489,7 +499,7 @@ A facilitator must enforce:
 8. **Balance check** (deposit only): the client must have sufficient token balance.
 9. **Deposit sufficiency**: `maxClaimableAmount` must be at most `balance` (or `balance + depositAmount` for deposit payloads).
 10. **Not below claimed**: `maxClaimableAmount` must exceed onchain `totalClaimed`. For refund payloads (`payload.type == "refund"`), this rule is relaxed to `maxClaimableAmount >= totalClaimed`, since refund vouchers are zero-charge and may match the already-claimed total exactly.
-11. **Signed refunds**: the refund nonce must equal the onchain refund nonce; the EIP-712 refund digest must bind the same amount submitted in the transaction.
+11. **Signed refunds**: the refund nonce must equal the onchain `refundNonce` at the time of submission; the EIP-712 `Refund` digest (`Refund(bytes32 channelId,uint256 nonce,uint128 amount)`) must bind the same `amount` submitted in the transaction. The contract increments the nonce before computing the capped transfer amount, so the nonce advances even when no tokens move.
 
 The facilitator must return the channel snapshot (`balance`, `totalClaimed`, `withdrawRequestedAt`, `refundNonce`) in every `/verify` response `extra` field and in every `/settle` response under `extra.channelState`. If `withdrawRequestedAt` is non-zero, the server should claim outstanding vouchers promptly before the withdraw delay elapses.
 
@@ -497,7 +507,7 @@ The facilitator must return the channel snapshot (`balance`, `totalClaimed`, `wi
 
 ## Claim & Settlement Strategy
 
-`claimWithSignature(claims, signature)` validates payer voucher signatures and updates accounting across multiple channels in a single transaction. No token transfer occurs. The committed cumulative total per channel is `totalClaimed`, which the receiver authorizer determines up to `maxClaimableAmount`. All channels in a single call must share the same receiver authorizer. Anyone can submit the transaction.
+`claim(voucherClaims)` validates payer voucher signatures and updates accounting for multiple channels; `msg.sender` must be `receiver` or `receiverAuthorizer` for every row. `claimWithSignature(claims, signature)` is the relay-friendly variant: anyone can submit it with a valid EIP-712 `ClaimBatch` signature from `receiverAuthorizer` covering all rows (all rows must share the same `receiverAuthorizer`). No token transfer occurs in either path.
 
 `settle(receiver, token)` transfers all claimed-but-unsettled funds for a receiver+token pair to the receiver in one transfer. Permissionless.
 
@@ -613,6 +623,14 @@ The recovery baseline is:
 3. **Cross-function replay prevention**: `Voucher`, `Refund`, and `ClaimBatch` use distinct EIP-712 type hashes so a signature for one cannot be replayed as another. Refunds additionally carry a per-channel nonce.
 
 4. **Voucher expiry via escrow depletion**: Vouchers carry no expiry field. A voucher remains claimable as long as `balance - totalClaimed > 0`; `finalizeWithdraw` and `refundWithSignature` close the claim window by draining available escrow. The ERC-3009 `validBefore`/`validAfter` fields bound only the deposit authorization, not the voucher.
+
+---
+
+## Reference Implementation: `x402BatchSettlement`
+
+The `batch-settlement` scheme is implemented by the `x402BatchSettlement` contract, deployed to the same address across all supported EVM chains via CREATE2.
+
+**Canonical Address:** `0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003`
 
 ---
 


### PR DESCRIPTION
# Summary
Introduces the `batch-settlement` payment scheme specification for EVM chains, following the network agnostic specification introduced in https://github.com/x402-foundation/x402/pull/1145 by @CameronWhiteside.

This scheme enables capital-backed, high-throughput, low-cost payments using stateless unidirectional payment channels. Clients deposit funds into onchain escrow once and sign off-chain cumulative vouchers per request. Servers batch-claim vouchers across many channels in a single transaction and settle earned funds with a separate sweep transfer, reducing per-request latency and gas costs.

# Key Features
- **Fully gasless for client and server**: All onchain transactions (deposits, claims, settlements, refunds, withdrawals) are relayed by the facilitator or any third party via EIP-712 signatures 
- **Stateless unidirectional channels**: Channel identity is deterministically derived from an immutable `ChannelConfig` struct (`channelId = keccak256(abi.encode(config))`), fully reconstructible from the 402 response for recovery after client state loss
- **Cumulative vouchers**: Each voucher carries a monotonically increasing `maxClaimableAmount`; old vouchers are naturally superseded, eliminating the need for nonces
- **Dynamic pricing**: Clients authorize a maximum per-request, and servers charge the actual cost (`actualPrice <= amount`) within that ceiling
- **Batched claims + sweep settlement**: `claimWithSignature` aggregates claims across many channels (only onchain accounting, no transfers); `settle` sweeps claimed-but-unsettled funds to the receiver in one transfer
- **Pluggable deposit collectors**: Deposit via `eip3009` (e.g. USDC `receiveWithAuthorization`) or `permit2` as a universal ERC-20 fallback
- **Flexible authorizer roles**: `payerAuthorizer` supports fast ECDSA recovery (EOA) or EIP-1271 smart-wallet verification (zero address). `receiverAuthorizer` authorizes claims and refunds via EIP-712 and can be a server-owned address or a facilitator-provided delegate
- **Cooperative refunds + timed-withdrawal escape hatch**: Instant `refundWithSignature` when the server cooperates; `initiateWithdraw` / `finalizeWithdraw` with a 15 min – 30 day configurable delay as unilateral fallback
- **Long-lived channel reuse**: Channels can be topped up and reused after refund; config changes require a new channel.

# Use Cases
- High-frequency pay-as-you-go API requests
- Streaming / metered API access (charge per token, data chuncks)

# Links
x402BatchSettlement contract: https://github.com/x402-foundation/x402/pull/1950

# Related work
Deferred scheme: https://github.com/x402-foundation/x402/pull/426

Session scheme: https://github.com/x402-foundation/x402/pull/2080