### PR TITLE
feat(extensions): add trust-provider extension for behavioral trust gating

### DIFF
--- a/typescript/packages/extensions/src/trust-provider/index.ts
+++ b/typescript/packages/extensions/src/trust-provider/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Trust-Provider Extension for x402
+ *
+ * Gates payment settlement on behavioral trust evaluation from external providers.
+ * Uses the onBeforeSettle hook to query trust providers, aggregate decisions,
+ * and block settlement for untrusted agents.
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * import {
+ *   createTrustProviderExtension,
+ *   declareTrustProviderExtension,
+ *   TRUST_PROVIDER,
+ * } from '@x402/extensions/trust-provider';
+ *
+ * const config = {
+ *   providers: [{
+ *     name: 'dominion-observatory',
+ *     evaluate: async (query) => {
+ *       const res = await fetch(
+ *         'https://dominion-observatory.sgdata.workers.dev/api/agent-query/' + query.payer.agent_id
+ *       );
+ *       const data = await res.json();
+ *       return {
+ *         schema: 'x402-trust-evaluation-v0.1',
+ *         provider: 'dominion-observatory',
+ *         provider_url: 'https://dominion-observatory.sgdata.workers.dev',
+ *         decision: data.server.trust_score >= 60 ? 'PASS' : data.server.trust_score < 40 ? 'FAIL' : 'UNCERTAIN',
+ *         score: data.server.trust_score / 100,
+ *         evaluated_at: new Date().toISOString(),
+ *       };
+ *     },
+ *   }],
+ *   policy: { kind: 'strict' },
+ *   failureMode: 'fail-closed',
+ * };
+ *
+ * // Register with resource server
+ * const extension = createTrustProviderExtension(config);
+ * server.registerExtension(extension);
+ *
+ * // Include in PaymentRequired response
+ * const paymentRequired = {
+ *   extensions: {
+ *     [TRUST_PROVIDER]: declareTrustProviderExtension(config),
+ *   },
+ * };
+ * ```
+ */
+
+export type {
+  TrustQuery,
+  TrustEvaluation,
+  TrustDecision,
+  TrustProviderConfig,
+  TrustProviderExtensionConfig,
+  TrustProviderDeclaration,
+  AggregationPolicy,
+} from "./types";
+
+export { TRUST_PROVIDER } from "./types";
+
+export { aggregateStrict, aggregateQuorum, aggregate } from "./utils";
+
+export {
+  createTrustProviderExtension,
+  declareTrustProviderExtension,
+} from "./resourceServer";

--- a/typescript/packages/extensions/src/trust-provider/resourceServer.ts
+++ b/typescript/packages/extensions/src/trust-provider/resourceServer.ts
@@ -1,0 +1,140 @@
+/**
+ * Trust-Provider Extension — Resource Server hooks
+ *
+ * Implements onBeforeSettle to gate payment settlement on behavioral trust scores.
+ * Queries configured trust providers in parallel, aggregates decisions, and
+ * aborts settlement if trust evaluation fails.
+ */
+
+import type { ResourceServerExtension } from "@x402/core/types";
+import type {
+  TrustQuery,
+  TrustEvaluation,
+  TrustDecision,
+  TrustProviderExtensionConfig,
+  TrustProviderDeclaration,
+} from "./types";
+import { TRUST_PROVIDER } from "./types";
+import { aggregate } from "./utils";
+
+/**
+ * Creates a trust-provider declaration for PaymentRequired.extensions.
+ *
+ * Resource servers call this to advertise that trust evaluation is performed
+ * before settlement. Clients can inspect this to understand trust requirements.
+ */
+export function declareTrustProviderExtension(
+  config: TrustProviderExtensionConfig,
+): TrustProviderDeclaration {
+  return {
+    info: {
+      providers: config.providers.map((p) => p.name),
+      policy: config.policy.kind,
+      failureMode: config.failureMode,
+    },
+  };
+}
+
+/**
+ * Creates a ResourceServerExtension that gates settlement on trust evaluation.
+ *
+ * The onBeforeSettle hook:
+ * 1. Constructs a TrustQuery from the settlement context
+ * 2. Queries all configured providers in parallel (with timeout)
+ * 3. Aggregates decisions per the configured policy
+ * 4. Returns void (proceed) on PASS, abort on FAIL/UNCERTAIN
+ *
+ * The enrichSettlementResponse hook adds advisory trust headers to the response.
+ */
+export function createTrustProviderExtension(
+  config: TrustProviderExtensionConfig,
+): ResourceServerExtension {
+  const timeout = config.perProviderTimeoutMs ?? 5000;
+
+  // Store last evaluation results for enrichSettlementResponse
+  let lastEvaluations: TrustEvaluation[] = [];
+  let lastDecision: TrustDecision = "UNCERTAIN";
+
+  return {
+    key: TRUST_PROVIDER,
+
+    hooks: {
+      onBeforeSettle: async (_declaration, context) => {
+        const query: TrustQuery = {
+          schema: "x402-trust-query-v0.1",
+          payer: {
+            wallet: context.paymentPayload?.payload?.authorization?.from,
+          },
+          resource: {
+            url: context.requirements?.resource?.url ?? "",
+            method: context.requirements?.resource?.method,
+            amount: context.requirements?.maxAmountRequired
+              ? {
+                  value: context.requirements.maxAmountRequired.amount,
+                  currency: context.requirements.maxAmountRequired.asset?.symbol ?? "USDC",
+                  chain: context.requirements.maxAmountRequired.asset?.network ?? "unknown",
+                }
+              : undefined,
+          },
+          requested_at: new Date().toISOString(),
+        };
+
+        const evaluations = await Promise.all(
+          config.providers.map(async (provider) => {
+            try {
+              return await Promise.race([
+                provider.evaluate(query),
+                new Promise<never>((_, reject) =>
+                  setTimeout(() => reject(new Error("timeout")), timeout),
+                ),
+              ]);
+            } catch {
+              return {
+                schema: "x402-trust-evaluation-v0.1" as const,
+                provider: provider.name,
+                provider_url: "error",
+                decision: (config.failureMode === "fail-closed" ? "UNCERTAIN" : "PASS") as TrustDecision,
+                reason_code: "provider_error",
+                evaluated_at: new Date().toISOString(),
+              };
+            }
+          }),
+        );
+
+        lastEvaluations = evaluations;
+        const decision = aggregate(evaluations, config.policy);
+        lastDecision = decision;
+
+        if (decision === "FAIL") {
+          return {
+            abort: true,
+            reason: "trust_evaluation_failed",
+            message: `Trust gate blocked settlement: ${evaluations.map((e) => e.reason_code).join(", ")}`,
+          };
+        }
+
+        if (decision === "UNCERTAIN" && config.failureMode === "fail-closed") {
+          return {
+            abort: true,
+            reason: "trust_evaluation_uncertain",
+            message: "Trust evaluation inconclusive under fail-closed policy",
+          };
+        }
+
+        // PASS or UNCERTAIN+fail-open: proceed with settlement
+      },
+    },
+
+    enrichSettlementResponse: async () => {
+      if (lastEvaluations.length === 0) return undefined;
+
+      const topEval = lastEvaluations[0];
+      return {
+        decision: lastDecision,
+        score: topEval?.score,
+        evidence_uri: topEval?.evidence_uri,
+        provider: topEval?.provider,
+      };
+    },
+  };
+}

--- a/typescript/packages/extensions/src/trust-provider/types.ts
+++ b/typescript/packages/extensions/src/trust-provider/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Trust-Provider Extension — wire types
+ *
+ * Defines the trust query, evaluation, and configuration types
+ * used by the onBeforeSettle hook to gate settlement on behavioral trust.
+ */
+
+export const TRUST_PROVIDER = "trust-provider" as const;
+
+export type TrustDecision = "PASS" | "FAIL" | "UNCERTAIN";
+
+export interface TrustQuery {
+  schema: "x402-trust-query-v0.1";
+  payer: {
+    wallet?: string;
+    agent_id?: string;
+    session_id?: string;
+  };
+  resource: {
+    url: string;
+    method?: string;
+    amount?: {
+      value: string;
+      currency: string;
+      chain: string;
+    };
+  };
+  context?: {
+    category?: string;
+    risk_band?: "low" | "medium" | "high";
+  };
+  requested_at: string;
+}
+
+export interface TrustEvaluation {
+  schema: "x402-trust-evaluation-v0.1";
+  provider: string;
+  provider_url: string;
+  decision: TrustDecision;
+  score?: number;
+  evidence_uri?: string;
+  reason_code?: string;
+  ttl_seconds?: number;
+  evaluated_at: string;
+}
+
+export type AggregationPolicy =
+  | { kind: "strict" }
+  | { kind: "quorum" }
+  | { kind: "custom"; combine: (evals: TrustEvaluation[]) => TrustDecision };
+
+export interface TrustProviderConfig {
+  name: string;
+  evaluate: (query: TrustQuery) => Promise<TrustEvaluation>;
+}
+
+export interface TrustProviderExtensionConfig {
+  providers: TrustProviderConfig[];
+  policy: AggregationPolicy;
+  failureMode: "fail-closed" | "fail-open";
+  perProviderTimeoutMs?: number;
+}
+
+export interface TrustProviderDeclaration {
+  info: {
+    providers: string[];
+    policy: string;
+    failureMode: string;
+  };
+}

--- a/typescript/packages/extensions/src/trust-provider/utils.ts
+++ b/typescript/packages/extensions/src/trust-provider/utils.ts
@@ -1,0 +1,38 @@
+/**
+ * Trust-Provider Extension — aggregation utilities
+ */
+
+import type { TrustEvaluation, TrustDecision } from "./types";
+
+/** STRICT: all providers must PASS. Any FAIL => FAIL, any UNCERTAIN => UNCERTAIN. */
+export function aggregateStrict(evals: TrustEvaluation[]): TrustDecision {
+  if (evals.some((e) => e.decision === "FAIL")) return "FAIL";
+  if (evals.some((e) => e.decision === "UNCERTAIN")) return "UNCERTAIN";
+  return "PASS";
+}
+
+/** QUORUM: majority rules. Ties resolve to UNCERTAIN. */
+export function aggregateQuorum(evals: TrustEvaluation[]): TrustDecision {
+  const n = evals.length;
+  const threshold = Math.ceil(n / 2);
+  const fails = evals.filter((e) => e.decision === "FAIL").length;
+  const passes = evals.filter((e) => e.decision === "PASS").length;
+  if (fails >= threshold) return "FAIL";
+  if (passes >= threshold && fails === 0) return "PASS";
+  return "UNCERTAIN";
+}
+
+/** Resolve aggregation for a given policy. */
+export function aggregate(
+  evals: TrustEvaluation[],
+  policy: { kind: "strict" } | { kind: "quorum" } | { kind: "custom"; combine: (e: TrustEvaluation[]) => TrustDecision },
+): TrustDecision {
+  switch (policy.kind) {
+    case "strict":
+      return aggregateStrict(evals);
+    case "quorum":
+      return aggregateQuorum(evals);
+    case "custom":
+      return policy.combine(evals);
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **trust-provider** extension under `typescript/packages/extensions/src/trust-provider/` that gates payment settlement on behavioral trust evaluation via the existing `onBeforeSettle` hook.

Closes #2299

## What it does

- Queries configured trust providers (e.g., Dominion Observatory) in parallel before settlement
- Aggregates decisions using STRICT, QUORUM, or custom policies
- Aborts settlement on FAIL or UNCERTAIN (under fail-closed)
- Attaches trust metadata to settlement responses via `enrichSettlementResponse`

## Files

| File | Purpose |
|------|---------|
| `types.ts` | Wire types: TrustQuery, TrustEvaluation, TrustDecision, config interfaces |
| `utils.ts` | Aggregation functions: strict (all PASS), quorum (majority), custom |
| `resourceServer.ts` | `onBeforeSettle` hook implementation + `enrichSettlementResponse` |
| `index.ts` | Public API barrel exports |

## No core changes

Uses only the existing `ResourceServerExtensionHooks.onBeforeSettle` interface. Zero modifications to core packages.

## Reference provider

[Dominion Observatory](https://dominion-observatory.sgdata.workers.dev) — behavioral trust scores for 14,800+ MCP servers. Working testnet demo with Base Sepolia USDC available at [daee-engine/testnet-demo](https://github.com/vdineshk/daee-engine/tree/main/testnet-demo).
