### PR TITLE
ecosystem: add _nullpath

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/_nullpath/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/_nullpath/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "_nullpath",
+  "description": "AI agent marketplace with x402 micropayments. Register agents for $0.10 USDC, discover by capability and reputation, execute with per-request payments. Features multi-agent orchestration, trust tiers, and MCP integration.",
+  "logoUrl": "/logos/nullpath.svg",
+  "websiteUrl": "https://nullpath.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/nullpath.svg
+++ b/typescript/site/public/logos/nullpath.svg
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="168"
+   height="168"
+   viewBox="0 0 44.449999 44.45"
+   version="1.1"
+   id="svg1"
+   inkscape:export-filename="brandmark.svg"
+   inkscape:export-xdpi="99.590767"
+   inkscape:export-ydpi="99.590767"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   sodipodi:docname="drawing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.3484711"
+     inkscape:cx="131.63055"
+     inkscape:cy="-117.91131"
+     inkscape:window-width="1472"
+     inkscape:window-height="891"
+     inkscape:window-x="0"
+     inkscape:window-y="37"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g4-7"
+       transform="matrix(0.04641606,0,0,0.04546598,-25.295781,-2.0976723)"
+       style="display:inline">
+      <path
+         style="display:inline;fill:#29dda1;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+         d="M 673.51438,440.66705 895.04033,376.4527 818.12927,337.30303 c 84.61286,-97.97031 245.04813,-133.34839 381.89333,-31.44989 l 52.7343,-52.34173 C 1195.4426,196.89746 958.42252,87.413142 762.79374,282.70578 l -46.24217,-67.05745 z"
+         id="path1-15"
+         sodipodi:nodetypes="cccccccc" />
+      <path
+         style="display:inline;fill:#29dda1;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+         d="m 665.5232,477.87534 81.99064,-23.54194 c -29.94525,133.01893 7.54,196.28013 48.58695,258.59905 l -53.47212,51.15323 C 689.5851,701.90493 643.14646,607.5574 665.5232,477.87534 Z"
+         id="path3-2"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:#346868;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+         d="m 742.55174,764.20061 31.56645,-30.1966 C 725.01445,694.86965 675.83697,615.81652 660.37376,563.95532 c 2.322,72.2535 34.14209,143.14029 82.17798,200.24529 z"
+         id="path4-1"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+         d="m 655.08509,872.84916 38.1609,30.02133 C 923.82083,665.88444 1222.2742,380.53944 1392.5157,198.46415 L 1359.81,167.05794 C 1202.9663,327.37743 888.45302,635.31409 655.08509,872.84916 Z"
+         id="path5-1"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:#29dda1;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+         d="m 1252.9114,359.44614 53.2988,-52.34407 c 177.5379,223.46183 37.2236,521.7823 -173.4883,574.57152 158.9606,-105.72886 247.1833,-355.30652 120.1895,-522.22745 z"
+         id="path6-0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="display:inline;fill:#29dda1;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+         d="m 819.64709,792.15536 26.53421,-29.23265 c 49.95541,38.65803 174.2988,104.86062 331.7835,17.10817 -91.5471,80.17789 -227.68071,91.66598 -358.31771,12.12448 z"
+         id="path7-18"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="display:inline;fill:#346868;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+         d="m 825.60963,785.61045 -30.3857,31.09731 c 205.44507,174.19539 593.29417,79.89093 515.93167,-314.74769 10.7568,214.31234 -139.0983,279.85601 -181.8857,306.54416 -141.65463,73.96872 -231.91936,15.63654 -303.66027,-22.89378 z"
+         id="path8-7"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="display:inline;fill:#346868;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-dasharray:none;stroke-opacity:1"
+         d="M 818.14639,337.30919 C 872.43508,222.30578 1062.3455,159.25601 1229.9801,276.10601 l -29.9562,29.77487 c -97.1854,-73.41992 -265.40722,-96.36543 -381.87751,31.42831 z"
+         id="path14-6"
+         sodipodi:nodetypes="cccc"
+         inkscape:label="path14" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Add _nullpath to x402 ecosystem

**_nullpath** is an AI agent marketplace on Cloudflare Workers using x402 micropayments on Base mainnet.

### What it does
- Register AI agents for $0.10 USDC
- Discover agents by capability, price, and reputation
- Execute capabilities with per-request x402 payments
- Multi-agent orchestration, trust tiers, MCP integration

### Links
- https://nullpath.com
- https://docs.nullpath.com
- https://nullpath.com/openapi.json
- https://www.npmjs.com/package/nullpath-mcp

### Category
Services/Endpoints

### Files
- `typescript/site/app/ecosystem/partners-data/_nullpath/metadata.json`
- `typescript/site/public/logos/nullpath.svg`