### PR TITLE
spec(schemes): add mandate-bound — overview + EVM impl

### DIFF
--- a/specs/schemes/mandate-bound/scheme_mandate-bound.md
+++ b/specs/schemes/mandate-bound/scheme_mandate-bound.md
@@ -1,0 +1,32 @@
+# Scheme: `mandate-bound`
+
+## Summary
+
+`mandate-bound` settles a payment under a constraint envelope — a typed-data mandate the principal signs once and the agent reuses across multiple HTTP-402 settlements within its bounds (per-tx cap, cumulative cap, asset allowlist, validity window). The settling contract verifies the envelope, walks a policy chain, and either settles or reverts with a typed refusal code. A state-read-only `dryRun` simulator returns the same code, so buyer agents can plan multi-leg flows without burning nonces.
+
+## Example Use Cases
+
+- An agent settles N micropayments to N sellers under one principal-signed envelope, without re-prompting the human per-call.
+- A buyer agent simulates a payment off-chain (`dryRun`), reads back a typed refusal code (e.g. `MANDATE_PER_TX_CAP`), and adjusts its plan before submitting.
+- A seller batches accumulated micropayments from one mandate into a single on-chain settlement, charging the cumulative-cap counter once.
+
+## Critical Validation Requirements
+
+Implementations MUST:
+
+1. Verify the principal's signature over the mandate envelope using EIP-712 typed-data hashing (or the chain-specific equivalent). Smart-contract principals are first-class via EIP-1271 fall-through.
+2. Verify the agent's signature over the same envelope when `agent != principal`.
+3. Reject envelopes outside the `[notBefore, expiresAt]` window.
+4. Reject settlements exceeding `maxPerTxUsd` or projecting past `maxTotalUsd` against a registry-tracked cumulative-spend counter keyed on `mandateId`.
+5. Reject settlements where the destination asset is not in `assetAllowlist` (or the list is the explicit "any asset" sentinel).
+6. Treat `(mandateId, nonce)` as one-shot to prevent replay.
+7. Surface refusals as typed codes, not opaque error strings, so agents can branch on the cause.
+8. Provide a state-read-only `dryRun` simulator whose returned refusal code is byte-equivalent to the code a real settlement would revert with.
+
+The envelope shape is rail-agnostic; this scheme covers the on-chain settlement path. Per-chain documents specify concrete envelope encoding, signature verification, and settlement flow.
+
+- [EVM](scheme_mandate-bound_evm.md)
+
+## Appendix
+
+Reference implementation under MIT at https://github.com/rivier-ai/rivr (`contracts/src/rivier-token/`). The implementation is independent of the spec; the scheme contract is the envelope, the verification ordering, and the typed refusal codes.

--- a/specs/schemes/mandate-bound/scheme_mandate-bound_evm.md
+++ b/specs/schemes/mandate-bound/scheme_mandate-bound_evm.md
@@ -1,0 +1,59 @@
+# Mandate-bound payment envelope — settlement-side primitive for x402 sellers
+
+## Summary
+
+Proposing a contribution to x402 from the **settlement side**: a typed
+mandate envelope verified at the token contract, so an x402 seller's
+receiver can prove the payment carried a valid AP2-compatible
+authorization without trusting the relaying agent or the buyer's wallet
+client.
+
+## Context
+
+x402 today specifies the request/response shape for HTTP 402 payments
+on top of EIP-3009 `transferWithAuthorization`. The seller verifies
+that USDC moved; what the seller can't currently verify on-chain is
+**why** the buyer's agent authorized the transfer — caps, asset
+allowlists, expiry, principal binding.
+
+We've shipped this as a token-level primitive in RIVR: every
+transferring path verifies an EIP-712 `MandateEnvelope` carrying the
+constraints the user pre-signed. The same envelope shape is an obvious
+fit for x402 sellers who want stronger guarantees than "the agent paid"
+— specifically, "the agent paid within the user's mandated cap on a
+mandated asset before mandate expiry."
+
+## What we're proposing
+
+A **non-breaking** addition to the x402 `payment_requirements` shape:
+an optional `mandate_envelope_required: true` flag plus a verifier
+contract address. When set, the facilitator validates the buyer's
+mandate envelope against the verifier before settling.
+
+This composes cleanly with EIP-3009 — `transferWithAuthorization` runs
+as today; the mandate gate is an *additional* check, not a replacement.
+
+## Reference implementation
+
+- Contract: https://github.com/rivier-ai/rivier/blob/main/contracts/src/rivier-token/RivierTokenCCT.sol
+- Mandate type: https://github.com/rivier-ai/rivier/blob/main/contracts/src/rivier-token/types/MandateEnvelope.sol
+- Test suite: https://github.com/rivier-ai/rivier/tree/main/contracts/test/rivier-token (113 tests)
+- 113 forge tests including `dryRun` byte-equivalence (10 dedicated cases) and namespace sum-preserving fuzz invariants
+- Audit: not yet commissioned (independent contributor, pre-funding); engagement planned post-launch
+
+## Position
+
+RIVR is the first stablecoin where mandate validation, agent
+attestation, programmable batching, and continuous settlement streams
+are token-contract primitives — not orchestration above an inert
+ERC-20. We're contributing the mandate-envelope shape upstream so x402
+sellers can adopt the pattern even when settling in USDC.
+
+## What we're asking for
+
+1. Feedback on the proposed shape from facilitator implementers
+2. A path to a draft spec PR if the shape is acceptable
+3. Working-group discussion on whether mandate verification belongs
+   in the x402 spec or in a sibling specification
+
+Happy to write the draft PR, run the working-group sync, or both.

