### PR TITLE
docs: add Go integration test .env example

### DIFF
--- a/go/.env.example
+++ b/go/.env.example
@@ -1,0 +1,20 @@
+# Go integration test environment.
+#
+# Copy this file to `go/.env`, fill in testnet-only values, then run:
+#
+#   source .env
+#   make test-integration
+#
+# Never commit real private keys. The integration tests that use these values
+# submit real transactions on Base Sepolia and Solana Devnet.
+
+# EVM configuration (Base Sepolia)
+EVM_CLIENT_PRIVATE_KEY=<hex_private_key_without_0x>
+EVM_FACILITATOR_PRIVATE_KEY=<hex_private_key_without_0x>
+EVM_RESOURCE_SERVER_ADDRESS=<0x_ethereum_address>
+
+# SVM configuration (Solana Devnet)
+SVM_CLIENT_PRIVATE_KEY=<base58_private_key>
+SVM_FACILITATOR_PRIVATE_KEY=<base58_private_key>
+SVM_FACILITATOR_ADDRESS=<base58_solana_address>
+SVM_RESOURCE_SERVER_ADDRESS=<base58_solana_address>

--- a/go/test/integration/README.md
+++ b/go/test/integration/README.md
@@ -36,6 +36,8 @@ make test-integration
 ### With Configuration (All Tests + Real Transactions)
 ```bash
 # Set environment variables
+cp .env.example .env
+# Edit .env with testnet-only keys and addresses
 source .env
 
 # Run integration tests
@@ -54,7 +56,7 @@ make test-integration
 
 ## Configuration
 
-Create a `.env` file in the `go/` directory:
+Copy `go/.env.example` to `go/.env`, then fill in testnet-only values:
 
 ```bash
 # EVM Configuration (Base Sepolia)
@@ -189,7 +191,7 @@ spl-token create-account 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU --url devn
 ## Security Notes
 
 ⚠️ **NEVER commit private keys to git**
-⚠️ Use `.env` file and ensure it's in `.gitignore`
+⚠️ Use `.env` file and ensure it's in `.gitignore`; commit only `.env.example`
 ⚠️ Only use testnet keys with no real value
 ⚠️ These tests use devnet/testnet networks only
 


### PR DESCRIPTION
## Summary

- add `go/.env.example` for integration test configuration
- update the Go integration test README to point contributors at the example file
- clarify that real private keys belong only in ignored `.env`, while `.env.example` is safe to commit

## Context

This addresses the Go SDK part of #2045, where the integration test README referenced `.env.example` but the file was not present on disk.

## Safety

The example uses placeholders only. It does not include real private keys, wallet addresses, tokens, or transactions.

## Tests

Docs-only change; not run.