### PR TITLE
docs(extensions/bazaar): list AlgoVoi as third discovery facilitator

### DIFF
--- a/docs/extensions/bazaar.mdx
+++ b/docs/extensions/bazaar.mdx
@@ -81,6 +81,12 @@ GET https://api.cdp.coinbase.com/platform/v2/x402/discovery/resources
 GET https://facilitator.payai.network/discovery/resources
 ```
 
+##### AlgoVoi
+```bash
+GET https://api.algovoi.co.uk/discovery/resources
+```
+
+AlgoVoi is a multi-chain facilitator covering Base, Solana, Tempo, Algorand, VOI, Hedera, and Stellar. Each resource's `metadata.compliance` block (when present) advertises sanctions-screening sources, facilitator jurisdiction, and a link to a live `/compliance/attestation` document.
 
 **Note**: The recommended way to use this endpoint is to use the `useFacilitator` hook as described below.
 


### PR DESCRIPTION
## Summary

Adds AlgoVoi to the Bazaar `List Endpoint` section in `docs/extensions/bazaar.mdx` alongside Coinbase and PayAI. AlgoVoi has been serving `/discovery/resources` in production for some time and currently lists 7-network resources (Base, Solana, Tempo, Algorand, VOI, Hedera, Stellar).

## Why

The current docs imply only two facilitators expose `/discovery/resources`. The spec already says any facilitator may implement its own discovery layer ("the spec for marketplace items is open and part of the x402 scheme"), so listing a third worked example helps buyers find an option that covers non-EVM networks.

The added paragraph also documents a small community convention AlgoVoi already ships in its discovery output: an optional `metadata.compliance` block on each item declaring sanctions-screening sources, facilitator jurisdiction, and a URL to a live `/compliance/attestation` document. That field is already permitted by the open metadata field — this is documentation of an in-the-wild use, not a spec change.

## Live evidence

- Discovery: `curl https://api.algovoi.co.uk/discovery/resources`
- Attestation referenced from discovery items: `https://api.algovoi.co.uk/compliance/attestation`

## Scope

- One file: `docs/extensions/bazaar.mdx`
- 6 inserted lines, no removed lines
- No spec change, no schema change, no SDK change

## AI disclosure

This PR was drafted with an AI coding assistant. The wording was reviewed line-by-line before submission; the live discovery and attestation URLs were verified responding before the commit landed.
