### PR TITLE
improve client error surfacing

### DIFF
--- a/examples/typescript/clients/axios/index.ts
+++ b/examples/typescript/clients/axios/index.ts
@@ -40,16 +40,16 @@ async function main(): Promise<void> {
   client.register("solana:*", new ExactSvmScheme(svmSigner));
 
   const api = wrapAxiosWithPayment(axios.create(), client);
+  const httpClient = new x402HTTPClient(client);
 
   console.log(`Making request to: ${url}\n`);
   const response = await api.get(url);
-  const body = response.data;
-  console.log("Response body:", body);
-
-  const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(
-    name => response.headers[name.toLowerCase()],
-  );
-  console.log("\nPayment response:", paymentResponse);
+  const result = httpClient.parsePaymentResult({
+    status: response.status,
+    getHeader: name => response.headers[name.toLowerCase()],
+    body: response.data,
+  });
+  console.dir(result, { depth: null });
 }
 
 main().catch(error => {

--- a/examples/typescript/clients/batch-settlement/index.ts
+++ b/examples/typescript/clients/batch-settlement/index.ts
@@ -70,7 +70,7 @@ async function main(): Promise<void> {
     const response = await fetchWithPayment(url, { method: "GET" });
     const result = await httpClient.processResponse(response);
 
-    if (result.status === 200) {
+    if (result.paymentStatus === "settled") {
       console.log(`Request ${i + 1} — RESPONSE`);
       console.log(result.body);
       console.log(JSON.stringify(result.header, null, 2));

--- a/examples/typescript/clients/batch-settlement/index.ts
+++ b/examples/typescript/clients/batch-settlement/index.ts
@@ -70,12 +70,12 @@ async function main(): Promise<void> {
     const response = await fetchWithPayment(url, { method: "GET" });
     const result = await httpClient.processResponse(response);
 
-    if (result.kind === "success") {
+    if (result.status === 200) {
       console.log(`Request ${i + 1} — RESPONSE`);
       console.log(result.body);
-      console.log(JSON.stringify(result.settleResponse, null, 2));
+      console.log(JSON.stringify(result.header, null, 2));
     } else {
-      console.log(`Request ${i + 1} — ${result.kind}`);
+      console.log(`Request ${i + 1} — no settlement`);
       console.log(JSON.stringify(result, null, 2));
     }
     console.log(

--- a/examples/typescript/clients/fetch/index.ts
+++ b/examples/typescript/clients/fetch/index.ts
@@ -39,19 +39,12 @@ async function main(): Promise<void> {
   client.register("solana:*", new ExactSvmScheme(svmSigner));
 
   const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+  const httpClient = new x402HTTPClient(client);
 
   console.log(`Making request to: ${url}\n`);
   const response = await fetchWithPayment(url, { method: "GET" });
-  const contentType = response.headers.get("content-type") ?? "";
-  const body = contentType.includes("application/json")
-    ? await response.json()
-    : await response.text();
-  console.log("Response body:", body);
-
-  const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(name =>
-    response.headers.get(name),
-  );
-  console.log("\nPayment response:", JSON.stringify(paymentResponse, null, 2));
+  const result = await httpClient.processResponse(response);
+  console.dir(result, { depth: null });
 }
 
 main().catch(error => {

--- a/typescript/.changeset/client-error-surfacing.md
+++ b/typescript/.changeset/client-error-surfacing.md
@@ -1,0 +1,7 @@
+---
+'@x402/core': minor
+'@x402/axios': minor
+'@x402/fetch': minor
+---
+
+Add transport-agnostic `parsePaymentResult` and simplify the parsed result to `HTTPResourceResponse` (`{ status, body, header }`), where `header` is the decoded `SettleResponse` (from `PAYMENT-RESPONSE`) or `PaymentRequired` (from `PAYMENT-REQUIRED`, whose `error` carries the server's failure reason). This lets clients surface server-delivered payment errors without branching.

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -117,4 +117,5 @@ export {
   PaymentRequiredHook,
   HTTPClientExtensionHooks,
   HTTPResourceResponse,
+  HTTPPaymentStatus,
 } from "./x402HTTPClient";

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -116,4 +116,5 @@ export {
   PaymentRequiredContext,
   PaymentRequiredHook,
   HTTPClientExtensionHooks,
+  HTTPResourceResponse,
 } from "./x402HTTPClient";

--- a/typescript/packages/core/src/http/x402HTTPClient.ts
+++ b/typescript/packages/core/src/http/x402HTTPClient.ts
@@ -220,48 +220,53 @@ export class x402HTTPClient {
   }
 
   /**
-   * Parses a fetch Response into a discriminated `x402PaymentResult` for app-level convenience.
+   * Parses HTTP status, headers, and body into an `HTTPResourceResponse`.
    *
-   * @param response - The fetch Response to process
-   * @returns A discriminated union describing the payment outcome
+   * Decodes the x402 payment header into `header`: the `PAYMENT-RESPONSE`
+   * settlement if present, otherwise the `PAYMENT-REQUIRED` declaration
+   * (whose `error` field carries the server's failure reason).
+   *
+   * @param args - Normalized response inputs from any HTTP transport
+   * @param args.status - HTTP response status code
+   * @param args.getHeader - Callback to read response headers by name
+   * @param args.body - Response body payload
+   * @returns The parsed status, body, and decoded payment header
    */
-  async processResponse(response: Response): Promise<x402PaymentResult> {
-    const getHeader = (name: string) => response.headers.get(name);
+  parsePaymentResult(args: {
+    status: number;
+    getHeader: (name: string) => string | null | undefined;
+    body: unknown;
+  }): HTTPResourceResponse {
+    const { status, getHeader, body } = args;
 
-    let settleResponse: SettleResponse | undefined;
+    let header: SettleResponse | PaymentRequired | undefined;
     try {
-      settleResponse = this.getPaymentSettleResponse(getHeader);
+      header = this.getPaymentSettleResponse(getHeader);
     } catch {
-      /* no header */
+      try {
+        header = this.getPaymentRequiredResponse(getHeader, body);
+      } catch {
+        /* no payment header */
+      }
     }
 
+    return { status, body, header };
+  }
+
+  /**
+   * Parses a fetch Response into an `HTTPResourceResponse` for app-level convenience.
+   *
+   * @param response - The fetch Response to process
+   * @returns The parsed status, body, and decoded payment header
+   */
+  async processResponse(response: Response): Promise<HTTPResourceResponse> {
+    const getHeader = (name: string) => response.headers.get(name);
     const contentType = response.headers.get("content-type") ?? "";
     const body = contentType.includes("application/json")
       ? await response.json()
       : await response.text();
 
-    if (settleResponse && settleResponse.success) {
-      return { kind: "success", response, body, settleResponse };
-    }
-
-    if (settleResponse && !settleResponse.success) {
-      return { kind: "settle_failed", response, body, settleResponse };
-    }
-
-    if (response.status === 402) {
-      try {
-        const paymentRequired = this.getPaymentRequiredResponse(getHeader, body);
-        return { kind: "payment_required", response, paymentRequired };
-      } catch {
-        /* no payment-required header */
-      }
-    }
-
-    if (response.ok) {
-      return { kind: "passthrough", response, body };
-    }
-
-    return { kind: "error", response, status: response.status, body };
+    return this.parsePaymentResult({ status: response.status, getHeader, body });
   }
 
   /**
@@ -288,11 +293,17 @@ export class x402HTTPClient {
 }
 
 /**
- * Discriminated union describing the outcome of a payment-enabled request.
+ * Parsed result of an HTTP request to an x402 resource.
  */
-export type x402PaymentResult =
-  | { kind: "success"; response: Response; body: unknown; settleResponse: SettleResponse }
-  | { kind: "settle_failed"; response: Response; body: unknown; settleResponse: SettleResponse }
-  | { kind: "payment_required"; response: Response; paymentRequired: PaymentRequired }
-  | { kind: "error"; response: Response; status: number; body: unknown }
-  | { kind: "passthrough"; response: Response; body: unknown };
+export type HTTPResourceResponse = {
+  /** HTTP status code. */
+  status: number;
+  /** Parsed response body. */
+  body: unknown;
+  /**
+   * Decoded x402 payment header, if present:
+   * - SettleResponse  (from PAYMENT-RESPONSE / X-PAYMENT-RESPONSE)
+   * - PaymentRequired (from PAYMENT-REQUIRED; its `error` carries the server reason)
+   */
+  header?: SettleResponse | PaymentRequired;
+};

--- a/typescript/packages/core/src/http/x402HTTPClient.ts
+++ b/typescript/packages/core/src/http/x402HTTPClient.ts
@@ -223,8 +223,8 @@ export class x402HTTPClient {
    * Parses HTTP status, headers, and body into an `HTTPResourceResponse`.
    *
    * Decodes the x402 payment header into `header`: the `PAYMENT-RESPONSE`
-   * settlement if present, otherwise the `PAYMENT-REQUIRED` declaration
-   * (whose `error` field carries the server's failure reason).
+   * settlement if present, otherwise the `PAYMENT-REQUIRED` declaration on
+   * 402 responses (whose `error` field carries the server's failure reason).
    *
    * @param args - Normalized response inputs from any HTTP transport
    * @param args.status - HTTP response status code
@@ -243,14 +243,24 @@ export class x402HTTPClient {
     try {
       header = this.getPaymentSettleResponse(getHeader);
     } catch {
-      try {
-        header = this.getPaymentRequiredResponse(getHeader, body);
-      } catch {
-        /* no payment header */
+      if (status === 402) {
+        try {
+          header = this.getPaymentRequiredResponse(getHeader, body);
+        } catch {
+          /* no payment header */
+        }
       }
     }
 
-    return { status, body, header };
+    let paymentStatus: HTTPPaymentStatus = "none";
+    if (header && !("success" in header)) {
+      paymentStatus = "payment_required";
+    }
+    if (header && "success" in header) {
+      paymentStatus = header.success ? "settled" : "settle_failed";
+    }
+
+    return { status, paymentStatus, body, header };
   }
 
   /**
@@ -298,6 +308,8 @@ export class x402HTTPClient {
 export type HTTPResourceResponse = {
   /** HTTP status code. */
   status: number;
+  /** x402 payment outcome. */
+  paymentStatus: HTTPPaymentStatus;
   /** Parsed response body. */
   body: unknown;
   /**
@@ -307,3 +319,5 @@ export type HTTPResourceResponse = {
    */
   header?: SettleResponse | PaymentRequired;
 };
+
+export type HTTPPaymentStatus = "settled" | "settle_failed" | "payment_required" | "none";

--- a/typescript/packages/core/test/unit/http/x402HTTPClient.parsePaymentResult.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPClient.parsePaymentResult.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { x402Client } from "../../../src/client/x402Client";
+import { encodePaymentRequiredHeader, encodePaymentResponseHeader } from "../../../src/http";
+import { x402HTTPClient } from "../../../src/http/x402HTTPClient";
+import { buildPaymentRequired, buildSettleResponse } from "../../mocks";
+
+describe("x402HTTPClient.parsePaymentResult", () => {
+  const httpClient = new x402HTTPClient(new x402Client());
+
+  it("decodes the PAYMENT-RESPONSE settlement into header on success", () => {
+    const settleResponse = buildSettleResponse({ success: true, transaction: "0xabc" });
+    const body = { temperature: 72 };
+    const headers: Record<string, string> = {
+      "PAYMENT-RESPONSE": encodePaymentResponseHeader(settleResponse),
+    };
+
+    const result = httpClient.parsePaymentResult({
+      status: 200,
+      getHeader: name => headers[name] ?? null,
+      body,
+    });
+
+    expect(result).toEqual({
+      status: 200,
+      paymentStatus: "settled",
+      body,
+      header: settleResponse,
+    });
+  });
+
+  it("decodes a failed settlement into header", () => {
+    const settleResponse = buildSettleResponse({
+      success: false,
+      errorReason: "insufficient_funds",
+      errorMessage: "Not enough USDC",
+    });
+    const body = { error: "payment failed" };
+    const headers: Record<string, string> = {
+      "PAYMENT-RESPONSE": encodePaymentResponseHeader(settleResponse),
+    };
+
+    const result = httpClient.parsePaymentResult({
+      status: 402,
+      getHeader: name => headers[name] ?? null,
+      body,
+    });
+
+    expect(result).toEqual({
+      status: 402,
+      paymentStatus: "settle_failed",
+      body,
+      header: settleResponse,
+    });
+    expect(result.header).toMatchObject({
+      success: false,
+      errorReason: "insufficient_funds",
+      errorMessage: "Not enough USDC",
+    });
+  });
+
+  it("decodes the PAYMENT-REQUIRED declaration into header on 402", () => {
+    const paymentRequired = buildPaymentRequired({
+      error: "invalid_exact_evm_payload_signature",
+    });
+    const body = {};
+    const headers: Record<string, string> = {
+      "PAYMENT-REQUIRED": encodePaymentRequiredHeader(paymentRequired),
+    };
+
+    const result = httpClient.parsePaymentResult({
+      status: 402,
+      getHeader: name => headers[name] ?? null,
+      body,
+    });
+
+    expect(result).toEqual({
+      status: 402,
+      paymentStatus: "payment_required",
+      body,
+      header: paymentRequired,
+    });
+    expect(result.header).toMatchObject({ error: "invalid_exact_evm_payload_signature" });
+  });
+
+  it("ignores PAYMENT-REQUIRED on non-402 responses", () => {
+    const paymentRequired = buildPaymentRequired();
+    const body = { message: "ok" };
+    const headers: Record<string, string> = {
+      "PAYMENT-REQUIRED": encodePaymentRequiredHeader(paymentRequired),
+    };
+
+    const result = httpClient.parsePaymentResult({
+      status: 200,
+      getHeader: name => headers[name] ?? null,
+      body,
+    });
+
+    expect(result).toEqual({ status: 200, paymentStatus: "none", body, header: undefined });
+  });
+
+  it("leaves header undefined when no payment header is present", () => {
+    const body = { error: "internal server error" };
+
+    const result = httpClient.parsePaymentResult({
+      status: 500,
+      getHeader: () => null,
+      body,
+    });
+
+    expect(result).toEqual({ status: 500, paymentStatus: "none", body, header: undefined });
+  });
+
+  it("leaves header undefined for a 2xx response without payment headers", () => {
+    const body = { message: "ok" };
+
+    const result = httpClient.parsePaymentResult({
+      status: 200,
+      getHeader: () => null,
+      body,
+    });
+
+    expect(result).toEqual({ status: 200, paymentStatus: "none", body, header: undefined });
+  });
+});

--- a/typescript/packages/http/axios/src/index.ts
+++ b/typescript/packages/http/axios/src/index.ts
@@ -273,6 +273,7 @@ export function wrapAxiosWithPaymentFromConfig(
 // Re-export types and utilities for convenience
 export { x402Client, x402HTTPClient } from "@x402/core/client";
 export type {
+  HTTPResourceResponse,
   PaymentPolicy,
   SchemeRegistration,
   SelectPaymentRequirements,

--- a/typescript/packages/http/fetch/src/index.ts
+++ b/typescript/packages/http/fetch/src/index.ts
@@ -171,7 +171,7 @@ export function wrapFetchWithPaymentFromConfig(
 
 // Re-export types and utilities for convenience
 export { x402Client, x402HTTPClient } from "@x402/core/client";
-export type { x402PaymentResult } from "@x402/core/client";
+export type { HTTPResourceResponse } from "@x402/core/client";
 export type {
   PaymentPolicy,
   SchemeRegistration,


### PR DESCRIPTION
## Description

Adds transport-agnostic `parsePaymentResult` and simplify the parsed result to `HTTPResourceResponse` (`{ status, body, header }`), where `header` is the decoded `SettleResponse` (from `PAYMENT-RESPONSE`) or `PaymentRequired` (from `PAYMENT-REQUIRED`, whose `error` carries the server's failure reason). This lets clients surface server-delivered payment errors without branching.

For failed payments, client examples currently just show a generic error message:
```
Response body: {}
Error: Payment response header not found
```

After fix:
```
{
  status: 402,
  body: {},
  header: {
    x402Version: 2,
    error: '....',
    resource: {
      url: 'http://localhost:4021/api/generate',
      description: 'AI text generation — billed by token usage',
      mimeType: 'application/json'
    },
    accepts:  ...,
    extensions: ...,
  }
}
```

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 