### PR TITLE
docs(evm): clarify channel id and transfer method defaults

### DIFF
--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -12,7 +12,7 @@ This is implemented via one of three asset transfer methods, depending on the to
 | **2. Permit2**      | Tokens without EIP-3009. Uses a Proxy + Permit2.             | **Universal Fallback** (Works for any ERC-20). | One-time use                        |
 | **3. ERC-7710**      | Smart accounts with delegation support.                              | **Smart Account Option** (Paid from ERC-7710 compatible account). | One-time use and multi-use |
 
-If no `assetTransferMethod` is specified in the payload, the implementation should prioritize `eip3009` (if compatible) and then `permit2`.
+If no `assetTransferMethod` is specified in `PaymentRequirements.extra`, the implementation should prioritize `eip3009` (if compatible) and then `permit2`. Resource servers MAY omit `extra.assetTransferMethod` in `PaymentRequired` when they are offering this default selection behavior; clients and facilitators MUST NOT treat the field as required unless a concrete payment payload has selected a method-specific shape.
 
 In all cases, the Facilitator cannot modify the amount or destination. They serve only as the transaction broadcaster.
 
@@ -68,7 +68,7 @@ The `payload` field must contain:
 
 **`extra` field definitions specific to `eip3009`:**
 
-- `extra.assetTransferMethod` (required): MUST be `"eip3009"`.
+- `extra.assetTransferMethod` (conditional): MUST be `"eip3009"` when the payment payload uses the EIP-3009 shape. It MAY be omitted from `PaymentRequired` to request default method selection.
 - `extra.name` (required): The EIP-712 domain name of the token contract. Used for `transferWithAuthorization` signature construction.
 - `extra.version` (required): The EIP-712 domain version of the token contract. Used for `transferWithAuthorization` signature construction.
 
@@ -165,7 +165,7 @@ The `payload` field must contain:
 
 **`extra` field definitions specific to `permit2`:**
 
-- `extra.assetTransferMethod` (required): MUST be `"permit2"`.
+- `extra.assetTransferMethod` (conditional): MUST be `"permit2"` when the payment payload uses the Permit2 shape. It MAY be omitted from `PaymentRequired` to request default method selection.
 - `extra.name` (conditional): The EIP-712 domain name of the token contract. Required when the token supports EIP-2612 for gasless Permit2 approval.
 - `extra.version` (conditional): The EIP-712 domain version of the token contract. Required when the token supports EIP-2612 for gasless Permit2 approval.
 

--- a/specs/transports-v2/http.md
+++ b/specs/transports-v2/http.md
@@ -49,6 +49,10 @@ The base64 header decodes to:
 }
 ```
 
+This example intentionally omits `accepts[].extra.assetTransferMethod`. For EVM `exact`
+payments, that field is optional in `PaymentRequired`; omitting it asks compatible
+clients to use the scheme's default method selection.
+
 ## Payment Payload Transmission
 
 Clients send payment data using the `PAYMENT-SIGNATURE` HTTP header.

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -101,6 +101,10 @@ When a resource server requires payment, it responds with a payment required sig
 }
 ```
 
+The example's `accepts[].extra` uses only token EIP-712 domain metadata. Scheme-specific
+selectors such as EVM `exact`'s `assetTransferMethod` are optional unless the scheme
+document explicitly requires them for a selected payload shape.
+
 **5.1.2 Field Descriptions**
 
 The `PaymentRequired` schema contains the following fields:

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/client/voucher.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/client/voucher.ts
@@ -12,7 +12,8 @@ import { getBatchSettlementEip712Domain } from "../utils";
  * under the batched domain.
  *
  * @param signer - Client wallet used to produce the EIP-712 signature.
- * @param channelId - Identifier of the payment channel (`keccak256(abi.encode(ChannelConfig))`).
+ * @param channelId - Identifier of the payment channel computed with `computeChannelId`, i.e. the
+ * EIP-712 typed-data hash of `ChannelConfig` under the batch-settlement domain.
  * @param maxClaimableAmount - Cumulative ceiling the receiver may claim (decimal string in token units).
  * @param network - CAIP-2 network identifier (e.g. `eip155:84532`).
  * @returns Signed voucher fields ready to be included in a payment payload.


### PR DESCRIPTION
## Summary
- fix the batch-settlement voucher `channelId` docstring to reference the EIP-712 `computeChannelId` derivation instead of `keccak256(abi.encode(ChannelConfig))`
- clarify that EVM `exact` `extra.assetTransferMethod` can be omitted from `PaymentRequired` for default method selection
- add notes to the v2 HTTP and core examples explaining why their `extra` objects include token domain metadata but no transfer-method selector

## Why
This addresses #2323. The previous wording could send external implementers toward an incompatible channel id derivation, and the EVM exact examples made `assetTransferMethod` look required even though canonical `PaymentRequired` examples omit it.

## Verification
- `git diff --check`
- `pnpm exec prettier -c .prettierrc --check src/batch-settlement/client/voucher.ts ../../../../specs/schemes/exact/scheme_exact_evm.md ../../../../specs/transports-v2/http.md ../../../../specs/x402-specification-v2.md` from `typescript/packages/mechanisms/evm`
- `pnpm --filter @x402/evm lint:check`

## Notes
- `pnpm --filter @x402/evm test -- --runInBand` currently fails locally before exercising this docs change because the package-level Vitest run cannot resolve workspace imports such as `@x402/core/http`, `@x402/core/client`, and `@x402/core/utils` in this checkout. The collected unit tests that did not hit those aliases passed.