### PR TITLE
fix: include PAYMENT-REQUIRED on HTML paywalls

### DIFF
--- a/go/http/server.go
+++ b/go/http/server.go
@@ -897,12 +897,18 @@ func (s *x402HTTPResourceServer) isWebBrowser(adapter HTTPAdapter) bool {
 //	customHTML: Optional custom HTML for the paywall
 //	unpaidResponse: Optional custom response for API clients (ignored for browser requests)
 func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.PaymentRequired, isWebBrowser bool, paywallConfig *PaywallConfig, customHTML string, unpaidResponse *UnpaidResponse) (*HTTPResponseInstructions, error) {
+	encodedHeader, err := encodePaymentRequiredHeader(paymentRequired)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode payment required header: %w", err)
+	}
+
 	if isWebBrowser {
 		html := s.generatePaywallHTMLV2(paymentRequired, paywallConfig, customHTML)
 		return &HTTPResponseInstructions{
 			Status: 402,
 			Headers: map[string]string{
-				"Content-Type": "text/html",
+				"Content-Type":      "text/html",
+				"PAYMENT-REQUIRED": encodedHeader,
 			},
 			Body:   html,
 			IsHTML: true,
@@ -916,11 +922,6 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 	if unpaidResponse != nil {
 		contentType = unpaidResponse.ContentType
 		body = unpaidResponse.Body
-	}
-
-	encodedHeader, err := encodePaymentRequiredHeader(paymentRequired)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode payment required header: %w", err)
 	}
 
 	return &HTTPResponseInstructions{

--- a/go/http/server_test.go
+++ b/go/http/server_test.go
@@ -311,6 +311,9 @@ func TestProcessHTTPRequestWithBrowser(t *testing.T) {
 	if result.Response.Headers["Content-Type"] != "text/html" {
 		t.Error("Expected text/html content type")
 	}
+	if result.Response.Headers["PAYMENT-REQUIRED"] == "" {
+		t.Error("Expected PAYMENT-REQUIRED header")
+	}
 
 	// Check HTML contains expected elements
 	html := result.Response.Body.(string)

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -739,6 +739,8 @@ class x402HTTPServerBase:
         unpaid_response: Any = None,
     ) -> HTTPResponseInstructions:
         """Create HTTP response instructions."""
+        payment_required_header = encode_payment_required_header(payment_required)
+
         if is_web_browser:
             html_content = self._generate_paywall_html(
                 payment_required,
@@ -747,7 +749,10 @@ class x402HTTPServerBase:
             )
             return HTTPResponseInstructions(
                 status=402,
-                headers={"Content-Type": "text/html"},
+                headers={
+                    "Content-Type": "text/html",
+                    PAYMENT_REQUIRED_HEADER: payment_required_header,
+                },
                 body=html_content,
                 is_html=True,
             )
@@ -764,7 +769,7 @@ class x402HTTPServerBase:
             status=402,
             headers={
                 "Content-Type": content_type,
-                PAYMENT_REQUIRED_HEADER: encode_payment_required_header(payment_required),
+                PAYMENT_REQUIRED_HEADER: payment_required_header,
             },
             body=body,
         )

--- a/python/x402/tests/integrations/test_http_integration.py
+++ b/python/x402/tests/integrations/test_http_integration.py
@@ -279,6 +279,38 @@ class TestHTTPIntegration:
         assert settlement.success is True
         assert "PAYMENT-RESPONSE" in settlement.headers
 
+    def test_browser_html_paywall_includes_payment_required_header(
+        self,
+        components: HTTPComponentsFixture,
+    ) -> None:
+        """Browser HTML 402 responses still expose protocol payment requirements."""
+        mock_adapter = MockHTTPAdapter(
+            path="/api/protected",
+            method="GET",
+            headers={
+                "Accept": "text/html,application/xhtml+xml",
+                "User-Agent": "Mozilla/5.0",
+            },
+        )
+        context = HTTPRequestContext(
+            adapter=mock_adapter,
+            path="/api/protected",
+            method="GET",
+        )
+
+        result = components.process_http_request(context)
+
+        assert result.type == "payment-error"
+        assert result.response is not None
+        assert result.response.status == 402
+        assert result.response.is_html is True
+        assert result.response.headers["Content-Type"] == "text/html"
+        assert "PAYMENT-REQUIRED" in result.response.headers
+        payment_required = decode_payment_required_header(
+            result.response.headers["PAYMENT-REQUIRED"]
+        )
+        assert len(payment_required.accepts) == 1
+
     def test_no_payment_required_for_unprotected_route(
         self,
         components: HTTPComponentsFixture,

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1041,17 +1041,17 @@ export class x402HTTPResourceServer {
     // This signals client needs to approve Permit2 before retrying
     const status = paymentRequired.error === "permit2_allowance_required" ? 412 : 402;
 
+    const response = this.createHTTPPaymentRequiredResponse(paymentRequired);
+
     if (isWebBrowser) {
       const html = this.generatePaywallHTML(paymentRequired, paywallConfig, customHtml);
       return {
         status,
-        headers: { "Content-Type": "text/html" },
+        headers: { "Content-Type": "text/html", ...response.headers },
         body: html,
         isHtml: true,
       };
     }
-
-    const response = this.createHTTPPaymentRequiredResponse(paymentRequired);
 
     // Use callback result if provided, otherwise default to JSON with empty object
     const contentType = unpaidResponse ? unpaidResponse.contentType : "application/json";

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -14,6 +14,7 @@ import {
   buildPaymentRequirements,
 } from "../../mocks";
 import { Network, Price } from "../../../src/types";
+import { decodePaymentRequiredHeader } from "../../../src/http";
 
 // Mock HTTP Adapter
 /**
@@ -1273,6 +1274,41 @@ describe("x402HTTPResourceServer", () => {
       // Should return HTML paywall for browsers
       if (result.type === "payment-error") {
         expect(result.response.isHtml).toBe(true);
+      }
+    });
+
+    it("should include PAYMENT-REQUIRED on browser HTML paywall responses", async () => {
+      const routes = {
+        "/api/test": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00" as Price,
+            network: "eip155:8453" as Network,
+          },
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+      const adapter = new MockHTTPAdapter();
+      adapter.getAcceptHeader = () => "text/html,application/xhtml+xml";
+      adapter.getUserAgent = () => "Mozilla/5.0 (Windows NT 10.0; Win64; x64)";
+
+      const result = await httpServer.processHTTPRequest({
+        adapter,
+        path: "/api/test",
+        method: "GET",
+      });
+
+      expect(result.type).toBe("payment-error");
+      if (result.type === "payment-error") {
+        expect(result.response.isHtml).toBe(true);
+        expect(result.response.headers["Content-Type"]).toBe("text/html");
+        expect(result.response.headers["PAYMENT-REQUIRED"]).toBeDefined();
+        expect(
+          decodePaymentRequiredHeader(result.response.headers["PAYMENT-REQUIRED"]).accepts,
+        ).toHaveLength(1);
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes #2418 by ensuring browser HTML paywall `402` responses also include the protocol-level `PAYMENT-REQUIRED` header.

Covered resource server implementations:
- TypeScript core HTTP resource server
- Go HTTP resource server
- Python HTTP resource server base (sync + async wrappers)

## Details

Previously the HTML branch returned only `Content-Type: text/html`, while JSON/API `402` responses carried `PAYMENT-REQUIRED`. This keeps the HTML response body unchanged and adds the same encoded payment requirements header so agents, wallets, SDKs, and browser-side integrations can still read protocol requirements from headers.

## Verification

- `corepack pnpm --filter @x402/core test -- test/unit/http/x402HTTPResourceService.test.ts` ✅
- `uv run pytest tests/integrations/test_http_integration.py -k browser_html_paywall_includes_payment_required_header` ✅
- `python -m py_compile python\\x402\\http\\x402_http_server_base.py python\\x402\\tests\\integrations\\test_http_integration.py` ✅

Note: Go toolchain is not installed in this environment (`go` / `gofmt` not found), so I added the Go regression assertion but could not run Go tests locally.
