### PR TITLE
fix(paywall): use dynamic token decimals instead of hardcoded 6

### DIFF
--- a/typescript/packages/http/paywall/package.json
+++ b/typescript/packages/http/paywall/package.json
@@ -75,6 +75,7 @@
     "@wallet-standard/base": "^1.1.0",
     "@wallet-standard/features": "^1.1.0",
     "@x402/core": "workspace:~",
+    "@x402/evm": "workspace:~",
     "viem": "^2.39.3",
     "wagmi": "^2.17.1",
     "zod": "^3.24.2"

--- a/typescript/packages/http/paywall/src/evm/EvmPaywall.tsx
+++ b/typescript/packages/http/paywall/src/evm/EvmPaywall.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createPublicClient, formatUnits, http, publicActions, type Chain } from "viem";
+import {
+  createPublicClient,
+  formatUnits,
+  http,
+  publicActions,
+  type Address,
+  type Chain,
+} from "viem";
 import * as allChains from "viem/chains";
 import { useAccount, useSwitchChain, useWalletClient, useConnect, useDisconnect } from "wagmi";
 
@@ -7,7 +14,7 @@ import { ExactEvmScheme } from "@x402/evm/exact/client";
 import { x402Client } from "@x402/core/client";
 import { encodePaymentSignatureHeader } from "@x402/core/http";
 import type { PaymentRequired } from "@x402/core/types";
-import { getUSDCBalance } from "./utils";
+import { getTokenBalance, getTokenDecimals } from "./utils";
 
 import { Spinner } from "./Spinner";
 import { getNetworkDisplayName, isTestnetNetwork } from "../paywallUtils";
@@ -36,7 +43,8 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
   const [status, setStatus] = useState<string>("");
   const [isCorrectChain, setIsCorrectChain] = useState<boolean | null>(null);
   const [isPaying, setIsPaying] = useState(false);
-  const [formattedUsdcBalance, setFormattedUsdcBalance] = useState<string>("");
+  const [formattedTokenBalance, setFormattedTokenBalance] = useState<string>("");
+  const [tokenDecimals, setTokenDecimals] = useState<number>(6);
   const [hideBalance, setHideBalance] = useState(true);
   const [selectedConnectorId, setSelectedConnectorId] = useState<string>("");
 
@@ -50,6 +58,7 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
 
   const network = firstRequirement.network;
   const tokenName = (firstRequirement.extra?.name as string) || "Token";
+  const tokenAddress = firstRequirement.asset as Address | undefined;
   const chainName = getNetworkDisplayName(network);
   const testnet = isTestnetNetwork(network);
 
@@ -71,14 +80,31 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
     [paymentChain],
   );
 
