### PR TITLE
Add Prosharky Agent Gateway to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/prosharky-agent-gateway/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/prosharky-agent-gateway/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Prosharky Agent Gateway",
+  "description": "Unified agent gateway spanning EVM and Solana with 32 MCP tools over JSON-RPC 2.0. x402 USDC billing on Base for 5 paid data endpoints (Aave V4 + Morpho Blue risk analytics, ERC-4337 paymaster leaderboard, middleware mempool stream, recurring-bot leaderboard). Swap aggregators (0x / LI.FI / deBridge / Mayan / KyberSwap / Relay) and Jupiter v6 Solana Referral Program with 50 bps integrator fees. LLM inference via LiteLLM proxy (Claude / GPT-5 / Grok / DeepSeek V4). FHA-defended against arxiv:2604.20994. Includes Morpho MCP upstream.",
+  "logoUrl": "/logos/prosharky-agent-gateway.png",
+  "websiteUrl": "https://prosharky-gw.173-249-14-219.sslip.io/llms.txt",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## Summary
Adding Prosharky Agent Gateway to the x402 ecosystem directory. The gateway is a remote MCP server (JSON-RPC 2.0) that exposes 32 tools with 5 x402-gated paid endpoints settled in USDC on Base via the official https://x402.org/facilitator.

## Details
- **Name**: Prosharky Agent Gateway
- **Homepage / llms.txt**: https://prosharky-gw.173-249-14-219.sslip.io/llms.txt
- **MCP endpoint**: https://prosharky-gw.173-249-14-219.sslip.io/mcp
- **Category**: Services/Endpoints (x402-gated data APIs)
- **License**: MIT
- **Payment network**: Base mainnet, asset USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)

## x402-gated endpoints
All return a spec-compliant `HTTP 402` with `accepts[]` array per `specs/x402-specification-v1.md`, referring to `https://x402.org/facilitator`:
- `GET /v1/paymaster/top` — $0.05 — ERC-4337 paymaster revenue leaderboard
- `GET /v1/mempool/middleware` — $0.02 — 9-protocol middleware mempool stream
- `GET /v1/recurring_bots` — $0.10 — 24h recurring-bot leaderboard
- `GET /v1/middleware/analyze` — $0.05 — on-demand middleware flow classifier
- `GET /v1/risk/premium` — $0.05 — 7-factor Aave V4 hub-and-spoke + Morpho Blue risk report

## Notes
- Gateway also integrates Jupiter v6 Referral Program on Solana and 6 EVM swap aggregators with 50 bps integrator fees for free discovery surfaces.
- Includes the first-party Morpho MCP (`https://mcp.morpho.org`) as an upstream proxied through our metering layer.
- Follows x402 v1 spec strictly; `/.well-known/x402` manifest exposes full resources list with `extensions: ["bazaar", "outputSchema"]` for CDP vector-search indexation.

Logo at `/logos/prosharky-agent-gateway.png` — happy to provide a PNG if the directory requires one uploaded in this PR; will push in a follow-up commit if so.
## Update 2026-04-24 — Hermetic Key XIII: Thoth Inscription

The gateway facilitator endpoint is now exposed under the Hermetic Keys naming scheme as **Thoth Inscription** (Key XIII), with the classical name `x402_facilitator` retained as a backward-compatible alias.

Both names point to the same x402 facilitator routing logic — agents may select either based on their preferred lexicon. This is informational; no functional change to the resource itself.

- **Tool name (classical)**: `x402_facilitator`
- **Tool name (alias)**: `thoth_inscription`
- **Display name**: Thoth Inscription: x402 Facilitator
- **Settlement**: USDC on Base via official https://x402.org/facilitator
- **Coverage**: 5 paid endpoints (`/v1/paymaster/top`, `/v1/mempool/middleware`, `/v1/recurring_bots`, `/v1/middleware/analyze`, `/v1/risk/premium`) under x402 challenge-response
- **Audit**: passes our internal `/mcp/audit` FHA detector (CLEAN; per arxiv:2604.20994 mitigation)

Audit endpoint: https://prosharky-gw.173-249-14-219.sslip.io/mcp/audit

