### PR TITLE
specs: add TRON scheme specifications

### DIFF
--- a/specs/schemes/batch-settlement/scheme_batch_settlement.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement.md
@@ -75,3 +75,7 @@ Network bindings may use optional extensions to communicate additional requireme
 [`exact`](../exact/scheme_exact.md) — value is transferred immediately per request.
 
 [`upto`](../upto/scheme_upto.md) — value is transferred immediately, variable amount up to a client-authorized maximum.
+
+### Network-specific bindings
+
+- TRON: See [`scheme_batch_settlement_tron.md`](./scheme_batch_settlement_tron.md)

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_tron.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_tron.md
@@ -1,0 +1,153 @@
+# Scheme: `batch-settlement` on `TRON`
+
+## Summary
+
+The TRON binding implements capital-backed, unidirectional payment channels. The payer deposits
+TRC-20 funds once, signs cumulative TIP-712 vouchers for requests, and the receiver later claims and
+settles many vouchers on-chain. A cooperative refund returns unused funds.
+
+The wire structures match the EVM binding where possible. TRON Base58Check addresses are accepted at
+the protocol boundary and normalized to 20-byte hex for hashing, typed data, and contract calls.
+
+## Networks and Contracts
+
+| Network | Channel contract | ERC-3009 collector | Permit2 collector |
+| --- | --- | --- | --- |
+| `tron:0x2b6653dc` | `TW9yNhTySkEHYfjnGQU2u4NAsdb1tW4fbm` | `TTWA7aWMdx4jfcbp8XRAS2JAd2sUhyF9qj` | `TAg5qqp1K9x5KeSTWnRa8LT79B5HUjzSHY` |
+| `tron:0xcd8690dc` | `TWBwWHZWwH8TzrZnbxit1J645VGYY1K2fA` | `TJUQ3BQt4YFg8EeevjiUa5LbfSGz5BxzRW` | `TEp6bCqSEKAr99sCiqANC84RtRwx7xGbA4` |
+| `tron:0x94a9059e` | `TA3MZHMLsgi8JMU1DL8H4gKp1YjJKATibf` | `TRd1KBfy1iUs6R45oZrtbLUjtcSKzXAvPG` | `TNmfrxbKCHqPUTj9zHVfg4Dq8WNZXPyf1x` |
+
+The channel TIP-712 domain is `{ name: "x402 Batch Settlement", version: "1", chainId,
+verifyingContract: channelContract }`.
+
+## Payment Requirements
+
+`PaymentRequirements.extra` contains:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `receiverAuthorizer` | Yes | Key authorized to approve claims and cooperative refunds |
+| `withdrawDelay` | Yes | Withdrawal delay in seconds, from 900 through 2,592,000 |
+| `name`, `version` | For ERC-3009 deposits | Token TIP-712 domain |
+| `assetTransferMethod` | No | `eip3009` (default) or `permit2` |
+| `channelState`, `voucherState` | Corrective 402 only | Server state used to resynchronize a client |
+
+The receiver authorizer may be held by the resource server or advertised by the facilitator. It MUST
+be non-zero and must match `channelConfig.receiverAuthorizer`.
+
+## Channel Configuration and ID
+
+```text
+ChannelConfig(
+  address payer,
+  address payerAuthorizer,
+  address receiver,
+  address receiverAuthorizer,
+  address token,
+  uint40 withdrawDelay,
+  bytes32 salt
+)
+```
+
+The channel ID is the hash of the typed channel configuration under the network's channel-contract
+domain. `payerAuthorizer` signs vouchers; it may equal the payer or be a delegated key.
+
+## Request Payloads
+
+The first request or a top-up uses `type: "deposit"`:
+
+```json
+{
+  "type": "deposit",
+  "channelConfig": {
+    "payer": "TPayerAddress",
+    "payerAuthorizer": "TPayerAddress",
+    "receiver": "TReceiverAddress",
+    "receiverAuthorizer": "TAuthorizerAddress",
+    "token": "TTokenAddress",
+    "withdrawDelay": 900,
+    "salt": "0x0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "voucher": {
+    "channelId": "0x...",
+    "maxClaimableAmount": "1000",
+    "signature": "0x..."
+  },
+  "deposit": {
+    "amount": "5000",
+    "authorization": {
+      "permit2Authorization": {
+        "from": "0x...",
+        "permitted": { "token": "0x...", "amount": "5000" },
+        "spender": "0x...",
+        "nonce": "1",
+        "deadline": "1786500000",
+        "witness": { "channelId": "0x..." },
+        "signature": "0x..."
+      }
+    }
+  }
+}
+```
+
+An EIP-3009 deposit instead carries `erc3009Authorization` with `validAfter`, `validBefore`, `salt`,
+and `signature`. Its signed `ReceiveWithAuthorization` sends the deposit to the configured collector;
+the nonce is `keccak256(abi.encode(channelId, salt))`.
+
+Subsequent requests use `type: "voucher"` with the same `channelConfig` and a voucher whose
+`maxClaimableAmount` is cumulative. The voucher primary type is
+`Voucher(bytes32 channelId,uint128 maxClaimableAmount)`.
+
+The server MAY accept a `type: "refund"` payload carrying the latest voucher and an optional amount.
+It enriches that request with current claim data and authorizer signatures before facilitator
+settlement.
+
+## Verification
+
+For deposits, the facilitator MUST validate:
+
+1. Scheme, network, channel ID, receiver, receiver authorizer, token, and withdrawal delay.
+2. The deposit authorization selected by `assetTransferMethod`.
+3. For Permit2: configured collector spender, token, deposit amount, channel witness, deadline,
+   signature, and sufficient allowance.
+4. For ERC-3009: token domain, collector recipient, deposit amount, derived nonce, time window, and
+   signature.
+5. The cumulative voucher signature and that `maxClaimableAmount` fits within post-deposit balance
+   and is greater than already claimed value.
+
+For vouchers and refunds, the facilitator verifies channel configuration, voucher signature,
+on-chain channel existence, monotonic cumulative value, and balance bounds.
+
+The resource server serializes same-channel requests with a bounded pending reservation. It rejects a
+voucher whose cumulative value does not equal `chargedCumulativeAmount + requestAmount`, and returns
+corrective `channelState`/`voucherState` when the client must resynchronize.
+
+## Settlement and Deferred Actions
+
+| Payload type | Action |
+| --- | --- |
+| `deposit` | Call channel `deposit` through the selected collector and return the updated channel state |
+| `voucher` | No immediate transfer; persist the verified cumulative commitment |
+| `claim` | Call `claimWithSignature` for a batch of vouchers and update accounting |
+| `settle` | Transfer claimed-but-unsettled tokens for a receiver/token pair |
+| enriched `refund` | Claim as needed, then call `refundWithSignature` cooperatively |
+
+Successful deposit settlement returns the deposited amount and channel state. Voucher request
+responses carry `chargedAmount`, channel state, and the latest signed voucher in `SettleResponse.extra`.
+
+## Error Codes
+
+TRON errors use the prefix `invalid_batch_settlement_tron_`. Stable categories cover channel lookup
+and ID mismatch, token/receiver/authorizer mismatch, invalid voucher signatures, cumulative amount
+bounds, deposit authorization or allowance failures, channel busy/resynchronization, invalid refund
+amounts, RPC reads, and failed deposit/claim/settle/refund transactions. The exported names in
+`typescript/packages/mechanisms/tron/src/batch-settlement/errors.ts` are the authoritative list.
+
+## Security Considerations
+
+- Vouchers are cumulative and MUST be monotonic relative to on-chain claimed state.
+- A server MUST durably store its charged cumulative amount before accepting concurrent work.
+- The receiver authorizer can approve claims and refunds; operators SHOULD isolate and rotate this key.
+- `withdrawDelay` bounds unilateral exit risk and MUST stay within the contract limits.
+- Deposit collectors and Permit2 addresses are network constants, never payload-selected contracts.
+- A corrective 402 is part of state recovery, not authorization to reduce an already claimed amount.

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_tron.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_tron.md
@@ -13,9 +13,9 @@ the protocol boundary and normalized to 20-byte hex for hashing, typed data, and
 
 | Network | Channel contract | ERC-3009 collector | Permit2 collector |
 | --- | --- | --- | --- |
