### PR TITLE
feat: add MCP Bazaar discovery support across TypeScript, Python, and Go SDKs

### DIFF
--- a/docs/extensions/bazaar.mdx
+++ b/docs/extensions/bazaar.mdx
@@ -130,13 +130,13 @@ The `type` field indicates the resource type:
 
 For MCP tools, the `outputSchema.input` object will contain:
 - `type: "mcp"` - Identifies this as an MCP tool
-- `tool` - The MCP tool name (used in `tools/call` requests)
+- `toolName` - The MCP tool name (used in `tools/call` requests)
 - `inputSchema` - JSON Schema for the tool's arguments (follows MCP `Tool.inputSchema` format)
 - `description` - Human-readable description of the tool (optional)
 - `transport` - MCP transport protocol: `"streamable-http"` (default) or `"sse"` (optional)
 - `example` - Example arguments object (optional)
 
-**Note:** For MCP tools, the unique resource identifier is the tuple (`resource`, `input.tool`) since MCP multiplexes multiple tools over a single server endpoint.
+**Note:** For MCP tools, the unique resource identifier is the tuple (`resource`, `input.toolName`) since MCP multiplexes multiple tools over a single server endpoint.
 
 ### Quickstart for Buyers
 
@@ -155,6 +155,7 @@ Fetch the list of available x402 services using the facilitator client:
     });
     const client = withBazaar(facilitatorClient);
 
+    // List HTTP services; use type: "mcp" to list MCP tools instead
     const response = await client.extensions.discovery.listResources({ type: "http" });
 
     // Filter services under $0.10
@@ -321,6 +322,43 @@ Once you've found a suitable service, use an x402 client to call it:
 
 
     asyncio.run(main())
+    ```
+  </Tab>
+</Tabs>
+
+#### Step 2 (MCP tools): Call a Discovered MCP Tool
+
+For discovered MCP tools, use the x402 MCP client to call the tool after paying:
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```typescript
+    import { createx402MCPClient } from "@x402/mcp";
+    import { ExactEvmScheme } from "@x402/evm/exact/client";
+    import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+    import { privateKeyToAccount } from "viem/accounts";
+
+    const account = privateKeyToAccount("0xYourPrivateKey");
+
+    // Discover MCP tools from the Bazaar
+    const mcpItems = await client.extensions.discovery.listResources({ type: "mcp" });
+    const selectedTool = mcpItems.items[0];
+    const { toolName } = selectedTool.discoveryInfo.input;
+
+    // Connect the x402 MCP client to the tool's server
+    const x402Mcp = createx402MCPClient({
+      name: "my-mcp-client",
+      schemes: [{ network: "eip155:8453", scheme: new ExactEvmScheme(account) }],
+    });
+
+    const transport = new SSEClientTransport(new URL(`${selectedTool.resource}/sse`));
+    await x402Mcp.connect(transport);
+
+    // Call the paid tool — x402Mcp handles payment automatically
+    const result = await x402Mcp.callTool(toolName, { city: "San Francisco" });
+    console.log("Tool result:", result);
+
+    await x402Mcp.close();
     ```
   </Tab>
 </Tabs>
@@ -543,6 +581,108 @@ To enhance your listing with descriptions and schemas, include them when setting
 
         r.Run(":4021")
     }
+    ```
+  </Tab>
+</Tabs>
+
+#### Adding Metadata for MCP Tools
+
+To make paid MCP tools discoverable, pass the discovery extension in your payment wrapper config:
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```typescript
+    import { createPaymentWrapper } from "@x402/mcp";
+    import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+
+    const paid = createPaymentWrapper(resourceServer, {
+      accepts,
+      resource: {
+        url: "mcp://tool/get_weather",
+        description: "Get current weather for a city",
+      },
+      extensions: declareDiscoveryExtension({
+        toolName: "get_weather",
+        description: "Get current weather for a city",
+        inputSchema: {
+          properties: { city: { type: "string", description: "City name" } },
+          required: ["city"],
+        },
+        example: { city: "San Francisco" },
+      }),
+    });
+
+    mcpServer.tool("get_weather", "Get current weather ($0.001)", { city: z.string() },
+      paid(async ({ city }) => ({ content: [{ type: "text", text: JSON.stringify(await fetchWeather(city)) }] }))
+    );
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```python
+    from x402.mcp import create_payment_wrapper
+    from x402.extensions.bazaar import DeclareMcpDiscoveryConfig, declare_mcp_discovery_extension
+
+    weather_discovery = declare_mcp_discovery_extension(
+        DeclareMcpDiscoveryConfig(
+            tool_name="get_weather",
+            description="Get current weather for a city",
+            input_schema={
+                "properties": {"city": {"type": "string", "description": "City name"}},
+                "required": ["city"],
+            },
+            example={"city": "San Francisco"},
+        )
+    )
+
+    weather_wrapper = create_payment_wrapper(
+        resource_server,
+        accepts=weather_accepts,
+        resource=ResourceInfo(
+            url="mcp://tool/get_weather",
+            description="Get current weather for a city",
+        ),
+        extensions=weather_discovery,
+    )
+
+    @mcp.tool(name="get_weather", description="Get current weather ($0.001)")
+    @weather_wrapper
+    async def get_weather(city: str) -> str:
+        return json.dumps(await fetch_weather(city))
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```go
+    import (
+        "github.com/coinbase/x402/go/extensions/bazaar"
+        exttypes "github.com/coinbase/x402/go/extensions/types"
+        mcp402 "github.com/coinbase/x402/go/mcp"
+    )
+
+    weatherDiscovery, _ := bazaar.DeclareMcpDiscoveryExtension(exttypes.DeclareMcpDiscoveryConfig{
+        ToolName:    "get_weather",
+        Description: "Get current weather for a city",
+        InputSchema: exttypes.JSONSchema{
+            "properties": map[string]interface{}{
+                "city": map[string]interface{}{
+                    "type":        "string",
+                    "description": "City name",
+                },
+            },
+            "required": []string{"city"},
+        },
+        Example: map[string]interface{}{"city": "San Francisco"},
+    })
+
+    paymentWrapper := mcp402.NewPaymentWrapper(resourceServer, mcp402.PaymentWrapperConfig{
+        Accepts: weatherAccepts,
+        Resource: &types.ResourceInfo{
+            URL:         "mcp://tool/get_weather",
+            Description: "Get current weather for a city",
+        },
+        Extensions: map[string]interface{}{
+            exttypes.BAZAAR.Key(): weatherDiscovery,
+        },
+    })
     ```
   </Tab>
 </Tabs>

