### PR TITLE
Specs(exact): propose Canton exact scheme for x402 (spec-only)

### DIFF
--- a/specs/schemes/exact/scheme_exact_canton.md
+++ b/specs/schemes/exact/scheme_exact_canton.md
@@ -1,68 +1,56 @@
 # Exact Payment Scheme for Canton Network (`exact`)
 
 This document specifies the `exact` payment scheme for the x402 protocol on
-Canton Network. Payments use the CIP-56 `TransferFactory_Transfer` primitive;
-the facilitator verifies read-only via SV Scan and does not submit on-ledger
-settlement transactions.
+Canton Network. The client creates a `Splice.ExternalPartyAmuletRules.TransferCommand`
+via Ed25519 external-party signing; the facilitator, acting as `delegate`,
+exercises `TransferCommand_Send` — submitting the transaction and sponsoring
+sequencer traffic.
 
 ## Scheme Name
 
 `exact`
 
-> **Reference stack note:** The FTP reference stack (`@ftp/x402-canton-*`) currently
-> uses `exact-canton` as its external package scheme name. The upstream canonical
-> form is `scheme: "exact"` with `network: "canton:*"` identifiers.
-
 ## Networks
 
-Canton Network is a Daml-based network using the Global Synchronizer.
-
-CAIP-2-style identifiers:
-
-| Network | Identifier | Notes |
-|---|---|---|
-| Canton TestNet | `canton:testnet` | Public test network |
-| Canton MainNet | `canton:mainnet` | Production network |
+| Network | Identifier |
+|---|---|
+| Canton MainNet | `canton:mainnet` |
+| Canton TestNet | `canton:testnet` |
 
 ## Protocol Flow
 
-Canton x402 settles **on-ledger**: the payer exercises a CIP-56
-`TransferFactory_Transfer` on its own participant, and the facilitator verifies
-it by reading the **SV Scan API** (read-only; on RBAC-gated deployments the
-facilitator authenticates to Scan, no stakeholder status required). When the
-merchant holds a `TransferPreapproval` the transfer completes synchronously;
-otherwise it lands as a pending `TransferInstruction`.
+1. **Client** requests a resource from the **Resource Server**.
+2. **Resource Server** responds with a 402 containing `PaymentRequirements`.
+   The `extra` field includes `facilitatorParty` (the delegate that will
+   execute the transfer) and `synchronizerId`.
+3. **Client** reads its next nonce from SV Scan:
+   `GET /api/scan/v0/transfer-command-counters/{party}`. First payment from
+   a new party defaults to nonce `0`.
+4. **Client** exercises `ExternalPartyAmuletRules_CreateTransferCommand` via
+   interactive submission on its own participant:
+   - `POST /v2/interactive-submission/prepare` → `preparedTransactionHash`
+   - Client signs the hash with its Ed25519 key
+   - `POST /v2/interactive-submission/execute` with the signature
+5. **Client** locates the created `TransferCommand` in its ACS by matching
+   `(sender, nonce)` and extracts the `transferCommandCid`.
+6. **Client** retries the original request with a `PAYMENT-SIGNATURE` header
+   containing the `transferCommandCid`, `payerParty`, and `nonce`.
+7. **Resource Server** forwards the payload to the facilitator's `/verify`.
+8. **Facilitator** reads the `TransferCommand` by `cid` from ACS (it is a
+   stakeholder as `delegate`), reads the sender's `TransferCommandCounter`
+   from Scan, and validates the command against `PaymentRequirements`.
+9. **Facilitator** returns `VerifyResponse` to the **Resource Server**.
+10. **Resource Server** forwards the payload to the facilitator's `/settle`.
+11. **Facilitator** re-verifies, fetches `AmuletRules`, `OpenMiningRound`,
+    `IssuingMiningRounds`, and `TransferCommandCounter` from SV Scan as
+    disclosed contracts, then exercises `TransferCommand_Send`. The ledger
+    atomically moves Canton Coin from sender to receiver and archives the
+    `TransferCommand`.
+12. **Facilitator** returns `SettlementResponse` with the ledger `updateId`.
+13. **Resource Server** grants the **Client** access and echoes settlement
+    metadata in the `PAYMENT-RESPONSE` header.
 