-| `tron:0x2b6653dc` | `TW9yNhTySkEHYfjnGQU2u4NAsdb1tW4fbm` | `TTWA7aWMdx4jfcbp8XRAS2JAd2sUhyF9qj` | `TAg5qqp1K9x5KeSTWnRa8LT79B5HUjzSHY` |
-| `tron:0xcd8690dc` | `TWBwWHZWwH8TzrZnbxit1J645VGYY1K2fA` | `TJUQ3BQt4YFg8EeevjiUa5LbfSGz5BxzRW` | `TEp6bCqSEKAr99sCiqANC84RtRwx7xGbA4` |
-| `tron:0x94a9059e` | `TA3MZHMLsgi8JMU1DL8H4gKp1YjJKATibf` | `TRd1KBfy1iUs6R45oZrtbLUjtcSKzXAvPG` | `TNmfrxbKCHqPUTj9zHVfg4Dq8WNZXPyf1x` |
+| `tron:728126428` | `TW9yNhTySkEHYfjnGQU2u4NAsdb1tW4fbm` | `TTWA7aWMdx4jfcbp8XRAS2JAd2sUhyF9qj` | `TAg5qqp1K9x5KeSTWnRa8LT79B5HUjzSHY` |
+| `tron:3448148188` | `TWBwWHZWwH8TzrZnbxit1J645VGYY1K2fA` | `TJUQ3BQt4YFg8EeevjiUa5LbfSGz5BxzRW` | `TEp6bCqSEKAr99sCiqANC84RtRwx7xGbA4` |
+| `tron:2494104990` | `TA3MZHMLsgi8JMU1DL8H4gKp1YjJKATibf` | `TRd1KBfy1iUs6R45oZrtbLUjtcSKzXAvPG` | `TNmfrxbKCHqPUTj9zHVfg4Dq8WNZXPyf1x` |
 
 The channel TIP-712 domain is `{ name: "x402 Batch Settlement", version: "1", chainId,
 verifyingContract: channelContract }`.
@@ -135,12 +135,25 @@ corrective `channelState`/`voucherState` when the client must resynchronize.
 Successful deposit settlement returns the deposited amount and channel state. Voucher request
 responses carry `chargedAmount`, channel state, and the latest signed voucher in `SettleResponse.extra`.
 
+For every broadcast action (`deposit`, `claim`, `settle`, or `refund`), the facilitator waits for a
+receipt using a configurable confirmation budget (90 seconds by default). If the budget expires,
+receipt RPC fails, or receipt effect processing is indeterminate after broadcast, it returns
+`success: false`, `errorReason: "settlement_pending"`, and the original transaction ID. An explicit
+revert is terminal and also preserves the transaction ID. The original transaction MUST be
+reconciled and MUST NOT be rebroadcast.
+
+When an operation returns `settlement_pending`, the resource server MUST retain the corresponding
+channel reservation until the original transaction reaches a terminal status. It commits channel
+state after confirmed success and releases only the matching reservation after confirmed revert.
+Status-query failures remain fail-closed and MUST NOT cause a reservation to be released merely
+because its ordinary TTL elapsed.
+
 ## Error Codes
 
 TRON errors use the prefix `invalid_batch_settlement_tron_`. Stable categories cover channel lookup
 and ID mismatch, token/receiver/authorizer mismatch, invalid voucher signatures, cumulative amount
 bounds, deposit authorization or allowance failures, channel busy/resynchronization, invalid refund
