### PR TITLE
auth-capture client scheme (TypeScript)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -13,17 +13,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
----
-
-auth-capture scheme:
-
-The auth-capture payment scheme and its TypeScript implementation in
-@x402/evm were contributed by the x402r team. See proposal issue
-#1011 and specification PR #1425. The implementation was developed
-in https://github.com/BackTrackCo/x402r-scheme prior to upstreaming.
-
-The implementation originated from the "x402-escrow" proposal by
-Agentokratia in issue #834, published as @agentokratia/x402-escrow
-on npm under the MIT License, and incorporates code from that
-package.

--- a/NOTICE
+++ b/NOTICE
@@ -13,3 +13,17 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+---
+
+auth-capture scheme:
+
+The auth-capture payment scheme and its TypeScript implementation in
+@x402/evm were contributed by the x402r team. See proposal issue
+#1011 and specification PR #1425. The implementation was developed
+in https://github.com/BackTrackCo/x402r-scheme prior to upstreaming.
+
+The implementation originated from the "x402-escrow" proposal by
+Agentokratia in issue #834, published as @agentokratia/x402-escrow
+on npm under the MIT License, and incorporates code from that
+package.

--- a/examples/typescript/clients/auth-capture/.env-local
+++ b/examples/typescript/clients/auth-capture/.env-local
@@ -1,0 +1,4 @@
+EVM_PRIVATE_KEY=0x...
+
+RESOURCE_SERVER_URL=http://localhost:4021
+ENDPOINT_PATH=/weather

--- a/examples/typescript/clients/auth-capture/.prettierignore
+++ b/examples/typescript/clients/auth-capture/.prettierignore
@@ -1,0 +1,8 @@
+docs/
+dist/
+node_modules/
+coverage/
+.github/
+src/client
+**/**/*.json
+*.md

