### PR TITLE
fix(go): preserve v1 outputSchema.input.pathParams in ExtractDiscoveryInfoV1

### DIFF
--- a/go/.changes/unreleased/preserve-v1-pathparams.yaml
+++ b/go/.changes/unreleased/preserve-v1-pathparams.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Preserve `pathParams` from v1 `outputSchema.input` in `ExtractDiscoveryInfoV1` for both query and body methods, so v1 dynamic-route metadata is no longer dropped when converting to `extensions.bazaar.info`.
+time: 2026-05-30T01:15:00Z

--- a/go/extensions/v1/facilitator.go
+++ b/go/extensions/v1/facilitator.go
@@ -158,11 +158,13 @@ func ExtractDiscoveryInfoV1(paymentRequirements interface{}) (*types.DiscoveryIn
 	if types.IsQueryMethod(method) {
 		// Query parameter method (GET, HEAD, DELETE)
 		queryParams := extractQueryParams(v1Input)
+		pathParams := extractPathParams(v1Input)
 
 		queryInput := types.QueryInput{
 			Type:        "http",
 			Method:      types.QueryParamMethods(method),
 			QueryParams: queryParams,
+			PathParams:  pathParams,
 			Headers:     headers,
 		}
 
@@ -174,6 +176,7 @@ func ExtractDiscoveryInfoV1(paymentRequirements interface{}) (*types.DiscoveryIn
 		// Body method (POST, PUT, PATCH)
 		body, bodyType := extractBodyInfo(v1Input)
 		queryParams := extractQueryParams(v1Input) // Some POST requests also have query params
+		pathParams := extractPathParams(v1Input)   // Dynamic routes may carry path params too
 
 		bodyInput := types.BodyInput{
 			Type:        "http",
@@ -181,6 +184,7 @@ func ExtractDiscoveryInfoV1(paymentRequirements interface{}) (*types.DiscoveryIn
 			BodyType:    bodyType,
 			Body:        body,
 			QueryParams: queryParams,
+			PathParams:  pathParams,
 			Headers:     headers,
 		}
 
@@ -208,6 +212,20 @@ func extractQueryParams(v1Input map[string]interface{}) map[string]interface{} {
 	}
 	if params, ok := v1Input["params"].(map[string]interface{}); ok {
 		return params
+	}
+	return nil
+}
+
+// extractPathParams extracts path parameters from v1 input.
+// v1 dynamic-route metadata carries these so they must be preserved when
+// converting to extensions.bazaar.info (see ExtractDiscoveryInfoV1).
+func extractPathParams(v1Input map[string]interface{}) map[string]interface{} {
+	// Check both camelCase and snake_case field names used in v1.
+	if pathParams, ok := v1Input["pathParams"].(map[string]interface{}); ok {
+		return pathParams
+	}
+	if pathParams, ok := v1Input["path_params"].(map[string]interface{}); ok {
+		return pathParams
 	}
 	return nil
 }

--- a/go/extensions/v1/facilitator_test.go
+++ b/go/extensions/v1/facilitator_test.go
@@ -1,0 +1,106 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/x402-foundation/x402/go/v2/extensions/types"
+)
+
+// TestExtractDiscoveryInfoV1_PreservesPathParams verifies that v1 dynamic-route
+// metadata (outputSchema.input.pathParams) survives the conversion to
+// extensions.bazaar.info for both query (GET) and body (POST) methods.
+func TestExtractDiscoveryInfoV1_PreservesPathParams(t *testing.T) {
+	pathParams := map[string]interface{}{
+		"id":     "string",
+		"region": "string",
+	}
+
+	t.Run("query method preserves pathParams", func(t *testing.T) {
+		req := map[string]interface{}{
+			"outputSchema": map[string]interface{}{
+				"input": map[string]interface{}{
+					"type":   "http",
+					"method": "GET",
+					"queryParams": map[string]interface{}{
+						"limit": "number",
+					},
+					"pathParams": pathParams,
+				},
+			},
+		}
+
+		info, err := ExtractDiscoveryInfoV1(req)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		queryInput, ok := info.Input.(types.QueryInput)
+		require.True(t, ok, "expected QueryInput, got %T", info.Input)
+		assert.Equal(t, pathParams, queryInput.PathParams)
+		// Existing behaviour must be unaffected.
+		assert.Equal(t, map[string]interface{}{"limit": "number"}, queryInput.QueryParams)
+	})
+
+	t.Run("body method preserves pathParams", func(t *testing.T) {
+		req := map[string]interface{}{
+			"outputSchema": map[string]interface{}{
+				"input": map[string]interface{}{
+					"type":   "http",
+					"method": "POST",
+					"bodyFields": map[string]interface{}{
+						"name": "string",
+					},
+					"pathParams": pathParams,
+				},
+			},
+		}
+
+		info, err := ExtractDiscoveryInfoV1(req)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		bodyInput, ok := info.Input.(types.BodyInput)
+		require.True(t, ok, "expected BodyInput, got %T", info.Input)
+		assert.Equal(t, pathParams, bodyInput.PathParams)
+	})
+
+	t.Run("snake_case path_params is also read", func(t *testing.T) {
+		req := map[string]interface{}{
+			"outputSchema": map[string]interface{}{
+				"input": map[string]interface{}{
+					"type":        "http",
+					"method":      "GET",
+					"path_params": pathParams,
+				},
+			},
+		}
+
+		info, err := ExtractDiscoveryInfoV1(req)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		queryInput, ok := info.Input.(types.QueryInput)
+		require.True(t, ok, "expected QueryInput, got %T", info.Input)
+		assert.Equal(t, pathParams, queryInput.PathParams)
+	})
+
+	t.Run("absent pathParams stays nil", func(t *testing.T) {
+		req := map[string]interface{}{
+			"outputSchema": map[string]interface{}{
+				"input": map[string]interface{}{
+					"type":   "http",
+					"method": "GET",
+				},
+			},
+		}
+
+		info, err := ExtractDiscoveryInfoV1(req)
+		require.NoError(t, err)
+		require.NotNil(t, info)
+
+		queryInput, ok := info.Input.(types.QueryInput)
+		require.True(t, ok, "expected QueryInput, got %T", info.Input)
+		assert.Nil(t, queryInput.PathParams)
+	})
+}


### PR DESCRIPTION
## What

`ExtractDiscoveryInfoV1` normalized v1 `outputSchema.input` query params, body fields, and headers, but did **not** read `pathParams`. As a result, v1 dynamic-route metadata was silently dropped when converting to `extensions.bazaar.info`.

This adds an `extractPathParams` helper (mirroring `extractQueryParams`, supporting both `pathParams` and `path_params`) and populates the already-existing `PathParams` field on both `QueryInput` and `BodyInput`.

Fixes #2507

## Changes
- `go/extensions/v1/facilitator.go`: extract `pathParams` and set `QueryInput.PathParams` / `BodyInput.PathParams`.
- `go/extensions/v1/facilitator_test.go`: new tests covering query method, body method, snake_case `path_params`, and the absent-stays-nil case.
- `go/.changes/unreleased/preserve-v1-pathparams.yaml`: Changie fragment (Fixed).

## Testing
```
go test ./extensions/v1/ ./extensions/bazaar/   # ok
go vet ./extensions/v1/                          # clean
gofmt -l                                         # clean
```
The `QueryInput`/`BodyInput` structs already declared `PathParams map[string]interface{} \`json:"pathParams,omitempty"\``, so this only wires up the extraction — no type or serialization changes.