--- a/docs/getting-started/quickstart-for-sellers.mdx
+++ b/docs/getting-started/quickstart-for-sellers.mdx
@@ -1008,36 +1008,49 @@ To verify:
 
 ### 4. Enhance Discovery with Metadata (Recommended)
 
-When using a facilitator that supports the Bazaar extension, your endpoints can be listed in the [x402 Bazaar](/extensions/bazaar), the discovery layer that helps buyers and AI agents find services. To enable discovery:
+When using a facilitator that supports the Bazaar extension, your endpoints can be listed in the [x402 Bazaar](/extensions/bazaar), the discovery layer that helps buyers and AI agents find services.
+
+**For HTTP endpoints**, add the discovery extension to your route config:
 
 ```typescript
+import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+
 {
   "GET /weather": {
-    accepts: [
-      {
-        scheme: "exact",
-        price: "$0.001",
-        network: "eip155:8453",
-        payTo: "0xYourAddress",
-      },
-      {
-        scheme: "exact",
-        price: "$0.001",
-        network: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",  // Solana mainnet
-        payTo: "YourSolanaAddress",
-      },
-    ],
+    accepts: [{ scheme: "exact", price: "$0.001", network: "eip155:8453", payTo: "0xYourAddress" }],
     description: "Get real-time weather data including temperature, conditions, and humidity",
     mimeType: "application/json",
     extensions: {
-      bazaar: {
-        discoverable: true,
-        category: "weather",
-        tags: ["forecast", "real-time"],
-      },
+      ...declareDiscoveryExtension({
+        input: { city: "San Francisco" },
+        inputSchema: {
+          properties: { city: { type: "string", description: "City name" } },
+          required: ["city"],
+        },
+      }),
     },
   },
 }
+```
+
+**For MCP tools**, pass the discovery extension in your payment wrapper config:
+
+```typescript
+import { createPaymentWrapper } from "@x402/mcp";
+import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+
+const paid = createPaymentWrapper(resourceServer, {
+  accepts,
+  resource: { url: "mcp://tool/get_weather", description: "Get current weather for a city" },
+  extensions: declareDiscoveryExtension({
+    toolName: "get_weather",
+    description: "Get current weather for a city",
+    inputSchema: {
+      properties: { city: { type: "string", description: "City name" } },
+      required: ["city"],
+    },
+  }),
+});
 ```
 
 Learn more about the discovery layer in the [Bazaar documentation](/extensions/bazaar).

--- a/docs/guides/mcp-server-with-x402.md
+++ b/docs/guides/mcp-server-with-x402.md
@@ -304,9 +304,51 @@ The example uses these x402 v2 packages:
 
 ***
 
+***
+
+### Making Your MCP Tools Discoverable via Bazaar
+
+If you are building an MCP **server** (not just a client bridge), you can make your paid tools visible in the [x402 Bazaar](/extensions/bazaar) so AI agents and other buyers can discover them without prior knowledge of your server.
+
+Pass `extensions` in the payment wrapper config with the Bazaar discovery metadata:
+
+```typescript
+import { createPaymentWrapper } from "@x402/mcp";
+import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+
+const paid = createPaymentWrapper(resourceServer, {
+  accepts,
+  resource: {
+    url: "mcp://tool/get_weather",
+    description: "Get current weather for a city",
+  },
+  // Bazaar discovery metadata — facilitators will catalog this tool
+  extensions: declareDiscoveryExtension({
+    toolName: "get_weather",
+    description: "Get current weather for a city",
+    inputSchema: {
+      properties: { city: { type: "string", description: "City name" } },
+      required: ["city"],
+    },
+    example: { city: "San Francisco" },
+  }),
+});
+```
+
+When a client pays for the tool, the facilitator extracts the Bazaar extension from the payment payload and indexes the tool in `/discovery/resources` with `type: "mcp"`. Buyers can then discover it by querying a Bazaar-enabled facilitator:
+
+```typescript
+const mcpTools = await client.extensions.discovery.listResources({ type: "mcp" });
+```
+
+See the full [Bazaar documentation](/extensions/bazaar) for details on buyers querying and calling discovered MCP tools.
+
+***
+
 ### Next Steps
 
 * [See the full example in the repo](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/mcp)
 * Try integrating with your own x402-compatible APIs
 * Extend the MCP server with more tools or custom logic as needed
 * [Learn about building x402 servers](/getting-started/quickstart-for-sellers)
+* [Explore the Bazaar discovery layer](/extensions/bazaar)

