### PR TITLE
Add Skim to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/skim/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/skim/metadata.json
@@ -1,0 +1,1 @@
+{"name":"Skim","category":"Services/Endpoints","logoUrl":"/logos/skim.svg","description":"Clean web reader API for AI agents. POST a URL, get back agent-ready markdown plus structured metadata. $0.002 per call in USDC on Base, settled via x402 — no signup, no API keys. Ships an MCP server (npm: skim-mcp) for Claude/Cursor/Cline.","websiteUrl":"https://skim402.com"}

--- a/typescript/site/public/logos/skim.svg
+++ b/typescript/site/public/logos/skim.svg
@@ -1,0 +1,24 @@
+<svg width="800" height="300" viewBox="0 0 800 300" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=Mulish:ital,wght@1,800&amp;display=swap');</style>
+  </defs>
+  <path d="M 678 195
+           C 612 222, 500 240, 398 240
+           C 332 240, 278 228, 246 195
+           C 222 165, 224 120, 252 96
+           C 276 76, 314 71, 330 88
+           C 306 106, 286 134, 286 160
+           C 286 194, 312 214, 358 220
+           C 428 226, 528 222, 602 213
+           C 642 208, 666 200, 678 195 Z"
+        fill="#236CFF"/>
+  <text x="465" y="148"
+        text-anchor="middle"
+        dominant-baseline="central"
+        font-family="'Mulish', ui-sans-serif, system-ui, sans-serif"
+        font-style="italic"
+        font-weight="800"
+        font-size="120"
+        letter-spacing="-2"
+        fill="#236CFF">SKIM</text>
+</svg>


### PR DESCRIPTION
Adds Skim, an x402-native clean web reader API for AI agents.

- Site: https://skim402.com
- MCP server (npm): https://www.npmjs.com/package/skim-mcp
- Network: Base mainnet, via Coinbase CDP facilitator
- Price: $0.002 per call in USDC
- Scheme: exact

Skim is a paid `POST /api/v1/read` endpoint — agents send a URL and get back clean markdown plus structured metadata in milliseconds. Payment is per-call in USDC over x402; no signup, no API keys, no monthly minimum.

`skim-mcp` wraps the endpoint as a Model Context Protocol server so Claude Desktop / Cursor / Cline can call it directly via tool calls. Install: `npx skim-mcp`.

Category: Services/Endpoints (working mainnet integration, public API docs at the site).