### PR TITLE
feat(extensions): add code and cause to SIWx failure results

### DIFF
--- a/specs/extensions/sign-in-with-x.md
+++ b/specs/extensions/sign-in-with-x.md
@@ -272,6 +272,21 @@ Base64 decode the header value and JSON parse the result.
 - **Not Before**: If `notBefore` is present, it MUST be in the past.
 - **Nonce**: MUST be unique. Server SHOULD track used nonces to prevent replay attacks.
 
+Validation failures SHOULD be reported with a machine-readable code identifying the failed check:
+
+| Code                               | Failed check                                            |
+| ---------------------------------- | ------------------------------------------------------- |
+| `invalid_siwx_domain_mismatch`     | `domain` does not match the request host                |
+| `invalid_siwx_uri_mismatch`        | `uri` does not start with the expected resource origin  |
+| `invalid_siwx_issued_at`           | `issuedAt` is not a valid timestamp                     |
+| `invalid_siwx_issued_at_too_old`   | `issuedAt` exceeds the maximum age                      |
+| `invalid_siwx_issued_at_in_future` | `issuedAt` is in the future                             |
+| `invalid_siwx_expiration_time`     | `expirationTime` is not a valid timestamp               |
+| `invalid_siwx_expired`             | `expirationTime` is in the past                         |
+| `invalid_siwx_not_before`          | `notBefore` is not a valid timestamp                    |
+| `invalid_siwx_not_yet_valid`       | `notBefore` is in the future                            |
+| `invalid_siwx_nonce`               | nonce failed uniqueness validation                      |
+
 ### 3. Verify Signature
 
 Route verification by `chainId` prefix:

--- a/typescript/.changeset/siwx-structured-errors.md
+++ b/typescript/.changeset/siwx-structured-errors.md
@@ -2,4 +2,4 @@
 "@x402/extensions": minor
 ---
 
-Added a `code` field (new exported `SIWxValidationCode` union) to `validateSIWxMessage` failure results and a `cause` field carrying the original thrown error to `verifySIWxSignature` failures when verification threw, so callers can branch on failures without string matching. Also fixed `verifySIWxSignature` rejecting on malformed CAIP-2 chainIds; it now resolves `{ valid: false }` as documented.
+Reshaped `SIWxValidationResult` into a discriminated union aligned with the facilitator verify response: `{ isValid: true } | { isValid: false; invalidReason: SIWxValidationCode; invalidMessage: string }`, where `invalidReason` is a stable spec-documented `invalid_siwx_*` code, replacing the previous `{ valid, error }` shape. Added a `cause` field carrying the original thrown error to `verifySIWxSignature` failures when verification threw, so callers can branch on failures without string matching. Also fixed `verifySIWxSignature` rejecting on malformed CAIP-2 chainIds; it now resolves with a failure result as documented.

--- a/typescript/.changeset/siwx-structured-errors.md
+++ b/typescript/.changeset/siwx-structured-errors.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": minor
+---
+
+Added a `code` field (new exported `SIWxValidationCode` union) to `validateSIWxMessage` failure results and a `cause` field carrying the original thrown error to `verifySIWxSignature` failures when verification threw, so callers can branch on failures without string matching. Also fixed `verifySIWxSignature` rejecting on malformed CAIP-2 chainIds; it now resolves `{ valid: false }` as documented.

--- a/typescript/packages/extensions/src/sign-in-with-x/README.md
+++ b/typescript/packages/extensions/src/sign-in-with-x/README.md
@@ -220,7 +220,19 @@ validateSIWxMessage(payload, resourceUri, {
   maxAge?: number;                    // Max age for issuedAt (default: 5 min)
   checkNonce?: (nonce) => boolean;    // Custom nonce validation
 })
