### PR TITLE
feat: solana cache deduplication

### DIFF
--- a/go/.changes/unreleased/fixed-20260527-091334.yaml
+++ b/go/.changes/unreleased/fixed-20260527-091334.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Fixed SVM exact facilitator deduplication to key on the transaction message hash rather than the full signed-transaction bytes, preventing an attacker from bypassing the cache by randomizing the mutable fee-payer signature slot.
+time: 2026-05-27T09:13:34.236144-07:00

--- a/go/mechanisms/svm/exact/facilitator/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/facilitator/duplicate_tx_test.go
@@ -1,10 +1,13 @@
 package facilitator
 
 import (
+	"encoding/base64"
 	"testing"
 	"time"
 
+	solana "github.com/gagliardetto/solana-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/x402-foundation/x402/go/mechanisms/svm"
 )
 
@@ -85,4 +88,84 @@ func TestDuplicateSettlementCache(t *testing.T) {
 		assert.Same(t, cache, scheme.settlementCache,
 			"scheme should hold the exact cache instance that was injected")
 	})
+}
+
+// TestMessageHashMalleabilityResistance verifies that manipulating the fee-payer
+// signature bytes (slot 0) — which the facilitator overwrites before broadcast —
+// does not change the cache key. An attacker who randomizes those bytes to bypass
+// a wire-bytes cache key must be caught by keying on the immutable message hash.
+func TestMessageHashMalleabilityResistance(t *testing.T) {
+	// Build a minimal but structurally valid Solana transaction so we have real
+	// binary that DecodeTransaction and Message.MarshalBinary can process.
+	payer := solana.NewWallet().PrivateKey.PublicKey()
+	recipient := solana.NewWallet().PrivateKey.PublicKey()
+
+	blockhash, err := solana.HashFromBase58("5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF")
+	require.NoError(t, err)
+
+	tx, err := solana.NewTransaction(
+		[]solana.Instruction{
+			solana.NewInstruction(
+				solana.SystemProgramID,
+				solana.AccountMetaSlice{
+					solana.NewAccountMeta(payer, true, true),
+					solana.NewAccountMeta(recipient, true, false),
+				},
+				[]byte{2, 0, 0, 0, 232, 3, 0, 0, 0, 0, 0, 0}, // SystemTransfer 1000 lamports
+			),
+		},
+		blockhash,
+		solana.TransactionPayer(payer),
+	)
+	require.NoError(t, err)
+
+	// Give the transaction a placeholder signature at slot 0 (simulates a payer-signed tx
+	// where the facilitator's fee-payer slot has garbage bytes the attacker controls).
+	placeholderSig := solana.Signature{}
+	copy(placeholderSig[:], make([]byte, 64))
+	tx.Signatures = []solana.Signature{placeholderSig}
+
+	h1, err := svm.MessageHash(tx)
+	require.NoError(t, err)
+
+	// Randomize the bytes at signature slot 0 — exactly what the attacker would do.
+	attackerSig := solana.Signature{}
+	for i := range attackerSig {
+		attackerSig[i] = byte(i + 1)
+	}
+	tx.Signatures[0] = attackerSig
+
+	h2, err := svm.MessageHash(tx)
+	require.NoError(t, err)
+
+	assert.Equal(t, h1, h2,
+		"message hash must be identical regardless of bytes in the fee-payer signature slot")
+
+	// Sanity: a different message produces a different hash.
+	tx2, err := solana.NewTransaction(
+		[]solana.Instruction{
+			solana.NewInstruction(
+				solana.SystemProgramID,
+				solana.AccountMetaSlice{
+					solana.NewAccountMeta(payer, true, true),
+					solana.NewAccountMeta(recipient, true, false),
+				},
+				[]byte{2, 0, 0, 0, 233, 3, 0, 0, 0, 0, 0, 0}, // SystemTransfer 1001 lamports
+			),
+		},
+		blockhash,
+		solana.TransactionPayer(payer),
+	)
+	require.NoError(t, err)
+
+	h3, err := svm.MessageHash(tx2)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, h1, h3,
+		"distinct messages must produce distinct hashes")
+
+	// Verify the hash is a valid base64 string (32-byte SHA-256 → 44 base64 chars).
+	decoded, err := base64.StdEncoding.DecodeString(h1)
+	require.NoError(t, err)
+	assert.Len(t, decoded, 32, "SHA-256 digest must be 32 bytes")
 }

--- a/go/mechanisms/svm/exact/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/facilitator/scheme.go
@@ -279,9 +279,7 @@ func (f *ExactSvmScheme) Settle(
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
 	}
 
-	// Duplicate settlement check keyed on the message hash, not the raw wire bytes.
-	// The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
-	// so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+	// Duplicate settlement check keyed on message hash (immune to mutable fee-payer sig at slot 0).
 	txKey, err := svm.MessageHash(tx)
 	if err != nil {
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())

--- a/go/mechanisms/svm/exact/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/facilitator/scheme.go
@@ -273,16 +273,21 @@ func (f *ExactSvmScheme) Settle(
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
 	}
 
-	// Duplicate settlement check: reject if this transaction is already being settled.
-	txKey := solanaPayload.Transaction
-	if f.settlementCache.IsDuplicate(txKey) {
-		return nil, x402.NewSettleError(ErrDuplicateSettlement, verifyResp.Payer, network, "", "duplicate transaction")
-	}
-
-	// Decode transaction
+	// Decode transaction before the cache check so we can key on the message hash.
 	tx, err := svm.DecodeTransaction(solanaPayload.Transaction)
 	if err != nil {
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
+	}
+
+	// Duplicate settlement check keyed on the message hash, not the raw wire bytes.
+	// The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
+	// so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+	txKey, err := svm.MessageHash(tx)
+	if err != nil {
+		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
+	}
+	if f.settlementCache.IsDuplicate(txKey) {
+		return nil, x402.NewSettleError(ErrDuplicateSettlement, verifyResp.Payer, network, "", "duplicate transaction")
 	}
 
 	// Extract and validate feePayer from requirements matches transaction

