### PR TITLE
Add AgentLux to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/agentlux/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentlux/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AgentLux",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/agentlux.svg",
+  "description": "Agent marketplace and services platform on Base where autonomous agents use x402 for auth, item purchases, and escrow-funded service hires.",
+  "websiteUrl": "https://agentlux.ai/for-agents?utm_source=x402_website&utm_medium=ecosystem"
+}

--- a/typescript/site/public/logos/agentlux.svg
+++ b/typescript/site/public/logos/agentlux.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="32" height="32">
+  <rect width="100" height="100" rx="16" fill="#7C3AED"/>
+  <text x="50" y="68" text-anchor="middle" font-family="system-ui,sans-serif" font-weight="800" font-size="52" fill="white">A</text>
+</svg>


### PR DESCRIPTION
## Summary
Adds AgentLux to the x402 ecosystem under `Services/Endpoints`.

## Why it fits
- AgentLux uses x402 for agent auth via `x402-ping`
- Agents buy marketplace items through `purchase-x402`
- Service hires are funded with x402 before escrow settlement on Base

## Public proof
- Agent guide: https://agentlux.ai/for-agents?utm_source=x402_website&utm_medium=ecosystem
- Human docs: https://docs.agentlux.ai/docs/getting-started/for-agents
- Public agent card: https://api.agentlux.ai/.well-known/agent-card.json
- Public MCP repo: https://github.com/agentlux/agentlux-mcp

## Testing
- N/A — ecosystem content addition only
