### PR TITLE
fix(evm): classify relayer gas exhaustion distinctly from contract reverts

### DIFF
--- a/go/.changes/unreleased/classify-relayer-gas-exhaustion.yaml
+++ b/go/.changes/unreleased/classify-relayer-gas-exhaustion.yaml
@@ -1,0 +1,2 @@
+kind: fixed
+body: Classified relayer gas exhaustion distinctly from EIP-3009 contract reverts in parseEIP3009TransferError. Added ErrRelayerInsufficientFunds so operators can alert on facilitator wallet gas drain without it being collapsed into the generic ErrFailedToExecuteTransfer bucket.

--- a/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
@@ -440,6 +440,11 @@ func mustNonce(nonce string) [32]byte {
 func parseEIP3009TransferError(err error) string {
 	msg := err.Error()
 	switch {
+	case strings.Contains(msg, "insufficient funds for gas") ||
+		strings.Contains(msg, "insufficient funds for transfer") ||
+		strings.Contains(msg, "exceeds the balance of the account") ||
+		strings.Contains(msg, "insufficient balance for transaction"):
+		return ErrRelayerInsufficientFunds
 	case strings.Contains(msg, "authorization is expired") || strings.Contains(msg, "AuthorizationExpired"):
 		return ErrValidBeforeExpired
 	case strings.Contains(msg, "authorization is not yet valid") || strings.Contains(msg, "AuthorizationNotYetValid"):

--- a/go/mechanisms/evm/exact/facilitator/eip3009_helpers_test.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_helpers_test.go
@@ -1,0 +1,58 @@
+package facilitator
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseEIP3009TransferError(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want string
+	}{
+		{"relayer gas exhaustion (go-ethereum)", "insufficient funds for gas * price + value", ErrRelayerInsufficientFunds},
+		{"relayer gas exhaustion (transfer phrasing)", "err: insufficient funds for transfer: address 0x...", ErrRelayerInsufficientFunds},
+		{"relayer gas exhaustion (account balance)", "exceeds the balance of the account", ErrRelayerInsufficientFunds},
+		{"relayer gas exhaustion (nethermind)", "insufficient balance for transaction", ErrRelayerInsufficientFunds},
+		{"AuthorizationExpired (string)", "FiatTokenV2: authorization is expired", ErrValidBeforeExpired},
+		{"AuthorizationExpired (custom)", "execution reverted: AuthorizationExpired()", ErrValidBeforeExpired},
+		{"AuthorizationNotYetValid (string)", "FiatTokenV2: authorization is not yet valid", ErrValidAfterInFuture},
+		{"AuthorizationNotYetValid (custom)", "execution reverted: AuthorizationNotYetValid()", ErrValidAfterInFuture},
+		{"AuthorizationUsed (string)", "FiatTokenV2: authorization is used", ErrNonceAlreadyUsed},
+		{"AuthorizationAlreadyUsed (custom)", "execution reverted: AuthorizationAlreadyUsed()", ErrNonceAlreadyUsed},
+		{"AuthorizationUsedOrCanceled (custom)", "execution reverted: AuthorizationUsedOrCanceled()", ErrNonceAlreadyUsed},
+		{"payer ERC-20 balance (string)", "ERC20: transfer amount exceeds balance", ErrInsufficientBalance},
+		{"payer ERC-20 balance (custom)", "execution reverted: ERC20InsufficientBalance(...)", ErrInsufficientBalance},
+		{"invalid signature (string)", "FiatTokenV2: invalid signature", ErrInvalidSignature},
+		{"SignerMismatch", "execution reverted: SignerMismatch()", ErrInvalidSignature},
+		{"InvalidSignatureV", "execution reverted: InvalidSignatureV()", ErrInvalidSignature},
+		{"InvalidSignatureS", "execution reverted: InvalidSignatureS()", ErrInvalidSignature},
+		{"unknown revert falls back", "something nobody has ever seen", ErrFailedToExecuteTransfer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseEIP3009TransferError(errors.New(tt.msg))
+			if got != tt.want {
+				t.Errorf("parseEIP3009TransferError(%q) = %q, want %q", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseEIP3009TransferError_NoMisclassificationAcrossBuckets(t *testing.T) {
+	t.Run("payer ERC-20 balance error is not classified as relayer gas exhaustion", func(t *testing.T) {
+		got := parseEIP3009TransferError(errors.New("ERC20: transfer amount exceeds balance"))
+		if got != ErrInsufficientBalance {
+			t.Errorf("got %q, want ErrInsufficientBalance", got)
+		}
+	})
+
+	t.Run("relayer gas exhaustion is not classified as payer ERC-20 balance error", func(t *testing.T) {
+		got := parseEIP3009TransferError(errors.New("insufficient funds for gas * price + value"))
+		if got != ErrRelayerInsufficientFunds {
+			t.Errorf("got %q, want ErrRelayerInsufficientFunds", got)
+		}
+	})
+}

--- a/go/mechanisms/evm/exact/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/facilitator/errors.go
@@ -36,6 +36,7 @@ const (
 	ErrFailedToExecuteTransfer = "invalid_exact_evm_failed_to_execute_transfer"
 	ErrFailedToGetReceipt      = "invalid_exact_evm_failed_to_get_receipt"
 	ErrTransactionFailed       = "invalid_exact_evm_transaction_failed"
+	ErrRelayerInsufficientFunds = "invalid_exact_evm_relayer_insufficient_funds"
 
 	// Smart wallet errors (shared by EIP-3009 and Permit2)
 	ErrUndeployedSmartWallet       = "invalid_exact_evm_payload_undeployed_smart_wallet"

--- a/python/x402/changelog.d/classify-relayer-gas-exhaustion.bugfix.md
+++ b/python/x402/changelog.d/classify-relayer-gas-exhaustion.bugfix.md
@@ -1,0 +1,1 @@
+Classified relayer gas exhaustion distinctly from EIP-3009 contract reverts in parse_eip3009_transfer_error. Added ERR_RELAYER_INSUFFICIENT_FUNDS so operators can alert on facilitator wallet gas drain without it being collapsed into the generic ERR_TRANSACTION_FAILED bucket.

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -338,6 +338,7 @@ ERR_FAILED_TO_GET_NETWORK_CONFIG = "invalid_exact_evm_failed_to_get_network_conf
 ERR_FAILED_TO_GET_ASSET_INFO = "invalid_exact_evm_failed_to_get_asset_info"
 ERR_FAILED_TO_VERIFY_SIGNATURE = "invalid_exact_evm_failed_to_verify_signature"
 ERR_TRANSACTION_FAILED = "transaction_failed"
+ERR_RELAYER_INSUFFICIENT_FUNDS = "invalid_exact_evm_relayer_insufficient_funds"
 ERR_TOKEN_NAME_MISMATCH = "invalid_exact_evm_token_name_mismatch"
 ERR_TOKEN_VERSION_MISMATCH = "invalid_exact_evm_token_version_mismatch"
 ERR_EIP3009_NOT_SUPPORTED = "invalid_exact_evm_eip3009_not_supported"

--- a/python/x402/mechanisms/evm/exact/eip3009_utils.py
+++ b/python/x402/mechanisms/evm/exact/eip3009_utils.py
@@ -11,6 +11,7 @@ from ..constants import (
     ERR_INSUFFICIENT_BALANCE,
     ERR_INVALID_SIGNATURE,
     ERR_NONCE_ALREADY_USED,
+    ERR_RELAYER_INSUFFICIENT_FUNDS,
     ERR_TOKEN_NAME_MISMATCH,
     ERR_TOKEN_VERSION_MISMATCH,
     ERR_TRANSACTION_FAILED,
@@ -277,6 +278,13 @@ def parse_eip3009_transfer_error(error: Exception) -> str:
     Falls back to ERR_TRANSACTION_FAILED when the revert reason is unknown.
     """
     msg = str(error).lower()
+    if (
+        "insufficient funds for gas" in msg
+        or "insufficient funds for transfer" in msg
+        or "exceeds the balance of the account" in msg
+        or "insufficient balance for transaction" in msg
+    ):
+        return ERR_RELAYER_INSUFFICIENT_FUNDS
     if "authorization is expired" in msg or "authorizationexpired" in msg:
         return ERR_VALID_BEFORE_EXPIRED
     if "authorization is not yet valid" in msg or "authorizationnotyetvalid" in msg:

--- a/python/x402/tests/unit/mechanisms/evm/test_eip3009_utils.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_eip3009_utils.py
@@ -1,0 +1,69 @@
+"""Tests for parse_eip3009_transfer_error error classification."""
+
+from __future__ import annotations
+
+import pytest
+
+from x402.mechanisms.evm.constants import (
+    ERR_INSUFFICIENT_BALANCE,
+    ERR_INVALID_SIGNATURE,
+    ERR_NONCE_ALREADY_USED,
+    ERR_RELAYER_INSUFFICIENT_FUNDS,
+    ERR_TRANSACTION_FAILED,
+    ERR_VALID_AFTER_FUTURE,
+    ERR_VALID_BEFORE_EXPIRED,
+)
+from x402.mechanisms.evm.exact.eip3009_utils import parse_eip3009_transfer_error
+
+
+@pytest.mark.parametrize(
+    "msg",
+    [
+        "insufficient funds for gas * price + value",
+        "err: insufficient funds for transfer: address 0x...",
+        "exceeds the balance of the account",
+        "insufficient balance for transaction",
+        "Error: insufficient funds for gas * price + value: address 0xabc want 100 have 1",
+    ],
+)
+def test_relayer_gas_exhaustion_classified(msg: str) -> None:
+    assert parse_eip3009_transfer_error(Exception(msg)) == ERR_RELAYER_INSUFFICIENT_FUNDS
+
+
+@pytest.mark.parametrize(
+    "msg, want",
+    [
+        ("FiatTokenV2: authorization is expired", ERR_VALID_BEFORE_EXPIRED),
+        ("execution reverted: AuthorizationExpired()", ERR_VALID_BEFORE_EXPIRED),
+        ("authorization is not yet valid", ERR_VALID_AFTER_FUTURE),
+        ("AuthorizationNotYetValid()", ERR_VALID_AFTER_FUTURE),
+        ("FiatTokenV2: authorization is used", ERR_NONCE_ALREADY_USED),
+        ("AuthorizationAlreadyUsed()", ERR_NONCE_ALREADY_USED),
+        ("AuthorizationUsedOrCanceled()", ERR_NONCE_ALREADY_USED),
+        ("ERC20: transfer amount exceeds balance", ERR_INSUFFICIENT_BALANCE),
+        ("ERC20InsufficientBalance(0x..., 100, 200)", ERR_INSUFFICIENT_BALANCE),
+        ("FiatTokenV2: invalid signature", ERR_INVALID_SIGNATURE),
+        ("SignerMismatch()", ERR_INVALID_SIGNATURE),
+        ("InvalidSignatureV()", ERR_INVALID_SIGNATURE),
+        ("InvalidSignatureS()", ERR_INVALID_SIGNATURE),
+    ],
+)
+def test_contract_revert_buckets(msg: str, want: str) -> None:
+    assert parse_eip3009_transfer_error(Exception(msg)) == want
+
+
+def test_payer_balance_error_not_classified_as_relayer_gas() -> None:
+    msg = "ERC20: transfer amount exceeds balance"
+    assert parse_eip3009_transfer_error(Exception(msg)) == ERR_INSUFFICIENT_BALANCE
+
+
+def test_relayer_gas_not_classified_as_payer_balance() -> None:
+    msg = "insufficient funds for gas * price + value"
+    assert parse_eip3009_transfer_error(Exception(msg)) == ERR_RELAYER_INSUFFICIENT_FUNDS
+
+
+def test_unknown_revert_falls_back_to_transaction_failed() -> None:
+    assert (
+        parse_eip3009_transfer_error(Exception("something nobody has ever seen"))
+        == ERR_TRANSACTION_FAILED
+    )

--- a/typescript/.changeset/classify-relayer-gas-exhaustion.md
+++ b/typescript/.changeset/classify-relayer-gas-exhaustion.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Classified relayer gas exhaustion distinctly from EIP-3009 contract reverts in parseEip3009TransferError. Added ErrRelayerInsufficientFunds (`invalid_exact_evm_relayer_insufficient_funds`) so operators can alert on facilitator wallet gas drain without it being collapsed into the generic ErrTransactionFailed bucket.

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009-utils.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009-utils.ts
@@ -197,6 +197,13 @@ export async function diagnoseEip3009SimulationFailure(
  */
 export function parseEip3009TransferError(error: unknown): string {
   const msg = error instanceof Error ? error.message : String(error);
+  if (
+    /insufficient funds for gas|insufficient funds for transfer|exceeds the balance of the account|insufficient balance for transaction/i.test(
+      msg,
+    )
+  ) {
+    return Errors.ErrRelayerInsufficientFunds;
+  }
   if (/authorization.*(expired|valid before)/i.test(msg) || /AuthorizationExpired/i.test(msg)) {
     return Errors.ErrValidBeforeExpired;
   }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
@@ -15,6 +15,7 @@ export const ErrValidAfterInFuture = "invalid_exact_evm_payload_authorization_va
 export const ErrInvalidAuthorizationValue = "invalid_exact_evm_authorization_value";
 export const ErrUndeployedSmartWallet = "invalid_exact_evm_payload_undeployed_smart_wallet";
 export const ErrTransactionFailed = "invalid_exact_evm_transaction_failed";
+export const ErrRelayerInsufficientFunds = "invalid_exact_evm_relayer_insufficient_funds";
 
 // EIP-3009 verify errors
 export const ErrEip3009TokenNameMismatch = "invalid_exact_evm_token_name_mismatch";

--- a/typescript/packages/mechanisms/evm/test/unit/exact/eip3009-utils.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/eip3009-utils.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { parseEip3009TransferError } from "../../../src/exact/facilitator/eip3009-utils";
+import * as Errors from "../../../src/exact/facilitator/errors";
+
+describe("parseEip3009TransferError", () => {
+  describe("relayer gas exhaustion", () => {
+    const messages: ReadonlyArray<[string, string]> = [
+      ["go-ethereum style", "insufficient funds for gas * price + value"],
+      ["geth alternate", "err: insufficient funds for transfer: address 0x..."],
+      [
+        "account balance phrasing",
+        "sender doesn't have enough funds to send tx. The max upfront cost is: 100000000000000000 and the sender's account only has: 10000000000000000 — exceeds the balance of the account",
+      ],
+      ["nethermind", "insufficient balance for transaction"],
+      [
+        "viem viem",
+        "Error: insufficient funds for gas * price + value: address 0xabc want 100 have 1",
+      ],
+    ];
+
+    for (const [label, msg] of messages) {
+      it(`classifies "${label}" as ErrRelayerInsufficientFunds`, () => {
+        expect(parseEip3009TransferError(new Error(msg))).toBe(Errors.ErrRelayerInsufficientFunds);
+      });
+    }
+  });
+
+  describe("EIP-3009 contract reverts", () => {
+    it("AuthorizationExpired -> ErrValidBeforeExpired", () => {
+      expect(parseEip3009TransferError(new Error("FiatTokenV2: authorization is expired"))).toBe(
+        Errors.ErrValidBeforeExpired,
+      );
+      expect(parseEip3009TransferError(new Error("AuthorizationExpired()"))).toBe(
+        Errors.ErrValidBeforeExpired,
+      );
+    });
+
+    it("AuthorizationNotYetValid -> ErrValidAfterInFuture", () => {
+      expect(parseEip3009TransferError(new Error("authorization is not yet valid"))).toBe(
+        Errors.ErrValidAfterInFuture,
+      );
+      expect(parseEip3009TransferError(new Error("AuthorizationNotYetValid()"))).toBe(
+        Errors.ErrValidAfterInFuture,
+      );
+    });
+
+    it("AuthorizationAlreadyUsed -> ErrEip3009NonceAlreadyUsed", () => {
+      expect(parseEip3009TransferError(new Error("FiatTokenV2: authorization is used"))).toBe(
+        Errors.ErrEip3009NonceAlreadyUsed,
+      );
+      expect(parseEip3009TransferError(new Error("AuthorizationAlreadyUsed()"))).toBe(
+        Errors.ErrEip3009NonceAlreadyUsed,
+      );
+      expect(parseEip3009TransferError(new Error("AuthorizationUsedOrCanceled()"))).toBe(
+        Errors.ErrEip3009NonceAlreadyUsed,
+      );
+    });
+
+    it("payer ERC-20 balance shortfall -> ErrEip3009InsufficientBalance", () => {
+      expect(parseEip3009TransferError(new Error("ERC20: transfer amount exceeds balance"))).toBe(
+        Errors.ErrEip3009InsufficientBalance,
+      );
+      expect(
+        parseEip3009TransferError(new Error("ERC20InsufficientBalance(0x..., 100, 200)")),
+      ).toBe(Errors.ErrEip3009InsufficientBalance);
+    });
+
+    it("signature reverts -> ErrInvalidSignature", () => {
+      expect(parseEip3009TransferError(new Error("FiatTokenV2: invalid signature"))).toBe(
+        Errors.ErrInvalidSignature,
+      );
+      expect(parseEip3009TransferError(new Error("SignerMismatch()"))).toBe(
+        Errors.ErrInvalidSignature,
+      );
+      expect(parseEip3009TransferError(new Error("InvalidSignatureV()"))).toBe(
+        Errors.ErrInvalidSignature,
+      );
+      expect(parseEip3009TransferError(new Error("InvalidSignatureS()"))).toBe(
+        Errors.ErrInvalidSignature,
+      );
+    });
+  });
+
+  describe("regressions across buckets", () => {
+    it("payer ERC-20 balance error is NOT classified as relayer gas exhaustion", () => {
+      expect(parseEip3009TransferError(new Error("ERC20: transfer amount exceeds balance"))).toBe(
+        Errors.ErrEip3009InsufficientBalance,
+      );
+    });
+
+    it("relayer gas exhaustion is NOT classified as payer ERC-20 balance error", () => {
+      expect(
+        parseEip3009TransferError(new Error("insufficient funds for gas * price + value")),
+      ).toBe(Errors.ErrRelayerInsufficientFunds);
+    });
+
+    it("unknown reverts still fall back to ErrTransactionFailed", () => {
+      expect(parseEip3009TransferError(new Error("something nobody has ever seen"))).toBe(
+        Errors.ErrTransactionFailed,
+      );
+    });
+
+    it("non-Error values are handled", () => {
+      expect(parseEip3009TransferError("authorization is expired")).toBe(
+        Errors.ErrValidBeforeExpired,
+      );
+      expect(parseEip3009TransferError({ toString: () => "insufficient funds for gas" })).toBe(
+        Errors.ErrRelayerInsufficientFunds,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description

`parseEip3009TransferError` / `parseEIP3009TransferError` / `parse_eip3009_transfer_error` currently collapse facilitator-relayer wallet gas exhaustion into the generic `ErrTransactionFailed` / `ErrFailedToExecuteTransfer` / `ERR_TRANSACTION_FAILED` bucket. From an operator's perspective, "the EIP-3009 contract revertted my authorization" and "my facilitator wallet needs a top-up" are indistinguishable in the wire response.

When the facilitator's relayer wallet runs out of native gas, `writeContract` rejects locally before the tx is broadcast, with a recognizable error pattern such as `insufficient funds for gas * price + value`. This PR routes that case to a new dedicated error code so dashboards and alerting can tell the two situations apart.

### Changes (all three SDKs)

- Add a new error constant:
  - TS: `ErrRelayerInsufficientFunds`
  - Go: `ErrRelayerInsufficientFunds`
  - Python: `ERR_RELAYER_INSUFFICIENT_FUNDS`
  - Wire string (character-identical across SDKs): `invalid_exact_evm_relayer_insufficient_funds`
- Add a new branch at the top of the existing `parse*TransferError` switch matching the canonical gas-exhaustion wording from go-ethereum, geth, nethermind, and viem.
- Place it ahead of the existing `transfer amount exceeds balance` branch so the payer's ERC-20 balance error (which is the buyer's problem) is not misclassified as the relayer's native-gas problem (which is the operator's problem), and vice-versa.

Behavior is otherwise unchanged: unknown reverts still fall back to the existing generic bucket.

### Why this is its own bucket (not just `ErrTransactionFailed`)

`transferWithAuthorization` was never executed in this case — the local node rejects the raw tx before broadcast because the sender (the facilitator's relayer wallet, **not** the payer) cannot cover `gasLimit * maxFeePerGas`. Mixing this with EIP-3009 contract reverts hides an actionable operational signal: top up the relayer.

## Tests

New dedicated unit tests in all three SDKs covering both directions of the new boundary:

- **TS** — `typescript/packages/mechanisms/evm/test/unit/exact/eip3009-utils.test.ts` (14 cases):
  - 5 gas-exhaustion phrasings (go-ethereum / geth / account-balance / nethermind / viem)
  - 5 existing-bucket cases (regression coverage)
  - bidirectional regressions: payer ERC-20 balance error NOT classified as relayer gas exhaustion; relayer gas exhaustion NOT classified as payer ERC-20 balance error
  - unknown reverts still fall back to `ErrTransactionFailed`
- **Go** — `go/mechanisms/evm/exact/facilitator/eip3009_helpers_test.go` (parity cases)
- **Python** — `python/x402/tests/unit/mechanisms/evm/test_eip3009_utils.py` (parity cases via `parametrize`)

Local verification:

- `pnpm -C typescript/packages/mechanisms/evm test` → **638 passed (25 files, 14 new)**, no regressions
- `pnpm -C typescript format` and `pnpm -C typescript lint:check` → clean
- `uv run --quiet pytest python/x402/tests/unit/mechanisms/evm/` → **275 passed**
- `ruff format` / `ruff check` on the changed Python files → clean
- Go tests were not run locally (no Go toolchain on this machine); the new tests mirror the TS/Python test matrix one-for-one and the helper is pure string matching, so CI should be authoritative.
- `pnpm-lock.yaml` is unchanged (PR does not modify any TS dependencies).

## Changelog fragments

- `typescript/.changeset/classify-relayer-gas-exhaustion.md` → `@x402/evm: patch`
- `go/.changes/unreleased/classify-relayer-gas-exhaustion.yaml` → `kind: fixed`
- `python/x402/changelog.d/classify-relayer-gas-exhaustion.bugfix.md`

## Disclosure

This change was prepared with the help of an AI coding assistant. The diff and the test matrix were reviewed against the existing `parseEip3009TransferError` switch and the parity rules called out in `typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts` ("These strings must be character-for-character identical to the Go constants ...") before commit.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass (TS + Python locally; Go covered by CI)
- [x] My commits are signed (SSH signing)
- [x] I added a changelog fragment for user-facing changes