--- a/go/mechanisms/svm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/scheme.go
@@ -276,9 +276,7 @@ func (f *ExactSvmSchemeV1) Settle(
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
 	}
 
-	// Duplicate settlement check keyed on the message hash, not the raw wire bytes.
-	// The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
-	// so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+	// Duplicate settlement check keyed on message hash (immune to mutable fee-payer sig at slot 0).
 	txKey, err := svm.MessageHash(tx)
 	if err != nil {
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())

--- a/go/mechanisms/svm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/svm/exact/v1/facilitator/scheme.go
@@ -270,16 +270,21 @@ func (f *ExactSvmSchemeV1) Settle(
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
 	}
 
-	// Duplicate settlement check: reject if this transaction is already being settled.
-	txKey := svmPayload.Transaction
-	if f.settlementCache.IsDuplicate(txKey) {
-		return nil, x402.NewSettleError(ErrDuplicateSettlement, verifyResp.Payer, network, "", "duplicate transaction")
-	}
-
-	// Decode transaction
+	// Decode transaction before the cache check so we can key on the message hash.
 	tx, err := svm.DecodeTransaction(svmPayload.Transaction)
 	if err != nil {
 		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
+	}
+
+	// Duplicate settlement check keyed on the message hash, not the raw wire bytes.
+	// The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
+	// so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+	txKey, err := svm.MessageHash(tx)
+	if err != nil {
+		return nil, x402.NewSettleError(ErrInvalidPayloadTransaction, verifyResp.Payer, network, "", err.Error())
+	}
+	if f.settlementCache.IsDuplicate(txKey) {
+		return nil, x402.NewSettleError(ErrDuplicateSettlement, verifyResp.Payer, network, "", "duplicate transaction")
 	}
 
 	// Parse extra field for feePayer (V1 uses *json.RawMessage)

--- a/go/mechanisms/svm/utils.go
+++ b/go/mechanisms/svm/utils.go
@@ -1,6 +1,7 @@
 package svm
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"math"
@@ -152,6 +153,20 @@ func FormatAmount(amount uint64, decimals int) string {
 	}
 
 	return fmt.Sprintf("%d.%s", quotient, decStr)
+}
+
+// MessageHash returns a stable, immutable cache key for a transaction by hashing its
+// message bytes. The fee-payer signature (slot 0) is mutable — the facilitator
+// overwrites it before broadcast — so keying on the full wire bytes would let an
+// attacker bypass deduplication by randomizing those bytes. The message is what
+// every signer commits to, so its hash uniquely and immutably identifies a payment.
+func MessageHash(tx *solana.Transaction) (string, error) {
+	msgBytes, err := tx.Message.MarshalBinary()
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize transaction message: %w", err)
+	}
+	hash := sha256.Sum256(msgBytes)
+	return base64.StdEncoding.EncodeToString(hash[:]), nil
 }
 
 // DecodeTransaction decodes a base64 encoded Solana transaction

--- a/python/x402/changelog.d/2482.bugfix.md
+++ b/python/x402/changelog.d/2482.bugfix.md
@@ -1,0 +1,1 @@
+Fixed SVM exact facilitator deduplication to key on the transaction message hash rather than the full signed-transaction bytes, preventing an attacker from bypassing the cache by randomizing the mutable fee-payer signature slot.

--- a/python/x402/mechanisms/svm/exact/facilitator.py
+++ b/python/x402/mechanisms/svm/exact/facilitator.py
@@ -54,9 +54,9 @@ from ..signer import FacilitatorSvmSigner
 from ..types import ExactSvmPayload
 from ..utils import (
     decode_transaction_from_payload,
-    transaction_message_hash,
     derive_ata,
     get_token_payer_from_transaction,
+    transaction_message_hash,
 )
 
 
@@ -393,9 +393,7 @@ class ExactSvmScheme:
         # Decode the transaction to compute the message hash used as the cache key.
         tx = decode_transaction_from_payload(svm_payload)
 
-        # Duplicate settlement check keyed on the message hash, not the raw wire bytes.
-        # The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
-        # so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+        # Duplicate settlement check keyed on message hash (immune to mutable fee-payer sig at slot 0).
         tx_key = transaction_message_hash(tx)
         if self._settlement_cache.is_duplicate(tx_key):
             return SettleResponse(

--- a/python/x402/mechanisms/svm/exact/facilitator.py
+++ b/python/x402/mechanisms/svm/exact/facilitator.py
@@ -54,6 +54,7 @@ from ..signer import FacilitatorSvmSigner
 from ..types import ExactSvmPayload
 from ..utils import (
     decode_transaction_from_payload,
+    transaction_message_hash,
     derive_ata,
     get_token_payer_from_transaction,
 )
@@ -389,8 +390,13 @@ class ExactSvmScheme:
                 transaction="",
             )
 