--- a/e2e/extensions/bazaar.ts
+++ b/e2e/extensions/bazaar.ts
@@ -40,6 +40,12 @@ interface ExpectedDiscoverableEndpoint {
   endpointPath: string;
   method: string;
   description: string;
+  /** For MCP tools: expected resource URL is mcp://tool/{toolName} */
+  expectedResourceUrl: string;
+  /** For MCP tools: the tool name expected in discoveryInfo.input.toolName */
+  toolName?: string;
+  /** Transport type ('http' or 'mcp') */
+  transport: string;
 }
 
 /**
@@ -95,6 +101,7 @@ function getDiscoverableEndpoints(
     return [];
   }
 
+  const serverTransport = server.config.transport ?? 'http';
   const serverUrl = `http://localhost:${serverPort}`;
   const discoverableEndpoints: ExpectedDiscoverableEndpoint[] = [];
 
@@ -104,12 +111,23 @@ function getDiscoverableEndpoints(
   ) || [];
 
   for (const endpoint of paymentEndpoints) {
+    const isMcpEndpoint = serverTransport === 'mcp' || endpoint.method === 'tool';
+    const toolName = endpoint.toolName ?? endpoint.path;
+
+    // MCP resources are identified by mcp://tool/{toolName}; HTTP by server URL + path
+    const expectedResourceUrl = isMcpEndpoint
+      ? `mcp://tool/${toolName}`
+      : `${serverUrl}${endpoint.path}`;
+
     discoverableEndpoints.push({
       serverName: server.config.name,
       serverUrl,
       endpointPath: endpoint.path,
       method: endpoint.method,
       description: endpoint.description,
+      expectedResourceUrl,
+      toolName: isMcpEndpoint ? toolName : undefined,
+      transport: isMcpEndpoint ? 'mcp' : 'http',
     });
   }
 
@@ -189,9 +207,9 @@ async function validateFacilitatorDiscovery(
 
   verboseLog(`  📊 Total resources discovered: ${discoveryResponse.items.length}`);
 
-  // Build set of discovered resource URLs for easy comparison
-  const discoveredUrls = new Set(
-    discoveryResponse.items.map(item => item.resource)
+  // Build map of discovered resource URL → item for easy lookup
+  const discoveredItemsByUrl = new Map(
+    discoveryResponse.items.map(item => [item.resource, item])
   );
 
   // Check which expected endpoints were discovered
@@ -199,11 +217,28 @@ async function validateFacilitatorDiscovery(
   const discoveredEndpoints: string[] = [];
 
   for (const expected of expectedEndpoints) {
-    const expectedResourceUrl = `${expected.serverUrl}${expected.endpointPath}`;
+    const { expectedResourceUrl } = expected;
+    const discoveredItem = discoveredItemsByUrl.get(expectedResourceUrl);
 
-    if (discoveredUrls.has(expectedResourceUrl)) {
+    if (discoveredItem) {
       discoveredEndpoints.push(expectedResourceUrl);
       verboseLog(`  ✅ Discovered: ${expected.method} ${expectedResourceUrl}`);
+
+      // For MCP resources, additionally verify type and toolName in discoveryInfo
+      if (expected.transport === 'mcp' && expected.toolName) {
+        const inputType = discoveredItem.discoveryInfo?.input?.type;
+        const inputToolName = discoveredItem.discoveryInfo?.input?.toolName;
+
+        if (inputType !== 'mcp') {
+          verboseLog(`  ⚠️  MCP resource ${expectedResourceUrl}: expected discoveryInfo.input.type "mcp", got "${inputType}"`);
+        }
+        if (inputToolName !== expected.toolName) {
+          verboseLog(`  ⚠️  MCP resource ${expectedResourceUrl}: expected toolName "${expected.toolName}", got "${inputToolName}"`);
+        }
+        if (inputType === 'mcp' && inputToolName === expected.toolName) {
+          verboseLog(`  ✅ MCP discovery metadata verified for tool: ${expected.toolName}`);
+        }
+      }
     } else {
       missingEndpoints.push(expected);
       verboseLog(`  ❌ Missing: ${expected.method} ${expectedResourceUrl}`);
@@ -211,9 +246,7 @@ async function validateFacilitatorDiscovery(
   }
 
   // Find any unexpected resources (discovered but not expected)
-  const expectedUrls = new Set(
-    expectedEndpoints.map(e => `${e.serverUrl}${e.endpointPath}`)
-  );
+  const expectedUrls = new Set(expectedEndpoints.map(e => e.expectedResourceUrl));
   const unexpectedEndpoints = discoveryResponse.items
     .filter(item => !expectedUrls.has(item.resource))
     .map(item => item.resource);
@@ -289,7 +322,7 @@ export async function handleDiscoveryValidation(
   if (allExpectedEndpoints.length > 0) {
     verboseLog('');
     allExpectedEndpoints.forEach(endpoint => {
-      verboseLog(`  • ${endpoint.method} ${endpoint.serverUrl}${endpoint.endpointPath} (${endpoint.serverName})`);
+      verboseLog(`  • ${endpoint.method} ${endpoint.expectedResourceUrl} (${endpoint.serverName})`);
     });
   }
 
@@ -354,7 +387,7 @@ export async function handleDiscoveryValidation(
     if (result.missingEndpoints.length > 0) {
       errorLog(`   ❌ Missing: ${result.missingEndpoints.length}`);
       result.missingEndpoints.forEach(endpoint => {
-        errorLog(`      • ${endpoint.method} ${endpoint.serverUrl}${endpoint.endpointPath}`);
+        errorLog(`      • ${endpoint.method} ${endpoint.expectedResourceUrl}`);
       });
     } else if (result.expectedEndpoints.length > 0) {
       log(`   ✅ All expected endpoints discovered`);

--- a/e2e/facilitators/go/bazaar.go
+++ b/e2e/facilitators/go/bazaar.go
@@ -47,12 +47,20 @@ func (c *BazaarCatalog) CatalogResource(
 		log.Printf("   Route template: %s", routeTemplate)
 	}
 
+	// Derive type from discovery info input type
+	resourceType := "http"
+	if discoveryInfo != nil {
+		if _, ok := discoveryInfo.Input.(exttypes.McpInput); ok {
+			resourceType = "mcp"
+		}
+	}
+
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	c.discoveredResources[resourceURL] = DiscoveredResource{
 		Resource:      resourceURL,
-		Type:          "http",
+		Type:          resourceType,
 		X402Version:   x402Version,
 		Accepts:       []x402.PaymentRequirements{paymentRequirements},
 		DiscoveryInfo: discoveryInfo,

--- a/e2e/servers/mcp-go/test.config.json
+++ b/e2e/servers/mcp-go/test.config.json
@@ -4,10 +4,12 @@
   "transport": "mcp",
   "language": "go",
   "x402Version": 2,
+  "extensions": ["bazaar"],
   "endpoints": [
     {
       "path": "get_weather",
       "method": "tool",
+      "toolName": "get_weather",
       "description": "Paid weather tool via MCP transport",
       "requiresPayment": true,
       "protocolFamily": "evm",

--- a/e2e/servers/mcp-python/main.py
+++ b/e2e/servers/mcp-python/main.py
@@ -40,6 +40,7 @@ def main() -> None:
     from mcp.server.fastmcp import FastMCP
 
     from x402 import ResourceConfig, ResourceInfo, x402ResourceServer
+    from x402.extensions.bazaar import DeclareMcpDiscoveryConfig, declare_mcp_discovery_extension
     from x402.http import FacilitatorConfig, HTTPFacilitatorClient
     from x402.mcp import create_payment_wrapper
     from x402.mechanisms.evm.exact import register_exact_evm_server
@@ -64,6 +65,19 @@ def main() -> None:
     )
     weather_accepts = resource_server.build_payment_requirements(weather_config)
 
+    # Declare Bazaar discovery metadata for the weather tool
+    weather_discovery = declare_mcp_discovery_extension(
+        DeclareMcpDiscoveryConfig(
+            tool_name="get_weather",
+            description="Get current weather for a city",
+            input_schema={
+                "properties": {"city": {"type": "string", "description": "City name"}},
+                "required": ["city"],
+            },
+            example={"city": "San Francisco"},
+        )
+    )
+
     # Create payment wrapper for the weather tool
     weather_wrapper = create_payment_wrapper(
         resource_server,
@@ -73,6 +87,7 @@ def main() -> None:
             description="Get current weather for a city",
             mime_type="application/json",
         ),
+        extensions=weather_discovery,
     )
 
     @mcp.tool(

--- a/e2e/servers/mcp-python/test.config.json
+++ b/e2e/servers/mcp-python/test.config.json
@@ -4,10 +4,12 @@
   "transport": "mcp",
   "language": "python",
   "x402Version": 2,
+  "extensions": ["bazaar"],
   "endpoints": [
     {
       "path": "get_weather",
       "method": "tool",
+      "toolName": "get_weather",
       "description": "Paid weather tool via MCP transport",
       "requiresPayment": true,
       "protocolFamily": "evm",

--- a/e2e/src/types.ts
+++ b/e2e/src/types.ts
@@ -56,6 +56,8 @@ export interface TestEndpoint {
   protocolFamily?: ProtocolFamily;
   transferMethod?: TransferMethod;
   extensions?: string[];
+  /** For MCP tools: the tool name used in tools/call. Defaults to path if not specified. */
+  toolName?: string;
   /** True for Permit2 standard/direct settle - requires pre-approval (approve before test, not revoke) */
   permit2Direct?: boolean;
   /** True for endpoints that require Permit2 revocation + fund/drain state setup before the first test (coldstart). */

