### PR TITLE
fix(site): improve x402 discoverability for isitagentready scanner

### DIFF
--- a/typescript/site/app/sitemap.ts
+++ b/typescript/site/app/sitemap.ts
@@ -25,5 +25,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.7,
     },
+    {
+      url: "https://x402.org/protected",
+      lastModified: new Date("2026-04-23"),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
   ];
 }

--- a/typescript/site/next.config.ts
+++ b/typescript/site/next.config.ts
@@ -32,6 +32,10 @@ const nextConfig: NextConfig = {
             value:
               '</.well-known/api-catalog>; rel="api-catalog", </writing/x402-v2-launch>; rel="service-doc", </protected>; rel="payment-required"',
           },
+          {
+            key: "X-X402-Supported",
+            value: "true",
+          },
         ],
       },
     ];


### PR DESCRIPTION
## Summary

Follow-up to #2113 — the isitagentready.com scanner can't detect x402 support on x402.org despite `/protected` returning a proper 402 with `PAYMENT-REQUIRED` header.

- Add `/protected` to sitemap so the scanner discovers the x402-gated endpoint
- Add `X-X402-Supported: true` response header on homepage as an additional signal

## Test plan

- [ ] Deploy and re-scan on https://isitagentready.com — verify x402 commerce check detects the protocol
- [ ] `curl -I https://www.x402.org/` shows `X-X402-Supported: true` header
- [ ] `curl https://www.x402.org/sitemap.xml` includes `/protected` entry