### PR TITLE
Extension: risk-check — Counterparty risk verification for x402 payments

### DIFF
--- a/go/types.go
+++ b/go/types.go
@@ -124,7 +124,7 @@ type SettlementOverrides struct {
 type RiskCheckExtensionInfo struct {
 	Required     bool     `json:"required"`
 	RiskCheckURL string   `json:"risk_check_url,omitempty"`
-	MinScore     int      `json:"min_score,omitempty"` // Valid range: 0-100 inclusive
+	MinScore     *int     `json:"min_score,omitempty"` // Pointer type: 0 is valid (no minimum threshold). Valid range: 0-100 inclusive
 	Categories   []string `json:"categories,omitempty"`
 }
 
@@ -132,7 +132,7 @@ type RiskCheckExtensionInfo struct {
 // VerifyResponse and SettleResponse extensions["risk-check"]
 type RiskCheckResult struct {
 	Checked    bool     `json:"checked"`
-	Score      int      `json:"score,omitempty"`
+	Score      *int     `json:"score,omitempty"` // Pointer type: 0 is a valid score (highest risk), nil means unchecked
 	Tier       string   `json:"tier,omitempty"`
 	Provider   string   `json:"provider,omitempty"`
 	Categories []string `json:"categories,omitempty"`

--- a/go/types.go
+++ b/go/types.go
@@ -119,6 +119,29 @@ type SettlementOverrides struct {
 	Amount string `json:"amount,omitempty"`
 }
 
+// RiskCheckExtensionInfo represents the risk-check extension info
+// advertised by a resource server in PaymentRequired.extensions["risk-check"].info
+type RiskCheckExtensionInfo struct {
+	Required     bool     `json:"required"`
+	RiskCheckURL string   `json:"risk_check_url,omitempty"`
+	MinScore     int      `json:"min_score,omitempty"`
+	Categories   []string `json:"categories,omitempty"`
+}
+
+// RiskCheckResult represents the risk-check result included in
+// VerifyResponse and SettleResponse extensions["risk-check"]
+type RiskCheckResult struct {
+	Checked    bool     `json:"checked"`
+	Score      int      `json:"score,omitempty"`
+	Tier       string   `json:"tier,omitempty"`
+	Provider   string   `json:"provider,omitempty"`
+	Categories []string `json:"categories,omitempty"`
+	JWS        string   `json:"jws,omitempty"`
+	JWKSURL    string   `json:"jwks_url,omitempty"`
+	CheckedAt  string   `json:"checked_at,omitempty"`
+	ExpiresAt  string   `json:"expires_at,omitempty"`
+}
+
 // ResourceConfig defines payment configuration for a protected resource
 type ResourceConfig struct {
 	Scheme            string                 `json:"scheme"`

--- a/go/types.go
+++ b/go/types.go
@@ -124,7 +124,7 @@ type SettlementOverrides struct {
 type RiskCheckExtensionInfo struct {
 	Required     bool     `json:"required"`
 	RiskCheckURL string   `json:"risk_check_url,omitempty"`
-	MinScore     int      `json:"min_score,omitempty"`
+	MinScore     int      `json:"min_score,omitempty"` // Valid range: 0-100 inclusive
 	Categories   []string `json:"categories,omitempty"`
 }
 

--- a/specs/extensions/risk-check.md
+++ b/specs/extensions/risk-check.md
@@ -293,7 +293,9 @@ Facilitators that do not support the extension MUST ignore it and proceed with n
 
 ## Server Enforcement
 
-When `required` is `true`, the resource server MUST check `VerifyResponse.extensions["risk-check"]` or `SettleResponse.extensions["risk-check"]`:
+When `required` is `true`, the resource server MUST enforce the risk check **before serving the resource**. In the standard verify-then-settle flow, this means checking `VerifyResponse.extensions["risk-check"]`; the resource MUST NOT be served if verification does not include a passing risk check. `SettleResponse.extensions["risk-check"]` carries the same attestation and is used as confirmation for settlement-time auditing and for batch or deferred-settlement flows where enforcement is delegated to settle.
+
+The server MUST apply the following checks against the chosen response:
 
 1. If `checked` is `false` or the `risk-check` key is absent, the server MUST reject the request (the facilitator did not support the extension or did not perform the check).
 2. If `score` is below `min_score`, the server MUST reject the request with an appropriate error.

--- a/specs/extensions/risk-check.md
+++ b/specs/extensions/risk-check.md
@@ -320,7 +320,7 @@ When `required` is `false`, the risk-check result is informational. The server M
 - **Provider**: [Revettr](https://revettr.com) — counterparty risk scoring for x402 agent commerce
   - Discovery: `https://revettr.com/.well-known/risk-check.json`
   - JWKS: `https://revettr.com/.well-known/jwks.json`
-  - Scoring: `POST https://revettr.com/v1/score`
+  - Risk Check: `POST https://revettr.com/v1/risk-check`
   - Attestation: `POST https://revettr.com/v1/attest` (free tier)
   - SDK: `pip install revettr` ([PyPI](https://pypi.org/project/revettr/))
 

--- a/specs/extensions/risk-check.md
+++ b/specs/extensions/risk-check.md
@@ -25,7 +25,8 @@ Risk-check providers publish a discovery document at `/.well-known/risk-check.js
   "name": "Example Risk Provider",
   "version": "0.1.0",
   "description": "Counterparty risk scoring for x402 agent commerce",
-  "endpoint": "/v1/score",
+  "endpoint": "/v1/risk-check",
+  "batch_endpoint": "/v1/risk-check/batch",
   "method": "POST",
   "pricing": {
     "amount": "10000",
@@ -44,6 +45,22 @@ Risk-check providers publish a discovery document at `/.well-known/risk-check.js
   }
 }
 ```
+
+### Discovery Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | `string` | Yes | Provider display name |
+| `version` | `string` | Yes | Discovery document version |
+| `description` | `string` | No | Human-readable provider description |
+| `endpoint` | `string` | Yes | Scoring endpoint path (returns `RiskCheckResult`) |
+| `batch_endpoint` | `string` | No | Batch scoring endpoint for multiple payers in one request |
+| `method` | `string` | Yes | HTTP method (`POST` or `GET`) |
+| `pricing` | `object` | No | x402 pricing info for paid risk checks |
+| `signals` | `string[]` | No | Scoring signal types supported (e.g., `wallet`, `domain`, `ip`) |
+| `chains_supported` | `string[]` | No | Blockchain networks supported |
+| `response_time_ms` | `string` | No | Expected response time |
+| `attestation` | `object` | No | JWS attestation configuration (`jwks_url`, `algorithm`, `kid`, `ttl`) |
 
 Facilitators SHOULD cache discovery documents with a TTL of no more than 24 hours.
 
@@ -164,6 +181,8 @@ The client MAY append `payer_wallet` and `payer_domain` to the `info` object to 
 | `payer_wallet` | `string` | No | The payer's wallet address for risk scoring |
 | `payer_domain` | `string` | No | The payer's domain for domain-level risk signals |
 
+> **Identity derivation:** Facilitators MUST derive the payer wallet address from the validated payment payload (e.g., the signing address of the payment authorization). Client-supplied `payer_wallet` and `payer_domain` are supplementary hints for additional scoring signals (e.g., domain reputation) and MUST NOT be used as the primary payer identity when calling the risk-check provider.
+
 ---
 
 ## `VerifyResponse`
@@ -232,6 +251,24 @@ After settlement, the facilitator includes the full risk attestation with a veri
 | `checked_at` | `string` (ISO 8601) | If checked | Timestamp when the risk check was performed |
 | `expires_at` | `string` (ISO 8601) | If checked | Expiry timestamp for the attestation (typically 1 hour) |
 
+### JWS Claims
+
+When a risk-check provider signs an attestation as a compact JWS (RFC 7515), the JWT payload MUST include:
+
+| Claim | Required | Description |
+|-------|----------|-------------|
+| `iss` | Yes | Provider DID (e.g., `did:web:provider.example`) |
+| `sub` | Yes | Payer wallet address (facilitator-derived, not client-asserted) |
+| `score` | Yes | Risk score 0-100 |
+| `tier` | Yes | Risk tier (`low`, `medium`, `high`, `critical`) |
+| `iat` | Yes | Issued-at timestamp (Unix epoch) |
+| `exp` | Yes | Expiry timestamp (Unix epoch) |
+| `aud` | Recommended | Resource server URL for context binding |
+| `categories` | If applicable | Categories covered by this attestation |
+| `input_hash` | Recommended | Hash of scoring inputs for audit trail |
+
+Servers verifying the JWS SHOULD check that `sub` matches the payer from the payment payload and that `aud` (if present) matches the resource URL. This prevents replay of attestations across different payment contexts.
+
 ---
 
 ## Facilitator Behavior
@@ -243,22 +280,23 @@ Facilitators that support the `risk-check` extension SHOULD:
 3. **Call** the provider's scoring endpoint with the payer's wallet address (and optionally domain/IP).
 4. **Include** the result in `VerifyResponse.extensions["risk-check"]` and `SettleResponse.extensions["risk-check"]`.
 5. **Reject** verification if `required` is `true` and the score is below `min_score`, returning `isValid: false` with `invalidReason: "risk-check-failed"`.
+6. **Reject** verification if `required` is `true` and the facilitator does not support the `risk-check` extension, returning `isValid: false` with `invalidReason: "risk-check-unsupported"`. This prevents the charge-then-deny case where settlement succeeds but the server discovers the risk check was skipped after the fact.
 
 Facilitators MAY choose to:
 - Cache risk-check results per payer wallet (respecting `expires_at`)
 - Amortize a single risk check across multiple batched voucher settlements for the same payer
 - Support multiple risk-check providers and select based on `categories`
 
-Facilitators that do not support the extension MUST ignore it and proceed with normal verification/settlement. The extension is always optional at the facilitator level.
+Facilitators that do not support the extension MUST ignore it and proceed with normal verification/settlement when `required` is `false`. When `required` is `true`, the facilitator MUST return `isValid: false` with `invalidReason: "risk-check-unsupported"` rather than proceeding without a risk check.
 
 ---
 
 ## Server Enforcement
 
-When `required` is `true`, the resource server SHOULD check `SettleResponse.extensions["risk-check"]` after receiving a successful settlement:
+When `required` is `true`, the resource server MUST check `VerifyResponse.extensions["risk-check"]` or `SettleResponse.extensions["risk-check"]`:
 
-1. If `checked` is `false` or the `risk-check` key is absent, the server MAY reject the request (the facilitator did not support the extension).
-2. If `score` is below `min_score`, the server SHOULD reject the request with an appropriate error.
+1. If `checked` is `false` or the `risk-check` key is absent, the server MUST reject the request (the facilitator did not support the extension or did not perform the check).
+2. If `score` is below `min_score`, the server MUST reject the request with an appropriate error.
 3. If `jws` is present, the server MAY verify the signature against `jwks_url` for independent attestation verification.
 
 When `required` is `false`, the risk-check result is informational. The server MAY use the score for logging, analytics, or adaptive behavior without blocking the request.

--- a/specs/extensions/risk-check.md
+++ b/specs/extensions/risk-check.md
@@ -1,0 +1,295 @@
+# Extension: `risk-check`
+
+## Summary
+
+The `risk-check` extension enables **counterparty risk verification** for x402-protected resources. Resource servers declare a minimum risk score requirement and an optional risk-check provider URL. Facilitators call the provider during verification or settlement and include the signed risk attestation in their response. Servers can then enforce score thresholds before serving resources.
+
+This extension is **provider-agnostic**. Any service implementing the `/.well-known/risk-check.json` discovery endpoint qualifies as a risk-check provider. The extension defines the interface, not the scoring methodology.
+
+---
+
+## Motivation
+
+x402 batch settlement (May 2026) made sub-cent micropayments economically rational. At sub-cent transaction values, a 5-cent counterparty risk check destroys unit economics if performed per-transaction. By integrating risk verification into the facilitator's settlement flow, a single risk check can be amortized across thousands of batched voucher redemptions.
+
+Without this extension, risk verification is an aftermarket bolt-on that each resource server must implement independently. With it, verification becomes a protocol-level primitive that facilitators can bundle into the same transaction flow.
+
+---
+
+## Discovery
+
+Risk-check providers publish a discovery document at `/.well-known/risk-check.json`:
+
+```json
+{
+  "name": "Example Risk Provider",
+  "version": "0.1.0",
+  "description": "Counterparty risk scoring for x402 agent commerce",
+  "endpoint": "/v1/score",
+  "method": "POST",
+  "pricing": {
+    "amount": "10000",
+    "currency": "USDC",
+    "protocol": "x402",
+    "network": "eip155:8453"
+  },
+  "signals": ["wallet", "domain", "ip", "sanctions"],
+  "chains_supported": ["base", "ethereum"],
+  "response_time_ms": "<3000",
+  "attestation": {
+    "jwks_url": "https://provider.example/.well-known/jwks.json",
+    "algorithm": "ES256",
+    "kid": "provider-attest-v1",
+    "ttl": "1h"
+  }
+}
+```
+
+Facilitators SHOULD cache discovery documents with a TTL of no more than 24 hours.
+
+---
+
+## `PaymentRequired`
+
+A resource server advertises risk-check support by including the `risk-check` key in the `extensions` object of the **402 Payment Required** response.
+
+### Example
+
+```json
+{
+  "x402Version": 2,
+  "error": "Payment required",
+  "resource": {
+    "url": "https://api.example.com/sensitive-data",
+    "description": "High-value data endpoint",
+    "mimeType": "application/json"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "amount": "10000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "maxTimeoutSeconds": 60,
+      "extra": {
+        "name": "USDC",
+        "version": "2"
+      }
+    }
+  ],
+  "extensions": {
+    "risk-check": {
+      "info": {
+        "required": false,
+        "risk_check_url": "https://provider.example/.well-known/risk-check.json",
+        "min_score": 60,
+        "categories": ["compliance_risk"]
+      },
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "required": {
+            "type": "boolean",
+            "description": "Whether the server requires a risk check to proceed"
+          },
+          "risk_check_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the risk-check provider's discovery document"
+          },
+          "min_score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Minimum acceptable risk score (0 = highest risk, 100 = safest)"
+          },
+          "categories": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Required attestation categories (e.g., compliance_risk, behavioral, identity)"
+          }
+        },
+        "required": ["required"]
+      }
+    }
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `required` | `boolean` | Yes | Whether the server requires a passing risk check to serve the resource |
+| `risk_check_url` | `string` (URI) | No | URL to the provider's `/.well-known/risk-check.json` discovery document. If omitted, the facilitator may use any registered provider. |
+| `min_score` | `integer` | No | Minimum acceptable score (0-100). Default: `0` (any score accepted). |
+| `categories` | `string[]` | No | Attestation categories the server requires. Maps to the [Composable Trust Evidence Format](https://github.com/agentgraph-co/agentgraph/discussions/1734) taxonomy. |
+
+---
+
+## `PaymentPayload`
+
+The client echoes the extension and may append provider preferences:
+
+```json
+{
+  "x402Version": 2,
+  "resource": { "url": "https://api.example.com/sensitive-data" },
+  "accepted": { "..." },
+  "payload": { "..." },
+  "extensions": {
+    "risk-check": {
+      "info": {
+        "required": false,
+        "risk_check_url": "https://provider.example/.well-known/risk-check.json",
+        "min_score": 60,
+        "categories": ["compliance_risk"],
+        "payer_wallet": "0xabc123...",
+        "payer_domain": "agent.example.com"
+      },
+      "schema": { "..." }
+    }
+  }
+}
+```
+
+The client MAY append `payer_wallet` and `payer_domain` to the `info` object to provide additional context for the risk-check provider. Per the x402 v2 extension rules, clients can append but cannot delete or overwrite existing info.
+
+### Additional Client Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `payer_wallet` | `string` | No | The payer's wallet address for risk scoring |
+| `payer_domain` | `string` | No | The payer's domain for domain-level risk signals |
+
+---
+
+## `VerifyResponse`
+
+When a facilitator performs a risk check during verification, it includes the result in the `extensions` field of `VerifyResponse`:
+
+```json
+{
+  "isValid": true,
+  "payer": "0xabc123...",
+  "extensions": {
+    "risk-check": {
+      "checked": true,
+      "score": 87,
+      "tier": "low",
+      "provider": "did:web:provider.example",
+      "categories": ["compliance_risk"],
+      "checked_at": "2026-05-21T14:00:00Z",
+      "expires_at": "2026-05-21T15:00:00Z"
+    }
+  }
+}
+```
+
+If the facilitator does not perform a risk check (e.g., the extension is not required and the facilitator does not support it), the `risk-check` key is omitted from `extensions`.
+
+---
+
+## `SettleResponse`
+
+After settlement, the facilitator includes the full risk attestation with a verifiable JWS:
+
+```json
+{
+  "success": true,
+  "payer": "0xabc123...",
+  "transaction": "0xdef456...",
+  "network": "eip155:8453",
+  "extensions": {
+    "risk-check": {
+      "checked": true,
+      "score": 87,
+      "tier": "low",
+      "provider": "did:web:provider.example",
+      "categories": ["compliance_risk"],
+      "jws": "eyJhbGciOiJFUzI1NiIsInR5cCI6InJpc2stY2hlY2srand0Iiwia2lkIjoicHJvdmlkZXItYXR0ZXN0LXYxIn0.eyJpc3MiOiJkaWQ6d2ViOnByb3ZpZGVyLmV4YW1wbGUiLCJzdWIiOiIweGFiYzEyMyIsInNjb3JlIjo4NywidGllciI6Imxvd...",
+      "jwks_url": "https://provider.example/.well-known/jwks.json",
+      "checked_at": "2026-05-21T14:00:00Z",
+      "expires_at": "2026-05-21T15:00:00Z"
+    }
+  }
+}
+```
+
+### Result Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `checked` | `boolean` | Yes | Whether a risk check was performed |
+| `score` | `integer` | If checked | Risk score 0-100 (0 = highest risk, 100 = safest) |
+| `tier` | `string` | If checked | Risk tier: `"low"` (80-100), `"medium"` (60-79), `"high"` (30-59), `"critical"` (0-29) |
+| `provider` | `string` | If checked | Provider DID (e.g., `did:web:provider.example`) |
+| `categories` | `string[]` | If checked | Categories covered by this attestation |
+| `jws` | `string` | No | Compact JWS (RFC 7515) signed attestation, verifiable against `jwks_url` |
+| `jwks_url` | `string` (URI) | If `jws` present | URL to the provider's JWKS endpoint for signature verification |
+| `checked_at` | `string` (ISO 8601) | If checked | Timestamp when the risk check was performed |
+| `expires_at` | `string` (ISO 8601) | If checked | Expiry timestamp for the attestation (typically 1 hour) |
+
+---
+
+## Facilitator Behavior
+
+Facilitators that support the `risk-check` extension SHOULD:
+
+1. **Read** the `risk-check` extension from the `PaymentRequired` and `PaymentPayload`.
+2. **Fetch** the provider's discovery document from `risk_check_url` (cache with ≤24h TTL).
+3. **Call** the provider's scoring endpoint with the payer's wallet address (and optionally domain/IP).
+4. **Include** the result in `VerifyResponse.extensions["risk-check"]` and `SettleResponse.extensions["risk-check"]`.
+5. **Reject** verification if `required` is `true` and the score is below `min_score`, returning `isValid: false` with `invalidReason: "risk-check-failed"`.
+
+Facilitators MAY choose to:
+- Cache risk-check results per payer wallet (respecting `expires_at`)
+- Amortize a single risk check across multiple batched voucher settlements for the same payer
+- Support multiple risk-check providers and select based on `categories`
+
+Facilitators that do not support the extension MUST ignore it and proceed with normal verification/settlement. The extension is always optional at the facilitator level.
+
+---
+
+## Server Enforcement
+
+When `required` is `true`, the resource server SHOULD check `SettleResponse.extensions["risk-check"]` after receiving a successful settlement:
+
+1. If `checked` is `false` or the `risk-check` key is absent, the server MAY reject the request (the facilitator did not support the extension).
+2. If `score` is below `min_score`, the server SHOULD reject the request with an appropriate error.
+3. If `jws` is present, the server MAY verify the signature against `jwks_url` for independent attestation verification.
+
+When `required` is `false`, the risk-check result is informational. The server MAY use the score for logging, analytics, or adaptive behavior without blocking the request.
+
+---
+
+## Security Considerations
+
+- **JWS Verification**: Servers SHOULD verify the `jws` attestation against the provider's published JWKS rather than trusting the facilitator alone. This prevents a compromised facilitator from fabricating risk scores.
+- **TTL Enforcement**: Attestations include `expires_at`. Servers and facilitators MUST NOT cache or reuse attestations beyond their expiry.
+- **Provider Trust**: The extension does not establish trust in the risk-check provider itself. Servers choose which providers to accept via `risk_check_url`. Facilitators MAY maintain an allowlist of trusted providers.
+- **Privacy**: The payer's wallet address is sent to the risk-check provider. Providers SHOULD NOT store or share this data beyond what is needed for scoring. The extension does not define a data retention policy; providers publish their own.
+- **Availability**: If the risk-check provider is unavailable and `required` is `true`, the facilitator SHOULD return `isValid: false` with `invalidReason: "risk-check-unavailable"` rather than silently proceeding.
+
+---
+
+## Reference Implementation
+
+- **Provider**: [Revettr](https://revettr.com) — counterparty risk scoring for x402 agent commerce
+  - Discovery: `https://revettr.com/.well-known/risk-check.json`
+  - JWKS: `https://revettr.com/.well-known/jwks.json`
+  - Scoring: `POST https://revettr.com/v1/score`
+  - Attestation: `POST https://revettr.com/v1/attest` (free tier)
+  - SDK: `pip install revettr` ([PyPI](https://pypi.org/project/revettr/))
+
+---
+
+## Related Specifications
+
+- [x402 Specification v2](../x402-specification-v2.md) — Core protocol
+- [Composable Trust Evidence Format (A2A RFC #1734)](https://github.com/agentgraph-co/agentgraph/discussions/1734) — Attestation taxonomy
+- [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) — Agent identity and validation registry
+- [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515) — JSON Web Signature
+- [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517) — JSON Web Key Set

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -47,6 +47,12 @@ export type {
   SettleFailureContext,
   VerifiedPaymentCanceledContext,
 } from "./extensions";
+export type {
+  RiskCheckExtensionInfo,
+  RiskCheckClientInfo,
+  RiskCheckResult,
+  RiskCheckDiscovery,
+} from "./risk-check";
 
 export type { DeepReadonly } from "./readonly";
 

--- a/typescript/packages/core/src/types/risk-check.ts
+++ b/typescript/packages/core/src/types/risk-check.ts
@@ -18,7 +18,10 @@ export type RiskCheckExtensionInfo = {
   required: boolean;
   /** URL to the provider's /.well-known/risk-check.json discovery document */
   risk_check_url?: string;
-  /** Minimum acceptable score (0 = highest risk, 100 = safest) */
+  /**
+   * Minimum acceptable score (0 = highest risk, 100 = safest).
+   * Valid range: 0-100 inclusive. Values outside this range MUST be rejected.
+   */
   min_score?: number;
   /** Required attestation categories (e.g., "compliance_risk", "behavioral") */
   categories?: string[];
@@ -68,6 +71,8 @@ export type RiskCheckDiscovery = {
   version: string;
   description?: string;
   endpoint: string;
+  /** Optional batch scoring endpoint for multiple payers in one request */
+  batch_endpoint?: string;
   method: "POST" | "GET";
   pricing?: {
     amount: string;

--- a/typescript/packages/core/src/types/risk-check.ts
+++ b/typescript/packages/core/src/types/risk-check.ts
@@ -1,0 +1,87 @@
+/**
+ * Types for the `risk-check` x402 extension.
+ *
+ * Enables counterparty risk verification in x402 payment flows.
+ * Resource servers declare risk-check requirements in PaymentRequired,
+ * facilitators perform the check and include results in VerifyResponse
+ * and SettleResponse.
+ *
+ * @see {@link https://github.com/x402-foundation/x402/blob/main/specs/extensions/risk-check.md}
+ */
+
+/**
+ * Risk-check extension info advertised by the resource server
+ * in PaymentRequired.extensions["risk-check"].info
+ */
+export type RiskCheckExtensionInfo = {
+  /** Whether the server requires a risk check to proceed */
+  required: boolean;
+  /** URL to the provider's /.well-known/risk-check.json discovery document */
+  risk_check_url?: string;
+  /** Minimum acceptable score (0 = highest risk, 100 = safest) */
+  min_score?: number;
+  /** Required attestation categories (e.g., "compliance_risk", "behavioral") */
+  categories?: string[];
+};
+
+/**
+ * Additional fields the client may append in PaymentPayload
+ */
+export type RiskCheckClientInfo = RiskCheckExtensionInfo & {
+  /** Payer's wallet address for risk scoring */
+  payer_wallet?: string;
+  /** Payer's domain for domain-level risk signals */
+  payer_domain?: string;
+};
+
+/**
+ * Risk-check result included in VerifyResponse and SettleResponse
+ * extensions["risk-check"]
+ */
+export type RiskCheckResult = {
+  /** Whether a risk check was performed */
+  checked: boolean;
+  /** Risk score 0-100 (0 = highest risk, 100 = safest) */
+  score?: number;
+  /** Risk tier */
+  tier?: "low" | "medium" | "high" | "critical";
+  /** Provider DID (e.g., "did:web:provider.example") */
+  provider?: string;
+  /** Categories covered by this attestation */
+  categories?: string[];
+  /** Compact JWS (RFC 7515) signed attestation */
+  jws?: string;
+  /** URL to provider's JWKS for signature verification */
+  jwks_url?: string;
+  /** ISO 8601 timestamp when the check was performed */
+  checked_at?: string;
+  /** ISO 8601 expiry timestamp for the attestation */
+  expires_at?: string;
+};
+
+/**
+ * Risk-check provider discovery document
+ * served at /.well-known/risk-check.json
+ */
+export type RiskCheckDiscovery = {
+  name: string;
+  version: string;
+  description?: string;
+  endpoint: string;
+  method: "POST" | "GET";
+  pricing?: {
+    amount: string;
+    currency: string;
+    protocol: string;
+    network: string;
+  };
+  signals?: string[];
+  chains_supported?: string[];
+  response_time_ms?: string;
+  attestation?: {
+    jwks_url: string;
+    algorithm: string;
+    kid: string;
+    ttl: string;
+  };
+};


### PR DESCRIPTION
## Summary

- Adds `risk-check` extension spec at `specs/extensions/risk-check.md`
- Adds TypeScript types (`RiskCheckExtensionInfo`, `RiskCheckResult`, `RiskCheckDiscovery`) at `typescript/packages/core/src/types/risk-check.ts`
- Fixes Go/TypeScript parity: adds missing `Extensions` field to Go `VerifyResponse` and `SettleResponse`
- Adds Go types (`RiskCheckExtensionInfo`, `RiskCheckResult`) at `go/types.go`

Discussed in #2421.

## Design

Resource servers declare a minimum risk score in `PaymentRequired.extensions["risk-check"]`. Facilitators call a risk-check provider during verification, cache the result per payer, and include the signed attestation in `SettleResponse.extensions["risk-check"]`. One check amortized across all voucher settlements for the same payer within the TTL window.

Key design choices:
- **Provider-agnostic**: any service publishing `/.well-known/risk-check.json` qualifies
- **JWS-verified**: results carry a compact JWS attestation verifiable against the provider's JWKS
- **Optional at every layer**: servers opt in, facilitators that don't support it ignore it
- **Batch-friendly**: facilitators cache per payer, amortize across batched voucher settlements

## AI Disclosure

This contribution was made with AI assistance (Claude) and has been human-reviewed.

## Reference Implementation

[Revettr](https://revettr.com) implements this pattern in production with facilitator-facing endpoints (`POST /v1/risk-check`, `POST /v1/risk-check/batch`) returning the exact `RiskCheckResult` format from this spec.