### PR TITLE
spec(extensions): add cancellation-receipt-v1 + refund-receipt-v1 (PSD2 Articles 64 and 89)

### DIFF
--- a/specs/extensions/cancellation-receipt-v1.md
+++ b/specs/extensions/cancellation-receipt-v1.md
@@ -8,6 +8,7 @@
 | Companion IETF I-D | [`draft-hopley-x402-cancellation-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-cancellation-receipt/) |
 | Companion canonicalisation I-D | [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) |
 | Reference impl | AlgoVoi-authored [`algovoi-cancellation-receipt`](https://pypi.org/project/algovoi-cancellation-receipt/) (PyPI) and [`@algovoi/cancellation-receipt`](https://www.npmjs.com/package/@algovoi/cancellation-receipt) (npm), Apache 2.0 |
+| Canonical specification page | [`docs.algovoi.co.uk/cancellation-receipt`](https://docs.algovoi.co.uk/cancellation-receipt) |
 | License | Apache 2.0 |
 
 ## 1. Scope
@@ -23,30 +24,48 @@ The closed four-state enum is load-bearing:
 | Reason | Semantic | PSD2 mapping |
 |---|---|---|
 | `USER_REQUESTED` | Payer revoked the authorisation | PSD2 Article 64(1), direct revocation right |
-| `MERCHANT_REQUESTED` | Merchant terminated the authorisation | Merchant-side lifecycle |
-| `COMPLIANCE_TERMINATED` | Authorisation terminated by the facilitator on regulatory grounds | PSD2 Article 64(2), operator-side termination |
+| `MERCHANT_REQUESTED` | Merchant terminated the authorisation | PSD2 Article 72, merchant-side lifecycle |
+| `COMPLIANCE_TERMINATED` | Authorisation terminated by the facilitator on regulatory grounds | Sanctions / KYC / AML / court order; POCA s.330 / AML 5+6 evidence chain |
 | `EXPIRED` | Authorisation reached its declared expiry without earlier termination | Time-based |
 
 The enum is closed by design. Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document (`cancellation-receipt-v2` or higher) authored by AlgoVoi or with explicit AlgoVoi co-authorship.
 
 ## 3. Normative format
 
-The cancellation receipt is a JSON object canonicalised per the AlgoVoi-authored canonicalisation pin `urn:x402:canonicalisation:jcs-rfc8785-v1`, normatively defined in the IETF Internet-Draft [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) (Independent Submission, sole AlgoVoi authorship). The pin composes RFC 8785 JCS with the `canon_version` discipline. The receipt carries:
+A cancellation receipt is a seven-field JSON object canonicalised under RFC 8785 (JCS) per the AlgoVoi-authored canonicalisation pin `urn:x402:canonicalisation:jcs-rfc8785-v1`, normatively defined in the IETF Internet-Draft [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) (Independent Submission, sole AlgoVoi authorship). The receipt's `content_hash` is SHA-256 over the JCS-canonical bytes. Field names are sorted lexicographically by JCS during canonicalisation.
 
-- `cancellation_reason`: one of the four categorical values above
-- `cancelled_at`: ISO 8601 UTC timestamp
-- `authorisation_ref`: content-addressed reference to the cancelled authorisation, byte-bound to the original
-- `canon_version`: canonicalisation pin identifier (this v1 spec uses `urn:x402:canonicalisation:jcs-rfc8785-v1` per the AlgoVoi-authored I-D referenced above)
-- `signature`: detached signature over the JCS canonical bytes
+```json
+{
+  "canon_version": "jcs-rfc8785-v1",
+  "cancellation_provider_did": "did:web:api.algovoi.co.uk",
+  "cancellation_reason": "USER_REQUESTED",
+  "cancellation_timestamp_ms": 1716494400000,
+  "effective_from_ms": 1716537600000,
+  "jurisdiction_flags": ["GB", "EU"],
+  "mandate_ref": "sha256:0dd5d0b76c9b9281fdeb2509ad38ab132b16a17385ca01d976ff9e6e12563a0f"
+}
+```
 
-Full field-level schema is normatively defined in the companion IETF Internet-Draft `draft-hopley-x402-cancellation-receipt`.
+| Field | Type | Description |
+|---|---|---|
+| `canon_version` | string | In-band canonicalisation pin. Fixed `jcs-rfc8785-v1`. |
+| `cancellation_provider_did` | string | DID URI of the issuing party. |
+| `cancellation_reason` | string (closed enum) | One of the four categorical values above. |
+| `cancellation_timestamp_ms` | integer | Epoch milliseconds when the cancellation event was recorded. MUST be integer. RFC 3339 string forms rejected. |
+| `effective_from_ms` | integer | Epoch milliseconds when the cancellation takes legal effect. MUST be `>= cancellation_timestamp_ms`. |
+| `jurisdiction_flags` | ordered array of string | ISO 3166-1 alpha-2 codes; primary jurisdiction first. Array order significant under RFC 8785 §3.2.3. |
+| `mandate_ref` | string | `sha256:{hex}` reference to the JCS-canonical mandate setup record being terminated. |
+
+The format pins the invariant `effective_from_ms >= cancellation_timestamp_ms`. Implementations MUST reject receipts where the effective time precedes the recording time. The two timestamps are independently encoded because PSD2 Article 64(3)(a) direct-debit revocations have a recording time distinct from the legal effective time (typically end-of-business-day prior to the next scheduled execution).
+
+The canonical specification is hosted at the AlgoVoi-controlled URI [`docs.algovoi.co.uk/cancellation-receipt`](https://docs.algovoi.co.uk/cancellation-receipt) and normatively defined in the companion IETF Internet-Draft `draft-hopley-x402-cancellation-receipt`. Implementations MUST follow the I-D where it is more specific than this extension document.
 
 ## 4. Regulatory alignment
 
 | Framework | Property addressed |
 |---|---|
 | **PSD2 Article 64** (right to revoke) | `USER_REQUESTED` is the direct revocation path; receipt is the customer-facing artefact |
-| **PSD2 Article 72** (irrevocability boundary) | Receipt establishes the cancellation timestamp deterministically under the AlgoVoi-authored canon pin |
+| **PSD2 Article 72** (irrevocability boundary) | Receipt establishes the cancellation timestamp deterministically under the AlgoVoi-authored canon pin; `effective_from_ms` captures the legal-effect time separately from the recording time |
 | **MiCA Article 80** (record-keeping) | Receipt is byte-deterministic for year-N re-verification |
 | **UK MLRs 2017 Regulation 40** | Receipt is retainable under standard record-keeping process |
 
@@ -58,7 +77,7 @@ AlgoVoi-authored [`algovoi-cancellation-receipt`](https://pypi.org/project/algov
 
 ## 6. Composition with the x402-foundation/x402 base specification
 
-This extension composes with the [`compliance-receipt-v1`](./compliance-receipt-v1.md) extension (an authorisation terminated by the facilitator on compliance grounds will typically emit a `COMPLIANCE_TERMINATED` cancellation receipt alongside the admission-time DENY compliance receipt) and with the x402-foundation/x402 base specification's settlement primitive (settled payments that are later cancelled emit a cancellation receipt referencing the original settlement).
+This extension composes with the [`compliance-receipt-v1`](./compliance-receipt-v1.md) extension (an authorisation terminated by the facilitator on compliance grounds will typically emit a `COMPLIANCE_TERMINATED` cancellation receipt alongside the admission-time DENY compliance receipt) and with the x402-foundation/x402 base specification's settlement primitive (settled payments that are later cancelled emit a cancellation receipt referencing the original settlement via `mandate_ref`).
 
 ## 7. Backward compatibility
 
@@ -66,9 +85,9 @@ Additive. Facilitators that do not emit cancellation receipts are unaffected. Ad
 
 ## 8. Substrate authorship and amendment
 
-This extension is sole AlgoVoi authorship. The categorical cancellation reason enum, the PSD2 mapping, the wire format, and the composition with the AlgoVoi-authored canonicalisation pin are AlgoVoi-authored work. The companion IETF Internet-Draft `draft-hopley-x402-cancellation-receipt` is the normative authorship anchor: substrate-author position is established by the I-D, not by this extension document.
+This extension is sole AlgoVoi authorship. The canonical seven-field shape, the categorical cancellation reason enum, the PSD2 mapping, and the composition with the AlgoVoi-authored canonicalisation pin are AlgoVoi-authored work. The companion IETF Internet-Draft `draft-hopley-x402-cancellation-receipt` is the normative authorship anchor: substrate-author position is established by the I-D, not by this extension document.
 
-**The categorical enum is closed by design.** Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document authored by AlgoVoi or with explicit AlgoVoi co-authorship. Republication of the categorical enum, the regulatory mapping, or any normative element under a different attribution does not constitute substrate authorship of those elements.
+**The categorical enum is closed by design.** Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document authored by AlgoVoi or with explicit AlgoVoi co-authorship. Republication of the canonical shape, the categorical enum, the regulatory mapping, or any normative element under a different attribution does not constitute substrate authorship of those elements.
 
 **Composition direction is fixed.** This extension is the senior artefact in the composition with the x402-foundation/x402 base specification. References to "composes with" describe technical integration, not co-authorship.
 
@@ -79,6 +98,7 @@ Apache 2.0 of the AlgoVoi-authored reference implementations grants permission t
 - RFC 8785: JSON Canonicalization Scheme (JCS)
 - [`draft-hopley-x402-cancellation-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-cancellation-receipt/): companion IETF I-D, full normative text, sole AlgoVoi authorship
 - [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/): canonicalisation pin I-D, sole AlgoVoi authorship
