### PR TITLE
solve discovery probes time out on serverless

### DIFF
--- a/typescript/.changeset/fix-cold-start-discovery-probe-timeouts.md
+++ b/typescript/.changeset/fix-cold-start-discovery-probe-timeouts.md
@@ -1,0 +1,9 @@
+---
+"@x402/core": patch
+"@x402/express": patch
+"@x402/fastify": patch
+"@x402/hono": patch
+"@x402/next": patch
+---
+
+Fix cold-start discovery probe timeouts on serverless/edge runtimes. Decouples facilitator init from 402 generation: probes no longer block on the facilitator round-trip; init is awaited only when a payment header is present.

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -368,6 +368,15 @@ export class x402HTTPResourceServer {
   }
 
   /**
+   * Whether the server has been initialized (facilitator support fetched).
+   *
+   * @returns True if initialize() has completed successfully at least once
+   */
+  get initialized(): boolean {
+    return this.ResourceServer.initialized;
+  }
+
+  /**
    * Get the routes configuration.
    *
    * @returns The routes configuration

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -206,6 +206,7 @@ export class x402ResourceServer {
     new Map();
   private registeredExtensions: Map<string, ResourceServerExtension> = new Map();
   private extensionHookAdapters = new Map<string, ExtensionAdapterHandles>();
+  private _initialized = false;
 
   private beforeVerifyHooks: BeforeVerifyHook[] = [];
   private afterVerifyHooks: AfterVerifyHook[] = [];
@@ -232,6 +233,15 @@ export class x402ResourceServer {
       // Single client provided
       this.facilitatorClients = [facilitatorClients];
     }
+  }
+
+  /**
+   * Whether the server has been initialized (facilitator support fetched).
+   *
+   * @returns True if initialize() has completed successfully at least once
+   */
+  get initialized(): boolean {
+    return this._initialized;
   }
 
   /**
@@ -527,6 +537,8 @@ export class x402ResourceServer {
             "Failed to initialize: no supported payment kinds loaded from any facilitator.",
           );
     }
+
+    this._initialized = true;
   }
 
   /**
@@ -604,12 +616,23 @@ export class x402ResourceServer {
       SchemeNetworkServer.scheme,
     );
 
-    if (!supportedKind) {
+    if (!supportedKind && this._initialized) {
+      // Server has been initialized but facilitator doesn't support this combination
       throw new Error(
         `Facilitator does not support ${SchemeNetworkServer.scheme} on ${resourceConfig.network}. ` +
           `Make sure to call initialize() to fetch supported kinds from facilitators.`,
       );
     }
+
+    // When not yet initialized, use a synthetic kind from route config so 402 responses
+    // can be generated without waiting for the facilitator round-trip.  This is safe
+    // because the 402 metadata comes from the route config; the facilitator-provided
+    // extras (e.g. feePayer, areFeesSponsored) are only needed at verify/settle time.
+    const effectiveKind = supportedKind ?? {
+      x402Version,
+      scheme: SchemeNetworkServer.scheme,
+      network: resourceConfig.network,
+    };
 
     // Get facilitator extensions for this combination
     const facilitatorExtensions = this.getFacilitatorExtensions(
@@ -639,11 +662,10 @@ export class x402ResourceServer {
     };
 
     // Delegate to the implementation for scheme-specific enhancements
-    // Note: enhancePaymentRequirements expects x402Version in the kind, so we add it back
     const requirement = await SchemeNetworkServer.enhancePaymentRequirements(
       baseRequirements,
       {
-        ...supportedKind,
+        ...effectiveKind,
         x402Version,
       },
       facilitatorExtensions,

--- a/typescript/packages/core/test/mocks/generic/MockFacilitatorClient.ts
+++ b/typescript/packages/core/test/mocks/generic/MockFacilitatorClient.ts
@@ -14,6 +14,7 @@ import { PaymentPayload, PaymentRequirements } from "../../../src/types/payments
  */
 export class MockFacilitatorClient implements FacilitatorClient {
   private supportedResponse: SupportedResponse;
+  private supportedError: Error | null = null;
   private verifyResponseOrError: VerifyResponse | Error;
   private settleResponseOrError: SettleResponse | Error;
 
@@ -43,6 +44,9 @@ export class MockFacilitatorClient implements FacilitatorClient {
    */
   async getSupported(): Promise<SupportedResponse> {
     this.getSupportedCalls++;
+    if (this.supportedError) {
+      throw this.supportedError;
+    }
     return this.supportedResponse;
   }
 
@@ -127,6 +131,14 @@ export class MockFacilitatorClient implements FacilitatorClient {
    */
   setSettleResponse(response: SettleResponse | Error): void {
     this.settleResponseOrError = response;
+  }
+
+  /**
+   *
+   * @param error
+   */
+  setSupportedError(error: Error | null): void {
+    this.supportedError = error;
   }
 
   /**

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -403,6 +403,54 @@ describe("x402ResourceServer", () => {
           }),
       ).rejects.toThrow("Facilitator does not support test-scheme on test:network");
     });
+
+    it("should build requirements without initialize() for discovery (cold-start tolerance)", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "test-scheme", network: "test:network" as Network }],
+        }),
+      );
+
+      const server = new x402ResourceServer(mockClient);
+      const mockScheme = new MockSchemeNetworkServer("test-scheme");
+      server.register("test:network" as Network, mockScheme);
+
+      // Do NOT call initialize() — simulates cold serverless isolate
+      expect(server.initialized).toBe(false);
+
+      const requirements = await server.buildPaymentRequirements({
+        scheme: "test-scheme",
+        payTo: "recipient",
+        price: 1.0,
+        network: "test:network" as Network,
+      });
+
+      // Should succeed with synthetic kind (no facilitator data)
+      expect(requirements).toHaveLength(1);
+      expect(requirements[0].scheme).toBe("test-scheme");
+      expect(requirements[0].network).toBe("test:network");
+      expect(requirements[0].payTo).toBe("recipient");
+    });
+
+    it("should set initialized to true after successful initialize()", async () => {
+      const mockClient = new MockFacilitatorClient(buildSupportedResponse());
+      const server = new x402ResourceServer(mockClient);
+
+      expect(server.initialized).toBe(false);
+      await server.initialize();
+      expect(server.initialized).toBe(true);
+    });
+
+    it("should not set initialized to true when initialize() fails", async () => {
+      const mockClient = new MockFacilitatorClient(buildSupportedResponse());
+      mockClient.setSupportedError(new Error("Network failure"));
+
+      const server = new x402ResourceServer(mockClient);
+
+      expect(server.initialized).toBe(false);
+      await expect(server.initialize()).rejects.toThrow();
+      expect(server.initialized).toBe(false);
+    });
   });
 
   describe("Lifecycle hooks", () => {

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -524,7 +524,10 @@ describe("paymentMiddleware", () => {
   it("does not block on init for discovery probes (no payment header)", async () => {
     let resolveInit: () => void;
     const initialize = vi.fn().mockImplementation(
-      () => new Promise<void>(resolve => { resolveInit = resolve; }),
+      () =>
+        new Promise<void>(resolve => {
+          resolveInit = resolve;
+        }),
     );
 
     vi.mocked(HTTPResourceServer).mockImplementation(

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -428,7 +428,7 @@ describe("paymentMiddleware", () => {
     expect(res.json).toHaveBeenCalledWith({});
   });
 
-  it("returns 502 when facilitator init fails during protected request", async () => {
+  it("returns 502 when facilitator init fails during protected request with payment", async () => {
     const initialize = vi.fn().mockRejectedValue(
       new Error("Failed to initialize: no supported payment kinds loaded from any facilitator.", {
         cause: new FacilitatorResponseError(
@@ -454,7 +454,9 @@ describe("paymentMiddleware", () => {
     );
 
     const middleware = paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer);
-    const req = createMockRequest();
+    const req = createMockRequest({
+      headers: { "payment-signature": "test-sig" },
+    });
     const res = createMockResponse();
     const next = vi.fn();
 
@@ -501,13 +503,69 @@ describe("paymentMiddleware", () => {
     const secondRes = createMockResponse();
     const next = vi.fn();
 
-    await middleware(createMockRequest(), firstRes, next);
-    await middleware(createMockRequest(), secondRes, next);
+    // Requests with payment header block on init — first fails, second retries
+    await middleware(
+      createMockRequest({ headers: { "payment-signature": "test-sig" } }),
+      firstRes,
+      next,
+    );
+    await middleware(
+      createMockRequest({ headers: { "payment-signature": "test-sig" } }),
+      secondRes,
+      next,
+    );
 
     expect(firstRes.status).toHaveBeenCalledWith(502);
     expect(initialize).toHaveBeenCalledTimes(2);
     expect(mockProcessHTTPRequest).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not block on init for discovery probes (no payment header)", async () => {
+    let resolveInit: () => void;
+    const initialize = vi.fn().mockImplementation(
+      () => new Promise<void>(resolve => { resolveInit = resolve; }),
+    );
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize,
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+    mockProcessHTTPRequest.mockResolvedValue({
+      type: "payment-error",
+      response: {
+        status: 402,
+        headers: { "PAYMENT-REQUIRED": "encoded-data" },
+        body: {},
+      },
+    });
+
+    const middleware = paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer);
+    const req = createMockRequest();
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    // Discovery probe (no payment header) should NOT block on init
+    await middleware(req, res, next);
+
+    // processHTTPRequest was called even though init hasn't resolved
+    expect(mockProcessHTTPRequest).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(402);
+    expect(next).not.toHaveBeenCalled();
+
+    // Clean up pending promise
+    resolveInit!();
   });
 
   it("returns 502 when processHTTPRequest surfaces FacilitatorResponseError", async () => {

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -141,18 +141,25 @@ export function paymentMiddlewareFromHTTPServer(
       return next();
     }
 
-    // Only initialize when processing a protected route
+    // Only block on init when a payment header is present (verify/settle path).
+    // Discovery probes (no payment header) can generate a 402 from route config
+    // without waiting for the facilitator round-trip, avoiding cold-start timeouts
+    // on serverless/edge runtimes.
+    const hasPaymentHeader = !!context.paymentHeader;
     if (syncFacilitatorOnStart && !isInitialized) {
-      try {
-        await initializeHttpServer();
-      } catch (error) {
-        const facilitatorError = getFacilitatorResponseError(error);
-        if (facilitatorError) {
-          sendFacilitatorError(res, facilitatorError);
-          return;
+      if (hasPaymentHeader) {
+        try {
+          await initializeHttpServer();
+        } catch (error) {
+          const facilitatorError = getFacilitatorResponseError(error);
+          if (facilitatorError) {
+            sendFacilitatorError(res, facilitatorError);
+            return;
+          }
+          return next(error);
         }
-        return next(error);
       }
+      // else: no payment header — proceed without init; background init continues
     }
 
     // Await bazaar extension loading if needed

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -316,16 +316,24 @@ export function paymentMiddlewareFromHTTPServer(
       return;
     }
 
+    // Only block on init when a payment header is present (verify/settle path).
+    // Discovery probes (no payment header) can generate a 402 from route config
+    // without waiting for the facilitator round-trip, avoiding cold-start timeouts
+    // on serverless/edge runtimes.
+    const hasPaymentHeader = !!context.paymentHeader;
     if (syncFacilitatorOnStart && !isInitialized) {
-      try {
-        await initializeHttpServer();
-      } catch (error) {
-        const facilitatorError = getFacilitatorResponseError(error);
-        if (facilitatorError) {
-          return sendFacilitatorError(reply, facilitatorError);
+      if (hasPaymentHeader) {
+        try {
+          await initializeHttpServer();
+        } catch (error) {
+          const facilitatorError = getFacilitatorResponseError(error);
+          if (facilitatorError) {
+            return sendFacilitatorError(reply, facilitatorError);
+          }
+          throw error;
         }
-        throw error;
       }
+      // else: no payment header — proceed without init; background init continues
     }
 
     if (bazaarPromise) {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -452,12 +452,65 @@ describe("paymentMiddleware", () => {
     const middleware = paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer);
     const next = vi.fn().mockResolvedValue(undefined);
 
-    await middleware(createMockContext(), next);
-    await middleware(createMockContext(), next);
+    // Requests with a payment header block on init and trigger retry on failure
+    const ctxWithPayment = createMockContext({
+      headers: { "payment-signature": "test-sig" },
+    });
+    await middleware(ctxWithPayment, next);
+
+    const ctxWithPayment2 = createMockContext({
+      headers: { "payment-signature": "test-sig" },
+    });
+    await middleware(ctxWithPayment2, next);
 
     expect(initialize).toHaveBeenCalledTimes(2);
     expect(mockProcessHTTPRequest).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not block on init for discovery probes (no payment header)", async () => {
+    let resolveInit: () => void;
+    const initialize = vi.fn().mockImplementation(
+      () => new Promise<void>(resolve => { resolveInit = resolve; }),
+    );
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize,
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+    mockProcessHTTPRequest.mockResolvedValue({
+      type: "payment-error",
+      response: {
+        status: 402,
+        headers: { "PAYMENT-REQUIRED": "encoded-data" },
+        body: {},
+      },
+    });
+
+    const middleware = paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer);
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    // Discovery probe (no payment header) should NOT block on init
+    const ctx = createMockContext();
+    await middleware(ctx, next);
+
+    // processHTTPRequest was called even though init hasn't resolved
+    expect(mockProcessHTTPRequest).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalled();
+
+    // Clean up pending promise
+    resolveInit!();
   });
 
   it("returns 402 when settlement returns success: false", async () => {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -471,7 +471,10 @@ describe("paymentMiddleware", () => {
   it("does not block on init for discovery probes (no payment header)", async () => {
     let resolveInit: () => void;
     const initialize = vi.fn().mockImplementation(
-      () => new Promise<void>(resolve => { resolveInit = resolve; }),
+      () =>
+        new Promise<void>(resolve => {
+          resolveInit = resolve;
+        }),
     );
 
     vi.mocked(HTTPResourceServer).mockImplementation(

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -142,17 +142,24 @@ export function paymentMiddlewareFromHTTPServer(
       return next();
     }
 
-    // Only initialize when processing a protected route
+    // Only block on init when a payment header is present (verify/settle path).
+    // Discovery probes (no payment header) can generate a 402 from route config
+    // without waiting for the facilitator round-trip, avoiding cold-start timeouts
+    // on serverless/edge runtimes.
+    const hasPaymentHeader = !!context.paymentHeader;
     if (syncFacilitatorOnStart && !isInitialized) {
-      try {
-        await initializeHttpServer();
-      } catch (error) {
-        const facilitatorError = getFacilitatorResponseError(error);
-        if (facilitatorError) {
-          return facilitatorErrorResponse(c, facilitatorError);
+      if (hasPaymentHeader) {
+        try {
+          await initializeHttpServer();
+        } catch (error) {
+          const facilitatorError = getFacilitatorResponseError(error);
+          if (facilitatorError) {
+            return facilitatorErrorResponse(c, facilitatorError);
+          }
+          throw error;
         }
-        throw error;
       }
+      // else: no payment header — proceed without init; background init continues
     }
 
     // Await bazaar extension loading if needed

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -88,9 +88,13 @@ export function paymentProxyFromHTTPServer(
       return NextResponse.next();
     }
 
-    // Only initialize when processing a protected route
+    // Only block on init when a payment header is present (verify/settle path).
+    // Discovery probes (no payment header) can generate a 402 from route config
+    // without waiting for the facilitator round-trip, avoiding cold-start timeouts
+    // on serverless/edge runtimes.
+    const hasPaymentHeader = !!context.paymentHeader;
     try {
-      await init();
+      await init({ requireCompletion: hasPaymentHeader });
     } catch (error) {
       const facilitatorError = getFacilitatorResponseError(error);
       if (facilitatorError) {
@@ -281,16 +285,20 @@ export function withX402FromHTTPServer<T = unknown>(
   }
 
   return async (request: NextRequest): Promise<NextResponse<T>> => {
-    // Only initialize when processing a protected route
-    await init();
+    const context = createRequestContext(request);
+
+    // Only block on init when a payment header is present (verify/settle path).
+    // Discovery probes (no payment header) can generate a 402 from route config
+    // without waiting for the facilitator round-trip, avoiding cold-start timeouts
+    // on serverless/edge runtimes.
+    const hasPaymentHeader = !!context.paymentHeader;
+    await init({ requireCompletion: hasPaymentHeader });
 
     // Await bazaar extension loading if needed
     if (bazaarPromise) {
       await bazaarPromise;
       bazaarPromise = null;
     }
-
-    const context = createRequestContext(request);
 
     // Process payment requirement check
     const result = await httpServer.processHTTPRequest(context, paywallConfig);

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -150,9 +150,31 @@ describe("createHttpServer", () => {
 
     const { init } = createHttpServer(routes, server);
 
-    await expect(init()).rejects.toThrow("not-json");
-    await expect(init()).resolves.toBeUndefined();
+    await expect(init({ requireCompletion: true })).rejects.toThrow("not-json");
+    await expect(init({ requireCompletion: true })).resolves.toBeUndefined();
     expect(mockInitialize).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not block when requireCompletion is false (discovery path)", async () => {
+    let resolveInit: () => void;
+    mockInitialize = vi.fn().mockImplementation(
+      () => new Promise<void>(resolve => { resolveInit = resolve; }),
+    );
+    const routes = {
+      "/api/*": {
+        accepts: { scheme: "exact", payTo: "0x123", price: "$0.01", network: "eip155:84532" },
+      },
+    } as const;
+    const server = createMockResourceServer();
+
+    const { init } = createHttpServer(routes, server);
+
+    // Without requireCompletion, init returns immediately even though promise is pending
+    await expect(init()).resolves.toBeUndefined();
+    expect(mockInitialize).toHaveBeenCalled();
+
+    // Clean up pending promise
+    resolveInit!();
   });
 });
 

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -158,7 +158,10 @@ describe("createHttpServer", () => {
   it("does not block when requireCompletion is false (discovery path)", async () => {
     let resolveInit: () => void;
     mockInitialize = vi.fn().mockImplementation(
-      () => new Promise<void>(resolve => { resolveInit = resolve; }),
+      () =>
+        new Promise<void>(resolve => {
+          resolveInit = resolve;
+        }),
     );
     const routes = {
       "/api/*": {

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -17,7 +17,7 @@ import { NextAdapter } from "./adapter";
  */
 export interface HttpServerInstance {
   httpServer: x402HTTPResourceServer;
-  init: () => Promise<void>;
+  init: (options?: { requireCompletion?: boolean }) => Promise<void>;
 }
 
 export const getFacilitatorResponseError = getCoreFacilitatorResponseError;
@@ -62,14 +62,23 @@ export function prepareHttpServer(
     httpServer,
     /**
      * Ensures facilitator initialization succeeds once, while allowing retries after failures.
+     *
+     * @param options.requireCompletion - When true, awaits init completion (needed for verify/settle).
+     *   When false (default), returns immediately if init hasn't completed — allows discovery probes
+     *   to generate 402 responses from route config without blocking on the facilitator round-trip.
      */
-    async init() {
+    async init(options?: { requireCompletion?: boolean }) {
       if (!syncFacilitatorOnStart || isInitialized) {
         return;
       }
 
       if (!initPromise) {
         initPromise = httpServer.initialize();
+      }
+
+      if (!options?.requireCompletion) {
+        // Don't block — let background init continue while discovery proceeds
+        return;
       }
 
       try {

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -63,6 +63,7 @@ export function prepareHttpServer(
     /**
      * Ensures facilitator initialization succeeds once, while allowing retries after failures.
      *
+     * @param options - Optional configuration for init behaviour.
      * @param options.requireCompletion - When true, awaits init completion (needed for verify/settle).
      *   When false (default), returns immediately if init hasn't completed — allows discovery probes
      *   to generate 402 responses from route config without blocking on the facilitator round-trip.


### PR DESCRIPTION
## Description

Fixes discovery probe timeouts on cold serverless/edge isolates (Cloudflare Workers, Vercel Edge, Lambda@Edge) for all x402 HTTP middleware packages.

Closes #2157

**Root cause — two coupled problems:**

1. All middleware awaited `httpServer.initialize()` (a blocking `/supported` round-trip to the facilitator) before processing *any* request on a paid route, including discovery probes that only need a 402 response.
2. `x402ResourceServer.buildPaymentRequirements()` threw immediately when `getSupportedKind()` returned undefined, making it impossible to generate a 402 without completing init — so simply not awaiting init would produce a 5xx instead of a 402.

**Fix — decouple init from 402 generation (Approach 1 from the issue):**

### `@x402/core`

- `x402ResourceServer`: Added `_initialized` flag and `initialized` getter. Modified `buildPaymentRequirements()`: when `getSupportedKind()` returns `undefined` **and the server is not yet initialized**, a synthetic `SupportedKind` is constructed from the route config (`{x402Version, scheme, network}`) and passed to `enhancePaymentRequirements()` instead of throwing. This allows 402 responses to be generated from static route config without a facilitator round-trip. When the server **has** been initialized and a kind is not found, the existing error is still thrown (legitimate misconfiguration).
- `x402HTTPResourceServer`: Exposes `initialized` getter delegating to the resource server.

### `@x402/hono`, `@x402/express`, `@x402/fastify`, `@x402/next`

All middleware now split the init-await on the presence of a payment header:

- **No payment header (discovery probe):** proceed immediately to `processHTTPRequest` — background init continues, 402 is generated from route config.
- **Payment header present (verify/settle path):** await init as before — facilitator data is required to verify and settle.

**Behavior table:**

| Scenario | Before | After |
|---|---|---|
| Cold isolate + discovery probe | Blocks 10–15 s on facilitator | 402 returned immediately |
| Cold isolate + payment request | Blocks on init, then verify/settle | Same (correct — init required) |
| Hot isolate + any request | Fast ~300 ms | Unchanged |
| Init failure + discovery probe | 502 / timeout | 402 from route config; init retries in background |
| Init failure + payment request | 502, retry on next request | Same |

## Tests

```bash
cd typescript && pnpm test
```

- **3 new core unit tests** (`x402ResourceServer`):
  - `buildPaymentRequirements` succeeds without `initialize()` (cold-start tolerance)
  - `initialized` is `true` after successful `initialize()`
  - `initialized` stays `false` when `initialize()` fails

- **Updated + new middleware tests** (hono, express, next):
  - Existing retry-on-init-failure tests updated to send requests **with** a payment header (the path that still blocks on init)
  - New "does not block on init for discovery probes" test in hono and express
  - New "does not block when `requireCompletion` is false" test in next utils

All existing tests pass unchanged:
- `@x402/core`: 419 tests ✓
- `@x402/hono`: 20 tests ✓
- `@x402/express`: 23 tests ✓
- `@x402/fastify`: 23 tests ✓
- `@x402/next`: 53 tests ✓

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)