### PR TITLE
feat(site): redesign hero section and update navigation CTAs

### DIFF
--- a/typescript/site/app/components/CodeSnippet.tsx
+++ b/typescript/site/app/components/CodeSnippet.tsx
@@ -4,15 +4,18 @@ import { useState } from "react";
 
 interface CodeSnippetProps {
   code: string;
+  /** If provided, this value is copied to clipboard instead of `code`. Use to
+   *  show a compact display version while preserving properly-formatted copy. */
+  copyCode?: string;
   title?: string;
   description?: string;
 }
 
-export function CodeSnippet({ code, title, description }: CodeSnippetProps) {
+export function CodeSnippet({ code, copyCode, title, description }: CodeSnippetProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(code);
+    navigator.clipboard.writeText(copyCode ?? code);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -39,26 +42,58 @@ export function CodeSnippet({ code, title, description }: CodeSnippetProps) {
                 fill="black"
               />
             </svg>
-            <h3 className="font-mono text-lg font-medium tracking-tight">
-              {title}
-            </h3>
+            <h3 className="font-mono text-lg font-medium tracking-tight">{title}</h3>
           </div>
         )}
 
-        <div className="relative bg-[#F1F1F1] px-3 py-2 mb-4">
+        <div className="relative bg-[#F1F1F1] px-3 py-2 pb-2 mb-4">
           <button
             onClick={handleCopy}
             className="absolute top-2 right-2 p-1.5 bg-black text-white hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-2"
             aria-label={copied ? "Copied to clipboard" : "Copy code"}
           >
             {copied ? (
-              <svg width="14" height="14" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                <path d="M4 10L8 14L16 6" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <path
+                  d="M4 10L8 14L16 6"
+                  stroke="white"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
               </svg>
             ) : (
-              <svg width="14" height="14" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                <rect x="6" y="6" width="10" height="12" rx="1" stroke="white" strokeWidth="2" fill="none"/>
-                <path d="M4 14V3C4 2.44772 4.44772 2 5 2H12" stroke="white" strokeWidth="2" strokeLinecap="round"/>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <rect
+                  x="6"
+                  y="6"
+                  width="10"
+                  height="12"
+                  rx="1"
+                  stroke="white"
+                  strokeWidth="2"
+                  fill="none"
+                />
+                <path
+                  d="M4 14V3C4 2.44772 4.44772 2 5 2H12"
+                  stroke="white"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
               </svg>
             )}
           </button>
@@ -69,7 +104,7 @@ export function CodeSnippet({ code, title, description }: CodeSnippetProps) {
                 fontFamily: '"DM Mono", monospace',
                 fontStyle: "normal",
                 fontWeight: 400,
-                lineHeight: "20px",
+                lineHeight: "18px",
                 letterSpacing: "-0.7px",
               }}
             >