-amounts, RPC reads, and failed deposit/claim/settle/refund transactions. The exported names in
+amounts, RPC reads, `settlement_pending`, and failed deposit/claim/settle/refund transactions. The exported names in
 `typescript/packages/mechanisms/tron/src/batch-settlement/errors.ts` are the authoritative list.
 
 ## Security Considerations

--- a/specs/schemes/exact-gasfree/scheme_exact_gasfree_tron.md
+++ b/specs/schemes/exact-gasfree/scheme_exact_gasfree_tron.md
@@ -1,0 +1,136 @@
+# Scheme: `exact_gasfree` on `TRON`
+
+## Summary
+
+The client signs a TIP-712 `PermitTransfer` for the network's GasFreeController. The facilitator
+verifies the signed terms, submits them to a GasFree relayer, polls until the transaction succeeds or
+fails, and returns the resulting TRON transaction ID.
+
+## Networks and Contracts
+
+| Network | GasFreeController | Beacon | Default relayer base URL |
+| --- | --- | --- | --- |
+| `tron:0x2b6653dc` | `TFFAMQLZybALaLb4uxHA9RBE7pxhUAjF3U` | `TSP9UW6FQhT76XD2jWA6ipGMx3yGbjDffP` | `https://facilitator.bankofai.io/mainnet` |
+| `tron:0xcd8690dc` | `THQGuFzL87ZqhxkgqYEryRAd7gqFqL5rdc` | `TLtCGmaxH3PbuaF6kbybwteZcHptEdgQGC` | `https://facilitator.bankofai.io/nile` |
+| `tron:0x94a9059e` | `TQghdCeVDA6CnuNVTUhfaAyPfTetqZWNpm` | `TQ1jvA3nLDMDNbJoMPLzTPoqAg8NvZ5CCW` | `https://facilitator.bankofai.io/shasta` |
+
+Deployments MAY override the relayer URL, but MUST retain the controller associated with the selected
+network unless using a separately specified GasFree deployment.
+
+## Payment Requirements
+
+`scheme` is `exact_gasfree`; `network` is a supported `tron:*` identifier; `asset`, `amount`, and
+`payTo` identify the TRC-20 payment. GasFree provider fees are not included in requirements and MUST
+NOT be advertised as `extra.fee`.
+
+## Payment Payload
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "exact_gasfree",
+    "network": "tron:0xcd8690dc",
+    "amount": "1000",
+    "asset": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+    "payTo": "TReceiverAddress",
+    "maxTimeoutSeconds": 60,
+    "extra": {}
+  },
+  "payload": {
+    "signature": "0x...",
+    "gasfreeAddress": "TGasFreeAddress",
+    "gasfree": {
+      "token": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+      "serviceProvider": "TProviderAddress",
+      "user": "TPayerAddress",
+      "receiver": "TReceiverAddress",
+      "value": "1000",
+      "maxFee": "1000000",
+      "deadline": "1786500000",
+      "version": "1",
+      "nonce": "7"
+    }
+  },
+  "extensions": {
+    "scheme": "exact_gasfree",
+    "gasfreeAddress": "TGasFreeAddress"
+  }
+}
+```
+
+The `extensions` fields above are emitted by the current client as compatibility metadata. The
+facilitator validates the `payload` fields.
+
+## TIP-712 Authorization
+
+The domain is:
+
+```json
+{
+  "name": "GasFreeController",
+  "version": "V1.0.0",
+  "chainId": 3448148188,
+  "verifyingContract": "0x..."
+}
+```
+
+`verifyingContract` is the selected controller normalized to 20-byte hex. The primary type is:
+
+```text
+PermitTransfer(
+  address token,
+  address serviceProvider,
+  address user,
+  address receiver,
+  uint256 value,
+  uint256 maxFee,
+  uint256 deadline,
+  uint256 version,
+  uint256 nonce
+)
+```
+
+The client obtains its GasFree address, activation state, nonce, supported assets, fees, and available
+providers from the relayer. `maxFee` is the transfer fee plus activation fee when required. If fee
+metadata is unavailable, the current SDK uses one whole token as a conservative fallback.
+
+Mainnet deadlines are clamped to roughly 55–595 seconds from creation; testnet deadlines are clamped
+to roughly 55–3595 seconds. A caller-requested deadline below the minimum is rejected.
+
+## Verification
+
+The facilitator MUST:
+
+1. Require a complete `gasfree` object and signature.
+2. Match scheme and network.
+3. Match token and receiver after TRON address normalization.
+4. Require `gasfree.value >= requirements.amount`.
+5. Fetch providers and require an exact provider address match. Provider lookup failure or an empty
+   list is invalid.
+6. Reject an expired deadline.
+7. Reconstruct the TIP-712 message and verify the signature against `gasfree.user`.
+
+## Settlement
+
+The facilitator re-verifies, performs a best-effort balance check for `amount + maxFee` at
+`gasfreeAddress`, submits the message and signature to `POST /api/v1/gasfree/submit`, and polls the
+returned trace ID. Success requires a terminal success/on-chain state and a non-empty transaction
+hash.
+
+## Error Codes
+
+Stable reasons include `invalid_exact_gasfree_scheme`, `invalid_exact_gasfree_network_mismatch`,
+`missing_gasfree_payload`, `gasfree_token_mismatch`, `gasfree_amount_mismatch`,
+`gasfree_payto_mismatch`, `gasfree_fee_to_mismatch`, `gasfree_expired`,
+`invalid_gasfree_signature`, `insufficient_funds`, `gasfree_api_no_response`,
+`gasfree_missing_transaction_hash`, and `gasfree_provider_list_unavailable`.
+
+Relayer transport errors may be returned as `errorReason` text by the current implementation.
+
+## Security Considerations
+
+The provider and `maxFee` are signed, preventing facilitator substitution. The account nonce and
+deadline limit replay. The facilitator MUST validate the provider list at verification time so that a
+payment accepted by `/verify` is likely to be accepted by `/settle`. Operators SHOULD use authenticated
+or trusted relayer endpoints and avoid logging full signed payloads.

--- a/specs/schemes/exact-gasfree/scheme_exact_gasfree_tron.md
+++ b/specs/schemes/exact-gasfree/scheme_exact_gasfree_tron.md
@@ -10,9 +10,9 @@ fails, and returns the resulting TRON transaction ID.
 
 | Network | GasFreeController | Beacon | Default relayer base URL |
 | --- | --- | --- | --- |
-| `tron:0x2b6653dc` | `TFFAMQLZybALaLb4uxHA9RBE7pxhUAjF3U` | `TSP9UW6FQhT76XD2jWA6ipGMx3yGbjDffP` | `https://facilitator.bankofai.io/mainnet` |
-| `tron:0xcd8690dc` | `THQGuFzL87ZqhxkgqYEryRAd7gqFqL5rdc` | `TLtCGmaxH3PbuaF6kbybwteZcHptEdgQGC` | `https://facilitator.bankofai.io/nile` |
-| `tron:0x94a9059e` | `TQghdCeVDA6CnuNVTUhfaAyPfTetqZWNpm` | `TQ1jvA3nLDMDNbJoMPLzTPoqAg8NvZ5CCW` | `https://facilitator.bankofai.io/shasta` |
+| `tron:728126428` | `TFFAMQLZybALaLb4uxHA9RBE7pxhUAjF3U` | `TSP9UW6FQhT76XD2jWA6ipGMx3yGbjDffP` | `https://facilitator.bankofai.io/mainnet` |
+| `tron:3448148188` | `THQGuFzL87ZqhxkgqYEryRAd7gqFqL5rdc` | `TLtCGmaxH3PbuaF6kbybwteZcHptEdgQGC` | `https://facilitator.bankofai.io/nile` |
+| `tron:2494104990` | `TQghdCeVDA6CnuNVTUhfaAyPfTetqZWNpm` | `TQ1jvA3nLDMDNbJoMPLzTPoqAg8NvZ5CCW` | `https://facilitator.bankofai.io/shasta` |
 
 Deployments MAY override the relayer URL, but MUST retain the controller associated with the selected
 network unless using a separately specified GasFree deployment.