-// Returns: { valid: boolean; error?: string }
+// Returns: { valid: boolean; code?: SIWxValidationCode; error?: string }
+
+type SIWxValidationCode =
+  | "domain_mismatch"
+  | "uri_mismatch"
+  | "invalid_issued_at"
+  | "too_old"
+  | "issued_at_in_future"
+  | "invalid_expiration_time"
+  | "expired"
+  | "invalid_not_before"
+  | "not_yet_valid"
+  | "nonce_invalid";
 ```
 
 ### `verifySIWxSignature(payload, options?)`
@@ -231,7 +243,7 @@ Verifies the cryptographic signature and recovers the signer address.
 verifySIWxSignature(payload, {
   evmVerifier?: EVMMessageVerifier;  // For smart wallet support
 })
-// Returns: { valid: boolean; address?: string; error?: string }
+// Returns: { valid: boolean; address?: string; error?: string; cause?: unknown }
 ```
 
 **Smart Wallet Support (EIP-1271 / EIP-6492):**

--- a/typescript/packages/extensions/src/sign-in-with-x/README.md
+++ b/typescript/packages/extensions/src/sign-in-with-x/README.md
@@ -94,8 +94,8 @@ async function handleRequest(request: Request) {
     payload,
     'https://api.example.com/data'
   );
