### PR TITLE
fix(ts): preserve encoded path separators in normalizePath

### DIFF
--- a/typescript/.changeset/preserve-encoded-path-separators.md
+++ b/typescript/.changeset/preserve-encoded-path-separators.md
@@ -1,0 +1,5 @@
+---
+'@x402/core': patch
+---
+
+Preserve %2F/%5C in normalizePath so encoded path separators can no longer hide segment boundaries from :param route regexes, closing a paywall bypass on requests like /api/report/a%2Fb.

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1102,14 +1102,24 @@ export class x402HTTPResourceServer {
   private normalizePath(path: string): string {
     const pathWithoutQuery = path.split(/[?#]/)[0];
 
-    let decodedOrRawPath: string;
-    try {
-      decodedOrRawPath = decodeURIComponent(pathWithoutQuery);
-    } catch {
-      decodedOrRawPath = pathWithoutQuery;
-    }
+    // Decode percent-escapes per segment, preserving encoded path separators
+    // (%2F, %5C) as their literal escaped form. Otherwise an attacker could
+    // hide a "/" inside a single segment (e.g. /api/report/a%2Fb), bypassing
+    // a :param route whose regex compiles to [^/]+ while the framework still
+    // dispatches the request as a single-segment match.
+    const parts = pathWithoutQuery.split(/(%2[fF]|%5[cC])/);
+    const decoded = parts
+      .map((part, i) => {
+        if (i % 2 === 1) return part;
+        try {
+          return decodeURIComponent(part);
+        } catch {
+          return part;
+        }
+      })
+      .join("");
 
-    return decodedOrRawPath
+    return decoded
       .replace(/\\/g, "/")
       .replace(/\/+/g, "/")
       .replace(/(.+?)\/+$/, "$1");

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -630,6 +630,118 @@ describe("x402HTTPResourceServer", () => {
         expect(httpServer.requiresPayment(context)).toBe(true);
       });
     });
+
+    describe("encoded path separators", () => {
+      it("should require payment when an encoded slash hides inside a :param segment", async () => {
+        const routes = {
+          "/api/report/:id": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/report/a%2Fb",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(result.type).toBe("payment-error");
+      });
+
+      it("should require payment for lowercase %2f as well", async () => {
+        const routes = {
+          "/api/report/:id": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/report/a%2fb",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(result.type).toBe("payment-error");
+      });
+
+      it.each([
+        ["uppercase %5C", "/api/report/a%5Cb"],
+        ["lowercase %5c", "/api/report/a%5cb"],
+      ])(
+        "should require payment when an encoded backslash hides inside a :param segment (%s)",
+        async (_, path) => {
+          const routes = {
+            "/api/report/:id": {
+              accepts: {
+                scheme: "exact",
+                payTo: "0xabc",
+                price: "$1.00" as Price,
+                network: "eip155:8453" as Network,
+              },
+            },
+          };
+
+          const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+          const adapter = new MockHTTPAdapter();
+          const context: HTTPRequestContext = {
+            adapter,
+            path,
+            method: "GET",
+          };
+
+          const result = await httpServer.processHTTPRequest(context);
+
+          expect(result.type).toBe("payment-error");
+        },
+      );
+
+      it("should still decode non-separator percent-escapes for non-ASCII route patterns", async () => {
+        const routes = {
+          "/api/categoría/:id": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/categor%C3%ADa/42",
+          method: "GET",
+        };
+
+        const result = await httpServer.processHTTPRequest(context);
+
+        expect(result.type).toBe("payment-error");
+      });
+    });
   });
 
   describe("Payment processing", () => {

--- a/typescript/packages/http/express/src/encodedPathBypass.test.ts
+++ b/typescript/packages/http/express/src/encodedPathBypass.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import type { Server } from "node:http";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { x402ResourceServer } from "@x402/core/server";
+import { paymentMiddleware } from "./index";
+
+/**
+ * Issue a single HTTP GET to the given port + raw path and return the
+ * response status. The path is sent verbatim — Node does not re-encode
+ * it — which is exactly what an attacker on the wire could do.
+ *
+ * @param port - The local server port.
+ * @param rawPath - The raw HTTP path (already percent-encoded as desired).
+ * @returns The response status code.
+ */
+async function statusFor(port: number, rawPath: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, method: "GET", path: rawPath }, res => {
+      res.resume();
+      res.on("end", () => resolve(res.statusCode ?? 0));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("express end-to-end: encoded path separator", () => {
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    const app = express();
+    const resourceServer = new x402ResourceServer();
+    app.use(
+      paymentMiddleware(
+        {
+          "/api/report/:id": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00",
+              network: "eip155:84532",
+            },
+          },
+        },
+        resourceServer,
+        undefined,
+        undefined,
+        // syncFacilitatorOnStart=false so the test does not try to call a real facilitator
+        false,
+      ),
+    );
+    // Catch-all so an unprotected route returns 200, not 404, letting us
+    // tell "middleware skipped the route" apart from "framework 404".
+    app.use((_req, res) => res.status(200).send("ok"));
+
+    server = app.listen(0);
+    await new Promise<void>(resolve => server.once("listening", () => resolve()));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  });
+
+  it("returns 402 for a baseline single-segment :id", async () => {
+    expect(await statusFor(port, "/api/report/baseline")).toBe(402);
+  });
+
+  it("returns 402 even when the :id segment contains %2F (uppercase)", async () => {
+    expect(await statusFor(port, "/api/report/a%2Fb")).toBe(402);
+  });
+
+  it("returns 402 even when the :id segment contains %2f (lowercase)", async () => {
+    expect(await statusFor(port, "/api/report/a%2fb")).toBe(402);
+  });
+
+  it("returns 402 even when the :id segment contains %5C (encoded backslash)", async () => {
+    expect(await statusFor(port, "/api/report/a%5Cb")).toBe(402);
+  });
+
+  it("returns 200 (middleware skipped) for an unrelated path", async () => {
+    expect(await statusFor(port, "/health")).toBe(200);
+  });
+});


### PR DESCRIPTION
## Description

`normalizePath` calls `decodeURIComponent` on the request path before matching it against compiled route regexes. Every framework adapter in this repo (Express `req.path`, Fastify `request.url`, Hono `c.req.path`, Next `nextUrl.pathname`) returns the raw undecoded path and the frameworks themselves dispatch on the raw path. So a request like `/api/report/a%2Fb` is routed to `/api/report/:id` by the framework, but the middleware decodes it to `/api/report/a/b` — three segments — and the `:param` regex (`[^/]+`) fails to match, returning `no-payment-required`. The protected handler then runs without payment.

Decode percent-escapes per segment, treating `%2F`/`%2f`/`%5C`/`%5c` as opaque tokens that survive normalization. Segment count is preserved for the route regex, and everything else still decodes so existing patterns that contain literal non-ASCII characters keep matching their percent-encoded request paths.

## Tests

- `pnpm run test` from `/typescript` — full suite passes.
- New unit tests under `packages/core/test/unit/http/x402HTTPResourceService.test.ts` cover encoded slash (both cases), encoded backslash (both cases), and a non-ASCII pattern as a guard against the simpler "drop decoding entirely" approach.
- New end-to-end test under `packages/http/express/src/encodedPathBypass.test.ts` mounts the real middleware against a live HTTP server and confirms `%2F`-encoded paths return 402.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
