### PR TITLE
feat(evm): add HPP mainnet (chain ID 190415) and HPP Sepolia (chain ID 181228) support with USDC.e

### DIFF
--- a/go/.changes/unreleased/add-hpp-chains-default-stablecoin.yaml
+++ b/go/.changes/unreleased/add-hpp-chains-default-stablecoin.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add HPP mainnet (chain ID 190415) and HPP Sepolia (chain ID 181228) support with USDC.e (Bridged USDC) as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -82,6 +82,8 @@ var (
 	ChainIDArbSepolia    = big.NewInt(421614)
 	ChainIDRadius        = big.NewInt(723487)
 	ChainIDRadiusTestnet = big.NewInt(72344)
+	ChainIDHPP           = big.NewInt(190415)
+	ChainIDHPPSepolia    = big.NewInt(181228)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -221,6 +223,26 @@ var (
 				Decimals:            DefaultDecimals,
 				AssetTransferMethod: AssetTransferMethodPermit2,
 				SupportsEip2612:     true,
+			},
+		},
+		// HPP Mainnet
+		"eip155:190415": {
+			ChainID: ChainIDHPP,
+			DefaultAsset: AssetInfo{
+				Address:  "0x401eCb1D350407f13ba348573E5630B83638E30D", // USDC.e (Bridged USDC) on HPP
+				Name:     "Bridged USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// HPP Sepolia
+		"eip155:181228": {
+			ChainID: ChainIDHPPSepolia,
+			DefaultAsset: AssetInfo{
+				Address:  "0x401eCb1D350407f13ba348573E5630B83638E30D", // USDC.e (Bridged USDC) on HPP Sepolia
+				Name:     "Bridged USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
 			},
 		},
 	}

--- a/python/x402/changelog.d/add-hpp-chains-default-stablecoin.feature.md
+++ b/python/x402/changelog.d/add-hpp-chains-default-stablecoin.feature.md
@@ -1,0 +1,1 @@
+Add HPP mainnet (chain ID 190415) and HPP Sepolia (chain ID 181228) support with USDC.e (Bridged USDC) as the default stablecoin

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -534,6 +534,26 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "supports_eip2612": True,
         },
     },
+    # HPP Mainnet
+    "eip155:190415": {
+        "chain_id": 190415,
+        "default_asset": {
+            "address": "0x401eCb1D350407f13ba348573E5630B83638E30D",
+            "name": "Bridged USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
+    # HPP Sepolia
+    "eip155:181228": {
+        "chain_id": 181228,
+        "default_asset": {
+            "address": "0x401eCb1D350407f13ba348573E5630B83638E30D",
+            "name": "Bridged USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
 }
 
 # V1 legacy constants are in x402.mechanisms.evm.v1.constants

--- a/typescript/.changeset/add-hpp-chains-default-stablecoin.md
+++ b/typescript/.changeset/add-hpp-chains-default-stablecoin.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": minor
+---
+
+Add HPP mainnet (chain ID 190415) and HPP Sepolia (chain ID 181228) support with USDC.e (Bridged USDC) as the default stablecoin

--- a/typescript/packages/http/paywall/src/evm/gen/decimals.ts
+++ b/typescript/packages/http/paywall/src/evm/gen/decimals.ts
@@ -11,6 +11,8 @@
 export const NETWORK_DECIMALS: Record<string, number> = {
   "eip155:137": 6,
   "eip155:143": 6,
+  "eip155:181228": 6,
+  "eip155:190415": 6,
   "eip155:2201": 6,
   "eip155:31611": 18,
   "eip155:42161": 6,

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -121,6 +121,18 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     assetTransferMethod: "permit2",
     supportsEip2612: true,
   }, // Radius Testnet SBC (no EIP-3009, supports EIP-2612)
+  "eip155:190415": {
+    address: "0x401eCb1D350407f13ba348573E5630B83638E30D",
+    name: "Bridged USDC",
+    version: "2",
+    decimals: 6,
+  }, // HPP mainnet USDC.e
+  "eip155:181228": {
+    address: "0x401eCb1D350407f13ba348573E5630B83638E30D",
+    name: "Bridged USDC",
+    version: "2",
+    decimals: 6,
+  }, // HPP Sepolia USDC.e
 };
 
 /**


### PR DESCRIPTION
Add USDC.e (Bridged USDC) as the default stablecoin for HPP mainnet
(chain ID 190415) and HPP Sepolia (chain ID 181228) across all three SDKs:

- TypeScript: `DEFAULT_STABLECOINS` map in `@x402/evm`
- Go: `ChainIDHPP` / `ChainIDHPPSepolia` constants, `NetworkConfigs` entries
- Python: `NETWORK_CONFIGS` dict in `x402.mechanisms.evm`

## Contract details (verified on-chain)

- Token: USDC.e (Bridged USDC, FiatTokenV2_2)
- Address: `0x401eCb1D350407f13ba348573E5630B83638E30D` (identical on both networks)
- EIP-712 domain: `name="Bridged USDC"`, `version="2"`
- Decimals: 6
- EIP-3009: `transferWithAuthorization` supported
- TYPEHASH: `0x7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267` (standard-conformant)

## Chain details

- HPP is an Arbitrum Orbit L2 operated by the HPP team
- Mainnet (190415): https://mainnet.hpp.io | Explorer: https://explorer.hpp.io
- Sepolia (181228): https://sepolia.hpp.io | Explorer: https://sepolia-explorer.hpp.io
- Portal (bridge / staking / ecosystem hub): https://portal.hpp.io

USDC.e is the official bridged USDC issued by HPP, submitted by the HPP chain team (chain-endorsed asset per `DEFAULT_ASSETS.md`).

---

Note: This PR was originally filed against `coinbase/x402#162` before I noticed the repo move; closed in favor of this one.