### PR TITLE
feat(ecosystem): add AgentCredit — autonomous flash-loan facilitator

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/agentcredit/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentcredit/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AgentCredit",
+  "description": "Autonomous flash-loan facilitator for AI agents on x402. When an agent's USDC balance can't cover an HTTP 402 payment, AgentCredit silently extends micro-credit ($1–$5), completes the payment, and collects repayment from subsequent revenue — no human intervention required.",
+  "logoUrl": "/logos/agentcredit.svg",
+  "websiteUrl": "https://agentlending.spekn.com",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/agentcredit.svg
+++ b/typescript/site/public/logos/agentcredit.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect width="120" height="120" rx="24" fill="#0D0D0D"/>
+  <circle cx="60" cy="52" r="28" stroke="#22C55E" stroke-width="4" fill="none"/>
+  <path d="M52 52 L60 60 L72 44" stroke="#22C55E" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="60" y="95" text-anchor="middle" font-family="system-ui,sans-serif" font-size="14" font-weight="700" fill="#22C55E">AC</text>
+</svg>


### PR DESCRIPTION
## Summary

- Adds **AgentCredit** to the x402 ecosystem page under **Infrastructure & Tooling**
- AgentCredit is an autonomous flash-loan facilitator for AI agents on Base mainnet
- When an agent's USDC balance can't cover an HTTP 402 payment, AgentCredit silently extends micro-credit ($1–$5), completes the payment, and collects repayment from subsequent revenue — no human intervention required

## Integration

- **npm package**: `@spekn/agentcredit-x402` — 3-line drop-in interceptor for any x402 client
- **Live facilitator**: https://agentlending.spekn.com
- **Supported network**: Base mainnet (eip155:8453)
- **Asset**: USDC

## Files changed

| File | Description |
|------|-------------|
| `app/ecosystem/partners-data/agentcredit/metadata.json` | Project metadata |
| `public/logos/agentcredit.svg` | SVG logo |

🤖 Generated with [Claude Code](https://claude.com/claude-code)