### PR TITLE
fix(go): cache Go SVM exact mint metadata

### DIFF
--- a/go/.changes/unreleased/fixed-20260525-2216-svm-mint-cache.yaml
+++ b/go/.changes/unreleased/fixed-20260525-2216-svm-mint-cache.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Cache SVM mint metadata in exact clients to avoid repeated mint account RPC lookups.
+time: 2026-05-25T15:50:14+09:00

--- a/go/mechanisms/svm/exact/client/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/client/duplicate_tx_test.go
@@ -27,6 +27,10 @@ const (
 )
 
 func mockSolanaRPCHandler(t *testing.T, blockhashFunc func() string) http.HandlerFunc {
+	return mockSolanaRPCHandlerWithAccountInfoCount(t, blockhashFunc, nil)
+}
+
+func mockSolanaRPCHandlerWithAccountInfoCount(t *testing.T, blockhashFunc func() string, accountInfoCalls *int32) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			Method string        `json:"method"`
@@ -71,6 +75,10 @@ func mockSolanaRPCHandler(t *testing.T, blockhashFunc func() string) http.Handle
 			})
 
 		case "getAccountInfo":
+			if accountInfoCalls != nil {
+				atomic.AddInt32(accountInfoCalls, 1)
+			}
+
 			mint := token.Mint{
 				MintAuthority:   nil,
 				Supply:          1000000000000,
@@ -154,6 +162,41 @@ func TestDuplicateTransactionAttackVector(t *testing.T) {
 		slotTimeMs := 400
 		assert.Less(t, slotTimeMs, 1000, "Slot time is very short")
 	})