-```mermaid
-sequenceDiagram
-  participant C as Client / Agent
-  participant RS as Resource Server
-  participant F as Facilitator
-  participant L as Canton Ledger
-
-  Note over C, L: Per-request flow
-  C->>RS: GET /api/data
-  RS-->>C: 402 PAYMENT-REQUIRED (scheme: exact, amount, asset, payTo, extra)
-
-  Note over C, L: Client exercises TransferFactory_Transfer on its own participant
-  C->>L: TransferFactory_Transfer — sender, receiver, amount, instrumentId, x402 meta
-  L-->>C: updateId — Completed or pending TransferInstruction
-
-  C->>RS: retry with PAYMENT-SIGNATURE header
-  RS->>F: POST /verify
-  F->>L: GET /api/scan/v2/updates/updateId — read-only, no stakeholder needed
-  F-->>RS: 200 isValid + proven payer
-
-  RS->>F: POST /settle (paymentPayload, paymentRequirements)
-  F->>F: re-verify + single-use guard — settle is a read-only echo
-  F-->>RS: 200 { success: true, transaction (= updateId), payer, network }
-  RS-->>C: 200 + response body (PAYMENT-RESPONSE header carries settlement metadata)
-```
-
-## PaymentRequirements
-
-A 402 response includes one or more entries in its `accepts[]` array.
-Below is the canonical form.
+## `PaymentRequirements` for `exact`
 
 ```json
 {
@@ -73,56 +61,26 @@ Below is the canonical form.
   "payTo": "merchant_party::1220abc...",
   "maxTimeoutSeconds": 60,
   "extra": {
-    "transferMethod": "cip56-transfer-factory",
+    "transferMethod": "external-party-amulet-rules",
     "facilitatorParty": "ftp_facilitator::1220def...",
     "synchronizerId": "global-domain::1220xyz...",
-    "transferFactoryCid": "00factory...",
-    "transferFactoryTemplateId": "<pkg-hash>:Splice.Api.Token.TransferInstructionV1:TransferFactory",
-    "instrumentId": { "admin": "DSO::1220...", "id": "Amulet" },
-    "memo": "optional invoice id"
+    "merchantContractCid": "00mc..."
   }
 }
 ```
 
-### Field semantics
+- `amount`: Atomic units as a JSON string. Canton Coin uses 10 decimal places
+  (`"1000000000"` = 0.1 CC).
+- `asset`: `"canton-coin"`. This transfer method settles Canton Coin only.
+- `payTo`: Receiver party id in canonical form `"<name>::<fingerprint>"`.
+- `extra.transferMethod`: MUST be `"external-party-amulet-rules"`.
+- `extra.facilitatorParty`: The facilitator's Canton party id. MUST be set as
+  `delegate` in the `TransferCommand`. Clients MUST NOT alter this value.
+- `extra.synchronizerId`: The Global Synchronizer the transfer settles on.
+- `extra.merchantContractCid` (optional): When present, the facilitator
+  verifies the merchant is registered before accepting the payment.
 
-- `amount` — atomic units, JSON string for precision. Canton Coin uses
-  10 decimals (so `"1000000000"` = 0.1 CC). For CIP-56 tokens, atomic
-  units of the instrument's declared `decimals`.
-- `asset` — `"canton-coin"` for Splice Amulet, or
-  `"<adminParty>::<id>"` for a CIP-56 token instrument.
-- `payTo` — receiver party id in canonical form `"<name>::<fingerprint>"`.
-- `extra.transferMethod` — MUST be `cip56-transfer-factory` (the only method).
-  Absent is treated as `cip56-transfer-factory`.
-- `extra.facilitatorParty` — the facilitator's own party id. Clients stamp it
-  into `Transfer.meta["x402.facilitatorParty"]`.
-- `extra.synchronizerId` — the Global Synchronizer the transfer settles on.
-- `extra.transferFactoryCid` / `extra.transferFactoryTemplateId` — the CIP-56
-  `TransferFactory` (cid + hash-prefixed template id) the client exercises.
-- `extra.instrumentId` — `{admin, id}` of the token instrument (e.g.
-  `{admin: "DSO::1220…", id: "Amulet"}` for Canton Coin).
-- `extra.memo` (optional) — opaque text for the merchant's records. Maximum
-  256 bytes.
-
-### Transfer Methods
-
-This specification defines one on-ledger path.
-
-| Method | On-ledger primitive |
-|---|---|
-| `cip56-transfer-factory` | `Splice.Api.Token.TransferInstructionV1.TransferFactory_Transfer` + `TransferPreapproval` |
-
-The `cip56-transfer-factory` method supports Canton Coin (Amulet) and any other
-CIP-56 instrument. For Canton Coin: `asset: "canton-coin"`,
-`extra.instrumentId: { admin: "DSO::1220...", id: "Amulet" }`.
-
-## PaymentPayload
-
-The client constructs the on-ledger transfer first, then sends the `payload` to
-the facilitator. The facilitator does NOT submit on the client's behalf — the
-client's own key authorizes the `TransferFactory_Transfer` exercise.
-
-### Full PAYMENT-SIGNATURE header shape (x402 v2)
+## `PaymentPayload` `payload` Field
 
 ```json
 {
@@ -135,76 +93,43 @@ client's own key authorizes the `TransferFactory_Transfer` exercise.
   "accepted": {
     "scheme": "exact",
     "network": "canton:mainnet",
-    "amount": "1000000",
-    "asset": "issuer::1220abc...::USDC",
-    "payTo": "merchant_party::1220def...",
+    "amount": "1000000000",
+    "asset": "canton-coin",
+    "payTo": "merchant_party::1220abc...",
     "maxTimeoutSeconds": 60,
     "extra": {
-      "transferMethod": "cip56-transfer-factory",
-      "facilitatorParty": "ftp_facilitator::1220...",
-      "synchronizerId": "global-domain::1220xyz...",
-      "transferFactoryCid": "00factory...",
-      "transferFactoryTemplateId": "<pkg-hash>:Splice.Api.Token.TransferInstructionV1:TransferFactory",
-      "instrumentId": { "admin": "issuer::1220abc...", "id": "USDC" }
+      "transferMethod": "external-party-amulet-rules",
+      "facilitatorParty": "ftp_facilitator::1220def...",
+      "synchronizerId": "global-domain::1220xyz..."
     }
   },
   "payload": {
-    "transferMethod": "cip56-transfer-factory",
+    "transferMethod": "external-party-amulet-rules",
+    "transferCommandCid": "00abc...",
     "payerParty": "agent_party::1220...",
-    "updateId": "1220abc..."
+    "nonce": 42
   }
 }
 ```
 
