### PR TITLE
Add Wayforth to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/wayforth/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/wayforth/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Wayforth",
+  "category": "Infrastructure & Tooling",
+  "logoUrl": "/logos/wayforth.svg",
+  "description": "The search engine AI agents use to find and pay for APIs. 293+ verified APIs indexed with WayforthRank payment-signal scoring. x402 detection and routing built in. MCP native — install with `uvx wayforth-mcp`.",
+  "websiteUrl": "https://wayforth.io"
+}

--- a/typescript/site/public/logos/wayforth.svg
+++ b/typescript/site/public/logos/wayforth.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#4F46E5"/>
+  <text x="100" y="140" font-family="system-ui, -apple-system, sans-serif" font-size="120" font-weight="700" text-anchor="middle" fill="white">W</text>
+</svg>


### PR DESCRIPTION
## Wayforth — The search engine AI agents use to find and pay for APIs

**Website:** https://wayforth.io
**Category:** Infrastructure & Tooling

### What is Wayforth?

Wayforth is the discovery and execution layer for AI agents that need to find and pay for APIs. It indexes 293+ verified APIs with **WayforthRank** — a payment-signal weighted scoring algorithm — and exposes them through:

- **MCP server** (`uvx wayforth-mcp`) — plug directly into Claude, Claude Code, and any MCP-compatible agent
- **REST API** (`/search`, `/execute`, `/query`) — for programmatic agent use
- **WayforthQL** — a structured query language for deterministic API discovery

### x402 integration

Wayforth has x402 detection and routing built into its core:

- Detects `x402_supported` services in its catalog and surfaces them in search results
- Routes payment through x402 for compatible services (Track C in Wayforth's three-track payment rail)
- WayforthRank v2 uses real payment-signal data (conversion rates, execution volume) to score and rank APIs — x402-native services get ranked on real payment outcomes

### Install

```bash
uvx wayforth-mcp
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)