+}
+
+func TestMintMetadataCacheAvoidsRepeatedMintRPC(t *testing.T) {
+	var accountInfoCalls int32
+	server := httptest.NewServer(mockSolanaRPCHandlerWithAccountInfoCount(t, func() string {
+		return fixedBlockhash
+	}, &accountInfoCalls))
+	defer server.Close()
+
+	signer := &mockClientSigner{
+		keypair: solana.NewWallet().PrivateKey,
+	}
+
+	client := NewExactSvmScheme(signer, &svm.ClientConfig{RPCURL: server.URL})
+
+	requirements := types.PaymentRequirements{
+		Scheme:            "exact",
+		Network:           "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+		Asset:             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+		Amount:            "100000",
+		PayTo:             solana.NewWallet().PublicKey().String(),
+		MaxTimeoutSeconds: 3600,
+		Extra: map[string]interface{}{
+			"feePayer": solana.NewWallet().PublicKey().String(),
+		},
+	}
+
+	ctx := context.Background()
+	_, err := client.CreatePaymentPayload(ctx, requirements)
+	require.NoError(t, err)
+
+	_, err = client.CreatePaymentPayload(ctx, requirements)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&accountInfoCalls))
 }
 
 func TestFixedBlockhashProducesDistinctTransactions(t *testing.T) {
@@ -269,9 +312,10 @@ func TestFixedBlockhashProducesDistinctTransactions(t *testing.T) {
 	})
 
 	t.Run("concurrent requests with same blockhash", func(t *testing.T) {
-		server := httptest.NewServer(mockSolanaRPCHandler(t, func() string {
+		var accountInfoCalls int32
+		server := httptest.NewServer(mockSolanaRPCHandlerWithAccountInfoCount(t, func() string {
 			return fixedBlockhash
-		}))
+		}, &accountInfoCalls))
 		defer server.Close()
 
 		signer := &mockClientSigner{
@@ -323,6 +367,7 @@ func TestFixedBlockhashProducesDistinctTransactions(t *testing.T) {
 
 		assert.Equal(t, numConcurrent, len(unique),
 			"Memo mitigation: All %d concurrent requests should produce unique transactions", numConcurrent)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&accountInfoCalls))
 
 		t.Logf("\n=== CONCURRENT UNIQUENESS CHECK ===")
 		t.Logf("Concurrent requests: %d", numConcurrent)

--- a/go/mechanisms/svm/exact/client/scheme.go
+++ b/go/mechanisms/svm/exact/client/scheme.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strconv"
 
-	bin "github.com/gagliardetto/binary"
 	solana "github.com/gagliardetto/solana-go"
 	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 	"github.com/gagliardetto/solana-go/programs/token"
@@ -20,8 +19,9 @@ import (
 
 // ExactSvmScheme implements the SchemeNetworkClient interface for SVM (Solana) exact payments (V2)
 type ExactSvmScheme struct {
-	signer svm.ClientSvmSigner
-	config *svm.ClientConfig // Optional custom RPC configuration
+	signer    svm.ClientSvmSigner
+	config    *svm.ClientConfig // Optional custom RPC configuration
+	mintCache *svm.MintMetadataCache
 }
 
 // NewExactSvmScheme creates a new ExactSvmScheme
@@ -32,8 +32,9 @@ func NewExactSvmScheme(signer svm.ClientSvmSigner, config ...*svm.ClientConfig) 
 		cfg = config[0]
 	}
 	return &ExactSvmScheme{
-		signer: signer,
-		config: cfg,
+		signer:    signer,
+		config:    cfg,
+		mintCache: svm.NewMintMetadataCache(),
 	}
 }
 
@@ -74,14 +75,19 @@ func (c *ExactSvmScheme) CreatePaymentPayload(
 		return types.PaymentPayload{}, fmt.Errorf(ErrInvalidAssetAddress+": %w", err)
 	}
 
-	// Get mint account to determine token program
-	mintAccount, err := rpcClient.GetAccountInfo(ctx, mintPubkey)
+	mintMetadata, err := c.mintCache.GetOrFetch(ctx, rpcClient, networkStr, mintPubkey)
 	if err != nil {
+		if errors.Is(err, svm.ErrUnknownMintTokenProgram) {
+			return types.PaymentPayload{}, errors.New(ErrUnknownTokenProgram)
+		}
+		if errors.Is(err, svm.ErrFailedToDecodeMintData) {
+			return types.PaymentPayload{}, fmt.Errorf(ErrFailedToDecodeMintData+": %w", err)
+		}
 		return types.PaymentPayload{}, fmt.Errorf(ErrFailedToGetMintAccount+": %w", err)
 	}
 
 	// Determine token program (Token or Token-2022)
-	tokenProgramID := mintAccount.Value.Owner
+	tokenProgramID := mintMetadata.TokenProgramID
 	if tokenProgramID != solana.TokenProgramID && tokenProgramID != solana.Token2022ProgramID {
 		return types.PaymentPayload{}, errors.New(ErrUnknownTokenProgram)
 	}
@@ -121,13 +127,6 @@ func (c *ExactSvmScheme) CreatePaymentPayload(
 		return types.PaymentPayload{}, fmt.Errorf(ErrInvalidFeePayerAddress+": %w", err)
 	}
 
-	// Get mint account data to get decimals
-	var mintData token.Mint
-	err = bin.NewBinDecoder(mintAccount.Value.Data.GetBinary()).Decode(&mintData)
-	if err != nil {
-		return types.PaymentPayload{}, fmt.Errorf(ErrFailedToDecodeMintData+": %w", err)
-	}
-
 	// Get latest blockhash
 	latestBlockhash, err := rpcClient.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
 	if err != nil {
@@ -153,7 +152,7 @@ func (c *ExactSvmScheme) CreatePaymentPayload(
 	// Build final transfer instruction
 	transferIx, err := token.NewTransferCheckedInstructionBuilder().
 		SetAmount(amount).
-		SetDecimals(mintData.Decimals).
+		SetDecimals(mintMetadata.Decimals).
 		SetSourceAccount(sourceATA).
 		SetMintAccount(mintPubkey).
 		SetDestinationAccount(destinationATA).

--- a/go/mechanisms/svm/exact/v1/client/mint_cache_test.go
+++ b/go/mechanisms/svm/exact/v1/client/mint_cache_test.go
@@ -1,0 +1,152 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/x402-foundation/x402/go/mechanisms/svm"
+	"github.com/x402-foundation/x402/go/types"
+)
+
+const fixedV1Blockhash = "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF"
+
+type mockV1ClientSigner struct {
+	keypair solana.PrivateKey
+}
+
+func (m *mockV1ClientSigner) Address() solana.PublicKey {
+	return m.keypair.PublicKey()
+}
+
+func (m *mockV1ClientSigner) SignTransaction(ctx context.Context, tx *solana.Transaction) error {
+	_ = ctx
+
+	messageBytes, err := tx.Message.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	signature, err := m.keypair.Sign(messageBytes)
+	if err != nil {
+		return err
+	}
+
+	accountIndex, err := tx.GetAccountIndex(m.keypair.PublicKey())
+	if err != nil {
+		return err
+	}
+
+	if len(tx.Signatures) <= int(accountIndex) {
+		newSignatures := make([]solana.Signature, accountIndex+1)
+		copy(newSignatures, tx.Signatures)
+		tx.Signatures = newSignatures
+	}
+
+	tx.Signatures[accountIndex] = signature
+	return nil
+}
+
+func mockV1SolanaRPCHandler(t *testing.T, accountInfoCalls *int32) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     interface{} `json:"id"`
+		}
+
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		w.Header().Set("Content-Type", "application/json")
+
+		writeResult := func(result interface{}) {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result":  result,
+			})
+		}
+
+		switch req.Method {
+		case "getLatestBlockhash":
+			writeResult(map[string]interface{}{
+				"context": map[string]interface{}{"slot": 1234},
+				"value": map[string]interface{}{
+					"blockhash":            fixedV1Blockhash,
+					"lastValidBlockHeight": 12345678,
+				},
+			})
+		case "getAccountInfo":
+			atomic.AddInt32(accountInfoCalls, 1)
+
+			mint := token.Mint{
+				Supply:        1000000000000,
+				Decimals:      6,
+				IsInitialized: true,
+			}
+
+			buf := new(bytes.Buffer)
+			require.NoError(t, mint.MarshalWithEncoder(bin.NewBinEncoder(buf)))
+			mintDataB64 := base64.StdEncoding.EncodeToString(buf.Bytes())
+
+			writeResult(map[string]interface{}{
+				"context": map[string]interface{}{"slot": 1234},
+				"value": map[string]interface{}{
+					"data":       []interface{}{mintDataB64, "base64"},
+					"executable": false,
+					"lamports":   1000000000,
+					"owner":      solana.TokenProgramID.String(),
+					"rentEpoch":  0,
+				},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"error": map[string]interface{}{
+					"code":    -32601,
+					"message": "method not found",
+				},
+			})
+		}
+	}
+}
+
+func TestMintMetadataCacheAvoidsRepeatedMintRPC(t *testing.T) {
+	var accountInfoCalls int32
+	server := httptest.NewServer(mockV1SolanaRPCHandler(t, &accountInfoCalls))
+	defer server.Close()
+
+	signer := &mockV1ClientSigner{keypair: solana.NewWallet().PrivateKey}
+	client := NewExactSvmSchemeV1(signer, &svm.ClientConfig{RPCURL: server.URL})
+
+	extra := json.RawMessage(`{"feePayer":"` + solana.NewWallet().PublicKey().String() + `"}`)
+	requirements := types.PaymentRequirementsV1{
+		Scheme:            "exact",
+		Network:           "solana-devnet",
+		MaxAmountRequired: "100000",
+		Resource:          "https://example.com",
+		PayTo:             solana.NewWallet().PublicKey().String(),
+		MaxTimeoutSeconds: 3600,
+		Asset:             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+		Extra:             &extra,
+	}
+
+	ctx := context.Background()
+	_, err := client.CreatePaymentPayload(ctx, requirements)
+	require.NoError(t, err)
+
+	_, err = client.CreatePaymentPayload(ctx, requirements)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&accountInfoCalls))
+}

