### PR TITLE
feat(python/batch-settlement): add cross-language byte-equivalence fixtures

### DIFF
--- a/.github/workflows/check_byte_equivalence_fixtures.yml
+++ b/.github/workflows/check_byte_equivalence_fixtures.yml
@@ -1,0 +1,35 @@
+name: Check Batch-Settlement Fixture Drift
+on: [pull_request]
+
+permissions:
+  contents: read
+  id-token: none
+
+jobs:
+  check-byte-equivalence-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Install generator deps
+        working-directory: ./python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0
+        run: npm install --no-audit --no-fund --ignore-scripts
+
+      - name: Regenerate fixtures
+        working-directory: ./python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0
+        run: npx tsx _generator.ts
+
+      - name: Check for drift
+        run: |
+          if ! git diff --exit-code -- 'python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L[0-9].[0-9]*.json'; then
+            echo "::error::Batch-settlement byte-equivalence fixtures are out of date."
+            echo "::error::Regenerate locally:"
+            echo "::error::  cd python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0"
+            echo "::error::  npm install && npx tsx _generator.ts"
+            echo "::error::Then commit the updated JSON files."
+            exit 1
+          fi

--- a/python/x402/changelog.d/+batch-settlement-byte-equiv-fixtures.feature.md
+++ b/python/x402/changelog.d/+batch-settlement-byte-equiv-fixtures.feature.md
@@ -1,0 +1,8 @@
+Add pure EIP-712 digest helpers for the batch-settlement EVM scheme
+(`compute_channel_config_digest` / `compute_voucher_digest` /
+`compute_refund_digest` / `compute_claim_batch_digest` in
+`x402.mechanisms.evm.batch_settlement.digest`), plus cross-language
+byte-equivalence fixtures under
+`tests/fixtures/batch-settlement-byte-equivalence/v0/` and a CI
+drift-detection job. The existing `compute_channel_id` helper is now a thin
+wrapper over `compute_channel_config_digest` (behaviour unchanged).

--- a/python/x402/mechanisms/evm/batch_settlement/__init__.py
+++ b/python/x402/mechanisms/evm/batch_settlement/__init__.py
@@ -22,6 +22,12 @@ from .constants import (
     SCHEME_BATCH_SETTLEMENT,
     VOUCHER_TYPES,
 )
