### PR TITLE
fix(go): reject non-canonical EIP-3009 ECDSA signatures

### DIFF
--- a/go/.changes/unreleased/fixed-20260525-090533.yaml
+++ b/go/.changes/unreleased/fixed-20260525-090533.yaml
@@ -1,3 +1,3 @@
 kind: fixed
 body: Reject non-canonical high-s EIP-3009 ECDSA signatures before settlement in the Go SDK
-time: 2026-05-25T00:00:00+09:00
+time: 2026-05-25T09:05:33.109502+09:00

--- a/go/.changes/unreleased/fixed-20260525-eip3009-high-s.yaml
+++ b/go/.changes/unreleased/fixed-20260525-eip3009-high-s.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Reject non-canonical high-s EIP-3009 ECDSA signatures before settlement in the Go SDK
+time: 2026-05-25T00:00:00+09:00

--- a/go/mechanisms/evm/exact/facilitator/eip3009.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009.go
@@ -82,6 +82,14 @@ func (f *ExactEvmScheme) verifyEIP3009(
 		return nil, x402.NewVerifyError(ErrInvalidSignatureFormat, evmPayload.Authorization.From, err.Error())
 	}
 
+	nonCanonical, err := IsPlainNonCanonicalECDSASignature(ctx, f.signer, evmPayload.Authorization.From, signatureBytes)
+	if err != nil {
+		return nil, x402.NewVerifyError(ErrFailedToVerifySignature, evmPayload.Authorization.From, err.Error())
+	}
+	if nonCanonical {
+		return nil, x402.NewVerifyError(ErrInvalidSignatureS, evmPayload.Authorization.From, "invalid signature s")
+	}
+
 	classification, err := ClassifyEIP3009Signature(
 		ctx,
 		f.signer,

--- a/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
@@ -146,6 +146,26 @@ func ClassifyEIP3009Signature(
 	return classification, nil
 }
 
+// IsPlainNonCanonicalECDSASignature reports whether signature is a high-s EOA signature.
+func IsPlainNonCanonicalECDSASignature(
+	ctx context.Context,
+	signer evm.FacilitatorEvmSigner,
+	payer string,
+	signature []byte,
+) (bool, error) {
+	// Plain ECDSA signatures are r || s || v (65 bytes); other lengths may be ERC-1271/6492 wrappers.
+	if len(signature) != 65 || evm.IsCanonicalECDSASignature(signature) {
+		return false, nil
+	}
+
+	code, err := signer.GetCode(ctx, payer)
+	if err != nil {
+		return false, err
+	}
+
+	return len(code) == 0, nil
+}
+
 // SimulateEIP3009Transfer runs the transfer via eth_call.
 func SimulateEIP3009Transfer(
 	ctx context.Context,

--- a/go/mechanisms/evm/exact/facilitator/eip3009_signature_test.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_signature_test.go
@@ -1,0 +1,119 @@
+package facilitator
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+)
+
+type canonicalSignatureTestSigner struct {
+	code []byte
+	err  error
+}
+
+func (s canonicalSignatureTestSigner) GetAddresses() []string {
+	return nil
+}
+
+func (s canonicalSignatureTestSigner) ReadContract(context.Context, string, []byte, string, ...interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (s canonicalSignatureTestSigner) VerifyTypedData(context.Context, string, evm.TypedDataDomain, map[string][]evm.TypedDataField, string, map[string]interface{}, []byte) (bool, error) {
+	return false, nil
+}
+
+func (s canonicalSignatureTestSigner) WriteContract(context.Context, string, []byte, string, []byte, ...interface{}) (string, error) {
+	return "", nil
+}
+
+func (s canonicalSignatureTestSigner) SendTransaction(context.Context, string, []byte) (string, error) {
+	return "", nil
+}
+
+func (s canonicalSignatureTestSigner) WaitForTransactionReceipt(context.Context, string) (*evm.TransactionReceipt, error) {
+	return nil, nil
+}
+
+func (s canonicalSignatureTestSigner) GetBalance(context.Context, string, string) (*big.Int, error) {
+	return nil, nil
+}
+
+func (s canonicalSignatureTestSigner) GetChainID(context.Context) (*big.Int, error) {
+	return nil, nil
+}
+
+func (s canonicalSignatureTestSigner) GetCode(context.Context, string) ([]byte, error) {
+	return s.code, s.err
+}
+
+func TestIsPlainNonCanonicalECDSASignature(t *testing.T) {
+	halfN := new(big.Int).Rsh(crypto.S256().Params().N, 1)
+
+	makeSig := func(s *big.Int) []byte {
+		sig := make([]byte, 65)
+		s.FillBytes(sig[32:64])
+		sig[64] = 27
+		return sig
+	}
+
+	ctx := context.Background()
+	payer := "0x0000000000000000000000000000000000000001"
+
+	t.Run("rejects high-s EOA signature", func(t *testing.T) {
+		highS := new(big.Int).Add(halfN, big.NewInt(1))
+		got, err := IsPlainNonCanonicalECDSASignature(ctx, canonicalSignatureTestSigner{}, payer, makeSig(highS))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got {
+			t.Fatal("expected high-s EOA signature to be non-canonical")
+		}
+	})
+
+	t.Run("allows low-s EOA signature", func(t *testing.T) {
+		got, err := IsPlainNonCanonicalECDSASignature(ctx, canonicalSignatureTestSigner{}, payer, makeSig(halfN))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("expected low-s signature to be allowed")
+		}
+	})
+
+	t.Run("allows high-s deployed wallet signature", func(t *testing.T) {
+		highS := new(big.Int).Add(halfN, big.NewInt(1))
+		signer := canonicalSignatureTestSigner{code: []byte{1}}
+		got, err := IsPlainNonCanonicalECDSASignature(ctx, signer, payer, makeSig(highS))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("expected deployed wallet signature to be allowed")
+		}
+	})
+
+	t.Run("allows non-65-byte signatures", func(t *testing.T) {
+		got, err := IsPlainNonCanonicalECDSASignature(ctx, canonicalSignatureTestSigner{}, payer, []byte{1, 2, 3})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got {
+			t.Fatal("expected non-65-byte signature to be allowed")
+		}
+	})
+
+	t.Run("returns get code errors", func(t *testing.T) {
+		highS := new(big.Int).Add(halfN, big.NewInt(1))
+		wantErr := errors.New("get code failed")
+		_, err := IsPlainNonCanonicalECDSASignature(ctx, canonicalSignatureTestSigner{err: wantErr}, payer, makeSig(highS))
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("err = %v, want %v", err, wantErr)
+		}
+	})
+}

