### PR TITLE
fix(evm/batch-settlement): submit settle() with an explicit gas limit

### DIFF
--- a/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/settle.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/settle.ts
@@ -7,6 +7,24 @@ import { BATCH_SETTLEMENT_ADDRESS } from "../constants";
 import * as Errors from "../errors";
 
 /**
+ * Explicit gas limit for the `settle` transaction.
+ *
+ * `settle` auto-estimation is unsafe: the on-chain `settle` is bimodal — it
+ * early-returns (~25.5k gas) when `totalClaimed == totalSettled`, and performs
+ * an SSTORE plus an ERC-20 transfer (~57k gas) otherwise. The `eth_estimateGas`
+ * viem runs for `writeContract` is an independent RPC call that can resolve
+ * against a node whose state has not yet caught up to the just-mined `claim`;
+ * it then estimates the early-return path and the transaction is broadcast
+ * under-gassed, reverting out of gas once the claim is visible.
+ *
+ * `settle`'s cost is bounded (one SSTORE + one transfer, no loop — it does not
+ * scale with voucher or channel count), so a fixed limit is correct here. This
+ * value leaves roughly a 2x margin over the observed transfer-path cost.
+ * `deposit-permit2.ts` uses the same explicit-gas pattern.
+ */
+const SETTLE_GAS_LIMIT = 120_000n;
+
+/**
  * Transfers claimed funds from the contract.
  *
  * This should be called after one or more `claim()` transactions have updated the
@@ -79,6 +97,7 @@ export async function executeSettle(
       abi: batchSettlementABI,
       functionName: "settle",
       args: [receiver, token],
+      gas: SETTLE_GAS_LIMIT,
     });
 
     const receipt = await signer.waitForTransactionReceipt({ hash: tx });

--- a/typescript/packages/mechanisms/evm/test/unit/batch-settlement/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/batch-settlement/facilitator.test.ts
@@ -896,6 +896,36 @@ describe("BatchSettlementEvmScheme (Facilitator) — settle routing", () => {
     );
   });
 
+  it("submits settle with an explicit gas limit (not an auto-estimate)", async () => {
+    // `settle` is bimodal on-chain — a no-op early-return when nothing is
+    // claimed, an ERC-20 transfer otherwise. An auto-estimate that races a
+    // node lagging the just-mined `claim` budgets the no-op path and reverts
+    // out of gas. executeSettle must pass an explicit `gas`.
+    const signer = buildSigner({
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({
+        status: "success",
+        logs: [buildSettledLog({ amount: "4321" })],
+      }),
+    });
+    const scheme = new BatchSettlementEvmScheme(signer, authorizer);
+    const sp: BatchSettlementSettlePayload = {
+      type: "settle",
+      receiver: RECEIVER,
+      token: ASSET,
+    };
+    const result = await scheme.settle(
+      envelopeSettle(sp as unknown as Record<string, unknown>),
+      makeRequirements(),
+    );
+    expect(result.success).toBe(true);
+    const settleCall = (signer.writeContract as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([arg]) => arg?.functionName === "settle",
+    );
+    expect(settleCall).toBeDefined();
+    expect(typeof settleCall?.[0].gas).toBe("bigint");
+    expect(settleCall?.[0].gas).toBeGreaterThan(0n);
+  });
+
   it("returns zero amount for no-op settle receipts without a Settled event", async () => {
     const signer = buildSigner({
       waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success", logs: [] }),


### PR DESCRIPTION
Fixes #2374.

`executeSettle` submits the `settle(receiver, token)` transaction via `writeContract` with no explicit `gas`, so viem auto-estimates immediately before broadcasting.

## The bug

The on-chain `settle` is bimodal (`contracts/evm/src/x402BatchSettlement.sol`): it early-returns (~25.5k gas) when `totalClaimed == totalSettled`, and performs an `SSTORE` plus an ERC-20 `safeTransfer` (~57k gas) otherwise. The `eth_estimateGas` viem runs for `writeContract` is an independent RPC call that can resolve against a node whose state has not yet caught up to the just-mined `claim`. It then estimates the early-return path, the transaction is broadcast under-gassed, and it reverts out of gas once the claim is visible. Observed intermittently on Base mainnet — the reverted `settle` had `gasLimit == gasUsed`, the out-of-gas signature.

## The fix

Pass an explicit `gas` to the `settle` `writeContract`. `FacilitatorEvmSigner.writeContract` already accepts an optional `gas` ("When provided, skips eth_estimateGas simulation"), and `deposit-permit2.ts` already uses this explicit-gas pattern (`gas: 300_000n`). `settle`'s cost is bounded — one `SSTORE` plus one transfer, no loop, so it does not scale with voucher or channel count — so a fixed limit is correct here. `SETTLE_GAS_LIMIT` is `120_000n`, roughly a 2x margin over the transfer-path cost.

## Scope

This PR fixes `settle` only. `executeClaimWithSignature` is also a `writeContract`-without-`gas` call and can mis-estimate the same way, but `claimWithSignature` loops over `voucherClaims` so its gas scales with batch size — a fixed limit would be wrong there. That needs a buffered estimate instead and is left as a separate follow-up (noted in #2374).

## Testing

Full `@x402/evm` unit suite passes (625 tests). Adds one test asserting `executeSettle` passes an explicit `gas` to `writeContract`. ESLint and Prettier clean.