### PR TITLE
fix: add maxValue payment ceiling to withPaymentInterceptor

### DIFF
--- a/typescript/.changeset/add-maxvalue-ceiling-x402-axios.md
+++ b/typescript/.changeset/add-maxvalue-ceiling-x402-axios.md
@@ -1,0 +1,5 @@
+---
+"x402-axios": minor
+---
+
+Fixed missing payment amount ceiling in the 402 response interceptor. Added a mandatory `maxValue` parameter (defaulting to 0.10 USDC) that is checked against the server-provided `maxAmountRequired` before any payment signature is produced. A server advertising an amount above `maxValue` now throws `"Payment amount exceeds maximum allowed"` instead of proceeding, matching the existing guard in `x402-fetch`.

--- a/typescript/packages/legacy/x402-axios/src/index.test.ts
+++ b/typescript/packages/legacy/x402-axios/src/index.test.ts
@@ -24,7 +24,7 @@ describe("withPaymentInterceptor()", () => {
     {
       scheme: "exact",
       network: "base-sepolia",
-      maxAmountRequired: "1000000", // 1 USDC in base units
+      maxAmountRequired: "100000", // 0.1 USDC in base units
       resource: "https://api.example.com/resource",
       description: "Test payment",
       mimeType: "application/json",
@@ -254,7 +254,7 @@ describe("withPaymentInterceptor() - SVM and MultiNetwork", () => {
       {
         scheme: "exact",
         network: "solana",
-        maxAmountRequired: "1000000",
+        maxAmountRequired: "100000",
         resource: "https://api.example.com/resource",
         description: "Test payment",
         mimeType: "application/json",
@@ -324,7 +324,7 @@ describe("withPaymentInterceptor() - SVM and MultiNetwork", () => {
       {
         scheme: "exact",
         network: "base",
-        maxAmountRequired: "1000000",
+        maxAmountRequired: "100000",
         resource: "https://api.example.com/resource",
         description: "Test payment",
         mimeType: "application/json",

--- a/typescript/packages/legacy/x402-axios/src/index.ts
+++ b/typescript/packages/legacy/x402-axios/src/index.ts
@@ -22,12 +22,14 @@ import {
  *
  * When a request receives a 402 response:
  * 1. Extracts payment requirements from the response
- * 2. Creates a payment header using the provided wallet client
- * 3. Retries the original request with the payment header
- * 4. Exposes the X-PAYMENT-RESPONSE header in the final response
+ * 2. Verifies the payment amount is within the allowed maximum
+ * 3. Creates a payment header using the provided wallet client
+ * 4. Retries the original request with the payment header
+ * 5. Exposes the X-PAYMENT-RESPONSE header in the final response
  *
  * @param axiosClient - The Axios instance to add the interceptor to
  * @param walletClient - A wallet client that can sign transactions and create payment headers
+ * @param maxValue - The maximum allowed payment amount in base units (defaults to 0.1 USDC)
  * @param paymentRequirementsSelector - A function that selects the payment requirements from the response
  * @param config - Optional configuration for X402 operations (e.g., custom RPC URLs)
  * @returns The modified Axios instance with the payment interceptor
@@ -44,16 +46,20 @@ import {
  *   axios.create(),
  *   signer,
  *   undefined,
+ *   undefined,
  *   { svmConfig: { rpcUrl: "http://localhost:8899" } }
  * );
  *
  * // The client will automatically handle 402 responses
  * const response = await client.get('https://api.example.com/premium-content');
  * ```
+ *
+ * @throws {Error} If the payment amount exceeds the maximum allowed value
  */
 export function withPaymentInterceptor(
   axiosClient: AxiosInstance,
   walletClient: Signer | MultiNetworkSigner,
+  maxValue: bigint = BigInt(0.1 * 10 ** 6), // Default to 0.10 USDC
   paymentRequirementsSelector: PaymentRequirementsSelector = selectPaymentRequirements,
   config?: X402Config,
 ) {
@@ -89,6 +95,11 @@ export function withPaymentInterceptor(
               : undefined;
 
         const selectedPaymentRequirements = paymentRequirementsSelector(parsed, network, "exact");
+
+        if (BigInt(selectedPaymentRequirements.maxAmountRequired) > maxValue) {
+          throw new Error("Payment amount exceeds maximum allowed");
+        }
+
         const paymentHeader = await createPaymentHeader(
           walletClient,
           x402Version,


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

- x402-axios passed the server-provided maxAmountRequired directly to createPaymentHeader with no client-side ceiling, allowing a malicious server to drain a client's wallet via a single irrevocable EIP-3009 signature
- Added a maxValue: bigint parameter (3rd positional, default 0.10 USDC) to withPaymentInterceptor, matching the existing guard in the sibling x402-fetch package
- Any PaymentRequirements whose maxAmountRequired exceeds maxValue now throws "Payment amount exceeds maximum allowed" before any signing occurs

###  Breaking change

The parameter order of withPaymentInterceptor has changed. maxValue is inserted before paymentRequirementsSelector:
```
- withPaymentInterceptor(axiosClient, walletClient, selector?, config?)
+ withPaymentInterceptor(axiosClient, walletClient, maxValue?, selector?, config?)
```

Callers passing a custom paymentRequirementsSelector positionally must insert undefined (or an explicit maxValue) as the new third argument.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 