### PR TITLE
validAfter patch

### DIFF
--- a/go/.changes/unreleased/sdk-timeout-valid-after-2601.yaml
+++ b/go/.changes/unreleased/sdk-timeout-valid-after-2601.yaml
@@ -1,0 +1,2 @@
+kind: changed
+body: Set EVM and batch-settlement authorization validAfter to 0, use maxTimeoutSeconds for validBefore/deadlines, and raise the default resource server maxTimeoutSeconds from 60 to 300 to reduce onchain timing failures when payloads are queued or block timestamps lag.

--- a/go/mechanisms/evm/batch-settlement/client/eip3009.go
+++ b/go/mechanisms/evm/batch-settlement/client/eip3009.go
@@ -59,7 +59,9 @@ func CreateBatchedEIP3009DepositPayload(
 		return types.PaymentPayload{}, fmt.Errorf("failed to create salt: %w", err)
 	}
 
-	validAfter, validBefore := evm.CreateValidityWindow(time.Hour)
+	now := time.Now().Unix()
+	validAfter := big.NewInt(0)
+	validBefore := big.NewInt(now + int64(requirements.MaxTimeoutSeconds))
 
 	// Compute channel ID
 	channelId, err := batchsettlement.ComputeChannelId(channelConfig, chainId)

--- a/go/mechanisms/evm/exact/client/permit2.go
+++ b/go/mechanisms/evm/exact/client/permit2.go
@@ -33,7 +33,7 @@ func CreatePermit2Payload(
 	}
 
 	now := time.Now().Unix()
-	validAfter := fmt.Sprintf("%d", now-600) // 10 minutes buffer for clock skew
+	validAfter := "0"
 	deadline := fmt.Sprintf("%d", now+int64(requirements.MaxTimeoutSeconds))
 
 	// Normalize addresses

--- a/go/mechanisms/evm/upto/client/permit2.go
+++ b/go/mechanisms/evm/upto/client/permit2.go
@@ -39,7 +39,7 @@ func CreateUptoPermit2Payload(
 	}
 
 	now := time.Now().Unix()
-	validAfter := fmt.Sprintf("%d", now-600)
+	validAfter := "0"
 	deadline := fmt.Sprintf("%d", now+int64(requirements.MaxTimeoutSeconds))
 
 	tokenAddress := evm.NormalizeAddress(requirements.Asset)