--- a/examples/typescript/clients/auth-capture/.prettierrc
+++ b/examples/typescript/clients/auth-capture/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/examples/typescript/clients/auth-capture/README.md
+++ b/examples/typescript/clients/auth-capture/README.md
@@ -1,0 +1,40 @@
+# auth-capture Client Example
+
+Fetch-based client that pays for a single request to an [auth-capture](../../../specs/schemes/auth-capture/scheme_auth-capture_evm.md)-protected endpoint. Signs an ERC-3009 `ReceiveWithAuthorization` whose `nonce` is the payer-agnostic PaymentInfo hash (per the [scheme spec](../../../specs/schemes/auth-capture/scheme_auth-capture_evm.md#nonce-derivation-both-methods)).
+
+## Prerequisites
+
+- Node.js v20+, pnpm v10
+- A running auth-capture server to pay against (the server/facilitator SDK lands separately; point `RESOURCE_SERVER_URL` at any auth-capture endpoint)
+- A funded EVM key holding the requested asset (USDC on Base Sepolia by default)
+
+## Setup
+
+```bash
+cp .env-local .env
+# Fill EVM_PRIVATE_KEY (and override RESOURCE_SERVER_URL if needed)
+
+cd ../../..
+pnpm install && pnpm build
+cd examples/clients/auth-capture
+
+pnpm start
+```
+
+## Environment
+
+| Variable              | Required | Default                 |
+| :-------------------- | :------- | :---------------------- |
+| `EVM_PRIVATE_KEY`     | Yes      | (none)                  |
+| `RESOURCE_SERVER_URL` | No       | `http://localhost:4021` |
+| `ENDPOINT_PATH`       | No       | `/weather`              |
+
+## What happens
+
+1. Client builds and signs an ERC-3009 payload with the `Eip3009Payload` shape.
+2. `wrapFetchWithPayment` retries the request with the `PAYMENT-SIGNATURE` header on first `402`.
+3. Server verifies, then asks the facilitator to settle.
+4. Facilitator submits `AuthCaptureEscrow.authorize(...)` (two-phase); funds are locked in escrow under the captureAuthorizer's control.
+5. Server returns the resource; the example prints the body and the payment response.
+
+Capture, void, and refund are performed by whoever holds the `captureAuthorizer` role and are out of scope for the client.

--- a/examples/typescript/clients/auth-capture/eslint.config.js
+++ b/examples/typescript/clients/auth-capture/eslint.config.js
@@ -1,0 +1,72 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+];

--- a/examples/typescript/clients/auth-capture/index.ts
+++ b/examples/typescript/clients/auth-capture/index.ts
@@ -1,0 +1,56 @@
+import { AuthCaptureEvmScheme } from "@x402/evm/auth-capture/client";
+import { x402Client, wrapFetchWithPayment, x402HTTPClient } from "@x402/fetch";
+import { config } from "dotenv";
+import { privateKeyToAccount } from "viem/accounts";
+
+config();
+
+const evmPrivateKeyRaw = process.env.EVM_PRIVATE_KEY?.trim();
+const baseURL = process.env.RESOURCE_SERVER_URL?.trim() || "http://localhost:4021";
+const endpointPath = process.env.ENDPOINT_PATH?.trim() || "/weather";
+const url = `${baseURL}${endpointPath}`;
+
+if (!evmPrivateKeyRaw) {
+  console.error("EVM_PRIVATE_KEY environment variable is required");
+  process.exit(1);
+}
+const evmPrivateKey = evmPrivateKeyRaw as `0x${string}`;
+
+/**
+ * Runs a single paid request against an auth-capture-protected endpoint.
+ *
+ * The scheme signs a payer-agnostic PaymentInfo hash (as the ERC-3009 nonce by
+ * default; Permit2 is also supported). The facilitator submits the resulting
+ * authorization to the AuthCaptureEscrow contract; funds are locked there until
+ * the captureAuthorizer captures, voids, or the authorization expires.
+ *
+ * @returns Resolves after the request completes and the payment response is logged.
+ */
+async function main(): Promise<void> {
+  const evmAccount = privateKeyToAccount(evmPrivateKey);
+
+  const client = new x402Client();
+  client.register("eip155:*", new AuthCaptureEvmScheme(evmAccount));
+
+  const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+  console.log(`Payer: ${evmAccount.address}`);
+  console.log(`Making request to: ${url}\n`);
+
+  const response = await fetchWithPayment(url, { method: "GET" });
+  const contentType = response.headers.get("content-type") ?? "";
+  const body = contentType.includes("application/json")
+    ? await response.json()
+    : await response.text();
+  console.log("Response body:", body);
+
+  const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(name =>
+    response.headers.get(name),
+  );
+  console.log("\nPayment response:", JSON.stringify(paymentResponse, null, 2));
+}
+
+main().catch(error => {
+  console.error(error?.response?.data?.error ?? error);
+  process.exit(1);
+});

--- a/examples/typescript/clients/auth-capture/package.json
+++ b/examples/typescript/clients/auth-capture/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@x402/auth-capture-client-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts",
+    "dev": "tsx index.ts",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "dependencies": {
+    "@x402/core": "workspace:*",
+    "@x402/evm": "workspace:*",
+    "@x402/fetch": "workspace:*",
+    "dotenv": "^16.4.7",
+    "viem": "^2.48.11"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@types/node": "^22.13.4",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/examples/typescript/clients/auth-capture/tsconfig.json
+++ b/examples/typescript/clients/auth-capture/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -1127,6 +1127,58 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  clients/auth-capture:
+    dependencies:
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/core
+      '@x402/evm':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/mechanisms/evm
+      '@x402/fetch':
+        specifier: workspace:*
+        version: link:../../../../typescript/packages/http/fetch
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      viem:
+        specifier: ^2.48.11
+        version: 2.48.11(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.1.13)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.33.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.17.2
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.33.0(jiti@2.6.1)
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.48.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.33.0(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint@9.33.0(jiti@2.6.1))(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   clients/axios:
     dependencies:
       '@scure/base':

--- a/typescript/.changeset/auth-capture-evm-scheme.md
+++ b/typescript/.changeset/auth-capture-evm-scheme.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": minor
+---
+
+Add auth-capture client scheme for detecting and signing payment payloads

--- a/typescript/packages/mechanisms/evm/NOTICE
+++ b/typescript/packages/mechanisms/evm/NOTICE
@@ -1,0 +1,12 @@
+auth-capture scheme:
+
+The auth-capture payment scheme and the client portion of its TypeScript
+implementation in @x402/evm were contributed by the x402r team. See
+proposal issue #1011 and specification PR #1425. The implementation was
+developed in https://github.com/BackTrackCo/x402r-scheme prior to
+upstreaming.
+
+The implementation originated from the "x402-escrow" proposal by
+Agentokratia in issue #834, published as @agentokratia/x402-escrow
+on npm under the MIT License, and incorporates code from that
+package.

--- a/typescript/packages/mechanisms/evm/package.json
+++ b/typescript/packages/mechanisms/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402/evm",
-  "version": "2.13.0",
+  "version": "2.12.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",
@@ -208,6 +208,16 @@
       "require": {
         "types": "./dist/cjs/batch-settlement/facilitator/index.d.ts",
         "default": "./dist/cjs/batch-settlement/facilitator/index.js"
+      }
+    },
+    "./auth-capture/client": {
+      "import": {
+        "types": "./dist/esm/auth-capture/client/index.d.mts",
+        "default": "./dist/esm/auth-capture/client/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/auth-capture/client/index.d.ts",
+        "default": "./dist/cjs/auth-capture/client/index.js"
       }
     }
   },

--- a/typescript/packages/mechanisms/evm/src/auth-capture/README.md
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/README.md
@@ -1,0 +1,82 @@
+# auth-capture EVM Scheme (client)
+
+The **auth-capture** scheme adds refundable payments to x402, built on Base's audited [Commerce Payments Protocol](https://github.com/base/commerce-payments). The client signs a single payload (ERC-3009 or Permit2) over a payer-agnostic PaymentInfo hash. A facilitator later submits that payload to `AuthCaptureEscrow`, where funds are held under a `captureAuthorizer` role rather than transferred straight to the merchant, enabling capture, void, and refund flows before settlement is final.
+
+This package currently ships the **client only**: detecting auth-capture payment requirements and signing the payment payload. Server and facilitator support follow in a later change.
+
+See the [scheme specification](https://github.com/x402-foundation/x402/blob/main/specs/schemes/auth-capture/scheme_auth-capture_evm.md) for full protocol details.
+
+## Import
+
+| Role   | Import                          |
+| ------ | ------------------------------- |
+| Client | `@x402/evm/auth-capture/client` |
+
+## Usage
+
+Register `AuthCaptureEvmScheme` with an `x402Client`. The client validates the requirement's `extra` fields, reconstructs the PaymentInfo struct, computes the payer-agnostic hash, and emits an ERC-3009 (default) or Permit2 payload.
+
+```typescript
+import { x402Client } from "@x402/core/client";
+import { AuthCaptureEvmScheme } from "@x402/evm/auth-capture/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const account = privateKeyToAccount(process.env.EVM_PRIVATE_KEY as `0x${string}`);
+
+const client = new x402Client();
+client.register("eip155:*", new AuthCaptureEvmScheme(account));
+```
+
+`ClientEvmSigner` only needs `address` + `signTypedData`; a bare viem `LocalAccount` satisfies the shape, with no `PublicClient` required.
+
+## Payment requirements the client reads
+
+The client reads these fields from `requirements.extra` and throws if any required field is missing or wrongly typed:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `captureAuthorizer` | `address` | Committed on-chain as `PaymentInfo.operator`. |
+| `feeRecipient` | `address` | Address that receives the fee portion. |
+| `captureDeadline` | `uint48` | Absolute Unix seconds; capture must occur before this. |
+| `refundDeadline` | `uint48` | Absolute Unix seconds; refunds allowed until this. |
+| `minFeeBps` | `uint16` | Floor on the `captureAuthorizer`'s fee. `0` = no minimum. |
+| `maxFeeBps` | `uint16` | Cap on the `captureAuthorizer`'s fee. |
+| `name` | `string` | EIP-712 token-domain name (e.g. `"USDC"`). |
+| `version` | `string` | EIP-712 token-domain version (e.g. `"2"`). |
+
+`maxTimeoutSeconds` on the requirements (not `extra`) is used to derive the authorization's `preApprovalExpiry`.
+
+Optional:
+
+| Field | Default | Notes |
+| --- | --- | --- |
+| `assetTransferMethod` | `"eip3009"` | `"eip3009"` (ERC-3009) or `"permit2"` (Uniswap Permit2). See below. |
+
+## Asset transfer methods
+
+The `assetTransferMethod` field selects how the signed authorization is shaped:
+
+| Method | Description | Wire shape |
+| --- | --- | --- |
+| `"eip3009"` (default) | ERC-3009 `ReceiveWithAuthorization` to the canonical EIP-3009 token collector. EIP-712 domain is bound to the **token contract**. | `Eip3009Payload` |
+| `"permit2"` | Uniswap Permit2 `PermitTransferFrom` to the canonical Permit2 token collector. Useful for tokens without `receiveWithAuthorization` (e.g. BSC USDC). | `Permit2Payload` |
+
+A server may advertise multiple `accepts[]` entries with different `assetTransferMethod` values so the client picks whichever matches its token approvals.
+
+## Supported networks
+
+| Network      | CAIP-2 ID      |
+| ------------ | -------------- |
+| Base Mainnet | `eip155:8453`  |
+| Base Sepolia | `eip155:84532` |
+
+Canonical `AuthCaptureEscrow` and EIP-3009 / Permit2 token collector addresses live in [`./constants.ts`](./constants.ts).
+
+## Examples
+
+- [Client example](../../../../../examples/clients/auth-capture)
+
+## See also
+
+- [Scheme specification](https://github.com/x402-foundation/x402/blob/main/specs/schemes/auth-capture/scheme_auth-capture_evm.md)
+- [`AuthCaptureEscrow` contract](https://github.com/base/commerce-payments)

--- a/typescript/packages/mechanisms/evm/src/auth-capture/client/index.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/client/index.ts
@@ -1,0 +1,1 @@
+export { AuthCaptureEvmScheme } from "./scheme";

--- a/typescript/packages/mechanisms/evm/src/auth-capture/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/client/scheme.ts
@@ -1,0 +1,167 @@
+/**
+ * AuthCapture Scheme - Client
+ * Builds payment payloads for auth-capture payments.
+ *
+ * Implements x402's SchemeNetworkClient interface so it can be registered
+ * on an x402Client via client.register('eip155:84532', new AuthCaptureEvmScheme(signer)).
+ */
+
+import type {
+  PaymentPayloadContext,
+  PaymentPayloadResult,
+  PaymentRequirements,
+  SchemeNetworkClient,
+} from "@x402/core/types";
+import type { ClientEvmSigner } from "../../signer";
+import { hexToBigInt } from "viem";
+import {
+  AUTH_CAPTURE_SCHEME,
+  EIP3009_TOKEN_COLLECTOR_ADDRESS,
+  PERMIT2_TOKEN_COLLECTOR_ADDRESS,
+} from "../constants";
+import {
+  computePayerAgnosticPaymentInfoHash,
+  generateSalt,
+  signERC3009,
+  signPermit2,
+} from "../nonce";
+import type { AuthCaptureExtra, Eip3009Payload, PaymentInfoStruct, Permit2Payload } from "../types";
+import { parseChainId } from "../utils";
+
+/**
+ * Client-side implementation of the auth-capture scheme: derives the canonical
+ * payer-agnostic PaymentInfo hash, signs an ERC-3009 ReceiveWithAuthorization
+ * (default) or a Permit2 PermitTransferFrom against it, and returns a wire
+ * payload the facilitator can settle. Implements `SchemeNetworkClient`.
+ */
+export class AuthCaptureEvmScheme implements SchemeNetworkClient {
+  readonly scheme = AUTH_CAPTURE_SCHEME;
+
+  /**
+   * Construct a client-side auth-capture scheme bound to a specific signer.
+   *
+   * @param signer - Client-side signer that exposes `address` and `signTypedData`.
+   */
+  constructor(private readonly signer: ClientEvmSigner) {}
+
+  /**
+   * Build and sign an auth-capture payment payload for the given requirements.
+   * Validates all spec-mandated `extra` fields and the asset-transfer method
+   * (default `eip3009`, alternative `permit2`), reconstructs the on-chain
+   * PaymentInfo struct, computes its payer-agnostic hash, and returns the
+   * signed wire payload.
+   *
+   * @param x402Version - Wire protocol version; only `2` is supported.
+   * @param requirements - Resource server's payment requirements (includes scheme `extra`).
+   * @param _ - Unused FacilitatorContext (interface compatibility).
+   * @returns The signed wire payload tagged with the x402 protocol version.
+   * @throws If `x402Version !== 2` or any required `extra` field is missing.
+   */
+  async createPaymentPayload(
+    x402Version: number,
+    requirements: PaymentRequirements,
+    _?: PaymentPayloadContext,
+  ): Promise<PaymentPayloadResult> {
+    if (x402Version !== 2) {
+      throw new Error(`Unsupported x402Version: ${x402Version}. Only version 2 is supported.`);
+    }
+
+    const extra = requirements.extra as unknown as AuthCaptureExtra;
+
+    // Validate required EIP-712 token-domain parameters
+    if (!extra.name) {
+      throw new Error(
+        `EIP-712 domain parameter 'name' is required in payment requirements for asset ${requirements.asset}`,
+      );
+    }
+    if (!extra.version) {
+      throw new Error(
+        `EIP-712 domain parameter 'version' is required in payment requirements for asset ${requirements.asset}`,
+      );
+    }
+    if (!extra.captureAuthorizer) {
+      throw new Error(`'captureAuthorizer' is required in payment requirements extra`);
+    }
+    if (!extra.feeRecipient) {
+      throw new Error(`'feeRecipient' is required in payment requirements extra`);
+    }
+    if (typeof extra.captureDeadline !== "number") {
+      throw new Error(`'captureDeadline' is required in payment requirements extra`);
+    }
+    if (typeof extra.refundDeadline !== "number") {
+      throw new Error(`'refundDeadline' is required in payment requirements extra`);
+    }
+    if (typeof extra.minFeeBps !== "number") {
+      throw new Error(`'minFeeBps' is required in payment requirements extra`);
+    }
+    if (typeof extra.maxFeeBps !== "number") {
+      throw new Error(`'maxFeeBps' is required in payment requirements extra`);
+    }
+    if (typeof requirements.maxTimeoutSeconds !== "number") {
+      throw new Error(
+        `'maxTimeoutSeconds' is required in PaymentRequirements (used to derive preApprovalExpiry)`,
+      );
+    }
+
+    const chainId = parseChainId(requirements.network);
+    const maxAmount = requirements.amount;
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const preApprovalExpiry = nowSeconds + requirements.maxTimeoutSeconds;
+    const salt = generateSalt();
+    const assetTransferMethod = extra.assetTransferMethod ?? "eip3009";
+
+    // Build the canonical PaymentInfo struct (Solidity field names — do not rename).
+    const paymentInfo: PaymentInfoStruct = {
+      operator: extra.captureAuthorizer,
+      payer: this.signer.address,
+      receiver: requirements.payTo as `0x${string}`,
+      token: requirements.asset as `0x${string}`,
+      maxAmount,
+      preApprovalExpiry,
+      authorizationExpiry: extra.captureDeadline,
+      refundExpiry: extra.refundDeadline,
+      minFeeBps: extra.minFeeBps,
+      maxFeeBps: extra.maxFeeBps,
+      feeReceiver: extra.feeRecipient,
+      salt,
+    };
+
+    // Payer-agnostic PaymentInfo hash — used as ERC-3009 nonce or Permit2 nonce.
+    const nonce = computePayerAgnosticPaymentInfoHash(chainId, paymentInfo);
+
+    if (assetTransferMethod === "permit2") {
+      const permit2Authorization: Permit2Payload["permit2Authorization"] = {
+        from: this.signer.address,
+        permitted: {
+          token: requirements.asset as `0x${string}`,
+          amount: maxAmount,
+        },
+        spender: PERMIT2_TOKEN_COLLECTOR_ADDRESS,
+        nonce: hexToBigInt(nonce).toString(),
+        deadline: String(preApprovalExpiry),
+      };
+      const signature = await signPermit2(this.signer, permit2Authorization, chainId);
+      const payload: Permit2Payload = { permit2Authorization, signature, salt };
+      return { x402Version, payload: payload as unknown as Record<string, unknown> };
+    }
+
+    // Default: EIP-3009 ReceiveWithAuthorization to the canonical EIP-3009 token collector.
+    const authorization: Eip3009Payload["authorization"] = {
+      from: this.signer.address,
+      to: EIP3009_TOKEN_COLLECTOR_ADDRESS,
+      value: maxAmount,
+      validAfter: "0",
+      validBefore: String(preApprovalExpiry),
+      nonce,
+    };
+    const signature = await signERC3009(
+      this.signer,
+      authorization,
+      extra,
+      requirements.asset as `0x${string}`,
+      chainId,
+    );
+    const payload: Eip3009Payload = { authorization, signature, salt };
+    return { x402Version, payload: payload as unknown as Record<string, unknown> };
+  }
+}

--- a/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
@@ -1,0 +1,43 @@
+// Scheme identifier for the auth-capture payment scheme.
+export const AUTH_CAPTURE_SCHEME = "auth-capture" as const;
+
+// Canonical AuthCaptureEscrow + token collector deployments from
+// base/commerce-payments (https://github.com/base/commerce-payments). These are
+// the audited, live addresses listed in the upstream README — the source of
+// truth for this scheme. Universal constants — not configurable per merchant.
+//
+// Currently live on: Base (8453) and Base Sepolia (84532). Additional EVM chains
+// will land at the same addresses as the upstream extends coverage; expand the
+// supported-chain list here as those deployments ship.
+export const AUTH_CAPTURE_ESCROW_ADDRESS =
+  "0xBdEA0D1bcC5966192B070Fdf62aB4EF5b4420cff" as const satisfies `0x${string}`;
+export const EIP3009_TOKEN_COLLECTOR_ADDRESS =
+  "0x0E3dF9510de65469C4518D7843919c0b8C7A7757" as const satisfies `0x${string}`;
+export const PERMIT2_TOKEN_COLLECTOR_ADDRESS =
+  "0x992476B9Ee81d52a5BdA0622C333938D0Af0aB26" as const satisfies `0x${string}`;
+
+// ERC-3009 ReceiveWithAuthorization EIP-712 types
+export const RECEIVE_AUTHORIZATION_TYPES = {
+  ReceiveWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+} as const;
+
+// Uniswap Permit2 PermitTransferFrom EIP-712 types
+export const PERMIT2_TRANSFER_FROM_TYPES = {
+  PermitTransferFrom: [
+    { name: "permitted", type: "TokenPermissions" },
+    { name: "spender", type: "address" },
+    { name: "nonce", type: "uint256" },
+    { name: "deadline", type: "uint256" },
+  ],
+  TokenPermissions: [
+    { name: "token", type: "address" },
+    { name: "amount", type: "uint256" },
+  ],
+} as const;

--- a/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/constants.ts
@@ -3,12 +3,9 @@ export const AUTH_CAPTURE_SCHEME = "auth-capture" as const;
 
 // Canonical AuthCaptureEscrow + token collector deployments from
 // base/commerce-payments (https://github.com/base/commerce-payments). These are
-// the audited, live addresses listed in the upstream README — the source of
-// truth for this scheme. Universal constants — not configurable per merchant.
-//
-// Currently live on: Base (8453) and Base Sepolia (84532). Additional EVM chains
-// will land at the same addresses as the upstream extends coverage; expand the
-// supported-chain list here as those deployments ship.
+// the audited, live addresses listed in the upstream README and are the source
+// of truth for this scheme. They are universal constants, not configurable per
+// merchant.
 export const AUTH_CAPTURE_ESCROW_ADDRESS =
   "0xBdEA0D1bcC5966192B070Fdf62aB4EF5b4420cff" as const satisfies `0x${string}`;
 export const EIP3009_TOKEN_COLLECTOR_ADDRESS =

--- a/typescript/packages/mechanisms/evm/src/auth-capture/index.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/index.ts
@@ -1,0 +1,1 @@
+export { AuthCaptureEvmScheme } from "./client/scheme";

--- a/typescript/packages/mechanisms/evm/src/auth-capture/nonce.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/nonce.ts
@@ -1,0 +1,186 @@
+/**
+ * Nonce computation, salt generation, and signing helpers.
+ */
+
+import { encodeAbiParameters, getAddress, keccak256, toHex, zeroAddress } from "viem";
+import type { ClientEvmSigner } from "../signer";
+import { PERMIT2_ADDRESS } from "../constants";
+import {
+  AUTH_CAPTURE_ESCROW_ADDRESS,
+  PERMIT2_TRANSFER_FROM_TYPES,
+  RECEIVE_AUTHORIZATION_TYPES,
+} from "./constants";
+import type { AuthCaptureExtra, Eip3009Payload, PaymentInfoStruct, Permit2Payload } from "./types";
+
+/**
+ * PaymentInfo typehash — must match AuthCaptureEscrow.PAYMENT_INFO_TYPEHASH.
+ */
+const PAYMENT_INFO_TYPEHASH = keccak256(
+  new TextEncoder().encode(
+    "PaymentInfo(address operator,address payer,address receiver,address token,uint120 maxAmount,uint48 preApprovalExpiry,uint48 authorizationExpiry,uint48 refundExpiry,uint16 minFeeBps,uint16 maxFeeBps,address feeReceiver,uint256 salt)",
+  ),
+);
+
+/**
+ * Compute the payer-agnostic PaymentInfo hash that auth-capture uses as both
+ * the ERC-3009 nonce (`bytes32`) and the Permit2 nonce (`uint256`, via the
+ * same 32 bytes interpreted as an integer). The payer field is zeroed before
+ * hashing so the facilitator can reconstruct the same hash on the verify side
+ * without knowing payer identity in advance.
+ *
+ * Freshness comes from `paymentInfo.salt`; generate a new salt per signing
+ * call via `generateSalt`. Identical extras + same salt would collide across
+ * payers.
+ *
+ * @param chainId - EVM chain id; binds the hash to a specific chain.
+ * @param paymentInfo - The reconstructed PaymentInfo struct (canonical Solidity field names).
+ * @returns The 32-byte hash to use as the nonce on the wire.
+ */
+export function computePayerAgnosticPaymentInfoHash(
+  chainId: number,
+  paymentInfo: PaymentInfoStruct,
+): `0x${string}` {
+  const paymentInfoEncoded = encodeAbiParameters(
+    [
+      { name: "typehash", type: "bytes32" },
+      { name: "operator", type: "address" },
+      { name: "payer", type: "address" },
+      { name: "receiver", type: "address" },
+      { name: "token", type: "address" },
+      { name: "maxAmount", type: "uint120" },
+      { name: "preApprovalExpiry", type: "uint48" },
+      { name: "authorizationExpiry", type: "uint48" },
+      { name: "refundExpiry", type: "uint48" },
+      { name: "minFeeBps", type: "uint16" },
+      { name: "maxFeeBps", type: "uint16" },
+      { name: "feeReceiver", type: "address" },
+      { name: "salt", type: "uint256" },
+    ],
+    [
+      PAYMENT_INFO_TYPEHASH,
+      paymentInfo.operator,
+      zeroAddress,
+      paymentInfo.receiver,
+      paymentInfo.token,
+      BigInt(paymentInfo.maxAmount),
+      paymentInfo.preApprovalExpiry,
+      paymentInfo.authorizationExpiry,
+      paymentInfo.refundExpiry,
+      paymentInfo.minFeeBps,
+      paymentInfo.maxFeeBps,
+      paymentInfo.feeReceiver,
+      BigInt(paymentInfo.salt),
+    ],
+  );
+  const paymentInfoHash = keccak256(paymentInfoEncoded);
+
+  const outerEncoded = encodeAbiParameters(
+    [
+      { name: "chainId", type: "uint256" },
+      { name: "escrow", type: "address" },
+      { name: "paymentInfoHash", type: "bytes32" },
+    ],
+    [BigInt(chainId), AUTH_CAPTURE_ESCROW_ADDRESS, paymentInfoHash],
+  );
+
+  return keccak256(outerEncoded);
+}
+
+/**
+ * Sign an ERC-3009 `ReceiveWithAuthorization` over the supplied authorization
+ * fields. The EIP-712 domain is bound to the **token contract** (not the
+ * escrow), so the token's `name` and `version` come from `extra` because they
+ * vary per asset (e.g. `"USDC"` on Sepolia vs `"USD Coin"` on mainnet).
+ *
+ * @param signer - Client signer with `signTypedData`.
+ * @param authorization - The ERC-3009 authorization to sign.
+ * @param extra - Carries the token EIP-712 domain `name` + `version`.
+ * @param tokenAddress - Address of the token contract (verifyingContract in the domain).
+ * @param chainId - EVM chain id (chainId in the domain).
+ * @returns The 65-byte ECDSA signature (or EIP-1271 / EIP-6492 envelope, depending on the signer).
+ */
+export async function signERC3009(
+  signer: ClientEvmSigner,
+  authorization: Eip3009Payload["authorization"],
+  extra: AuthCaptureExtra,
+  tokenAddress: `0x${string}`,
+  chainId: number,
+): Promise<`0x${string}`> {
+  const domain = {
+    name: extra.name,
+    version: extra.version,
+    chainId,
+    verifyingContract: getAddress(tokenAddress),
+  };
+
+  const message = {
+    from: getAddress(authorization.from),
+    to: getAddress(authorization.to),
+    value: BigInt(authorization.value),
+    validAfter: BigInt(authorization.validAfter),
+    validBefore: BigInt(authorization.validBefore),
+    nonce: authorization.nonce,
+  };
+
+  return signer.signTypedData({
+    domain,
+    types: RECEIVE_AUTHORIZATION_TYPES,
+    primaryType: "ReceiveWithAuthorization",
+    message,
+  });
+}
+
+/**
+ * Sign a Permit2 `PermitTransferFrom` over the supplied permit fields. Domain
+ * is bound to the canonical Permit2 contract. No witness struct is needed —
+ * the deterministic nonce (the payer-agnostic PaymentInfo hash, packed into
+ * uint256) cryptographically binds all payment parameters including receiver,
+ * amount, and deadlines.
+ *
+ * @param signer - Client signer with `signTypedData`.
+ * @param permit - The Permit2 PermitTransferFrom message to sign.
+ * @param chainId - EVM chain id (chainId in the Permit2 domain).
+ * @returns The 65-byte ECDSA signature (or EIP-1271 / EIP-6492 envelope, depending on the signer).
+ */
+export async function signPermit2(
+  signer: ClientEvmSigner,
+  permit: Permit2Payload["permit2Authorization"],
+  chainId: number,
+): Promise<`0x${string}`> {
+  const domain = {
+    name: "Permit2",
+    chainId,
+    verifyingContract: PERMIT2_ADDRESS,
+  };
+
+  const message = {
+    permitted: {
+      token: getAddress(permit.permitted.token),
+      amount: BigInt(permit.permitted.amount),
+    },
+    spender: getAddress(permit.spender),
+    nonce: BigInt(permit.nonce),
+    deadline: BigInt(permit.deadline),
+  };
+
+  return signer.signTypedData({
+    domain,
+    types: PERMIT2_TRANSFER_FROM_TYPES,
+    primaryType: "PermitTransferFrom",
+    message,
+  });
+}
+
+/**
+ * Generate a fresh cryptographically-random 32-byte salt. MUST be called once
+ * per signing request — never reuse across requests. Freshness is required
+ * because the nonce derivation zeroes the payer field; identical extras with
+ * the same salt would collide across payers.
+ *
+ * @returns A new 32-byte salt as a `0x`-prefixed hex string.
+ */
+export function generateSalt(): `0x${string}` {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return toHex(bytes);
+}

--- a/typescript/packages/mechanisms/evm/src/auth-capture/types.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/types.ts
@@ -1,0 +1,172 @@
+/**
+ * auth-capture wire-format types.
+ *
+ * Spec-level field names (captureAuthorizer, captureDeadline, refundDeadline,
+ * feeRecipient) live here at the extra/wire layer. The on-chain PaymentInfo
+ * struct keeps the canonical Solidity field names (operator, authorizationExpiry,
+ * refundExpiry, feeReceiver) so the EIP-712 typehash stays byte-identical with
+ * the AuthCaptureEscrow contract.
+ *
+ * Salt is NOT in extra. It is generated client-side per signing call and rides
+ * on the payload alongside the signature.
+ */
+
+import type { AssetTransferMethod } from "../types";
+
+// AuthCaptureExtra — fields in PaymentRequirements.extra.
+//
+// Fee-policy fields (minFeeBps, maxFeeBps, feeRecipient) are all required.
+// No implicit defaults: a merchant who wants no minimum fee writes
+// `minFeeBps: 0` explicitly. This forces fee policy to be a conscious choice
+// on the wire and avoids "did they mean 0 or did they forget?" ambiguity.
+export interface AuthCaptureExtra {
+  // Required
+  // The only address allowed to call authorize/capture/void/refund/charge on
+  // AuthCaptureEscrow (each of those is gated by onlySender(paymentInfo.operator))
+  // — i.e., it must be msg.sender of the "Authorize" call. In x402's
+  // facilitator-submits flow that means either the facilitator's EOA, or any
+  // smart contract that ultimately calls escrow (arbiter with dispute logic,
+  // multisig, etc.). Independent of assetTransferMethod — applies to both
+  // EIP-3009 and Permit2.
+  captureAuthorizer: `0x${string}`; // formerly `operator` in commerce-payments
+  captureDeadline: number; // absolute Unix seconds; capture must occur before this
+  refundDeadline: number; // absolute Unix seconds; refunds allowed until this
+  feeRecipient: `0x${string}`; // address that receives the fee portion (renamed from feeReceiver)
+  minFeeBps: number; // floor on the captureAuthorizer's fee; 0 = no minimum
+  maxFeeBps: number; // cap on the captureAuthorizer's fee
+  name: string; // EIP-712 token-domain name (e.g., "USDC")
+  version: string; // EIP-712 token-domain version (e.g., "2")
+  // Optional
+  autoCapture?: boolean; // default: false. true → facilitator calls charge(), false → authorize()
+  assetTransferMethod?: AssetTransferMethod; // default: 'eip3009'
+}
+
+/**
+ * Type guard for AuthCaptureExtra. Checks the structural shape an auth-capture
+ * scheme requires inside `PaymentRequirements.extra`: every spec-mandated
+ * required field present with the right primitive type.
+ *
+ * @param value - Candidate object from `requirements.extra`.
+ * @returns True if `value` has every required AuthCaptureExtra field.
+ */
+export function isAuthCaptureExtra(value: unknown): value is AuthCaptureExtra {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.captureAuthorizer === "string" &&
+    typeof v.captureDeadline === "number" &&
+    typeof v.refundDeadline === "number" &&
+    typeof v.feeRecipient === "string" &&
+    typeof v.minFeeBps === "number" &&
+    typeof v.maxFeeBps === "number" &&
+    typeof v.name === "string" &&
+    typeof v.version === "string"
+  );
+}
+
+// EIP-3009 payload — ReceiveWithAuthorization to the canonical EIP-3009 token collector.
+export interface Eip3009Payload {
+  authorization: {
+    from: `0x${string}`;
+    to: `0x${string}`; // EIP3009_TOKEN_COLLECTOR_ADDRESS
+    value: string;
+    validAfter: string;
+    validBefore: string; // = preApprovalExpiry
+    nonce: `0x${string}`; // = payer-agnostic PaymentInfo hash
+  };
+  signature: `0x${string}`;
+  salt: `0x${string}`; // bytes32, fresh per request, used to reconstruct PaymentInfo
+}
+
+/**
+ * Type guard for an EIP-3009-shaped auth-capture payload. Checks for an
+ * `authorization` object plus the required `signature` and `salt` fields;
+ * field-level validation happens later in `verify()`.
+ *
+ * @param value - Candidate payment payload from the wire.
+ * @returns True if `value` has the EIP-3009 envelope shape.
+ */
+export function isEip3009Payload(value: unknown): value is Eip3009Payload {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    "authorization" in v &&
+    typeof v.authorization === "object" &&
+    v.authorization !== null &&
+    typeof v.signature === "string" &&
+    typeof v.salt === "string"
+  );
+}
+
+// Permit2 payload — PermitTransferFrom to the canonical Permit2 token collector.
+export interface Permit2Payload {
+  permit2Authorization: {
+    from: `0x${string}`;
+    permitted: {
+      token: `0x${string}`;
+      amount: string;
+    };
+    spender: `0x${string}`; // PERMIT2_TOKEN_COLLECTOR_ADDRESS
+    nonce: string; // uint256 string, = uint256(payer-agnostic PaymentInfo hash)
+    deadline: string; // = preApprovalExpiry
+  };
+  signature: `0x${string}`;
+  salt: `0x${string}`; // bytes32, fresh per request, used to reconstruct PaymentInfo
+}
+
+/**
+ * Type guard for a Permit2-shaped auth-capture payload. Checks for the
+ * `permit2Authorization` envelope (with `from`, `spender`, `nonce`,
+ * `deadline`, `permitted`) plus the required `signature` and `salt` fields.
+ *
+ * @param value - Candidate payment payload from the wire.
+ * @returns True if `value` has the Permit2 envelope shape.
+ */
+export function isPermit2Payload(value: unknown): value is Permit2Payload {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.signature !== "string" || typeof v.salt !== "string") return false;
+  if (typeof v.permit2Authorization !== "object" || v.permit2Authorization === null) return false;
+  const a = v.permit2Authorization as Record<string, unknown>;
+  return (
+    typeof a.from === "string" &&
+    typeof a.spender === "string" &&
+    typeof a.nonce === "string" &&
+    typeof a.deadline === "string" &&
+    typeof a.permitted === "object" &&
+    a.permitted !== null
+  );
+}
+
+// Discriminated union of all auth-capture payload shapes.
+export type AuthCapturePayload = Eip3009Payload | Permit2Payload;
+
+/**
+ * Type guard for any auth-capture payload. Returns true if `value` matches
+ * either the EIP-3009 envelope or the Permit2 envelope.
+ *
+ * @param value - Candidate payment payload from the wire.
+ * @returns True if `value` is a valid auth-capture envelope of either shape.
+ */
+export function isAuthCapturePayload(value: unknown): value is AuthCapturePayload {
+  return isEip3009Payload(value) || isPermit2Payload(value);
+}
+
+/**
+ * On-chain PaymentInfo struct (canonical Solidity names — DO NOT RENAME).
+ * Reconstructed by the facilitator from extra + payload.salt + payer + receiver/asset/amount.
+ */
+export interface PaymentInfoStruct {
+  operator: `0x${string}`; // = extra.captureAuthorizer
+  payer: `0x${string}`;
+  receiver: `0x${string}`; // = requirements.payTo
+  token: `0x${string}`; // = requirements.asset
+  maxAmount: string; // = requirements.amount
+  preApprovalExpiry: number;
+  authorizationExpiry: number; // = extra.captureDeadline
+  refundExpiry: number; // = extra.refundDeadline
+  minFeeBps: number;
+  maxFeeBps: number;
+  feeReceiver: `0x${string}`; // = extra.feeRecipient
+  salt: `0x${string}`; // = payload.salt
+}

--- a/typescript/packages/mechanisms/evm/src/auth-capture/utils.ts
+++ b/typescript/packages/mechanisms/evm/src/auth-capture/utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Parse chainId from CAIP-2 network identifier
+ *
+ * @param network - CAIP-2 network identifier (e.g., 'eip155:84532')
+ * @returns The chain ID as a number
+ */
+export function parseChainId(network: string): number {
+  const parts = network.split(":");
+  if (parts.length !== 2 || parts[0] !== "eip155") {
+    throw new Error(`Invalid network format: ${network}. Expected 'eip155:<chainId>'`);
+  }
+  const chainId = parseInt(parts[1], 10);
+  if (isNaN(chainId)) {
+    throw new Error(`Invalid chainId in network: ${network}`);
+  }
+  return chainId;
+}

--- a/typescript/packages/mechanisms/evm/src/index.ts
+++ b/typescript/packages/mechanisms/evm/src/index.ts
@@ -97,3 +97,24 @@ export {
 
 // Default-asset registry (network → token metadata)
 export { DEFAULT_STABLECOINS } from "./shared/defaultAssets";
+
+// AuthCapture scheme
+export { AuthCaptureEvmScheme } from "./auth-capture";
+
+// AuthCapture types
+export type {
+  AuthCaptureExtra,
+  AuthCapturePayload,
+  Eip3009Payload as AuthCaptureEip3009Payload,
+  PaymentInfoStruct as AuthCapturePaymentInfo,
+  Permit2Payload as AuthCapturePermit2Payload,
+} from "./auth-capture/types";
+export { isAuthCaptureExtra, isAuthCapturePayload } from "./auth-capture/types";
+
+// AuthCapture constants
+export {
+  AUTH_CAPTURE_ESCROW_ADDRESS,
+  AUTH_CAPTURE_SCHEME,
+  EIP3009_TOKEN_COLLECTOR_ADDRESS,
+  PERMIT2_TOKEN_COLLECTOR_ADDRESS,
+} from "./auth-capture/constants";

--- a/typescript/packages/mechanisms/evm/test/unit/auth-capture/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/auth-capture/client.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AuthCaptureEvmScheme } from "../../../src/auth-capture/client/index";
+import {
+  EIP3009_TOKEN_COLLECTOR_ADDRESS,
+  PERMIT2_TOKEN_COLLECTOR_ADDRESS,
+} from "../../../src/auth-capture/constants";
+import { PERMIT2_ADDRESS } from "../../../src/constants";
+import { isEip3009Payload, isPermit2Payload } from "../../../src/auth-capture/types";
+import type { Eip3009Payload, Permit2Payload } from "../../../src/auth-capture/types";
+
+const FUTURE = Math.floor(Date.now() / 1000) + 86400;
+
+describe("AuthCaptureEvmScheme", () => {
+  const createMockSigner = () => ({
+    address: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const,
+    signTypedData: vi.fn().mockResolvedValue("0xdeadbeef" as `0x${string}`),
+  });
+
+  let mockSigner: ReturnType<typeof createMockSigner>;
+
+  beforeEach(() => {
+    mockSigner = createMockSigner();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockRequirements = {
+    scheme: "auth-capture",
+    network: "eip155:84532",
+    amount: "1000000",
+    asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    payTo: "0x1234567890123456789012345678901234567890",
+    maxTimeoutSeconds: 3600,
+    extra: {
+      captureAuthorizer: "0xcccccccccccccccccccccccccccccccccccccccc" as `0x${string}`,
+      captureDeadline: FUTURE,
+      refundDeadline: FUTURE + 86400,
+      feeRecipient: "0x4444444444444444444444444444444444444444" as `0x${string}`,
+      minFeeBps: 0,
+      maxFeeBps: 100,
+      name: "USDC",
+      version: "2",
+    },
+  };
+
+  describe("constructor and properties", () => {
+    it('should have scheme set to "auth-capture"', () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      expect(scheme.scheme).toBe("auth-capture");
+    });
+  });
+
+  describe("createPaymentPayload — EIP-3009 (default)", () => {
+    it("should create a valid EIP-3009 payload for x402Version 2", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const result = await scheme.createPaymentPayload(2, mockRequirements);
+
+      expect(result.x402Version).toBe(2);
+      expect(isEip3009Payload(result.payload)).toBe(true);
+      const payload = result.payload as unknown as Eip3009Payload;
+      expect(payload.authorization).toBeDefined();
+      expect(payload.signature).toBe("0xdeadbeef");
+      expect(payload.salt).toMatch(/^0x[a-fA-F0-9]{64}$/);
+    });
+
+    it("should throw for unsupported x402Version", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      await expect(scheme.createPaymentPayload(1, mockRequirements)).rejects.toThrow(
+        "Unsupported x402Version: 1. Only version 2 is supported.",
+      );
+    });
+
+    it("should throw for x402Version 0", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      await expect(scheme.createPaymentPayload(0, mockRequirements)).rejects.toThrow(
+        "Unsupported x402Version: 0",
+      );
+    });
+
+    it("should throw when EIP-712 name is missing", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const requirementsNoName = {
+        ...mockRequirements,
+        extra: { ...mockRequirements.extra, name: "" },
+      };
+      await expect(scheme.createPaymentPayload(2, requirementsNoName)).rejects.toThrow(
+        "EIP-712 domain parameter 'name' is required",
+      );
+    });
+
+    it("should throw when EIP-712 version is missing", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const requirementsNoVersion = {
+        ...mockRequirements,
+        extra: { ...mockRequirements.extra, version: "" },
+      };
+      await expect(scheme.createPaymentPayload(2, requirementsNoVersion)).rejects.toThrow(
+        "EIP-712 domain parameter 'version' is required",
+      );
+    });
+
+    it("should throw when captureAuthorizer is missing", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const bad = {
+        ...mockRequirements,
+        extra: { ...mockRequirements.extra, captureAuthorizer: "" as `0x${string}` },
+      };
+      await expect(scheme.createPaymentPayload(2, bad)).rejects.toThrow(
+        "'captureAuthorizer' is required",
+      );
+    });
+
+    it("should throw when feeRecipient is missing", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const bad = {
+        ...mockRequirements,
+        extra: { ...mockRequirements.extra, feeRecipient: "" as `0x${string}` },
+      };
+      await expect(scheme.createPaymentPayload(2, bad)).rejects.toThrow(
+        "'feeRecipient' is required",
+      );
+    });
+
+    it("should set authorization.from to signer address", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const result = await scheme.createPaymentPayload(2, mockRequirements);
+      const payload = result.payload as unknown as Eip3009Payload;
+      expect(payload.authorization.from).toBe(mockSigner.address);
+    });
+
+    it("should set authorization.to to the canonical EIP-3009 token collector", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const result = await scheme.createPaymentPayload(2, mockRequirements);
+      const payload = result.payload as unknown as Eip3009Payload;
+      expect(payload.authorization.to).toBe(EIP3009_TOKEN_COLLECTOR_ADDRESS);
+    });
+
+    it("should set authorization.value to requirements amount", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const result = await scheme.createPaymentPayload(2, mockRequirements);
+      const payload = result.payload as unknown as Eip3009Payload;
+      expect(payload.authorization.value).toBe("1000000");
+    });
+
+    it("should derive validBefore from now + maxTimeoutSeconds", async () => {
+      const fakeNowMs = 1700000000000;
+      vi.spyOn(Date, "now").mockReturnValue(fakeNowMs);
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const result = await scheme.createPaymentPayload(2, {
+        ...mockRequirements,
+        maxTimeoutSeconds: 600,
+      });
+      const payload = result.payload as unknown as Eip3009Payload;
+      expect(payload.authorization.validBefore).toBe("1700000600");
+    });
+
+    it("should generate a fresh salt on each call", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const a = (await scheme.createPaymentPayload(2, mockRequirements))
+        .payload as unknown as Eip3009Payload;
+      const b = (await scheme.createPaymentPayload(2, mockRequirements))
+        .payload as unknown as Eip3009Payload;
+      expect(a.salt).not.toBe(b.salt);
+    });
+
+    it("should throw for invalid network format", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const badNetworkRequirements = { ...mockRequirements, network: "solana:mainnet" };
+      await expect(scheme.createPaymentPayload(2, badNetworkRequirements)).rejects.toThrow(
+        "Invalid network format",
+      );
+    });
+
+    it("should call signTypedData on signer", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      await scheme.createPaymentPayload(2, mockRequirements);
+      expect(mockSigner.signTypedData).toHaveBeenCalledOnce();
+    });
+
+    it("should sign with EIP-712 domain bound to the asset (verifyingContract = requirements.asset)", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      await scheme.createPaymentPayload(2, mockRequirements);
+      const args = mockSigner.signTypedData.mock.calls[0][0];
+      expect(args.primaryType).toBe("ReceiveWithAuthorization");
+      expect(args.domain.name).toBe("USDC");
+      expect(args.domain.version).toBe("2");
+      expect(args.domain.chainId).toBe(84532);
+      // Critical: verifyingContract is the token, NOT the collector
+      expect(args.domain.verifyingContract.toLowerCase()).toBe(
+        mockRequirements.asset.toLowerCase(),
+      );
+    });
+  });
+
+  describe("createPaymentPayload — Permit2", () => {
+    it("should create a valid Permit2 payload when assetTransferMethod is permit2", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const result = await scheme.createPaymentPayload(2, {
+        ...mockRequirements,
+        extra: { ...mockRequirements.extra, assetTransferMethod: "permit2" as const },
+      });
+
+      expect(isPermit2Payload(result.payload)).toBe(true);
+      const payload = result.payload as unknown as Permit2Payload;
+      expect(payload.permit2Authorization.from).toBe(mockSigner.address);
+      expect(payload.permit2Authorization.spender).toBe(PERMIT2_TOKEN_COLLECTOR_ADDRESS);
+      expect(payload.permit2Authorization.permitted.token).toBe(mockRequirements.asset);
+      expect(payload.permit2Authorization.permitted.amount).toBe(mockRequirements.amount);
+      expect(payload.salt).toMatch(/^0x[a-fA-F0-9]{64}$/);
+    });
+
+    it("should compute a uint256-string Permit2 nonce", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      const result = await scheme.createPaymentPayload(2, {
+        ...mockRequirements,
+        extra: { ...mockRequirements.extra, assetTransferMethod: "permit2" as const },
+      });
+      const payload = result.payload as unknown as Permit2Payload;
+      // uint256 stringified — should parse as a valid bigint
+      expect(() => BigInt(payload.permit2Authorization.nonce)).not.toThrow();
+      expect(payload.permit2Authorization.nonce.length).toBeGreaterThan(0);
+    });
+
+    it("should sign with EIP-712 domain bound to canonical Permit2 (NOT the token)", async () => {
+      const scheme = new AuthCaptureEvmScheme(mockSigner);
+      await scheme.createPaymentPayload(2, {
+        ...mockRequirements,
+        extra: { ...mockRequirements.extra, assetTransferMethod: "permit2" as const },
+      });
+      const args = mockSigner.signTypedData.mock.calls[0][0];
+      expect(args.primaryType).toBe("PermitTransferFrom");
+      expect(args.domain.name).toBe("Permit2");
+      expect(args.domain.chainId).toBe(84532);
+      // Critical: verifyingContract is the canonical Permit2, NOT the token, NOT the collector
+      expect(args.domain.verifyingContract).toBe(PERMIT2_ADDRESS);
+    });
+  });
+});

