### PR TITLE
fix: include payment headers on HTML paywalls

### DIFF
--- a/go/http/server.go
+++ b/go/http/server.go
@@ -897,12 +897,18 @@ func (s *x402HTTPResourceServer) isWebBrowser(adapter HTTPAdapter) bool {
 //	customHTML: Optional custom HTML for the paywall
 //	unpaidResponse: Optional custom response for API clients (ignored for browser requests)
 func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.PaymentRequired, isWebBrowser bool, paywallConfig *PaywallConfig, customHTML string, unpaidResponse *UnpaidResponse) (*HTTPResponseInstructions, error) {
+	encodedHeader, err := encodePaymentRequiredHeader(paymentRequired)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode payment required header: %w", err)
+	}
+
 	if isWebBrowser {
 		html := s.generatePaywallHTMLV2(paymentRequired, paywallConfig, customHTML)
 		return &HTTPResponseInstructions{
 			Status: 402,
 			Headers: map[string]string{
-				"Content-Type": "text/html",
+				"Content-Type":     "text/html",
+				"PAYMENT-REQUIRED": encodedHeader,
 			},
 			Body:   html,
 			IsHTML: true,
@@ -916,11 +922,6 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 	if unpaidResponse != nil {
 		contentType = unpaidResponse.ContentType
 		body = unpaidResponse.Body
-	}
-
-	encodedHeader, err := encodePaymentRequiredHeader(paymentRequired)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode payment required header: %w", err)
 	}
 
 	return &HTTPResponseInstructions{

--- a/go/http/server_test.go
+++ b/go/http/server_test.go
@@ -311,6 +311,9 @@ func TestProcessHTTPRequestWithBrowser(t *testing.T) {
 	if result.Response.Headers["Content-Type"] != "text/html" {
 		t.Error("Expected text/html content type")
 	}
+	if result.Response.Headers["PAYMENT-REQUIRED"] == "" {
+		t.Error("Expected PAYMENT-REQUIRED header")
+	}
 
 	// Check HTML contains expected elements
 	html := result.Response.Body.(string)

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -743,7 +743,10 @@ class x402HTTPServerBase:
             )
             return HTTPResponseInstructions(
                 status=402,
-                headers={"Content-Type": "text/html"},
+                headers={
+                    "Content-Type": "text/html",
+                    PAYMENT_REQUIRED_HEADER: encode_payment_required_header(payment_required),
+                },
                 body=html_content,
                 is_html=True,
             )

--- a/python/x402/tests/integrations/test_http_integration.py
+++ b/python/x402/tests/integrations/test_http_integration.py
@@ -297,6 +297,37 @@ class TestHTTPIntegration:
         result = components.process_http_request(context)
         assert result.type == "no-payment-required"
 
+    def test_browser_paywall_includes_payment_required_header(
+        self,
+        components: HTTPComponentsFixture,
+    ) -> None:
+        """Test browser HTML paywalls keep the protocol payment header."""
+        mock_adapter = MockHTTPAdapter(
+            path="/api/protected",
+            method="GET",
+            headers={
+                "Accept": "text/html,application/xhtml+xml",
+                "User-Agent": "Mozilla/5.0",
+            },
+        )
+        context = HTTPRequestContext(
+            adapter=mock_adapter,
+            path="/api/protected",
+            method="GET",
+        )
+
+        result = components.process_http_request(context)
+
+        assert result.type == "payment-error"
+        assert result.response is not None
+        assert result.response.status == 402
+        assert result.response.is_html is True
+        assert result.response.headers["Content-Type"] == "text/html"
+        payment_required = decode_payment_required_header(
+            result.response.headers["PAYMENT-REQUIRED"]
+        )
+        assert payment_required.accepts[0].network == "x402:cash"
+
 
 class TestDynamicPricing:
     """Tests for dynamic pricing - run against both sync and async implementations."""

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1040,18 +1040,20 @@ export class x402HTTPResourceServer {
     // Use 412 Precondition Failed for permit2_allowance_required error
     // This signals client needs to approve Permit2 before retrying
     const status = paymentRequired.error === "permit2_allowance_required" ? 412 : 402;
+    const response = this.createHTTPPaymentRequiredResponse(paymentRequired);
 
     if (isWebBrowser) {
       const html = this.generatePaywallHTML(paymentRequired, paywallConfig, customHtml);
       return {
         status,
-        headers: { "Content-Type": "text/html" },
+        headers: {
+          "Content-Type": "text/html",
+          ...response.headers,
+        },
         body: html,
         isHtml: true,
       };
     }
-
-    const response = this.createHTTPPaymentRequiredResponse(paymentRequired);
 
     // Use callback result if provided, otherwise default to JSON with empty object
     const contentType = unpaidResponse ? unpaidResponse.contentType : "application/json";

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -1270,10 +1270,12 @@ describe("x402HTTPResourceServer", () => {
 
       const result = await httpServer.processHTTPRequest(context);
 
-      // Should return HTML paywall for browsers
-      if (result.type === "payment-error") {
-        expect(result.response.isHtml).toBe(true);
+      expect(result.type).toBe("payment-error");
+      if (result.type !== "payment-error") {
+        throw new Error("Expected payment-error result");
       }
+      expect(result.response.isHtml).toBe(true);
+      expect(result.response.headers["PAYMENT-REQUIRED"]).toBeDefined();
     });
 
     it("should bypass the resource handler when an AfterVerifyHook returns skipHandler", async () => {


### PR DESCRIPTION
## Summary
- include `PAYMENT-REQUIRED` on browser HTML paywall 402 responses in TypeScript, Go, and Python HTTP resource servers
- keep the existing HTML paywall behavior while preserving the machine-readable protocol header
- add regression coverage for browser paywall responses

## Why
Browser-like requests received a human-readable paywall but lost the protocol-level payment requirements header. That made the 402 response less useful for wallet helpers, browser extensions, and automated clients that still expect to inspect `PAYMENT-REQUIRED`.

Closes #2418

## Checks
- `go test ./http`
- `ASDF_NODEJS_VERSION=24.15.0 pnpm --dir typescript/packages/core test -- test/unit/http/x402HTTPResourceService.test.ts`
- `ASDF_NODEJS_VERSION=24.15.0 pnpm --dir typescript/packages/core lint:check`
- `ASDF_NODEJS_VERSION=24.15.0 pnpm --dir typescript/packages/core exec tsc --noEmit`
- `uv run pytest tests/integrations/test_http_integration.py`
- `uv run ruff check http/x402_http_server_base.py tests/integrations/test_http_integration.py`