--- a/go/mechanisms/evm/utils.go
+++ b/go/mechanisms/evm/utils.go
@@ -213,8 +213,7 @@ func GetAssetInfo(network string, assetSymbolOrAddress string) (*AssetInfo, erro
 // CreateValidityWindow creates valid after/before timestamps
 func CreateValidityWindow(duration time.Duration) (validAfter, validBefore *big.Int) {
 	now := time.Now().Unix()
-	// Add 10 minute buffer to account for clock skew and block time
-	validAfter = big.NewInt(now - 600)
+	validAfter = big.NewInt(0)
 	validBefore = big.NewInt(now + int64(duration.Seconds()))
 	return validAfter, validBefore
 }

--- a/go/server.go
+++ b/go/server.go
@@ -639,7 +639,7 @@ func (s *x402ResourceServer) BuildPaymentRequirements(
 	// Apply default timeout if not specified
 	maxTimeout := config.MaxTimeoutSeconds
 	if maxTimeout == 0 {
-		maxTimeout = 60 // Default to 60 seconds
+		maxTimeout = 300 // Default to 5 minutes
 	}
 
 	// Build base requirements

--- a/go/test/unit/evm_utils_test.go
+++ b/go/test/unit/evm_utils_test.go
@@ -535,28 +535,29 @@ func TestGetAssetInfo(t *testing.T) {
 // TestCreateValidityWindow tests validity window creation
 func TestCreateValidityWindow(t *testing.T) {
 	t.Run("Creates valid window", func(t *testing.T) {
+		now := time.Now().Unix()
 		validAfter, validBefore := evm.CreateValidityWindow(time.Hour) // 1 hour
 
-		// validAfter should be ~30 seconds in the past
+		if validAfter.Int64() != 0 {
+			t.Errorf("validAfter should be 0, got %d", validAfter.Int64())
+		}
+
 		if validAfter.Int64() >= validBefore.Int64() {
 			t.Error("validAfter should be before validBefore")
 		}
 
-		// Window should be approximately 1 hour + 600 seconds buffer
-		window := validBefore.Int64() - validAfter.Int64()
-		if window < 4100 || window > 4300 { // Allow some tolerance
-			t.Errorf("Expected window ~4200 seconds, got %d", window)
+		// validBefore should be approximately now + 1 hour
+		diff := validBefore.Int64() - now
+		if diff < 3595 || diff > 3605 { // Allow some tolerance
+			t.Errorf("Expected validBefore ~3600 seconds in the future, diff was %d", diff)
 		}
 	})
 
-	t.Run("validAfter is in the past", func(t *testing.T) {
-		now := time.Now().Unix()
+	t.Run("validAfter is zero", func(t *testing.T) {
 		validAfter, _ := evm.CreateValidityWindow(time.Minute)
 
-		// validAfter should be approximately now - 600
-		diff := now - validAfter.Int64()
-		if diff < 595 || diff > 605 { // Allow tolerance for test execution time
-			t.Errorf("validAfter should be ~600 seconds in the past, diff was %d", diff)
+		if validAfter.Int64() != 0 {
+			t.Errorf("validAfter should be 0, got %d", validAfter.Int64())
 		}
 	})
 

--- a/python/x402/changelog.d/2601.bugfix.md
+++ b/python/x402/changelog.d/2601.bugfix.md
@@ -1,0 +1,1 @@
+Set EVM authorization ``validAfter`` to 0 to reduce onchain timing failures when payloads are queued or block timestamps lag behind client clocks.

--- a/python/x402/mechanisms/evm/__init__.py
+++ b/python/x402/mechanisms/evm/__init__.py
@@ -95,7 +95,6 @@ from .types import (
 from .utils import (
     bytes_to_hex,
     create_nonce,
-    create_validity_window,
     format_amount,
     get_asset_info,
     get_evm_chain_id,
@@ -204,7 +203,6 @@ __all__ = [
     "is_valid_address",
     "parse_amount",
     "format_amount",
-    "create_validity_window",
     "hex_to_bytes",
     "bytes_to_hex",
     "parse_money_to_decimal",

--- a/python/x402/mechanisms/evm/batch_settlement/client/eip3009.py
+++ b/python/x402/mechanisms/evm/batch_settlement/client/eip3009.py
@@ -47,7 +47,7 @@ def create_batch_settlement_eip3009_deposit_payload(
 
     salt = create_nonce()
     now = int(time.time())
-    valid_after = now - 600
+    valid_after = 0
     valid_before = now + int(requirements.max_timeout_seconds)
     chain_id = get_evm_chain_id(str(requirements.network))
     channel_id = compute_channel_id(channel_config, str(requirements.network))

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -20,9 +20,6 @@ TX_STATUS_FAILED = 0
 # Default validity period (1 hour in seconds)
 DEFAULT_VALIDITY_PERIOD = 3600
 
-# Default validity buffer (10 minutes before now for clock skew)
-DEFAULT_VALIDITY_BUFFER = 600
-
 # ERC-6492 magic value (32 bytes)
 # bytes32(uint256(keccak256("erc6492.invalid.signature")) - 1)
 ERC6492_MAGIC_VALUE = bytes.fromhex(

--- a/python/x402/mechanisms/evm/exact/client.py
+++ b/python/x402/mechanisms/evm/exact/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+import time
 from typing import Any
 
 from ....schemas import PaymentRequirements
@@ -16,7 +16,6 @@ from ..signer import (
 from ..types import ExactEIP3009Authorization, ExactEIP3009Payload, TypedDataField
 from ..utils import (
     create_nonce,
-    create_validity_window,
     get_asset_info,
     get_evm_chain_id,
     normalize_address,
@@ -94,16 +93,16 @@ class ExactEvmScheme:
             return result
 
         nonce = create_nonce()
-        valid_after, valid_before = create_validity_window(
-            timedelta(seconds=requirements.max_timeout_seconds or 3600)
-        )
+        now = int(time.time())
+        valid_after = "0"
+        valid_before = str(now + (requirements.max_timeout_seconds or 3600))
 
         authorization = ExactEIP3009Authorization(
             from_address=self._signer.address,
             to=requirements.pay_to,
             value=requirements.amount,
-            valid_after=str(valid_after),
-            valid_before=str(valid_before),
+            valid_after=valid_after,
+            valid_before=valid_before,
             nonce=nonce,
         )
 

--- a/python/x402/mechanisms/evm/exact/permit2_utils.py
+++ b/python/x402/mechanisms/evm/exact/permit2_utils.py
@@ -82,8 +82,7 @@ def create_permit2_payload(
     now = int(time.time())
     nonce = create_permit2_nonce()
 
-    # Lower time bound - allow clock skew
-    valid_after = str(now - 600)
+    valid_after = "0"
     # Upper time bound - permit2 deadline
     deadline = str(now + (requirements.max_timeout_seconds or 3600))
 

--- a/python/x402/mechanisms/evm/upto/client.py
+++ b/python/x402/mechanisms/evm/upto/client.py
@@ -208,10 +208,16 @@ def _create_upto_permit2_payload(
             "Ensure the server is configured with an upto facilitator that provides getExtra()."
         )
 
+    timeout = requirements.max_timeout_seconds
+    if timeout is not None and timeout <= 0:
+        raise ValueError(
+            f"Invalid time window: max_timeout_seconds ({timeout}) must be positive."
+        )
+
     now = int(time.time())
     nonce = create_permit2_nonce()
     valid_after = "0"
-    deadline = str(now + (requirements.max_timeout_seconds or 3600))
+    deadline = str(now + (timeout or 3600))
     if int(deadline) <= int(valid_after):
         raise ValueError(
             f"Invalid time window: deadline ({deadline}) must be after validAfter ({valid_after}). "

--- a/python/x402/mechanisms/evm/upto/client.py
+++ b/python/x402/mechanisms/evm/upto/client.py
@@ -210,9 +210,7 @@ def _create_upto_permit2_payload(
 
     timeout = requirements.max_timeout_seconds
     if timeout is not None and timeout <= 0:
-        raise ValueError(
-            f"Invalid time window: max_timeout_seconds ({timeout}) must be positive."
-        )
+        raise ValueError(f"Invalid time window: max_timeout_seconds ({timeout}) must be positive.")
 
     now = int(time.time())
     nonce = create_permit2_nonce()

--- a/python/x402/mechanisms/evm/upto/client.py
+++ b/python/x402/mechanisms/evm/upto/client.py
@@ -210,7 +210,7 @@ def _create_upto_permit2_payload(
 
     now = int(time.time())
     nonce = create_permit2_nonce()
-    valid_after = str(now - 600)
+    valid_after = "0"
     deadline = str(now + (requirements.max_timeout_seconds or 3600))
     if int(deadline) <= int(valid_after):
         raise ValueError(

--- a/python/x402/mechanisms/evm/utils.py
+++ b/python/x402/mechanisms/evm/utils.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-from datetime import datetime, timedelta
 from decimal import Decimal
 
 try:
@@ -13,8 +12,6 @@ except ImportError as e:
     ) from e
 
 from .constants import (
-    DEFAULT_VALIDITY_BUFFER,
-    DEFAULT_VALIDITY_PERIOD,
     NETWORK_CONFIGS,
     AssetInfo,
     NetworkConfig,
@@ -211,28 +208,6 @@ def format_amount(amount: int, decimals: int) -> str:
     d = Decimal(amount)
     divisor = Decimal(10**decimals)
     return str(d / divisor)
-
-
-def create_validity_window(
-    duration: timedelta | None = None,
-    buffer: int = DEFAULT_VALIDITY_BUFFER,
-) -> tuple[int, int]:
-    """Create valid_after/valid_before timestamps.
-
-    Args:
-        duration: How long authorization is valid (default: 1 hour).
-        buffer: Seconds before now for valid_after (clock skew).
-
-    Returns:
-        (valid_after, valid_before) as Unix timestamps.
-    """
-    if duration is None:
-        duration = timedelta(seconds=DEFAULT_VALIDITY_PERIOD)
-
-    now = int(datetime.now().timestamp())
-    valid_after = now - buffer
-    valid_before = now + int(duration.total_seconds())
-    return (valid_after, valid_before)
 
 
 def hex_to_bytes(hex_str: str) -> bytes:

--- a/python/x402/tests/integrations/test_evm_batch_settlement_extended.py
+++ b/python/x402/tests/integrations/test_evm_batch_settlement_extended.py
@@ -662,6 +662,7 @@ class TestBatchSettlementWithdrawalPendingRefund:
             assert len(pending) == 1
             assert pending[0].channel_id.lower() == channel_id
 
+            _wait_for_pending_transactions(pipe.facilitator_address)
             results = manager.refund([channel_id])
             assert len(results) == 1 and results[0].transaction, (
                 f"expected 1 refund result with tx hash, got {results}"

--- a/python/x402/tests/unit/mechanisms/evm/batch_settlement/client/test_eip3009.py
+++ b/python/x402/tests/unit/mechanisms/evm/batch_settlement/client/test_eip3009.py
@@ -130,8 +130,8 @@ class TestCreateEip3009DepositPayload:
             max_claimable_amount="100",
         )
         auth = payload.deposit.authorization.erc3009_authorization
-        # valid_after ~= now - 600, valid_before ~= now + timeout
-        assert int(auth.valid_after) <= before
+        # valid_after is 0, valid_before ~= now + timeout
+        assert int(auth.valid_after) == 0
         assert int(auth.valid_before) >= before
 
         cid = compute_channel_id(cc, NETWORK)

--- a/python/x402/tests/unit/mechanisms/evm/test_client.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_client.py
@@ -179,3 +179,32 @@ class TestLocalAccountAutoWrap:
         assert "signature" in payload
         assert payload["signature"].startswith("0x")
         assert len(payload["signature"]) > 2  # not just "0x"
+
+    def test_eip3009_payload_sets_valid_after_to_zero(self):
+        """EIP-3009 payload should use validAfter=0 and maxTimeout for validBefore."""
+        import time
+
+        account = Account.create()
+        client = ExactEvmClientScheme(signer=account)
+        network = "eip155:8453"
+        now = int(time.time())
+
+        requirements = PaymentRequirements(
+            scheme="exact",
+            network=network,
+            asset="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            amount="500000",
+            pay_to="0x0987654321098765432109876543210987654321",
+            max_timeout_seconds=600,
+            extra={
+                "name": "USD Coin",
+                "version": "2",
+            },
+        )
+
+        payload = client.create_payment_payload(requirements)
+        auth = payload["authorization"]
+
+        assert auth["validAfter"] == "0"
+        assert int(auth["validBefore"]) >= now + 600 - 2
+        assert int(auth["validBefore"]) <= now + 600 + 2

--- a/python/x402/tests/unit/mechanisms/evm/test_index.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_index.py
@@ -20,7 +20,6 @@ from x402.mechanisms.evm import (
     FacilitatorWeb3Signer,
     bytes_to_hex,
     create_nonce,
-    create_validity_window,
     format_amount,
     get_asset_info,
     get_evm_chain_id,
@@ -278,40 +277,6 @@ class TestFormatAmount:
         assert format_amount(1000000000, 9) == "1"
         assert format_amount(100, 2) == "1"
         assert format_amount(1, 0) == "1"
-
-
-class TestCreateValidityWindow:
-    """Test create_validity_window function."""
-
-    def test_should_create_validity_window_with_default_duration(self):
-        """Should create validity window with default duration."""
-
-        valid_after, valid_before = create_validity_window()
-
-        assert valid_after is not None
-        assert valid_before is not None
-        assert valid_before > valid_after
-        # Should be approximately 1 hour apart (3600 seconds)
-        assert valid_before - valid_after >= 3600 - 100  # Allow some tolerance
-
-    def test_should_create_validity_window_with_custom_duration(self):
-        """Should create validity window with custom duration."""
-        from datetime import timedelta
-
-        duration = timedelta(hours=2)
-        valid_after, valid_before = create_validity_window(duration=duration)
-
-        assert valid_before - valid_after >= 7200 - 100  # Approximately 2 hours
-
-    def test_should_apply_buffer_to_valid_after(self):
-        """Should apply buffer to valid_after (clock skew)."""
-        valid_after, valid_before = create_validity_window()
-
-        import time
-
-        now = int(time.time())
-        # valid_after should be in the past (with buffer)
-        assert valid_after < now
 
 
 class TestHexToBytes:

--- a/typescript/.changeset/sdk-timeout-valid-after-2601.md
+++ b/typescript/.changeset/sdk-timeout-valid-after-2601.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Set EVM authorization `validAfter` to 0 to reduce onchain timing failures when payloads are queued or block timestamps lag behind client clocks

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/client/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/client/eip3009.ts
@@ -62,7 +62,7 @@ export async function createBatchSettlementEIP3009DepositPayload(
       from: getAddress(signer.address),
       to: getAddress(ERC3009_DEPOSIT_COLLECTOR_ADDRESS),
       value: BigInt(depositAmount),
-      validAfter: BigInt(now - 600),
+      validAfter: BigInt(0),
       validBefore: BigInt(now + paymentRequirements.maxTimeoutSeconds),
       nonce: erc3009Nonce,
     },
@@ -84,7 +84,7 @@ export async function createBatchSettlementEIP3009DepositPayload(
       amount: depositAmount,
       authorization: {
         erc3009Authorization: {
-          validAfter: (now - 600).toString(),
+          validAfter: "0",
           validBefore: (now + paymentRequirements.maxTimeoutSeconds).toString(),
           salt,
           signature,

--- a/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
@@ -25,7 +25,7 @@ export async function createEIP3009Payload(
     from: signer.address,
     to: getAddress(paymentRequirements.payTo),
     value: paymentRequirements.amount,
-    validAfter: (now - 600).toString(),
+    validAfter: "0",
     validBefore: (now + paymentRequirements.maxTimeoutSeconds).toString(),
     nonce,
   };

--- a/typescript/packages/mechanisms/evm/src/shared/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/permit2.ts
@@ -632,7 +632,7 @@ export async function createPermit2PayloadForProxy(
   const nonce = createPermit2Nonce();
 
   // Lower time bound - allow some clock skew
-  const validAfter = (now - 600).toString();
+  const validAfter = "0";
   // Upper time bound is enforced by Permit2's deadline field
   const deadline = (now + paymentRequirements.maxTimeoutSeconds).toString();
 

--- a/typescript/packages/mechanisms/evm/src/upto/client/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/client/permit2.ts
@@ -41,7 +41,7 @@ export async function createUptoPermit2Payload(
 
   const now = Math.floor(Date.now() / 1000);
   const nonce = createPermit2Nonce();
-  const validAfter = (now - 600).toString();
+  const validAfter = "0";
   const deadline = (now + paymentRequirements.maxTimeoutSeconds).toString();
 
   if (BigInt(deadline) <= BigInt(validAfter)) {

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -74,7 +74,7 @@ describe("ExactEvmScheme (Client)", () => {
       expect(result1.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/i);
     });
 
-    it("should set validAfter to 10 minutes before current time", async () => {
+    it("should set validAfter to 0", async () => {
       const requirements: PaymentRequirements = {
         scheme: "exact",
         network: "eip155:8453",
@@ -85,14 +85,9 @@ describe("ExactEvmScheme (Client)", () => {
         extra: { name: "USD Coin", version: "2" },
       };
 
-      const beforeTime = Math.floor(Date.now() / 1000) - 600;
       const result = await client.createPaymentPayload(2, requirements);
-      const afterTime = Math.floor(Date.now() / 1000) - 600;
 
-      const validAfter = parseInt(result.payload.authorization.validAfter);
-
-      expect(validAfter).toBeGreaterThanOrEqual(beforeTime);
-      expect(validAfter).toBeLessThanOrEqual(afterTime + 1); // Allow 1 second tolerance
+      expect(result.payload.authorization.validAfter).toBe("0");
     });
 
     it("should set validBefore based on maxTimeoutSeconds", async () => {

--- a/typescript/packages/mechanisms/evm/test/unit/upto/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/upto/client.test.ts
@@ -141,17 +141,14 @@ describe("UptoEvmScheme (Client)", () => {
       }
     });
 
-    it("should set validAfter to 10 minutes before current time", async () => {
+    it("should set validAfter to 0", async () => {
       const fakeNow = 1700000000000;
       vi.useFakeTimers();
       vi.setSystemTime(fakeNow);
 
       try {
         const result = await client.createPaymentPayload(2, makeRequirements());
-        const validAfter = parseInt(result.payload.permit2Authorization.witness.validAfter);
-        const expectedValidAfter = Math.floor(fakeNow / 1000) - 600;
-
-        expect(validAfter).toBe(expectedValidAfter);
+        expect(result.payload.permit2Authorization.witness.validAfter).toBe("0");
       } finally {
         vi.useRealTimers();
       }


### PR DESCRIPTION

## Description

- Sets `maxTimeoutSeconds` default to 300s; was already for TS/py, only go used 60
- Sets `validAfter = 0`

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 