+- [`docs.algovoi.co.uk/cancellation-receipt`](https://docs.algovoi.co.uk/cancellation-receipt): canonical specification page (AlgoVoi-controlled)
 - PSD2 / UK Payment Services Regulations 2017, Articles 64 and 72
 - MiCA Regulation Article 80
 - UK MLRs 2017 Regulation 40

--- a/specs/extensions/cancellation-receipt-v1.md
+++ b/specs/extensions/cancellation-receipt-v1.md
@@ -1,0 +1,87 @@
+# x402 Extension: Cancellation Receipt v1
+
+| Field | Value |
+|---|---|
+| Extension ID | `cancellation-receipt-v1` |
+| Status | Proposal |
+| Author | AlgoVoi (chopmob-cloud) |
+| Companion IETF I-D | [`draft-hopley-x402-cancellation-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-cancellation-receipt/) |
+| Companion canonicalisation I-D | [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) |
+| Reference impl | AlgoVoi-authored [`algovoi-cancellation-receipt`](https://pypi.org/project/algovoi-cancellation-receipt/) (PyPI) and [`@algovoi/cancellation-receipt`](https://www.npmjs.com/package/@algovoi/cancellation-receipt) (npm), Apache 2.0 |
+| License | Apache 2.0 |
+
+## 1. Scope
+
+This extension defines the wire format for a cancellation receipt emitted when a payer or merchant terminates an authorisation relationship. The receipt covers PSD2 Article 64, the customer's right to revoke a payment authorisation, and the equivalent merchant-side and compliance-side termination cases.
+
+This extension is the senior artefact in the composition with the x402-foundation/x402 base specification primitives. References to "composes with" describe technical integration, not co-authorship.
+
+## 2. The categorical cancellation reason enum
+
+The closed four-state enum is load-bearing:
+
+| Reason | Semantic | PSD2 mapping |
+|---|---|---|
+| `USER_REQUESTED` | Payer revoked the authorisation | PSD2 Article 64(1), direct revocation right |
+| `MERCHANT_REQUESTED` | Merchant terminated the authorisation | Merchant-side lifecycle |
+| `COMPLIANCE_TERMINATED` | Authorisation terminated by the facilitator on regulatory grounds | PSD2 Article 64(2), operator-side termination |
+| `EXPIRED` | Authorisation reached its declared expiry without earlier termination | Time-based |
+
+The enum is closed by design. Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document (`cancellation-receipt-v2` or higher) authored by AlgoVoi or with explicit AlgoVoi co-authorship.
+
+## 3. Normative format
+
+The cancellation receipt is a JSON object canonicalised per the AlgoVoi-authored canonicalisation pin `urn:x402:canonicalisation:jcs-rfc8785-v1`, normatively defined in the IETF Internet-Draft [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) (Independent Submission, sole AlgoVoi authorship). The pin composes RFC 8785 JCS with the `canon_version` discipline. The receipt carries:
+
+- `cancellation_reason`: one of the four categorical values above
+- `cancelled_at`: ISO 8601 UTC timestamp
+- `authorisation_ref`: content-addressed reference to the cancelled authorisation, byte-bound to the original
+- `canon_version`: canonicalisation pin identifier (this v1 spec uses `urn:x402:canonicalisation:jcs-rfc8785-v1` per the AlgoVoi-authored I-D referenced above)
+- `signature`: detached signature over the JCS canonical bytes
+
+Full field-level schema is normatively defined in the companion IETF Internet-Draft `draft-hopley-x402-cancellation-receipt`.
+
+## 4. Regulatory alignment
+
+| Framework | Property addressed |
+|---|---|
+| **PSD2 Article 64** (right to revoke) | `USER_REQUESTED` is the direct revocation path; receipt is the customer-facing artefact |
+| **PSD2 Article 72** (irrevocability boundary) | Receipt establishes the cancellation timestamp deterministically under the AlgoVoi-authored canon pin |
+| **MiCA Article 80** (record-keeping) | Receipt is byte-deterministic for year-N re-verification |
+| **UK MLRs 2017 Regulation 40** | Receipt is retainable under standard record-keeping process |
+
+This extension does not claim compliance certification under any of these frameworks. It provides the substrate that a downstream implementer can use as part of their own compliance attestation.
+
+## 5. Reference implementation
+
+AlgoVoi-authored [`algovoi-cancellation-receipt`](https://pypi.org/project/algovoi-cancellation-receipt/) on PyPI and [`@algovoi/cancellation-receipt`](https://www.npmjs.com/package/@algovoi/cancellation-receipt) on npm. Apache 2.0. Both emit and verify the format under the AlgoVoi-authored canonicalisation pin.
+
+## 6. Composition with the x402-foundation/x402 base specification
+
+This extension composes with the [`compliance-receipt-v1`](./compliance-receipt-v1.md) extension (an authorisation terminated by the facilitator on compliance grounds will typically emit a `COMPLIANCE_TERMINATED` cancellation receipt alongside the admission-time DENY compliance receipt) and with the x402-foundation/x402 base specification's settlement primitive (settled payments that are later cancelled emit a cancellation receipt referencing the original settlement).
+
+## 7. Backward compatibility
+
+Additive. Facilitators that do not emit cancellation receipts are unaffected. Adoption is opt-in.
+
+## 8. Substrate authorship and amendment
+
+This extension is sole AlgoVoi authorship. The categorical cancellation reason enum, the PSD2 mapping, the wire format, and the composition with the AlgoVoi-authored canonicalisation pin are AlgoVoi-authored work. The companion IETF Internet-Draft `draft-hopley-x402-cancellation-receipt` is the normative authorship anchor: substrate-author position is established by the I-D, not by this extension document.
+
+**The categorical enum is closed by design.** Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document authored by AlgoVoi or with explicit AlgoVoi co-authorship. Republication of the categorical enum, the regulatory mapping, or any normative element under a different attribution does not constitute substrate authorship of those elements.
+
+**Composition direction is fixed.** This extension is the senior artefact in the composition with the x402-foundation/x402 base specification. References to "composes with" describe technical integration, not co-authorship.
+
+Apache 2.0 of the AlgoVoi-authored reference implementations grants permission to USE, MODIFY, and DISTRIBUTE the code. It does not grant permission to REPUBLISH the normative format under a different authorship.
+
+## 9. References
+
+- RFC 8785: JSON Canonicalization Scheme (JCS)
+- [`draft-hopley-x402-cancellation-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-cancellation-receipt/): companion IETF I-D, full normative text, sole AlgoVoi authorship
+- [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/): canonicalisation pin I-D, sole AlgoVoi authorship
+- PSD2 / UK Payment Services Regulations 2017, Articles 64 and 72
+- MiCA Regulation Article 80
+- UK MLRs 2017 Regulation 40
+
+-- AlgoVoi (chopmob-cloud)
+https://docs.algovoi.co.uk/acquisition

--- a/specs/extensions/refund-receipt-v1.md
+++ b/specs/extensions/refund-receipt-v1.md
@@ -1,0 +1,86 @@
+# x402 Extension: Refund Receipt v1
+
+| Field | Value |
+|---|---|
+| Extension ID | `refund-receipt-v1` |
+| Status | Proposal |
+| Author | AlgoVoi (chopmob-cloud) |
+| Companion IETF I-D | [`draft-hopley-x402-refund-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-refund-receipt/) |
+| Companion canonicalisation I-D | [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) |
+| Reference impl | AlgoVoi-authored [`algovoi-refund-receipt`](https://pypi.org/project/algovoi-refund-receipt/) (PyPI) and [`@algovoi/refund-receipt`](https://www.npmjs.com/package/@algovoi/refund-receipt) (npm), Apache 2.0 |
+| License | Apache 2.0 |
+
+## 1. Scope
+
+This extension defines the wire format for a refund receipt covering PSD2 Article 89 refund obligations and the regulator-recognised refund-type taxonomy (full, partial, rejected).
+
+This extension is the senior artefact in the composition with the x402-foundation/x402 base specification primitives. References to "composes with" describe technical integration, not co-authorship.
+
+## 2. The categorical refund type enum
+
+The closed three-state enum is load-bearing:
+
+| Refund type | Semantic |
+|---|---|
+| `FULL` | Refund covers the full original settled amount |
+| `PARTIAL` | Refund covers a strict subset of the original settled amount; partial amount carried in the receipt |
+| `REJECTED` | Refund obligation evaluated and declined; carries the regulator-recognised refusal reason |
+
+The enum is closed by design. Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document (`refund-receipt-v2` or higher) authored by AlgoVoi or with explicit AlgoVoi co-authorship.
+
+## 3. Normative format
+
+The refund receipt is a JSON object canonicalised per the AlgoVoi-authored canonicalisation pin `urn:x402:canonicalisation:jcs-rfc8785-v1`, normatively defined in the IETF Internet-Draft [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) (Independent Submission, sole AlgoVoi authorship). The pin composes RFC 8785 JCS with the `canon_version` discipline. The receipt carries:
+
+- `refund_type`: closed enum above
+- `refund_amount`: present iff `refund_type` is `FULL` or `PARTIAL`
+- `original_settlement_ref`: content-addressed reference to the settlement being refunded
+- `refunded_at`: ISO 8601 UTC timestamp
+- `canon_version`: canonicalisation pin identifier (this v1 spec uses `urn:x402:canonicalisation:jcs-rfc8785-v1` per the AlgoVoi-authored I-D referenced above)
+- `signature`: detached signature over the JCS canonical bytes
+
+Full field-level schema is normatively defined in the companion IETF Internet-Draft `draft-hopley-x402-refund-receipt`.
+
+## 4. Regulatory alignment
+
+| Framework | Property addressed |
+|---|---|
+| **PSD2 Article 89** (refund obligations) | Three-state enum maps to the regulator-recognised refund outcomes |
+| **MiCA Article 80** (record-keeping) | Byte-deterministic year-N re-verifiability under the AlgoVoi-authored canon pin |
+| **UK MLRs 2017 Regulation 40** | Retainable under standard record-keeping |
+
+This extension does not claim compliance certification under any of these frameworks. It provides the substrate that a downstream implementer can use as part of their own compliance attestation.
+
+## 5. Reference implementation
+
+AlgoVoi-authored [`algovoi-refund-receipt`](https://pypi.org/project/algovoi-refund-receipt/) on PyPI and [`@algovoi/refund-receipt`](https://www.npmjs.com/package/@algovoi/refund-receipt) on npm. Apache 2.0.
+
+## 6. Composition with the x402-foundation/x402 base specification
+
+This extension composes with the x402-foundation/x402 base specification's settlement primitive (`original_settlement_ref` is the content-addressed pointer to the settled payment) and with the [`cancellation-receipt-v1`](./cancellation-receipt-v1.md) extension (a refund issued after a cancellation references both the cancellation and the original settlement).
+
+## 7. Backward compatibility
+
+Additive. Facilitators that do not emit refund receipts are unaffected. Adoption is opt-in.
+
+## 8. Substrate authorship and amendment
+
+This extension is sole AlgoVoi authorship. The categorical refund-type enum, the PSD2 Article 89 mapping, the wire format, and the composition with the AlgoVoi-authored canonicalisation pin are AlgoVoi-authored work. The companion IETF Internet-Draft `draft-hopley-x402-refund-receipt` is the normative authorship anchor: substrate-author position is established by the I-D, not by this extension document.
+
+**The categorical enum is closed by design.** Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document authored by AlgoVoi or with explicit AlgoVoi co-authorship. Republication of the categorical enum, the regulatory mapping, or any normative element under a different attribution does not constitute substrate authorship of those elements.
+
+**Composition direction is fixed.** This extension is the senior artefact in the composition with the x402-foundation/x402 base specification. References to "composes with" describe technical integration, not co-authorship.
+
+Apache 2.0 of the AlgoVoi-authored reference implementations grants permission to USE, MODIFY, and DISTRIBUTE the code. It does not grant permission to REPUBLISH the normative format under a different authorship.
+
+## 9. References
+
+- RFC 8785: JSON Canonicalization Scheme (JCS)
+- [`draft-hopley-x402-refund-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-refund-receipt/): companion IETF I-D, full normative text, sole AlgoVoi authorship
+- [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/): canonicalisation pin I-D, sole AlgoVoi authorship
+- PSD2 / UK Payment Services Regulations 2017, Article 89
+- MiCA Regulation Article 80
+- UK MLRs 2017 Regulation 40
+
+-- AlgoVoi (chopmob-cloud)
+https://docs.algovoi.co.uk/acquisition

--- a/specs/extensions/refund-receipt-v1.md
+++ b/specs/extensions/refund-receipt-v1.md
@@ -8,44 +8,61 @@
 | Companion IETF I-D | [`draft-hopley-x402-refund-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-refund-receipt/) |
 | Companion canonicalisation I-D | [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) |
 | Reference impl | AlgoVoi-authored [`algovoi-refund-receipt`](https://pypi.org/project/algovoi-refund-receipt/) (PyPI) and [`@algovoi/refund-receipt`](https://www.npmjs.com/package/@algovoi/refund-receipt) (npm), Apache 2.0 |
+| Canonical specification page | [`docs.algovoi.co.uk/refund-receipt`](https://docs.algovoi.co.uk/refund-receipt) |
 | License | Apache 2.0 |
 
 ## 1. Scope
 
-This extension defines the wire format for a refund receipt covering PSD2 Article 89 refund obligations and the regulator-recognised refund-type taxonomy (full, partial, rejected).
+This extension defines the wire format for a refund receipt covering PSD2 Article 89 refund obligations and the regulator-recognised refund-outcome taxonomy (full, partial, rejected).
 
 This extension is the senior artefact in the composition with the x402-foundation/x402 base specification primitives. References to "composes with" describe technical integration, not co-authorship.
 
-## 2. The categorical refund type enum
+## 2. The categorical refund result enum
 
 The closed three-state enum is load-bearing:
 
-| Refund type | Semantic |
-|---|---|
-| `FULL` | Refund covers the full original settled amount |
-| `PARTIAL` | Refund covers a strict subset of the original settled amount; partial amount carried in the receipt |
-| `REJECTED` | Refund obligation evaluated and declined; carries the regulator-recognised refusal reason |
+| Refund result | Semantic | Regulatory significance |
+|---|---|---|
+| `FULL` | Refund covers the full original settled amount | Closes the consumer's right to further remedy under UK Consumer Rights Act 2015 and EU Consumer Rights Directive 2011/83/EU Article 9 |
+| `PARTIAL` | Refund covers a strict subset of the original settled amount; refunded value carried in the receipt | Does not close consumer-rights remedies; further refund obligations may remain |
+| `REJECTED` | Refund obligation evaluated and declined; the receipt records the denial event so downstream dispute chains can reference it | Required under PSD2 Article 89 for unauthorised-payment refund disputes; documented denial obligation |
 
 The enum is closed by design. Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document (`refund-receipt-v2` or higher) authored by AlgoVoi or with explicit AlgoVoi co-authorship.
 
 ## 3. Normative format
 
-The refund receipt is a JSON object canonicalised per the AlgoVoi-authored canonicalisation pin `urn:x402:canonicalisation:jcs-rfc8785-v1`, normatively defined in the IETF Internet-Draft [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) (Independent Submission, sole AlgoVoi authorship). The pin composes RFC 8785 JCS with the `canon_version` discipline. The receipt carries:
+A refund receipt is a seven-field JSON object canonicalised under RFC 8785 (JCS) per the AlgoVoi-authored canonicalisation pin `urn:x402:canonicalisation:jcs-rfc8785-v1`, normatively defined in the IETF Internet-Draft [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) (Independent Submission, sole AlgoVoi authorship). The receipt's `content_hash` is SHA-256 over the JCS-canonical bytes. Field names are sorted lexicographically by JCS during canonicalisation.
 
-- `refund_type`: closed enum above
-- `refund_amount`: present iff `refund_type` is `FULL` or `PARTIAL`
-- `original_settlement_ref`: content-addressed reference to the settlement being refunded
-- `refunded_at`: ISO 8601 UTC timestamp
-- `canon_version`: canonicalisation pin identifier (this v1 spec uses `urn:x402:canonicalisation:jcs-rfc8785-v1` per the AlgoVoi-authored I-D referenced above)
-- `signature`: detached signature over the JCS canonical bytes
+```json
+{
+  "canon_version": "jcs-rfc8785-v1",
+  "jurisdiction_flags": ["GB", "EU"],
+  "original_payment_ref": "sha256:0dd5d0b76c9b9281fdeb2509ad38ab132b16a17385ca01d976ff9e6e12563a0f",
+  "refund_amount": {"amount_minor": "100000", "asset_id": "USDC.6"},
+  "refund_provider_did": "did:web:api.algovoi.co.uk",
+  "refund_result": "FULL",
+  "refund_timestamp_ms": 1716494400000
+}
+```
 
-Full field-level schema is normatively defined in the companion IETF Internet-Draft `draft-hopley-x402-refund-receipt`.
+| Field | Type | Description |
+|---|---|---|
+| `canon_version` | string | In-band canonicalisation pin. Fixed `jcs-rfc8785-v1`. |
+| `jurisdiction_flags` | ordered array of string | ISO 3166-1 alpha-2 codes; primary jurisdiction first. Array order significant under RFC 8785 §3.2.3. |
+| `original_payment_ref` | string | `sha256:{hex}` reference to the original payment record (compliance receipt `content_hash`, settlement attestation, or operator-specific reference). |
+| `refund_amount` | object | `{amount_minor: string, asset_id: string}`. String `amount_minor` avoids float-precision and JS-integer-overflow concerns. |
+| `refund_provider_did` | string | DID URI identifying the refund-issuing party. |
+| `refund_result` | string (closed enum) | `FULL` / `PARTIAL` / `REJECTED`. |
+| `refund_timestamp_ms` | integer | Epoch milliseconds. MUST be integer. RFC 3339 string forms rejected. |
+
+The canonical specification is hosted at the AlgoVoi-controlled URI [`docs.algovoi.co.uk/refund-receipt`](https://docs.algovoi.co.uk/refund-receipt) and normatively defined in the companion IETF Internet-Draft `draft-hopley-x402-refund-receipt`. Implementations MUST follow the I-D where it is more specific than this extension document.
 
 ## 4. Regulatory alignment
 
 | Framework | Property addressed |
 |---|---|
 | **PSD2 Article 89** (refund obligations) | Three-state enum maps to the regulator-recognised refund outcomes |
+| **UK Consumer Rights Act 2015** + **EU Consumer Rights Directive 2011/83/EU Article 9** | `FULL` closes the consumer's right to further remedy within the statutory window |
 | **MiCA Article 80** (record-keeping) | Byte-deterministic year-N re-verifiability under the AlgoVoi-authored canon pin |
 | **UK MLRs 2017 Regulation 40** | Retainable under standard record-keeping |
 
@@ -57,7 +74,7 @@ AlgoVoi-authored [`algovoi-refund-receipt`](https://pypi.org/project/algovoi-ref
 
 ## 6. Composition with the x402-foundation/x402 base specification
 
-This extension composes with the x402-foundation/x402 base specification's settlement primitive (`original_settlement_ref` is the content-addressed pointer to the settled payment) and with the [`cancellation-receipt-v1`](./cancellation-receipt-v1.md) extension (a refund issued after a cancellation references both the cancellation and the original settlement).
+This extension composes with the x402-foundation/x402 base specification's settlement primitive (`original_payment_ref` is the content-addressed pointer to the settled payment) and with the [`cancellation-receipt-v1`](./cancellation-receipt-v1.md) extension (a refund issued after a cancellation references both the cancellation and the original settlement via `original_payment_ref`).
 
 ## 7. Backward compatibility
 
@@ -65,9 +82,9 @@ Additive. Facilitators that do not emit refund receipts are unaffected. Adoption
 
 ## 8. Substrate authorship and amendment
 
-This extension is sole AlgoVoi authorship. The categorical refund-type enum, the PSD2 Article 89 mapping, the wire format, and the composition with the AlgoVoi-authored canonicalisation pin are AlgoVoi-authored work. The companion IETF Internet-Draft `draft-hopley-x402-refund-receipt` is the normative authorship anchor: substrate-author position is established by the I-D, not by this extension document.
+This extension is sole AlgoVoi authorship. The canonical seven-field shape, the categorical refund-result enum, the PSD2 Article 89 mapping, and the composition with the AlgoVoi-authored canonicalisation pin are AlgoVoi-authored work. The companion IETF Internet-Draft `draft-hopley-x402-refund-receipt` is the normative authorship anchor: substrate-author position is established by the I-D, not by this extension document.
 
-**The categorical enum is closed by design.** Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document authored by AlgoVoi or with explicit AlgoVoi co-authorship. Republication of the categorical enum, the regulatory mapping, or any normative element under a different attribution does not constitute substrate authorship of those elements.
+**The categorical enum is closed by design.** Implementations MUST NOT extend the enum in-band. New values MAY be introduced only by a normative successor extension document authored by AlgoVoi or with explicit AlgoVoi co-authorship. Republication of the canonical shape, the categorical enum, the regulatory mapping, or any normative element under a different attribution does not constitute substrate authorship of those elements.
 
 **Composition direction is fixed.** This extension is the senior artefact in the composition with the x402-foundation/x402 base specification. References to "composes with" describe technical integration, not co-authorship.
 
@@ -78,7 +95,10 @@ Apache 2.0 of the AlgoVoi-authored reference implementations grants permission t
 - RFC 8785: JSON Canonicalization Scheme (JCS)
 - [`draft-hopley-x402-refund-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-refund-receipt/): companion IETF I-D, full normative text, sole AlgoVoi authorship
 - [`draft-hopley-x402-canonicalisation-jcs-v1`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/): canonicalisation pin I-D, sole AlgoVoi authorship
+- [`docs.algovoi.co.uk/refund-receipt`](https://docs.algovoi.co.uk/refund-receipt): canonical specification page (AlgoVoi-controlled)
 - PSD2 / UK Payment Services Regulations 2017, Article 89
+- UK Consumer Rights Act 2015
+- EU Consumer Rights Directive 2011/83/EU Article 9
 - MiCA Regulation Article 80
 - UK MLRs 2017 Regulation 40
 


### PR DESCRIPTION
## Summary

Adds two extension specifications covering the PSD2 post-payment lifecycle: `cancellation-receipt-v1` and `refund-receipt-v1`. Both formats use the AlgoVoi-authored canonicalisation pin `urn:x402:canonicalisation:jcs-rfc8785-v1` (per IETF I-D `draft-hopley-x402-canonicalisation-jcs-v1`) and SHA-256 binding. Both are categorical closed-enum verdict formats.

## Why x402 needs both

x402 today specifies the settlement primitive but has no formal lifecycle semantics after settlement. PSD2 Article 64 (right to revoke a payment authorisation) and PSD2 Article 89 (refund obligations) impose regulatory requirements on real payment systems that x402 does not currently address. This PR adds two minimal, additive extensions that close that gap.

## Authorship and substrate-author position

This PR is sole AlgoVoi authorship across spec text (both files), normative format, categorical enums, regulatory mappings, and the composition with the AlgoVoi-authored canonicalisation pin (`urn:x402:canonicalisation:jcs-rfc8785-v1` per IETF I-D `draft-hopley-x402-canonicalisation-jcs-v1`).

Companion IETF Internet-Drafts:

- [`draft-hopley-x402-cancellation-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-cancellation-receipt/), sole AlgoVoi authorship
- [`draft-hopley-x402-refund-receipt`](https://datatracker.ietf.org/doc/draft-hopley-x402-refund-receipt/), sole AlgoVoi authorship

Reference implementations, AlgoVoi-authored, Apache 2.0:

- `algovoi-cancellation-receipt` ([PyPI](https://pypi.org/project/algovoi-cancellation-receipt/), [npm](https://www.npmjs.com/package/@algovoi/cancellation-receipt))
- `algovoi-refund-receipt` ([PyPI](https://pypi.org/project/algovoi-refund-receipt/), [npm](https://www.npmjs.com/package/@algovoi/refund-receipt))

Both categorical enums are closed by design and may be amended only by a normative successor extension authored by AlgoVoi or with explicit AlgoVoi co-authorship. Re-publication of either format under a different attribution does not constitute substrate authorship of the elements defined here.

No coalition acknowledgements. This extension does not absorb from, depend on, or share authorship with any other party's work.

## Scope

Two new files, one per extension. No changes to existing spec files. No code changes.

- `specs/extensions/cancellation-receipt-v1.md`
- `specs/extensions/refund-receipt-v1.md`

-- AlgoVoi (chopmob-cloud)
https://docs.algovoi.co.uk/acquisition
