### PR TITLE
fix: go payment verify result discarded

### DIFF
--- a/go/.changes/unreleased/go-payment-verification-result-discarded.yaml
+++ b/go/.changes/unreleased/go-payment-verification-result-discarded.yaml
@@ -1,0 +1,2 @@
+kind: fixed
+body: Fix security bug where a facilitator HTTP-200 response with `isValid:false` was not treated as a hard gate failure — `VerifyPaymentWithExtensions` now returns a `*VerifyError` when the facilitator explicitly rejects a payment, preventing any structurally well-formed payment header from bypassing the protected handler

--- a/go/server.go
+++ b/go/server.go
@@ -770,7 +770,7 @@ func (s *x402ResourceServer) VerifyPaymentWithExtensions(
 	// Use already marshaled bytes for network call
 	verifyResult, verifyErr := facilitator.Verify(ctx, payloadBytes, requirementsBytes)
 
-	// Handle failure
+	// Handle failure (network/protocol error from facilitator)
 	if verifyErr != nil {
 		failureCtx := VerifyFailureContext{VerifyContext: hookCtx, Error: verifyErr}
 		for _, lh := range verifyFailureHooks {
@@ -780,6 +780,30 @@ func (s *x402ResourceServer) VerifyPaymentWithExtensions(
 			}
 		}
 		return verifyResult, verifyErr
+	}
+
+	// Handle IsValid: false — facilitator reachable but explicitly rejected the payment.
+	// Conflating "no network error" with "payment valid" is a security bug: an HTTP-200
+	// response carrying {"isValid":false} must be treated as a hard gate failure.
+	if verifyResult == nil || !verifyResult.IsValid {
+		reason := ErrCodeInvalidPayment
+		var payer, message string
+		if verifyResult != nil {
+			if verifyResult.InvalidReason != "" {
+				reason = verifyResult.InvalidReason
+			}
+			payer = verifyResult.Payer
+			message = verifyResult.InvalidMessage
+		}
+		ve := NewVerifyError(reason, payer, message)
+		failureCtx := VerifyFailureContext{VerifyContext: hookCtx, Error: ve}
+		for _, lh := range verifyFailureHooks {
+			result, _ := lh.Hook(failureCtx)
+			if result != nil && result.Recovered {
+				return result.Result, nil
+			}
+		}
+		return verifyResult, ve
 	}
 
 	// Execute afterVerify hooks. The last hook to return a SkipHandler directive

--- a/go/server_test.go
+++ b/go/server_test.go
@@ -466,6 +466,71 @@ func TestServerVerifyPayment(t *testing.T) {
 	}
 }
 
+// TestServerVerifyPayment_InvalidFacilitatorResponse is a regression test for the security
+// bug where a facilitator HTTP-200 response with isValid:false was not treated as an error,
+// allowing any structurally well-formed payment header to pass the gate.
+func TestServerVerifyPayment_InvalidFacilitatorResponse(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name           string
+		verifyResponse *VerifyResponse
+		wantReason     string
+	}{
+		{
+			name:           "isValid false with reason",
+			verifyResponse: &VerifyResponse{IsValid: false, InvalidReason: "insufficient_balance", Payer: "0xpayer"},
+			wantReason:     "insufficient_balance",
+		},
+		{
+			name:           "isValid false without reason",
+			verifyResponse: &VerifyResponse{IsValid: false},
+			wantReason:     ErrCodeInvalidPayment,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := &mockFacilitatorClient{
+				kinds: []SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				verify: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*VerifyResponse, error) {
+					return tc.verifyResponse, nil // HTTP-200 but isValid:false
+				},
+			}
+
+			server := Newx402ResourceServer(WithFacilitatorClient(mockClient))
+			if err := server.Initialize(ctx); err != nil {
+				t.Fatalf("Failed to initialize server: %v", err)
+			}
+
+			requirements := types.PaymentRequirements{
+				Scheme:  "exact",
+				Network: "eip155:1",
+				Asset:   "USDC",
+				Amount:  "1000000",
+				PayTo:   "0xrecipient",
+			}
+			payload := types.PaymentPayload{
+				X402Version: 2,
+				Accepted:    requirements,
+				Payload:     map[string]interface{}{},
+			}
+
+			_, err := server.VerifyPayment(ctx, payload, requirements)
+			if err == nil {
+				t.Fatal("Expected error for isValid:false facilitator response, got nil — payment gate bypass")
+			}
+			var ve *VerifyError
+			if !errors.As(err, &ve) {
+				t.Fatalf("Expected *VerifyError, got %T: %v", err, err)
+			}
+			if ve.InvalidReason != tc.wantReason {
+				t.Fatalf("Expected reason %q, got %q", tc.wantReason, ve.InvalidReason)
+			}
+		})
+	}
+}
+
 func TestServerSettlePayment(t *testing.T) {
 	ctx := context.Background()
 

--- a/go/test/integration/http_test.go
+++ b/go/test/integration/http_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -248,4 +250,142 @@ func TestHTTPIntegration(t *testing.T) {
 			t.Errorf("Expected successful settlement, got error: %s", settleResponse.ErrorReason)
 		}
 	})
