### PR TITLE
fix: reject malformed payment signature headers

### DIFF
--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -519,7 +519,25 @@ export class x402HTTPResourceServer {
     const paymentOptions = this.normalizePaymentOptions(routeConfig);
 
     // Check for payment header (v1 or v2)
-    const paymentPayload = this.extractPayment(adapter);
+    let paymentPayload: PaymentPayload | null;
+    try {
+      paymentPayload = this.extractPayment(adapter);
+    } catch (error) {
+      return {
+        type: "payment-error",
+        response: {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+          body: {
+            error: "invalid_payment_signature_header",
+            message:
+              error instanceof Error
+                ? error.message
+                : "PAYMENT-SIGNATURE header could not be decoded",
+          },
+        },
+      };
+    }
 
     // Create resource info, using config override if provided
     const resourceInfo = {
@@ -1027,6 +1045,7 @@ export class x402HTTPResourceServer {
         return decodePaymentSignatureHeader(header);
       } catch (error) {
         console.warn("Failed to decode PAYMENT-SIGNATURE header:", error);
+        throw new Error("PAYMENT-SIGNATURE header could not be decoded");
       }
     }
 

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -775,6 +775,44 @@ describe("x402HTTPResourceServer", () => {
       }
     });
 
+    it("should return 400 if PAYMENT-SIGNATURE is present but malformed", async () => {
+      const routes = {
+        "/api/test": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00" as Price,
+            network: "eip155:8453" as Network,
+          },
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+      const adapter = new MockHTTPAdapter({
+        "payment-signature": "garbage-value",
+      });
+      const context: HTTPRequestContext = {
+        adapter,
+        path: "/api/test",
+        method: "GET",
+      };
+
+      const result = await httpServer.processHTTPRequest(context);
+
+      expect(result.type).toBe("payment-error");
+      if (result.type === "payment-error") {
+        expect(result.response.status).toBe(400);
+        expect(result.response.headers["Content-Type"]).toBe("application/json");
+        expect(result.response.headers["PAYMENT-REQUIRED"]).toBeUndefined();
+        expect(result.response.body).toEqual({
+          error: "invalid_payment_signature_header",
+          message: "PAYMENT-SIGNATURE header could not be decoded",
+        });
+      }
+      expect(mockFacilitator.verifyCalls.length).toBe(0);
+    });
+
     it("should include bazaar service metadata on PaymentRequired.resource", async () => {
       const routes = {
         "/api/weather": {


### PR DESCRIPTION
## Summary

Fixes #2397.

Malformed `PAYMENT-SIGNATURE` headers are now treated as syntactically invalid client input instead of falling through to the no-payment path:

- present but undecodable `PAYMENT-SIGNATURE` returns `400 Bad Request`
- response body uses `invalid_payment_signature_header`
- absent payment header still returns the normal `402 Payment Required`
- invalid headers do not call facilitator verification

## Test

```bash
corepack pnpm --dir typescript/packages/core test test/unit/http/x402HTTPResourceService.test.ts
```

43 tests passed.
