### PR TITLE
Validate Retry After delta seconds

### DIFF
--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -79,10 +79,10 @@ export function computeRetryDelay(retryAfter: string | null, attempt: number): n
   let delay: number | null = null;
 
   if (retryAfter !== null) {
-    const seconds = Number(retryAfter);
-    if (!isNaN(seconds)) {
+    const trimmedRetryAfter = retryAfter.trim();
+    if (/^\d+$/.test(trimmedRetryAfter)) {
       // delta-seconds form
-      delay = seconds * 1000;
+      delay = Number(trimmedRetryAfter) * 1000;
     } else {
       // HTTP-date form
       const retryDate = Date.parse(retryAfter);

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -295,6 +295,10 @@ describe("computeRetryDelay", () => {
     expect(computeRetryDelay("not-a-date", 1)).toBe(2000);
   });
 
+  it("does not treat fractional Retry-After values as delta-seconds", () => {
+    expect(computeRetryDelay("1.5", 1)).toBe(2000);
+  });
+
   it("caps the delay to MAX_RETRY_DELAY_MS to prevent pathological waits", () => {
     expect(computeRetryDelay("9999", 0)).toBe(30_000);
   });


### PR DESCRIPTION
The Retry After header defines delta seconds as nonnegative decimal integers. The current parser accepts fractional values like `1.5` via `Number()`, which can produce nonstandard retry delays instead of falling back to the existing backoff path.

This tightens delta seconds parsing to integer digits only and keeps HTTP date parsing unchanged.