### PR TITLE
docs: add x402-policy Python SDK to third-party SDKs list

### DIFF
--- a/docs/dev-tools/third-party-sdks.md
+++ b/docs/dev-tools/third-party-sdks.md
@@ -8,3 +8,5 @@ description: "Community-maintained x402 SDKs."
 | [Mogami](https://mogami.gitbook.io/mogami) | Java x402 stack | Java | [GitHub](https://github.com/mogami-tech/) |
 | [x402-rs](https://github.com/x402-rs/x402-rs/blob/main/README.md) | Rust toolkit for x402 | Rust | [GitHub](https://github.com/x402-rs/x402-rs) |
 | [x402-rails](https://github.com/quiknode-labs/x402-rails/blob/main/README.md) | x402 for Rails applications by Quicknode | Ruby | [GitHub](https://github.com/quiknode-labs/x402-rails) |
+
+| [x402-policy](https://pypi.org/project/x402-policy/) | Python server for AI agent spending policy enforcement via x402 v2. Budget caps, per-call limits, trust scores. Live API on Base Mainnet. | Python | [PyPI](https://pypi.org/project/x402-policy/) · [API](https://x402-api-seven.vercel.app) |


### PR DESCRIPTION
## What

Adds [x402-policy](https://pypi.org/project/x402-policy/) to the third-party SDKs list — a Python server library for AI agent spending policy enforcement via x402 v2 micropayments on Base Mainnet.

## Details

- **PyPI**: https://pypi.org/project/x402-policy/
- **Live API**: https://x402-api-seven.vercel.app
- **Network**: Base Mainnet (eip155:8453), USDC
- **Features**: Daily budget caps, per-call limits, ERC-8004 trust scores, EIP-4337 session keys

The live API is deployed and validated on Agentic.Market (Bazaar). Listed on x402scan.com.