### PR TITLE
fixtures: risk-check-attestation-sample v0 ; 2 vectors (ALLOW/DENY)

### DIFF
--- a/fixtures/risk-check-attestation-sample/v0/README.md
+++ b/fixtures/risk-check-attestation-sample/v0/README.md
@@ -46,6 +46,7 @@ Implications for emitters:
 |---|---|---|---|
 | `0001-allow-uk-eu` | `ALLOW` | `["UK", "EU"]` | Nominal UK+EU jurisdiction pass ; demonstrates array order significance |
 | `0002-deny-jurisdiction` | `DENY` | `["BLOCKED"]` | Sanctioned jurisdiction ; payment rejected |
+| `0003-refer-sar` | `REFER` | `["UK", "EU"]` | Match triggers SAR obligation (UK POCA 2002 s.330) |
 
 ## JCS reproduction
 

--- a/fixtures/risk-check-attestation-sample/v0/README.md
+++ b/fixtures/risk-check-attestation-sample/v0/README.md
@@ -1,0 +1,63 @@
+# risk-check-attestation-sample v0
+
+Canonical JCS test vectors for the x402 risk-check attestation format.
+
+**Spec originator**: @AlexanderLawson17 (x402 issue #2421, PR #2422)
+**Production reference**: AlgoVoi (@chopmob-cloud) ; `/compliance/screen`, UK MLR 2017 / SAMLA Reg 40(3) / FCA 7-year retention
+
+## Schema
+
+Six required fields per receipt.
+
+| Field | Type | Description |
+|---|---|---|
+| `payer_ref` | `sha256:<hex>` | SHA-256(JCS(payer_identity_object)) ; no raw PII (GDPR/CCPA compatible) |
+| `screen_result` | `ALLOW` / `REFER` / `DENY` | `REFER` triggers SAR obligation under UK POCA 2002 s.330 |
+| `screen_timestamp_ms` | integer | Epoch milliseconds ; NOT RFC 3339 (RFC 3339 admits multiple encodings, divergent digests at year-5 re-verification) |
+| `screen_provider_did` | `did:web:` or `did:key:` | Screening provider identity |
+| `jurisdiction_flags` | array of strings | ISO 3166-1 alpha-2 codes ; `BLOCKED` for sanctioned jurisdictions |
+| `canon_version` | `jcs-rfc8785-v1` | RFC 8785 JCS canonicalization marker |
+
+`expected_hash` is present in test vectors only; absent in live receipts.
+
+## Vectors
+
+| Vector | `screen_result` | `jurisdiction_flags` | Description |
+|---|---|---|---|
+| `0001-allow-uk-eu` | `ALLOW` | `["EU", "UK"]` | Nominal UK+EU jurisdiction pass |
+| `0002-deny-jurisdiction` | `DENY` | `["BLOCKED"]` | Sanctioned jurisdiction ; payment rejected |
+
+## JCS reproduction
+
+All `expected_hash` values are `sha256:` prefixed hex digests of `SHA-256(JCS(receipt_object_without_expected_hash))`.
+
+Reproduce with any RFC 8785 implementation:
+
+```js
+// JS (canonicalize npm + node:crypto)
+const { createRequire } = require('module');
+const c = createRequire(import.meta.url)('canonicalize');
+const hash = 'sha256:' + crypto.createHash('sha256')
+  .update(Buffer.from(c(receiptWithoutExpectedHash), 'utf8'))
+  .digest('hex');
+```
+
+```python
+# Python (jcs pip + hashlib)
+import jcs, hashlib
+digest = 'sha256:' + hashlib.sha256(jcs.canonicalize(receipt)).hexdigest()
+```
+
+Compatible implementations: `canonicalize` (JS), `gowebpki/jcs` (Go), `cyberphone/json-canonicalization` (Java), `serde_jcs` (Rust), `jcs` (Python).
+
+## Cross-axis binding
+
+These vectors share the JCS canonicalization substrate defined in Axis 0 (x402 PR #2412, AlgoVoi).
+
+The `payer_ref` content-addressing pattern is consistent with `action_ref = SHA-256(JCS(preimage))` from Axis 3 (PR #2398, andysalvo).
+
+As an Axis 4 composite trust-query emitter row, the risk-check receipt binds to `(payment_hash, action_ref)` alongside AlgoVoi compliance-screening, Vauban STARK proof-of-payment-conditions, and nobulex verascore-evidence-schema rows. Tetra-party composite structure per x402 issue #2322.
+
+## Session-level amortisation
+
+Per AlgoVoi production data: one screen per payer session, not per micropayment. A payer session covering 1,000 micropayments incurs one screen cost. The protocol SHOULD specify session-scope as the default amortisation unit to preserve micropayment unit economics without compromising screening depth.

--- a/fixtures/risk-check-attestation-sample/v0/README.md
+++ b/fixtures/risk-check-attestation-sample/v0/README.md
@@ -15,16 +15,36 @@ Six required fields per receipt.
 | `screen_result` | `ALLOW` / `REFER` / `DENY` | `REFER` triggers SAR obligation under UK POCA 2002 s.330 |
 | `screen_timestamp_ms` | integer | Epoch milliseconds ; NOT RFC 3339 (RFC 3339 admits multiple encodings, divergent digests at year-5 re-verification) |
 | `screen_provider_did` | `did:web:` or `did:key:` | Screening provider identity |
-| `jurisdiction_flags` | array of strings | ISO 3166-1 alpha-2 codes ; `BLOCKED` for sanctioned jurisdictions |
+| `jurisdiction_flags` | array of strings | ISO 3166-1 alpha-2 codes ; `BLOCKED` for sanctioned jurisdictions ; **array order is significant** (see below) |
 | `canon_version` | `jcs-rfc8785-v1` | RFC 8785 JCS canonicalization marker |
 
 `expected_hash` is present in test vectors only; absent in live receipts.
+
+## Array ordering discipline (per PR #2436 normative section)
+
+JCS preserves array element order ; it does NOT sort arrays. Two receipts identical except for `jurisdiction_flags` order produce different canonical digests.
+
+Demonstration (vector 0001 with the in-file order `["UK", "EU"]`) :
+
+```
+JCS_canonical_bytes := '{"canon_version":"jcs-rfc8785-v1","jurisdiction_flags":["UK","EU"],"payer_ref":"sha256:4a7b...","screen_provider_did":"did:web:api.algovoi.co.uk","screen_result":"ALLOW","screen_timestamp_ms":1748000000000}'
+expected_hash        := sha256:f4e8d652c6cf6c903adf08a0b0b77a3de099e5e0a4b3b01f78fd16cd2fa4da54
+```
+
+If the same payload were emitted with `["EU", "UK"]` instead, the digest would be `sha256:9c72e3d6b945492f088b4830274d6efcc00c1664841c15919a479b81f0c74580` ; a different attestation.
+
+Implications for emitters:
+- Document the canonical jurisdiction listing order alongside the receipt schema
+- Do not sort `jurisdiction_flags` between observation and emission
+- A verifier computes the digest with the array order as-received; no re-sort
+
+(This discipline is codified in the shared canonicalisation section ; see x402 PR #2436.)
 
 ## Vectors
 
 | Vector | `screen_result` | `jurisdiction_flags` | Description |
 |---|---|---|---|
-| `0001-allow-uk-eu` | `ALLOW` | `["EU", "UK"]` | Nominal UK+EU jurisdiction pass |
+| `0001-allow-uk-eu` | `ALLOW` | `["UK", "EU"]` | Nominal UK+EU jurisdiction pass ; demonstrates array order significance |
 | `0002-deny-jurisdiction` | `DENY` | `["BLOCKED"]` | Sanctioned jurisdiction ; payment rejected |
 
 ## JCS reproduction
@@ -35,28 +55,29 @@ Reproduce with any RFC 8785 implementation:
 
 ```js
 // JS (canonicalize npm + node:crypto)
-const { createRequire } = require('module');
+import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 const c = createRequire(import.meta.url)('canonicalize');
-const hash = 'sha256:' + crypto.createHash('sha256')
+const hash = 'sha256:' + createHash('sha256')
   .update(Buffer.from(c(receiptWithoutExpectedHash), 'utf8'))
   .digest('hex');
 ```
 
 ```python
-# Python (jcs pip + hashlib)
-import jcs, hashlib
-digest = 'sha256:' + hashlib.sha256(jcs.canonicalize(receipt)).hexdigest()
+# Python (rfc8785 pip + hashlib)
+import rfc8785, hashlib
+digest = 'sha256:' + hashlib.sha256(rfc8785.dumps(receipt)).hexdigest()
 ```
 
-Compatible implementations: `canonicalize` (JS), `gowebpki/jcs` (Go), `cyberphone/json-canonicalization` (Java), `serde_jcs` (Rust), `jcs` (Python).
+Cross-implementations compatible: `canonicalize` (JS), `gowebpki/jcs` (Go), `cyberphone/json-canonicalization` (Java), `serde_jcs` (Rust), `rfc8785` (Python).
 
 ## Cross-axis binding
 
-These vectors share the JCS canonicalization substrate defined in Axis 0 (x402 PR #2412, AlgoVoi).
+These vectors share the JCS canonicalization substrate codified in PR #2436 ; `jcs-rfc8785-v1` marker is the canonical version reference.
 
 The `payer_ref` content-addressing pattern is consistent with `action_ref = SHA-256(JCS(preimage))` from Axis 3 (PR #2398, andysalvo).
 
-As an Axis 4 composite trust-query emitter row, the risk-check receipt binds to `(payment_hash, action_ref)` alongside AlgoVoi compliance-screening, Vauban STARK proof-of-payment-conditions, and nobulex verascore-evidence-schema rows. Tetra-party composite structure per x402 issue #2322.
+As an Axis 4 composite trust-query emitter row, the risk-check receipt binds to `(payment_hash, action_ref)` alongside AlgoVoi compliance-screening, Vauban STARK proof-of-payment-conditions, and nobulex bilateral-receipt (#2322) rows. Tetra-party composite structure per x402 issue #2322 ; composite preimage algorithm per AlgoVoi.
 
 ## Session-level amortisation
 

--- a/fixtures/risk-check-attestation-sample/v0/schema/risk-check-receipt.schema.json
+++ b/fixtures/risk-check-attestation-sample/v0/schema/risk-check-receipt.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/x402-foundation/x402/fixtures/risk-check-attestation-sample/v0/schema/risk-check-receipt.schema.json",
+  "title": "RiskCheckReceipt",
+  "description": "Canonical receipt schema for x402 risk-check attestation (Axis 4 composite trust-query). JCS-canonicalisable; all expected_hash values are SHA-256(JCS(receipt_object_without_expected_hash)).",
+  "type": "object",
+  "required": [
+    "payer_ref",
+    "screen_result",
+    "screen_timestamp_ms",
+    "screen_provider_did",
+    "jurisdiction_flags",
+    "canon_version"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "payer_ref": {
+      "type": "string",
+      "description": "sha256: prefixed hex digest of SHA-256(JCS(payer_identity_object)). Content-addressable reference to the payer identity; no raw PII stored in receipt (GDPR/CCPA compatible).",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "screen_result": {
+      "type": "string",
+      "description": "Screening outcome. REFER triggers SAR obligation under UK POCA 2002 s.330; it is not merely enhanced due diligence.",
+      "enum": ["ALLOW", "REFER", "DENY"]
+    },
+    "screen_timestamp_ms": {
+      "type": "integer",
+      "description": "Screen timestamp as epoch milliseconds (integer). NOT RFC 3339; RFC 3339 admits multiple encodings of the same instant and produces divergent digests at year-5 re-verification.",
+      "minimum": 0
+    },
+    "screen_provider_did": {
+      "type": "string",
+      "description": "DID of the screening provider. did:web: or did:key: forms accepted.",
+      "pattern": "^did:(web|key):.+"
+    },
+    "jurisdiction_flags": {
+      "type": "array",
+      "description": "ISO 3166-1 alpha-2 jurisdiction codes observed during screening, or BLOCKED for jurisdictions under active sanction.",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "canon_version": {
+      "type": "string",
+      "description": "Canonicalization version marker. jcs-rfc8785-v1 indicates RFC 8785 JCS canonicalization.",
+      "enum": ["jcs-rfc8785-v1"]
+    },
+    "expected_hash": {
+      "type": "string",
+      "description": "sha256: prefixed hex digest of SHA-256(JCS(receipt_object_without_expected_hash)). Present in test vectors only; absent in live receipts.",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/fixtures/risk-check-attestation-sample/v0/vectors/0001-allow-uk-eu.json
+++ b/fixtures/risk-check-attestation-sample/v0/vectors/0001-allow-uk-eu.json
@@ -3,7 +3,7 @@
   "screen_result": "ALLOW",
   "screen_timestamp_ms": 1748000000000,
   "screen_provider_did": "did:web:api.algovoi.co.uk",
-  "jurisdiction_flags": ["EU", "UK"],
+  "jurisdiction_flags": ["UK", "EU"],
   "canon_version": "jcs-rfc8785-v1",
   "expected_hash": "sha256:f4e8d652c6cf6c903adf08a0b0b77a3de099e5e0a4b3b01f78fd16cd2fa4da54"
 }

--- a/fixtures/risk-check-attestation-sample/v0/vectors/0001-allow-uk-eu.json
+++ b/fixtures/risk-check-attestation-sample/v0/vectors/0001-allow-uk-eu.json
@@ -1,0 +1,9 @@
+{
+  "payer_ref": "sha256:4a7b9c2d1e3f5a8b0c6d2e4f7a9b1c3d5e7f9a1b3c5d7e9f1a3b5c7d9e1f3a5b7",
+  "screen_result": "ALLOW",
+  "screen_timestamp_ms": 1748000000000,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["EU", "UK"],
+  "canon_version": "jcs-rfc8785-v1",
+  "expected_hash": "sha256:f4e8d652c6cf6c903adf08a0b0b77a3de099e5e0a4b3b01f78fd16cd2fa4da54"
+}

--- a/fixtures/risk-check-attestation-sample/v0/vectors/0002-deny-jurisdiction.json
+++ b/fixtures/risk-check-attestation-sample/v0/vectors/0002-deny-jurisdiction.json
@@ -1,0 +1,9 @@
+{
+  "payer_ref": "sha256:9f1a3b5c7d9e1f3a5b4a7b9c2d1e3f5a8b0c6d2e4f7a9b1c3d5e7f9a1b3c5d7e",
+  "screen_result": "DENY",
+  "screen_timestamp_ms": 1748000100000,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["BLOCKED"],
+  "canon_version": "jcs-rfc8785-v1",
+  "expected_hash": "sha256:4b781b0d6f3fc2d502e6426c901def4e0a1d3d02859f0d495d4360bc8b956b1a"
+}

--- a/fixtures/risk-check-attestation-sample/v0/vectors/0003-refer-sar.json
+++ b/fixtures/risk-check-attestation-sample/v0/vectors/0003-refer-sar.json
@@ -1,0 +1,9 @@
+{
+  "payer_ref": "sha256:c8e2f4a6b9d1e3f5a7c9b1d3e5f7a9c1b3d5e7f9a1c3b5d7e9f1a3c5b7d9e1f3",
+  "screen_result": "REFER",
+  "screen_timestamp_ms": 1748000200000,
+  "screen_provider_did": "did:web:api.algovoi.co.uk",
+  "jurisdiction_flags": ["UK", "EU"],
+  "canon_version": "jcs-rfc8785-v1",
+  "expected_hash": "sha256:10779e0ae2df6715a9c5b61c6a48ebd3e4e414d6e75a23b2a6ba4917275c3e43"
+}


### PR DESCRIPTION
Proposes canonical JCS test vectors for the x402 risk-check attestation format.

## Attribution

**Spec originator**: @AlexanderLawson17 ; x402 issue #2421, PR #2422
**Production reference**: @chopmob-cloud (AlgoVoi) ; `/compliance/screen` in production under UK MLR 2017 / SAMLA Reg 40(3) / FCA 7-year retention

## Schema (6 required fields)

| Field | Type | Design rationale |
|---|---|---|
| `payer_ref` | `sha256:<hex>` | SHA-256(JCS(payer_identity_object)) ; no raw PII (GDPR/CCPA compatible) |
| `screen_result` | ALLOW / REFER / DENY | `REFER` triggers SAR obligation UK POCA 2002 s.330 |
| `screen_timestamp_ms` | integer | Epoch ms, NOT RFC 3339 ; RFC 3339 produces divergent digests at year-5 re-verification |
| `screen_provider_did` | `did:web:` / `did:key:` | Screening provider identity |
| `jurisdiction_flags` | string[] | ISO 3166-1 alpha-2 ; `BLOCKED` for sanctioned jurisdictions |
| `canon_version` | `jcs-rfc8785-v1` | RFC 8785 JCS marker |

## Vectors

- `0001-allow-uk-eu` ; nominal UK+EU pass
- `0002-deny-jurisdiction` ; sanctioned jurisdiction, payment rejected

All `expected_hash` values are `sha256:SHA-256(JCS(receipt_without_expected_hash))`, reproducible with any RFC 8785 implementation.

## Cross-axis binding

Shares the JCS canonicalization substrate from Axis 0 (#2412, AlgoVoi). `payer_ref` content-addressing is consistent with `action_ref = SHA-256(JCS(preimage))` from Axis 3 (#2398, andysalvo).

As Axis 4 composite trust-query emitter row, binds to `(payment_hash, action_ref)` alongside AlgoVoi compliance-screening, Vauban STARK proof-of-payment-conditions, and nobulex verascore rows. Tetra-party composite per #2322.

## Review request

@AlexanderLawson17 ; does this schema match the v0 shape in PR #2422 ? Flag any divergence and we update.
@chopmob-cloud ; does the `screen_timestamp_ms` + `payer_ref` + `jurisdiction_flags` shape match your production receipt ? Flag any field we should add or rename.

Vauban Pay (seritalien)