### PR TITLE
chore: add core package npm metadata links

### DIFF
--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -20,6 +20,10 @@
   "license": "Apache-2.0",
   "author": "x402 Foundation",
   "repository": "https://github.com/x402-foundation/x402",
+  "homepage": "https://github.com/x402-foundation/x402/tree/main/typescript/packages/core#readme",
+  "bugs": {
+    "url": "https://github.com/x402-foundation/x402/issues"
+  },
   "description": "x402 Payment Protocol",
   "devDependencies": {
     "@eslint/js": "^9.24.0",


### PR DESCRIPTION
## Summary
- Add npm `homepage` metadata for `@x402/core`, pointing at the package README in this repository
- Add npm `bugs.url` metadata pointing at the repository issue tracker
- Keep runtime code, exports, and dependencies unchanged

## Validation
- `node -e` metadata assertion for `@x402/core` homepage and bugs fields
- `cd typescript/packages/core && npm pack --dry-run --json`
- `git diff --check`

This is a package metadata-only cleanup for npm consumers looking for the package documentation and issue tracker.
