### PR TITLE
feat(core): add onUncertainSettlement hook to x402Facilitator

### DIFF
--- a/typescript/.changeset/twenty-squids-tie.md
+++ b/typescript/.changeset/twenty-squids-tie.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Add `onUncertainSettlement` facilitator hook for observing unrecovered settlement failures with structured metadata.

--- a/typescript/packages/core/src/facilitator/x402Facilitator.ts
+++ b/typescript/packages/core/src/facilitator/x402Facilitator.ts
@@ -1,5 +1,5 @@
 import { x402Version } from "..";
-import { SettleResponse, VerifyResponse } from "../types/facilitator";
+import { SettleResponse, SettleError, VerifyResponse } from "../types/facilitator";
 import { FacilitatorExtension } from "../types/extensions";
 import { SchemeNetworkFacilitator, FacilitatorContext } from "../types/mechanisms";
 import { PaymentPayload, PaymentRequirements } from "../types/payments";
@@ -36,6 +36,20 @@ export interface FacilitatorSettleFailureContext extends FacilitatorSettleContex
   error: Error;
 }
 
+export interface FacilitatorUncertainSettlementContext {
+  paymentPayload: PaymentPayload;
+  requirements: PaymentRequirements;
+  payer?: string;
+  payTo: string;
+  value: string;
+  nonce?: string;
+  txHash?: string;
+  validBefore?: number;
+  network: Network;
+  facilitatorResponse?: SettleResponse;
+  error: Error;
+}
+
 /**
  * Facilitator Hook Type Definitions
  */
@@ -60,6 +74,10 @@ export type FacilitatorOnSettleFailureHook = (
   context: FacilitatorSettleFailureContext,
 ) => Promise<void | { recovered: true; result: SettleResponse }>;
 
+export type FacilitatorOnUncertainSettlementHook = (
+  context: FacilitatorUncertainSettlementContext,
+) => void | Promise<void>;
+
 /**
  * Facilitator client for the x402 payment protocol.
  * Manages payment scheme registration, verification, and settlement.
@@ -77,6 +95,7 @@ export class x402Facilitator {
   private beforeSettleHooks: FacilitatorBeforeSettleHook[] = [];
   private afterSettleHooks: FacilitatorAfterSettleHook[] = [];
   private onSettleFailureHooks: FacilitatorOnSettleFailureHook[] = [];
+  private onUncertainSettlementHooks: FacilitatorOnUncertainSettlementHook[] = [];
 
   /**
    * Registers a scheme facilitator for the current x402 version.
@@ -206,6 +225,19 @@ export class x402Facilitator {
    */
   onSettleFailure(hook: FacilitatorOnSettleFailureHook): x402Facilitator {
     this.onSettleFailureHooks.push(hook);
+    return this;
+  }
+
+  /**
+   * Register a hook to execute when settlement fails and onSettleFailure hooks
+   * cannot recover. Fires with structured metadata for downstream reconciliation.
+   * Hook errors are caught and never break the main settlement response.
+   *
+   * @param hook - The hook function to register
+   * @returns The x402Facilitator instance for chaining
+   */
+  onUncertainSettlement(hook: FacilitatorOnUncertainSettlementHook): x402Facilitator {
+    this.onUncertainSettlementHooks.push(hook);
     return this;
   }
 
@@ -482,6 +514,20 @@ export class x402Facilitator {
         }
       }
 
+      // Fire onUncertainSettlement hooks — settlement is uncertain
+      const uncertainContext = this.buildUncertainSettlementContext(
+        paymentPayload,
+        paymentRequirements,
+        error as Error,
+      );
+      for (const hook of this.onUncertainSettlementHooks) {
+        try {
+          await hook(uncertainContext);
+        } catch {
+          // Hook errors must not break main payment response
+        }
+      }
+
       throw error;
     }
   }
@@ -500,6 +546,66 @@ export class x402Facilitator {
       ): T | undefined {
         return extensionsMap.get(key) as T | undefined;
       },