-        # Duplicate settlement check: reject if this transaction is already being settled.
-        tx_key = svm_payload.transaction
+        # Decode the transaction to compute the message hash used as the cache key.
+        tx = decode_transaction_from_payload(svm_payload)
+
+        # Duplicate settlement check keyed on the message hash, not the raw wire bytes.
+        # The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
+        # so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+        tx_key = transaction_message_hash(tx)
         if self._settlement_cache.is_duplicate(tx_key):
             return SettleResponse(
                 success=False,

--- a/python/x402/mechanisms/svm/exact/v1/facilitator.py
+++ b/python/x402/mechanisms/svm/exact/v1/facilitator.py
@@ -49,6 +49,7 @@ from ...signer import FacilitatorSvmSigner
 from ...types import ExactSvmPayload
 from ...utils import (
     decode_transaction_from_payload,
+    transaction_message_hash,
     derive_ata,
     get_token_payer_from_transaction,
 )
@@ -368,8 +369,13 @@ class ExactSvmSchemeV1:
                 transaction="",
             )
 
-        # Duplicate settlement check: reject if this transaction is already being settled.
-        tx_key = svm_payload.transaction
+        # Decode the transaction to compute the message hash used as the cache key.
+        tx = decode_transaction_from_payload(svm_payload)
+
+        # Duplicate settlement check keyed on the message hash, not the raw wire bytes.
+        # The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
+        # so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+        tx_key = transaction_message_hash(tx)
         if self._settlement_cache.is_duplicate(tx_key):
             return SettleResponse(
                 success=False,

--- a/python/x402/mechanisms/svm/exact/v1/facilitator.py
+++ b/python/x402/mechanisms/svm/exact/v1/facilitator.py
@@ -49,9 +49,9 @@ from ...signer import FacilitatorSvmSigner
 from ...types import ExactSvmPayload
 from ...utils import (
     decode_transaction_from_payload,
-    transaction_message_hash,
     derive_ata,
     get_token_payer_from_transaction,
+    transaction_message_hash,
 )
 
 
@@ -372,9 +372,7 @@ class ExactSvmSchemeV1:
         # Decode the transaction to compute the message hash used as the cache key.
         tx = decode_transaction_from_payload(svm_payload)
 
-        # Duplicate settlement check keyed on the message hash, not the raw wire bytes.
-        # The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
-        # so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+        # Duplicate settlement check keyed on message hash (immune to mutable fee-payer sig at slot 0).
         tx_key = transaction_message_hash(tx)
         if self._settlement_cache.is_duplicate(tx_key):
             return SettleResponse(

--- a/python/x402/mechanisms/svm/utils.py
+++ b/python/x402/mechanisms/svm/utils.py
@@ -1,6 +1,7 @@
 """SVM utility functions for network, address, and amount handling."""
 
 import base64
+import hashlib
 import re
 from decimal import Decimal
 
@@ -209,6 +210,23 @@ def parse_money_to_decimal(money: str | float | int) -> float:
     clean = clean.strip()
 
     return float(clean)
+
+
+def transaction_message_hash(tx: VersionedTransaction) -> str:
+    """Return a stable, immutable cache key for a transaction.
+
+    The fee-payer signature (slot 0) is overwritten by the facilitator before
+    broadcast, so an attacker can randomize those bytes to bypass a wire-bytes
+    cache key. The message is what every signer commits to, so its SHA-256 hash
+    uniquely and immutably identifies a payment.
+
+    Args:
+        tx: Decoded versioned transaction.
+
+    Returns:
+        Base64-encoded SHA-256 hash of the serialized transaction message.
+    """
+    return base64.b64encode(hashlib.sha256(bytes(tx.message)).digest()).decode()
 
 
 def decode_transaction_from_payload(payload: ExactSvmPayload) -> VersionedTransaction:

--- a/python/x402/tests/unit/mechanisms/svm/test_duplicate_tx.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_duplicate_tx.py
@@ -1,7 +1,6 @@
 """Memo-based uniqueness tests for SVM payments."""
 
 import base64
-
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/python/x402/tests/unit/mechanisms/svm/test_duplicate_tx.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_duplicate_tx.py
@@ -1,11 +1,14 @@
 """Memo-based uniqueness tests for SVM payments."""
 
+import base64
+
 from unittest.mock import MagicMock, patch
 
 import pytest
 from solders.hash import Hash
 from solders.keypair import Keypair
 from solders.pubkey import Pubkey
+from solders.transaction import VersionedTransaction
 
 from x402.mechanisms.svm import (
     DEFAULT_COMPUTE_UNIT_LIMIT,
@@ -18,7 +21,7 @@ from x402.mechanisms.svm import (
 from x402.mechanisms.svm.exact import ExactSvmClientScheme
 from x402.mechanisms.svm.signers import KeypairSigner
 from x402.mechanisms.svm.types import ExactSvmPayload
-from x402.mechanisms.svm.utils import decode_transaction_from_payload
+from x402.mechanisms.svm.utils import decode_transaction_from_payload, transaction_message_hash
 from x402.schemas import PaymentRequirements
 
 FIXED_BLOCKHASH = "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF"
@@ -461,3 +464,111 @@ class TestSellerMemo:
         with patch.object(client, "_get_client", return_value=mock_rpc_client):
             with pytest.raises(ValueError, match="extra.memo exceeds maximum 256 bytes"):
                 client.create_payment_payload(requirements)
+
+
+class TestMessageHashMalleabilityResistance:
+    """Verify that randomizing fee-payer signature bytes (slot 0) does not change
+    the cache key. The facilitator overwrites slot 0 before broadcast, so an
+    attacker who randomizes those bytes to bypass a wire-bytes cache key must be
+    caught by keying on the immutable message hash."""
+
+    @pytest.fixture
+    def mock_rpc_client(self):
+        mock_client = MagicMock()
+        mock_blockhash_resp = MagicMock()
+        mock_blockhash_resp.value.blockhash = Hash.from_string(FIXED_BLOCKHASH)
+        mock_client.get_latest_blockhash.return_value = mock_blockhash_resp
+
+        mock_account_info = MagicMock()
+        mock_account_info.value = MagicMock()
+        mock_account_info.value.owner = Pubkey.from_string(TOKEN_PROGRAM_ADDRESS)
+        mock_account_info.value.data = bytes(44) + bytes([6]) + bytes(37)
+        mock_client.get_account_info.return_value = mock_account_info
+        return mock_client
+
+    @pytest.fixture
+    def test_keypair(self):
+        return Keypair.from_seed(bytes([1] * 32))
+
+    @pytest.fixture
+    def test_requirements(self):
+        return PaymentRequirements(
+            scheme="exact",
+            network=SOLANA_DEVNET_CAIP2,
+            asset=USDC_DEVNET_ADDRESS,
+            amount="100000",
+            pay_to=str(Keypair.from_seed(bytes([3] * 32)).pubkey()),
+            max_timeout_seconds=3600,
+            extra={"feePayer": str(Keypair.from_seed(bytes([2] * 32)).pubkey())},
+        )
+
+    def test_cache_key_unchanged_when_fee_payer_sig_bytes_are_mutated(
+        self, mock_rpc_client, test_keypair, test_requirements
+    ):
+        """Flipping bytes in signature slot 0 must not change the message hash cache key."""
+        client = ExactSvmClientScheme(KeypairSigner(test_keypair))
+
+        with patch.object(client, "_get_client", return_value=mock_rpc_client):
+            payload = client.create_payment_payload(test_requirements)
+
+        tx = decode_transaction_from_payload(ExactSvmPayload(transaction=payload["transaction"]))
+        hash_before = transaction_message_hash(tx)
+
+        # Flip every bit in fee-payer signature slot (bytes 1–64 in the wire format;
+        # byte 0 is the compact-u16 num_signatures prefix for small counts).
+        tx_bytes = bytearray(base64.b64decode(payload["transaction"]))
+        for i in range(1, 65):
+            tx_bytes[i] ^= 0xFF
+
+        mutated_tx = VersionedTransaction.from_bytes(bytes(tx_bytes))
+        hash_after = transaction_message_hash(mutated_tx)
+
+        assert hash_before == hash_after, (
+            "message hash must be identical regardless of bytes in the fee-payer signature slot"
+        )
+
+    def test_different_messages_produce_different_hashes(
+        self, mock_rpc_client, test_keypair, test_requirements
+    ):
+        """Distinct transaction messages must produce distinct cache keys."""
+        call_count = [0]
+        blockhash_values = [FIXED_BLOCKHASH, FIXED_BLOCKHASH_ALT]
+
+        def get_mock_client(network):
+            mock = MagicMock()
+            mock_resp = MagicMock()
+            mock_resp.value.blockhash = Hash.from_string(blockhash_values[call_count[0] % 2])
+            call_count[0] += 1
+            mock.get_latest_blockhash.return_value = mock_resp
+
+            mock_account_info = MagicMock()
+            mock_account_info.value = MagicMock()
+            mock_account_info.value.owner = Pubkey.from_string(TOKEN_PROGRAM_ADDRESS)
+            mock_account_info.value.data = bytes(44) + bytes([6]) + bytes(37)
+            mock.get_account_info.return_value = mock_account_info
+            return mock
+
+        client = ExactSvmClientScheme(KeypairSigner(test_keypair))
+        with patch.object(client, "_get_client", side_effect=get_mock_client):
+            payload1 = client.create_payment_payload(test_requirements)
+            payload2 = client.create_payment_payload(test_requirements)
+
+        tx1 = decode_transaction_from_payload(ExactSvmPayload(transaction=payload1["transaction"]))
+        tx2 = decode_transaction_from_payload(ExactSvmPayload(transaction=payload2["transaction"]))
+
+        assert transaction_message_hash(tx1) != transaction_message_hash(tx2), (
+            "distinct messages (different blockhashes) must produce distinct hashes"
+        )
+
+    def test_hash_is_valid_base64_sha256(self, mock_rpc_client, test_keypair, test_requirements):
+        """Output must be a base64-encoded 32-byte SHA-256 digest."""
+        client = ExactSvmClientScheme(KeypairSigner(test_keypair))
+
+        with patch.object(client, "_get_client", return_value=mock_rpc_client):
+            payload = client.create_payment_payload(test_requirements)
+
+        tx = decode_transaction_from_payload(ExactSvmPayload(transaction=payload["transaction"]))
+        h = transaction_message_hash(tx)
+
+        decoded = base64.b64decode(h)
+        assert len(decoded) == 32, "SHA-256 digest must be 32 bytes"

--- a/python/x402/tests/unit/mechanisms/svm/test_facilitator.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_facilitator.py
@@ -1,6 +1,8 @@
 """Tests for ExactSvmScheme facilitator."""
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+
+import pytest
 
 from x402.mechanisms.svm import (
     SOLANA_DEVNET_CAIP2,
@@ -294,8 +296,40 @@ class TestFacilitatorSchemeAttributes:
         assert result == addresses
 
 
+class _FakeMsg:
+    """Fake Solana message whose bytes() are derived from the transaction string."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def __bytes__(self) -> bytes:
+        return self._data
+
+
+class _FakeTx:
+    """Fake VersionedTransaction for cache-key tests that don't need real binary."""
+
+    def __init__(self, transaction_str: str) -> None:
+        self.message = _FakeMsg(transaction_str.encode())
+
+
 class TestDuplicateSettlementCache:
     """Test duplicate settlement cache in settle method."""
+
+    @pytest.fixture(autouse=True)
+    def mock_decode(self):
+        """Patch decode_transaction_from_payload in both V1 and V2 facilitator modules.
+
+        The settle method now decodes the transaction to compute its message hash before
+        the cache check. These tests use arbitrary strings, not real Solana binaries, so
+        we return a fake transaction whose message bytes are deterministically derived
+        from the transaction string. Same string → same hash → cache hit; different
+        strings → different hashes → cache miss.
+        """
+        fake = lambda payload: _FakeTx(payload.transaction)  # noqa: E731
+        with patch("x402.mechanisms.svm.exact.facilitator.decode_transaction_from_payload", side_effect=fake):
+            with patch("x402.mechanisms.svm.exact.v1.facilitator.decode_transaction_from_payload", side_effect=fake):
+                yield
 
     def _make_payload(self, transaction: str) -> PaymentPayload:
         return PaymentPayload(

--- a/python/x402/tests/unit/mechanisms/svm/test_facilitator.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_facilitator.py
@@ -1,6 +1,6 @@
 """Tests for ExactSvmScheme facilitator."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -327,8 +327,14 @@ class TestDuplicateSettlementCache:
         strings → different hashes → cache miss.
         """
         fake = lambda payload: _FakeTx(payload.transaction)  # noqa: E731
-        with patch("x402.mechanisms.svm.exact.facilitator.decode_transaction_from_payload", side_effect=fake):
-            with patch("x402.mechanisms.svm.exact.v1.facilitator.decode_transaction_from_payload", side_effect=fake):
+        with patch(
+            "x402.mechanisms.svm.exact.facilitator.decode_transaction_from_payload",
+            side_effect=fake,
+        ):
+            with patch(
+                "x402.mechanisms.svm.exact.v1.facilitator.decode_transaction_from_payload",
+                side_effect=fake,
+            ):
                 yield
 
     def _make_payload(self, transaction: str) -> PaymentPayload:

--- a/typescript/.changeset/solana-cache-deduplication-fix.md
+++ b/typescript/.changeset/solana-cache-deduplication-fix.md
@@ -1,0 +1,6 @@
+---
+"@x402/svm": patch
+"x402": patch
+---
+
+Fixed SVM exact facilitator deduplication to key on the transaction message hash rather than the full signed-transaction bytes, preventing an attacker from bypassing the cache by randomizing the mutable fee-payer signature slot.

--- a/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settle.test.ts
+++ b/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settle.test.ts
@@ -15,7 +15,18 @@ import * as settleModule from "./settle";
 import { SettlementCache } from "./settlement-cache";
 
 // Mocking dependencies
-vi.mock("../../../../shared/svm");
+vi.mock("../../../../shared/svm", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../../../shared/svm")>();
+  return {
+    ...actual, // real transactionMessageHash so cache keys are meaningful
+    decodeTransactionFromPayload: vi.fn().mockImplementation((payload: { transaction: string }) => ({
+      messageBytes: new TextEncoder().encode(payload.transaction),
+      signatures: {},
+    })),
+    getTokenPayerFromTransaction: vi.fn(),
+    signTransactionWithSigner: vi.fn(),
+  };
+});
 vi.mock("../../../../shared/svm/rpc");
 vi.mock("./verify");
 vi.mock("@solana/kit", async importOriginal => {
@@ -121,6 +132,7 @@ describe("SVM Settle", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    settleModule.settlementCache.clear();
   });
 
   describe("settle", () => {
@@ -716,7 +728,13 @@ describe("SVM Settle", () => {
     function setupMocksForSettle() {
       const mockVerifyResponse = { isValid: true, invalidReason: undefined };
       vi.mocked(verify).mockResolvedValue(mockVerifyResponse);
-      vi.mocked(decodeTransactionFromPayload).mockReturnValue(mockSignedTransaction);
+      // Use mockImplementation so distinct transaction strings produce distinct cache keys.
+      vi.mocked(decodeTransactionFromPayload).mockImplementation(
+        (payload: { transaction: string }) => ({
+          ...mockSignedTransaction,
+          messageBytes: new TextEncoder().encode(payload.transaction),
+        }),
+      );
       vi.mocked(getRpcClient).mockReturnValue(mockRpcClient);
       vi.mocked(getRpcSubscriptions).mockReturnValue(mockRpcSubscriptions);
       vi.mocked(mockRpcClient.sendTransaction).mockReturnValue({

--- a/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settle.test.ts
+++ b/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settle.test.ts
@@ -19,10 +19,12 @@ vi.mock("../../../../shared/svm", async importOriginal => {
   const actual = await importOriginal<typeof import("../../../../shared/svm")>();
   return {
     ...actual, // real transactionMessageHash so cache keys are meaningful
-    decodeTransactionFromPayload: vi.fn().mockImplementation((payload: { transaction: string }) => ({
-      messageBytes: new TextEncoder().encode(payload.transaction),
-      signatures: {},
-    })),
+    decodeTransactionFromPayload: vi
+      .fn()
+      .mockImplementation((payload: { transaction: string }) => ({
+        messageBytes: new TextEncoder().encode(payload.transaction),
+        signatures: {},
+      })),
     getTokenPayerFromTransaction: vi.fn(),
     signTransactionWithSigner: vi.fn(),
   };

--- a/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settle.ts
+++ b/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settle.ts
@@ -48,7 +48,7 @@ import { SettlementCache } from "./settlement-cache";
  * @param config - Optional configuration for X402 operations (e.g., custom RPC URLs)
  * @returns A SettleResponse indicating if the payment is settled and any error reason
  */
-const settlementCache = new SettlementCache();
+export const settlementCache = new SettlementCache();
 
 /**
  * Settles an exact SVM payment by verifying the payment and recording the settlement.
@@ -82,9 +82,7 @@ export async function settle(
   // the same payment are caught before any async work begins.
   const decodedTransaction = decodeTransactionFromPayload(svmPayload);
 
-  // Duplicate settlement check keyed on the message hash, not the raw wire bytes.
-  // The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
-  // so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+  // Duplicate settlement check keyed on message hash (immune to mutable fee-payer sig at slot 0).
   const txKey = transactionMessageHash(decodedTransaction);
   if (settlementCache.isDuplicate(txKey)) {
     return {

--- a/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settle.ts
+++ b/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settle.ts
@@ -27,6 +27,7 @@ import {
   decodeTransactionFromPayload,
   getTokenPayerFromTransaction,
   signTransactionWithSigner,
+  transactionMessageHash,
 } from "../../../../shared/svm";
 import { getRpcClient, getRpcSubscriptions } from "../../../../shared/svm/rpc";
 import {
@@ -76,9 +77,15 @@ export async function settle(
 
   const svmPayload = payload.payload as ExactSvmPayload;
 
-  // Duplicate settlement check: reject if this transaction is already being settled.
-  // Must occur before any async work so concurrent calls for the same tx are caught.
-  const txKey = svmPayload.transaction;
+  // Decode the transaction to compute the message hash used as the cache key.
+  // Must remain synchronous (before any await) so concurrent settle calls for
+  // the same payment are caught before any async work begins.
+  const decodedTransaction = decodeTransactionFromPayload(svmPayload);
+
+  // Duplicate settlement check keyed on the message hash, not the raw wire bytes.
+  // The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
+  // so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+  const txKey = transactionMessageHash(decodedTransaction);
   if (settlementCache.isDuplicate(txKey)) {
     return {
       success: false,
@@ -87,7 +94,6 @@ export async function settle(
       transaction: "",
     };
   }
-  const decodedTransaction = decodeTransactionFromPayload(svmPayload);
   const signedTransaction = await signTransactionWithSigner(signer, decodedTransaction);
   assertTransactionFullySigned(signedTransaction);
   const payer = getTokenPayerFromTransaction(signedTransaction);

--- a/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settlement-cache.ts
+++ b/typescript/packages/legacy/x402/src/schemes/exact/svm/facilitator/settlement-cache.ts
@@ -31,6 +31,11 @@ export class SettlementCache {
     return false;
   }
 
+  /** Remove all entries. Used in tests to reset shared singleton state between cases. */
+  clear(): void {
+    this.entries.clear();
+  }
+
   /**
    * Remove entries older than the settlement TTL.
    * Leverages Map insertion-order guarantee to break early.

--- a/typescript/packages/legacy/x402/src/shared/svm/transaction.ts
+++ b/typescript/packages/legacy/x402/src/shared/svm/transaction.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { ExactSvmPayload } from "../../types/verify/x402Specs";
 import {
   getBase64EncodedWireTransaction,
@@ -19,6 +20,20 @@ import {
 } from "@solana/kit";
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import { TOKEN_2022_PROGRAM_ADDRESS } from "@solana-program/token-2022";
+
+/**
+ * Compute a stable, immutable cache key for a decoded transaction by hashing its
+ * message bytes. The fee-payer signature (slot 0) is overwritten by the facilitator
+ * before broadcast, so an attacker can randomize those bytes to bypass a wire-bytes
+ * cache key. The message is what every signer commits to, making its hash a reliable
+ * payment identity.
+ *
+ * @param transaction - Decoded transaction whose message bytes to hash
+ * @returns Base64-encoded SHA-256 hash of the transaction message bytes
+ */
+export function transactionMessageHash(transaction: Transaction): string {
+  return createHash("sha256").update(Buffer.from(transaction.messageBytes)).digest("base64");
+}
 
 /**
  * Given an object with a base64 encoded transaction, decode the

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -390,9 +390,7 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     // the same payment are caught before any async work begins.
     const decodedTx = decodeTransactionFromPayload(exactSvmPayload);
 
-    // Duplicate settlement check keyed on the message hash, not the raw wire bytes.
-    // The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
-    // so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+    // Duplicate settlement check keyed on message hash (immune to mutable fee-payer sig at slot 0).
     const txKey = transactionMessageHash(decodedTx);
     if (this.settlementCache.isDuplicate(txKey)) {
       return {

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -32,7 +32,11 @@ import {
 import { SettlementCache } from "../../settlement-cache";
 import type { FacilitatorSvmSigner } from "../../signer";
 import type { ExactSvmPayloadV2 } from "../../types";
-import { decodeTransactionFromPayload, getTokenPayerFromTransaction } from "../../utils";
+import {
+  decodeTransactionFromPayload,
+  getTokenPayerFromTransaction,
+  transactionMessageHash,
+} from "../../utils";
 
 /**
  * SVM facilitator implementation for the Exact payment scheme.
@@ -381,9 +385,15 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       };
     }
 
-    // Duplicate settlement check: reject if this transaction is already being settled.
-    // Must occur before any async work so concurrent calls for the same tx are caught.
-    const txKey = exactSvmPayload.transaction;
+    // Decode the transaction to compute the message hash used as the cache key.
+    // Must remain synchronous (before any await) so concurrent settle calls for
+    // the same payment are caught before any async work begins.
+    const decodedTx = decodeTransactionFromPayload(exactSvmPayload);
+
+    // Duplicate settlement check keyed on the message hash, not the raw wire bytes.
+    // The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
+    // so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+    const txKey = transactionMessageHash(decodedTx);
     if (this.settlementCache.isDuplicate(txKey)) {
       return {
         success: false,

--- a/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
@@ -394,9 +394,7 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
     // the same payment are caught before any async work begins.
     const decodedTx = decodeTransactionFromPayload(exactSvmPayload);
 
-    // Duplicate settlement check keyed on the message hash, not the raw wire bytes.
-    // The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
-    // so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+    // Duplicate settlement check keyed on message hash (immune to mutable fee-payer sig at slot 0).
     const txKey = transactionMessageHash(decodedTx);
     if (this.settlementCache.isDuplicate(txKey)) {
       return {

--- a/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
@@ -33,7 +33,11 @@ import {
 import { SettlementCache } from "../../../settlement-cache";
 import type { FacilitatorSvmSigner } from "../../../signer";
 import type { ExactSvmPayloadV1 } from "../../../types";
-import { decodeTransactionFromPayload, getTokenPayerFromTransaction } from "../../../utils";
+import {
+  decodeTransactionFromPayload,
+  getTokenPayerFromTransaction,
+  transactionMessageHash,
+} from "../../../utils";
 
 /**
  * SVM facilitator implementation for the Exact payment scheme (V1).
@@ -385,9 +389,15 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
       };
     }
 
-    // Duplicate settlement check: reject if this transaction is already being settled.
-    // Must occur before any async work so concurrent calls for the same tx are caught.
-    const txKey = exactSvmPayload.transaction;
+    // Decode the transaction to compute the message hash used as the cache key.
+    // Must remain synchronous (before any await) so concurrent settle calls for
+    // the same payment are caught before any async work begins.
+    const decodedTx = decodeTransactionFromPayload(exactSvmPayload);
+
+    // Duplicate settlement check keyed on the message hash, not the raw wire bytes.
+    // The fee-payer signature (slot 0) is overwritten by the facilitator before broadcast,
+    // so an attacker could randomize those bytes to bypass a wire-bytes cache key.
+    const txKey = transactionMessageHash(decodedTx);
     if (this.settlementCache.isDuplicate(txKey)) {
       return {
         success: false,

--- a/typescript/packages/mechanisms/svm/src/utils.ts
+++ b/typescript/packages/mechanisms/svm/src/utils.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   getBase64Encoder,
   getTransactionDecoder,
@@ -65,6 +66,20 @@ export function normalizeNetwork(network: Network): string {
  */
 export function validateSvmAddress(address: string): boolean {
   return SVM_ADDRESS_REGEX.test(address);
+}
+
+/**
+ * Compute a stable, immutable cache key for a decoded transaction by hashing its
+ * message bytes. The fee-payer signature (slot 0) is overwritten by the facilitator
+ * before broadcast, so an attacker can randomize those bytes to bypass a wire-bytes
+ * cache key. The message is what every signer commits to, making its hash a reliable
+ * payment identity.
+ *
+ * @param transaction - Decoded transaction whose message bytes to hash
+ * @returns Base64-encoded SHA-256 hash of the transaction message bytes
+ */
+export function transactionMessageHash(transaction: Transaction): string {
+  return createHash("sha256").update(Buffer.from(transaction.messageBytes)).digest("base64");
 }
 
 /**

--- a/typescript/packages/mechanisms/svm/test/unit/duplicateTx.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/duplicateTx.test.ts
@@ -5,6 +5,8 @@ import {
   decompileTransactionMessage,
   generateKeyPairSigner,
   getCompiledTransactionMessageDecoder,
+  getBase64Encoder,
+  getTransactionDecoder,
 } from "@solana/kit";
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import {
@@ -12,6 +14,7 @@ import {
   SOLANA_DEVNET_CAIP2,
   USDC_DEVNET_ADDRESS,
 } from "../../src/constants";
+import { transactionMessageHash } from "../../src/utils";
 
 const FIXED_BLOCKHASH = "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF";
 const FIXED_BLOCKHASH_ALT = "7ZCxc2SDhzV2bYgEQqdxTpweYJkpwshVSDtXuY7uPtjf";
@@ -499,5 +502,100 @@ describe("Memo Uniqueness", () => {
     );
     expect(memoIx).toBeDefined();
     expect(memoIx!.accounts ?? []).toHaveLength(0);
+  });
+});
+
+// Verify that randomizing the fee-payer signature bytes (slot 0) — which the
+// facilitator overwrites before broadcast — does not change the cache key.
+describe("transactionMessageHash malleability resistance", () => {
+  it("produces identical hash when fee-payer signature bytes are changed", async () => {
+    blockhashes = [FIXED_BLOCKHASH];
+
+    const { ExactSvmScheme } = await import("../../src/exact/client/scheme");
+
+    const clientSigner = await generateKeyPairSigner();
+    const feePayer = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+
+    const client = new ExactSvmScheme(clientSigner);
+    mockAtaMap = {
+      [clientSigner.address]: clientSigner.address as Address,
+      [payTo.address]: payTo.address as Address,
+    };
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: feePayer.address },
+    };
+
+    const payload = await client.createPaymentPayload(2, requirements);
+    const txBase64 = (payload.payload as { transaction: string }).transaction;
+
+    // Decode the transaction to get its binary representation.
+    const base64Encoder = getBase64Encoder();
+    const txDecoder = getTransactionDecoder();
+    const txBytes = base64Encoder.encode(txBase64);
+    const tx = txDecoder.decode(txBytes);
+
+    const hashBefore = transactionMessageHash(tx);
+
+    // Flip every bit in the fee-payer signature slot (first 64 bytes after the
+    // compact-u16 signature-count prefix). This simulates an attacker submitting
+    // the same payment with different garbage bytes at slot 0.
+    const mutated = new Uint8Array(txBytes);
+    // byte 0 is the compact-u16 num_signatures prefix (value < 128 → 1 byte)
+    for (let i = 1; i <= 64; i++) {
+      mutated[i] = mutated[i] ^ 0xff;
+    }
+    const mutatedTx = txDecoder.decode(mutated);
+
+    const hashAfter = transactionMessageHash(mutatedTx);
+
+    expect(hashBefore).toBe(hashAfter);
+  });
+
+  it("produces different hashes for transactions with different messages", async () => {
+    blockhashes = [FIXED_BLOCKHASH, FIXED_BLOCKHASH_ALT];
+
+    const { ExactSvmScheme } = await import("../../src/exact/client/scheme");
+
+    const clientSigner = await generateKeyPairSigner();
+    const feePayer = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+
+    const client = new ExactSvmScheme(clientSigner);
+    mockAtaMap = {
+      [clientSigner.address]: clientSigner.address as Address,
+      [payTo.address]: payTo.address as Address,
+    };
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: feePayer.address },
+    };
+
+    const payload1 = await client.createPaymentPayload(2, requirements);
+    const payload2 = await client.createPaymentPayload(2, requirements);
+
+    const decode = (b64: string) => {
+      const bytes = getBase64Encoder().encode(b64);
+      return getTransactionDecoder().decode(bytes);
+    };
+
+    const tx1 = decode((payload1.payload as { transaction: string }).transaction);
+    const tx2 = decode((payload2.payload as { transaction: string }).transaction);
+
+    // Different blockhashes → different messages → different hashes
+    expect(transactionMessageHash(tx1)).not.toBe(transactionMessageHash(tx2));
   });
 });

--- a/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { COMPUTE_BUDGET_PROGRAM_ADDRESS } from "@solana-program/compute-budget";
 import { ExactSvmScheme } from "../../src/exact/facilitator/scheme";
 import { ExactSvmSchemeV1 } from "../../src/exact/v1/facilitator/scheme";
@@ -11,6 +11,7 @@ import {
   SOLANA_DEVNET_CAIP2,
   MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS,
 } from "../../src/constants";
+import * as svmUtils from "../../src/utils";
 
 // Encodes a SetComputeUnitPrice instruction: discriminator(3) + microLamports as u64 LE
 function makeComputePriceData(microLamports: bigint): Uint8Array {
@@ -332,6 +333,20 @@ describe("ExactSvmScheme", () => {
   });
 
   describe("duplicate settlement cache", () => {
+    beforeEach(() => {
+      // Return a fake decoded Transaction whose messageBytes are derived deterministically
+      // from the transaction string. This lets the cache key tests work with arbitrary
+      // test strings without needing real Solana transaction binaries.
+      vi.spyOn(svmUtils, "decodeTransactionFromPayload").mockImplementation(
+        (payload: { transaction: string }) =>
+          ({ messageBytes: new TextEncoder().encode(payload.transaction) }) as never,
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     function makePayload(transaction: string): PaymentPayload {
       return {
         x402Version: 2,

--- a/typescript/packages/mechanisms/svm/test/unit/v1/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/v1/facilitator.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { COMPUTE_BUDGET_PROGRAM_ADDRESS } from "@solana-program/compute-budget";
 import { ExactSvmSchemeV1 } from "../../../src/exact/v1/facilitator/scheme";
 import type { FacilitatorSvmSigner } from "../../../src/signer";
 import type { PaymentRequirementsV1 } from "@x402/core/types/v1";
 import type { PaymentPayloadV1 } from "@x402/core/types/v1";
 import { USDC_DEVNET_ADDRESS, MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS } from "../../../src/constants";
+import * as svmUtils from "../../../src/utils";
 
 // Encodes a SetComputeUnitPrice instruction: discriminator(3) + microLamports as u64 LE
 function makeComputePriceData(microLamports: bigint): Uint8Array {
@@ -274,6 +275,20 @@ describe("ExactSvmSchemeV1", () => {
   });
 
   describe("duplicate settlement cache", () => {
+    beforeEach(() => {
+      // Return a fake decoded Transaction whose messageBytes are derived deterministically
+      // from the transaction string. This lets the cache key tests work with arbitrary
+      // test strings without needing real Solana transaction binaries.
+      vi.spyOn(svmUtils, "decodeTransactionFromPayload").mockImplementation(
+        (payload: { transaction: string }) =>
+          ({ messageBytes: new TextEncoder().encode(payload.transaction) }) as never,
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     function makePayload(transaction: string): PaymentPayloadV1 {
       return {
         x402Version: 1,


### PR DESCRIPTION
## Description

The SVM exact facilitator uses the full base64-encoded signed transaction as the dedup cache key. In fee-payer mode, signature slot 0 (the facilitator's) is overwritten before broadcast, so an attacker can randomize those 64 bytes to produce many distinct cache keys that all decode to the same valid payer-signed message. Each variant misses the cache, passes verification, and the resource server serves N responses — but only one on-chain transfer settles.

This PR fixes the deduplication logic to handle this.

## Tests

Added unit tests

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 