### PR TITLE
feat(site): register Hedera testnet on the facilitator

### DIFF
--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -843,7 +843,7 @@ importers:
         version: 1.36.1(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
       '@solana/kit':
         specifier: ^5.0.0
-        version: 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        version: 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       express:
         specifier: ^4.18.2
         version: 4.21.2
@@ -1548,6 +1548,9 @@ importers:
       '@x402/extensions':
         specifier: workspace:*
         version: link:../packages/extensions
+      '@x402/hedera':
+        specifier: workspace:*
+        version: link:../packages/mechanisms/hedera
       '@x402/next':
         specifier: workspace:*
         version: link:../packages/http/next
@@ -14108,7 +14111,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/kit@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/kit@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/addresses': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
@@ -14123,11 +14126,11 @@ snapshots:
       '@solana/rpc': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/rpc-parsed-types': 5.1.0(typescript@5.9.2)
       '@solana/rpc-spec-types': 5.1.0(typescript@5.9.2)
-      '@solana/rpc-subscriptions': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/signers': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/sysvars': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/transaction-confirmation': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/transaction-confirmation': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/transaction-messages': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/transactions': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       typescript: 5.9.2
@@ -14530,7 +14533,7 @@ snapshots:
       typescript: 5.9.2
       ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
-  '@solana/rpc-subscriptions-channel-websocket@5.1.0(typescript@5.9.2)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions-channel-websocket@5.1.0(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 5.1.0(typescript@5.9.2)
       '@solana/functional': 5.1.0(typescript@5.9.2)
@@ -14538,7 +14541,7 @@ snapshots:
       '@solana/subscribable': 5.1.0(typescript@5.9.2)
       typescript: 5.9.2
     optionalDependencies:
-      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   '@solana/rpc-subscriptions-channel-websocket@6.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)':
     dependencies:
@@ -14622,7 +14625,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/rpc-subscriptions@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 5.1.0(typescript@5.9.2)
       '@solana/fast-stable-stringify': 5.1.0(typescript@5.9.2)
@@ -14630,7 +14633,7 @@ snapshots:
       '@solana/promises': 5.1.0(typescript@5.9.2)
       '@solana/rpc-spec-types': 5.1.0(typescript@5.9.2)
       '@solana/rpc-subscriptions-api': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions-channel-websocket': 5.1.0(typescript@5.9.2)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-channel-websocket': 5.1.0(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/rpc-subscriptions-spec': 5.1.0(typescript@5.9.2)
       '@solana/rpc-transformers': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/rpc-types': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
@@ -15010,7 +15013,7 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/transaction-confirmation@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/transaction-confirmation@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/addresses': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/codecs-strings': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
@@ -15018,7 +15021,7 @@ snapshots:
       '@solana/keys': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/promises': 5.1.0(typescript@5.9.2)
       '@solana/rpc': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
-      '@solana/rpc-subscriptions': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.20.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/transaction-messages': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
       '@solana/transactions': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)

--- a/typescript/site/README.md
+++ b/typescript/site/README.md
@@ -44,6 +44,14 @@ x402 is an open protocol for internet-native payments built around the HTTP 402 
   FACILITATOR_AVM_PRIVATE_KEY=your_algorand_private_key
   ```
 
+  Optionally enable Hedera (registers `hedera:testnet` only when both are set):
+
+  ```bash
+  # FACILITATOR_HEDERA_PRIVATE_KEY must be an ECDSA (secp256k1) key
+  FACILITATOR_HEDERA_ACCOUNT_ID=0.0.xxxx
+  FACILITATOR_HEDERA_PRIVATE_KEY=your_hedera_ecdsa_private_key
+  ```
+
 ### Running the Development Server
 
 ```bash

--- a/typescript/site/app/facilitator/index.ts
+++ b/typescript/site/app/facilitator/index.ts
@@ -15,6 +15,14 @@ import {
   createErc20ApprovalGasSponsoringExtension,
 } from "@x402/extensions";
 import { BuilderCodeFacilitatorExtension } from "@x402/extensions/builder-code";
+import {
+  PrivateKey as HederaPrivateKey,
+  createHederaClient,
+  createHederaPreflightTransfer,
+  createHederaSignAndSubmitTransaction,
+  toFacilitatorHederaSigner,
+} from "@x402/hedera";
+import { ExactHederaScheme } from "@x402/hedera/exact/facilitator";
 import { createEd25519Signer } from "@x402/stellar";
 import { ExactStellarScheme } from "@x402/stellar/exact/facilitator";
 import { toFacilitatorSvmSigner } from "@x402/svm";
@@ -27,7 +35,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import { baseSepolia } from "viem/chains";
 
 /**
- * Initialize and configure the x402 facilitator with EVM, SVM, AVM, Aptos, and Stellar support
+ * Initialize and configure the x402 facilitator with EVM, SVM, AVM, Aptos, Stellar, and Hedera support
  * This is called lazily on first use to support Next.js module loading
  *
  * @returns A configured x402Facilitator instance
@@ -167,6 +175,30 @@ async function createFacilitator(): Promise<x402Facilitator> {
     facilitator.register(
       "stellar:testnet",
       new ExactStellarScheme(stellarSigners, { feeBumpSigner }),
+    );
+  }
+
+  // Optionally register Hedera if configured
+  if (process.env.FACILITATOR_HEDERA_PRIVATE_KEY && process.env.FACILITATOR_HEDERA_ACCOUNT_ID) {
+    // Facilitator fee-payer key is expected to be an ECDSA (secp256k1) key.
+    const hederaFeePayerKey = HederaPrivateKey.fromStringECDSA(
+      process.env.FACILITATOR_HEDERA_PRIVATE_KEY,
+    );
+    const hederaFeePayer = process.env.FACILITATOR_HEDERA_ACCOUNT_ID;
+    const buildHederaClient = (network: string) => createHederaClient(network);
+
+    const hederaSigner = toFacilitatorHederaSigner({
+      getAddresses: () => [hederaFeePayer],
+      signAndSubmitTransaction: createHederaSignAndSubmitTransaction(
+        buildHederaClient,
+        hederaFeePayerKey,
+      ),
+      preflightTransfer: createHederaPreflightTransfer(buildHederaClient),
+    });
+
+    facilitator.register(
+      "hedera:testnet",
+      new ExactHederaScheme(hederaSigner, { aliasPolicy: "reject" }),
     );
   }
 

--- a/typescript/site/package.json
+++ b/typescript/site/package.json
@@ -26,6 +26,7 @@
     "@x402/core": "workspace:*",
     "@x402/evm": "workspace:*",
     "@x402/extensions": "workspace:*",
+    "@x402/hedera": "workspace:*",
     "@x402/next": "workspace:*",
     "@x402/paywall": "workspace:*",
     "@x402/stellar": "workspace:*",


### PR DESCRIPTION
## Description

Adds Hedera testnet support to the hosted x402.org facilitator (`typescript/site/app/facilitator`).

The `@x402/hedera` mechanism package already exists and is fully tested, but it was never wired into the site facilitator, which currently registers EVM, SVM, AVM, Aptos, and Stellar. This PR registers `hedera:testnet` following the same optional, environment-gated pattern used for Aptos and Stellar — the network is only enabled when its credentials are present, so the change is inert until secrets are provisioned.

Changes:
- Add `@x402/hedera` as a `site` dependency.
- Register `hedera:testnet` with `ExactHederaScheme` (`aliasPolicy: "reject"`) plus a preflight balance/association check, gated on both `FACILITATOR_HEDERA_ACCOUNT_ID` and `FACILITATOR_HEDERA_PRIVATE_KEY` being set.
- Parse the fee-payer key with `PrivateKey.fromStringECDSA` (secp256k1); plain `fromString` is deprecated in the Hiero SDK. The fee-payer account must therefore be an ECDSA account.
- Document the Hedera env vars in the site README.

Note: requires a funded Hedera testnet fee-payer (ECDSA) account and the two env vars set in the deployment environment to take effect.

## Tests

No new tests — this is integration/wiring of an already-tested mechanism (`@x402/hedera` ships its own unit + integration suites). Verified locally from `/typescript`:

- `tsc --noEmit` on `site` → passes clean
- `eslint app/facilitator/index.ts` → passes clean
- Dependency packages build successfully and `@x402/hedera` links/resolves in the site

After deploy with credentials set, `GET /facilitator/supported` should list a `hedera:testnet` / `exact` entry.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
