### PR TITLE
Fix settlementOverrides for next

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 dist/
 .turbo/
 .next/
+next-env.d.ts
 proxy
 .env
 __pycache__/

--- a/examples/typescript/fullstack/next-batch-settlement-redis/app/api/weather/route.ts
+++ b/examples/typescript/fullstack/next-batch-settlement-redis/app/api/weather/route.ts
@@ -1,27 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
-import { withX402 } from "@x402/next";
+import { withX402, setSettlementOverrides } from "@x402/next";
 import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
 
 import { evmAddress, NETWORK, server } from "../../../lib/server";
 
-const price = "$0.001";
+// Authorize up to this amount per request; handler bills a random fraction via setSettlementOverrides.
+const maxPrice = "$0.01";
 
 /**
  * Weather API handler for the batch-settlement Next example (API-only; no paywall HTML).
+ *
+ * The client authorizes up to maxPrice, but settlement charges only actual usage
+ * via setSettlementOverrides.
  *
  * @param _ - Incoming Next.js request
  * @returns JSON response with weather data
  */
 const handler = async (_: NextRequest) => {
-  return NextResponse.json(
-    {
-      report: {
-        weather: "sunny",
-        temperature: 72,
-      },
+  const chargedPercent = 1 + Math.floor(Math.random() * 100);
+
+  const response = NextResponse.json({
+    report: {
+      weather: "sunny",
+      temperature: 72,
     },
-    { status: 200 },
-  );
+    usage: {
+      authorizedMax: maxPrice,
+      chargedPercent,
+    },
+  });
+
+  setSettlementOverrides(response, { amount: `${chargedPercent}%` });
+
+  return response;
 };
 
 /**
@@ -33,7 +44,7 @@ export const GET = withX402(
     accepts: [
       {
         scheme: "batch-settlement",
-        price,
+        price: maxPrice,
         network: NETWORK,
         payTo: evmAddress,
       },

--- a/examples/typescript/fullstack/next-batch-settlement-redis/next-env.d.ts
+++ b/examples/typescript/fullstack/next-batch-settlement-redis/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/typescript/fullstack/next-batch-settlement-redis/next-env.d.ts
+++ b/examples/typescript/fullstack/next-batch-settlement-redis/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/typescript/.changeset/hip-steaks-flow.md
+++ b/typescript/.changeset/hip-steaks-flow.md
@@ -1,0 +1,5 @@
+---
+'@x402/next': minor
+---
+
+Fixed a bug in handleSettlement which never forwarded response headers to processSettlement, so setSettlementOverrides was ignored breaking dynamic pricing for upto and batch-settlement

--- a/typescript/.changeset/yellow-terms-build.md
+++ b/typescript/.changeset/yellow-terms-build.md
@@ -1,0 +1,8 @@
+---
+'@x402/express': patch
+'@x402/fastify': patch
+'@x402/hono': patch
+'@x402/next': patch
+---
+
+Strip internal settlement-overrides header after settlement reads it, so its not exposed to the client

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -395,6 +395,37 @@ describe("paymentMiddleware", () => {
     expect(res.setHeader).toHaveBeenCalledWith("PAYMENT-RESPONSE", "settled");
   });
 
+  it("strips settlement override header from client response", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest();
+    const res = createMockResponse();
+    const next = vi.fn(() => {
+      res.setHeader("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
+      res.statusCode = 200;
+      res.end();
+    });
+
+    await middleware(req, res, next);
+
+    expect(res.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
+    expect(res._headers["Settlement-Overrides"]).toBeUndefined();
+  });
+
   it("skips settlement when handler returns >= 400", async () => {
     setupMockHttpServer(
       {

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -447,6 +447,7 @@ describe("paymentMiddleware", () => {
     const res = createMockResponse();
     const next = vi.fn(() => {
       // Simulate handler returning error
+      res.setHeader("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
       res.statusCode = 500;
       res.end();
     });
@@ -455,6 +456,8 @@ describe("paymentMiddleware", () => {
 
     expect(next).toHaveBeenCalled();
     expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(res.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
+    expect(res._headers["Settlement-Overrides"]).toBeUndefined();
     const cancellationDispatcher = (await mockProcessHTTPRequest.mock.results[0].value)
       .cancellationDispatcher;
     expect(cancellationDispatcher.cancel).toHaveBeenCalledWith(
@@ -522,12 +525,14 @@ describe("paymentMiddleware", () => {
     const req = createMockRequest();
     const res = createMockResponse();
     const next = vi.fn(() => {
+      res.setHeader("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
       res.statusCode = 200;
       res.end();
     });
 
     await middleware(req, res, next);
 
+    expect(res.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
     expect(res.status).toHaveBeenCalledWith(402);
     expect(res.json).toHaveBeenCalledWith({});
   });
@@ -703,12 +708,14 @@ describe("paymentMiddleware", () => {
     const req = createMockRequest();
     const res = createMockResponse();
     const next = vi.fn(() => {
+      res.setHeader("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
       res.statusCode = 200;
       res.end();
     });
 
     await middleware(req, res, next);
 
+    expect(res.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
     expect(res.setHeader).toHaveBeenCalledWith("PAYMENT-RESPONSE", "settlement-failed-encoded");
     expect(res.status).toHaveBeenCalledWith(402);
     expect(res.json).toHaveBeenCalledWith({});

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -288,6 +288,7 @@ export function paymentMiddlewareFromHTTPServer(
             reason: "handler_failed",
             responseStatus: res.statusCode,
           });
+          res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
           restoreResponseMethods();
           // Replay all buffered calls in order
           for (const [method, args] of bufferedCalls) {
@@ -328,6 +329,7 @@ export function paymentMiddlewareFromHTTPServer(
           if (!settleResult.success) {
             bufferedCalls = [];
             const { response } = settleResult;
+            res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
             Object.entries(response.headers).forEach(([key, value]) => {
               res.setHeader(key, value);
             });
@@ -343,20 +345,23 @@ export function paymentMiddlewareFromHTTPServer(
           Object.entries(settleResult.headers).forEach(([key, value]) => {
             res.setHeader(key, value);
           });
-          res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
         } catch (error) {
           if (error instanceof FacilitatorResponseError) {
             bufferedCalls = [];
+            res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
             sendFacilitatorError(res, error);
             return;
           }
           console.error(error);
           // If settlement fails, don't send the buffered response
           bufferedCalls = [];
+          res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
           res.status(402).json({});
           return;
         } finally {
           restoreResponseMethods();
+
+          res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
 
           // Replay all buffered calls in order
           for (const [method, args] of bufferedCalls) {

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -329,7 +329,6 @@ export function paymentMiddlewareFromHTTPServer(
           if (!settleResult.success) {
             bufferedCalls = [];
             const { response } = settleResult;
-            res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
             Object.entries(response.headers).forEach(([key, value]) => {
               res.setHeader(key, value);
             });
@@ -348,14 +347,12 @@ export function paymentMiddlewareFromHTTPServer(
         } catch (error) {
           if (error instanceof FacilitatorResponseError) {
             bufferedCalls = [];
-            res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
             sendFacilitatorError(res, error);
             return;
           }
           console.error(error);
           // If settlement fails, don't send the buffered response
           bufferedCalls = [];
-          res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
           res.status(402).json({});
           return;
         } finally {

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -343,6 +343,7 @@ export function paymentMiddlewareFromHTTPServer(
           Object.entries(settleResult.headers).forEach(([key, value]) => {
             res.setHeader(key, value);
           });
+          res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
         } catch (error) {
           if (error instanceof FacilitatorResponseError) {
             bufferedCalls = [];

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -584,10 +584,13 @@ describe("paymentMiddleware", () => {
     await hooks.onRequest[0](request, reply);
 
     reply.statusCode = 500;
+    reply._headers["Settlement-Overrides"] = JSON.stringify({ amount: "32%" });
     const payload = JSON.stringify({ error: "Server error" });
     const result = await hooks.onSend[0](request, reply, payload);
 
     expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(reply.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
+    expect(reply._headers["Settlement-Overrides"]).toBeUndefined();
     expect(request.x402Context?.cancellationDispatcher.cancel).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: "handler_failed",
@@ -635,9 +638,12 @@ describe("paymentMiddleware", () => {
     await hooks.onRequest[0](request, reply);
 
     reply.type("application/octet-stream");
+    reply._headers["Settlement-Overrides"] = JSON.stringify({ amount: "32%" });
     const payload = JSON.stringify({ data: "premium content" });
     const result = await hooks.onSend[0](request, reply, payload);
 
+    expect(reply.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
+    expect(reply._headers["Settlement-Overrides"]).toBeUndefined();
     expect(reply.status).toHaveBeenCalledWith(402);
     expect(reply.header).toHaveBeenCalledWith("PAYMENT-RESPONSE", "failed");
     expect(reply.type).toHaveBeenCalledWith("application/json");
@@ -667,9 +673,11 @@ describe("paymentMiddleware", () => {
 
     await hooks.onRequest[0](request, reply);
 
+    reply._headers["Settlement-Overrides"] = JSON.stringify({ amount: "32%" });
     const payload = JSON.stringify({ data: "premium content" });
     const result = await hooks.onSend[0](request, reply, payload);
 
+    expect(reply.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
     expect(reply.status).toHaveBeenCalledWith(402);
     expect(reply.type).toHaveBeenCalledWith("application/json");
     expect(result).toBe(JSON.stringify({}));

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -472,6 +472,37 @@ describe("paymentMiddleware", () => {
     expect(result).toBe(payload);
   });
 
+  it("strips settlement override header from client response", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+    reply._headers["Settlement-Overrides"] = JSON.stringify({ amount: "32%" });
+
+    await hooks.onRequest[0](request, reply);
+    await hooks.onSend[0](request, reply, JSON.stringify({ data: "premium content" }));
+
+    expect(reply.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
+    expect(reply._headers["Settlement-Overrides"]).toBeUndefined();
+  });
+
   it("passes Buffer payload bytes to settlement without JSON stringifying them", async () => {
     setupMockHttpServer(
       {

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -426,6 +426,7 @@ export function paymentMiddlewareFromHTTPServer(
         reason: "handler_failed",
         responseStatus: reply.statusCode,
       });
+      reply.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
       return effectivePayload;
     }
 
@@ -448,6 +449,7 @@ export function paymentMiddlewareFromHTTPServer(
 
       if (!settleResult.success) {
         const { response } = settleResult;
+        reply.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
         for (const [key, value] of Object.entries(response.headers)) {
           reply.header(key, value);
         }
@@ -466,11 +468,13 @@ export function paymentMiddlewareFromHTTPServer(
       return effectivePayload;
     } catch (error) {
       if (error instanceof FacilitatorResponseError) {
+        reply.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
         reply.status(502);
         reply.type("application/json");
         return JSON.stringify({ error: error.message });
       }
       console.error(error);
+      reply.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
       reply.status(402);
       reply.type("application/json");
       return JSON.stringify({});

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -462,6 +462,7 @@ export function paymentMiddlewareFromHTTPServer(
       for (const [key, value] of Object.entries(settleResult.headers)) {
         reply.header(key, value);
       }
+      reply.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
       return effectivePayload;
     } catch (error) {
       if (error instanceof FacilitatorResponseError) {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -384,6 +384,45 @@ describe("paymentMiddleware", () => {
     expect(responseHeaders.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
+  it("strips settlement override header from client response", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const context = createMockContext();
+
+    const responseHeaders = new Headers();
+    responseHeaders.set("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
+    const mockResponse = {
+      status: 200,
+      headers: responseHeaders,
+      clone: () => ({
+        arrayBuffer: async () => new ArrayBuffer(0),
+      }),
+    } as unknown as Response;
+
+    const next = vi.fn().mockImplementation(async () => {
+      context.res = mockResponse;
+    });
+
+    await middleware(context, next);
+
+    expect(responseHeaders.has("Settlement-Overrides")).toBe(false);
+    expect(responseHeaders.get("PAYMENT-RESPONSE")).toBe("settled");
+  });
+
   it("skips settlement when handler returns >= 400", async () => {
     setupMockHttpServer(
       {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -442,14 +442,17 @@ describe("paymentMiddleware", () => {
     );
     const context = createMockContext();
 
+    const responseHeaders = new Headers();
+    responseHeaders.set("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
     const next = vi.fn().mockImplementation(async () => {
-      context.res = new Response("Error", { status: 500 });
+      context.res = new Response("Error", { status: 500, headers: responseHeaders });
     });
 
     await middleware(context, next);
 
     expect(next).toHaveBeenCalled();
     expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(context.res?.headers.has("Settlement-Overrides")).toBe(false);
   });
 
   it("returns 402 when settlement throws error", async () => {

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -221,10 +221,7 @@ export function paymentMiddlewareFromHTTPServer(
             reason: "handler_failed",
             responseStatus: res.status,
           });
-          const headers = new Headers(res.headers);
-          headers.delete(SETTLEMENT_OVERRIDES_HEADER);
-          const body = await res.clone().arrayBuffer();
-          c.res = new Response(body, { status: res.status, headers });
+          res.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
           return;
         }
 

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -258,6 +258,7 @@ export function paymentMiddlewareFromHTTPServer(
             Object.entries(settleResult.headers).forEach(([key, value]) => {
               res.headers.set(key, value);
             });
+            res.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
           }
         } catch (error) {
           if (error instanceof FacilitatorResponseError) {

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -221,6 +221,10 @@ export function paymentMiddlewareFromHTTPServer(
             reason: "handler_failed",
             responseStatus: res.status,
           });
+          const headers = new Headers(res.headers);
+          headers.delete(SETTLEMENT_OVERRIDES_HEADER);
+          const body = await res.clone().arrayBuffer();
+          c.res = new Response(body, { status: res.status, headers });
           return;
         }
 

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -46,6 +46,7 @@ vi.mock("@x402/core/server", () => ({
     }
     return null;
   },
+  SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
   x402ResourceServer: vi.fn().mockImplementation(() => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     registerExtension: vi.fn(),

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -46,6 +46,7 @@ vi.mock("@x402/core/server", () => {
       }
       return null;
     },
+    SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
     x402HTTPResourceServer: MockHTTPResourceServer,
     x402ResourceServer: vi.fn(),
     checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
@@ -323,6 +324,52 @@ describe("handleSettlement", () => {
       mockDeclaredExtensions,
       undefined,
     );
+  });
+
+  it("forwards response headers to processSettlement for settlement overrides", async () => {
+    const response = new NextResponse("OK", { status: 200 });
+    response.headers.set("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
+    const httpContext = createRequestContext(createMockRequest());
+
+    await handleSettlement(
+      mockHttpServer,
+      response,
+      mockPaymentPayload,
+      mockRequirements,
+      mockDeclaredExtensions,
+      mockPaymentCancellationDispatcher,
+      httpContext,
+    );
+
+    expect(mockHttpServer.processSettlement).toHaveBeenCalledWith(
+      mockPaymentPayload,
+      mockRequirements,
+      mockDeclaredExtensions,
+      expect.objectContaining({
+        request: httpContext,
+        responseBody: expect.any(Buffer),
+        responseHeaders: expect.objectContaining({
+          "settlement-overrides": JSON.stringify({ amount: "32%" }),
+        }),
+      }),
+    );
+  });
+
+  it("strips settlement override header from client response", async () => {
+    const response = new NextResponse("OK", { status: 200 });
+    response.headers.set("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
+
+    const result = await handleSettlement(
+      mockHttpServer,
+      response,
+      mockPaymentPayload,
+      mockRequirements,
+      mockDeclaredExtensions,
+      mockPaymentCancellationDispatcher,
+    );
+
+    expect(result.headers.has("Settlement-Overrides")).toBe(false);
+    expect(result.headers.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
   it("returns 402 error response when settlement returns failure", async () => {

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -244,6 +244,7 @@ describe("handlePaymentError", () => {
 
 describe("handleSettlement", () => {
   let mockHttpServer: x402HTTPResourceServer;
+  let mockHttpContext: ReturnType<typeof createRequestContext>;
   const mockPaymentPayload = {
     scheme: "exact",
     network: "eip155:84532",
@@ -256,6 +257,7 @@ describe("handleSettlement", () => {
   let mockPaymentCancellationDispatcher: PaymentCancellationDispatcher;
 
   beforeEach(() => {
+    mockHttpContext = createRequestContext(createMockRequest());
     mockPaymentCancellationDispatcher = {
       cancel: vi.fn().mockResolvedValue(undefined),
     } as unknown as PaymentCancellationDispatcher;
@@ -276,6 +278,7 @@ describe("handleSettlement", () => {
       mockRequirements,
       mockDeclaredExtensions,
       mockPaymentCancellationDispatcher,
+      mockHttpContext,
     );
 
     expect(result.status).toBe(500);
@@ -298,6 +301,7 @@ describe("handleSettlement", () => {
       mockRequirements,
       mockDeclaredExtensions,
       mockPaymentCancellationDispatcher,
+      mockHttpContext,
     );
 
     expect(result.status).toBe(400);
@@ -314,6 +318,7 @@ describe("handleSettlement", () => {
       mockRequirements,
       mockDeclaredExtensions,
       mockPaymentCancellationDispatcher,
+      mockHttpContext,
     );
 
     expect(result.status).toBe(200);
@@ -322,7 +327,11 @@ describe("handleSettlement", () => {
       mockPaymentPayload,
       mockRequirements,
       mockDeclaredExtensions,
-      undefined,
+      expect.objectContaining({
+        request: mockHttpContext,
+        responseBody: expect.any(Buffer),
+        responseHeaders: expect.any(Object),
+      }),
     );
   });
 
@@ -366,6 +375,7 @@ describe("handleSettlement", () => {
       mockRequirements,
       mockDeclaredExtensions,
       mockPaymentCancellationDispatcher,
+      mockHttpContext,
     );
 
     expect(result.headers.has("Settlement-Overrides")).toBe(false);
@@ -383,6 +393,7 @@ describe("handleSettlement", () => {
       mockRequirements,
       mockDeclaredExtensions,
       mockPaymentCancellationDispatcher,
+      mockHttpContext,
     );
 
     expect(result.status).toBe(500);
@@ -415,6 +426,7 @@ describe("handleSettlement", () => {
       mockRequirements,
       mockDeclaredExtensions,
       mockPaymentCancellationDispatcher,
+      mockHttpContext,
     );
 
     expect(result.status).toBe(402);
@@ -434,6 +446,7 @@ describe("handleSettlement", () => {
       mockRequirements,
       mockDeclaredExtensions,
       mockPaymentCancellationDispatcher,
+      mockHttpContext,
     );
 
     expect(result.status).toBe(402);

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -372,6 +372,24 @@ describe("handleSettlement", () => {
     expect(result.headers.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
+  it("strips settlement override header when handler returns >= 400", async () => {
+    const response = new NextResponse("Error", { status: 500 });
+    response.headers.set("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
+
+    const result = await handleSettlement(
+      mockHttpServer,
+      response,
+      mockPaymentPayload,
+      mockRequirements,
+      mockDeclaredExtensions,
+      mockPaymentCancellationDispatcher,
+    );
+
+    expect(result.status).toBe(500);
+    expect(result.headers.has("Settlement-Overrides")).toBe(false);
+    expect(mockHttpServer.processSettlement).not.toHaveBeenCalled();
+  });
+
   it("returns 402 error response when settlement returns failure", async () => {
     vi.mocked(mockHttpServer.processSettlement).mockResolvedValue({
       success: false,

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -155,7 +155,7 @@ export function handlePaymentError(response: HTTPResponseInstructions): NextResp
  * @param paymentRequirements - The payment requirements for the route
  * @param declaredExtensions - Optional declared extensions (for per-key enrichment)
  * @param cancellationDispatcher - Cancels verified payments that should not settle
- * @param httpContext - Optional HTTP request context for extensions
+ * @param httpContext - HTTP request context for extensions
  * @returns The response with settlement headers or an error response if settlement fails
  */
 export async function handleSettlement(
@@ -165,7 +165,7 @@ export async function handleSettlement(
   paymentRequirements: PaymentRequirements,
   declaredExtensions: Record<string, unknown> | undefined,
   cancellationDispatcher: PaymentCancellationDispatcher,
-  httpContext?: HTTPRequestContext,
+  httpContext: HTTPRequestContext,
 ): Promise<NextResponse> {
   // If the response from the protected route is >= 400, do not settle payment
   if (response.status >= 400) {
@@ -190,7 +190,7 @@ export async function handleSettlement(
       paymentPayload,
       paymentRequirements,
       declaredExtensions,
-      httpContext ? { request: httpContext, responseBody, responseHeaders } : undefined,
+      { request: httpContext, responseBody, responseHeaders },
     );
 
     if (!result.success) {

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -173,6 +173,7 @@ export async function handleSettlement(
       reason: "handler_failed",
       responseStatus: response.status,
     });
+    response.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
     return response;
   }
 

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -9,6 +9,7 @@ import {
   FacilitatorResponseError,
   getFacilitatorResponseError as getCoreFacilitatorResponseError,
   PaymentCancellationDispatcher,
+  SETTLEMENT_OVERRIDES_HEADER,
 } from "@x402/core/server";
 import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
 import { NextAdapter } from "./adapter";
@@ -179,11 +180,16 @@ export async function handleSettlement(
     // Get response body for extensions
     const responseBody = Buffer.from(await response.clone().arrayBuffer());
 
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      responseHeaders[key] = value;
+    });
+
     const result = await httpServer.processSettlement(
       paymentPayload,
       paymentRequirements,
       declaredExtensions,
-      httpContext ? { request: httpContext, responseBody } : undefined,
+      httpContext ? { request: httpContext, responseBody, responseHeaders } : undefined,
     );
 
     if (!result.success) {
@@ -200,6 +206,9 @@ export async function handleSettlement(
     Object.entries(result.headers).forEach(([key, value]) => {
       response.headers.set(key, value);
     });
+
+    // Strip internal settlement override header before sending to client.
+    response.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
 
     return response;
   } catch (error) {


### PR DESCRIPTION
## Description

- Fixes a bug in @x402/next's `handleSettlement` which never forwarded response headers to processSettlement, so setSettlementOverrides was ignored breaking dynamic pricing for `upto` and `batch-settlement`
- strips internal settlement-overrides header in all TS middleware packages after settlement reads it, so its not exposed to the client. Go/py middlewares already do this

## Tests

Added dynamic pricing to `next-batch-settlement-redis` and tested manually 

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 