### PR TITLE
add svm smart wallet e2e test

### DIFF
--- a/e2e/clients/svm-smart-wallet/README.md
+++ b/e2e/clients/svm-smart-wallet/README.md
@@ -1,0 +1,47 @@
+# SVM Smart Wallet E2E Client
+
+Exercises x402 SVM **Path 2** (simulation-based smart wallet verification) using a [Swig](https://build.onswig.com/) wallet via [`@swig-wallet/kit`](https://build.onswig.com/reference/typescript/kit).
+
+Path 1 static validation rejects Swig-wrapped transactions (unknown program layout). With `enableSmartWalletVerification: true` on the facilitator, verification falls back to Path 2: simulate the transaction, inspect CPI inner instructions for `TransferChecked`, and match amount/mint/recipient.
+
+## How it works
+
+`CLIENT_SVM_PRIVATE_KEY` (passed as `SVM_PRIVATE_KEY`) is the Swig **authority** — the Ed25519 key that owns the root role. Before each endpoint, the e2e harness calls `scripts/swig-setup.ts` to ensure the Swig account exists, create ATAs if needed, and top up USDC when balance is below one payment (to 10× one payment). On first creation it writes `SWIG_ACCOUNT_ADDRESS` (and `SWIG_ID_BASE58` when generated) to `e2e/.env`. The client only builds and signs payment transactions.
+
+## Requirements
+
+- `SVM_PRIVATE_KEY` — Ed25519 authority (base58); e2e maps this from `CLIENT_SVM_PRIVATE_KEY`
+- `SWIG_ACCOUNT_ADDRESS` — written to `e2e/.env` automatically on first Swig creation
+- Devnet **SOL** on the authority key (~0.005 SOL for Swig creation; [Solana faucet](https://faucet.solana.com/))
+- Devnet **USDC** on the authority key ([Circle faucet](https://faucet.circle.com/))
+- `RESOURCE_SERVER_URL` / `ENDPOINT_PATH` — set by the e2e framework (target `/exact/svm`)
+
+Optional:
+
+- `SWIG_ID_BASE58` — fixed Swig id when creating a new account
+- `SVM_RPC_URL` — custom RPC (also forwarded from the e2e network config)
+- `SVM_USDC_MINT` — override devnet USDC mint for setup script
+
+## Setup (manual)
+
+From `e2e/` (same pattern as permit2):
+
+```bash
+pnpm swig:setup
+```
+
+First run writes `SWIG_ACCOUNT_ADDRESS` to `e2e/.env` automatically.
+
+## Run
+
+```bash
+cd e2e
+pnpm install
+pnpm test --testnet --clients=svm-smart-wallet --servers=express --facilitators=typescript --endpoints=/exact/svm --min
+```
+
+The harness runs `swig-setup` automatically before each svm-smart-wallet endpoint when the Swig USDC balance is below one payment — no manual setup needed for `pnpm test`.
+
+Use the **TypeScript** facilitator — it must register `ExactSvmScheme` with `enableSmartWalletVerification: true` (configured in `e2e/facilitators/typescript`).
+
+Go and Python facilitators do not implement SVM Path 2 yet; tests against those facilitators will fail verification.

--- a/e2e/clients/svm-smart-wallet/build.sh
+++ b/e2e/clients/svm-smart-wallet/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 0

--- a/e2e/clients/svm-smart-wallet/index.ts
+++ b/e2e/clients/svm-smart-wallet/index.ts
@@ -1,0 +1,90 @@
+import { config } from "dotenv";
+import { base58 } from "@scure/base";
+import { createKeyPairSignerFromBytes, type Address } from "@solana/kit";
+import { wrapFetchWithPayment } from "@x402/fetch";
+import { x402Client, x402HTTPClient } from "@x402/core/client";
+import { ExactSwigSvmScheme } from "./swigScheme.js";
+
+config();
+
+const baseURL = process.env.RESOURCE_SERVER_URL as string;
+const endpointPath = process.env.ENDPOINT_PATH as string;
+const url = `${baseURL}${endpointPath}`;
+
+if (!baseURL || !endpointPath || !process.env.SVM_PRIVATE_KEY) {
+  console.log(
+    JSON.stringify({
+      success: false,
+      error: "RESOURCE_SERVER_URL, ENDPOINT_PATH, and SVM_PRIVATE_KEY are required",
+    }),
+  );
+  process.exit(1);
+}
+
+const swigAccountAddress = process.env.SWIG_ACCOUNT_ADDRESS;
+if (!swigAccountAddress) {
+  console.log(
+    JSON.stringify({
+      success: false,
+      error:
+        "SWIG_ACCOUNT_ADDRESS is required (set in e2e/.env or run via e2e harness which runs swig-setup automatically)",
+    }),
+  );
+  process.exit(1);
+}
+
+const authority = await createKeyPairSignerFromBytes(
+  base58.decode(process.env.SVM_PRIVATE_KEY as string),
+);
+
+const client = new x402Client().register(
+  "solana:*",
+  new ExactSwigSvmScheme(
+    authority,
+    swigAccountAddress as Address,
+    process.env.SVM_RPC_URL,
+  ),
+);
+
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+fetchWithPayment(url, {
+  method: "GET",
+})
+  .then(async response => {
+    const data = await response.json();
+    const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(name =>
+      response.headers.get(name),
+    );
+
+    if (!paymentResponse) {
+      console.log(
+        JSON.stringify({
+          success: true,
+          data,
+          status_code: response.status,
+        }),
+      );
+      process.exit(0);
+      return;
+    }
+
+    console.log(
+      JSON.stringify({
+        success: paymentResponse.success,
+        data,
+        status_code: response.status,
+        payment_response: paymentResponse,
+      }),
+    );
+    process.exit(paymentResponse.success ? 0 : 1);
+  })
+  .catch(error => {
+    console.log(
+      JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    process.exit(1);
+  });

--- a/e2e/clients/svm-smart-wallet/install.sh
+++ b/e2e/clients/svm-smart-wallet/install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 0

--- a/e2e/clients/svm-smart-wallet/package.json
+++ b/e2e/clients/svm-smart-wallet/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@x402/svm-smart-wallet-e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx index.ts",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "dependencies": {
+    "@scure/base": "^1.2.6",
+    "@solana-program/compute-budget": "^0.11.0",
+    "@solana-program/token": "^0.9.0",
+    "@solana-program/token-2022": "^0.6.1",
+    "@solana/kit": "^6.1.0",
+    "@swig-wallet/kit": "^2.0.0",
+    "@swig-wallet/lib": "^2.0.0",
+    "@x402/core": "workspace:*",
+    "@x402/fetch": "workspace:*",
+    "dotenv": "^16.4.7"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/e2e/clients/svm-smart-wallet/run.sh
+++ b/e2e/clients/svm-smart-wallet/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pnpm dev

--- a/e2e/clients/svm-smart-wallet/swigScheme.ts
+++ b/e2e/clients/svm-smart-wallet/swigScheme.ts
@@ -1,0 +1,183 @@
+import {
+  getSetComputeUnitLimitInstruction,
+  setTransactionMessageComputeUnitPrice,
+} from "@solana-program/compute-budget";
+import {
+  fetchMint,
+  findAssociatedTokenPda,
+  getTransferCheckedInstruction,
+} from "@solana-program/token-2022";
+import {
+  addSignersToTransactionMessage,
+  appendTransactionMessageInstructions,
+  createSolanaRpc,
+  createTransactionMessage,
+  getBase64EncodedWireTransaction,
+  partiallySignTransactionMessageWithSigners,
+  pipe,
+  prependTransactionMessageInstruction,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Address,
+  type Instruction,
+  type KeyPairSigner,
+} from "@solana/kit";
+import { fetchSwig, getSignInstructions, getSwigWalletAddress } from "@swig-wallet/kit";
+import type { PaymentPayload, PaymentRequirements, SchemeNetworkClient } from "@x402/core/types";
+
+const DEVNET_RPC_URL = "https://api.devnet.solana.com";
+const MEMO_PROGRAM_ADDRESS = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr" as Address;
+const MAX_MEMO_BYTES = 256;
+const SMART_WALLET_COMPUTE_UNIT_LIMIT = 200_000;
+const SMART_WALLET_COMPUTE_UNIT_PRICE_MICROLAMPORTS = 10_000n;
+
+/**
+ * x402 Exact client that builds Swig smart-wallet payment transactions.
+ * Routes token transfers through Swig so the facilitator exercises SVM Path 2
+ * (simulation-based smart wallet verification).
+ *
+ * Expects Swig account setup to be done by `e2e/scripts/swig-setup.ts` (run
+ * automatically before each svm-smart-wallet endpoint when USDC balance is low).
+ */
+export class ExactSwigSvmScheme implements SchemeNetworkClient {
+  readonly scheme = "exact";
+
+  /**
+   * @param authority - Ed25519 signer for the Swig root role
+   * @param swigAccountAddress - Swig account PDA (from SWIG_ACCOUNT_ADDRESS)
+   * @param rpcUrl - Optional Solana RPC URL override
+   */
+  constructor(
+    private readonly authority: KeyPairSigner,
+    private readonly swigAccountAddress: Address,
+    private readonly rpcUrl?: string,
+  ) {}
+
+  /**
+   * Creates a Swig-signed payment payload with facilitator fee sponsorship.
+   *
+   * @param x402Version - x402 protocol version
+   * @param paymentRequirements - Accepted payment requirements from the 402 response
+   * @returns Payment payload containing a base64-encoded transaction
+   */
+  async createPaymentPayload(
+    x402Version: number,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<Pick<PaymentPayload, "x402Version" | "payload">> {
+    const rpc = createSolanaRpc(this.rpcUrl ?? DEVNET_RPC_URL);
+    const mint = paymentRequirements.asset as Address;
+    const amount = BigInt(paymentRequirements.amount);
+    const payTo = paymentRequirements.payTo as Address;
+
+    const swig = await fetchSwig(rpc as never, this.swigAccountAddress);
+    const swigWalletAddress = await getSwigWalletAddress(swig);
+    const rootRole = swig.findRolesByEd25519SignerPk(this.authority.address)[0];
+    if (!rootRole) {
+      throw new Error("Swig root role not found for authority");
+    }
+
+    const mintInfo = await fetchMint(rpc, mint);
+    const tokenProgram = mintInfo.programAddress;
+
+    const [sourceAta] = await findAssociatedTokenPda({
+      mint,
+      owner: swigWalletAddress,
+      tokenProgram,
+    });
+    const [destinationAta] = await findAssociatedTokenPda({
+      mint,
+      owner: payTo,
+      tokenProgram,
+    });
+
+    try {
+      const swigBalance = await rpc.getTokenAccountBalance(sourceAta).send();
+      if (BigInt(swigBalance.value.amount) < amount) {
+        throw new Error(
+          "Swig wallet USDC balance too low for payment. The e2e harness tops up automatically before each endpoint " +
+            "or run `pnpm swig:setup` from e2e/.",
+        );
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("Swig wallet USDC")) {
+        throw error;
+      }
+      throw new Error(
+        "Swig wallet token account missing or unfunded. Run `pnpm swig:setup` from e2e/ first.",
+      );
+    }
+
+    const transferIx = getTransferCheckedInstruction(
+      {
+        source: sourceAta,
+        mint,
+        destination: destinationAta,
+        authority: swigWalletAddress,
+        amount,
+        decimals: mintInfo.data.decimals,
+      },
+      { programAddress: tokenProgram },
+    );
+
+    const feePayer = paymentRequirements.extra?.feePayer as Address | undefined;
+    if (!feePayer) {
+      throw new Error("feePayer is required in paymentRequirements.extra for SVM transactions");
+    }
+
+    const refreshedSwig = await fetchSwig(rpc as never, this.swigAccountAddress);
+    const signIxs = (await getSignInstructions(refreshedSwig, rootRole.id, [
+      transferIx as never,
+    ])) as Instruction[];
+
+    const sellerMemo = paymentRequirements.extra?.memo as string | undefined;
+    let memoData: Uint8Array;
+    if (sellerMemo) {
+      memoData = new TextEncoder().encode(sellerMemo);
+      if (memoData.byteLength > MAX_MEMO_BYTES) {
+        throw new Error(`extra.memo exceeds maximum ${MAX_MEMO_BYTES} bytes`);
+      }
+    } else {
+      memoData = new TextEncoder().encode(
+        Array.from(crypto.getRandomValues(new Uint8Array(16)))
+          .map(b => b.toString(16).padStart(2, "0"))
+          .join(""),
+      );
+    }
+
+    const memoIx: Instruction = {
+      programAddress: MEMO_PROGRAM_ADDRESS,
+      accounts: [],
+      data: memoData,
+    };
+
+    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+    const tx = pipe(
+      createTransactionMessage({ version: 0 }),
+      message =>
+        setTransactionMessageComputeUnitPrice(
+          SMART_WALLET_COMPUTE_UNIT_PRICE_MICROLAMPORTS,
+          message,
+        ),
+      message => setTransactionMessageFeePayer(feePayer, message),
+      message =>
+        prependTransactionMessageInstruction(
+          getSetComputeUnitLimitInstruction({ units: SMART_WALLET_COMPUTE_UNIT_LIMIT }),
+          message,
+        ),
+      message => appendTransactionMessageInstructions([...signIxs, memoIx], message),
+      message => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, message),
+      message => addSignersToTransactionMessage([this.authority], message),
+    );
+
+    const signedTransaction = await partiallySignTransactionMessageWithSigners(tx);
+    const base64EncodedWireTransaction = getBase64EncodedWireTransaction(signedTransaction);
+
+    return {
+      x402Version,
+      payload: {
+        transaction: base64EncodedWireTransaction,
+      },
+    };
+  }
+}

--- a/e2e/clients/svm-smart-wallet/test.config.json
+++ b/e2e/clients/svm-smart-wallet/test.config.json
@@ -1,0 +1,12 @@
+{
+  "name": "svm-smart-wallet",
+  "type": "client",
+  "language": "typescript",
+  "protocolFamilies": ["svm"],
+  "x402Versions": [2],
+  "schemes": ["exact"],
+  "environment": {
+    "required": ["SVM_PRIVATE_KEY", "SWIG_ACCOUNT_ADDRESS", "RESOURCE_SERVER_URL", "ENDPOINT_PATH"],
+    "optional": ["SVM_RPC_URL", "SWIG_ID_BASE58"]
+  }
+}

--- a/e2e/clients/svm-smart-wallet/tsconfig.json
+++ b/e2e/clients/svm-smart-wallet/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/e2e/facilitators/typescript/index.ts
+++ b/e2e/facilitators/typescript/index.ts
@@ -423,7 +423,12 @@ facilitator
     new BatchSettlementEvmScheme(evmSigner, authorizerSigner),
   )
   .registerV1(EVM_V1_NETWORKS as Network[], new ExactEvmSchemeV1(evmSigner))
-  .register(SVM_NETWORK as Network, new ExactSvmScheme(svmSigner))
+  .register(
+    SVM_NETWORK as Network,
+    new ExactSvmScheme(svmSigner, undefined, {
+      enableSmartWalletVerification: true,
+    }),
+  )
   .registerV1(SVM_V1_NETWORKS as Network[], new ExactSvmSchemeV1(svmSigner));
 if (avmSigner) {
   facilitator.register(AVM_NETWORK as Network, new ExactAvmScheme(avmSigner));

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,9 +14,15 @@
     "clean": "rm -rf dist",
     "clean:ports": "lsof -ti:4022-4060 | xargs kill -9 2>/dev/null || echo 'Ports cleared'",
     "permit2:approve": "tsx scripts/permit2-approval.ts approve",
-    "permit2:revoke": "tsx scripts/permit2-approval.ts revoke"
+    "permit2:revoke": "tsx scripts/permit2-approval.ts revoke",
+    "swig:setup": "tsx scripts/swig-setup.ts"
   },
   "dependencies": {
+    "@scure/base": "^1.2.6",
+    "@solana-program/token-2022": "^0.6.1",
+    "@solana/kit": "^6.1.0",
+    "@swig-wallet/kit": "^2.0.0",
+    "@swig-wallet/lib": "^2.0.0",
     "dotenv": "^17.0.1",
     "prompts": "^2.4.2",
     "tsx": "^4.21.0",

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -8,6 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@scure/base':
+        specifier: ^1.2.6
+        version: 1.2.6
+      '@solana-program/token-2022':
+        specifier: ^0.6.1
+        version: 0.6.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      '@solana/kit':
+        specifier: ^6.1.0
+        version: 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@swig-wallet/kit':
+        specifier: ^2.0.0
+        version: 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@swig-wallet/lib':
+        specifier: ^2.0.0
+        version: 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       dotenv:
         specifier: ^17.0.1
         version: 17.0.1
@@ -1718,20 +1733,29 @@ importers:
         specifier: ^5.7.3
         version: 5.8.3
 
-  clients/svm-swig:
+  clients/svm-smart-wallet:
     dependencies:
       '@scure/base':
         specifier: ^1.2.6
         version: 1.2.6
-      '@solana/spl-token':
-        specifier: ^0.4.13
-        version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/web3.js':
-        specifier: ^1.98.4
-        version: 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@swig-wallet/classic':
+      '@solana-program/compute-budget':
+        specifier: ^0.11.0
+        version: 0.11.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana-program/token':
+        specifier: ^0.9.0
+        version: 0.9.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
+      '@solana-program/token-2022':
+        specifier: ^0.6.1
+        version: 0.6.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      '@solana/kit':
+        specifier: ^6.1.0
+        version: 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@swig-wallet/kit':
         specifier: ^2.0.0
-        version: 2.0.0(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@swig-wallet/lib':
+        specifier: ^2.0.0
+        version: 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@x402/core':
         specifier: workspace:*
         version: link:../../../typescript/packages/core
@@ -4114,11 +4138,9 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
-    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
-    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -4128,11 +4150,9 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
-    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
-    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -4422,7 +4442,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
+    deprecated: 'The package is now available as "qr": npm install qr'
 
   '@perawallet/connect@1.5.2':
     resolution: {integrity: sha512-Lq4nLaQBisZUkBIWirhRn4b9MjrKWvlMxfrU6On5al/14E5mm3dlnwGHhpJ88IGlnGs7JyL625LVMgUK1TOTrg==}
@@ -4691,7 +4711,6 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -4882,18 +4901,9 @@ packages:
       typescript:
         optional: true
 
-  '@solana/buffer-layout-utils@0.2.0':
-    resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
-    engines: {node: '>= 10'}
-
   '@solana/buffer-layout@4.0.1':
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
-
-  '@solana/codecs-core@2.0.0-rc.1':
-    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
-    peerDependencies:
-      typescript: '>=5'
 
   '@solana/codecs-core@2.3.0':
     resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
@@ -4928,11 +4938,6 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-data-structures@2.0.0-rc.1':
-    resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
-    peerDependencies:
-      typescript: '>=5'
-
   '@solana/codecs-data-structures@2.3.0':
     resolution: {integrity: sha512-qvU5LE5DqEdYMYgELRHv+HMOx73sSoV1ZZkwIrclwUmwTbTaH8QAJURBj0RhQ/zCne7VuLLOZFFGv6jGigWhSw==}
     engines: {node: '>=20.18.0'}
@@ -4966,11 +4971,6 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@2.0.0-rc.1':
-    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
-    peerDependencies:
-      typescript: '>=5'
-
   '@solana/codecs-numbers@2.3.0':
     resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
     engines: {node: '>=20.18.0'}
@@ -5003,12 +5003,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  '@solana/codecs-strings@2.0.0-rc.1':
-    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
-    peerDependencies:
-      fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5'
 
   '@solana/codecs-strings@2.3.0':
     resolution: {integrity: sha512-y5pSBYwzVziXu521hh+VxqUtp0hYGTl1eWGoc1W+8mdvBdC1kTqm/X7aYQw33J42hw03JjryvYOvmGgk3Qz/Ug==}
@@ -5053,11 +5047,6 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs@2.0.0-rc.1':
-    resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
-    peerDependencies:
-      typescript: '>=5'
-
   '@solana/codecs@2.3.0':
     resolution: {integrity: sha512-JVqGPkzoeyU262hJGdH64kNLH0M+Oew2CIPOa/9tR3++q2pEd4jU2Rxdfye9sd0Ce3XJrR5AIa8ZfbyQXzjh+g==}
     engines: {node: '>=20.18.0'}
@@ -5090,12 +5079,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  '@solana/errors@2.0.0-rc.1':
-    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5'
 
   '@solana/errors@2.3.0':
     resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
@@ -5374,11 +5357,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  '@solana/options@2.0.0-rc.1':
-    resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
-    peerDependencies:
-      typescript: '>=5'
 
   '@solana/options@2.3.0':
     resolution: {integrity: sha512-PPnnZBRCWWoZQ11exPxf//DRzN2C6AoFsDI/u2AsQfYih434/7Kp4XLpfOMT/XESi+gdBMFNNfbES5zg3wAIkw==}
@@ -5944,24 +5922,6 @@ packages:
       typescript:
         optional: true
 
-  '@solana/spl-token-group@0.0.7':
-    resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@solana/web3.js': ^1.95.3
-
-  '@solana/spl-token-metadata@0.1.6':
-    resolution: {integrity: sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@solana/web3.js': ^1.95.3
-
-  '@solana/spl-token@0.4.14':
-    resolution: {integrity: sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      '@solana/web3.js': ^1.95.5
-
   '@solana/subscribable@2.3.0':
     resolution: {integrity: sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==}
     engines: {node: '>=20.18.0'}
@@ -6230,13 +6190,11 @@ packages:
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
 
-  '@swig-wallet/classic@2.0.0':
-    resolution: {integrity: sha512-CtCf4nINRZgUH40UR+1NB+Og3NLIN9Ms7kKOm2J0PlY32mM8r7JFpG/WRnSqeHhq0td2vplXwdlOC7dX5+zqkQ==}
-    peerDependencies:
-      '@solana/web3.js': ^1.98.0
-
   '@swig-wallet/coder@2.0.0':
     resolution: {integrity: sha512-TWiRk23RKHplhQJLT86EBDhgbACoKwDdBTc1pGzukTWQA2RclvFNwXHGnUaNjIC5zODe1PyAoZGHfDDPOUprtQ==}
+
+  '@swig-wallet/kit@2.0.0':
+    resolution: {integrity: sha512-dwXL1OhBtWrkBA5q9s+B3n8yrnsQsaf2jmMzV29ldWeF+qXLMYhGjBVV09F11J46oyu3MY9dIB5CxVhfIaQihg==}
 
   '@swig-wallet/lib@2.0.0':
     resolution: {integrity: sha512-FhK+aCPai6170ENsC5AWjbCe7VFifeVLTclQPMcuOqlMfuATfCboiIg1ap8otjfjZ6MwsRNEvyMlJTONzy88/g==}
@@ -6742,7 +6700,6 @@ packages:
 
   '@walletconnect/ethereum-provider@2.21.1':
     resolution: {integrity: sha512-SSlIG6QEVxClgl1s0LMk4xr2wg4eT3Zn/Hb81IocyqNSGfXpjtawWxKxiC5/9Z95f1INyBD6MctJbL/R1oBwIw==}
-    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/events@1.0.1':
     resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
@@ -6829,11 +6786,9 @@ packages:
 
   '@walletconnect/universal-provider@2.21.0':
     resolution: {integrity: sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg==}
-    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/universal-provider@2.21.1':
     resolution: {integrity: sha512-Wjx9G8gUHVMnYfxtasC9poGm8QMiPCpXpbbLFT+iPoQskDDly8BwueWnqKs4Mx2SdIAWAwuXeZ5ojk5qQOxJJg==}
-    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/utils@1.8.0':
     resolution: {integrity: sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==}
@@ -7139,10 +7094,6 @@ packages:
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
 
-  bigint-buffer@1.1.5:
-    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
-    engines: {node: '>= 10.0.0'}
-
   bignumber.js@9.1.1:
     resolution: {integrity: sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==}
 
@@ -7152,9 +7103,6 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
@@ -8193,9 +8141,6 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -10730,12 +10675,10 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valtio@1.13.2:
@@ -10891,7 +10834,6 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -14175,6 +14117,10 @@ snapshots:
     dependencies:
       '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
 
+  '@solana-program/compute-budget@0.11.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+
   '@solana-program/compute-budget@0.8.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
@@ -14198,9 +14144,14 @@ snapshots:
       '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/sysvars': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
 
-  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/token-2022@0.6.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))':
     dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@solana/sysvars': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+
+  '@solana-program/token@0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/token@0.5.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -14217,6 +14168,10 @@ snapshots:
   '@solana-program/token@0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+
+  '@solana-program/token@0.9.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
 
   '@solana/accounts@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
     dependencies:
@@ -14361,26 +14316,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@solana/buffer-layout-utils@0.2.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      bigint-buffer: 1.1.5
-      bignumber.js: 9.3.1
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - typescript
-      - utf-8-validate
-
   '@solana/buffer-layout@4.0.1':
     dependencies:
       buffer: 6.0.3
-
-  '@solana/codecs-core@2.0.0-rc.1(typescript@5.8.3)':
-    dependencies:
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
-      typescript: 5.8.3
 
   '@solana/codecs-core@2.3.0(typescript@5.8.3)':
     dependencies:
@@ -14406,13 +14344,6 @@ snapshots:
     dependencies:
       '@solana/errors': 6.1.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 5.8.3
-
-  '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
       typescript: 5.8.3
 
   '@solana/codecs-data-structures@2.3.0(typescript@5.8.3)':
@@ -14451,12 +14382,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
-      typescript: 5.8.3
-
   '@solana/codecs-numbers@2.3.0(typescript@5.8.3)':
     dependencies:
       '@solana/codecs-core': 2.3.0(typescript@5.8.3)
@@ -14486,14 +14411,6 @@ snapshots:
       '@solana/codecs-core': 6.1.0(typescript@5.8.3)
       '@solana/errors': 6.1.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 5.8.3
-
-  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
-      fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.8.3
 
   '@solana/codecs-strings@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
@@ -14537,17 +14454,6 @@ snapshots:
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.8.3
-
-  '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
 
   '@solana/codecs@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
     dependencies:
@@ -14604,12 +14510,6 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
-
-  '@solana/errors@2.0.0-rc.1(typescript@5.8.3)':
-    dependencies:
-      chalk: 5.6.2
-      commander: 12.1.0
-      typescript: 5.8.3
 
   '@solana/errors@2.3.0(typescript@5.8.3)':
     dependencies:
@@ -14816,7 +14716,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -14829,11 +14729,11 @@ snapshots:
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/rpc-parsed-types': 2.3.0(typescript@5.8.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/signers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       typescript: 5.8.3
@@ -15001,17 +14901,6 @@ snapshots:
       '@solana/keys': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/nominal-types': 6.1.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.8.3)
-      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 2.0.0-rc.1(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -15394,14 +15283,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.8.3)
       '@solana/functional': 2.3.0(typescript@5.8.3)
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.8.3)
       '@solana/subscribable': 2.3.0(typescript@5.8.3)
       typescript: 5.8.3
-      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
@@ -15496,7 +15385,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.8.3)
       '@solana/fast-stable-stringify': 2.3.0(typescript@5.8.3)
@@ -15504,7 +15393,7 @@ snapshots:
       '@solana/promises': 2.3.0(typescript@5.8.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.8.3)
       '@solana/rpc-subscriptions-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.8.3)
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -15914,37 +15803,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - typescript
-
-  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)':
-    dependencies:
-      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - typescript
-
-  '@solana/spl-token@0.4.14(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
-    dependencies:
-      '@solana/buffer-layout': 4.0.1
-      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      buffer: 6.0.3
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
-
   '@solana/subscribable@2.3.0(typescript@5.8.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.8.3)
@@ -16022,7 +15880,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -16030,7 +15888,7 @@ snapshots:
       '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/promises': 2.3.0(typescript@5.8.3)
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -16448,35 +16306,34 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swig-wallet/classic@2.0.0(@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@swig-wallet/coder@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - ws
+
+  '@swig-wallet/kit@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@noble/curves': 1.9.7
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@swig-wallet/coder': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@swig-wallet/lib': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@swig-wallet/coder': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@swig-wallet/lib': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       bn.js: 5.2.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
       - ws
 
-  '@swig-wallet/coder@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - ws
-
-  '@swig-wallet/lib@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@swig-wallet/lib@2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
-      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@swig-wallet/coder': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana-program/token': 0.5.1(@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@swig-wallet/coder': 2.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       bn.js: 5.2.2
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -18627,19 +18484,11 @@ snapshots:
 
   big.js@6.2.2: {}
 
-  bigint-buffer@1.1.5:
-    dependencies:
-      bindings: 1.5.0
-
   bignumber.js@9.1.1: {}
 
   bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   blakejs@1.2.1: {}
 
@@ -20040,8 +19889,6 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
-
-  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:

--- a/e2e/scripts/swig-setup.ts
+++ b/e2e/scripts/swig-setup.ts
@@ -1,0 +1,322 @@
+/**
+ * Swig Smart Wallet Setup Script
+ *
+ * Creates a Swig account for CLIENT_SVM_PRIVATE_KEY (if needed), creates ATAs,
+ * and funds the Swig wallet with devnet USDC for svm-smart-wallet e2e tests.
+ *
+ * Usage:
+ *   pnpm tsx scripts/swig-setup.ts
+ *   pnpm swig:setup
+ *
+ * Environment variables:
+ *   CLIENT_SVM_PRIVATE_KEY - Swig authority (required)
+ *   SVM_RPC_URL            - Solana RPC (optional, defaults to devnet)
+ *   SWIG_ACCOUNT_ADDRESS   - Reuse existing Swig account (optional)
+ *   SWIG_ID_BASE58         - Fixed Swig id when creating (optional)
+ *   SVM_USDC_MINT          - Token mint to fund (optional, devnet USDC default)
+ *
+ * Funding uses the standard e2e exact price ($0.001 = 1000 base units). If Swig
+ * balance is below one payment, tops up to 10× that amount.
+ *
+ * On first Swig creation, persists SWIG_ACCOUNT_ADDRESS (and SWIG_ID_BASE58 when
+ * generated) to e2e/.env automatically.
+ *
+ * Prints a JSON result line on success:
+ *   {"ok":true,"swigAccountAddress":"..."}
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { config } from "dotenv";
+import { base58 } from "@scure/base";
+import {
+  fetchMint,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  getTransferCheckedInstruction,
+} from "@solana-program/token-2022";
+import {
+  addSignersToTransactionMessage,
+  appendTransactionMessageInstructions,
+  createKeyPairSignerFromBytes,
+  createSolanaRpc,
+  createSolanaRpcSubscriptions,
+  createTransactionMessage,
+  getSignatureFromTransaction,
+  pipe,
+  sendAndConfirmTransactionFactory,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+  type Address,
+  type Instruction,
+  type KeyPairSigner,
+  type Rpc,
+  type RpcSubscriptions,
+  type SolanaRpcApi,
+  type SolanaRpcSubscriptionsApi,
+} from "@solana/kit";
+import {
+  fetchSwig,
+  findSwigPda,
+  getCreateSwigInstruction,
+  getSwigWalletAddress,
+} from "@swig-wallet/kit";
+import { Actions, createEd25519AuthorityInfo } from "@swig-wallet/lib";
+
+config();
+
+const DEVNET_RPC_URL = "https://api.devnet.solana.com";
+const DEVNET_WS_URL = "wss://api.devnet.solana.com";
+const USDC_DEVNET_MINT = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+const MIN_AUTHORITY_SOL = 5_000_000n;
+/** Standard e2e exact endpoint price: $0.001 USDC (6 decimals). */
+const E2E_EXACT_PAYMENT_BASE_UNITS = 1_000n;
+const SWIG_FUND_MULTIPLIER = 10n;
+
+type SwigConnection = {
+  rpc: Rpc<SolanaRpcApi>;
+  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+};
+
+function createConnection(rpcUrl?: string): SwigConnection {
+  const url = rpcUrl ?? DEVNET_RPC_URL;
+  const wsUrl = rpcUrl?.replace(/^http/i, "ws") ?? DEVNET_WS_URL;
+  return {
+    rpc: createSolanaRpc(url),
+    rpcSubscriptions: createSolanaRpcSubscriptions(wsUrl),
+  };
+}
+
+async function sendInstructions(
+  connection: SwigConnection,
+  payer: KeyPairSigner,
+  instructions: Instruction[],
+  signers: KeyPairSigner[] = [],
+): Promise<string> {
+  const sendAndConfirm = sendAndConfirmTransactionFactory(connection);
+  const { value: latestBlockhash } = await connection.rpc.getLatestBlockhash().send();
+
+  const txMessage = pipe(
+    createTransactionMessage({ version: 0 }),
+    tx => setTransactionMessageFeePayerSigner(payer, tx),
+    tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+    tx => appendTransactionMessageInstructions(instructions, tx),
+    tx => addSignersToTransactionMessage(signers, tx),
+  );
+
+  const signedTx = await signTransactionMessageWithSigners(txMessage);
+  await sendAndConfirm(signedTx as Parameters<typeof sendAndConfirm>[0], {
+    commitment: "confirmed",
+  });
+  return getSignatureFromTransaction(signedTx);
+}
+
+async function requireSolBalance(
+  connection: SwigConnection,
+  address: Address,
+  minimumLamports: bigint,
+): Promise<void> {
+  const balance = await connection.rpc.getBalance(address).send();
+  if (balance.value >= minimumLamports) {
+    return;
+  }
+
+  throw new Error(
+    `CLIENT_SVM_PRIVATE_KEY (${address}) needs at least ${minimumLamports} lamports of devnet SOL ` +
+      `(current: ${balance.value}). Fund via https://faucet.solana.com/ then retry.`,
+  );
+}
+
+type ResolvedSwigAccount = {
+  address: Address;
+  created: boolean;
+  /** Set when a new random Swig id was generated (persisted to .env). */
+  swigIdBase58?: string;
+};
+
+function upsertEnvFile(envPath: string, updates: Record<string, string>): void {
+  let content = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
+
+  for (const [key, value] of Object.entries(updates)) {
+    const line = `${key}=${value}`;
+    const pattern = new RegExp(`^${key}=.*$`, "m");
+    if (pattern.test(content)) {
+      content = content.replace(pattern, line);
+    } else {
+      if (content.length > 0 && !content.endsWith("\n")) {
+        content += "\n";
+      }
+      content += `${line}\n`;
+    }
+  }
+
+  writeFileSync(envPath, content);
+}
+
+function persistSwigEnv(envPath: string, resolved: ResolvedSwigAccount): void {
+  const updates: Record<string, string> = {
+    SWIG_ACCOUNT_ADDRESS: resolved.address,
+  };
+  if (resolved.swigIdBase58) {
+    updates.SWIG_ID_BASE58 = resolved.swigIdBase58;
+  }
+
+  upsertEnvFile(envPath, updates);
+  console.log(`💾 Saved Swig settings to ${envPath}`);
+}
+
+async function resolveSwigAccountAddress(
+  connection: SwigConnection,
+  authority: KeyPairSigner,
+): Promise<ResolvedSwigAccount> {
+  const fromEnv = process.env.SWIG_ACCOUNT_ADDRESS;
+  if (fromEnv) {
+    console.log(`ℹ️  Using existing Swig account ${fromEnv}`);
+    return { address: fromEnv as Address, created: false };
+  }
+
+  await requireSolBalance(connection, authority.address, MIN_AUTHORITY_SOL);
+
+  const swigIdFromEnv = process.env.SWIG_ID_BASE58;
+  const swigId = swigIdFromEnv ? base58.decode(swigIdFromEnv) : (() => {
+    const id = new Uint8Array(32);
+    crypto.getRandomValues(id);
+    return id;
+  })();
+  const swigAccountAddress = await findSwigPda(swigId);
+  const createSwigIx = await getCreateSwigInstruction({
+    payer: authority.address,
+    id: swigId,
+    authorityInfo: createEd25519AuthorityInfo(authority.address),
+    actions: Actions.set().all().get(),
+  });
+
+  console.log(`🔄 Creating Swig account ${swigAccountAddress}...`);
+  const sig = await sendInstructions(connection, authority, [createSwigIx as Instruction]);
+  console.log(`   ✅ Swig create tx: ${sig}`);
+
+  return {
+    address: swigAccountAddress,
+    created: true,
+    swigIdBase58: swigIdFromEnv ? undefined : base58.encode(swigId),
+  };
+}
+
+async function ensureSwigFunded(
+  connection: SwigConnection,
+  authority: KeyPairSigner,
+  swigAccountAddress: Address,
+  mint: Address,
+): Promise<void> {
+  const swig = await fetchSwig(connection.rpc as never, swigAccountAddress);
+  const swigWalletAddress = await getSwigWalletAddress(swig);
+
+  const mintInfo = await fetchMint(connection.rpc, mint);
+  const tokenProgram = mintInfo.programAddress;
+  const decimals = mintInfo.data.decimals;
+
+  const [authorityAta] = await findAssociatedTokenPda({
+    mint,
+    owner: authority.address,
+    tokenProgram,
+  });
+  const [swigAta] = await findAssociatedTokenPda({
+    mint,
+    owner: swigWalletAddress,
+    tokenProgram,
+  });
+
+  const createAuthorityAtaIx = await getCreateAssociatedTokenInstructionAsync({
+    payer: authority,
+    mint,
+    owner: authority.address,
+    tokenProgram,
+  });
+  const createSwigAtaIx = await getCreateAssociatedTokenInstructionAsync({
+    payer: authority,
+    mint,
+    owner: swigWalletAddress,
+    tokenProgram,
+  });
+
+  try {
+    await connection.rpc.getTokenAccountBalance(authorityAta).send();
+  } catch {
+    console.log("🔄 Creating authority USDC ATA...");
+    await sendInstructions(connection, authority, [createAuthorityAtaIx]);
+  }
+
+  try {
+    await connection.rpc.getTokenAccountBalance(swigAta).send();
+  } catch {
+    console.log("🔄 Creating Swig wallet USDC ATA...");
+    await sendInstructions(connection, authority, [createSwigAtaIx]);
+  }
+
+  const swigBalance = await connection.rpc.getTokenAccountBalance(swigAta).send();
+  const swigAmount = BigInt(swigBalance.value.amount);
+  const fundTarget = E2E_EXACT_PAYMENT_BASE_UNITS * SWIG_FUND_MULTIPLIER;
+
+  if (swigAmount >= E2E_EXACT_PAYMENT_BASE_UNITS) {
+    console.log(
+      `✅ Swig wallet has ${swigBalance.value.uiAmountString} USDC (≥ ${E2E_EXACT_PAYMENT_BASE_UNITS} base units for one payment)`,
+    );
+    return;
+  }
+
+  const topUpAmount = fundTarget - swigAmount;
+  const authorityBalance = await connection.rpc.getTokenAccountBalance(authorityAta).send();
+  if (BigInt(authorityBalance.value.amount) < topUpAmount) {
+    throw new Error(
+      "Authority USDC balance too low. Fund CLIENT_SVM_PRIVATE_KEY with devnet USDC " +
+        "(https://faucet.circle.com/) then retry.",
+    );
+  }
+
+  console.log(`🔄 Funding Swig wallet with ${topUpAmount} base units of USDC...`);
+  const fundIx = getTransferCheckedInstruction(
+    {
+      source: authorityAta,
+      mint,
+      destination: swigAta,
+      authority,
+      amount: topUpAmount,
+      decimals,
+    },
+    { programAddress: tokenProgram },
+  );
+  const sig = await sendInstructions(connection, authority, [fundIx]);
+  console.log(`   ✅ Fund tx: ${sig}`);
+}
+
+async function main(): Promise<void> {
+  const privateKey = process.env.CLIENT_SVM_PRIVATE_KEY;
+  if (!privateKey) {
+    console.error("❌ CLIENT_SVM_PRIVATE_KEY environment variable is required");
+    process.exit(1);
+  }
+
+  const rpcUrl = process.env.SVM_RPC_URL;
+  const mint = (process.env.SVM_USDC_MINT ?? USDC_DEVNET_MINT) as Address;
+  const connection = createConnection(rpcUrl);
+  const authority = await createKeyPairSignerFromBytes(base58.decode(privateKey));
+
+  console.log(`\n🔑 Authority: ${authority.address}`);
+  console.log(`📍 RPC: ${rpcUrl ?? DEVNET_RPC_URL}`);
+  console.log(`💰 Mint: ${mint}\n`);
+
+  const resolved = await resolveSwigAccountAddress(connection, authority);
+  await ensureSwigFunded(connection, authority, resolved.address, mint);
+
+  if (resolved.created) {
+    persistSwigEnv(join(process.cwd(), ".env"), resolved);
+  }
+
+  console.log(JSON.stringify({ ok: true, swigAccountAddress: resolved.address }));
+}
+
+main().catch(error => {
+  console.error("Error:", error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/e2e/src/clients/generic-client.ts
+++ b/e2e/src/clients/generic-client.ts
@@ -31,6 +31,8 @@ export class GenericClientProxy extends BaseProxy implements ClientProxy {
         ENDPOINT_PATH: config.endpointPath,
         EVM_NETWORK: config.evmNetwork,
         EVM_RPC_URL: config.evmRpcUrl,
+        SVM_NETWORK: config.svmNetwork,
+        SVM_RPC_URL: config.svmRpcUrl,
         HEDERA_NETWORK: config.hederaNetwork,
         HEDERA_NODE_URL: config.hederaNodeUrl,
         TVM_NETWORK: config.tvmNetwork,

--- a/e2e/src/types.ts
+++ b/e2e/src/types.ts
@@ -86,6 +86,8 @@ export interface ClientConfig {
   endpointPath: string;
   evmNetwork: string;
   evmRpcUrl: string;
+  svmNetwork: string;
+  svmRpcUrl: string;
   hederaNetwork: string;
   hederaNodeUrl: string;
   tvmNetwork: string;

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -132,6 +132,80 @@ async function revokePermit2Approval(tokenAddress?: string): Promise<boolean> {
 }
 
 /**
+ * Prepare Swig smart-wallet state for svm-smart-wallet e2e client tests.
+ * Called before each endpoint; creates/funds via scripts/swig-setup.ts when balance is low.
+ */
+async function setupSwigWallet(svmRpcUrl: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    verboseLog('  🔧 Running Swig wallet setup...');
+
+    const child = spawn('tsx', ['scripts/swig-setup.ts'], {
+      cwd: process.cwd(),
+      stdio: 'pipe',
+      shell: true,
+      env: {
+        ...process.env,
+        SVM_RPC_URL: svmRpcUrl,
+      },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout?.on('data', (data) => {
+      const text = data.toString();
+      stdout += text;
+      verboseLog(text.trim());
+    });
+
+    child.stderr?.on('data', (data) => {
+      stderr += data.toString();
+      verboseLog(data.toString().trim());
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        errorLog(`  ❌ Swig setup failed (exit code ${code})`);
+        if (stderr) {
+          errorLog(`  Error: ${stderr}`);
+        }
+        resolve(false);
+        return;
+      }
+
+      const lines = stdout.trim().split('\n');
+      for (let i = lines.length - 1; i >= 0; i--) {
+        try {
+          const parsed = JSON.parse(lines[i]!) as { ok?: boolean; swigAccountAddress?: string };
+          if (parsed.ok && parsed.swigAccountAddress) {
+            process.env.SWIG_ACCOUNT_ADDRESS = parsed.swigAccountAddress;
+            verboseLog(`  ✅ Swig setup complete: ${parsed.swigAccountAddress}`);
+            resolve(true);
+            return;
+          }
+        } catch {
+          // not JSON — keep scanning
+        }
+      }
+
+      if (process.env.SWIG_ACCOUNT_ADDRESS) {
+        verboseLog(`  ✅ Swig setup complete (using SWIG_ACCOUNT_ADDRESS=${process.env.SWIG_ACCOUNT_ADDRESS})`);
+        resolve(true);
+        return;
+      }
+
+      errorLog('  ❌ Swig setup succeeded but no swigAccountAddress in output');
+      resolve(false);
+    });
+
+    child.on('error', (error) => {
+      errorLog(`  ❌ Failed to run Swig setup: ${error.message}`);
+      resolve(false);
+    });
+  });
+}
+
+/**
  * Shared EVM clients for the ETH sandwich helpers.
  * Lazily initialised on first use so that missing env vars don't blow up
  * non-EVM test runs.
@@ -782,6 +856,15 @@ async function runTest() {
     }
   }
 
+  const hasSwigSmartWalletScenarios = filteredScenarios.some(
+    s => s.client.name === 'svm-smart-wallet',
+  );
+
+  if (hasSwigSmartWalletScenarios) {
+    log('🔧 Swig smart-wallet scenarios detected — swig-setup runs before each endpoint when balance is low');
+    log('');
+  }
+
   // Collect unique facilitators and servers
   const uniqueFacilitators = new Map<string, any>();
   const uniqueServers = new Map<string, any>();
@@ -815,6 +898,7 @@ async function runTest() {
     'TVM_NETWORK',
     'EVM_RPC_URL',
     'SVM_RPC_URL',
+    'SWIG_ACCOUNT_ADDRESS',
     'APTOS_RPC_URL',
     'HEDERA_NODE_URL',
     'STELLAR_RPC_URL',
@@ -1036,6 +1120,8 @@ async function runTest() {
       endpointPath: scenario.endpoint.path,
       evmNetwork: networks.evm.caip2,
       evmRpcUrl: networks.evm.rpcUrl,
+      svmNetwork: networks.svm.caip2,
+      svmRpcUrl: networks.svm.rpcUrl,
       hederaNetwork: networks.hedera.caip2,
       hederaNodeUrl: networks.hedera.rpcUrl,
       tvmNetwork: networks.tvm.caip2,
@@ -1326,6 +1412,10 @@ async function runTest() {
       for (const scenario of scenarios) {
         const tn = nextTestNumber();
         const isEvm = scenario.protocolFamily === 'evm';
+
+        if (scenario.client.name === 'svm-smart-wallet') {
+          await setupSwigWallet(networks.svm.rpcUrl);
+        }
 
         if (scenario.endpoint.schemeOptions?.permit2Direct === true) {
           await approvePermit2Approval(evmPermit2Asset);

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -47,7 +47,8 @@ import { verifySmartWalletTransaction, verifyPostSettlement } from "./smartWalle
 const DEFAULT_SMART_WALLET_ALLOWED_PROGRAMS = [
   "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf", // Squads Multisig v4
   "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG", // Squads Smart Account
-  "swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB", // Swig
+  "SWiGmQedKzMz1tiTqoJCWeGDnGXfNBp2PkXLkpCAtQo", // Swig (legacy)
+  "swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB", // Swig v2 (@swig-wallet/kit 2.x)
   "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw", // SPL Governance
   "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d", // Metaplex Core
   LIGHTHOUSE_PROGRAM_ADDRESS, // Phantom's wallet-protection assertions (see #2097)

--- a/typescript/site/app/facilitator/index.ts
+++ b/typescript/site/app/facilitator/index.ts
@@ -125,7 +125,10 @@ async function createFacilitator(): Promise<x402Facilitator> {
     )
     .register("eip155:84532", new UptoEvmScheme(evmSigner))
     .register("eip155:84532", new BatchSettlementEvmScheme(evmSigner, receiverAuthorizerSigner))
-    .register("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", new ExactSvmScheme(svmSigner))
+    .register(
+      "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+      new ExactSvmScheme(svmSigner, undefined, { enableSmartWalletVerification: true }),
+    )
     .registerV1("solana-devnet" as Network, new ExactSvmSchemeV1(svmSigner));
 
   // Optionally register Algorand if configured


### PR DESCRIPTION
## Description

- Adds a svm smart wallet client to e2e tests
- Enables svm smart wallet support for the x402.org facilitator

## Tests

✅ PASSED TESTS:

```
  # 1: fetch → express → /exact/svm
      Facilitator: typescript
      Network: solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1
      Tx: 3qadgMFC6rEMv9n1SEPaLeRvLyvW3o859UEWodAuHkGkiVdWhgGBrgMgmVqE8AZUVp3YHUrsVP3ivTjtSpHt8ssg
  # 2: svm-smart-wallet → express → /exact/svm
      Facilitator: typescript
      Network: solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1
      Tx: 2yvRfgR4FYeVKcN6CyCfgL9q4rz6ZXYWk81HwnAcnvy24qwpyncyTv6e2irtVTFf1hfzimrkYVbpYjaubcxFGVbG
```
## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 