--- a/examples/typescript/facilitator/advanced/bazaar.ts
+++ b/examples/typescript/facilitator/advanced/bazaar.ts
@@ -118,7 +118,7 @@ const facilitator = new x402Facilitator()
           resource: discovered.resourceUrl,
           description: discovered.description,
           mimeType: discovered.mimeType,
-          type: "http",
+          type: discovered.discoveryInfo.input.type,
           x402Version: discovered.x402Version,
           accepts: [context.requirements],
           discoveryInfo: discovered.discoveryInfo,

--- a/go/extensions/README.md
+++ b/go/extensions/README.md
@@ -160,11 +160,42 @@ github.com/x402-foundation/x402/go/extensions/bazaar
 - Enables building API marketplaces and search engines
 
 **What it provides:**
-- `DeclareDiscoveryExtension()` - Server helper to declare discovery metadata
+- `DeclareDiscoveryExtension()` - Server helper to declare discovery metadata for HTTP endpoints
+- `DeclareMcpDiscoveryExtension()` - Server helper to declare discovery metadata for MCP tools
 - `ExtractDiscoveredResourceFromPaymentPayload()` - Facilitator helper to extract discovered resources from client payments
 - `ExtractDiscoveredResourceFromPaymentRequired()` - Client helper to extract discovered resources from 402 responses
 - `ValidateDiscoveryExtension()` - Validation helper
 - JSON Schema types for structure validation
+
+**MCP Tool Example:**
+
+```go
+import (
+    "github.com/coinbase/x402/go/extensions/bazaar"
+    exttypes "github.com/coinbase/x402/go/extensions/types"
+    mcp402 "github.com/coinbase/x402/go/mcp"
+)
+
+weatherDiscovery, _ := bazaar.DeclareMcpDiscoveryExtension(exttypes.DeclareMcpDiscoveryConfig{
+    ToolName:    "get_weather",
+    Description: "Get current weather for a city",
+    InputSchema: exttypes.JSONSchema{
+        "properties": map[string]interface{}{
+            "city": map[string]interface{}{"type": "string", "description": "City name"},
+        },
+        "required": []string{"city"},
+    },
+    Example: map[string]interface{}{"city": "San Francisco"},
+})
+
+paymentWrapper := mcp402.NewPaymentWrapper(resourceServer, mcp402.PaymentWrapperConfig{
+    Accepts: weatherAccepts,
+    Resource: &types.ResourceInfo{URL: "mcp://tool/get_weather"},
+    Extensions: map[string]interface{}{
+        exttypes.BAZAAR.Key(): weatherDiscovery,
+    },
+})
+```
 
 **What it does NOT dictate:**
 - How facilitators should catalog the data

