### PR TITLE
Add buildercode s array

### DIFF
--- a/examples/go/clients/builder-code/main.go
+++ b/examples/go/clients/builder-code/main.go
@@ -64,7 +64,7 @@ func main() {
 	client := x402.Newx402Client()
 	client.Register("eip155:*", exactevm.NewExactEvmScheme(evmSigner, rpcConfig))
 	if clientBuilderCode != "" {
-		client.RegisterExtension(buildercode.NewBuilderCodeClientExtension(clientBuilderCode))
+		client.RegisterExtension(buildercode.NewBuilderCodeClientExtension(clientBuilderCode))	
 	}
 
 	httpClient := x402http.WrapHTTPClientWithPayment(
@@ -131,7 +131,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("\nBuilder-code attribution verified onchain: %+v\n", attribution)
+	b, _ := json.MarshalIndent(attribution, "", "  ")
+	fmt.Printf("\nBuilder-code attribution verified onchain: %s\n", b)
 	fmt.Printf("Explorer: https://sepolia.basescan.org/tx/%s\n", settleResp.Transaction)
 }
 

--- a/examples/typescript/clients/builder-code/index.ts
+++ b/examples/typescript/clients/builder-code/index.ts
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
   const client = new x402Client();
   client.register("eip155:*", new ExactEvmScheme(evmSigner, rpcOptions));
   if (clientBuilderCode) {
-    client.registerExtension(new BuilderCodeClientExtension([clientBuilderCode, "bc_my_client_2"]));
+    client.registerExtension(new BuilderCodeClientExtension(clientBuilderCode));
   }
 
   const fetchWithPayment = wrapFetchWithPayment(fetch, client);

--- a/examples/typescript/clients/builder-code/index.ts
+++ b/examples/typescript/clients/builder-code/index.ts
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
   const client = new x402Client();
   client.register("eip155:*", new ExactEvmScheme(evmSigner, rpcOptions));
   if (clientBuilderCode) {
-    client.registerExtension(new BuilderCodeClientExtension(clientBuilderCode));
+    client.registerExtension(new BuilderCodeClientExtension([clientBuilderCode, "bc_my_client_2"]));
   }
 
   const fetchWithPayment = wrapFetchWithPayment(fetch, client);

--- a/go/.changes/unreleased/builder-code-multiple-s.yaml
+++ b/go/.changes/unreleased/builder-code-multiple-s.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: builder-code extension now supports multiple service codes (`s`). NewBuilderCodeClientExtension accepts one or more codes (variadic), BuilderCodeExtensionData.S is now a []string, and the facilitator/CBOR encode and parse paths keep every valid entry so layered clients (e.g. an MCP middleware) can attribute multiple participants onchain.

--- a/go/extensions/buildercode/cbor.go
+++ b/go/extensions/buildercode/cbor.go
@@ -86,13 +86,13 @@ func encodeCborMap(data BuilderCodeExtensionData) ([]byte, error) {
 		entries = append(entries, value...)
 	}
 
-	if data.S != "" {
+	if len(data.S) > 0 {
 		mapSize++
 		key, err := encodeCborString("s")
 		if err != nil {
 			return nil, err
 		}
-		value, err := encodeCborArray([]string{data.S})
+		value, err := encodeCborArray(data.S)
 		if err != nil {
 			return nil, err
 		}
@@ -216,12 +216,12 @@ func parseCborMap(bytes []byte) (*BuilderCodeExtensionData, bool) {
 			if !ok {
 				return nil, false
 			}
-			firstCode, ok := readServiceCodeArray(bytes, &o, arraySize)
+			codes, ok := readServiceCodeArray(bytes, &o, arraySize)
 			if !ok {
 				return nil, false
 			}
-			if firstCode != "" {
-				result.S = firstCode
+			if len(codes) > 0 {
+				result.S = codes
 			}
 		default:
 			return nil, false
@@ -253,22 +253,20 @@ func readCborLength(bytes []byte, o *int) (int, bool) {
 	return 0, false
 }
 
-// readServiceCodeArray reads arraySize CBOR text strings, returning the first
+// readServiceCodeArray reads arraySize CBOR text strings, returning every
 // decoded entry and advancing o past all of them.
-func readServiceCodeArray(bytes []byte, o *int, arraySize int) (string, bool) {
-	var firstCode string
+func readServiceCodeArray(bytes []byte, o *int, arraySize int) ([]string, bool) {
+	codes := make([]string, 0, arraySize)
 	for i := 0; i < arraySize; i++ {
 		if *o >= len(bytes) || bytes[*o]>>5 != 3 {
-			return "", false
+			return nil, false
 		}
 		itemLen, ok := readCborLength(bytes, o)
 		if !ok || *o+itemLen > len(bytes) {
-			return "", false
+			return nil, false
 		}
-		if i == 0 {
-			firstCode = string(bytes[*o : *o+itemLen])
-		}
+		codes = append(codes, string(bytes[*o:*o+itemLen]))
 		*o += itemLen
 	}
-	return firstCode, true
+	return codes, true
 }

--- a/go/extensions/buildercode/cbor_test.go
+++ b/go/extensions/buildercode/cbor_test.go
@@ -2,6 +2,7 @@ package buildercode
 
 import (
 	"encoding/hex"
+	"reflect"
 	"testing"
 )
 
@@ -44,7 +45,7 @@ func TestEncodeBuilderCodeSuffixSpecVectors(t *testing.T) {
 }
 
 func TestSuffixRoundTrip(t *testing.T) {
-	suffix, err := EncodeBuilderCodeSuffix(BuilderCodeExtensionData{A: appCode, W: walletCode, S: serviceCode})
+	suffix, err := EncodeBuilderCodeSuffix(BuilderCodeExtensionData{A: appCode, W: walletCode, S: []string{serviceCode}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -54,7 +55,24 @@ func TestSuffixRoundTrip(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a valid suffix")
 	}
-	if parsed.A != appCode || parsed.W != walletCode || parsed.S != serviceCode {
+	if parsed.A != appCode || parsed.W != walletCode || !reflect.DeepEqual(parsed.S, []string{serviceCode}) {
+		t.Fatalf("round-trip mismatch: %+v", parsed)
+	}
+}
+
+func TestSuffixRoundTripMultipleServiceCodes(t *testing.T) {
+	want := []string{serviceCode, "bc_other"}
+	suffix, err := EncodeBuilderCodeSuffix(BuilderCodeExtensionData{A: appCode, W: walletCode, S: want})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	calldata := "0xdeadbeef" + hex.EncodeToString(suffix)
+	parsed, ok := ParseBuilderCodeSuffixFromCalldata(calldata)
+	if !ok {
+		t.Fatal("expected a valid suffix")
+	}
+	if parsed.A != appCode || parsed.W != walletCode || !reflect.DeepEqual(parsed.S, want) {
 		t.Fatalf("round-trip mismatch: %+v", parsed)
 	}
 }
@@ -71,7 +89,7 @@ func TestParseSpecAppOnlyVector(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a valid suffix")
 	}
-	if parsed.A != "bc_myapp" || parsed.W != "" || parsed.S != "" {
+	if parsed.A != "bc_myapp" || parsed.W != "" || len(parsed.S) != 0 {
 		t.Fatalf("parse mismatch: %+v", parsed)
 	}
 }

--- a/go/extensions/buildercode/client.go
+++ b/go/extensions/buildercode/client.go
@@ -8,22 +8,25 @@ import (
 )
 
 // BuilderCodeClientExtension adds builder-code attribution to payment payloads
-// by attaching the client's service code (`s`). The core client merge preserves
-// the server-declared app code (`a`) and schema after enrichment.
+// by attaching the client's service code(s) (`s`). The core client merge
+// preserves the server-declared app code (`a`) and schema after enrichment.
 type BuilderCodeClientExtension struct {
-	serviceCode string
+	serviceCodes []string
 }
 
 // NewBuilderCodeClientExtension creates a client extension that attaches the
-// given service code to payments.
+// given service code(s) to payments. It accepts one or more codes so layered
+// clients (e.g. an MCP middleware) can attribute multiple participants.
 //
-// It panics when serviceCode is not a valid builder code (1-32 lowercase
+// It panics when any serviceCode is not a valid builder code (1-32 lowercase
 // alphanumeric and underscore characters)
-func NewBuilderCodeClientExtension(serviceCode string) *BuilderCodeClientExtension {
-	if !validateCode(serviceCode) {
-		panic(fmt.Sprintf("invalid builder code: %q. Must be 1-32 characters, lowercase alphanumeric and underscores only.", serviceCode))
+func NewBuilderCodeClientExtension(serviceCodes ...string) *BuilderCodeClientExtension {
+	for _, code := range serviceCodes {
+		if !validateCode(code) {
+			panic(fmt.Sprintf("invalid builder code: %q. Must be 1-32 characters, lowercase alphanumeric and underscores only.", code))
+		}
 	}
-	return &BuilderCodeClientExtension{serviceCode: serviceCode}
+	return &BuilderCodeClientExtension{serviceCodes: serviceCodes}
 }
 
 // Key returns the builder-code extension identifier.
@@ -31,8 +34,8 @@ func (e *BuilderCodeClientExtension) Key() string {
 	return BUILDER_CODE
 }
 
-// EnrichPaymentPayload attaches this client's service code (`s`). Core extension
-// merging re-applies the server's advertised `a`/`schema` afterwards.
+// EnrichPaymentPayload attaches this client's service code(s) (`s`). Core
+// extension merging re-applies the server's advertised `a`/`schema` afterwards.
 func (e *BuilderCodeClientExtension) EnrichPaymentPayload(
 	_ context.Context,
 	payload types.PaymentPayload,
@@ -43,7 +46,7 @@ func (e *BuilderCodeClientExtension) EnrichPaymentPayload(
 		extensions[k] = v
 	}
 	extensions[BUILDER_CODE] = map[string]interface{}{
-		"info": map[string]interface{}{"s": e.serviceCode},
+		"info": map[string]interface{}{"s": e.serviceCodes},
 	}
 	payload.Extensions = extensions
 	return payload, nil

--- a/go/extensions/buildercode/client_test.go
+++ b/go/extensions/buildercode/client_test.go
@@ -30,7 +30,20 @@ func TestClientExtensionAttachesServiceCode(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := map[string]interface{}{"info": map[string]interface{}{"s": serviceCode}}
+	want := map[string]interface{}{"info": map[string]interface{}{"s": []string{serviceCode}}}
+	if !reflect.DeepEqual(enriched.Extensions[BUILDER_CODE], want) {
+		t.Fatalf("expected %v, got %v", want, enriched.Extensions[BUILDER_CODE])
+	}
+}
+
+func TestClientExtensionAttachesMultipleServiceCodes(t *testing.T) {
+	ext := NewBuilderCodeClientExtension(serviceCode, "bc_other")
+	enriched, err := ext.EnrichPaymentPayload(context.Background(), types.PaymentPayload{X402Version: 2}, types.PaymentRequired{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]interface{}{"info": map[string]interface{}{"s": []string{serviceCode, "bc_other"}}}
 	if !reflect.DeepEqual(enriched.Extensions[BUILDER_CODE], want) {
 		t.Fatalf("expected %v, got %v", want, enriched.Extensions[BUILDER_CODE])
 	}
@@ -51,7 +64,7 @@ func TestClientExtensionPreservesUnrelatedExtensions(t *testing.T) {
 	if !reflect.DeepEqual(enriched.Extensions["other"], map[string]interface{}{"kept": true}) {
 		t.Fatalf("unrelated extension not preserved: %v", enriched.Extensions["other"])
 	}
-	want := map[string]interface{}{"info": map[string]interface{}{"s": serviceCode}}
+	want := map[string]interface{}{"info": map[string]interface{}{"s": []string{serviceCode}}}
 	if !reflect.DeepEqual(enriched.Extensions[BUILDER_CODE], want) {
 		t.Fatalf("expected %v, got %v", want, enriched.Extensions[BUILDER_CODE])
 	}

--- a/go/extensions/buildercode/facilitator.go
+++ b/go/extensions/buildercode/facilitator.go
@@ -35,9 +35,9 @@ func (e *BuilderCodeFacilitatorExtension) BuildDataSuffix(ctx evm.DataSuffixCont
 	if a, ok := clientExt["a"].(string); ok && validateCode(a) {
 		data.A = a
 	}
-	data.S = resolveServiceCode(clientExt["s"])
+	data.S = resolveServiceCodes(clientExt["s"])
 
-	if data.A == "" && data.W == "" && data.S == "" {
+	if data.A == "" && data.W == "" && len(data.S) == 0 {
 		return nil, nil
 	}
 
@@ -58,18 +58,30 @@ func extractClientExtension(extensions map[string]interface{}) map[string]interf
 	return info
 }
 
-// resolveServiceCode normalizes the client-provided `s` value, accepting a valid
-// string or the first valid entry of an array. Returns "" when missing or invalid.
-func resolveServiceCode(raw interface{}) string {
-	if s, ok := raw.(string); ok && validateCode(s) {
-		return s
+// resolveServiceCodes normalizes the client-provided `s` value, accepting a
+// string, a []string, or a []interface{} (JSON-decoded) and keeping every valid
+// entry. Returns nil when missing or all entries are invalid.
+func resolveServiceCodes(raw interface{}) []string {
+	var codes []string
+	appendValid := func(s string) {
+		if validateCode(s) {
+			codes = append(codes, s)
+		}
 	}
-	if arr, ok := raw.([]interface{}); ok {
-		for _, v := range arr {
-			if s, ok := v.(string); ok && validateCode(s) {
-				return s
+
+	switch v := raw.(type) {
+	case string:
+		appendValid(v)
+	case []string:
+		for _, s := range v {
+			appendValid(s)
+		}
+	case []interface{}:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				appendValid(s)
 			}
 		}
 	}
-	return ""
+	return codes
 }

--- a/go/extensions/buildercode/facilitator_test.go
+++ b/go/extensions/buildercode/facilitator_test.go
@@ -2,6 +2,7 @@ package buildercode
 
 import (
 	"encoding/hex"
+	"reflect"
 	"testing"
 
 	evm "github.com/x402-foundation/x402/go/v2/mechanisms/evm"
@@ -43,7 +44,7 @@ func parsedFromFacilitator(t *testing.T, ctx evm.DataSuffixContext) *BuilderCode
 
 func TestBuildDataSuffixWalletOnly(t *testing.T) {
 	parsed := parsedFromFacilitator(t, suffixContext(nil))
-	if parsed.W != walletCode || parsed.A != "" || parsed.S != "" {
+	if parsed.W != walletCode || parsed.A != "" || len(parsed.S) != 0 {
 		t.Fatalf("expected wallet code only, got %+v", parsed)
 	}
 }
@@ -59,7 +60,7 @@ func TestBuildDataSuffixOmitsWalletWhenUnset(t *testing.T) {
 	if !ok {
 		t.Fatal("expected a valid suffix")
 	}
-	if parsed.A != appCode || parsed.S != serviceCode || parsed.W != "" {
+	if parsed.A != appCode || !reflect.DeepEqual(parsed.S, []string{serviceCode}) || parsed.W != "" {
 		t.Fatalf("expected app+service only, got %+v", parsed)
 	}
 }
@@ -77,7 +78,7 @@ func TestBuildDataSuffixNoAttribution(t *testing.T) {
 
 func TestBuildDataSuffixSpecShapedCodes(t *testing.T) {
 	parsed := parsedFromFacilitator(t, suffixContext(map[string]interface{}{"a": appCode, "s": serviceCode}))
-	if parsed.W != walletCode || parsed.A != appCode || parsed.S != serviceCode {
+	if parsed.W != walletCode || parsed.A != appCode || !reflect.DeepEqual(parsed.S, []string{serviceCode}) {
 		t.Fatalf("expected all codes, got %+v", parsed)
 	}
 }
@@ -85,21 +86,21 @@ func TestBuildDataSuffixSpecShapedCodes(t *testing.T) {
 func TestBuildDataSuffixServiceCodeArray(t *testing.T) {
 	info := map[string]interface{}{"s": []interface{}{"INVALID", serviceCode, "bc_other"}}
 	parsed := parsedFromFacilitator(t, suffixContext(info))
-	if parsed.W != walletCode || parsed.S != serviceCode {
-		t.Fatalf("expected first valid service code, got %+v", parsed)
+	if parsed.W != walletCode || !reflect.DeepEqual(parsed.S, []string{serviceCode, "bc_other"}) {
+		t.Fatalf("expected all valid service codes, got %+v", parsed)
 	}
 }
 
 func TestBuildDataSuffixIgnoresInvalidServiceCode(t *testing.T) {
 	parsed := parsedFromFacilitator(t, suffixContext(map[string]interface{}{"s": "Also_Invalid"}))
-	if parsed.W != walletCode || parsed.S != "" || parsed.A != "" {
+	if parsed.W != walletCode || len(parsed.S) != 0 || parsed.A != "" {
 		t.Fatalf("expected wallet code only, got %+v", parsed)
 	}
 }
 
 func TestBuildDataSuffixReadsAppCode(t *testing.T) {
 	parsed := parsedFromFacilitator(t, suffixContext(map[string]interface{}{"a": appCode}))
-	if parsed.W != walletCode || parsed.A != appCode || parsed.S != "" {
+	if parsed.W != walletCode || parsed.A != appCode || len(parsed.S) != 0 {
 		t.Fatalf("expected wallet+app, got %+v", parsed)
 	}
 }

--- a/go/extensions/buildercode/types.go
+++ b/go/extensions/buildercode/types.go
@@ -27,12 +27,12 @@ var BUILDER_CODE_PATTERN = regexp.MustCompile(`^[a-z0-9_]{1,32}$`)
 // PaymentRequired/PaymentPayload extensions.
 //   - A: app builder code — the x402 service that exposed the paid endpoint.
 //   - W: wallet builder code — the facilitator that settled the payment on-chain.
-//   - S: service builder code — client-provided attribution code (wrapped in a
-//     single-element array on wire).
+//   - S: service builder codes — client-provided attribution codes (encoded as an
+//     array on wire).
 type BuilderCodeExtensionData struct {
-	A string `json:"a,omitempty"`
-	W string `json:"w,omitempty"`
-	S string `json:"s,omitempty"`
+	A string   `json:"a,omitempty"`
+	W string   `json:"w,omitempty"`
+	S []string `json:"s,omitempty"`
 }
 
 // validateCode reports whether code matches BUILDER_CODE_PATTERN.

--- a/specs/extensions/builder_code.md
+++ b/specs/extensions/builder_code.md
@@ -31,7 +31,7 @@ Wire order: `[cborData][cborLength (2B)][schemaId (1B)][ercMarker (16B)]`
 | --- | --------------- | --------------------------------------------------------------- |
 | `a` | string          | App code — the application that exposed the paid endpoint       |
 | `w` | string          | Wallet code — the facilitator that settled the payment on-chain |
-| `s` | string          | Service code — client-provided attribution (wrapped in a single-element array on wire) |
+| `s` | string or array of strings | Service code(s) — client-provided attribution |
 
 All fields are optional.
 
@@ -92,7 +92,7 @@ The application declares its builder code per-route in the payment middleware co
 
 ## `PaymentPayload`
 
-The client echoes the server's app code (`a`) and attaches its own service code (`s`).
+The client echoes the server's app code (`a`) and attaches its own service code(s) (`s`).
 
 ```json
 {
@@ -100,6 +100,19 @@ The client echoes the server's app code (`a`) and attaches its own service code 
     "builder-code": {
       "a": "my_app",
       "s": "my_client"
+    }
+  }
+}
+```
+
+Layered clients (e.g. an MCP server acting as middleware) can attribute multiple participants by listing several codes as an array:
+
+```json
+{
+  "extensions": {
+    "builder-code": {
+      "a": "my_app",
+      "s": ["base_mcp", "demo_app"]
     }
   }
 }

--- a/typescript/.changeset/builder-code-multiple-s.md
+++ b/typescript/.changeset/builder-code-multiple-s.md
@@ -1,0 +1,5 @@
+---
+'@x402/extensions': minor
+---
+
+builder-code: accept and encode multiple service codes (`s`). The client extension now accepts a string or an array of codes, and the facilitator/CBOR layers encode and parse every valid entry, so layered clients (e.g. an MCP middleware) can attribute multiple participants onchain.

--- a/typescript/packages/extensions/src/builder-code/cbor.ts
+++ b/typescript/packages/extensions/src/builder-code/cbor.ts
@@ -14,6 +14,18 @@ import { type Hex } from "viem";
 import { ERC_8021_MARKER, SCHEMA_2_ID, type BuilderCodeExtensionData } from "./types";
 
 /**
+ * Normalizes the `s` field (string or array of strings) into an array of strings.
+ *
+ * @param s - Service code value as a string, array of strings, or undefined
+ * @returns Array of service code strings (empty when absent)
+ */
+function normalizeServiceCodes(s: BuilderCodeExtensionData["s"]): string[] {
+  if (typeof s === "string") return [s];
+  if (Array.isArray(s)) return s;
+  return [];
+}
+
+/**
  * Encodes a CBOR map from builder code extension data.
  *
  * Produces a minimal CBOR map with:
@@ -42,10 +54,11 @@ function encodeCborMap(data: BuilderCodeExtensionData): Uint8Array {
     entries.push(encodeCborString(data.w));
   }
 
-  if (data.s) {
+  const serviceCodes = normalizeServiceCodes(data.s);
+  if (serviceCodes.length > 0) {
     mapSize++;
     entries.push(encodeCborString("s"));
-    entries.push(encodeCborArray([data.s]));
+    entries.push(encodeCborArray(serviceCodes));
   }
 
   // CBOR map header
@@ -280,7 +293,7 @@ export function parseBuilderCodeSuffixFromCalldata(
         return undefined;
       }
 
-      let firstCode: string | undefined;
+      const codes: string[] = [];
       for (let i = 0; i < arraySize; i++) {
         if (bytes[o] >> 5 !== 3) {
           return undefined;
@@ -292,14 +305,12 @@ export function parseBuilderCodeSuffixFromCalldata(
           return undefined;
         }
 
-        if (i === 0) {
-          firstCode = new TextDecoder().decode(bytes.subarray(o, o + itemLen));
-        }
+        codes.push(new TextDecoder().decode(bytes.subarray(o, o + itemLen)));
         o += itemLen;
       }
 
-      if (firstCode) {
-        result.s = firstCode;
+      if (codes.length > 0) {
+        result.s = codes;
       }
       continue;
     }

--- a/typescript/packages/extensions/src/builder-code/client.ts
+++ b/typescript/packages/extensions/src/builder-code/client.ts
@@ -21,25 +21,32 @@ import { BUILDER_CODE, BUILDER_CODE_PATTERN } from "./types";
  */
 export class BuilderCodeClientExtension implements ClientExtension {
   readonly key = BUILDER_CODE;
-  private readonly serviceCode: string;
+  private readonly serviceCodes: string[];
 
   /**
-   * Creates a client extension that attaches the given service code to payments.
+   * Creates a client extension that attaches the given service code(s) to payments.
    *
-   * @param serviceCode - Client service code (`s`), 1-32 lowercase alphanumeric/underscore characters
+   * Accepts a single code or an array of codes so layered clients (e.g. an MCP
+   * middleware) can attribute multiple participants. Codes are normalized to an
+   * array and sent as the `s` field.
+   *
+   * @param serviceCodes - Client service code(s) (`s`), each 1-32 lowercase alphanumeric/underscore characters
    */
-  constructor(serviceCode: string) {
-    if (!BUILDER_CODE_PATTERN.test(serviceCode)) {
-      throw new Error(
-        `Invalid builder code: "${serviceCode}". ` +
-          `Must be 1-32 characters, lowercase alphanumeric and underscores only.`,
-      );
+  constructor(serviceCodes: string | string[]) {
+    const codes = Array.isArray(serviceCodes) ? serviceCodes : [serviceCodes];
+    for (const code of codes) {
+      if (!BUILDER_CODE_PATTERN.test(code)) {
+        throw new Error(
+          `Invalid builder code: "${code}". ` +
+            `Must be 1-32 characters, lowercase alphanumeric and underscores only.`,
+        );
+      }
     }
-    this.serviceCode = serviceCode;
+    this.serviceCodes = codes;
   }
 
   /**
-   * Attaches this client's service code (`s`).
+   * Attaches this client's service code(s) (`s`).
    *
    * @param payload - Payment payload to enrich
    * @param _ - Server payment requirements; core merges server extension data
@@ -50,7 +57,7 @@ export class BuilderCodeClientExtension implements ClientExtension {
       ...payload,
       extensions: {
         ...payload.extensions,
-        [BUILDER_CODE]: { info: { s: this.serviceCode } },
+        [BUILDER_CODE]: { info: { s: this.serviceCodes } },
       },
     };
   }

--- a/typescript/packages/extensions/src/builder-code/facilitator.ts
+++ b/typescript/packages/extensions/src/builder-code/facilitator.ts
@@ -32,20 +32,17 @@ function extractClientExtension(
 }
 
 /**
- * Normalizes `s` from the client payload — accepts a string or first-valid-entry from an array.
+ * Normalizes `s` from the client payload — accepts a string or an array and keeps
+ * every valid entry.
  *
  * @param raw - Client-provided service code value (string or array of strings)
- * @returns Valid service code, or undefined if missing or invalid
+ * @returns Array of valid service codes (empty when missing or all invalid)
  */
-function resolveServiceCode(raw: unknown): string | undefined {
-  if (typeof raw === "string" && BUILDER_CODE_PATTERN.test(raw)) return raw;
-  if (Array.isArray(raw)) {
-    const first = raw.find(
-      (v): v is string => typeof v === "string" && BUILDER_CODE_PATTERN.test(v),
-    );
-    return first;
-  }
-  return undefined;
+function resolveServiceCodes(raw: unknown): string[] {
+  const candidates = typeof raw === "string" ? [raw] : Array.isArray(raw) ? raw : [];
+  return candidates.filter(
+    (v): v is string => typeof v === "string" && BUILDER_CODE_PATTERN.test(v),
+  );
 }
 
 /**
@@ -96,15 +93,15 @@ export class BuilderCodeFacilitatorExtension implements FacilitatorExtension {
       typeof clientExt?.a === "string" && BUILDER_CODE_PATTERN.test(clientExt.a)
         ? clientExt.a
         : undefined;
-    const s = resolveServiceCode(clientExt?.s);
+    const s = resolveServiceCodes(clientExt?.s);
 
     const data: BuilderCodeExtensionData = {
       ...(this.config.builderCode && { w: this.config.builderCode }),
       ...(a && { a }),
-      ...(s && { s }),
+      ...(s.length > 0 && { s }),
     };
 
-    if (!data.a && !data.w && !data.s) {
+    if (!data.a && !data.w && (!data.s || (Array.isArray(data.s) && data.s.length === 0))) {
       return undefined;
     }
 

--- a/typescript/packages/extensions/src/builder-code/types.ts
+++ b/typescript/packages/extensions/src/builder-code/types.ts
@@ -51,10 +51,11 @@ export interface BuilderCodeExtensionData {
   w?: string;
 
   /**
-   * Service builder code — client-provided attribution code.
-   * Maps to the "s" field in ERC-8021 Schema 2 (wrapped in a single-element array on wire).
+   * Service builder codes — client-provided attribution codes.
+   * Maps to the "s" field in ERC-8021 Schema 2 (encoded as an array on wire).
+   * Accepts a single string or an array of strings; normalized to an array internally.
    */
-  s?: string;
+  s?: string | string[];
 }
 
 /**

--- a/typescript/packages/extensions/test/builder-code.test.ts
+++ b/typescript/packages/extensions/test/builder-code.test.ts
@@ -111,6 +111,12 @@ describe("Builder Code Extension", () => {
       expect(() => new BuilderCodeClientExtension("Bad-Code")).toThrow(/Invalid builder code/);
     });
 
+    it("rejects when any code in an array is invalid", () => {
+      expect(() => new BuilderCodeClientExtension([SERVICE, "Bad-Code"])).toThrow(
+        /Invalid builder code/,
+      );
+    });
+
     it("attaches service code for core extension merging", async () => {
       const client = new BuilderCodeClientExtension(SERVICE);
       const enriched = await client.enrichPaymentPayload!(
@@ -118,14 +124,24 @@ describe("Builder Code Extension", () => {
         paymentRequiredWithApp(APP),
       );
 
-      expect(enriched.extensions?.[BUILDER_CODE]).toEqual({ info: { s: SERVICE } });
+      expect(enriched.extensions?.[BUILDER_CODE]).toEqual({ info: { s: [SERVICE] } });
+    });
+
+    it("attaches multiple service codes when given an array", async () => {
+      const client = new BuilderCodeClientExtension([SERVICE, "bc_other"]);
+      const enriched = await client.enrichPaymentPayload!(
+        basePayload(),
+        paymentRequiredWithApp(APP),
+      );
+
+      expect(enriched.extensions?.[BUILDER_CODE]).toEqual({ info: { s: [SERVICE, "bc_other"] } });
     });
 
     it("attaches only service code when server omits builder-code", async () => {
       const client = new BuilderCodeClientExtension(SERVICE);
       const enriched = await client.enrichPaymentPayload!(basePayload(), paymentRequiredWithApp());
 
-      expect(enriched.extensions?.[BUILDER_CODE]).toEqual({ info: { s: SERVICE } });
+      expect(enriched.extensions?.[BUILDER_CODE]).toEqual({ info: { s: [SERVICE] } });
     });
 
     it("leaves server info preservation to core extension merging", async () => {
@@ -140,7 +156,7 @@ describe("Builder Code Extension", () => {
       };
 
       const enriched = await client.enrichPaymentPayload!(basePayload(), paymentRequired);
-      expect(enriched.extensions?.[BUILDER_CODE]).toEqual({ info: { s: SERVICE } });
+      expect(enriched.extensions?.[BUILDER_CODE]).toEqual({ info: { s: [SERVICE] } });
     });
 
     it("preserves unrelated payload extensions", async () => {
@@ -153,7 +169,7 @@ describe("Builder Code Extension", () => {
       const enriched = await client.enrichPaymentPayload!(payload, paymentRequiredWithApp(APP));
 
       expect(enriched.extensions?.other).toEqual({ kept: true });
-      expect(enriched.extensions?.[BUILDER_CODE]).toEqual({ info: { s: SERVICE } });
+      expect(enriched.extensions?.[BUILDER_CODE]).toEqual({ info: { s: [SERVICE] } });
     });
   });
 
@@ -185,7 +201,7 @@ describe("Builder Code Extension", () => {
       const parsed = parseBuilderCodeSuffixFromCalldata(
         `0xdeadbeef${suffix.slice(2)}` as `0x${string}`,
       );
-      expect(parsed).toEqual({ a: APP, s: SERVICE });
+      expect(parsed).toEqual({ a: APP, s: [SERVICE] });
     });
 
     it("omits the settlement suffix when no attribution is present", () => {
@@ -202,10 +218,10 @@ describe("Builder Code Extension", () => {
         }),
       );
 
-      expect(parsed).toEqual({ w: WALLET, a: APP, s: SERVICE });
+      expect(parsed).toEqual({ w: WALLET, a: APP, s: [SERVICE] });
     });
 
-    it("picks the first valid entry from a service code array", () => {
+    it("encodes all valid entries from a service code array and drops invalid ones", () => {
       const parsed = parsedFromFacilitator(
         suffixContext({
           paymentPayloadExtensions: {
@@ -214,7 +230,7 @@ describe("Builder Code Extension", () => {
         }),
       );
 
-      expect(parsed).toEqual({ w: WALLET, s: SERVICE });
+      expect(parsed).toEqual({ w: WALLET, s: [SERVICE, "bc_other"] });
     });
 
     it("ignores invalid client service codes", () => {
@@ -250,7 +266,18 @@ describe("Builder Code Extension", () => {
       expect(parseBuilderCodeSuffixFromCalldata(calldata)).toEqual({
         a: APP,
         w: WALLET,
-        s: SERVICE,
+        s: [SERVICE],
+      });
+    });
+
+    it("round-trips multiple service codes through calldata", () => {
+      const suffix = encodeBuilderCodeSuffix({ a: APP, w: WALLET, s: [SERVICE, "bc_other"] });
+      const calldata = `0xdeadbeef${suffix.slice(2)}` as `0x${string}`;
+
+      expect(parseBuilderCodeSuffixFromCalldata(calldata)).toEqual({
+        a: APP,
+        w: WALLET,
+        s: [SERVICE, "bc_other"],
       });
     });
 

--- a/typescript/packages/extensions/test/integrations/builder-code.test.ts
+++ b/typescript/packages/extensions/test/integrations/builder-code.test.ts
@@ -61,7 +61,7 @@ describe("Builder Code Integration Tests", () => {
     const paymentPayload = await client.createPaymentPayload(paymentRequired);
 
     expect(paymentPayload.extensions?.[BUILDER_CODE]).toEqual({
-      info: { a: APP, s: SERVICE },
+      info: { a: APP, s: [SERVICE] },
       schema: expect.any(Object),
     });
   });
@@ -104,7 +104,38 @@ describe("Builder Code Integration Tests", () => {
     }
 
     const parsed = parseBuilderCodeSuffixFromCalldata(`0x${"00".repeat(4)}${suffix.slice(2)}`);
-    expect(parsed).toEqual({ w: WALLET, a: APP, s: SERVICE });
+    expect(parsed).toEqual({ w: WALLET, a: APP, s: [SERVICE] });
+  });
+
+  it("attributes multiple service codes from a layered client end-to-end", async () => {
+    const layeredClient = new x402Client()
+      .register("x402:cash", new CashSchemeNetworkClient("payer"))
+      .registerExtension(new BuilderCodeClientExtension(["bc_base_mcp", "bc_demo_app"]));
+
+    const accepts = [buildCashPaymentRequirements("merchant@example.com", "USD", "1")];
+    const resource = {
+      url: "https://example.com/api/weather",
+      description: "Weather API",
+      mimeType: "application/json",
+    };
+    const paymentRequired = await server.createPaymentRequiredResponse(accepts, resource);
+    paymentRequired.extensions = {
+      [BUILDER_CODE]: declareBuilderCodeExtension(APP),
+    };
+
+    const paymentPayload = await layeredClient.createPaymentPayload(paymentRequired);
+    const builderExt = facilitator.getExtension<BuilderCodeFacilitatorExtensionType>(BUILDER_CODE)!;
+
+    const suffix = builderExt.buildDataSuffix!({
+      paymentPayload,
+      paymentRequirements: paymentPayload.accepted,
+    });
+    if (!suffix) {
+      throw new Error("Expected builder-code suffix");
+    }
+
+    const parsed = parseBuilderCodeSuffixFromCalldata(`0x${"00".repeat(4)}${suffix.slice(2)}`);
+    expect(parsed).toEqual({ w: WALLET, a: APP, s: ["bc_base_mcp", "bc_demo_app"] });
   });
 
   it("settlement suffix encodes only wallet code when server did not declare builder-code", async () => {


### PR DESCRIPTION
## Description

Adds option for layered clients (e.g. an MCP server acting as middleware) to include multiple `s` codes for attribution.
Client extension accepts string or an array of strings as `s` input, internally array is used

Closes https://github.com/x402-foundation/x402/issues/2602

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 