### PR TITLE
Add Decision Anchor to ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/decision-anchor/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/decision-anchor/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Decision Anchor",
+  "category": "Infrastructure & Tooling",
+  "logoUrl": "/logos/decision-anchor.svg",
+  "description": "External anchoring layer for AI agent decisions — records what was authorized, when, and at what scope, before x402 payment execution. Non-judgmental, content-blind.",
+  "websiteUrl": "https://decision-anchor.com"
+}

--- a/typescript/site/public/logos/decision-anchor.svg
+++ b/typescript/site/public/logos/decision-anchor.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" role="img" aria-label="Decision Anchor">
+  <rect width="160" height="160" rx="28" fill="#0a0a0a"/>
+  <rect x="0.75" y="0.75" width="158.5" height="158.5" rx="27.25" fill="none" stroke="#2a2a2a" stroke-width="1.5"/>
+  <text x="80" y="98" text-anchor="middle" font-family="'DM Mono','SFMono-Regular',Menlo,Consolas,monospace" font-size="62" font-weight="500" letter-spacing="2" fill="#c4956a">DA</text>
+</svg>


### PR DESCRIPTION
Adds Decision Anchor to the ecosystem partners list.

Per maintainer guidance in #1954, resubmitting to the ecosystem page (the earlier PR added an example client under examples/; this is the correct ecosystem-listing channel).

- **Name:** Decision Anchor
- **Category:** Infrastructure & Tooling
- **What it is:** External anchoring layer for AI agent decisions — records what was authorized, when, and at what scope, before x402 payment execution. Non-judgmental, content-blind.
- **Website:** https://decision-anchor.com

Settles in USDC on Base via x402 (CDP facilitator). Two files added: `partners-data/decision-anchor/metadata.json` + logo. Logo is a placeholder monogram — happy to swap for a maintainer-preferred format.