### PR TITLE
docs(batch-settlement): remove link to non-existent streaming server example

### DIFF
--- a/typescript/packages/mechanisms/evm/src/batch-settlement/README.md
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/README.md
@@ -214,7 +214,6 @@ Deposits are sponsored by the facilitator (gasless for the client).
 - [Server example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/batch-settlement)
 - [Client example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/clients/batch-settlement)
 - [Facilitator example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/facilitator/batch-settlement)
-- [Streaming server (SSE, mid-stream voucher renewal)](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/batch-settlement-streaming)
 
 ## See Also
 


### PR DESCRIPTION
The batch-settlement EVM README links to `examples/typescript/servers/batch-settlement-streaming`, but that directory was never merged into `main` (returns 404 on github.com). Remove the dead bullet so the Examples section only points to directories that actually exist.

### Why

New users following the batch-settlement docs hit a 404 and assume the SDK is broken or abandoned. The other three example bullets all resolve; only the streaming bullet is dead.