### PR TITLE
feat(ecosystem): add OT/ICS Threat Intelligence API

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/ot-intel-api/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/ot-intel-api/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "OT/ICS Threat Intelligence API",
+  "description": "Hardware-aware threat intel for ICS/SCADA environments. Six pay-per-call endpoints: CVE triage with OT-adjusted severity and CISA KEV status, AI-powered patch feasibility with estimated downtime, internet-exposed OT device lookup, ICS threat actor profiles (VOLTZITE, SANDWORM, XENOTIME), IOC enrichment via AlienVault OTX, and live CISA ICS advisory feed. DeepSeek-enriched. No API keys — pure USDC micropayments on Base.",
+  "logoUrl": "/logos/ot-intel-api.png",
+  "websiteUrl": "https://ot-intel-api.onrender.com",
+  "category": "Services/Endpoints"
+}


### PR DESCRIPTION
## OT/ICS Threat Intelligence API

Live URL: https://ot-intel-api.onrender.com

**What it does:**
Hardware-aware threat intelligence for ICS/SCADA environments, 
paying via USDC micropayments on Base mainnet.

**6 pay-per-call endpoints:**
- `/ot/cve` ($0.02) — CVE triage with OT-adjusted severity + CISA KEV status
- `/ot/patch` ($0.05) — AI patch feasibility with downtime estimation
- `/ot/device` ($0.05) — Internet-exposed OT device lookup
- `/ot/actor` ($0.03) — ICS threat actor profiles (VOLTZITE, SANDWORM...)
- `/ot/ioc` ($0.01) — IOC enrichment via AlienVault OTX
- `/ot/advisory` ($0.02) — Live CISA ICS advisory feed

**Stack:** Express.js + @x402/express + CDP Facilitator + DeepSeek LLM
**Network:** Base mainnet (eip155:8453)
**Discovery:** Listed on agentic.market