### PR TITLE
feat(ecosystem): add x402-anthropic client integrations (Python + TypeScript)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-anthropic-python/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-anthropic-python/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402-anthropic (Python)",
+  "category": "Client-Side Integrations",
+  "logoUrl": "/logos/x402-anthropic.svg",
+  "description": "x402 payment transport for the Anthropic Python SDK. Wraps the Anthropic client so HTTP 402 responses are automatically paid with USDC on EVM (Base, Ethereum) or SVM (Solana) — no code changes needed.",
+  "websiteUrl": "https://github.com/kinance/x402-anthropic-python"
+}

--- a/typescript/site/app/ecosystem/partners-data/x402-anthropic-typescript/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-anthropic-typescript/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402-anthropic (TypeScript)",
+  "category": "Client-Side Integrations",
+  "logoUrl": "/logos/x402-anthropic.svg",
+  "description": "x402 payment transport for the Anthropic TypeScript SDK. Wraps the Anthropic client so HTTP 402 responses are automatically paid with USDC on EVM (Base, Ethereum) or SVM (Solana) — no code changes needed.",
+  "websiteUrl": "https://github.com/kinance/x402-anthropic-typescript"
+}

--- a/typescript/site/public/logos/x402-anthropic.svg
+++ b/typescript/site/public/logos/x402-anthropic.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#1a1a1a"/>
+  <text x="32" y="22" font-family="monospace" font-size="11" font-weight="bold" fill="#ffffff" text-anchor="middle">x402</text>
+  <text x="32" y="42" font-family="monospace" font-size="11" font-weight="bold" fill="#d4a849" text-anchor="middle">anthro</text>
+  <text x="32" y="56" font-family="monospace" font-size="8" fill="#888888" text-anchor="middle">pic</text>
+</svg>


### PR DESCRIPTION
Adds ecosystem listings for `x402-anthropic`, a thin transport-level wrapper around the official Anthropic SDKs that transparently handles HTTP 402 responses.

## What this adds

- **[x402-anthropic (Python)](https://github.com/kinance/x402-anthropic-python)**
  Wraps `httpx.BaseTransport`/`AsyncBaseTransport` to intercept 402 responses, pay with USDC on EVM (Base, Ethereum) or SVM (Solana), and retry — zero changes to normal `anthropic.Anthropic` usage.

- **[x402-anthropic (TypeScript)](https://github.com/kinance/x402-anthropic-typescript)**
  Custom `fetch` wrapper passed to `@anthropic-ai/sdk` — same transparent 402-pay-and-retry behaviour, ESM, fully typed.

## Implementation notes

- Follows the same transport-wrapper pattern as `x402-openai-python` / `x402-openai-typescript` (QNTX).
- Single paid retry; preserves all original SDK response types including streaming.
- Payment handler is a protocol/interface — works with any EVM/SVM signing helper; wires to the official x402 signing helpers once stable.

## Review history

Originally submitted to coinbase/x402#185 (May 2026). That repo is now dormant following the foundation migration; resubmitting here to land in the live ecosystem.