### PR TITLE
docs: fix version mismatch in README installation steps

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -60,7 +60,7 @@ Then add the dependency to your Maven project:
 <dependency>
     <groupId>org.x402</groupId>
     <artifactId>x402</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description

Fixes version mismatch in README installation steps by aligning it with `pom.xml`.

Closes #2059 
## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)