### PR TITLE
fix(core): harden token amount validation

### DIFF
--- a/typescript/packages/core/src/utils/index.ts
+++ b/typescript/packages/core/src/utils/index.ts
@@ -47,7 +47,7 @@ export function convertToTokenAmount(decimalAmount: string, decimals: number): s
       `Invalid amount: ${decimalAmount} — use decimal notation, not scientific notation`,
     );
   }
-  if (!/^-?\d+\.?\d*$/.test(decimalAmount)) {
+  if (!isPlainDecimalAmount(decimalAmount)) {
     throw new Error(`Invalid amount: ${decimalAmount}`);
   }
   const [intPart, decPart = ""] = decimalAmount.split(".");
@@ -59,6 +59,53 @@ export function convertToTokenAmount(decimalAmount: string, decimals: number): s
     );
   }
   return tokenAmount;
+}
+
+/**
+ * Validates a plain decimal string with a linear scan to avoid regex backtracking.
+ */
+function isPlainDecimalAmount(decimalAmount: string): boolean {
+  if (decimalAmount.length === 0) {
+    return false;
+  }
+
+  let index = decimalAmount.startsWith("-") ? 1 : 0;
+  if (index === decimalAmount.length) {
+    return false;
+  }
+
+  let hasIntegerDigit = false;
+  while (index < decimalAmount.length) {
+    const charCode = decimalAmount.charCodeAt(index);
+    if (charCode < 48 || charCode > 57) {
+      break;
+    }
+    hasIntegerDigit = true;
+    index++;
+  }
+
+  if (!hasIntegerDigit) {
+    return false;
+  }
+
+  if (index === decimalAmount.length) {
+    return true;
+  }
+
+  if (decimalAmount[index] !== ".") {
+    return false;
+  }
+
+  index++;
+  while (index < decimalAmount.length) {
+    const charCode = decimalAmount.charCodeAt(index);
+    if (charCode < 48 || charCode > 57) {
+      return false;
+    }
+    index++;
+  }
+
+  return true;
 }
 
 /**

--- a/typescript/packages/core/test/unit/utils/utils.test.ts
+++ b/typescript/packages/core/test/unit/utils/utils.test.ts
@@ -361,6 +361,11 @@ describe("Utils", () => {
         expect(convertToTokenAmount("0.1000000", 7)).toBe("1000000");
       });
 
+      it("should handle trailing decimal points", () => {
+        expect(convertToTokenAmount("1.", 6)).toBe("1000000");
+        expect(convertToTokenAmount("0.", 6)).toBe("0");
+      });
+
       it("should handle negative numbers", () => {
         expect(convertToTokenAmount("-1.5", 6)).toBe("-1500000");
       });
@@ -419,6 +424,22 @@ describe("Utils", () => {
         expect(() => convertToTokenAmount("abc", 6)).toThrow("Invalid amount");
         expect(() => convertToTokenAmount("", 6)).toThrow("Invalid amount");
         expect(() => convertToTokenAmount("NaN", 6)).toThrow("Invalid amount");
+      });
+
+      it("should throw for malformed decimal strings", () => {
+        expect(() => convertToTokenAmount(".5", 6)).toThrow("Invalid amount");
+        expect(() => convertToTokenAmount("+1", 6)).toThrow("Invalid amount");
+        expect(() => convertToTokenAmount("-", 6)).toThrow("Invalid amount");
+        expect(() => convertToTokenAmount("1.2.3", 6)).toThrow("Invalid amount");
+        expect(() => convertToTokenAmount("1 ", 6)).toThrow("Invalid amount");
+      });
+
+      it("should reject long adversarial invalid strings", () => {
+        const longIntegerWithSuffix = `${"0".repeat(10000)}x`;
+        const longDecimalWithSuffix = `0.${"0".repeat(10000)}x`;
+
+        expect(() => convertToTokenAmount(longIntegerWithSuffix, 6)).toThrow("Invalid amount");
+        expect(() => convertToTokenAmount(longDecimalWithSuffix, 6)).toThrow("Invalid amount");
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes #2090.

Replaces the decimal validation regex in `convertToTokenAmount()` with a linear validator to avoid ReDoS-style backtracking on long invalid input.

## Changes

- Preserve valid integer, decimal, trailing-decimal, and negative amount behavior.
- Keep rejecting scientific notation and malformed numeric strings.
- Add regression coverage for long adversarial invalid input.

## Tests

- `git diff --check`
- Not run: `pnpm --filter @x402/core test -- test/unit/utils/utils.test.ts` because local Node is v18.19.1 and pnpm requires Node v22.13+
- Not run: `pnpm --filter @x402/core lint:check` because local Node is v18.19.1 and pnpm requires Node v22.13+
- Not run: `pnpm --filter @x402/core format:check` because local Node is v18.19.1 and pnpm requires Node v22.13+
- Not run: `pnpm --filter @x402/core build` because local Node is v18.19.1 and pnpm requires Node v22.13+