### PR TITLE
feat: add ADI Chain (chain ID 36900) support with USDC.e

### DIFF
--- a/go/.changes/unreleased/adi-chain.yaml
+++ b/go/.changes/unreleased/adi-chain.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add ADI Chain (chain ID 36900) support with USDC.e as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -82,6 +82,7 @@ var (
 	ChainIDArbSepolia    = big.NewInt(421614)
 	ChainIDRadius        = big.NewInt(723487)
 	ChainIDRadiusTestnet = big.NewInt(72344)
+	ChainIDADI           = big.NewInt(36900)
 	ChainIDHPP           = big.NewInt(190415)
 	ChainIDHPPSepolia    = big.NewInt(181228)
 
@@ -223,6 +224,16 @@ var (
 				Decimals:            DefaultDecimals,
 				AssetTransferMethod: AssetTransferMethodPermit2,
 				SupportsEip2612:     true,
+			},
+		},
+		// ADI Chain
+		"eip155:36900": {
+			ChainID: ChainIDADI,
+			DefaultAsset: AssetInfo{
+				Address:  "0x9cb8142aEBBcdc60AF7c97Af897A67A8f3CA71C2", // USDC.e on ADI Chain
+				Name:     "USDC.e",
+				Version:  "2",
+				Decimals: DefaultDecimals,
 			},
 		},
 		// HPP Mainnet

--- a/python/x402/changelog.d/adi-chain.feature.md
+++ b/python/x402/changelog.d/adi-chain.feature.md
@@ -1,0 +1,1 @@
+Add ADI Chain (chain ID 36900) support with USDC.e as the default stablecoin

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -534,6 +534,16 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "supports_eip2612": True,
         },
     },
+    # ADI Chain
+    "eip155:36900": {
+        "chain_id": 36900,
+        "default_asset": {
+            "address": "0x9cb8142aEBBcdc60AF7c97Af897A67A8f3CA71C2",
+            "name": "USDC.e",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
     # HPP Mainnet
     "eip155:190415": {
         "chain_id": 190415,

--- a/typescript/.changeset/adi-chain.md
+++ b/typescript/.changeset/adi-chain.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": minor
+---
+
+Add ADI Chain (chain ID 36900) support with USDC.e as the default stablecoin

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -121,6 +121,12 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     assetTransferMethod: "permit2",
     supportsEip2612: true,
   }, // Radius Testnet SBC (no EIP-3009, supports EIP-2612)
+  "eip155:36900": {
+    address: "0x9cb8142aEBBcdc60AF7c97Af897A67A8f3CA71C2",
+    name: "USDC.e",
+    version: "2",
+    decimals: 6,
+  }, // ADI Chain USDC.e (EIP-3009 supported)
   "eip155:190415": {
     address: "0x401eCb1D350407f13ba348573E5630B83638E30D",
     name: "Bridged USDC",


### PR DESCRIPTION
Add ADI Chain (CAIP-2 eip155:36900, chain ID 36900) as a default EVM chain across all three SDKs (TypeScript, Go, Python).

Default stablecoin: USDC.e at 0x9cb8142aEBBcdc60AF7c97Af897A67A8f3CA71C2, 6 decimals, EIP-3009 supported.

## Rationale

ADI Chain is an EVM L2 secured by Ethereum with Chainlink CCIP as its canonical cross-chain bridge. USDC.e is deployed on mainnet with full EIP-3009 and EIP-2612 support, making it ideal for x402 payments.

## Changes

- **Go** (go/mechanisms/evm/constants.go): Added eip155:36900 entry to NetworkConfigs
- **TypeScript** (typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts): Added eip155:36900 to DEFAULT_STABLECOINS
- **Python** (python/x402/mechanisms/evm/constants.py): Added eip155:36900 to NETWORK_CONFIGS
- Changelog fragments for all three SDKs

## Verification

All token parameters (address, name, version, decimals, EIP-3009 support) were verified on-chain via ADI Explorer (explorer.adifoundation.ai) and RPC calls to rpc.adifoundation.ai.