### PR TITLE
feat(evm): add Kaia mainnet and Kairos testnet networks

### DIFF
--- a/typescript/.changeset/add-kaia-networks.md
+++ b/typescript/.changeset/add-kaia-networks.md
@@ -1,0 +1,6 @@
+---
+'x402': minor
+'@x402/evm': minor
+---
+
+Add Kaia networks: `kaia` (mainnet, chainId 8217) and `kaia-kairos` (Kairos testnet, chainId 1001), wired to viem's existing `kaia`/`kairos` chains.

--- a/typescript/packages/legacy/x402/src/types/shared/evm/wallet.ts
+++ b/typescript/packages/legacy/x402/src/types/shared/evm/wallet.ts
@@ -26,6 +26,8 @@ import {
   abstractTestnet,
   story,
   eduChain,
+  kaia,
+  kairos,
 } from "viem/chains";
 import { skaleBaseSepolia } from "../custom-chains";
 import { privateKeyToAccount } from "viem/accounts";
@@ -235,6 +237,10 @@ export function getChainFromNetwork(network: string | undefined): Chain {
       return iotexTestnet;
     case "skale-base-sepolia":
       return skaleBaseSepolia;
+    case "kaia":
+      return kaia;
+    case "kaia-kairos":
+      return kairos;
     default:
       throw new Error(`Unsupported network: ${network}`);
   }

--- a/typescript/packages/legacy/x402/src/types/shared/network.ts
+++ b/typescript/packages/legacy/x402/src/types/shared/network.ts
@@ -18,6 +18,8 @@ export const NetworkSchema = z.enum([
   "story",
   "educhain",
   "skale-base-sepolia",
+  "kaia",
+  "kaia-kairos",
 ]);
 export type Network = z.infer<typeof NetworkSchema>;
 
@@ -38,6 +40,8 @@ export const SupportedEVMNetworks: Network[] = [
   "story",
   "educhain",
   "skale-base-sepolia",
+  "kaia",
+  "kaia-kairos",
 ];
 export const EvmNetworkToChainId = new Map<Network, number>([
   ["abstract", 2741],
@@ -55,6 +59,8 @@ export const EvmNetworkToChainId = new Map<Network, number>([
   ["story", 1514],
   ["educhain", 41923],
   ["skale-base-sepolia", 324705682],
+  ["kaia", 8217],
+  ["kaia-kairos", 1001],
 ]);
 
 // svm

--- a/typescript/packages/mechanisms/evm/src/v1/index.ts
+++ b/typescript/packages/mechanisms/evm/src/v1/index.ts
@@ -22,6 +22,8 @@ export const EVM_NETWORK_CHAIN_ID_MAP = {
   monad: 143,
   stable: 988,
   "stable-testnet": 2201,
+  kaia: 8217,
+  "kaia-kairos": 1001,
 } as const;
 
 export type EvmNetworkV1 = keyof typeof EVM_NETWORK_CHAIN_ID_MAP;


### PR DESCRIPTION
## What
Registers two EVM networks:
- `kaia` — Kaia mainnet (chainId **8217**)
- `kaia-kairos` — Kaia Kairos testnet (chainId **1001**)

## Why
Kaia (the Klaytn/Finschia merger) is EVM-equivalent and a major chain in Korea, where won-denominated stablecoin micropayments are a natural x402 use case. Without a registered network, clients and facilitators can't address Kaia by name.

## Changes
- `mechanisms/evm/src/v1/index.ts` — add `kaia` / `kaia-kairos` to `EVM_NETWORK_CHAIN_ID_MAP` (canonical map; `NETWORKS` derives from it).
- `legacy/x402/.../shared/network.ts` — add to `NetworkSchema`, `SupportedEVMNetworks`, `EvmNetworkToChainId`.
- `legacy/x402/.../shared/evm/wallet.ts` — resolve both networks to viem's existing `kaia` / `kairos` chains in `getChainFromNetwork`.
- changeset (`x402`, `@x402/evm`: minor).

No chain constants invented — IDs and chain configs come from viem's `kaia` (8217) and `kairos` (1001), matching the existing pattern for other networks.

## Verification
- `tsc --noEmit` on `legacy/x402` passes clean (covers the `Network` enum + `getChainFromNetwork`).
- viem ships `kaia` / `kairos`; chain IDs confirmed 8217 / 1001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)