--- a/specs/schemes/mandate-bound/scheme_mandate-bound_evm.md
+++ b/specs/schemes/mandate-bound/scheme_mandate-bound_evm.md
@@ -1,59 +1,138 @@
-# Mandate-bound payment envelope — settlement-side primitive for x402 sellers
+# Scheme: `mandate-bound` `evm`
 
 ## Summary
 
-Proposing a contribution to x402 from the **settlement side**: a typed
-mandate envelope verified at the token contract, so an x402 seller's
-receiver can prove the payment carried a valid AP2-compatible
-authorization without trusting the relaying agent or the buyer's wallet
-client.
+On EVM chains, `mandate-bound` settles via a token-contract entry point that consumes an EIP-712-signed `MandateEnvelope` alongside the settlement leg. The token verifies both signatures, walks a policy chain (credential validity, registry-tracked cumulative spend, sanctions, optional travel-rule attestation), debits and credits balances, records cumulative spend against `mandateId`, and emits a versioned settlement event carrying agent attestation context.
 
-## Context
+## PaymentPayload `payload` Field
 
-x402 today specifies the request/response shape for HTTP 402 payments
-on top of EIP-3009 `transferWithAuthorization`. The seller verifies
-that USDC moved; what the seller can't currently verify on-chain is
-**why** the buyer's agent authorized the transfer — caps, asset
-allowlists, expiry, principal binding.
+The `payload` carries the `MandateEnvelope` plus the leg amount. EIP-712 typed-data hashing uses the typehash:
 
-We've shipped this as a token-level primitive in RIVR: every
-transferring path verifies an EIP-712 `MandateEnvelope` carrying the
-constraints the user pre-signed. The same envelope shape is an obvious
-fit for x402 sellers who want stronger guarantees than "the agent paid"
-— specifically, "the agent paid within the user's mandated cap on a
-mandated asset before mandate expiry."
+```
+MandateEnvelope(address principal,address agent,bytes32 kyaCredentialHash,address[] assetAllowlist,uint256 maxPerTxUsd,uint256 maxTotalUsd,uint64 notBefore,uint64 expiresAt,bytes32 mandateId,bytes32 nonce)
+```
 
-## What we're proposing
+Signatures (`principalSignature`, `agentSignature`) sit alongside the struct but are excluded from the typehash.
 
-A **non-breaking** addition to the x402 `payment_requirements` shape:
-an optional `mandate_envelope_required: true` flag plus a verifier
-contract address. When set, the facilitator validates the buyer's
-mandate envelope against the verifier before settling.
+| Field | Type | Notes |
+|---|---|---|
+| `principal` | `address` | Whose funds move. |
+| `agent` | `address` | Authorized to call the entry point. May equal `principal`. |
+| `kyaCredentialHash` | `bytes32` | `keccak256` of the principal's W3C VC. The token checks the on-chain credential-registry mirror against this hash. |
+| `assetAllowlist` | `address[]` | Token addresses this mandate may spend. The single-element `[address(0)]` is the "any asset" sentinel. EIP-712 v4 array hash. |
+| `maxPerTxUsd` | `uint256` | Per-tx cap in 6-decimal USD (1e6 = $1.00). |
+| `maxTotalUsd` | `uint256` | Cumulative cap in 6-decimal USD, enforced against the registry counter. |
+| `notBefore` | `uint64` | Unix seconds. |
+| `expiresAt` | `uint64` | Unix seconds. |
+| `mandateId` | `bytes32` | Unique per mandate. The cumulative-spend counter is keyed on this. |
+| `nonce` | `bytes32` | One-shot replay guard. |
 
-This composes cleanly with EIP-3009 — `transferWithAuthorization` runs
-as today; the mandate gate is an *additional* check, not a replacement.
+Example payload:
 
