### PR TITLE
fix: preserve v1 path params in discovery

### DIFF
--- a/go/extensions/bazaar/bazaar_test.go
+++ b/go/extensions/bazaar/bazaar_test.go
@@ -841,6 +841,30 @@ func TestV1Transformation(t *testing.T) {
 		assert.Equal(t, "integer parameter", queryInput.QueryParams["offset"])
 	})
 
+	t.Run("should extract discovery info from v1 GET with pathParams", func(t *testing.T) {
+		v1Requirements := map[string]interface{}{
+			"outputSchema": map[string]interface{}{
+				"input": map[string]interface{}{
+					"discoverable": true,
+					"method":       "GET",
+					"pathParams": map[string]interface{}{
+						"resourceId": "string parameter",
+					},
+					"type": "http",
+				},
+				"output": map[string]interface{}{"type": "object"},
+			},
+		}
+
+		info, err := v1.ExtractDiscoveryInfoV1(v1Requirements)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		queryInput, ok := info.Input.(bazaar.QueryInput)
+		require.True(t, ok)
+		assert.Equal(t, "string parameter", queryInput.PathParams["resourceId"])
+	})
+
 	t.Run("should extract discovery info from v1 POST with bodyFields", func(t *testing.T) {
 		v1Requirements := map[string]interface{}{
 			"outputSchema": map[string]interface{}{
@@ -936,6 +960,34 @@ func TestV1Transformation(t *testing.T) {
 		bodyMap, ok := bodyInput.Body.(map[string]interface{})
 		require.True(t, ok)
 		assert.NotNil(t, bodyMap["question"])
+	})
+
+	t.Run("should extract discovery info from v1 POST with pathParams", func(t *testing.T) {
+		v1Requirements := map[string]interface{}{
+			"outputSchema": map[string]interface{}{
+				"input": map[string]interface{}{
+					"bodyFields": map[string]interface{}{
+						"name": map[string]interface{}{
+							"type": "string",
+						},
+					},
+					"discoverable": true,
+					"method":       "POST",
+					"pathParams": map[string]interface{}{
+						"resourceId": "string parameter",
+					},
+					"type": "http",
+				},
+			},
+		}
+
+		info, err := v1.ExtractDiscoveryInfoV1(v1Requirements)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		bodyInput, ok := info.Input.(bazaar.BodyInput)
+		require.True(t, ok)
+		assert.Equal(t, "string parameter", bodyInput.PathParams["resourceId"])
 	})
 
 	t.Run("should extract discovery info from v1 POST with properties field", func(t *testing.T) {

--- a/go/extensions/v1/facilitator.go
+++ b/go/extensions/v1/facilitator.go
@@ -158,11 +158,13 @@ func ExtractDiscoveryInfoV1(paymentRequirements interface{}) (*types.DiscoveryIn
 	if types.IsQueryMethod(method) {
 		// Query parameter method (GET, HEAD, DELETE)
 		queryParams := extractQueryParams(v1Input)
+		pathParams := extractPathParams(v1Input)
 
 		queryInput := types.QueryInput{
 			Type:        "http",
 			Method:      types.QueryParamMethods(method),
 			QueryParams: queryParams,
+			PathParams:  pathParams,
 			Headers:     headers,
 		}
 
@@ -174,6 +176,7 @@ func ExtractDiscoveryInfoV1(paymentRequirements interface{}) (*types.DiscoveryIn
 		// Body method (POST, PUT, PATCH)
 		body, bodyType := extractBodyInfo(v1Input)
 		queryParams := extractQueryParams(v1Input) // Some POST requests also have query params
+		pathParams := extractPathParams(v1Input)
 
 		bodyInput := types.BodyInput{
 			Type:        "http",
@@ -181,6 +184,7 @@ func ExtractDiscoveryInfoV1(paymentRequirements interface{}) (*types.DiscoveryIn
 			BodyType:    bodyType,
 			Body:        body,
 			QueryParams: queryParams,
+			PathParams:  pathParams,
 			Headers:     headers,
 		}
 
@@ -208,6 +212,17 @@ func extractQueryParams(v1Input map[string]interface{}) map[string]interface{} {
 	}
 	if params, ok := v1Input["params"].(map[string]interface{}); ok {
 		return params
+	}
+	return nil
+}
+
+// extractPathParams extracts path parameters from v1 input.
+func extractPathParams(v1Input map[string]interface{}) map[string]interface{} {
+	if pathParams, ok := v1Input["pathParams"].(map[string]interface{}); ok {
+		return pathParams
+	}
+	if pathParams, ok := v1Input["path_params"].(map[string]interface{}); ok {
+		return pathParams
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #2507

## Summary
- Preserve v1 `outputSchema.input.pathParams` when converting to v2 Bazaar discovery info.
- Apply the preserved path params for both query-based and body-based HTTP inputs.
- Add v1 transformation tests for GET and POST path params.

## Impact
V1 dynamic route metadata is no longer dropped when converted into `extensions.bazaar.info`.

## Validation
- `go test ./extensions/v1 ./extensions/bazaar`
  - `github.com/x402-foundation/x402/go/extensions/v1`: no test files
  - `github.com/x402-foundation/x402/go/extensions/bazaar`: passed