### PR TITLE
docs(spec): clarify HTTP payment required header

### DIFF
--- a/specs/transports-v2/http.md
+++ b/specs/transports-v2/http.md
@@ -12,9 +12,7 @@ The server indicates payment is required using the HTTP 402 "Payment Required" s
 **Data Format**: Base64-encoded `PaymentRequired` schema in header
 
 The `PAYMENT-REQUIRED` header is the canonical HTTP transport location for the
-`PaymentRequired` object. A response body may duplicate the same information
-for humans or backward compatibility, but clients and crawlers must not depend
-on the body alone for x402 protocol data.
+`PaymentRequired` object.
 
 **Example:**
 

--- a/specs/transports-v2/http.md
+++ b/specs/transports-v2/http.md
@@ -11,6 +11,11 @@ The server indicates payment is required using the HTTP 402 "Payment Required" s
 **Mechanism**: HTTP 402 status code with `PAYMENT-REQUIRED` header
 **Data Format**: Base64-encoded `PaymentRequired` schema in header
 
+The `PAYMENT-REQUIRED` header is the canonical HTTP transport location for the
+`PaymentRequired` object. A response body may duplicate the same information
+for humans or backward compatibility, but clients and crawlers must not depend
+on the body alone for x402 protocol data.
+
 **Example:**
 
 ```http

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -69,7 +69,9 @@ This section defines the core data structures used in the x402 protocol. These a
 
 **5.1.1 JSON Payload**
 
-When a resource server requires payment, it responds with a payment required signal and a JSON payload containing payment requirements. Example:
+When a resource server requires payment, it responds with a payment required signal containing the `PaymentRequired` object. The transport defines where this object is carried. For HTTP, the canonical wire location is the base64-encoded `PAYMENT-REQUIRED` response header, not only the response body. See [HTTP Payment Required Signaling](./transports-v2/http.md#payment-required-signaling).
+
+Example `PaymentRequired` object:
 
 ```json
 {

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -69,7 +69,7 @@ This section defines the core data structures used in the x402 protocol. These a
 
 **5.1.1 JSON Payload**
 
-When a resource server requires payment, it responds with a payment required signal containing the `PaymentRequired` object. The transport defines where this object is carried. For HTTP, the canonical wire location is the base64-encoded `PAYMENT-REQUIRED` response header, not only the response body. See [HTTP Payment Required Signaling](./transports-v2/http.md#payment-required-signaling).
+When a resource server requires payment, it responds with a payment required signal containing the `PaymentRequired` object. The transport defines where this object is carried. For HTTP, the canonical wire location is the base64-encoded `PAYMENT-REQUIRED` response header, see [HTTP Payment Required Signaling](./transports-v2/http.md#payment-required-signaling).
 
 Example `PaymentRequired` object:
 


### PR DESCRIPTION
Summary
- Cross-reference the HTTP transport from the core v2 PaymentRequired schema section.
- Clarify that HTTP carries the canonical `PaymentRequired` object in the base64 `PAYMENT-REQUIRED` response header.
- Note that response bodies may duplicate this information, but protocol clients/crawlers should not depend on body-only data.

Context
- Addresses the documentation ambiguity discussed in #2207 around implementations returning PaymentRequired only in the response body.

Verification
- `git diff --check`