### PR TITLE
Patch e2e runner

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -7,8 +7,8 @@ name: E2E Tests
 
 on:
   schedule:
-    - cron: "0 10 * * 0-4,6" # daily except Friday — v2 only
-    - cron: "0 10 * * 5"     # Friday — v1 legacy + v2
+    - cron: "0 5 * * 0-4,6" # daily except Friday — v2 only
+    - cron: "0 5 * * 5"     # Friday — v1 legacy + v2
   workflow_dispatch:
     inputs:
       include_legacy:
@@ -65,7 +65,7 @@ jobs:
           FACILITATOR_STELLAR_PRIVATE_KEY: ${{ secrets.FACILITATOR_STELLAR_PRIVATE_KEY }}
           FACILITATOR_TVM_PRIVATE_KEY: ${{ secrets.FACILITATOR_TVM_PRIVATE_KEY }}
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" && "${{ github.event.schedule }}" == "0 10 * * 5" ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" && "${{ github.event.schedule }}" == "0 5 * * 5" ]]; then
             VERSIONS="1,2"
             RUN_SCOPE="friday v1 legacy + v2"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.include_legacy }}" == "true" ]]; then
@@ -177,7 +177,7 @@ jobs:
       - name: Run minimized e2e tests (testnet)
         if: steps.families.outputs.configured == 'true'
         run: |
-          pnpm test --testnet --min --parallel --log --output-json=e2e-results.json --families=${{ steps.families.outputs.families }} --versions=${{ steps.families.outputs.versions }}
+          pnpm test --testnet --min --parallel --log=e2e-run.log --output-json=e2e-results.json --families=${{ steps.families.outputs.families }} --versions=${{ steps.families.outputs.versions }}
 
       - name: Upload test results
         if: always() && steps.families.outputs.configured == 'true'
@@ -186,5 +186,6 @@ jobs:
           name: e2e-results
           path: |
             e2e/e2e-results.json
+            e2e/e2e-run.log
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
## Description

e2e runner failed due to missing log/ dir

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 