### PR TITLE
Add Satoshi API Facilitator to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/satoshi-api-facilitator/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/satoshi-api-facilitator/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Satoshi API Facilitator",
+  "description": "Self-hosted x402 facilitator for Satoshi API. Supports Base, Base Sepolia, Solana, and Solana Devnet with public resource discovery for paid Bitcoin API endpoints.",
+  "logoUrl": "/logos/satoshi-api.svg",
+  "websiteUrl": "https://facilitator.bitcoinsapi.com/docs",
+  "category": "Facilitators",
+  "facilitator": {
+    "baseUrl": "https://facilitator.bitcoinsapi.com",
+    "networks": ["base", "base-sepolia", "solana", "solana-devnet"],
+    "addresses": {
+      "base": ["0xe166267c3648b5ca4419F2c58fAEd8Cd4DF87d54"],
+      "base-sepolia": ["0xe166267c3648b5ca4419F2c58fAEd8Cd4DF87d54"],
+      "solana": ["24D2XixrqnocvG5DChLJgUsyaNy7tqvj9iD6YS1KaEsu"],
+      "solana-devnet": ["24D2XixrqnocvG5DChLJgUsyaNy7tqvj9iD6YS1KaEsu"]
+    },
+    "schemes": ["exact"],
+    "assets": ["EIP-3009", "SPL"],
+    "supports": { "verify": true, "settle": true, "supported": true, "list": true }
+  }
+}

--- a/typescript/site/public/logos/satoshi-api.svg
+++ b/typescript/site/public/logos/satoshi-api.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="16" fill="#111827"/>
+  <circle cx="32" cy="32" r="22" fill="#f59e0b"/>
+  <path d="M26 18h8c6.1 0 11 4.9 11 11 0 4.7-2.9 8.8-7.1 10.4L42 46h-7l-3.6-5.8H26V46h-6V18h6zm0 6v10h8c2.2 0 4-1.8 4-4s-1.8-6-4-6h-8z" fill="#111827"/>
+</svg>


### PR DESCRIPTION
## Summary
- add Satoshi API Facilitator to the x402 ecosystem page
- include a small logo asset for the facilitator card and details view

## Live facilitator
- Base URL: https://facilitator.bitcoinsapi.com
- Docs: https://facilitator.bitcoinsapi.com/docs
- Status: https://facilitator.bitcoinsapi.com/status
- Resource discovery: https://facilitator.bitcoinsapi.com/discovery/resources

## Capability details
- networks: base, base-sepolia, solana, solana-devnet
- schemes: exact
- assets: EIP-3009, SPL
- supports: verify, settle, supported, and public resource listing

## Verification
- validated metadata.json with python -m json.tool
- confirmed the site auto-loads new partners-data/*/metadata.json folders from typescript/site/app/ecosystem/page.tsx
- confirmed the live facilitator advertises discovery and capability data at /status and /discovery/resources