### PR TITLE
Add KDP Intelligence API to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/kdp-intelligence-api/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/kdp-intelligence-api/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "KDP Intelligence API",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/kdp-intelligence-api.svg",
+  "description": "Niche demand and competition intelligence for Kindle Direct Publishing. AI agents pay $0.03 USDC per query via x402 for real-time BSR, revenue estimates, and competition scores — no API keys needed.",
+  "websiteUrl": "https://kdp-intelligence-api.vercel.app/docs"
+}

--- a/typescript/site/public/logos/kdp-intelligence-api.svg
+++ b/typescript/site/public/logos/kdp-intelligence-api.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="24" fill="#1a1a2e"/>
+  <text x="100" y="90" text-anchor="middle" font-family="system-ui, sans-serif" font-size="48" font-weight="700" fill="#e94560">KDP</text>
+  <text x="100" y="130" text-anchor="middle" font-family="system-ui, sans-serif" font-size="20" font-weight="500" fill="#0f3460">Intelligence</text>
+  <rect x="40" y="148" width="120" height="3" rx="1.5" fill="#e94560" opacity="0.6"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds **KDP Intelligence API** to the x402 ecosystem directory under **Services/Endpoints**.

KDP Intelligence API provides niche demand and competition intelligence for Kindle Direct Publishing (KDP) authors. AI agents pay $0.03 USDC per query via x402 — no API keys or subscriptions needed. Payment is the auth.

### What it does
- Returns real-time BSR (Best Seller Rank), revenue estimates, competition scores, and demand metrics for KDP niches
- Agents discover niches via `GET /v1/niches` (free) and get full intelligence via `GET /v1/niche/{keyword}` (x402-gated)
- Supports the standard x402 payment flow: HTTP 402 → EIP-712 signature → X-Payment header

### Files added
- `typescript/site/app/ecosystem/partners-data/kdp-intelligence-api/metadata.json` — project metadata
- `typescript/site/public/logos/kdp-intelligence-api.svg` — logo

### Links
- API docs: https://kdp-intelligence-api.vercel.app/docs
- OpenAPI spec: https://kdp-intelligence-api.vercel.app/openapi.json