### PR TITLE
docs(specs): fix broken link to batch-settlement spec in cloudflare scheme

### DIFF
--- a/specs/schemes/batch-settlement/scheme_batch_settlement_cloudflare.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_cloudflare.md
@@ -5,7 +5,7 @@
 The `batch-settlement` scheme on the Cloudflare network `cloudflare:402` enables access to resources through cryptographically signed payment commitments that are settled later through the network's infrastructure.
 
 **Network Identifier**: `cloudflare:402`
-**Trust Model**: Credit-backed (see [batch_settlement.md](./batch_settlement.md#credit-backed))
+**Trust Model**: Credit-backed (see [scheme_batch_settlement.md](./scheme_batch_settlement.md#credit-backed))
 
 **Authentication Method**: This implementation uses **HTTP Message Signatures (RFC 9421)** to authenticate payment commitments. The network acts as a trusted intermediary to provide immediate resource access while settlement is batched and handled later.
 


### PR DESCRIPTION
## Description

`specs/schemes/batch-settlement/scheme_batch_settlement_cloudflare.md` links to `./batch_settlement.md#credit-backed`, but no `batch_settlement.md` exists in that directory. The file is `scheme_batch_settlement.md`, so the link 404s on GitHub.

This points the link (and its label, for consistency) at `./scheme_batch_settlement.md#credit-backed`. The `#credit-backed` anchor is unchanged and already resolves to the `### Credit-backed` heading in that file.

## Tests

Docs-only change. Verified `specs/schemes/batch-settlement/scheme_batch_settlement.md` exists in the same directory and contains a `### Credit-backed` heading, so the corrected link and its anchor both resolve.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

Note: the commit is currently unsigned; happy to rebase with a signed commit if needed before merge.