### PR TITLE
feat(ecosystem): Add Node4All entry to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/node4all/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/node4all/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Node4All",
+  "description": "Node4All is an agent-first platform shipping x402-ready services, alongside the documentation, testing tools, and code examples needed to build payment-ready agents. Live services include Markdown to PDF and PDF to Markdown, and our @node4all/x402-agent-toolkit MCP server lets agents pay and consume them natively.",
+  "logoUrl": "/logos/node4all.svg",
+  "websiteUrl": "https://node4all.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/node4all.svg
+++ b/typescript/site/public/logos/node4all.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 250 300" width="32" height="32">
+  <rect x="45" y="75" width="25" height="15" fill="#1E5624" />
+  <rect x="45" y="75" width="15" height="150" fill="#1E5624" />
+  <rect x="45" y="210" width="25" height="15" fill="#1E5624" />
+  <rect x="180" y="75" width="25" height="15" fill="#1E5624" />
+  <rect x="190" y="75" width="15" height="150" fill="#1E5624" />
+  <rect x="180" y="210" width="25" height="15" fill="#1E5624" />
+  <rect x="57.5" y="216" width="135" height="3" fill="#1E5624" />
+  <rect x="75" y="105" width="20" height="90" fill="#000000" />
+  <rect x="125" y="105" width="20" height="90" fill="#000000" />
+  <polygon points="75,105 95,105 145,195 125,195" fill="#000000" />
+  <rect x="155" y="120" width="20" height="20" fill="#888888" />
+  <rect x="155" y="160" width="20" height="20" fill="#888888" />
+</svg>


### PR DESCRIPTION
## Summary

Adds Node4All to the ecosystem under **Services/Endpoints**.

Node4All ships spec-compliant x402 v2 paid endpoints on Base, plus an MCP server (`@node4all/x402-agent-toolkit`) that lets agents pay and consume them natively. Live services today:

- `GET /v1/x402-test` — fortune-cookie demo for end-to-end x402 v2 verification
- `POST /v1/md2pdf` — Markdown to PDF conversion for agent document workflows
- `POST /v1/pdf2md` — layout-aware PDF to Markdown for ingesting long documents into context windows

All three are live on both `sandbox.node4all.com` (Base Sepolia) and `api.node4all.com` (Base Mainnet), and currently surface in the CDP bazaar.

## Files

- `typescript/site/app/ecosystem/partners-data/node4all/metadata.json`
- `typescript/site/public/logos/node4all.svg` (250×300 viewBox, explicit hex colors, no `currentColor`)

## Checklist

- [x] Commit is signed (SSH signing key registered on the author account)
- [x] Logo renders correctly on a white background
- [x] `metadata.json` parses as valid JSON and follows the existing partner shape
- [x] Description is brand-led, no pricing details, no facilitator-specific mentions

## Links

- Website: https://node4all.com
- Discovery: https://node4all.com/.well-known/x402.json
- Agent toolkit: https://www.npmjs.com/package/@node4all/x402-agent-toolkit