### PR TITLE
feat: add PAYGRID to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/paygrid/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/paygrid/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "PAYGRID",
+  "description": "Three AI data APIs (hotel readiness scoring, content QA, M&A deal flow intel) running on a live x402 server. Pay-per-request with USDC on Base mainnet — no accounts, no API keys.",
+  "logoUrl": "/logos/paygrid.png",
+  "websiteUrl": "https://github.com/AutopilotPR/paygrid",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## PAYGRID — x402-powered AI data API

Live server at https://api.autopilotpr.com running three pay-per-request endpoints on Base mainnet:

- `POST /score/hotel` — $0.05 — hotel readiness scoring
- `POST /critic/content` — $0.03 — content QA pass/fail
- `POST /intel/deal-flow` — $0.25 — M&A deal flow scan

Health check: `curl https://api.autopilotpr.com/health` returns `"mode":"production"`.

Docs + code: https://github.com/AutopilotPR/paygrid