--- a/go/mechanisms/svm/exact/v1/client/scheme.go
+++ b/go/mechanisms/svm/exact/v1/client/scheme.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strconv"
 
-	bin "github.com/gagliardetto/binary"
 	solana "github.com/gagliardetto/solana-go"
 	computebudget "github.com/gagliardetto/solana-go/programs/compute-budget"
 	"github.com/gagliardetto/solana-go/programs/token"
@@ -21,8 +20,9 @@ import (
 
 // ExactSvmSchemeV1 implements the SchemeNetworkClientV1 interface for SVM (Solana) exact payments (V1)
 type ExactSvmSchemeV1 struct {
-	signer svm.ClientSvmSigner
-	config *svm.ClientConfig // Optional custom RPC configuration
+	signer    svm.ClientSvmSigner
+	config    *svm.ClientConfig // Optional custom RPC configuration
+	mintCache *svm.MintMetadataCache
 }
 
 // NewExactSvmSchemeV1 creates a new ExactSvmSchemeV1
@@ -33,8 +33,9 @@ func NewExactSvmSchemeV1(signer svm.ClientSvmSigner, config ...*svm.ClientConfig
 		cfg = config[0]
 	}
 	return &ExactSvmSchemeV1{
-		signer: signer,
-		config: cfg,
+		signer:    signer,
+		config:    cfg,
+		mintCache: svm.NewMintMetadataCache(),
 	}
 }
 
