### PR TITLE
Add SignalsFeed to x402 ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/signalsfeed/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/signalsfeed/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "SignalsFeed",
+  "description": "Agent-ready feed of AI, semiconductor, and macro signals with credibility, sentiment, and impact scoring. Free discovery with paid full-record fetches via x402.",
+  "logoUrl": "/logos/signalsfeed.svg",
+  "websiteUrl": "https://signalsfeed.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/signalsfeed.svg
+++ b/typescript/site/public/logos/signalsfeed.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="SignalsFeed icon">
+  <defs>
+    <linearGradient id="tile" x1="6" y1="4" x2="26" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fbfbfc"/>
+      <stop offset="1" stop-color="#e8eaee"/>
+    </linearGradient>
+    <linearGradient id="ink" x1="9" y1="8" x2="22" y2="24" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="1" stop-color="#374151"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="1.5" y="1.5" width="29" height="29" rx="8" fill="url(#tile)"/>
+  <rect x="1.5" y="1.5" width="29" height="29" rx="8" fill="none" stroke="rgba(17,24,39,0.08)"/>
+
+  <path
+    d="M21.7 9.5c-1.2-1-3.1-1.6-5.2-1.6-4.3 0-7 2-7 5 0 2.3 1.5 3.6 4.7 4.3l2.3.5c2 .4 2.9.9 2.9 2.1 0 1.5-1.4 2.5-3.8 2.5-2.3 0-4.2-.8-5.5-2.2"
+    fill="none"
+    stroke="url(#ink)"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    stroke-width="2.8"
+  />
+</svg>


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Adds SignalsFeed to the x402 ecosystem page under `Services/Endpoints`.

This PR adds the following:
- a new ecosystem partner entry at `typescript/site/app/ecosystem/partners-data/signalsfeed/metadata.json`
- a new logo asset at `typescript/site/public/logos/signalsfeed.svg`

SignalsFeed is a paid, agent-ready feed of AI, semiconductor, and macro signals with credibility, sentiment, and impact scoring. It supports x402 payments and offers free discovery plus paid full-record fetches.

## Tests

Not run.

This change only adds ecosystem metadata and a static logo asset for the site.

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 