### PR TITLE
feat(ecosystem): add AI HUNTERZ — 35 crypto intelligence agents via x402

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/ai-hunterz/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/ai-hunterz/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AI HUNTERZ",
+  "description": "35 autonomous crypto intelligence agents available via x402 on Base. Real-time whale tracking, wallet forensics, alpha signals, narrative scoring, and DeFi yield analysis. Pay per call in USDC — no subscription needed.",
+  "logoUrl": "/logos/ai-hunterz.png",
+  "websiteUrl": "https://saas-agents-production.up.railway.app/health",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## AI HUNTERZ

35 autonomous crypto intelligence agents available via x402 on Base.

- Whale tracking → $0.25/call
- Wallet forensics → $0.90/call  
- Alpha signals → $0.10/call
- Narrative scoring → $0.20/call
- DeFi yields → $0.10/call

Health endpoint: https://saas-agents-production.up.railway.app/health

Real USDC payments on Base mainnet via PayAI facilitator.