### PR TITLE
Add PowForge x402-Lightning to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/powforge-x402-lightning/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/powforge-x402-lightning/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "PowForge x402-Lightning",
+  "description": "Lightning facilitator for x402 with both LNBits and NWC (Nostr Wallet Connect) backends. Self-custodial: operator keeps custody, no hosted endpoints required. Works with Alby Hub, Mutiny, Zeus, Coinos, and any NIP-47 wallet.",
+  "logoUrl": "/logos/powforge-x402-lightning.png",
+  "websiteUrl": "https://www.npmjs.com/package/@powforge/x402-lightning",
+  "category": "Infrastructure & Tooling"
+}

--- a/typescript/site/app/ecosystem/partners-data/powforge-x402-lightning/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/powforge-x402-lightning/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "PowForge x402-Lightning",
   "description": "Lightning facilitator for x402 with both LNBits and NWC (Nostr Wallet Connect) backends. Self-custodial: operator keeps custody, no hosted endpoints required. Works with Alby Hub, Mutiny, Zeus, Coinos, and any NIP-47 wallet.",
-  "logoUrl": "/logos/powforge-x402-lightning.png",
+  "logoUrl": "/logos/powforge-x402-lightning.svg",
   "websiteUrl": "https://www.npmjs.com/package/@powforge/x402-lightning",
   "category": "Infrastructure & Tooling"
 }

--- a/typescript/site/public/logos/powforge-x402-lightning.svg
+++ b/typescript/site/public/logos/powforge-x402-lightning.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f7931a"/>
+      <stop offset="100%" stop-color="#ffcc33"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="200" rx="36" fill="#0a0a0a"/>
+  <path d="M118 36 L70 110 L96 110 L82 164 L130 90 L104 90 Z" fill="url(#g)" stroke="#000" stroke-width="2"/>
+  <text x="100" y="190" text-anchor="middle" font-family="ui-monospace, monospace" font-size="14" font-weight="700" fill="#f7931a">x402</text>
+</svg>


### PR DESCRIPTION
Adds `@powforge/x402-lightning` to the x402 ecosystem registry under **Infrastructure & Tooling**.

### What this PR does
- Creates `typescript/site/app/ecosystem/partners-data/powforge-x402-lightning/metadata.json`
- Adds `typescript/site/public/logos/powforge-x402-lightning.svg`

### What `@powforge/x402-lightning` is
`@powforge/x402-lightning` is the first x402 facilitator implementation that accepts Lightning payments from **self-custodial NWC (Nostr Wallet Connect / NIP-47) wallets** — Alby Hub, Mutiny, Zeus, Coinos, Phoenixd-via-bridge — in addition to a custodial LNBits backend.

- npm: https://www.npmjs.com/package/@powforge/x402-lightning (v0.2.3, MIT)
- Source: https://gitlab.com/powforge/x402-lightning
- Differentiator: only x402 facilitator with NWC backend support. The Coinbase CDP facilitator is EVM-only; x402-rs is EVM/SVM-only; the draft TypeScript Lightning PR (#2262) ships LNBits + Blink, no NWC.
- Network identifiers follow #1311: `bip122:000000000019d6689c085ae165831e93` (mainnet), millisat precision matching BOLT11.

It is a library (self-hosted by the operator), so we use the standard Infrastructure & Tooling entry format rather than the Facilitators block with `baseUrl` — consistent with how `clawpay-mcp`, `cascade`, `daydreams`, and other library/SDK projects are listed.

### Verification
- `metadata.json` follows the format documented in `typescript/site/README.md`
- Required fields present: `name`, `description`, `logoUrl`, `websiteUrl`, `category`
- Category is one of the four valid values: **Infrastructure & Tooling**
- Logo SVG exists at `/logos/powforge-x402-lightning.svg`
