### PR TITLE
feat(python): thread bazaar service metadata from RouteConfig to ResourceInfo

### DIFF
--- a/python/x402/changelog.d/route-config-service-metadata.feature.md
+++ b/python/x402/changelog.d/route-config-service-metadata.feature.md
@@ -1,0 +1,1 @@
+Thread bazaar service metadata fields (`service_name`, `tags`, `icon_url`) from `RouteConfig` through to `ResourceInfo`. The wire-format schema fields landed in #2200 but the server-side `RouteConfig` had no way to populate them — servers wanting rich Bazaar listings had to bypass the SDK. This wires the missing plumbing.

--- a/python/x402/http/types.py
+++ b/python/x402/http/types.py
@@ -192,7 +192,16 @@ class PaymentOption:
 
 @dataclass
 class RouteConfig:
-    """Configuration for a payment-protected route."""
+    """Configuration for a payment-protected route.
+
+    ``service_name``, ``tags``, and ``icon_url`` are forwarded as-is to
+    ``ResourceInfo`` for Bazaar discovery. ``RouteConfig`` itself does not
+    enforce indexer-side limits — the stricter ``resource_info`` helper path
+    soft-drops values that exceed Bazaar's caps (service_name ≤ 32 chars,
+    ≤ 5 tags of ≤ 32 chars each, absolute http(s) icon URLs ≤ 2048 chars).
+    Server authors should keep names short, tag sets small, and icon URLs
+    absolute http(s) to ensure listings are accepted by indexers.
+    """
 
     accepts: PaymentOption | list[PaymentOption]
     resource: str | None = None

--- a/python/x402/http/types.py
+++ b/python/x402/http/types.py
@@ -198,6 +198,9 @@ class RouteConfig:
     resource: str | None = None
     description: str | None = None
     mime_type: str | None = None
+    service_name: str | None = None
+    tags: list[str] | None = None
+    icon_url: str | None = None
     custom_paywall_html: str | None = None
     unpaid_response_body: UnpaidResponseBody | None = None
     settlement_failed_response_body: SettlementFailedResponseBody | None = None

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -194,6 +194,9 @@ class x402HTTPServerBase:
             resource=config.get("resource"),
             description=config.get("description"),
             mime_type=config.get("mimeType", config.get("mime_type")),
+            service_name=config.get("serviceName", config.get("service_name")),
+            tags=config.get("tags"),
+            icon_url=config.get("iconUrl", config.get("icon_url")),
             custom_paywall_html=config.get("customPaywallHtml", config.get("custom_paywall_html")),
             unpaid_response_body=config.get(
                 "unpaidResponseBody", config.get("unpaid_response_body")
@@ -362,6 +365,9 @@ class x402HTTPServerBase:
             url=route_config.resource or context.adapter.get_url(),
             description=route_config.description or "",
             mime_type=route_config.mime_type or "",
+            service_name=route_config.service_name,
+            tags=route_config.tags,
+            icon_url=route_config.icon_url,
         )
 
         # Yield for option resolution (handles async/sync dynamic values)

--- a/python/x402/tests/integrations/test_http_integration.py
+++ b/python/x402/tests/integrations/test_http_integration.py
@@ -393,6 +393,43 @@ class TestDynamicPricing:
         assert payment_required.resource.tags == ["weather", "forecast"]
         assert payment_required.resource.icon_url == "https://example.com/icon.png"
 