-Example uses a generic CIP-56 token. Canton Coin (Amulet) is also supported
-via the same method with `asset: "canton-coin"` and
-`instrumentId: { admin: "DSO::1220...", id: "Amulet" }`.
+- `transferCommandCid`: Contract id of the `TransferCommand` created by the
+  client on-ledger.
+- `payerParty`: The client's Canton party id (`TransferCommand.sender`).
+- `nonce`: The monotonic nonce used when creating the `TransferCommand`.
 
-### `payload` field variants
-
-Two variants depending on whether the registry returned
-`TransferInstructionResult_Completed` (synchronous; tokens already moved) or
-`TransferInstructionResult_Pending` (asynchronous; instruction contract advances
-later). Exactly one of `updateId` and `transferInstructionCid` MUST be set.
-
-> A live `TransferInstruction` means tokens have **not** moved yet. A facilitator
-> that reads a still-live instruction MUST NOT report settlement success. Use a
-> merchant `TransferPreapproval` to ensure synchronous completion.
-
-```json
-// Completed case
-{
-  "transferMethod": "cip56-transfer-factory",
-  "payerParty": "agent_party::1220...",
-  "updateId": "1220abc..."
-}
-
-// Pending case
-{
-  "transferMethod": "cip56-transfer-factory",
-  "payerParty": "agent_party::1220...",
-  "transferInstructionCid": "00abc..."
-}
-```
-
-## SettlementResponse
-
-Returned by the facilitator from `POST /settle` on success and echoed back in
-the `PAYMENT-RESPONSE` HTTP header by the resource server.
+## `SettlementResponse`
 
 ```json
 {
   "success": true,
   "payer": "agent_party::1220...",
-  "transaction": "00f1abc...",
-  "network": "canton:mainnet",
-  "amount": "1000000000"
+  "transaction": "122038abc...",
+  "network": "canton:mainnet"
 }
 ```
 
-- `transaction` — Canton ledger `updateId` of the `TransferFactory_Transfer`
-  exercise (echoed; CIP-56 settle is a no-op). Resolvable in any Scan API for
-  proof-of-settlement.
+`transaction` is the Canton ledger `updateId` of the `TransferCommand_Send`
+exercise. Resolvable in any SV Scan API as proof of settlement.
 
 On failure:
 
@@ -218,122 +143,106 @@ On failure:
 
 ## Facilitator Verification Rules (MUST)
 
-`cip56-transfer-factory` is the only payment method. For a payment whose
-`payload` carries an `updateId` (the transfer completed synchronously) the
-facilitator MUST validate ALL of the following before returning `isValid: true`:
+1. **Network match.** `paymentRequirements.network` MUST equal the
+   facilitator's configured network.
 
-1. **Network match.** `paymentRequirements.network` equals the facilitator's
-   configured network; cross-network claims are rejected.
-2. **Authoritative Scan read.** Read the SV Scan API
-   `GET /api/scan/v2/updates/{updateId}` and locate the exercised
-   `TransferFactory_Transfer` whose
-   `exercise_result.output.tag == "TransferInstructionResult_Completed"`. A
-   Scan mismatch is DEFINITIVE and MUST NOT be retried through other means.
-3. **Amount equality.** `transfer.amount` == PaymentRequirements.amount.
-4. **Payer = sender.** The returned `payer` is the proven `transfer.sender`,
-   not the client's claim.
-5. **Receiver / merchant match.** `transfer.receiver` == PaymentRequirements.payTo.
-6. **Instrument match.** `transfer.instrumentId.{admin,id}` == `extra.instrumentId`.
-7. **Resource binding.** When the client stamped `x402.resourceUrl` into
-   `transfer.meta.values`, it MUST equal `resource.url`
-   (`invalid_exact_canton_resource_url_mismatch` otherwise).
-8. **Single-use.** The `updateId` MUST NOT have settled before
-   (`invalid_exact_canton_payment_already_settled`).
+2. **TransferCommand exists.** The facilitator MUST locate the
+   `TransferCommand` by `payload.transferCommandCid` in its ACS (it is an
+   observer as `delegate`). If absent or archived, reject with
+   `invalid_exact_canton_transfer_command_not_found`.
 