--- a/go/extensions/bazaar/doc.go
+++ b/go/extensions/bazaar/doc.go
@@ -2,7 +2,8 @@
 Package bazaar provides the Bazaar Discovery Extension for x402 v2 and v1.
 
 Enables facilitators to automatically catalog and index x402-enabled resources
-by following the server's provided discovery instructions.
+by following the server's provided discovery instructions. Supports both HTTP
+endpoints and MCP (Model Context Protocol) tools.
 
 # V2 Usage
 
@@ -10,7 +11,7 @@ The v2 extension follows a pattern where:
   - `info`: Contains the actual discovery data (the values)
   - `schema`: JSON Schema that validates the structure of `info`
 
-# For Resource Servers (V2)
+# For HTTP Resource Servers (V2)
 
 	import "github.com/x402-foundation/x402/go/extensions/bazaar"
 
@@ -66,6 +67,35 @@ The v2 extension follows a pattern where:
 			bazaar.BAZAAR.Key(): extension,
 		},
 	}
+
+# For MCP Tool Servers (V2)
+
+	import (
+		"github.com/coinbase/x402/go/extensions/bazaar"
+		exttypes "github.com/coinbase/x402/go/extensions/types"
+		mcp402 "github.com/coinbase/x402/go/mcp"
+	)
+
+	// Declare an MCP tool for Bazaar discovery
+	extension, err := bazaar.DeclareMcpDiscoveryExtension(exttypes.DeclareMcpDiscoveryConfig{
+		ToolName:    "get_weather",
+		Description: "Get current weather for a city",
+		InputSchema: exttypes.JSONSchema{
+			"properties": map[string]interface{}{
+				"city": map[string]interface{}{"type": "string"},
+			},
+			"required": []string{"city"},
+		},
+	})
+
+	// Pass in MCP payment wrapper config
+	paymentWrapper := mcp402.NewPaymentWrapper(resourceServer, mcp402.PaymentWrapperConfig{
+		Accepts: accepts,
+		Resource: &types.ResourceInfo{URL: "mcp://tool/get_weather"},
+		Extensions: map[string]interface{}{
+			exttypes.BAZAAR.Key(): extension,
+		},
+	})
 
 # For Facilitators (V2 and V1)
 

--- a/go/extensions/bazaar/resource_service.go
+++ b/go/extensions/bazaar/resource_service.go
@@ -475,3 +475,4 @@ func createBodyDiscoveryExtension(
 		Schema: schema,
 	}, nil
 }
+

