### PR TITLE
Add img402 to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/img402/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/img402/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "img402",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/img402.svg",
+  "description": "Image hosting for AI agents, paid via x402. Upload an image, get a public CDN-backed URL — free 7-day tier plus $0.01 (1-year) and $1 (permanent) tiers in USDC on Base and Solana.",
+  "websiteUrl": "https://img402.dev"
+}

--- a/typescript/site/public/logos/img402.svg
+++ b/typescript/site/public/logos/img402.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#0a0a0a"/>
+  <text x="2" y="23" font-family="ui-monospace,monospace" font-weight="700" font-size="18" fill="#e5e5e5">4</text>
+  <rect x="12" y="11" width="9" height="9" fill="#22c55e"/>
+  <text x="21" y="23" font-family="ui-monospace,monospace" font-weight="700" font-size="18" fill="#e5e5e5">2</text>
+</svg>


### PR DESCRIPTION
Adds [img402](https://img402.dev) to the ecosystem directory under **Services/Endpoints**.

img402 is a live x402-native image hosting service for AI agents: upload an image, pay via x402, get a public CDN-backed URL. Agents use it to embed screenshots, diagrams, and mockups in GitHub PRs, chat messages, and documents.

- **Tiers:** free (1MB, 7-day retention), $0.01 USDC (5MB, 1-year), $1 USDC (5MB, permanent)
- **Networks:** USDC on Base mainnet and Solana, settled via the Coinbase CDP facilitator; indexed in the CDP Bazaar
- **No API keys or signup** — fully autonomous agent flow
- **Discovery:** [openapi.json](https://img402.dev/openapi.json) · [llms.txt](https://img402.dev/llms.txt) · [/.well-known/agent.json](https://img402.dev/.well-known/agent.json)
- Open-source agent skills: [img402/skills](https://github.com/img402/skills)

Follows the existing partner format: `partners-data/img402/metadata.json` + SVG logo in `public/logos/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)