-For a payment carrying a `transferInstructionCid` (still `Pending`), the
-facilitator reads the `TransferInstruction`, validates
-amount/sender/receiver/instrumentId, and rejects as
-`invalid_exact_canton_transfer_instruction_pending` — tokens have not moved.
-The payer SHOULD use a merchant `TransferPreapproval` for synchronous completion.
+3. **Delegate.** `TransferCommand.delegate` MUST equal `extra.facilitatorParty`.
+
+4. **Amount.** `TransferCommand.amount` MUST equal `PaymentRequirements.amount`
+   exactly (string comparison; no numeric coercion).
+
+5. **Expiry.** `TransferCommand.expiresAt` MUST be at least 5 seconds in the
+   future at verification time. Reject with `invalid_exact_canton_expired`.
+
+6. **Sender.** `TransferCommand.sender` MUST equal `payload.payerParty`.
+
+7. **Receiver.** `TransferCommand.receiver` MUST equal
+   `PaymentRequirements.payTo`.
+
+8. **Nonce.** `TransferCommand.nonce` MUST be ≥ `nextNonce` from the sender's
+   `TransferCommandCounter` on SV Scan. A missing counter (first payment)
+   defaults to `nextNonce = 0`. Reject with
+   `invalid_exact_canton_nonce_reuse` if stale.
+
+9. **Description.** `TransferCommand.description` MUST parse as a JSON object
+   containing a non-empty `paymentId` string and `resourceUrl` equal to
+   `resource.url`. Reject with `invalid_exact_canton_resource_url_mismatch`
+   if absent, unparseable, or mismatched.
+
+10. **Merchant registration** (when `extra.merchantContractCid` is present).
+    The referenced `MerchantContract` MUST be active and its `merchant` field
+    MUST equal `PaymentRequirements.payTo`. Reject with
+    `invalid_exact_canton_merchant_not_registered` otherwise.
 
 ## Duplicate Settlement Mitigation
 
-**Ledger-level:** A completed `TransferFactory_Transfer` is an immutable
-historical on-ledger record; double-spend is impossible.
+Canton provides native replay protection: `TransferCommand_Send` consumes
+(archives) the `TransferCommand` contract. A second `Send` on the same
+contract id fails at the ledger with `CONTRACT_NOT_FOUND`. No off-chain
+deduplication store is required.
 
-**HTTP-level:** Facilitators MUST enforce single-use settlement for each
-`updateId` and reject a second settle with
-`invalid_exact_canton_payment_already_settled`. The storage mechanism is
-implementation-defined.
+## Settlement
 
-## Canton-specific: Verification via SV Scan
+After verification succeeds:
 
-Canton has stakeholder-scoped contract visibility. The facilitator reads the
-SV Scan API — `GET /api/scan/v2/updates/{updateId}` — and validates
-`sender`, `receiver`, `amount`, `instrumentId` from the exercised
-`TransferFactory_Transfer` choice argument directly. No stakeholder status
-required. On RBAC-gated deployments the facilitator authenticates to Scan.
+1. Fetch in parallel from SV Scan:
+   - `AmuletRules` (contract + `created_event_blob`)
+   - Open and issuing mining rounds (contracts + `created_event_blob` for each)
+   - `TransferCommandCounter` for the payer (contract + `created_event_blob`)
 
-When the Scan read resolves but the transfer is invalid, the facilitator MUST
-reject with the specific reason and MUST NOT retry through other means.
+2. Select the active `OpenMiningRound`: among rounds where `opensAt ≤ now`,
+   pick the highest `round.number`. Fall back to the highest overall if none
+   are open yet.
 
