### PR TITLE
Add Korea Filings to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/korea-filings/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/korea-filings/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Korea Filings",
+  "description": "Pay-per-call API for AI-summarised Korean DART (전자공시) corporate disclosures. Free company directory and recent-filings feed for discovery; paid English summaries via x402 (USDC on Base mainnet).",
+  "logoUrl": "/logos/korea-filings.svg",
+  "websiteUrl": "https://koreafilings.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/korea-filings.svg
+++ b/typescript/site/public/logos/korea-filings.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="Korea Filings">
+  <!--
+    Korea Filings brand mark — geometric "KF" monogram on
+    institutional navy (#0F1F3A), with a single Coinbase Base blue
+    (#0052FF) accent line below referencing the x402-on-Base
+    payment rail. The K and F are drawn geometrically (not pulled
+    from a system font) so the mark is ownable. Sized at 256×256
+    for the agent.market ecosystem listing; the same SVG renders
+    cleanly at 16-px favicon. Selected from a 10-candidate review
+    on 2026-05-08 over a Bloomberg-style records-stack mark and
+    a red/blue Korean-candlestick mark; chosen for the strongest
+    fit with PRD's global-agent-builder ICP, where wordmark logos
+    out-convert chart icons in API directories.
+  -->
+  <rect width="256" height="256" rx="56" fill="#0F1F3A"/>
+
+  <!-- KF monogram, white -->
+  <g fill="#ffffff">
+    <!-- K: vertical stroke -->
+    <rect x="48" y="60" width="22" height="120" rx="4"/>
+    <!-- K: top diagonal -->
+    <polygon points="70,120 110,60 138,60 86,120"/>
+    <!-- K: bottom diagonal -->
+    <polygon points="70,120 110,180 138,180 86,120"/>
+    <!-- F: vertical stroke -->
+    <rect x="156" y="60" width="22" height="120" rx="4"/>
+    <!-- F: top horizontal -->
+    <rect x="156" y="60" width="60" height="20" rx="4"/>
+    <!-- F: middle horizontal (shorter) -->
+    <rect x="156" y="108" width="44" height="20" rx="4"/>
+  </g>
+
+  <!-- Single accent line — record / data motif -->
+  <rect x="48" y="200" width="168" height="6" rx="3" fill="#0052FF"/>
+</svg>


### PR DESCRIPTION
Adds **Korea Filings** to the ecosystem listing.

Pay-per-call API for AI-summarised Korean DART (전자공시) corporate disclosures. Free company directory + recent-filings feed for discovery; paid English summaries via x402 v2 on Base mainnet.

## Links

- Live: https://api.koreafilings.com
- Landing: https://koreafilings.com
- Repo: https://github.com/OldTemple91/korea-filings-api (MIT)
- Discovery: https://api.koreafilings.com/.well-known/x402
- Pricing: https://api.koreafilings.com/v1/pricing
- Free sample (no payment, returns the paid response shape): https://api.koreafilings.com/v1/disclosures/sample

## SDKs

- TypeScript: `npm install koreafilings` ([0.1.3 on npm](https://www.npmjs.com/package/koreafilings))
- Python: `pip install koreafilings` ([0.3.2 on PyPI](https://pypi.org/project/koreafilings/))
- MCP server (Claude Desktop / Cursor / Continue): `uv tool install koreafilings-mcp` ([0.3.0 on PyPI](https://pypi.org/project/koreafilings-mcp/))

## Settlement layer

Coinbase CDP facilitator (Ed25519 JWT auth), EIP-3009 TransferWithAuthorization on Base mainnet (`eip155:8453`), USDC asset `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`.

## Files added

- `typescript/site/app/ecosystem/partners-data/korea-filings/metadata.json`
- `typescript/site/public/logos/korea-filings.svg`

Category: **Services/Endpoints**.