### PR TITLE
fix(go): implement SupportedCache Clear

### DIFF
--- a/go/server.go
+++ b/go/server.go
@@ -117,6 +117,15 @@ func (c *SupportedCache) Get(key string) (SupportedResponse, bool) {
 	return response, true
 }
 
+// Clear removes all cached supported responses and expiry entries
+func (c *SupportedCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	clear(c.data)
+	clear(c.expiry)
+}
+
 // ResourceServerOption configures the server
 type ResourceServerOption func(*x402ResourceServer)
 

--- a/go/server_test.go
+++ b/go/server_test.go
@@ -571,8 +571,6 @@ func TestServerProcessPaymentRequest(t *testing.T) {
 }
 */
 
-// TestSupportedCache - SKIPPED: Cache.Clear method not implemented
-/*
 func TestSupportedCache(t *testing.T) {
 	cache := &SupportedCache{
 		data:   make(map[string]SupportedResponse),
@@ -588,16 +586,22 @@ func TestSupportedCache(t *testing.T) {
 		Signers:    make(map[string][]string),
 	}
 
-	// Set and verify
+	// Set stores the value.
 	cache.Set("test", response)
 	if len(cache.data) != 1 {
 		t.Fatal("Expected item in cache")
 	}
 
-	// Wait for expiry
-	time.Sleep(150 * time.Millisecond)
+	// Get returns the stored value before expiry.
+	cached, ok := cache.Get("test")
+	if !ok {
+		t.Fatal("Expected cached item to be found")
+	}
+	if len(cached.Kinds) != 1 || cached.Kinds[0].Scheme != "exact" || cached.Kinds[0].Network != "eip155:1" {
+		t.Fatalf("Expected cached response to match stored value, got %+v", cached)
+	}
 
-	// Clear cache
+	// Clear removes all data and expiry state.
 	cache.Clear()
 	if len(cache.data) != 0 {
 		t.Fatal("Expected cache to be cleared")
@@ -605,8 +609,12 @@ func TestSupportedCache(t *testing.T) {
 	if len(cache.expiry) != 0 {
 		t.Fatal("Expected expiry map to be cleared")
 	}
+
+	// Get returns false after the cache is cleared.
+	if _, ok := cache.Get("test"); ok {
+		t.Fatal("Expected cache miss after Clear")
+	}
 }
-*/
 
 func TestResolveSettlementOverrideAmount(t *testing.T) {
 	baseReqs := types.PaymentRequirements{


### PR DESCRIPTION
## Description

Implements `SupportedCache.Clear()` and restores the focused cache test that was previously skipped because the method was missing.

`Clear()` now clears both cached supported responses and their expiry entries while holding the existing cache lock.

## Tests

- `go test . -run TestSupportedCache -v`
