### PR TITLE
fix(python): use named constants for erc20-approval gas fee defaults

### DIFF
--- a/python/x402/changelog.d/erc20-approval-default-gas-fees.misc.md
+++ b/python/x402/changelog.d/erc20-approval-default-gas-fees.misc.md
@@ -1,0 +1,1 @@
+Expose `DEFAULT_MAX_FEE_PER_GAS` and `DEFAULT_MAX_PRIORITY_FEE_PER_GAS` from `x402.mechanisms.evm.constants` and use them as the fallback when fee estimation is unavailable in `sign_erc20_approval_transaction`. Mirrors the TypeScript SDK's named constants; numeric defaults (1 gwei / 0.1 gwei) are unchanged.

--- a/python/x402/extensions/erc20_approval_gas_sponsoring/client.py
+++ b/python/x402/extensions/erc20_approval_gas_sponsoring/client.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 from ...mechanisms.evm.constants import (
+    DEFAULT_MAX_FEE_PER_GAS,
+    DEFAULT_MAX_PRIORITY_FEE_PER_GAS,
     ERC20_APPROVE_ABI,
     ERC20_APPROVE_GAS_LIMIT,
     PERMIT2_ADDRESS,
@@ -54,8 +56,8 @@ def sign_erc20_approval_transaction(
 
     nonce = signer.get_transaction_count(signer.address)
 
-    max_fee = 1_000_000_000
-    max_priority_fee = 100_000_000
+    max_fee = DEFAULT_MAX_FEE_PER_GAS
+    max_priority_fee = DEFAULT_MAX_PRIORITY_FEE_PER_GAS
     if hasattr(signer, "estimate_fees_per_gas"):
         try:
             fees = signer.estimate_fees_per_gas()

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -193,6 +193,12 @@ EIP2612_PERMIT_TYPES: dict[str, list[dict[str, str]]] = {
 # Gas limit for a standard ERC-20 approve() transaction
 ERC20_APPROVE_GAS_LIMIT = 70_000
 
+# Fallback max fee per gas (1 gwei) when fee estimation fails
+DEFAULT_MAX_FEE_PER_GAS = 1_000_000_000
+
+# Fallback max priority fee per gas (0.1 gwei) when fee estimation fails
+DEFAULT_MAX_PRIORITY_FEE_PER_GAS = 100_000_000
+
 # Permit2 deadline buffer (seconds) for verification
 PERMIT2_DEADLINE_BUFFER = 6
 

--- a/python/x402/tests/unit/extensions/test_erc20_approval_gas_sponsoring.py
+++ b/python/x402/tests/unit/extensions/test_erc20_approval_gas_sponsoring.py
@@ -11,7 +11,14 @@ from x402.extensions.erc20_approval_gas_sponsoring import (
     extract_erc20_approval_gas_sponsoring_info,
     validate_erc20_approval_gas_sponsoring_info,
 )
-from x402.mechanisms.evm.constants import PERMIT2_ADDRESS
+from x402.extensions.erc20_approval_gas_sponsoring.client import (
+    sign_erc20_approval_transaction,
+)
+from x402.mechanisms.evm.constants import (
+    DEFAULT_MAX_FEE_PER_GAS,
+    DEFAULT_MAX_PRIORITY_FEE_PER_GAS,
+    PERMIT2_ADDRESS,
+)
 from x402.schemas import PaymentPayload, PaymentRequirements, ResourceInfo
 
 TOKEN_ADDRESS = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
@@ -109,3 +116,56 @@ class TestValidation:
     def test_invalid_signed_transaction(self):
         info = _make_info(signed_transaction="not-hex")
         assert validate_erc20_approval_gas_sponsoring_info(info) is False
+
+
+class _StubSigner:
+    """Minimal signer that records the transaction it was asked to sign."""
+
+    def __init__(self, fees: tuple[int, int] | None = None, raise_on_estimate: bool = False):
+        self.address = PAYER
+        self._fees = fees
+        self._raise = raise_on_estimate
+        self.signed_tx: dict[str, Any] | None = None
+        if fees is not None or raise_on_estimate:
+
+            def estimate_fees_per_gas() -> tuple[int, int]:
+                if self._raise:
+                    raise RuntimeError("rpc unavailable")
+                assert self._fees is not None
+                return self._fees
+
+            self.estimate_fees_per_gas = estimate_fees_per_gas
+
+    def get_transaction_count(self, address: str) -> int:
+        return 0
+
+    def sign_transaction(self, tx: dict[str, Any]) -> str:
+        self.signed_tx = tx
+        return "0x" + "ab" * 100
+
+
+class TestGasFeeFallback:
+    def test_constants_exported_with_expected_values(self):
+        assert DEFAULT_MAX_FEE_PER_GAS == 1_000_000_000
+        assert DEFAULT_MAX_PRIORITY_FEE_PER_GAS == 100_000_000
+
+    def test_uses_defaults_when_signer_has_no_estimator(self):
+        signer = _StubSigner()
+        sign_erc20_approval_transaction(signer, TOKEN_ADDRESS, chain_id=84532)
+        assert signer.signed_tx is not None
+        assert signer.signed_tx["maxFeePerGas"] == DEFAULT_MAX_FEE_PER_GAS
+        assert signer.signed_tx["maxPriorityFeePerGas"] == DEFAULT_MAX_PRIORITY_FEE_PER_GAS
+
+    def test_uses_defaults_when_estimator_raises(self):
+        signer = _StubSigner(raise_on_estimate=True)
+        sign_erc20_approval_transaction(signer, TOKEN_ADDRESS, chain_id=84532)
+        assert signer.signed_tx is not None
+        assert signer.signed_tx["maxFeePerGas"] == DEFAULT_MAX_FEE_PER_GAS
+        assert signer.signed_tx["maxPriorityFeePerGas"] == DEFAULT_MAX_PRIORITY_FEE_PER_GAS
+
+    def test_uses_estimated_fees_when_available(self):
+        signer = _StubSigner(fees=(5_000_000_000, 250_000_000))
+        sign_erc20_approval_transaction(signer, TOKEN_ADDRESS, chain_id=84532)
+        assert signer.signed_tx is not None
+        assert signer.signed_tx["maxFeePerGas"] == 5_000_000_000
+        assert signer.signed_tx["maxPriorityFeePerGas"] == 250_000_000


### PR DESCRIPTION
## Summary

The Python `erc20_approval_gas_sponsoring` client was hardcoding `1_000_000_000` / `100_000_000` as EIP-1559 gas-fee fallbacks when a signer didn't expose `estimate_fees_per_gas`. The TypeScript SDK already names these as `DEFAULT_MAX_FEE_PER_GAS` / `DEFAULT_MAX_PRIORITY_FEE_PER_GAS` in `evm/constants` — this PR mirrors that on the Python side and uses the constants in the client.

No behavior change: numeric defaults are unchanged (1 gwei / 0.1 gwei).

### Changes

- `python/x402/mechanisms/evm/constants.py`: add `DEFAULT_MAX_FEE_PER_GAS` and `DEFAULT_MAX_PRIORITY_FEE_PER_GAS` (matches TS `evm/constants.ts`).
- `python/x402/extensions/erc20_approval_gas_sponsoring/client.py`: use the new constants instead of magic numbers.
- `python/x402/tests/unit/extensions/test_erc20_approval_gas_sponsoring.py`: first unit tests for `sign_erc20_approval_transaction` covering the fallback path, the estimator-raises path, and the estimator-succeeds path.
- Towncrier fragment under `python/x402/changelog.d/`.

### Why

`CONTRIBUTING.md` calls this out directly:
> Never hardcode chain IDs, token addresses, or decimal values from memory.
> MATCH EXISTING PATTERNS: TypeScript SDK uses pattern X → Python SDK MUST use pattern X.

## Test plan

- [x] `uv run pytest x402/tests/unit/extensions/test_erc20_approval_gas_sponsoring.py` — 13 passed (4 new).
- [x] Full Python suite: `uv run pytest` — 1076 passed.
- [x] `uv run ruff check` / `uv run ruff format --check` — clean.
- [x] No behavior change verified: numeric fallback values are byte-identical to before.