@@ -76,14 +77,19 @@ func (c *ExactSvmSchemeV1) CreatePaymentPayload(
 		return types.PaymentPayloadV1{}, fmt.Errorf(ErrInvalidAssetAddress+": %w", err)
 	}
 
-	// Get mint account to determine token program
-	mintAccount, err := rpcClient.GetAccountInfo(ctx, mintPubkey)
+	mintMetadata, err := c.mintCache.GetOrFetch(ctx, rpcClient, networkStr, mintPubkey)
 	if err != nil {
+		if errors.Is(err, svm.ErrUnknownMintTokenProgram) {
+			return types.PaymentPayloadV1{}, errors.New(ErrUnknownTokenProgram)
+		}
+		if errors.Is(err, svm.ErrFailedToDecodeMintData) {
+			return types.PaymentPayloadV1{}, fmt.Errorf(ErrFailedToDecodeMintData+": %w", err)
+		}
 		return types.PaymentPayloadV1{}, fmt.Errorf(ErrFailedToGetMintAccount+": %w", err)
 	}
 
 	// Determine token program (Token or Token-2022)
-	tokenProgramID := mintAccount.Value.Owner
+	tokenProgramID := mintMetadata.TokenProgramID
 	if tokenProgramID != solana.TokenProgramID && tokenProgramID != solana.Token2022ProgramID {
 		return types.PaymentPayloadV1{}, errors.New(ErrUnknownTokenProgram)
 	}
@@ -132,13 +138,6 @@ func (c *ExactSvmSchemeV1) CreatePaymentPayload(
 		return types.PaymentPayloadV1{}, fmt.Errorf(ErrInvalidFeePayerAddress+": %w", err)
 	}
 
