### PR TITLE
feat(ecosystem): add x402station.io

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402station-io/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402station-io/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402station.io",
+  "description": "Pay-per-call oracle for autonomous agents on x402. Agents call us before any paid request to detect decoys, zombie endpoints, price traps, and dead services. We independently probe every endpoint on agentic.market — including those no agent has ever paid — so we surface what facilitator-only monitors cannot.",
+  "logoUrl": "/logos/x402station-io.svg",
+  "websiteUrl": "https://x402station.io",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/x402station-io.svg
+++ b/typescript/site/public/logos/x402station-io.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="7" fill="#0a0a0a"/>
+  <text x="5.5" y="22" font-family="SF Mono, Menlo, monospace" font-size="15" font-weight="700" fill="#ededed" letter-spacing="-0.5">x4</text>
+  <circle cx="21.5" cy="21.5" r="3" fill="#34d399"/>
+</svg>


### PR DESCRIPTION
Adds x402station.io to the ecosystem directory under Services/Endpoints.

x402station.io is a pay-per-call oracle (x402 itself as billing) that agents call before any other paid x402 request. We independently probe every endpoint listed on agentic.market — including ones no one has paid — so we can flag decoys (161 endpoints priced ≥$1k USDC), zombie services, and price traps that facilitator-only monitors miss.

Live paid endpoints (Base Sepolia; Base mainnet after rotation of prober wallet):
- `POST /api/v1/preflight` — $0.0001 USDC
- `POST /api/v1/forensics` — $0.001 USDC

Manifests: `/.well-known/x402`, `/.well-known/agent-card.json`, `/api/openapi.json`, `/llms.txt`.

Note: the existing `x402station` directory entry (x402station.com, PR #457) is a separate project — a human-facing analytics dashboard. This submission is an agent-facing paid oracle, different product, different website. Using slug `x402station-io` to disambiguate.

---
AI-assisted per CONTRIBUTING.md: metadata and PR body drafted with Claude; reviewed before submission.