+    def test_route_config_service_metadata_snake_case_input(
+        self,
+        components_factory: Any,
+    ) -> None:
+        """snake_case keys on the route config dict should also populate resource."""
+        routes = {
+            "GET /api/weather": {
+                "accepts": {
+                    "scheme": "cash",
+                    "payTo": "merchant@example.com",
+                    "price": "$0.10",
+                    "network": "x402:cash",
+                },
+                "service_name": "Weather API",
+                "tags": ["weather", "forecast"],
+                "icon_url": "https://example.com/icon.png",
+            },
+        }
+
+        components = components_factory.create(routes)
+        adapter = MockHTTPAdapter(path="/api/weather", method="GET")
+        context = HTTPRequestContext(
+            adapter=adapter,
+            path="/api/weather",
+            method="GET",
+        )
+
+        result = components.process_http_request(context)
+        payment_required = decode_payment_required_header(
+            result.response.headers["PAYMENT-REQUIRED"]
+        )
+
+        assert payment_required.resource is not None
+        assert payment_required.resource.service_name == "Weather API"
+        assert payment_required.resource.tags == ["weather", "forecast"]
+        assert payment_required.resource.icon_url == "https://example.com/icon.png"
+
     def test_dynamic_price_from_query_params(
         self,
         components_factory: Any,

--- a/python/x402/tests/integrations/test_http_integration.py
+++ b/python/x402/tests/integrations/test_http_integration.py
@@ -356,6 +356,43 @@ class TestDynamicPricing:
         assert payment_required.accepts[0].extra["assetTransferMethod"] == "permit2"
         assert payment_required.accepts[0].extra["merchantNote"] == "route-level-extra"
 
+    def test_route_config_service_metadata_flows_to_resource(
+        self,
+        components_factory: Any,
+    ) -> None:
+        """service_name/tags/icon_url on RouteConfig should populate resource."""
+        routes = {
+            "GET /api/weather": {
+                "accepts": {
+                    "scheme": "cash",
+                    "payTo": "merchant@example.com",
+                    "price": "$0.10",
+                    "network": "x402:cash",
+                },
+                "serviceName": "Weather API",
+                "tags": ["weather", "forecast"],
+                "iconUrl": "https://example.com/icon.png",
+            },
+        }
+
+        components = components_factory.create(routes)
+        adapter = MockHTTPAdapter(path="/api/weather", method="GET")
+        context = HTTPRequestContext(
+            adapter=adapter,
+            path="/api/weather",
+            method="GET",
+        )
+
+        result = components.process_http_request(context)
+        payment_required = decode_payment_required_header(
+            result.response.headers["PAYMENT-REQUIRED"]
+        )
+
+        assert payment_required.resource is not None
+        assert payment_required.resource.service_name == "Weather API"
+        assert payment_required.resource.tags == ["weather", "forecast"]
+        assert payment_required.resource.icon_url == "https://example.com/icon.png"
+
     def test_dynamic_price_from_query_params(
         self,
         components_factory: Any,


### PR DESCRIPTION
## Description

\`resource.{serviceName,tags,iconUrl}\` landed in the spec/schema via #2200 (merged 2026-05-06), and the Python \`ResourceInfo\` Pydantic model already carries the three optional fields. But the server-side \`RouteConfig\` dataclass has no fields to populate them, and \`x402_http_server_base.py\` hardcodes the \`ResourceInfo\` constructor to only the original three (\`url\`, \`description\`, \`mime_type\`).

The result: a server author who wants the Bazaar-rich metadata on their 402 has to bypass \`RouteConfig\` entirely or post-process the response — which is what motivated this PR. This wires the missing plumbing so the three fields flow through the documented path.

## Changes

- **\`python/x402/http/types.py\`** — add \`service_name\`, \`tags\`, \`icon_url\` to \`RouteConfig\` (all \`Optional\`, default \`None\`, placed after the existing \`mime_type\` field).
- **\`python/x402/http/x402_http_server_base.py\`**
  - \`_parse_route_config\`: accept both \`serviceName\`/\`iconUrl\` (camelCase) and snake_case, matching the existing \`mimeType\`/\`customPaywallHtml\` parsing convention.
  - \`ResourceInfo\` construction: pass the three new fields straight through. \`None\` values stay \`None\` so the existing Pydantic serialization behavior (excluding unset optionals) is preserved.
- **Tests** — \`test_route_config_service_metadata_flows_to_resource\` asserts the fields land on \`payment_required.resource\`. Modeled on \`test_route_option_extra_is_preserved\` directly above it; runs under both sync and async via the existing \`components_factory\` fixture.
- **Changelog** — fragment in \`changelog.d/route-config-service-metadata.feature.md\`.

## Validation

\`service_name\` / \`tags\` / \`icon_url\` validation rules (≤32 ASCII chars, ≤5 tags, ≤2048-char URL) live facilitator-side in \`extensions/bazaar/facilitator.py\` per the existing convention — this PR is plumbing only and intentionally doesn't duplicate that validation. The facilitator extractor (\`_sanitize_resource_service_metadata\`) continues to enforce the rules on read.

## Verified against the spec

Field locations match \`specs/extensions/bazaar.md\` "Service Metadata on resource" and the existing \`ResourceInfo\` schema in \`python/x402/schemas/payments.py\`. No new constants, no chain/asset assumptions.

## Disclosure

Used AI assistance (Claude Code) to scaffold the diff and test; reviewed both before submission.