### PR TITLE
Add GoldBean to ecosystem directory

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/goldbean/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/goldbean/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "GoldBean",
+  "description": "x402 micropaid API marketplace for crypto data and analysis, with seven paid endpoints advertised through an x402 Bazaar manifest.",
+  "logoUrl": "/logos/goldbean.svg",
+  "websiteUrl": "https://goldbean-api.xyz",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/goldbean.svg
+++ b/typescript/site/public/logos/goldbean.svg
@@ -1,0 +1,15 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">GoldBean logo</title>
+  <desc id="desc">A gold bean mark for the GoldBean x402 API marketplace.</desc>
+  <rect width="256" height="256" rx="64" fill="#1A1208"/>
+  <path d="M73.9 183.1c-25.8-25.8-22.4-73.9 7.5-103.9 29.9-29.9 78.1-33.3 103.9-7.5 25.8 25.8 22.4 73.9-7.5 103.9-29.9 29.9-78 33.3-103.9 7.5Z" fill="url(#bean)"/>
+  <path d="M88.5 166.8c27.4-3.3 75.2-34.3 83.4-76.8" stroke="#6C3F00" stroke-width="13" stroke-linecap="round" opacity="0.7"/>
+  <path d="M88.7 99.2c15.4-18.2 46.6-28.7 70.3-20.9" stroke="#FFE6A0" stroke-width="9" stroke-linecap="round" opacity="0.8"/>
+  <defs>
+    <linearGradient id="bean" x1="67.3" y1="188.8" x2="190.5" y2="65.6" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C77700"/>
+      <stop offset="0.45" stop-color="#F8B737"/>
+      <stop offset="1" stop-color="#FFE08A"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- add GoldBean to the x402 ecosystem partner data under Services/Endpoints
- add a lightweight GoldBean SVG logo asset for the ecosystem card

## Notes
- I verified the homepage and `.well-known/x402-bazaar` manifest are currently reachable before adding the listing.
- The issue mentions Base Sepolia, while the live Bazaar manifest currently advertises `eip155:8453`; this PR keeps the public listing description chain-neutral rather than copying a potentially stale network value.

Fixes #2409

## Verification
- `git diff --check`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('typescript/site/app/ecosystem/partners-data/goldbean/metadata.json','utf8')); console.log('metadata ok')"`
- fetched `https://goldbean-api.xyz` and `https://goldbean-api.xyz/.well-known/x402-bazaar` successfully