--- a/go/mechanisms/evm/exact/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/facilitator/errors.go
@@ -22,6 +22,7 @@ const (
 	ErrInvalidSignatureFormat      = "invalid_exact_evm_signature_format"
 	ErrFailedToVerifySignature     = "invalid_exact_evm_failed_to_verify_signature"
 	ErrInvalidSignature            = "invalid_exact_evm_signature"
+	ErrInvalidSignatureS           = "invalid_exact_evm_non_canonical_signature"
 	ErrValidBeforeExpired          = "invalid_exact_evm_payload_authorization_valid_before"
 	ErrValidAfterInFuture          = "invalid_exact_evm_payload_authorization_valid_after"
 	ErrEip3009TokenNameMismatch    = "invalid_exact_evm_token_name_mismatch"

--- a/go/mechanisms/evm/exact/v1/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/v1/facilitator/errors.go
@@ -20,6 +20,7 @@ const (
 	ErrInvalidSignatureFormat          = "invalid_exact_evm_signature_format"
 	ErrFailedToVerifySignature         = "invalid_exact_evm_failed_to_verify_signature"
 	ErrInvalidSignature                = "invalid_exact_evm_payload_signature"
+	ErrInvalidSignatureS               = "invalid_exact_evm_non_canonical_signature"
 
 	// Settle errors
 	ErrVerificationFailed      = "invalid_exact_evm_verification_failed"

--- a/go/mechanisms/evm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/v1/facilitator/scheme.go
@@ -188,6 +188,14 @@ func (f *ExactEvmSchemeV1) verify(
 		return nil, x402.NewVerifyError(ErrInvalidSignatureFormat, evmPayload.Authorization.From, err.Error())
 	}
 
+	nonCanonical, err := exactfacilitator.IsPlainNonCanonicalECDSASignature(ctx, f.signer, evmPayload.Authorization.From, signatureBytes)
+	if err != nil {
+		return nil, x402.NewVerifyError(ErrFailedToVerifySignature, evmPayload.Authorization.From, err.Error())
+	}
+	if nonCanonical {
+		return nil, x402.NewVerifyError(ErrInvalidSignatureS, evmPayload.Authorization.From, "invalid signature s")
+	}
+
 	classification, err := exactfacilitator.ClassifyEIP3009Signature(
 		ctx,
 		f.signer,

--- a/go/mechanisms/evm/signature.go
+++ b/go/mechanisms/evm/signature.go
@@ -1,0 +1,19 @@
+package evm
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var secp256k1HalfN = new(big.Int).Rsh(crypto.S256().Params().N, 1)
+
+// IsCanonicalECDSASignature reports whether a 65-byte ECDSA signature uses a low-s value.
+func IsCanonicalECDSASignature(signature []byte) bool {
+	if len(signature) != 65 {
+		return false
+	}
+
+	s := new(big.Int).SetBytes(signature[32:64])
+	return s.Cmp(secp256k1HalfN) <= 0
+}

--- a/go/mechanisms/evm/signature_test.go
+++ b/go/mechanisms/evm/signature_test.go
@@ -1,0 +1,38 @@
+package evm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestIsCanonicalECDSASignature(t *testing.T) {
+	halfN := new(big.Int).Rsh(crypto.S256().Params().N, 1)
+
+	makeSig := func(s *big.Int) []byte {
+		sig := make([]byte, 65)
+		s.FillBytes(sig[32:64])
+		sig[64] = 27
+		return sig
+	}
+
+	t.Run("accepts low-s signature", func(t *testing.T) {
+		if !IsCanonicalECDSASignature(makeSig(halfN)) {
+			t.Fatal("expected half-order s to be canonical")
+		}
+	})
+
+	t.Run("rejects high-s signature", func(t *testing.T) {
+		highS := new(big.Int).Add(halfN, big.NewInt(1))
+		if IsCanonicalECDSASignature(makeSig(highS)) {
+			t.Fatal("expected high-s signature to be non-canonical")
+		}
+	})
+
+	t.Run("rejects malformed length", func(t *testing.T) {
+		if IsCanonicalECDSASignature([]byte{1, 2, 3}) {
+			t.Fatal("expected malformed signature to be non-canonical")
+		}
+	})
+}


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

- Reject non-canonical high-s EIP-3009 ECDSA signatures in the Go SDK before verification/settlement
- Keep smart-wallet and ERC-6492 signatures unaffected by only applying the rejection to plain EOA signatures
- Add unit tests for canonical signature detection and EOA/smart-wallet classification
- Add a Go changelog fragment

This PR intentionally scopes #2386 to the Go EIP-3009 path. The TypeScript and Python parity work remains to be handled in follow-up PRs.

## Related Issue

Refs #2386

## Tests

- `GOCACHE=/tmp/go-build-cache go test ./mechanisms/evm/...`

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 