### PR TITLE
fix(core): reject null v2 payment extra

### DIFF
--- a/typescript/packages/core/src/schemas/index.ts
+++ b/typescript/packages/core/src/schemas/index.ts
@@ -25,6 +25,13 @@ export type Any = z.infer<typeof Any>;
 export const OptionalAny = z.record(z.unknown()).optional().nullable();
 export type OptionalAny = z.infer<typeof OptionalAny>;
 
+/**
+ * Optional record schema with an empty object default.
+ * Used for v2 wire fields that may be absent but must not be `null` when present.
+ */
+export const OptionalRecord = z.record(z.unknown()).optional().default({});
+export type OptionalRecord = z.infer<typeof OptionalRecord>;
+
 // ============================================================================
 // Network Schemas
 // ============================================================================
@@ -138,7 +145,7 @@ export const PaymentRequirementsV2Schema = z.object({
   asset: NonEmptyString,
   payTo: NonEmptyString,
   maxTimeoutSeconds: z.number().positive(),
-  extra: OptionalAny,
+  extra: OptionalRecord,
 });
 export type PaymentRequirementsV2 = z.infer<typeof PaymentRequirementsV2Schema>;
 

--- a/typescript/packages/core/test/unit/schemas/schemas.test.ts
+++ b/typescript/packages/core/test/unit/schemas/schemas.test.ts
@@ -214,6 +214,13 @@ describe("x402 Schemas", () => {
         delete (withoutExtra as Record<string, unknown>).extra;
         const result = PaymentRequirementsV2Schema.safeParse(withoutExtra);
         expect(result.success).toBe(true);
+        expect(result.data?.extra).toEqual({});
+      });
+
+      it("should reject null extra field", () => {
+        const withNullExtra = { ...validPaymentRequirementsV2, extra: null };
+        const result = PaymentRequirementsV2Schema.safeParse(withNullExtra);
+        expect(result.success).toBe(false);
       });
     });
 


### PR DESCRIPTION
## Summary
- introduce a non-nullable optional record schema for v2 metadata fields
- default missing `PaymentRequirementsV2.extra` to `{}` so parsed values still match the existing TS shape
- add coverage that omitted `extra` is accepted but `extra: null` is rejected

Closes #2406

## Verification
- `corepack pnpm --dir typescript/packages/core test test/unit/schemas/schemas.test.ts`
- `corepack pnpm --dir typescript/packages/core build`