-## Reference implementation
+```json
+{
+  "scheme": "mandate-bound",
+  "network": "eip155:8453",
+  "payload": {
+    "envelope": {
+      "principal": "0xPrincipal...",
+      "agent": "0xAgent...",
+      "kyaCredentialHash": "0xabc...",
+      "assetAllowlist": ["0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"],
+      "maxPerTxUsd": "1000000",
+      "maxTotalUsd": "100000000",
+      "notBefore": 1735689600,
+      "expiresAt": 1738281600,
+      "mandateId": "0xMandateId...",
+      "nonce": "0xNonce..."
+    },
+    "principalSignature": "0x...",
+    "agentSignature": "0x...",
+    "amount": "100000",
+    "amountUsd6": "100000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "to": "0xRecipient...",
+    "intentClass": 0,
+    "memoHash": "0x..."
+  }
+}
+```
 
-- Contract: https://github.com/rivier-ai/rivier/blob/main/contracts/src/rivier-token/RivierTokenCCT.sol
-- Mandate type: https://github.com/rivier-ai/rivier/blob/main/contracts/src/rivier-token/types/MandateEnvelope.sol
-- Test suite: https://github.com/rivier-ai/rivier/tree/main/contracts/test/rivier-token (113 tests)
-- 113 forge tests including `dryRun` byte-equivalence (10 dedicated cases) and namespace sum-preserving fuzz invariants
-- Audit: not yet commissioned (independent contributor, pre-funding); engagement planned post-launch
+## Verification
 
-## Position
+Before debiting any balance, the verifier MUST in order:
 
-RIVR is the first stablecoin where mandate validation, agent
-attestation, programmable batching, and continuous settlement streams
-are token-contract primitives — not orchestration above an inert
-ERC-20. We're contributing the mandate-envelope shape upstream so x402
-sellers can adopt the pattern even when settling in USDC.
+1. Recover the principal's signature over the EIP-712 hash and require it match `envelope.principal`. If the principal is a contract, fall through to EIP-1271 `isValidSignature`.
+2. If `envelope.agent != envelope.principal`, recover the agent's signature with the same fall-through and require it match `envelope.agent`.
+3. Require `block.timestamp >= envelope.notBefore && block.timestamp < envelope.expiresAt`.
+4. Require the credential-registry record for `envelope.kyaCredentialHash` to be valid (not expired, not revoked).
+5. Require `(envelope.mandateId, envelope.nonce)` has not been consumed. Mark it consumed.
+6. Require `payload.amountUsd6 <= envelope.maxPerTxUsd`.
+7. Require `envelope.assetAllowlist` contains `payload.asset` (or the `[address(0)]` sentinel).
+8. Require `mandateRegistry.cumulativeSpend(envelope.mandateId) + payload.amountUsd6 <= envelope.maxTotalUsd`.
+9. Call the policy hook and require it return `OK`.
 
-## What we're asking for
+A failed check reverts with `RivierRefused(reason, ctx)` where `reason` is the typed code and `ctx` is a 32-byte producer-defined tag (mandate id, credential hash, etc.).
 
-1. Feedback on the proposed shape from facilitator implementers
-2. A path to a draft spec PR if the shape is acceptable
-3. Working-group discussion on whether mandate verification belongs
-   in the x402 spec or in a sibling specification
+### Refusal Codes
 
