### PR TITLE
spec: capabilities field on SupportedKind for explicit facilitator variant support

### DIFF
--- a/specs/schemes/exact/scheme_exact_evm.md
+++ b/specs/schemes/exact/scheme_exact_evm.md
@@ -16,6 +16,25 @@ If no `assetTransferMethod` is specified in `PaymentRequired.extra`, clients sho
 
 In all cases, the Facilitator cannot modify the amount or destination. They serve only as the transaction broadcaster.
 
+### Facilitator Capability Declaration
+
+`assetTransferMethod` is the discriminator field for this scheme. Facilitators declare which values they support via `capabilities.assetTransferMethod` in their `/supported` response (see core spec §7.3.2). Valid values are `"eip3009"`, `"permit2"`, and `"erc7710"`. A facilitator omitting `capabilities` is assumed to support all three.
+
+Example kind entry for a facilitator that supports `eip3009` and `permit2` but not `erc7710`:
+
+```json
+{
+  "x402Version": 2,
+  "scheme": "exact",
+  "network": "eip155:84532",
+  "capabilities": {
+    "assetTransferMethod": ["eip3009", "permit2"]
+  }
+}
+```
+
+Servers must not advertise an `assetTransferMethod` in `PaymentRequired.extra` that is absent from the matched facilitator kind's `capabilities`.
+
 ---
 
 ## 1. AssetTransferMethod: `EIP-3009`

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -456,7 +456,10 @@ Returns the list of payment schemes, networks, and extensions supported by the f
     {
       "x402Version": 2,
       "scheme": "exact",
-      "network": "eip155:84532"
+      "network": "eip155:84532",
+      "capabilities": {
+        "assetTransferMethod": ["eip3009", "permit2"]
+      }
     },
     {
       "x402Version": 2,
@@ -494,10 +497,19 @@ Each `SupportedKind` object in the `kinds` array contains:
 
 | Field Name    | Type     | Required | Description                                                |
 | ------------- | -------- | -------- | ---------------------------------------------------------- |
-| `x402Version` | `number` | Required | Protocol version supported (2 for v2)                      |
-| `scheme`      | `string` | Required | Payment scheme identifier (e.g., "exact")                  |
-| `network`     | `string` | Required | Blockchain network identifier in CAIP-2 format             |
-| `extra`       | `object` | Optional | Additional scheme-specific configuration                   |
+| `x402Version`  | `number` | Required | Protocol version supported (2 for v2)                                                                             |
+| `scheme`       | `string` | Required | Payment scheme identifier (e.g., "exact")                                                                         |
+| `network`      | `string` | Required | Blockchain network identifier in CAIP-2 format                                                                    |
+| `extra`        | `object` | Optional | Additional scheme-specific configuration                                                                          |
+| `capabilities` | `object` | Optional | Discriminator-keyed capability constraints; see section 7.3.2. Absence implies full support for the scheme.       |
+
+**7.3.2 Capabilities**
+
+The optional `capabilities` object on a `SupportedKind` entry declares which discriminated variants of that scheme the facilitator supports on a given network. Each key in `capabilities` matches a discriminator field name in `PaymentRequirements.extra` for that scheme; each value is the array of accepted string values for that field.
+
+**Default behavior:** If `capabilities` is absent from a kind, the facilitator is assumed to support all variants the scheme defines. This is the backwards-compatible default for facilitators that predate this field.
+
+**Scheme obligation:** Scheme specifications that introduce discriminator fields in `PaymentRequirements.extra` must document the corresponding `capabilities` key and enumerate its valid values.
 
 **8. Discovery API**
 

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -501,15 +501,17 @@ Each `SupportedKind` object in the `kinds` array contains:
 | `scheme`       | `string` | Required | Payment scheme identifier (e.g., "exact")                                                                         |
 | `network`      | `string` | Required | Blockchain network identifier in CAIP-2 format                                                                    |
 | `extra`        | `object` | Optional | Additional scheme-specific configuration                                                                          |
-| `capabilities` | `object` | Optional | Discriminator-keyed capability constraints; see section 7.3.2. Absence implies full support for the scheme.       |
+| `capabilities` | `object` | Optional | Restricts which values the facilitator accepts for scheme-specific `PaymentRequirements.extra` fields; see §7.3.2. Absence implies full support. |
 
 **7.3.2 Capabilities**
 
-The optional `capabilities` object on a `SupportedKind` entry declares which discriminated variants of that scheme the facilitator supports on a given network. Each key in `capabilities` matches a discriminator field name in `PaymentRequirements.extra` for that scheme; each value is the array of accepted string values for that field.
+The optional `capabilities` object on a `SupportedKind` entry declares which values the facilitator will accept for specific fields in the server's `PaymentRequirements.extra` — the payment requirements the server advertises to clients. It does not describe the facilitator kind's own `extra` field above.
 
-**Default behavior:** If `capabilities` is absent from a kind, the facilitator is assumed to support all variants the scheme defines. This is the backwards-compatible default for facilitators that predate this field.
+Each key in `capabilities` is the name of a field in `PaymentRequirements.extra` for that scheme. Each value is an array of the strings the facilitator will accept for that field. Servers must not advertise a `PaymentRequirements.extra` field value that is absent from the corresponding `capabilities` array for the matched kind.
 
-**Scheme obligation:** Scheme specifications that introduce discriminator fields in `PaymentRequirements.extra` must document the corresponding `capabilities` key and enumerate its valid values.
+**Default behavior:** If `capabilities` is absent from a kind, the facilitator is assumed to accept all values the scheme defines for that field. This is the backwards-compatible default for facilitators that predate this field.
+
+**Scheme obligation:** Scheme specifications that introduce selectable fields in `PaymentRequirements.extra` must document the corresponding `capabilities` key and enumerate its valid values.
 
 **8. Discovery API**
 


### PR DESCRIPTION
## Problem

Facilitators' GET /supported responses have no way to declare which variants of a scheme they support — e.g. which assetTransferMethod values (eip3009, permit2, erc7710) an EVM facilitator handles. Servers are expected to know this out-of-band, which breaks for third-party facilitators and makes startup validation impossible.

## Solution

Adds an optional capabilities object to SupportedKind entries in GET /supported. Each key is a discriminator field name from  PaymentRequirements.extra for that scheme; each value is the array of accepted string values for that discriminator.

**This keying is intentional**: capabilities keys mirror the exact field names already present in PaymentRequirements.extra, enabling generic validation logic with no scheme-specific code — iterate capabilities entries, check each against the matching extra field of the same name.

**Backwards compatibility**: absence of capabilities means full support. Existing facilitators require no changes.

**Scheme obligation**: scheme specs that introduce discriminator fields in extra must document the corresponding capabilities key and enumerate valid values. Schemes with no discriminators omit capabilities entirely.

##  Changes

`specs/x402-specification-v2.md`
- SupportedKind field table: adds capabilities (optional)
- §7.3 example: one EVM kind now shows capabilities: { assetTransferMethod: ["eip3009", "permit2"] }
- §7.3.2 (new): defines semantics, default behavior, and scheme documentation obligation

`specs/schemes/exact/scheme_exact_evm.md`
- New "Facilitator Capability Declaration" section: names assetTransferMethod as the discriminator, enumerates valid values ("eip3009", "permit2", "erc7710"), shows an example kind entry, and states that servers must not advertise a method absent from the matched kind's capabilities