### PR TITLE
Nightly e2e runs

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,8 +7,8 @@ name: E2E Tests
 
 on:
   schedule:
-    - cron: "0 6 * * 1-6"
-    - cron: "0 6 * * 0"
+    - cron: "0 10 * * 0-4,6" # daily except Friday — v2 only
+    - cron: "0 10 * * 5"     # Friday — v1 legacy + v2
   workflow_dispatch:
     inputs:
       include_legacy:
@@ -65,9 +65,9 @@ jobs:
           FACILITATOR_STELLAR_PRIVATE_KEY: ${{ secrets.FACILITATOR_STELLAR_PRIVATE_KEY }}
           FACILITATOR_TVM_PRIVATE_KEY: ${{ secrets.FACILITATOR_TVM_PRIVATE_KEY }}
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" && "${{ github.event.schedule }}" == "0 6 * * 0" ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" && "${{ github.event.schedule }}" == "0 10 * * 5" ]]; then
             VERSIONS="1,2"
-            RUN_SCOPE="weekly v1 legacy + v2"
+            RUN_SCOPE="friday v1 legacy + v2"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.include_legacy }}" == "true" ]]; then
             VERSIONS="1,2"
             RUN_SCOPE="manual v1 legacy + v2"

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -2,13 +2,6 @@
 #
 # Runs the minimized end-to-end test suite on testnet. Protocol families are
 # included only when all required wallet secrets for that family are configured.
-#
-# Trigger: Daily v2-only runs (06:00 UTC Monday-Saturday), weekly full run
-# with legacy v1 coverage (06:00 UTC Sunday), or manual (workflow_dispatch).
-#
-# Secrets are written to e2e/.env before the test run. The harness loads that
-# file via dotenv (test.ts) and child servers/clients/facilitators also read
-# it from their working directories when spawned.
 
 name: E2E Tests
 

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,0 +1,197 @@
+# E2E Test Workflow for x402 Protocol
+#
+# Runs the minimized end-to-end test suite on testnet. Protocol families are
+# included only when all required wallet secrets for that family are configured.
+#
+# Trigger: Daily v2-only runs (06:00 UTC Monday-Saturday), weekly full run
+# with legacy v1 coverage (06:00 UTC Sunday), or manual (workflow_dispatch).
+#
+# Secrets are written to e2e/.env before the test run. The harness loads that
+# file via dotenv (test.ts) and child servers/clients/facilitators also read
+# it from their working directories when spawned.
+
+name: E2E Tests
+
+on:
+  schedule:
+    - cron: "0 6 * * 1-6"
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+    inputs:
+      include_legacy:
+        description: "Include legacy v1 coverage"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: none
+
+jobs:
+  e2e:
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: e2e
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Detect families from GitHub secrets directly (before any install).
+      # Step-level env maps secrets into the shell so ci-select-families.sh
+      # can read them the same way as a local .env-backed run.
+      - name: Select protocol families from configured secrets
+        id: families
+        env:
+          CLIENT_EVM_PRIVATE_KEY: ${{ secrets.CLIENT_EVM_PRIVATE_KEY }}
+          CLIENT_SVM_PRIVATE_KEY: ${{ secrets.CLIENT_SVM_PRIVATE_KEY }}
+          CLIENT_AVM_PRIVATE_KEY: ${{ secrets.CLIENT_AVM_PRIVATE_KEY }}
+          CLIENT_APTOS_PRIVATE_KEY: ${{ secrets.CLIENT_APTOS_PRIVATE_KEY }}
+          CLIENT_HEDERA_ACCOUNT_ID: ${{ secrets.CLIENT_HEDERA_ACCOUNT_ID }}
+          CLIENT_HEDERA_PRIVATE_KEY: ${{ secrets.CLIENT_HEDERA_PRIVATE_KEY }}
+          CLIENT_STELLAR_PRIVATE_KEY: ${{ secrets.CLIENT_STELLAR_PRIVATE_KEY }}
+          CLIENT_TVM_PRIVATE_KEY: ${{ secrets.CLIENT_TVM_PRIVATE_KEY }}
+          SERVER_EVM_ADDRESS: ${{ secrets.SERVER_EVM_ADDRESS }}
+          SERVER_SVM_ADDRESS: ${{ secrets.SERVER_SVM_ADDRESS }}
+          SERVER_AVM_ADDRESS: ${{ secrets.SERVER_AVM_ADDRESS }}
+          SERVER_APTOS_ADDRESS: ${{ secrets.SERVER_APTOS_ADDRESS }}
+          SERVER_HEDERA_ADDRESS: ${{ secrets.SERVER_HEDERA_ADDRESS }}
+          SERVER_STELLAR_ADDRESS: ${{ secrets.SERVER_STELLAR_ADDRESS }}
+          SERVER_TVM_ADDRESS: ${{ secrets.SERVER_TVM_ADDRESS }}
+          FACILITATOR_EVM_PRIVATE_KEY: ${{ secrets.FACILITATOR_EVM_PRIVATE_KEY }}
+          FACILITATOR_SVM_PRIVATE_KEY: ${{ secrets.FACILITATOR_SVM_PRIVATE_KEY }}
+          FACILITATOR_AVM_PRIVATE_KEY: ${{ secrets.FACILITATOR_AVM_PRIVATE_KEY }}
+          FACILITATOR_APTOS_PRIVATE_KEY: ${{ secrets.FACILITATOR_APTOS_PRIVATE_KEY }}
+          FACILITATOR_HEDERA_ACCOUNT_ID: ${{ secrets.FACILITATOR_HEDERA_ACCOUNT_ID }}
+          FACILITATOR_HEDERA_PRIVATE_KEY: ${{ secrets.FACILITATOR_HEDERA_PRIVATE_KEY }}
+          FACILITATOR_STELLAR_PRIVATE_KEY: ${{ secrets.FACILITATOR_STELLAR_PRIVATE_KEY }}
+          FACILITATOR_TVM_PRIVATE_KEY: ${{ secrets.FACILITATOR_TVM_PRIVATE_KEY }}
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" && "${{ github.event.schedule }}" == "0 6 * * 0" ]]; then
+            VERSIONS="1,2"
+            RUN_SCOPE="weekly v1 legacy + v2"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.include_legacy }}" == "true" ]]; then
+            VERSIONS="1,2"
+            RUN_SCOPE="manual v1 legacy + v2"
+          else
+            VERSIONS="2"
+            RUN_SCOPE="v2 only"
+          fi
+
+          set +e
+          FAMILIES=$(bash scripts/ci-select-families.sh)
+          status=$?
+          set -e
+          if [[ $status -ne 0 ]]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "No wallet secrets configured — skipping e2e run." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "families=$FAMILIES" >> "$GITHUB_OUTPUT"
+          echo "versions=$VERSIONS" >> "$GITHUB_OUTPUT"
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+          echo "Running minimized e2e for families: **$FAMILIES** ($RUN_SCOPE, versions: **$VERSIONS**)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Setup pnpm
+        if: steps.families.outputs.configured == 'true'
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.1.1
+          run_install: false
+
+      - name: Setup Node.js
+        if: steps.families.outputs.configured == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Setup Go
+        if: steps.families.outputs.configured == 'true'
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: "1.24"
+          cache: false
+
+      - name: Setup uv
+        if: steps.families.outputs.configured == 'true'
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          enable-cache: false
+
+      - name: Install Python
+        if: steps.families.outputs.configured == 'true'
+        run: uv python install 3.10
+
+      - name: Install and build TypeScript SDK
+        if: steps.families.outputs.configured == 'true'
+        working-directory: ./typescript
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Install E2E dependencies
+        if: steps.families.outputs.configured == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Setup E2E components
+        if: steps.families.outputs.configured == 'true'
+        run: ./setup.sh
+
+      # Write secrets to e2e/.env so test.ts (dotenv) and spawned
+      # servers/clients/facilitators (dotenv/godotenv) can read wallet config.
+      - name: Create .env file
+        if: steps.families.outputs.configured == 'true'
+        run: |
+          {
+            echo "SERVER_EVM_ADDRESS=${{ secrets.SERVER_EVM_ADDRESS }}"
+            echo "SERVER_SVM_ADDRESS=${{ secrets.SERVER_SVM_ADDRESS }}"
+            echo "SERVER_AVM_ADDRESS=${{ secrets.SERVER_AVM_ADDRESS }}"
+            echo "SERVER_APTOS_ADDRESS=${{ secrets.SERVER_APTOS_ADDRESS }}"
+            echo "SERVER_HEDERA_ADDRESS=${{ secrets.SERVER_HEDERA_ADDRESS }}"
+            echo "SERVER_STELLAR_ADDRESS=${{ secrets.SERVER_STELLAR_ADDRESS }}"
+            echo "SERVER_TVM_ADDRESS=${{ secrets.SERVER_TVM_ADDRESS }}"
+            echo "CLIENT_EVM_PRIVATE_KEY=${{ secrets.CLIENT_EVM_PRIVATE_KEY }}"
+            echo "CLIENT_SVM_PRIVATE_KEY=${{ secrets.CLIENT_SVM_PRIVATE_KEY }}"
+            echo "CLIENT_AVM_PRIVATE_KEY=${{ secrets.CLIENT_AVM_PRIVATE_KEY }}"
+            echo "CLIENT_APTOS_PRIVATE_KEY=${{ secrets.CLIENT_APTOS_PRIVATE_KEY }}"
+            echo "CLIENT_HEDERA_ACCOUNT_ID=${{ secrets.CLIENT_HEDERA_ACCOUNT_ID }}"
+            echo "CLIENT_HEDERA_PRIVATE_KEY=${{ secrets.CLIENT_HEDERA_PRIVATE_KEY }}"
+            echo "CLIENT_STELLAR_PRIVATE_KEY=${{ secrets.CLIENT_STELLAR_PRIVATE_KEY }}"
+            echo "CLIENT_TVM_PRIVATE_KEY=${{ secrets.CLIENT_TVM_PRIVATE_KEY }}"
+            echo "FACILITATOR_EVM_PRIVATE_KEY=${{ secrets.FACILITATOR_EVM_PRIVATE_KEY }}"
+            echo "FACILITATOR_SVM_PRIVATE_KEY=${{ secrets.FACILITATOR_SVM_PRIVATE_KEY }}"
+            echo "FACILITATOR_AVM_PRIVATE_KEY=${{ secrets.FACILITATOR_AVM_PRIVATE_KEY }}"
+            echo "FACILITATOR_APTOS_PRIVATE_KEY=${{ secrets.FACILITATOR_APTOS_PRIVATE_KEY }}"
+            echo "FACILITATOR_HEDERA_ACCOUNT_ID=${{ secrets.FACILITATOR_HEDERA_ACCOUNT_ID }}"
+            echo "FACILITATOR_HEDERA_PRIVATE_KEY=${{ secrets.FACILITATOR_HEDERA_PRIVATE_KEY }}"
+            echo "FACILITATOR_STELLAR_PRIVATE_KEY=${{ secrets.FACILITATOR_STELLAR_PRIVATE_KEY }}"
+            echo "FACILITATOR_TVM_PRIVATE_KEY=${{ secrets.FACILITATOR_TVM_PRIVATE_KEY }}"
+            echo "SERVER_EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY=${{ secrets.SERVER_EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY }}"
+            echo "CLIENT_EVM_VOUCHER_SIGNER_PRIVATE_KEY=${{ secrets.CLIENT_EVM_VOUCHER_SIGNER_PRIVATE_KEY }}"
+            echo "TVM_PROVIDER=${{ secrets.TVM_PROVIDER }}"
+            echo "TONAPI_API_KEY=${{ secrets.TONAPI_API_KEY }}"
+            echo "TONAPI_BASE_URL=${{ secrets.TONAPI_BASE_URL }}"
+            echo "TONCENTER_API_KEY=${{ secrets.TONCENTER_API_KEY }}"
+            echo "BASE_SEPOLIA_RPC_URL=${{ secrets.BASE_SEPOLIA_RPC_URL }}"
+            echo "SOLANA_DEVNET_RPC_URL=${{ secrets.SOLANA_DEVNET_RPC_URL }}"
+          } > .env
+
+      - name: Run minimized e2e tests (testnet)
+        if: steps.families.outputs.configured == 'true'
+        run: |
+          pnpm test --testnet --min --parallel --log --output-json=e2e-results.json --families=${{ steps.families.outputs.families }} --versions=${{ steps.families.outputs.versions }}
+
+      - name: Upload test results
+        if: always() && steps.families.outputs.configured == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-results
+          path: |
+            e2e/e2e-results.json
+          retention-days: 7
+          if-no-files-found: ignore

