### PR TITLE
Add JapanAgent Bridge to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/japanagent-bridge/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/japanagent-bridge/metadata.json
@@ -1,0 +1,13 @@
+{
+    "name": "JapanAgent Bridge",
+    "description": "Japan-action API for global AI
+   agents — verify Japanese identifiers, search
+  municipal grant forms, query Japanese business
+  data, and queue long-running Japanese research
+  jobs. Physical mail, keigo voice call, and fax
+  dispatch in build. x402-native, no API key, no
+  monthly contract.",
+    "logoUrl": "/logos/japanagent-bridge.svg",
+    "websiteUrl": "https://japanagent.dev",
+    "category": "Services/Endpoints"
+  }

--- a/typescript/site/public/logos/japanagent-bridge.svg
+++ b/typescript/site/public/logos/japanagent-bridge.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="JapanAgent Bridge">
+  <title>JapanAgent Bridge</title>
+  <rect width="200" height="200" rx="28" fill="#ffffff" stroke="#e5e5e5" stroke-width="1.5"/>
+  <circle cx="100" cy="100" r="60" fill="#BC002D"/>
+</svg>


### PR DESCRIPTION
## Description

  Adds **JapanAgent Bridge** — an x402-native Japan-action API for global AI agents
   — to the ecosystem partners list.

  **Files added:**
  - `typescript/site/app/ecosystem/partners-data/japanagent-bridge/metadata.json`
  - `typescript/site/public/logos/japanagent-bridge.svg`

  **Service summary:**
  - URL: https://japanagent.dev
  - Manifest: https://japanagent.dev/.well-known/x402 (18 paid_routes, 15 enforced
  + 3 stub)
  - OpenAPI: https://japanagent.dev/api/openapi.json
  - Stack: Cloudflare Workers + Hono + x402-hono on Base mainnet, USDC via CDP
  facilitator
  - Receiving: 0x64E81E0287FfDF31EB21D0891398899879f1fA6a

  **Surface:**
  12 live primitives (verify zipcode/Japanese corporate number
  (法人番号)/phone/address, gov find-form/precheck/translate/fill, biz
  company-snapshot/zoning/transit/calendar) plus 3 async research endpoints
  (news-pulse, competitor-map, supplier-discovery). 3 Layer D dispatch routes
  (snail-mail/voice-call/fax) declared in manifest with `enforced_now: false` until
   partner integration completes.

  **Why this slot:**
  Filling an empty geographic niche — no Japan-action listing currently in the
  ecosystem. Built by a Japan-resident operator for global agents that need to
  verify Japanese suppliers, find municipal subsidies, mail paper letters, place
  keigo calls, etc.

  Happy to adjust category, description, or logo on reviewer feedback.

  ## Tests

  Ecosystem-only change (static `metadata.json` + 404-byte SVG logo). No code or
  test pipeline impacted.

  Manual verification:
  - `curl https://japanagent.dev/.well-known/x402` returns the declared 18
  paid_routes
  - Logo: 200×200 viewBox, white background + #BC002D 日の丸 disc (3:5 ratio per
  JIS spec)

  ## Checklist

  - [x] I have formatted and linted my code (N/A — JSON + SVG only)
  - [x] All new and existing tests pass (N/A — no test pipeline for ecosystem
  additions)
  - [x] My commits are signed (committed via GitHub Web UI which auto-signs with
  the github web-flow GPG key — "Verified" badge appears on the commit)
  - [x] I added a changelog fragment (N/A — ecosystem partner addition, no
  publishable @x402/* package changed)