@@ -79,9 +114,7 @@ export function CodeSnippet({ code, title, description }: CodeSnippetProps) {
         </div>
 
         {description && (
-          <p className="text-sm text-gray-60 font-mono leading-normal">
-            {description}
-          </p>
+          <p className="text-sm text-gray-60 font-mono leading-normal">{description}</p>
         )}
       </div>
     </div>

--- a/typescript/site/app/components/Footer.tsx
+++ b/typescript/site/app/components/Footer.tsx
@@ -65,6 +65,14 @@ export function Footer() {
               >
                 Whitepaper
               </Link>
+              <Link
+                href="https://docs.google.com/forms/d/e/1FAIpQLSc2rlaeH31rZpJ_RFNL7egxi9fYTEUjW9r2kwkhd2pMae2dog/viewform"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-white hover:text-gray-300 text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                Contact
+              </Link>
             </div>
           </nav>
         </div>
@@ -97,8 +105,8 @@ export function Footer() {
         {/* Copyright row */}
         <div className="flex justify-between items-center">
           <p className="text-white/40 text-sm">
-            While x402 is an open and neutral standard, this website is maintained by
-            {" "}Coinbase Developer Platform. By using this site, you agree to be bound by the{" "}
+            While x402 is an open and neutral standard, this website is maintained by Coinbase
+            Developer Platform. By using this site, you agree to be bound by the{" "}
             <Link
               href="https://www.coinbase.com/legal/developer-platform/terms-of-service"
               target="_blank"
@@ -128,7 +136,7 @@ export function Footer() {
           alt=""
           aria-hidden="true"
           className="w-full h-auto"
-          style={{ filter: 'brightness(0.75)' }}
+          style={{ filter: "brightness(0.75)" }}
         />
       </div>
     </footer>

--- a/typescript/site/app/components/HeroIllustration.tsx
+++ b/typescript/site/app/components/HeroIllustration.tsx
@@ -18,7 +18,7 @@ export function HeroIllustration() {
         href="https://www.x402.org/protected"
         target="_blank"
         rel="noopener noreferrer"
-        className="absolute bottom-[260px] right-[190px] z-10"
+        className="absolute bottom-[300px] right-[190px] z-10"
       >
         <Image
           src="/images/phone.svg"

--- a/typescript/site/app/components/HeroSection.tsx
+++ b/typescript/site/app/components/HeroSection.tsx
@@ -1,14 +1,17 @@
 "use client";
 
+import Link from "next/link";
 import { motion } from "motion/react";
 import { CodeSnippet } from "./CodeSnippet";
 import { HeroIllustration } from "./HeroIllustration";
 import { X402Logo } from "./Logo";
-import { textStagger, fadeInUp, fadeInFromRight } from "@/lib/animations";
+import { BrandSet, StatItem, STATIC_STATS } from "./StatsSection";
+import { textStagger, fadeInUp } from "@/lib/animations";
 
 interface HeroSectionProps {
   codeSnippet: {
     code: string;
+    copyCode?: string;
     title: string;
     description: string;
   };
@@ -16,11 +19,11 @@ interface HeroSectionProps {
 
 export function HeroSection({ codeSnippet }: HeroSectionProps) {
   return (
-    <section className="max-w-container mx-auto px-4 sm:px-6 md:px-10 pt-8 md:pt-10 pb-12 sm:pb-16 md:pb-20 overflow-x-clip">
-      <div className="flex flex-col lg:flex-row gap-8 md:gap-12 lg:gap-8 items-start lg:items-center">
+    <section className="hero-section max-w-container mx-auto px-4 sm:px-6 md:px-10 pt-8 md:pt-10 pb-12 sm:pb-16 md:pb-20 overflow-x-clip">
+      <div className="hero-flex-row flex flex-col lg:flex-row gap-8 md:gap-12 lg:gap-8">
         {/* Animated left column */}
         <motion.div
-          className="flex-1 flex flex-col gap-4"
+          className="hero-left-col flex-1 min-w-0 flex flex-col gap-4"
           variants={textStagger}
           initial="initial"
           animate="animate"
@@ -32,7 +35,7 @@ export function HeroSection({ codeSnippet }: HeroSectionProps) {
 
           <motion.p
             variants={fadeInUp}
-            className="text-base sm:text-lg font-medium leading-relaxed max-w-[600px]"
+            className="text-sm sm:text-base font-medium text-gray-70 leading-relaxed max-w-[600px]"
           >
             x402 is an open, neutral standard for internet-native payments. It absolves the
             Internet's original sin by natively making payments possible between clients and
@@ -44,20 +47,43 @@ export function HeroSection({ codeSnippet }: HeroSectionProps) {
             <CodeSnippet
               title={codeSnippet.title}
               code={codeSnippet.code}
+              copyCode={codeSnippet.copyCode}
               description={codeSnippet.description}
             />
           </motion.div>
+
+          <motion.div variants={fadeInUp}>
+            <Link href="/ecosystem" className="block" aria-label="View ecosystem partners">
+              <p className="text-xs font-medium text-gray-40 uppercase tracking-wide mb-4">
+                Trusted by
+              </p>
+              <div className="overflow-hidden [--gap:2.5rem] sm:[--gap:3rem] md:[--gap:4rem] [mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
+                <div className="flex [gap:var(--gap)]">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <BrandSet key={i} />
+                  ))}
+                </div>
+              </div>
+            </Link>
+          </motion.div>
+
+          {/* Stats pinned to the bottom of the left column — desktop only */}
+          <div className="mt-auto hidden xl:block pt-8" aria-label="Platform statistics">
+            <p className="text-xs font-medium text-gray-40 uppercase tracking-wide mb-4">
+              Last 30 days
+            </p>
+            <div className="flex flex-wrap items-end gap-6 sm:gap-8 md:gap-16 lg:gap-20">
+              <StatItem value={STATIC_STATS.transactions} label="Transactions" />
+              <StatItem value={STATIC_STATS.volume} label="Volume" />
+              <StatItem value={STATIC_STATS.buyers} label="Buyers" />
+              <StatItem value={STATIC_STATS.sellers} label="Sellers" />
+            </div>
+          </div>
         </motion.div>
 
-        {/* Animated right column - only show at xl (1280px+) where there's room */}
-        <motion.div
-          className="relative hidden xl:block flex-shrink-0 xl:w-[720px]"
-          variants={fadeInFromRight}
-          initial="initial"
-          animate="animate"
-        >
+        <div className="hero-illustration-col">
           <HeroIllustration />
-        </motion.div>
+        </div>
       </div>
     </section>
   );

--- a/typescript/site/app/components/NavBar.tsx
+++ b/typescript/site/app/components/NavBar.tsx
@@ -44,13 +44,7 @@ export function NavBar({ animateLogo = false }: NavBarProps): React.ReactElement
             {mobileMenuOpen ? (
               <CloseIcon />
             ) : (
-              <Image
-                src="/images/hamburger.svg"
-                alt=""
-                width={24}
-                height={24}
-                aria-hidden="true"
-              />
+              <Image src="/images/hamburger.svg" alt="" width={24} height={24} aria-hidden="true" />
             )}
           </button>
 
@@ -87,67 +81,73 @@ export function NavBar({ animateLogo = false }: NavBarProps): React.ReactElement
 
           {/* Desktop: Right side actions */}
           <div className="hidden lg:flex flex-1 items-center gap-6 justify-end">
-            {/* Docs button */}
-            <Link
-              href="https://docs.x402.org"
-              className="flex items-center gap-1 px-4 py-2 border border-black text-black font-medium text-sm hover:bg-gray-10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 20 20"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                aria-hidden="true"
+            {/* Social icons */}
+            <div className="flex items-center gap-6">
+              <Link
+                href="https://github.com/x402-foundation/x402"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:opacity-60 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
+                aria-label="GitHub"
               >
-                <path
-                  d="M4.76172 3.1001L15.2207 3.10107L16.915 4.79639L16.916 16.9019H15.2383L15.2373 16.8999H4.7793L3.08398 15.2056V3.09814H4.7627L4.76172 3.1001ZM4.7627 14.5093L5.47461 15.2212H15.2373L15.2383 5.4917L14.5254 4.77881H4.76172L4.7627 14.5093Z"
+                <svg
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
                   fill="currentColor"
-                />
-                <path
-                  d="M13.8297 6.55029C13.9402 6.55029 14.0297 6.63984 14.0297 6.75029V7.73018C14.0297 7.84063 13.9402 7.93018 13.8297 7.93018H6.17021C6.05976 7.93018 5.97021 7.84063 5.97021 7.73018V6.75029C5.97021 6.63984 6.05976 6.55029 6.17021 6.55029H13.8297Z"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                >
+                  <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+                </svg>
+              </Link>
+              <Link
+                href="https://discord.com/invite/cdp"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:opacity-60 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
+                aria-label="Discord"
+              >
+                <svg
+                  className="w-5 h-5"
+                  viewBox="0 0 24 24"
                   fill="currentColor"
-                />
-                <path
-                  d="M13.8297 9.31006C13.9402 9.31006 14.0297 9.3996 14.0297 9.51006V10.4899C14.0297 10.6004 13.9402 10.6899 13.8297 10.6899H6.17021C6.05976 10.6899 5.97021 10.6004 5.97021 10.4899V9.51006C5.97021 9.3996 6.05976 9.31006 6.17021 9.31006H13.8297Z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M13.8297 12.0698C13.9402 12.0698 14.0297 12.1594 14.0297 12.2698V13.2497C14.0297 13.3602 13.9402 13.4497 13.8297 13.4497H6.17021C6.05976 13.4497 5.97021 13.3602 5.97021 13.2497V12.2698C5.97021 12.1594 6.05976 12.0698 6.17021 12.0698H13.8297Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <span>Docs</span>
-            </Link>
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                >
+                  <path d="M20.317 4.37a19.791 19.791 0 00-4.885-1.515.074.074 0 00-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 00-5.487 0 12.64 12.64 0 00-.617-1.25.077.077 0 00-.079-.037A19.736 19.736 0 003.677 4.37a.07.07 0 00-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 00.031.057 19.9 19.9 0 005.993 3.03.078.078 0 00.084-.028 14.09 14.09 0 001.226-1.994.076.076 0 00-.041-.106 13.107 13.107 0 01-1.872-.892.077.077 0 01-.008-.128 10.2 10.2 0 00.372-.292.074.074 0 01.077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 01.078.01c.12.098.246.198.373.292a.077.077 0 01-.006.127 12.299 12.299 0 01-1.873.892.077.077 0 00-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 00.084.028 19.839 19.839 0 006.002-3.03.077.077 0 00.032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 00-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+                </svg>
+              </Link>
+            </div>
 
-            {/* Build with us button */}
-            <Link
-              href="https://docs.google.com/forms/d/e/1FAIpQLSc2rlaeH31rZpJ_RFNL7egxi9fYTEUjW9r2kwkhd2pMae2dog/viewform"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1 px-4 py-2 bg-black text-white font-medium text-sm hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
-            >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 20 20"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                aria-hidden="true"
+            {/* CTA buttons */}
+            <div className="flex items-center gap-3">
+              {/* Get Started button */}
+              <Link
+                href="https://docs.x402.org/getting-started/quickstart-for-buyers"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 px-4 py-2 bg-black text-white font-medium text-sm hover:bg-gray-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2"
               >
-                <path
-                  d="M10.1772 14.2772L14.027 10.4274L14.027 9.57257L10.1772 5.72285L11.1851 4.71495L15.4524 8.98217L15.4524 11.0178L11.1851 15.285L10.1772 14.2772Z"
-                  fill="currentColor"
-                />
-                <path
-                  d="M4.54761 9.45635C4.54761 9.369 4.64796 9.2982 4.77174 9.2982H14.0704C14.1941 9.2982 14.2945 9.369 14.2945 9.45635V10.5633C14.2945 10.6507 14.1941 10.7215 14.0704 10.7215H4.77174C4.64796 10.7215 4.54761 10.6507 4.54761 10.5633V9.45635Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <span>Contact</span>
-            </Link>
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M10.1772 14.2772L14.027 10.4274L14.027 9.57257L10.1772 5.72285L11.1851 4.71495L15.4524 8.98217L15.4524 11.0178L11.1851 15.285L10.1772 14.2772Z"
+                    fill="currentColor"
+                  />
+                  <path
+                    d="M4.54761 9.45635C4.54761 9.369 4.64796 9.2982 4.77174 9.2982H14.0704C14.1941 9.2982 14.2945 9.369 14.2945 9.45635V10.5633C14.2945 10.6507 14.1941 10.7215 14.0704 10.7215H4.77174C4.64796 10.7215 4.54761 10.6507 4.54761 10.5633V9.45635Z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span>Get Started</span>
+              </Link>
+            </div>
           </div>
 
           {/* Mobile: Spacer to balance hamburger */}
@@ -192,22 +192,13 @@ export function NavBar({ animateLogo = false }: NavBarProps): React.ReactElement
             {/* CTA buttons */}
             <div className="space-y-3 pt-2">
               <Link
-                href="https://docs.x402.org"
-                className="flex items-center justify-center gap-2 w-full px-4 py-3 border border-black text-black font-medium text-sm hover:bg-gray-10 transition-colors"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => setMobileMenuOpen(false)}
-              >
-                Docs
-              </Link>
-              <Link
-                href="https://docs.google.com/forms/d/e/1FAIpQLSc2rlaeH31rZpJ_RFNL7egxi9fYTEUjW9r2kwkhd2pMae2dog/viewform"
+                href="https://docs.x402.org/getting-started/quickstart-for-buyers"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center justify-center gap-2 w-full px-4 py-3 bg-black text-white font-medium text-sm hover:bg-gray-800 transition-colors"
                 onClick={() => setMobileMenuOpen(false)}
               >
-                Contact
+                Get Started
               </Link>
             </div>
           </div>

--- a/typescript/site/app/components/StatsSection.tsx
+++ b/typescript/site/app/components/StatsSection.tsx
@@ -10,7 +10,7 @@ interface StatsData {
   sellers: string;
 }
 
-const STATIC_STATS: StatsData = {
+export const STATIC_STATS: StatsData = {
   transactions: "75.41M",
   volume: "$24.24M",
   buyers: "94.06K",
@@ -22,7 +22,7 @@ interface StatItemProps {
   label: string;
 }
 
-function StatItem({ value, label }: StatItemProps) {
+export function StatItem({ value, label }: StatItemProps) {
   return (
     <div className="flex flex-col items-start gap-1.5">
       <div className="text-3xl sm:text-4xl md:text-[56px] font-display leading-none tracking-tighter text-black">
@@ -33,7 +33,7 @@ function StatItem({ value, label }: StatItemProps) {
   );
 }
 
-const brands = [
+export const brands = [
   { name: "Stripe", logo: "/logos/stripe-mono.svg" },
   { name: "AWS", logo: "/logos/aws.-mono.svg", className: "h-8" },
   { name: "Messari", logo: "/logos/messari-mono.svg" },
@@ -45,10 +45,10 @@ const brands = [
   { name: "Quicknode", logo: "/logos/quicknode-mono.svg", className: "h-7" },
 ];
 
-function BrandSet() {
+export function BrandSet() {
   return (
     <div className="flex shrink-0 items-center [gap:var(--gap)] animate-marquee">
-      {brands.map((brand) => (
+      {brands.map(brand => (
         <Image
           key={brand.name}
           src={brand.logo}
@@ -64,26 +64,16 @@ function BrandSet() {
 
 export function StatsSection() {
   return (
-    <section className="max-w-container mx-auto px-4 sm:px-6 md:px-10 py-10 sm:py-12 md:py-14" aria-label="Platform statistics">
+    <section
+      className="max-w-container mx-auto px-4 sm:px-6 md:px-10 py-10 sm:py-12 md:py-14 xl:pt-4 xl:pb-14"
+      aria-label="Platform statistics"
+    >
       <p className="text-xs font-medium text-gray-40 uppercase tracking-wide mb-4">Last 30 days</p>
       <div className="flex flex-wrap items-end gap-6 sm:gap-8 md:gap-16 lg:gap-20">
         <StatItem value={STATIC_STATS.transactions} label="Transactions" />
         <StatItem value={STATIC_STATS.volume} label="Volume" />
         <StatItem value={STATIC_STATS.buyers} label="Buyers" />
         <StatItem value={STATIC_STATS.sellers} label="Sellers" />
-      </div>
-
-      <div className="border-t border-gray-10 mt-10 sm:mt-12 pt-6 sm:pt-8">
-        <Link href="/ecosystem" className="block" aria-label="View ecosystem partners">
-          <p className="text-xs font-medium text-gray-40 uppercase tracking-wide mb-5">Adopted by</p>
-          <div className="overflow-hidden [--gap:2.5rem] sm:[--gap:3rem] md:[--gap:4rem] [mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
-            <div className="flex [gap:var(--gap)]">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <BrandSet key={i} />
-              ))}
-            </div>
-          </div>
-        </Link>
       </div>
     </section>
   );

--- a/typescript/site/app/globals.css
+++ b/typescript/site/app/globals.css
@@ -70,3 +70,40 @@ body {
 @utility animate-marquee {
   animation: marquee var(--duration, 40s) linear infinite reverse;
 }
+
+/* Hero section — explicit media queries for xl layout */
+.hero-illustration-col {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  /* At lg, layout is flex-row — align columns to top */
+  .hero-flex-row {
+    align-items: flex-start;
+  }
+}
+
+@media (min-width: 1280px) {
+  /* Remove section top padding — illustration fills from nav bottom */
+  .hero-section {
+    padding-top: 0;
+  }
+
+  /* Restore top padding on left column only */
+  .hero-left-col {
+    padding-top: 2.5rem; /* 40px = pt-10 */
+  }
+
+  /* Stretch both columns to illustration height at xl */
+  .hero-flex-row {
+    align-items: stretch;
+  }
+
+  /* Show illustration column */
+  .hero-illustration-col {
+    display: block;
+    position: relative;
+    flex-shrink: 0;
+    width: 720px;
+  }
+}

--- a/typescript/site/app/page.tsx
+++ b/typescript/site/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
+
 import { NavBar } from "./components/NavBar";
 import { Footer } from "./components/Footer";
 import {
@@ -87,7 +88,13 @@ const x402Steps = [
 ];
 
 const heroCodeSnippet = {
-  code: `app.use(
+  code: `app.use(paymentMiddleware({
+  "GET /weather": {
+    accepts: [...],                 // As many networks / schemes as you want to support
+    description: "Weather data",    // What your endpoint does
+  },
+}));`,
+  copyCode: `app.use(
   paymentMiddleware(
     {
       "GET /weather": {
@@ -98,7 +105,8 @@ const heroCodeSnippet = {
   )
 );`,
   title: "Accept payments with a single line of code",
-  description: "That's it. Add one line of code to require payment for each incoming request. If a request arrives without payment, the server responds with HTTP 402, prompting the client to pay and retry.",
+  description:
+    "That's it. Add one line of code to require payment for each incoming request. If a request arrives without payment, the server responds with HTTP 402, prompting the client to pay and retry.",
 };
 
 export default function HomePage() {
@@ -108,8 +116,10 @@ export default function HomePage() {
 
       <HeroSection codeSnippet={heroCodeSnippet} />
 
-      {/* Stats & Social Proof */}
-      <StatsSection />
+      {/* Stats & Social Proof — hidden on xl where stats live inside HeroSection */}
+      <div className="xl:hidden">
+        <StatsSection />
+      </div>
 
       {/* What's x402? */}
       <WhatsX402Section />
@@ -165,10 +175,7 @@ export default function HomePage() {
             descriptionSize="small"
           />
 
-          <ComparisonTable
-            traditionalSteps={traditionalSteps}
-            x402Steps={x402Steps}
-          />
+          <ComparisonTable traditionalSteps={traditionalSteps} x402Steps={x402Steps} />
         </div>
       </section>
 
@@ -182,7 +189,10 @@ export default function HomePage() {
           />
 
           <div className="mb-12">
-            <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-5 gap-3 sm:gap-4 lg:h-[425px]" aria-label="Community photos">
+            <div
+              className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-5 gap-3 sm:gap-4 lg:h-[425px]"
+              aria-label="Community photos"
+            >
               <div className="col-span-1 relative rounded overflow-hidden">
                 <Image
                   src="/images/homepage_build1.jpeg"
@@ -224,11 +234,11 @@ export default function HomePage() {
 
           <div className="flex flex-col items-center gap-4 sm:gap-6">
             <p className="text-sm sm:text-base font-medium text-center max-w-[491px]">
-              Join a global community of thousands of builders contributing to an
-              open codebase, faster financial system, and freer internet.
+              Join a global community of thousands of builders contributing to an open codebase,
+              faster financial system, and freer internet.
             </p>
             <Link
-              href="https://docs.google.com/forms/d/e/1FAIpQLSc2rlaeH31rZpJ_RFNL7egxi9fYTEUjW9r2kwkhd2pMae2dog/viewform"
+              href="https://docs.x402.org/getting-started/quickstart-for-sellers"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-2 px-6 sm:px-10 md:px-16 py-3 bg-black text-white font-medium text-base hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-2"


### PR DESCRIPTION
## Summary

- Replace nav Contact button with a **Get Started** CTA linking to the buyer quickstart docs; move the Contact link (Google Form) to the footer
- Add GitHub and Discord icon links to the desktop nav alongside Docs
- Move the **Trusted By** partner logo marquee into the `HeroSection` below the code snippet, eliminating the separate floating logo block
- Pin platform stats to the bottom of the hero left column on desktop (xl breakpoint) using `mt-auto` / `items-stretch`; hide the standalone `StatsSection` at xl so stats only render once
- Fix `HeroIllustration` not rendering at 1280px+: removed a broken `fadeInFromRight` animation holding opacity at 0, added `min-w-0` to the flex-1 left column to prevent the marquee from pushing the illustration off-screen
- Replace unreliable Tailwind `xl:` responsive variants with explicit `@media` rules in `globals.css` for hero section padding, column alignment, and illustration visibility
- Fix mobile hero left column overflow by scoping `align-items: flex-start` to `lg+` only, restoring full-width stretch on mobile
- Add `copyCode` prop to `CodeSnippet` so the display code can be compact while the clipboard copy retains full fidelity
- Adjust phone illustration `bottom` position for flush top alignment with the section at xl

## Test plan

- [ ] Desktop (≥1280px): hero illustration visible, stats pinned to bottom-left of hero
- [ ] Tablet (1024–1279px): hero illustration hidden, standalone stats visible
- [ ] Mobile: hero left column wraps/condenses to full width, no horizontal overflow
- [ ] Nav: Get Started links to buyer quickstart, GitHub/Discord icons render
- [ ] Footer: Contact link present
- [ ] Code snippet: copy button copies full-fidelity code