-  const checkUSDCBalance = useCallback(async () => {
-    if (!address) {
+  const checkTokenBalance = useCallback(async () => {
+    if (!address || !tokenAddress) {
       return;
     }
-    const balance = await getUSDCBalance(publicClient, address);
-    const formattedBalance = formatUnits(balance, 6);
-    setFormattedUsdcBalance(formattedBalance);
-  }, [address, publicClient]);
+    const balance = await getTokenBalance(publicClient, tokenAddress, address);
+    const formattedBalance = formatUnits(balance, tokenDecimals);
+    setFormattedTokenBalance(formattedBalance);
+  }, [address, publicClient, tokenAddress, tokenDecimals]);
+
+  // Read the token's decimals once per token/client so the balance and
+  // insufficient-funds checks scale to non-USDC tokens.
+  useEffect(() => {
+    if (!tokenAddress) {
+      return;
+    }
+    let active = true;
+    void getTokenDecimals(publicClient, tokenAddress).then(decimals => {
+      if (active) {
+        setTokenDecimals(decimals);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [publicClient, tokenAddress]);
 
   const handleSwitchChain = useCallback(async () => {
     if (isCorrectChain) {
@@ -100,8 +126,8 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
     }
 
     void handleSwitchChain();
-    void checkUSDCBalance();
-  }, [address, handleSwitchChain, checkUSDCBalance]);
+    void checkTokenBalance();
+  }, [address, handleSwitchChain, checkTokenBalance]);
 
   useEffect(() => {
     if (isConnected && chainId === connectedChainId) {
@@ -140,7 +166,10 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
 
     try {
       setStatus("Checking balance...");
-      const balance = await getUSDCBalance(publicClient, address);
+      if (!tokenAddress) {
+        throw new Error("Payment requirement is missing a token asset address");
+      }
+      const balance = await getTokenBalance(publicClient, tokenAddress, address);
 
       if (balance === 0n) {
         throw new Error(`Insufficient balance. Make sure you have ${tokenName} on ${chainName}`);
@@ -259,8 +288,8 @@ export function EvmPaywall({ paymentRequired, onSuccessfulResponse }: EvmPaywall
                 <span className="payment-label">Available balance:</span>
                 <span className="payment-value">
                   <button className="balance-button" onClick={() => setHideBalance(prev => !prev)}>
-                    {formattedUsdcBalance && !hideBalance
-                      ? `$${formattedUsdcBalance} ${tokenName}`
+                    {formattedTokenBalance && !hideBalance
+                      ? `${formattedTokenBalance} ${tokenName}`
                       : `••••• ${tokenName}`}
                   </button>
                 </span>

--- a/typescript/packages/http/paywall/src/evm/index.ts
+++ b/typescript/packages/http/paywall/src/evm/index.ts
@@ -1,3 +1,5 @@
+import { getDefaultAsset } from "@x402/evm";
+import type { Network } from "@x402/core/types";
 import type {
   PaywallNetworkHandler,
   PaymentRequirements,
@@ -5,6 +7,21 @@ import type {
   PaywallConfig,
 } from "../types";
 import { getEvmPaywallHtml } from "./paywall";
+
+/**
+ * Resolves the decimal precision for the payment token of a given EVM network.
+ * Falls back to 6 (USDC standard) when the network has no default asset registered.
+ *
+ * @param network - CAIP-2 EVM network identifier (e.g. "eip155:8453")
+ * @returns Decimal precision for the network's default payment asset
+ */
+function getNetworkDecimals(network: string): number {
+  try {
+    return getDefaultAsset(network as Network).decimals;
+  } catch {
+    return 6;
+  }
+}
 
 /**
  * EVM paywall handler that supports EVM-based networks (CAIP-2 format only)
@@ -33,10 +50,12 @@ export const evmPaywall: PaywallNetworkHandler = {
     paymentRequired: PaymentRequired,
     config: PaywallConfig,
   ): string {
+    const decimals = getNetworkDecimals(requirement.network);
+    const divisor = 10 ** decimals;
     const amount = requirement.amount
-      ? parseFloat(requirement.amount) / 1000000
+      ? parseFloat(requirement.amount) / divisor
       : requirement.maxAmountRequired
-        ? parseFloat(requirement.maxAmountRequired) / 1000000
+        ? parseFloat(requirement.maxAmountRequired) / divisor
         : 0;
 
     return getEvmPaywallHtml({

--- a/typescript/packages/http/paywall/src/evm/index.ts
+++ b/typescript/packages/http/paywall/src/evm/index.ts
@@ -9,18 +9,30 @@ import type {
 import { getEvmPaywallHtml } from "./paywall";
 
 /**
- * Resolves the decimal precision for the payment token of a given EVM network.
- * Falls back to 6 (USDC standard) when the network has no default asset registered.
+ * Resolves the decimal precision for a payment requirement's token.
  *
- * @param network - CAIP-2 EVM network identifier (e.g. "eip155:8453")
- * @returns Decimal precision for the network's default payment asset
+ * Server-side we cannot read `decimals()` from the token contract, so we trust the
+ * x402 default-asset registry only when the requirement's `asset` matches the
+ * registered default token address for the network. For any other asset we fall
+ * back to 6 (USDC standard) — the on-chain `decimals()` read on the client side
+ * still produces the correct precision for balance display.
+ *
+ * @param requirement - The payment requirement whose amount needs scaling
+ * @returns Decimal precision to use when formatting the displayed amount
  */
-function getNetworkDecimals(network: string): number {
+function getRequirementDecimals(requirement: PaymentRequirements): number {
   try {
-    return getDefaultAsset(network as Network).decimals;
+    const defaultAsset = getDefaultAsset(requirement.network as Network);
+    if (
+      requirement.asset &&
+      requirement.asset.toLowerCase() === defaultAsset.address.toLowerCase()
+    ) {
+      return defaultAsset.decimals;
+    }
   } catch {
-    return 6;
+    // No default asset registered for this network; fall through to fallback.
   }
+  return 6;
 }
 
 /**
@@ -50,7 +62,7 @@ export const evmPaywall: PaywallNetworkHandler = {
     paymentRequired: PaymentRequired,
     config: PaywallConfig,
   ): string {
-    const decimals = getNetworkDecimals(requirement.network);
+    const decimals = getRequirementDecimals(requirement);
     const divisor = 10 ** decimals;
     const amount = requirement.amount
       ? parseFloat(requirement.amount) / divisor

--- a/typescript/packages/http/paywall/src/evm/utils.test.ts
+++ b/typescript/packages/http/paywall/src/evm/utils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import type { Address } from "viem";
+import { getTokenBalance, getTokenDecimals } from "./utils";
+
+const TOKEN: Address = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+const OWNER: Address = "0x209693Bc6afc0C5328bA36FaF04C514EF312287C";
+
+/**
+ * Builds a minimal viem-compatible client whose `readContract` is a vi.fn we control.
+ *
+ * @param impl - Implementation for the mocked `readContract` call
+ * @returns A client object with the mocked method, typed loosely for test ergonomics
+ */
+function makeClient(impl: (params: { functionName: string }) => unknown) {
+  return {
+    readContract: vi.fn(impl),
+  } as unknown as Parameters<typeof getTokenBalance>[0];
+}
+
+describe("getTokenBalance", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the balance reported by the token contract", async () => {
+    const client = makeClient(({ functionName }) =>
+      functionName === "balanceOf" ? 1234567890n : 0n,
+    );
+
+    const balance = await getTokenBalance(client, TOKEN, OWNER);
+    expect(balance).toBe(1234567890n);
+  });
+
+  it("returns 0n and logs when the contract read throws", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const client = makeClient(() => {
+      throw new Error("rpc unreachable");
+    });
+
+    const balance = await getTokenBalance(client, TOKEN, OWNER);
+    expect(balance).toBe(0n);
+    expect(errSpy).toHaveBeenCalled();
+  });
+});
+
+describe("getTokenDecimals", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the decimals reported by the token contract", async () => {
+    const client = makeClient(({ functionName }) => (functionName === "decimals" ? 18 : 0n));
+
+    const decimals = await getTokenDecimals(client, TOKEN);
+    expect(decimals).toBe(18);
+  });
+
+  it("coerces a bigint return value to a number", async () => {
+    const client = makeClient(() => 6n);
+
+    const decimals = await getTokenDecimals(client, TOKEN);
+    expect(decimals).toBe(6);
+  });
+
+  it("falls back to 6 and logs when the contract read throws", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const client = makeClient(() => {
+      throw new Error("not an erc20");
+    });
+
+    const decimals = await getTokenDecimals(client, TOKEN);
+    expect(decimals).toBe(6);
+    expect(errSpy).toHaveBeenCalled();
+  });
+});

--- a/typescript/packages/http/paywall/src/evm/utils.ts
+++ b/typescript/packages/http/paywall/src/evm/utils.ts
@@ -1,18 +1,9 @@
 import type { Address, Client, Chain, Transport, Account } from "viem";
 
 /**
- * USDC contract addresses by chain ID
+ * Minimal ERC-20 ABI covering the read-only methods used by the paywall.
  */
-const USDC_ADDRESSES: Record<number, Address> = {
-  1: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // Ethereum Mainnet
-  8453: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // Base Mainnet
-  84532: "0x036CbD53842c5426634e7929541eC2318f3dCF7e", // Base Sepolia
-};
-
-/**
- * ERC20 balanceOf ABI
- */
-const ERC20_BALANCE_ABI = [
+const ERC20_ABI = [
   {
     name: "balanceOf",
     type: "function",
@@ -20,36 +11,69 @@ const ERC20_BALANCE_ABI = [
     inputs: [{ name: "account", type: "address" }],
     outputs: [{ name: "balance", type: "uint256" }],
   },
+  {
+    name: "decimals",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "uint8" }],
+  },
 ] as const;
 
 /**
- * Gets the USDC balance for a specific address on the current chain.
+ * Gets the ERC-20 token balance for the given owner address.
+ * Returns 0n on any read failure so the paywall UI can degrade gracefully.
  *
  * @param client - Viem client instance connected to the blockchain
- * @param address - Address to check the USDC balance for
- * @returns USDC balance as bigint (0 if USDC not supported on chain or error)
+ * @param tokenAddress - The ERC-20 contract address
+ * @param ownerAddress - The address whose balance to look up
+ * @returns Balance in atomic units (0n on error)
  */
-export async function getUSDCBalance<
+export async function getTokenBalance<
   TTransport extends Transport,
   TChain extends Chain,
   TAccount extends Account | undefined = undefined,
->(client: Client<TTransport, TChain, TAccount>, address: Address): Promise<bigint> {
-  const chainId = client.chain?.id;
-  if (!chainId) return 0n;
-
-  const usdcAddress = USDC_ADDRESSES[chainId];
-  if (!usdcAddress) return 0n;
-
+>(
+  client: Client<TTransport, TChain, TAccount>,
+  tokenAddress: Address,
+  ownerAddress: Address,
+): Promise<bigint> {
   try {
     const balance = await client.readContract({
-      address: usdcAddress,
-      abi: ERC20_BALANCE_ABI,
+      address: tokenAddress,
+      abi: ERC20_ABI,
       functionName: "balanceOf",
-      args: [address],
+      args: [ownerAddress],
     });
     return balance as bigint;
   } catch (error) {
-    console.error("Failed to fetch USDC balance:", error);
+    console.error("Failed to fetch token balance:", error);
     return 0n;
+  }
+}
+
+/**
+ * Reads the ERC-20 `decimals()` precision from the token contract.
+ * Falls back to 6 (USDC standard) on any read failure so the paywall keeps rendering.
+ *
+ * @param client - Viem client instance connected to the blockchain
+ * @param tokenAddress - The ERC-20 contract address
+ * @returns The token's decimal precision (6 on error)
+ */
+export async function getTokenDecimals<
+  TTransport extends Transport,
+  TChain extends Chain,
+  TAccount extends Account | undefined = undefined,
+>(client: Client<TTransport, TChain, TAccount>, tokenAddress: Address): Promise<number> {
+  try {
+    const decimals = await client.readContract({
+      address: tokenAddress,
+      abi: ERC20_ABI,
+      functionName: "decimals",
+    });
+    return Number(decimals);
+  } catch (error) {
+    console.error("Failed to fetch token decimals:", error);
+    return 6;
   }
 }

--- a/typescript/packages/http/paywall/src/network-handlers.test.ts
+++ b/typescript/packages/http/paywall/src/network-handlers.test.ts
@@ -68,11 +68,32 @@ describe("Network Handlers", () => {
 
     it("scales the displayed amount for 18-decimal tokens (e.g. MegaUSD on MegaETH)", () => {
       const html = evmPaywall.generateHtml(
-        { ...evmRequirement, network: "eip155:4326", amount: "100000000000000000" },
+        {
+          ...evmRequirement,
+          network: "eip155:4326",
+          asset: "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7", // MegaUSD (18 decimals)
+          amount: "100000000000000000",
+        },
         mockPaymentRequired,
         { appName: "Test", testnet: false },
       );
       // 10^17 / 10^18 = 0.1; previously hardcoded /1e6 produced 100000000000.
+      expect(html).toContain("amount: 0.1,");
+    });
+
+    it("falls back to 6 decimals when the asset is not the network's default token", () => {
+      // Some custom 6-decimal token on MegaETH whose default is MegaUSD (18 decimals).
+      const html = evmPaywall.generateHtml(
+        {
+          ...evmRequirement,
+          network: "eip155:4326",
+          asset: "0xDeadBeefDeadBeefDeadBeefDeadBeefDeadBeef",
+          amount: "100000",
+        },
+        mockPaymentRequired,
+        { appName: "Test", testnet: false },
+      );
+      // Without asset-default match the divisor falls back to 1e6, so 100000 → 0.1.
       expect(html).toContain("amount: 0.1,");
     });
 

--- a/typescript/packages/http/paywall/src/network-handlers.test.ts
+++ b/typescript/packages/http/paywall/src/network-handlers.test.ts
@@ -55,6 +55,36 @@ describe("Network Handlers", () => {
       expect(html).toContain("<!DOCTYPE html>");
       expect(html).toMatch(/Test App|EVM Paywall/);
     });
+
+    it("scales the displayed amount by the network's token decimals (6 for USDC)", () => {
+      const html = evmPaywall.generateHtml(
+        { ...evmRequirement, network: "eip155:8453", amount: "100000" },
+        mockPaymentRequired,
+        { appName: "Test", testnet: false },
+      );
+      // 100000 / 10^6 = 0.1
+      expect(html).toContain("amount: 0.1,");
+    });
+
+    it("scales the displayed amount for 18-decimal tokens (e.g. MegaUSD on MegaETH)", () => {
+      const html = evmPaywall.generateHtml(
+        { ...evmRequirement, network: "eip155:4326", amount: "100000000000000000" },
+        mockPaymentRequired,
+        { appName: "Test", testnet: false },
+      );
+      // 10^17 / 10^18 = 0.1; previously hardcoded /1e6 produced 100000000000.
+      expect(html).toContain("amount: 0.1,");
+    });
+
+    it("falls back to 6 decimals for networks without a default asset", () => {
+      const html = evmPaywall.generateHtml(
+        { ...evmRequirement, network: "eip155:99999999", amount: "100000" },
+        mockPaymentRequired,
+        { appName: "Test", testnet: false },
+      );
+      // 100000 / 10^6 = 0.1 via fallback
+      expect(html).toContain("amount: 0.1,");
+    });
   });
 
   describe("svmPaywall", () => {

--- a/typescript/packages/mechanisms/evm/src/index.ts
+++ b/typescript/packages/mechanisms/evm/src/index.ts
@@ -13,6 +13,9 @@ export {
   type Permit2AllowanceParams,
 } from "./exact/client";
 
+// Default asset registry
+export { getDefaultAsset } from "./shared/defaultAssets";
+
 // Signers
 export { toClientEvmSigner, toFacilitatorEvmSigner } from "./signer";
 export type { ClientEvmSigner, FacilitatorEvmSigner } from "./signer";

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -589,6 +589,9 @@ importers:
       '@x402/core':
         specifier: workspace:~
         version: link:../../core
+      '@x402/evm':
+        specifier: workspace:~
+        version: link:../../mechanisms/evm
       lute-connect:
         specifier: ^1.6.3
         version: 1.7.0
@@ -626,9 +629,6 @@ importers:
       '@x402/avm':
         specifier: workspace:~
         version: link:../../mechanisms/avm
-      '@x402/evm':
-        specifier: workspace:~
-        version: link:../../mechanisms/evm
       '@x402/svm':
         specifier: workspace:~
         version: link:../../mechanisms/svm


### PR DESCRIPTION
## Summary

Closes #1979.

The EVM paywall hardcoded 6 decimals (USDC) in three places, breaking display amounts and balance reads for any token with different precision (e.g. MegaUSD on MegaETH uses 18 decimals).

### Changes

- **`evm/index.ts`** — read decimals from `getDefaultAsset(network)` instead of dividing by `1_000_000`. Falls back to 6 when the network has no default asset.
- **`evm/utils.ts`** — replace the USDC-only `getUSDCBalance` (with its 3-chain hardcoded address map) with generic `getTokenBalance(client, tokenAddress, owner)` and `getTokenDecimals(client, tokenAddress)` that work on any ERC-20.
- **`evm/EvmPaywall.tsx`** — use the requirement's `asset` address as the token, read the on-chain `decimals()`, and format the balance with the resolved precision.
- **`@x402/evm`** — export `getDefaultAsset` from the package root so the paywall can consume the existing default-asset registry.

### Behavior

```
USDC (6 decimals):   amount=100000             → displays 0.1
MegaUSD (18 decimals): amount=100000000000000000 → displays 0.1 (was 100000000000)
unknown network:     amount=100000             → displays 0.1 via fallback to 6
```

Balance reads now query `decimals()` on the token contract per the issue's recommended client-side approach, so any new chain adding a non-6-decimal default token works without further code changes.

## Test plan

- [x] New tests for `getTokenBalance` / `getTokenDecimals` covering normal returns, bigint coercion, and RPC failure (`evm/utils.test.ts`)
- [x] New `evmPaywall.generateHtml` cases for 6-decimal, 18-decimal, and fallback paths (`network-handlers.test.ts`)
- [x] `pnpm --filter @x402/paywall run test / lint / format:check / build` all pass
- [x] `pnpm run test` (monorepo) — 45/45 tasks pass