### PR TITLE
feat(go/http): add AVM paywall handler

### DIFF
--- a/go/.changes/unreleased/added-20260427-110708.yaml
+++ b/go/.changes/unreleased/added-20260427-110708.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Add built-in AVM paywall selection for Algorand networks in the Go HTTP server
+time: 2026-04-27T11:07:08.544658+09:00

--- a/go/http/paywall.go
+++ b/go/http/paywall.go
@@ -12,7 +12,7 @@ import (
 
 // PaywallProvider generates HTML for browser-facing 402 responses.
 // Register a custom implementation via RegisterPaywallProvider to override
-// the built-in EVM/SVM templates.
+// the built-in EVM/SVM/AVM templates.
 type PaywallProvider interface {
 	GenerateHTML(paymentRequired types.PaymentRequired, config *PaywallConfig) string
 }
@@ -55,6 +55,19 @@ func (h *SVMPaywallHandler) Supports(requirement types.PaymentRequirements) bool
 // GenerateHTML generates paywall HTML using the built-in SVM template.
 func (h *SVMPaywallHandler) GenerateHTML(_ types.PaymentRequirements, paymentRequired types.PaymentRequired, config *PaywallConfig) string {
 	return injectPaywallConfig(SVMPaywallTemplate, paymentRequired, config)
+}
+
+// AVMPaywallHandler generates paywall HTML for Algorand AVM networks (algorand:*).
+type AVMPaywallHandler struct{}
+
+// Supports returns true for Algorand AVM networks (algorand:* CAIP-2 identifiers).
+func (h *AVMPaywallHandler) Supports(requirement types.PaymentRequirements) bool {
+	return strings.HasPrefix(requirement.Network, "algorand:")
+}
+
+// GenerateHTML generates paywall HTML using the built-in AVM template.
+func (h *AVMPaywallHandler) GenerateHTML(_ types.PaymentRequirements, paymentRequired types.PaymentRequired, config *PaywallConfig) string {
+	return injectPaywallConfig(AVMPaywallTemplate, paymentRequired, config)
 }
 
 // ============================================================================
@@ -117,10 +130,11 @@ func (p *compositePaywallProvider) GenerateHTML(paymentRequired types.PaymentReq
 	return ""
 }
 
-// DefaultPaywallProvider creates a PaywallProvider with built-in EVM and SVM handlers.
+// DefaultPaywallProvider creates a PaywallProvider with built-in EVM, SVM, and AVM handlers.
 func DefaultPaywallProvider() PaywallProvider {
 	return NewPaywallBuilder().
 		WithNetwork(&EVMPaywallHandler{}).
 		WithNetwork(&SVMPaywallHandler{}).
+		WithNetwork(&AVMPaywallHandler{}).
 		Build()
 }

--- a/go/http/paywall_test.go
+++ b/go/http/paywall_test.go
@@ -63,6 +63,7 @@ func TestEVMPaywallHandler_Supports(t *testing.T) {
 		{"eip155:84532", true},
 		{"solana:mainnet", false},
 		{"solana:devnet", false},
+		{"algorand:mainnet", false},
 		{"aptos:mainnet", false},
 		{"", false},
 	}
@@ -91,6 +92,7 @@ func TestSVMPaywallHandler_Supports(t *testing.T) {
 		{"solana:devnet", true},
 		{"eip155:1", false},
 		{"eip155:8453", false},
+		{"algorand:mainnet", false},
 		{"aptos:mainnet", false},
 		{"", false},
 	}
@@ -101,6 +103,35 @@ func TestSVMPaywallHandler_Supports(t *testing.T) {
 			got := handler.Supports(req)
 			if got != tt.want {
 				t.Errorf("SVMPaywallHandler.Supports(%q) = %v, want %v", tt.network, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- AVMPaywallHandler tests ---
+
+func TestAVMPaywallHandler_Supports(t *testing.T) {
+	handler := &AVMPaywallHandler{}
+
+	tests := []struct {
+		network string
+		want    bool
+	}{
+		{"algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=", true},
+		{"algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=", true},
+		{"eip155:1", false},
+		{"eip155:8453", false},
+		{"solana:mainnet", false},
+		{"aptos:mainnet", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.network, func(t *testing.T) {
+			req := types.PaymentRequirements{Network: tt.network}
+			got := handler.Supports(req)
+			if got != tt.want {
+				t.Errorf("AVMPaywallHandler.Supports(%q) = %v, want %v", tt.network, got, tt.want)
 			}
 		})
 	}
@@ -209,10 +240,35 @@ func TestDefaultPaywallProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("Algorand network returns non-empty HTML", func(t *testing.T) {
+		got := provider.GenerateHTML(makePaymentRequired("algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8="), nil)
+		if got == "" {
+			t.Error("expected non-empty HTML for Algorand network")
+		}
+		if !strings.Contains(got, "window.x402") {
+			t.Error("expected window.x402 config injection in HTML")
+		}
+		if !strings.Contains(got, "Algorand") {
+			t.Error("expected Algorand paywall template")
+		}
+	})
+
 	t.Run("unsupported network returns empty", func(t *testing.T) {
 		got := provider.GenerateHTML(makePaymentRequired("aptos:mainnet"), nil)
 		if got != "" {
 			t.Errorf("expected empty string for unsupported network, got length %d", len(got))
+		}
+	})
+
+	t.Run("no provider falls back to built-in AVM template", func(t *testing.T) {
+		server := Newx402HTTPResourceServer(RoutesConfig{})
+
+		got := server.generatePaywallHTMLV2(makePaymentRequired("algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8="), nil, "")
+		if got == "" {
+			t.Error("expected non-empty HTML from built-in AVM template")
+		}
+		if !strings.Contains(got, "Algorand") {
+			t.Error("expected built-in AVM template")
 		}
 	})
 }

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -921,7 +921,7 @@ func (s *x402HTTPResourceServer) generatePaywallHTMLV2(paymentRequired types.Pay
 		return s.paywallProvider.GenerateHTML(paymentRequired, config)
 	}
 
-	// Tier 3: Built-in EVM/SVM templates (default fallback)
+	// Tier 3: Built-in EVM/SVM/AVM templates (default fallback)
 	// Convert V2 to generic format to reuse existing HTML generation
 	genericRequired := x402.PaymentRequired{
 		X402Version: paymentRequired.X402Version,
@@ -1003,8 +1003,9 @@ func (s *x402HTTPResourceServer) generatePaywallHTML(paymentRequired x402.Paymen
 	return strings.Replace(template, "</head>", configScript+"\n</head>", 1)
 }
 
-// selectPaywallTemplate chooses the appropriate paywall template based on the network
-// Returns EVM template for eip155:* networks, SVM template for solana:* networks
+// selectPaywallTemplate chooses the appropriate paywall template based on the network.
+// Returns EVM template for eip155:* networks, SVM template for solana:* networks,
+// and AVM template for algorand:* networks.
 func (s *x402HTTPResourceServer) selectPaywallTemplate(paymentRequired x402.PaymentRequired) string {
 	if len(paymentRequired.Accepts) == 0 {
 		return EVMPaywallTemplate // Default to EVM
@@ -1013,6 +1014,9 @@ func (s *x402HTTPResourceServer) selectPaywallTemplate(paymentRequired x402.Paym
 	network := paymentRequired.Accepts[0].Network
 	if strings.HasPrefix(network, "solana:") {
 		return SVMPaywallTemplate
+	}
+	if strings.HasPrefix(network, "algorand:") {
+		return AVMPaywallTemplate
 	}
 	return EVMPaywallTemplate
 }


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

- Add a built-in Go HTTP paywall handler for AVM / Algorand networks.
- Wire `algorand:*` payment requirements to the generated `AVMPaywallTemplate`.
- Include AVM coverage in the default paywall provider and paywall selection tests.

### Changes

- Added `AVMPaywallHandler` in `go/http/paywall.go`.
- Updated `DefaultPaywallProvider()` to include EVM, SVM, and AVM handlers.
- Updated legacy template selection so `algorand:*` networks render the AVM paywall template.
- Added tests for AVM handler support and built-in AVM paywall fallback.
- Added a Go changelog fragment.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

```bash
cd go
go test ./http -run 'Paywall|AVM' -count=1
go test ./...
```

## Checklist

- [v] I have formatted and linted my code
- [v] All new and existing tests pass
- [v] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [v] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 

Related: #2160 adds chain-aware faucet URL support across paywall templates. This PR complements it by wiring the existing AVM template into the Go HTTP paywall provider and network selector.