--- a/typescript/packages/mechanisms/evm/test/unit/auth-capture/nonce.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/auth-capture/nonce.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { zeroAddress } from "viem";
+import { computePayerAgnosticPaymentInfoHash, generateSalt } from "../../../src/auth-capture/nonce";
+import type { PaymentInfoStruct } from "../../../src/auth-capture/types";
+
+describe("nonce utilities", () => {
+  describe("computePayerAgnosticPaymentInfoHash", () => {
+    const mockPaymentInfo: PaymentInfoStruct = {
+      operator: "0x1111111111111111111111111111111111111111",
+      payer: "0xPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP".toLowerCase() as `0x${string}`,
+      receiver: "0x2222222222222222222222222222222222222222",
+      token: "0x3333333333333333333333333333333333333333",
+      maxAmount: "1000000",
+      preApprovalExpiry: 281474976710655,
+      authorizationExpiry: 281474976710655,
+      refundExpiry: 281474976710655,
+      minFeeBps: 0,
+      maxFeeBps: 100,
+      feeReceiver: "0x4444444444444444444444444444444444444444",
+      salt: "0x0000000000000000000000000000000000000000000000000000000000000001",
+    };
+
+    it("should produce a 32-byte hex string", () => {
+      const nonce = computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo);
+      expect(nonce).toMatch(/^0x[a-fA-F0-9]{64}$/);
+    });
+
+    it("should produce deterministic results for same inputs", () => {
+      const nonce1 = computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo);
+      const nonce2 = computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo);
+      expect(nonce1).toBe(nonce2);
+    });
+
+    it("should produce different results for different chainIds", () => {
+      const nonce1 = computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo);
+      const nonce2 = computePayerAgnosticPaymentInfoHash(8453, mockPaymentInfo);
+      expect(nonce1).not.toBe(nonce2);
+    });
+
+    it("should produce different results for different payment info", () => {
+      const nonce1 = computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo);
+      const nonce2 = computePayerAgnosticPaymentInfoHash(84532, {
+        ...mockPaymentInfo,
+        maxAmount: "2000000",
+      });
+      expect(nonce1).not.toBe(nonce2);
+    });
+
+    it("should produce different results for different salts (freshness check)", () => {
+      const nonce1 = computePayerAgnosticPaymentInfoHash(84532, mockPaymentInfo);
+      const nonce2 = computePayerAgnosticPaymentInfoHash(84532, {
+        ...mockPaymentInfo,
+        salt: "0x0000000000000000000000000000000000000000000000000000000000000002",
+      });
+      expect(nonce1).not.toBe(nonce2);
+    });
+
+    it("should be payer-agnostic — different payers produce identical nonces", () => {
+      const nonceA = computePayerAgnosticPaymentInfoHash(84532, {
+        ...mockPaymentInfo,
+        payer: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".toLowerCase() as `0x${string}`,
+      });
+      const nonceB = computePayerAgnosticPaymentInfoHash(84532, {
+        ...mockPaymentInfo,
+        payer: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB".toLowerCase() as `0x${string}`,
+      });
+      const nonceZero = computePayerAgnosticPaymentInfoHash(84532, {
+        ...mockPaymentInfo,
+        payer: zeroAddress,
+      });
+      expect(nonceA).toBe(nonceB);
+      expect(nonceA).toBe(nonceZero);
+    });
+  });
+
+  describe("generateSalt", () => {
+    it("should produce a 32-byte hex string", () => {
+      const salt = generateSalt();
+      expect(salt).toMatch(/^0x[a-fA-F0-9]{64}$/);
+    });
+
+    it("should produce unique values on each call", () => {
+      const salt1 = generateSalt();
+      const salt2 = generateSalt();
+      const salt3 = generateSalt();
+      expect(salt1).not.toBe(salt2);
+      expect(salt2).not.toBe(salt3);
+      expect(salt1).not.toBe(salt3);
+    });
+
+    it("should produce valid hex characters only", () => {
+      const salt = generateSalt();
+      const hexPart = salt.slice(2);
+      expect(hexPart).toMatch(/^[0-9a-f]+$/);
+    });
+  });
+});

