### PR TITLE
Add fiscal authority readiness card sample index

### DIFF
--- a/fixtures/fiscal-authority-readiness-card-sample/v0/0001-vauban-bounded-spend.json
+++ b/fixtures/fiscal-authority-readiness-card-sample/v0/0001-vauban-bounded-spend.json
@@ -1,0 +1,34 @@
+{
+  "schema": "x402.fiscal_authority.readiness_card_reference.v0",
+  "id": "0001-vauban-bounded-spend",
+  "status": "pending_contributor_owned_reference",
+  "variant": {
+    "cap_enforcement": "cryptographic",
+    "charge_evidence_type": "receipt"
+  },
+  "contributor": {
+    "name": "Vauban Pay",
+    "public_site": "https://pay.vauban.tech"
+  },
+  "expected_reference_fields": {
+    "card_url": null,
+    "content_hash": null,
+    "content_hash_algorithm": "sha256 over JCS-canonicalized bytes",
+    "canon_version": "jcs-rfc8785-v1",
+    "grant_hash_field": "grant_hash",
+    "receipt_hash_field": null,
+    "cap_unit_or_currency_field": null,
+    "revocation_or_dispute_ref_field": null
+  },
+  "notes": [
+    "This stub reserves the cryptographic-cap / receipt example slot.",
+    "The filled card should remain in a Vauban-owned public location once available.",
+    "The x402 sample should reference the contributor-owned card by URL and hash rather than copying authoritative bytes."
+  ],
+  "safe_public_boundary": {
+    "requires_secrets": false,
+    "requires_wallet_access": false,
+    "requires_private_dashboard": false,
+    "requires_customer_data": false
+  }
+}

