### PR TITLE
Map simulation and settlement failures to more detailed errors

### DIFF
--- a/go/mechanisms/evm/exact/facilitator/eip3009.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009.go
@@ -113,7 +113,7 @@ func (f *ExactEvmScheme) verifyEIP3009(
 			classification.SigData,
 		)
 		if err != nil {
-			return nil, x402.NewVerifyError(ErrInvalidPayload, evmPayload.Authorization.From, err.Error())
+			return nil, x402.NewVerifyError(ErrEip3009SimulationFailed, evmPayload.Authorization.From, err.Error())
 		}
 		if !simulationSucceeded {
 			reason := DiagnoseEIP3009SimulationFailure(
@@ -193,7 +193,7 @@ func (f *ExactEvmScheme) settleEIP3009(
 
 	txHash, err := ExecuteTransferWithAuthorization(ctx, f.signer, tokenAddress, parsedAuthorization, sigData)
 	if err != nil {
-		return nil, x402.NewSettleError(ErrFailedToExecuteTransfer, verifyResp.Payer, network, "", err.Error())
+		return nil, x402.NewSettleError(parseEIP3009TransferError(err), verifyResp.Payer, network, "", err.Error())
 	}
 
 	receipt, err := f.signer.WaitForTransactionReceipt(ctx, txHash)

--- a/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
@@ -436,6 +436,25 @@ func mustNonce(nonce string) [32]byte {
 	return nonceArray
 }
 
+// parseEIP3009TransferError maps EIP-3009 contract revert reasons to specific error codes.
+func parseEIP3009TransferError(err error) string {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "authorization is expired") || strings.Contains(msg, "AuthorizationExpired"):
+		return ErrValidBeforeExpired
+	case strings.Contains(msg, "authorization is not yet valid") || strings.Contains(msg, "AuthorizationNotYetValid"):
+		return ErrValidAfterInFuture
+	case strings.Contains(msg, "authorization is used") || strings.Contains(msg, "AuthorizationAlreadyUsed") || strings.Contains(msg, "AuthorizationUsedOrCanceled"):
+		return ErrNonceAlreadyUsed
+	case strings.Contains(msg, "transfer amount exceeds balance") || strings.Contains(msg, "ERC20InsufficientBalance"):
+		return ErrInsufficientBalance
+	case strings.Contains(msg, "invalid signature") || strings.Contains(msg, "SignerMismatch") || strings.Contains(msg, "InvalidSignatureV") || strings.Contains(msg, "InvalidSignatureS"):
+		return ErrInvalidSignature
+	default:
+		return ErrFailedToExecuteTransfer
+	}
+}
+
 func asBigInt(value interface{}) *big.Int {
 	switch v := value.(type) {
 	case *big.Int:

--- a/go/mechanisms/evm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/v1/facilitator/scheme.go
@@ -215,7 +215,7 @@ func (f *ExactEvmSchemeV1) verify(
 			classification.SigData,
 		)
 		if err != nil {
-			return nil, x402.NewVerifyError(ErrInvalidPayload, evmPayload.Authorization.From, err.Error())
+			return nil, x402.NewVerifyError(exactfacilitator.ErrEip3009SimulationFailed, evmPayload.Authorization.From, err.Error())
 		}
 		if !simulationSucceeded {
 			reason := exactfacilitator.DiagnoseEIP3009SimulationFailure(

--- a/python/x402/mechanisms/evm/exact/eip3009_utils.py
+++ b/python/x402/mechanisms/evm/exact/eip3009_utils.py
@@ -9,10 +9,14 @@ from ..constants import (
     BALANCE_OF_ABI,
     ERR_EIP3009_NOT_SUPPORTED,
     ERR_INSUFFICIENT_BALANCE,
+    ERR_INVALID_SIGNATURE,
     ERR_NONCE_ALREADY_USED,
     ERR_TOKEN_NAME_MISMATCH,
     ERR_TOKEN_VERSION_MISMATCH,
+    ERR_TRANSACTION_FAILED,
     ERR_TRANSACTION_SIMULATION_FAILED,
+    ERR_VALID_AFTER_FUTURE,
+    ERR_VALID_BEFORE_EXPIRED,
     FUNCTION_TRANSFER_WITH_AUTHORIZATION,
     NAME_ABI,
     TRANSFER_WITH_AUTHORIZATION_BYTES_ABI,
@@ -265,6 +269,29 @@ def diagnose_eip3009_simulation_failure(
             pass
 
     return ERR_TRANSACTION_SIMULATION_FAILED
+
+
+def parse_eip3009_transfer_error(error: Exception) -> str:
+    """Map an EIP-3009 contract revert to a specific error code.
+
+    Falls back to ERR_TRANSACTION_FAILED when the revert reason is unknown.
+    """
+    msg = str(error).lower()
+    if "authorization is expired" in msg or "authorizationexpired" in msg:
+        return ERR_VALID_BEFORE_EXPIRED
+    if "authorization is not yet valid" in msg or "authorizationnotyetvalid" in msg:
+        return ERR_VALID_AFTER_FUTURE
+    if (
+        "authorization is used" in msg
+        or "authorizationalreadyused" in msg
+        or "authorizationusedorcanceled" in msg
+    ):
+        return ERR_NONCE_ALREADY_USED
+    if "transfer amount exceeds balance" in msg or "erc20insufficientbalance" in msg:
+        return ERR_INSUFFICIENT_BALANCE
+    if "invalid signature" in msg or "signermismatch" in msg or "invalidsignaturev" in msg or "invalidsignatures" in msg:
+        return ERR_INVALID_SIGNATURE
+    return ERR_TRANSACTION_FAILED
 
 
 def execute_transfer_with_authorization(

--- a/python/x402/mechanisms/evm/exact/eip3009_utils.py
+++ b/python/x402/mechanisms/evm/exact/eip3009_utils.py
@@ -289,7 +289,12 @@ def parse_eip3009_transfer_error(error: Exception) -> str:
         return ERR_NONCE_ALREADY_USED
     if "transfer amount exceeds balance" in msg or "erc20insufficientbalance" in msg:
         return ERR_INSUFFICIENT_BALANCE
-    if "invalid signature" in msg or "signermismatch" in msg or "invalidsignaturev" in msg or "invalidsignatures" in msg:
+    if (
+        "invalid signature" in msg
+        or "signermismatch" in msg
+        or "invalidsignaturev" in msg
+        or "invalidsignatures" in msg
+    ):
         return ERR_INVALID_SIGNATURE
     return ERR_TRANSACTION_FAILED
 

--- a/python/x402/mechanisms/evm/exact/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/facilitator.py
@@ -34,6 +34,7 @@ from ..exact.eip3009_utils import (
     diagnose_eip3009_simulation_failure,
     execute_transfer_with_authorization,
     parse_eip3009_authorization,
+    parse_eip3009_transfer_error,
     simulate_eip3009_transfer,
 )
 from ..exact.permit2_utils import settle_permit2, verify_permit2
@@ -379,7 +380,7 @@ class ExactEvmScheme:
         except Exception as e:
             return SettleResponse(
                 success=False,
-                error_reason=ERR_TRANSACTION_FAILED,
+                error_reason=parse_eip3009_transfer_error(e),
                 error_message=str(e),
                 network=network,
                 payer=payer,

--- a/python/x402/mechanisms/evm/exact/v1/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/v1/facilitator.py
@@ -34,6 +34,7 @@ from ..eip3009_utils import (
     diagnose_eip3009_simulation_failure,
     execute_transfer_with_authorization,
     parse_eip3009_authorization,
+    parse_eip3009_transfer_error,
     simulate_eip3009_transfer,
 )
 
@@ -366,7 +367,7 @@ class ExactEvmSchemeV1:
         except Exception as e:
             return SettleResponse(
                 success=False,
-                error_reason=ERR_TRANSACTION_FAILED,
+                error_reason=parse_eip3009_transfer_error(e),
                 error_message=str(e),
                 network=network,
                 payer=payer,

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009-utils.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009-utils.ts
@@ -189,6 +189,35 @@ export async function diagnoseEip3009SimulationFailure(
 }
 
 /**
+ * Maps an EIP-3009 contract revert error to a specific error code.
+ * Falls back to ErrTransactionFailed when the revert reason is unknown.
+ *
+ * @param error - The error thrown during transfer execution
+ * @returns A specific error reason string
+ */
+export function parseEip3009TransferError(error: unknown): string {
+  const msg = error instanceof Error ? error.message : String(error);
+  if (/authorization.*(expired|valid before)/i.test(msg) || /AuthorizationExpired/i.test(msg)) {
+    return Errors.ErrValidBeforeExpired;
+  }
+  if (/authorization.*not.*valid|AuthorizationNotYetValid/i.test(msg)) {
+    return Errors.ErrValidAfterInFuture;
+  }
+  if (
+    /authorization.*used|AuthorizationAlreadyUsed|AuthorizationUsedOrCanceled/i.test(msg)
+  ) {
+    return Errors.ErrEip3009NonceAlreadyUsed;
+  }
+  if (/transfer.*exceeds.*balance|insufficient.*balance|ERC20InsufficientBalance/i.test(msg)) {
+    return Errors.ErrEip3009InsufficientBalance;
+  }
+  if (/invalid.*signature|SignerMismatch|InvalidSignatureV|InvalidSignatureS/i.test(msg)) {
+    return Errors.ErrInvalidSignature;
+  }
+  return Errors.ErrTransactionFailed;
+}
+
+/**
  * Executes transferWithAuthorization onchain.
  *
  * @param signer - EVM signer for contract writes

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009-utils.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009-utils.ts
@@ -203,9 +203,7 @@ export function parseEip3009TransferError(error: unknown): string {
   if (/authorization.*not.*valid|AuthorizationNotYetValid/i.test(msg)) {
     return Errors.ErrValidAfterInFuture;
   }
-  if (
-    /authorization.*used|AuthorizationAlreadyUsed|AuthorizationUsedOrCanceled/i.test(msg)
-  ) {
+  if (/authorization.*used|AuthorizationAlreadyUsed|AuthorizationUsedOrCanceled/i.test(msg)) {
     return Errors.ErrEip3009NonceAlreadyUsed;
   }
   if (/transfer.*exceeds.*balance|insufficient.*balance|ERC20InsufficientBalance/i.test(msg)) {

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -13,6 +13,7 @@ import * as Errors from "./errors";
 import {
   diagnoseEip3009SimulationFailure,
   executeTransferWithAuthorization,
+  parseEip3009TransferError,
   simulateEip3009Transfer,
 } from "./eip3009-utils";
 
@@ -318,10 +319,10 @@ export async function settleEIP3009(
       network: payload.accepted.network,
       payer,
     };
-  } catch {
+  } catch (error) {
     return {
       success: false,
-      errorReason: Errors.ErrTransactionFailed,
+      errorReason: parseEip3009TransferError(error),
       transaction: "",
       network: payload.accepted.network,
       payer,


### PR DESCRIPTION
## Summary

- In `verifyEIP3009` (Go v2 and v1), simulation RPC/network errors now return `ErrEip3009SimulationFailed` instead of the generic `ErrInvalidPayload`, making it clear the payload itself was valid but simulation could not run.
- In `settleEIP3009` (Go v2), errors from `ExecuteTransferWithAuthorization` are now parsed by a new `parseEIP3009TransferError` function that maps known EIP-3009 contract revert reasons (authorization expired, not yet valid, nonce already used, insufficient balance, invalid signature) to specific error codes rather than the blanket `ErrFailedToExecuteTransfer`.
- In `settleEIP3009` (TypeScript), the catch block now calls `parseEip3009TransferError` to surface the same specific error codes.

## Test plan

Tests passing