### PR TITLE
spec(upto): clarify settle-time verification for partial settlements

### DIFF
--- a/specs/schemes/upto/scheme_upto.md
+++ b/specs/schemes/upto/scheme_upto.md
@@ -57,7 +57,7 @@ In the x402 protocol, the verify and settle requests share the same `PaymentPayl
 The actual settled amount is communicated by the resource server to the facilitator via the `amount` field in the settlement-time `PaymentRequirements`. This allows the resource server to determine the final charge based on actual resource consumption (e.g., tokens generated, bytes transferred) and communicate it to the facilitator without requiring additional fields or a separate settlement type.
 
 - Rationale: Reusing the existing `PaymentRequirements` type for both phases keeps the protocol simple and avoids introducing settlement-specific message types. The `amount` field naturally maps to "how much" in both contexts — "how much is authorized" at verification time and "how much to charge" at settlement time.
-- Implementation: The resource server MUST set the `amount` field in the `PaymentRequirements` passed to the facilitator's settle endpoint to the desired settlement amount. The facilitator MUST verify that this amount does not exceed the authorized maximum from the client's signed authorization.
+- Implementation: The resource server MUST set the `amount` field in the `PaymentRequirements` passed to the facilitator's settle endpoint to the desired settlement amount. The facilitator MUST verify that this amount does not exceed the authorized maximum from the client's signed authorization. **Critically, the facilitator MUST re-verify the client's signature using the authorized maximum (`permitted.amount`), not the settlement-time `requirements.amount`.** See network-specific specs (e.g., [EVM — Settle-Time Verification](./scheme_upto_evm.md#settle-time-verification)) for the exact procedure.
 
 ## Out of Scope
 

--- a/specs/schemes/upto/scheme_upto_evm.md
+++ b/specs/schemes/upto/scheme_upto_evm.md
@@ -156,6 +156,8 @@ The verifier must execute these checks in order:
 
 4.  **Verify** the `permit2Authorization.permitted.amount` equals the `amount` from requirements.
 
+    > **Note**: This check applies at **verification** time, where `requirements.amount` represents the authorized maximum. At **settlement** time, `requirements.amount` carries the actual settlement amount, which may be less than `permitted.amount`. See [Phase 4 — Settle-Time Verification](#settle-time-verification) for the required handling.
+
 5.  **Verify** the `deadline` (not expired) and `witness.validAfter` (active).
 
 6.  **Verify** the Token and Network match the requirement.
@@ -177,6 +179,48 @@ The server determines the actual amount based on resource consumption during the
 - The settled `amount` MUST be `<=` the authorized maximum
 - The settled `amount` MAY be `0` (no charge if no usage occurred)
 - The settled `amount` is determined by the resource server, not the client
+
+#### Settle-Time Verification
+
+Before executing an on-chain settlement, the facilitator MUST re-verify the client's signature. Because the `upto` scheme uses phase-dependent `amount` semantics (see [§2 PaymentRequirements Schema](#2-paymentrequirements-schema)), the `/settle` request will carry `paymentRequirements.amount` set to the **actual settlement amount** (as communicated by the resource server via `setSettlementOverrides`), which may be less than `paymentPayload.payload.permit2Authorization.permitted.amount` (the **authorized maximum** the client signed).
+
+The facilitator MUST handle this case as follows:
+
+1.  **Verify the signature against `permitted.amount`** — When re-verifying the client's signature at settle time, use `permit2Authorization.permitted.amount` (the ceiling from the signed payload), NOT `paymentRequirements.amount` (the actual settlement amount). The client signed for the ceiling; comparing against the metered amount would always fail for partial settlements.
+
+2.  **Validate** `paymentRequirements.amount <= permit2Authorization.permitted.amount` — The actual settlement amount must not exceed the authorized maximum.
+
+3.  **Execute the on-chain transfer for `paymentRequirements.amount`** — The `x402UptoPermit2Proxy.settle` call uses the actual settlement amount, not the ceiling.
+
+> **Conformance note**: A facilitator that enforces `paymentRequirements.amount === permit2Authorization.permitted.amount` at settle time will reject all partial settlements, breaking the core `upto` value proposition. The Phase 3 step 4 equality check (`permitted.amount === requirements.amount`) applies only to the `/verify` endpoint, where `requirements.amount` carries the ceiling.
+
+**Example settle request wire shape** (partial settlement):
+
+```json
+{
+  "x402Version": 2,
+  "paymentPayload": {
+    "x402Version": 2,
+    "accepted": { "scheme": "upto", "network": "eip155:84532", "amount": "20000", ... },
+    "payload": {
+      "signature": "0x...",
+      "permit2Authorization": {
+        "permitted": { "token": "0x036CbD53...", "amount": "20000" },
+        "from": "<buyer>", "spender": "0x4020A4f3b7b90ccA423B9fabCc0CE57C6C240002",
+        "nonce": "...", "deadline": "...",
+        "witness": { "to": "<payTo>", "facilitator": "<facilitatorAddress>", "validAfter": "0" }
+      }
+    }
+  },
+  "paymentRequirements": {
+    "scheme": "upto", "network": "eip155:84532",
+    "asset": "0x036CbD53...", "payTo": "<payTo>",
+    "amount": "1858"
+  }
+}
+```
+
+In this example, the buyer signed for up to `20000` atomic units. The resource server consumed `1858` units of work. The facilitator verifies the signature against `permitted.amount` (`20000`), confirms `1858 <= 20000`, then transfers `1858` on-chain.
 
 **Settlement Process:**
 

--- a/typescript/packages/mechanisms/evm/test/unit/upto/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/upto/facilitator.test.ts
@@ -356,6 +356,95 @@ describe("UptoEvmScheme (Facilitator)", () => {
     });
   });
 
+  describe("settle-time verification convention (spec §Phase 4)", () => {
+    // These tests verify the settle-time verification convention documented in
+    // specs/schemes/upto/scheme_upto_evm.md §Phase 4 "Settle-Time Verification".
+    //
+    // The wire shape for a partial settlement has:
+    //   paymentRequirements.amount = actual metered amount (e.g. 1858)
+    //   permit2Authorization.permitted.amount = authorized ceiling (e.g. 20000)
+    //
+    // The facilitator MUST verify the signature against permitted.amount (the
+    // ceiling), NOT requirements.amount (the metered actual). Enforcing
+    // requirements.amount === permitted.amount at settle time breaks all partial
+    // settlements. See: https://github.com/x402-foundation/x402/issues/2437
+
+    it("should verify signature against permitted.amount, not requirements.amount", async () => {
+      const ceiling = "20000";
+      const metered = "1858";
+
+      const p2 = makePermit2Payload();
+      p2.permit2Authorization.permitted.amount = ceiling;
+      const payload = makePayload(p2);
+      const requirements = makeRequirements({ amount: metered });
+
+      const result = await settleUptoPermit2(mockSigner, payload, requirements, p2);
+
+      expect(result.success).toBe(true);
+
+      // Verify that verifyTypedData was called with the ceiling amount,
+      // not the metered amount — this is the swap convention.
+      const verifyCall = (mockSigner.verifyTypedData as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(verifyCall.message.permitted.amount).toBe(BigInt(ceiling));
+    });
+
+    it("should transfer the metered amount on-chain, not the ceiling", async () => {
+      const ceiling = "20000";
+      const metered = "1858";
+
+      const p2 = makePermit2Payload();
+      p2.permit2Authorization.permitted.amount = ceiling;
+      const payload = makePayload(p2);
+      const requirements = makeRequirements({ amount: metered });
+
+      const result = await settleUptoPermit2(mockSigner, payload, requirements, p2);
+
+      expect(result.success).toBe(true);
+      expect(result.amount).toBe(metered);
+
+      const writeCall = (mockSigner.writeContract as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(writeCall.args[1]).toBe(BigInt(metered));
+    });
+
+    it("should succeed across a range of partial settlement ratios", async () => {
+      const ceiling = "1000000";
+      const testAmounts = ["1", "500000", "999999", "1000000"];
+
+      for (const metered of testAmounts) {
+        vi.clearAllMocks();
+        mockSigner.readContract = vi.fn().mockResolvedValue(BigInt("999999999999999999"));
+        mockSigner.verifyTypedData = vi.fn().mockResolvedValue(true);
+        mockSigner.writeContract = vi.fn().mockResolvedValue("0xtxhash1234" as `0x${string}`);
+        mockSigner.waitForTransactionReceipt = vi.fn().mockResolvedValue({ status: "success" });
+
+        const p2 = makePermit2Payload();
+        p2.permit2Authorization.permitted.amount = ceiling;
+        const payload = makePayload(p2);
+        const requirements = makeRequirements({ amount: metered });
+
+        const result = await settleUptoPermit2(mockSigner, payload, requirements, p2);
+
+        expect(result.success).toBe(true);
+        expect(result.amount).toBe(metered);
+      }
+    });
+
+    it("should reject when metered amount exceeds ceiling", async () => {
+      const ceiling = "20000";
+      const metered = "20001";
+
+      const p2 = makePermit2Payload();
+      p2.permit2Authorization.permitted.amount = ceiling;
+      const payload = makePayload(p2);
+      const requirements = makeRequirements({ amount: metered });
+
+      const result = await settleUptoPermit2(mockSigner, payload, requirements, p2);
+
+      expect(result.success).toBe(false);
+      expect(result.errorReason).toBe(ErrUptoSettlementExceedsAmount);
+    });
+  });
+
   describe("settle error mapping", () => {
     it("should map Permit2612AmountMismatch revert", async () => {
       mockSigner.writeContract = vi


### PR DESCRIPTION
> **Note:** This supersedes #2472, which was auto-closed by GitHub after a force-push removed its common ancestor with `main` and could not be reopened. Same change, now with a signed/verified commit and phdargen's `x402UptoPermit2Proxy` naming fix applied.

## Summary

Closes #2437.

The upto EVM spec's Phase 3 step 4 requires `permitted.amount === requirements.amount` but doesn't distinguish verify-time (where `requirements.amount` is the ceiling) from settle-time (where `requirements.amount` is the metered actual). This ambiguity allows facilitator implementations to enforce the equality check at settle time, rejecting all partial settlements — the core upto value proposition.

The reference implementation already handles this correctly (`settleUptoPermit2` swaps `requirements.amount` → `permitted.amount` before re-verification), but the spec doesn't mandate it. This has led to at least one hosted facilitator (CDP) routing upto settle requests through exact-scheme validation, rejecting every metered settle with `invalid_exact_evm_payload_authorization_value_too_low`.

## Changes

**Spec (`specs/schemes/upto/`)**
- Add "Settle-Time Verification" subsection to Phase 4 of `scheme_upto_evm.md` documenting the required facilitator behavior:
  1. Verify signature against `permitted.amount` (ceiling), not `requirements.amount` (metered actual)
  2. Validate `requirements.amount <= permitted.amount`
  3. Transfer `requirements.amount` on-chain
- Add conformance note explicitly stating that enforcing `requirements.amount === permitted.amount` at settle time breaks partial settlements
- Add annotated Phase 3 step 4 cross-reference to the new Phase 4 section
- Add settle-time wire-shape example showing the partial settlement request
- Cross-reference from abstract `scheme_upto.md` to the EVM-specific settle-time verification section

**Tests (`typescript/packages/mechanisms/evm/`)**
- Add 4 conformance tests to `test/unit/upto/facilitator.test.ts` under new `settle-time verification convention (spec §Phase 4)` describe block:
  - Signature verified against `permitted.amount`, not `requirements.amount`
  - Metered amount (not ceiling) transferred on-chain
  - Range of partial settlement ratios all succeed
  - Settlement exceeding ceiling is rejected

## Test plan

- [x] `pnpm test` in `typescript/packages/mechanisms/evm/` — 25 test files, 633 tests passing (including 4 new)
- [ ] Verify spec renders correctly in docs site (Markdown-only change, no build needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