--- a/typescript/packages/mechanisms/evm/test/unit/auth-capture/types.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/auth-capture/types.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+  isAuthCaptureExtra,
+  isAuthCapturePayload,
+  isEip3009Payload,
+  isPermit2Payload,
+} from "../../../src/auth-capture/types";
+
+describe("type guards", () => {
+  const FUTURE = Math.floor(Date.now() / 1000) + 86400;
+
+  const validExtra = {
+    captureAuthorizer: "0xcccccccccccccccccccccccccccccccccccccccc",
+    captureDeadline: FUTURE,
+    refundDeadline: FUTURE + 86400,
+    feeRecipient: "0x4444444444444444444444444444444444444444",
+    minFeeBps: 0,
+    maxFeeBps: 100,
+    name: "USDC",
+    version: "2",
+  };
+
+  const validEip3009 = {
+    authorization: {
+      from: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      to: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      value: "1000000",
+      validAfter: "0",
+      validBefore: String(FUTURE),
+      nonce: "0x1234567890123456789012345678901234567890123456789012345678901234",
+    },
+    signature: "0xabcd",
+    salt: "0x0000000000000000000000000000000000000000000000000000000000000abc",
+  };
+
+  const validPermit2 = {
+    permit2Authorization: {
+      from: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      permitted: { token: "0xeeee", amount: "1000000" },
+      spender: "0xdddd",
+      nonce: "12345",
+      deadline: String(FUTURE),
+    },
+    signature: "0xabcd",
+    salt: "0x0000000000000000000000000000000000000000000000000000000000000abc",
+  };
+
+  describe("isAuthCaptureExtra", () => {
+    it("accepts a valid extra object", () => {
+      expect(isAuthCaptureExtra(validExtra)).toBe(true);
+    });
+
+    it("rejects null and undefined", () => {
+      expect(isAuthCaptureExtra(null)).toBe(false);
+      expect(isAuthCaptureExtra(undefined)).toBe(false);
+    });
+
+    it("rejects non-objects", () => {
+      expect(isAuthCaptureExtra("string")).toBe(false);
+      expect(isAuthCaptureExtra(42)).toBe(false);
+      expect(isAuthCaptureExtra(true)).toBe(false);
+    });
+
+    it("rejects when captureAuthorizer is missing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { captureAuthorizer: _ca, ...rest } = validExtra;
+      expect(isAuthCaptureExtra(rest)).toBe(false);
+    });
+
+    it("rejects when captureDeadline is not a number", () => {
+      expect(isAuthCaptureExtra({ ...validExtra, captureDeadline: "soon" })).toBe(false);
+    });
+
+    it("rejects when feeRecipient is not a string", () => {
+      expect(isAuthCaptureExtra({ ...validExtra, feeRecipient: 42 })).toBe(false);
+    });
+
+    it("rejects when name/version are missing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { name: _n, ...rest } = validExtra;
+      expect(isAuthCaptureExtra(rest)).toBe(false);
+    });
+
+    it("rejects when minFeeBps is missing (required per spec, no implicit default)", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { minFeeBps: _m, ...rest } = validExtra;
+      expect(isAuthCaptureExtra(rest)).toBe(false);
+    });
+
+    it("rejects when maxFeeBps is missing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { maxFeeBps: _m, ...rest } = validExtra;
+      expect(isAuthCaptureExtra(rest)).toBe(false);
+    });
+
+    it("rejects the old commerce-era extra shape", () => {
+      const oldShape = {
+        escrowAddress: "0xeee",
+        operatorAddress: "0xccc",
+        tokenCollector: "0xbbb",
+        name: "USDC",
+        version: "2",
+      };
+      expect(isAuthCaptureExtra(oldShape)).toBe(false);
+    });
+  });
+
+  describe("isEip3009Payload", () => {
+    it("accepts a valid EIP-3009 payload", () => {
+      expect(isEip3009Payload(validEip3009)).toBe(true);
+    });
+
+    it("rejects when authorization is missing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { authorization: _a, ...rest } = validEip3009;
+      expect(isEip3009Payload(rest)).toBe(false);
+    });
+
+    it("rejects when signature is missing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { signature: _s, ...rest } = validEip3009;
+      expect(isEip3009Payload(rest)).toBe(false);
+    });
+
+    it("rejects when salt is missing (regression: salt is required on payload)", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { salt: _salt, ...rest } = validEip3009;
+      expect(isEip3009Payload(rest)).toBe(false);
+    });
+
+    it("rejects a Permit2 payload (no authorization field)", () => {
+      expect(isEip3009Payload(validPermit2)).toBe(false);
+    });
+
+    it("rejects null", () => {
+      expect(isEip3009Payload(null)).toBe(false);
+    });
+  });
+
+  describe("isPermit2Payload", () => {
+    it("accepts a valid Permit2 payload", () => {
+      expect(isPermit2Payload(validPermit2)).toBe(true);
+    });
+
+    it("rejects when permit2Authorization is missing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { permit2Authorization: _p, ...rest } = validPermit2;
+      expect(isPermit2Payload(rest)).toBe(false);
+    });
+
+    it("rejects when salt is missing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { salt: _s, ...rest } = validPermit2;
+      expect(isPermit2Payload(rest)).toBe(false);
+    });
+
+    it("rejects when permit2Authorization.from is not a string", () => {
+      expect(
+        isPermit2Payload({
+          ...validPermit2,
+          permit2Authorization: { ...validPermit2.permit2Authorization, from: 42 },
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects an EIP-3009 payload", () => {
+      expect(isPermit2Payload(validEip3009)).toBe(false);
+    });
+  });
+
+  describe("isAuthCapturePayload (discriminated union)", () => {
+    it("accepts both EIP-3009 and Permit2 payloads", () => {
+      expect(isAuthCapturePayload(validEip3009)).toBe(true);
+      expect(isAuthCapturePayload(validPermit2)).toBe(true);
+    });
+
+    it("rejects shapes that match neither variant", () => {
+      expect(isAuthCapturePayload({ signature: "0xabcd", salt: "0x00" })).toBe(false);
+      expect(isAuthCapturePayload({ authorization: {} })).toBe(false);
+      expect(isAuthCapturePayload(null)).toBe(false);
+    });
+  });
+});

