### PR TITLE
spec(batch-settlement): add corrective-402 recovery contract spec and reference vectors

### DIFF
--- a/docs/schemes/batch-settlement-recovery-vectors/v0/README.md
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/README.md
@@ -1,0 +1,62 @@
+# batch-settlement recovery vectors (v0)
+
+Machine-readable test vectors for the corrective-402 recovery contract specified in [`../batch-settlement-recovery.mdx`](../batch-settlement-recovery.mdx).
+
+Each JSON file describes a single recovery scenario as a sequence of `(client request → server response)` pairs, plus the expected client behaviour and the wire-level invariants that must hold.
+
+## Files
+
+| File | Scenario | Recovery outcome |
+| --- | --- | --- |
+| `happy-path.json` | Stale local cumulative | Single retry succeeds |
+| `loop-guard.json` | Retry also returns corrective 402 | Client emits hard error (`PERSISTENT_STALE`) |
+| `cas-conflict.json` | Concurrent same-channel requests, one wins | Loser recovers via single retry, tagged separately for telemetry |
+
+## Vector schema
+
+Each file has this shape:
+
+```jsonc
+{
+  "scenario": "<id>",
+  "description": "<human-readable summary>",
+  "channel": {
+    "channel_id": "0x…",
+    "domain": { "name": "x402 Batch Settlement", "version": "1", "chainId": 84532, "verifyingContract": "0x…" }
+  },
+  "initial_state": {
+    "onchain_total_claimed": "<wei>",
+    "server_charged_cumulative": "<wei>",
+    "client_local_cumulative": "<wei>",
+    "comment": "<optional human note about the precondition>"
+  },
+  "steps": [
+    { "step": <n>, "actor": "client" | "client_a" | "client_b" | "server",
+      "action": "<text>",
+      "request": { … } /* OR */ "response": { … } }
+  ],
+  "expected_client_behaviour": { "after_step_<n>": "<text>" },
+  "invariants": [ "<text>" ]
+}
+```
+
+`signature` fields are placeholders. EIP-712 signing is independently pinned by the [byte-equivalence fixtures](../../../../python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/) and does not affect the recovery state-machine. SDK integration tests can use any deterministic signing key; the recovery contract is independent of signature validity.
+
+## How SDK integration tests use these vectors
+
+A conformant SDK should read each `steps` entry in order and:
+
+1. **`actor: "client"` with `request`** — construct the request shape from the vector, sign with a test key (any deterministic signer is fine), submit to a test server.
+2. **`actor: "server"` with `response`** — assert the server's response matches the vector's status and `extra.channelState` shape, byte-by-byte where possible.
+3. After each step, evaluate `expected_client_behaviour.after_step_<n>` as the contract the SDK's client implementation must satisfy (e.g. parse and verify `channelState`, retry exactly once, emit a specific telemetry label, escalate to hard error).
+4. At the end of the sequence, assert all `invariants` still hold for the captured state.
+
+Two SDKs implementing the same vector will produce byte-identical request bodies (modulo signatures) and state transitions, and either both pass or both fail at the same step. That is the convergence property these vectors exist to provide.
+
+## Version pinning
+
+This directory is `v0/`. Breaking changes to the schema (new top-level fields, removed fields, semantics change) will be introduced as `v1/` rather than mutating `v0/`, so downstream SDK tests can pin the version they implement against. Adding new scenarios under the same schema is non-breaking and stays in `v0/`.
+
+## Why vectors, not just spec prose
+
+Spec prose tells implementers *what* the recovery contract is; the vectors fix *exactly* what each wire payload looks like, what state transitions occur, and what the client must do after each step. Two SDKs implementing the same prose can diverge in edge-case interpretation (is `total_claimed > charged_cumulative_amount` valid? does a `cas_conflict` telemetry label apply when `charged_cumulative_amount` is unchanged?). Two SDKs implementing the same vectors converge by construction.

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/README.md
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/README.md
@@ -21,21 +21,21 @@ Each file has this shape:
   "scenario": "<id>",
   "description": "<human-readable summary>",
   "channel": {
-    "channel_id": "0x…",
+    "channelId": "0x…",
     "domain": { "name": "x402 Batch Settlement", "version": "1", "chainId": 84532, "verifyingContract": "0x…" }
   },
