### PR TITLE
Add scripts + workflow to prepare python sdk releases

### DIFF
--- a/.github/scripts/create-github-release-commit.py
+++ b/.github/scripts/create-github-release-commit.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Create a GitHub-verified bot commit through the GraphQL API.
+
+Generic release helper. It takes a branch, a commit message, and a set of paths, 
+then creates a branch and a verified commit containing the current local contents of those paths. 
+Stdlib-only so it runs on CI runners via `python3` without any toolchain setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+CREATE_COMMIT_MUTATION = """
+mutation($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit {
+      oid
+      url
+    }
+  }
+}
+"""
+
+
+class GitHubCommitError(RuntimeError):
+    """Raised when the GitHub API commit cannot be created."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a GitHub-verified commit from local file changes."
+    )
+    parser.add_argument("--branch", required=True, help="Release branch to create and commit to.")
+    parser.add_argument("--message", required=True, help="Commit message headline.")
+    parser.add_argument("paths", nargs="+", help="Files or directories to include in the commit.")
+    return parser.parse_args()
+
+
+def run(command: list[str], *, input_text: str | None = None) -> str:
+    try:
+        completed = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            input=input_text,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise GitHubCommitError(f"Required command not found: {command[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+        raise GitHubCommitError(message) from exc
+
+    return completed.stdout.strip()
+
+
+def github_repository() -> str:
+    repository = os.environ.get("GITHUB_REPOSITORY")
+    if not repository:
+        raise GitHubCommitError("GITHUB_REPOSITORY is required.")
+    return repository
+
+
+def changed_paths(paths: list[str]) -> list[str]:
+    output = run(["git", "diff", "--name-only", "HEAD", "--", *paths])
+    return output.splitlines()
+
+
+def file_changes(paths: list[str]) -> dict[str, list[dict[str, str]]]:
+    additions = []
+    deletions = []
+
+    for path in paths:
+        file_path = Path(path)
+        if file_path.is_file():
+            additions.append(
+                {
+                    "path": path,
+                    "contents": base64.b64encode(file_path.read_bytes()).decode(),
+                }
+            )
+            continue
+
+        deletions.append({"path": path})
+
+    return {"additions": additions, "deletions": deletions}
+
+
+def create_branch(repository: str, branch: str, head_sha: str) -> None:
+    payload = json.dumps({"ref": f"refs/heads/{branch}", "sha": head_sha})
+    run(
+        ["gh", "api", "--method", "POST", f"repos/{repository}/git/refs", "--input", "-"],
+        input_text=payload,
+    )
+
+
+def create_commit(
+    repository: str,
+    branch: str,
+    message: str,
+    expected_head: str,
+    changes: dict[str, list[dict[str, str]]],
+) -> str:
+    request = {
+        "query": CREATE_COMMIT_MUTATION,
+        "variables": {
+            "input": {
+                "branch": {
+                    "repositoryNameWithOwner": repository,
+                    "branchName": branch,
+                },
+                "message": {"headline": message},
+                "fileChanges": changes,
+                "expectedHeadOid": expected_head,
+            }
+        },
+    }
+
+    return run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "--method",
+            "POST",
+            "--input",
+            "-",
+            "--jq",
+            ".data.createCommitOnBranch.commit.url",
+        ],
+        input_text=json.dumps(request),
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    repository = github_repository()
+    head_sha = run(["git", "rev-parse", "HEAD"])
+    paths = changed_paths(args.paths)
+    if not paths:
+        raise GitHubCommitError("No changed paths found.")
+
+    create_branch(repository, args.branch, head_sha)
+    commit_url = create_commit(
+        repository,
+        args.branch,
+        args.message,
+        head_sha,
+        file_changes(paths),
+    )
+    print(commit_url)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except GitHubCommitError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/.github/workflows/check_verified_commits.yml
+++ b/.github/workflows/check_verified_commits.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
   id-token: none
 

--- a/.github/workflows/prepare_python_release.yml
+++ b/.github/workflows/prepare_python_release.yml
@@ -16,7 +16,7 @@ on:
           - minor
           - patch
   schedule:
-    - cron: "0 16 * * 5"
+    - cron: "0 14 * * 5"
 
 permissions:
   contents: write

--- a/.github/workflows/prepare_python_release.yml
+++ b/.github/workflows/prepare_python_release.yml
@@ -1,0 +1,146 @@
+name: Prepare Python Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Python SDK release version in X.Y.Z format. Leave blank to use bump."
+        required: false
+        type: string
+      bump:
+        description: "Version bump to use when version is blank. Scheduled releases always use minor."
+        required: false
+        default: minor
+        type: choice
+        options:
+          - minor
+          - patch
+  schedule:
+    - cron: "0 16 * * 5"
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: none
+
+concurrency:
+  group: prepare-python-release
+  cancel-in-progress: false
+
+jobs:
+  prepare-python-release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: "python/x402/uv.lock"
+
+      - name: Set up Python
+        working-directory: ./python/x402
+        run: uv python install
+
+      - name: Install dependencies
+        working-directory: ./python/x402
+        run: uv sync --all-extras --dev
+
+      - name: Prepare release branch
+        id: branch
+        run: |
+          set -euo pipefail
+
+          branch="release/python-$(date -u +%F)-${GITHUB_RUN_NUMBER}"
+          echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
+
+      - name: Prepare Python release files
+        id: prep
+        working-directory: ./python/x402
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || '' }}
+          INPUT_BUMP: ${{ github.event_name == 'workflow_dispatch' && inputs.bump || 'minor' }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${INPUT_VERSION}" ]]; then
+            uv run python scripts/prepare-release.py --version "${INPUT_VERSION}"
+          else
+            uv run python scripts/prepare-release.py --bump "${INPUT_BUMP}"
+          fi
+
+          version="$(
+            uv run python - <<'PY'
+          from pathlib import Path
+          import re
+
+          pyproject = Path("pyproject.toml")
+          match = re.search(r'^version = "([^"]+)"$', pyproject.read_text(), re.MULTILINE)
+          if match is None:
+              raise SystemExit("Could not read Python SDK version from pyproject.toml")
+          print(match.group(1))
+          PY
+          )"
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create GitHub-signed release commit
+        id: commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          paths=(
+            python/x402/pyproject.toml
+            python/x402/uv.lock
+            python/x402/__init__.py
+            python/x402/CHANGELOG.md
+            python/x402/changelog.d
+          )
+
+          git status --short -- "${paths[@]}"
+          if git diff --quiet HEAD -- "${paths[@]}"; then
+            echo "committed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          python3 .github/scripts/create-github-release-commit.py \
+            --branch "${BRANCH}" \
+            --message "chore: version python package" \
+            "${paths[@]}"
+
+          echo "committed=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Create release PR
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          VERSION: ${{ steps.prep.outputs.version }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          title="chore: prepare Python SDK release ${VERSION}"
+          body="$(
+            cat <<EOF
+          ## Summary
+          Bumps the Python SDK package version to ${VERSION}.
+          EOF
+          )"
+
+          gh pr create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base "${BASE_BRANCH}" \
+            --head "${BRANCH}" \
+            --title "${title}" \
+            --body "${body}"

--- a/.github/workflows/publish_npm_scoped_x402_aptos.yml
+++ b/.github/workflows/publish_npm_scoped_x402_aptos.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-aptos:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_avm.yml
+++ b/.github/workflows/publish_npm_scoped_x402_avm.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-avm:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_axios.yml
+++ b/.github/workflows/publish_npm_scoped_x402_axios.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-axios:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_core.yml
+++ b/.github/workflows/publish_npm_scoped_x402_core.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-core:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_evm.yml
+++ b/.github/workflows/publish_npm_scoped_x402_evm.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-evm:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_express.yml
+++ b/.github/workflows/publish_npm_scoped_x402_express.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-express:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_extensions.yml
+++ b/.github/workflows/publish_npm_scoped_x402_extensions.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-extensions:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_fastify.yml
+++ b/.github/workflows/publish_npm_scoped_x402_fastify.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-fastify:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_fetch.yml
+++ b/.github/workflows/publish_npm_scoped_x402_fetch.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-fetch:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_hedera.yml
+++ b/.github/workflows/publish_npm_scoped_x402_hedera.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-hedera:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_hono.yml
+++ b/.github/workflows/publish_npm_scoped_x402_hono.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-hono:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_mcp.yml
+++ b/.github/workflows/publish_npm_scoped_x402_mcp.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-mcp:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_next.yml
+++ b/.github/workflows/publish_npm_scoped_x402_next.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-next:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_paywall.yml
+++ b/.github/workflows/publish_npm_scoped_x402_paywall.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-paywall:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_stellar.yml
+++ b/.github/workflows/publish_npm_scoped_x402_stellar.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-stellar:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_scoped_x402_svm.yml
+++ b/.github/workflows/publish_npm_scoped_x402_svm.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-svm:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_x402.yml
+++ b/.github/workflows/publish_npm_x402.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_x402_axios.yml
+++ b/.github/workflows/publish_npm_x402_axios.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-axios:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_x402_express.yml
+++ b/.github/workflows/publish_npm_x402_express.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-express:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_x402_fetch.yml
+++ b/.github/workflows/publish_npm_x402_fetch.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-fetch:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_x402_hono.yml
+++ b/.github/workflows/publish_npm_x402_hono.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-hono:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_npm_x402_next.yml
+++ b/.github/workflows/publish_npm_x402_next.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-npm-x402-next:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/.github/workflows/publish_pypi_x402.yml
+++ b/.github/workflows/publish_pypi_x402.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish-pypi-x402:
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:

--- a/python/x402/scripts/prepare-release.py
+++ b/python/x402/scripts/prepare-release.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Prepare a Python SDK release by bumping versions and building the changelog.
+
+Run from the ``python/x402`` directory:
+
+    uv run python scripts/prepare-release.py --version 1.2.3
+    uv run python scripts/prepare-release.py --bump minor
+    uv run python scripts/prepare-release.py --bump patch --dry-run
+
+Either ``--version X.Y.Z`` or ``--bump {minor,patch}`` is required. Use ``--dry-run``
+to validate without writing files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+VERSION_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+PYPROJECT_VERSION_RE = re.compile(r'^version = "([^"]+)"$', re.MULTILINE)
+INIT_VERSION_RE = re.compile(r'^__version__ = "([^"]+)"$', re.MULTILINE)
+DEFAULT_REPOSITORY = "x402-foundation/x402"
+REPOSITORY_URL = f"https://github.com/{DEFAULT_REPOSITORY}"
+
+PR_COMMIT_AUTHORS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      commits(first: 100, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          commit {
+            authors(first: 100) {
+              nodes {
+                user {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+class ReleasePrepError(RuntimeError):
+    """Raised when the release-prep inputs or files are invalid."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prepare the Python SDK release version and Towncrier changelog."
+    )
+    version_group = parser.add_mutually_exclusive_group(required=True)
+    version_group.add_argument("--version", help="Explicit release version, in X.Y.Z format.")
+    version_group.add_argument(
+        "--bump",
+        choices=["minor", "patch"],
+        help="Bump the current version. Scheduled releases use 'minor'.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and print the target version without modifying files.",
+    )
+    return parser.parse_args()
+
+
+def package_dir() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def require_file(path: Path) -> None:
+    if not path.is_file():
+        raise ReleasePrepError(f"Required file does not exist: {path}")
+
+
+def require_directory(path: Path) -> None:
+    if not path.is_dir():
+        raise ReleasePrepError(f"Required directory does not exist: {path}")
+
+
+def changelog_fragments(changelog_dir: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in changelog_dir.iterdir()
+        if path.is_file() and not path.name.startswith(".")
+    )
+
+
+def validate_version(version: str) -> tuple[int, int, int]:
+    match = VERSION_RE.fullmatch(version)
+    if match is None:
+        raise ReleasePrepError(f"Expected version in X.Y.Z format, got: {version}")
+    return tuple(int(part) for part in match.groups())
+
+
+def extract_single_version(path: Path, pattern: re.Pattern[str], label: str) -> str:
+    content = path.read_text()
+    matches = pattern.findall(content)
+    if len(matches) != 1:
+        raise ReleasePrepError(f"Expected exactly one {label} version in {path}, found {len(matches)}")
+    validate_version(matches[0])
+    return matches[0]
+
+
+def bump_version(version: str, bump: str) -> str:
+    major, minor, patch = validate_version(version)
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    if bump == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise ReleasePrepError(f"Unsupported bump type: {bump}")
+
+
+def assert_version_increases(current_version: str, target_version: str) -> None:
+    if validate_version(target_version) <= validate_version(current_version):
+        raise ReleasePrepError(
+            f"Target version {target_version} must be greater than current version {current_version}"
+        )
+
+
+def replace_single(path: Path, pattern: re.Pattern[str], replacement: str, label: str) -> None:
+    content = path.read_text()
+    updated, count = pattern.subn(replacement, content)
+    if count != 1:
+        raise ReleasePrepError(f"Expected to update exactly one {label} version in {path}, updated {count}")
+    path.write_text(updated)
+
+
+def git_output(sdk_dir: Path, command: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *command],
+            cwd=sdk_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    return completed.stdout.strip()
+
+
+def gh_output(sdk_dir: Path, command: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["gh", *command],
+            cwd=sdk_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    return completed.stdout.strip()
+
+
+def fragment_issue(fragment: Path) -> str:
+    return fragment.name.split(".", 1)[0]
+
+
+def fragment_text(fragment: Path) -> str:
+    return " ".join(fragment.read_text().split())
+
+
+def repository_name() -> str:
+    repository = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY)
+    if "/" not in repository:
+        return DEFAULT_REPOSITORY
+
+    return repository
+
+
+def fragment_commit_sha(sdk_dir: Path, fragment: Path) -> str | None:
+    relative_fragment = fragment.relative_to(sdk_dir)
+    output = git_output(
+        sdk_dir,
+        ["log", "-1", "--format=%H", "--", str(relative_fragment)],
+    )
+    if not output:
+        return None
+
+    return output
+
+
+def add_unique(items: list[str], item: str | None) -> None:
+    if item is not None and item not in items:
+        items.append(item)
+
+
+def pr_commit_author_logins(sdk_dir: Path, issue: str) -> list[str]:
+    owner, name = repository_name().split("/", 1)
+    logins: list[str] = []
+    cursor = None
+
+    while True:
+        command = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={PR_COMMIT_AUTHORS_QUERY}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={issue}",
+        ]
+        if cursor is not None:
+            command.extend(["-f", f"after={cursor}"])
+
+        output = gh_output(sdk_dir, command)
+        if not output:
+            return logins
+
+        try:
+            data = json.loads(output)
+            commits = data["data"]["repository"]["pullRequest"]["commits"]
+        except (KeyError, TypeError, json.JSONDecodeError):
+            return logins
+
+        for node in commits["nodes"]:
+            for author in node["commit"]["authors"]["nodes"]:
+                user = author.get("user")
+                if user is not None:
+                    add_unique(logins, user.get("login"))
+
+        if not commits["pageInfo"]["hasNextPage"]:
+            return logins
+
+        cursor = commits["pageInfo"]["endCursor"]
+
+
+def thanks_text(logins: list[str]) -> str | None:
+    if not logins:
+        return None
+
+    links = [f"[@{login}](https://github.com/{login})" for login in logins]
+    return f"Thanks {' '.join(links)}!"
+
+
+def fragment_preview_line(sdk_dir: Path, fragment: Path) -> str | None:
+    issue = fragment_issue(fragment)
+    text = fragment_text(fragment)
+    if not issue.isdecimal() or not text:
+        return None
+
+    commit_sha = fragment_commit_sha(sdk_dir, fragment)
+    logins = pr_commit_author_logins(sdk_dir, issue)
+    parts = [f"- [#{issue}]({REPOSITORY_URL}/pull/{issue})"]
+
+    if commit_sha is not None:
+        short_sha = commit_sha[:7]
+        parts.append(f"[`{short_sha}`]({REPOSITORY_URL}/commit/{commit_sha})")
+
+    if (thanks := thanks_text(logins)) is not None:
+        parts.append(thanks)
+
+    return f"{' '.join(parts)} - {text}"
+
+
+def changelog_fragment_preview(sdk_dir: Path, fragments: list[Path]) -> list[str]:
+    return [
+        line
+        for fragment in fragments
+        if (line := fragment_preview_line(sdk_dir, fragment)) is not None
+    ]
+
+
+def print_changelog_fragment_preview(lines: list[str]) -> None:
+    if not lines:
+        return
+
+    print("Changelog fragment preview:")
+    for line in lines:
+        print(line)
+    print()
+
+
+def run_towncrier(sdk_dir: Path, version: str) -> None:
+    try:
+        subprocess.run(
+            ["uv", "run", "towncrier", "build", "--yes", f"--version={version}"],
+            cwd=sdk_dir,
+            check=True,
+        )
+    except FileNotFoundError as exc:
+        raise ReleasePrepError("uv is required to build the Towncrier changelog.") from exc
+    except subprocess.CalledProcessError as exc:
+        raise ReleasePrepError(f"Towncrier failed with exit code {exc.returncode}.") from exc
+
+
+def main() -> int:
+    args = parse_args()
+    sdk_dir = package_dir()
+    pyproject = sdk_dir / "pyproject.toml"
+    init_file = sdk_dir / "__init__.py"
+    changelog_dir = sdk_dir / "changelog.d"
+
+    require_file(pyproject)
+    require_file(init_file)
+    require_directory(changelog_dir)
+
+    fragments = changelog_fragments(changelog_dir)
+    if not fragments:
+        print("No changelog fragments found; release preparation skipped.")
+        return 0
+
+    current_version = extract_single_version(pyproject, PYPROJECT_VERSION_RE, "pyproject.toml")
+    init_version = extract_single_version(init_file, INIT_VERSION_RE, "__init__.py")
+    if init_version != current_version:
+        raise ReleasePrepError(
+            f"Version mismatch: pyproject.toml has {current_version}, __init__.py has {init_version}"
+        )
+
+    target_version = args.version if args.version is not None else bump_version(current_version, args.bump)
+    validate_version(target_version)
+    assert_version_increases(current_version, target_version)
+
+    preview_lines = changelog_fragment_preview(sdk_dir, fragments)
+    print_changelog_fragment_preview(preview_lines)
+
+    if args.dry_run:
+        print(f"Current Python SDK version: {current_version}")
+        print(f"Target Python SDK version: {target_version}")
+        print("Dry run complete; no files were changed.")
+        return 0
+
+    replace_single(
+        pyproject,
+        PYPROJECT_VERSION_RE,
+        f'version = "{target_version}"',
+        "pyproject.toml",
+    )
+    replace_single(
+        init_file,
+        INIT_VERSION_RE,
+        f'__version__ = "{target_version}"',
+        "__init__.py",
+    )
+    run_towncrier(sdk_dir, target_version)
+
+    print(f"Prepared Python SDK release {target_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ReleasePrepError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/python/x402/scripts/prepare-release.py
+++ b/python/x402/scripts/prepare-release.py
@@ -318,19 +318,14 @@ def fragment_changelog_body(sdk_dir: Path, fragment: Path) -> str | None:
     commit_sha = fragment_commit_sha(sdk_dir, fragment)
     pr_number = commit_pr_number(sdk_dir, commit_sha) if commit_sha is not None else None
 
-    parts: list[str] = []
+    body = text
     if pr_number is not None:
-        parts.append(f"[#{pr_number}]({REPOSITORY_URL}/pull/{pr_number})")
-
-    if commit_sha is not None:
-        short_sha = commit_sha[:7]
-        parts.append(f"[`{short_sha}`]({REPOSITORY_URL}/commit/{commit_sha})")
+        body += f" ([#{pr_number}]({REPOSITORY_URL}/pull/{pr_number}))"
 
     if (thanks := fragment_thanks(sdk_dir, pr_number, commit_sha)) is not None:
-        parts.append(thanks)
+        body += f" - {thanks}"
 
-    prefix = " ".join(parts)
-    return f"{prefix} - {text}" if prefix else text
+    return body
 
 
 def changelog_fragment_bodies(sdk_dir: Path, fragments: list[Path]) -> list[tuple[Path, str]]:

--- a/python/x402/scripts/prepare-release.py
+++ b/python/x402/scripts/prepare-release.py
@@ -31,6 +31,9 @@ PR_COMMIT_AUTHORS_QUERY = """
 query($owner: String!, $name: String!, $number: Int!, $after: String) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
+      author {
+        login
+      }
       commits(first: 100, after: $after) {
         pageInfo {
           hasNextPage
@@ -198,9 +201,15 @@ def add_unique(items: list[str], item: str | None) -> None:
         items.append(item)
 
 
-def pr_commit_author_logins(sdk_dir: Path, issue: str) -> list[str]:
+def pr_authors(sdk_dir: Path, issue: str) -> tuple[str | None, list[str]]:
+    """Return ``(pr_author, contributors)`` for a pull request.
+
+    ``pr_author`` is the login of the user who opened the PR. ``contributors`` are
+    the distinct commit-author logins on the PR, with ``pr_author`` removed so it
+    is never listed twice."""
     owner, name = repository_name().split("/", 1)
-    logins: list[str] = []
+    pr_author: str | None = None
+    commit_authors: list[str] = []
     cursor = None
 
     while True:
@@ -221,32 +230,49 @@ def pr_commit_author_logins(sdk_dir: Path, issue: str) -> list[str]:
 
         output = gh_output(sdk_dir, command)
         if not output:
-            return logins
+            break
 
         try:
             data = json.loads(output)
-            commits = data["data"]["repository"]["pullRequest"]["commits"]
+            pull_request = data["data"]["repository"]["pullRequest"]
+            commits = pull_request["commits"]
         except (KeyError, TypeError, json.JSONDecodeError):
-            return logins
+            break
+
+        if (author := pull_request.get("author")) is not None:
+            pr_author = author.get("login")
 
         for node in commits["nodes"]:
-            for author in node["commit"]["authors"]["nodes"]:
-                user = author.get("user")
+            for commit_author in node["commit"]["authors"]["nodes"]:
+                user = commit_author.get("user")
                 if user is not None:
-                    add_unique(logins, user.get("login"))
+                    add_unique(commit_authors, user.get("login"))
 
         if not commits["pageInfo"]["hasNextPage"]:
-            return logins
+            break
 
         cursor = commits["pageInfo"]["endCursor"]
 
+    if pr_author is None and commit_authors:
+        pr_author = commit_authors[0]
 
-def thanks_text(logins: list[str]) -> str | None:
-    if not logins:
+    contributors = [login for login in commit_authors if login != pr_author]
+    return pr_author, contributors
+
+
+def author_link(login: str) -> str:
+    return f"[@{login}](https://github.com/{login})"
+
+
+def thanks_text(pr_author: str | None, contributors: list[str]) -> str | None:
+    if pr_author is None:
         return None
 
-    links = [f"[@{login}](https://github.com/{login})" for login in logins]
-    return f"Thanks {' '.join(links)}!"
+    text = author_link(pr_author)
+    if contributors:
+        text += " and " + ", ".join(author_link(login) for login in contributors)
+
+    return f"Thanks {text}!"
 
 
 def commit_author_login(sdk_dir: Path, commit_sha: str) -> str | None:
@@ -271,19 +297,17 @@ def commit_pr_number(sdk_dir: Path, commit_sha: str) -> str | None:
     return output
 
 
-def fragment_author_logins(
-    sdk_dir: Path, pr_number: str | None, commit_sha: str | None
-) -> list[str]:
+def fragment_thanks(sdk_dir: Path, pr_number: str | None, commit_sha: str | None) -> str | None:
+    pr_author: str | None = None
+    contributors: list[str] = []
+
     if pr_number is not None:
-        logins = pr_commit_author_logins(sdk_dir, pr_number)
-        if logins:
-            return logins
+        pr_author, contributors = pr_authors(sdk_dir, pr_number)
 
-    if commit_sha is None:
-        return []
+    if pr_author is None and commit_sha is not None:
+        pr_author = commit_author_login(sdk_dir, commit_sha)
 
-    login = commit_author_login(sdk_dir, commit_sha)
-    return [login] if login is not None else []
+    return thanks_text(pr_author, contributors)
 
 
 def fragment_changelog_body(sdk_dir: Path, fragment: Path) -> str | None:
@@ -293,7 +317,6 @@ def fragment_changelog_body(sdk_dir: Path, fragment: Path) -> str | None:
 
     commit_sha = fragment_commit_sha(sdk_dir, fragment)
     pr_number = commit_pr_number(sdk_dir, commit_sha) if commit_sha is not None else None
-    logins = fragment_author_logins(sdk_dir, pr_number, commit_sha)
 
     parts: list[str] = []
     if pr_number is not None:
@@ -303,7 +326,7 @@ def fragment_changelog_body(sdk_dir: Path, fragment: Path) -> str | None:
         short_sha = commit_sha[:7]
         parts.append(f"[`{short_sha}`]({REPOSITORY_URL}/commit/{commit_sha})")
 
-    if (thanks := thanks_text(logins)) is not None:
+    if (thanks := fragment_thanks(sdk_dir, pr_number, commit_sha)) is not None:
         parts.append(thanks)
 
     prefix = " ".join(parts)

--- a/python/x402/scripts/prepare-release.py
+++ b/python/x402/scripts/prepare-release.py
@@ -96,9 +96,7 @@ def require_directory(path: Path) -> None:
 
 def changelog_fragments(changelog_dir: Path) -> list[Path]:
     return sorted(
-        path
-        for path in changelog_dir.iterdir()
-        if path.is_file() and not path.name.startswith(".")
+        path for path in changelog_dir.iterdir() if path.is_file() and not path.name.startswith(".")
     )
 
 
@@ -113,7 +111,9 @@ def extract_single_version(path: Path, pattern: re.Pattern[str], label: str) -> 
     content = path.read_text()
     matches = pattern.findall(content)
     if len(matches) != 1:
-        raise ReleasePrepError(f"Expected exactly one {label} version in {path}, found {len(matches)}")
+        raise ReleasePrepError(
+            f"Expected exactly one {label} version in {path}, found {len(matches)}"
+        )
     validate_version(matches[0])
     return matches[0]
 
@@ -138,7 +138,9 @@ def replace_single(path: Path, pattern: re.Pattern[str], replacement: str, label
     content = path.read_text()
     updated, count = pattern.subn(replacement, content)
     if count != 1:
-        raise ReleasePrepError(f"Expected to update exactly one {label} version in {path}, updated {count}")
+        raise ReleasePrepError(
+            f"Expected to update exactly one {label} version in {path}, updated {count}"
+        )
     path.write_text(updated)
 
 
@@ -397,7 +399,9 @@ def main() -> int:
             f"Version mismatch: pyproject.toml has {current_version}, __init__.py has {init_version}"
         )
 
-    target_version = args.version if args.version is not None else bump_version(current_version, args.bump)
+    target_version = (
+        args.version if args.version is not None else bump_version(current_version, args.bump)
+    )
     validate_version(target_version)
     assert_version_increases(current_version, target_version)
 

--- a/python/x402/scripts/prepare-release.py
+++ b/python/x402/scripts/prepare-release.py
@@ -169,10 +169,6 @@ def gh_output(sdk_dir: Path, command: list[str]) -> str | None:
     return completed.stdout.strip()
 
 
-def fragment_issue(fragment: Path) -> str:
-    return fragment.name.split(".", 1)[0]
-
-
 def fragment_text(fragment: Path) -> str:
     return " ".join(fragment.read_text().split())
 
@@ -253,15 +249,55 @@ def thanks_text(logins: list[str]) -> str | None:
     return f"Thanks {' '.join(links)}!"
 
 
-def fragment_preview_line(sdk_dir: Path, fragment: Path) -> str | None:
-    issue = fragment_issue(fragment)
+def commit_author_login(sdk_dir: Path, commit_sha: str) -> str | None:
+    output = gh_output(
+        sdk_dir,
+        ["api", f"repos/{repository_name()}/commits/{commit_sha}", "--jq", ".author.login"],
+    )
+    if not output or output == "null":
+        return None
+
+    return output
+
+
+def commit_pr_number(sdk_dir: Path, commit_sha: str) -> str | None:
+    output = gh_output(
+        sdk_dir,
+        ["api", f"repos/{repository_name()}/commits/{commit_sha}/pulls", "--jq", ".[0].number"],
+    )
+    if not output or output == "null":
+        return None
+
+    return output
+
+
+def fragment_author_logins(
+    sdk_dir: Path, pr_number: str | None, commit_sha: str | None
+) -> list[str]:
+    if pr_number is not None:
+        logins = pr_commit_author_logins(sdk_dir, pr_number)
+        if logins:
+            return logins
+
+    if commit_sha is None:
+        return []
+
+    login = commit_author_login(sdk_dir, commit_sha)
+    return [login] if login is not None else []
+
+
+def fragment_changelog_body(sdk_dir: Path, fragment: Path) -> str | None:
     text = fragment_text(fragment)
-    if not issue.isdecimal() or not text:
+    if not text:
         return None
 
     commit_sha = fragment_commit_sha(sdk_dir, fragment)
-    logins = pr_commit_author_logins(sdk_dir, issue)
-    parts = [f"- [#{issue}]({REPOSITORY_URL}/pull/{issue})"]
+    pr_number = commit_pr_number(sdk_dir, commit_sha) if commit_sha is not None else None
+    logins = fragment_author_logins(sdk_dir, pr_number, commit_sha)
+
+    parts: list[str] = []
+    if pr_number is not None:
+        parts.append(f"[#{pr_number}]({REPOSITORY_URL}/pull/{pr_number})")
 
     if commit_sha is not None:
         short_sha = commit_sha[:7]
@@ -270,25 +306,41 @@ def fragment_preview_line(sdk_dir: Path, fragment: Path) -> str | None:
     if (thanks := thanks_text(logins)) is not None:
         parts.append(thanks)
 
-    return f"{' '.join(parts)} - {text}"
+    prefix = " ".join(parts)
+    return f"{prefix} - {text}" if prefix else text
 
 
-def changelog_fragment_preview(sdk_dir: Path, fragments: list[Path]) -> list[str]:
+def changelog_fragment_bodies(sdk_dir: Path, fragments: list[Path]) -> list[tuple[Path, str]]:
     return [
-        line
+        (fragment, body)
         for fragment in fragments
-        if (line := fragment_preview_line(sdk_dir, fragment)) is not None
+        if (body := fragment_changelog_body(sdk_dir, fragment)) is not None
     ]
 
 
-def print_changelog_fragment_preview(lines: list[str]) -> None:
-    if not lines:
+def print_changelog_fragment_preview(bodies: list[tuple[Path, str]]) -> None:
+    if not bodies:
         return
 
     print("Changelog fragment preview:")
-    for line in lines:
-        print(line)
+    for _, body in bodies:
+        print(f"- {body}")
     print()
+
+
+def rewrite_fragments_as_orphans(sdk_dir: Path, bodies: list[tuple[Path, str]]) -> None:
+    """Replace each fragment with an orphan fragment whose body is the rendered
+    changelog line. Towncrier renders orphan fragments (filenames prefixed with
+    ``+``) verbatim without appending its own issue link, so the PR link, commit
+    hash, and author attribution from the preview land in CHANGELOG.md.
+
+    The orphan files are staged so Towncrier's git-based cleanup can remove them;
+    otherwise it invokes ``git rm`` with no paths and prints a spurious error."""
+    for fragment, body in bodies:
+        orphan = fragment.with_name(f"+{fragment.name}")
+        orphan.write_text(f"{body}\n")
+        fragment.unlink()
+        git_output(sdk_dir, ["add", "--", str(orphan.relative_to(sdk_dir))])
 
 
 def run_towncrier(sdk_dir: Path, version: str) -> None:
@@ -331,8 +383,8 @@ def main() -> int:
     validate_version(target_version)
     assert_version_increases(current_version, target_version)
 
-    preview_lines = changelog_fragment_preview(sdk_dir, fragments)
-    print_changelog_fragment_preview(preview_lines)
+    fragment_bodies = changelog_fragment_bodies(sdk_dir, fragments)
+    print_changelog_fragment_preview(fragment_bodies)
 
     if args.dry_run:
         print(f"Current Python SDK version: {current_version}")
@@ -352,6 +404,7 @@ def main() -> int:
         f'__version__ = "{target_version}"',
         "__init__.py",
     )
+    rewrite_fragments_as_orphans(sdk_dir, fragment_bodies)
     run_towncrier(sdk_dir, target_version)
 
     print(f"Prepared Python SDK release {target_version}")


### PR DESCRIPTION
## Description

- Adds script to prepare py releases and adds author attribution to CHANGELOG, eg:
```
- Run Python payment creation failure hooks when after-payment hooks raise. ([#2540](…/pull/2540)) - Thanks [@skyc1e](…)!
- Fixed a bug where EVM facilitator verify accepted payments … ([#2554](…/pull/2554)) - Thanks [@CarsonRoscoe](…)!
```
- Adds workflow to open weekly PR or on manual trigger

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 