### PR TITLE
feat(ecosystem): add Blue Hub — AI tools for Base builders

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/blue-hub/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/blue-hub/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Blue Hub",
+  "description": "35+ AI-powered tools for Base builders and autonomous agents — token signals, contract audits, market analysis, due diligence, launch readiness, and more. Pay per call in USDC on Base. No API keys, no subscriptions.",
+  "logoUrl": "/logos/blue-hub.svg",
+  "websiteUrl": "https://blueagent.dev/hub",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/blue-hub.svg
+++ b/typescript/site/public/logos/blue-hub.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><rect width="100" height="100" rx="20" fill="#0052FF"/><text x="50" y="62" font-family="Arial,sans-serif" font-size="42" font-weight="bold" text-anchor="middle" fill="white">B</text></svg>


### PR DESCRIPTION
## Summary

Adds Blue Hub to the x402 ecosystem.

**Blue Hub** runs 35+ AI-powered tools for Base builders and autonomous agents — token signals, contract security audits, market-fit analysis, deep due diligence, launch readiness, ecosystem intel, and more. Each tool is a pay-per-call HTTP endpoint that speaks x402 v2 natively, so Base MCP and any x402-compatible client can call any tool and settle USDC payments without extra wiring.

- Website: https://blueagent.dev/hub
- API catalog: https://blueagent.dev/api/catalog
- Plugin manifest: https://blueagent.dev/plugin.md
- MCP server: https://blueagent.dev/api/mcp
- Category: Services/Endpoints

**Network:** Base mainnet (`eip155:8453`)  
**Asset:** USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)  
**Payment:** x402 v2 · pay-per-call · no API key · no subscription  
**Facilitator:** Coinbase CDP (on-chain transferWithAuthorization)