+from .digest import (
+    compute_channel_config_digest,
+    compute_claim_batch_digest,
+    compute_refund_digest,
+    compute_voucher_digest,
+)
 from .types import (
     AuthorizerSigner,
     ChannelConfig,
@@ -96,5 +102,9 @@ __all__ = [
     "is_settle_payload",
     "is_enriched_refund_payload",
     "compute_channel_id",
+    "compute_channel_config_digest",
+    "compute_voucher_digest",
+    "compute_refund_digest",
+    "compute_claim_batch_digest",
     "get_batch_settlement_eip712_domain",
 ]

--- a/python/x402/mechanisms/evm/batch_settlement/digest.py
+++ b/python/x402/mechanisms/evm/batch_settlement/digest.py
@@ -1,0 +1,155 @@
+"""EIP-712 digest helpers for the batch-settlement EVM scheme.
+
+These pure functions expose the raw 32-byte EIP-712 message digest for each
+signing-time primitive: ``ChannelConfig``, ``Voucher``, ``Refund``, and
+``ClaimBatch``. The internal computation mirrors ``compute_channel_id`` in
+``.utils`` but returns the digest as ``bytes`` rather than a 0x-prefixed hex
+string and covers all four signing surfaces in one module.
+
+The existing ``compute_channel_id`` is kept as a thin wrapper over
+``compute_channel_config_digest`` for the common case where the caller wants
+the channelId as a wire-shape hex string.
+
+Use cases beyond cross-language byte-equivalence testing:
+
+- Client-side pre-computation of a digest before delegating signing to a
+  hardware wallet or remote KMS.
+- Debug / observability of EIP-712 wire payloads.
+- Future Go / Java SDK conformance against shared JSON fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from eth_account.messages import encode_typed_data
+    from eth_utils import keccak
+except ImportError as e:
+    raise ImportError(
+        "EVM mechanism requires ethereum packages. Install with: pip install x402[evm]"
+    ) from e
+
+from .constants import (
+    CHANNEL_CONFIG_TYPES,
+    CLAIM_BATCH_TYPES,
+    REFUND_TYPES,
+    VOUCHER_TYPES,
+)
+from .types import ChannelConfig
+from .utils import (
+    channel_config_to_signing_message,
+    coerce_bytes32,
+    get_batch_settlement_eip712_domain,
+)
+
+
+def _eip712_digest(
+    domain: dict[str, Any],
+    types: dict[str, list[dict[str, str]]],
+    message: dict[str, Any],
+) -> bytes:
+    """Compute the EIP-712 32-byte digest from (domain, types, message).
+
+    Internal helper. Mirrors the well-formed signing path in ``eth_account``:
+    ``digest = keccak(0x19 || 0x01 || domainSeparator || structHash)``.
+    """
+    signable = encode_typed_data(
+        domain_data=domain,
+        message_types=types,
+        message_data=message,
+    )
+    # SignableMessage exposes .version = b"\x01", .header = domainSeparator,
+    # .body = structHash. The 0x19 prefix is prepended explicitly.
+    return keccak(b"\x19" + signable.version + signable.header + signable.body)
+
+
+def compute_channel_config_digest(config: ChannelConfig, chain_id: int) -> bytes:
+    """Return the EIP-712 digest of a ``ChannelConfig`` (used as channelId).
+
+    Returns the digest as raw 32 bytes. Callers that want the 0x-hex form
+    should use ``compute_channel_id`` in ``.utils``, which wraps this function.
+
+    Args:
+        config: Immutable channel configuration.
+        chain_id: Numeric EVM chain id (bound into the EIP-712 domain).
+    """
+    domain = get_batch_settlement_eip712_domain(chain_id)
+    message = channel_config_to_signing_message(config)
+    return _eip712_digest(domain, CHANNEL_CONFIG_TYPES, message)
+
+
+def compute_voucher_digest(
+    channel_id: str | bytes,
+    max_claimable_amount: int | str,
+    chain_id: int,
+) -> bytes:
+    """Return the EIP-712 digest of a ``Voucher`` (channelId + maxClaimableAmount).
+
+    Args:
+        channel_id: 0x-prefixed hex string or raw 32 bytes.
+        max_claimable_amount: Cumulative ceiling as int or numeric string.
+        chain_id: Numeric EVM chain id.
+    """
+    domain = get_batch_settlement_eip712_domain(chain_id)
+    message = {
+        "channelId": coerce_bytes32(channel_id),
+        "maxClaimableAmount": int(max_claimable_amount),
+    }
+    return _eip712_digest(domain, VOUCHER_TYPES, message)
+
+
+def compute_refund_digest(
+    channel_id: str | bytes,
+    nonce: int | str,
+    amount: int | str,
+    chain_id: int,
+) -> bytes:
+    """Return the EIP-712 digest of a ``Refund`` (channelId + nonce + amount).
+
+    Args:
+        channel_id: 0x-prefixed hex string or raw 32 bytes.
+        nonce: Refund replay-protection nonce.
+        amount: Refund amount (uint128 range).
+        chain_id: Numeric EVM chain id.
+    """
+    domain = get_batch_settlement_eip712_domain(chain_id)
+    message = {
+        "channelId": coerce_bytes32(channel_id),
+        "nonce": int(nonce),
+        "amount": int(amount),
+    }
+    return _eip712_digest(domain, REFUND_TYPES, message)
+
+
+def compute_claim_batch_digest(
+    claims: list[dict[str, Any]],
+    chain_id: int,
+) -> bytes:
+    """Return the EIP-712 digest of a ``ClaimBatch`` (array of ClaimEntry).
+
+    Args:
+        claims: List of dicts, each with ``channelId`` (0x-hex or bytes),
+            ``maxClaimableAmount`` (int or numeric string), and ``totalClaimed``
+            (int or numeric string).
+        chain_id: Numeric EVM chain id.
+    """
+    domain = get_batch_settlement_eip712_domain(chain_id)
+    normalized_claims = [
+        {
+            "channelId": coerce_bytes32(c["channelId"]),
+            "maxClaimableAmount": int(c["maxClaimableAmount"]),
+            "totalClaimed": int(c["totalClaimed"]),
+        }
+        for c in claims
+    ]
+    message = {"claims": normalized_claims}
+    return _eip712_digest(domain, CLAIM_BATCH_TYPES, message)
+
+
+__all__ = [
+    "compute_channel_config_digest",
+    "compute_voucher_digest",
+    "compute_refund_digest",
+    "compute_claim_batch_digest",
+]

--- a/python/x402/mechanisms/evm/batch_settlement/utils.py
+++ b/python/x402/mechanisms/evm/batch_settlement/utils.py
@@ -6,8 +6,7 @@ import re
 from typing import Any
 
 try:
-    from eth_account.messages import encode_typed_data
-    from eth_utils import keccak, to_checksum_address
+    from eth_utils import to_checksum_address
 except ImportError as e:
     raise ImportError(
         "EVM mechanism requires ethereum packages. Install with: pip install x402[evm]"
@@ -18,7 +17,6 @@ from .constants import (
     BATCH_SETTLEMENT_ADDRESS,
     BATCH_SETTLEMENT_DOMAIN_NAME,
     BATCH_SETTLEMENT_DOMAIN_VERSION,
-    CHANNEL_CONFIG_TYPES,
 )
 from .errors import ERR_CHANNEL_ID_MISMATCH, ERR_INVALID_CHANNEL_ID
 from .types import ChannelConfig
@@ -114,6 +112,9 @@ def coerce_bytes32(value: str | bytes) -> bytes:
 def compute_channel_id(config: ChannelConfig, network_or_chain_id: str | int) -> str:
     """Compute the chain-bound channel id for a `ChannelConfig`.
 
+    Thin wrapper over `compute_channel_config_digest` that returns the digest
+    as a 0x-prefixed hex string, matching the wire-shape used as channelId.
+
     Args:
         config: Immutable channel configuration.
         network_or_chain_id: CAIP-2 network identifier or numeric chain id.
@@ -121,18 +122,13 @@ def compute_channel_id(config: ChannelConfig, network_or_chain_id: str | int) ->
     Returns:
         0x-prefixed bytes32 channel id.
     """
-    chain_id = _resolve_chain_id(network_or_chain_id)
-    domain = get_batch_settlement_eip712_domain(chain_id)
-    message = _channel_config_message(config)
+    # Local import: digest.py imports helpers (channel_config_to_signing_message,
+    # coerce_bytes32, get_batch_settlement_eip712_domain) from this module at top
+    # level, so a top-level import here would form an import cycle.
+    from .digest import compute_channel_config_digest
 
-    signable = encode_typed_data(
-        domain_data=domain,
-        message_types=CHANNEL_CONFIG_TYPES,
-        message_data=message,
-    )
-    # SignableMessage: .version = b"\x01", .header = domainSeparator, .body = structHash.
-    # EIP-712 digest is keccak(0x19 || 0x01 || domainSeparator || structHash).
-    digest = keccak(b"\x19" + signable.version + signable.header + signable.body)
+    chain_id = _resolve_chain_id(network_or_chain_id)
+    digest = compute_channel_config_digest(config, chain_id)
     return "0x" + digest.hex()
 
 

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/.gitignore
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/.gitignore
@@ -1,0 +1,4 @@
+# Local install artifacts for the self-contained generator.
+# The committed fixtures (L2.*.json) are the source-of-truth verified by CI.
+node_modules/
+package-lock.json

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.1-channel-config.json
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.1-channel-config.json
@@ -1,0 +1,58 @@
+{
+  "vector": "L2.1",
+  "description": "ChannelConfig EIP-712 digest (baseline flat scalar struct; also serves as channelId).",
+  "domain": {
+    "name": "x402 Batch Settlement",
+    "version": "1",
+    "chainId": 84532,
+    "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+  },
+  "primaryType": "ChannelConfig",
+  "types": {
+    "ChannelConfig": [
+      {
+        "name": "payer",
+        "type": "address"
+      },
+      {
+        "name": "payerAuthorizer",
+        "type": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "name": "receiverAuthorizer",
+        "type": "address"
+      },
+      {
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "name": "withdrawDelay",
+        "type": "uint40"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32"
+      }
+    ]
+  },
+  "input": {
+    "payer": "0x1111111111111111111111111111111111111111",
+    "payerAuthorizer": "0x1111111111111111111111111111111111111111",
+    "receiver": "0x3333333333333333333333333333333333333333",
+    "receiverAuthorizer": "0x4444444444444444444444444444444444444444",
+    "token": "0x5555555555555555555555555555555555555555",
+    "withdrawDelay": 900,
+    "salt": "0x0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "expected_digest": "0x5aa0c653042e33ac01a3e944daa7f9a9db4153a203423551757927bca6a8fc93",
+  "meta": {
+    "generator": "_generator.ts",
+    "generator_version": "1",
+    "viem_version": "2.48.11"
+  }
+}

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.2-voucher.json
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.2-voucher.json
@@ -1,0 +1,33 @@
+{
+  "vector": "L2.2",
+  "description": "Voucher EIP-712 digest (flat scalar: channelId from L2.1 + maxClaimableAmount).",
+  "domain": {
+    "name": "x402 Batch Settlement",
+    "version": "1",
+    "chainId": 84532,
+    "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+  },
+  "primaryType": "Voucher",
+  "types": {
+    "Voucher": [
+      {
+        "name": "channelId",
+        "type": "bytes32"
+      },
+      {
+        "name": "maxClaimableAmount",
+        "type": "uint128"
+      }
+    ]
+  },
+  "input": {
+    "channelId": "0x5aa0c653042e33ac01a3e944daa7f9a9db4153a203423551757927bca6a8fc93",
+    "maxClaimableAmount": "1000"
+  },
+  "expected_digest": "0xbeff2905f91d80520e5393b1e6aa65c14c4cf4f6e9c36eab64b49a90953873e2",
+  "meta": {
+    "generator": "_generator.ts",
+    "generator_version": "1",
+    "viem_version": "2.48.11"
+  }
+}

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.3-claim-batch.json
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.3-claim-batch.json
@@ -1,0 +1,48 @@
+{
+  "vector": "L2.3",
+  "description": "ClaimBatch EIP-712 digest (array of ClaimEntry struct; single-entry baseline).",
+  "domain": {
+    "name": "x402 Batch Settlement",
+    "version": "1",
+    "chainId": 84532,
+    "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+  },
+  "primaryType": "ClaimBatch",
+  "types": {
+    "ClaimBatch": [
+      {
+        "name": "claims",
+        "type": "ClaimEntry[]"
+      }
+    ],
+    "ClaimEntry": [
+      {
+        "name": "channelId",
+        "type": "bytes32"
+      },
+      {
+        "name": "maxClaimableAmount",
+        "type": "uint128"
+      },
+      {
+        "name": "totalClaimed",
+        "type": "uint128"
+      }
+    ]
+  },
+  "input": {
+    "claims": [
+      {
+        "channelId": "0x5aa0c653042e33ac01a3e944daa7f9a9db4153a203423551757927bca6a8fc93",
+        "maxClaimableAmount": "1000",
+        "totalClaimed": "500"
+      }
+    ]
+  },
+  "expected_digest": "0xfecd0b3504fb3b63b76003ba280d5303975ed18f1e0332b42b2428389b3569e4",
+  "meta": {
+    "generator": "_generator.ts",
+    "generator_version": "1",
+    "viem_version": "2.48.11"
+  }
+}

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.4-refund.json
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.4-refund.json
@@ -1,0 +1,38 @@
+{
+  "vector": "L2.4",
+  "description": "Refund EIP-712 digest (flat scalar: channelId + nonce + amount).",
+  "domain": {
+    "name": "x402 Batch Settlement",
+    "version": "1",
+    "chainId": 84532,
+    "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+  },
+  "primaryType": "Refund",
+  "types": {
+    "Refund": [
+      {
+        "name": "channelId",
+        "type": "bytes32"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint128"
+      }
+    ]
+  },
+  "input": {
+    "channelId": "0x5aa0c653042e33ac01a3e944daa7f9a9db4153a203423551757927bca6a8fc93",
+    "nonce": "0",
+    "amount": "500"
+  },
+  "expected_digest": "0xc1a94fb1c3b10ade231ee6347ba905daef6c2ce0217deb1901d7f61960e49a49",
+  "meta": {
+    "generator": "_generator.ts",
+    "generator_version": "1",
+    "viem_version": "2.48.11"
+  }
+}

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/README.md
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/README.md
@@ -87,15 +87,22 @@ cross-language byte-equivalence tests against the TS SDK. Without such
 tests, a `viem` change, a Python `eth_account` change, or a spec change
 could silently shift one side's digest while the other stays stable —
 breaking signature recovery in production. These fixtures + the
-drift-detection CI job close that gap for the four signing-time primitives.
-The complementary `collectorData` ABI-encoding equivalence (the 2-stage
-encoding case) is tracked in a follow-up PR.
+drift-detection CI job close that gap for the four
+batch-settlement-internal signing-time primitives (`ChannelConfig`,
+`Voucher`, `Refund`, `ClaimBatch`). The complementary deposit-side
+EIP-712 primitives (ERC-3009 `ReceiveWithAuthorization` and Permit2
+`PermitWitnessTransferFrom`) plus the `collectorData` ABI-encoding
+equivalence (the 2-stage encoding case) are tracked in a follow-up PR
+(#2499 — L2.5–L2.8).
 
 ## Related
 
 - Python digest API: `python/x402/mechanisms/evm/batch_settlement/digest.py`
 - Python verifier test: `python/x402/tests/unit/mechanisms/evm/batch_settlement/test_byte_equivalence_fixtures.py`
-- TS digest source: `typescript/packages/mechanisms/evm/src/batch-settlement/utils.ts`
-  (uses `viem.hashTypedData`)
-- TS EIP-712 type definitions: `typescript/packages/mechanisms/evm/src/batch-settlement/constants.ts`
+- TS EIP-712 type definitions (SSOT mirrored by `_generator.ts`):
+  `typescript/packages/mechanisms/evm/src/batch-settlement/constants.ts`
+- TS digest call sites (each uses `viem.hashTypedData` against the SSOT types):
+  - `ChannelConfig`: `batch-settlement/utils.ts` (`computeChannelId`)
+  - `Voucher`: `batch-settlement/client/voucher.ts` (signer), `batch-settlement/server/verify.ts` & `batch-settlement/facilitator/utils.ts` (verifiers)
+  - `Refund` / `ClaimBatch`: `batch-settlement/authorizerSigner.ts`
 - CI drift check: `.github/workflows/check_byte_equivalence_fixtures.yml`

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/README.md
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/README.md
@@ -1,0 +1,101 @@
+# batch-settlement byte-equivalence fixtures (v0)
+
+Cross-language EIP-712 byte-equivalence fixtures for the `batch-settlement`
+EVM scheme. Each JSON file pins the exact 32-byte digest that the TypeScript
+SDK (via `viem.hashTypedData`) produces for a given input. The Python SDK
+`test_byte_equivalence_fixtures` test re-computes the digest from the same
+input and asserts byte-for-byte equality.
+
+A failure of the verifier — in either direction — means TS / Python / spec
+drift has been introduced, and the operational invariant that
+`ecrecover(digest_TS, sig)` and `ecrecover(digest_Py, sig)` resolve to the
+same signer no longer holds.
+
+## Vectors
+
+| File                          | Vector | EIP-712 primary type | What it pins                                              |
+| ----------------------------- | ------ | -------------------- | --------------------------------------------------------- |
+| `L2.1-channel-config.json`    | L2.1   | `ChannelConfig`      | Flat scalar struct (also serves as channelId)             |
+| `L2.2-voucher.json`           | L2.2   | `Voucher`            | Cumulative voucher (channelId + maxClaimableAmount)       |
+| `L2.3-claim-batch.json`       | L2.3   | `ClaimBatch`         | Array of `ClaimEntry` (nested struct array)               |
+| `L2.4-refund.json`            | L2.4   | `Refund`             | Cooperative refund (channelId + nonce + amount)           |
+
+Each JSON file has the shape:
+
+```jsonc
+{
+  "vector": "L2.x",
+  "description": "…",
+  "domain":      { "name": "x402 Batch Settlement", "version": "1", "chainId": 84532, "verifyingContract": "0x…" },
+  "primaryType": "…",
+  "types":       { "<TypeName>": [ { "name": "…", "type": "…" }, … ] },
+  "input":       { … },
+  "expected_digest": "0x…32 bytes…",
+  "meta": { "generator": "_generator.ts", "generator_version": "1", "viem_version": "…" }
+}
+```
+
+The `expected_digest` is the source-of-truth — it is produced by the TS-side
+generator and the Python-side verifier must match it.
+
+## Regenerating
+
+The generator is self-contained: it imports only `viem` and inlines the
+EIP-712 domain and type definitions. To regenerate:
+
+```bash
+cd python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0
+npm install
+npx tsx _generator.ts
+```
+
+The CI workflow `check_byte_equivalence_fixtures` runs the same command on
+every PR and fails if the regenerated JSON differs from what is committed —
+so silent TS / spec drift is caught immediately.
+
+`node_modules/` and `package-lock.json` are git-ignored locally; the
+committed JSON files are the source-of-truth.
+
+## When to update
+
+Regenerate and commit the new JSON when any of the following change:
+
+- TS SDK EIP-712 type definitions (`typescript/.../batch-settlement/constants.ts`)
+- TS SDK EIP-712 domain (name / version / verifyingContract)
+- `viem` major version in `package.json`
+- This generator's inlined type / domain definitions
+
+If you change the **input** values to keep the same shape but new mock
+addresses, you must also regenerate. Both the input and the digest are part
+of the contract.
+
+## Version pinning
+
+This directory is versioned as `v0/`. If a breaking change to the fixture
+shape is required (e.g. new top-level fields, breaking JSON schema change),
+introduce `v1/` rather than mutating `v0/` so downstream verifiers can
+migrate explicitly.
+
+`viem` is pinned exactly in `package.json` (`"viem": "2.48.11"`, no `^`) so
+that re-running the generator on a fresh machine produces byte-identical
+output.
+
+## Why this exists
+
+The Python SDK was added in #2402 as a single large PR and does not include
+cross-language byte-equivalence tests against the TS SDK. Without such
+tests, a `viem` change, a Python `eth_account` change, or a spec change
+could silently shift one side's digest while the other stays stable —
+breaking signature recovery in production. These fixtures + the
+drift-detection CI job close that gap for the four signing-time primitives.
+The complementary `collectorData` ABI-encoding equivalence (the 2-stage
+encoding case) is tracked in a follow-up PR.
+
+## Related
+
+- Python digest API: `python/x402/mechanisms/evm/batch_settlement/digest.py`
+- Python verifier test: `python/x402/tests/unit/mechanisms/evm/batch_settlement/test_byte_equivalence_fixtures.py`
+- TS digest source: `typescript/packages/mechanisms/evm/src/batch-settlement/utils.ts`
+  (uses `viem.hashTypedData`)
+- TS EIP-712 type definitions: `typescript/packages/mechanisms/evm/src/batch-settlement/constants.ts`
+- CI drift check: `.github/workflows/check_byte_equivalence_fixtures.yml`

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/_generator.ts
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/_generator.ts
@@ -11,9 +11,9 @@
  * script to regenerate the fixtures. The CI drift-detection job will fail
  * if a regenerated fixture differs from the committed one.
  *
- * Run from the monorepo so the workspace `viem` is resolved:
- *   cd typescript/packages/mechanisms/evm
- *   pnpm tsx ../../../../python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/_generator.ts
+ * Run:
+ *   cd python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0
+ *   npm install && npx tsx _generator.ts
  */
 
 import { writeFileSync } from "node:fs";

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/_generator.ts
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/_generator.ts
@@ -1,0 +1,248 @@
+/**
+ * Generates EIP-712 byte-equivalence fixtures for the batch-settlement Python SDK.
+ *
+ * This script is intentionally self-contained: it imports only `viem` and
+ * inlines the EIP-712 domain and type definitions. The output JSON files are
+ * the source-of-truth that the Python `test_byte_equivalence_fixtures` test
+ * verifies against.
+ *
+ * When the TS SDK constants or types change (e.g. a new field is added to
+ * `ChannelConfig`), update the inline definitions below and re-run this
+ * script to regenerate the fixtures. The CI drift-detection job will fail
+ * if a regenerated fixture differs from the committed one.
+ *
+ * Run from the monorepo so the workspace `viem` is resolved:
+ *   cd typescript/packages/mechanisms/evm
+ *   pnpm tsx ../../../../python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/_generator.ts
+ */
+
+import { writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { hashTypedData, type Address, type Hex } from "viem";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// --- Domain (mirrors batch-settlement/constants.ts) ---------------------------
+//
+// Upstream source-of-truth for these constants:
+//   typescript/packages/mechanisms/evm/src/batch-settlement/constants.ts
+// When the SDK constants change, mirror the change here and re-run this
+// generator. The CI drift-detection job will catch a forgotten update.
+
+const BATCH_SETTLEMENT_ADDRESS =
+  "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003" as Address;
+const BATCH_SETTLEMENT_DOMAIN_BASE = {
+  name: "x402 Batch Settlement",
+  version: "1",
+} as const;
+const TEST_CHAIN_ID = 84532; // Base Sepolia
+
+const domain = {
+  ...BATCH_SETTLEMENT_DOMAIN_BASE,
+  chainId: TEST_CHAIN_ID,
+  verifyingContract: BATCH_SETTLEMENT_ADDRESS,
+} as const;
+
+// --- EIP-712 type definitions (mirrors batch-settlement/constants.ts) ---------
+
+const channelConfigTypes = {
+  ChannelConfig: [
+    { name: "payer", type: "address" },
+    { name: "payerAuthorizer", type: "address" },
+    { name: "receiver", type: "address" },
+    { name: "receiverAuthorizer", type: "address" },
+    { name: "token", type: "address" },
+    { name: "withdrawDelay", type: "uint40" },
+    { name: "salt", type: "bytes32" },
+  ],
+} as const;
+
+const voucherTypes = {
+  Voucher: [
+    { name: "channelId", type: "bytes32" },
+    { name: "maxClaimableAmount", type: "uint128" },
+  ],
+} as const;
+
+const refundTypes = {
+  Refund: [
+    { name: "channelId", type: "bytes32" },
+    { name: "nonce", type: "uint256" },
+    { name: "amount", type: "uint128" },
+  ],
+} as const;
+
+const claimBatchTypes = {
+  ClaimBatch: [{ name: "claims", type: "ClaimEntry[]" }],
+  ClaimEntry: [
+    { name: "channelId", type: "bytes32" },
+    { name: "maxClaimableAmount", type: "uint128" },
+    { name: "totalClaimed", type: "uint128" },
+  ],
+} as const;
+
+// --- Vector inputs (aligned with python/x402/tests/.../test_channel.py mocks) -
+
+const PAYER = "0x1111111111111111111111111111111111111111" as Address;
+const RECEIVER = "0x3333333333333333333333333333333333333333" as Address;
+const RECEIVER_AUTHORIZER =
+  "0x4444444444444444444444444444444444444444" as Address;
+const TOKEN = "0x5555555555555555555555555555555555555555" as Address;
+const ZERO_SALT = ("0x" + "00".repeat(32)) as Hex;
+const WITHDRAW_DELAY = 900;
+
+const channelConfigInput = {
+  payer: PAYER,
+  payerAuthorizer: PAYER, // self-authorized baseline
+  receiver: RECEIVER,
+  receiverAuthorizer: RECEIVER_AUTHORIZER,
+  token: TOKEN,
+  withdrawDelay: WITHDRAW_DELAY,
+  salt: ZERO_SALT,
+};
+
+const channelConfigDigest = hashTypedData({
+  domain,
+  types: channelConfigTypes,
+  primaryType: "ChannelConfig",
+  message: channelConfigInput,
+});
+
+const voucherInput = {
+  channelId: channelConfigDigest,
+  maxClaimableAmount: 1000n,
+};
+
+const voucherDigest = hashTypedData({
+  domain,
+  types: voucherTypes,
+  primaryType: "Voucher",
+  message: voucherInput,
+});
+
+const refundInput = {
+  channelId: channelConfigDigest,
+  nonce: 0n,
+  amount: 500n,
+};
+
+const refundDigest = hashTypedData({
+  domain,
+  types: refundTypes,
+  primaryType: "Refund",
+  message: refundInput,
+});
+
+const claimBatchInput = {
+  claims: [
+    {
+      channelId: channelConfigDigest,
+      maxClaimableAmount: 1000n,
+      totalClaimed: 500n,
+    },
+  ],
+};
+
+const claimBatchDigest = hashTypedData({
+  domain,
+  types: claimBatchTypes,
+  primaryType: "ClaimBatch",
+  message: claimBatchInput,
+});
+
+// --- Write fixtures ----------------------------------------------------------
+
+type Fixture = {
+  vector: string;
+  description: string;
+  domain: typeof domain;
+  primaryType: string;
+  types: Record<string, ReadonlyArray<{ name: string; type: string }>>;
+  input: unknown;
+  expected_digest: Hex;
+  meta: {
+    generator: string;
+    generator_version: string;
+    viem_version: string;
+  };
+};
+
+const VIEM_VERSION = "2.48.11"; // mirrors typescript/packages/mechanisms/evm/package.json
+const GENERATOR_VERSION = "1";
+
+function bigintReplacer(_key: string, value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : value;
+}
+
+function writeFixture(name: string, fixture: Fixture): void {
+  const outPath = join(__dirname, `${name}.json`);
+  writeFileSync(outPath, JSON.stringify(fixture, bigintReplacer, 2) + "\n", "utf8");
+  console.log(`wrote ${outPath}`);
+}
+
+writeFixture("L2.1-channel-config", {
+  vector: "L2.1",
+  description:
+    "ChannelConfig EIP-712 digest (baseline flat scalar struct; also serves as channelId).",
+  domain,
+  primaryType: "ChannelConfig",
+  types: channelConfigTypes,
+  input: channelConfigInput,
+  expected_digest: channelConfigDigest,
+  meta: {
+    generator: "_generator.ts",
+    generator_version: GENERATOR_VERSION,
+    viem_version: VIEM_VERSION,
+  },
+});
+
+writeFixture("L2.2-voucher", {
+  vector: "L2.2",
+  description:
+    "Voucher EIP-712 digest (flat scalar: channelId from L2.1 + maxClaimableAmount).",
+  domain,
+  primaryType: "Voucher",
+  types: voucherTypes,
+  input: voucherInput,
+  expected_digest: voucherDigest,
+  meta: {
+    generator: "_generator.ts",
+    generator_version: GENERATOR_VERSION,
+    viem_version: VIEM_VERSION,
+  },
+});
+
+writeFixture("L2.3-claim-batch", {
+  vector: "L2.3",
+  description:
+    "ClaimBatch EIP-712 digest (array of ClaimEntry struct; single-entry baseline).",
+  domain,
+  primaryType: "ClaimBatch",
+  types: claimBatchTypes,
+  input: claimBatchInput,
+  expected_digest: claimBatchDigest,
+  meta: {
+    generator: "_generator.ts",
+    generator_version: GENERATOR_VERSION,
+    viem_version: VIEM_VERSION,
+  },
+});
+
+writeFixture("L2.4-refund", {
+  vector: "L2.4",
+  description:
+    "Refund EIP-712 digest (flat scalar: channelId + nonce + amount).",
+  domain,
+  primaryType: "Refund",
+  types: refundTypes,
+  input: refundInput,
+  expected_digest: refundDigest,
+  meta: {
+    generator: "_generator.ts",
+    generator_version: GENERATOR_VERSION,
+    viem_version: VIEM_VERSION,
+  },
+});

--- a/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/package.json
+++ b/python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "batch-settlement-byte-equivalence-fixtures",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Self-contained generator for batch-settlement EIP-712 byte-equivalence fixtures. Run `npm install && npx tsx _generator.ts` to regenerate.",
+  "type": "module",
+  "scripts": {
+    "generate": "tsx _generator.ts"
+  },
+  "dependencies": {
+    "viem": "2.48.11"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/python/x402/tests/unit/mechanisms/evm/batch_settlement/test_byte_equivalence_fixtures.py
+++ b/python/x402/tests/unit/mechanisms/evm/batch_settlement/test_byte_equivalence_fixtures.py
@@ -1,0 +1,114 @@
+"""Cross-language byte-equivalence verification for batch-settlement EIP-712 digests.
+
+Each JSON fixture under ``tests/fixtures/batch-settlement-byte-equivalence/v0/``
+was produced by the TS-side ``_generator.ts`` (using ``viem.hashTypedData``) and
+records the input plus the ``expected_digest``. This module re-computes the
+digest via the Python SDK and asserts byte-for-byte equivalence.
+
+A failure here means TS SDK / Python SDK / spec drift has been introduced and
+the silent corruption invariant (``ecrecover`` returning a different signer
+between the two implementations) is no longer prevented.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+try:
+    from x402.mechanisms.evm.batch_settlement.digest import (
+        compute_channel_config_digest,
+        compute_claim_batch_digest,
+        compute_refund_digest,
+        compute_voucher_digest,
+    )
+    from x402.mechanisms.evm.batch_settlement.types import ChannelConfig
+except ImportError:
+    pytest.skip("batch_settlement requires evm extras", allow_module_level=True)
+
+
+# Path: this test file lives at
+#   python/x402/tests/unit/mechanisms/evm/batch_settlement/test_byte_equivalence_fixtures.py
+# parents[4] resolves to `python/x402/tests/`, then we append the fixture path.
+FIXTURE_DIR = Path(__file__).parents[4] / "fixtures" / "batch-settlement-byte-equivalence" / "v0"
+
+
+FIXTURE_NAMES = [
+    "L2.1-channel-config",
+    "L2.2-voucher",
+    "L2.3-claim-batch",
+    "L2.4-refund",
+]
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((FIXTURE_DIR / f"{name}.json").read_text())
+
+
+def _python_digest_for(fixture: dict[str, Any]) -> bytes:
+    """Dispatch to the Python digest helper matching the fixture's primaryType."""
+    primary = fixture["primaryType"]
+    chain_id = int(fixture["domain"]["chainId"])
+    inp = fixture["input"]
+
+    if primary == "ChannelConfig":
+        config = ChannelConfig(
+            payer=inp["payer"],
+            payer_authorizer=inp["payerAuthorizer"],
+            receiver=inp["receiver"],
+            receiver_authorizer=inp["receiverAuthorizer"],
+            token=inp["token"],
+            withdraw_delay=int(inp["withdrawDelay"]),
+            salt=inp["salt"],
+        )
+        return compute_channel_config_digest(config, chain_id)
+    if primary == "Voucher":
+        return compute_voucher_digest(
+            inp["channelId"],
+            inp["maxClaimableAmount"],
+            chain_id,
+        )
+    if primary == "Refund":
+        return compute_refund_digest(
+            inp["channelId"],
+            inp["nonce"],
+            inp["amount"],
+            chain_id,
+        )
+    if primary == "ClaimBatch":
+        return compute_claim_batch_digest(
+            inp["claims"],
+            chain_id,
+        )
+    raise AssertionError(f"unknown primaryType in fixture: {primary}")
+
+
+@pytest.mark.parametrize("name", FIXTURE_NAMES)
+def test_byte_equivalence(name: str) -> None:
+    fixture = _load_fixture(name)
+    expected_hex = fixture["expected_digest"]
+    assert expected_hex.startswith("0x"), f"{name}: expected_digest must be 0x-prefixed"
+    expected_bytes = bytes.fromhex(expected_hex[2:])
+    assert len(expected_bytes) == 32, f"{name}: expected_digest must decode to 32 bytes"
+
+    actual_bytes = _python_digest_for(fixture)
+    assert actual_bytes == expected_bytes, (
+        f"{name}: Python SDK digest does not match TS-generated fixture.\n"
+        f"  expected (TS): {expected_hex}\n"
+        f"  actual (Py):   0x{actual_bytes.hex()}"
+    )
+
+
+def test_all_fixture_files_present() -> None:
+    """Guard: every entry in FIXTURE_NAMES has a matching JSON file."""
+    for name in FIXTURE_NAMES:
+        path = FIXTURE_DIR / f"{name}.json"
+        assert path.exists(), f"missing fixture: {path}"
+
+
+def test_fixture_dir_exists() -> None:
+    """Guard against accidental relocation: the fixture directory must resolve."""
+    assert FIXTURE_DIR.is_dir(), f"fixture directory missing: {FIXTURE_DIR}"

--- a/python/x402/tests/unit/mechanisms/evm/batch_settlement/test_byte_equivalence_fixtures.py
+++ b/python/x402/tests/unit/mechanisms/evm/batch_settlement/test_byte_equivalence_fixtures.py
@@ -19,6 +19,11 @@ from typing import Any
 import pytest
 
 try:
+    from x402.mechanisms.evm.batch_settlement.constants import (
+        BATCH_SETTLEMENT_ADDRESS,
+        BATCH_SETTLEMENT_DOMAIN_NAME,
+        BATCH_SETTLEMENT_DOMAIN_VERSION,
+    )
     from x402.mechanisms.evm.batch_settlement.digest import (
         compute_channel_config_digest,
         compute_claim_batch_digest,
@@ -28,6 +33,28 @@ try:
     from x402.mechanisms.evm.batch_settlement.types import ChannelConfig
 except ImportError:
     pytest.skip("batch_settlement requires evm extras", allow_module_level=True)
+
+
+def _assert_fixture_domain_matches_python(fixture: dict[str, Any]) -> None:
+    """Defense-in-depth: fixture-recorded domain matches Python SDK constants.
+
+    The byte-equivalence assertion below catches any drift at the digest layer,
+    but explicit domain crosscheck gives more actionable failure messages
+    (e.g. ``domain.name drifted`` vs the bare ``digest mismatch``).
+    """
+    d = fixture["domain"]
+    assert d["name"] == BATCH_SETTLEMENT_DOMAIN_NAME, (
+        f"fixture domain.name {d['name']!r} drifted from "
+        f"BATCH_SETTLEMENT_DOMAIN_NAME {BATCH_SETTLEMENT_DOMAIN_NAME!r}"
+    )
+    assert d["version"] == BATCH_SETTLEMENT_DOMAIN_VERSION, (
+        f"fixture domain.version {d['version']!r} drifted from "
+        f"BATCH_SETTLEMENT_DOMAIN_VERSION {BATCH_SETTLEMENT_DOMAIN_VERSION!r}"
+    )
+    assert d["verifyingContract"].lower() == BATCH_SETTLEMENT_ADDRESS.lower(), (
+        f"fixture domain.verifyingContract {d['verifyingContract']!r} drifted "
+        f"from BATCH_SETTLEMENT_ADDRESS {BATCH_SETTLEMENT_ADDRESS!r}"
+    )
 
 
 # Path: this test file lives at
@@ -89,6 +116,7 @@ def _python_digest_for(fixture: dict[str, Any]) -> bytes:
 @pytest.mark.parametrize("name", FIXTURE_NAMES)
 def test_byte_equivalence(name: str) -> None:
     fixture = _load_fixture(name)
+    _assert_fixture_domain_matches_python(fixture)
     expected_hex = fixture["expected_digest"]
     assert expected_hex.startswith("0x"), f"{name}: expected_digest must be 0x-prefixed"
     expected_bytes = bytes.fromhex(expected_hex[2:])

--- a/python/x402/tests/unit/mechanisms/evm/batch_settlement/test_digest.py
+++ b/python/x402/tests/unit/mechanisms/evm/batch_settlement/test_digest.py
@@ -1,0 +1,234 @@
+"""Unit tests for batch-settlement digest helpers (`digest.py`).
+
+Sanity + edge case coverage for the four pure EIP-712 digest functions:
+- `compute_channel_config_digest`
+- `compute_voucher_digest`
+- `compute_refund_digest`
+- `compute_claim_batch_digest`
+
+Cross-language byte-equivalence vs. the TS SDK lives in
+`test_byte_equivalence_fixtures.py`; this file covers Python-side invariants
+only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    from eth_utils import keccak
+
+    from x402.mechanisms.evm.batch_settlement.digest import (
+        compute_channel_config_digest,
+        compute_claim_batch_digest,
+        compute_refund_digest,
+        compute_voucher_digest,
+    )
+    from x402.mechanisms.evm.batch_settlement.types import ChannelConfig
+    from x402.mechanisms.evm.batch_settlement.utils import compute_channel_id
+except ImportError:
+    pytest.skip("batch_settlement requires evm extras", allow_module_level=True)
+
+
+# Test vectors aligned with the existing test_channel.py mock pattern
+TEST_CHAIN_ID = 84532  # Base Sepolia
+PAYER_ADDR = "0x1111111111111111111111111111111111111111"
+RECEIVER_ADDR = "0x3333333333333333333333333333333333333333"
+RECEIVER_AUTHORIZER_ADDR = "0x4444444444444444444444444444444444444444"
+TOKEN_ADDR = "0x5555555555555555555555555555555555555555"
+ZERO_SALT = "0x" + "00" * 32
+
+
+def _basic_config(payer_authorizer: str = PAYER_ADDR) -> ChannelConfig:
+    return ChannelConfig(
+        payer=PAYER_ADDR,
+        payer_authorizer=payer_authorizer,
+        receiver=RECEIVER_ADDR,
+        receiver_authorizer=RECEIVER_AUTHORIZER_ADDR,
+        token=TOKEN_ADDR,
+        withdraw_delay=900,
+        salt=ZERO_SALT,
+    )
+
+
+class TestComputeChannelConfigDigest:
+    def test_returns_32_bytes(self):
+        config = _basic_config()
+        digest = compute_channel_config_digest(config, TEST_CHAIN_ID)
+        assert isinstance(digest, bytes)
+        assert len(digest) == 32
+
+    def test_deterministic(self):
+        config = _basic_config()
+        d1 = compute_channel_config_digest(config, TEST_CHAIN_ID)
+        d2 = compute_channel_config_digest(config, TEST_CHAIN_ID)
+        assert d1 == d2
+
+    def test_chain_id_affects_digest(self):
+        config = _basic_config()
+        d_sepolia = compute_channel_config_digest(config, TEST_CHAIN_ID)
+        d_mainnet = compute_channel_config_digest(config, 1)
+        assert d_sepolia != d_mainnet
+
+    def test_field_change_affects_digest(self):
+        """Changing any signed field (here: withdraw_delay) must change the digest."""
+        config_a = _basic_config()
+        config_b = ChannelConfig(
+            payer=PAYER_ADDR,
+            payer_authorizer=PAYER_ADDR,
+            receiver=RECEIVER_ADDR,
+            receiver_authorizer=RECEIVER_AUTHORIZER_ADDR,
+            token=TOKEN_ADDR,
+            withdraw_delay=901,
+            salt=ZERO_SALT,
+        )
+        d_a = compute_channel_config_digest(config_a, TEST_CHAIN_ID)
+        d_b = compute_channel_config_digest(config_b, TEST_CHAIN_ID)
+        assert d_a != d_b
+
+    def test_compute_channel_id_wraps_digest(self):
+        """`compute_channel_id` must equal `"0x" + compute_channel_config_digest.hex()`."""
+        config = _basic_config()
+        cid = compute_channel_id(config, TEST_CHAIN_ID)
+        digest = compute_channel_config_digest(config, TEST_CHAIN_ID)
+        assert cid == "0x" + digest.hex()
+
+    def test_zero_payer_authorizer_normalized(self):
+        """payer_authorizer = '0x0...0' should normalize to the zero address."""
+        config_zero = _basic_config(payer_authorizer="0x" + "00" * 20)
+        config_explicit = _basic_config(
+            payer_authorizer="0x0000000000000000000000000000000000000000"
+        )
+        d_zero = compute_channel_config_digest(config_zero, TEST_CHAIN_ID)
+        d_explicit = compute_channel_config_digest(config_explicit, TEST_CHAIN_ID)
+        assert d_zero == d_explicit
+
+
+class TestComputeVoucherDigest:
+    def test_returns_32_bytes(self):
+        cid = "0x" + "ab" * 32
+        d = compute_voucher_digest(cid, 1000, TEST_CHAIN_ID)
+        assert isinstance(d, bytes)
+        assert len(d) == 32
+
+    def test_accepts_hex_or_bytes_channel_id(self):
+        cid_hex = "0x" + "ab" * 32
+        cid_bytes = bytes.fromhex("ab" * 32)
+        d_hex = compute_voucher_digest(cid_hex, 1000, TEST_CHAIN_ID)
+        d_bytes = compute_voucher_digest(cid_bytes, 1000, TEST_CHAIN_ID)
+        assert d_hex == d_bytes
+
+    def test_amount_int_or_str_equivalent(self):
+        cid = "0x" + "ab" * 32
+        d_int = compute_voucher_digest(cid, 1000, TEST_CHAIN_ID)
+        d_str = compute_voucher_digest(cid, "1000", TEST_CHAIN_ID)
+        assert d_int == d_str
+
+    def test_amount_change_affects_digest(self):
+        cid = "0x" + "ab" * 32
+        d1 = compute_voucher_digest(cid, 1000, TEST_CHAIN_ID)
+        d2 = compute_voucher_digest(cid, 1001, TEST_CHAIN_ID)
+        assert d1 != d2
+
+    def test_chain_id_change_affects_digest(self):
+        cid = "0x" + "ab" * 32
+        d_sepolia = compute_voucher_digest(cid, 1000, TEST_CHAIN_ID)
+        d_mainnet = compute_voucher_digest(cid, 1000, 1)
+        assert d_sepolia != d_mainnet
+
+
+class TestComputeRefundDigest:
+    def test_returns_32_bytes(self):
+        cid = "0x" + "ab" * 32
+        d = compute_refund_digest(cid, 0, 500, TEST_CHAIN_ID)
+        assert isinstance(d, bytes)
+        assert len(d) == 32
+
+    def test_nonce_change_affects_digest(self):
+        cid = "0x" + "ab" * 32
+        d0 = compute_refund_digest(cid, 0, 500, TEST_CHAIN_ID)
+        d1 = compute_refund_digest(cid, 1, 500, TEST_CHAIN_ID)
+        assert d0 != d1
+
+    def test_amount_change_affects_digest(self):
+        cid = "0x" + "ab" * 32
+        d_a = compute_refund_digest(cid, 0, 500, TEST_CHAIN_ID)
+        d_b = compute_refund_digest(cid, 0, 501, TEST_CHAIN_ID)
+        assert d_a != d_b
+
+    def test_differs_from_voucher_digest_with_overlapping_inputs(self):
+        """Refund and Voucher share channelId but use different EIP-712 types.
+
+        Different typeHash should yield different digests even when the
+        numeric payloads overlap.
+        """
+        cid = "0x" + "ab" * 32
+        v = compute_voucher_digest(cid, 500, TEST_CHAIN_ID)
+        r = compute_refund_digest(cid, 0, 500, TEST_CHAIN_ID)
+        assert v != r
+
+
+class TestComputeClaimBatchDigest:
+    def test_returns_32_bytes(self):
+        cid = "0x" + "ab" * 32
+        d = compute_claim_batch_digest(
+            [{"channelId": cid, "maxClaimableAmount": 1000, "totalClaimed": 500}],
+            TEST_CHAIN_ID,
+        )
+        assert isinstance(d, bytes)
+        assert len(d) == 32
+
+    def test_empty_claims_pinned(self):
+        """Empty claims array digest is pinned to catch encoding drift in unit tests.
+
+        The TS-generated cross-language fixtures (`L2.3`) cover the populated
+        case; this pin covers the empty edge case and gives the digest test
+        suite a drift sensor even without the TS fixture round-trip.
+        """
+        d = compute_claim_batch_digest([], TEST_CHAIN_ID)
+        assert isinstance(d, bytes)
+        assert len(d) == 32
+        expected = bytes.fromhex("57b970b91bd540b4ca1aa82be12adbc9b769b6e978e5285b2a859bd989304e9a")
+        assert d == expected, f"empty-claims digest changed: 0x{d.hex()}"
+
+    def test_claim_order_affects_digest(self):
+        """Array of struct: element order matters in EIP-712 encoding."""
+        cid_a = "0x" + "ab" * 32
+        cid_b = "0x" + "cd" * 32
+        claims_ab = [
+            {"channelId": cid_a, "maxClaimableAmount": 1000, "totalClaimed": 500},
+            {"channelId": cid_b, "maxClaimableAmount": 2000, "totalClaimed": 800},
+        ]
+        claims_ba = [
+            {"channelId": cid_b, "maxClaimableAmount": 2000, "totalClaimed": 800},
+            {"channelId": cid_a, "maxClaimableAmount": 1000, "totalClaimed": 500},
+        ]
+        d_ab = compute_claim_batch_digest(claims_ab, TEST_CHAIN_ID)
+        d_ba = compute_claim_batch_digest(claims_ba, TEST_CHAIN_ID)
+        assert d_ab != d_ba
+
+    def test_multiple_claims_differ_from_single(self):
+        cid = "0x" + "ab" * 32
+        single = compute_claim_batch_digest(
+            [{"channelId": cid, "maxClaimableAmount": 1000, "totalClaimed": 500}],
+            TEST_CHAIN_ID,
+        )
+        multi = compute_claim_batch_digest(
+            [
+                {"channelId": cid, "maxClaimableAmount": 1000, "totalClaimed": 500},
+                {"channelId": cid, "maxClaimableAmount": 1000, "totalClaimed": 500},
+            ],
+            TEST_CHAIN_ID,
+        )
+        assert single != multi
+
+
+class TestKeccakSanity:
+    """Sanity: our environment's keccak matches the well-known constant.
+
+    Guards against accidental use of SHA3-256 instead of Keccak-256.
+    """
+
+    def test_empty_keccak_is_known_value(self):
+        expected = bytes.fromhex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+        assert keccak(b"") == expected


### PR DESCRIPTION
## Description

Adds cross-language byte-equivalence fixtures for the `batch-settlement` EVM scheme, plus the public Python digest API needed to verify them.

After #2402 landed the Python `batch-settlement` SDK, the TS and Python sides share no `bytes`-level fixture that pins their EIP-712 digests against the same input. A future change in `viem`, in the Python `eth_account` library, or in the spec itself could silently shift one side's digest while the other stays stable — breaking `ecrecover` resolution in production with no test signal. This PR closes that gap for the four signing-time primitives (`ChannelConfig` / `Voucher` / `Refund` / `ClaimBatch`). The complementary `collectorData` ABI-encoding equivalence is tracked separately as a follow-up.

## What this PR adds

The three parts together form a single concern — **keeping the cross-language EIP-712 digest invariant verifiable over time**:

```mermaid
flowchart LR
    TS["TS SDK<br/>(viem.hashTypedData)"]
    JSON["Static JSON fixtures<br/>L2.1-L2.4"]
    PY["Python SDK<br/>compute_*_digest"]
    CI["CI: regenerate &<br/>diff committed JSON"]

    TS -->|"(1) generates"| JSON
    JSON -->|"(2) verifier re-computes<br/>and byte-compares"| PY
    JSON -.->|"(3) drift guard"| CI
```

1. **Python digest API** (`mechanisms/evm/batch_settlement/digest.py`): four pure functions returning the 32-byte EIP-712 digest of each signing-time primitive. The existing `compute_channel_id` is now a thin wrapper over `compute_channel_config_digest`, so behaviour is unchanged but external callers can now obtain raw digests without going through the signer / verifier paths (useful for client-side pre-computation, debug / observability, and any future Go / Java verifier).

2. **Static JSON fixtures** (`tests/fixtures/batch-settlement-byte-equivalence/v0/`): four vectors (`L2.1` ChannelConfig, `L2.2` Voucher, `L2.3` ClaimBatch, `L2.4` Refund) generated by `_generator.ts` using `viem.hashTypedData`. Each file records the input, the expected 32-byte digest, the EIP-712 domain + types, and generator metadata. The Python verifier test (`test_byte_equivalence_fixtures.py`) reads each JSON, re-computes the digest via the Python SDK, and asserts byte-for-byte equality.

3. **CI drift detection** (`.github/workflows/check_byte_equivalence_fixtures.yml`): on every PR, the workflow re-runs the TS generator and fails if the regenerated JSON differs from the committed JSON. This catches TS-side or spec drift; the Python verifier test catches Python-side drift. Together the two guard the invariant from both directions.

## Test plan

```bash
cd python/x402

# 1. Python digest API unit tests (20 tests)
uv run pytest tests/unit/mechanisms/evm/batch_settlement/test_digest.py

# 2. Cross-language byte-equivalence verifier (4 vectors + 2 guards = 6 tests)
uv run pytest tests/unit/mechanisms/evm/batch_settlement/test_byte_equivalence_fixtures.py

# 3. Regression: existing batch-settlement tests
uv run pytest tests/unit/mechanisms/evm/batch_settlement/
```

All green locally (20 + 6 + 57 = 83 tests, full module 372 tests). The drift-detection workflow can also be reproduced locally:

```bash
cd python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0
npm install && npx tsx _generator.ts
# expected: no `git diff` against the committed JSON
```

## Acknowledged scope choices

- **Fixture path**: placed at `python/x402/tests/fixtures/...` rather than a repo-root `fixtures/` directory. The latter is being established in #2412 by another contributor; this PR avoids the top-level-precedent overhead and keeps the scope cleanly inside the python label. If `fixtures/` graduates, this directory can be promoted later in a separate PR — the naming `batch-settlement-byte-equivalence` already preserves the cross-language intent.

- **Generator is self-contained**: `_generator.ts` inlines the EIP-712 domain and type definitions and depends only on `viem`. Drift between the inlined definitions and the TS SDK constants is caught by the drift-detection job via the regenerated digest, not by structural comparison. This avoids cross-package `@x402/evm` workspace coupling in a python tree.

- **TS SDK exports unchanged**: only the digest helpers are added on the Python side. The TS SDK already exports `computeChannelId`; adding parity helpers (`computeVoucherDigest` etc) on the TS side is out of scope here and is a natural follow-up if you'd like it.

- **L2.5 / L2.6 deferred**: the ERC-3009 deposit nonce and the `collectorData` ABI encoding (the dynamic-bytes-of-tuple case where 2-stage encoding errors historically appear in TS↔Python interop) are out of scope here and tracked separately so this PR stays scoped to the fixture-format + digest-API establishment.

## Refs

- #2061 (TS batch-settlement) — introduced the wire shape
- #2402 (Python batch-settlement) — landed the Python SDK
- #2199 (closed) — earlier Python port draft that prefigured this work, including discussion of cross-language test vectors.

Happy to split this into per-component PRs if that's preferred.