-  "initial_state": {
-    "onchain_total_claimed": "<wei>",
-    "server_charged_cumulative": "<wei>",
-    "client_local_cumulative": "<wei>",
+  "initialState": {
+    "onchainTotalClaimed": "<wei>",
+    "serverChargedCumulative": "<wei>",
+    "clientLocalCumulative": "<wei>",
     "comment": "<optional human note about the precondition>"
   },
   "steps": [
-    { "step": <n>, "actor": "client" | "client_a" | "client_b" | "server",
+    { "step": <n>, "actor": "client" | "clientA" | "clientB" | "server",
       "action": "<text>",
       "request": { … } /* OR */ "response": { … } }
   ],
-  "expected_client_behaviour": { "after_step_<n>": "<text>" },
+  "expectedClientBehaviour": { "afterStep<n>": "<text>" },
   "invariants": [ "<text>" ]
 }
 ```
@@ -48,7 +48,7 @@ A conformant SDK should read each `steps` entry in order and:
 
 1. **`actor: "client"` with `request`** — construct the request shape from the vector, sign with a test key (any deterministic signer is fine), submit to a test server.
 2. **`actor: "server"` with `response`** — assert the server's response matches the vector's status and `extra.channelState` shape, byte-by-byte where possible.
-3. After each step, evaluate `expected_client_behaviour.after_step_<n>` as the contract the SDK's client implementation must satisfy (e.g. parse and verify `channelState`, retry exactly once, emit a specific telemetry label, escalate to hard error).
+3. After each step, evaluate `expectedClientBehaviour.afterStep<n>` as the contract the SDK's client implementation must satisfy (e.g. parse and verify `channelState`, retry exactly once, emit a specific telemetry label, escalate to hard error).
 4. At the end of the sequence, assert all `invariants` still hold for the captured state.
 
 Two SDKs implementing the same vector will produce byte-identical request bodies (modulo signatures) and state transitions, and either both pass or both fail at the same step. That is the convergence property these vectors exist to provide.
@@ -59,4 +59,4 @@ This directory is `v0/`. Breaking changes to the schema (new top-level fields, r
 
 ## Why vectors, not just spec prose
 
-Spec prose tells implementers *what* the recovery contract is; the vectors fix *exactly* what each wire payload looks like, what state transitions occur, and what the client must do after each step. Two SDKs implementing the same prose can diverge in edge-case interpretation (is `total_claimed > charged_cumulative_amount` valid? does a `cas_conflict` telemetry label apply when `charged_cumulative_amount` is unchanged?). Two SDKs implementing the same vectors converge by construction.
+Spec prose tells implementers *what* the recovery contract is; the vectors fix *exactly* what each wire payload looks like, what state transitions occur, and what the client must do after each step. Two SDKs implementing the same prose can diverge in edge-case interpretation (is `totalClaimed > chargedCumulativeAmount` valid? does a `cas_conflict` telemetry label apply when `chargedCumulativeAmount` is unchanged?). Two SDKs implementing the same vectors converge by construction.

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/README.md
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/README.md
@@ -9,8 +9,10 @@ Each JSON file describes a single recovery scenario as a sequence of `(client re
 | File | Scenario | Recovery outcome |
 | --- | --- | --- |
 | `happy-path.json` | Stale local cumulative | Single retry succeeds |
-| `loop-guard.json` | Retry also returns corrective 402 | Client emits hard error (`PERSISTENT_STALE`) |
-| `cas-conflict.json` | Concurrent same-channel requests, one wins | Loser recovers via single retry, tagged separately for telemetry |
+| `invalid-corrective-state.json` | Onchain claimed exceeds server cumulative | Client emits hard error (`INVALID_CORRECTIVE_STATE`) without retry |
+| `loop-guard.json` | Retry returns corrective 402 with an advanced cumulative | Client emits hard error (`PERSISTENT_STALE`) |
+| `loop-guard-unchanged.json` | Retry returns corrective 402 with an unchanged cumulative | Client emits the same hard error (`PERSISTENT_STALE`) |
+| `cas-conflict.json` | Concurrent same-channel requests, one wins | Loser recovers via single retry; CAS is an optional suspected cause |
 
 ## Vector schema
 
@@ -59,4 +61,4 @@ This directory is `v0/`. Breaking changes to the schema (new top-level fields, r
 
 ## Why vectors, not just spec prose
 
-Spec prose tells implementers *what* the recovery contract is; the vectors fix *exactly* what each wire payload looks like, what state transitions occur, and what the client must do after each step. Two SDKs implementing the same prose can diverge in edge-case interpretation (is `totalClaimed > chargedCumulativeAmount` valid? does a `cas_conflict` telemetry label apply when `chargedCumulativeAmount` is unchanged?). Two SDKs implementing the same vectors converge by construction.
+Spec prose tells implementers *what* the recovery contract is; the vectors fix *exactly* what each wire payload looks like, what state transitions occur, and what the client must do after each step. Two SDKs implementing the same prose can diverge in edge-case interpretation (is `totalClaimed > chargedCumulativeAmount` valid? does the loop guard apply when the second `chargedCumulativeAmount` is unchanged? can a client infer a CAS conflict from a wire-identical corrective response?). Two SDKs implementing the same vectors converge by construction.

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/README.md
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/README.md
@@ -13,6 +13,7 @@ Each JSON file describes a single recovery scenario as a sequence of `(client re
 | `loop-guard.json` | Retry returns corrective 402 with an advanced cumulative | Client emits hard error (`PERSISTENT_STALE`) |
 | `loop-guard-unchanged.json` | Retry returns corrective 402 with an unchanged cumulative | Client emits the same hard error (`PERSISTENT_STALE`) |
 | `cas-conflict.json` | Concurrent same-channel requests, one wins | Loser recovers via single retry; CAS is an optional suspected cause |
+| `transient-state-unavailable.json` | Onchain read needed to verify the snapshot is unavailable | Client emits non-terminal `TRANSIENT_STATE_UNAVAILABLE`; no mutation, signature, or retry, and no loop-guard attempt consumed |
 
 ## Vector schema
 
@@ -30,6 +31,7 @@ Each file has this shape:
     "onchainTotalClaimed": "<wei>",
     "serverChargedCumulative": "<wei>",
     "clientLocalCumulative": "<wei>",
+    "onchainReadAvailable": <bool>,   /* optional, defaults to true; false pins that the trust-but-verify read cannot complete */
     "comment": "<optional human note about the precondition>"
   },
   "steps": [

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/cas-conflict.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/cas-conflict.json
@@ -1,6 +1,6 @@
 {
   "scenario": "cas-conflict",
-  "description": "Two clients (or two in-flight requests from the same client) sign vouchers against the same prior cumulative; one wins the race, the other receives corrective 402 and recovers with a single retry. Wire-identical to happy-path, but operationally distinct (normal contention, not stale local state).",
+  "description": "Two clients (or two in-flight requests from the same client) sign vouchers against the same prior cumulative; one wins the race, the other receives corrective 402 and recovers with a single retry. The response is wire-identical to happy-path, so CAS is an optional suspected cause rather than a normative protocol outcome.",
   "channel": {
     "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
     "domain": {
@@ -79,7 +79,7 @@
     {
       "step": 5,
       "actor": "clientB",
-      "action": "Recovery: verify totalClaimed onchain, advance local cumulative to 110, sign new voucher with maxClaimableAmount = 120, retry exactly once. Telemetry label is recovery.cas_conflict, not recovery.stale_state — B's prior local view was current, it lost a race.",
+      "action": "Recovery: verify totalClaimed onchain, advance local cumulative to 110, sign new voucher with maxClaimableAmount = 120, retry exactly once. Emit the normative recovery.stale_state outcome. An implementation with supporting evidence may additionally record cas_conflict as a suspected diagnostic cause.",
       "request": {
         "voucher": {
           "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
@@ -107,12 +107,12 @@
     }
   ],
   "expectedClientBehaviour": {
-    "afterStep4ClientB": "Same recovery as happy-path: parse channelState, verify totalClaimed onchain, update local cumulative, sign new voucher, retry exactly once. Telemetry label MUST be recovery.cas_conflict rather than recovery.stale_state — distinguishing the two lets operators identify normal contention (expected, especially at high request rates on a shared channel) from unexpected drift (worth investigating).",
+    "afterStep4ClientB": "Same recovery as happy-path: parse channelState, verify totalClaimed onchain, update local cumulative, sign new voucher, retry exactly once, and emit recovery.stale_state. Because the corrective response does not prove its cause, cas_conflict MAY be recorded only as a suspected diagnostic cause when the implementation has supporting evidence. The optional diagnostic MUST NOT alter recovery behaviour.",
     "afterStep6ClientB": "Accept response. Update local cumulative to 120. Effective charge for B's request = 10."
   },
   "invariants": [
-    "The wire shape of the corrective 402 in step 4 is byte-identical to the corrective 402 in happy-path.json step 2; only the precondition (both clients consistent before the race) and the telemetry label differ.",
+    "The wire shape of the corrective 402 in step 4 is byte-identical to the corrective 402 in happy-path.json step 2; the client therefore emits the same normative recovery.stale_state outcome.",
     "Recovery still completes in a single retry, so the loop guard (max 1 retry) is not triggered.",
-    "When CAS conflicts are frequent on a single channel, the application should consider serialising requests through that channel rather than relying on recovery as the steady-state path; recovery is for occasional races, not for replacing application-level concurrency control."
+    "If supporting evidence indicates frequent CAS conflicts on a single channel, the application should consider serialising requests through that channel rather than relying on recovery as the steady-state path; recovery is for occasional races, not for replacing application-level concurrency control."
   ]
 }

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/cas-conflict.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/cas-conflict.json
@@ -2,7 +2,7 @@
   "scenario": "cas-conflict",
   "description": "Two clients (or two in-flight requests from the same client) sign vouchers against the same prior cumulative; one wins the race, the other receives corrective 402 and recovers with a single retry. Wire-identical to happy-path, but operationally distinct (normal contention, not stale local state).",
   "channel": {
-    "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
     "domain": {
       "name": "x402 Batch Settlement",
       "version": "1",
@@ -10,105 +10,105 @@
       "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
     }
   },
-  "initial_state": {
-    "onchain_total_claimed": "0",
-    "server_charged_cumulative": "100",
-    "client_a_local_cumulative": "100",
-    "client_b_local_cumulative": "100",
-    "comment": "Both clients (or workers) start with a consistent and up-to-date view (charged_cumulative_amount = 100). They independently sign vouchers for the same channel; A's request arrives at the server first."
+  "initialState": {
+    "onchainTotalClaimed": "0",
+    "serverChargedCumulative": "100",
+    "clientALocalCumulative": "100",
+    "clientBLocalCumulative": "100",
+    "comment": "Both clients (or workers) start with a consistent and up-to-date view (chargedCumulativeAmount = 100). They independently sign vouchers for the same channel; A's request arrives at the server first."
   },
   "steps": [
     {
       "step": 1,
-      "actor": "client_a",
-      "action": "POST with voucher max_claimable_amount = 110 (charge = 10 on top of 100).",
+      "actor": "clientA",
+      "action": "POST with voucher maxClaimableAmount = 110 (charge = 10 on top of 100).",
       "request": {
         "voucher": {
-          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
-          "max_claimable_amount": "110",
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "110",
           "signature": "<placeholder, signed by client A>"
         },
-        "request_charge": "10"
+        "requestCharge": "10"
       }
     },
     {
       "step": 2,
       "actor": "server",
-      "action": "Accept A's voucher; advance server charged_cumulative_amount to 110.",
+      "action": "Accept A's voucher; advance server chargedCumulativeAmount to 110.",
       "response": {
         "status": 200,
         "extra": {
           "channelState": {
-            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
             "balance": "1000",
-            "total_claimed": "0",
-            "charged_cumulative_amount": "110"
+            "totalClaimed": "0",
+            "chargedCumulativeAmount": "110"
           }
         }
       }
     },
     {
       "step": 3,
-      "actor": "client_b",
-      "action": "POST with voucher max_claimable_amount = 110 (same numeric charge as A, signed against the same prior cumulative 100). B did not see A's request before signing.",
+      "actor": "clientB",
+      "action": "POST with voucher maxClaimableAmount = 110 (same numeric charge as A, signed against the same prior cumulative 100). B did not see A's request before signing.",
       "request": {
         "voucher": {
-          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
-          "max_claimable_amount": "110",
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "110",
           "signature": "<placeholder, signed by client B>"
         },
-        "request_charge": "10"
+        "requestCharge": "10"
       }
     },
     {
       "step": 4,
       "actor": "server",
-      "action": "Server's charged_cumulative_amount is now 110 (advanced by A). B's voucher does not strictly exceed it. Return corrective 402.",
+      "action": "Server's chargedCumulativeAmount is now 110 (advanced by A). B's voucher does not strictly exceed it. Return corrective 402.",
       "response": {
         "status": 402,
         "extra": {
           "channelState": {
-            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
             "balance": "1000",
-            "total_claimed": "0",
-            "charged_cumulative_amount": "110"
+            "totalClaimed": "0",
+            "chargedCumulativeAmount": "110"
           }
         }
       }
     },
     {
       "step": 5,
-      "actor": "client_b",
-      "action": "Recovery: verify total_claimed onchain, advance local cumulative to 110, sign new voucher with max_claimable_amount = 120, retry exactly once. Telemetry label is recovery.cas_conflict, not recovery.stale_state — B's prior local view was current, it lost a race.",
+      "actor": "clientB",
+      "action": "Recovery: verify totalClaimed onchain, advance local cumulative to 110, sign new voucher with maxClaimableAmount = 120, retry exactly once. Telemetry label is recovery.cas_conflict, not recovery.stale_state — B's prior local view was current, it lost a race.",
       "request": {
         "voucher": {
-          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
-          "max_claimable_amount": "120",
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "120",
           "signature": "<placeholder, signed by client B>"
         },
-        "request_charge": "10"
+        "requestCharge": "10"
       }
     },
     {
       "step": 6,
       "actor": "server",
-      "action": "Accept B's retry; advance server charged_cumulative_amount to 120.",
+      "action": "Accept B's retry; advance server chargedCumulativeAmount to 120.",
       "response": {
         "status": 200,
         "extra": {
           "channelState": {
-            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
             "balance": "1000",
-            "total_claimed": "0",
-            "charged_cumulative_amount": "120"
+            "totalClaimed": "0",
+            "chargedCumulativeAmount": "120"
           }
         }
       }
     }
   ],
-  "expected_client_behaviour": {
-    "after_step_4_client_b": "Same recovery as happy-path: parse channelState, verify total_claimed onchain, update local cumulative, sign new voucher, retry exactly once. Telemetry label MUST be recovery.cas_conflict rather than recovery.stale_state — distinguishing the two lets operators identify normal contention (expected, especially at high request rates on a shared channel) from unexpected drift (worth investigating).",
-    "after_step_6_client_b": "Accept response. Update local cumulative to 120. Effective charge for B's request = 10."
+  "expectedClientBehaviour": {
+    "afterStep4ClientB": "Same recovery as happy-path: parse channelState, verify totalClaimed onchain, update local cumulative, sign new voucher, retry exactly once. Telemetry label MUST be recovery.cas_conflict rather than recovery.stale_state — distinguishing the two lets operators identify normal contention (expected, especially at high request rates on a shared channel) from unexpected drift (worth investigating).",
+    "afterStep6ClientB": "Accept response. Update local cumulative to 120. Effective charge for B's request = 10."
   },
   "invariants": [
     "The wire shape of the corrective 402 in step 4 is byte-identical to the corrective 402 in happy-path.json step 2; only the precondition (both clients consistent before the race) and the telemetry label differ.",

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/cas-conflict.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/cas-conflict.json
@@ -1,0 +1,118 @@
+{
+  "scenario": "cas-conflict",
+  "description": "Two clients (or two in-flight requests from the same client) sign vouchers against the same prior cumulative; one wins the race, the other receives corrective 402 and recovers with a single retry. Wire-identical to happy-path, but operationally distinct (normal contention, not stale local state).",
+  "channel": {
+    "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "domain": {
+      "name": "x402 Batch Settlement",
+      "version": "1",
+      "chainId": 84532,
+      "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+    }
+  },
+  "initial_state": {
+    "onchain_total_claimed": "0",
+    "server_charged_cumulative": "100",
+    "client_a_local_cumulative": "100",
+    "client_b_local_cumulative": "100",
+    "comment": "Both clients (or workers) start with a consistent and up-to-date view (charged_cumulative_amount = 100). They independently sign vouchers for the same channel; A's request arrives at the server first."
+  },
+  "steps": [
+    {
+      "step": 1,
+      "actor": "client_a",
+      "action": "POST with voucher max_claimable_amount = 110 (charge = 10 on top of 100).",
+      "request": {
+        "voucher": {
+          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "max_claimable_amount": "110",
+          "signature": "<placeholder, signed by client A>"
+        },
+        "request_charge": "10"
+      }
+    },
+    {
+      "step": 2,
+      "actor": "server",
+      "action": "Accept A's voucher; advance server charged_cumulative_amount to 110.",
+      "response": {
+        "status": 200,
+        "extra": {
+          "channelState": {
+            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "total_claimed": "0",
+            "charged_cumulative_amount": "110"
+          }
+        }
+      }
+    },
+    {
+      "step": 3,
+      "actor": "client_b",
+      "action": "POST with voucher max_claimable_amount = 110 (same numeric charge as A, signed against the same prior cumulative 100). B did not see A's request before signing.",
+      "request": {
+        "voucher": {
+          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "max_claimable_amount": "110",
+          "signature": "<placeholder, signed by client B>"
+        },
+        "request_charge": "10"
+      }
+    },
+    {
+      "step": 4,
+      "actor": "server",
+      "action": "Server's charged_cumulative_amount is now 110 (advanced by A). B's voucher does not strictly exceed it. Return corrective 402.",
+      "response": {
+        "status": 402,
+        "extra": {
+          "channelState": {
+            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "total_claimed": "0",
+            "charged_cumulative_amount": "110"
+          }
+        }
+      }
+    },
+    {
+      "step": 5,
+      "actor": "client_b",
+      "action": "Recovery: verify total_claimed onchain, advance local cumulative to 110, sign new voucher with max_claimable_amount = 120, retry exactly once. Telemetry label is recovery.cas_conflict, not recovery.stale_state — B's prior local view was current, it lost a race.",
+      "request": {
+        "voucher": {
+          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "max_claimable_amount": "120",
+          "signature": "<placeholder, signed by client B>"
+        },
+        "request_charge": "10"
+      }
+    },
+    {
+      "step": 6,
+      "actor": "server",
+      "action": "Accept B's retry; advance server charged_cumulative_amount to 120.",
+      "response": {
+        "status": 200,
+        "extra": {
+          "channelState": {
+            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "total_claimed": "0",
+            "charged_cumulative_amount": "120"
+          }
+        }
+      }
+    }
+  ],
+  "expected_client_behaviour": {
+    "after_step_4_client_b": "Same recovery as happy-path: parse channelState, verify total_claimed onchain, update local cumulative, sign new voucher, retry exactly once. Telemetry label MUST be recovery.cas_conflict rather than recovery.stale_state — distinguishing the two lets operators identify normal contention (expected, especially at high request rates on a shared channel) from unexpected drift (worth investigating).",
+    "after_step_6_client_b": "Accept response. Update local cumulative to 120. Effective charge for B's request = 10."
+  },
+  "invariants": [
+    "The wire shape of the corrective 402 in step 4 is byte-identical to the corrective 402 in happy-path.json step 2; only the precondition (both clients consistent before the race) and the telemetry label differ.",
+    "Recovery still completes in a single retry, so the loop guard (max 1 retry) is not triggered.",
+    "When CAS conflicts are frequent on a single channel, the application should consider serialising requests through that channel rather than relying on recovery as the steady-state path; recovery is for occasional races, not for replacing application-level concurrency control."
+  ]
+}

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/happy-path.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/happy-path.json
@@ -2,7 +2,7 @@
   "scenario": "happy-path",
   "description": "Stale local cumulative recovered by a single retry against the server's authoritative state.",
   "channel": {
-    "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
     "domain": {
       "name": "x402 Batch Settlement",
       "version": "1",
@@ -10,10 +10,10 @@
       "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
     }
   },
-  "initial_state": {
-    "onchain_total_claimed": "0",
-    "server_charged_cumulative": "100",
-    "client_local_cumulative": "0",
+  "initialState": {
+    "onchainTotalClaimed": "0",
+    "serverChargedCumulative": "100",
+    "clientLocalCumulative": "0",
     "comment": "Client believes the channel is fresh (e.g. restarted from disk and lost local state); server has already charged 100 from prior requests that have not yet been claimed onchain."
   },
   "steps": [
@@ -23,25 +23,25 @@
       "action": "POST a paid request with a voucher signed against the stale local cumulative.",
       "request": {
         "voucher": {
-          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
-          "max_claimable_amount": "10",
-          "signature": "<placeholder; signing covered by ../../../../python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.2-voucher.json>"
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "10",
+          "signature": "<placeholder; voucher signing semantics pinned by byte-equivalence fixtures in #2489>"
         },
-        "request_charge": "10"
+        "requestCharge": "10"
       }
     },
     {
       "step": 2,
       "actor": "server",
-      "action": "Reject the voucher (server.charged_cumulative_amount ≥ voucher.max_claimable_amount) and return the authoritative channel state.",
+      "action": "Reject the voucher (server.chargedCumulativeAmount ≥ voucher.maxClaimableAmount) and return the authoritative channel state.",
       "response": {
         "status": 402,
         "extra": {
           "channelState": {
-            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
             "balance": "1000",
-            "total_claimed": "0",
-            "charged_cumulative_amount": "100"
+            "totalClaimed": "0",
+            "chargedCumulativeAmount": "100"
           }
         }
       }
@@ -49,40 +49,40 @@
     {
       "step": 3,
       "actor": "client",
-      "action": "Verify total_claimed against the onchain BatchSettlement.channels(channel_id) call. Replace local cumulative with charged_cumulative_amount (100). Sign a new voucher with max_claimable_amount = charged_cumulative_amount + request_charge = 110. Retry exactly once.",
+      "action": "Verify totalClaimed against the onchain BatchSettlement.channels(channelId) call. Replace local cumulative with chargedCumulativeAmount (100). Sign a new voucher with maxClaimableAmount = chargedCumulativeAmount + requestCharge = 110. Retry exactly once.",
       "request": {
         "voucher": {
-          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
-          "max_claimable_amount": "110",
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "110",
           "signature": "<placeholder>"
         },
-        "request_charge": "10"
+        "requestCharge": "10"
       }
     },
     {
       "step": 4,
       "actor": "server",
-      "action": "Accept the retried voucher. Advance server charged_cumulative_amount to 110.",
+      "action": "Accept the retried voucher. Advance server chargedCumulativeAmount to 110.",
       "response": {
         "status": 200,
         "extra": {
           "channelState": {
-            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
             "balance": "1000",
-            "total_claimed": "0",
-            "charged_cumulative_amount": "110"
+            "totalClaimed": "0",
+            "chargedCumulativeAmount": "110"
           }
         }
       }
     }
   ],
-  "expected_client_behaviour": {
-    "after_step_2": "Detect corrective 402, parse channelState, verify total_claimed against onchain BatchSettlement.channels(channel_id), replace local cumulative with charged_cumulative_amount, sign new voucher, retry exactly once. Emit telemetry label recovery.stale_state.",
-    "after_step_4": "Accept response. Effective charge for this request = request_charge = 10. Update local cumulative to 110."
+  "expectedClientBehaviour": {
+    "afterStep2": "Detect corrective 402, parse channelState, verify totalClaimed against onchain BatchSettlement.channels(channelId), replace local cumulative with chargedCumulativeAmount, sign new voucher, retry exactly once. Emit telemetry label recovery.stale_state.",
+    "afterStep4": "Accept response. Effective charge for this request = requestCharge = 10. Update local cumulative to 110."
   },
   "invariants": [
-    "onchain.total_claimed (0) ≤ server.charged_cumulative_amount (100 → 110) ≤ voucher.max_claimable_amount (110 after retry).",
-    "The client must verify total_claimed against the onchain channel state before trusting charged_cumulative_amount; the server's value is only used to advance the local cumulative ceiling, never to confirm onchain truth.",
+    "onchain.totalClaimed (0) ≤ server.chargedCumulativeAmount (100 → 110) ≤ voucher.maxClaimableAmount (110 after retry).",
+    "The client must verify totalClaimed against the onchain channel state before trusting chargedCumulativeAmount; the server's value is only used to advance the local cumulative ceiling, never to confirm onchain truth.",
     "Retry happens at most once. A second corrective 402 must escalate to a hard error (see loop-guard.json)."
   ]
 }

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/happy-path.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/happy-path.json
@@ -1,0 +1,88 @@
+{
+  "scenario": "happy-path",
+  "description": "Stale local cumulative recovered by a single retry against the server's authoritative state.",
+  "channel": {
+    "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "domain": {
+      "name": "x402 Batch Settlement",
+      "version": "1",
+      "chainId": 84532,
+      "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+    }
+  },
+  "initial_state": {
+    "onchain_total_claimed": "0",
+    "server_charged_cumulative": "100",
+    "client_local_cumulative": "0",
+    "comment": "Client believes the channel is fresh (e.g. restarted from disk and lost local state); server has already charged 100 from prior requests that have not yet been claimed onchain."
+  },
+  "steps": [
+    {
+      "step": 1,
+      "actor": "client",
+      "action": "POST a paid request with a voucher signed against the stale local cumulative.",
+      "request": {
+        "voucher": {
+          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "max_claimable_amount": "10",
+          "signature": "<placeholder; signing covered by ../../../../python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/L2.2-voucher.json>"
+        },
+        "request_charge": "10"
+      }
+    },
+    {
+      "step": 2,
+      "actor": "server",
+      "action": "Reject the voucher (server.charged_cumulative_amount ≥ voucher.max_claimable_amount) and return the authoritative channel state.",
+      "response": {
+        "status": 402,
+        "extra": {
+          "channelState": {
+            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "total_claimed": "0",
+            "charged_cumulative_amount": "100"
+          }
+        }
+      }
+    },
+    {
+      "step": 3,
+      "actor": "client",
+      "action": "Verify total_claimed against the onchain BatchSettlement.channels(channel_id) call. Replace local cumulative with charged_cumulative_amount (100). Sign a new voucher with max_claimable_amount = charged_cumulative_amount + request_charge = 110. Retry exactly once.",
+      "request": {
+        "voucher": {
+          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "max_claimable_amount": "110",
+          "signature": "<placeholder>"
+        },
+        "request_charge": "10"
+      }
+    },
+    {
+      "step": 4,
+      "actor": "server",
+      "action": "Accept the retried voucher. Advance server charged_cumulative_amount to 110.",
+      "response": {
+        "status": 200,
+        "extra": {
+          "channelState": {
+            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "total_claimed": "0",
+            "charged_cumulative_amount": "110"
+          }
+        }
+      }
+    }
+  ],
+  "expected_client_behaviour": {
+    "after_step_2": "Detect corrective 402, parse channelState, verify total_claimed against onchain BatchSettlement.channels(channel_id), replace local cumulative with charged_cumulative_amount, sign new voucher, retry exactly once. Emit telemetry label recovery.stale_state.",
+    "after_step_4": "Accept response. Effective charge for this request = request_charge = 10. Update local cumulative to 110."
+  },
+  "invariants": [
+    "onchain.total_claimed (0) ≤ server.charged_cumulative_amount (100 → 110) ≤ voucher.max_claimable_amount (110 after retry).",
+    "The client must verify total_claimed against the onchain channel state before trusting charged_cumulative_amount; the server's value is only used to advance the local cumulative ceiling, never to confirm onchain truth.",
+    "Retry happens at most once. A second corrective 402 must escalate to a hard error (see loop-guard.json)."
+  ]
+}

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/invalid-corrective-state.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/invalid-corrective-state.json
@@ -1,0 +1,59 @@
+{
+  "scenario": "invalid-corrective-state",
+  "description": "The server returns a corrective snapshot whose chargedCumulativeAmount is below the authoritative onchain totalClaimed. The client must fail closed without mutating state, signing, or retrying.",
+  "channel": {
+    "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "domain": {
+      "name": "x402 Batch Settlement",
+      "version": "1",
+      "chainId": 84532,
+      "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+    }
+  },
+  "initialState": {
+    "onchainTotalClaimed": "150",
+    "serverChargedCumulative": "100",
+    "clientLocalCumulative": "0",
+    "comment": "The server restored stale cumulative state after an onchain claim had already advanced totalClaimed. No retry voucher constructed from chargedCumulativeAmount = 100 can satisfy the contract's onchain lower bound of 150."
+  },
+  "steps": [
+    {
+      "step": 1,
+      "actor": "client",
+      "action": "POST a paid request with a voucher constructed from local cumulative 0.",
+      "request": {
+        "voucher": {
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "10",
+          "signature": "<placeholder>"
+        },
+        "requestCharge": "10"
+      }
+    },
+    {
+      "step": 2,
+      "actor": "server",
+      "action": "Return a corrective 402 from stale server state with chargedCumulativeAmount = 100.",
+      "response": {
+        "status": 402,
+        "extra": {
+          "channelState": {
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "totalClaimed": "150",
+            "chargedCumulativeAmount": "100"
+          }
+        }
+      }
+    }
+  ],
+  "expectedClientBehaviour": {
+    "afterStep2": "Read BatchSettlement.channels(channelId), observe authoritative totalClaimed = 150, and reject the corrective snapshot because 150 > 100. Emit hard error INVALID_CORRECTIVE_STATE and telemetry label recovery.invalid_corrective_state. Do not update local channel state, do not sign a replacement voucher, and do not retry."
+  },
+  "invariants": [
+    "A valid corrective snapshot must satisfy onchain.totalClaimed ≤ server.chargedCumulativeAmount; this snapshot violates that invariant (150 > 100).",
+    "The client local cumulative remains 0 because invalid corrective state is never persisted.",
+    "No replacement voucher is signed and no retry request is sent.",
+    "Recovery requires the server to reconcile its local cumulative state with onchain totalClaimed before issuing another corrective response."
+  ]
+}

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/loop-guard-unchanged.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/loop-guard-unchanged.json
@@ -1,0 +1,88 @@
+{
+  "scenario": "loop-guard-unchanged",
+  "description": "The corrected retry receives another corrective 402 with the same chargedCumulativeAmount. The attempt-based loop guard must emit PERSISTENT_STALE and stop.",
+  "channel": {
+    "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "domain": {
+      "name": "x402 Batch Settlement",
+      "version": "1",
+      "chainId": 84532,
+      "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+    }
+  },
+  "initialState": {
+    "onchainTotalClaimed": "0",
+    "serverChargedCumulative": "100",
+    "clientLocalCumulative": "0",
+    "comment": "The first corrective is valid and the client reconstructs a voucher against it, but the server rejects that corrected voucher without advancing its cumulative. This points to voucher reconstruction, signature, or server verification failure rather than ordinary state drift."
+  },
+  "steps": [
+    {
+      "step": 1,
+      "actor": "client",
+      "action": "POST a paid request with a voucher signed against stale local cumulative 0.",
+      "request": {
+        "voucher": {
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "10",
+          "signature": "<placeholder>"
+        },
+        "requestCharge": "10"
+      }
+    },
+    {
+      "step": 2,
+      "actor": "server",
+      "action": "Return corrective 402 with chargedCumulativeAmount = 100.",
+      "response": {
+        "status": 402,
+        "extra": {
+          "channelState": {
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "totalClaimed": "0",
+            "chargedCumulativeAmount": "100"
+          }
+        }
+      }
+    },
+    {
+      "step": 3,
+      "actor": "client",
+      "action": "Verify totalClaimed onchain, update local cumulative to 100, sign maxClaimableAmount = 110, and perform the single allowed retry.",
+      "request": {
+        "voucher": {
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "110",
+          "signature": "<placeholder>"
+        },
+        "requestCharge": "10"
+      }
+    },
+    {
+      "step": 4,
+      "actor": "server",
+      "action": "Return another corrective 402 with chargedCumulativeAmount still equal to 100.",
+      "response": {
+        "status": 402,
+        "extra": {
+          "channelState": {
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "totalClaimed": "0",
+            "chargedCumulativeAmount": "100"
+          }
+        }
+      }
+    }
+  ],
+  "expectedClientBehaviour": {
+    "afterStep2": "Apply the valid corrective state and retry exactly once, as in happy-path.json.",
+    "afterStep4": "DO NOT sign or retry again. Emit hard error PERSISTENT_STALE, surface it to the caller, and emit telemetry label recovery.persistent_stale. The unchanged cumulative is diagnostic metadata only."
+  },
+  "invariants": [
+    "The loop guard is based on whether recovery has already been attempted for the logical request, not on whether chargedCumulativeAmount changed.",
+    "A second valid corrective response always produces PERSISTENT_STALE and no further retry.",
+    "The unchanged value may help diagnose voucher reconstruction or server verification, but it cannot authorize another automatic recovery attempt."
+  ]
+}

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/loop-guard.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/loop-guard.json
@@ -1,0 +1,88 @@
+{
+  "scenario": "loop-guard",
+  "description": "The retry also receives a corrective 402 with a different charged_cumulative_amount; the client must hard-error and not retry further.",
+  "channel": {
+    "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "domain": {
+      "name": "x402 Batch Settlement",
+      "version": "1",
+      "chainId": 84532,
+      "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+    }
+  },
+  "initial_state": {
+    "onchain_total_claimed": "0",
+    "server_charged_cumulative": "100",
+    "client_local_cumulative": "0",
+    "comment": "Same starting condition as happy-path, but the server's charged_cumulative_amount advances again between step 2 and step 4 — either due to genuine concurrent traffic that keeps winning the race, a server-side bug, or a malicious server intentionally driving the client into a retry loop."
+  },
+  "steps": [
+    {
+      "step": 1,
+      "actor": "client",
+      "action": "POST a paid request with a voucher signed against the stale local cumulative.",
+      "request": {
+        "voucher": {
+          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "max_claimable_amount": "10",
+          "signature": "<placeholder>"
+        },
+        "request_charge": "10"
+      }
+    },
+    {
+      "step": 2,
+      "actor": "server",
+      "action": "Return corrective 402 with charged_cumulative_amount = 100.",
+      "response": {
+        "status": 402,
+        "extra": {
+          "channelState": {
+            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "total_claimed": "0",
+            "charged_cumulative_amount": "100"
+          }
+        }
+      }
+    },
+    {
+      "step": 3,
+      "actor": "client",
+      "action": "Recovery flow as in happy-path: verify total_claimed onchain, update local cumulative to 100, sign new voucher with max_claimable_amount = 110, retry.",
+      "request": {
+        "voucher": {
+          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "max_claimable_amount": "110",
+          "signature": "<placeholder>"
+        },
+        "request_charge": "10"
+      }
+    },
+    {
+      "step": 4,
+      "actor": "server",
+      "action": "Return ANOTHER corrective 402 with a higher charged_cumulative_amount (200), indicating the server's cumulative kept advancing between the two requests. Wire shape is identical to step 2; only the numeric value of charged_cumulative_amount has moved.",
+      "response": {
+        "status": 402,
+        "extra": {
+          "channelState": {
+            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "total_claimed": "0",
+            "charged_cumulative_amount": "200"
+          }
+        }
+      }
+    }
+  ],
+  "expected_client_behaviour": {
+    "after_step_2": "Same as happy-path: detect corrective 402, recovery flow, retry exactly once.",
+    "after_step_4": "DO NOT retry again. Emit hard error with code PERSISTENT_STALE, surface to caller, log channelState for operator diagnosis. Telemetry label: recovery.persistent_stale. The original paid request cannot be completed against this server on this channel; the caller should escalate (e.g. settle outstanding claims onchain, open a new channel, or migrate to a different facilitator)."
+  },
+  "invariants": [
+    "Retry must happen at most ONCE. A second corrective 402 implies persistent server-side drift, a server-side bug, or an adversarial server attempting denial-of-service. None of these are recoverable by further retries from the client.",
+    "recovery.persistent_stale is operationally distinct from recovery.stale_state: the former should alert on the dashboard, the latter is part of normal recovery.",
+    "The server cannot extract money via this attack (the client verifies total_claimed onchain) but can deny service by forcing an unbounded retry loop; the loop guard collapses that surface."
+  ]
+}

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/loop-guard.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/loop-guard.json
@@ -1,8 +1,8 @@
 {
   "scenario": "loop-guard",
-  "description": "The retry also receives a corrective 402 with a different charged_cumulative_amount; the client must hard-error and not retry further.",
+  "description": "The retry also receives a corrective 402 with a different chargedCumulativeAmount; the client must hard-error and not retry further.",
   "channel": {
-    "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
     "domain": {
       "name": "x402 Batch Settlement",
       "version": "1",
@@ -10,11 +10,11 @@
       "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
     }
   },
-  "initial_state": {
-    "onchain_total_claimed": "0",
-    "server_charged_cumulative": "100",
-    "client_local_cumulative": "0",
-    "comment": "Same starting condition as happy-path, but the server's charged_cumulative_amount advances again between step 2 and step 4 — either due to genuine concurrent traffic that keeps winning the race, a server-side bug, or a malicious server intentionally driving the client into a retry loop."
+  "initialState": {
+    "onchainTotalClaimed": "0",
+    "serverChargedCumulative": "100",
+    "clientLocalCumulative": "0",
+    "comment": "Same starting condition as happy-path, but the server's chargedCumulativeAmount advances again between step 2 and step 4 — either due to genuine concurrent traffic that keeps winning the race, a server-side bug, or a malicious server intentionally driving the client into a retry loop."
   },
   "steps": [
     {
@@ -23,25 +23,25 @@
       "action": "POST a paid request with a voucher signed against the stale local cumulative.",
       "request": {
         "voucher": {
-          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
-          "max_claimable_amount": "10",
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "10",
           "signature": "<placeholder>"
         },
-        "request_charge": "10"
+        "requestCharge": "10"
       }
     },
     {
       "step": 2,
       "actor": "server",
-      "action": "Return corrective 402 with charged_cumulative_amount = 100.",
+      "action": "Return corrective 402 with chargedCumulativeAmount = 100.",
       "response": {
         "status": 402,
         "extra": {
           "channelState": {
-            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
             "balance": "1000",
-            "total_claimed": "0",
-            "charged_cumulative_amount": "100"
+            "totalClaimed": "0",
+            "chargedCumulativeAmount": "100"
           }
         }
       }
@@ -49,40 +49,40 @@
     {
       "step": 3,
       "actor": "client",
-      "action": "Recovery flow as in happy-path: verify total_claimed onchain, update local cumulative to 100, sign new voucher with max_claimable_amount = 110, retry.",
+      "action": "Recovery flow as in happy-path: verify totalClaimed onchain, update local cumulative to 100, sign new voucher with maxClaimableAmount = 110, retry.",
       "request": {
         "voucher": {
-          "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
-          "max_claimable_amount": "110",
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "110",
           "signature": "<placeholder>"
         },
-        "request_charge": "10"
+        "requestCharge": "10"
       }
     },
     {
       "step": 4,
       "actor": "server",
-      "action": "Return ANOTHER corrective 402 with a higher charged_cumulative_amount (200), indicating the server's cumulative kept advancing between the two requests. Wire shape is identical to step 2; only the numeric value of charged_cumulative_amount has moved.",
+      "action": "Return ANOTHER corrective 402 with a higher chargedCumulativeAmount (200), indicating the server's cumulative kept advancing between the two requests. Wire shape is identical to step 2; only the numeric value of chargedCumulativeAmount has moved.",
       "response": {
         "status": 402,
         "extra": {
           "channelState": {
-            "channel_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
             "balance": "1000",
-            "total_claimed": "0",
-            "charged_cumulative_amount": "200"
+            "totalClaimed": "0",
+            "chargedCumulativeAmount": "200"
           }
         }
       }
     }
   ],
-  "expected_client_behaviour": {
-    "after_step_2": "Same as happy-path: detect corrective 402, recovery flow, retry exactly once.",
-    "after_step_4": "DO NOT retry again. Emit hard error with code PERSISTENT_STALE, surface to caller, log channelState for operator diagnosis. Telemetry label: recovery.persistent_stale. The original paid request cannot be completed against this server on this channel; the caller should escalate (e.g. settle outstanding claims onchain, open a new channel, or migrate to a different facilitator)."
+  "expectedClientBehaviour": {
+    "afterStep2": "Same as happy-path: detect corrective 402, recovery flow, retry exactly once.",
+    "afterStep4": "DO NOT retry again. Emit hard error with code PERSISTENT_STALE, surface to caller, log channelState for operator diagnosis. Telemetry label: recovery.persistent_stale. The original paid request cannot be completed against this server on this channel; the caller should escalate (e.g. settle outstanding claims onchain, open a new channel, or migrate to a different facilitator)."
   },
   "invariants": [
     "Retry must happen at most ONCE. A second corrective 402 implies persistent server-side drift, a server-side bug, or an adversarial server attempting denial-of-service. None of these are recoverable by further retries from the client.",
     "recovery.persistent_stale is operationally distinct from recovery.stale_state: the former should alert on the dashboard, the latter is part of normal recovery.",
-    "The server cannot extract money via this attack (the client verifies total_claimed onchain) but can deny service by forcing an unbounded retry loop; the loop guard collapses that surface."
+    "The server cannot extract money via this attack (the client verifies totalClaimed onchain) but can deny service by forcing an unbounded retry loop; the loop guard collapses that surface."
   ]
 }

--- a/docs/schemes/batch-settlement-recovery-vectors/v0/transient-state-unavailable.json
+++ b/docs/schemes/batch-settlement-recovery-vectors/v0/transient-state-unavailable.json
@@ -1,0 +1,61 @@
+{
+  "scenario": "transient-state-unavailable",
+  "description": "A corrective 402 arrives carrying a snapshot the client cannot verify, because the onchain read of BatchSettlement.channels(channelId) is unavailable. The snapshot may be perfectly valid; the client simply cannot establish that. The client must not mutate state, sign, or retry, and must surface the condition as non-terminal rather than blaming the server.",
+  "channel": {
+    "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+    "domain": {
+      "name": "x402 Batch Settlement",
+      "version": "1",
+      "chainId": 84532,
+      "verifyingContract": "0x4020074e9dF2ce1deE5A9C1b5c3f541D02a10003"
+    }
+  },
+  "initialState": {
+    "onchainTotalClaimed": "40",
+    "serverChargedCumulative": "50",
+    "clientLocalCumulative": "0",
+    "onchainReadAvailable": false,
+    "comment": "The corrective snapshot satisfies the invariant (40 ≤ 50), so a client that could read the chain would recover on a single retry. This vector holds the chain read unavailable — an RPC transport failure, a node error, or a timeout — so the trust-but-verify step cannot complete."
+  },
+  "steps": [
+    {
+      "step": 1,
+      "actor": "client",
+      "action": "POST a paid request with a voucher constructed from local cumulative 0.",
+      "request": {
+        "voucher": {
+          "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+          "maxClaimableAmount": "10",
+          "signature": "<placeholder>"
+        },
+        "requestCharge": "10"
+      }
+    },
+    {
+      "step": 2,
+      "actor": "server",
+      "action": "Return a corrective 402 with chargedCumulativeAmount = 50.",
+      "response": {
+        "status": 402,
+        "extra": {
+          "channelState": {
+            "channelId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "balance": "1000",
+            "totalClaimed": "40",
+            "chargedCumulativeAmount": "50"
+          }
+        }
+      }
+    }
+  ],
+  "expectedClientBehaviour": {
+    "afterStep2": "Attempt to read BatchSettlement.channels(channelId) and fail to obtain an answer. Surface the non-terminal error TRANSIENT_STATE_UNAVAILABLE with the underlying cause preserved, and emit telemetry label recovery.transient_state_unavailable. Do not update local channel state from the unverified snapshot, do not sign a replacement voucher, and do not retry. Do not emit INVALID_CORRECTIVE_STATE: the invariant was never evaluated, so the snapshot has not been shown to be invalid. The loop-guard attempt count is unchanged, because no replacement voucher was signed."
+  },
+  "invariants": [
+    "The corrective snapshot itself is valid (onchain.totalClaimed 40 ≤ server.chargedCumulativeAmount 50); the failure is in the client's ability to establish that, not in the server's state.",
+    "The client local cumulative remains 0 because an unverified snapshot is never persisted.",
+    "No replacement voucher is signed and no retry request is sent.",
+    "The outcome is non-terminal: the same logical request may be attempted again once the chain read is available, and that attempt starts with a fresh loop-guard budget.",
+    "TRANSIENT_STATE_UNAVAILABLE and INVALID_CORRECTIVE_STATE are mutually exclusive. The first means the invariant could not be evaluated; the second means it was evaluated and violated."
+  ]
+}

--- a/docs/schemes/batch-settlement-recovery.mdx
+++ b/docs/schemes/batch-settlement-recovery.mdx
@@ -16,13 +16,13 @@ server.chargedCumulativeAmount < voucher.maxClaimableAmount   →   accept
 server.chargedCumulativeAmount ≥ voucher.maxClaimableAmount   →   corrective 402
 ```
 
-This happens in three operationally distinct (but wire-identical) situations:
+This happens in three representative situations:
 
-1. **Stale state (happy path)** — the client's local cumulative is behind the server's, for example because a previous response was lost, the client restarted from disk without re-syncing, or the channel was just opened and the client did not see prior charges.
-2. **CAS conflict** — two concurrent requests on the same channel both signed against the same prior cumulative; one arrived first and bumped the server, the other is now stale.
-3. **Persistent server-side drift (pathological)** — the server keeps bumping its cumulative between retries; the client cannot converge. This may be genuine concurrent traffic, a server-side bug, or an adversarial server.
+1. **Stale client state (happy path)** — the client's local cumulative is behind the server's, for example because a previous response was lost, the client restarted from disk without re-syncing, or the channel was just opened and the client did not see prior charges.
+2. **Concurrent advancement** — two concurrent requests on the same channel both signed against the same prior cumulative; one arrived first and bumped the server, so the other request is stale when it arrives. A server-observed compare-and-set failure is one possible cause, but the corrective response does not prove that cause to the client.
+3. **Persistent failure (pathological)** — the corrected retry also receives a corrective response. The server cumulative may have advanced again, or it may be unchanged because voucher reconstruction or server verification is faulty. In either case, the client cannot complete the logical request through another automatic retry.
 
-Cases (1) and (2) are recoverable by a single retry. Case (3) is what the loop guard prevents.
+Cases (1) and (2) have the same wire-visible protocol state and are recoverable by a single retry. Case (3) is what the loop guard prevents.
 
 ## Invariant
 
@@ -33,6 +33,8 @@ onchain.totalClaimed   ≤   server.chargedCumulativeAmount   ≤   voucher.maxC
 ```
 
 The middle term is monotone non-decreasing per channel; the left term lags it by at most one batched `claim()` transaction. The client trusts the server's `chargedCumulativeAmount` **only after** verifying `totalClaimed` against the onchain `BatchSettlement.channels(channelId)` call — the trust-but-verify split that lets the client safely retry without re-reading the chain on every request.
+
+If the verified onchain `totalClaimed` exceeds the corrective `chargedCumulativeAmount`, the corrective snapshot is invalid. The client MUST surface a hard error (`INVALID_CORRECTIVE_STATE`), MUST NOT update its local channel state from the snapshot, MUST NOT sign a replacement voucher, and MUST NOT retry the request. Recovery requires the server to reconcile its local cumulative state with the onchain state before issuing another corrective response. See [`invalid-corrective-state.json`](./batch-settlement-recovery-vectors/v0/invalid-corrective-state.json).
 
 ## Wire shape of the corrective response
 
@@ -52,11 +54,12 @@ A corrective 402 carries the authoritative server state in `extra.channelState`:
 This is the same `ChannelStateExtra` shape used by successful responses; only the HTTP status (402 vs 200) distinguishes them at the transport layer. The client uses this snapshot to:
 
 1. **Verify** `totalClaimed` against onchain `BatchSettlement.channels(channelId)` (trust-but-verify)
-2. **Replace** its local cumulative with `chargedCumulativeAmount`
-3. **Sign** a new voucher with `maxClaimableAmount = chargedCumulativeAmount + requestCharge`
-4. **Retry exactly once**
+2. **Validate** that the corrective snapshot satisfies `totalClaimed ≤ chargedCumulativeAmount`
+3. **Replace** its local cumulative with `chargedCumulativeAmount`
+4. **Sign** a new voucher with `maxClaimableAmount = chargedCumulativeAmount + requestCharge`
+5. **Retry exactly once**
 
-If the retry also receives a corrective 402, the client must surface a hard error (`PERSISTENT_STALE`) and not retry further. See [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json).
+If the retry also receives a corrective 402, the client MUST surface a hard error (`PERSISTENT_STALE`) and MUST NOT retry further, regardless of whether the second `chargedCumulativeAmount` advanced or remained unchanged. The observed value movement is diagnostic metadata only and MUST NOT trigger another signature or retry. See [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json) and [`loop-guard-unchanged.json`](./batch-settlement-recovery-vectors/v0/loop-guard-unchanged.json).
 
 ## Recovery flow
 
@@ -83,33 +86,38 @@ sequenceDiagram
 
 ## Why retry is exactly once
 
-A second corrective 402 means one of three things, none of which a client retry can fix:
+A second corrective 402 means one of several things, none of which another client retry can fix:
 
 - **Client-side bug** — the voucher reconstruction after the first recovery is producing the wrong `maxClaimableAmount`.
 - **Server-side persistent drift** — the server's `chargedCumulativeAmount` keeps advancing between retries due to concurrent traffic or a server bug.
-- **Adversarial server** — a malicious server can keep returning different `chargedCumulativeAmount` values to force the client into a retry loop and deny the client's ability to complete any paid request. (The server cannot extract money — the client verifies `totalClaimed` against onchain — but it can deny service.)
+- **Server-side verification failure** — the server rejects the corrected voucher even though its `chargedCumulativeAmount` has not changed.
+- **Adversarial server** — a malicious server can keep returning corrective states to force the client into a retry loop and deny the client's ability to complete any paid request. (The server cannot extract money — the client verifies `totalClaimed` against onchain — but it can deny service.)
 
 The loop guard caps client resource burn, surfaces the failure for human or operational diagnosis, and removes the denial-of-service surface.
 
 ## Telemetry
 
-Implementations should emit a distinguishable label for each recovery type even though the wire shape is identical:
+Implementations should emit a distinguishable label for each wire-observable recovery outcome:
 
 | Label | Trigger | Operational meaning |
 | --- | --- | --- |
-| `recovery.stale_state` | First corrective 402, client local cumulative was behind | Unexpected drift; investigate if frequent on a single channel |
-| `recovery.cas_conflict` | First corrective 402, client had an up-to-date view but lost a concurrent race | Normal contention; expected at high request rates |
+| `recovery.stale_state` | First valid corrective 402 | Recoverable cumulative mismatch; investigate if frequent on a single channel |
 | `recovery.persistent_stale` | Second corrective 402 on the same logical request | Bug or attack; alert on the dashboard, do not retry |
+| `recovery.invalid_corrective_state` | Corrective snapshot violates `onchain.totalClaimed ≤ server.chargedCumulativeAmount` | Invalid server state; do not mutate local state or retry |
 
-The first two are recoverable by the standard single-retry flow; the third triggers the loop guard and surfaces a hard error.
+The first outcome is recoverable by the standard single-retry flow. The other two surface hard errors.
+
+The wire response cannot establish why the client's signing base became stale. Implementations MAY record `cas_conflict` as a suspected diagnostic cause when they have supporting evidence, such as locally observed concurrent requests built from the same base or a server-observed compare-and-set failure. This diagnostic is not a protocol outcome and MUST NOT alter recovery behavior. Persisted base-provenance metadata is not required for conformance.
 
 ## Reference vectors
 
-Three machine-readable JSON vectors under [`batch-settlement-recovery-vectors/v0/`](./batch-settlement-recovery-vectors/v0/) pin the wire shape and expected client behaviour for each scenario:
+Five machine-readable JSON vectors under [`batch-settlement-recovery-vectors/v0/`](./batch-settlement-recovery-vectors/v0/) pin the wire shape and expected client behaviour for each scenario:
 
 - [`happy-path.json`](./batch-settlement-recovery-vectors/v0/happy-path.json) — stale local cumulative, single retry succeeds
-- [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json) — retry also corrective, hard error
-- [`cas-conflict.json`](./batch-settlement-recovery-vectors/v0/cas-conflict.json) — concurrent same-channel requests, one wins, the other recovers
+- [`invalid-corrective-state.json`](./batch-settlement-recovery-vectors/v0/invalid-corrective-state.json) — onchain claimed exceeds the server cumulative, hard error without retry
+- [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json) — retry receives a corrective with an advanced cumulative, hard error
+- [`loop-guard-unchanged.json`](./batch-settlement-recovery-vectors/v0/loop-guard-unchanged.json) — retry receives a corrective with an unchanged cumulative, same hard error
+- [`cas-conflict.json`](./batch-settlement-recovery-vectors/v0/cas-conflict.json) — concurrent same-channel requests, one wins, the other recovers; CAS is an optional suspected cause
 
 SDKs implementing the `batch-settlement` scheme should add an integration test that walks each vector's `steps` array and asserts the `expectedClientBehaviour`.
 

--- a/docs/schemes/batch-settlement-recovery.mdx
+++ b/docs/schemes/batch-settlement-recovery.mdx
@@ -3,17 +3,17 @@ title: "Batch Settlement Recovery"
 description: "Wire-level recovery contract for stale-cumulative voucher conflicts in the batch-settlement scheme."
 ---
 
-The `batch-settlement` scheme uses cumulative vouchers for repeated paid requests on a single channel. When two clients (or two in-flight retries) sign vouchers against the same channel state, one of them can arrive at the server with a `max_claimable_amount` that is already below the server's tracked cumulative. The server cannot accept that voucher — but the client also cannot recover without an authoritative state snapshot.
+The `batch-settlement` scheme uses cumulative vouchers for repeated paid requests on a single channel. When two clients (or two in-flight retries) sign vouchers against the same channel state, one of them can arrive at the server with a `maxClaimableAmount` that is already below the server's tracked cumulative. The server cannot accept that voucher — but the client also cannot recover without an authoritative state snapshot.
 
 This document specifies the **corrective-402 recovery contract** that closes this gap, and links to the [reference vectors](./batch-settlement-recovery-vectors/v0/) any x402 SDK can implement against.
 
 ## When recovery is needed
 
-A `corrective 402` is returned when the server's `charged_cumulative_amount` for the channel meets or exceeds the `max_claimable_amount` of the voucher in the incoming request:
+A `corrective 402` is returned when the server's `chargedCumulativeAmount` for the channel meets or exceeds the `maxClaimableAmount` of the voucher in the incoming request:
 
 ```
-server.charged_cumulative_amount > voucher.max_claimable_amount   →   accept
-server.charged_cumulative_amount ≥ voucher.max_claimable_amount   →   corrective 402
+server.chargedCumulativeAmount < voucher.maxClaimableAmount   →   accept
+server.chargedCumulativeAmount ≥ voucher.maxClaimableAmount   →   corrective 402
 ```
 
 This happens in three operationally distinct (but wire-identical) situations:
@@ -29,10 +29,10 @@ Cases (1) and (2) are recoverable by a single retry. Case (3) is what the loop g
 After recovery, the channel must satisfy:
 
 ```
-onchain.total_claimed   ≤   server.charged_cumulative_amount   ≤   voucher.max_claimable_amount
+onchain.totalClaimed   ≤   server.chargedCumulativeAmount   ≤   voucher.maxClaimableAmount
 ```
 
-The middle term is monotone non-decreasing per channel; the left term lags it by at most one batched `claim()` transaction. The client trusts the server's `charged_cumulative_amount` **only after** verifying `total_claimed` against the onchain `BatchSettlement.channels(channel_id)` call — the trust-but-verify split that lets the client safely retry without re-reading the chain on every request.
+The middle term is monotone non-decreasing per channel; the left term lags it by at most one batched `claim()` transaction. The client trusts the server's `chargedCumulativeAmount` **only after** verifying `totalClaimed` against the onchain `BatchSettlement.channels(channelId)` call — the trust-but-verify split that lets the client safely retry without re-reading the chain on every request.
 
 ## Wire shape of the corrective response
 
@@ -41,19 +41,19 @@ A corrective 402 carries the authoritative server state in `extra.channelState`:
 ```json
 {
   "channelState": {
-    "channel_id": "0x...",
+    "channelId": "0x...",
     "balance": "<escrow balance>",
-    "total_claimed": "<onchain total_claimed>",
-    "charged_cumulative_amount": "<server cumulative, may exceed total_claimed>"
+    "totalClaimed": "<onchain totalClaimed>",
+    "chargedCumulativeAmount": "<server cumulative, may exceed totalClaimed>"
   }
 }
 ```
 
 This is the same `ChannelStateExtra` shape used by successful responses; only the HTTP status (402 vs 200) distinguishes them at the transport layer. The client uses this snapshot to:
 
-1. **Verify** `total_claimed` against onchain `BatchSettlement.channels(channel_id)` (trust-but-verify)
-2. **Replace** its local cumulative with `charged_cumulative_amount`
-3. **Sign** a new voucher with `max_claimable_amount = charged_cumulative_amount + request_charge`
+1. **Verify** `totalClaimed` against onchain `BatchSettlement.channels(channelId)` (trust-but-verify)
+2. **Replace** its local cumulative with `chargedCumulativeAmount`
+3. **Sign** a new voucher with `maxClaimableAmount = chargedCumulativeAmount + requestCharge`
 4. **Retry exactly once**
 
 If the retry also receives a corrective 402, the client must surface a hard error (`PERSISTENT_STALE`) and not retry further. See [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json).
@@ -67,9 +67,9 @@ sequenceDiagram
     participant Chain
 
     Client->>Server: POST + voucher (stale)
-    Server->>Server: detect charged ≥ max_claimable
+    Server->>Server: detect charged ≥ maxClaimable
     Server-->>Client: 402 + channelState
-    Client->>Chain: verify total_claimed
+    Client->>Chain: verify totalClaimed
     Chain-->>Client: confirmed
     Client->>Client: update local state, sign new voucher
     Client->>Server: POST + voucher (corrected, retry 1/1)
@@ -85,9 +85,9 @@ sequenceDiagram
 
 A second corrective 402 means one of three things, none of which a client retry can fix:
 
-- **Client-side bug** — the voucher reconstruction after the first recovery is producing the wrong `max_claimable_amount`.
-- **Server-side persistent drift** — the server's `charged_cumulative_amount` keeps advancing between retries due to concurrent traffic or a server bug.
-- **Adversarial server** — a malicious server can keep returning different `charged_cumulative_amount` values to force the client into a retry loop and deny the client's ability to complete any paid request. (The server cannot extract money — the client verifies `total_claimed` against onchain — but it can deny service.)
+- **Client-side bug** — the voucher reconstruction after the first recovery is producing the wrong `maxClaimableAmount`.
+- **Server-side persistent drift** — the server's `chargedCumulativeAmount` keeps advancing between retries due to concurrent traffic or a server bug.
+- **Adversarial server** — a malicious server can keep returning different `chargedCumulativeAmount` values to force the client into a retry loop and deny the client's ability to complete any paid request. (The server cannot extract money — the client verifies `totalClaimed` against onchain — but it can deny service.)
 
 The loop guard caps client resource burn, surfaces the failure for human or operational diagnosis, and removes the denial-of-service surface.
 
@@ -111,7 +111,7 @@ Three machine-readable JSON vectors under [`batch-settlement-recovery-vectors/v0
 - [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json) — retry also corrective, hard error
 - [`cas-conflict.json`](./batch-settlement-recovery-vectors/v0/cas-conflict.json) — concurrent same-channel requests, one wins, the other recovers
 
-SDKs implementing the `batch-settlement` scheme should add an integration test that walks each vector's `steps` array and asserts the `expected_client_behaviour`.
+SDKs implementing the `batch-settlement` scheme should add an integration test that walks each vector's `steps` array and asserts the `expectedClientBehaviour`.
 
 ## Refs
 

--- a/docs/schemes/batch-settlement-recovery.mdx
+++ b/docs/schemes/batch-settlement-recovery.mdx
@@ -36,6 +36,8 @@ The middle term is monotone non-decreasing per channel; the left term lags it by
 
 If the verified onchain `totalClaimed` exceeds the corrective `chargedCumulativeAmount`, the corrective snapshot is invalid. The client MUST surface a hard error (`INVALID_CORRECTIVE_STATE`), MUST NOT update its local channel state from the snapshot, MUST NOT sign a replacement voucher, and MUST NOT retry the request. Recovery requires the server to reconcile its local cumulative state with the onchain state before issuing another corrective response. See [`invalid-corrective-state.json`](./batch-settlement-recovery-vectors/v0/invalid-corrective-state.json).
 
+The verification can also fail to produce an answer at all — an RPC transport failure, a node error, or a timeout while reading `BatchSettlement.channels(channelId)`. That is a different condition and MUST NOT be reported as the one above: the invariant was never evaluated, so the snapshot has not been shown to be invalid and the server has done nothing observably wrong. The client MUST surface a distinct **non-terminal** error (`TRANSIENT_STATE_UNAVAILABLE`) that preserves the underlying cause, MUST NOT update its local channel state from the unverified snapshot, MUST NOT sign a replacement voucher, and MUST NOT retry. Because no replacement voucher is signed, this outcome does not consume a loop-guard attempt: the same logical request MAY be attempted again once the read is available, and that attempt starts with a fresh budget. This mirrors how the settle path treats `settlement_pending` — a broadcast whose confirmation cannot be established is reported as non-terminal with its evidence attached, rather than collapsed into either success or failure. See [`transient-state-unavailable.json`](./batch-settlement-recovery-vectors/v0/transient-state-unavailable.json).
+
 ## Wire shape of the corrective response
 
 A corrective 402 carries the authoritative server state in `extra.channelState`:
@@ -59,7 +61,7 @@ This is the same `ChannelStateExtra` shape used by successful responses; only th
 4. **Sign** a new voucher with `maxClaimableAmount = chargedCumulativeAmount + requestCharge`
 5. **Retry exactly once**
 
-If the retry also receives a corrective 402, the client MUST surface a hard error (`PERSISTENT_STALE`) and MUST NOT retry further, regardless of whether the second `chargedCumulativeAmount` advanced or remained unchanged. The observed value movement is diagnostic metadata only and MUST NOT trigger another signature or retry. See [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json) and [`loop-guard-unchanged.json`](./batch-settlement-recovery-vectors/v0/loop-guard-unchanged.json).
+If the retry also receives a corrective 402, the client MUST surface a hard error (`PERSISTENT_STALE`) and MUST NOT retry further, regardless of whether the second `chargedCumulativeAmount` advanced or remained unchanged. The observed value movement is diagnostic metadata only and MUST NOT trigger another signature or retry. The client MAY replace its local cumulative with the second snapshot, subject to the same onchain verification it applies to the first, so that a later logical request does not start stale again; that update MUST NOT be followed by a signature or a retry within this request. See [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json) and [`loop-guard-unchanged.json`](./batch-settlement-recovery-vectors/v0/loop-guard-unchanged.json).
 
 ## Recovery flow
 
@@ -104,20 +106,22 @@ Implementations should emit a distinguishable label for each wire-observable rec
 | `recovery.stale_state` | First valid corrective 402 | Recoverable cumulative mismatch; investigate if frequent on a single channel |
 | `recovery.persistent_stale` | Second corrective 402 on the same logical request | Bug or attack; alert on the dashboard, do not retry |
 | `recovery.invalid_corrective_state` | Corrective snapshot violates `onchain.totalClaimed ≤ server.chargedCumulativeAmount` | Invalid server state; do not mutate local state or retry |
+| `recovery.transient_state_unavailable` | Corrective 402 whose snapshot could not be verified because the onchain read was unavailable | Chain access problem, not a server fault; non-terminal, attempt the logical request again once reads recover |
 
-The first outcome is recoverable by the standard single-retry flow. The other two surface hard errors.
+The first outcome is recoverable by the standard single-retry flow. `recovery.transient_state_unavailable` is non-terminal but not recoverable in place — it reports that the client could not establish the facts it needs. The remaining two surface hard errors.
 
 The wire response cannot establish why the client's signing base became stale. Implementations MAY record `cas_conflict` as a suspected diagnostic cause when they have supporting evidence, such as locally observed concurrent requests built from the same base or a server-observed compare-and-set failure. This diagnostic is not a protocol outcome and MUST NOT alter recovery behavior. Persisted base-provenance metadata is not required for conformance.
 
 ## Reference vectors
 
-Five machine-readable JSON vectors under [`batch-settlement-recovery-vectors/v0/`](./batch-settlement-recovery-vectors/v0/) pin the wire shape and expected client behaviour for each scenario:
+Six machine-readable JSON vectors under [`batch-settlement-recovery-vectors/v0/`](./batch-settlement-recovery-vectors/v0/) pin the wire shape and expected client behaviour for each scenario:
 
 - [`happy-path.json`](./batch-settlement-recovery-vectors/v0/happy-path.json) — stale local cumulative, single retry succeeds
 - [`invalid-corrective-state.json`](./batch-settlement-recovery-vectors/v0/invalid-corrective-state.json) — onchain claimed exceeds the server cumulative, hard error without retry
 - [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json) — retry receives a corrective with an advanced cumulative, hard error
 - [`loop-guard-unchanged.json`](./batch-settlement-recovery-vectors/v0/loop-guard-unchanged.json) — retry receives a corrective with an unchanged cumulative, same hard error
 - [`cas-conflict.json`](./batch-settlement-recovery-vectors/v0/cas-conflict.json) — concurrent same-channel requests, one wins, the other recovers; CAS is an optional suspected cause
+- [`transient-state-unavailable.json`](./batch-settlement-recovery-vectors/v0/transient-state-unavailable.json) — the onchain read needed to verify the snapshot is unavailable, non-terminal error without mutation or retry
 
 SDKs implementing the `batch-settlement` scheme should add an integration test that walks each vector's `steps` array and asserts the `expectedClientBehaviour`.
 
@@ -125,4 +129,6 @@ SDKs implementing the `batch-settlement` scheme should add an integration test t
 
 - [`batch-settlement` scheme](./batch-settlement.mdx) — base scheme this recovery contract extends
 - [#2061](https://github.com/x402-foundation/x402/pull/2061) — original TS implementation thread where the corrective-402 contract was proposed by @phdargen, with discussion of recovery semantics from @jithinraj and @Bortlesboat
+- [#3083](https://github.com/x402-foundation/x402/pull/3083) — introduced `settlement_pending` as a non-terminal settle outcome, the settle-path counterpart to `TRANSIENT_STATE_UNAVAILABLE` here
+- [#2908](https://github.com/x402-foundation/x402/issues/2908) — typed recovery outcomes for SDK clients; `TRANSIENT_STATE_UNAVAILABLE` was identified there while scoping a Go implementation against these vectors
 - Byte-equivalence fixtures for the EIP-712 signing layer that this recovery contract sits above: `python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/`

--- a/docs/schemes/batch-settlement-recovery.mdx
+++ b/docs/schemes/batch-settlement-recovery.mdx
@@ -1,0 +1,120 @@
+---
+title: "Batch Settlement Recovery"
+description: "Wire-level recovery contract for stale-cumulative voucher conflicts in the batch-settlement scheme."
+---
+
+The `batch-settlement` scheme uses cumulative vouchers for repeated paid requests on a single channel. When two clients (or two in-flight retries) sign vouchers against the same channel state, one of them can arrive at the server with a `max_claimable_amount` that is already below the server's tracked cumulative. The server cannot accept that voucher — but the client also cannot recover without an authoritative state snapshot.
+
+This document specifies the **corrective-402 recovery contract** that closes this gap, and links to the [reference vectors](./batch-settlement-recovery-vectors/v0/) any x402 SDK can implement against.
+
+## When recovery is needed
+
+A `corrective 402` is returned when the server's `charged_cumulative_amount` for the channel meets or exceeds the `max_claimable_amount` of the voucher in the incoming request:
+
+```
+server.charged_cumulative_amount > voucher.max_claimable_amount   →   accept
+server.charged_cumulative_amount ≥ voucher.max_claimable_amount   →   corrective 402
+```
+
+This happens in three operationally distinct (but wire-identical) situations:
+
+1. **Stale state (happy path)** — the client's local cumulative is behind the server's, for example because a previous response was lost, the client restarted from disk without re-syncing, or the channel was just opened and the client did not see prior charges.
+2. **CAS conflict** — two concurrent requests on the same channel both signed against the same prior cumulative; one arrived first and bumped the server, the other is now stale.
+3. **Persistent server-side drift (pathological)** — the server keeps bumping its cumulative between retries; the client cannot converge. This may be genuine concurrent traffic, a server-side bug, or an adversarial server.
+
+Cases (1) and (2) are recoverable by a single retry. Case (3) is what the loop guard prevents.
+
+## Invariant
+
+After recovery, the channel must satisfy:
+
+```
+onchain.total_claimed   ≤   server.charged_cumulative_amount   ≤   voucher.max_claimable_amount
+```
+
+The middle term is monotone non-decreasing per channel; the left term lags it by at most one batched `claim()` transaction. The client trusts the server's `charged_cumulative_amount` **only after** verifying `total_claimed` against the onchain `BatchSettlement.channels(channel_id)` call — the trust-but-verify split that lets the client safely retry without re-reading the chain on every request.
+
+## Wire shape of the corrective response
+
+A corrective 402 carries the authoritative server state in `extra.channelState`:
+
+```json
+{
+  "channelState": {
+    "channel_id": "0x...",
+    "balance": "<escrow balance>",
+    "total_claimed": "<onchain total_claimed>",
+    "charged_cumulative_amount": "<server cumulative, may exceed total_claimed>"
+  }
+}
+```
+
+This is the same `ChannelStateExtra` shape used by successful responses; only the HTTP status (402 vs 200) distinguishes them at the transport layer. The client uses this snapshot to:
+
+1. **Verify** `total_claimed` against onchain `BatchSettlement.channels(channel_id)` (trust-but-verify)
+2. **Replace** its local cumulative with `charged_cumulative_amount`
+3. **Sign** a new voucher with `max_claimable_amount = charged_cumulative_amount + request_charge`
+4. **Retry exactly once**
+
+If the retry also receives a corrective 402, the client must surface a hard error (`PERSISTENT_STALE`) and not retry further. See [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json).
+
+## Recovery flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+    participant Chain
+
+    Client->>Server: POST + voucher (stale)
+    Server->>Server: detect charged ≥ max_claimable
+    Server-->>Client: 402 + channelState
+    Client->>Chain: verify total_claimed
+    Chain-->>Client: confirmed
+    Client->>Client: update local state, sign new voucher
+    Client->>Server: POST + voucher (corrected, retry 1/1)
+    alt success
+      Server-->>Client: 200 + channelState
+    else still stale
+      Server-->>Client: 402 + channelState
+      Client->>Client: hard error (PERSISTENT_STALE)
+    end
+```
+
+## Why retry is exactly once
+
+A second corrective 402 means one of three things, none of which a client retry can fix:
+
+- **Client-side bug** — the voucher reconstruction after the first recovery is producing the wrong `max_claimable_amount`.
+- **Server-side persistent drift** — the server's `charged_cumulative_amount` keeps advancing between retries due to concurrent traffic or a server bug.
+- **Adversarial server** — a malicious server can keep returning different `charged_cumulative_amount` values to force the client into a retry loop and deny the client's ability to complete any paid request. (The server cannot extract money — the client verifies `total_claimed` against onchain — but it can deny service.)
+
+The loop guard caps client resource burn, surfaces the failure for human or operational diagnosis, and removes the denial-of-service surface.
+
+## Telemetry
+
+Implementations should emit a distinguishable label for each recovery type even though the wire shape is identical:
+
+| Label | Trigger | Operational meaning |
+| --- | --- | --- |
+| `recovery.stale_state` | First corrective 402, client local cumulative was behind | Unexpected drift; investigate if frequent on a single channel |
+| `recovery.cas_conflict` | First corrective 402, client had an up-to-date view but lost a concurrent race | Normal contention; expected at high request rates |
+| `recovery.persistent_stale` | Second corrective 402 on the same logical request | Bug or attack; alert on the dashboard, do not retry |
+
+The first two are recoverable by the standard single-retry flow; the third triggers the loop guard and surfaces a hard error.
+
+## Reference vectors
+
+Three machine-readable JSON vectors under [`batch-settlement-recovery-vectors/v0/`](./batch-settlement-recovery-vectors/v0/) pin the wire shape and expected client behaviour for each scenario:
+
+- [`happy-path.json`](./batch-settlement-recovery-vectors/v0/happy-path.json) — stale local cumulative, single retry succeeds
+- [`loop-guard.json`](./batch-settlement-recovery-vectors/v0/loop-guard.json) — retry also corrective, hard error
+- [`cas-conflict.json`](./batch-settlement-recovery-vectors/v0/cas-conflict.json) — concurrent same-channel requests, one wins, the other recovers
+
+SDKs implementing the `batch-settlement` scheme should add an integration test that walks each vector's `steps` array and asserts the `expected_client_behaviour`.
+
+## Refs
+
+- [`batch-settlement` scheme](./batch-settlement.mdx) — base scheme this recovery contract extends
+- [#2061](https://github.com/x402-foundation/x402/pull/2061) — original TS implementation thread where the corrective-402 contract was proposed by @phdargen, with discussion of recovery semantics from @jithinraj and @Bortlesboat
+- Byte-equivalence fixtures for the EIP-712 signing layer that this recovery contract sits above: `python/x402/tests/fixtures/batch-settlement-byte-equivalence/v0/`


### PR DESCRIPTION
## Description

Adds a wire-level specification and three machine-readable reference vectors for the `batch-settlement` scheme's corrective-402 recovery contract, so any x402 SDK (TS / Python / Go / Java) can converge on the same recovery semantics.

The `batch-settlement` scheme uses cumulative vouchers; when two concurrent requests on the same channel race, or when a client's local cumulative drifts behind the server's, the server returns `402` with an authoritative state snapshot so the client can recover. The wire shape for this corrective response and the expected client behaviour (verify against onchain, update local state, retry exactly once, hard-error on a second corrective) are discussed in #2061 by @phdargen, @jithinraj and @Bortlesboat but not pinned in machine-readable form. This PR pins them.

## What this PR adds

```mermaid
flowchart LR
    Spec["Spec doc<br/>(batch-settlement-recovery.mdx)"]
    Vectors["Reference vectors<br/>(v0/*.json)"]
    SDKs["x402 SDKs<br/>(TS / Py / Go / Java)"]
    Conformance["wire-level portable<br/>recovery behaviour"]

    Spec -->|"defines contract"| Vectors
    Vectors -->|"SDKs read & implement<br/>integration tests"| SDKs
    SDKs -->|"converge by construction"| Conformance
```

Five files, no executable code:

1. **`docs/schemes/batch-settlement-recovery.mdx`** — normative spec: when a corrective 402 is returned, the wire shape of `extra.channelState`, the invariant `onchain.total_claimed ≤ server.charged_cumulative_amount ≤ voucher.max_claimable_amount`, the recovery flow (Mermaid sequence diagram), the loop-guard rationale (resource burn / bug detection / DoS surface), the telemetry labels (`stale_state` / `cas_conflict` / `persistent_stale`), and cross-references to the byte-equivalence fixtures.

2. **`docs/schemes/batch-settlement-recovery-vectors/v0/README.md`** — vector format documentation plus a quick-start for SDK integration tests (how to walk a `steps` array and assert against `expected_client_behaviour`).

3-5. **Three scenario vectors** under `v0/`:
- `happy-path.json` — stale local cumulative, single retry succeeds
- `loop-guard.json` — second corrective on retry, hard error (`PERSISTENT_STALE`)
- `cas-conflict.json` — concurrent same-channel requests, one wins, the other recovers

Each vector describes a wire-level sequence of `(request → response)` steps, an `expected_client_behaviour` block per step, and the operational `invariants` that must hold.

## Why vectors, not just spec prose

Two SDKs implementing the same prose can diverge at edge cases (is `total_claimed > charged_cumulative_amount` valid? does a retry that produces the same digest as the first attempt re-trigger the loop guard? what telemetry label applies when the corrective `charged_cumulative_amount` is unchanged?). Vectors fix the exact wire payload, state transitions, and expected behaviour. Two SDKs implementing the same vectors converge by construction.

## Acknowledged scope choices

- **Spec-only, no implementation in this PR**: this ships normative documentation + machine-readable vectors. SDK integration tests that walk each vector are out of scope here and should land as follow-ups on each language's SDK. Python's recovery handler in `client/recovery.py` (from #2402) can be tested against `happy-path.json` immediately.

- **Three scenarios, not six**: the #2061 thread also discussed dynamic-price-below-cap, HTTP-compatibility, and telemetry-privacy as recovery-adjacent. Those are operational concerns that vary by SDK and deployment; this PR is scoped to the three wire-level invariants every SDK must agree on. Additional vectors can be added under the same `v0/` schema (non-breaking), or as `v1/` if the schema needs a breaking change.

- **`signature` fields are placeholders**: EIP-712 signing semantics are independently pinned by #2489 (`tests/fixtures/batch-settlement-byte-equivalence/v0/`). The recovery contract is independent of signature validity — what matters here is the state-machine transition, not the cryptographic signing.

- **Placed under `docs/schemes/<scheme>-vectors/v<N>/` rather than a repo-root `fixtures/` directory**: same reasoning as #2489 — the repo-root `fixtures/` directory is being established by #2412 and avoiding precedent overhead keeps this PR's review surface inside the existing `docs/schemes/` area.

## Refs

- #2061 (TS batch-settlement) — original corrective-402 contract proposal and recovery-semantics discussion
- #2402 (Python batch-settlement) — landed `client/recovery.py` which already implements the contract; this PR pins it spec-side so other SDKs can converge
- #2489 (this same series) — byte-equivalence fixtures for the signing-time primitives; this PR complements that by pinning the state-machine layer

Happy to split spec / vectors / individual scenarios into separate PRs if preferred.
