### PR TITLE
test(paywall): replace placeholder entrypoint test

### DIFF
--- a/typescript/packages/http/paywall/src/index.test.ts
+++ b/typescript/packages/http/paywall/src/index.test.ts
@@ -1,12 +1,64 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+import { avmPaywall, createPaywall, evmPaywall, PaywallBuilder, svmPaywall } from "./index";
+import type { PaywallNetworkHandler, PaymentRequired, PaymentRequirements } from "./index";
 
-describe("@x402/paywall", () => {
-  it("should be defined", () => {
-    expect(true).toBe(true);
+describe("@x402/paywall entrypoint", () => {
+  it("exports the paywall builder helpers", () => {
+    expect(createPaywall()).toBeInstanceOf(PaywallBuilder);
+    expect(typeof PaywallBuilder).toBe("function");
   });
 
-  // TODO: Add actual tests for paywall functionality
-  it.todo("should handle payment required responses");
-  it.todo("should render paywall UI");
-  it.todo("should process payments");
+  it("exports network handlers with their CAIP-2 support checks", () => {
+    const evmRequirement = createRequirement("eip155:8453");
+    const svmRequirement = createRequirement("solana:mainnet");
+    const avmRequirement = createRequirement("algorand:mainnet");
+
+    expect(evmPaywall.supports(evmRequirement)).toBe(true);
+    expect(evmPaywall.supports(svmRequirement)).toBe(false);
+
+    expect(svmPaywall.supports(svmRequirement)).toBe(true);
+    expect(svmPaywall.supports(avmRequirement)).toBe(false);
+
+    expect(avmPaywall.supports(avmRequirement)).toBe(true);
+    expect(avmPaywall.supports(evmRequirement)).toBe(false);
+  });
+
+  it("builds a provider from the exported factory", () => {
+    const handler: PaywallNetworkHandler = {
+      supports: requirement => requirement.network === "test:network",
+      generateHtml: (requirement, paymentRequired, config) =>
+        `${requirement.network}:${paymentRequired.x402Version}:${config.appName ?? ""}`,
+    };
+
+    const provider = createPaywall()
+      .withConfig({ appName: "builder app" })
+      .withNetwork(handler)
+      .build();
+
+    expect(provider.generateHtml(createPaymentRequired("test:network"))).toBe(
+      "test:network:2:builder app",
+    );
+    expect(
+      provider.generateHtml(createPaymentRequired("test:network"), { appName: "runtime app" }),
+    ).toBe("test:network:2:runtime app");
+  });
 });
+
+function createRequirement(network: string): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network,
+    asset: "USDC",
+    amount: "100000",
+    payTo: "0x209693Bc6afc0C5328bA36FaF04C514EF312287C",
+    maxTimeoutSeconds: 60,
+  };
+}
+
+function createPaymentRequired(network: string): PaymentRequired {
+  return {
+    x402Version: 2,
+    error: "Payment required",
+    accepts: [createRequirement(network)],
+  };
+}


### PR DESCRIPTION
## Summary

- Replace the placeholder `@x402/paywall` entrypoint test with real assertions
- Cover exported builder helpers from the package entrypoint
- Verify exported EVM, SVM, and AVM paywall handlers route their CAIP-2 network prefixes correctly
- Add a small provider factory test using the public `createPaywall` export

## Verification

- `pnpm --filter @x402/core build`
- `pnpm --filter @x402/evm build`
- `pnpm --filter @x402/paywall test`
- `pnpm --filter @x402/paywall exec eslint src/index.test.ts --ext .ts`
- `git diff --check`
