### PR TITLE
fix(python-legacy): html-safe JSON serialization in paywall script tag

### DIFF
--- a/python/legacy/src/x402/paywall.py
+++ b/python/legacy/src/x402/paywall.py
@@ -7,6 +7,22 @@ from x402.evm_paywall_template import EVM_PAYWALL_TEMPLATE
 from x402.svm_paywall_template import SVM_PAYWALL_TEMPLATE
 
 
+# Escape characters that have special meaning when JSON is embedded in a
+# <script> block. Without this, an attacker-controlled string containing
+# `</script>` (e.g. via the request URL that becomes payment_requirements.resource)
+# closes the script tag and lets arbitrary HTML/JS run on the merchant's origin.
+_JSON_SCRIPT_ESCAPES = {
+    ord(">"): "\\u003E",
+    ord("<"): "\\u003C",
+    ord("&"): "\\u0026",
+}
+
+
+def _htmlsafe_json_dumps(obj: Any) -> str:
+    """Serialize ``obj`` to JSON safe for inline ``<script>`` embedding."""
+    return json.dumps(obj).translate(_JSON_SCRIPT_ESCAPES)
+
+
 def get_paywall_template(network: str) -> str:
     """Get the appropriate paywall template for the given network."""
     if network.startswith("solana:"):