@@ -30,7 +30,7 @@ NOT be advertised as `extra.fee`.
   "x402Version": 2,
   "accepted": {
     "scheme": "exact_gasfree",
-    "network": "tron:0xcd8690dc",
+    "network": "tron:3448148188",
     "amount": "1000",
     "asset": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
     "payTo": "TReceiverAddress",
@@ -116,7 +116,10 @@ The facilitator MUST:
 The facilitator re-verifies, performs a best-effort balance check for `amount + maxFee` at
 `gasfreeAddress`, submits the message and signature to `POST /api/v1/gasfree/submit`, and polls the
 returned trace ID. Success requires a terminal success/on-chain state and a non-empty transaction
-hash.
+hash that is a valid TRON transaction ID. If polling becomes indeterminate after the relayer has
+exposed a valid transaction ID, settlement returns `settlement_pending` with that transaction ID.
+This matches the receipt-timeout behavior of the other settlement schemes and does not imply a
+Facilitator-managed reconciliation workflow.
 
 ## Error Codes
 
@@ -124,7 +127,8 @@ Stable reasons include `invalid_exact_gasfree_scheme`, `invalid_exact_gasfree_ne
 `missing_gasfree_payload`, `gasfree_token_mismatch`, `gasfree_amount_mismatch`,
 `gasfree_payto_mismatch`, `gasfree_fee_to_mismatch`, `gasfree_expired`,
 `invalid_gasfree_signature`, `insufficient_funds`, `gasfree_api_no_response`,
-`gasfree_missing_transaction_hash`, and `gasfree_provider_list_unavailable`.
+`gasfree_missing_transaction_hash`, `gasfree_invalid_transaction_hash`,
+`gasfree_transaction_failed`, `settlement_pending`, and `gasfree_provider_list_unavailable`.
 
 Relayer transport errors may be returned as `errorReason` text by the current implementation.
 

--- a/specs/schemes/exact/scheme_exact.md
+++ b/specs/schemes/exact/scheme_exact.md
@@ -54,4 +54,4 @@ While implementation details vary by network, facilitators MUST enforce security
 - Replay protection: the SNIP-9 nonce MUST be unused at verification; it is consumed on-chain at execution.
 - Simulation verification: MUST simulate the settlement and fail closed unless it shows exactly one asset `Transfer` from payer to `payTo` for the exact amount.
 
-Network-specific rules are in per-network documents: `scheme_exact_svm.md` (Solana), `scheme_exact_stellar.md` (Stellar), `scheme_exact_evm.md` (EVM), `scheme_exact_sui.md` (SUI), `scheme_exact_ton.md` (TON), `scheme_exact_starknet.md` (Starknet).
+Network-specific rules are in per-network documents: `scheme_exact_svm.md` (Solana), `scheme_exact_stellar.md` (Stellar), `scheme_exact_evm.md` (EVM), `scheme_exact_sui.md` (SUI), `scheme_exact_ton.md` (TON), `scheme_exact_starknet.md` (Starknet), `scheme_exact_tron.md` (TRON).

--- a/specs/schemes/exact/scheme_exact_tron.md
+++ b/specs/schemes/exact/scheme_exact_tron.md
@@ -1,0 +1,154 @@
+# Scheme: `exact` on `TRON`
+
+## Summary
+
+The TRON `exact` binding transfers one fixed TRC-20 amount. It supports:
+
+| `extra.assetTransferMethod` | Authorization | Settlement |
+| --- | --- | --- |
+| `eip3009` or omitted | TIP-712 `TransferWithAuthorization` | Call the token's `transferWithAuthorization` |
+| `permit2` | TIP-712 `PermitWitnessTransferFrom` | Call the network's `x402ExactPermit2Proxy.settle` |
+
+TRON Base58Check addresses are used in requirements and deployment configuration. Addresses inside
+TIP-712 typed data are normalized to 20-byte, `0x`-prefixed hex by removing the TRON `0x41` network
+prefix.
+
+## Networks and Contracts
+
+| Network | CAIP-2 ID | Permit2 | Exact proxy |
+| --- | --- | --- | --- |
+| Mainnet | `tron:0x2b6653dc` | `TTJxU3P8rHycAyFY4kVtGNfmnMH4ezcuM9` | `TN49yaJmZMZoEdDCqjB4uPzQLHvYkGw95m` |
+| Nile | `tron:0xcd8690dc` | `TYQuuhGbEMxF7nZxUHV3uHJxAVVAegNU9h` | `TFGoaq2KjizijgjtkVxT7yjffW1A5T1j6F` |
+| Shasta | `tron:0x94a9059e` | `TJMkP7a3ucTMkvi17p7ChhTCw6zriFX3tg` | `TGZkC38n14f2GpBWPMQLF2BpmcpWW3QNhg` |
+
+The numeric TIP-712 `chainId` is the hexadecimal CAIP-2 reference interpreted as an unsigned
+integer.
+
+## Payment Requirements
+
+The common fields follow the [core specification](../../x402-specification-v2.md#51-paymentrequired-schema).
+`extra` contains:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `assetTransferMethod` | No | `eip3009` (default) or `permit2` |
+| `name` | For `eip3009` | Token TIP-712 domain name |
+| `version` | For `eip3009` | Token TIP-712 domain version |
+
+The built-in token registry selects Permit2 for mainstream USDT/USDD deployments because those
+tokens do not expose TransferWithAuthorization.
+
+## TransferWithAuthorization Payload
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "exact",
+    "network": "tron:0xcd8690dc",
+    "amount": "1000",
+    "asset": "TTokenAddress",
+    "payTo": "TReceiverAddress",
+    "maxTimeoutSeconds": 60,
+    "extra": {
+      "assetTransferMethod": "eip3009",
+      "name": "Example Token",
+      "version": "1"
+    }
+  },
+  "payload": {
+    "signature": "0x...",
+    "authorization": {
+      "from": "0x1111111111111111111111111111111111111111",
+      "to": "0x2222222222222222222222222222222222222222",
+      "value": "1000",
+      "validAfter": "0",
+      "validBefore": "1786500000",
+      "nonce": "0x0000000000000000000000000000000000000000000000000000000000000001"
+    }
+  }
+}
+```
+
+The TIP-712 domain is `{ name, version, chainId, verifyingContract = asset }`. The primary type is
+`TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256
+validBefore,bytes32 nonce)`.
+
+## Permit2 Payload
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "exact",
+    "network": "tron:0xcd8690dc",
+    "amount": "1000",
+    "asset": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+    "payTo": "TReceiverAddress",
+    "maxTimeoutSeconds": 60,
+    "extra": { "assetTransferMethod": "permit2" }
+  },
+  "payload": {
+    "signature": "0x...",
+    "permit2Authorization": {
+      "from": "0x1111111111111111111111111111111111111111",
+      "permitted": {
+        "token": "0x2222222222222222222222222222222222222222",
+        "amount": "1000"
+      },
+      "spender": "0x3333333333333333333333333333333333333333",
+      "nonce": "1",
+      "deadline": "1786500000",
+      "witness": {
+        "to": "0x4444444444444444444444444444444444444444",
+        "validAfter": "0"
+      }
+    }
+  }
+}
+```
+
+The TIP-712 domain is `{ name: "Permit2", chainId, verifyingContract: Permit2 }`. The spender MUST
+be the configured exact proxy. The witness binds `payTo`; `permitted.token` and `permitted.amount`
+bind the asset and exact amount. The payer MUST first grant the Permit2 contract sufficient TRC-20
+allowance. The SDK-created client signer automatically broadcasts a one-time unlimited approval when
+needed and when its wallet can sign TRON transactions.
+
+## Verification
+
+The facilitator MUST:
+
+1. Match both schemes and the accepted network.
+2. Reconstruct typed data using the requirement's network and configured contracts.
+3. Verify the payer signature.
+4. Match recipient, asset, and exact amount.
+5. Require at least six seconds of remaining validity and reject a future `validAfter`.
+6. For Permit2, match the exact proxy spender and check Permit2 allowance when readable.
+7. Check payer token balance when readable.
+
+Allowance and balance read failures are treated optimistically by the current implementation; all
+cryptographic and term checks remain mandatory, and settlement is authoritative.
+
+## Settlement
+
+- TransferWithAuthorization: the facilitator calls the TRC-20 token directly with `(from, to,
+  value, validAfter, validBefore, nonce, v, r, s)`.
+- Permit2: the facilitator calls `x402ExactPermit2Proxy.settle(permit, owner, witness, signature)`.
+
+The facilitator waits for a successful receipt and returns the TRON transaction ID. It MUST re-run
+verification immediately before broadcasting.
+
+## Error Codes
+
+Stable reasons include `invalid_exact_tron_scheme`, `invalid_exact_tron_network_mismatch`,
+`invalid_exact_tron_payload_signature`, `invalid_exact_tron_payload_recipient_mismatch`,
+`invalid_exact_tron_payload_authorization_value_mismatch`, `invalid_permit2_spender`,
+`permit2_amount_mismatch`, `permit2_token_mismatch`, `permit2_allowance_required`,
+`insufficient_funds`, `invalid_transaction_state`, and `transaction_failed`.
+
+## Security Considerations
+
+Only configured chain IDs, Permit2 deployments, and proxy deployments may be used. Payload-supplied
+addresses MUST NOT replace those constants. Permit2 nonce consumption and token authorization nonces
+provide replay protection. The proxy is required because a raw Permit2 authorization without a
+recipient-bound witness would let the submitter redirect funds.

--- a/specs/schemes/exact/scheme_exact_tron.md
+++ b/specs/schemes/exact/scheme_exact_tron.md
@@ -17,12 +17,13 @@ prefix.
 
 | Network | CAIP-2 ID | Permit2 | Exact proxy |
 | --- | --- | --- | --- |
-| Mainnet | `tron:0x2b6653dc` | `TTJxU3P8rHycAyFY4kVtGNfmnMH4ezcuM9` | `TN49yaJmZMZoEdDCqjB4uPzQLHvYkGw95m` |
-| Nile | `tron:0xcd8690dc` | `TYQuuhGbEMxF7nZxUHV3uHJxAVVAegNU9h` | `TFGoaq2KjizijgjtkVxT7yjffW1A5T1j6F` |
-| Shasta | `tron:0x94a9059e` | `TJMkP7a3ucTMkvi17p7ChhTCw6zriFX3tg` | `TGZkC38n14f2GpBWPMQLF2BpmcpWW3QNhg` |
+| Mainnet | `tron:728126428` | `TTJxU3P8rHycAyFY4kVtGNfmnMH4ezcuM9` | `TN49yaJmZMZoEdDCqjB4uPzQLHvYkGw95m` |
+| Nile | `tron:3448148188` | `TYQuuhGbEMxF7nZxUHV3uHJxAVVAegNU9h` | `TFGoaq2KjizijgjtkVxT7yjffW1A5T1j6F` |
+| Shasta | `tron:2494104990` | `TJMkP7a3ucTMkvi17p7ChhTCw6zriFX3tg` | `TGZkC38n14f2GpBWPMQLF2BpmcpWW3QNhg` |
 
-The numeric TIP-712 `chainId` is the hexadecimal CAIP-2 reference interpreted as an unsigned
-integer.
+The numeric TIP-712 `chainId` is the decimal CAIP-2 reference interpreted as an unsigned integer.
+Deprecated hexadecimal CAIP-2 aliases may be accepted as inputs during migration, but requirements
+and responses use the decimal identifiers above.
 
 ## Payment Requirements
 
@@ -45,7 +46,7 @@ tokens do not expose TransferWithAuthorization.
   "x402Version": 2,
   "accepted": {
     "scheme": "exact",
-    "network": "tron:0xcd8690dc",
+    "network": "tron:3448148188",
     "amount": "1000",
     "asset": "TTokenAddress",
     "payTo": "TReceiverAddress",
@@ -81,7 +82,7 @@ validBefore,bytes32 nonce)`.
   "x402Version": 2,
   "accepted": {
     "scheme": "exact",
-    "network": "tron:0xcd8690dc",
+    "network": "tron:3448148188",
     "amount": "1000",
     "asset": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
     "payTo": "TReceiverAddress",
@@ -135,8 +136,13 @@ cryptographic and term checks remain mandatory, and settlement is authoritative.
   value, validAfter, validBefore, nonce, v, r, s)`.
 - Permit2: the facilitator calls `x402ExactPermit2Proxy.settle(permit, owner, witness, signature)`.
 
-The facilitator waits for a successful receipt and returns the TRON transaction ID. It MUST re-run
-verification immediately before broadcasting.
+The facilitator waits for a receipt using a configurable confirmation budget (90 seconds by
+default) and returns the TRON transaction ID. It MUST re-run verification immediately before
+broadcasting. If the budget expires, receipt RPC fails, or receipt effect processing is
+indeterminate after broadcast, it returns `success: false`, `errorReason: "settlement_pending"`,
+and the original transaction ID. An explicit revert is terminal and also preserves the transaction
+ID. A caller MUST reconcile the original transaction and MUST NOT rebroadcast the authorization in
+response to `settlement_pending`.
 
 ## Error Codes
 
@@ -144,7 +150,7 @@ Stable reasons include `invalid_exact_tron_scheme`, `invalid_exact_tron_network_
 `invalid_exact_tron_payload_signature`, `invalid_exact_tron_payload_recipient_mismatch`,
 `invalid_exact_tron_payload_authorization_value_mismatch`, `invalid_permit2_spender`,
 `permit2_amount_mismatch`, `permit2_token_mismatch`, `permit2_allowance_required`,