--- a/fixtures/fiscal-authority-readiness-card-sample/v0/0001-vauban-bounded-spend.json
+++ b/fixtures/fiscal-authority-readiness-card-sample/v0/0001-vauban-bounded-spend.json
@@ -1,7 +1,7 @@
 {
   "schema": "x402.fiscal_authority.readiness_card_reference.v0",
   "id": "0001-vauban-bounded-spend",
-  "status": "pending_contributor_owned_reference",
+  "status": "committed_contributor_owned_reference",
   "variant": {
     "cap_enforcement": "cryptographic",
     "charge_evidence_type": "receipt"
@@ -11,19 +11,22 @@
     "public_site": "https://pay.vauban.tech"
   },
   "expected_reference_fields": {
-    "card_url": null,
-    "content_hash": null,
+    "card_url": "https://github.com/vauban-org/x402-stark-receipts-conformance/blob/main/cards/0001-vauban-bounded-spend.json",
+    "content_hash": "sha256:9b63024da81a7a6ca3a6ae1171d5b3bd1ee47317f4511b24b48855a1e022af7e",
     "content_hash_algorithm": "sha256 over JCS-canonicalized bytes",
     "canon_version": "jcs-rfc8785-v1",
-    "grant_hash_field": "grant_hash",
-    "receipt_hash_field": null,
-    "cap_unit_or_currency_field": null,
-    "revocation_or_dispute_ref_field": null
+    "approval_source_field": "capabilities.approval_source",
+    "buyer_agent_can_spend_without_human_field": "capabilities.buyer_agent_can_spend_without_human",
+    "preflight_verdict_field": "capabilities.preflight_verdict",
+    "charge_evidence_field": "evidence_anchors.on_chain",
+    "cap_unit_or_currency_field": "capabilities.cap.currency",
+    "revocation_or_dispute_ref_field": "capabilities.cap.revocation.endpoint"
   },
   "notes": [
-    "This stub reserves the cryptographic-cap / receipt example slot.",
-    "The filled card should remain in a Vauban-owned public location once available.",
-    "The x402 sample should reference the contributor-owned card by URL and hash rather than copying authoritative bytes."
+    "This stub indexes the cryptographic-cap / receipt example slot.",
+    "The filled card remains in a Vauban-owned public repository.",
+    "Vauban reports status PARTIAL while buyer_agent_can_spend_without_human remains false pending revocation endpoint liveness and canon_version normalization.",
+    "The x402 sample references the contributor-owned card by URL and hash rather than copying authoritative bytes."
   ],
   "safe_public_boundary": {
     "requires_secrets": false,

--- a/fixtures/fiscal-authority-readiness-card-sample/v0/0002-algovoi-signed-attestation.json
+++ b/fixtures/fiscal-authority-readiness-card-sample/v0/0002-algovoi-signed-attestation.json
@@ -1,0 +1,35 @@
+{
+  "schema": "x402.fiscal_authority.readiness_card_reference.v0",
+  "id": "0002-algovoi-signed-attestation",
+  "status": "ready_contributor_owned_reference",
+  "variant": {
+    "cap_enforcement": "facilitator_policy",
+    "charge_evidence_type": "signed_attestation"
+  },
+  "contributor": {
+    "name": "AlgoVoi",
+    "github_repository": "chopmob-cloud/algovoi-jcs-conformance-vectors"
+  },
+  "reference": {
+    "card_url": "https://github.com/chopmob-cloud/algovoi-jcs-conformance-vectors/blob/main/fixtures/fiscal-authority-readiness-card/algovoi-signed-attestation/v0/card.json",
+    "readme_url": "https://github.com/chopmob-cloud/algovoi-jcs-conformance-vectors/blob/main/fixtures/fiscal-authority-readiness-card/algovoi-signed-attestation/v0/README.md",
+    "source_commit": "4d49978",
+    "observed_raw_sha256": "ab23571e02363a7a16f43c13b77146de2ae5f9a1c4241380ea5f0d32feacdafc"
+  },
+  "observed_discriminator_coverage": {
+    "cap.enforcement": "facilitator_policy",
+    "charge_evidence.type": "signed_attestation",
+    "preflight_verdict.buyer_agent_can_spend_without_human": false
+  },
+  "notes": [
+    "The AlgoVoi card stays contributor-owned and byte-fresh in the AlgoVoi conformance vectors repository.",
+    "This x402-side sample only indexes the public card URL and observed hash.",
+    "The sample card remains not spend-without-human because authority and price are intentionally partial in the sample."
+  ],
+  "safe_public_boundary": {
+    "requires_secrets": false,
+    "requires_wallet_access": false,
+    "requires_private_dashboard": false,
+    "requires_customer_data": false
+  }
+}

--- a/fixtures/fiscal-authority-readiness-card-sample/v0/README.md
+++ b/fixtures/fiscal-authority-readiness-card-sample/v0/README.md
@@ -47,10 +47,9 @@ buyer-agent needs before spend:
 
 | File | Status | Variant |
 | --- | --- | --- |
-| 0001-vauban-bounded-spend.json | pending contributor-owned reference | cryptographic cap / receipt |
+| 0001-vauban-bounded-spend.json | committed contributor-owned reference | cryptographic cap / receipt |
 | 0002-algovoi-signed-attestation.json | ready contributor-owned reference | facilitator policy cap / signed attestation |
 
 Future examples, such as a CREST urn:crest:trust-check-v1 independent
 observation envelope, can be added as separate reference stubs when a public
 no-secret URL and content hash are available.
-

--- a/fixtures/fiscal-authority-readiness-card-sample/v0/README.md
+++ b/fixtures/fiscal-authority-readiness-card-sample/v0/README.md
@@ -1,0 +1,56 @@
+# Fiscal authority readiness card sample
+
+This directory is a small discovery index for public, no-secret fiscal-authority
+readiness card examples.
+
+The sample is intentionally a reference index, not the authoritative store for
+contributor-maintained card bytes. Contributors keep their filled cards in
+their own repositories or public surfaces, where they can keep values fresh
+against their source systems. The x402-side files here point to those cards by
+URL and content hash so buyer-agent preflight implementations can discover and
+verify them without copying contributor-owned bytes into this repository.
+
+## Scope
+
+The readiness card is a buyer-agent preflight artifact for x402 resources. It
+answers whether an autonomous buyer-agent can spend without a human in the loop
+and records the public evidence behind that answer.
+
+The card is not a wallet, credential, private dashboard, payment link, or
+compliance oracle. Every referenced field must be safe to publish.
+
+## Common substrate
+
+The examples in this directory should converge on these common primitives:
+
+- content-addressed references use sha256:<lowercase-hex-64> over
+  JCS-canonicalized bytes when the referenced object exists
+- canon_version is in-band, currently jcs-rfc8785-v1
+- freshness is explicit enough for buyer-agent preflight
+- absent evidence remains informative: missing, partial, null, or omitted by
+  domain rule; examples should not invent fake hashes or fake authority
+
+## Domain fields
+
+Fiscal-authority readiness cards are expected to carry the domain fields that a
+buyer-agent needs before spend:
+
+- price or discovery-time ceiling
+- authority / approval source
+- cap, including enforcement type and currency or unit
+- charge evidence, including receipt or signed attestation references
+- canonicalization and hash profile
+- revocation or dispute path
+- preflight verdict, including buyer_agent_can_spend_without_human
+
+## Indexed examples
+
+| File | Status | Variant |
+| --- | --- | --- |
+| 0001-vauban-bounded-spend.json | pending contributor-owned reference | cryptographic cap / receipt |
+| 0002-algovoi-signed-attestation.json | ready contributor-owned reference | facilitator policy cap / signed attestation |
+
+Future examples, such as a CREST urn:crest:trust-check-v1 independent
+observation envelope, can be added as separate reference stubs when a public
+no-secret URL and content hash are available.
+


### PR DESCRIPTION
## Summary\n\nAdds a small public/no-secret discovery index for fiscal-authority readiness card examples:\n\n- fixtures/fiscal-authority-readiness-card-sample/v0/README.md\n- 0001-vauban-bounded-spend.json as a pending contributor-owned cryptographic-cap / receipt reference\n- 0002-algovoi-signed-attestation.json as a ready contributor-owned facilitator-policy / signed-attestation reference\n\nThis follows the discussion in #2405: contributor-maintained filled cards stay in contributor-owned repos or public surfaces, while the x402-side sample indexes them by URL and content hash rather than copying authoritative bytes.\n\n## Notes\n\n- AlgoVoi reference points at chopmob-cloud/algovoi-jcs-conformance-vectors, commit 4d49978\n- Observed raw SHA-256 for the AlgoVoi card: ab23571e02363a7a16f43c13b77146de2ae5f9a1c4241380ea5f0d32feacdafc\n- Vauban is left as a pending stub until a Vauban-owned public card URL/hash exists\n- No secrets, wallets, private dashboards, customer data, production credentials, or payment access are included\n\n## Validation\n\n- Parsed both JSON stubs with Node\n- Ran git diff --check\n- Fetched the AlgoVoi public card and verified the observed raw SHA-256\n