### PR TITLE
Fix Swig smart wallet program allowlist

### DIFF
--- a/typescript/.changeset/swig-smart-wallet-program-id.md
+++ b/typescript/.changeset/swig-smart-wallet-program-id.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": patch
+---
+
+Fix the default SVM smart wallet allowlist to use Swig's active program ID.

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -47,7 +47,7 @@ import { verifySmartWalletTransaction, verifyPostSettlement } from "./smartWalle
 const DEFAULT_SMART_WALLET_ALLOWED_PROGRAMS = [
   "SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf", // Squads Multisig v4
   "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG", // Squads Smart Account
-  "SWiGmQedKzMz1tiTqoJCWeGDnGXfNBp2PkXLkpCAtQo", // Swig
+  "swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB", // Swig
   "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw", // SPL Governance
   "CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d", // Metaplex Core
   LIGHTHOUSE_PROGRAM_ADDRESS, // Phantom's wallet-protection assertions (see #2097)

--- a/typescript/packages/mechanisms/svm/test/unit/smartWalletFallback.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/smartWalletFallback.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../src/constants";
 
 const COMPUTE_BUDGET_PROGRAM = "ComputeBudget111111111111111111111111111111" as Address;
+const SWIG_PROGRAM = "swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB" as Address;
 const TOKEN_PROGRAM = TOKEN_PROGRAM_ADDRESS.toString();
 
 const FAKE_BLOCKHASH = {
@@ -232,6 +233,80 @@ describe("ExactSvmScheme smart wallet fallback path", () => {
     const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
       enableSmartWalletVerification: true,
       smartWalletAllowedPrograms: [unknownProgram.address],
+    });
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted: {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: payTo.address,
+          maxTimeoutSeconds: 3600,
+          extra: { feePayer: feePayer.address },
+        },
+        payload: { transaction: txBase64 },
+      } as never,
+      {
+        scheme: "exact",
+        network: SOLANA_DEVNET_CAIP2,
+        asset: USDC_DEVNET_ADDRESS,
+        amount: "100000",
+        payTo: payTo.address,
+        maxTimeoutSeconds: 3600,
+        extra: { feePayer: feePayer.address },
+      } as never,
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.payer).toBe(payer.address);
+    expect(mockSigner.simulateTransactionWithInnerInstructions).toHaveBeenCalled();
+  });
+
+  it("verify allows Swig through the default smart wallet allowlist", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    const txBase64 = await buildSmartWalletPayload(feePayer.address, SWIG_PROGRAM, payer.address);
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi.fn().mockResolvedValue({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              buildMockInnerTransfer(
+                TOKEN_PROGRAM,
+                USDC_DEVNET_ADDRESS,
+                expectedAta,
+                payer.address as string,
+                "100000",
+              ),
+            ],
+          },
+        ],
+      }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never, undefined, {
+      enableSmartWalletVerification: true,
     });
 
     const result = await scheme.verify(


### PR DESCRIPTION
## Summary
- Replace the default SVM smart wallet allowlist entry for Swig with the active Swig program ID: `swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB`
- Add a regression test proving Swig passes the default smart wallet allowlist
- Add a patch changeset for `@x402/svm`

## Verification
- Verified `swigypWHEksbC64pWKwah1WTeh9JXwx8H1rJHLdbQMB` is executable on Solana mainnet and devnet
- Verified `SWiGmQedKzMz1tiTqoJCWeGDnGXfNBp2PkXLkpCAtQo` returns `AccountNotFound` on Solana mainnet and devnet
- Cross-checked against Swig wallet source `declare_id!` and swig-ts `SWIG_PROGRAM_ADDRESS_STRING`

## Tests
- `pnpm --dir typescript --filter @x402/svm test -- smartWalletFallback.test.ts`
- `pnpm --dir typescript --filter @x402/svm format:check`
- `pnpm --dir typescript --filter @x402/svm lint:check`
- `pnpm --dir typescript --filter @x402/svm build`