### PR TITLE
fix(ts): replace dynamic fallback paywall with a static template

### DIFF
--- a/typescript/.changeset/static-fallback-paywall.md
+++ b/typescript/.changeset/static-fallback-paywall.md
@@ -1,0 +1,5 @@
+---
+'@x402/core': patch
+---
+
+Replace the dynamic fallback paywall HTML (used when @x402/paywall is not installed) with a static template, eliminating reflected XSS surface from interpolated request URLs and config values.

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -338,6 +338,32 @@ export class RouteConfigurationError extends Error {
   }
 }
 
+// Static fallback paywall served when @x402/paywall is not installed.
+// Intentionally contains zero request- or config-derived interpolation:
+// the protocol-level payment requirements still ship in response headers
+// and the JSON 402 body for non-browser clients, so any agent or SDK can
+// read them without us reflecting attacker-controlled bytes into HTML.
+// Browser-end-user payment requires installing @x402/paywall.
+const FALLBACK_PAYWALL_HTML = `<!DOCTYPE html>
+<html>
+  <head>
+    <title>Payment Required</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <body>
+    <div style="max-width: 600px; margin: 50px auto; padding: 20px; font-family: system-ui, -apple-system, sans-serif;">
+      <h1>Payment Required</h1>
+      <p>This resource is protected by the x402 payment protocol.</p>
+      <p style="margin-top: 2rem; padding: 1rem; background: #fef3c7; border-radius: 0.5rem;">
+        <strong>Note to developers:</strong> install <code>@x402/paywall</code> to enable
+        the in-browser wallet connection and payment UI. Programmatic clients should read
+        the payment requirements from the 402 response headers and JSON body.
+      </p>
+    </div>
+  </body>
+</html>`;
+
 /**
  * HTTP-enhanced x402 resource server
  * Provides framework-agnostic HTTP protocol handling
@@ -1157,50 +1183,7 @@ export class x402HTTPResourceServer {
       // @x402/paywall not installed, fall back to basic HTML
     }
 
-    // Fallback: Basic HTML paywall
-    const resource = paymentRequired.resource;
-    const displayAmount = this.getDisplayAmount(paymentRequired);
-    const firstAccept = paymentRequired.accepts?.[0];
-    const decimals =
-      firstAccept && "amount" in firstAccept
-        ? this.ResourceServer.getAssetDecimalsForRequirements(firstAccept)
-        : 6;
-    const safeDecimals = Math.min(Math.max(decimals, 0), 100);
-    const displayAmountText = parseFloat(displayAmount.toFixed(safeDecimals)).toString();
-    const assetLabel =
-      typeof firstAccept?.extra?.name === "string"
-        ? firstAccept.extra.name
-        : firstAccept?.asset
-          ? `...${firstAccept.asset.slice(-6)}`
-          : "Token";
-
-    return `
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>Payment Required</title>
-          <meta charset="UTF-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        </head>
-        <body>
-          <div style="max-width: 600px; margin: 50px auto; padding: 20px; font-family: system-ui, -apple-system, sans-serif;">
-            ${paywallConfig?.appLogo ? `<img src="${paywallConfig.appLogo}" alt="${paywallConfig.appName || "App"}" style="max-width: 200px; margin-bottom: 20px;">` : ""}
-            <h1>Payment Required</h1>
-            ${resource ? `<p><strong>Resource:</strong> ${resource.description || resource.url}</p>` : ""}
-            <p><strong>Amount:</strong> ${displayAmountText} ${assetLabel}</p>
-            <div id="payment-widget" 
-                 data-requirements='${JSON.stringify(paymentRequired)}'
-                 data-app-name="${paywallConfig?.appName || ""}"
-                 data-testnet="${paywallConfig?.testnet || false}">
-              <!-- Install @x402/paywall for full wallet integration -->
-              <p style="margin-top: 2rem; padding: 1rem; background: #fef3c7; border-radius: 0.5rem;">
-                <strong>Note:</strong> Install <code>@x402/paywall</code> for full wallet connection and payment UI.
-              </p>
-            </div>
-          </div>
-        </body>
-      </html>
-    `;
+    return FALLBACK_PAYWALL_HTML;
   }
 
   /**

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -1051,6 +1051,86 @@ describe("x402HTTPResourceServer", () => {
     });
   });
 
+  describe("Fallback paywall HTML", () => {
+    /**
+     * Render the fallback paywall HTML for a request whose URL contains the
+     * given attacker-controlled tail. Returns the raw response body string.
+     *
+     * @param attackerTail - Attacker-controlled portion of the URL/query string
+     * @param appName - Optional appName from paywall config (developer-controlled,
+     *   but treated as untrusted in multi-tenant deployments).
+     * @returns The HTML body returned by the fallback paywall
+     */
+    async function renderFallbackPaywallFor(
+      attackerTail: string,
+      appName?: string,
+    ): Promise<string> {
+      const routes = {
+        "/api/protected": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00" as Price,
+            network: "eip155:8453" as Network,
+          },
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+      const adapter = new MockHTTPAdapter();
+      adapter.getAcceptHeader = () => "text/html,application/xhtml+xml";
+      adapter.getUserAgent = () => "Mozilla/5.0";
+      adapter.getUrl = () => `https://example.com/api/protected${attackerTail}`;
+
+      const context: HTTPRequestContext = {
+        adapter,
+        path: "/api/protected",
+        method: "GET",
+      };
+
+      const result = await httpServer.processHTTPRequest(
+        context,
+        appName !== undefined ? { appName } : undefined,
+      );
+      if (result.type !== "payment-error" || !result.response.isHtml) {
+        throw new Error(`expected HTML payment-error, got ${JSON.stringify(result)}`);
+      }
+      return String(result.response.body);
+    }
+
+    it("does not reflect any portion of the request URL into the HTML", async () => {
+      const html = await renderFallbackPaywallFor(
+        "?token=ATTACKER_SENTINEL_8a7b6c&x='%3Cscript%3Ealert(1)%3C/script%3E",
+      );
+
+      expect(html).not.toContain("ATTACKER_SENTINEL_8a7b6c");
+      expect(html).not.toContain("<script>");
+      expect(html).not.toContain("alert(1)");
+      expect(html).not.toMatch(/'\s*onfocus/i);
+    });
+
+    it("does not reflect paywallConfig.appName into the HTML", async () => {
+      const html = await renderFallbackPaywallFor("", "TENANT_SENTINEL_x9y8z7\"' onerror=alert(1)");
+
+      expect(html).not.toContain("TENANT_SENTINEL_x9y8z7");
+      expect(html).not.toContain("onerror=alert");
+    });
+
+    it("does not emit a data-requirements attribute (no JSON reflection surface)", async () => {
+      const html = await renderFallbackPaywallFor("?q=anything");
+
+      expect(html).not.toContain("data-requirements");
+    });
+
+    it("still tells the developer to install @x402/paywall", async () => {
+      const html = await renderFallbackPaywallFor("");
+
+      expect(html).toContain("@x402/paywall");
+      expect(html).toMatch(/Payment Required/);
+    });
+  });
+
   describe("Browser detection", () => {
     it("should detect web browser from accept header and user agent", async () => {
       const routes = {

--- a/typescript/packages/http/express/src/fallbackPaywallXss.test.ts
+++ b/typescript/packages/http/express/src/fallbackPaywallXss.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import type { Server } from "node:http";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { x402ResourceServer } from "@x402/core/server";
+import { paymentMiddleware } from "./index";
+
+/**
+ * Issue an HTTP GET to the local server, simulating a real browser
+ * (Accept: text/html + Mozilla User-Agent so the middleware serves the
+ * paywall HTML branch), and return the response body.
+ *
+ * @param port - The local server port.
+ * @param rawPath - The raw HTTP path (already percent-encoded as desired).
+ * @returns The decoded response body as a UTF-8 string.
+ */
+async function fetchHtml(port: number, rawPath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method: "GET",
+        path: rawPath,
+        headers: {
+          Accept: "text/html,application/xhtml+xml",
+          "User-Agent": "Mozilla/5.0",
+        },
+      },
+      res => {
+        const chunks: Buffer[] = [];
+        res.on("data", c => chunks.push(c as Buffer));
+        res.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("express end-to-end: fallback paywall HTML does not reflect attacker input", () => {
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    const app = express();
+    const resourceServer = new x402ResourceServer();
+    app.use(
+      paymentMiddleware(
+        {
+          "/api/protected": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00",
+              network: "eip155:84532",
+            },
+          },
+        },
+        resourceServer,
+        // App config with a sentinel appName that should never be reflected,
+        // since the fallback is fully static.
+        { appName: "TENANT_SENTINEL_q9w8e7\"' onerror=alert(1)" },
+        undefined,
+        false,
+      ),
+    );
+
+    server = app.listen(0);
+    await new Promise<void>(resolve => server.once("listening", () => resolve()));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  });
+
+  it("does not reflect any portion of the request URL into the rendered HTML", async () => {
+    const body = await fetchHtml(
+      port,
+      "/api/protected?token=ATTACKER_SENTINEL_8a7b6c&x='%3Cscript%3Ealert(1)%3C/script%3E",
+    );
+
+    expect(body).not.toContain("ATTACKER_SENTINEL_8a7b6c");
+    expect(body).not.toContain("<script>alert");
+    expect(body).not.toMatch(/'\s*onfocus/i);
+  });
+
+  it("does not reflect the configured appName into the rendered HTML", async () => {
+    const body = await fetchHtml(port, "/api/protected");
+
+    expect(body).not.toContain("TENANT_SENTINEL_q9w8e7");
+    expect(body).not.toContain("onerror=alert");
+  });
+
+  it("does not include a data-requirements attribute (no JSON reflection surface)", async () => {
+    const body = await fetchHtml(port, "/api/protected?q=anything");
+
+    expect(body).not.toContain("data-requirements");
+  });
+
+  it("still tells the developer to install @x402/paywall", async () => {
+    const body = await fetchHtml(port, "/api/protected");
+
+    expect(body).toContain("@x402/paywall");
+    expect(body).toMatch(/Payment Required/);
+  });
+});


### PR DESCRIPTION
## Description

The fallback HTML served when `@x402/paywall` is not installed interpolated request- and config-derived strings into HTML attributes and body text without escaping. The most direct attack: `paymentRequired.resource.url` is sourced from `adapter.getUrl()`, which returns the raw request URL. An apostrophe in that URL broke out of the single-quoted `data-requirements` attribute and could inject event handlers (e.g. `onfocus`/`autofocus`). The same template also rendered `resource.url` as raw HTML body text and relied on `JSON.stringify` to be HTML-safe (it is not).

Per-site HTML escaping would close the immediate bug but leaves the template load-bearing on developer discipline forever, plus residual surface for `javascript:`/`data:` URLs in `paywallConfig.appLogo` and any future interpolation that forgets to escape.

Replace the entire fallback body with a static template that contains zero interpolation. Programmatic clients still get the payment requirements via the 402 status, response headers, and JSON body (unchanged); browser-based payment requires installing `@x402/paywall`, which the page tells the developer to do.

## Tests

- `pnpm run test` from `/typescript` — full suite passes.
- New unit tests under `packages/core/test/unit/http/x402HTTPResourceService.test.ts` assert no portion of the request URL, the `paywallConfig.appName`, or a `data-requirements` attribute survives into the rendered HTML.
- New end-to-end test under `packages/http/express/src/fallbackPaywallXss.test.ts` mounts the real middleware against a live HTTP server and confirms the same against actual browser-shaped requests.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
