### PR TITLE
Fix: invoke lifecycle hooks in payment payload creation

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -249,22 +249,40 @@ func (c *x402Client) CreatePaymentPayloadV1(
 	}
 
 	// Before hooks
+	creationCtxV1 := PaymentCreationContext{
+		Ctx:                  ctx,
+		Version:              1,
+		SelectedRequirements: requirements,
+	}
 	for _, hook := range c.beforePaymentCreationHooks {
-		if err := hook(ctx, requirements); err != nil {
+		result, err := hook(creationCtxV1)
+		if err != nil {
 			return types.PaymentPayloadV1{}, err
+		}
+		if result != nil && result.Abort {
+			return types.PaymentPayloadV1{}, &PaymentError{
+				Code:    ErrCodeUnsupportedScheme,
+				Message: result.Reason,
+			}
 		}
 	}
 
 	payload, err := client.CreatePaymentPayload(ctx, requirements)
 	if err != nil {
 		for _, hook := range c.onPaymentCreationFailureHooks {
-			hook(ctx, requirements, err)
+			hook(PaymentCreationFailureContext{
+				PaymentCreationContext: creationCtxV1,
+				Error:                  err,
+			})
 		}
 		return types.PaymentPayloadV1{}, err
 	}
 
 	for _, hook := range c.afterPaymentCreationHooks {
-		hook(ctx, payload)
+		hook(PaymentCreatedContext{
+			PaymentCreationContext: creationCtxV1,
+			Payload:                payload,
+		})
 	}
 	return payload, nil
 }
@@ -300,12 +318,24 @@ func (c *x402Client) CreatePaymentPayload(
 	}
 
 	// Before hooks
+	creationCtxV2 := PaymentCreationContext{
+		Ctx:                  ctx,
+		Version:              2,
+		SelectedRequirements: requirements,
+	}
 	for _, hook := range c.beforePaymentCreationHooks {
-		if err := hook(ctx, requirements); err != nil {
+		result, err := hook(creationCtxV2)
+		if err != nil {
 			return types.PaymentPayload{}, err
 		}
+		if result != nil && result.Abort {
+			return types.PaymentPayload{}, &PaymentError{
+				Code:    ErrCodeUnsupportedScheme,
+				Message: result.Reason,
+			}
+		}
 	}
-	
+
 	// Get partial payload from mechanism.
 	// If the scheme supports extensions (e.g., EIP-2612), pass them for enrichment.
 	var partial types.PaymentPayload
@@ -317,7 +347,10 @@ func (c *x402Client) CreatePaymentPayload(
 	}
 	if err != nil {
 		for _, hook := range c.onPaymentCreationFailureHooks {
-			hook(ctx, requirements, err)
+			hook(PaymentCreationFailureContext{
+				PaymentCreationContext: creationCtxV2,
+				Error:                  err,
+			})
 		}
 		return types.PaymentPayload{}, err
 	}
@@ -337,13 +370,19 @@ func (c *x402Client) CreatePaymentPayload(
 	})
 	if err != nil {
 		for _, hook := range c.onPaymentCreationFailureHooks {
-			hook(ctx, requirements, err)
+			hook(PaymentCreationFailureContext{
+				PaymentCreationContext: creationCtxV2,
+				Error:                  err,
+			})
 		}
 		return types.PaymentPayload{}, err
 	}
 
 	for _, hook := range c.afterPaymentCreationHooks {
-		hook(ctx, partial)
+		hook(PaymentCreatedContext{
+			PaymentCreationContext: creationCtxV2,
+			Payload:                partial,
+		})
 	}
 	return partial, nil
 }

