### PR TITLE
Upfront specs

### DIFF
--- a/specs/schemes/upfront/scheme_upfront.md
+++ b/specs/schemes/upfront/scheme_upfront.md
@@ -1,0 +1,88 @@
+# Scheme: `upfront`
+
+## Summary
+
+`upfront` settles a fixed payment **before** the resource server executes the protected request. Like [`exact`](../exact/scheme_exact.md), it transfers a server-specified amount, but the payment is final before the route handler runs.
+
+```
+exact:    verify → route handler → settle → resource delivery
+upfront:  verify + settle → route handler → resource delivery
+```
+
+## Example Use Cases
+
+`upfront` is intended for cases where the server needs payment finality **before** doing work:
+
+- Resources that perform expensive compute (e.g. long-running inference).
+- Resources that trigger irreversible or hard-to-reverse actions (e.g. sending a message, minting an NFT).
+- Networks that have no smart-contract pull-settlement and can only verify a payment the client has already made (see [Asset Transfer Methods](#asset-transfer-methods)).
+
+## `upfront` vs `exact`
+
+The two schemes differ only in *when* settlement happens relative to the route handler, but that ordering changes who carries the residual risk.
+
+### `exact`: settle after a successful response
+
+Under `exact`, the server settles only if its route handler returns success. If the handler returns a status `>= 400`, the server does not settle and **the client is never charged**, so refunds are generally unnecessary.
+
+`exact` guarantees that **no resource is delivered if settlement fails**. The residual risk falls on the *server*, and is small:
+
+- The payment authorization can become invalid between `verify` and `settle` (for example it expires, or the client double-spends the nonce, while the route handler runs).
+- The settlement transaction can fail to land (e.g. network congestion).
+
+In either case the server may have already spent resources producing a response it cannot get paid for.
+
+### `upfront`: settle before the route handler
+
+Under `upfront`, payment is final before the route handler runs. This removes the server's settlement-failure risk (funds are confirmed before any work begins), at the cost of shifting **delivery risk to the client**: the client has paid before knowing whether the resource will be delivered successfully.
+
+- Clients **opt in** to `upfront` acknowledging this risk, and SHOULD prefer `exact` when it is offered for the same resource.
+- Servers **MAY** offer refunds for failed or undelivered resources, but refunds are **out of protocol**: whether, when, and how a refund is issued depends entirely on the server implementation. The x402 protocol provides no refund mechanism for `upfront`.
+
+### When to choose `upfront`
+
+Choose `upfront` when the server needs a payment-finality guarantee before route execution. This is most relevant for expensive compute or irreversible actions, where the server cannot safely begin work on the promise of a later settlement. It also applies when the underlying network cannot pull funds and only supports client-initiated payment with a proof.
+
+## Asset Transfer Methods
+
+`upfront` is defined independently of how the asset moves. The `extra.assetTransferMethod` field selects a method, and methods fall into two families. Both satisfy the defining property: **payment is final before the route handler executes.**
+
+### 1. Authorization-based (facilitator-settled)
+
+The client signs an off-chain payment authorization; the facilitator submits the settlement transaction **before** the route handler runs. This gives the client a gasless UX while giving the server finality first.
+
+- Requires a network primitive that lets a third party pull funds against a client signature (e.g. EIP-3009 / Permit2 on EVM).
+- Verification confirms the signed authorization is valid and will settle; settlement is then performed by the facilitator ahead of execution.
+
+### 2. Payment-proof (client-settled)
+
+The client **pays first** (broadcasting the transfer and paying any network fee) and presents a **payment proof** with the request. The server/facilitator verifies the proof before executing the route handler.
+
+- The proof is a network-native settlement reference: an onchain transaction hash/id, or a cryptographic settlement secret.
+- Because the client has already settled, the verifier only confirms the proof matches the requirement (amount, recipient, freshness, and single-use); there is no separate settlement step for the facilitator.
+
+## Core Properties (MUST)
+
+All `upfront` implementations, regardless of network or asset transfer method, MUST enforce:
+
+1. **Settle-before-execute ordering.** The payment MUST be confirmed final before the protected route handler is invoked. If verification or settlement fails, the server MUST NOT execute the resource.
+2. **Exact amount.** The settled amount MUST equal the server-specified `amount` (modulo network dust/fee conventions documented per network).
+3. **Recipient binding.** The settlement MUST be bound to the `payTo` recipient; neither facilitator nor any relayer can redirect funds.
+4. **Single-use / replay protection.** Each authorization or payment proof MUST be accepted at most once. For payment-proof methods, the verifier MUST track consumed proofs (e.g. transaction hashes) and reject reuse.
+
+## Refunds
+
+Refunds for undelivered or failed resources are **out of protocol** under `upfront`. Servers MAY implement them, but clients MUST NOT assume a refund path exists. This is the primary reason a client SHOULD prefer `exact` when available.
+
+## Network-Specific Implementation
+
+Network-specific rules and implementation details are defined in the per-network scheme documents:
+
+- EVM chains: See [`scheme_upfront_evm.md`](./scheme_upfront_evm.md)
+
+---
+## Version History
+
+| Version | Date       | Changes       | Authors                 |
+| ------- | ---------- | ------------- | ----------------------- |
+| v1.0    | 2025-05-29 | Initial draft | @phdargen               |

--- a/specs/schemes/upfront/scheme_upfront_evm.md
+++ b/specs/schemes/upfront/scheme_upfront_evm.md
@@ -1,0 +1,179 @@
+# Scheme: `upfront` on `EVM`
+
+## Summary
+
+This document specifies the EVM implementation of the `upfront` scheme. See [`scheme_upfront.md`](./scheme_upfront.md) for the network-agnostic scheme definition, the `upfront` vs `exact` comparison, trust model, and security considerations.
+
+On EVM, `upfront` uses the authorization-based (facilitator-settled) asset transfer family and supports two methods:
+
+| `extra.assetTransferMethod` | Who submits | Asset support | Client gas |
+| :-------------------------- | :---------- | :------------ | :--------- |
+| **`eip3009`**               | Facilitator | Tokens with `transferWithAuthorization` (e.g. USDC) | Gasless |
+| **`permit2`**               | Facilitator | Any ERC-20 with one-time Permit2 approval | Gasless |
+
+The methods are mutually exclusive per payment; the server selects which it accepts in `PaymentRequired`. Clients SHOULD NOT mix asset transfer methods within a single payment.
+
+Both methods reuse the same onchain primitives, signing flows, and verification logic as their `exact`-scheme counterparts ([`scheme_exact_evm.md`](../exact/scheme_exact_evm.md)). The only behavioral difference is settlement ordering: the facilitator settles **before** the resource server executes the protected request.
+
+---
+
+## 1. AssetTransferMethod: `eip3009`
+
+The `eip3009` method under `upfront` uses the same EIP-3009 `transferWithAuthorization` flow as `exact`, with one behavioral change: **the facilitator settles before the resource server executes the protected request**.
+
+This gives the client a gasless UX (no onchain transaction from the client wallet) while giving the server payment finality before doing any work.
+
+### 1.1 Payment Requirements
+
+```json
+{
+  "scheme": "upfront",
+  "network": "eip155:84532",
+  "amount": "10000",
+  "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+  "maxTimeoutSeconds": 60,
+  "extra": {
+    "assetTransferMethod": "eip3009",
+    "name": "USDC",
+    "version": "2"
+  }
+}
+```
+
+### 1.2 Payment Payload
+
+Identical to the `exact` scheme's `eip3009` payload:
+
+```json
+{
+  "x402Version": 2,
+  "resource": { "...": "..." },
+  "accepted": {
+    "scheme": "upfront",
+    "network": "eip155:84532",
+    "amount": "10000",
+    "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+    "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+    "maxTimeoutSeconds": 60,
+    "extra": {
+      "assetTransferMethod": "eip3009",
+      "name": "USDC",
+      "version": "2"
+    }
+  },
+  "payload": {
+    "signature": "0x...",
+    "authorization": {
+      "from": "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+      "to": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "value": "10000",
+      "validAfter": "1740672089",
+      "validBefore": "1740672154",
+      "nonce": "0x..."
+    }
+  }
+}
+```
+
+### 1.3 Verification
+
+Identical to the `exact` scheme's `eip3009` verification (signature recovery, balance check, parameter match, validity window, simulation). See [`scheme_exact_evm.md`](./scheme_exact_evm.md#phase-2-verification-logic).
+
+### 1.4 Settlement (pre-execution)
+
+The resource server MUST `/settle` **before** invoking the protected resource handler. Concretely:
+
+```
+verify(payload, requirements)         # facilitator
+  → on failure: return 402, do not execute resource
+settle(payload, requirements)         # facilitator broadcasts transferWithAuthorization
+  → on failure: return 402, do not execute resource
+execute(protected resource)           # only after settle succeeds
+return response + PAYMENT-RESPONSE
+```
+
+Settlement is performed by the facilitator calling `transferWithAuthorization` on the ERC-20 contract, identical to `exact` settlement.
+
+---
+
+## 2. AssetTransferMethod: `permit2`
+
+The `permit2` method under `upfront` mirrors the `exact` scheme's `permit2` flow, with the same settlement-ordering change as `eip3009`.
+
+### 2.1 Payment Requirements
+
+```json
+{
+  "scheme": "upfront",
+  "network": "eip155:84532",
+  "amount": "10000",
+  "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  "payTo": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+  "maxTimeoutSeconds": 60,
+  "extra": {
+    "assetTransferMethod": "permit2",
+    "name": "USDC",
+    "version": "2"
+  }
+}
+```
+
+### 2.2 Payment Payload
+
+Identical to the `exact` scheme's `permit2` payload (including the `x402ExactPermit2Proxy` spender, the `permit2Authorization` object, and the witness). See [`scheme_exact_evm.md`](./scheme_exact_evm.md#2-assettransfermethod-permit2).
+
+### 2.3 Verification
+
+Identical to the `exact` scheme's `permit2` verification, including:
+
+- One-time Permit2 approval check (or use of the `erc20ApprovalGasSponsoring` / `eip2612GasSponsoring` extensions),
+- Witness validation,
+- Simulation of `x402ExactPermit2Proxy.settle`.
+
+### 2.4 Settlement (pre-execution)
+
+The resource server MUST invoke `/settle` **before** invoking the protected resource handler. Settlement is performed by calling the canonical `x402ExactPermit2Proxy`, using the same settlement logic as `exact`, but ordered before the protected resource handler.
+
+### 2.5 Permit2 reuse across schemes
+
+The same `x402ExactPermit2Proxy` contract serves both `exact` and `upfront` for the `permit2` asset transfer method. No new contract deployment is required.
+
+---
+
+## 3. Error Codes
+
+In addition to the standard x402 error codes, `upfront` on EVM defines:
+
+### Common to all asset transfer methods
+
+- **`upfront_settlement_failed`**: `/settle` failed before resource execution; client was not charged.
+- **`upfront_unsupported_asset_transfer_method`**: `extra.assetTransferMethod` is not supported by this facilitator on this network.
+
+### `eip3009`-specific
+
+Same verification failures as `exact` `eip3009`, but reported under `upfront`-scoped codes:
+
+- **`invalid_upfront_evm_payload_signature`**: Payment authorization signature is invalid or improperly signed.
+- **`invalid_upfront_evm_payload_authorization_valid_after`**: Payment authorization is not yet valid (before `validAfter` timestamp).
+- **`invalid_upfront_evm_payload_authorization_valid_before`**: Payment authorization has expired (after `validBefore` timestamp).
+- **`invalid_upfront_evm_payload_authorization_value_mismatch`**: Payment amount does not exactly match the required amount.
+- **`invalid_upfront_evm_payload_recipient_mismatch`**: Recipient address does not match payment requirements.
+
+### `permit2`-specific
+
+Same verification failures as `exact` `permit2`, but reported under `upfront`-scoped codes:
+
+- **`invalid_upfront_evm_permit2_allowance_required`**: Permit2 allowance is required before payment.
+- **`invalid_upfront_evm_permit2_invalid_signature`**: Permit2 authorization signature is invalid.
+- **`invalid_upfront_evm_permit2_amount_mismatch`**: Permit2 authorization amount does not match the required amount.
+- **`invalid_upfront_evm_permit2_deadline_expired`**: Permit2 authorization deadline has expired.
+- **`invalid_upfront_evm_permit2_invalid_spender`**: Permit2 authorization spender is not the expected spender.
+- **`invalid_upfront_evm_permit2_recipient_mismatch`**: Witness recipient does not match payment requirements.
+---
+
+## Version History
+
+| Version | Date       | Changes       | Authors                 |
+| ------- | ---------- | ------------- | ----------------------- |
+| v1.0    | 2025-05-29 | Initial draft | @phdargen               |


### PR DESCRIPTION
## Introducing the `upfront` scheme

`upfront` settles a fixed payment **before** the resource server executes the protected request. Like [`exact`](../exact/scheme_exact.md), it transfers a server-specified amount, but the payment is final before the route handler runs.

```
exact:    verify → route handler → settle → resource delivery
upfront:  verify + settle → route handler → resource delivery
```

## Example Use Cases

`upfront` is intended for cases where the server needs payment finality **before** doing work:

- Resources that perform expensive compute (e.g. long-running inference).
- Resources that trigger irreversible or hard-to-reverse actions (e.g. sending a message, minting an NFT).
- Networks that have no smart-contract pull-settlement and can only verify a payment the client has already made (see [Asset Transfer Methods](#asset-transfer-methods)).

## Asset Transfer Methods

`upfront` is defined independently of how the asset moves. The `extra.assetTransferMethod` field selects a method, and methods fall into two families. Both satisfy the defining property: **payment is final before the route handler executes.**

### 1. Authorization-based (facilitator-settled)

The client signs an off-chain payment authorization; the facilitator submits the settlement transaction **before** the route handler runs. This gives the client a gasless UX while giving the server finality first.

- Requires a network primitive that lets a third party pull funds against a client signature (e.g. EIP-3009 / Permit2 on EVM).
- Verification confirms the signed authorization is valid and will settle; settlement is then performed by the facilitator ahead of execution.
- EVM upfront spec for `"assetTransferMethod": "eip3009,permit2"` included in this PR

### 2. Payment-proof (client-settled)

The client **pays first** (broadcasting the transfer and paying any network fee) and presents a **payment proof** with the request. The server/facilitator verifies the proof before executing the route handler.

This would cover eg:
- EVM TxID: https://github.com/x402-foundation/x402/pull/1004
- ZCash: https://github.com/x402-foundation/x402/pull/1634
- BTC lightning: https://github.com/x402-foundation/x402/pull/1311
- BSV: https://github.com/x402-foundation/x402/pull/1844 
- Near intents: https://github.com/x402-foundation/x402/pull/2102
