### PR TITLE
feat: add Northeast Deal Intel API to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/northeast-deal-intel/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/northeast-deal-intel/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Northeast Deal Intel API",
+  "description": "Commercial real estate intelligence API \u2014 AI deal scoring, sell-probability signals, closed comp search, and owner-lookup across 9 Northeast US states. 100K+ deed records. Per-call pricing via x402.",
+  "logoUrl": "/logos/northeast-deal-intel.png",
+  "websiteUrl": "https://northeastdealintel.com/agent-api.html",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## New Ecosystem Partner — Northeast Deal Intel API

**Category:** Services/Endpoints

**Website:** https://northeastdealintel.com/agent-api.html

### What it does

Northeast Deal Intel provides commercial real estate intelligence via x402-gated API endpoints:

- **`POST /v1/agent/score`** ($0.10) — AI deal scoring across 5 dimensions: cap rate vs. submarket, price/SF vs. closed comps, location, tenant credit, 1031 suitability. Returns 1–10 score + thesis label + investor match.
- **`GET /v1/agent/sell-signal`** ($0.05) — Sell probability score (0–100%) using aging ownership, days on market, distress signals, and deal momentum.
- **`GET /v1/agent/owner-lookup`** ($0.05) — Owner name, years held, aging ownership signal from 100K+ Northeast deed records.
- **`GET /v1/agent/market-benchmarks`** ($0.02) — Live cap rate benchmarks by state and property type.
- **`GET /v1/agent/search`** ($0.02) — Search 16K+ active CRE listings with filters.

### x402 Integration

- **Network:** `eip155:84532` (Base Sepolia)
- **Scheme:** `exact`
- **Asset:** USDC
- **Facilitator:** https://x402.org/facilitator

### Live endpoint

Try it (returns 402 with full payment spec):
```
curl -I https://api.northeastdealintel.com/v1/agent/sell-signal?address=123+Main+St&state=CT
```

Built with the Python `x402` library + FastAPI middleware.