-The facilitator matches only `TransferInstructionResult_Completed`. A
-`TransferInstructionResult_Pending` result MUST NOT be accepted as settled.
+3. Exercise `TransferCommand_Send` as `delegate`:
+
+   ```
+   choiceArgument = {
+     context: {
+       amuletRules: <AmuletRules contractId>,
+       context: {
+         openMiningRound: <active round contractId>,
+         issuingMiningRounds: [[{number: "N"}, <contractId>], ...],
+         validatorRights: [],
+         featuredAppRight: null
+       }
+     },
+     inputs: [],
+     transferCounterCid: <TransferCommandCounter contractId>
+   }
+   disclosedContracts: [AmuletRules, OpenMiningRound, TransferCommandCounter,
+                        ...IssuingMiningRounds]
+   ```
+
+4. **Stale counter retry.** If the ledger rejects with
+   `LOCAL_VERDICT_INACTIVE_CONTRACTS` (SV Scan counter cache lagging behind
+   the ledger), refresh the counter from Scan and retry up to 5 times with
+   exponential backoff starting at 500 ms. Return
+   `unexpected_canton_ledger_error` after 5 failed attempts.
+
+## Error Reason Codes
+
+| Code | Meaning |
+|---|---|
+| `invalid_exact_canton_transfer_command_not_found` | `transferCommandCid` does not resolve to an active `TransferCommand` visible to the facilitator. |
+| `invalid_exact_canton_amount_mismatch` | `TransferCommand.amount` != `PaymentRequirements.amount`. |
+| `invalid_exact_canton_expired` | `TransferCommand.expiresAt` is past or within the 5-second safety margin. |
+| `invalid_exact_canton_payer_mismatch` | `TransferCommand.sender` != `payload.payerParty`. |
+| `invalid_exact_canton_merchant_mismatch` | `TransferCommand.receiver` != `PaymentRequirements.payTo`. |
+| `invalid_exact_canton_nonce_reuse` | `TransferCommand.nonce` < `TransferCommandCounter.nextNonce`. |
+| `invalid_exact_canton_resource_url_mismatch` | `TransferCommand.description` is absent, unparseable, or `resourceUrl` does not match `resource.url`. |
+| `invalid_exact_canton_merchant_not_registered` | `MerchantContract` is absent or belongs to a different merchant. |
+| `invalid_exact_canton_counter_not_ready` | No `TransferCommandCounter` exists for the sender; first-payment settle not yet possible. |
+| `unexpected_canton_ledger_error` | Scan API failure, ledger rejection, or timeout not covered above. |
 
 ## References
 
 - [x402 v2 spec](https://github.com/x402-foundation/x402/blob/main/specs/x402-specification-v2.md)
 - [SVM scheme spec (precedent)](https://github.com/x402-foundation/x402/blob/main/specs/schemes/exact/scheme_exact_svm.md)
-- [`Splice.AmuletRules` (TransferPreapproval)](https://github.com/hyperledger-labs/splice/blob/main/daml/splice-amulet/daml/Splice/AmuletRules.daml)
-- [CIP-56 Token Standard](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)
-
-## Appendix
-
-### Privacy Considerations
-
-- **Facilitator scope.** The facilitator validates payments through SV Scan
-  and cannot see a payer's wallet balance or unrelated transactions.
-- **PII in memo/description.** Avoid PII in `extra.memo`; facilitator logs
-  and indexers will surface these strings.
-- **Resource URL.** `x402.resourceUrl` in Transfer.meta identifies the paid
-  API endpoint. Truncate or hash if sensitive.
-- **PartyToKeyMapping.** The payer's signing key is visible to all
-  participants on the same synchronizer.
-
-### Network identifiers in `/supported`
-
-A conformant Canton facilitator advertises CAIP-2-style network IDs.
-Example response:
-
-```json
-{
-  "kinds": [
-    {
-      "x402Version": 2,
-      "scheme": "exact",
-      "network": "canton:mainnet",
-      "extra": { "transferMethods": ["cip56-transfer-factory"] }
-    },
-    {
-      "x402Version": 2,
-      "scheme": "exact",
-      "network": "canton:testnet",
-      "extra": { "transferMethods": ["cip56-transfer-factory"] }
-    }
-  ],
-  "extensions": [],
-  "signers": { "canton:*": ["ftp_facilitator::1220def..."] }
-}
-```
-
-### Error Reason Codes
-
-Canton-specific error codes. All MUST be prefixed `invalid_exact_canton_*`
-or `unexpected_canton_*`.
-
-| Code | Meaning |
-|---|---|
-| `invalid_exact_canton_transfer_not_found` | The transfer (updateId / TransferInstruction) does not resolve to a completed `TransferFactory_Transfer` on Scan. |
-| `invalid_exact_canton_amount_mismatch` | `transfer.amount` != PaymentRequirements.amount. |
-| `invalid_exact_canton_asset_mismatch` | Token type does not match the requirements. |
-| `invalid_exact_canton_expired` | The transfer is past its `executeBefore` (or within the settle-latency margin). |
-| `invalid_exact_canton_payer_mismatch` | `payload.payerParty` != the proven `transfer.sender`. |
-| `invalid_exact_canton_merchant_mismatch` | `transfer.receiver` != PaymentRequirements.payTo. |
-| `invalid_exact_canton_resource_url_mismatch` | `transfer.meta["x402.resourceUrl"]` != the requested resource. |
-| `invalid_exact_canton_transfer_instruction_not_found` | CIP-56: `transferInstructionCid` does not resolve / facilitator is not a stakeholder. |
-| `invalid_exact_canton_transfer_instruction_pending` | CIP-56: a `TransferInstruction` was found and is valid, but still pending (tokens not moved). Use a `TransferPreapproval` for synchronous completion. |
-| `invalid_exact_canton_instrument_id_mismatch` | CIP-56: token `instrumentId` (admin/id) does not match PaymentRequirements. |
-| `invalid_exact_canton_transfer_factory_not_found` | CIP-56: the advertised `transferFactoryCid` does not resolve. |
-| `invalid_exact_canton_missing_proof` | CIP-56: neither a valid `updateId` nor `transferInstructionCid` was supplied. |
-| `invalid_exact_canton_payment_already_settled` | The payment (updateId) was already settled — single-use replay protection. |
-| `unexpected_canton_ledger_error` | Catch-all for Canton ledger / Scan API failures, network timeouts, etc. |
+- [`Splice.ExternalPartyAmuletRules`](https://github.com/hyperledger-labs/splice/blob/main/daml/splice-amulet/daml/Splice/ExternalPartyAmuletRules.daml)
+- [Canton external-party signing](https://docs.digitalasset.com/build/3.4/tutorials/app-dev/external_signing_overview)

--- a/specs/schemes/exact/scheme_exact_canton.md
+++ b/specs/schemes/exact/scheme_exact_canton.md
@@ -1,0 +1,339 @@
+# Exact Payment Scheme for Canton Network (`exact`)
+
+This document specifies the `exact` payment scheme for the x402 protocol on
+Canton Network. Payments use the CIP-56 `TransferFactory_Transfer` primitive;
+the facilitator verifies read-only via SV Scan and does not submit on-ledger
+settlement transactions.
+
+## Scheme Name
+
+`exact`
+
+> **Reference stack note:** The FTP reference stack (`@ftp/x402-canton-*`) currently
+> uses `exact-canton` as its external package scheme name. The upstream canonical
+> form is `scheme: "exact"` with `network: "canton:*"` identifiers.
+
+## Networks
+
+Canton Network is a Daml-based network using the Global Synchronizer.
+
+CAIP-2-style identifiers:
+
+| Network | Identifier | Notes |
+|---|---|---|
+| Canton TestNet | `canton:testnet` | Public test network |
+| Canton MainNet | `canton:mainnet` | Production network |
+
+## Protocol Flow
+
+Canton x402 settles **on-ledger**: the payer exercises a CIP-56
+`TransferFactory_Transfer` on its own participant, and the facilitator verifies
+it by reading the **SV Scan API** (read-only; on RBAC-gated deployments the
+facilitator authenticates to Scan, no stakeholder status required). When the
+merchant holds a `TransferPreapproval` the transfer completes synchronously;
+otherwise it lands as a pending `TransferInstruction`.
+
+```mermaid
+sequenceDiagram
+  participant C as Client / Agent
+  participant RS as Resource Server
+  participant F as Facilitator
+  participant L as Canton Ledger
+
+  Note over C, L: Per-request flow
+  C->>RS: GET /api/data
+  RS-->>C: 402 PAYMENT-REQUIRED (scheme: exact, amount, asset, payTo, extra)
+
+  Note over C, L: Client exercises TransferFactory_Transfer on its own participant
+  C->>L: TransferFactory_Transfer — sender, receiver, amount, instrumentId, x402 meta
+  L-->>C: updateId — Completed or pending TransferInstruction
+
+  C->>RS: retry with PAYMENT-SIGNATURE header
+  RS->>F: POST /verify
+  F->>L: GET /api/scan/v2/updates/updateId — read-only, no stakeholder needed
+  F-->>RS: 200 isValid + proven payer
+
+  RS->>F: POST /settle (paymentPayload, paymentRequirements)
+  F->>F: re-verify + single-use guard — settle is a read-only echo
+  F-->>RS: 200 { success: true, transaction (= updateId), payer, network }
+  RS-->>C: 200 + response body (PAYMENT-RESPONSE header carries settlement metadata)
+```
+
+## PaymentRequirements
+
+A 402 response includes one or more entries in its `accepts[]` array.
+Below is the canonical form.
+
+```json
+{
+  "scheme": "exact",
+  "network": "canton:mainnet",
+  "amount": "1000000000",
+  "asset": "canton-coin",
+  "payTo": "merchant_party::1220abc...",
+  "maxTimeoutSeconds": 60,
+  "extra": {
+    "transferMethod": "cip56-transfer-factory",
+    "facilitatorParty": "ftp_facilitator::1220def...",
+    "synchronizerId": "global-domain::1220xyz...",
+    "transferFactoryCid": "00factory...",
+    "transferFactoryTemplateId": "<pkg-hash>:Splice.Api.Token.TransferInstructionV1:TransferFactory",
+    "instrumentId": { "admin": "DSO::1220...", "id": "Amulet" },
+    "memo": "optional invoice id"
+  }
+}
+```
+
+### Field semantics
+
+- `amount` — atomic units, JSON string for precision. Canton Coin uses
+  10 decimals (so `"1000000000"` = 0.1 CC). For CIP-56 tokens, atomic
+  units of the instrument's declared `decimals`.
+- `asset` — `"canton-coin"` for Splice Amulet, or
+  `"<adminParty>::<id>"` for a CIP-56 token instrument.
+- `payTo` — receiver party id in canonical form `"<name>::<fingerprint>"`.
+- `extra.transferMethod` — MUST be `cip56-transfer-factory` (the only method).
+  Absent is treated as `cip56-transfer-factory`.
+- `extra.facilitatorParty` — the facilitator's own party id. Clients stamp it
+  into `Transfer.meta["x402.facilitatorParty"]`.
+- `extra.synchronizerId` — the Global Synchronizer the transfer settles on.
+- `extra.transferFactoryCid` / `extra.transferFactoryTemplateId` — the CIP-56
+  `TransferFactory` (cid + hash-prefixed template id) the client exercises.
+- `extra.instrumentId` — `{admin, id}` of the token instrument (e.g.
+  `{admin: "DSO::1220…", id: "Amulet"}` for Canton Coin).
+- `extra.memo` (optional) — opaque text for the merchant's records. Maximum
+  256 bytes.
+
+### Transfer Methods
+
+This specification defines one on-ledger path.
+
+| Method | On-ledger primitive |
+|---|---|
+| `cip56-transfer-factory` | `Splice.Api.Token.TransferInstructionV1.TransferFactory_Transfer` + `TransferPreapproval` |
+
+The `cip56-transfer-factory` method supports Canton Coin (Amulet) and any other
+CIP-56 instrument. For Canton Coin: `asset: "canton-coin"`,
+`extra.instrumentId: { admin: "DSO::1220...", id: "Amulet" }`.
+
+## PaymentPayload
+
+The client constructs the on-ledger transfer first, then sends the `payload` to
+the facilitator. The facilitator does NOT submit on the client's behalf — the
+client's own key authorizes the `TransferFactory_Transfer` exercise.
+
+### Full PAYMENT-SIGNATURE header shape (x402 v2)
+
+```json
+{
+  "x402Version": 2,
+  "resource": {
+    "url": "https://api.example.com/data",
+    "description": "Access to protected resource",
+    "mimeType": "application/json"
+  },
+  "accepted": {
+    "scheme": "exact",
+    "network": "canton:mainnet",
+    "amount": "1000000",
+    "asset": "issuer::1220abc...::USDC",
+    "payTo": "merchant_party::1220def...",
+    "maxTimeoutSeconds": 60,
+    "extra": {
+      "transferMethod": "cip56-transfer-factory",
+      "facilitatorParty": "ftp_facilitator::1220...",
+      "synchronizerId": "global-domain::1220xyz...",
+      "transferFactoryCid": "00factory...",
+      "transferFactoryTemplateId": "<pkg-hash>:Splice.Api.Token.TransferInstructionV1:TransferFactory",
+      "instrumentId": { "admin": "issuer::1220abc...", "id": "USDC" }
+    }
+  },
+  "payload": {
+    "transferMethod": "cip56-transfer-factory",
+    "payerParty": "agent_party::1220...",
+    "updateId": "1220abc..."
+  }
+}
+```
+
+Example uses a generic CIP-56 token. Canton Coin (Amulet) is also supported
+via the same method with `asset: "canton-coin"` and
+`instrumentId: { admin: "DSO::1220...", id: "Amulet" }`.
+
+### `payload` field variants
+
+Two variants depending on whether the registry returned
+`TransferInstructionResult_Completed` (synchronous; tokens already moved) or
+`TransferInstructionResult_Pending` (asynchronous; instruction contract advances
+later). Exactly one of `updateId` and `transferInstructionCid` MUST be set.
+
+> A live `TransferInstruction` means tokens have **not** moved yet. A facilitator
+> that reads a still-live instruction MUST NOT report settlement success. Use a
+> merchant `TransferPreapproval` to ensure synchronous completion.
+
+```json
+// Completed case
+{
+  "transferMethod": "cip56-transfer-factory",
+  "payerParty": "agent_party::1220...",
+  "updateId": "1220abc..."
+}
+
+// Pending case
+{
+  "transferMethod": "cip56-transfer-factory",
+  "payerParty": "agent_party::1220...",
+  "transferInstructionCid": "00abc..."
+}
+```
+
+## SettlementResponse
+
+Returned by the facilitator from `POST /settle` on success and echoed back in
+the `PAYMENT-RESPONSE` HTTP header by the resource server.
+
+```json
+{
+  "success": true,
+  "payer": "agent_party::1220...",
+  "transaction": "00f1abc...",
+  "network": "canton:mainnet",
+  "amount": "1000000000"
+}
+```
+
+- `transaction` — Canton ledger `updateId` of the `TransferFactory_Transfer`
+  exercise (echoed; CIP-56 settle is a no-op). Resolvable in any Scan API for
+  proof-of-settlement.
+
+On failure:
+
+```json
+{
+  "success": false,
+  "errorReason": "invalid_exact_canton_amount_mismatch",
+  "transaction": ""
+}
+```
+
+## Facilitator Verification Rules (MUST)
+
+`cip56-transfer-factory` is the only payment method. For a payment whose
+`payload` carries an `updateId` (the transfer completed synchronously) the
+facilitator MUST validate ALL of the following before returning `isValid: true`:
+
+1. **Network match.** `paymentRequirements.network` equals the facilitator's
+   configured network; cross-network claims are rejected.
+2. **Authoritative Scan read.** Read the SV Scan API
+   `GET /api/scan/v2/updates/{updateId}` and locate the exercised
+   `TransferFactory_Transfer` whose
+   `exercise_result.output.tag == "TransferInstructionResult_Completed"`. A
+   Scan mismatch is DEFINITIVE and MUST NOT be retried through other means.
+3. **Amount equality.** `transfer.amount` == PaymentRequirements.amount.
+4. **Payer = sender.** The returned `payer` is the proven `transfer.sender`,
+   not the client's claim.
+5. **Receiver / merchant match.** `transfer.receiver` == PaymentRequirements.payTo.
+6. **Instrument match.** `transfer.instrumentId.{admin,id}` == `extra.instrumentId`.
+7. **Resource binding.** When the client stamped `x402.resourceUrl` into
+   `transfer.meta.values`, it MUST equal `resource.url`
+   (`invalid_exact_canton_resource_url_mismatch` otherwise).
+8. **Single-use.** The `updateId` MUST NOT have settled before
+   (`invalid_exact_canton_payment_already_settled`).
+
+For a payment carrying a `transferInstructionCid` (still `Pending`), the
+facilitator reads the `TransferInstruction`, validates
+amount/sender/receiver/instrumentId, and rejects as
+`invalid_exact_canton_transfer_instruction_pending` — tokens have not moved.
+The payer SHOULD use a merchant `TransferPreapproval` for synchronous completion.
+
+## Duplicate Settlement Mitigation
+
+**Ledger-level:** A completed `TransferFactory_Transfer` is an immutable
+historical on-ledger record; double-spend is impossible.
+
+**HTTP-level:** Facilitators MUST enforce single-use settlement for each
+`updateId` and reject a second settle with
+`invalid_exact_canton_payment_already_settled`. The storage mechanism is
+implementation-defined.
+
+## Canton-specific: Verification via SV Scan
+
+Canton has stakeholder-scoped contract visibility. The facilitator reads the
+SV Scan API — `GET /api/scan/v2/updates/{updateId}` — and validates
+`sender`, `receiver`, `amount`, `instrumentId` from the exercised
+`TransferFactory_Transfer` choice argument directly. No stakeholder status
+required. On RBAC-gated deployments the facilitator authenticates to Scan.
+
+When the Scan read resolves but the transfer is invalid, the facilitator MUST
+reject with the specific reason and MUST NOT retry through other means.
+
+The facilitator matches only `TransferInstructionResult_Completed`. A
+`TransferInstructionResult_Pending` result MUST NOT be accepted as settled.
+
+## References
+
+- [x402 v2 spec](https://github.com/x402-foundation/x402/blob/main/specs/x402-specification-v2.md)
+- [SVM scheme spec (precedent)](https://github.com/x402-foundation/x402/blob/main/specs/schemes/exact/scheme_exact_svm.md)
+- [`Splice.AmuletRules` (TransferPreapproval)](https://github.com/hyperledger-labs/splice/blob/main/daml/splice-amulet/daml/Splice/AmuletRules.daml)
+- [CIP-56 Token Standard](https://github.com/canton-foundation/cips/blob/main/cip-0056/cip-0056.md)
+
+## Appendix
+
+### Privacy Considerations
+
+- **Facilitator scope.** The facilitator validates payments through SV Scan
+  and cannot see a payer's wallet balance or unrelated transactions.
+- **PII in memo/description.** Avoid PII in `extra.memo`; facilitator logs
+  and indexers will surface these strings.
+- **Resource URL.** `x402.resourceUrl` in Transfer.meta identifies the paid
+  API endpoint. Truncate or hash if sensitive.
+- **PartyToKeyMapping.** The payer's signing key is visible to all
+  participants on the same synchronizer.
+
+### Network identifiers in `/supported`
+
+A conformant Canton facilitator advertises CAIP-2-style network IDs.
+Example response:
+
+```json
+{
+  "kinds": [
+    {
+      "x402Version": 2,
+      "scheme": "exact",
+      "network": "canton:mainnet",
+      "extra": { "transferMethods": ["cip56-transfer-factory"] }
+    },
+    {
+      "x402Version": 2,
+      "scheme": "exact",
+      "network": "canton:testnet",
+      "extra": { "transferMethods": ["cip56-transfer-factory"] }
+    }
+  ],
+  "extensions": [],
+  "signers": { "canton:*": ["ftp_facilitator::1220def..."] }
+}
+```
+
+### Error Reason Codes
+
+Canton-specific error codes. All MUST be prefixed `invalid_exact_canton_*`
+or `unexpected_canton_*`.
+
+| Code | Meaning |
+|---|---|
+| `invalid_exact_canton_transfer_not_found` | The transfer (updateId / TransferInstruction) does not resolve to a completed `TransferFactory_Transfer` on Scan. |
+| `invalid_exact_canton_amount_mismatch` | `transfer.amount` != PaymentRequirements.amount. |
+| `invalid_exact_canton_asset_mismatch` | Token type does not match the requirements. |
+| `invalid_exact_canton_expired` | The transfer is past its `executeBefore` (or within the settle-latency margin). |
+| `invalid_exact_canton_payer_mismatch` | `payload.payerParty` != the proven `transfer.sender`. |
+| `invalid_exact_canton_merchant_mismatch` | `transfer.receiver` != PaymentRequirements.payTo. |
+| `invalid_exact_canton_resource_url_mismatch` | `transfer.meta["x402.resourceUrl"]` != the requested resource. |
+| `invalid_exact_canton_transfer_instruction_not_found` | CIP-56: `transferInstructionCid` does not resolve / facilitator is not a stakeholder. |
+| `invalid_exact_canton_transfer_instruction_pending` | CIP-56: a `TransferInstruction` was found and is valid, but still pending (tokens not moved). Use a `TransferPreapproval` for synchronous completion. |
+| `invalid_exact_canton_instrument_id_mismatch` | CIP-56: token `instrumentId` (admin/id) does not match PaymentRequirements. |
+| `invalid_exact_canton_transfer_factory_not_found` | CIP-56: the advertised `transferFactoryCid` does not resolve. |
+| `invalid_exact_canton_missing_proof` | CIP-56: neither a valid `updateId` nor `transferInstructionCid` was supplied. |
+| `invalid_exact_canton_payment_already_settled` | The payment (updateId) was already settled — single-use replay protection. |
+| `unexpected_canton_ledger_error` | Catch-all for Canton ledger / Scan API failures, network timeouts, etc. |


### PR DESCRIPTION
## Description

Adds an `exact` scheme implementation spec for Canton Network under
`specs/schemes/exact/`.

The spec defines Canton payment requirements, payment payload shape,
read-only SV Scan verification, settlement semantics, replay protection, and
Canton-specific error reasons for the CIP-56 `TransferFactory_Transfer` path.

Related discussion: #2551

## Tests

Docs/spec-only change. No SDK code changed.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

Docs-only/spec-only change; changelog fragment skipped per template guidance.
