### PR TITLE
Reject partial money strings

### DIFF
--- a/examples/typescript/facilitator/advanced/bazaar.ts
+++ b/examples/typescript/facilitator/advanced/bazaar.ts
@@ -19,7 +19,10 @@ import { ExactEvmScheme } from "@x402/evm/exact/facilitator";
 import { UptoEvmScheme } from "@x402/evm/upto/facilitator";
 import { toFacilitatorSvmSigner } from "@x402/svm";
 import { ExactSvmScheme } from "@x402/svm/exact/facilitator";
-import { extractDiscoveryInfo, type DiscoveryResource } from "@x402/extensions/bazaar";
+import {
+  extractDiscoveryInfo,
+  type DiscoveryResource,
+} from "@x402/extensions/bazaar";
 import dotenv from "dotenv";
 import express from "express";
 import { createWalletClient, http, publicActions } from "viem";

--- a/typescript/packages/core/src/utils/index.ts
+++ b/typescript/packages/core/src/utils/index.ts
@@ -33,6 +33,26 @@ export function numberToDecimalString(n: number): string {
 }
 
 /**
+ * Parses a money string into a finite, non-negative decimal number.
+ * Accepts plain decimal strings with an optional leading dollar sign.
+ *
+ * @param money - The money string to parse
+ * @returns Decimal number
+ */
+export function parseMoneyString(money: string): number {
+  const cleaned = money.replace(/^\$/, "").trim();
+  if (!/^-?\d+(?:\.\d+)?$/.test(cleaned) || /[eE]/.test(cleaned)) {
+    throw new Error(`Invalid money format: ${money}`);
+  }
+
+  const amount = Number(cleaned);
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error(`Invalid money format: ${money}`);
+  }
+  return amount;
+}
+
+/**
  * Convert a decimal amount to token smallest units.
  * Accepts only plain decimal strings — scientific notation is not allowed.
  * Throws if the amount is non-zero but too small to represent with the given decimal precision.

--- a/typescript/packages/mechanisms/aptos/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/aptos/src/exact/server/scheme.ts
@@ -7,6 +7,7 @@ import type {
   Price,
   SchemeNetworkServer,
 } from "@x402/core/types";
+import { parseMoneyString } from "@x402/core/utils";
 import { APTOS_ADDRESS_REGEX, USDC_MAINNET_FA, USDC_TESTNET_FA } from "../../constants";
 
 /**
@@ -99,12 +100,8 @@ export class ExactAptosScheme implements SchemeNetworkServer {
     if (typeof money === "number") {
       return money;
     }
-    const cleanMoney = money.replace(/^\$/, "").trim();
-    const amount = parseFloat(cleanMoney);
-    if (isNaN(amount)) {
-      throw new Error(`Invalid money format: ${money}`);
-    }
-    return amount;
+
+    return parseMoneyString(money);
   }
 
   /**

--- a/typescript/packages/mechanisms/avm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/avm/src/exact/server/scheme.ts
@@ -12,7 +12,7 @@ import type {
   SchemeNetworkServer,
   MoneyParser,
 } from "@x402/core/types";
-import { convertToTokenAmount, numberToDecimalString } from "@x402/core/utils";
+import { convertToTokenAmount, numberToDecimalString, parseMoneyString } from "@x402/core/utils";
 import { USDC_CONFIG, USDC_DECIMALS } from "../../constants";
 
 /**
@@ -149,15 +149,7 @@ export class ExactAvmScheme implements SchemeNetworkServer {
       return money;
     }
 
-    // Remove $ sign and whitespace, then parse
-    const cleanMoney = money.replace(/^\$/, "").trim();
-    const amount = parseFloat(cleanMoney);
-
-    if (isNaN(amount)) {
-      throw new Error(`Invalid money format: ${money}`);
-    }
-
-    return amount;
+    return parseMoneyString(money);
   }
 
   /**

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/server/scheme.ts
@@ -10,7 +10,7 @@ import {
 } from "@x402/core/types";
 import type { DeepReadonly } from "@x402/core/types";
 import type { SettleContext, SettleResultContext } from "@x402/core/server";
-import { convertToTokenAmount, numberToDecimalString } from "@x402/core/utils";
+import { convertToTokenAmount, numberToDecimalString, parseMoneyString } from "@x402/core/utils";
 import type { FacilitatorClient } from "@x402/core/server";
 import { getAddress } from "viem";
 import { BatchSettlementChannelManager } from "./channelManager";
@@ -383,14 +383,7 @@ export class BatchSettlementEvmScheme implements SchemeNetworkServer {
       return money;
     }
 
-    const cleanMoney = money.replace(/^\$/, "").trim();
-    const amount = parseFloat(cleanMoney);
-
-    if (isNaN(amount)) {
-      throw new Error(`Invalid money format: ${money}`);
-    }
-
-    return amount;
+    return parseMoneyString(money);
   }
 
   /**

--- a/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
@@ -6,7 +6,7 @@ import {
   SchemeNetworkServer,
   MoneyParser,
 } from "@x402/core/types";
-import { convertToTokenAmount, numberToDecimalString } from "@x402/core/utils";
+import { convertToTokenAmount, numberToDecimalString, parseMoneyString } from "@x402/core/utils";
 import { getDefaultAsset, type ExactDefaultAssetInfo } from "../../shared/defaultAssets";
 
 /**
@@ -135,15 +135,7 @@ export class ExactEvmScheme implements SchemeNetworkServer {
       return money;
     }
 
-    // Remove $ sign and whitespace, then parse
-    const cleanMoney = money.replace(/^\$/, "").trim();
-    const amount = parseFloat(cleanMoney);
-
-    if (isNaN(amount)) {
-      throw new Error(`Invalid money format: ${money}`);
-    }
-
-    return amount;
+    return parseMoneyString(money);
   }
 
   /**

--- a/typescript/packages/mechanisms/evm/src/upto/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/server/scheme.ts
@@ -6,7 +6,7 @@ import {
   SchemeNetworkServer,
   MoneyParser,
 } from "@x402/core/types";
-import { convertToTokenAmount, numberToDecimalString } from "@x402/core/utils";
+import { convertToTokenAmount, numberToDecimalString, parseMoneyString } from "@x402/core/utils";
 import { getAddress } from "viem";
 import { getDefaultAsset } from "../../shared/defaultAssets";
 
@@ -122,14 +122,7 @@ export class UptoEvmScheme implements SchemeNetworkServer {
       return money;
     }
 
-    const cleanMoney = money.replace(/^\$/, "").trim();
-    const amount = parseFloat(cleanMoney);
-
-    if (isNaN(amount)) {
-      throw new Error(`Invalid money format: ${money}`);
-    }
-
-    return amount;
+    return parseMoneyString(money);
   }
 
   /**

--- a/typescript/packages/mechanisms/hedera/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/hedera/src/exact/server/scheme.ts
@@ -7,7 +7,7 @@ import type {
   Price,
   SchemeNetworkServer,
 } from "@x402/core/types";
-import { convertToTokenAmount } from "@x402/core/utils";
+import { convertToTokenAmount, parseMoneyString } from "@x402/core/utils";
 import { assertSupportedHederaNetwork, isValidHederaAsset } from "../../utils";
 import {
   HEDERA_MAINNET_CAIP2,
@@ -130,12 +130,8 @@ export class ExactHederaScheme implements SchemeNetworkServer {
     if (typeof money === "number") {
       return money;
     }
-    const cleanMoney = money.replace(/^\$/, "").trim();
-    const amount = parseFloat(cleanMoney);
-    if (isNaN(amount)) {
-      throw new Error(`Invalid money format: ${money}`);
-    }
-    return amount;
+
+    return parseMoneyString(money);
   }
 
   /**

--- a/typescript/packages/mechanisms/stellar/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/server/scheme.ts
@@ -1,4 +1,4 @@
-import { convertToTokenAmount, numberToDecimalString } from "@x402/core/utils";
+import { convertToTokenAmount, numberToDecimalString, parseMoneyString } from "@x402/core/utils";
 import { DEFAULT_TOKEN_DECIMALS } from "../../constants";
 import { getUsdcAddress } from "../../utils";
 import type {
@@ -119,15 +119,7 @@ export class ExactStellarScheme implements SchemeNetworkServer {
       return money;
     }
 
-    // Remove $ sign and whitespace, then parse
-    const cleanMoney = money.replace(/^\$/, "").trim();
-    const amount = parseFloat(cleanMoney);
-
-    if (isNaN(amount)) {
-      throw new Error(`Invalid money format: ${money}`);
-    }
-
-    return amount;
+    return parseMoneyString(money);
   }
 
   /**

--- a/typescript/packages/mechanisms/stellar/test/unit/server.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/server.test.ts
@@ -93,6 +93,12 @@ describe("ExactStellarScheme", () => {
           async () => await server.parsePrice("abc", STELLAR_PUBNET_CAIP2),
         ).rejects.toThrow("Invalid money format");
       });
+
+      it("should reject partially numeric money strings", async () => {
+        await expect(
+          async () => await server.parsePrice("1abc", STELLAR_PUBNET_CAIP2),
+        ).rejects.toThrow("Invalid money format");
+      });
     });
   });
 

--- a/typescript/packages/mechanisms/svm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/server/scheme.ts
@@ -6,6 +6,7 @@ import type {
   SchemeNetworkServer,
   MoneyParser,
 } from "@x402/core/types";
+import { parseMoneyString } from "@x402/core/utils";
 import { convertToTokenAmount, getUsdcAddress, numberToDecimalString } from "../../utils";
 
 /**
@@ -116,15 +117,7 @@ export class ExactSvmScheme implements SchemeNetworkServer {
       return money;
     }
 
-    // Remove $ sign and whitespace, then parse
-    const cleanMoney = money.replace(/^\$/, "").trim();
-    const amount = parseFloat(cleanMoney);
-
-    if (isNaN(amount)) {
-      throw new Error(`Invalid money format: ${money}`);
-    }
-
-    return amount;
+    return parseMoneyString(money.replace(/\s+(?:USD|USDC)$/i, ""));
   }
 
   /**

--- a/typescript/packages/mechanisms/svm/test/unit/server.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/server.test.ts
@@ -104,6 +104,12 @@ describe("ExactSvmScheme", () => {
           async () => await server.parsePrice("abc", SOLANA_MAINNET_CAIP2),
         ).rejects.toThrow("Invalid money format");
       });
+
+      it("should reject partially numeric money strings", async () => {
+        await expect(
+          async () => await server.parsePrice("1abc", SOLANA_MAINNET_CAIP2),
+        ).rejects.toThrow("Invalid money format");
+      });
     });
   });
 


### PR DESCRIPTION
Several server-side money parsers use `parseFloat` after trimming a leading `$`. `parseFloat` accepts numeric prefixes, so values like `1abc` are parsed as `1` instead of rejected.

This changes the parsers to require the full string to be a plain decimal amount before converting it, and adds regression coverage for SVM and Stellar server parsing.