### PR TITLE
fix(examples/ts): align custom client env vars with .env-local

### DIFF
--- a/examples/typescript/clients/custom/index.ts
+++ b/examples/typescript/clients/custom/index.ts
@@ -29,8 +29,9 @@ config();
 
 const evmPrivateKey = process.env.EVM_PRIVATE_KEY as `0x${string}`;
 const svmPrivateKey = process.env.SVM_PRIVATE_KEY as string;
-const baseURL = process.env.SERVER_URL || "http://localhost:4021";
-const url = `${baseURL}/weather`;
+const baseURL = process.env.RESOURCE_SERVER_URL || "http://localhost:4021";
+const endpointPath = process.env.ENDPOINT_PATH || "/weather";
+const url = `${baseURL}${endpointPath}`;
 
 /**
  * Makes a request with x402 payment handling.


### PR DESCRIPTION
## Description

The TypeScript custom client example at `examples/typescript/clients/custom/index.ts` reads `process.env.SERVER_URL` (which is not declared in this example's `.env-local`) and hardcodes the path `/weather`. As a result, developers following the `.env-local` template see no effect from their edits: the env-var fallback `http://localhost:4021` always wins, and the path is unconfigurable despite `.env-local` providing `ENDPOINT_PATH`.

Every other client example in the same directory (`fetch/`, `axios/`) already uses the canonical three-line pattern. This PR aligns the custom client with that pattern:

```ts
const baseURL = process.env.RESOURCE_SERVER_URL || "http://localhost:4021";
const endpointPath = process.env.ENDPOINT_PATH || "/weather";
const url = `${baseURL}${endpointPath}`;
```

The new three-line block is byte-identical to `examples/typescript/clients/fetch/index.ts:15-17` and `examples/typescript/clients/axios/index.ts:16-18`. No other changes to the file, the example README, or `.env-local`.

**Disclosure**: this change was prepared with the help of an AI coding assistant. The diff was independently reviewed and verified line-for-line against the canonical sibling pattern before commit.

## Tests

There are no tests in `examples/typescript/clients/custom/` (it ships as a runnable `tsx` example, not a build target). Local verification performed against `main`:

- `pnpm install` from `examples/typescript/`: exit 0
- `pnpm-lock.yaml` diff vs `main`: empty (passes `check_package_lock.yml`)
- Prettier check on the changed file (LF line endings, matching Linux CI): clean
- ESLint on the changed file (LF line endings): clean
- Byte-for-byte equality of the new 3-line block against `fetch/index.ts:15-17` and `axios/index.ts:16-18`: confirmed

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (skipped: examples are not published as a package)
