### PR TITLE
Add XDC Network mainnet (50) and Apothem testnet (51) USDC default stablecoins

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -102,6 +102,8 @@ When you use `"$0.01"` syntax, x402 needs to know which stablecoin to use. The f
 | ADI Chain | `eip155:36900` | `0x9cb8142aEBBcdc60AF7c97Af897A67A8f3CA71C2` | USDC.e | 6 | EIP-3009 |
 | HPP | `eip155:190415` | `0x401eCb1D350407f13ba348573E5630B83638E30D` | Bridged USDC | 6 | EIP-3009 |
 | HPP Sepolia | `eip155:181228` | `0x401eCb1D350407f13ba348573E5630B83638E30D` | Bridged USDC | 6 | EIP-3009 |
+| XDC Network | `eip155:50` | `0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1` | USDC | 6 | EIP-3009 |
+| XDC Apothem Testnet | `eip155:51` | `0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4` | USDC | 6 | EIP-3009 |
 
 
 

--- a/go/.changes/unreleased/add-xdc-network-default-stablecoin.yaml
+++ b/go/.changes/unreleased/add-xdc-network-default-stablecoin.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add XDC Network mainnet (chain ID 50) and Apothem testnet (chain ID 51) support with USDC as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -86,6 +86,8 @@ var (
 	ChainIDADI           = big.NewInt(36900)
 	ChainIDHPP           = big.NewInt(190415)
 	ChainIDHPPSepolia    = big.NewInt(181228)
+	ChainIDXDC           = big.NewInt(50)
+	ChainIDXDCApothem    = big.NewInt(51)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -265,6 +267,26 @@ var (
 			DefaultAsset: AssetInfo{
 				Address:  "0x401eCb1D350407f13ba348573E5630B83638E30D", // USDC.e (Bridged USDC) on HPP Sepolia
 				Name:     "Bridged USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// XDC Network Mainnet
+		"eip155:50": {
+			ChainID: ChainIDXDC,
+			DefaultAsset: AssetInfo{
+				Address:  "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1", // USDC (Bridged USDC Standard) on XDC Network
+				Name:     "USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// XDC Apothem Testnet
+		"eip155:51": {
+			ChainID: ChainIDXDCApothem,
+			DefaultAsset: AssetInfo{
+				Address:  "0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4", // USDC (Bridged USDC Standard) on XDC Apothem
+				Name:     "USDC",
 				Version:  "2",
 				Decimals: DefaultDecimals,
 			},

--- a/python/x402/changelog.d/add-xdc-network-default-stablecoin.feature.md
+++ b/python/x402/changelog.d/add-xdc-network-default-stablecoin.feature.md
@@ -1,0 +1,1 @@
+Add XDC Network mainnet (chain ID 50) and Apothem testnet (chain ID 51) support with USDC as the default stablecoin

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -578,6 +578,26 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "decimals": 6,
         },
     },
+    # XDC Network Mainnet
+    "eip155:50": {
+        "chain_id": 50,
+        "default_asset": {
+            "address": "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
+    # XDC Apothem Testnet
+    "eip155:51": {
+        "chain_id": 51,
+        "default_asset": {
+            "address": "0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
 }
 
 # V1 legacy constants are in x402.mechanisms.evm.v1.constants

--- a/typescript/.changeset/add-xdc-network-default-stablecoin.md
+++ b/typescript/.changeset/add-xdc-network-default-stablecoin.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": minor
+---
+
+Add XDC Network mainnet (chain ID 50) and Apothem testnet (chain ID 51) support with USDC as the default stablecoin

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -147,6 +147,18 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     version: "2",
     decimals: 6,
   }, // HPP Sepolia USDC.e
+  "eip155:50": {
+    address: "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1",
+    name: "USDC",
+    version: "2",
+    decimals: 6,
+  }, // XDC Network mainnet USDC (Bridged USDC Standard, EIP-3009 supported)
+  "eip155:51": {
+    address: "0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4",
+    name: "USDC",
+    version: "2",
+    decimals: 6,
+  }, // XDC Apothem testnet USDC (Bridged USDC Standard, EIP-3009 supported)
 };
 
 /**


### PR DESCRIPTION
## Description

Adds **XDC Network mainnet** (`eip155:50`) and **XDC Apothem testnet** (`eip155:51`) to the default stablecoin maps of all three SDKs (TypeScript, Go, Python), per the process in `DEFAULT_ASSETS.md`.

| Network | CAIP-2 | USDC address | EIP-712 domain | Decimals |
|---|---|---|---|---|
| XDC mainnet | `eip155:50` | `0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1` | `name: "USDC"`, `version: "2"` | 6 |
| XDC Apothem | `eip155:51` | `0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4` | `name: "USDC"`, `version: "2"` | 6 |

Also adds the two corresponding rows to the "Default Assets for Dollar-String Pricing" table in `docs/core-concepts/network-and-token-support.mdx`.

**Asset rationale:** This is Circle's [Bridged USDC Standard](https://www.circle.com/bridged-usdc) deployment on XDC (launched with XSwap — [announcement](https://xdc.org/articles/xswap-protocol-launches-circles-bridged-usdc-on-xdcs-network)), listed on [Circle's official USDC contract addresses page](https://developers.circle.com/stablecoins/usdc-contract-addresses). It is the chain-endorsed USDC for XDC. Both deployments are FiatToken v2.2 — full EIP-3009 support, so the default `eip3009` transfer method applies (no `assetTransferMethod` override needed).

### On-chain verification performed

- **Domain parameters** read from each contract (`name()`, `version()`, `decimals()`); locally derived EIP-712 domain separators match on-chain `DOMAIN_SEPARATOR()` byte-for-byte on both chain 50 and 51.
- **EIP-3009 selectors** confirmed in both implementations (proxy → impl): both `transferWithAuthorization` overloads, `receiveWithAuthorization`, `cancelAuthorization`, and EIP-2612 `permit`.
- **Live Apothem functional test:** a signed `TransferWithAuthorization` executes successfully against the canonical USDC contract via `eth_call`; a tampered signature correctly reverts with `ECRecover: invalid signature`.
- **Full x402 v2.14.0 end-to-end on Apothem (chain id 51):** self-hosted facilitator (`ExactEvmScheme`) + Express resource server + fetch client — `402 → sign → verify → settle → 200`, including a settlement broadcast on the live Apothem network ([tx `0x1298904e...112b`](https://testnet.xdcscan.com/tx/0x1298904eddd5ff37f3e22caf157a41458a758abc997096c51876cd15e115112b), block 82,959,242) and a payment using the canonical USDC contract bytecode on an Apothem fork.
- Apothem/XDC EVM is Cancun-level (CHAINID, PUSH0, MCOPY, TSTORE verified live), so no compatibility caveats for token tooling.

Both defaults use 6 decimals, so the paywall decimals regeneration step is not required.

## Tests

- **TypeScript:** `pnpm --filter @x402/evm test` — 28 files, **687 passed** (after `pnpm --filter @x402/core build`); `pnpm --filter @x402/evm lint` clean
- **Python:** `cd python/x402 && uv run pytest` — **1651 passed**, 56 skipped
- **Go:** `go test ./mechanisms/evm/...` — **all packages ok**; `gofmt` clean

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)


