### PR TITLE
feat(site): add x402 demo API endpoint for scanner discoverability

### DIFF
--- a/typescript/site/app/api/x402/demo/route.ts
+++ b/typescript/site/app/api/x402/demo/route.ts
@@ -1,0 +1,40 @@
+const paymentRequired = {
+  x402Version: 2,
+  error: "Payment required",
+  resource: {
+    url: "https://x402.org/api/x402/demo",
+    description: "x402 demo endpoint",
+    mimeType: "application/json",
+  },
+  accepts: [
+    {
+      scheme: "exact",
+      network: "eip155:84532",
+      amount: "10000",
+      asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      payTo: "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      maxTimeoutSeconds: 300,
+      extra: {
+        name: "USDC",
+        version: "2",
+      },
+    },
+  ],
+};
+
+const encodedPaymentRequired = Buffer.from(JSON.stringify(paymentRequired)).toString("base64");
+
+/**
+ * Demo endpoint returning HTTP 402 with x402 payment requirements for scanner discoverability.
+ *
+ * @returns 402 response with PAYMENT-REQUIRED header
+ */
+export function GET() {
+  return new Response(JSON.stringify({}), {
+    status: 402,
+    headers: {
+      "Content-Type": "application/json",
+      "PAYMENT-REQUIRED": encodedPaymentRequired,
+    },
+  });
+}


### PR DESCRIPTION
## Summary

The isitagentready.com scanner still can't detect x402 support on x402.org despite `/protected` returning a proper 402 with `PAYMENT-REQUIRED` header. Previous attempts (#2113, #2128) to make it discoverable via sitemap, Link headers, and `X-X402-Supported` header didn't work.

Adds a dedicated API endpoint at `/api/x402/demo` that returns a clean HTTP 402 with the `PAYMENT-REQUIRED` header. Uses the same payment config (address, network, amount) as the existing `/protected` route.

## Why not just use /protected?

The scanner appears to only probe API-style routes or well-known paths. `/protected` works perfectly for actual x402 payment flows but the scanner can't find it through any standard discovery mechanism we've tried.

## Test plan

- [ ] `curl -s -o /dev/null -w "%{http_code}" https://x402.org/api/x402/demo` returns `402`
- [ ] `curl -s -D - https://x402.org/api/x402/demo` includes `PAYMENT-REQUIRED` header
- [ ] Re-scan on https://isitagentready.com — verify Commerce/x402 check passes