### PR TITLE
Add workflow checking verified commits

### DIFF
--- a/.github/workflows/check_verified_commits.yml
+++ b/.github/workflows/check_verified_commits.yml
@@ -1,0 +1,117 @@
+name: Verified Commits
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+  id-token: none
+
+jobs:
+  check-verified-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure commits are verified
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pullRequest = context.payload.pull_request;
+            const marker = '<!-- verified-commits-required -->';
+            const unverifiedLabel = 'unverified';
+            const ignoreNotFound = error => {
+              if (error.status !== 404) {
+                throw error;
+              }
+            };
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner,
+              repo,
+              pull_number: pullRequest.number,
+              per_page: 100
+            });
+
+            const unverifiedCommits = commits.filter(commit => !commit.commit.verification?.verified);
+
+            if (unverifiedCommits.length === 0) {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pullRequest.number,
+                name: unverifiedLabel
+              }).catch(ignoreNotFound);
+              core.notice('All pull request commits are verified.');
+              return;
+            }
+
+            await github.rest.issues.getLabel({
+              owner,
+              repo,
+              name: unverifiedLabel
+            }).catch(async error => {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: unverifiedLabel,
+                color: 'd73a4a',
+                description: 'Pull request contains unverified commits'
+              });
+            });
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: pullRequest.number,
+              labels: [unverifiedLabel]
+            });
+
+            const commitList = unverifiedCommits
+              .map(commit => '- `' + commit.sha.slice(0, 7) + '`: ' + (commit.commit.verification?.reason || 'unverified'))
+              .join('\n');
+            const body = [
+              marker,
+              'Thanks for your contribution @' + pullRequest.user.login + '!',
+              'Note that we require commit signing, please rebase and verify your commits.',
+              '',
+              'See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification',
+              '',
+              'The team will not review this PR before ALL commits have been verified and it will be closed after 1 week of inactivity.',
+              '',
+              'Unverified commits:',
+              commitList
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: pullRequest.number,
+              per_page: 100
+            });
+            const existingComment = comments.find(comment => (
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            ));
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullRequest.number,
+                body
+              });
+            }
+
+            core.setFailed('Pull request contains unverified commits.');

--- a/.github/workflows/check_verified_commits.yml
+++ b/.github/workflows/check_verified_commits.yml
@@ -115,3 +115,4 @@ jobs:
             }
 
             core.setFailed('Pull request contains unverified commits.');
+            


### PR DESCRIPTION
## Description

Adds workflow to check if all commits are verified, if not comments on the PR:

> Thanks for your contribution `@author`!
> Note that we require commit signing, please rebase and verify your commits.
> See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
> The team will not review this PR before ALL commits have been verified and it will be closed after 1 week of inactivity

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 