### PR TITLE
Add TWZRD Agent Intelligence to the ecosystem directory

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/twzrd-agent-intelligence/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/twzrd-agent-intelligence/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "TWZRD Agent Intelligence",
+  "description": "Trust + receipt layer for x402 agents on Solana: a free preflight ReadinessCard scores any counterparty on a wash/Sybil-resistant cross-facilitator reputation corpus, then a paid 0.05 USDC endpoint returns a portable Ed25519-signed V5 receipt verifiable offline. Indexed on x402scan with an MCP server on the official MCP Registry.",
+  "logoUrl": "/logos/twzrd.svg",
+  "websiteUrl": "https://intel.twzrd.xyz",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/twzrd.svg
+++ b/typescript/site/public/logos/twzrd.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-labelledby="title">
+  <title id="title">WZRD</title>
+  <rect width="32" height="32" rx="7" fill="#181512" />
+  <path
+    d="M8 10L12.5 22.5L16 14L19.5 22.5L24 10"
+    fill="none"
+    stroke="#f6efe3"
+    stroke-width="1.6"
+    stroke-linejoin="miter"
+    stroke-linecap="square"
+  />
+</svg>


### PR DESCRIPTION
Adds **TWZRD Agent Intelligence** to the ecosystem directory under **Services/Endpoints**.

- `partners-data/twzrd-agent-intelligence/metadata.json`
- `public/logos/twzrd.svg`

A trust + receipt layer for x402 agents on Solana:
- Free preflight **ReadinessCard** scores any counterparty on a wash/Sybil-resistant cross-facilitator reputation corpus — decide *before* paying.
- Paid `GET /v1/intel/trust/{pubkey}` (0.05 USDC, Solana mainnet) returns the trust score **plus** a portable Ed25519-signed **V5 receipt** verifiable offline.

Live on mainnet at https://intel.twzrd.xyz, indexed on x402scan, MCP server on the official MCP Registry (`io.github.twzrd-sol/twzrd-agent-intel`). Full OpenAPI 3.1 with x402 annotations + `/.well-known/x402` discovery.