### PR TITLE
fix(python): export MCP client factories

### DIFF
--- a/python/x402/changelog.d/export-mcp-client-factories.bugfix.md
+++ b/python/x402/changelog.d/export-mcp-client-factories.bugfix.md
@@ -1,0 +1,1 @@
+Export documented Python MCP client factory helpers from ``x402.mcp``.

--- a/python/x402/mcp/__init__.py
+++ b/python/x402/mcp/__init__.py
@@ -48,6 +48,9 @@ __all__ = [
     "SyncPaymentWrapperConfig",
     # Client
     "create_x402_mcp_client",
+    "create_x402_mcp_client_from_config",
+    "wrap_mcp_client_with_payment",
+    "wrap_mcp_client_with_payment_from_config",
     "x402MCPSession",
     "x402MCPClient",
     "x402MCPClientSync",
@@ -90,6 +93,14 @@ def __getattr__(name: str):
         from . import client as _client
 
         return getattr(_client, name)
+    if name in (
+        "create_x402_mcp_client_from_config",
+        "wrap_mcp_client_with_payment",
+        "wrap_mcp_client_with_payment_from_config",
+    ):
+        from . import client_async as _client_async
+
+        return getattr(_client_async, name)
     if name == "MCPToolResult":
         from .types import MCPToolResult
 


### PR DESCRIPTION
## Summary
- export the documented Python MCP client factory helpers from `x402.mcp`
- keep imports lazy so importing `x402.mcp` still does not eagerly load optional MCP client code
- add a Python changelog fragment

## Why
`client_async.py` implements `wrap_mcp_client_with_payment`, `wrap_mcp_client_with_payment_from_config`, and `create_x402_mcp_client_from_config`, and the MCP README documents importing these helpers from `x402.mcp`. The package-level lazy exports did not expose them, so the documented import path raised `ImportError`.

## Verification
- `cd python/x402 && uv run pytest mcp/tests/test_client_async.py::test_wrap_mcp_client_with_payment_async -q` failed before the fix
- `cd python/x402 && uv run pytest mcp/tests/test_client_async.py::test_wrap_mcp_client_with_payment_async -q`
- `uv --project python/x402 run ruff check python/x402/mcp/__init__.py`
- `uv --project python/x402 run ruff format --check python/x402/mcp/__init__.py`
- `cd python/x402 && uv run pytest -q`