@@ -96,7 +112,7 @@ def inject_payment_data(
 
     config_script = f"""
   <script>
-    window.x402 = {json.dumps(x402_config)};
+    window.x402 = {_htmlsafe_json_dumps(x402_config)};
     {log_on_testnet}
   </script>"""
 

--- a/python/legacy/tests/fastapi_tests/test_paywall_xss.py
+++ b/python/legacy/tests/fastapi_tests/test_paywall_xss.py
@@ -1,0 +1,102 @@
+"""End-to-end regression test for CDPAI-1054 / ANT-2026-21985.
+
+The require_payment middleware fills the paywall's `resource` field with
+`str(request.url)`. Without HTML-safe JSON encoding, an attacker who
+lures a victim to a URL containing `</script>` closes the inline
+<script> tag and runs arbitrary JavaScript on the merchant origin.
+
+This test drives the FULL flow: real FastAPI + real middleware + real
+TestClient request. It does not poke at internal helpers.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from x402.fastapi.middleware import require_payment
+
+
+async def _ok():
+    return {"message": "success"}
+
+
+def _build_client() -> TestClient:
+    app = FastAPI()
+    app.get("/api/{tail:path}")(_ok)
+    app.middleware("http")(
+        require_payment(
+            price="$1.00",
+            pay_to_address="0x1111111111111111111111111111111111111111",
+            network="base-sepolia",
+            description="Test payment",
+        )
+    )
+    return TestClient(app)
+
+
+def _inline_script_body(html: str) -> str:
+    """Return the JSON literal assigned to window.x402, untrimmed."""
+    marker = "window.x402 = "
+    start = html.index(marker) + len(marker)
+    end = html.index(";\n", start)
+    return html[start:end]
+
+
+def test_paywall_html_does_not_let_resource_url_close_the_script_tag():
+    client = _build_client()
+    # Hostile path: contains </script> and an XSS payload that would fire
+    # if the script tag is successfully closed.
+    response = client.get(
+        "/api/protected</script><img src=x onerror=alert(1)>",
+        headers={
+            "Accept": "text/html",
+            "User-Agent": "Mozilla/5.0",
+        },
+    )
+
+    assert response.status_code == 402
+    body = response.text
+    # The browser-served paywall HTML must contain an inline window.x402 block.
+    assert "window.x402 = " in body
+    # The raw </script> from the URL must not survive into the rendered HTML
+    # (anywhere — but especially not inside the inline script body).
+    assert "</script><img" not in body
+    script_body = _inline_script_body(body)
+    assert "<" not in script_body
+    assert ">" not in script_body
+
+
+def test_paywall_html_escapes_lt_gt_amp_in_url():
+    client = _build_client()
+    response = client.get(
+        "/api/protected?q=<script>alert(1)</script>&x=&amp;",
+        headers={
+            "Accept": "text/html",
+            "User-Agent": "Mozilla/5.0",
+        },
+    )
+
+    assert response.status_code == 402
+    script_body = _inline_script_body(response.text)
+    assert "<" not in script_body
+    assert ">" not in script_body
+    assert "&" not in script_body
+
+
+def test_paywall_html_json_still_round_trips_after_escaping():
+    import json
+
+    client = _build_client()
+    response = client.get(
+        "/api/protected/foo</script>?q=<>&amp;",
+        headers={
+            "Accept": "text/html",
+            "User-Agent": "Mozilla/5.0",
+        },
+    )
+
+    assert response.status_code == 402
+    config = json.loads(_inline_script_body(response.text))
+    # The escaped JSON must still parse back to the original characters,
+    # so the in-page JavaScript can read the values verbatim.
+    assert "</script>" in config["currentUrl"]
+    assert "</script>" in config["paymentRequirements"][0]["resource"]

--- a/python/legacy/tests/test_paywall.py
+++ b/python/legacy/tests/test_paywall.py
@@ -228,6 +228,67 @@ class TestInjectPaymentData:
         assert script_pos < head_end_pos
 
 
+class TestInjectPaymentDataXSS:
+    """Regression tests: attacker-controlled fields must not break out of <script>."""
+
+    @staticmethod
+    def _build(resource: str, error: str = "Payment required") -> str:
+        payment_req = PaymentRequirements(
+            scheme="exact",
+            network="base-sepolia",
+            max_amount_required="1000000",
+            resource=resource,
+            description="Test",
+            mime_type="application/json",
+            pay_to="0x123",
+            max_timeout_seconds=60,
+            asset="0xUSDC",
+        )
+        html = "<html><head><title>t</title></head><body></body></html>"
+        return inject_payment_data(html, error, [payment_req])
+
+    @staticmethod
+    def _extract_inline_script(result: str) -> str:
+        """Return the JSON literal assigned to window.x402, untrimmed."""
+        marker = "window.x402 = "
+        start = result.index(marker) + len(marker)
+        # The inline script is built as `window.x402 = <json>;\n    {log_or_blank}\n  </script>`.
+        # The JSON literal is everything up to the first `;\n` after the marker.
+        end = result.index(";\n", start)
+        return result[start:end]
+
+    def test_script_close_tag_in_resource_url_is_escaped(self):
+        # An attacker who lures a victim to a URL with </script> in the path
+        # would otherwise close the inline <script> and inject arbitrary HTML.
+        result = self._build(
+            "https://example.com/foo</script><img src=x onerror=alert(1)>"
+        )
+
+        # The raw closing tag must not survive into the rendered HTML.
+        assert "</script><img" not in result
+        # And no literal < or > may appear inside the inline script body.
+        script_json = self._extract_inline_script(result)
+        assert "<" not in script_json
+        assert ">" not in script_json
+
+    def test_lt_gt_amp_escaped_inside_script_block(self):
+        result = self._build("https://example.com/?q=<script>alert(1)</script>&x=&amp;")
+
+        script_json = self._extract_inline_script(result)
+        assert "<" not in script_json
+        assert ">" not in script_json
+        assert "&" not in script_json
+
+    def test_escaped_json_still_round_trips(self):
+        import json as _json
+
+        url = "https://example.com/foo</script>?q=<>&amp;"
+        result = self._build(url)
+        config = _json.loads(self._extract_inline_script(result))
+        assert config["currentUrl"] == url
+        assert config["paymentRequirements"][0]["resource"] == url
+
+
 class TestGetPaywallHtml:
     """Test the main paywall HTML generation function."""
 


### PR DESCRIPTION
## Description

The legacy x402 paywall embeds payment configuration into the page via `window.x402 = {json.dumps(x402_config)};` inside a `<script>` block. `json.dumps` does not escape `<`, `>`, or `&`, so a `</script>` sequence inside any string field closes the script tag and lets an attacker run arbitrary JavaScript on the merchant's origin. The `resource` field is populated from `str(request.url)` in the FastAPI and Flask middleware, so a victim who follows a crafted link is sufficient to trigger this.

Add a private `_htmlsafe_json_dumps` mirroring the helper that already exists in the v2 (non-legacy) tree at `python/x402/http/utils.py`: escape `<`, `>`, `&` to their `^@XXXX` forms after `json.dumps`. Use it for the inline-script payload.

## Tests

- `uv run pytest` from `python/legacy/` — full suite passes.
- New regression tests under `python/legacy/tests/test_paywall.py` drive `inject_payment_data` with payloads containing `</script>`, raw `<`, `>`, `&`, and assert none of those characters appear inside the inline script body and that the escaped JSON still parses back to the original values.
- New end-to-end test under `python/legacy/tests/fastapi_tests/test_paywall_xss.py` mounts the real `require_payment` middleware against a `TestClient` request to confirm the same behavior through the full middleware path.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip) — N/A: `python/legacy` has no changelog convention (no `CHANGELOG.md`, no towncrier config; PR template only covers `python/x402` v2)
