### PR TITLE
docs: clarify EVM channel and transfer method semantics

### DIFF
--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -12,7 +12,7 @@ This is implemented via one of three asset transfer methods, depending on the to
 | **2. Permit2**      | Tokens without EIP-3009. Uses a Proxy + Permit2.             | **Universal Fallback** (Works for any ERC-20). | One-time use                        |
 | **3. ERC-7710**      | Smart accounts with delegation support.                              | **Smart Account Option** (Paid from ERC-7710 compatible account). | One-time use and multi-use |
 
-If no `assetTransferMethod` is specified in the payload, the implementation should prioritize `eip3009` (if compatible) and then `permit2`.
+If no `assetTransferMethod` is specified in `PaymentRequired.extra`, clients should treat it as `"eip3009"` for backwards compatibility. Payment payloads that use a non-default transfer method should echo the selected `assetTransferMethod` in `accepted.extra`.
 
 In all cases, the Facilitator cannot modify the amount or destination. They serve only as the transaction broadcaster.
 
@@ -68,7 +68,7 @@ The `payload` field must contain:
 
 **`extra` field definitions specific to `eip3009`:**
 
-- `extra.assetTransferMethod` (required): MUST be `"eip3009"`.
+- `extra.assetTransferMethod` (optional in `PaymentRequired`, default `"eip3009"`): if present, MUST be `"eip3009"`.
 - `extra.name` (required): The EIP-712 domain name of the token contract. Used for `transferWithAuthorization` signature construction.
 - `extra.version` (required): The EIP-712 domain version of the token contract. Used for `transferWithAuthorization` signature construction.
 

--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -12,7 +12,7 @@ This is implemented via one of three asset transfer methods, depending on the to
 | **2. Permit2**      | Tokens without EIP-3009. Uses a Proxy + Permit2.             | **Universal Fallback** (Works for any ERC-20). | One-time use                        |
 | **3. ERC-7710**      | Smart accounts with delegation support.                              | **Smart Account Option** (Paid from ERC-7710 compatible account). | One-time use and multi-use |
 
-If no `assetTransferMethod` is specified in `PaymentRequired.extra`, clients should treat it as `"eip3009"` for backwards compatibility. Payment payloads that use a non-default transfer method should echo the selected `assetTransferMethod` in `accepted.extra`.
+If no `assetTransferMethod` is specified in `PaymentRequired.extra`, clients should default to `"eip3009"`. Payment payloads that use a non-default transfer method should echo the selected `assetTransferMethod` in `accepted.extra`.
 
 In all cases, the Facilitator cannot modify the amount or destination. They serve only as the transaction broadcaster.
 

--- a/specs/transports-v2/http.md
+++ b/specs/transports-v2/http.md
@@ -49,6 +49,11 @@ The base64 header decodes to:
 }
 ```
 
+For the EVM `exact` scheme, omitting `extra.assetTransferMethod` in
+`PaymentRequired` indicates the default `"eip3009"` method. Servers should set
+`extra.assetTransferMethod` when advertising a non-default method such as
+`"permit2"` or `"erc7710"`.
+
 ## Payment Payload Transmission
 
 Clients send payment data using the `PAYMENT-SIGNATURE` HTTP header.

--- a/specs/transports-v2/http.md
+++ b/specs/transports-v2/http.md
@@ -49,11 +49,6 @@ The base64 header decodes to:
 }
 ```
 
-For the EVM `exact` scheme, omitting `extra.assetTransferMethod` in
-`PaymentRequired` indicates the default `"eip3009"` method. Servers should set
-`extra.assetTransferMethod` when advertising a non-default method such as
-`"permit2"` or `"erc7710"`.
-
 ## Payment Payload Transmission
 
 Clients send payment data using the `PAYMENT-SIGNATURE` HTTP header.

--- a/typescript/.changeset/quiet-cycles-serve.md
+++ b/typescript/.changeset/quiet-cycles-serve.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Clarify exact EVM channel asset semantics and align voucher asset selection with the transfer method.

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/client/voucher.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/client/voucher.ts
@@ -12,7 +12,9 @@ import { getBatchSettlementEip712Domain } from "../utils";
  * under the batched domain.
  *
  * @param signer - Client wallet used to produce the EIP-712 signature.
- * @param channelId - Identifier of the payment channel (`keccak256(abi.encode(ChannelConfig))`).
+ * @param channelId - Identifier of the payment channel. This is the EIP-712
+ * hash of the `ChannelConfig` typed data for the batch settlement domain; see
+ * `computeChannelId`.
  * @param maxClaimableAmount - Cumulative ceiling the receiver may claim (decimal string in token units).
  * @param network - CAIP-2 network identifier (e.g. `eip155:84532`).
  * @returns Signed voucher fields ready to be included in a payment payload.


### PR DESCRIPTION
## Summary
- Correct the batch-settlement voucher docstring for `channelId` so it points to the EIP-712 `ChannelConfig` hash used by `computeChannelId`
- Clarify that omitted `extra.assetTransferMethod` in EVM `exact` `PaymentRequired` means the default `eip3009` method
- Add the same defaulting note to the HTTP transport example, where `extra.assetTransferMethod` is intentionally omitted

Fixes #2323

## Verification
- pnpm --dir typescript/packages/mechanisms/evm exec prettier -c .prettierrc --check src/batch-settlement/client/voucher.ts ../../../../specs/schemes/exact/scheme_exact_evm.md ../../../../specs/transports-v2/http.md
- pnpm --dir typescript/packages/mechanisms/evm exec vitest run test/unit/batch-settlement/utils.test.ts
- pnpm --dir typescript/packages/mechanisms/evm lint:check
- git diff --check