--- a/e2e/clients/axios/index.ts
+++ b/e2e/clients/axios/index.ts
@@ -54,6 +54,7 @@ const evmSchemeOptions: ExactEvmSchemeOptions | undefined = process.env.EVM_RPC_
 const uptoSchemeOptions: UptoEvmSchemeOptions | undefined = process.env.EVM_RPC_URL
   ? { rpcUrl: process.env.EVM_RPC_URL }
   : undefined;
+const svmSchemeOptions = process.env.SVM_RPC_URL ? { rpcUrl: process.env.SVM_RPC_URL } : undefined;
 
 // Batch-settlement scheme uses a per-scenario salt (CHANNEL_SALT) so concurrent
 // e2e runs don't collide on the same on-chain channel id. An optional voucher
@@ -114,9 +115,9 @@ const client = new x402Client()
   .register("eip155:*", batchSettlementScheme)
   .registerV1("base-sepolia", new ExactEvmSchemeV1(evmSigner))
   .registerV1("base", new ExactEvmSchemeV1(evmSigner))
-  .register("solana:*", new ExactSvmScheme(svmSigner))
-  .registerV1("solana-devnet", new ExactSvmSchemeV1(svmSigner))
-  .registerV1("solana", new ExactSvmSchemeV1(svmSigner));
+  .register("solana:*", new ExactSvmScheme(svmSigner, svmSchemeOptions))
+  .registerV1("solana-devnet", new ExactSvmSchemeV1(svmSigner, svmSchemeOptions))
+  .registerV1("solana", new ExactSvmSchemeV1(svmSigner, svmSchemeOptions));
 if (aptosAccount) {
   client.register("aptos:*", new ExactAptosScheme(aptosAccount));
 }

--- a/e2e/clients/fetch/index.ts
+++ b/e2e/clients/fetch/index.ts
@@ -53,6 +53,7 @@ const evmSchemeOptions: ExactEvmSchemeOptions | undefined = process.env.EVM_RPC_
 const uptoSchemeOptions: UptoEvmSchemeOptions | undefined = process.env.EVM_RPC_URL
   ? { rpcUrl: process.env.EVM_RPC_URL }
   : undefined;
+const svmSchemeOptions = process.env.SVM_RPC_URL ? { rpcUrl: process.env.SVM_RPC_URL } : undefined;
 
 // Batch-settlement scheme uses a per-scenario salt (CHANNEL_SALT) so concurrent
 // e2e runs don't collide on the same on-chain channel id. An optional voucher
@@ -113,9 +114,9 @@ const client = new x402Client()
   .register("eip155:*", batchSettlementScheme)
   .registerV1("base-sepolia", new ExactEvmSchemeV1(evmSigner))
   .registerV1("base", new ExactEvmSchemeV1(evmSigner))
-  .register("solana:*", new ExactSvmScheme(svmSigner))
-  .registerV1("solana-devnet", new ExactSvmSchemeV1(svmSigner))
-  .registerV1("solana", new ExactSvmSchemeV1(svmSigner));
+  .register("solana:*", new ExactSvmScheme(svmSigner, svmSchemeOptions))
+  .registerV1("solana-devnet", new ExactSvmSchemeV1(svmSigner, svmSchemeOptions))
+  .registerV1("solana", new ExactSvmSchemeV1(svmSigner, svmSchemeOptions));
 if (aptosAccount) {
   client.register("aptos:*", new ExactAptosScheme(aptosAccount));
 }