--- a/go/client.go
+++ b/go/client.go
@@ -270,10 +270,18 @@ func (c *x402Client) CreatePaymentPayloadV1(
 	payload, err := client.CreatePaymentPayload(ctx, requirements)
 	if err != nil {
 		for _, hook := range c.onPaymentCreationFailureHooks {
-			_ = hook(PaymentCreationFailureContext{
+			result, hookErr := hook(PaymentCreationFailureContext{
 				PaymentCreationContext: creationCtxV1,
 				Error:                  err,
 			})
+			if hookErr != nil {
+				return types.PaymentPayloadV1{}, hookErr
+			}
+			if result != nil && result.Recovered {
+				if recovered, ok := result.Payload.(types.PaymentPayloadV1); ok {
+					return recovered, nil
+				}
+			}
 		}
 		return types.PaymentPayloadV1{}, err
 	}
@@ -347,10 +355,18 @@ func (c *x402Client) CreatePaymentPayload(
 	}
 	if err != nil {
 		for _, hook := range c.onPaymentCreationFailureHooks {
-			_ = hook(PaymentCreationFailureContext{
+			result, hookErr := hook(PaymentCreationFailureContext{
 				PaymentCreationContext: creationCtxV2,
 				Error:                  err,
 			})
+			if hookErr != nil {
+				return types.PaymentPayload{}, hookErr
+			}
+			if result != nil && result.Recovered {
+				if recovered, ok := result.Payload.(types.PaymentPayload); ok {
+					return recovered, nil
+				}
+			}
 		}
 		return types.PaymentPayload{}, err
 	}
@@ -370,10 +386,18 @@ func (c *x402Client) CreatePaymentPayload(
 	})
 	if err != nil {
 		for _, hook := range c.onPaymentCreationFailureHooks {
-			_ = hook(PaymentCreationFailureContext{
+			result, hookErr := hook(PaymentCreationFailureContext{
 				PaymentCreationContext: creationCtxV2,
 				Error:                  err,
 			})
+			if hookErr != nil {
+				return types.PaymentPayload{}, hookErr
+			}
+			if result != nil && result.Recovered {
+				if recovered, ok := result.Payload.(types.PaymentPayload); ok {
+					return recovered, nil
+				}
+			}
 		}
 		return types.PaymentPayload{}, err
 	}

--- a/go/client.go
+++ b/go/client.go
@@ -270,7 +270,7 @@ func (c *x402Client) CreatePaymentPayloadV1(
 	payload, err := client.CreatePaymentPayload(ctx, requirements)
 	if err != nil {
 		for _, hook := range c.onPaymentCreationFailureHooks {
-			hook(PaymentCreationFailureContext{
+			_ = hook(PaymentCreationFailureContext{
 				PaymentCreationContext: creationCtxV1,
 				Error:                  err,
 			})
@@ -279,7 +279,7 @@ func (c *x402Client) CreatePaymentPayloadV1(
 	}
 
 	for _, hook := range c.afterPaymentCreationHooks {
-		hook(PaymentCreatedContext{
+		_ = hook(PaymentCreatedContext{
 			PaymentCreationContext: creationCtxV1,
 			Payload:                payload,
 		})
@@ -347,7 +347,7 @@ func (c *x402Client) CreatePaymentPayload(
 	}
 	if err != nil {
 		for _, hook := range c.onPaymentCreationFailureHooks {
-			hook(PaymentCreationFailureContext{
+			_ = hook(PaymentCreationFailureContext{
 				PaymentCreationContext: creationCtxV2,
 				Error:                  err,
 			})
@@ -370,7 +370,7 @@ func (c *x402Client) CreatePaymentPayload(
 	})
 	if err != nil {
 		for _, hook := range c.onPaymentCreationFailureHooks {
-			hook(PaymentCreationFailureContext{
+			_ = hook(PaymentCreationFailureContext{
 				PaymentCreationContext: creationCtxV2,
 				Error:                  err,
 			})
@@ -379,7 +379,7 @@ func (c *x402Client) CreatePaymentPayload(
 	}
 
 	for _, hook := range c.afterPaymentCreationHooks {
-		hook(PaymentCreatedContext{
+		_ = hook(PaymentCreatedContext{
 			PaymentCreationContext: creationCtxV2,
 			Payload:                partial,
 		})

--- a/go/client.go
+++ b/go/client.go
@@ -248,7 +248,25 @@ func (c *x402Client) CreatePaymentPayloadV1(
 		}
 	}
 
-	return client.CreatePaymentPayload(ctx, requirements)
+	// Before hooks
+	for _, hook := range c.beforePaymentCreationHooks {
+		if err := hook(ctx, requirements); err != nil {
+			return types.PaymentPayloadV1{}, err
+		}
+	}
+
+	payload, err := client.CreatePaymentPayload(ctx, requirements)
+	if err != nil {
+		for _, hook := range c.onPaymentCreationFailureHooks {
+			hook(ctx, requirements, err)
+		}
+		return types.PaymentPayloadV1{}, err
+	}
+
+	for _, hook := range c.afterPaymentCreationHooks {
+		hook(ctx, payload)
+	}
+	return payload, nil
 }
 
 // CreatePaymentPayload creates a payment payload (V2, default)
@@ -281,6 +299,13 @@ func (c *x402Client) CreatePaymentPayload(
 		}
 	}
 
+	// Before hooks
+	for _, hook := range c.beforePaymentCreationHooks {
+		if err := hook(ctx, requirements); err != nil {
+			return types.PaymentPayload{}, err
+		}
+	}
+	
 	// Get partial payload from mechanism.
 	// If the scheme supports extensions (e.g., EIP-2612), pass them for enrichment.
 	var partial types.PaymentPayload
@@ -291,6 +316,9 @@ func (c *x402Client) CreatePaymentPayload(
 		partial, err = client.CreatePaymentPayload(ctx, requirements)
 	}
 	if err != nil {
+		for _, hook := range c.onPaymentCreationFailureHooks {
+			hook(ctx, requirements, err)
+		}
 		return types.PaymentPayload{}, err
 	}
 
@@ -308,9 +336,15 @@ func (c *x402Client) CreatePaymentPayload(
 		Resource:    resource,
 	})
 	if err != nil {
+		for _, hook := range c.onPaymentCreationFailureHooks {
+			hook(ctx, requirements, err)
+		}
 		return types.PaymentPayload{}, err
 	}
 
+	for _, hook := range c.afterPaymentCreationHooks {
+		hook(ctx, partial)
+	}
 	return partial, nil
 }
 

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -3,8 +3,10 @@ package x402
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/x402-foundation/x402/go/types"
 )
 
@@ -351,4 +353,99 @@ func TestClientNetworkPatternMatching(t *testing.T) {
 	if payload.Accepted.Scheme != "exact" {
 		t.Fatal("Expected payload to be created with pattern match")
 	}
+}
+
+// mockFailableV1 and mockFailableV2 support failure simulation for hook tests
+
+type mockFailableV1 struct{ fail bool }
+
+func (m *mockFailableV1) Scheme() string { return "mock" }
+func (m *mockFailableV1) CreatePaymentPayload(
+	_ context.Context,
+	_ types.PaymentRequirementsV1,
+) (types.PaymentPayloadV1, error) {
+	if m.fail {
+		return types.PaymentPayloadV1{}, fmt.Errorf("fail")
+	}
+	return types.PaymentPayloadV1{}, nil
+}
+
+type mockFailableV2 struct{ fail bool }
+
+func (m *mockFailableV2) Scheme() string { return "mock" }
+func (m *mockFailableV2) CreatePaymentPayload(
+	_ context.Context,
+	_ types.PaymentRequirements,
+) (types.PaymentPayload, error) {
+	if m.fail {
+		return types.PaymentPayload{}, fmt.Errorf("fail")
+	}
+	return types.PaymentPayload{}, nil
+}
+
+func TestPaymentHooksOrder_V1_vs_V2(t *testing.T) {
+	ctx := context.Background()
+
+	makeClient := func(fail bool) *x402Client {
+		c := Newx402Client()
+		c.RegisterV1(Network("test"), &mockFailableV1{fail: fail})
+		c.Register(Network("test"), &mockFailableV2{fail: fail})
+		return c
+	}
+
+	run := func(c *x402Client, useV1 bool, expectErr bool) []string {
+		var calls []string
+		// СТАЛО:
+		c.OnBeforePaymentCreation(func(pcc PaymentCreationContext) (*BeforePaymentCreationHookResult, error) {
+			calls = append(calls, "before")
+			return nil, nil
+		})
+		c.OnAfterPaymentCreation(func(pcc PaymentCreatedContext) error {
+			calls = append(calls, "after")
+			return nil
+		})
+		c.OnPaymentCreationFailure(func(pcc PaymentCreationFailureContext) (*PaymentCreationFailureHookResult, error) {
+			calls = append(calls, "failure")
+			return nil, nil
+		})
+
+		if useV1 {
+			_, err := c.CreatePaymentPayloadV1(ctx, types.PaymentRequirementsV1{
+				Scheme:  "mock",
+				Network: "test",
+			})
+			if expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		} else {
+			_, err := c.CreatePaymentPayload(ctx, types.PaymentRequirements{
+				Scheme:  "mock",
+				Network: "test",
+			}, nil, nil)
+			if expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		}
+		return calls
+	}
+
+	t.Run("success", func(t *testing.T) {
+		v1 := run(makeClient(false), true, false)
+		v2 := run(makeClient(false), false, false)
+		require.Equal(t, []string{"before", "after"}, v1)
+		require.Equal(t, []string{"before", "after"}, v2)
+		require.Equal(t, v1, v2)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		v1 := run(makeClient(true), true, true)
+		v2 := run(makeClient(true), false, true)
+		require.Equal(t, []string{"before", "failure"}, v1)
+		require.Equal(t, []string{"before", "failure"}, v2)
+		require.Equal(t, v1, v2)
+	})
 }


### PR DESCRIPTION
Add before, after, and failure lifecycle hook invocations that were registered but never called in CreatePaymentPayload and CreatePaymentPayloadV1 methods.