### PR TITLE
fix: aptos gas price vulnerability

### DIFF
--- a/specs/schemes/exact/scheme_exact_aptos.md
+++ b/specs/schemes/exact/scheme_exact_aptos.md
@@ -115,7 +115,8 @@ Steps to verify a payment for the `exact` scheme:
 8. Verify the transfer amount matches `requirements.amount`.
 9. Verify the transfer recipient matches `requirements.payTo`.
 10. Verify the transaction sender has sufficient balance of the `asset` to cover the required amount.
-11. Simulate the transaction using the Aptos REST API to ensure it would succeed and has not already been executed/committed to the chain. This also validates the sequence number to prevent replay attacks.
+11. Verify `gas_unit_price` is within an acceptable upper bound (e.g., no greater than a configured maximum such as 100 octas). This MUST be enforced to prevent a malicious client from setting an arbitrarily high gas price that drains the fee payer's account. Transactions with `gas_unit_price` exceeding the bound MUST be rejected.
+12. Simulate the transaction using the Aptos REST API to ensure it would succeed and has not already been executed/committed to the chain. This also validates the sequence number to prevent replay attacks.
 
 ## Settlement
 
@@ -179,6 +180,8 @@ The facilitator operates (or integrates with) a gas station service that handles
 - Abuse prevention policies
 
 Both approaches are transparent to the client - they simply check for `extra.feePayer` and construct their transaction accordingly.
+
+**Gas Price Bounding:** Because the fee payer covers gas costs, the facilitator MUST enforce an upper bound on `gas_unit_price` during verification. A client that sets an arbitrarily high gas price can cause the fee payer to spend far more APT than the payment is worth. Facilitators SHOULD publish their maximum accepted `gas_unit_price` (e.g., via `extra` fields in payment requirements) so well-behaved clients can set an appropriate value.
 
 ### Non-Sponsored Transactions
 

--- a/typescript/.changeset/fix-aptos-gas-unit-price-unbounded.md
+++ b/typescript/.changeset/fix-aptos-gas-unit-price-unbounded.md
@@ -1,0 +1,5 @@
+---
+"@x402/aptos": patch
+---
+
+Fixed a security vulnerability where an attacker could submit a sponsored transaction with an unbounded `gas_unit_price`, draining the facilitator's APT balance. Added a `MAX_GAS_UNIT_PRICE` ceiling (1,000 Octas, 10× the Aptos protocol minimum) checked in `verify()` before the fee-payer signature step.