-`insufficient_funds`, `invalid_transaction_state`, and `transaction_failed`.
+`insufficient_funds`, `invalid_transaction_state`, `settlement_pending`, and `transaction_failed`.
 
 ## Security Considerations
 

--- a/specs/schemes/upto/scheme_upto.md
+++ b/specs/schemes/upto/scheme_upto.md
@@ -76,3 +76,4 @@ The following patterns are NOT supported by `upto` and would require different s
 Network-specific rules and implementation details are defined in the per-network scheme documents:
 
 - EVM chains: See [`scheme_upto_evm.md`](./scheme_upto_evm.md)
+- TRON: See [`scheme_upto_tron.md`](./scheme_upto_tron.md)

--- a/specs/schemes/upto/scheme_upto_tron.md
+++ b/specs/schemes/upto/scheme_upto_tron.md
@@ -1,0 +1,106 @@
+# Scheme: `upto` on `TRON`
+
+## Summary
+
+The TRON `upto` binding uses Permit2 and `x402UptoPermit2Proxy`. The payer signs a maximum token
+amount. After performing the protected work, the resource server supplies an actual settlement
+amount no greater than the maximum.
+
+## Networks and Contracts
+
+The Permit2 deployments are listed in the [TRON exact binding](../exact/scheme_exact_tron.md#networks-and-contracts).
+The upto proxy deployments are:
+
+| Network | `x402UptoPermit2Proxy` |
+| --- | --- |
+| `tron:0x2b6653dc` | `TBLeFPkfDiweBbYmAPqnakaFBPDt9p93sR` |
+| `tron:0xcd8690dc` | `TKvcqQ7S2bYyys5ZZNpjj9xGiPhiwzHq1K` |
+| `tron:0x94a9059e` | `TMxpieW75DQiA9QaoTB1ifJWeQpuppSB1g` |
+
+## Payment Requirements
+
+`extra.assetTransferMethod` MUST be `permit2`. `extra.permit2FacilitatorAddress` MUST contain one
+facilitator signer address advertised by `GET /supported`; the client binds it into the witness.
+
+At verification time, `PaymentRequirements.amount` is the authorized maximum. At settlement time,
+the resource server replaces it with the actual amount. The signed maximum remains in
+`payload.permit2Authorization.permitted.amount`.
+
+## Payment Payload
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "upto",
+    "network": "tron:0xcd8690dc",
+    "amount": "10000",
+    "asset": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+    "payTo": "TReceiverAddress",
+    "maxTimeoutSeconds": 60,
+    "extra": {
+      "assetTransferMethod": "permit2",
+      "permit2FacilitatorAddress": "TFacilitatorAddress"
+    }
+  },
+  "payload": {
+    "signature": "0x...",
+    "permit2Authorization": {
+      "from": "0x1111111111111111111111111111111111111111",
+      "permitted": {
+        "token": "0x2222222222222222222222222222222222222222",
+        "amount": "10000"
+      },
+      "spender": "0x3333333333333333333333333333333333333333",
+      "nonce": "1",
+      "deadline": "1786500000",
+      "witness": {
+        "to": "0x4444444444444444444444444444444444444444",
+        "facilitator": "0x5555555555555555555555555555555555555555",
+        "validAfter": "0"
+      }
+    }
+  }
+}
+```
+
+The TIP-712 domain is `{ name: "Permit2", chainId, verifyingContract: Permit2 }`. The primary type
+is `PermitWitnessTransferFrom`; its `Witness` is `(address to,address facilitator,uint256
+validAfter)`.
+
+## Verification
+
+The facilitator MUST verify:
+
+1. Both schemes are `upto` and networks match.
+2. `spender` is the configured upto proxy.
+3. The witness recipient equals `payTo`.
+4. The witness facilitator equals one of its own signer addresses.
+5. The authorization is active and has at least six seconds before its deadline.
+6. The permitted token equals the requirement asset.
+7. The permitted amount equals the verification-time requirement amount.
+8. The signature is valid under the configured TRON Permit2 domain.
+9. Permit2 allowance and balance cover the maximum when those reads succeed.
+
+## Settlement
+
+Before settlement, the facilitator reconstructs verification requirements using the signed maximum,
+then verifies again. It rejects `actualAmount > signedMaximum`.
+
+- For `actualAmount > 0`, it calls `x402UptoPermit2Proxy.settle(permit, actualAmount, owner,
+  witness, signature)` and returns `SettleResponse.amount`.
+- For `actualAmount == 0`, it returns success with an empty transaction ID and `amount: "0"`; no
+  nonce is consumed on-chain.
+
+## Error Codes
+
+Stable reasons include `invalid_upto_tron_scheme`, `invalid_upto_tron_network_mismatch`,
+`unsupported_payload_type`, `invalid_permit2_spender`, `invalid_permit2_facilitator`,
+`permit2_amount_mismatch`, `permit2_token_mismatch`, `permit2_allowance_required`,
+`upto_settlement_exceeds_amount`, `insufficient_funds`, and `transaction_failed`.
+
+## Security Considerations
+
+The facilitator witness prevents a different submitter from consuming the authorization. The server
+chooses the actual charge, so the payer trusts the server's metering up to the signed maximum. A zero
+settlement does not consume the Permit2 nonce and MUST NOT be represented as an on-chain payment.

--- a/specs/schemes/upto/scheme_upto_tron.md
+++ b/specs/schemes/upto/scheme_upto_tron.md
@@ -13,9 +13,9 @@ The upto proxy deployments are:
 
 | Network | `x402UptoPermit2Proxy` |
 | --- | --- |
-| `tron:0x2b6653dc` | `TBLeFPkfDiweBbYmAPqnakaFBPDt9p93sR` |
-| `tron:0xcd8690dc` | `TKvcqQ7S2bYyys5ZZNpjj9xGiPhiwzHq1K` |
-| `tron:0x94a9059e` | `TMxpieW75DQiA9QaoTB1ifJWeQpuppSB1g` |
+| `tron:728126428` | `TBLeFPkfDiweBbYmAPqnakaFBPDt9p93sR` |
+| `tron:3448148188` | `TKvcqQ7S2bYyys5ZZNpjj9xGiPhiwzHq1K` |
+| `tron:2494104990` | `TMxpieW75DQiA9QaoTB1ifJWeQpuppSB1g` |
 
 ## Payment Requirements
 
@@ -33,7 +33,7 @@ the resource server replaces it with the actual amount. The signed maximum remai
   "x402Version": 2,
   "accepted": {
     "scheme": "upto",
-    "network": "tron:0xcd8690dc",
+    "network": "tron:3448148188",
     "amount": "10000",
     "asset": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
     "payTo": "TReceiverAddress",
@@ -92,12 +92,20 @@ then verifies again. It rejects `actualAmount > signedMaximum`.
 - For `actualAmount == 0`, it returns success with an empty transaction ID and `amount: "0"`; no
   nonce is consumed on-chain.
 
+For a nonzero settlement, the facilitator waits for a receipt using a configurable confirmation
+budget (90 seconds by default). If the budget expires, receipt RPC fails, or receipt effect
+processing is indeterminate after broadcast, it returns `success: false`,
+`errorReason: "settlement_pending"`, and the original transaction ID. An explicit revert is
+terminal and also preserves the transaction ID. A caller MUST reconcile the original transaction
+and MUST NOT rebroadcast the authorization in response to `settlement_pending`.
+
 ## Error Codes
 
 Stable reasons include `invalid_upto_tron_scheme`, `invalid_upto_tron_network_mismatch`,
 `unsupported_payload_type`, `invalid_permit2_spender`, `invalid_permit2_facilitator`,
 `permit2_amount_mismatch`, `permit2_token_mismatch`, `permit2_allowance_required`,
-`upto_settlement_exceeds_amount`, `insufficient_funds`, and `transaction_failed`.
+`upto_settlement_exceeds_amount`, `insufficient_funds`, `settlement_pending`, and
+`transaction_failed`.
 
 ## Security Considerations
 


### PR DESCRIPTION
### Description

Adds the current TRON bindings for the x402 v2 payment schemes implemented by BankofAI:

- `exact`
- `upto`
- `exact_gasfree`
- `batch-settlement`

Relates to #2075.

### Specifications

#### `exact`

Supports two asset transfer methods:

- `eip3009`: TIP-712 `TransferWithAuthorization`
- `permit2`: TIP-712 `PermitWitnessTransferFrom` settled through `x402ExactPermit2Proxy`

#### `upto`

Uses Permit2 and `x402UptoPermit2Proxy`. The payer signs a maximum amount, while the Resource Server supplies an actual settlement amount that cannot exceed the signed maximum. The witness binds the authorized facilitator.

#### `exact_gasfree`

Uses a TIP-712 `PermitTransfer` for TRON's GasFreeController. The configured GasFree provider relays the signed payment and pays the on-chain resource cost.

#### `batch-settlement`

Defines capital-backed, unidirectional TRC-20 payment channels. The payer deposits through EIP-3009 or Permit2 and signs cumulative off-chain vouchers that can later be claimed and settled on-chain. The binding also defines cooperative refunds and client/server state recovery.

### Files

- Adds `specs/schemes/exact/scheme_exact_tron.md`.
- Adds `specs/schemes/upto/scheme_upto_tron.md`.
- Adds `specs/schemes/exact-gasfree/scheme_exact_gasfree_tron.md`.
- Adds `specs/schemes/batch-settlement/scheme_batch_settlement_tron.md`.
- Adds TRON links to the `exact`, `upto`, and `batch-settlement` scheme indexes.

### Shared TRON conventions

- Uses the canonical decimal CAIP-2 references defined by the merged [TRON namespace specification](https://github.com/ChainAgnostic/namespaces/pull/170).
- Uses Base58Check addresses at the protocol boundary.
- Normalizes addresses to 20-byte, `0x`-prefixed hex inside TIP-712 typed data.
- Keeps configured network contracts authoritative; payload-supplied values cannot replace them.
- Defines verification, settlement, replay protection, security constraints, and stable error behavior for each binding.

### Supported networks

| Network | Canonical CAIP-2 | Deprecated input alias |
| --- | --- | --- |
| Mainnet | `tron:728126428` | `tron:0x2b6653dc` |
| Nile | `tron:3448148188` | `tron:0xcd8690dc` |
| Shasta | `tron:2494104990` | `tron:0x94a9059e` |

The numeric TIP-712 `chainId` is unchanged. Implementations may accept the previous hexadecimal identifiers as deprecated input aliases, normalize them internally, and emit the canonical decimal identifiers.

Each specification lists the applicable Permit2, settlement proxy, GasFree, channel, and deposit-collector contracts for these networks.

### Scope

This PR contains specifications only. The BankofAI TypeScript implementation is maintained downstream and will be proposed separately.

The decimal CAIP-2 migration and hexadecimal compatibility aliases are already implemented on the BankofAI `develop` branch. They have not been released yet and are planned for the release coordinated with wallet-cli 4.14.

Permit2 Approval resource sponsoring will be proposed as a separate optional Extension so it can be reviewed independently from the base TRON scheme bindings.

### Validation performed

- All JSON examples parse successfully.
- All listed Permit2, proxy, GasFree, channel, and deposit-collector addresses return deployed contract bytecode from their corresponding TRON network nodes.
- `git diff --check` passes.
- All update commits are signed.

### Checklist

- [x] Based on the current upstream `main` branch
- [x] Aligned with the merged TRON CAIP namespace specification
- [x] TRON `exact` binding
- [x] TRON `upto` binding
- [x] TRON `exact_gasfree` binding
- [x] TRON `batch-settlement` binding
- [x] Mainnet, Nile, and Shasta deployments
- [x] Scheme index updates
- [x] TypeScript implementation kept out of this specification PR
- [x] Approval resource sponsoring kept in a separate Extension proposal