+    };
+  }
+
+  /**
+   * Builds an UncertainSettlementContext from payment and error data.
+   * Extracts payer, nonce, txHash, and validBefore from the payload
+   * without deriving values from policy fields.
+   *
+   * @param paymentPayload - The payment payload being settled
+   * @param paymentRequirements - The payment requirements
+   * @param error - The error thrown during settlement
+   * @returns Structured metadata for downstream reconciliation
+   */
+  private buildUncertainSettlementContext(
+    paymentPayload: PaymentPayload,
+    paymentRequirements: PaymentRequirements,
+    error: Error,
+  ): FacilitatorUncertainSettlementContext {
+    const isSettleError =
+      error instanceof SettleError ||
+      ("errorReason" in error && "transaction" in error && "network" in error);
+
+    const payloadRecord = paymentPayload.payload as Record<string, unknown>;
+
+    const payer = isSettleError
+      ? (error as SettleError).payer
+      : typeof payloadRecord?.from === "string"
+        ? (payloadRecord.from as string)
+        : undefined;
+
+    const txHash = isSettleError ? (error as SettleError).transaction : undefined;
+
+    let facilitatorResponse: SettleResponse | undefined;
+    if (isSettleError) {
+      const se = error as SettleError;
+      facilitatorResponse = {
+        success: false,
+        errorReason: se.errorReason,
+        errorMessage: se.errorMessage,
+        transaction: se.transaction,
+        network: se.network,
+        payer: se.payer,
+      };
+    }
+
+    const nonceCandidate = payloadRecord?.nonce ?? payloadRecord?.salt;
+    const validBeforeCandidate = payloadRecord?.validBefore ?? payloadRecord?.deadline;
+
+    return {
+      paymentPayload,
+      requirements: paymentRequirements,
+      payer,
+      payTo: paymentRequirements.payTo,
+      value: paymentRequirements.amount,
+      nonce: typeof nonceCandidate === "string" ? nonceCandidate : undefined,
+      txHash,
+      validBefore: typeof validBeforeCandidate === "number" ? validBeforeCandidate : undefined,
+      network: paymentRequirements.network,
+      facilitatorResponse,
+      error,
     };
   }
 

