### PR TITLE
fixtures: stark-vauban-pay-v1 v0 ; Axis 1 STARK receipt conformance

### DIFF
--- a/fixtures/stark-vauban-pay-v1/v0/README.md
+++ b/fixtures/stark-vauban-pay-v1/v0/README.md
@@ -1,0 +1,94 @@
+# Axis 1 STARK Receipt Canonicalisation Fixtures
+
+**Axis:** 1 - STARK proof-of-payment-conditions receipt  
+**Proof scheme:** `stark-vauban-pay-v1`  
+**Proof system:** Stwo Circle STARK M31 (FRI-based, post-quantum)  
+**Anchor chain:** Starknet  
+**Canonicaliser:** RFC 8785 (JCS) via `rfc8785@0.1.4`  
+**Provenance:** Vauban Pay (`seritalien`), 2026-05-21  
+**License:** Apache-2.0
+
+## Overview
+
+This fixture set demonstrates that the `stark-vauban-pay-v1` receipt format is canonically deterministic under JCS (RFC 8785). It parallels the coalition structure established by AlgoVoi's Axis 0 substrate vectors, FeedOracle's Axis 2 hybrid-PQC vectors (PR #2411), and andysalvo's Axis 3 work-receipt vectors (PR #2398).
+
+The four vectors test three properties:
+
+1. **JCS key-sorting independence** (0001 vs 0008): two source objects with identical field values in different insertion orders produce byte-for-byte identical canonical bytes after JCS serialisation.
+2. **Field-name load-bearing discipline** (0002): renaming `payment_hash` to `paymentHash` (camelCase) changes the canonical bytes even though the value is identical. JCS treats field names as opaque UTF-8 byte sequences.
+3. **Proof tamper evidence** (0003): mutating one byte of `proof_blob_b64` changes the canonical bytes, making the digest diverge from the expected value and causing STARK proof verification to fail independently.
+
+The `receipt_core` shape is a subset of the `BoundReceipt<SettlementReceipt>` structure defined in `crates/zkpay-x402/src/lib.rs`. See the Open Questions section below for the structural mismatch between the Rust type and the fixture shape.
+
+## Vectors
+
+| File | Name | Expected result | Invariant tested |
+|------|------|-----------------|------------------|
+| `vectors/0001-baseline.json` | baseline-stark-vauban-pay | PASS | Canonical reference |
+| `vectors/0002-field-name-load-bearing.json` | field-name-load-bearing | FAIL | Field-name canonicalisation |
+| `vectors/0003-stark-proof-tamper-evidence.json` | stark-proof-tamper-evidence | FAIL | Proof blob tamper detection |
+| `vectors/0008-interop-shared-payment-hash.json` | interop-shared-payment-hash | PASS | JCS key-sorting independence + cross-axis interop bind |
+
+## Cross-axis interop bindings
+
+Both `payment_hash` and `action_ref` in every vector in this set are shared verbatim with the other axes:
+
+**`payment_hash`: `2ed186ebc66947eaac6a05a88c7bc096ee07ac11a2c44bb5580bd72b3670f580`**
+
+Shared with FeedOracle Axis 2 (PR #2411). The same 32-byte hex string appears in FeedOracle's `receipt_core.payment_hash`. A conformant cross-implementation check: take the FeedOracle baseline JCS bytes, extract `payment_hash`, assert byte equality with the value above.
+
+**`action_ref`: `10d8a38c01d8672176aa6e5209a368fde3e1831640d69e15283142b35880c2c1`**
+
+Shared with andysalvo Axis 3 (PR #2398). This is `SHA-256(JCS({"action_type":"sanctions_screen","agent_id":"did:web:agent-7.example.com","scope":"counterparty-due-diligence","timestamp_ms":1747728000000}))`. The andysalvo work-receipt harness recomputes this value from the preimage and asserts byte equality. The binding is a pure hash reference: the STARK receipt knows nothing about the work-layer preimage internals; the work layer knows nothing about the STARK proof internals.
+
+## Conformance instructions
+
+1. For each vector, take `receipt_core` verbatim (preserve all field names and value types exactly).
+2. Canonicalise with RFC 8785 (any conformant JCS implementation).
+3. Compute `SHA-256(canonical_bytes)`, lowercase hex, prefixed `sha256:`.
+4. For `PASS` vectors: assert computed digest equals `expected_core_digest`.
+5. For `FAIL` vectors: assert computed digest equals `expected_divergent_digest` (not `expected_core_digest`, which is `null`).
+6. For vector 0008: additionally assert `expected_core_digest` equals vector 0001 `expected_core_digest` byte-for-byte (the interop bind).
+
+Expected conformance runner result: 4/4 vectors produce the expected outcome, 1/1 interop bind asserts pass.
+
+A conformance runner stub (`runner-stark-axis-1`) is not yet published. Contribution welcome.
+
+## Cross-implementation validation status
+
+This set is Vauban-authored. The digests were computed using a pure-Python RFC 8785 implementation and verified against the `serde_jcs` Rust crate output (via the fixture in `crates/zkpay-x402/src/lib.rs`). Cross-implementation validation by a third party is a Phase 2 ask on the PR thread.
+
+## Open questions
+
+### Structural mismatch: `BoundReceipt<R>` vs `receipt_core`
+
+The Rust type `BoundReceipt<SettlementReceipt>` in `crates/zkpay-x402/src/lib.rs` is a two-field wrapper:
+
+```rust
+pub struct BoundReceipt<R> {
+    pub receipt: R,           // nested SettlementReceipt
+    pub action_ref: Option<[u8; 32]>,
+}
+
+pub struct SettlementReceipt {
+    pub payment_id: String,
+    pub tx_hash: String,
+    pub block_number: u64,
+    pub settled_at: u64,
+}
+```
+
+The `receipt_core` shape in these fixtures is flat and combines fields from the VPSF `SettlementReceipt` Claim (spec v0.3 §4.3) with x402 wire-format extensions (`payment_hash`, `proof_blob_b64`, `proof_scheme`, `canon_version`). This is intentional: the fixture `receipt_core` represents the canonical preimage for JCS hashing at the x402 wire layer, not the CBOR-encoded `BoundReceipt<R>` used in `PAYMENT-RESPONSE` headers.
+
+The mapping between the two shapes is:
+
+- `receipt_core.payment_hash` corresponds to the `nullifier` field of the VPSF `SettlementReceipt.Predicate.Settlement` (spec §4.3); the fixture uses `payment_hash` because that is the x402 V2 field name per issue #2357 open item.
+- `receipt_core.action_ref` corresponds to `BoundReceipt.action_ref` (serialised as hex string in the fixture vs raw `[u8; 32]` in Rust).
+- `receipt_core.payer_pseudonym`, `merchant_id`, `amount`, `currency`, `timestamp_ms` are derived from the VPSF Claim sextuplet fields (Subject, Predicate.Settlement.amount, etc.).
+- `receipt_core.proof_blob_b64` has no direct equivalent in `BoundReceipt<R>`; it belongs to the `Evidence.StarkProofEnvelope` of the VPSF Claim (spec §4.3).
+
+Resolution of this mismatch (flatten vs nest, field name mapping for x402 TSC review) is tracked on x402-foundation/x402#2357. These fixtures use the flat shape as the canonical preimage for Axis 1; the CBOR encoding for `PAYMENT-RESPONSE` headers remains the nested `BoundReceipt<R>` shape.
+
+### proof_blob_b64 inclusion in canonical preimage
+
+The manifest notes that in production the proof blob is stripped before the digest is computed (signatures cover the receipt without the proof blob, analogous to JWS detached payload). This fixture set includes `proof_blob_b64` in `receipt_core` and therefore in the canonical preimage. The production protocol is to be resolved in the PR thread before TSC ratification.

--- a/fixtures/stark-vauban-pay-v1/v0/manifest.json
+++ b/fixtures/stark-vauban-pay-v1/v0/manifest.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "1.0",
+  "artefact_id": "x402-stark-vauban-pay-v1-axis1-conformance-v0",
+  "published_at": "2026-05-21T00:00:00Z",
+  "canonicalizer": "rfc8785@0.1.4",
+  "proof_scheme": "stark-vauban-pay-v1",
+  "proof_system": "Stwo Circle STARK M31 (FRI-based, post-quantum)",
+  "anchor_chains": ["starknet"],
+  "contributing_chains": ["starknet"],
+  "axis": "1 - STARK receipt canonicalisation (payment conditions proof)",
+  "digest_algorithm": "SHA-256",
+  "canonicalization": "RFC 8785 (JCS)",
+  "derivation": "digest covers SHA-256(JCS(receipt_core)); proof_blob_b64 is stripped before digest computation in production — for these fixtures the blob is present in receipt_core and IS included in the canonical bytes (the blob is a fixture placeholder, not a live proof commitment; production provers strip before hashing per x402-foundation/x402#2357 open item)",
+  "anchored_to": {
+    "thread": "https://github.com/x402-foundation/x402/issues/2357",
+    "canonicalisation_discipline": "https://github.com/x402-foundation/x402/issues/2326",
+    "related": [
+      "https://github.com/x402-foundation/x402/pull/2411",
+      "https://github.com/x402-foundation/x402/pull/2398",
+      "https://github.com/x402-foundation/x402/issues/2332"
+    ]
+  },
+  "interop_bindings": {
+    "axis_0_substrate": {
+      "description": "AlgoVoi privacy_class attestation substrate (x402#2326 v3 canonicalisation discipline). This axis 1 fixture set adopts the same canon_version field discipline.",
+      "source": "x402-foundation/x402 fixtures/substrate/privacy-class-v0/"
+    },
+    "axis_2_hybrid_pqc": {
+      "description": "FeedOracle hybrid-PQC receipt (PR #2411). Shared payment_hash field: `2ed186ebc66947eaac6a05a88c7bc096ee07ac11a2c44bb5580bd72b3670f580`. The same JCS key-sorting and SHA-256 digest discipline applies to both axes.",
+      "source": "https://gist.github.com/feedoracle/704ab891170e2b43050f6f0ae00e6923"
+    },
+    "axis_3_work_receipt": {
+      "description": "andysalvo TrailRecord work-receipt (PR #2398). Shared action_ref field: `10d8a38c01d8672176aa6e5209a368fde3e1831640d69e15283142b35880c2c1`. The cross-layer binding is a pure hash reference; each layer is independently verifiable.",
+      "source": "https://github.com/andysalvo/action-ref-verify"
+    }
+  },
+  "vectors": [
+    {"file": "vectors/0001-baseline.json", "expected_result": "PASS"},
+    {"file": "vectors/0002-field-name-load-bearing.json", "expected_result": "FAIL"},
+    {"file": "vectors/0003-stark-proof-tamper-evidence.json", "expected_result": "FAIL"},
+    {"file": "vectors/0008-interop-shared-payment-hash.json", "expected_result": "PASS"}
+  ],
+  "digest_pinning_convention": "FAIL vectors pin the actual divergent digest (expected_divergent_digest field). PASS vectors pin the canonical digest (expected_core_digest field). Cross-axis interop vectors pin the same expected_core_digest as the baseline to prove digest equality across implementations.",
+  "conformance_runner": "runner-stark-axis-1 (TBD; contribution welcome). Expected result: 4/4 vectors pass, 1/1 interop bind (0008 digest equals 0001 digest).",
+  "source": "https://github.com/vauban-org/vauban-zkpay",
+  "license": "Apache-2.0"
+}

--- a/fixtures/stark-vauban-pay-v1/v0/vectors/0001-baseline.json
+++ b/fixtures/stark-vauban-pay-v1/v0/vectors/0001-baseline.json
@@ -1,0 +1,20 @@
+{
+  "name": "baseline-stark-vauban-pay",
+  "spec": "stark-vauban-pay-v1-jcs-stark-receipt",
+  "expected_result": "PASS",
+  "receipt_core": {
+    "payment_hash": "2ed186ebc66947eaac6a05a88c7bc096ee07ac11a2c44bb5580bd72b3670f580",
+    "action_ref": "10d8a38c01d8672176aa6e5209a368fde3e1831640d69e15283142b35880c2c1",
+    "amount": 50000,
+    "currency": "USDC",
+    "payer_pseudonym": "a3f2c1d4e5b6a7890123456789abcdef0123456789abcdef0123456789abcdef01",
+    "merchant_id": "b4e5d6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5",
+    "timestamp_ms": 1747843200000,
+    "proof_scheme": "stark-vauban-pay-v1",
+    "proof_blob_b64": "AAECBAUGB",
+    "canon_version": "1.0"
+  },
+  "expected_jcs_bytes_b64": "eyJhY3Rpb25fcmVmIjoiMTBkOGEzOGMwMWQ4NjcyMTc2YWE2ZTUyMDlhMzY4ZmRlM2UxODMxNjQwZDY5ZTE1MjgzMTQyYjM1ODgwYzJjMSIsImFtb3VudCI6NTAwMDAsImNhbm9uX3ZlcnNpb24iOiIxLjAiLCJjdXJyZW5jeSI6IlVTREMiLCJtZXJjaGFudF9pZCI6ImI0ZTVkNmY3YThiOWMwZDFlMmYzYTRiNWM2ZDdlOGY5YTBiMWMyZDNlNGY1YTZiN2M4ZDllMGYxYTJiM2M0ZDUiLCJwYXllcl9wc2V1ZG9ueW0iOiJhM2YyYzFkNGU1YjZhNzg5MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVmMDEiLCJwYXltZW50X2hhc2giOiIyZWQxODZlYmM2Njk0N2VhYWM2YTA1YTg4YzdiYzA5NmVlMDdhYzExYTJjNDRiYjU1ODBiZDcyYjM2NzBmNTgwIiwicHJvb2ZfYmxvYl9iNjQiOiJBQUVDQkFVR0IiLCJwcm9vZl9zY2hlbWUiOiJzdGFyay12YXViYW4tcGF5LXYxIiwidGltZXN0YW1wX21zIjoxNzQ3ODQzMjAwMDAwfQ==",
+  "expected_core_digest": "sha256:89e01af0770494243e7ba6d003332688ca7107dd05c52cc8c73f470b13d5767f",
+  "notes": "Canonical STARK receipt core. Ten fields in source-object order; JCS sorts to alphabetical key order (action_ref, amount, canon_version, currency, merchant_id, payer_pseudonym, payment_hash, proof_blob_b64, proof_scheme, timestamp_ms). SHA-256 of the JCS bytes produces the expected_core_digest. payment_hash and action_ref are shared verbatim with FeedOracle Axis 2 (PR #2411) and andysalvo Axis 3 (PR #2398). amount is in microunits (1 USDC = 1 000 000 microunits; 50000 = 0.05 USDC). payer_pseudonym is Poseidon(payer_secret, app_domain, salt) per spec v0.3 §4.2, Hidden RevelationMask — the fixture value is synthetic. proof_blob_b64 is a synthetic 6-byte placeholder; production provers emit real Stwo Circle STARK M31 serialised proof bytes here. canon_version follows x402#2326 v3 MUST-when-retention-obligated discipline; stark-vauban-pay-v1 receipts are not under MiCA Art. 80 by default but the field is present for cross-ecosystem interop discipline."
+}

--- a/fixtures/stark-vauban-pay-v1/v0/vectors/0002-field-name-load-bearing.json
+++ b/fixtures/stark-vauban-pay-v1/v0/vectors/0002-field-name-load-bearing.json
@@ -1,0 +1,20 @@
+{
+  "name": "field-name-load-bearing",
+  "spec": "stark-vauban-pay-v1-jcs-stark-receipt",
+  "expected_result": "FAIL",
+  "receipt_core": {
+    "paymentHash": "2ed186ebc66947eaac6a05a88c7bc096ee07ac11a2c44bb5580bd72b3670f580",
+    "action_ref": "10d8a38c01d8672176aa6e5209a368fde3e1831640d69e15283142b35880c2c1",
+    "amount": 50000,
+    "currency": "USDC",
+    "payer_pseudonym": "a3f2c1d4e5b6a7890123456789abcdef0123456789abcdef0123456789abcdef01",
+    "merchant_id": "b4e5d6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5",
+    "timestamp_ms": 1747843200000,
+    "proof_scheme": "stark-vauban-pay-v1",
+    "proof_blob_b64": "AAECBAUGB",
+    "canon_version": "1.0"
+  },
+  "expected_core_digest": null,
+  "expected_divergent_digest": "sha256:5c80351f61a9a1d85d9cb055b8a54500d104d74caf2188a714f615fa6eabb053",
+  "notes": "payment_hash renamed to paymentHash (camelCase). Value is byte-for-byte identical to 0001. JCS treats field names as opaque UTF-8 byte sequences; `p-a-y-m-e-n-t-_-h-a-s-h` and `p-a-y-m-e-n-t-H-a-s-h` differ at byte 8 (underscore vs uppercase H), and camelCase sorts before snake_case in lexicographic order (H=0x48 < _=0x5F). The canonical bytes differ from 0001 even though the semantic value is identical. A receipt verifier that normalises field names before hashing would silently accept this receipt as equivalent to 0001, which would allow receipt substitution across implementations. expected_core_digest is null because there is no valid core digest for a non-conformant receipt. expected_divergent_digest is the actual SHA-256 of JCS(this receipt_core) for pinning purposes per cross-axis convention on PR #2398."
+}

--- a/fixtures/stark-vauban-pay-v1/v0/vectors/0003-stark-proof-tamper-evidence.json
+++ b/fixtures/stark-vauban-pay-v1/v0/vectors/0003-stark-proof-tamper-evidence.json
@@ -1,0 +1,20 @@
+{
+  "name": "stark-proof-tamper-evidence",
+  "spec": "stark-vauban-pay-v1-jcs-stark-receipt",
+  "expected_result": "FAIL",
+  "receipt_core": {
+    "payment_hash": "2ed186ebc66947eaac6a05a88c7bc096ee07ac11a2c44bb5580bd72b3670f580",
+    "action_ref": "10d8a38c01d8672176aa6e5209a368fde3e1831640d69e15283142b35880c2c1",
+    "amount": 50000,
+    "currency": "USDC",
+    "payer_pseudonym": "a3f2c1d4e5b6a7890123456789abcdef0123456789abcdef0123456789abcdef01",
+    "merchant_id": "b4e5d6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5",
+    "timestamp_ms": 1747843200000,
+    "proof_scheme": "stark-vauban-pay-v1",
+    "proof_blob_b64": "BAECBAUGB",
+    "canon_version": "1.0"
+  },
+  "expected_core_digest": null,
+  "expected_divergent_digest": "sha256:c9641d87a5043dfb07f739e09a2c0c049937262ebc4ffb8db539d374aa353832",
+  "notes": "proof_blob_b64 mutated by one byte: first byte changed from A (0x00 decoded) to B (0x04 decoded). All other fields are byte-for-byte identical to 0001. The JCS canonical bytes differ at the proof_blob_b64 field value position. A STARK receipt verifier must detect this: (1) the expected_core_digest of the claimed receipt does not match the digest recomputed from these canonical bytes, and (2) even if a verifier skipped the digest check, the STARK proof bytes themselves would fail the Stwo Circle STARK M31 verifier because the polynomial commitments are inconsistent with the mutated first byte. expected_core_digest is null because there is no valid core digest for a tampered receipt. expected_divergent_digest is the actual SHA-256 of JCS(this receipt_core). This vector demonstrates that proof_blob_b64 is a load-bearing field in the canonical preimage, not an opaque attachment."
+}

--- a/fixtures/stark-vauban-pay-v1/v0/vectors/0008-interop-shared-payment-hash.json
+++ b/fixtures/stark-vauban-pay-v1/v0/vectors/0008-interop-shared-payment-hash.json
@@ -1,0 +1,27 @@
+{
+  "name": "interop-shared-payment-hash",
+  "spec": "stark-vauban-pay-v1-jcs-stark-receipt",
+  "expected_result": "PASS",
+  "receipt_core": {
+    "currency": "USDC",
+    "timestamp_ms": 1747843200000,
+    "payment_hash": "2ed186ebc66947eaac6a05a88c7bc096ee07ac11a2c44bb5580bd72b3670f580",
+    "proof_blob_b64": "AAECBAUGB",
+    "canon_version": "1.0",
+    "action_ref": "10d8a38c01d8672176aa6e5209a368fde3e1831640d69e15283142b35880c2c1",
+    "merchant_id": "b4e5d6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5",
+    "proof_scheme": "stark-vauban-pay-v1",
+    "amount": 50000,
+    "payer_pseudonym": "a3f2c1d4e5b6a7890123456789abcdef0123456789abcdef0123456789abcdef01"
+  },
+  "expected_jcs_bytes_b64": "eyJhY3Rpb25fcmVmIjoiMTBkOGEzOGMwMWQ4NjcyMTc2YWE2ZTUyMDlhMzY4ZmRlM2UxODMxNjQwZDY5ZTE1MjgzMTQyYjM1ODgwYzJjMSIsImFtb3VudCI6NTAwMDAsImNhbm9uX3ZlcnNpb24iOiIxLjAiLCJjdXJyZW5jeSI6IlVTREMiLCJtZXJjaGFudF9pZCI6ImI0ZTVkNmY3YThiOWMwZDFlMmYzYTRiNWM2ZDdlOGY5YTBiMWMyZDNlNGY1YTZiN2M4ZDllMGYxYTJiM2M0ZDUiLCJwYXllcl9wc2V1ZG9ueW0iOiJhM2YyYzFkNGU1YjZhNzg5MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWYwMTIzNDU2Nzg5YWJjZGVmMDEiLCJwYXltZW50X2hhc2giOiIyZWQxODZlYmM2Njk0N2VhYWM2YTA1YTg4YzdiYzA5NmVlMDdhYzExYTJjNDRiYjU1ODBiZDcyYjM2NzBmNTgwIiwicHJvb2ZfYmxvYl9iNjQiOiJBQUVDQkFVR0IiLCJwcm9vZl9zY2hlbWUiOiJzdGFyay12YXViYW4tcGF5LXYxIiwidGltZXN0YW1wX21zIjoxNzQ3ODQzMjAwMDAwfQ==",
+  "expected_core_digest": "sha256:89e01af0770494243e7ba6d003332688ca7107dd05c52cc8c73f470b13d5767f",
+  "interop_bind": {
+    "axis_2_payment_hash": "2ed186ebc66947eaac6a05a88c7bc096ee07ac11a2c44bb5580bd72b3670f580",
+    "axis_2_source": "FeedOracle hybrid-PQC fixture PR #2411; same payment_hash field verbatim",
+    "axis_3_action_ref": "10d8a38c01d8672176aa6e5209a368fde3e1831640d69e15283142b35880c2c1",
+    "axis_3_source": "andysalvo TrailRecord PR #2398; action_ref_preimage SHA-256(JCS({action_type,agent_id,scope,timestamp_ms}))",
+    "digest_equality_assertion": "expected_core_digest MUST equal 0001-baseline expected_core_digest: sha256:89e01af0770494243e7ba6d003332688ca7107dd05c52cc8c73f470b13d5767f"
+  },
+  "notes": "Source object keys are in a different order than 0001-baseline (currency first, then timestamp_ms, payment_hash, etc.). JCS sorts all object keys lexicographically before serialising; the canonical bytes are byte-for-byte identical to 0001-baseline. expected_core_digest MUST equal the 0001 digest, demonstrating JCS key-sorting independence: an implementation that hashes the unsorted source bytes would produce a different digest and fail to interoperate with any conformant implementation. The shared payment_hash and action_ref bind this STARK receipt to FeedOracle Axis 2 (PR #2411) and andysalvo Axis 3 (PR #2398) respectively."
+}


### PR DESCRIPTION
Per @andysalvo's greenlight on #2398 ("STARK Axis 1 under \`fixtures/stark-vzk2p-v1/v0/\` as a separate PR also makes sense"), opening this PR with the Vauban-anchored Axis 1 fixture set.

Note on naming : the proof scheme was renamed from \`stark-vzk2p-v1\` to \`stark-vauban-pay-v1\` per Vauban brand discipline (the \`vzk2p\` codename is internal-only, the public surface uses the \`vauban-pay\` brand). The directory path follows the rename.

## What this PR adds

\`fixtures/stark-vauban-pay-v1/v0/\` with :

- \`manifest.json\` ; proof scheme, proof system, anchor chain, cross-axis interop bindings
- \`README.md\` ; 4-vector table, cross-axis bindings, open question on \`BoundReceipt<R>\` vs flat \`receipt_core\` shape
- \`vectors/0001-baseline.json\` ; canonical reference, PASS
- \`vectors/0002-field-name-load-bearing.json\` ; \`payment_hash\` -> \`paymentHash\` rename, FAIL, divergent digest pinned
- \`vectors/0003-stark-proof-tamper-evidence.json\` ; 1-byte \`proof_blob_b64\` mutation, FAIL, divergent digest pinned
- \`vectors/0008-interop-shared-payment-hash.json\` ; key-reorder + Axis 2/3 interop bind, PASS

**Total : 4 vectors, 1 cross-vector interop bind.**

## Cross-axis interop bindings

Every vector in this set shares the canonical values with sibling coalition fixture sets so a conformance harness can validate the cross-axis bindings byte-for-byte :

- **\`payment_hash\`** = \`2ed186ebc66947eaac6a05a88c7bc096ee07ac11a2c44bb5580bd72b3670f580\`  
  Shared verbatim with FeedOracle Axis 2 \`fixtures/hybrid-pqc/v0/\` per PR #2411.

- **\`action_ref\`** = \`10d8a38c01d8672176aa6e5209a368fde3e1831640d69e15283142b35880c2c1\`  
  Shared verbatim with andysalvo Axis 3 \`fixtures/action-ref-verify/v0/\` per PR #2398.

This is the cross-axis substrate the coalition discussed on #2357 : the four axes (substrate, STARK, hybrid-PQC, work-receipt) compose without overlap, each axis independently verifiable, with shared binding values that let a downstream conformance suite validate the interop is real.

## Canonicalisation discipline alignment with #2326 v3

This fixture set adopts the v3-converged discipline :

- JCS (RFC 8785) is the only canonicaliser ; SHA-256 of canonical bytes, lowercase hex
- Field names treated as load-bearing opaque UTF-8 bytes (the \`paymentHash\` vector 0002 proves the rule)
- Asymmetric failure surface : producer-loud (reject non-canonical input at wire) ; verifier-silent (any equivalent canonical input accepted)
- \`canon_version\` field shipped on every vector ; good-discipline default even though \`stark-vauban-pay-v1\` is not under MiCA Art. 80 retention by default

## Open question (intentionally surfaced rather than hidden)

The \`BoundReceipt<R>\` Rust type in \`crates/zkpay-x402/src/lib.rs\` is a nested structure (\`receipt: R\`, \`action_ref: Option<[u8; 32]>\`). The fixture's \`receipt_core\` is a flat structure that combines VPSF Claim fields with x402 wire extensions for digest purposes. The mapping between the Rust type and the canonical fixture shape is documented in the README §Open Questions. This is an open TSC item on #2357 that the fixture surfaces explicitly rather than papering over.

Two resolutions are plausible :

1. The Rust type adapts to match the flat \`receipt_core\` shape (breaks the Phase 2a serialisation invariant in the spec)
2. The fixture's canonical preimage is computed by a dedicated \`receipt_core_from_bound_receipt(BoundReceipt<R>) -> ReceiptCore\` adapter (preserves the Rust type, makes the canonical surface explicit)

Vauban's working preference is option 2 (clean separation between in-memory type and canonical wire form). Feedback welcome.

## Cross-implementation status

- Author : Vauban Pay (\`@seritalien\`)
- Self-validated : 4/4 vectors PASS-or-FAIL as expected, 1/1 interop bind under serde_jcs (5th-impl per the substrate matrix in #2412)
- Cross-implementation validation : Phase 2 ask ; happy to coordinate runners with AlgoVoi / FeedOracle / andysalvo for parity with the substrate coverage (5-impl 53/53 + 37/37)

## Conformance runner

\`runner-stark-axis-1\` is TBD ; expected result 4/4 vectors + 1/1 interop bind. Contribution welcome ; the privacy_class runner pattern from gist \`seritalien/b0b86baabae33e289fdb6d2f3fb30130\` transfers cleanly (only delta is the field naming from \`attestation_body\` to \`receipt_core\` and the digest field name).

## Related fixture sets

- \`fixtures/canonicalisation-substrate/v0/\` ; Axis 0, 53 vectors + 37 pair invariants (PR #2412)
- \`fixtures/hybrid-pqc/v0/\` ; Axis 2, hybrid-PQC receipt cores (PR #2411, validated by AlgoVoi 4-impl + Vauban serde_jcs 5th-impl)
- \`fixtures/action-ref-verify/v0/\` ; Axis 3, work-receipt binding (PR #2398)

## License

Apache 2.0

Refs #2357 #2326 #2411 #2398 #2332