### PR TITLE
feat(evm): add Mezo Mainnet mUSD as default stablecoin (Permit2 + EIP-2612)

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -95,6 +95,7 @@ When you use `"$0.01"` syntax, x402 needs to know which stablecoin to use. The f
 | Stable | `eip155:988` | `0x779Ded0c9e1022225f8E0630b35a9b54bE713736` | USDT0 | 6 | EIP-3009 |
 | Stable Testnet | `eip155:2201` | `0x78Cf24370174180738C5B8E352B6D14c83a6c9A9` | USDT0 | 6 | EIP-3009 |
 | MegaETH | `eip155:4326` | `0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7` | MegaUSD | 18 | Permit2 + EIP-2612 |
+| Mezo | `eip155:31612` | `0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186` | Mezo USD | 18 | Permit2 + EIP-2612 |
 | Mezo Testnet | `eip155:31611` | `0x118917a40FAf1CD7a13dB0Ef56C86De7973Ac503` | Mezo USD | 18 | Permit2 + EIP-2612 |
 | Radius | `eip155:723487` | `0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb` | Stable Coin | 6 | Permit2 + EIP-2612 |
 | Radius Testnet | `eip155:72344` | `0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb` | Stable Coin | 6 | Permit2 + EIP-2612 |

--- a/go/.changes/unreleased/add-mezo-mainnet-default-stablecoin.yaml
+++ b/go/.changes/unreleased/add-mezo-mainnet-default-stablecoin.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add Mezo mainnet (chain ID 31612) support with mUSD as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -74,6 +74,7 @@ var (
 	ChainIDBaseSepolia   = big.NewInt(84532)
 	ChainIDMegaETH       = big.NewInt(4326)
 	ChainIDMonad         = big.NewInt(143)
+	ChainIDMezo          = big.NewInt(31612)
 	ChainIDMezoTestnet   = big.NewInt(31611)
 	ChainIDStable        = big.NewInt(988)
 	ChainIDStableTestnet = big.NewInt(2201)
@@ -138,6 +139,18 @@ var (
 				Name:     "USD Coin",
 				Version:  "2",
 				Decimals: DefaultDecimals,
+			},
+		},
+		// Mezo Mainnet (uses Permit2 instead of EIP-3009, supports EIP-2612)
+		"eip155:31612": {
+			ChainID: ChainIDMezo,
+			DefaultAsset: AssetInfo{
+				Address:             "0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186", // mUSD on Mezo
+				Name:                "Mezo USD",
+				Version:             "1",
+				Decimals:            18,
+				AssetTransferMethod: AssetTransferMethodPermit2,
+				SupportsEip2612:     true,
 			},
 		},
 		// Mezo Testnet (uses Permit2 instead of EIP-3009, supports EIP-2612)

--- a/python/x402/changelog.d/add-mezo-mainnet-default-stablecoin.feature.md
+++ b/python/x402/changelog.d/add-mezo-mainnet-default-stablecoin.feature.md
@@ -1,0 +1,1 @@
+Add Mezo mainnet (chain ID 31612) support with mUSD as the default stablecoin

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -442,6 +442,18 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "decimals": 6,
         },
     },
+    # Mezo Mainnet (uses Permit2 instead of EIP-3009, supports EIP-2612)
+    "eip155:31612": {
+        "chain_id": 31612,
+        "default_asset": {
+            "address": "0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186",
+            "name": "Mezo USD",
+            "version": "1",
+            "decimals": 18,
+            "asset_transfer_method": "permit2",
+            "supports_eip2612": True,
+        },
+    },
     # Mezo Testnet (uses Permit2 instead of EIP-3009, supports EIP-2612)
     "eip155:31611": {
         "chain_id": 31611,

--- a/typescript/.changeset/add-mezo-mainnet-default-stablecoin.md
+++ b/typescript/.changeset/add-mezo-mainnet-default-stablecoin.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": minor
+---
+
+Add Mezo mainnet (chain ID 31612) support with mUSD as the default stablecoin

--- a/typescript/packages/http/paywall/src/evm/gen/decimals.ts
+++ b/typescript/packages/http/paywall/src/evm/gen/decimals.ts
@@ -10,5 +10,6 @@
  */
 export const NETWORK_DECIMALS: Record<string, number> = {
   "eip155:31611": 18,
+  "eip155:31612": 18,
   "eip155:4326": 18,
 };

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -97,6 +97,14 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     version: "2",
     decimals: 6,
   }, // Arbitrum Sepolia USDC
+  "eip155:31612": {
+    address: "0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186",
+    name: "Mezo USD",
+    version: "1",
+    decimals: 18,
+    assetTransferMethod: "permit2",
+    supportsEip2612: true,
+  }, // Mezo mainnet mUSD (no EIP-3009, supports EIP-2612)
   "eip155:31611": {
     address: "0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503",
     name: "Mezo USD",


### PR DESCRIPTION
## Description

Add [mUSD](https://explorer.mezo.org/address/0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186) as the default stablecoin for Mezo mainnet (`eip155:31612`) across all three SDKs, following the [DEFAULT_ASSETS.md](https://github.com/x402-foundation/x402/blob/main/DEFAULT_ASSETS.md) guide. Mirrors the existing Mezo Testnet entry (`eip155:31611`, #1774).

[Mezo](https://mezo.org) is a Bitcoin-native EVM L2. mUSD is its chain-endorsed stablecoin (Liquity V2 fork, 18 decimals). mUSD does **not** support EIP-3009, so Permit2 is the required transfer method. mUSD **does** support EIP-2612 `permit()` for gasless approval.

| Field | Value |
|-------|-------|
| Network | `eip155:31612` (Mezo mainnet) |
| Asset | `0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186` |
| EIP-712 name | `Mezo USD` |
| EIP-712 version | `1` |
| Decimals | 18 |
| Transfer method | `permit2` |
| EIP-2612 support | `true` |

**Files changed (cross-SDK checklist per DEFAULT_ASSETS.md):**
- **TypeScript:** `typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts`
- **Go:** `go/mechanisms/evm/constants.go`
- **Python:** `python/x402/mechanisms/evm/constants.py`
- **Paywall:** `typescript/packages/http/paywall/src/evm/gen/decimals.ts` (regenerated — 18-decimal entry, DEFAULT_ASSETS.md step 3)
- **Docs:** Mezo mainnet row in `docs/core-concepts/network-and-token-support.mdx`
- **Changesets:** TS `.changeset`, Go `.changes/unreleased` yaml, Python `changelog.d` feature.md

## Tests

- EIP-712 domain parameters verified on-chain via ERC-5267 `eip712Domain()` (`name="Mezo USD"`, `version="1"`)
- Canonical `Permit2` deployed at `0x000000000022D473030F116dDEE9F6B43aC78BA3` on Mezo mainnet
- Canonical `x402ExactPermit2Proxy` deployed at `0x402085c248EeA27D92E8b30b2C58ed07f9E20001` on Mezo mainnet
- No existing tests affected — config-only change appending to existing maps

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes

## AI disclosure

This PR was prepared with the assistance of a coding agent and reviewed by Ryan R. Fox (an actual human) before submission.
