### PR TITLE
feat(ecosystem): add Mycelium Trails — post-execution accountability layer

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/mycelium-trails/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/mycelium-trails/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Mycelium Trails",
+  "description": "Post-execution accountability layer for AI agents. After any x402-authorized action, agents write a signed TrailRecord anchored on Arbitrum One and Base mainnet — payment_hash as the cross-surface key linking payment authorization to on-chain execution proof. Public verify endpoint, no API key required.",
+  "logoUrl": "/logos/mycelium-trails.png",
+  "websiteUrl": "https://argentum.rgiskard.xyz/trails/demo",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## What this adds

Mycelium Trails as a post-execution accountability layer in the x402 ecosystem directory.

## What it does

After any x402-authorized action executes, the agent writes a signed TrailRecord anchored on Arbitrum One and Base mainnet. `payment_hash` is the cross-surface key — the same field x402 uses for payment authorization becomes the anchor linking the payment record to the on-chain execution proof.

Public verify endpoint (no API key):
```
GET https://argentum.rgiskard.xyz/trails/verify?payment_hash=<hex>
```
Returns `anchors.arbitrum` and `anchors.base` with real block numbers and tx_hashes.

## Composability pattern

Discussed with @chox-cell in #2198:

```
x402 payment authorization
  → AgentKit / framework execution
  → Mycelium Trails post-action record
```

Each layer answers a different question. x402: is the payment authorized? Mycelium: what happened after execution, and can it be verified independently?

## Live example

Three TrailRecords from the permit-revocation-reissue pattern, dual-chain anchored:
```bash
curl -s "https://argentum.rgiskard.xyz/trails/verify?payment_hash=3d08d796a0ca189fc0890e8f7e9523d0e19e617519d0d3f35bb05c8111d5b1bc" | jq .anchors
```

## Disclaimer

Community-built. No partnership claim. No official integration claim. No Stripe or x402-foundation endorsement. Composability pattern only.