--- a/typescript/packages/core/test/unit/facilitator/x402Facilitator.hooks.test.ts
+++ b/typescript/packages/core/test/unit/facilitator/x402Facilitator.hooks.test.ts
@@ -326,9 +326,160 @@ describe("x402Facilitator - Lifecycle Hooks", () => {
         .onVerifyFailure(async () => {})
         .onBeforeSettle(async () => {})
         .onAfterSettle(async () => {})
-        .onSettleFailure(async () => {});
+        .onSettleFailure(async () => {})
+        .onUncertainSettlement(async () => {});
 
       expect(result).toBe(facilitator);
+    });
+
+    it("should support sync hook for onUncertainSettlement", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(undefined, async () => {
+        throw new Error("Settlement failed");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      let hookFired = false;
+      facilitator.onUncertainSettlement(() => {
+        hookFired = true;
+      });
+
+      await expect(
+        facilitator.settle(buildPaymentPayload(), buildPaymentRequirements()),
+      ).rejects.toThrow("Settlement failed");
+
+      expect(hookFired).toBe(true);
+    });
+  });
+
+  describe("onUncertainSettlement", () => {
+    it("should fire when settlement fails and is not recovered", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(undefined, async () => {
+        throw new Error("Settlement failed");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      let capturedContext: any = undefined;
+      facilitator.onUncertainSettlement(async context => {
+        capturedContext = context;
+      });
+
+      await expect(
+        facilitator.settle(buildPaymentPayload(), buildPaymentRequirements()),
+      ).rejects.toThrow("Settlement failed");
+
+      expect(capturedContext).toBeDefined();
+      expect(capturedContext.payTo).toBe("0xRecipient");
+      expect(capturedContext.value).toBe("1000000");
+      expect(capturedContext.network).toBe("eip155:8453");
+      expect(capturedContext.error.message).toBe("Settlement failed");
+      expect(capturedContext.txHash).toBeUndefined();
+      expect(capturedContext.paymentPayload).toBeDefined();
+      expect(capturedContext.requirements).toBeDefined();
+    });
+
+    it("should NOT fire when onSettleFailure recovers", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(undefined, async () => {
+        throw new Error("Settlement failed");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      let hookFired = false;
+      facilitator.onUncertainSettlement(async () => {
+        hookFired = true;
+      });
+
+      facilitator.onSettleFailure(async () => {
+        return {
+          recovered: true,
+          result: {
+            success: true,
+            transaction: "0xRecovered",
+            network: "eip155:8453",
+          },
+        };
+      });
+
+      const result = await facilitator.settle(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.success).toBe(true);
+      expect(hookFired).toBe(false);
+    });
+
+    it("should include canonical identity fields and handle missing txHash", async () => {
+      const facilitator = new x402Facilitator();
+
+      const payload = buildPaymentPayload();
+      payload.payload = { nonce: "42", from: "0xPayer" };
+
+      const mockScheme = new MockSchemeFacilitator(undefined, async () => {
+        throw new Error("Network error");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      let capturedContext: any = undefined;
+      facilitator.onUncertainSettlement(async context => {
+        capturedContext = context;
+      });
+
+      await expect(facilitator.settle(payload, buildPaymentRequirements())).rejects.toThrow(
+        "Network error",
+      );
+
+      expect(capturedContext.payer).toBe("0xPayer");
+      expect(capturedContext.payTo).toBe("0xRecipient");
+      expect(capturedContext.value).toBe("1000000");
+      expect(capturedContext.nonce).toBe("42");
+      expect(capturedContext.txHash).toBeUndefined();
+      expect(capturedContext.network).toBe("eip155:8453");
+      expect(capturedContext.error.message).toBe("Network error");
+    });
+
+    it("should fall back to salt when nonce is absent", async () => {
+      const facilitator = new x402Facilitator();
+
+      const payload = buildPaymentPayload();
+      payload.payload = { salt: "0xSalt", from: "0xPayer" };
+
+      const mockScheme = new MockSchemeFacilitator(undefined, async () => {
+        throw new Error("Network error");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      let capturedContext: any = undefined;
+      facilitator.onUncertainSettlement(async context => {
+        capturedContext = context;
+      });
+
+      await expect(facilitator.settle(payload, buildPaymentRequirements())).rejects.toThrow(
+        "Network error",
+      );
+
+      expect(capturedContext.nonce).toBe("0xSalt");
+    });
+
+    it("should isolate hook errors so settlement flow is not broken", async () => {
+      const facilitator = new x402Facilitator();
+
+      const mockScheme = new MockSchemeFacilitator(undefined, async () => {
+        throw new Error("Settlement failed");
+      });
+      facilitator.register("eip155:8453", mockScheme);
+
+      facilitator.onUncertainSettlement(async () => {
+        throw new Error("Hook exploded");
+      });
+
+      const error = await facilitator
+        .settle(buildPaymentPayload(), buildPaymentRequirements())
+        .catch(e => e);
+
+      expect(error.message).toBe("Settlement failed");
     });
   });
 });


### PR DESCRIPTION
## Description

Adds `onUncertainSettlement` to `x402Facilitator`: a structured metadata hook for settlement timeout or uncertain settlement outcomes.

Relates to [x402 issue #2294](https://github.com/x402-foundation/x402/issues/2294).

## Why

Some settlement flows can enter an uncertain state when facilitator settlement fails, times out, or errors before the application has a final answer. Today there is no stable structured hook for observing those cases.

This hook gives applications enough metadata to persist and reconcile later without adding recovery behavior to x402 core.

## Behavior

```txt
settle() throws
  → run existing onSettleFailure hooks
    → if recovered, return result, do not fire onUncertainSettlement
    → if not recovered, fire onUncertainSettlement hooks
  → rethrow original error
```

Hook errors are caught and isolated. The original settlement error still propagates unchanged.

## Metadata

| Field | Source |
| --- | --- |
| `paymentPayload` | original payment payload |
| `requirements` | payment requirements |
| `payer?` | `SettleError.payer` or `payload.from` |
| `payTo` | `requirements.payTo` |
| `value` | `requirements.amount` |
| `nonce?` | `payload.nonce` |
| `txHash?` | `SettleError.transaction` |
| `validBefore?` | `payload.validBefore` or `payload.deadline` only |
| `network` | `requirements.network` |
| `facilitatorResponse?` | reconstructed from `SettleError` when available |
| `error` | original thrown error |

`txHash` is optional because some failures happen before a transaction hash is available. `validBefore` is only read from explicit authorization payload fields and is not derived from timeout settings.

## Non-goals

This PR only adds an observation hook. It does not add recovery logic, persistence, queues, polling, receipt verification, facilitator-side dedup, or changes to `x402ResourceServer` / `schemeHooks`.

## Future work

If maintainers agree with this hook shape, the same metadata contract can be considered for `x402ResourceServer` / scheme hook orchestration in a follow-up PR.

## Tests

4 unit tests covering:

- Hook fires when `settle()` fails and `onSettleFailure` does not recover
- Hook does not fire when `onSettleFailure` recovers
- Metadata includes canonical identity fields, `txHash` optional
- Hook error isolated, original error still propagates

```txt
pnpm test   → 460 passed, 1 pre-existing flaky timeout
pnpm build  → CJS + ESM + DTS clean
```

## Changelog

`@x402/core` patch: add `onUncertainSettlement` facilitator hook for observing unrecovered settlement failures with structured metadata.

## Checklist

- [x] Formatted and linted clean
- [x] All new and existing tests pass
- [x] Commits signed
- [x] Changelog fragment added

Commit: `d443ba4`