-	// Get mint account data to get decimals
-	var mintData token.Mint
-	err = bin.NewBinDecoder(mintAccount.Value.Data.GetBinary()).Decode(&mintData)
-	if err != nil {
-		return types.PaymentPayloadV1{}, fmt.Errorf(ErrFailedToDecodeMintData+": %w", err)
-	}
-
 	// Get latest blockhash
 	latestBlockhash, err := rpcClient.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
 	if err != nil {
@@ -164,7 +163,7 @@ func (c *ExactSvmSchemeV1) CreatePaymentPayload(
 	// Build final transfer instruction
 	transferIx, err := token.NewTransferCheckedInstructionBuilder().
 		SetAmount(amount).
-		SetDecimals(mintData.Decimals).
+		SetDecimals(mintMetadata.Decimals).
 		SetSourceAccount(sourceATA).
 		SetMintAccount(mintPubkey).
 		SetDestinationAccount(destinationATA).

--- a/go/mechanisms/svm/mint_cache.go
+++ b/go/mechanisms/svm/mint_cache.go
@@ -1,0 +1,92 @@
+package svm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	bin "github.com/gagliardetto/binary"
+	solana "github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/token"
+	"github.com/gagliardetto/solana-go/rpc"
+)
+
+var (
+	ErrMintAccountNotFound     = errors.New("mint account not found")
+	ErrUnknownMintTokenProgram = errors.New("unknown token program")
+	ErrFailedToDecodeMintData  = errors.New("failed to decode mint data")
+)
+
+// MintMetadata contains the stable fields clients need to build SPL transfers.
+type MintMetadata struct {
+	TokenProgramID solana.PublicKey
+	Decimals       uint8
+}
+
+// MintMetadataCache caches mint owner and decimals for one client instance.
+type MintMetadataCache struct {
+	mu      sync.RWMutex
+	entries map[mintMetadataCacheKey]MintMetadata
+}
+
+type mintMetadataCacheKey struct {
+	network string
+	mint    solana.PublicKey
+}
+
+func NewMintMetadataCache() *MintMetadataCache {
+	return &MintMetadataCache{
+		entries: make(map[mintMetadataCacheKey]MintMetadata),
+	}
+}
+
+func (c *MintMetadataCache) GetOrFetch(
+	ctx context.Context,
+	rpcClient *rpc.Client,
+	network string,
+	mint solana.PublicKey,
+) (MintMetadata, error) {
+	key := mintMetadataCacheKey{network: network, mint: mint}
+
+	c.mu.RLock()
+	metadata, ok := c.entries[key]
+	c.mu.RUnlock()
+	if ok {
+		return metadata, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if metadata, ok := c.entries[key]; ok {
+		return metadata, nil
+	}
+
+	mintAccount, err := rpcClient.GetAccountInfo(ctx, mint)
+	if err != nil {
+		return MintMetadata{}, err
+	}
+	if mintAccount == nil || mintAccount.Value == nil {
+		return MintMetadata{}, ErrMintAccountNotFound
+	}
+
+	tokenProgramID := mintAccount.Value.Owner
+	if tokenProgramID != solana.TokenProgramID && tokenProgramID != solana.Token2022ProgramID {
+		return MintMetadata{}, ErrUnknownMintTokenProgram
+	}
+
+	var mintData token.Mint
+	if err := bin.NewBinDecoder(mintAccount.Value.Data.GetBinary()).Decode(&mintData); err != nil {
+		return MintMetadata{}, fmt.Errorf("%w: %w", ErrFailedToDecodeMintData, err)
+	}
+
+	metadata = MintMetadata{
+		TokenProgramID: tokenProgramID,
+		Decimals:       mintData.Decimals,
+	}
+
+	c.entries[key] = metadata
+
+	return metadata, nil
+}


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

### Summary

- Cache SVM mint owner and decimals per Go exact client instance
- Reuse cached mint metadata in both V1 and V2 SVM exact client payload creation
- Add tests covering repeated payload creation and concurrent requests

### Why

The Go SVM exact client fetched the mint account on every payment payload creation to derive the token program and decimals. Those fields are stable for a mint, so repeated calls from the same client can reuse them and avoid unnecessary RPC requests.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

- `GOCACHE=/tmp/go-build-cache go test ./mechanisms/svm/...`

## Checklist

- [v] I have formatted and linted my code
- [v] All new and existing tests pass
- [v] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [v] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 

## Related Issue

Closes #2216 