--- a/typescript/packages/mechanisms/evm/tsup.config.ts
+++ b/typescript/packages/mechanisms/evm/tsup.config.ts
@@ -18,6 +18,7 @@ const baseConfig = {
     "batch-settlement/server/file-storage": "src/batch-settlement/server/fileStorage.ts",
     "batch-settlement/server/redis-storage": "src/batch-settlement/server/redisStorage.ts",
     "batch-settlement/facilitator/index": "src/batch-settlement/facilitator/index.ts",
+    "auth-capture/client/index": "src/auth-capture/client/index.ts",
   },
   dts: {
     resolve: true,


### PR DESCRIPTION
At [x402r.org](https://x402r.org), we've been working on refundable payments for x402. This PR splits the client portion out of the full auth-capture implementation (#2308) so agents can detect and sign auth-capture payloads now, ahead of full server and facilitator SDK support.

## Included

- `@x402/evm/auth-capture/client`: `AuthCaptureEvmScheme` implementing `SchemeNetworkClient`. Validates the spec-mandated `extra` fields, reconstructs the canonical PaymentInfo struct, computes the payer-agnostic PaymentInfo hash, and signs an ERC-3009 `ReceiveWithAuthorization` (default) or Permit2 `PermitTransferFrom` (`assetTransferMethod: "permit2"`).
- Supporting modules: payload/extra types and guards, nonce/salt derivation and signing helpers, canonical escrow and collector constants, CAIP-2 chain parsing.
- 51 unit tests covering payload construction, nonce/salt derivation, type guards, and the ERC-3009 vs Permit2 paths.
- Client example under `examples/typescript/clients/auth-capture/`.

The client is pure signing: no on-chain reads, no contract calls. capture/void/refund are operator-side and out of client scope; authorize vs charge produce an identical client signature, so the client is agnostic to that choice.

## Spec

Implements the client half of the auth-capture scheme (spec #1425). Original proposals: #1011, #834.

## Disclosure

This PR was written with AI assistance (Claude Code). Output was reviewed before submission per the AI guidance in `CONTRIBUTING.md`.

## Tests

- Unit tests: 51/51 passing
- Package builds; client subpath export resolves
- Client example typechecks
