### PR TITLE
fix(python): preserve FastMCP result metadata

### DIFF
--- a/python/x402/changelog.d/preserve-fastmcp-result-meta.bugfix.md
+++ b/python/x402/changelog.d/preserve-fastmcp-result-meta.bugfix.md
@@ -1,0 +1,1 @@
+Preserve existing FastMCP ``CallToolResult`` metadata when attaching x402 payment responses.

--- a/python/x402/mcp/server.py
+++ b/python/x402/mcp/server.py
@@ -191,6 +191,7 @@ def create_payment_wrapper(
                 )
 
             # Convert handler result to text content
+            result_meta: dict[str, Any] = {}
             if isinstance(result, dict):
                 result_text = json.dumps(result)
             elif isinstance(result, str):
@@ -199,6 +200,8 @@ def create_payment_wrapper(
                 if result.isError:
                     return result
                 result_text = result.content[0].text if result.content else ""
+                if isinstance(result.meta, dict):
+                    result_meta = result.meta.copy()
             else:
                 result_text = str(result)
 
@@ -210,7 +213,7 @@ def create_payment_wrapper(
                     [{"type": "text", "text": result_text}] if isinstance(result_text, str) else []
                 ),
                 is_error=False,
-                meta={},
+                meta=result_meta.copy(),
                 structured_content=None,
             )
 
@@ -270,10 +273,12 @@ def create_payment_wrapper(
 
             # Return result with payment response in _meta
             payment_response = settle_result.model_dump(by_alias=True)
+            response_meta = result_meta.copy()
+            response_meta[MCP_PAYMENT_RESPONSE_META_KEY] = payment_response
             return CallToolResult(
                 content=[TextContent(type="text", text=result_text)],
                 isError=False,
-                _meta={MCP_PAYMENT_RESPONSE_META_KEY: payment_response},
+                _meta=response_meta,
             )
 
         # --- Signature manipulation for FastMCP context injection ---

--- a/python/x402/mcp/tests/test_server_fastmcp.py
+++ b/python/x402/mcp/tests/test_server_fastmcp.py
@@ -1,0 +1,66 @@
+"""Tests for the FastMCP payment wrapper."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from mcp.types import CallToolResult, TextContent
+from x402.mcp.constants import MCP_PAYMENT_META_KEY, MCP_PAYMENT_RESPONSE_META_KEY
+from x402.mcp.server import create_payment_wrapper
+from x402.schemas import PaymentPayload, PaymentRequirements, SettleResponse
+
+
+class MockFastMCPContext:
+    """Minimal FastMCP context shape used by the wrapper."""
+
+    def __init__(self, meta: dict):
+        self.request_context = SimpleNamespace(
+            meta=SimpleNamespace(model_extra=meta),
+        )
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_wrapper_preserves_call_tool_result_meta():
+    """Preserve existing MCP metadata when adding the x402 payment response."""
+    requirements = PaymentRequirements(
+        scheme="exact",
+        network="eip155:84532",
+        amount="1000",
+        asset="USDC",
+        pay_to="0xrecipient",
+        max_timeout_seconds=300,
+    )
+    payload = PaymentPayload(
+        x402_version=2,
+        accepted=requirements.model_dump(by_alias=True),
+        payload={"signature": "0x123"},
+    )
+    resource_server = Mock()
+    resource_server.verify_payment = AsyncMock(return_value=Mock(is_valid=True))
+    resource_server.settle_payment = AsyncMock(
+        return_value=SettleResponse(
+            success=True,
+            transaction="0xtx123",
+            network="eip155:84532",
+        )
+    )
+
+    wrapper = create_payment_wrapper(resource_server, accepts=[requirements])
+
+    @wrapper
+    async def paid_tool() -> CallToolResult:
+        return CallToolResult(
+            content=[TextContent(type="text", text="ok")],
+            isError=False,
+            _meta={"traceId": "trace-123"},
+        )
+
+    result = await paid_tool(
+        ctx=MockFastMCPContext({MCP_PAYMENT_META_KEY: payload.model_dump(by_alias=True)})
+    )
+
+    assert result.isError is False
+    assert result.content[0].text == "ok"
+    assert result.meta["traceId"] == "trace-123"
+    assert result.meta[MCP_PAYMENT_RESPONSE_META_KEY]["transaction"] == "0xtx123"


### PR DESCRIPTION
## Summary
- preserve existing `CallToolResult.meta` values when FastMCP tool handlers return a successful MCP result
- merge the `x402/payment-response` metadata instead of replacing the handler metadata
- add a focused FastMCP regression test and Python changelog fragment

## Why
FastMCP handlers can return `CallToolResult` objects with their own MCP metadata, for example trace IDs, pagination cursors, or downstream protocol metadata. The payment wrapper previously replaced that metadata when adding the x402 settlement response. This keeps the existing metadata while still attaching the payment response.

## Verification
- `uv --project python/x402 run pytest python/x402/mcp/tests/test_server_fastmcp.py -q`
- `uv --project python/x402 run ruff check python/x402/mcp/server.py python/x402/mcp/tests/test_server_fastmcp.py`
- `uv --project python/x402 run ruff format --check python/x402/mcp/server.py python/x402/mcp/tests/test_server_fastmcp.py`
- `cd python/x402 && uv run pytest -q`