### PR TITLE
Add Satoshi API to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/satoshi-api/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/satoshi-api/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Satoshi API",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/satoshi-api.svg",
+  "description": "Bitcoin fee intelligence for AI agents and apps. Satoshi API exposes x402-paid endpoints for fee landscape, AI fee advice, next-block pressure, transaction context, and fee-estimator accuracy over Base USDC.",
+  "websiteUrl": "https://bitcoinsapi.com/x402"
+}

--- a/typescript/site/public/logos/satoshi-api.svg
+++ b/typescript/site/public/logos/satoshi-api.svg
@@ -1,0 +1,7 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="96" fill="#101418"/>
+  <circle cx="256" cy="256" r="176" fill="#F7931A"/>
+  <path d="M215 148h70c45 0 74 22 74 58 0 24-13 42-35 51 27 8 44 30 44 60 0 42-33 67-83 67h-70V148Z" fill="#101418"/>
+  <path d="M235 189v50h42c23 0 37-9 37-25 0-16-14-25-37-25h-42Zm0 88v66h49c26 0 41-12 41-33 0-20-15-33-42-33h-48Z" fill="#F7F4EA"/>
+  <path d="M246 116h32v48h-32v-48Zm0 232h32v48h-32v-48Zm49-232h32v55h-32v-55Zm0 225h32v55h-32v-55Z" fill="#101418"/>
+</svg>


### PR DESCRIPTION
## Summary
- Add Satoshi API to the x402 ecosystem directory as a Services/Endpoints project
- Include a lightweight SVG logo for the listing

## x402 proof
- Production docs: https://bitcoinsapi.com/x402
- Well-known x402 metadata: https://bitcoinsapi.com/.well-known/x402
- Paid OpenAPI discovery surface: https://bitcoinsapi.com/openapi.json
- AgentCash discovery currently returns paid x402 endpoints from OpenAPI

## Notes
Satoshi API exposes Bitcoin fee intelligence endpoints over x402, including fee landscape, AI fee advice, next-block pressure, transaction context, and fee-estimator accuracy.