### PR TITLE
Add homepage and bugs metadata to @x402/mcp

### DIFF
--- a/typescript/packages/mcp/package.json
+++ b/typescript/packages/mcp/package.json
@@ -60,5 +60,9 @@
   },
   "files": [
     "dist"
-  ]
+  ],
+  "homepage": "https://github.com/x402-foundation/x402#readme",
+  "bugs": {
+    "url": "https://github.com/x402-foundation/x402/issues"
+  }
 }


### PR DESCRIPTION
Adds homepage and bugs.url metadata to the MCP package.json so npm consumers and tooling can find the project README and issue tracker.

- Added homepage: https://github.com/x402-foundation/x402#readme
- Added bugs.url: https://github.com/x402-foundation/x402/issues

Related: charles-openclaw/charles-microbounties#377