### PR TITLE
fix: java uri mismatch

### DIFF
--- a/java/src/main/java/org/x402/server/PaymentFilter.java
+++ b/java/src/main/java/org/x402/server/PaymentFilter.java
@@ -18,6 +18,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.math.BigInteger;
@@ -84,10 +85,10 @@ public class PaymentFilter implements Filter {
 
         HttpServletRequest  request  = (HttpServletRequest)  req;
         HttpServletResponse response = (HttpServletResponse) res;
-        String              path     = request.getRequestURI();
+        String              path     = normalizePath(request.getRequestURI());
 
         /* -------- path is free? skip check ----------------------------- */
-        if (!priceTable.containsKey(path)) {
+        if (path == null || !priceTable.containsKey(path)) {
             chain.doFilter(req, res);
             return;
         }
@@ -208,6 +209,38 @@ public class PaymentFilter implements Filter {
         pr.payTo             = payTo;
         pr.maxTimeoutSeconds = 30;
         return pr;
+    }
+
+    /**
+     * Normalizes a raw HTTP request URI to the canonical path the servlet container routes to.
+     *
+     * Servlet containers (Tomcat, Jetty, Undertow) normalize paths before dispatch, but
+     * {@code getRequestURI()} returns the raw, un-normalized value. An attacker can bypass a
+     * price-table lookup by sending {@code /%70rivate}, {@code /private;x}, {@code //private},
+     * or {@code /./private} — all of which the container routes identically to {@code /private}.
+     *
+     * This method mirrors that normalization: strips matrix parameters, percent-decodes,
+     * resolves {@code .}/{@code ..} segments, and collapses consecutive slashes.
+     *
+     * Note: prepending a dummy scheme+authority ({@code http://x}) before parsing is required
+     * because {@code new URI("//private")} incorrectly treats {@code //private} as an
+     * authority component, returning an empty path. The dummy prefix forces path-only parsing.
+     *
+     * @return the normalized path, or {@code null} if the URI cannot be parsed
+     */
+    private static String normalizePath(String rawUri) {
+        if (rawUri == null) return null;
+        try {
+            // Strip matrix parameters (;param) that servlet containers remove before routing.
+            String stripped = rawUri.replaceAll(";[^/?#]*", "");
+            // Prepend dummy scheme+authority so URI treats the value as a path component.
+            // Without this, "//foo" would be parsed as authority="foo", path="".
+            String normalized = new URI("http://x" + stripped).normalize().getPath();
+            // Collapse consecutive slashes that normalize() leaves intact (e.g. //foo → /foo).
+            return normalized.replaceAll("/+", "/");
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     /** Create a base64-encoded payment response header. */

--- a/java/src/test/java/org/x402/server/PaymentFilterTest.java
+++ b/java/src/test/java/org/x402/server/PaymentFilterTest.java
@@ -516,6 +516,73 @@ class PaymentFilterTest {
             "Settlement response should contain null payer when authorization malformed: " + jsonString);
     }
 
+    /* ------------ URI normalization bypass attempts → 402 ---------------
+     *
+     * These tests verify that an attacker cannot bypass payment enforcement by
+     * sending obfuscated paths that the servlet container normalizes to a paid
+     * route before dispatch but that a raw-URI lookup would miss.
+     * --------------------------------------------------------------------- */
+
+    @Test
+    void percentEncodedPathRequiresPayment() throws Exception {
+        // "%70" == 'p', so /%70rivate normalises to /private (a paid route)
+        when(req.getRequestURI()).thenReturn("/%70rivate");
+        when(req.getHeader("X-PAYMENT")).thenReturn(null);
+
+        filter.doFilter(req, resp, chain);
+
+        verify(resp).setStatus(HttpServletResponse.SC_PAYMENT_REQUIRED);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void matrixParameterPathRequiresPayment() throws Exception {
+        // Servlet containers strip ;params before routing — filter must do the same
+        when(req.getRequestURI()).thenReturn("/private;jsessionid=abc123");
+        when(req.getHeader("X-PAYMENT")).thenReturn(null);
+
+        filter.doFilter(req, resp, chain);
+
+        verify(resp).setStatus(HttpServletResponse.SC_PAYMENT_REQUIRED);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void doubleSlashPathRequiresPayment() throws Exception {
+        // //private normalises to /private in all major servlet containers
+        when(req.getRequestURI()).thenReturn("//private");
+        when(req.getHeader("X-PAYMENT")).thenReturn(null);
+
+        filter.doFilter(req, resp, chain);
+
+        verify(resp).setStatus(HttpServletResponse.SC_PAYMENT_REQUIRED);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void dotSegmentPathRequiresPayment() throws Exception {
+        // /./private normalises to /private
+        when(req.getRequestURI()).thenReturn("/./private");
+        when(req.getHeader("X-PAYMENT")).thenReturn(null);
+
+        filter.doFilter(req, resp, chain);
+
+        verify(resp).setStatus(HttpServletResponse.SC_PAYMENT_REQUIRED);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void parentSegmentPathRequiresPayment() throws Exception {
+        // /api/../private normalises to /private
+        when(req.getRequestURI()).thenReturn("/api/../private");
+        when(req.getHeader("X-PAYMENT")).thenReturn(null);
+
+        filter.doFilter(req, resp, chain);
+
+        verify(resp).setStatus(HttpServletResponse.SC_PAYMENT_REQUIRED);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
     /* ------------ facilitator IOException returns 500 --------------------- */
     @Test
     void facilitatorIOExceptionReturns500() throws Exception {


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Fixes a payment-bypass vulnerability in the Java `PaymentFilter` where an attacker can reach a protected handler without paying by sending an obfuscated path that the servlet contianer normalizes before dispatch but that the raw-URI price-table lookup misses.

## Tests

Added new unit tests

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 