-Happy to write the draft PR, run the working-group sync, or both.
+```solidity
+enum RefusalReason {
+    OK,                              // 0
+    KYA_INVALID,                     // 1
+    KYA_EXPIRED,                     // 2
+    KYA_REVOKED,                     // 3
+    MANDATE_EXPIRED,                 // 4
+    MANDATE_PER_TX_CAP,              // 5
+    MANDATE_CUMULATIVE_CAP,          // 6
+    MANDATE_ASSET_NOT_ALLOWED,       // 7
+    MANDATE_PRINCIPAL_MISMATCH,      // 8
+    MANDATE_REVOKED,                 // 9
+    MANDATE_SIGNATURE_INVALID,       // 10
+    MANDATE_AGENT_SIGNATURE_INVALID, // 11
+    JURISDICTION_GATE,               // 12
+    TRAVEL_RULE_BLOCK,               // 13
+    SANCTIONS_HIT,                   // 14
+    POR_STALE,                       // 15
+    POR_INSUFFICIENT,                // 16
+    PERMISSIONED_RWA,                // 17
+    PAUSED,                          // 18
+    NAMESPACE_INSUFFICIENT,          // 19
+    STREAM_INVALID,                  // 20
+    STREAM_PAUSED,                   // 21
+    POLICY_HOOK_REVERTED,            // 22
+    UNKNOWN                          // 23
+}
+
+error RivierRefused(RefusalReason reason, bytes32 ctx);
+```
+
+`OK` (0) is the success sentinel. Producers MUST NOT return `UNKNOWN` (23) under normal flow; it is reserved as a defensive default.
+
+### Dry Run
+
+The settler MUST expose a state-read-only simulator returning the same `RefusalReason` a real settlement would revert with:
+
+```solidity
+function dryRun(DryRunInput calldata input) external view returns (DryRunResult memory);
+```
+
+Byte-equivalence invariant: for any `(caller, envelope, leg)` tuple, `dryRun({legs:[leg], envelope, caller}).reason` MUST equal the `RefusalReason` a real settlement call would revert with (or `OK` if it would succeed). Multi-leg `dryRun` simulates batched settlement and projects cumulative-cap checks against the sum.
+
+## Settlement
+
+After verification passes the settler MUST:
+
+1. Debit `payload.amount` from the payer.
+2. Credit `payload.amount` to `payload.to`.
+3. Record cumulative spend: `mandateRegistry.recordMandateUse(envelope.mandateId, payload.amountUsd6)`.
+4. Emit a versioned settlement event carrying `(transferRef, from, to, amount, intentClass, memoHash, mandateId, kyaCredentialHash, extensionVersion, extensionData)`. The `extensionData` blob is opaque per `extensionVersion`; v1 carries agent attestation (model id, version, confidence, reasoning hash, prompt hash, MCP server DID, TEE attestation hash, policy compliance proof).
+5. Emit the standard ERC-20 `Transfer(from, to, amount)` for off-chain indexer compatibility.
+
+`transferRef` is `keccak256(abi.encode(envelope.mandateId, envelope.nonce, blockNumber, legIndex))` — deterministic and unique per leg.
+
+## Appendix
+
+Reference implementation under MIT at https://github.com/rivier-ai/rivr. The token contract is at `contracts/src/rivier-token/RivierTokenCCT.sol` (`transferWithMandate` entry point); types at `contracts/src/rivier-token/types/`; tests at `contracts/test/rivier-token/`. The 113-test forge suite covers the byte-equivalence invariant, namespace sum-preservation under fuzzing, replay protection, and reentrancy safety of cumulative-spend tracking.
+
+The implementation is independent of the spec. Any compliant implementation may use a different policy chain, registry shape, or storage layout. The scheme contract is the envelope, the verification ordering, and the typed refusal codes.


### PR DESCRIPTION
# Add `mandate-bound` scheme — overview + EVM impl

Draft spec PR for the `mandate-bound` scheme proposed in #2176. This PR adds two files:

- `specs/schemes/mandate-bound/scheme_mandate-bound.md` — overview, follows `scheme_template.md` (Summary / Example Use Cases / Critical Validation Requirements / Appendix).
- `specs/schemes/mandate-bound/scheme_mandate-bound_evm.md` — EVM implementation, follows `scheme_impl_template.md` (Summary / PaymentPayload payload Field / Verification / Settlement / Appendix).

## Scope of this PR

PR 1 of a planned 2-PR sequence.

- This PR: overview + EVM impl.
- Follow-up PR (after envelope-shape feedback lands on #2176): chain-specific impls for non-EVM rails (Sui, Solana, etc.) once their MandateEnvelope encoding is settled.

## What `mandate-bound` adds

A new scheme where the buyer settles a payment under an EIP-712-signed envelope (or chain-equivalent) carrying per-tx cap, cumulative cap, asset allowlist, validity window, credential hash, mandate id, and nonce. The settling contract verifies both signatures, walks a policy chain, and either settles or reverts with a typed `RefusalReason` code. A state-read-only `dryRun` simulator returns the same code.

The constraint envelope is rail-agnostic; this scheme covers the on-chain settlement path. The same envelope shape applies to card-network mandates and ACH/SEPA/FedNow agent-bound authorizations and is being submitted in parallel to fiat-rail venues.

## Reference implementation

MIT, at https://github.com/rivier-ai/rivr.

- Token contract: `contracts/src/rivier-token/RivierTokenCCT.sol` (`transferWithMandate` entry point)
- Types: `contracts/src/rivier-token/types/`
- Test suite: `contracts/test/rivier-token/` — 113 forge tests covering the `dryRun` byte-equivalence invariant (10 dedicated cases), namespace sum-preservation under fuzzing, replay protection, and reentrancy safety of cumulative-spend tracking.

The implementation is independent of the spec. Any compliant implementation may use a different policy chain, registry shape, or storage layout. The scheme contract is the envelope, the verification ordering, and the typed refusal codes.

Audit: not yet commissioned. Independent contributor, pre-funding; engagement is planned post-launch.

## Status

Draft. Will be promoted out of Draft after envelope-shape feedback on #2176 lands.

---

*Disclosure: parts of this PR description and the spec text were drafted with assistance from an AI model and reviewed before submission. The reference implementation, test suite, and design decisions are human-authored.*
