### PR TITLE
fix(ts): harden wildcard pattern matching

### DIFF
--- a/typescript/.changeset/safe-pattern-matchers.md
+++ b/typescript/.changeset/safe-pattern-matchers.md
@@ -1,0 +1,6 @@
+---
+'@x402/core': patch
+'x402': patch
+---
+
+Harden wildcard route and network pattern matching.

--- a/typescript/packages/core/src/facilitator/x402Facilitator.ts
+++ b/typescript/packages/core/src/facilitator/x402Facilitator.ts
@@ -4,7 +4,7 @@ import { FacilitatorExtension } from "../types/extensions";
 import { SchemeNetworkFacilitator, FacilitatorContext } from "../types/mechanisms";
 import { PaymentPayload, PaymentRequirements } from "../types/payments";
 import { Network } from "../types";
-import { type SchemeData } from "../utils";
+import { networkMatchesPattern, type SchemeData } from "../utils";
 
 /**
  * Facilitator Hook Context Interfaces
@@ -318,8 +318,7 @@ export class x402Facilitator {
             break;
           }
           // Try pattern matching
-          const patternRegex = new RegExp("^" + schemeData.pattern.replace("*", ".*") + "$");
-          if (patternRegex.test(paymentRequirements.network)) {
+          if (networkMatchesPattern(schemeData.pattern, paymentRequirements.network)) {
             schemeNetworkFacilitator = schemeData.facilitator;
             break;
           }
@@ -436,8 +435,7 @@ export class x402Facilitator {
             break;
           }
           // Try pattern matching
-          const patternRegex = new RegExp("^" + schemeData.pattern.replace("*", ".*") + "$");
-          if (patternRegex.test(paymentRequirements.network)) {
+          if (networkMatchesPattern(schemeData.pattern, paymentRequirements.network)) {
             schemeNetworkFacilitator = schemeData.facilitator;
             break;
           }

--- a/typescript/packages/core/src/utils/index.ts
+++ b/typescript/packages/core/src/utils/index.ts
@@ -70,6 +70,17 @@ export interface SchemeData<T> {
   pattern: Network;
 }
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const networkPatternToRegExp = (pattern: Network): RegExp => {
+  const source = escapeRegExp(pattern).replace(/\\\*/g, ".*");
+  return new RegExp(`^${source}$`);
+};
+
+export const networkMatchesPattern = (pattern: Network, network: Network): boolean => {
+  return networkPatternToRegExp(pattern).test(network);
+};
+
 export const findSchemesByNetwork = <T>(
   map: Map<string, Map<string, T>>,
   network: Network,
@@ -80,15 +91,7 @@ export const findSchemesByNetwork = <T>(
   if (!implementationsByScheme) {
     // Try pattern matching for registered network patterns
     for (const [registeredNetworkPattern, implementations] of map.entries()) {
-      // Convert the registered network pattern to a regex
-      // e.g., "eip155:*" becomes /^eip155:.*$/
-      const pattern = registeredNetworkPattern
-        .replace(/[.*+?^${}()|[\]\\]/g, "\\$&") // Escape special regex chars except *
-        .replace(/\\\*/g, ".*"); // Replace escaped * with .*
-
-      const regex = new RegExp(`^${pattern}$`);
-
-      if (regex.test(network)) {
+      if (networkMatchesPattern(registeredNetworkPattern as Network, network)) {
         implementationsByScheme = implementations;
         break;
       }
@@ -129,8 +132,7 @@ export const findFacilitatorBySchemeAndNetwork = <T>(
   }
 
   // Try pattern matching
-  const patternRegex = new RegExp("^" + schemeData.pattern.replace("*", ".*") + "$");
-  if (patternRegex.test(network)) {
+  if (networkMatchesPattern(schemeData.pattern, network)) {
     return schemeData.facilitator;
   }
 

--- a/typescript/packages/core/test/unit/facilitator/x402Facilitator.test.ts
+++ b/typescript/packages/core/test/unit/facilitator/x402Facilitator.test.ts
@@ -263,6 +263,24 @@ describe("x402Facilitator", () => {
       expect(testFacilitator.verifyCalls.length).toBe(1);
     });
 
+    it("should not treat regex metacharacters in network namespaces as wildcards", async () => {
+      const facilitator = new x402Facilitator();
+      const testFacilitator = new TestFacilitator("exact");
+
+      facilitator.register(["chain.v1:1" as Network, "chain.v1:2" as Network], testFacilitator);
+
+      const payload = buildPaymentPayload({ x402Version: 2 });
+      const requirements = buildPaymentRequirements({
+        scheme: "exact",
+        network: "chainXv1:3" as Network,
+      });
+
+      await expect(async () => await facilitator.verify(payload, requirements)).rejects.toThrow(
+        "No facilitator registered for scheme: exact and network: chainXv1:3",
+      );
+      expect(testFacilitator.verifyCalls.length).toBe(0);
+    });
+
     it("should throw if no facilitator registered for version", async () => {
       const facilitator = new x402Facilitator();
 

--- a/typescript/packages/core/test/unit/utils/utils.test.ts
+++ b/typescript/packages/core/test/unit/utils/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  findFacilitatorBySchemeAndNetwork,
   findByNetworkAndScheme,
   findSchemesByNetwork,
   deepEqual,
@@ -94,6 +95,30 @@ describe("Utils", () => {
 
       expect(result?.get("exact")).toBe("exactNetworkImpl");
     });
+
+    it("should escape regex metacharacters in network patterns", () => {
+      const map = new Map<string, Map<string, string>>();
+      const schemes = new Map<string, string>();
+      schemes.set("exact", "evmImpl");
+      map.set("eip155:8453.*", schemes);
+
+      const matching = findSchemesByNetwork(map, "eip155:8453.mainnet" as Network);
+      const nonMatching = findSchemesByNetwork(map, "eip155:8453xmainnet" as Network);
+
+      expect(matching?.get("exact")).toBe("evmImpl");
+      expect(nonMatching).toBeUndefined();
+    });
+
+    it("should handle multiple wildcard occurrences in network patterns", () => {
+      const map = new Map<string, Map<string, string>>();
+      const schemes = new Map<string, string>();
+      schemes.set("exact", "multiWildcardImpl");
+      map.set("eip155:*:*", schemes);
+
+      const result = findSchemesByNetwork(map, "eip155:8453:usdc" as Network);
+
+      expect(result?.get("exact")).toBe("multiWildcardImpl");
+    });
   });
 
   describe("findByNetworkAndScheme", () => {
@@ -137,6 +162,35 @@ describe("Utils", () => {
       const result = findByNetworkAndScheme(map, "exact", "eip155:8453" as Network);
 
       expect(result).toBe("evmImpl");
+    });
+  });
+
+  describe("findFacilitatorBySchemeAndNetwork", () => {
+    it("should escape regex metacharacters in facilitator patterns", () => {
+      const schemeMap = new Map([
+        [
+          "exact",
+          {
+            facilitator: "facilitator",
+            networks: new Set<Network>(),
+            pattern: "eip155:8453.*" as Network,
+          },
+        ],
+      ]);
+
+      const matching = findFacilitatorBySchemeAndNetwork(
+        schemeMap,
+        "exact",
+        "eip155:8453.base" as Network,
+      );
+      const nonMatching = findFacilitatorBySchemeAndNetwork(
+        schemeMap,
+        "exact",
+        "eip155:8453xbase" as Network,
+      );
+
+      expect(matching).toBe("facilitator");
+      expect(nonMatching).toBeUndefined();
     });
   });
 

--- a/typescript/packages/legacy/x402/src/shared/middleware.test.ts
+++ b/typescript/packages/legacy/x402/src/shared/middleware.test.ts
@@ -89,6 +89,27 @@ describe("computeRoutePatterns", () => {
     });
   });
 
+  it("should escape regex metacharacters in route paths", () => {
+    const routes: RoutesConfig = {
+      "/api/v1.0/*": "$0.01",
+    };
+
+    const patterns = computeRoutePatterns(routes);
+
+    expect(findMatchingRoute(patterns, "/api/v1.0/users", "GET")).toEqual(patterns[0]);
+    expect(findMatchingRoute(patterns, "/api/v1x0/users", "GET")).toBeUndefined();
+  });
+
+  it("should handle multiple wildcards in one route path", () => {
+    const routes: RoutesConfig = {
+      "/api/*/files/*": "$0.01",
+    };
+
+    const patterns = computeRoutePatterns(routes);
+
+    expect(findMatchingRoute(patterns, "/api/alice/files/report", "GET")).toEqual(patterns[0]);
+  });
+
   it("should handle route parameters", () => {
     const routes: RoutesConfig = {
       "/api/users/[id]": "$0.01",
@@ -100,7 +121,7 @@ describe("computeRoutePatterns", () => {
     expect(patterns).toHaveLength(2);
     expect(patterns[0]).toEqual({
       verb: "*",
-      pattern: /^\/api\/users\/[^\/]+$/i,
+      pattern: /^\/api\/users\/[^/]+$/i,
       config: {
         price: "$0.01",
         network: "base-sepolia",
@@ -108,7 +129,7 @@ describe("computeRoutePatterns", () => {
     });
     expect(patterns[1]).toEqual({
       verb: "GET",
-      pattern: /^\/api\/posts\/[^\/]+$/i,
+      pattern: /^\/api\/posts\/[^/]+$/i,
       config: {
         price: "$0.02",
         network: "base-sepolia",

--- a/typescript/packages/legacy/x402/src/shared/middleware.ts
+++ b/typescript/packages/legacy/x402/src/shared/middleware.ts
@@ -16,6 +16,38 @@ import { getUsdcChainConfigForChain } from "./evm";
 import { getNetworkId } from "./network";
 
 /**
+ * Converts a route path pattern to a regex source.
+ *
+ * @param path - Route path pattern using "*" and "[param]" syntax
+ * @returns Escaped regex source for the route path
+ */
+function routePathToRegexSource(path: string): string {
+  let source = "";
+
+  for (let i = 0; i < path.length; i++) {
+    const char = path[i];
+
+    if (char === "*") {
+      source += ".*?";
+      continue;
+    }
+
+    if (char === "[") {
+      const end = path.indexOf("]", i + 1);
+      if (end > i + 1) {
+        source += "[^/]+";
+        i = end;
+        continue;
+      }
+    }
+
+    source += char.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  return source;
+}
+
+/**
  * Computes the route patterns for the given routes config
  *
  * @param routes - The routes config to compute the patterns for
@@ -39,18 +71,7 @@ export function computeRoutePatterns(routes: RoutesConfig): RoutePattern[] {
     }
     return {
       verb: verb.toUpperCase(),
-      pattern: new RegExp(
-        `^${
-          path
-            // First escape all special regex characters except * and []
-            .replace(/[$()+.?^{|}]/g, "\\$&")
-            // Then handle our special pattern characters
-            .replace(/\*/g, ".*?") // Make wildcard non-greedy and optional
-            .replace(/\[([^\]]+)\]/g, "[^/]+") // Convert [param] to regex capture
-            .replace(/\//g, "\\/") // Escape slashes
-        }$`,
-        "i",
-      ),
+      pattern: new RegExp(`^${routePathToRegexSource(path)}$`, "i"),
       config: routeConfig,
     };
   });


### PR DESCRIPTION
Normalizes wildcard pattern matching in TypeScript paths that were still open-coding regex construction.

- reuses escaped network-pattern matching in core utilities and facilitator verify/settle lookup
- escapes regex metacharacters before reintroducing supported `*` wildcard syntax
- keeps legacy route `[param]` and `*` semantics while treating the rest of the path literally

Closes #2091

Checked with:
- `pnpm --filter @x402/core test -- test/unit/utils/utils.test.ts test/unit/facilitator/x402Facilitator.test.ts`
- `pnpm --filter x402 test -- src/shared/middleware.test.ts`
- `pnpm exec eslint src/utils/index.ts src/facilitator/x402Facilitator.ts test/unit/utils/utils.test.ts test/unit/facilitator/x402Facilitator.test.ts` (`packages/core`)
- `pnpm exec eslint src/shared/middleware.ts src/shared/middleware.test.ts` (`packages/legacy/x402`)
- `pnpm exec prettier --config .prettierrc --check ...` on touched package files
- `git diff --check`
