### PR TITLE
ecosystem: add npb-win-probability-oracle (Services/Endpoints — NPB x402 oracle, formerly agent-oracle)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/agent-oracle/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agent-oracle/metadata.json
@@ -1,6 +1,6 @@
 {
-  "name": "agent-oracle",
-  "description": "x402-native sports oracle for Nippon Professional Baseball (NPB). Win-probability predictions (XGBoost), Asian Handicap daily snapshots, post-game results and box scores, and per-season pitcher/batter/fielder stats — paid per call in USDC on Solana mainnet, with Bazaar discovery metadata on every paymentRequirements response.",
+  "name": "npb-win-probability-oracle",
+  "description": "x402-native sports-prediction oracle for Nippon Professional Baseball (NPB). Win-probability predictions (XGBoost AUC 0.5622, 28,968 games), Asian Handicap daily snapshots, post-game results and box scores, and per-season pitcher/batter/fielder stats — paid per call in USDC on Solana mainnet, with v2 Bazaar discovery metadata on every paymentRequirements response. Renamed from 'agent-oracle' for AI-agent semantic clarity (3-party namespace congestion with TKCollective/AgentOracle and aiagentoracle.ai).",
   "logoUrl": "/logos/agent-oracle.svg",
   "websiteUrl": "https://oracle-api-production-766f.up.railway.app",
   "category": "Services/Endpoints"

--- a/typescript/site/app/ecosystem/partners-data/agent-oracle/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agent-oracle/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "agent-oracle",
+  "description": "x402-native sports oracle for Nippon Professional Baseball (NPB). Win-probability predictions (XGBoost), Asian Handicap daily snapshots, post-game results and box scores, and per-season pitcher/batter/fielder stats — paid per call in USDC on Solana mainnet, with Bazaar discovery metadata on every paymentRequirements response.",
+  "logoUrl": "/logos/agent-oracle.svg",
+  "websiteUrl": "https://oracle-api-production-766f.up.railway.app",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/agent-oracle.svg
+++ b/typescript/site/public/logos/agent-oracle.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="agent-oracle">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0b1426"/>
+      <stop offset="100%" stop-color="#1c2c4a"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="48" fill="url(#g)"/>
+  <g fill="none" stroke="#7ad7ff" stroke-width="3" opacity="0.55">
+    <circle cx="128" cy="128" r="86"/>
+    <circle cx="128" cy="128" r="60"/>
+    <circle cx="128" cy="128" r="34"/>
+  </g>
+  <g font-family="'SF Mono','Menlo','Consolas',monospace" font-weight="700" fill="#ffffff" text-anchor="middle">
+    <text x="128" y="140" font-size="64" letter-spacing="-2">ao</text>
+    <text x="128" y="186" font-size="16" letter-spacing="2" opacity="0.85">agent-oracle</text>
+  </g>
+  <circle cx="128" cy="128" r="4" fill="#7ad7ff"/>
+</svg>


### PR DESCRIPTION
Adds npb-win-probability-oracle (formerly known as agent-oracle) to the ecosystem under **Services/Endpoints**.

**What npb-win-probability-oracle is**

x402-native sports oracle for Nippon Professional Baseball (NPB) on Solana mainnet. 12 paid endpoints across two surfaces:

- **Prediction** (`sports-prediction`): per-game `home_win_prob`, predicted winner, confidence, expected runs. XGBoost model trained on 28,968 historical NPB games (2008–2025), 61 features, AUC 0.5622, 3 OOS strategies passed.
- **Data** (`sports-data`): daily game schedule + Asian Handicap daily snapshot (rare in EN-speaking oracles), post-game results, full box scores, and per-season pitcher / batter / fielder stats from npb.jp official BIS.

Pricing: $0.001–$0.01 USDC per call (Solana mainnet, `exact` scheme via CDP facilitator).

**Mainnet evidence**

- Production: `https://oracle-api-production-766f.up.railway.app`
- Settlement: 7,075 paid x402 transactions to date (snapshot 2026-05-14 JST), 70.42 USDC cumulative settled on-chain.
- Every paid endpoint emits a v2 Bazaar discovery extension on its 402 response: `extensions.bazaar` includes `info.input`, `info.output.{example,format}`, `schema`, `routeTemplate`, and a `metadata` block with `category`, `tags`, and quality signals (`model_auc`, `mainnet_tx_count`, `training_set_size`, `oos_strategies_passed`, `coverage_seasons`), plus `product_name: "npb-win-probability-oracle"` and `legacy_name: "agent-oracle"` for backward discoverability across the rename.

You can verify the manifest live:

```
curl -i https://oracle-api-production-766f.up.railway.app/v1/npb/games/2099-11-15/win-prob
```

Decode the `payment-required` header (base64 JSON) to see the full Bazaar extension.

**Changes in this PR**

- `typescript/site/app/ecosystem/partners-data/agent-oracle/metadata.json` (directory name kept for PR history continuity; the `name` field inside is `npb-win-probability-oracle`)
- `typescript/site/public/logos/agent-oracle.svg` (256×256, SVG; path kept for the same reason, file content unchanged)

**AI-assisted disclosure**

Per CONTRIBUTING: this PR was prepared with AI assistance (Claude). All content was reviewed before submission. The change is a 2-file partner registry entry with no protocol code; metadata fields match the template in `typescript/site/README.md#adding-your-project-to-the-ecosystem`.

---

**Products & Services**:
- Selling [npb-win-probability-oracle](https://oracle-api-production-766f.up.railway.app) — NPB win-probability predictions for AI agents via x402 / Solana mainnet
- Available for x402 / Solana integration consulting

Contact: [contact@vaultshift.dev](mailto:contact@vaultshift.dev)