--- a/python/x402/extensions/README.md
+++ b/python/x402/extensions/README.md
@@ -65,6 +65,34 @@ routes = {
 }
 ```
 
+#### MCP Tool
+
+For paid MCP tools, use `declare_mcp_discovery_extension` instead:
+
+```python
+from x402.mcp import create_payment_wrapper
+from x402.extensions.bazaar import DeclareMcpDiscoveryConfig, declare_mcp_discovery_extension
+
+weather_discovery = declare_mcp_discovery_extension(
+    DeclareMcpDiscoveryConfig(
+        tool_name="get_weather",
+        description="Get current weather for a city",
+        input_schema={
+            "properties": {"city": {"type": "string", "description": "City name"}},
+            "required": ["city"],
+        },
+        example={"city": "San Francisco"},
+    )
+)
+
+weather_wrapper = create_payment_wrapper(
+    resource_server,
+    accepts=weather_accepts,
+    resource=ResourceInfo(url="mcp://tool/get_weather"),
+    extensions=weather_discovery,  # Bazaar metadata attached to PaymentRequired
+)
+```
+
 ### For Facilitators
 
 Extract discovery information from payment requests:

--- a/python/x402/extensions/bazaar/__init__.py
+++ b/python/x402/extensions/bazaar/__init__.py
@@ -69,9 +69,11 @@ from .facilitator_client import (
 )
 from .resource_service import (
     DeclareBodyDiscoveryConfig,
+    DeclareMcpDiscoveryConfig,
     DeclareQueryDiscoveryConfig,
     OutputConfig,
     declare_discovery_extension,
+    declare_mcp_discovery_extension,
 )
 from .server import bazaar_resource_server_extension
 from .types import (
@@ -83,6 +85,10 @@ from .types import (
     BodyType,
     DiscoveryExtension,
     DiscoveryInfo,
+    McpDiscoveryExtension,
+    McpDiscoveryInfo,
+    McpInput,
+    McpTransport,
     OutputInfo,
     QueryDiscoveryExtension,
     QueryDiscoveryInfo,
@@ -100,18 +106,23 @@ __all__ = [
     # Input types
     "QueryInput",
     "BodyInput",
+    "McpInput",
+    "McpTransport",
     "OutputInfo",
     # Discovery info types
     "QueryDiscoveryInfo",
     "BodyDiscoveryInfo",
+    "McpDiscoveryInfo",
     "DiscoveryInfo",
     # Extension types
     "QueryDiscoveryExtension",
     "BodyDiscoveryExtension",
+    "McpDiscoveryExtension",
     "DiscoveryExtension",
     # Config types
     "DeclareQueryDiscoveryConfig",
     "DeclareBodyDiscoveryConfig",
+    "DeclareMcpDiscoveryConfig",
     "OutputConfig",
     # Result types
     "ValidationResult",
@@ -127,6 +138,7 @@ __all__ = [
     "BazaarExtendedClient",
     # Functions
     "declare_discovery_extension",
+    "declare_mcp_discovery_extension",
     "validate_discovery_extension",
     "extract_discovery_info",
     "extract_discovery_info_from_extension",

--- a/python/x402/extensions/bazaar/resource_service.py
+++ b/python/x402/extensions/bazaar/resource_service.py
@@ -15,6 +15,10 @@ from .types import (
     BodyDiscoveryInfo,
     BodyInput,
     BodyType,
+    McpDiscoveryExtension,
+    McpDiscoveryInfo,
+    McpInput,
+    McpTransport,
     OutputInfo,
     QueryDiscoveryExtension,
     QueryDiscoveryInfo,
@@ -221,6 +225,113 @@ def _create_body_discovery_extension(
     }
 
     return BodyDiscoveryExtension(info=body_info, schema=schema)
+
+
+@dataclass
+class DeclareMcpDiscoveryConfig:
+    """Configuration for declaring an MCP tool discovery extension."""
+
+    tool_name: str
+    input_schema: dict[str, Any]
+    description: str | None = None
+    transport: McpTransport | None = None
+    example: dict[str, Any] | None = None
+    output: OutputConfig | None = None
+
+
+def declare_mcp_discovery_extension(
+    config: DeclareMcpDiscoveryConfig,
+) -> dict[str, Any]:
+    """Create a Bazaar discovery extension for an MCP tool.
+
+    Use this when registering a paid MCP tool so facilitators can catalog and
+    index it in the Bazaar under the ``"mcp"`` resource type.
+
+    Args:
+        config: MCP tool declaration configuration.
+
+    Returns:
+        A dict with ``"bazaar"`` key containing the discovery extension.
+        Pass this as ``extensions`` in your payment wrapper config.
+
+    Example:
+        ```python
+        from x402.extensions.bazaar import declare_mcp_discovery_extension, DeclareMcpDiscoveryConfig
+
+        extensions = declare_mcp_discovery_extension(
+            DeclareMcpDiscoveryConfig(
+                tool_name="get_weather",
+                description="Get current weather for a city",
+                input_schema={
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+                example={"city": "San Francisco"},
+            )
+        )
+        ```
+    """
+    mcp_input = McpInput(
+        toolName=config.tool_name,
+        description=config.description,
+        transport=config.transport,
+        inputSchema=config.input_schema,
+        example=config.example,
+    )
+
+    output_info = None
+    if config.output and config.output.example is not None:
+        output_info = OutputInfo(type="json", example=config.output.example)
+
+    mcp_info = McpDiscoveryInfo(input=mcp_input, output=output_info)
+
+    # Build the JSON Schema that validates the info structure
+    input_properties: dict[str, Any] = {
+        "type": {"type": "string", "const": "mcp"},
+        "toolName": {"type": "string"},
+        "inputSchema": {"type": "object"},
+    }
+    if config.description is not None:
+        input_properties["description"] = {"type": "string"}
+    if config.transport is not None:
+        input_properties["transport"] = {
+            "type": "string",
+            "enum": ["streamable-http", "sse"],
+        }
+    if config.example is not None:
+        input_properties["example"] = {"type": "object"}
+
+    schema_properties: dict[str, Any] = {
+        "input": {
+            "type": "object",
+            "properties": input_properties,
+            "required": ["type", "toolName", "inputSchema"],
+            "additionalProperties": False,
+        }
+    }
+
+    if config.output and config.output.example is not None:
+        output_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string"},
+                "example": {},
+            },
+            "required": ["type"],
+        }
+        if config.output.schema:
+            output_schema["properties"]["example"].update(config.output.schema)
+        schema_properties["output"] = output_schema
+
+    schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": schema_properties,
+        "required": ["input"],
+    }
+
+    extension = McpDiscoveryExtension(info=mcp_info, schema=schema)
+    return {BAZAAR.key: extension.model_dump(by_alias=True, exclude_none=True)}
 
 
 def declare_discovery_extension(

--- a/python/x402/extensions/bazaar/types.py
+++ b/python/x402/extensions/bazaar/types.py
@@ -95,8 +95,42 @@ class BodyDiscoveryInfo(BaseModel):
     model_config = {"extra": "allow"}
 
 
+McpTransport = Literal["streamable-http", "sse"]
+
+
+class McpInput(BaseModel):
+    """Input information for MCP tools."""
+
+    type: Literal["mcp"] = "mcp"
+    tool_name: str = Field(alias="toolName")
+    description: str | None = None
+    transport: McpTransport | None = None
+    input_schema: dict[str, Any] = Field(alias="inputSchema")
+    example: dict[str, Any] | None = None
+
+    model_config = {"extra": "allow", "populate_by_name": True}
+
+
+class McpDiscoveryInfo(BaseModel):
+    """Discovery info for MCP tools."""
+
+    input: McpInput
+    output: OutputInfo | None = None
+
+    model_config = {"extra": "allow"}
+
+
+class McpDiscoveryExtension(BaseModel):
+    """Discovery extension for MCP tools."""
+
+    info: McpDiscoveryInfo
+    schema_: dict[str, Any] = Field(alias="schema")
+
+    model_config = {"extra": "allow", "populate_by_name": True}
+
+
 # Union type for discovery info
-DiscoveryInfo = QueryDiscoveryInfo | BodyDiscoveryInfo
+DiscoveryInfo = QueryDiscoveryInfo | BodyDiscoveryInfo | McpDiscoveryInfo
 
 
 class QueryDiscoveryExtension(BaseModel):
@@ -118,25 +152,25 @@ class BodyDiscoveryExtension(BaseModel):
 
 
 # Union type for discovery extension
-DiscoveryExtension = QueryDiscoveryExtension | BodyDiscoveryExtension
+DiscoveryExtension = QueryDiscoveryExtension | BodyDiscoveryExtension | McpDiscoveryExtension
 
 
 def parse_discovery_extension(data: dict[str, Any]) -> DiscoveryExtension:
     """Parse a discovery extension from a dictionary.
 
-    Automatically determines if it's a query or body extension based on
-    the presence of bodyType in the input.
+    Determines type from the input.type field (mcp) or bodyType presence (body vs query).
 
     Args:
         data: Dictionary containing extension data.
 
     Returns:
-        Parsed DiscoveryExtension (Query or Body variant).
+        Parsed DiscoveryExtension (Query, Body, or Mcp variant).
     """
     info = data.get("info", {})
     input_data = info.get("input", {})
 
-    # Check if it's a body extension by looking for bodyType
+    if input_data.get("type") == "mcp":
+        return McpDiscoveryExtension.model_validate(data)
     if "bodyType" in input_data or "body_type" in input_data:
         return BodyDiscoveryExtension.model_validate(data)
     return QueryDiscoveryExtension.model_validate(data)
@@ -145,18 +179,18 @@ def parse_discovery_extension(data: dict[str, Any]) -> DiscoveryExtension:
 def parse_discovery_info(data: dict[str, Any]) -> DiscoveryInfo:
     """Parse discovery info from a dictionary.
 
-    Automatically determines if it's query or body info based on
-    the presence of bodyType in the input.
+    Determines type from the input.type field (mcp) or bodyType presence (body vs query).
 
     Args:
         data: Dictionary containing discovery info.
 
     Returns:
-        Parsed DiscoveryInfo (Query or Body variant).
+        Parsed DiscoveryInfo (Query, Body, or Mcp variant).
     """
     input_data = data.get("input", {})
 
-    # Check if it's body info by looking for bodyType
+    if input_data.get("type") == "mcp":
+        return McpDiscoveryInfo.model_validate(data)
     if "bodyType" in input_data or "body_type" in input_data:
         return BodyDiscoveryInfo.model_validate(data)
     return QueryDiscoveryInfo.model_validate(data)

--- a/python/x402/mcp/server.py
+++ b/python/x402/mcp/server.py
@@ -52,6 +52,7 @@ def create_payment_wrapper(
     accepts: list[PaymentRequirements],
     resource: ResourceInfo | None = None,
     hooks: PaymentWrapperHooks | None = None,
+    extensions: dict[str, Any] | None = None,
 ) -> Callable:
     """Create a decorator that wraps a FastMCP tool handler with x402 payment logic.
 
@@ -79,6 +80,9 @@ def create_payment_wrapper(
             Defaults to ``mcp://tool/{function_name}``.
         hooks: Optional ``PaymentWrapperHooks`` for on_before_execution,
             on_after_execution, on_after_settlement (matches server_async).
+        extensions: Optional x402 extensions to include in PaymentRequired responses.
+            Use this to attach Bazaar discovery metadata so facilitators can index
+            the tool. Example: ``declare_mcp_discovery_extension(config)``
 
     Returns:
         A decorator to apply to a FastMCP tool handler function.
@@ -127,7 +131,9 @@ def create_payment_wrapper(
             payment_data = _extract_payment_from_context(ctx)
 
             if not payment_data:
-                return _create_payment_required_result(accepts, tool_resource, "Payment Required")
+                return _create_payment_required_result(
+                    accepts, tool_resource, "Payment Required", extensions
+                )
 
             # Parse payment payload
             try:
@@ -136,7 +142,7 @@ def create_payment_wrapper(
                 payload = PaymentPayload.model_validate(payment_data)
             except Exception as e:
                 return _create_payment_required_result(
-                    accepts, tool_resource, f"Invalid payment payload: {e}"
+                    accepts, tool_resource, f"Invalid payment payload: {e}", extensions
                 )
 
             if asyncio.iscoroutinefunction(resource_server.verify_payment):
@@ -150,6 +156,7 @@ def create_payment_wrapper(
                     accepts,
                     tool_resource,
                     f"Payment verification failed: {verify_result.invalid_reason}",
+                    extensions,
                 )
 
             # OnBeforeExecution hook
@@ -168,6 +175,7 @@ def create_payment_wrapper(
                         accepts,
                         tool_resource,
                         "Execution blocked by on_before_execution hook",
+                        extensions,
                     )
 
             # Execute the original handler
@@ -234,12 +242,14 @@ def create_payment_wrapper(
                         accepts,
                         tool_resource,
                         f"Settlement failed: {settle_result.error_reason}",
+                        extensions,
                     )
             except Exception as e:
                 return _create_payment_required_result(
                     accepts,
                     tool_resource,
                     f"Settlement error: {e}",
+                    extensions,
                 )
 
             # OnAfterSettlement hook
@@ -326,17 +336,20 @@ def _create_payment_required_result(
     accepts: list[PaymentRequirements],
     resource: ResourceInfo,
     error_message: str,
+    extensions: dict[str, Any] | None = None,
 ) -> Any:
     """Create a payment required CallToolResult."""
     from mcp.types import CallToolResult, TextContent
 
     accepts_dicts = [req.model_dump(by_alias=True) for req in accepts]
-    payment_required = {
+    payment_required: dict[str, Any] = {
         "x402Version": 2,
         "accepts": accepts_dicts,
         "error": error_message,
         "resource": resource.model_dump(by_alias=True),
     }
+    if extensions:
+        payment_required["extensions"] = extensions
     return CallToolResult(
         content=[TextContent(type="text", text=json.dumps(payment_required))],
         structuredContent=payment_required,

--- a/python/x402/mcp/server_async.py
+++ b/python/x402/mcp/server_async.py
@@ -37,6 +37,7 @@ class PaymentWrapperConfig:
         accepts: list[PaymentRequirements],
         resource: ResourceInfo | None = None,
         hooks: PaymentWrapperHooks | None = None,
+        extensions: dict[str, Any] | None = None,
     ):
         """Initialize async payment wrapper config.
 
@@ -44,12 +45,16 @@ class PaymentWrapperConfig:
             accepts: List of payment requirements
             resource: Optional resource info
             hooks: Optional async server-side hooks
+            extensions: Optional x402 extensions to include in PaymentRequired responses.
+                Use this to attach Bazaar discovery metadata so facilitators can index
+                the tool. Example: ``declare_mcp_discovery_extension(config)``
         """
         if not accepts:
             raise ValueError("accepts must have at least one payment requirement")
         self.accepts = accepts
         self.resource = resource
         self.hooks = hooks
+        self.extensions = extensions
 
 
 def wrap_fastmcp_tool(
@@ -329,6 +334,7 @@ async def _create_payment_required_result_async(
         config.accepts,
         resource_info,
         error_message,
+        config.extensions,
     )
 
     # Convert to dict for structuredContent

--- a/python/x402/mcp/server_sync.py
+++ b/python/x402/mcp/server_sync.py
@@ -205,6 +205,7 @@ def _create_payment_required_result_sync(
         config.accepts,
         resource_info,
         error_message,
+        config.extensions,
     )
 
     payment_required_dict = (

--- a/python/x402/mcp/types.py
+++ b/python/x402/mcp/types.py
@@ -182,6 +182,7 @@ class SyncPaymentWrapperConfig:
         accepts: list[PaymentRequirements],
         resource: ResourceInfo | None = None,
         hooks: Optional["SyncPaymentWrapperHooks"] = None,  # type: ignore
+        extensions: dict[str, Any] | None = None,
     ):
         """Initialize payment wrapper config.
 
@@ -189,12 +190,16 @@ class SyncPaymentWrapperConfig:
             accepts: List of payment requirements
             resource: Optional resource info
             hooks: Optional server-side hooks
+            extensions: Optional x402 extensions to include in PaymentRequired responses.
+                Use this to attach Bazaar discovery metadata so facilitators can index
+                the tool. Example: ``declare_mcp_discovery_extension(config)``
         """
         if not accepts:
             raise ValueError("accepts must have at least one payment requirement")
         self.accepts = accepts
         self.resource = resource
         self.hooks = hooks
+        self.extensions = extensions
 
 
 class ServerHookContext:

--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -61,6 +61,26 @@ export interface PaymentWrapperConfig {
     /** Called after successful settlement */
     onAfterSettlement?: AfterSettlementHook;
   };
+
+  /**
+   * x402 extensions to include in the PaymentRequired response.
+   * Use this to attach Bazaar discovery metadata so facilitators can index the tool.
+   *
+   * @example
+   * ```typescript
+   * import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+   *
+   * extensions: declareDiscoveryExtension({
+   *   toolName: "get_weather",
+   *   description: "Get current weather for a city",
+   *   inputSchema: {
+   *     properties: { city: { type: "string" } },
+   *     required: ["city"],
+   *   },
+   * })
+   * ```
+   */
+  extensions?: Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Description

Adds Bazaar discovery support for paid MCP tools across TypeScript, Python, and Go SDKs. HTTP endpoints have had end-to-end Bazaar discovery since day one, but paid MCP tools never surfaced in \`/discovery/resources\` — the MCP payment wrappers in all three SDKs didn't attach \`extensions\` to \`PaymentRequired\` responses, so facilitators never saw any Bazaar metadata.

**Core fix:** Add an \`extensions\` field to \`PaymentWrapperConfig\` in each SDK's MCP wrapper and thread it through to \`createPaymentRequiredResponse\`.

**TypeScript** — declaration helpers (\`declareDiscoveryExtension({toolName})\`, \`McpDiscoveryInfo\`, etc.) already existed in \`@x402/extensions/bazaar/mcp/\`; only the wrapper wiring was missing. Also fixed a hardcoded \`type: "http"\` in the facilitator example.

**Python** — no MCP discovery types existed; added \`McpInput\`, \`McpDiscoveryInfo\`, \`McpDiscoveryExtension\`, \`declare_mcp_discovery_extension()\`, updated union types and parse helpers. Applied to both the async (\`server_async.py\`) and FastMCP (\`server.py\`) paths.

**Go** — fixed \`ExtractDiscoveredResourceFromPaymentPayload\` / \`ExtractDiscoveredResourceFromPaymentRequired\` which would error on MCP inputs; wired \`Extensions\` through the MCP payment wrapper; added \`declare_mcp_discovery_extension()\` to the Python SDK (Go already had it from upstream).

**E2E** — wired \`declare_mcp_discovery_extension\` into both MCP e2e servers, updated the Bazaar validator to expect \`mcp://tool/{toolName}\` resource URLs and verify \`discoveryInfo.input.type === "mcp"\`.

**Docs** — updated \`docs/extensions/bazaar.mdx\` (seller examples for all languages, MCP buyer Step 2, fixed \`tool\` → \`toolName\` field name), quickstart-for-sellers §4, \`mcp-server-with-x402.md\`, and SDK READMEs/package docs.

## Tests

- TypeScript: \`pnpm format && pnpm lint\` pass; \`@x402/mcp\` and \`@x402/extensions\` unit tests pass (pre-existing \`siwe\` failure in \`sign-in-with-x.test.ts\` reproduces on \`main\`)
- Python: \`uvx ruff format && uvx ruff check\` pass; \`pytest tests/unit/\` passes (pre-existing integration test failure reproduces on unmodified \`main\`)
- Go: \`make verify\` (fmt + lint + test) passes
- E2E: MCP payment scenarios pass and Bazaar Discovery Validation passes — \`mcp://tool/get_weather\` appears in \`/discovery/resources\` with \`type: "mcp"\` and correct \`toolName\` for both Python and Go MCP servers

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [ ] My commits are signed (required for merge)
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)