### PR TITLE
Add MCP npm homepage and bugs metadata

### DIFF
--- a/typescript/packages/mcp/package.json
+++ b/typescript/packages/mcp/package.json
@@ -19,7 +19,11 @@
   "keywords": [],
   "license": "Apache-2.0",
   "author": "x402 Foundation",
+  "homepage": "https://github.com/x402-foundation/x402/tree/main/typescript/packages/mcp#readme",
   "repository": "https://github.com/x402-foundation/x402",
+  "bugs": {
+    "url": "https://github.com/x402-foundation/x402/issues"
+  },
   "description": "x402 Payment Protocol",
   "devDependencies": {
     "@eslint/js": "^9.24.0",


### PR DESCRIPTION
## What
- Add npm homepage and bugs metadata for the `@x402/mcp` package.

## Why
- The published package currently exposes repository metadata, but not the package README homepage or issue tracker through standard npm metadata fields.
- This makes the npm package easier to inspect and gives users a direct path to docs and issue reporting.

## Validation
- npm view @x402/mcp@2.14.0 name version homepage repository bugs --json
- Metadata smoke check with Node.js
- npm pack --dry-run --ignore-scripts ./typescript/packages/mcp
- git diff --check

## Safety
- Metadata-only package.json change.
- No runtime behavior changes.
- No credentials, payment data, or private data.