--- a/typescript/packages/mechanisms/aptos/src/constants.ts
+++ b/typescript/packages/mechanisms/aptos/src/constants.ts
@@ -28,6 +28,13 @@ export const TRANSFER_FUNCTION = "0x1::primary_fungible_store::transfer";
 export const MAX_GAS_AMOUNT = 500000n;
 
 /**
+ * Maximum gas unit price (in Octas) allowed for sponsored transactions to prevent gas draining attacks.
+ * Aptos mainnet typically prices gas at ~100 Octas; this allows 10x headroom for network congestion.
+ * Gas cost = gas_used × gas_unit_price, so bounding both prevents fee-payer wallet draining.
+ */
+export const MAX_GAS_UNIT_PRICE = 1000n;
+
+/**
  * Maps CAIP-2 network identifiers to Aptos chain IDs.
  *
  * @param network - The CAIP-2 network identifier (e.g., "aptos:1")

--- a/typescript/packages/mechanisms/aptos/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/aptos/src/exact/facilitator/scheme.ts
@@ -9,7 +9,7 @@ import type {
 import type { FacilitatorAptosSigner } from "../../signer";
 import type { ExactAptosPayload } from "../../types";
 import { createAptosClient, deserializeAptosPayment } from "../../utils";
-import { getAptosChainId, MAX_GAS_AMOUNT } from "../../constants";
+import { getAptosChainId, MAX_GAS_AMOUNT, MAX_GAS_UNIT_PRICE } from "../../constants";
 
 /**
  * Aptos facilitator implementation for the Exact payment scheme.
@@ -124,13 +124,22 @@ export class ExactAptosScheme implements SchemeNetworkFacilitator {
         }
       }
 
-      // For sponsored transactions, verify max gas to prevent gas draining
+      // For sponsored transactions, verify max gas and gas unit price to prevent gas draining
       if (isSponsored) {
         const maxGasAmount = BigInt(transaction.rawTransaction.max_gas_amount);
         if (maxGasAmount > MAX_GAS_AMOUNT) {
           return {
             isValid: false,
             invalidReason: `invalid_exact_aptos_payload_gas_too_high: ${maxGasAmount} > ${MAX_GAS_AMOUNT}`,
+            payer: senderAddress,
+          };
+        }
+
+        const gasUnitPrice = BigInt(transaction.rawTransaction.gas_unit_price);
+        if (gasUnitPrice > MAX_GAS_UNIT_PRICE) {
+          return {
+            isValid: false,
+            invalidReason: `invalid_exact_aptos_payload_gas_unit_price_too_high: ${gasUnitPrice} > ${MAX_GAS_UNIT_PRICE}`,
             payer: senderAddress,
           };
         }

--- a/typescript/packages/mechanisms/aptos/test/unit/constants.test.ts
+++ b/typescript/packages/mechanisms/aptos/test/unit/constants.test.ts
@@ -6,6 +6,7 @@ import {
   APTOS_ADDRESS_REGEX,
   TRANSFER_FUNCTION,
   MAX_GAS_AMOUNT,
+  MAX_GAS_UNIT_PRICE,
   getAptosNetwork,
   getAptosRpcUrl,
   getAptosChainId,
@@ -94,6 +95,23 @@ describe("Aptos Constants", () => {
   describe("MAX_GAS_AMOUNT", () => {
     it("should be a reasonable limit for simple transfers", () => {
       expect(MAX_GAS_AMOUNT).toBe(500000n);
+    });
+  });
+
+  describe("MAX_GAS_UNIT_PRICE", () => {
+    it("should be a bigint", () => {
+      expect(typeof MAX_GAS_UNIT_PRICE).toBe("bigint");
+    });
+
+    it("should be well above typical mainnet gas price of ~100 Octas", () => {
+      expect(MAX_GAS_UNIT_PRICE).toBeGreaterThan(100n);
+    });
+
+    it("should cap the maximum fee-payer gas cost per transaction", () => {
+      // Worst-case gas cost in Octas: MAX_GAS_AMOUNT × MAX_GAS_UNIT_PRICE
+      const maxGasCostOctas = MAX_GAS_AMOUNT * MAX_GAS_UNIT_PRICE;
+      // 50 APT ceiling (5_000_000_000 Octas) — generous but finite
+      expect(maxGasCostOctas).toBeLessThanOrEqual(5_000_000_000n);
     });
   });
 

--- a/typescript/packages/mechanisms/aptos/test/unit/facilitator-verify.test.ts
+++ b/typescript/packages/mechanisms/aptos/test/unit/facilitator-verify.test.ts
@@ -1,0 +1,246 @@
+import {
+  Account,
+  AccountAddress,
+  ChainId,
+  EntryFunction,
+  Identifier,
+  ModuleId,
+  RawTransaction,
+  SimpleTransaction,
+  StructTag,
+  TransactionPayloadEntryFunction,
+  TypeTagStruct,
+  U64,
+} from "@aptos-labs/ts-sdk";
+import { describe, it, expect, beforeEach } from "vitest";
+import { ExactAptosScheme as ExactAptosFacilitator } from "../../src/exact/facilitator/scheme";
+import { toFacilitatorAptosSigner } from "../../src/signer";
+import { encodeAptosPayload } from "../../src/utils";
+import {
+  MAX_GAS_AMOUNT,
+  MAX_GAS_UNIT_PRICE,
+  USDC_TESTNET_FA,
+  APTOS_TESTNET_CAIP2,
+} from "../../src/constants";
+import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import type { ExactAptosPayload } from "../../src/types";
+
+const TESTNET_CHAIN_ID = 2;
+const FUTURE_EXPIRATION = BigInt(Math.floor(Date.now() / 1000) + 3600);
+// A past expiration lets us verify checks that come BEFORE the expiration check
+// pass without reaching network calls (balance lookup, simulation).
+const PAST_EXPIRATION = BigInt(Math.floor(Date.now() / 1000) - 100);
+const TEST_PAY_TO = "0x0000000000000000000000000000000000000000000000000000000000000001";
+const TEST_AMOUNT = 1000n;
+
+function buildTransferEntryFn(asset: string, payTo: string, amount: bigint): EntryFunction {
+  return new EntryFunction(
+    new ModuleId(AccountAddress.ONE, new Identifier("primary_fungible_store")),
+    new Identifier("transfer"),
+    [
+      new TypeTagStruct(
+        new StructTag(
+          AccountAddress.ONE,
+          new Identifier("fungible_asset"),
+          new Identifier("Metadata"),
+          [],
+        ),
+      ),
+    ],
+    [AccountAddress.from(asset), AccountAddress.from(payTo), new U64(amount)],
+  );
+}
+
+function buildEncodedTransaction(opts: {
+  sender: Account;
+  feePayer?: Account;
+  maxGasAmount?: bigint;
+  gasUnitPrice?: bigint;
+  expiration?: bigint;
+}): string {
+  const {
+    sender,
+    feePayer,
+    maxGasAmount = 200_000n,
+    gasUnitPrice = 100n,
+    expiration = FUTURE_EXPIRATION,
+  } = opts;
+
+  const rawTx = new RawTransaction(
+    sender.accountAddress,
+    0n,
+    new TransactionPayloadEntryFunction(
+      buildTransferEntryFn(USDC_TESTNET_FA, TEST_PAY_TO, TEST_AMOUNT),
+    ),
+    maxGasAmount,
+    gasUnitPrice,
+    expiration,
+    new ChainId(TESTNET_CHAIN_ID),
+  );
+
+  const simpleTx = feePayer
+    ? new SimpleTransaction(rawTx, feePayer.accountAddress)
+    : new SimpleTransaction(rawTx);
+  const senderAuth = sender.signTransactionWithAuthenticator(simpleTx);
+  return encodeAptosPayload(simpleTx.bcsToBytes(), senderAuth.bcsToBytes());
+}
+
+function buildPayload(encodedTx: string): PaymentPayload {
+  return {
+    x402Version: 2,
+    accepted: { scheme: "exact", network: APTOS_TESTNET_CAIP2 },
+    payload: { transaction: encodedTx } as ExactAptosPayload,
+  };
+}
+
+function buildRequirements(feePayerAddress?: string): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: APTOS_TESTNET_CAIP2,
+    asset: USDC_TESTNET_FA,
+    amount: TEST_AMOUNT.toString(),
+    payTo: TEST_PAY_TO,
+    maxTimeoutSeconds: 3600,
+    extra: feePayerAddress ? { feePayer: feePayerAddress } : {},
+  };
+}
+
+describe("ExactAptosFacilitator.verify() - gas parameter validation", () => {
+  let sender: Account;
+  let feePayerAccount: Account;
+  let facilitator: ExactAptosFacilitator;
+
+  beforeEach(() => {
+    sender = Account.generate();
+    feePayerAccount = Account.generate();
+    facilitator = new ExactAptosFacilitator(toFacilitatorAptosSigner(feePayerAccount));
+  });
+
+  describe("gas_unit_price bounds check", () => {
+    it("rejects when gas_unit_price exceeds MAX_GAS_UNIT_PRICE", async () => {
+      const encodedTx = buildEncodedTransaction({
+        sender,
+        feePayer: feePayerAccount,
+        gasUnitPrice: MAX_GAS_UNIT_PRICE + 1n,
+      });
+
+      const result = await facilitator.verify(
+        buildPayload(encodedTx),
+        buildRequirements(feePayerAccount.accountAddress.toStringLong()),
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toContain("invalid_exact_aptos_payload_gas_unit_price_too_high");
+    });
+
+    it("includes the offending value and limit in the error message", async () => {
+      const inflatedPrice = MAX_GAS_UNIT_PRICE + 5000n;
+      const encodedTx = buildEncodedTransaction({
+        sender,
+        feePayer: feePayerAccount,
+        gasUnitPrice: inflatedPrice,
+      });
+
+      const result = await facilitator.verify(
+        buildPayload(encodedTx),
+        buildRequirements(feePayerAccount.accountAddress.toStringLong()),
+      );
+
+      expect(result.invalidReason).toContain(inflatedPrice.toString());
+      expect(result.invalidReason).toContain(MAX_GAS_UNIT_PRICE.toString());
+    });
+
+    it("passes the gas_unit_price check when at the limit exactly", async () => {
+      // PAST_EXPIRATION causes the expiration check (which comes after gas checks) to reject.
+      // If we instead got a gas_unit_price error here the check would be rejecting valid prices.
+      const encodedTx = buildEncodedTransaction({
+        sender,
+        feePayer: feePayerAccount,
+        gasUnitPrice: MAX_GAS_UNIT_PRICE,
+        expiration: PAST_EXPIRATION,
+      });
+
+      const result = await facilitator.verify(
+        buildPayload(encodedTx),
+        buildRequirements(feePayerAccount.accountAddress.toStringLong()),
+      );
+
+      expect(result.invalidReason).not.toContain("gas_unit_price");
+      expect(result.invalidReason).toBe("invalid_exact_aptos_payload_transaction_expired");
+    });
+
+    it("passes the gas_unit_price check when below the limit", async () => {
+      const encodedTx = buildEncodedTransaction({
+        sender,
+        feePayer: feePayerAccount,
+        gasUnitPrice: 100n,
+        expiration: PAST_EXPIRATION,
+      });
+
+      const result = await facilitator.verify(
+        buildPayload(encodedTx),
+        buildRequirements(feePayerAccount.accountAddress.toStringLong()),
+      );
+
+      expect(result.invalidReason).not.toContain("gas_unit_price");
+      expect(result.invalidReason).toBe("invalid_exact_aptos_payload_transaction_expired");
+    });
+  });
+
+  describe("max_gas_amount bounds check", () => {
+    it("rejects when max_gas_amount exceeds MAX_GAS_AMOUNT", async () => {
+      const encodedTx = buildEncodedTransaction({
+        sender,
+        feePayer: feePayerAccount,
+        maxGasAmount: MAX_GAS_AMOUNT + 1n,
+      });
+
+      const result = await facilitator.verify(
+        buildPayload(encodedTx),
+        buildRequirements(feePayerAccount.accountAddress.toStringLong()),
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toContain("invalid_exact_aptos_payload_gas_too_high");
+    });
+
+    it("passes the max_gas_amount check when at the limit exactly", async () => {
+      const encodedTx = buildEncodedTransaction({
+        sender,
+        feePayer: feePayerAccount,
+        maxGasAmount: MAX_GAS_AMOUNT,
+        expiration: PAST_EXPIRATION,
+      });
+
+      const result = await facilitator.verify(
+        buildPayload(encodedTx),
+        buildRequirements(feePayerAccount.accountAddress.toStringLong()),
+      );
+
+      expect(result.invalidReason).not.toContain("gas_too_high");
+      expect(result.invalidReason).toBe("invalid_exact_aptos_payload_transaction_expired");
+    });
+  });
+
+  describe("non-sponsored transactions skip gas checks", () => {
+    it("does not apply gas checks when feePayer is absent from requirements", async () => {
+      // Both limits exceeded — would be rejected immediately if sponsored.
+      const encodedTx = buildEncodedTransaction({
+        sender,
+        maxGasAmount: MAX_GAS_AMOUNT + 1n,
+        gasUnitPrice: MAX_GAS_UNIT_PRICE + 1n,
+        expiration: PAST_EXPIRATION,
+      });
+
+      const result = await facilitator.verify(
+        buildPayload(encodedTx),
+        buildRequirements(), // no feePayer → non-sponsored
+      );
+
+      expect(result.invalidReason).not.toContain("gas_unit_price");
+      expect(result.invalidReason).not.toContain("gas_too_high");
+      // Falls through to expiration check, which rejects for the expected reason
+      expect(result.invalidReason).toBe("invalid_exact_aptos_payload_transaction_expired");
+    });
+  });
+});

--- a/typescript/packages/mechanisms/aptos/test/unit/index.test.ts
+++ b/typescript/packages/mechanisms/aptos/test/unit/index.test.ts
@@ -8,6 +8,7 @@ import {
   APTOS_ADDRESS_REGEX,
   TRANSFER_FUNCTION,
   MAX_GAS_AMOUNT,
+  MAX_GAS_UNIT_PRICE,
   getAptosNetwork,
   getAptosRpcUrl,
   getAptosChainId,
@@ -28,6 +29,7 @@ describe("@x402/aptos", () => {
       expect(APTOS_ADDRESS_REGEX).toBeDefined();
       expect(TRANSFER_FUNCTION).toBe("0x1::primary_fungible_store::transfer");
       expect(MAX_GAS_AMOUNT).toBe(500000n);
+      expect(MAX_GAS_UNIT_PRICE).toBe(1000n);
     });
 
     it("should export utility functions", () => {


### PR DESCRIPTION
## Description

bound `gas_unit_price` on sponsored transactions.


- verify() in @x402/aptos checked max_gas_amount ≤ 500,000 on sponsored transactions but never validated gas_unit_price. Because the facilitator's hot wallet pays gas_used × gas_unit_price Octas, an attacker could submit a structurally valid USDC transfer with an arbitrarily large gas_unit_price and drain the fee-payer's APT balance — passing every existing check including simulation (simulation only fails when the fee payer literally cannot afford the gas, not when the price is merely inflated).
- Added MAX_GAS_UNIT_PRICE = 1_000n Octas (10× the Aptos protocol minimum of 100 Octas) to constants.ts and a bounds check in verify() inside the existing isSponsored guard, immediately after the max_gas_amount check and before the fee-payer signature step.
- Added facilitator-verify.test.ts with 7 offline unit tests. These use directly-constructed RawTransaction objects (no network calls) and a PAST_EXPIRATION sentinel to confirm gas-valid transactions pass through the gas guard and reach the expiration check — proving both the rejection path and the pass-through path without a live testnet. Also backfills equivalent boundary coverage for the pre-existing max_gas_amount check, which had no unit tests.

## Tests

Added unit tests

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 