### PR TITLE
Add MemoryAPI example — persistent semantic memory with x402 pay-per-request

### DIFF
--- a/examples/typescript/servers/memoryapi/.env.example
+++ b/examples/typescript/servers/memoryapi/.env.example
@@ -1,0 +1,5 @@
+OPENAI_API_KEY=sk-...
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_KEY=your-service-role-key
+WALLET_ADDRESS=0xYourWalletAddress
+PORT=3000

--- a/examples/typescript/servers/memoryapi/README.md
+++ b/examples/typescript/servers/memoryapi/README.md
@@ -1,0 +1,210 @@
+# MemoryAPI x402 Example
+
+> Persistent semantic memory for AI agents — pay per request in USDC via x402
+
+This example demonstrates how to build a pay-per-request memory API for AI agents using x402. Agents store and retrieve memories without accounts or API keys — they simply pay $0.001 USDC per request on Base.
+
+## What It Does
+
+- **Store memories** — agents POST natural language memories, stored as vector embeddings
+- **Search memories** — agents search semantically using natural language queries
+- **Pay per request** — no accounts, no API keys, just USDC on Base via x402
+
+## Architecture
+
+```
+AI Agent → POST /memory (pays $0.001 USDC) → x402 middleware verifies → Stored in Supabase + pgvector
+AI Agent → GET /memory?query=... (pays $0.001 USDC) → x402 middleware verifies → Semantic search results
+```
+
+## Prerequisites
+
+- Node.js 18+
+- [Supabase](https://supabase.com) project with pgvector enabled
+- [OpenAI API key](https://platform.openai.com/api-keys) for embeddings
+- An EVM wallet address to receive USDC payments (e.g. Coinbase Wallet)
+
+## Setup
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/x402-foundation/x402
+cd examples/typescript/servers/memoryapi
+npm install
+```
+
+### 2. Set up Supabase
+
+Enable pgvector and run this schema in your Supabase SQL editor:
+
+```sql
+create extension if not exists vector;
+
+create table memories (
+  id uuid primary key default gen_random_uuid(),
+  agent_id text not null,
+  content text not null,
+  embedding vector(1536),
+  metadata jsonb default '{}',
+  created_at timestamptz default now()
+);
+
+create index on memories using hnsw (embedding vector_cosine_ops);
+create index on memories (agent_id);
+
+create or replace function search_memories(
+  query_embedding vector(1536),
+  match_agent_id text,
+  match_threshold float default 0.4,
+  match_count int default 10
+)
+returns table (
+  id uuid,
+  content text,
+  metadata jsonb,
+  similarity float,
+  created_at timestamptz
+)
+language sql stable
+as $$
+  select id, content, metadata,
+    1 - (embedding <=> query_embedding) as similarity,
+    created_at
+  from memories
+  where agent_id = match_agent_id
+    and 1 - (embedding <=> query_embedding) > match_threshold
+  order by embedding <=> query_embedding
+  limit match_count;
+$$;
+```
+
+### 3. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env`:
+
+```env
+OPENAI_API_KEY=sk-...
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_KEY=your-service-role-key
+WALLET_ADDRESS=0xYourWalletAddress
+PORT=3000
+```
+
+### 4. Run
+
+```bash
+npm run dev
+```
+
+## API Reference
+
+### `GET /`
+Free health check. Returns service info and pricing.
+
+```bash
+curl http://localhost:3000/
+```
+
+---
+
+### `POST /memory` — Store a memory
+**Price:** $0.001 USDC per request
+
+```bash
+# Without payment — returns 402 with payment instructions
+curl -X POST http://localhost:3000/memory \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "my-agent", "content": "User prefers dark mode"}'
+
+# Response: 402 Payment Required
+# {
+#   "x402Version": 1,
+#   "accepts": [{ "scheme": "exact", "price": "$0.001", "network": "eip155:8453" }]
+# }
+```
+
+**Request body:**
+```json
+{
+  "agent_id": "my-agent",
+  "content": "User prefers dark mode and React Native",
+  "metadata": { "type": "preference" }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "memory": {
+    "id": "uuid",
+    "content": "User prefers dark mode and React Native",
+    "metadata": { "type": "preference" },
+    "created_at": "2026-04-21T..."
+  }
+}
+```
+
+---
+
+### `GET /memory` — Search memories
+**Price:** $0.001 USDC per request
+
+**Query params:**
+- `agent_id` (required) — agent namespace
+- `query` (required) — natural language search
+- `limit` (optional, default 10, max 50)
+- `threshold` (optional, default 0.4)
+
+```bash
+curl "http://localhost:3000/memory?agent_id=my-agent&query=what+does+the+user+prefer"
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "count": 1,
+  "results": [
+    {
+      "id": "uuid",
+      "content": "User prefers dark mode and React Native",
+      "similarity": 0.87,
+      "metadata": { "type": "preference" },
+      "created_at": "2026-04-21T..."
+    }
+  ]
+}
+```
+
+## How x402 Payment Works
+
+1. Agent sends request without payment → server returns **402 Payment Required** with USDC price and wallet address
+2. Agent constructs payment on Base using USDC
+3. Agent resends request with `PAYMENT-SIGNATURE` header
+4. x402 middleware verifies payment via CDP facilitator
+5. Request proceeds and memory is stored/retrieved
+
+No accounts. No API keys. No monthly subscriptions. Just USDC.
+
+## Hosted Version
+
+A hosted version of this API is available at:
+
+- **API:** https://api.memoryapi.org
+- **Docs:** https://memoryapi.org
+- **GitHub:** https://github.com/heavysword1/memoryapi
+
+The hosted version also offers:
+- Traditional API key auth with monthly plans
+- MCP endpoint for Claude Desktop / Cursor / Windsurf
+- Free tier (100 memories)
+
+## License
+
+MIT © 2026 Ocean Digital Group

--- a/examples/typescript/servers/memoryapi/index.ts
+++ b/examples/typescript/servers/memoryapi/index.ts
@@ -1,0 +1,188 @@
+import express from "express";
+import { paymentMiddleware, x402ResourceServer } from "@x402/express";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+import { createClient } from "@supabase/supabase-js";
+import OpenAI from "openai";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+const app = express();
+app.use(express.json({ limit: "50kb" }));
+
+// --- Clients ---
+const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_KEY!
+);
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// --- Helpers ---
+async function generateEmbedding(text: string): Promise<number[]> {
+  const response = await openai.embeddings.create({
+    model: "text-embedding-3-small",
+    input: text,
+  });
+  return response.data[0].embedding;
+}
+
+const injectionPatterns = [
+  /ignore\s+(all\s+)?(previous|prior|above)\s+instructions/i,
+  /system\s*:\s*override/i,
+  /you\s+are\s+now\s+a/i,
+  /forget\s+(everything|all)\s+(you|above)/i,
+  /new\s+instructions?\s*:/i,
+];
+
+function hasInjection(text: string): boolean {
+  return injectionPatterns.some((p) => p.test(text));
+}
+
+// --- x402 Payment Middleware ---
+const PAY_TO = process.env.WALLET_ADDRESS!; // Your receiving wallet
+const NETWORK = "eip155:8453"; // Base mainnet
+
+const facilitator = new HTTPFacilitatorClient({
+  url: "https://api.cdp.coinbase.com/platform/v2/x402",
+});
+
+const server = new x402ResourceServer(facilitator).register(
+  NETWORK,
+  new ExactEvmScheme()
+);
+
+app.use(
+  paymentMiddleware(
+    {
+      "POST /memory": {
+        accepts: [
+          {
+            scheme: "exact",
+            price: "$0.001", // $0.001 USDC per store
+            network: NETWORK,
+            payTo: PAY_TO,
+          },
+        ],
+        description: "Store a memory for an AI agent",
+        mimeType: "application/json",
+      },
+      "GET /memory": {
+        accepts: [
+          {
+            scheme: "exact",
+            price: "$0.001", // $0.001 USDC per search
+            network: NETWORK,
+            payTo: PAY_TO,
+          },
+        ],
+        description: "Semantically search stored agent memories",
+        mimeType: "application/json",
+      },
+    },
+    server
+  )
+);
+
+// --- Routes ---
+
+// Health check (free)
+app.get("/", (req, res) => {
+  res.json({
+    service: "MemoryAPI x402",
+    version: "1.0.0",
+    description: "Persistent semantic memory for AI agents — pay per request in USDC",
+    pricing: {
+      store: "$0.001 USDC per memory",
+      search: "$0.001 USDC per search",
+    },
+    network: NETWORK,
+    payTo: PAY_TO,
+  });
+});
+
+// POST /memory — store a memory ($0.001 USDC)
+app.post("/memory", async (req, res) => {
+  try {
+    const { content, agent_id, metadata = {} } = req.body;
+
+    if (!agent_id || typeof agent_id !== "string") {
+      return res.status(400).json({ error: "agent_id is required." });
+    }
+
+    if (!content || typeof content !== "string") {
+      return res.status(400).json({ error: "content is required." });
+    }
+
+    if (content.length > 10000) {
+      return res.status(400).json({ error: "content exceeds 10,000 character limit." });
+    }
+
+    if (hasInjection(content)) {
+      return res.status(400).json({ error: "Content contains unsafe instruction patterns." });
+    }
+
+    const embedding = await generateEmbedding(content);
+
+    const { data, error } = await supabase
+      .from("memories")
+      .insert({ agent_id, content, embedding, metadata })
+      .select("id, content, metadata, created_at")
+      .single();
+
+    if (error) throw error;
+
+    return res.status(201).json({ success: true, memory: data });
+  } catch (err) {
+    console.error("POST /memory error:", err);
+    return res.status(500).json({ error: "Failed to store memory." });
+  }
+});
+
+// GET /memory?agent_id=...&query=... — semantic search ($0.001 USDC)
+app.get("/memory", async (req, res) => {
+  try {
+    const { agent_id, query, threshold = "0.4" } = req.query as Record<string, string>;
+    const limit = Math.min(parseInt(req.query.limit as string) || 10, 50);
+
+    if (!agent_id) {
+      return res.status(400).json({ error: "agent_id is required." });
+    }
+
+    if (!query) {
+      return res.status(400).json({ error: "query is required." });
+    }
+
+    if (query.length > 1000) {
+      return res.status(400).json({ error: "query must be under 1000 characters." });
+    }
+
+    const embedding = await generateEmbedding(query);
+
+    const { data, error } = await supabase.rpc("search_memories", {
+      query_embedding: embedding,
+      match_agent_id: agent_id,
+      match_threshold: parseFloat(threshold),
+      match_count: limit,
+    });
+
+    if (error) throw error;
+
+    return res.json({
+      success: true,
+      results: data,
+      count: data.length,
+    });
+  } catch (err) {
+    console.error("GET /memory error:", err);
+    return res.status(500).json({ error: "Failed to search memories." });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`MemoryAPI x402 running on port ${PORT}`);
+  console.log(`Receiving payments at: ${PAY_TO}`);
+  console.log(`Network: ${NETWORK}`);
+});

--- a/examples/typescript/servers/memoryapi/package.json
+++ b/examples/typescript/servers/memoryapi/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "memoryapi-x402",
+  "version": "1.0.0",
+  "description": "Persistent semantic memory API for AI agents — pay per request in USDC via x402",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node index.ts"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.0",
+    "@x402/core": "^0.4.0",
+    "@x402/evm": "^0.4.0",
+    "@x402/express": "^0.4.0",
+    "dotenv": "^16.4.1",
+    "express": "^4.18.2",
+    "openai": "^4.28.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/examples/typescript/servers/memoryapi/tsconfig.json
+++ b/examples/typescript/servers/memoryapi/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
…request

<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
MemoryAPI — Persistent Semantic Memory for AI Agents

This example shows how to build a pay-per-request memory API using x402. AI agents store and search natural language memories without accounts or API keys — they pay $0.001 USDC per request on Base.

Stack: Express + Supabase pgvector + OpenAI embeddings + x402 payment middleware

Features:

• POST /memory — store a memory ($0.001 USDC)
• GET /memory?query=... — semantic search ($0.001 USDC)
• Prompt injection protection
• Content size limits
• Full SQL schema included in README

A hosted production version is live at https://api.memoryapi.org (https://api.memoryapi.org/)

-->

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 