### PR TITLE
feat(ecosystem): add EZ Path service and facilitator

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/ez-path-facilitator/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/ez-path-facilitator/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "EZ Path Facilitator",
+  "description": "Self-hosted x402 facilitator on Base mainnet (eip155:8453). Supports verify, settle, and supported endpoints for autonomous agent payments in USDC.",
+  "logoUrl": "/logos/ez-path.svg",
+  "websiteUrl": "https://ezpath.myezverse.xyz",
+  "category": "Facilitators",
+  "facilitator": {
+    "baseUrl": "https://ezpath.myezverse.xyz/facilitator",
+    "networks": ["base"],
+    "schemes": ["exact"],
+    "assets": ["USDC"],
+    "supports": {
+      "verify": true,
+      "settle": true,
+      "supported": true,
+      "list": false
+    }
+  }
+}

--- a/typescript/site/app/ecosystem/partners-data/ez-path/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/ez-path/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "EZ Path",
+  "description": "Best-execution DEX aggregator on Base mainnet built for AI agents. Races 0x, ParaSwap, Aerodrome, and Uniswap V3 simultaneously and returns the highest buyAmount for $0.03 USDC per call.",
+  "logoUrl": "/logos/ez-path.svg",
+  "websiteUrl": "https://ezpath.myezverse.xyz",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/ez-path.svg
+++ b/typescript/site/public/logos/ez-path.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="none">
+  <rect width="256" height="256" rx="48" fill="#2563EB"/>
+  <!-- E -->
+  <rect x="44" y="72" width="56" height="12" rx="4" fill="white"/>
+  <rect x="44" y="122" width="44" height="12" rx="4" fill="white"/>
+  <rect x="44" y="172" width="56" height="12" rx="4" fill="white"/>
+  <rect x="44" y="72" width="12" height="112" rx="4" fill="white"/>
+  <!-- Z -->
+  <rect x="120" y="72" width="92" height="12" rx="4" fill="white"/>
+  <rect x="120" y="172" width="92" height="12" rx="4" fill="white"/>
+  <rect x="155" y="84" width="12" height="88" rx="4" transform="rotate(45 155 84)" fill="white"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds EZ Path to the x402 ecosystem in two categories:

**Services/Endpoints** (`ez-path/`)
- Best-execution DEX aggregator on Base mainnet
- Races 0x, ParaSwap, Aerodrome, and Uniswap V3 simultaneously
- $0.03 USDC per call via x402
- Endpoint: https://ezpath.myezverse.xyz/api/v1/quote

**Facilitators** (`ez-path-facilitator/`)
- Self-hosted x402 facilitator for Base mainnet (eip155:8453)
- Supports `/verify`, `/settle`, `/supported`
- Base URL: https://ezpath.myezverse.xyz/facilitator
- Asset: USDC

Logo included as SVG.