### PR TITLE
feat(ecosystem): add Japan Data APIs

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/japan-data-apis/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/japan-data-apis/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Japan Data APIs",
+  "description": "Seven x402-paid APIs for Japan-specific data: address normalization & geocoding, furigana/kana readings, real-time rail delays & routing, National Diet proceedings, public holidays, JMA weather, and the corporate-number registry. Also available as one MCP server (npx @mameta/japan-data-mcp).",
+  "logoUrl": "/logos/japan-data-apis.svg",
+  "websiteUrl": "https://www.npmjs.com/package/@mameta/japan-data-mcp",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/japan-data-apis.svg
+++ b/typescript/site/public/logos/japan-data-apis.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Japan Data APIs logo">
+  <rect width="256" height="256" rx="36" fill="#0f172a"/>
+  <circle cx="128" cy="100" r="34" fill="#e11d48"/>
+  <path d="M84 168h88v16H84zm0 30h88v16H84z" fill="#f8fafc"/>
+  <circle cx="68" cy="176" r="7" fill="#22d3ee"/>
+  <circle cx="68" cy="206" r="7" fill="#22d3ee"/>
+</svg>


### PR DESCRIPTION
## Description

Adds **Japan Data APIs** to the ecosystem list — seven x402-paid APIs for
Japan-specific data:

- Address normalization & geocoding
- Furigana / kana readings
- Real-time rail delays & routing
- National Diet proceedings search
- Public holidays
- JMA weather forecasts
- Corporate-number registry lookup

All seven are live on Base mainnet and also distributed as a single MCP
server, [`@mameta/japan-data-mcp`](https://www.npmjs.com/package/@mameta/japan-data-mcp)
(v1.0.0 on npm).

Changes are limited to one new directory under `partners-data/` plus its
logo — the ecosystem page's directory loader picks it up automatically.

- `typescript/site/app/ecosystem/partners-data/japan-data-apis/metadata.json`
- `typescript/site/public/logos/japan-data-apis.svg`

`category` is `Services/Endpoints`, matching sibling callable-paid-API
entries.

## Tests

Docs/data-only change — no SDK code touched. Verified:

- `metadata.json` parses as valid JSON and matches the `Partner` shape in
  `app/ecosystem/data.ts`.
- `logoUrl` path resolves to the added SVG under `public/logos/`.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
