### PR TITLE
ecosystem: add Token Risk Scanner — token security API for AI agents

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/token-risk-scanner/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/token-risk-scanner/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "Token Risk Scanner",
+  "description": "Smart contract security scanner for AI agents. Honeypot detection, rug pull analysis, tax traps, hidden owners, and risk scoring (0-100) across 10+ EVM chains. $0.003 USDC per scan on Base. No API keys, no signup.",
+  "url": "https://token-risk-scanner-production.up.railway.app",
+  "github": "https://github.com/xuansun/token-risk-scanner",
+  "category": "service",
+  "tags": ["security", "defi", "token-analysis", "risk-scoring"]
+}


### PR DESCRIPTION
## Description

Adding Token Risk Scanner to the x402 ecosystem page.

**Live URL:** https://token-risk-scanner-production.up.railway.app
**GitHub:** https://github.com/xuansun/token-risk-scanner

Pay-per-scan token security analysis for AI agents via x402 micropayments. Checks any EVM token contract for:
- Honeypot detection
- Rug pull signals (mintable supply, hidden owners, self-destruct)
- Tax analysis (buy/sell tax percentages)
- Ownership flags (renounced, proxy, blacklist)
- Liquidity info (DEX listings, pair data)

Returns a risk score (0-100) with verdict: LOW_RISK, CAUTION, RISKY, or DANGEROUS.

- **Endpoint:** GET /scan?address={0x...}&chain={chain}
- **Price:** $0.003 USDC on Base (eip155:8453)
- **Chains:** Base, Ethereum, BSC, Polygon, Arbitrum, Avalanche, Optimism, Fantom, Linea, Scroll, zkSync
- **Discovery:** /.well-known/x402 and /llms.txt
- **Stack:** Express.js + @x402/express + GoPlus Security API
- **Facilitator:** xpay.sh

## Tests

This is an ecosystem metadata addition only (JSON file). No code changes to the x402 codebase. The live API has been tested and is accepting x402 payments.

## Checklist
- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)