### PR TITLE
feat(ecosystem): add XRPL x402 facilitator

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/xrpl-x402-facilitator/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/xrpl-x402-facilitator/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "T54 XRPL x402 Facilitator",
+  "description": "First x402 facilitator on XRPL, providing reliable settlement for XRP and RLUSD payments.",
+  "logoUrl": "/logos/t54-x402-secure.jpg",
+  "websiteUrl": "https://xrpl-x402.t54.ai/",
+  "category": "Facilitators",
+  "facilitator": {
+    "baseUrl": "https://xrpl-facilitator-mainnet.t54.ai",
+    "networks": ["xrpl:0"],
+    "schemes": ["exact"],
+    "assets": ["XRP", "RLUSD"],
+    "supports": {
+      "verify": true,
+      "settle": true,
+      "supported": true,
+      "list": false
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds the T54 XRPL x402 Facilitator to the x402.org ecosystem site.

**Facilitator details:**
- **Website:** https://xrpl-x402.t54.ai/
- **XRPL x402 Explorer:** https://xrpl-ai.org/
- **Base URL:** `https://xrpl-facilitator-mainnet.t54.ai`
- **Network:** `xrpl:0`
- **Scheme:** `exact`
- **Assets:** `XRP`, `RLUSD`
- **Capabilities:** verify, settle, supported

## Tests

No code changes — ecosystem listing only. Verified:

- `metadata.json` parses successfully with `python3 -m json.tool`
- `GET /supported` returns 200 with `x402Version: 2`, `scheme: exact`, `network: xrpl:0`
- `POST /verify` and `POST /settle` with empty JSON return schema validation errors, confirming the endpoints are live
- `/list` returns 404, matching `list: false`

## Checklist

- [x] I have formatted and linted my code
- [ ] All new and existing tests pass — not run; ecosystem listing only
- [x] My commits are signed
- [ ] I added a changelog fragment — N/A, ecosystem listing only