### PR TITLE
docs: document v1→v2 schema declaration change in migration guide

### DIFF
--- a/docs/guides/migration-v1-to-v2.mdx
+++ b/docs/guides/migration-v1-to-v2.mdx
@@ -310,6 +310,10 @@ description: "This guide helps you migrate from x402 V1 to V2. The V2 protocol i
   </Tab>
 </Tabs>
 
+### Schema Declaration
+
+In V2, hand-rolling `extensions.bazaar.schema` on a route config passes through `@x402/core` unchanged but fails silently during discovery-crawler verification, because the required envelope fields (`type`, `method`, `bodyType`, `body` for input; `type`, `example` for output) are only populated by the `declareDiscoveryExtension()` helper from `@x402/extensions/bazaar`. V1 declared these as `config.inputSchema` / `config.outputSchema` and relied on middleware forwarding; V2 requires the helper and spreads its return value into `extensions.bazaar`. See the [Bazaar Discovery Extension](/extensions/bazaar) documentation for full helper usage.
+
 ## Network Identifier Mapping
 
 | V1 Name | V2 CAIP-2 ID | Chain ID | Description |


### PR DESCRIPTION
## Description

The migration guide documents package renames, CAIP-2 network format, the `accepts[]` route config change, and resource server registration, but does not mention that input/output schema declaration also moved between V1 and V2. Adopters who hand-roll `extensions.bazaar.schema` — a field path that looks plausible from the rendered 402 payload — pass validation on the way out of `@x402/core` but fail silently during discovery-crawler verification because the required envelope fields (`type`, `method`, `bodyType`, `body` for input; `type`, `example` for output) only get populated by the `declareDiscoveryExtension()` helper.

The `@x402/extensions/bazaar` README already documents the correct pattern; this PR adds the pointer from the migration guide so the change is discoverable for v2 adopters coming from v1.

## Tests

Docs-only change — no code paths affected, no tests required.

Verified locally:
- MDX renders correctly against existing `### Before` / `### After` / `### Key Changes` siblings under `## For Sellers`
- `/extensions/bazaar` link resolves to the Bazaar Discovery Extension docs page (path consistent with other cross-refs in this guide)
- New `### Schema Declaration` section sits between line 292 `### Key Changes` (For Sellers) and line 317 `## Network Identifier Mapping`

## Checklist

- [x] I have formatted and linted my code (docs-only, no lint applicable)
- [x] All new and existing tests pass (docs-only, no tests)
- [x] My commits are signed (required for merge) — verified as `e41a787`, GPG signature confirmed
- [x] I added a changelog fragment for user-facing changes (docs-only change, skipped per template guidance)

## AI disclosure

This PR used an agentic coding workflow and was reviewed by Ken Burbary (an actual human) before posting.