+}
+
+// TestHTTPIntegration_FacilitatorReturnsIsValidFalse is a regression test for the security
+// bug where a facilitator HTTP-200 response carrying {"isValid":false} was not treated as a
+// hard gate failure. It exercises the full local SDK stack:
+//
+//	httptest facilitator stub (HTTP 200, {"isValid":false})
+//	  → x402http.HTTPFacilitatorClient.verifyHTTP (parses response)
+//	  → x402.VerifyPaymentWithExtensions (new IsValid guard)
+//	  → x402http.ProcessHTTPRequest (must return ResultPaymentError, not ResultPaymentVerified)
+//
+// No real blockchain or external service is used.
+func TestHTTPIntegration_FacilitatorReturnsIsValidFalse(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		invalidReason  string
+		wantReason     string
+	}{
+		{
+			name:          "isValid false with reason",
+			invalidReason: "insufficient_balance",
+			wantReason:    "insufficient_balance",
+		},
+		{
+			name:          "isValid false without reason",
+			invalidReason: "",
+			wantReason:    x402.ErrCodeInvalidPayment,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Stand up a minimal HTTP facilitator stub. /supported tells the resource
+			// server which schemes are available; /verify always returns isValid:false
+			// with HTTP 200, simulating a facilitator that is reachable but rejects
+			// the payment at the protocol level.
+			stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/supported":
+					json.NewEncoder(w).Encode(map[string]interface{}{
+						"kinds": []map[string]interface{}{
+							{"x402Version": 2, "scheme": "cash", "network": "x402:cash"},
+						},
+						"extensions": []string{},
+						"signers":    map[string][]string{},
+					})
+				case "/verify":
+					resp := map[string]interface{}{"isValid": false}
+					if tc.invalidReason != "" {
+						resp["invalidReason"] = tc.invalidReason
+					}
+					json.NewEncoder(w).Encode(resp)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer stub.Close()
+
+			// Wire the real HTTPFacilitatorClient to the stub — this exercises the
+			// full HTTP parse path (verifyHTTP → parseVerifySuccessResponse).
+			facilitatorClient := x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+				URL: stub.URL,
+			})
+
+			routes := x402http.RoutesConfig{
+				"/api/protected": {
+					Accepts: x402http.PaymentOptions{
+						{
+							Scheme:  "cash",
+							PayTo:   "merchant@example.com",
+							Price:   "$0.10",
+							Network: "x402:cash",
+						},
+					},
+				},
+			}
+
+			server := x402http.Newx402HTTPResourceServer(
+				routes,
+				x402.WithFacilitatorClient(facilitatorClient),
+			)
+			server.Register("x402:cash", cash.NewSchemeNetworkServer())
+
+			if err := server.Initialize(ctx); err != nil {
+				t.Fatalf("server.Initialize: %v", err)
+			}
+
+			// Build a structurally valid payment payload using the cash client so
+			// the server accepts the header encoding and reaches the facilitator call.
+			x402Client := x402.Newx402Client()
+			x402Client.Register("x402:cash", cash.NewSchemeNetworkClient("Alice"))
+			httpClient := x402http.Newx402HTTPClient(x402Client)
+
+			requirements := cash.BuildPaymentRequirements("merchant@example.com", "USD", "0.10")
+			payload, err := x402Client.CreatePaymentPayload(ctx, requirements, nil, nil)
+			if err != nil {
+				t.Fatalf("CreatePaymentPayload: %v", err)
+			}
+			payloadBytes, _ := json.Marshal(payload)
+			paymentHeaders, err := httpClient.EncodePaymentSignatureHeader(payloadBytes)
+			if err != nil {
+				t.Fatalf("EncodePaymentSignatureHeader: %v", err)
+			}
+
+			reqCtx := x402http.HTTPRequestContext{
+				Adapter: &mockHTTPAdapter{
+					headers: paymentHeaders,
+					method:  "GET",
+					path:    "/api/protected",
+					url:     "https://example.com/api/protected",
+				},
+				Path:   "/api/protected",
+				Method: "GET",
+			}
+
+			result := server.ProcessHTTPRequest(ctx, reqCtx, nil)
+
+			// The gate must not pass — protected handler must not execute.
+			if result.Type == x402http.ResultPaymentVerified {
+				t.Fatal("ProcessHTTPRequest returned ResultPaymentVerified for isValid:false — payment gate bypass")
+			}
+			if result.Type != x402http.ResultPaymentError {
+				t.Fatalf("Expected ResultPaymentError, got %s", result.Type)
+			}
+			if result.Response == nil {
+				t.Fatal("Expected 402 response instructions, got nil")
+			}
+			if result.Response.Status != 402 {
+				t.Fatalf("Expected HTTP 402, got %d", result.Response.Status)
+			}
+
+			// The PAYMENT-REQUIRED header must be set so the client knows how to retry.
+			if result.Response.Headers["PAYMENT-REQUIRED"] == "" {
+				t.Error("Expected PAYMENT-REQUIRED header in 402 response")
+			}
+		})
+	}
 }

--- a/go/test/integration/http_test.go
+++ b/go/test/integration/http_test.go
@@ -264,9 +264,9 @@ func TestHTTPIntegration(t *testing.T) {
 // No real blockchain or external service is used.
 func TestHTTPIntegration_FacilitatorReturnsIsValidFalse(t *testing.T) {
 	for _, tc := range []struct {
-		name           string
-		invalidReason  string
-		wantReason     string
+		name          string
+		invalidReason string
+		wantReason    string
 	}{
 		{
 			name:          "isValid false with reason",


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Treat facilitator isValid:false as a hard payment gate failure

- VerifyPaymentWithExtensions now returns a *VerifyError when the facilitator responds HTTP 200 with {"isValid":false}, closing a security bypass where any  structurally well-formed payment header would pass the protected handler gate
- Added unit regression test covering both isValid:false with a specific InvalidReason and without one (fallback to ErrCodeInvalidPayment)
- Added SDK-level integration test using a real httptest facilitator stub exercising the full local stack: HTTPFacilitatorClient.verifyHTTP → VerifyPaymentWithExtensions → ProcessHTTPRequest

## Tests

Added new unit and integration tests

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 