-  if (!validation.valid) {
-    return { error: validation.error };
+  if (!validation.isValid) {
+    return { error: validation.invalidMessage };
   }
 
   // Verify signature and recover address
@@ -220,19 +220,20 @@ validateSIWxMessage(payload, resourceUri, {
   maxAge?: number;                    // Max age for issuedAt (default: 5 min)
   checkNonce?: (nonce) => boolean;    // Custom nonce validation
 })
-// Returns: { valid: boolean; code?: SIWxValidationCode; error?: string }
+// Returns: { isValid: true }
+//        | { isValid: false; invalidReason: SIWxValidationCode; invalidMessage: string }
 
 type SIWxValidationCode =
-  | "domain_mismatch"
-  | "uri_mismatch"
-  | "invalid_issued_at"
-  | "too_old"
-  | "issued_at_in_future"
-  | "invalid_expiration_time"
-  | "expired"
-  | "invalid_not_before"
-  | "not_yet_valid"
-  | "nonce_invalid";
+  | "invalid_siwx_domain_mismatch"
+  | "invalid_siwx_uri_mismatch"
+  | "invalid_siwx_issued_at"
+  | "invalid_siwx_issued_at_too_old"
+  | "invalid_siwx_issued_at_in_future"
+  | "invalid_siwx_expiration_time"
+  | "invalid_siwx_expired"
+  | "invalid_siwx_not_before"
+  | "invalid_siwx_not_yet_valid"
+  | "invalid_siwx_nonce";
 ```
 
 ### `verifySIWxSignature(payload, options?)`

--- a/typescript/packages/extensions/src/sign-in-with-x/hooks.ts
+++ b/typescript/packages/extensions/src/sign-in-with-x/hooks.ts
@@ -131,8 +131,12 @@ export function createSIWxRequestHook(options: CreateSIWxHookOptions) {
       const resourceUri = context.adapter.getUrl();
 
       const validation = await validateSIWxMessage(payload, resourceUri);
-      if (!validation.valid) {
-        onEvent?.({ type: "validation_failed", resource: context.path, error: validation.error });
+      if (!validation.isValid) {
+        onEvent?.({
+          type: "validation_failed",
+          resource: context.path,
+          error: validation.invalidMessage,
+        });
         return;
       }
 

--- a/typescript/packages/extensions/src/sign-in-with-x/index.ts
+++ b/typescript/packages/extensions/src/sign-in-with-x/index.ts
@@ -24,6 +24,7 @@ export type {
   DeclareSIWxOptions,
   SignatureScheme,
   SignatureType,
+  SIWxValidationCode,
   SIWxValidationResult,
   SIWxValidationOptions,
   SIWxVerifyResult,

--- a/typescript/packages/extensions/src/sign-in-with-x/types.ts
+++ b/typescript/packages/extensions/src/sign-in-with-x/types.ts
@@ -171,10 +171,27 @@ export interface DeclareSIWxOptions {
 }
 
 /**
+ * Machine-readable code identifying which validation check failed
+ */
+export type SIWxValidationCode =
+  | "domain_mismatch"
+  | "uri_mismatch"
+  | "invalid_issued_at"
+  | "too_old"
+  | "issued_at_in_future"
+  | "invalid_expiration_time"
+  | "expired"
+  | "invalid_not_before"
+  | "not_yet_valid"
+  | "nonce_invalid";
+
+/**
  * Validation result from validateSIWxMessage
  */
 export interface SIWxValidationResult {
   valid: boolean;
+  /** Code for the failed check (present when valid is false) */
+  code?: SIWxValidationCode;
   error?: string;
 }
 
@@ -184,7 +201,12 @@ export interface SIWxValidationResult {
 export interface SIWxValidationOptions {
   /** Maximum age for issuedAt in milliseconds (default: 5 minutes) */
   maxAge?: number;
-  /** Custom nonce validation function */
+  /**
+   * Custom nonce validation function.
+   *
+   * Errors thrown here are not caught: they propagate to the
+   * validateSIWxMessage caller, so a failing nonce backend fails closed.
+   */
   checkNonce?: (nonce: string) => boolean | Promise<boolean>;
 }
 
@@ -196,6 +218,8 @@ export interface SIWxVerifyResult {
   /** Recovered/verified address (checksummed) */
   address?: string;
   error?: string;
+  /** Error thrown during verification (absent when a signature check simply failed) */
+  cause?: unknown;
 }
 
 /**

--- a/typescript/packages/extensions/src/sign-in-with-x/types.ts
+++ b/typescript/packages/extensions/src/sign-in-with-x/types.ts
@@ -174,26 +174,26 @@ export interface DeclareSIWxOptions {
  * Machine-readable code identifying which validation check failed
  */
 export type SIWxValidationCode =
-  | "domain_mismatch"
-  | "uri_mismatch"
-  | "invalid_issued_at"
-  | "too_old"
-  | "issued_at_in_future"
-  | "invalid_expiration_time"
-  | "expired"
-  | "invalid_not_before"
-  | "not_yet_valid"
-  | "nonce_invalid";
+  | "invalid_siwx_domain_mismatch"
+  | "invalid_siwx_uri_mismatch"
+  | "invalid_siwx_issued_at"
+  | "invalid_siwx_issued_at_too_old"
+  | "invalid_siwx_issued_at_in_future"
+  | "invalid_siwx_expiration_time"
+  | "invalid_siwx_expired"
+  | "invalid_siwx_not_before"
+  | "invalid_siwx_not_yet_valid"
+  | "invalid_siwx_nonce";
 
 /**
- * Validation result from validateSIWxMessage
+ * Validation result from validateSIWxMessage.
+ *
+ * Failure fields follow the facilitator VerifyResponse naming
+ * (isValid/invalidReason/invalidMessage).
  */
-export interface SIWxValidationResult {
-  valid: boolean;
-  /** Code for the failed check (present when valid is false) */
-  code?: SIWxValidationCode;
-  error?: string;
-}
+export type SIWxValidationResult =
+  | { isValid: true }
+  | { isValid: false; invalidReason: SIWxValidationCode; invalidMessage: string };
 
 /**
  * Options for message validation

--- a/typescript/packages/extensions/src/sign-in-with-x/validate.ts
+++ b/typescript/packages/extensions/src/sign-in-with-x/validate.ts
@@ -54,6 +54,7 @@ export async function validateSIWxMessage(
   if (message.domain !== expectedUrl.hostname) {
     return {
       valid: false,
+      code: "domain_mismatch",
       error: `Domain mismatch: expected "${expectedUrl.hostname}", got "${message.domain}"`,
     };
   }
@@ -63,6 +64,7 @@ export async function validateSIWxMessage(
   if (!message.uri.startsWith(expectedUrl.origin)) {
     return {
       valid: false,
+      code: "uri_mismatch",
       error: `URI mismatch: expected origin "${expectedUrl.origin}", got "${message.uri}"`,
     };
   }
@@ -72,6 +74,7 @@ export async function validateSIWxMessage(
   if (isNaN(issuedAt.getTime())) {
     return {
       valid: false,
+      code: "invalid_issued_at",
       error: "Invalid issuedAt timestamp",
     };
   }
@@ -80,12 +83,14 @@ export async function validateSIWxMessage(
   if (age > maxAge) {
     return {
       valid: false,
+      code: "too_old",
       error: `Message too old: ${Math.round(age / 1000)}s exceeds ${maxAge / 1000}s limit`,
     };
   }
   if (age < 0) {
     return {
       valid: false,
+      code: "issued_at_in_future",
       error: "issuedAt is in the future",
     };
   }
@@ -96,12 +101,14 @@ export async function validateSIWxMessage(
     if (isNaN(expiration.getTime())) {
       return {
         valid: false,
+        code: "invalid_expiration_time",
         error: "Invalid expirationTime timestamp",
       };
     }
     if (expiration < new Date()) {
       return {
         valid: false,
+        code: "expired",
         error: "Message expired",
       };
     }
@@ -113,12 +120,14 @@ export async function validateSIWxMessage(
     if (isNaN(notBefore.getTime())) {
       return {
         valid: false,
+        code: "invalid_not_before",
         error: "Invalid notBefore timestamp",
       };
     }
     if (new Date() < notBefore) {
       return {
         valid: false,
+        code: "not_yet_valid",
         error: "Message not yet valid (notBefore is in the future)",
       };
     }
@@ -130,6 +139,7 @@ export async function validateSIWxMessage(
     if (!nonceValid) {
       return {
         valid: false,
+        code: "nonce_invalid",
         error: "Nonce validation failed (possible replay attack)",
       };
     }

--- a/typescript/packages/extensions/src/sign-in-with-x/validate.ts
+++ b/typescript/packages/extensions/src/sign-in-with-x/validate.ts
@@ -36,8 +36,8 @@ const DEFAULT_MAX_AGE_MS = 5 * 60 * 1000;
  *   { checkNonce: (n) => !usedNonces.has(n) }
  * );
  *
- * if (!result.valid) {
- *   return { error: result.error };
+ * if (!result.isValid) {
+ *   return { error: result.invalidMessage };
  * }
  * ```
  */
@@ -53,9 +53,9 @@ export async function validateSIWxMessage(
   // Use hostname (without port) per EIP-4361 convention
   if (message.domain !== expectedUrl.hostname) {
     return {
-      valid: false,
-      code: "domain_mismatch",
-      error: `Domain mismatch: expected "${expectedUrl.hostname}", got "${message.domain}"`,
+      isValid: false,
+      invalidReason: "invalid_siwx_domain_mismatch",
+      invalidMessage: `Domain mismatch: expected "${expectedUrl.hostname}", got "${message.domain}"`,
     };
   }
 
@@ -63,9 +63,9 @@ export async function validateSIWxMessage(
   // Allow the message URI to be the origin or the full resource URL
   if (!message.uri.startsWith(expectedUrl.origin)) {
     return {
-      valid: false,
-      code: "uri_mismatch",
-      error: `URI mismatch: expected origin "${expectedUrl.origin}", got "${message.uri}"`,
+      isValid: false,
+      invalidReason: "invalid_siwx_uri_mismatch",
+      invalidMessage: `URI mismatch: expected origin "${expectedUrl.origin}", got "${message.uri}"`,
     };
   }
 
@@ -73,25 +73,25 @@ export async function validateSIWxMessage(
   const issuedAt = new Date(message.issuedAt);
   if (isNaN(issuedAt.getTime())) {
     return {
-      valid: false,
-      code: "invalid_issued_at",
-      error: "Invalid issuedAt timestamp",
+      isValid: false,
+      invalidReason: "invalid_siwx_issued_at",
+      invalidMessage: "Invalid issuedAt timestamp",
     };
   }
 
   const age = Date.now() - issuedAt.getTime();
   if (age > maxAge) {
     return {
-      valid: false,
-      code: "too_old",
-      error: `Message too old: ${Math.round(age / 1000)}s exceeds ${maxAge / 1000}s limit`,
+      isValid: false,
+      invalidReason: "invalid_siwx_issued_at_too_old",
+      invalidMessage: `Message too old: ${Math.round(age / 1000)}s exceeds ${maxAge / 1000}s limit`,
     };
   }
   if (age < 0) {
     return {
-      valid: false,
-      code: "issued_at_in_future",
-      error: "issuedAt is in the future",
+      isValid: false,
+      invalidReason: "invalid_siwx_issued_at_in_future",
+      invalidMessage: "issuedAt is in the future",
     };
   }
 
@@ -100,16 +100,16 @@ export async function validateSIWxMessage(
     const expiration = new Date(message.expirationTime);
     if (isNaN(expiration.getTime())) {
       return {
-        valid: false,
-        code: "invalid_expiration_time",
-        error: "Invalid expirationTime timestamp",
+        isValid: false,
+        invalidReason: "invalid_siwx_expiration_time",
+        invalidMessage: "Invalid expirationTime timestamp",
       };
     }
     if (expiration < new Date()) {
       return {
-        valid: false,
-        code: "expired",
-        error: "Message expired",
+        isValid: false,
+        invalidReason: "invalid_siwx_expired",
+        invalidMessage: "Message expired",
       };
     }
   }
@@ -119,16 +119,16 @@ export async function validateSIWxMessage(
     const notBefore = new Date(message.notBefore);
     if (isNaN(notBefore.getTime())) {
       return {
-        valid: false,
-        code: "invalid_not_before",
-        error: "Invalid notBefore timestamp",
+        isValid: false,
+        invalidReason: "invalid_siwx_not_before",
+        invalidMessage: "Invalid notBefore timestamp",
       };
     }
     if (new Date() < notBefore) {
       return {
-        valid: false,
-        code: "not_yet_valid",
-        error: "Message not yet valid (notBefore is in the future)",
+        isValid: false,
+        invalidReason: "invalid_siwx_not_yet_valid",
+        invalidMessage: "Message not yet valid (notBefore is in the future)",
       };
     }
   }
@@ -138,12 +138,12 @@ export async function validateSIWxMessage(
     const nonceValid = await options.checkNonce(message.nonce);
     if (!nonceValid) {
       return {
-        valid: false,
-        code: "nonce_invalid",
-        error: "Nonce validation failed (possible replay attack)",
+        isValid: false,
+        invalidReason: "invalid_siwx_nonce",
+        invalidMessage: "Nonce validation failed (possible replay attack)",
       };
     }
   }
 
-  return { valid: true };
+  return { isValid: true };
 }

--- a/typescript/packages/extensions/src/sign-in-with-x/verify.ts
+++ b/typescript/packages/extensions/src/sign-in-with-x/verify.ts
@@ -50,7 +50,7 @@ export async function verifySIWxSignature(
   try {
     // Route by chain namespace
     if (payload.chainId.startsWith("eip155:")) {
-      return verifyEVMPayload(payload, options?.evmVerifier);
+      return await verifyEVMPayload(payload, options?.evmVerifier);
     }
 
     if (payload.chainId.startsWith("solana:")) {
@@ -65,6 +65,7 @@ export async function verifySIWxSignature(
     return {
       valid: false,
       error: error instanceof Error ? error.message : "Verification failed",
+      cause: error,
     };
   }
 }
@@ -117,6 +118,7 @@ async function verifyEVMPayload(
     return {
       valid: false,
       error: error instanceof Error ? error.message : "Signature verification failed",
+      cause: error,
     };
   }
 }

--- a/typescript/packages/extensions/test/sign-in-with-x.test.ts
+++ b/typescript/packages/extensions/test/sign-in-with-x.test.ts
@@ -32,6 +32,9 @@ import {
   type SolanaSigner,
   type EVMSigner,
   type EVMMessageVerifier,
+  type SIWxPayload,
+  type SIWxValidationCode,
+  type SIWxValidationOptions,
 } from "../src/sign-in-with-x/index";
 import { safeBase64Encode } from "@x402/core/utils";
 import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
@@ -235,12 +238,63 @@ describe("Sign-In-With-X Extension", () => {
 
       const result = await validateSIWxMessage(payload, "https://api.example.com/data");
       expect(result.valid).toBe(true);
+      expect(result.code).toBeUndefined();
     });
 
     it("should reject domain mismatch", async () => {
       const result = await validateSIWxMessage(validPayload, "https://different.example.com/data");
       expect(result.valid).toBe(false);
       expect(result.error).toContain("Domain mismatch");
+      expect(result.code).toBe("domain_mismatch");
+    });
+
+    const failureCases: Array<{
+      code: SIWxValidationCode;
+      overrides: Partial<SIWxPayload>;
+      options?: SIWxValidationOptions;
+    }> = [
+      { code: "uri_mismatch", overrides: { uri: "https://evil.example.com/data" } },
+      { code: "invalid_issued_at", overrides: { issuedAt: "not-a-date" } },
+      {
+        code: "too_old",
+        overrides: { issuedAt: new Date(Date.now() - 10 * 60 * 1000).toISOString() },
+      },
+      {
+        code: "issued_at_in_future",
+        overrides: { issuedAt: new Date(Date.now() + 60 * 1000).toISOString() },
+      },
+      { code: "invalid_expiration_time", overrides: { expirationTime: "not-a-date" } },
+      {
+        code: "expired",
+        overrides: { expirationTime: new Date(Date.now() - 1000).toISOString() },
+      },
+      { code: "invalid_not_before", overrides: { notBefore: "not-a-date" } },
+      {
+        code: "not_yet_valid",
+        overrides: { notBefore: new Date(Date.now() + 60 * 1000).toISOString() },
+      },
+      { code: "nonce_invalid", overrides: {}, options: { checkNonce: () => false } },
+    ];
+
+    it.each(failureCases)("should reject with code $code", async ({ code, overrides, options }) => {
+      const result = await validateSIWxMessage(
+        { ...validPayload, issuedAt: new Date().toISOString(), ...overrides },
+        "https://api.example.com/data",
+        options,
+      );
+      expect(result.valid).toBe(false);
+      expect(result.code).toBe(code);
+    });
+
+    it("should propagate checkNonce errors to the caller", async () => {
+      const payload = { ...validPayload, issuedAt: new Date().toISOString() };
+      await expect(
+        validateSIWxMessage(payload, "https://api.example.com/data", {
+          checkNonce: () => {
+            throw new Error("nonce store unavailable");
+          },
+        }),
+      ).rejects.toThrow("nonce store unavailable");
     });
   });
 
@@ -439,10 +493,12 @@ describe("Sign-In-With-X Extension", () => {
 
       expect(result.valid).toBe(false);
       expect(result.error).toContain("Signature verification failed");
+      expect(result.cause).toBeUndefined();
     });
 
     it("should return error when verifier throws", async () => {
-      const mockVerifier: EVMMessageVerifier = vi.fn().mockRejectedValue(new Error("RPC error"));
+      const rpcError = new Error("RPC error");
+      const mockVerifier: EVMMessageVerifier = vi.fn().mockRejectedValue(rpcError);
       const account = privateKeyToAccount(generatePrivateKey());
 
       const extension = createTestChallenge({
@@ -465,6 +521,7 @@ describe("Sign-In-With-X Extension", () => {
 
       expect(result.valid).toBe(false);
       expect(result.error).toContain("RPC error");
+      expect(result.cause).toBe(rpcError);
     });
 
     it("should not use verifier for Solana signatures", async () => {
@@ -687,6 +744,18 @@ describe("Sign-In-With-X Extension", () => {
       const result = await verifySIWxSignature(payload);
       expect(result.valid).toBe(false);
       expect(result.error).toContain("Unsupported chain namespace");
+    });
+
+    it("should return error for malformed EVM chainId", async () => {
+      const payload = {
+        ...validPayload,
+        chainId: "eip155:not-a-number",
+      };
+
+      const result = await verifySIWxSignature(payload);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("Invalid EVM chainId format");
+      expect(result.cause).toBeInstanceOf(Error);
     });
 
     it("should verify Solana signatures", async () => {

--- a/typescript/packages/extensions/test/sign-in-with-x.test.ts
+++ b/typescript/packages/extensions/test/sign-in-with-x.test.ts
@@ -237,54 +237,63 @@ describe("Sign-In-With-X Extension", () => {
       };
 
       const result = await validateSIWxMessage(payload, "https://api.example.com/data");
-      expect(result.valid).toBe(true);
-      expect(result.code).toBeUndefined();
+      expect(result).toEqual({ isValid: true });
     });
 
     it("should reject domain mismatch", async () => {
       const result = await validateSIWxMessage(validPayload, "https://different.example.com/data");
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain("Domain mismatch");
-      expect(result.code).toBe("domain_mismatch");
+      expect(result).toEqual({
+        isValid: false,
+        invalidReason: "invalid_siwx_domain_mismatch",
+        invalidMessage: expect.stringContaining("Domain mismatch"),
+      });
     });
 
     const failureCases: Array<{
-      code: SIWxValidationCode;
+      invalidReason: SIWxValidationCode;
       overrides: Partial<SIWxPayload>;
       options?: SIWxValidationOptions;
     }> = [
-      { code: "uri_mismatch", overrides: { uri: "https://evil.example.com/data" } },
-      { code: "invalid_issued_at", overrides: { issuedAt: "not-a-date" } },
       {
-        code: "too_old",
+        invalidReason: "invalid_siwx_uri_mismatch",
+        overrides: { uri: "https://evil.example.com/data" },
+      },
+      { invalidReason: "invalid_siwx_issued_at", overrides: { issuedAt: "not-a-date" } },
+      {
+        invalidReason: "invalid_siwx_issued_at_too_old",
         overrides: { issuedAt: new Date(Date.now() - 10 * 60 * 1000).toISOString() },
       },
       {
-        code: "issued_at_in_future",
+        invalidReason: "invalid_siwx_issued_at_in_future",
         overrides: { issuedAt: new Date(Date.now() + 60 * 1000).toISOString() },
       },
-      { code: "invalid_expiration_time", overrides: { expirationTime: "not-a-date" } },
       {
-        code: "expired",
+        invalidReason: "invalid_siwx_expiration_time",
+        overrides: { expirationTime: "not-a-date" },
+      },
+      {
+        invalidReason: "invalid_siwx_expired",
         overrides: { expirationTime: new Date(Date.now() - 1000).toISOString() },
       },
-      { code: "invalid_not_before", overrides: { notBefore: "not-a-date" } },
+      { invalidReason: "invalid_siwx_not_before", overrides: { notBefore: "not-a-date" } },
       {
-        code: "not_yet_valid",
+        invalidReason: "invalid_siwx_not_yet_valid",
         overrides: { notBefore: new Date(Date.now() + 60 * 1000).toISOString() },
       },
-      { code: "nonce_invalid", overrides: {}, options: { checkNonce: () => false } },
+      { invalidReason: "invalid_siwx_nonce", overrides: {}, options: { checkNonce: () => false } },
     ];
 
-    it.each(failureCases)("should reject with code $code", async ({ code, overrides, options }) => {
-      const result = await validateSIWxMessage(
-        { ...validPayload, issuedAt: new Date().toISOString(), ...overrides },
-        "https://api.example.com/data",
-        options,
-      );
-      expect(result.valid).toBe(false);
-      expect(result.code).toBe(code);
-    });
+    it.each(failureCases)(
+      "should reject with $invalidReason",
+      async ({ invalidReason, overrides, options }) => {
+        const result = await validateSIWxMessage(
+          { ...validPayload, issuedAt: new Date().toISOString(), ...overrides },
+          "https://api.example.com/data",
+          options,
+        );
+        expect(result).toMatchObject({ isValid: false, invalidReason });
+      },
+    );
 
     it("should propagate checkNonce errors to the caller", async () => {
       const payload = { ...validPayload, issuedAt: new Date().toISOString() };
@@ -354,7 +363,7 @@ describe("Sign-In-With-X Extension", () => {
       const parsed = parseSIWxHeader(header);
 
       const validation = await validateSIWxMessage(parsed, "https://api.example.com/resource");
-      expect(validation.valid).toBe(true);
+      expect(validation.isValid).toBe(true);
 
       const verification = await verifySIWxSignature(parsed);
       expect(verification.valid).toBe(true);
@@ -406,7 +415,7 @@ describe("Sign-In-With-X Extension", () => {
 
       const parsed = parseSIWxHeader(header);
       const validation = await validateSIWxMessage(parsed, resourceUri);
-      expect(validation.valid).toBe(true);
+      expect(validation.isValid).toBe(true);
 
       const result = await verifySIWxSignature(parsed);
       expect(result.valid).toBe(true);
@@ -933,7 +942,7 @@ describe("Sign-In-With-X Extension", () => {
         const parsed = parseSIWxHeader(header);
 
         const validation = await validateSIWxMessage(parsed, "https://api.example.com/resource");
-        expect(validation.valid).toBe(true);
+        expect(validation.isValid).toBe(true);
 
         const verification = await verifySIWxSignature(parsed);
         expect(verification.valid).toBe(true);


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

Closes #2586. 

- `validateSIWxMessage` failure results now include a `code` field (new exported `SIWxValidationCode` union) next to the existing prose `error`. 
- `verifySIWxSignature` failures now include `cause` with the original thrown error when verification threw, so callers can distinguish an invalid signature (401-class) from a verifier failure such as an RPC outage (503-class) without string matching. 
- The `checkNonce` JSDoc now states that errors it throws propagate to the `validateSIWxMessage` caller. All changes are additive and backward compatible.
- This also fixes a missing `await` in the EVM branch of `verifySIWxSignature`: a malformed CAIP-2 chainId such as `eip155:abc` previously made the function reject, and it now resolves `{ valid: false }` with `error` and `cause` as documented.

## Disclosure
This PR was prepared with the assistance of a coding agent (Claude Code) and reviewed by the author before submission.

## Tests

- `code` assertions on existing validate tests, plus an `it.each` table covering the remaining 9 codes (`domain_mismatch` is asserted on the existing domain-mismatch test)
- `checkNonce` throw propagation to the `validateSIWxMessage` caller
- `cause` is the thrown error when `evmVerifier` throws, and absent when the verifier returns `false`
- malformed chainId resolves `{ valid: false }` instead of rejecting

Verified locally from `typescript/`:
- `pnpm --filter @x402/extensions test` → 476 passed (95 in sign-in-with-x)
- `pnpm --filter @x402/extensions format:check` and `lint:check` → clean


<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 