### PR TITLE
feat(ecosystem): add @powforge/x402-lightning

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-lightning/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-lightning/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "@powforge/x402-lightning",
+  "description": "x402 Lightning facilitator with self-custodial NWC (Nostr Wallet Connect, NIP-47) support. Any NIP-47 wallet (Alby Hub, Mutiny, Zeus, Phoenixd) or LNBits instance plugs in as the settlement backend — no custodial intermediary. Implements SchemeNetworkFacilitator + SchemeNetworkClient for bip122:000000000019d6689c085ae165831e93/exact/lightning. Pairs with the forgesworn/402-mcp agent client.",
+  "logoUrl": "/logos/x402-lightning.svg",
+  "websiteUrl": "https://www.npmjs.com/package/@powforge/x402-lightning",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/public/logos/x402-lightning.svg
+++ b/typescript/site/public/logos/x402-lightning.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="x402 Lightning">
+  <rect width="100" height="100" rx="18" fill="#0B0B0B"/>
+  <path d="M55 12 L25 56 L46 56 L40 88 L75 40 L54 40 L60 12 Z" fill="#F7931A"/>
+  <text x="50" y="98" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9" fill="#F7931A" opacity="0.85">x402</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds @powforge/x402-lightning to the ecosystem partners page under **Infrastructure & Tooling**.

@powforge/x402-lightning is a TypeScript implementation of the x402 `bip122:000000000019d6689c085ae165831e93/exact/lightning` mechanism (the mainnet-Bitcoin / exact / Lightning Network triple). It ships:

- `ExactBip122LightningClientScheme` — client-side scheme that consumes a 402 challenge and produces a settled payment header
- `ExactBip122LightningServerScheme` — server-side scheme that issues challenges and verifies settled payments
- `ExactBip122LightningFacilitator` — a `SchemeNetworkFacilitator` implementation for operators who want to run their own facilitator

## What's new about this listing

The notable bit is the **settlement backend abstraction**: the facilitator can be wired to a **self-custodial NWC** (Nostr Wallet Connect, NIP-47) wallet, so operators settle through their own Alby Hub / Mutiny / Zeus / Phoenixd instance with no custodial intermediary in the path. LNBits is also supported as a backend for operators who prefer that route.

This pairs cleanly with [forgesworn/402-mcp](https://github.com/forgesworn/402-mcp), an MCP client that lets AI agents discover, pay for, and consume L402 + x402 APIs — so an agent on the client side and a self-custodial facilitator on the server side complete the Lightning path end-to-end.

## Files added

- `typescript/site/app/ecosystem/partners-data/x402-lightning/metadata.json`
- `typescript/site/public/logos/x402-lightning.svg`

## Links

- npm: https://www.npmjs.com/package/@powforge/x402-lightning
- Source: https://github.com/powforge/x402-lightning
- Companion MCP client: https://github.com/forgesworn/402-mcp

## Notes for reviewers

- This listing positions the package as a library/SDK, not a hosted facilitator service. Operators self-host. Category is **Infrastructure & Tooling**, matching how Alchemy and similar SDK-style integrations are categorized rather than the **Facilitators** category which is reserved for hosted endpoints.
- Schema mirrors the existing Alchemy / Firecrawl entries: 5 fields, no `facilitator` block.
- Logo is SVG (precedent: `actiongate.svg`, `agentmail-mono.svg`), 100x100 viewBox, Bitcoin orange (#F7931A) on dark background.
