### PR TITLE
Add Lithium Research Vault to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/lithium-research-vault/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/lithium-research-vault/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Lithium Research Vault",
+  "description": "Structured lithium mine + operator data from primary regulator filings (SEC, ASX, TSX, cninfo, IR). Production, AISC, reserves, ownership, royalties, offtakes. Every value cited to its source filing.",
+  "websiteUrl": "https://clink-lithium-vault.fly.dev",
+  "category": "Services/Endpoints",
+  "top_section": false
+}

--- a/typescript/site/app/ecosystem/partners-data/lithium-research-vault/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/lithium-research-vault/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Lithium Research Vault",
-  "description": "Structured lithium mine + operator data from primary regulator filings (SEC, ASX, TSX, cninfo, IR). Production, AISC, reserves, ownership, royalties, offtakes. Every value cited to its source filing.",
+  "description": "Primary-source data on lithium mining operators and battery-metal producers worldwide. Production, AISC, reserves, ownership, royalties, offtakes, SEC/ASX/TSX filings. Mine-level (Greenbushes, Pilgangoora, Atacama, Grota do Cirilo) or company-level (ALB, SGML, PILBF, IGO). Every value cited to its source filing.",
   "websiteUrl": "https://clink-lithium-vault.fly.dev",
   "category": "Services/Endpoints",
   "top_section": false


### PR DESCRIPTION
## What this adds

**Lithium Research Vault** — two x402-payable endpoints serving structured
lithium mine + operator data from a curated primary-source corpus (SEC, ASX,
TSX, SEDAR, cninfo, and IR filings). Running on Base mainnet since 2026-05-21.

**Category:** Services/Endpoints

### Endpoints

| Name | Endpoint | Price | Network |
|------|----------|-------|---------|
| Vault — raw data | `GET /vault` | $0.05 USDC | Base |
| Vault — narrative synthesis | `GET /vault/story` | $0.20 USDC | Base |

Both accept `?entity=<TICKER|MineName>&level=<company|mine>` and resolve
multi-operator mines (e.g., Greenbushes → IGO + ALB + TIANQI rows).

**Live URL:** https://clink-lithium-vault.fly.dev
**Current listing on agentic.market:** https://agentic.market/services/clink-lithium-vault-fly-dev

### Coverage (as of 2026-05-21)

- 40 vault operators (38 with extracted financials)
- 49 producing mines tracked across `Hardrock-Producers` + `Brine-Producers` reference lists
- Every numeric value FX-normalized to USD at extraction time with source filing URL on every row

### Technical details

- Scheme: `exact`
- Asset: USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)
- payTo: `0xB1eF5415E9D3695e16977B8be422AB7512F788C0`
- Refund-by-design: out-of-vault entities 400 before payment middleware
- Response: typed JSON validated by Zod (`vault-v1` schema)
- Differentiator vs other paid lithium feeds: curated primary-source corpus, not a wrapper around free public APIs. Citation URL on every numeric value.
- Story tier uses Anthropic tool_use for guaranteed-valid JSON output; every paragraph carries inline `[table:ticker:period:field]` citations resolving to a primary-source filing URL.

### About this PR

Adds `typescript/site/app/ecosystem/partners-data/lithium-research-vault/metadata.json`. Logo not included — happy to follow up with a 168×168 PNG (or other preferred format/dimensions) on this PR if requested, or you can use the service favicon at https://clink-lithium-vault.fly.dev/favicon.ico in the interim.

I've omitted `logoUrl` from metadata.json given no logo file exists yet — let me know if you'd prefer I add a placeholder reference and a logo file in the same PR.
