### PR TITLE
fixtures: filled fiscal_authority_readiness_card_v0 against Vauban bounded-spend (#2405)

### DIFF
--- a/fixtures/fiscal-authority-readiness-card-sample/v0/0001-vauban-bounded-spend.json
+++ b/fixtures/fiscal-authority-readiness-card-sample/v0/0001-vauban-bounded-spend.json
@@ -1,0 +1,64 @@
+{
+  "resource": {
+    "provider_id": "vauban-pay",
+    "resource_id": "bounded-spend-authorization-sample-v0-0001-baseline",
+    "resource_url": "https://pay.vauban.tech"
+  },
+  "price": {
+    "status": "PASS",
+    "discovery_ceiling": {
+      "max_amount": "1000000",
+      "asset": "urn:eip3009:USDC:starknet-sepolia",
+      "network": "starknet-sepolia"
+    },
+    "receipt_amount_field": "settlement_receipt.predicate.amount"
+  },
+  "authority": {
+    "status": "PASS",
+    "approval_source": {
+      "kind": "human_principal",
+      "principal_id": "0xa3f2c1d4e5b6a7890123456789abcdef0123456789abcdef0123456789abcdef",
+      "policy_ref": null,
+      "policy_version": null,
+      "controller_id": null,
+      "snapshot_hash": null
+    }
+  },
+  "cap": {
+    "status": "PASS",
+    "enforcement": "cryptographic",
+    "max_per_tx": "1000000",
+    "max_per_period": "100000000",
+    "period": "86400",
+    "grant_hash": "sha256:ff558f21b26c5045fb6997fef185b9993e33a29a7907dbcf349e49b9019c1fd2"
+  },
+  "charge_evidence": {
+    "status": "PASS",
+    "type": "receipt",
+    "reference_url": "https://github.com/x402-foundation/x402/tree/main/fixtures/bounded-spend-authorization-sample/v0/vectors/0001-baseline.json",
+    "hash": "sha256:0adc9aece973486e8c49fc1613225d629d71bdd7e3b2fe50576f55d6db68a5b5",
+    "attestation_manifest_root": null
+  },
+  "canonicalisation": {
+    "status": "PARTIAL",
+    "canon_version": "1.0",
+    "algorithm": "JCS-RFC8785",
+    "hash_algorithm": "SHA-256",
+    "test_vectors_url": "https://github.com/x402-foundation/x402/tree/main/fixtures/bounded-spend-authorization-sample/v0/vectors/0001-baseline.json"
+  },
+  "revocation": {
+    "status": "PARTIAL",
+    "check_url": "https://pay.vauban.tech/.well-known/revocation/v0/",
+    "dispute_url": null,
+    "last_checked_ms": null
+  },
+  "preflight_verdict": {
+    "status": "PARTIAL",
+    "buyer_agent_can_spend_without_human": true,
+    "missing_fields": [
+      "revocation.last_checked_ms",
+      "canonicalisation.canon_version (pending jcs-rfc8785-v1 normalisation; tracked under PR #2436)"
+    ],
+    "next_safe_step": "Resolve the revocation check_url at preflight before each spend; treat canon_version normalisation as tracked under PR #2436 and re-evaluate once that PR merges."
+  }
+}

--- a/fixtures/fiscal-authority-readiness-card-sample/v0/README.md
+++ b/fixtures/fiscal-authority-readiness-card-sample/v0/README.md
@@ -1,0 +1,46 @@
+# Fiscal Authority Readiness Card -- Sample v0
+
+## What this is
+
+This directory contains a filled `fiscal_authority_readiness_card_v0` artifact, using the card shape proposed by @egoriklok in x402-foundation/x402#2405.
+
+The card is filled against the **Vauban bounded-spend fixture** introduced in PR #2432 (`fixtures/bounded-spend-authorization-sample/v0/vectors/0001-baseline.json`). It is a public, no-secret preflight artifact: every field is inspectable without API keys, wallets, or dashboards. A buyer agent can evaluate fiscal authority coverage before attempting a spend.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `0001-vauban-bounded-spend.json` | Filled card for the Vauban bounded-spend baseline vector |
+
+## How the card maps to the fixture
+
+The source vector (`0001-baseline.json`) encodes a `DelegationGrant` plus a `SettlementReceipt`. The card surfaces the fiscally relevant fields in a single flat artifact:
+
+- **authority**: the grantor is a `human_principal` identified by a `UserPseudonym` pseudonymous address. The agent spending within the grant's cap requires no further human approval at spend time.
+- **cap.enforcement = cryptographic**: the `DelegationGrant` is cryptographically signed (HMAC-SHA-256 over a JCS-canonical payload). The cap is not a facilitator policy assertion; it is verifiable against the `grant_hash`.
+- **cap bounds**: 1 000 000 micro-USDC per transaction, 100 000 000 micro-USDC per 86 400-second period.
+- **charge_evidence**: a settled `SettlementReceipt` with a live Starknet Sepolia transaction hash anchors the charge.
+
+## Honest PARTIAL statuses
+
+Two fields carry `PARTIAL` status rather than `PASS`. These are honestly flagged, not elided:
+
+1. **canonicalisation.status = PARTIAL**: the fixture's `canon_version` field currently carries value `"1.0"`. A normalised identifier (`jcs-rfc8785-v1`) is tracked under PR #2436. The algorithm itself is JCS-RFC8785 with SHA-256; the partial flag signals the version string is not yet finalised.
+
+2. **revocation.status = PARTIAL**: the `revocation_authority` URL (`https://pay.vauban.tech/.well-known/revocation/v0/`) is declared in the grant anchor and present in the card. The endpoint is not yet a live status surface in Vauban Pay Phase MVP. A buyer agent should resolve this URL at preflight; if it returns no valid revocation status, treat the grant as unverified-for-revocation before spending.
+
+## Preflight interpretation
+
+`preflight_verdict.buyer_agent_can_spend_without_human = true` because:
+
+- The authority source is a `human_principal` who has pre-delegated spend authority via a signed grant.
+- The cap is cryptographically enforced and verifiable locally.
+- The two PARTIAL fields do not block spend; they signal verification gaps the agent should resolve or log before each transaction.
+
+`preflight_verdict.status = PARTIAL` (not `READY`) because the revocation endpoint has not been confirmed live at the time this card was produced.
+
+## Connection to x402#2405
+
+@egoriklok proposed this card shape to enable buyer agents to perform fiscal authority preflight without human escalation when grants are well-formed. This filled card is the concrete example they asked for: one card, one fixture, all fields populated, PARTIAL statuses explained.
+
+If you are evaluating whether a buyer agent can spend autonomously against a Vauban bounded-spend grant, this card is the artifact to inspect first.


### PR DESCRIPTION
## What this PR adds

A filled `fiscal_authority_readiness_card_v0` artifact, using the card shape @egoriklok proposed in #2405. This is the concrete example they asked for: one filled card against the Vauban bounded-spend fixture from PR #2432.

**New files:**
- `fixtures/fiscal-authority-readiness-card-sample/v0/0001-vauban-bounded-spend.json` -- the filled card
- `fixtures/fiscal-authority-readiness-card-sample/v0/README.md` -- field mapping, honest PARTIAL explanations, and preflight interpretation

## Mapping rationale

The source vector (`bounded-spend-authorization-sample/v0/vectors/0001-baseline.json`) contains a `DelegationGrant` + `SettlementReceipt`. The card surfaces the fiscally relevant fields:

- **authority.approval_source.kind = human_principal**: the grantor is a human who pre-delegated spend authority via a signed grant; the buyer agent needs no further human escalation at spend time within cap.
- **cap.enforcement = cryptographic**: the `DelegationGrant` is signed (HMAC-SHA-256 over JCS-canonical payload). The cap is not a facilitator policy assertion; it is locally verifiable against `grant_hash`.
- **cap bounds**: 1 000 000 micro-USDC per tx, 100 000 000 per 86 400-second period.
- **charge_evidence**: a live Starknet Sepolia tx hash anchors the settled receipt.

## Two honest PARTIAL statuses

Nothing is elided:

1. **canonicalisation = PARTIAL**: `canon_version` currently carries `"1.0"`. The normalised identifier (`jcs-rfc8785-v1`) is tracked under PR #2436. The algorithm is JCS-RFC8785 + SHA-256; the partial flag signals the version string is not yet finalised.

2. **revocation = PARTIAL**: `check_url` (`https://pay.vauban.tech/.well-known/revocation/v0/`) is declared in the grant anchor. The endpoint is not yet a live status surface in Vauban Pay Phase MVP. A buyer agent should resolve it at preflight; if no valid revocation status returns, treat the grant as unverified-for-revocation before spending.

## preflight_verdict

`buyer_agent_can_spend_without_human = true` because cryptographic cap + human_principal authority means the agent may spend within cap without further escalation. `status = PARTIAL` (not `READY`) because the revocation endpoint has not been confirmed live at card production time.

## Question for @egoriklok

Is the preferred landing path a companion PR like this one, or would you rather fold the filled card into the eventual #2405 PR when the card schema is finalised? Happy to rebase or close and re-open wherever makes the most sense for the fixture catalogue structure.

Ref: #2405