### PR TITLE
feat(ecosystem): add TWZRD Agent Intel — Solana x402 trust scoring MCP server

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/twzrd-agent-intel/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/twzrd-agent-intel/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "TWZRD Agent Intel",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/twzrd-agent-intel.svg",
+  "description": "Solana-native x402 MCP server for AI agent trust scoring and identity verification. 4 free preflight tools score any Solana wallet (on-chain activity, transaction patterns, network age, recurring behavior); paid get_trust_receipt returns a signed twzrd.receipt.v5 trust token via x402 USDC on Solana (<1s settlement). First pay-per-proof agent identity MCP on Solana.",
+  "websiteUrl": "https://intel.twzrd.xyz"
+}

--- a/typescript/site/public/logos/twzrd-agent-intel.svg
+++ b/typescript/site/public/logos/twzrd-agent-intel.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="24" fill="#0f0f0f"/>
+  <text x="100" y="80" text-anchor="middle" font-family="monospace" font-weight="bold" font-size="32" fill="#00ff88">TWZRD</text>
+  <text x="100" y="110" text-anchor="middle" font-family="monospace" font-size="14" fill="#888">Agent Intel</text>
+  <text x="100" y="145" text-anchor="middle" font-family="monospace" font-size="11" fill="#555">x402 · Solana</text>
+</svg>


### PR DESCRIPTION
## Summary

Adding **TWZRD Agent Intel** to the x402 ecosystem listing.

**Category**: Services/Endpoints

**About**: TWZRD Agent Intel is the first Solana-native x402 MCP server for AI agent trust scoring and identity verification. It enables agents to gate actions based on verified on-chain trust scores, with signed receipts delivered via HTTP 402 + USDC micropayments on Solana.

## What This Adds

- `typescript/site/app/ecosystem/partners-data/twzrd-agent-intel/metadata.json` — ecosystem metadata
- `typescript/site/public/logos/twzrd-agent-intel.svg` — project logo

## Details

- **Website**: https://intel.twzrd.xyz
- **MCP endpoint**: https://intel.twzrd.xyz/mcp
- **Chain**: Solana (USDC, <1s settlement)
- **Free tools**: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt` — on-chain wallet scoring, no payment required
- **Paid tool**: `get_trust_receipt` — signed `twzrd.receipt.v5` trust token via x402 HTTP 402 + USDC
- **MCP Registry ID**: `xyz.twzrd.intel/twzrd-agent-intel`
- **Install**: `claude mcp add twzrd-agent-intel --transport http https://intel.twzrd.xyz/mcp`

## Requirements Checklist (Services/Endpoints)

- [x] Working mainnet integration (live on Solana mainnet)
- [x] API documentation at https://intel.twzrd.xyz
- [x] High uptime (Caddy + DO VPS, monitored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)