--- a/e2e/clients/go-http/main.go
+++ b/e2e/clients/go-http/main.go
@@ -16,6 +16,7 @@ import (
 	exactevm "github.com/x402-foundation/x402/go/v2/mechanisms/evm/exact/client"
 	exactevmv1 "github.com/x402-foundation/x402/go/v2/mechanisms/evm/exact/v1/client"
 	uptoevm "github.com/x402-foundation/x402/go/v2/mechanisms/evm/upto/client"
+	svmconfig "github.com/x402-foundation/x402/go/v2/mechanisms/svm"
 	svm "github.com/x402-foundation/x402/go/v2/mechanisms/svm/exact/client"
 	svmv1 "github.com/x402-foundation/x402/go/v2/mechanisms/svm/exact/v1/client"
 	evmsigners "github.com/x402-foundation/x402/go/v2/signers/evm"
@@ -96,6 +97,11 @@ func main() {
 		uptoConfig = &uptoevm.UptoEvmSchemeConfig{RPCURL: evmRpcURL}
 	}
 
+	var svmConfig *svmconfig.ClientConfig
+	if svmRpcURL := os.Getenv("SVM_RPC_URL"); svmRpcURL != "" {
+		svmConfig = &svmconfig.ClientConfig{RPCURL: svmRpcURL}
+	}
+
 	// Batch-settlement scheme uses a per-scenario salt (CHANNEL_SALT) so concurrent
 	// e2e runs don't collide on the same on-chain channel id. An optional voucher
 	// signer (EVM_VOUCHER_SIGNER_PRIVATE_KEY) exercises the alt-EOA voucher branch
@@ -118,11 +124,11 @@ func main() {
 		Register("eip155:*", exactevm.NewExactEvmScheme(evmSigner, evmConfig)).
 		Register("eip155:*", uptoevm.NewUptoEvmScheme(evmSigner, uptoConfig)).
 		Register("eip155:*", batchedScheme).
-		Register("solana:*", svm.NewExactSvmScheme(svmSigner)).
+		Register("solana:*", svm.NewExactSvmScheme(svmSigner, svmConfig)).
 		RegisterV1("base-sepolia", exactevmv1.NewExactEvmSchemeV1(evmSigner)).
 		RegisterV1("base", exactevmv1.NewExactEvmSchemeV1(evmSigner)).
-		RegisterV1("solana-devnet", svmv1.NewExactSvmSchemeV1(svmSigner)).
-		RegisterV1("solana", svmv1.NewExactSvmSchemeV1(svmSigner))
+		RegisterV1("solana-devnet", svmv1.NewExactSvmSchemeV1(svmSigner, svmConfig)).
+		RegisterV1("solana", svmv1.NewExactSvmSchemeV1(svmSigner, svmConfig))
 
 	httpClient := x402http.Newx402HTTPClient(x402Client)
 	client := x402http.WrapHTTPClientWithPayment(http.DefaultClient, httpClient)

--- a/e2e/clients/httpx/main.py
+++ b/e2e/clients/httpx/main.py
@@ -46,6 +46,7 @@ evm_private_key = os.getenv("EVM_PRIVATE_KEY")
 svm_private_key = os.getenv("SVM_PRIVATE_KEY")
 tvm_private_key = os.getenv("TVM_PRIVATE_KEY")
 evm_rpc_url = os.getenv("EVM_RPC_URL", "https://sepolia.base.org")
+svm_rpc_url = os.getenv("SVM_RPC_URL")
 tvm_provider = (os.getenv("TVM_PROVIDER") or "").strip().lower()
 toncenter_api_key = os.getenv("TONCENTER_API_KEY")
 toncenter_base_url = os.getenv("TONCENTER_BASE_URL")
@@ -107,7 +108,7 @@ async def main():
     # Register SVM exact scheme if private key is available
     if svm_private_key:
         svm_signer = KeypairSigner.from_base58(svm_private_key)
-        register_exact_svm_client(client, svm_signer)
+        register_exact_svm_client(client, svm_signer, rpc_url=svm_rpc_url)
 
     if tvm_private_key:
         if tvm_network not in {TVM_TESTNET, TVM_MAINNET}:

--- a/e2e/clients/httpx/uv.lock
+++ b/e2e/clients/httpx/uv.lock
@@ -2160,7 +2160,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/mcp-python/uv.lock
+++ b/e2e/clients/mcp-python/uv.lock
@@ -2260,7 +2260,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/mcp-typescript/package.json
+++ b/e2e/clients/mcp-typescript/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.15.1",
+    "@x402/core": "workspace:*",
     "@x402/evm": "workspace:*",
     "@x402/mcp": "workspace:*",
     "viem": "^2.48.11"

--- a/e2e/clients/requests/main.py
+++ b/e2e/clients/requests/main.py
@@ -35,6 +35,7 @@ evm_private_key = os.getenv("EVM_PRIVATE_KEY")
 svm_private_key = os.getenv("SVM_PRIVATE_KEY")
 tvm_private_key = os.getenv("TVM_PRIVATE_KEY")
 evm_rpc_url = os.getenv("EVM_RPC_URL", "https://sepolia.base.org")
+svm_rpc_url = os.getenv("SVM_RPC_URL")
 tvm_provider = (os.getenv("TVM_PROVIDER") or "").strip().lower()
 toncenter_api_key = os.getenv("TONCENTER_API_KEY")
 toncenter_base_url = os.getenv("TONCENTER_BASE_URL")
@@ -90,7 +91,7 @@ def main():
     # Register SVM exact scheme if private key is available
     if svm_private_key:
         svm_signer = KeypairSigner.from_base58(svm_private_key)
-        register_exact_svm_client(client, svm_signer)
+        register_exact_svm_client(client, svm_signer, rpc_url=svm_rpc_url)
 
     if tvm_private_key:
         if tvm_network not in {TVM_TESTNET, TVM_MAINNET}:

--- a/e2e/clients/requests/uv.lock
+++ b/e2e/clients/requests/uv.lock
@@ -2160,7 +2160,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/svm-smart-wallet/test.config.json
+++ b/e2e/clients/svm-smart-wallet/test.config.json
@@ -1,12 +1,27 @@
 {
   "name": "svm-smart-wallet",
   "type": "client",
+  "enabled": false,
   "language": "typescript",
-  "protocolFamilies": ["svm"],
-  "x402Versions": [2],
-  "schemes": ["exact"],
+  "protocolFamilies": [
+    "svm"
+  ],
+  "x402Versions": [
+    2
+  ],
+  "schemes": [
+    "exact"
+  ],
   "environment": {
-    "required": ["SVM_PRIVATE_KEY", "SWIG_ACCOUNT_ADDRESS", "RESOURCE_SERVER_URL", "ENDPOINT_PATH"],
-    "optional": ["SVM_RPC_URL", "SWIG_ID_BASE58"]
+    "required": [
+      "SVM_PRIVATE_KEY",
+      "SWIG_ACCOUNT_ADDRESS",
+      "RESOURCE_SERVER_URL",
+      "ENDPOINT_PATH"
+    ],
+    "optional": [
+      "SVM_RPC_URL",
+      "SWIG_ID_BASE58"
+    ]
   }
 }

--- a/e2e/facilitators/go/main.go
+++ b/e2e/facilitators/go/main.go
@@ -313,31 +313,36 @@ func (s *realFacilitatorEvmSigner) WriteContract(
 	}
 	data = evmmech.AppendDataSuffix(data, dataSuffix)
 
+	// Get nonce
 	nonce, err := s.reserveNonce(ctx)
 	if err != nil {
 		return "", err
 	}
 
+	// Get gas price
 	gasPrice, err := s.client.SuggestGasPrice(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get gas price: %w", err)
 	}
 
+	// Create transaction
 	to := common.HexToAddress(contractAddress)
 	tx := types.NewTransaction(
 		nonce,
 		to,
-		big.NewInt(0),
-		300000,
+		big.NewInt(0), // value
+		300000,        // gas limit
 		gasPrice,
 		data,
 	)
 
+	// Sign transaction
 	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(s.chainID), s.privateKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to sign transaction: %w", err)
 	}
 
+	// Send transaction
 	err = s.client.SendTransaction(ctx, signedTx)
 	if err != nil {
 		return "", fmt.Errorf("failed to send transaction: %w", err)
@@ -351,31 +356,36 @@ func (s *realFacilitatorEvmSigner) SendTransaction(
 	to string,
 	data []byte,
 ) (string, error) {
+	// Get nonce
 	nonce, err := s.reserveNonce(ctx)
 	if err != nil {
 		return "", err
 	}
 
+	// Get gas price
 	gasPrice, err := s.client.SuggestGasPrice(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get gas price: %w", err)
 	}
 
+	// Create transaction with raw data
 	toAddr := common.HexToAddress(to)
 	tx := types.NewTransaction(
 		nonce,
 		toAddr,
-		big.NewInt(0),
-		300000,
+		big.NewInt(0), // value
+		300000,        // gas limit
 		gasPrice,
 		data,
 	)
 
+	// Sign transaction
 	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(s.chainID), s.privateKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to sign transaction: %w", err)
 	}
 
+	// Send transaction
 	err = s.client.SendTransaction(ctx, signedTx)
 	if err != nil {
 		return "", fmt.Errorf("failed to send transaction: %w", err)

--- a/e2e/facilitators/go/main.go
+++ b/e2e/facilitators/go/main.go
@@ -68,6 +68,9 @@ type realFacilitatorEvmSigner struct {
 	address    common.Address
 	client     *ethclient.Client
 	chainID    *big.Int
+	nonceMu    sync.Mutex
+	nextNonce  uint64
+	nonceInit  bool
 }
 
 func newRealFacilitatorEvmSigner(privateKeyHex string, rpcURL string) (*realFacilitatorEvmSigner, error) {
@@ -108,6 +111,26 @@ func (s *realFacilitatorEvmSigner) GetAddresses() []string {
 
 func (s *realFacilitatorEvmSigner) GetChainID(ctx context.Context) (*big.Int, error) {
 	return s.chainID, nil
+}
+
+func (s *realFacilitatorEvmSigner) reserveNonce(ctx context.Context) (uint64, error) {
+	s.nonceMu.Lock()
+	defer s.nonceMu.Unlock()
+
+	// Sync with chain so txs from outside this process (e.g. e2e harness
+	// fundClientForRevoke) are reflected before we reserve the next nonce.
+	pending, err := s.client.PendingNonceAt(ctx, s.address)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get nonce: %w", err)
+	}
+	if !s.nonceInit || pending > s.nextNonce {
+		s.nextNonce = pending
+		s.nonceInit = true
+	}
+
+	nonce := s.nextNonce
+	s.nextNonce++
+	return nonce, nil
 }
 
 func (s *realFacilitatorEvmSigner) VerifyTypedData(
@@ -290,36 +313,31 @@ func (s *realFacilitatorEvmSigner) WriteContract(
 	}
 	data = evmmech.AppendDataSuffix(data, dataSuffix)
 
-	// Get nonce
-	nonce, err := s.client.PendingNonceAt(ctx, s.address)
+	nonce, err := s.reserveNonce(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get nonce: %w", err)
+		return "", err
 	}
 
-	// Get gas price
 	gasPrice, err := s.client.SuggestGasPrice(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get gas price: %w", err)
 	}
 
-	// Create transaction
 	to := common.HexToAddress(contractAddress)
 	tx := types.NewTransaction(
 		nonce,
 		to,
-		big.NewInt(0), // value
-		300000,        // gas limit
+		big.NewInt(0),
+		300000,
 		gasPrice,
 		data,
 	)
 
-	// Sign transaction
 	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(s.chainID), s.privateKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to sign transaction: %w", err)
 	}
 
-	// Send transaction
 	err = s.client.SendTransaction(ctx, signedTx)
 	if err != nil {
 		return "", fmt.Errorf("failed to send transaction: %w", err)
@@ -333,36 +351,31 @@ func (s *realFacilitatorEvmSigner) SendTransaction(
 	to string,
 	data []byte,
 ) (string, error) {
-	// Get nonce
-	nonce, err := s.client.PendingNonceAt(ctx, s.address)
+	nonce, err := s.reserveNonce(ctx)
 	if err != nil {
-		return "", fmt.Errorf("failed to get nonce: %w", err)
+		return "", err
 	}
 
-	// Get gas price
 	gasPrice, err := s.client.SuggestGasPrice(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to get gas price: %w", err)
 	}
 
-	// Create transaction with raw data
 	toAddr := common.HexToAddress(to)
 	tx := types.NewTransaction(
 		nonce,
 		toAddr,
-		big.NewInt(0), // value
-		300000,        // gas limit
+		big.NewInt(0),
+		300000,
 		gasPrice,
 		data,
 	)
 
-	// Sign transaction
 	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(s.chainID), s.privateKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to sign transaction: %w", err)
 	}
 
-	// Send transaction
 	err = s.client.SendTransaction(ctx, signedTx)
 	if err != nil {
 		return "", fmt.Errorf("failed to send transaction: %w", err)
@@ -469,9 +482,9 @@ func (s *realFacilitatorEvmSigner) fundPayerGasIfNeeded(ctx context.Context, dec
 	deficit := new(big.Int).Sub(gasCost, payerBalance)
 	log.Printf("⛽ Funding payer %s with %s wei for gas", payerAddr.Hex(), deficit.String())
 
-	fundNonce, err := s.client.PendingNonceAt(ctx, s.address)
+	fundNonce, err := s.reserveNonce(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get funding nonce: %w", err)
+		return err
 	}
 	fundGasPrice, err := s.client.SuggestGasPrice(ctx)
 	if err != nil {

--- a/e2e/facilitators/python/main.py
+++ b/e2e/facilitators/python/main.py
@@ -156,9 +156,7 @@ class Erc20ApprovalSigner:
                         "value": deficit,
                         "gas": 21000,
                         "gasPrice": w3.eth.gas_price,
-                        "nonce": w3.eth.get_transaction_count(
-                            self._signer._account.address
-                        ),
+                        "nonce": self._signer._reserve_nonce(),
                         "chainId": w3.eth.chain_id,
                     }
                     signed_fund = self._signer._account.sign_transaction(fund_tx)

--- a/e2e/facilitators/python/uv.lock
+++ b/e2e/facilitators/python/uv.lock
@@ -3115,7 +3115,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -1797,145 +1797,6 @@ importers:
         specifier: ^5.3.0
         version: 5.8.3
 
-  facilitators/external-proxies/cdp:
-    dependencies:
-      '@coinbase/x402':
-        specifier: ^0.7.3
-        version: 0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.21.0
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-
-  facilitators/external-proxies/cdp-dev:
-    dependencies:
-      '@coinbase/cdp-sdk':
-        specifier: ^1.22.0
-        version: 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.21.0
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-      x402:
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/legacy/x402
-
-  facilitators/external-proxies/cdp-local:
-    dependencies:
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.21.0
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-      x402:
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/legacy/x402
-
-  facilitators/external-proxies/x402.org:
-    dependencies:
-      '@coinbase/x402':
-        specifier: ^0.7.3
-        version: 0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@x402/core':
-        specifier: workspace:*
-        version: link:../../../../typescript/packages/core
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.6.1
-      express:
-        specifier: ^4.19.2
-        version: 4.21.2
-    devDependencies:
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
-      '@types/node':
-        specifier: ^22.10.1
-        version: 22.16.0
-      eslint:
-        specifier: ^9.15.0
-        version: 9.38.0(jiti@1.21.7)
-      prettier:
-        specifier: ^3.3.3
-        version: 3.5.2
-      tsx:
-        specifier: ^4.19.2
-        version: 4.21.0
-      typescript:
-        specifier: ^5.7.2
-        version: 5.8.3
-
   facilitators/typescript:
     dependencies:
       '@aptos-labs/ts-sdk':
@@ -3306,9 +3167,6 @@ packages:
 
   '@coinbase/wallet-sdk@4.3.6':
     resolution: {integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==}
-
-  '@coinbase/x402@0.7.3':
-    resolution: {integrity: sha512-mSxxbPnDCvSLfq6ZZAB5P1HyYQfQNSdWyY01Cn7yjzTuGUFFgZ7onDkbZnZ1Yry0UnG467aqrmjs6AgoYgpzCQ==}
 
   '@craftamap/esbuild-plugin-html@0.9.0':
     resolution: {integrity: sha512-V5LFrcGXQWU1SSzYPwxEFjF8IjeXW0oTKh5c0xyhGuTNoEnjgJRNSX83HnZ5TTAutJfo/MAyWA4Z9/fIwbMhUQ==}
@@ -11114,9 +10972,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  x402@0.7.3:
-    resolution: {integrity: sha512-8CIZsdMTOn52PjMH/ErVke9ebeZ7ErwiZ5FL3tN3Wny7Ynxs3LkuB/0q7IoccRLdVXA7f2lueYBJ2iDrElhXnA==}
-
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -12116,26 +11971,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@base-org/account@1.1.1(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@3.25.71)
-      preact: 10.24.2
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zustand: 5.0.3(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
   '@blockshake/defly-connect@1.2.1(algosdk@3.5.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@likecoin/qr-code-styling': 1.6.6
@@ -12148,29 +11983,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana-program/system': 0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token': 0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/web3.js': 1.98.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      abitype: 1.0.6(typescript@5.8.3)(zod@3.25.71)
-      axios: 1.12.2
-      axios-retry: 4.5.0(axios@1.12.2)
-      jose: 6.1.3
-      md5: 2.3.0
-      uncrypto: 0.1.3
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zod: 3.25.71
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - typescript
-      - utf-8-validate
-      - ws
 
   '@coinbase/cdp-sdk@1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
@@ -12295,67 +12107,6 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
-
-  '@coinbase/wallet-sdk@4.3.6(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@3.25.71)
-      preact: 10.24.2
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zustand: 5.0.3(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-
-  '@coinbase/x402@0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@coinbase/cdp-sdk': 1.38.4(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      x402: 0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      zod: 3.25.71
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - ws
 
   '@craftamap/esbuild-plugin-html@0.9.0(bufferutil@4.0.9)(esbuild@0.27.7)(utf-8-validate@5.0.10)':
     dependencies:
@@ -13799,41 +13550,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      valtio: 1.13.2(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-pay@1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
@@ -13878,42 +13594,6 @@ snapshots:
       '@reown/appkit-utils': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.2)(react@19.2.1))(zod@3.25.71)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-pay@1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.6))(zod@3.25.71)
-      lit: 3.3.0
-      valtio: 1.13.2(react@19.2.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -14020,43 +13700,6 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-scaffold-ui@1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.6))(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.6))(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - valtio
-      - zod
-
   '@reown/appkit-ui@1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12)
@@ -14096,41 +13739,6 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@reown/appkit-controllers': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-      qrcode: 1.5.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-ui@1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -14238,44 +13846,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.6))(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      valtio: 1.13.2(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-wallet@1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -14344,49 +13914,6 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit@1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-pay': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.6))(zod@3.25.71)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.6))(zod@3.25.71)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      bs58: 6.0.0
-      valtio: 1.13.2(react@19.2.6)
       viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -14598,10 +14125,6 @@ snapshots:
     dependencies:
       '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
-    dependencies:
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-
   '@solana-program/system@0.8.1(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -14633,10 +14156,6 @@ snapshots:
   '@solana-program/token@0.5.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-
-  '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
-    dependencies:
-      '@solana/kit': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   '@solana-program/token@0.6.0(@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
@@ -15222,32 +14741,6 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/codecs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/functional': 3.0.3(typescript@5.8.3)
-      '@solana/instruction-plans': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/instructions': 3.0.3(typescript@5.8.3)
-      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/programs': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-parsed-types': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-spec-types': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/signers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/sysvars': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transaction-confirmation': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
   '@solana/kit@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -15808,15 +15301,6 @@ snapshots:
       typescript: 5.8.3
       ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
-  '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/functional': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.8.3)
-      '@solana/subscribable': 3.0.3(typescript@5.8.3)
-      typescript: 5.8.3
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-
   '@solana/rpc-subscriptions-channel-websocket@3.0.3(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 3.0.3(typescript@5.8.3)
@@ -15932,24 +15416,6 @@ snapshots:
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       '@solana/subscribable': 2.3.0(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/rpc-subscriptions@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/fast-stable-stringify': 3.0.3(typescript@5.8.3)
-      '@solana/functional': 3.0.3(typescript@5.8.3)
-      '@solana/promises': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-spec-types': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-subscriptions-api': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions-channel-websocket': 3.0.3(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-subscriptions-spec': 3.0.3(typescript@5.8.3)
-      '@solana/rpc-transformers': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/subscribable': 3.0.3(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -16448,23 +15914,6 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - ws
 
-  '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/codecs-strings': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/errors': 3.0.3(typescript@5.8.3)
-      '@solana/keys': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/promises': 3.0.3(typescript@5.8.3)
-      '@solana/rpc': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/rpc-subscriptions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transaction-messages': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/transactions': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
   '@solana/transaction-confirmation@3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/addresses': 3.0.3(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -16906,11 +16355,6 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.8
       react: 19.2.1
-
-  '@tanstack/react-query@5.90.8(react@19.2.6)':
-    dependencies:
-      '@tanstack/query-core': 5.90.8
-      react: 19.2.6
 
   '@tanstack/store@0.8.0': {}
 
@@ -17545,53 +16989,6 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/connectors@6.1.0(@tanstack/react-query@5.90.8(react@19.2.6))(@wagmi/core@2.22.1(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))(zod@3.25.71)':
-    dependencies:
-      '@base-org/account': 1.1.1(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@coinbase/wallet-sdk': 4.3.6(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@gemini-wallet/core': 0.2.0(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@wagmi/core': 2.22.1(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      '@walletconnect/ethereum-provider': 2.21.1(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.19(@tanstack/react-query@5.90.8(react@19.2.6))(@wagmi/core@2.22.1(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - uploadthing
-      - use-sync-external-store
-      - utf-8-validate
-      - wagmi
-      - zod
-
   '@wagmi/core@2.22.1(@tanstack/query-core@5.90.8)(@types/react@19.2.2)(react@19.2.0)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.0))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.1.12))':
     dependencies:
       eventemitter3: 5.0.1
@@ -17615,20 +17012,6 @@ snapshots:
       zustand: 5.0.0(@types/react@19.2.2)(react@19.2.1)(use-sync-external-store@1.4.0(react@19.2.1))
     optionalDependencies:
       '@tanstack/query-core': 5.90.8
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
-
-  '@wagmi/core@2.22.1(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@5.8.3)
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zustand: 5.0.0(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
-    optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
       - '@types/react'
@@ -17956,47 +17339,6 @@ snapshots:
   '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
     dependencies:
       '@reown/appkit': 1.7.8(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@walletconnect/jsonrpc-http-connection': 1.0.8
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/ethereum-provider@2.21.1(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
-    dependencies:
-      '@reown/appkit': 1.7.8(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
@@ -19708,10 +19050,6 @@ snapshots:
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.2)(react@19.2.1)):
     dependencies:
       valtio: 1.13.2(@types/react@19.2.2)(react@19.2.1)
-
-  derive-valtio@0.1.0(valtio@1.13.2(react@19.2.6)):
-    dependencies:
-      valtio: 1.13.2(react@19.2.6)
 
   des.js@1.1.0:
     dependencies:
@@ -22275,26 +21613,6 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  porto@0.2.19(@tanstack/react-query@5.90.8(react@19.2.6))(@wagmi/core@2.22.1(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)):
-    dependencies:
-      '@wagmi/core': 2.22.1(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      hono: 4.10.2
-      idb-keyval: 6.2.2
-      mipd: 0.0.7(typescript@5.8.3)
-      ox: 0.9.12(typescript@5.8.3)(zod@4.1.12)
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      zod: 4.1.12
-      zustand: 5.0.8(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
-    optionalDependencies:
-      '@tanstack/react-query': 5.90.8(react@19.2.6)
-      react: 19.2.6
-      typescript: 5.8.3
-      wagmi: 2.18.2(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - use-sync-external-store
-
   poseidon-lite@0.2.1: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -23577,10 +22895,6 @@ snapshots:
     dependencies:
       react: 19.2.1
 
-  use-sync-external-store@1.2.0(react@19.2.6):
-    dependencies:
-      react: 19.2.6
-
   use-sync-external-store@1.4.0(react@19.2.0):
     dependencies:
       react: 19.2.0
@@ -23588,10 +22902,6 @@ snapshots:
   use-sync-external-store@1.4.0(react@19.2.1):
     dependencies:
       react: 19.2.1
-
-  use-sync-external-store@1.4.0(react@19.2.6):
-    dependencies:
-      react: 19.2.6
 
   utf-8-validate@5.0.10:
     dependencies:
@@ -23632,14 +22942,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       react: 19.2.1
-
-  valtio@1.13.2(react@19.2.6):
-    dependencies:
-      derive-valtio: 0.1.0(valtio@1.13.2(react@19.2.6))
-      proxy-compare: 2.6.0
-      use-sync-external-store: 1.2.0(react@19.2.6)
-    optionalDependencies:
-      react: 19.2.6
 
   vary@1.1.2: {}
 
@@ -23905,45 +23207,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71):
-    dependencies:
-      '@tanstack/react-query': 5.90.8(react@19.2.6)
-      '@wagmi/connectors': 6.1.0(@tanstack/react-query@5.90.8(react@19.2.6))(@wagmi/core@2.22.1(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)))(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(wagmi@2.18.2(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71))(zod@3.25.71)
-      '@wagmi/core': 2.22.1(react@19.2.6)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
-      react: 19.2.6
-      use-sync-external-store: 1.4.0(react@19.2.6)
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - immer
-      - ioredis
-      - supports-color
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -24084,54 +23347,6 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
-  x402@0.7.3(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10):
-    dependencies:
-      '@scure/base': 1.2.6
-      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana-program/token': 0.9.0(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))
-      '@solana-program/token-2022': 0.6.1(@solana/kit@5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      '@solana/kit': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/transaction-confirmation': 5.3.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
-      '@solana/wallet-standard-features': 1.3.0
-      '@wallet-standard/app': 1.1.0
-      '@wallet-standard/base': 1.1.0
-      '@wallet-standard/features': 1.1.0
-      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
-      wagmi: 2.18.2(@tanstack/react-query@5.90.8(react@19.2.6))(bufferutil@4.0.9)(react@19.2.6)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))(zod@3.25.71)
-      zod: 3.25.71
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
-
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -24211,11 +23426,6 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
 
-  zustand@5.0.0(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6)):
-    optionalDependencies:
-      react: 19.2.6
-      use-sync-external-store: 1.4.0(react@19.2.6)
-
   zustand@5.0.3(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0)):
     optionalDependencies:
       '@types/react': 19.2.2
@@ -24228,11 +23438,6 @@ snapshots:
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
 
-  zustand@5.0.3(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6)):
-    optionalDependencies:
-      react: 19.2.6
-      use-sync-external-store: 1.4.0(react@19.2.6)
-
   zustand@5.0.8(@types/react@19.2.2)(react@19.2.0)(use-sync-external-store@1.4.0(react@19.2.0)):
     optionalDependencies:
       '@types/react': 19.2.2
@@ -24244,8 +23449,3 @@ snapshots:
       '@types/react': 19.2.2
       react: 19.2.1
       use-sync-external-store: 1.4.0(react@19.2.1)
-
-  zustand@5.0.8(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6)):
-    optionalDependencies:
-      react: 19.2.6
-      use-sync-external-store: 1.4.0(react@19.2.6)

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -1689,6 +1689,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.15.1
         version: 1.25.3(hono@4.10.2)(zod@4.1.12)
+      '@x402/core':
+        specifier: workspace:*
+        version: link:../../../typescript/packages/core
       '@x402/evm':
         specifier: workspace:*
         version: link:../../../typescript/packages/mechanisms/evm

--- a/e2e/scripts/ci-select-families.sh
+++ b/e2e/scripts/ci-select-families.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Detect which protocol families can run based on configured wallet env vars.
+# Prints a comma-separated list (e.g. evm,svm) to stdout.
+# Exits 1 when no family has all required secrets.
+#
+# Reads from the current shell environment. When unset, loads e2e/.env
+# (same variables as pnpm test / CI) without overriding existing exports.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$E2E_DIR/.env"
+
+load_env_file() {
+  local file=$1
+  [[ -f "$file" ]] || return 0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+
+    if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      local key="${BASH_REMATCH[1]}"
+      local val="${BASH_REMATCH[2]}"
+      # Strip optional surrounding quotes
+      if [[ "$val" =~ ^\"(.*)\"$ ]]; then
+        val="${BASH_REMATCH[1]}"
+      elif [[ "$val" =~ ^\'(.*)\'$ ]]; then
+        val="${BASH_REMATCH[1]}"
+      fi
+      if [[ -z "${!key:-}" ]]; then
+        export "$key=$val"
+      fi
+    fi
+  done < "$file"
+}
+
+load_env_file "$ENV_FILE"
+
+families=()
+
+all_set() {
+  for var in "$@"; do
+    if [[ -z "${!var:-}" ]]; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+if all_set SERVER_EVM_ADDRESS CLIENT_EVM_PRIVATE_KEY FACILITATOR_EVM_PRIVATE_KEY; then
+  families+=("evm")
+fi
+
+if all_set SERVER_SVM_ADDRESS CLIENT_SVM_PRIVATE_KEY FACILITATOR_SVM_PRIVATE_KEY; then
+  families+=("svm")
+fi
+
+if all_set SERVER_AVM_ADDRESS CLIENT_AVM_PRIVATE_KEY FACILITATOR_AVM_PRIVATE_KEY; then
+  families+=("avm")
+fi
+
+if all_set SERVER_APTOS_ADDRESS CLIENT_APTOS_PRIVATE_KEY FACILITATOR_APTOS_PRIVATE_KEY; then
+  families+=("aptos")
+fi
+
+if all_set \
+  SERVER_HEDERA_ADDRESS \
+  CLIENT_HEDERA_ACCOUNT_ID \
+  CLIENT_HEDERA_PRIVATE_KEY \
+  FACILITATOR_HEDERA_ACCOUNT_ID \
+  FACILITATOR_HEDERA_PRIVATE_KEY; then
+  families+=("hedera")
+fi
+
+if all_set SERVER_STELLAR_ADDRESS CLIENT_STELLAR_PRIVATE_KEY FACILITATOR_STELLAR_PRIVATE_KEY; then
+  families+=("stellar")
+fi
+
+if all_set SERVER_TVM_ADDRESS CLIENT_TVM_PRIVATE_KEY FACILITATOR_TVM_PRIVATE_KEY; then
+  families+=("tvm")
+fi
+
+if [[ ${#families[@]} -eq 0 ]]; then
+  echo "No protocol families have all required wallet secrets configured." >&2
+  echo "Set variables in e2e/.env or export them in your shell." >&2
+  exit 1
+fi
+
+(IFS=','; echo "${families[*]}")

--- a/e2e/scripts/permit2-approval.ts
+++ b/e2e/scripts/permit2-approval.ts
@@ -70,6 +70,20 @@ const erc20Abi = parseAbi([
   'function balanceOf(address account) view returns (uint256)',
 ]);
 
+async function waitForApprovalReceipt(
+  publicClient: {
+    waitForTransactionReceipt: (args: { hash: `0x${string}` }) => Promise<{ status: string }>;
+  },
+  hash: `0x${string}`,
+  actionLabel: string,
+) {
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+  if (receipt.status !== 'success') {
+    throw new Error(`${actionLabel} transaction failed: ${hash}`);
+  }
+  console.log(`   ✅ ${actionLabel} confirmed (tx: ${hash})`);
+}
+
 async function main() {
   const action = process.argv[2];
   const tokenAddressArg = process.argv[3];
@@ -176,6 +190,7 @@ Environment variables required:
       });
 
       console.log(`   ✅ Revoke submitted (tx: ${hash})`);
+      await waitForApprovalReceipt(publicClient, hash, 'Revoke');
     }
     return;
   }
@@ -198,6 +213,7 @@ Environment variables required:
     });
 
     console.log(`   ✅ Approve submitted (tx: ${hash})`);
+    await waitForApprovalReceipt(publicClient, hash, 'Approve');
   }
 }
 

--- a/e2e/servers/fastapi/uv.lock
+++ b/e2e/servers/fastapi/uv.lock
@@ -3115,7 +3115,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/flask/uv.lock
+++ b/e2e/servers/flask/uv.lock
@@ -2313,7 +2313,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/mcp-python/uv.lock
+++ b/e2e/servers/mcp-python/uv.lock
@@ -2260,7 +2260,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/mcp-typescript/test.config.json
+++ b/e2e/servers/mcp-typescript/test.config.json
@@ -39,7 +39,10 @@
       "requiresPayment": true,
       "protocolFamily": "evm",
       "scheme": "batch-settlement",
-      "assetTransferMethod": "permit2"
+      "assetTransferMethod": "permit2",
+      "schemeOptions": {
+        "permit2Direct": true
+      }
     },
     {
       "path": "/health",

--- a/e2e/servers/next/next.config.ts
+++ b/e2e/servers/next/next.config.ts
@@ -1,5 +1,15 @@
+import path from "node:path";
+
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {};
+// Workspace packages live in typescript/packages, outside e2e.
+const monorepoRoot = path.resolve(process.cwd(), "../../..");
+
+const nextConfig: NextConfig = {
+  turbopack: {
+    root: monorepoRoot,
+  },
+  outputFileTracingRoot: monorepoRoot,
+};
 
 export default nextConfig;

--- a/e2e/src/concurrency.ts
+++ b/e2e/src/concurrency.ts
@@ -2,8 +2,8 @@
  * Concurrency utilities for parallel E2E test execution.
  *
  * - Semaphore: bounds how many combos run at once.
- * - FacilitatorLock: async mutex keyed by facilitator name, used to serialize
- *   EVM tests through the same facilitator (prevents nonce collisions).
+ * - ResourceLock: async mutex keyed by arbitrary strings, used to serialize
+ *   access to shared mutable network/account state across facilitator processes.
  */
 
 /**
@@ -41,29 +41,24 @@ export class Semaphore {
 }
 
 /**
- * Per-facilitator async mutex for EVM tests.
+ * Keyed async mutex for shared resources (EVM accounts, Permit2 state, etc.).
  *
- * EVM transactions use `PendingNonceAt()` — two concurrent EVM tests routed
- * through the same facilitator will get the same nonce and one will fail.
- * This lock serializes EVM tests per facilitator while allowing SVM tests
- * (which use blockhash + random memo) to proceed freely.
+ * Parallel E2E runs multiple server+facilitator combos that may share the same
+ * on-chain accounts across Go, Python, and TypeScript facilitator processes.
+ * This lock serializes work that touches those accounts while leaving unrelated
+ * scenarios fully parallel.
  */
-export class FacilitatorLock {
+export class ResourceLock {
   private locks = new Map<string, Promise<void>>();
 
   /**
-   * Acquire the EVM lock for a facilitator. Returns a release function.
-   * Only call this for EVM tests — SVM tests should skip locking entirely.
+   * Acquire the lock for a resource key. Returns a release function.
    */
-  async acquire(facilitatorName: string): Promise<() => void> {
-    const key = `evm:${facilitatorName}`;
-
-    // Wait for the current holder (if any) to finish
+  async acquire(key: string): Promise<() => void> {
     while (this.locks.has(key)) {
       await this.locks.get(key);
     }
 
-    // Set up our own lock
     let releaseFn: () => void;
     const lockPromise = new Promise<void>((resolve) => {
       releaseFn = resolve;
@@ -73,6 +68,22 @@ export class FacilitatorLock {
     return () => {
       this.locks.delete(key);
       releaseFn!();
+    };
+  }
+
+  /**
+   * Acquire multiple resource locks in a stable order to avoid deadlocks.
+   */
+  async acquireAll(keys: string[]): Promise<() => void> {
+    const uniqueKeys = [...new Set(keys)].sort();
+    const releases: Array<() => void> = [];
+    for (const key of uniqueKeys) {
+      releases.push(await this.acquire(key));
+    }
+    return () => {
+      for (const release of releases.reverse()) {
+        release();
+      }
     };
   }
 }

--- a/e2e/src/discovery.ts
+++ b/e2e/src/discovery.ts
@@ -64,7 +64,7 @@ export class TestDiscovery {
           const configContent = readFileSync(configPath, 'utf-8');
           const config: TestConfig = JSON.parse(configContent);
 
-          if (config.type === 'server') {
+          if (config.type === 'server' && config.enabled !== false) {
             servers.push({
               name: namePrefix + serverName,
               directory: serverDir,
@@ -157,7 +157,7 @@ export class TestDiscovery {
           const configContent = readFileSync(configPath, 'utf-8');
           const config: TestConfig = JSON.parse(configContent);
 
-          if (config.type === 'facilitator') {
+          if (config.type === 'facilitator' && config.enabled !== false) {
             facilitators.push({
               name: namePrefix + facilitatorName,
               directory: facilitatorDir,
@@ -190,7 +190,7 @@ export class TestDiscovery {
           const configContent = readFileSync(configPath, 'utf-8');
           const config: TestConfig = JSON.parse(configContent);
 
-          if (config.type === 'client') {
+          if (config.type === 'client' && config.enabled !== false) {
             clients.push({
               name: namePrefix + clientName,
               directory: clientDir,

--- a/e2e/src/ports.ts
+++ b/e2e/src/ports.ts
@@ -1,0 +1,21 @@
+// Ports blocked by the Fetch spec; Node.js fetch (undici) refuses to connect to them.
+// See https://fetch.spec.whatwg.org/#block-bad-port
+const FETCH_BLOCKED_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79,
+  87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137,
+  139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532,
+  540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719, 1720, 1723,
+  2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669, 6679,
+  6697, 10080,
+]);
+
+/** Returns successive ports, skipping those blocked by Node.js fetch. */
+export function createPortAllocator(startPort = 4022): () => number {
+  let next = startPort;
+  return () => {
+    while (FETCH_BLOCKED_PORTS.has(next)) {
+      next++;
+    }
+    return next++;
+  };
+}

--- a/e2e/src/types.ts
+++ b/e2e/src/types.ts
@@ -145,6 +145,7 @@ export interface TestEndpoint {
 export interface TestConfig {
   name: string;
   type: 'server' | 'client' | 'facilitator';
+  enabled?: boolean;
   transport?: Transport;
   language: string;
   protocolFamilies?: ProtocolFamily[];

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -1490,12 +1490,26 @@ async function runTest() {
         const resourceKeys = getScenarioResourceKeys(scenario, evmResourceKeyContext);
 
         const runScenario = async (): Promise<DetailedTestResult> => {
+          const setupFailure = (error: string): DetailedTestResult => ({
+            testNumber: tn,
+            client: scenario.client.name,
+            server: scenario.server.name,
+            endpoint: scenario.endpoint.path,
+            facilitator: scenario.facilitator?.name || 'none',
+            protocolFamily: scenario.protocolFamily,
+            passed: false,
+            error,
+          });
+
           if (scenario.client.name === 'svm-smart-wallet') {
             await setupSwigWallet(networks.svm.rpcUrl);
           }
 
           if (scenario.endpoint.schemeOptions?.permit2Direct === true) {
-            await approvePermit2Approval(evmPermit2Asset);
+            const approved = await approvePermit2Approval(evmPermit2Asset);
+            if (!approved) {
+              return setupFailure('Permit2 approval setup failed');
+            }
           } else if (scenario.endpoint.schemeOptions?.coldstart === true) {
             // Key on (client, path) so each client independently runs its own
             // fund → revoke → drain cycle. Without the client name, the second
@@ -1503,17 +1517,26 @@ async function runTest() {
             // whatever wallet state the first client left behind.
             const endpointKey = `${scenario.client.name}::${scenario.endpoint.path}`;
             if (!coldStartedEndpoints.has(endpointKey)) {
-              coldStartedEndpoints.add(endpointKey);
-              await fundClientForRevoke();
+              const funded = await fundClientForRevoke();
+              if (!funded) {
+                return setupFailure('Client gas funding setup failed');
+              }
               // Give fund tx 1s to propagate before submitting revoke (from client wallet)
               await new Promise(resolve => setTimeout(resolve, 1000));
-              await revokePermit2Approval(evmPermit2Asset);
+              const revoked = await revokePermit2Approval(evmPermit2Asset);
+              if (!revoked) {
+                return setupFailure('Permit2 revoke setup failed');
+              }
               // Give revoke tx 2s to propagate before drain reads pending nonce.
               // Load-balanced RPCs can return a stale pending nonce if queried
               // immediately after the revoke submission, causing the drain to
               // collide with the revoke's nonce ("replacement transaction underpriced").
               await new Promise(resolve => setTimeout(resolve, 2000));
-              await drainClientETH();
+              const drained = await drainClientETH();
+              if (!drained) {
+                return setupFailure('Client ETH drain setup failed');
+              }
+              coldStartedEndpoints.add(endpointKey);
               // Wait for RPC nonce propagation across load-balanced nodes before the
               // test client (which may use a separate RPC connection) queries the nonce.
               await new Promise(resolve => setTimeout(resolve, 1500));

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -1,4 +1,4 @@
-import { config } from 'dotenv';
+import 'dotenv/config';
 import { spawn, execSync, ChildProcess } from 'child_process';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
@@ -398,9 +398,6 @@ async function drainClientETH(): Promise<boolean> {
     return false;
   }
 }
-
-// Load environment variables
-config();
 
 // Parse command line arguments
 const parsedArgs = parseArgs();

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -15,7 +15,7 @@ import { filterScenarios, TestFilters, shouldShowExtensionOutput } from './src/c
 import { minimizeScenarios } from './src/sampling';
 import { getNetworkSet, NetworkMode, getNetworkModeDescription, resolveEvmPermit2Asset } from './src/networks/networks';
 import { GenericServerProxy } from './src/servers/generic-server';
-import { Semaphore, FacilitatorLock } from './src/concurrency';
+import { Semaphore, ResourceLock } from './src/concurrency';
 import { FacilitatorManager } from './src/facilitators/facilitator-manager';
 import { waitForHealth } from './src/health';
 import { createPortAllocator } from './src/ports';
@@ -241,6 +241,47 @@ function getEvmClients() {
   });
 
   return { publicClient, facilitatorWallet, clientWallet, facilitatorAccount, clientAccount };
+}
+
+type EvmResourceKeyContext = {
+  evmCaip2: string;
+  evmPermit2Asset: string | undefined;
+  clientEvmAddress: string | undefined;
+  facilitatorEvmAddress: string | undefined;
+};
+
+/**
+ * Derive shared-resource lock keys for a scenario. Scenarios without shared
+ * mutable state return an empty list and stay fully parallel.
+ */
+function getScenarioResourceKeys(
+  scenario: TestScenario,
+  ctx: EvmResourceKeyContext,
+): string[] {
+  if (scenario.protocolFamily !== 'evm') {
+    return [];
+  }
+
+  const facilitatorAddress = ctx.facilitatorEvmAddress;
+  if (!facilitatorAddress) {
+    return [];
+  }
+
+  const keys: string[] = [
+    `evm:${ctx.evmCaip2}:facilitator:${facilitatorAddress.toLowerCase()}`,
+  ];
+
+  const touchesClientPermit2State =
+    scenario.endpoint.schemeOptions?.permit2Direct === true ||
+    scenario.endpoint.schemeOptions?.coldstart === true;
+
+  if (touchesClientPermit2State && ctx.clientEvmAddress && ctx.evmPermit2Asset) {
+    keys.push(
+      `evm:${ctx.evmCaip2}:client:${ctx.clientEvmAddress.toLowerCase()}:permit2:${ctx.evmPermit2Asset.toLowerCase()}`,
+    );
+  }
+
+  return keys;
 }
 
 const REVOKE_FUND_AMOUNT = parseEther('0.001');
@@ -1333,7 +1374,8 @@ async function runTest() {
   // ── Execute a single server+facilitator combo ─────────────────────────
   async function executeCombo(
     combo: ServerFacilitatorCombo,
-    evmLock: FacilitatorLock | null,
+    resourceLock: ResourceLock | null,
+    evmResourceKeyContext: EvmResourceKeyContext,
     nextTestNumber: () => number,
   ): Promise<DetailedTestResult[]> {
     const { serverName, facilitatorName, scenarios, port } = combo;
@@ -1420,50 +1462,45 @@ async function runTest() {
       for (const scenario of scenarios) {
         const tn = nextTestNumber();
         const isEvm = scenario.protocolFamily === 'evm';
-
-        if (scenario.client.name === 'svm-smart-wallet') {
-          await setupSwigWallet(networks.svm.rpcUrl);
-        }
-
-        if (scenario.endpoint.schemeOptions?.permit2Direct === true) {
-          await approvePermit2Approval(evmPermit2Asset);
-        } else if (scenario.endpoint.schemeOptions?.coldstart === true) {
-          // Key on (client, path) so each client independently runs its own
-          // fund → revoke → drain cycle. Without the client name, the second
-          // client in a combo silently skips the coldstart and inherits
-          // whatever wallet state the first client left behind.
-          const endpointKey = `${scenario.client.name}::${scenario.endpoint.path}`;
-          if (!coldStartedEndpoints.has(endpointKey)) {
-            coldStartedEndpoints.add(endpointKey);
-            await fundClientForRevoke();
-            // Give fund tx 1s to propagate before submitting revoke (from client wallet)
-            await new Promise(resolve => setTimeout(resolve, 1000));
-            await revokePermit2Approval(evmPermit2Asset);
-            // Give revoke tx 2s to propagate before drain reads pending nonce.
-            // Load-balanced RPCs can return a stale pending nonce if queried
-            // immediately after the revoke submission, causing the drain to
-            // collide with the revoke's nonce ("replacement transaction underpriced").
-            await new Promise(resolve => setTimeout(resolve, 2000));
-            await drainClientETH();
-            // Wait for RPC nonce propagation across load-balanced nodes before the
-            // test client (which may use a separate RPC connection) queries the nonce.
-            await new Promise(resolve => setTimeout(resolve, 1500));
-          }
-        }
-
         const isAvm = scenario.protocolFamily === 'avm';
+        const resourceKeys = getScenarioResourceKeys(scenario, evmResourceKeyContext);
 
-        if (isEvm && facilitatorName && evmLock) {
-          const releaseLock = await evmLock.acquire(facilitatorName);
-          try {
-            results.push(await runSingleTest(scenario, port, tn, cLog));
-            await new Promise(resolve => setTimeout(resolve, 1000));
-          } finally {
-            releaseLock();
+        const runScenario = async (): Promise<DetailedTestResult> => {
+          if (scenario.client.name === 'svm-smart-wallet') {
+            await setupSwigWallet(networks.svm.rpcUrl);
           }
-        } else {
-          results.push(await runSingleTest(scenario, port, tn, cLog));
-          if (isAvm) {
+
+          if (scenario.endpoint.schemeOptions?.permit2Direct === true) {
+            await approvePermit2Approval(evmPermit2Asset);
+          } else if (scenario.endpoint.schemeOptions?.coldstart === true) {
+            // Key on (client, path) so each client independently runs its own
+            // fund → revoke → drain cycle. Without the client name, the second
+            // client in a combo silently skips the coldstart and inherits
+            // whatever wallet state the first client left behind.
+            const endpointKey = `${scenario.client.name}::${scenario.endpoint.path}`;
+            if (!coldStartedEndpoints.has(endpointKey)) {
+              coldStartedEndpoints.add(endpointKey);
+              await fundClientForRevoke();
+              // Give fund tx 1s to propagate before submitting revoke (from client wallet)
+              await new Promise(resolve => setTimeout(resolve, 1000));
+              await revokePermit2Approval(evmPermit2Asset);
+              // Give revoke tx 2s to propagate before drain reads pending nonce.
+              // Load-balanced RPCs can return a stale pending nonce if queried
+              // immediately after the revoke submission, causing the drain to
+              // collide with the revoke's nonce ("replacement transaction underpriced").
+              await new Promise(resolve => setTimeout(resolve, 2000));
+              await drainClientETH();
+              // Wait for RPC nonce propagation across load-balanced nodes before the
+              // test client (which may use a separate RPC connection) queries the nonce.
+              await new Promise(resolve => setTimeout(resolve, 1500));
+            }
+          }
+
+          const result = await runSingleTest(scenario, port, tn, cLog);
+
+          if (isEvm && resourceLock) {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+          } else if (isAvm) {
             // Pause between AVM tests to avoid 403 rate limiting on free public Algorand nodes
             await new Promise(resolve => setTimeout(resolve, 8000));
           } else if (isEvm) {
@@ -1473,6 +1510,19 @@ async function runTest() {
             // the two can collide on the same nonce on load-balanced RPCs.
             await new Promise(resolve => setTimeout(resolve, 1500));
           }
+
+          return result;
+        };
+
+        if (resourceKeys.length > 0 && resourceLock) {
+          const releaseLock = await resourceLock.acquireAll(resourceKeys);
+          try {
+            results.push(await runScenario());
+          } finally {
+            releaseLock();
+          }
+        } else {
+          results.push(await runScenario());
         }
       }
     } finally {
@@ -1485,7 +1535,19 @@ async function runTest() {
 
   // ── Unified execution: concurrency=1 for sequential, N for parallel ──
   const effectiveConcurrency = parsedArgs.parallel ? parsedArgs.concurrency : 1;
-  const evmLock = parsedArgs.parallel ? new FacilitatorLock() : null;
+  const resourceLock = parsedArgs.parallel ? new ResourceLock() : null;
+  const clientEvmAddress = clientEvmPrivateKey
+    ? privateKeyToAccount(clientEvmPrivateKey as `0x${string}`).address
+    : undefined;
+  const facilitatorEvmAddress = facilitatorEvmPrivateKey
+    ? privateKeyToAccount(facilitatorEvmPrivateKey as `0x${string}`).address
+    : undefined;
+  const evmResourceKeyContext: EvmResourceKeyContext = {
+    evmCaip2: networks.evm.caip2,
+    evmPermit2Asset,
+    clientEvmAddress,
+    facilitatorEvmAddress,
+  };
   const semaphore = new Semaphore(effectiveConcurrency);
 
   let globalTestNumber = 0;
@@ -1494,7 +1556,7 @@ async function runTest() {
   const comboPromises = serverFacilitatorCombos.map(async (combo) => {
     const release = await semaphore.acquire();
     try {
-      return await executeCombo(combo, evmLock, nextTestNumber);
+      return await executeCombo(combo, resourceLock, evmResourceKeyContext, nextTestNumber);
     } finally {
       release();
     }

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -436,6 +436,28 @@ function isOffchainSettleResponse(paymentResponse: any): boolean {
   return isBatchSettlement;
 }
 
+function maskSecret(value: string): string {
+  if (value.length <= 10) return '[redacted]';
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+}
+
+function maskPrivateKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(maskPrivateKeys) as T;
+  }
+  if (value && typeof value === 'object') {
+    const masked: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      masked[key] =
+        /privateKey/i.test(key) && typeof entry === 'string' && entry.length > 0
+          ? maskSecret(entry)
+          : maskPrivateKeys(entry);
+    }
+    return masked as T;
+  }
+  return value;
+}
+
 async function runClientTest(
   client: any,
   callConfig: ClientConfig
@@ -447,7 +469,7 @@ async function runClientTest(
   };
 
   try {
-    bufferLog(`  📞 Running client: ${JSON.stringify(callConfig, null, 2)}`);
+    bufferLog(`  📞 Running client: ${JSON.stringify(maskPrivateKeys(callConfig), null, 2)}`);
     const result = await client.call(callConfig);
     bufferLog(`  📊 Client result: ${JSON.stringify(result, null, 2)}`);
     // Check if the client execution succeeded
@@ -598,6 +620,8 @@ async function runTest() {
 
   // Initialize logger
   loggerConfig({ logFile: parsedArgs.logFile, verbose: parsedArgs.verbose });
+
+  const startTime = Date.now();
 
   log('🚀 Starting X402 E2E Test Suite');
   log('===============================');
@@ -1640,6 +1664,7 @@ async function runTest() {
   log(`✅ Passed: ${passed}`);
   log(`❌ Failed: ${failed}`);
   log(`📈 Total: ${passed + failed}`);
+  log(`⏱️  Duration: ${((Date.now() - startTime) / 60_000).toFixed(2)} min`);
   log('');
 
   // Detailed results table

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -18,6 +18,7 @@ import { GenericServerProxy } from './src/servers/generic-server';
 import { Semaphore, FacilitatorLock } from './src/concurrency';
 import { FacilitatorManager } from './src/facilitators/facilitator-manager';
 import { waitForHealth } from './src/health';
+import { createPortAllocator } from './src/ports';
 
 /**
  * Generates a fresh 32-byte hex salt for a batch-settlement test scenario so
@@ -585,11 +586,6 @@ async function runTest() {
   const facilitatorStellarPrivateKey = process.env.FACILITATOR_STELLAR_PRIVATE_KEY;
   const facilitatorTvmPrivateKey = process.env.FACILITATOR_TVM_PRIVATE_KEY;
   const batchSettlementRecovery = envFlagDefaultTrue(process.env.BATCH_SETTLEMENT_RECOVERY);
-  if (!serverEvmAddress || !serverSvmAddress || !clientEvmPrivateKey || !clientSvmPrivateKey || !facilitatorEvmPrivateKey || !facilitatorSvmPrivateKey) {
-    errorLog('❌ Missing required environment variables:');
-    errorLog(' SERVER_EVM_ADDRESS, SERVER_SVM_ADDRESS, CLIENT_EVM_PRIVATE_KEY, CLIENT_SVM_PRIVATE_KEY, FACILITATOR_EVM_PRIVATE_KEY, and FACILITATOR_SVM_PRIVATE_KEY must be set');
-    process.exit(1);
-  }
 
   // Discover all servers, clients, and facilitators (always include legacy)
   const discovery = new TestDiscovery('.', true); // Always discover legacy
@@ -702,6 +698,18 @@ async function runTest() {
       ['SERVER_APTOS_ADDRESS', serverAptosAddress],
       ['CLIENT_APTOS_PRIVATE_KEY', clientAptosPrivateKey],
       ['FACILITATOR_APTOS_PRIVATE_KEY', facilitatorAptosPrivateKey],
+    ],
+    avm: [
+      ['SERVER_AVM_ADDRESS', serverAvmAddress],
+      ['CLIENT_AVM_PRIVATE_KEY', clientAvmPrivateKey],
+      ['FACILITATOR_AVM_PRIVATE_KEY', facilitatorAvmPrivateKey],
+    ],
+    hedera: [
+      ['SERVER_HEDERA_ADDRESS', serverHederaAddress],
+      ['CLIENT_HEDERA_ACCOUNT_ID', clientHederaAccountId],
+      ['CLIENT_HEDERA_PRIVATE_KEY', clientHederaPrivateKey],
+      ['FACILITATOR_HEDERA_ACCOUNT_ID', facilitatorHederaAccountId],
+      ['FACILITATOR_HEDERA_PRIVATE_KEY', facilitatorHederaPrivateKey],
     ],
     stellar: [
       ['SERVER_STELLAR_ADDRESS', serverStellarAddress],
@@ -965,7 +973,7 @@ async function runTest() {
   }
 
   let testResults: DetailedTestResult[] = [];
-  let currentPort = 4022;
+  const allocatePort = createPortAllocator(4022);
 
   // Assign ports and start all facilitators
   const facilitatorManagers = new Map<string, FacilitatorManager>();
@@ -1003,14 +1011,14 @@ async function runTest() {
       facilitatorName: firstScenario.facilitator?.name,
       scenarios,
       comboIndex,
-      port: currentPort++,
+      port: allocatePort(),
     });
     comboIndex++;
   }
 
   // Start all facilitators with unique ports
   for (const [facilitatorName, facilitator] of uniqueFacilitators) {
-    const port = currentPort++;
+    const port = allocatePort();
     log(`\n🏛️ Starting facilitator: ${facilitatorName} on port ${port}`);
 
     const manager = new FacilitatorManager(
@@ -1037,7 +1045,7 @@ async function runTest() {
 
   // Start mock facilitator (claims to support everything, used as fallback so
   // servers with routes unsupported by the real facilitator can still start)
-  const mockFacilitatorPort = currentPort++;
+  const mockFacilitatorPort = allocatePort();
   log(`\n🎭 Starting mock facilitator on port ${mockFacilitatorPort}...`);
   const mockFacilitatorProcess: ChildProcess = spawn(
     'npx', ['tsx', 'index.ts'],

--- a/python/x402/mechanisms/evm/signers.py
+++ b/python/x402/mechanisms/evm/signers.py
@@ -7,6 +7,7 @@ libraries like eth_account and web3.py.
 from __future__ import annotations
 
 import logging
+import threading
 from typing import Any
 
 logger = logging.getLogger("x402.signers")
@@ -282,6 +283,8 @@ class FacilitatorWeb3Signer:
 
         # Cache chain ID
         self._chain_id: int | None = None
+        self._nonce_lock = threading.Lock()
+        self._next_nonce: int | None = None
 
     @property
     def address(self) -> str:
@@ -305,6 +308,19 @@ class FacilitatorWeb3Signer:
         if self._chain_id is None:
             self._chain_id = self._w3.eth.chain_id
         return self._chain_id
+
+    def _reserve_nonce(self) -> int:
+        """Reserve the next pending nonce for this process."""
+        with self._nonce_lock:
+            pending = self._w3.eth.get_transaction_count(
+                self._account.address,
+                "pending",
+            )
+            if self._next_nonce is None or pending > self._next_nonce:
+                self._next_nonce = pending
+            nonce = self._next_nonce
+            self._next_nonce = nonce + 1
+            return nonce
 
     def read_contract(
         self,
@@ -475,7 +491,7 @@ class FacilitatorWeb3Signer:
         tx = func(*args).build_transaction(
             {
                 "from": self._account.address,
-                "nonce": self._w3.eth.get_transaction_count(self._account.address),
+                "nonce": self._reserve_nonce(),
                 "gas": 300000,
                 "gasPrice": self._w3.eth.gas_price,
             }
@@ -501,7 +517,7 @@ class FacilitatorWeb3Signer:
             "from": self._account.address,
             "to": Web3.to_checksum_address(to),
             "data": data,
-            "nonce": self._w3.eth.get_transaction_count(self._account.address),
+            "nonce": self._reserve_nonce(),
             "gas": 300000,
             "gasPrice": self._w3.eth.gas_price,
         }


### PR DESCRIPTION
## Description

- Adds nightly e2e runs
- Fixes parallel e2e runs

## Tests

`pnpm test --testnet --min --parallel --families=evm,svm --versions=2 -concurrency=8
`
```
📊 Breakdown by Facilitator:
 go              ✅ 114 / ❌ 0 (100%)
 python          ✅ 2 / ❌ 0 (100%)
 typescript      ✅ 2 / ❌ 0 (100%)

📊 Breakdown by Server:
 echo                 ✅ 18 / ❌ 0 (100%)
 express              ✅ 12 / ❌ 0 (100%)
 fastapi              ✅ 11 / ❌ 0 (100%)
 fastify              ✅ 12 / ❌ 0 (100%)
 flask                ✅ 11 / ❌ 0 (100%)
 gin                  ✅ 10 / ❌ 0 (100%)
 hono                 ✅ 12 / ❌ 0 (100%)
 nethttp              ✅ 10 / ❌ 0 (100%)
 next                 ✅ 15 / ❌ 0 (100%)
 mcp-go               ✅ 3 / ❌ 0 (100%)
 mcp-python           ✅ 1 / ❌ 0 (100%)
 mcp-typescript       ✅ 3 / ❌ 0 (100%)

📊 Breakdown by Client:
   axios                ✅ 103 / ❌ 0 (100%)
   fetch                ✅ 2 / ❌ 0 (100%)
   go-http              ✅ 2 / ❌ 0 (100%)
   httpx                ✅ 2 / ❌ 0 (100%)
   requests             ✅ 2 / ❌ 0 (100%)
   mcp-go               ✅ 3 / ❌ 0 (100%)
   mcp-python           ✅ 1 / ❌ 0 (100%)
   mcp-typescript       ✅ 3 / ❌ 0 (100%)

📊 Protocol Family Breakdown:
 EVM: ✅ 102 / ❌ 0 / 📈 102 total
 SVM: ✅ 16 / ❌ 0 / 📈 16 total
```


## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 