### PR TITLE
Add anchor-x402 to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/anchor-x402/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/anchor-x402/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "anchor-x402",
-    "description": "Nine x402-paid commodity services for AI agents on Base + Solana mainnet. Dual-chain hash anchoring, OFAC sanctions screening, signed decision attestation, tx decode, ENS/SNS resolution, USD price, calldata decode, datetime parser, and bundled wallet intelligence. Pay per call in USDC — no API keys, no accounts.",
+    "description": "Sixteen x402-paid services for AI agents on Base + Solana mainnet — nine commodity primitives (dual-chain hash anchoring, OFAC sanctions screening, signed decision attestation, tx decode, ENS/SNS resolution, USD price, calldata decode, datetime parser, bundled wallet intel), one async due-diligence investigator ($7.77, multi-step signed report, dual-chain anchored), one verifiable RNG (signed by treasury key), and five universal LLM endpoints (roast, oracle with anchored verdict, tldr, aura, grade). Plus a hosted chatbot at chat.anchor-x402.com. Pay per call in USDC, no API keys, no accounts.",
     "logoUrl": "/logos/anchor-x402.svg",
     "websiteUrl": "https://anchor-x402.com",
     "category": "Services/Endpoints"

--- a/typescript/site/app/ecosystem/partners-data/anchor-x402/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/anchor-x402/metadata.json
@@ -1,0 +1,7 @@
+{
+    "name": "anchor-x402",
+    "description": "Nine x402-paid commodity services for AI agents on Base + Solana mainnet. Dual-chain hash anchoring, OFAC sanctions screening, signed decision attestation, tx decode, ENS/SNS resolution, USD price, calldata decode, datetime parser, and bundled wallet intelligence. Pay per call in USDC — no API keys, no accounts.",
+    "logoUrl": "/logos/anchor-x402.svg",
+    "websiteUrl": "https://anchor-x402.com",
+    "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/anchor-x402.svg
+++ b/typescript/site/public/logos/anchor-x402.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="32" fill="#0b1220"/>
+  <g fill="none" stroke="#7dd3fc" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="100" cy="64" r="14"/>
+    <line x1="100" y1="78" x2="100" y2="152"/>
+    <line x1="76" y1="100" x2="124" y2="100"/>
+    <path d="M52 132 a48 48 0 0 0 96 0"/>
+    <line x1="52" y1="132" x2="42" y2="124"/>
+    <line x1="52" y1="132" x2="62" y2="124"/>
+    <line x1="148" y1="132" x2="138" y2="124"/>
+    <line x1="148" y1="132" x2="158" y2="124"/>
+  </g>
+  <text x="100" y="184" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14" fill="#94a3b8" font-weight="600">anchor-x402</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds **anchor-x402** to the ecosystem under **Services/Endpoints**. Followed the submission steps in `typescript/site/README.md` (new partner directory + logo + metadata.json).

- Live API: https://api.anchor-x402.com — production HTTPS, mainnet-ready
- Site: https://anchor-x402.com
- Source: https://github.com/hypeprinter007-stack/anchor-x402 (MIT)
- Indexed in CDP Bazaar and agentic.market (auto-discovered via `extensions.bazaar` in 402 responses)

## What it is

Nine x402-paid commodity services for AI agents:

| Endpoint | Method | Price |
|---|---|---|
| `/v1/anchor` | POST | $0.005 — dual-chain hash anchor (Base + Solana mainnet, parallel) |
| `/v1/screen` | GET | $0.001 — OFAC sanctions + AML screening |
| `/v1/attest` | POST | $0.010 — signed decision attestation (EIP-191 / Ed25519) + dual-chain anchor |
| `/v1/decode/tx` | POST | $0.001 — structured tx decode (Base + Ethereum) |
| `/v1/resolve/name` | GET | $0.001 — ENS / Bonfida SNS resolution |
| `/v1/price/token` | GET | $0.001 — USD spot price |
| `/v1/decode/calldata` | POST | $0.001 — 4byte selector + ABI param decode |
| `/v1/parse/datetime` | POST | $0.001 — freeform datetime → ISO 8601 |
| `/v1/intel/wallet` | GET | $0.005 — bundled wallet intel (balances + ENS/SNS + sanctions, parallel) |

## Requirements satisfied (Services/Endpoints)

- ✅ Working mainnet integration — all 9 services accept USDC on Base mainnet (and Solana mainnet for `/v1/anchor`)
- ✅ API documentation — https://api.anchor-x402.com/docs (Swagger UI, OpenAPI 3.1)
- ✅ Uptime — monitored at https://anchor-x402.betteruptime.com

Happy to swap the logo for a higher-fidelity asset if preferred — placeholder SVG used for now.