### PR TITLE
docs: add integration-test env setup for Python/TypeScript/Go SDKs (#2045)

### DIFF
--- a/go/.env.example
+++ b/go/.env.example
@@ -1,0 +1,31 @@
+# Example .env for running the Go SDK integration tests.
+# Copy this file to .env (cd go && cp .env.example .env) and fill in
+# test credentials for the chains you want to exercise. Integration
+# tests for a given chain are skipped when its required variables are
+# unset, so you can populate only the subsets you need.
+#
+# See go/CONTRIBUTING.md § Integration Tests and go/test/integration/
+# for the authoritative list of env vars each suite reads.
+
+# --- EVM (Base Sepolia testnet by default) ---
+# Private keys for the client (payer) and facilitator (settler).
+EVM_CLIENT_PRIVATE_KEY=
+EVM_FACILITATOR_PRIVATE_KEY=
+
+# Public address that receives test payments.
+EVM_RESOURCE_SERVER_ADDRESS=
+
+# Optional: override the RPC endpoint (defaults to Base Sepolia).
+# EVM_RPC_URL=https://sepolia.base.org
+
+# --- SVM (Solana devnet) ---
+# Base58-encoded private keys for the client and facilitator.
+SVM_CLIENT_PRIVATE_KEY=
+SVM_FACILITATOR_PRIVATE_KEY=
+
+# Public addresses of the facilitator and the resource server.
+SVM_FACILITATOR_ADDRESS=
+SVM_RESOURCE_SERVER_ADDRESS=
+
+# Optional: RPC endpoint for the SVM cluster you're testing against.
+# SVM_RPC_URL=https://api.devnet.solana.com

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -223,6 +223,42 @@ async def test_async_operation():
     assert result is not None
 ```
 
+### Integration Tests
+
+Tests under `tests/integrations/` exercise real RPC endpoints and require
+test credentials. They are skipped automatically when the required
+environment variables are not set, so a missing `.env` only disables those
+tests — unit tests still run normally.
+
+`tests/conftest.py` loads `.env` automatically, searching (in order):
+
+1. `python/x402/.env`
+2. the repository root `.env`
+
+Create one and populate the variables for the chains you want to cover:
+
+```bash
+cd python/x402
+cat > .env <<'EOF'
+# EVM (Base Sepolia testnet by default)
+EVM_CLIENT_PRIVATE_KEY=
+EVM_FACILITATOR_PRIVATE_KEY=
+EVM_RESOURCE_SERVER_ADDRESS=
+# Optional: override the RPC endpoint
+# EVM_RPC_URL=https://sepolia.base.org
+
+# SVM (Solana)
+SVM_CLIENT_PRIVATE_KEY=
+SVM_FACILITATOR_PRIVATE_KEY=
+SVM_FACILITATOR_ADDRESS=
+SVM_RESOURCE_SERVER_ADDRESS=
+SVM_RPC_URL=
+EOF
+```
+
+See `tests/integrations/test_evm.py`, `test_mcp_evm.py`, and `test_svm.py`
+for the authoritative list of variables each suite reads.
+
 ## Code Quality
 
 ### Linting

--- a/typescript/CONTRIBUTING.md
+++ b/typescript/CONTRIBUTING.md
@@ -206,15 +206,44 @@ pnpm test:watch
 
 ### Integration Tests
 
-Integration tests require network access and may use testnets:
+Integration tests require network access and may use testnets. They also
+require test credentials — most suites will skip themselves cleanly when the
+required environment variables are not set, so you only need to populate the
+subsets you want to exercise.
+
+Create a `.env` at the repository root (or in the specific package you're
+testing) with the variables the target suites read. A starting template:
 
 ```bash
-pnpm test:integration
+# --- EVM mechanism (@x402/evm) ---
+EVM_CLIENT_PRIVATE_KEY=
+EVM_FACILITATOR_PRIVATE_KEY=
+EVM_RESOURCE_SERVER_ADDRESS=
+# Optional: override the RPC endpoint (defaults to Base Sepolia)
+# EVM_RPC_URL=https://sepolia.base.org
+
+# --- SVM mechanism (@x402/svm) + Stellar ---
+CLIENT_PRIVATE_KEY=
+FACILITATOR_PRIVATE_KEY=
+FACILITATOR_ADDRESS=
+RESOURCE_SERVER_ADDRESS=
+
+# --- Aptos mechanism (@x402/aptos) ---
+APTOS_CLIENT_PRIVATE_KEY=
+APTOS_FACILITATOR_PRIVATE_KEY=
 ```
 
-Or for a specific package:
+Each mechanism's `test/integrations/*.test.ts` file is the authoritative
+source for the exact variables it consumes — read the one for your target
+package to see the complete list.
+
+Run everything or scope to a single package:
 
 ```bash
+# All packages
+pnpm test:integration
+
+# Single package
 pnpm --filter @x402/evm test:integration
 ```
 


### PR DESCRIPTION
Closes #2045.

Integration tests in all three SDKs require test credentials, but contributors today have to read test source code to find out which env vars to set. This PR closes that gap.

## What's in the PR

**`go/.env.example`** — new file. The Go `CONTRIBUTING.md` already walks through `cp .env.example .env` (line 217), but the template didn't exist on disk. This wires up the walkthrough. Variables mirror what `go/test/integration/evm_test.go` and `svm_test.go` actually read.

**`python/CONTRIBUTING.md`** — new "Integration Tests" subsection under Testing. Points at the existing autoloader in `tests/conftest.py` (which already searches `python/x402/.env` → root `.env`), and enumerates the `EVM_*` / `SVM_*` vars read by `tests/integrations/test_evm.py`, `test_mcp_evm.py`, and `test_svm.py`.

**`typescript/CONTRIBUTING.md`** — Integration Tests section now enumerates env vars used by `@x402/evm`, `@x402/svm`, Stellar, and Aptos suites. Each package's `test/integrations/*.test.ts` remains the authoritative list; the guide just surfaces the common variables so contributors can get started without spelunking.

## Scope

- Three docs files, one new config template. Additive only.
- No code changes, no test-runner changes.
- No `.env` itself committed (root and package `.gitignore`s already block `.env`; `.env.example` is not ignored, confirmed via `git check-ignore`).

## Verified

- Each `.env.example` variable name traced to a specific `os.Getenv` / `os.environ.get` / `process.env` site in the integration tests.
- Default `EVM_RPC_URL` value (`https://sepolia.base.org`) matches the fallback in `python/x402/tests/integrations/test_evm.py` and `test_mcp_evm.py`.
- `python/x402/tests/conftest.py` already auto-loads `.env` — no code change needed.

## AI assistance

This contribution was developed with AI assistance (Claude Code). Per x402's `AI-Assisted Contributions` policy: every env var in this PR was traced back to its `os.Getenv` / `os.environ.get` / `process.env` consumer in the integration tests before the body was written, and defaults were cross-checked against the fallbacks the tests already carry. Additive docs only; no code or test behavior changes.
