### PR TITLE
@x402/sui — exact scheme mechanism for Sui (gasless transfers)

### DIFF
--- a/.github/workflows/publish_npm_scoped_x402_sui.yml
+++ b/.github/workflows/publish_npm_scoped_x402_sui.yml
@@ -1,0 +1,49 @@
+name: Publish @x402/sui package to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-npm-x402-sui:
+    if: github.repository == 'x402-foundation/x402' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.1.1
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@11.14.1 --ignore-scripts
+
+      - name: Configure npm for trusted publishing
+        run: npm config delete always-auth 2>/dev/null || true
+
+      - name: Install and build
+        working-directory: ./typescript
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm -r --filter=@x402/core --filter=@x402/sui run build
+
+      - name: Publish @x402/sui package
+        working-directory: ./typescript/packages/mechanisms/sui
+        run: |
+          # Get package information directly
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          echo "Package: $PACKAGE_NAME@$PACKAGE_VERSION"
+
+          echo "Publishing to NPM (main branch)"
+          pnpm publish --provenance --access public

--- a/e2e/src/networks/networks.ts
+++ b/e2e/src/networks/networks.ts
@@ -6,7 +6,7 @@
  */
 
 export type NetworkMode = 'testnet' | 'mainnet';
-export type ProtocolFamily = 'evm' | 'svm' | 'avm' | 'aptos' | 'hedera' | 'keeta' | 'near' | 'stellar' | 'ccd' | 'tvm' | 'xrpl';
+export type ProtocolFamily = 'evm' | 'svm' | 'avm' | 'aptos' | 'sui' | 'hedera' | 'keeta' | 'near' | 'stellar' | 'ccd' | 'tvm' | 'xrpl';
 
 export type NetworkConfig = {
   name: string;
@@ -20,6 +20,7 @@ export type NetworkSet = {
   svm: NetworkConfig;
   avm: NetworkConfig;
   aptos: NetworkConfig;
+  sui: NetworkConfig;
   hedera: NetworkConfig;
   keeta: NetworkConfig;
   stellar: NetworkConfig;
@@ -59,6 +60,11 @@ const NETWORK_SETS: Record<NetworkMode, NetworkSet> = {
       name: 'Aptos Testnet',
       caip2: 'aptos:2',
       rpcUrl: process.env.APTOS_TESTNET_RPC_URL || 'https://fullnode.testnet.aptoslabs.com/v1',
+    },
+    sui: {
+      name: 'Sui Testnet',
+      caip2: 'sui:testnet',
+      rpcUrl: process.env.SUI_TESTNET_RPC_URL || 'https://fullnode.testnet.sui.io:443',
     },
     hedera: {
       name: 'Hedera Testnet',
@@ -118,6 +124,11 @@ const NETWORK_SETS: Record<NetworkMode, NetworkSet> = {
       name: 'Aptos',
       caip2: 'aptos:1',
       rpcUrl: process.env.APTOS_RPC_URL || 'https://fullnode.mainnet.aptoslabs.com/v1',
+    },
+    sui: {
+      name: 'Sui',
+      caip2: 'sui:mainnet',
+      rpcUrl: process.env.SUI_RPC_URL || 'https://fullnode.mainnet.sui.io:443',
     },
     hedera: {
       name: 'Hedera Mainnet',
@@ -184,7 +195,7 @@ export function resolveEvmPermit2Asset(networks: NetworkSet): string {
  * Get network config for a protocol family in a given mode
  *
  * @param mode - 'testnet' or 'mainnet'
- * @param protocolFamily - 'evm', 'svm', 'avm', 'aptos', 'hedera', 'near', 'stellar', 'ccd', 'tvm', or 'xrpl'
+ * @param protocolFamily - 'evm', 'svm', 'avm', 'aptos', 'sui', 'hedera', 'near', 'stellar', 'ccd', 'tvm', or 'xrpl'
  * @returns NetworkConfig for the specified protocol
  */
 export function getNetworkForProtocol(
@@ -202,6 +213,6 @@ export function getNetworkForProtocol(
  */
 export function getNetworkModeDescription(mode: NetworkMode): string {
   const set = NETWORK_SETS[mode];
-  const networks = [set.evm.name, set.svm.name, set.avm.name, set.aptos.name, set.hedera.name, set.keeta.name, set.near.name, set.stellar.name, set.ccd.name, set.tvm.name, set.xrpl.name];
+  const networks = [set.evm.name, set.svm.name, set.avm.name, set.aptos.name, set.sui.name, set.hedera.name, set.keeta.name, set.near.name, set.stellar.name, set.ccd.name, set.tvm.name, set.xrpl.name];
   return networks.join(' + ');
 }

--- a/e2e/src/types.ts
+++ b/e2e/src/types.ts
@@ -1,6 +1,6 @@
 import type { NetworkSet } from './networks/networks';
 
-export type ProtocolFamily = 'evm' | 'svm' | 'avm' | 'aptos' | 'hedera' | 'keeta' | 'near' | 'stellar' | 'ccd' | 'tvm' | 'xrpl';
+export type ProtocolFamily = 'evm' | 'svm' | 'avm' | 'aptos' | 'sui' | 'hedera' | 'keeta' | 'near' | 'stellar' | 'ccd' | 'tvm' | 'xrpl';
 export type Transport = 'http' | 'mcp';
 export type PaymentScheme = 'exact' | 'upto' | 'batch-settlement';
 export type AssetTransferMethod = 'eip3009' | 'permit2' | 'sequence' | 'ticketSequence';

--- a/typescript/.changeset/config.json
+++ b/typescript/.changeset/config.json
@@ -11,6 +11,7 @@
       "@x402/evm",
       "@x402/avm",
       "@x402/aptos",
+      "@x402/sui",
       "@x402/stellar",
       "@x402/svm",
       "@x402/tvm",

--- a/typescript/.changeset/sui-exact-mechanism.md
+++ b/typescript/.changeset/sui-exact-mechanism.md
@@ -1,0 +1,9 @@
+---
+"@x402/sui": minor
+---
+
+Add @x402/sui: exact-scheme mechanism for Sui (client, server, facilitator) per
+specs/schemes/exact/scheme_exact_sui.md. Supports gasless Address Balance transfers
+(protocol v125): zero-gas USDC payments with no coin object creation, optional declared
+outputs (extra.outputs) verified against exact payer debit, and optional prebuilt
+transactions (extra.buildUrl). Networks: sui:mainnet, sui:testnet, sui:devnet.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -29,4 +29,5 @@ This folder contains Typescript packages to help developers implement the x402 p
 | **Aptos** - [`@x402/aptos`](./packages/mechanisms/aptos) | Aptos implementation of the x402 payment protocol. | [![npm version](https://img.shields.io/npm/v/%40x402%2Faptos.svg)](https://www.npmjs.com/package/@x402/aptos) |
 | **Stellar** - [`@x402/stellar`](./packages/mechanisms/stellar) | Stellar implementation of x402 using Soroban token transfers. | [![npm version](https://img.shields.io/npm/v/%40x402%2Fstellar.svg)](https://www.npmjs.com/package/@x402/stellar) |
 | **Solana** - [`@x402/svm`](./packages/mechanisms/svm) | SVM implementation of x402 using SPL token transfers. | [![npm version](https://img.shields.io/npm/v/%40x402%2Fsvm.svg)](https://www.npmjs.com/package/@x402/svm) |
+| **Sui** - [`@x402/sui`](./packages/mechanisms/sui) | Sui implementation of x402 using gasless Address-Balance stablecoin transfers. | [![npm version](https://img.shields.io/npm/v/%40x402%2Fsui.svg)](https://www.npmjs.com/package/@x402/sui) |
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -17,7 +17,7 @@
     "lint:check": "turbo run lint:check",
     "format:check": "turbo run format:check",
     "test": "turbo run test",
-    "test:integration": "pnpm --filter @x402/core --filter @x402/evm --filter @x402/svm --filter @x402/avm --filter @x402/aptos --filter @x402/hedera --filter @x402/keeta --filter @x402/near --filter @x402/stellar --filter @x402/xrpl test:integration",
+    "test:integration": "pnpm --filter @x402/core --filter @x402/evm --filter @x402/svm --filter @x402/avm --filter @x402/aptos --filter @x402/sui --filter @x402/hedera --filter @x402/keeta --filter @x402/near --filter @x402/stellar --filter @x402/xrpl test:integration",
     "test:all": "pnpm test && pnpm test:integration"
   },
   "keywords": [],

--- a/typescript/packages/mechanisms/sui/.prettierignore
+++ b/typescript/packages/mechanisms/sui/.prettierignore
@@ -1,0 +1,3 @@
+# build output
+dist/
+node_modules/

--- a/typescript/packages/mechanisms/sui/.prettierrc
+++ b/typescript/packages/mechanisms/sui/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/typescript/packages/mechanisms/sui/README.md
+++ b/typescript/packages/mechanisms/sui/README.md
@@ -1,0 +1,83 @@
+# `@x402/sui` [![npm version](https://img.shields.io/npm/v/%40x402%2Fsui.svg)](https://www.npmjs.com/package/@x402/sui)
+
+Sui implementation of the x402 payment protocol — **zero-gas USDC payments**: no gas token, no sponsor, no interactive gas-station round trip, no coin-object storage cost.
+
+Implements [`scheme_exact_sui.md`](../../../../specs/schemes/exact/scheme_exact_sui.md), including the spec's stated follow-up: payments ride Sui's **Address Balances** gasless stablecoin transfers (protocol v125) — transactions with `gasPayment: []`, `gasPrice: 0`, composed exclusively of protocol-allowlisted stablecoin operations.
+
+## Installation
+
+```bash
+npm install @x402/sui
+# or
+pnpm add @x402/sui
+```
+
+## Networks
+
+| CAIP-2 | Default USDC | Decimals |
+| --- | --- | --- |
+| `sui:mainnet` | `0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC` | 6 |
+| `sui:testnet` | `0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC` | 6 |
+| `sui:devnet` | none (pass an explicit `AssetAmount` price) | — |
+
+## Usage
+
+### Client
+
+```typescript
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { ExactSuiScheme } from "@x402/sui/exact/client";
+import { toClientSuiSigner } from "@x402/sui";
+
+const keypair = Ed25519Keypair.fromSecretKey("suiprivkey1...");
+const client = new SuiGrpcClient({
+  network: "testnet",
+  baseUrl: "https://fullnode.testnet.sui.io:443",
+});
+const signer = toClientSuiSigner(keypair, client);
+
+x402Client.register("sui:testnet", new ExactSuiScheme(signer));
+```
+
+### Server
+
+```typescript
+import { x402ResourceServer } from "@x402/core/server";
+import { ExactSuiScheme } from "@x402/sui/exact/server";
+
+const server = new x402ResourceServer(facilitatorClient);
+server.register("sui:testnet", new ExactSuiScheme());
+
+// parsePrice converts "$0.05" / 0.05 / { amount, asset } to atomic USDC.
+```
+
+### Facilitator
+
+```typescript
+import { ExactSuiScheme } from "@x402/sui/exact/facilitator";
+import { toFacilitatorSuiSigner } from "@x402/sui";
+
+// Gasless is keyless — no sponsor key needed; the facilitator relays the
+// payer's already-signed bytes and verifies on-chain effects.
+const signer = toFacilitatorSuiSigner();
+facilitator.register("sui:testnet", new ExactSuiScheme(signer));
+```
+
+## Gasless construction
+
+The client builds one `0x2::balance::send_funds<USDC>` per recipient, drawn from the payer's Address Balance, and forces the gasless election (`gasBudget(0n)`). The facilitator's verify asserts `gasPrice == 0` ∧ `gasPayment == []` and that every command is an allowlisted gasless operation — the four functions that exist on-chain (`balance::send_funds` / `balance::redeem_funds`, `coin::send_funds` / `coin::into_balance`) plus the native `SplitCoins` / `MergeCoins` a coin-object source needs (see below). `TransferObjects` and every other command stay rejected; the exact-fee balance-change check binds the actual money movement, so there is no facilitator gas to drain and no hidden recipient is possible. Below an enforcing network's `0.01` minimum, fall back to the classic `Coin<T>` path.
+
+When the payer's USDC is a classic `Coin<T>` OBJECT rather than an Address Balance (the common case after a normal coin transfer), the SDK's `tx.balance({ type, balance })` intent resolves to `[SplitCoins, coin::into_balance, balance::send_funds, coin::send_funds]` — still gasless. The allowlist tolerates `SplitCoins` / `MergeCoins` for exactly this coin-plumbing; nothing else.
+
+## Declared outputs
+
+`PaymentRequirements.extra.outputs` (OPTIONAL) declares a multi-recipient split summing to `amount`. Verification anchors on the EXACT payer debit: every declared recipient is credited exactly its amount, the payer is debited exactly `amount`, and no undeclared recipient of the asset is allowed. Absent, verification is the unchanged single-`payTo` rule.
+
+## Prebuilt transactions
+
+`PaymentRequirements.extra.buildUrl` (OPTIONAL) advertises a facilitator endpoint that returns unsigned gasless bytes. The client INDEPENDENTLY verifies the bytes before signing — sender match, gasless gas fields, allowlisted commands, AND a dry-run that confirms the bytes pay EXACTLY the declared recipients/amounts (no hidden recipient). Signing is the only authorization act, so this pre-sign check — not trust in the facilitator — is what binds the signature to the agreed terms.
+
+## License
+
+Apache-2.0

--- a/typescript/packages/mechanisms/sui/README.md
+++ b/typescript/packages/mechanisms/sui/README.md
@@ -76,9 +76,9 @@ When the payer's USDC is a classic `Coin<T>` OBJECT rather than an Address Balan
 
 `PaymentRequirements.extra.outputs` (OPTIONAL) declares a multi-recipient split summing to `amount`. Verification anchors on the EXACT payer debit: every declared recipient is credited exactly its amount, the payer is debited exactly `amount`, and no undeclared recipient of the asset is allowed. Absent, verification is the unchanged single-`payTo` rule.
 
-## Prebuilt transactions
+## Asset transfer methods
 
-`PaymentRequirements.extra.buildUrl` (OPTIONAL) advertises a facilitator endpoint that returns unsigned gasless bytes. The client INDEPENDENTLY verifies the bytes before signing — sender match, gasless gas fields, allowlisted commands, AND a dry-run that confirms the bytes pay EXACTLY the declared recipients/amounts (no hidden recipient). Signing is the only authorization act, so this pre-sign check — not trust in the facilitator — is what binds the signature to the agreed terms.
+The Sui spec defines two `extra.assetTransferMethod` values: `address-balance` (the gasless Address-Balance path) and `coin` (the classic gas-paying path, optionally gas-station sponsored). This package implements `address-balance` end to end — the client builds gasless PTBs and the facilitator verifies the gasless shape and settles keylessly — and the facilitator announces the method in its `/supported` extras, so a resource server relays it into `PaymentRequirements.extra` and the payload echoes it. A declared or echoed `coin` method is rejected as unsupported; independently of any declaration, the facilitator derives the effective method from the decoded bytes (`gasPayment == []`), so a mislabeled payment cannot slip through.
 
 ## License
 

--- a/typescript/packages/mechanisms/sui/README.md
+++ b/typescript/packages/mechanisms/sui/README.md
@@ -40,6 +40,8 @@ const signer = toClientSuiSigner(keypair, client);
 x402Client.register("sui:testnet", new ExactSuiScheme(signer));
 ```
 
+`toClientSuiSigner` accepts any `Signer` from `@mysten/sui/cryptography` — the abstract class is the contract, not `Ed25519Keypair`. `Secp256k1Keypair`, wallet adapters, and remote-custody signers such as [`@mysten/aws-kms-signer`](https://www.npmjs.com/package/@mysten/aws-kms-signer) drop in unchanged: the private key never has to enter process memory.
+
 ### Server
 
 ```typescript

--- a/typescript/packages/mechanisms/sui/eslint.config.js
+++ b/typescript/packages/mechanisms/sui/eslint.config.js
@@ -1,0 +1,92 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: ["**/*.test.ts", "test/**/*"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        console: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+  {
+    files: ["**/*.test.ts", "test/**/*"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+    },
+    rules: {
+      "prettier/prettier": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/member-ordering": "off",
+    },
+  },
+];

--- a/typescript/packages/mechanisms/sui/package.json
+++ b/typescript/packages/mechanisms/sui/package.json
@@ -1,0 +1,98 @@
+{
+  "name": "@x402/sui",
+  "version": "2.14.0",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "scripts": {
+    "start": "tsx --env-file=.env index.ts",
+    "build": "tsup",
+    "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:watch": "vitest",
+    "watch": "tsc --watch",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "keywords": [
+    "x402",
+    "payment",
+    "protocol",
+    "sui"
+  ],
+  "license": "Apache-2.0",
+  "author": "Suize",
+  "contributors": [
+    "Daniel Ahn <et3rnal.d@gmail.com>"
+  ],
+  "repository": "https://github.com/x402-foundation/x402",
+  "description": "x402 Payment Protocol Sui Implementation",
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@types/node": "^22.13.4",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsup": "^8.4.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3",
+    "vite": "^6.2.6",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.0.5"
+  },
+  "dependencies": {
+    "@x402/core": "workspace:~",
+    "@mysten/sui": "^2.17.0"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./exact/client": {
+      "import": {
+        "types": "./dist/esm/exact/client/index.d.mts",
+        "default": "./dist/esm/exact/client/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/exact/client/index.d.ts",
+        "default": "./dist/cjs/exact/client/index.js"
+      }
+    },
+    "./exact/server": {
+      "import": {
+        "types": "./dist/esm/exact/server/index.d.mts",
+        "default": "./dist/esm/exact/server/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/exact/server/index.d.ts",
+        "default": "./dist/cjs/exact/server/index.js"
+      }
+    },
+    "./exact/facilitator": {
+      "import": {
+        "types": "./dist/esm/exact/facilitator/index.d.mts",
+        "default": "./dist/esm/exact/facilitator/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/exact/facilitator/index.d.ts",
+        "default": "./dist/cjs/exact/facilitator/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/typescript/packages/mechanisms/sui/src/constants.ts
+++ b/typescript/packages/mechanisms/sui/src/constants.ts
@@ -1,0 +1,149 @@
+// Portions copyright 2026 Danny Devs (https://github.com/Danny-Devs/x402-sui), Apache-2.0
+
+import { normalizeStructTag } from "@mysten/sui/utils";
+import type { Network } from "@x402/core/types";
+
+/**
+ * CAIP-2 network identifier for Sui Mainnet (matches the merged-spec example).
+ */
+export const SUI_MAINNET_CAIP2 = "sui:mainnet";
+
+/**
+ * CAIP-2 network identifier for Sui Testnet.
+ */
+export const SUI_TESTNET_CAIP2 = "sui:testnet";
+
+/**
+ * CAIP-2 network identifier for Sui Devnet.
+ */
+export const SUI_DEVNET_CAIP2 = "sui:devnet";
+
+/**
+ * Native Circle USDC on Sui mainnet (CCTP) — the canonical USDC, NOT the
+ * deprecated Wormhole-bridged version.
+ */
+export const USDC_MAINNET =
+  "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC";
+
+/**
+ * Circle native USDC on Sui testnet.
+ */
+export const USDC_TESTNET =
+  "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC";
+
+/**
+ * USDC decimal places (the same everywhere Circle USDC ships).
+ */
+export const USDC_DECIMALS = 6;
+
+/**
+ * Default RPC URL for Sui mainnet.
+ */
+export const MAINNET_RPC_URL = "https://fullnode.mainnet.sui.io:443";
+
+/**
+ * Default RPC URL for Sui testnet.
+ */
+export const TESTNET_RPC_URL = "https://fullnode.testnet.sui.io:443";
+
+/**
+ * Default RPC URL for Sui devnet.
+ */
+export const DEVNET_RPC_URL = "https://fullnode.devnet.sui.io:443";
+
+/**
+ * Sui address validation regex (0x followed by 64 hex characters).
+ * Short-form addresses (e.g. "0x2") must be normalized to full length first.
+ */
+export const SUI_ADDRESS_REGEX = /^0x[a-fA-F0-9]{64}$/;
+
+/**
+ * The minimum per-transfer amount the protocol applies to gasless transfers on
+ * networks that enforce the allowlist parameter (0.01 USDC = 10_000 atomic units).
+ *
+ * NOTE: this is a PROTOCOL PARAMETER, not a verification invariant — testnet does
+ * not always enforce it. Verification anchors on exact amounts regardless. Below
+ * this on an enforcing network, the payer falls back to the classic `Coin<T>` path.
+ */
+export const MIN_GASLESS_TRANSFER = 10_000n;
+
+/**
+ * Fully-normalized package id for the Sui framework (0x2).
+ */
+const FRAMEWORK = "0x0000000000000000000000000000000000000000000000000000000000000002";
+
+/**
+ * The protocol-allowlisted Move call targets a gasless stablecoin transfer may
+ * use. Every MoveCall command in a gasless transaction MUST resolve to one of
+ * these (after normalization). The SDK's `tx.balance({ type, balance })` input
+ * resolves to `balance::redeem_funds` for an Address Balance and `coin::into_balance`
+ * for a `Coin<T>`, then `balance::send_funds` (and, for a coin source, a final
+ * `coin::send_funds`) to the recipient.
+ *
+ * These are exactly the four functions that EXIST on testnet and mainnet, verified
+ * via `sui_getNormalizedMoveFunction`. Earlier drafts also listed
+ * `0x2::balance::withdrawal_split` and `0x2::balance::into_balance` — neither exists
+ * on-chain (the SDK never emits them); they are removed so the allowlist matches the
+ * actual framework.
+ *
+ * Keys are `package::module::function` with the package id fully normalized.
+ */
+export const GASLESS_ALLOWED_TARGETS: ReadonlySet<string> = new Set([
+  `${FRAMEWORK}::balance::send_funds`,
+  `${FRAMEWORK}::balance::redeem_funds`,
+  `${FRAMEWORK}::coin::send_funds`,
+  `${FRAMEWORK}::coin::into_balance`,
+]);
+
+/**
+ * Native (non-MoveCall) PTB commands a gasless payment may carry. When the payer
+ * sources the transfer from a `Coin<T>` OBJECT (the COMMON case — anyone who just
+ * received USDC via a classic coin transfer, with zero Address Balance), the SDK's
+ * `tx.balance({ type, balance })` intent resolves to a PTB that first SPLITS exact
+ * change off the coin (`SplitCoins`) and may MERGE coin fragments (`MergeCoins`),
+ * then converts to a balance and sends it. These commands move no asset to a third
+ * party — `TransferObjects` (the object-leak vector) and every other command stay
+ * rejected, and the exact-fee balance-change check (Verification step 5) binds the
+ * ACTUAL money movement regardless, so tolerating coin plumbing is safe.
+ */
+export const GASLESS_ALLOWED_NON_MOVECALL: ReadonlySet<string> = new Set([
+  "SplitCoins",
+  "MergeCoins",
+]);
+
+/**
+ * Get the default USDC coin type for a network. Devnet has no default asset:
+ * a price string on devnet is rejected (AssetAmount must be passed explicitly).
+ *
+ * @param network - CAIP-2 network identifier
+ * @returns USDC coin type string
+ */
+export function getUsdcCoinType(network: Network): string {
+  switch (network) {
+    case SUI_MAINNET_CAIP2:
+      return USDC_MAINNET;
+    case SUI_TESTNET_CAIP2:
+      return USDC_TESTNET;
+    default:
+      throw new Error(`No default USDC coin type configured for network: ${network}`);
+  }
+}
+
+/**
+ * Normalize a `package::module::function` Move call target so that the package
+ * id is fully zero-padded (the SDK emits `0x2`, the allowlist stores the long form).
+ *
+ * @param packageId - The package address of the Move call
+ * @param moduleName - The module name of the Move call
+ * @param functionName - The function name of the Move call
+ * @returns The normalized `package::module::function` string
+ */
+export function normalizeMoveTarget(
+  packageId: string,
+  moduleName: string,
+  functionName: string,
+): string {
+  // normalizeStructTag pads the address portion; reuse it via a synthetic struct.
+  const normalized = normalizeStructTag(`${packageId}::${moduleName}::${functionName}`);
+  return normalized;
+}

--- a/typescript/packages/mechanisms/sui/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/client/index.ts
@@ -1,0 +1,1 @@
+export { ExactSuiScheme } from "./scheme";

--- a/typescript/packages/mechanisms/sui/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/client/scheme.ts
@@ -1,0 +1,276 @@
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { Transaction } from "@mysten/sui/transactions";
+import { fromBase64 } from "@mysten/sui/utils";
+import type {
+  PaymentRequirements,
+  PaymentPayloadResult,
+  SchemeNetworkClient,
+} from "@x402/core/types";
+import type { ClientSuiSigner } from "../../signer";
+import type { ExactSuiPayload, SuiOutput } from "../../types";
+import {
+  GASLESS_ALLOWED_TARGETS,
+  GASLESS_ALLOWED_NON_MOVECALL,
+  TESTNET_RPC_URL,
+  MAINNET_RPC_URL,
+  DEVNET_RPC_URL,
+  SUI_MAINNET_CAIP2,
+  SUI_TESTNET_CAIP2,
+  SUI_DEVNET_CAIP2,
+  normalizeMoveTarget,
+} from "../../constants";
+import { createSuiClient, matchBalanceChanges, outputsOf } from "../../utils";
+
+/**
+ * Sui client implementation for the Exact payment scheme.
+ *
+ * Builds a GASLESS Address-Balance payment PTB — one `0x2::balance::send_funds`
+ * per declared output, drawn from the payer's Address Balance (the SDK's
+ * `tx.balance()` input resolves the coin source), built over gRPC so the gasless
+ * params (`gasPrice = 0`, `gasPayment = []`) resolve, with `setGasBudget(0n)` to
+ * force the resolver's gasless election deterministically. Signs but does NOT
+ * execute — the facilitator broadcasts during settlement.
+ *
+ * When the requirements advertise `extra.buildUrl`, the client MAY instead fetch
+ * the facilitator's prebuilt unsigned bytes — but it independently verifies them
+ * (sender, gasless gas fields, allowlisted commands) BEFORE signing.
+ */
+export class ExactSuiScheme implements SchemeNetworkClient {
+  readonly scheme = "exact";
+
+  /**
+   * Creates a new ExactSuiScheme client instance.
+   *
+   * @param signer - The client signer for signing transactions
+   * @param config - Optional config object
+   * @param config.rpcUrl - Optional custom gRPC RPC URL
+   */
+  constructor(
+    private readonly signer: ClientSuiSigner,
+    private readonly config?: { rpcUrl?: string },
+  ) {}
+
+  /**
+   * Creates a payment payload by building (or fetching) and signing a gasless PTB.
+   *
+   * @param x402Version - The x402 protocol version
+   * @param paymentRequirements - The payment requirements (amount, asset, payTo, network, extra)
+   * @returns Promise resolving to a signed payment payload
+   */
+  async createPaymentPayload(
+    x402Version: number,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<PaymentPayloadResult> {
+    const { asset, network } = paymentRequirements;
+    if (!asset) {
+      throw new Error("Asset is required");
+    }
+
+    const outputs = outputsOf(paymentRequirements);
+    this.assertOutputsSumToAmount(outputs, paymentRequirements.amount);
+
+    const client = this.grpcClient(network);
+
+    // PATH B: a prebuilt-transaction URL was advertised — fetch, VERIFY, then sign.
+    const buildUrl = paymentRequirements.extra?.buildUrl;
+    const bytes =
+      typeof buildUrl === "string"
+        ? await this.fetchAndVerifyBuildUrl(buildUrl, paymentRequirements, outputs)
+        : await this.buildGaslessOutputs(client, asset, outputs);
+
+    const tx = Transaction.from(fromBase64(bytes));
+    const { signature, bytes: signedBytes } = await this.signer.signTransaction(tx);
+
+    const payload: ExactSuiPayload = {
+      signature,
+      transaction: signedBytes,
+    };
+
+    return {
+      x402Version,
+      payload,
+    };
+  }
+
+  /**
+   * Build the gasless Address-Balance payment PTB: one `0x2::balance::send_funds`
+   * per declared output, `setGasBudget(0n)` to force the gasless election.
+   *
+   * @param client - A gRPC client (gasless eligibility resolves over gRPC)
+   * @param asset - The coin type to transfer
+   * @param outputs - The declared `{ to, amount }` outputs
+   * @returns Base64-encoded unsigned transaction bytes
+   */
+  private async buildGaslessOutputs(
+    client: SuiGrpcClient,
+    asset: string,
+    outputs: SuiOutput[],
+  ): Promise<string> {
+    const tx = new Transaction();
+    tx.setSender(this.signer.address);
+    for (const o of outputs) {
+      tx.moveCall({
+        target: "0x2::balance::send_funds",
+        typeArguments: [asset],
+        arguments: [tx.balance({ type: asset, balance: BigInt(o.amount) }), tx.pure.address(o.to)],
+      });
+    }
+    // Force the gasless election (the resolver's `budget === 0n` branch) so
+    // gaslessness does not depend on node-rebate behavior. Do NOT also set
+    // gasPrice/gasPayment manually — the protocol rejects those.
+    tx.setGasBudget(0n);
+    const built = await tx.build({ client });
+    return Buffer.from(built).toString("base64");
+  }
+
+  /**
+   * Fetch unsigned bytes from a facilitator `buildUrl` and INDEPENDENTLY verify
+   * them before signing: decode, assert the sender is this client, assert the
+   * gasless gas fields, assert every command is allowlisted, and assert the
+   * declared recipients/amounts match. The client MUST NOT sign bytes that fail.
+   *
+   * @param buildUrl - The facilitator's prebuilt-transaction endpoint
+   * @param requirements - The agreed payment requirements
+   * @param outputs - The declared `{ to, amount }` outputs
+   * @returns Base64-encoded, verified unsigned transaction bytes
+   */
+  private async fetchAndVerifyBuildUrl(
+    buildUrl: string,
+    requirements: PaymentRequirements,
+    outputs: SuiOutput[],
+  ): Promise<string> {
+    if (!/^https:\/\//.test(buildUrl)) {
+      throw new Error(`buildUrl must be an absolute https URL: ${buildUrl}`);
+    }
+
+    const res = await fetch(buildUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sender: this.signer.address, requirements }),
+    });
+    if (!res.ok) {
+      throw new Error(`buildUrl returned ${res.status}`);
+    }
+    const body = (await res.json()) as { transaction?: string; bytes?: string };
+    const bytes = body.transaction ?? body.bytes;
+    if (typeof bytes !== "string") {
+      throw new Error("buildUrl response missing transaction bytes");
+    }
+
+    await this.assertBytesSafe(bytes, requirements.network, requirements.asset, outputs);
+    return bytes;
+  }
+
+  /**
+   * Decode prebuilt (facilitator-built) bytes and assert they are safe to sign — the
+   * ENTIRE threat model of `buildUrl` is a malicious or buggy facilitator, so this is
+   * the one guard that matters. It asserts, in order: (1) the sender is this client,
+   * (2) the gasless gas fields (`gasPrice == 0` ∧ `gasPayment == []`), (3) every
+   * command is an allowlisted gasless op or tolerated coin plumbing, and (4) — the
+   * load-bearing check the old code SKIPPED — a DRY-RUN proves the exact-fee split:
+   * each declared recipient is credited exactly, this client is debited exactly the
+   * total, and NO undeclared address receives the asset. Without (4) a facilitator
+   * could slip a hidden recipient into bytes the client then blindly signs.
+   *
+   * Uses the same exact-fee balance-change matcher as the facilitator's verify,
+   * with `expectedPayer = sender`.
+   *
+   * @param bytes - Base64-encoded unsigned transaction bytes
+   * @param network - CAIP-2 network identifier (for the dry-run client)
+   * @param asset - The required coin type
+   * @param outputs - The declared `{ to, amount }` outputs
+   */
+  private async assertBytesSafe(
+    bytes: string,
+    network: string,
+    asset: string,
+    outputs: SuiOutput[],
+  ): Promise<void> {
+    const data = Transaction.from(fromBase64(bytes)).getData();
+
+    const sender = (data.sender ?? "").toLowerCase();
+    if (sender !== this.signer.address.toLowerCase()) {
+      throw new Error(`buildUrl sender mismatch: ${data.sender} ≠ ${this.signer.address}`);
+    }
+
+    const price = data.gasData?.price;
+    const payment = data.gasData?.payment;
+    const gasless =
+      (price === "0" || price === null || price === undefined) &&
+      (payment === null ||
+        payment === undefined ||
+        (Array.isArray(payment) && payment.length === 0));
+    if (!gasless) {
+      throw new Error(`buildUrl bytes are not gasless: ${JSON.stringify(data.gasData ?? {})}`);
+    }
+
+    for (const cmd of data.commands) {
+      if (cmd.$kind === "MoveCall" && cmd.MoveCall) {
+        const target = normalizeMoveTarget(
+          cmd.MoveCall.package,
+          cmd.MoveCall.module,
+          cmd.MoveCall.function,
+        );
+        if (!GASLESS_ALLOWED_TARGETS.has(target)) {
+          throw new Error(`buildUrl bytes contain a disallowed target: ${target}`);
+        }
+      } else if (!GASLESS_ALLOWED_NON_MOVECALL.has(cmd.$kind)) {
+        throw new Error(`buildUrl bytes contain a disallowed command: ${cmd.$kind}`);
+      }
+    }
+
+    // (4) The exact-fee match — dry-run the UNSIGNED bytes and verify the recipients
+    // and amounts BEFORE signing. `expectedPayer` is the sender we just matched.
+    const sim = await createSuiClient(network as never).dryRunTransactionBlock({
+      transactionBlock: bytes,
+    });
+    if (sim.effects?.status?.status !== "success") {
+      throw new Error(`buildUrl bytes fail dry-run: ${sim.effects?.status?.error ?? "unknown"}`);
+    }
+    const problems = matchBalanceChanges(
+      sim.balanceChanges ?? [],
+      asset,
+      outputs,
+      this.signer.address,
+    );
+    if (problems.length > 0) {
+      throw new Error(`buildUrl bytes do not pay the declared split: ${problems.join("; ")}`);
+    }
+  }
+
+  /**
+   * Assert that declared outputs sum to the total `amount`.
+   *
+   * @param outputs - The declared `{ to, amount }` outputs
+   * @param amount - The total atomic-unit amount
+   */
+  private assertOutputsSumToAmount(outputs: SuiOutput[], amount: string): void {
+    const total = outputs.reduce((s, o) => s + BigInt(o.amount), 0n);
+    if (total !== BigInt(amount)) {
+      throw new Error(`declared outputs sum ${total} ≠ amount ${amount}`);
+    }
+  }
+
+  /**
+   * Create a gRPC client for the given network (the transport gasless build needs).
+   *
+   * @param network - CAIP-2 network identifier
+   * @returns A SuiGrpcClient for the network
+   */
+  private grpcClient(network: string): SuiGrpcClient {
+    if (this.config?.rpcUrl) {
+      const ref = network.split(":")[1] as "testnet" | "mainnet" | "devnet";
+      return new SuiGrpcClient({ network: ref, baseUrl: this.config.rpcUrl });
+    }
+    switch (network) {
+      case SUI_MAINNET_CAIP2:
+        return new SuiGrpcClient({ network: "mainnet", baseUrl: MAINNET_RPC_URL });
+      case SUI_TESTNET_CAIP2:
+        return new SuiGrpcClient({ network: "testnet", baseUrl: TESTNET_RPC_URL });
+      case SUI_DEVNET_CAIP2:
+        return new SuiGrpcClient({ network: "devnet", baseUrl: DEVNET_RPC_URL });
+      default:
+        throw new Error(`Unsupported Sui network: ${network}`);
+    }
+  }
+}

--- a/typescript/packages/mechanisms/sui/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/client/scheme.ts
@@ -9,17 +9,14 @@ import type {
 import type { ClientSuiSigner } from "../../signer";
 import type { ExactSuiPayload, SuiOutput } from "../../types";
 import {
-  GASLESS_ALLOWED_TARGETS,
-  GASLESS_ALLOWED_NON_MOVECALL,
   TESTNET_RPC_URL,
   MAINNET_RPC_URL,
   DEVNET_RPC_URL,
   SUI_MAINNET_CAIP2,
   SUI_TESTNET_CAIP2,
   SUI_DEVNET_CAIP2,
-  normalizeMoveTarget,
 } from "../../constants";
-import { createSuiClient, matchBalanceChanges, outputsOf } from "../../utils";
+import { outputsOf } from "../../utils";
 
 /**
  * Sui client implementation for the Exact payment scheme.
@@ -31,9 +28,10 @@ import { createSuiClient, matchBalanceChanges, outputsOf } from "../../utils";
  * force the resolver's gasless election deterministically. Signs but does NOT
  * execute — the facilitator broadcasts during settlement.
  *
- * When the requirements advertise `extra.buildUrl`, the client MAY instead fetch
- * the facilitator's prebuilt unsigned bytes — but it independently verifies them
- * (sender, gasless gas fields, allowlisted commands) BEFORE signing.
+ * Implements the `address-balance` asset transfer method. When the requirements
+ * declare `extra.assetTransferMethod`, the payment MUST use that method — a
+ * declared `coin` method is rejected here (this client does not build the
+ * classic gas-paying path).
  */
 export class ExactSuiScheme implements SchemeNetworkClient {
   readonly scheme = "exact";
@@ -66,17 +64,20 @@ export class ExactSuiScheme implements SchemeNetworkClient {
       throw new Error("Asset is required");
     }
 
+    // A declared method is binding (spec "Method selection rules"); this client
+    // implements the gasless `address-balance` method only.
+    const method = paymentRequirements.extra?.assetTransferMethod;
+    if (method !== undefined && method !== "address-balance") {
+      throw new Error(
+        `unsupported assetTransferMethod: ${String(method)} (this client implements address-balance)`,
+      );
+    }
+
     const outputs = outputsOf(paymentRequirements);
     this.assertOutputsSumToAmount(outputs, paymentRequirements.amount);
 
     const client = this.grpcClient(network);
-
-    // PATH B: a prebuilt-transaction URL was advertised — fetch, VERIFY, then sign.
-    const buildUrl = paymentRequirements.extra?.buildUrl;
-    const bytes =
-      typeof buildUrl === "string"
-        ? await this.fetchAndVerifyBuildUrl(buildUrl, paymentRequirements, outputs)
-        : await this.buildGaslessOutputs(client, asset, outputs);
+    const bytes = await this.buildGaslessOutputs(client, asset, outputs);
 
     const tx = Transaction.from(fromBase64(bytes));
     const { signature, bytes: signedBytes } = await this.signer.signTransaction(tx);
@@ -121,121 +122,6 @@ export class ExactSuiScheme implements SchemeNetworkClient {
     tx.setGasBudget(0n);
     const built = await tx.build({ client });
     return Buffer.from(built).toString("base64");
-  }
-
-  /**
-   * Fetch unsigned bytes from a facilitator `buildUrl` and INDEPENDENTLY verify
-   * them before signing: decode, assert the sender is this client, assert the
-   * gasless gas fields, assert every command is allowlisted, and assert the
-   * declared recipients/amounts match. The client MUST NOT sign bytes that fail.
-   *
-   * @param buildUrl - The facilitator's prebuilt-transaction endpoint
-   * @param requirements - The agreed payment requirements
-   * @param outputs - The declared `{ to, amount }` outputs
-   * @returns Base64-encoded, verified unsigned transaction bytes
-   */
-  private async fetchAndVerifyBuildUrl(
-    buildUrl: string,
-    requirements: PaymentRequirements,
-    outputs: SuiOutput[],
-  ): Promise<string> {
-    if (!/^https:\/\//.test(buildUrl)) {
-      throw new Error(`buildUrl must be an absolute https URL: ${buildUrl}`);
-    }
-
-    const res = await fetch(buildUrl, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sender: this.signer.address, requirements }),
-    });
-    if (!res.ok) {
-      throw new Error(`buildUrl returned ${res.status}`);
-    }
-    const body = (await res.json()) as { transaction?: string; bytes?: string };
-    const bytes = body.transaction ?? body.bytes;
-    if (typeof bytes !== "string") {
-      throw new Error("buildUrl response missing transaction bytes");
-    }
-
-    await this.assertBytesSafe(bytes, requirements.network, requirements.asset, outputs);
-    return bytes;
-  }
-
-  /**
-   * Decode prebuilt (facilitator-built) bytes and assert they are safe to sign — the
-   * ENTIRE threat model of `buildUrl` is a malicious or buggy facilitator, so this is
-   * the one guard that matters. It asserts, in order: (1) the sender is this client,
-   * (2) the gasless gas fields (`gasPrice == 0` ∧ `gasPayment == []`), (3) every
-   * command is an allowlisted gasless op or tolerated coin plumbing, and (4) — the
-   * load-bearing check the old code SKIPPED — a DRY-RUN proves the exact-fee split:
-   * each declared recipient is credited exactly, this client is debited exactly the
-   * total, and NO undeclared address receives the asset. Without (4) a facilitator
-   * could slip a hidden recipient into bytes the client then blindly signs.
-   *
-   * Uses the same exact-fee balance-change matcher as the facilitator's verify,
-   * with `expectedPayer = sender`.
-   *
-   * @param bytes - Base64-encoded unsigned transaction bytes
-   * @param network - CAIP-2 network identifier (for the dry-run client)
-   * @param asset - The required coin type
-   * @param outputs - The declared `{ to, amount }` outputs
-   */
-  private async assertBytesSafe(
-    bytes: string,
-    network: string,
-    asset: string,
-    outputs: SuiOutput[],
-  ): Promise<void> {
-    const data = Transaction.from(fromBase64(bytes)).getData();
-
-    const sender = (data.sender ?? "").toLowerCase();
-    if (sender !== this.signer.address.toLowerCase()) {
-      throw new Error(`buildUrl sender mismatch: ${data.sender} ≠ ${this.signer.address}`);
-    }
-
-    const price = data.gasData?.price;
-    const payment = data.gasData?.payment;
-    const gasless =
-      (price === "0" || price === null || price === undefined) &&
-      (payment === null ||
-        payment === undefined ||
-        (Array.isArray(payment) && payment.length === 0));
-    if (!gasless) {
-      throw new Error(`buildUrl bytes are not gasless: ${JSON.stringify(data.gasData ?? {})}`);
-    }
-
-    for (const cmd of data.commands) {
-      if (cmd.$kind === "MoveCall" && cmd.MoveCall) {
-        const target = normalizeMoveTarget(
-          cmd.MoveCall.package,
-          cmd.MoveCall.module,
-          cmd.MoveCall.function,
-        );
-        if (!GASLESS_ALLOWED_TARGETS.has(target)) {
-          throw new Error(`buildUrl bytes contain a disallowed target: ${target}`);
-        }
-      } else if (!GASLESS_ALLOWED_NON_MOVECALL.has(cmd.$kind)) {
-        throw new Error(`buildUrl bytes contain a disallowed command: ${cmd.$kind}`);
-      }
-    }
-
-    // (4) The exact-fee match — dry-run the UNSIGNED bytes and verify the recipients
-    // and amounts BEFORE signing. `expectedPayer` is the sender we just matched.
-    const sim = await createSuiClient(network as never).dryRunTransactionBlock({
-      transactionBlock: bytes,
-    });
-    if (sim.effects?.status?.status !== "success") {
-      throw new Error(`buildUrl bytes fail dry-run: ${sim.effects?.status?.error ?? "unknown"}`);
-    }
-    const problems = matchBalanceChanges(
-      sim.balanceChanges ?? [],
-      asset,
-      outputs,
-      this.signer.address,
-    );
-    if (problems.length > 0) {
-      throw new Error(`buildUrl bytes do not pay the declared split: ${problems.join("; ")}`);
-    }
   }
 
   /**

--- a/typescript/packages/mechanisms/sui/src/exact/facilitator/index.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/facilitator/index.ts
@@ -1,0 +1,1 @@
+export { ExactSuiScheme } from "./scheme";

--- a/typescript/packages/mechanisms/sui/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/facilitator/scheme.ts
@@ -1,0 +1,335 @@
+import { Transaction } from "@mysten/sui/transactions";
+import { fromBase64 } from "@mysten/sui/utils";
+import type {
+  Network,
+  PaymentPayload,
+  PaymentRequirements,
+  SchemeNetworkFacilitator,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import type { FacilitatorSuiSigner } from "../../signer";
+import type { ExactSuiPayload } from "../../types";
+import {
+  GASLESS_ALLOWED_TARGETS,
+  GASLESS_ALLOWED_NON_MOVECALL,
+  normalizeMoveTarget,
+} from "../../constants";
+import { matchBalanceChanges, outputsOf } from "../../utils";
+
+/**
+ * Sui facilitator implementation for the Exact payment scheme.
+ *
+ * Verifies a signed-but-not-executed gasless transaction by binding the
+ * signature to the sender, asserting the gasless BCS shape (zero gas + an
+ * allowlisted-command-only PTB), rejecting an already-executed transaction (the
+ * stateless replay guard — simulation alone is NOT one for Address Balances),
+ * simulating it, and matching the asset balance changes against the declared
+ * outputs EXACTLY. Settles by keyless broadcast (idempotent, executed-first).
+ */
+export class ExactSuiScheme implements SchemeNetworkFacilitator {
+  readonly scheme = "exact";
+  readonly caipFamily = "sui:*";
+
+  /**
+   * Creates a new ExactSuiScheme facilitator instance.
+   *
+   * @param signer - The facilitator signer for verification, simulation, and broadcast
+   */
+  constructor(private readonly signer: FacilitatorSuiSigner) {}
+
+  /**
+   * Get mechanism-specific extra data for the supported kinds endpoint. The
+   * gasless path is sponsor-free, so there is no feePayer to advertise.
+   *
+   * @param _ - The network identifier (unused)
+   * @returns Always undefined — gasless needs no sponsor metadata
+   */
+  getExtra(_: Network): Record<string, unknown> | undefined {
+    void _;
+    return undefined;
+  }
+
+  /**
+   * Get the facilitator's broadcast identities for a network. Empty on the
+   * pure gasless path (keyless broadcast — there is no sponsor key).
+   *
+   * @param _ - The network identifier (unused)
+   * @returns Array of signer addresses
+   */
+  getSigners(_: string): string[] {
+    void _;
+    return [...this.signer.getAddresses()];
+  }
+
+  /**
+   * Verify a payment payload (the spec's `exact`-Sui verification):
+   * version/scheme/network/shape → signature binds the sender → gasless command
+   * shape → not-already-executed (the stateless replay guard) → simulate succeeds →
+   * exact balance-change match against the declared outputs.
+   *
+   * @param payload - The payment payload to verify
+   * @param requirements - The payment requirements
+   * @returns Promise resolving to verification response
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    try {
+      // Step 1: version + scheme + network + payload shape.
+      if (payload.x402Version !== 2) {
+        return { isValid: false, invalidReason: "invalid_x402_version", payer: "" };
+      }
+      if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
+        return { isValid: false, invalidReason: "invalid_scheme", payer: "" };
+      }
+      if (payload.accepted.network !== requirements.network) {
+        return { isValid: false, invalidReason: "invalid_network", payer: "" };
+      }
+      const suiPayload = payload.payload as ExactSuiPayload;
+      if (!suiPayload?.transaction || !suiPayload?.signature) {
+        return { isValid: false, invalidReason: "invalid_payload", payer: "" };
+      }
+
+      // Step 2: signature is valid AND the recovered address is the tx sender.
+      let payer: string;
+      try {
+        payer = await this.signer.verifySignature(
+          suiPayload.transaction,
+          suiPayload.signature,
+          requirements.network,
+        );
+      } catch (error) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_sui_payload_signature",
+          invalidMessage: error instanceof Error ? error.message : String(error),
+          payer: "",
+        };
+      }
+
+      const data = Transaction.from(fromBase64(suiPayload.transaction)).getData();
+      if ((data.sender ?? "").toLowerCase() !== payer.toLowerCase()) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_sui_payload_signature",
+          invalidMessage: `recovered ${payer} ≠ tx sender ${data.sender}`,
+          payer,
+        };
+      }
+
+      // Step 3: gasless-shape assertions — zero gas + allowlisted commands only.
+      const gasShape = this.assertGaslessShape(data);
+      if (gasShape) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_payload",
+          invalidMessage: gasShape,
+          payer,
+        };
+      }
+
+      // Step 4: replay guard — reject an ALREADY-EXECUTED transaction. Simulation is
+      // NOT a replay guard for the gasless Address-Balance path: a gasless transfer
+      // has no object inputs, so re-simulating already-executed bytes still succeeds
+      // (nothing was consumed). The stateless guard is to compute the digest from the
+      // signed bytes and ask the chain whether it is already committed.
+      const digest = await Transaction.from(fromBase64(suiPayload.transaction)).getDigest();
+      if (await this.signer.isTransactionExecuted(digest, requirements.network)) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_transaction_state",
+          invalidMessage: `transaction ${digest} already executed`,
+          payer,
+        };
+      }
+
+      // Step 5: simulate — proves it would succeed and is not expired (TTL).
+      const sim = await this.signer.simulateTransaction(
+        suiPayload.transaction,
+        requirements.network,
+      );
+      if (sim.effects?.status?.status !== "success") {
+        return {
+          isValid: false,
+          invalidReason: "invalid_transaction_state",
+          invalidMessage: sim.effects?.status?.error || "simulation failed",
+          payer,
+        };
+      }
+
+      // Step 6: balance-change match against the declared outputs.
+      const outputs = outputsOf(requirements);
+      const problems = matchBalanceChanges(
+        sim.balanceChanges ?? [],
+        requirements.asset,
+        outputs,
+        payer,
+      );
+      if (problems.length > 0) {
+        const declared = Array.isArray(requirements.extra?.outputs);
+        return {
+          isValid: false,
+          invalidReason: declared
+            ? "invalid_exact_sui_payload_outputs_mismatch"
+            : "invalid_exact_sui_payload_recipient_mismatch",
+          invalidMessage: problems.join("; "),
+          payer,
+        };
+      }
+
+      return { isValid: true, invalidReason: undefined, payer };
+    } catch (error) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_sui_payload_verification_error",
+        invalidMessage: error instanceof Error ? error.message : String(error),
+        payer: "",
+      };
+    }
+  }
+
+  /**
+   * Settle a payment by broadcasting the signed transaction (keyless).
+   *
+   * Idempotent by construction: it FIRST computes the digest from the signed bytes and
+   * checks whether the transaction is already committed on-chain. If so it returns the
+   * original digest as success WITHOUT re-broadcasting — re-broadcasting an executed
+   * gasless tx over gRPC throws (whereas JSON-RPC returns the digest), so the executed-
+   * first check is the portable way to make a re-settle a no-op rather than an error.
+   * This also avoids re-verifying an already-executed payment, which the verify replay
+   * guard (step 4) now rejects — a legitimate re-settle must still succeed.
+   *
+   * For a NOT-yet-executed payment it re-verifies (defense in depth) before broadcast.
+   *
+   * @param payload - The payment payload to settle
+   * @param requirements - The payment requirements
+   * @returns Promise resolving to settlement response
+   */
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    const suiPayload = payload.payload as ExactSuiPayload;
+
+    // Idempotency: an already-committed transaction settles to its original digest
+    // (no re-broadcast, no double charge). The signature/payload may be malformed,
+    // so guard the decode and fall through to verify on any failure.
+    let knownDigest: string | undefined;
+    try {
+      knownDigest = await Transaction.from(fromBase64(suiPayload.transaction)).getDigest();
+      if (
+        knownDigest &&
+        (await this.signer.isTransactionExecuted(knownDigest, requirements.network))
+      ) {
+        return {
+          success: true,
+          transaction: knownDigest,
+          network: payload.accepted.network,
+          payer: Transaction.from(fromBase64(suiPayload.transaction)).getData().sender ?? "",
+        };
+      }
+    } catch {
+      // Undecodable bytes — let verify produce the precise rejection below.
+    }
+
+    const verification = await this.verify(payload, requirements);
+    if (!verification.isValid) {
+      return {
+        success: false,
+        network: payload.accepted.network,
+        transaction: "",
+        errorReason: verification.invalidReason ?? "verification_failed",
+        payer: verification.payer,
+      };
+    }
+
+    try {
+      const digest = await this.signer.executeTransaction(
+        suiPayload.transaction,
+        suiPayload.signature,
+        requirements.network,
+      );
+      await this.signer.waitForTransaction(digest, requirements.network);
+
+      return {
+        success: true,
+        transaction: digest,
+        network: payload.accepted.network,
+        payer: verification.payer,
+      };
+    } catch (error) {
+      // A race: the tx committed between our executed-check and broadcast. If it is
+      // now on-chain, treat the settle as the idempotent success it is.
+      if (
+        knownDigest &&
+        (await this.signer.isTransactionExecuted(knownDigest, requirements.network))
+      ) {
+        return {
+          success: true,
+          transaction: knownDigest,
+          network: payload.accepted.network,
+          payer: verification.payer,
+        };
+      }
+      return {
+        success: false,
+        errorReason: "transaction_failed",
+        errorMessage: error instanceof Error ? error.message : String(error),
+        transaction: "",
+        network: payload.accepted.network,
+        payer: verification.payer,
+      };
+    }
+  }
+
+  /**
+   * Assert the gasless BCS shape of decoded transaction data: `gasPrice == 0`,
+   * `gasPayment == []`, and EVERY command is either an allowlisted gasless MoveCall
+   * or a tolerated native coin-plumbing command (`SplitCoins` / `MergeCoins`).
+   * Returns a problem string, or "" when gasless-safe.
+   *
+   * The coin-plumbing tolerance is load-bearing: a payer sourcing from a `Coin<T>`
+   * OBJECT (the COMMON case — anyone who just received USDC via a classic transfer,
+   * with zero Address Balance) gets a PTB the SDK builds as
+   * `[SplitCoins, coin::into_balance, balance::send_funds, coin::send_funds]`. Without
+   * `SplitCoins`/`MergeCoins` on the allowlist the facilitator would reject the very
+   * payloads its OWN client produces. This is safe because (a) `TransferObjects` — the
+   * object-leak vector — and every other command stay rejected, and (b) the exact-fee
+   * balance-change match (step 5, `matchBalanceChanges`) binds the ACTUAL money
+   * movement: every declared output is credited exactly, the payer is debited exactly,
+   * and no undeclared address receives the asset — so the plumbing commands can move
+   * nothing the exact-fee check does not already account for.
+   *
+   * @param data - The decoded transaction data (`Transaction.getData()`)
+   * @returns A problem description, or "" when the shape is gasless-safe
+   */
+  private assertGaslessShape(data: ReturnType<Transaction["getData"]>): string {
+    const price = data.gasData?.price;
+    if (!(price === "0" || price === null || price === undefined)) {
+      return `non-zero gasPrice: ${price}`;
+    }
+    const payment = data.gasData?.payment;
+    const emptyPayment =
+      payment === null || payment === undefined || (Array.isArray(payment) && payment.length === 0);
+    if (!emptyPayment) {
+      return `non-empty gasPayment: ${JSON.stringify(payment)}`;
+    }
+    for (const cmd of data.commands) {
+      if (cmd.$kind === "MoveCall" && cmd.MoveCall) {
+        const target = normalizeMoveTarget(
+          cmd.MoveCall.package,
+          cmd.MoveCall.module,
+          cmd.MoveCall.function,
+        );
+        if (!GASLESS_ALLOWED_TARGETS.has(target)) {
+          return `disallowed target: ${target}`;
+        }
+      } else if (!GASLESS_ALLOWED_NON_MOVECALL.has(cmd.$kind)) {
+        return `disallowed command: ${cmd.$kind}`;
+      }
+    }
+    return "";
+  }
+}

--- a/typescript/packages/mechanisms/sui/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/facilitator/scheme.ts
@@ -39,15 +39,18 @@ export class ExactSuiScheme implements SchemeNetworkFacilitator {
   constructor(private readonly signer: FacilitatorSuiSigner) {}
 
   /**
-   * Get mechanism-specific extra data for the supported kinds endpoint. The
-   * gasless path is sponsor-free, so there is no feePayer to advertise.
+   * Get mechanism-specific extra data for the supported kinds endpoint. This
+   * facilitator implements the gasless `address-balance` method and announces it
+   * here; the resource server relays it into `PaymentRequirements.extra`
+   * (requirements are server-defined — the facilitator only announces capability).
+   * The gasless path is sponsor-free, so there is no feePayer to advertise.
    *
    * @param _ - The network identifier (unused)
-   * @returns Always undefined — gasless needs no sponsor metadata
+   * @returns The supported asset transfer method
    */
   getExtra(_: Network): Record<string, unknown> | undefined {
     void _;
-    return undefined;
+    return { assetTransferMethod: "address-balance" };
   }
 
   /**
@@ -63,10 +66,13 @@ export class ExactSuiScheme implements SchemeNetworkFacilitator {
   }
 
   /**
-   * Verify a payment payload (the spec's `exact`-Sui verification):
-   * version/scheme/network/shape → signature binds the sender → gasless command
-   * shape → not-already-executed (the stateless replay guard) → simulate succeeds →
-   * exact balance-change match against the declared outputs.
+   * Verify a payment payload (the spec's `exact`-Sui verification, `address-balance`
+   * method): version/scheme/network/shape → method gate (a declared or echoed
+   * `assetTransferMethod` other than `address-balance` is rejected; the effective
+   * method is derived from the decoded bytes in the gas-shape step) → signature
+   * binds the sender → gasless command shape → not-already-executed (the stateless
+   * replay guard) → simulate succeeds → exact balance-change match against the
+   * declared outputs.
    *
    * @param payload - The payment payload to verify
    * @param requirements - The payment requirements
@@ -90,6 +96,24 @@ export class ExactSuiScheme implements SchemeNetworkFacilitator {
       const suiPayload = payload.payload as ExactSuiPayload;
       if (!suiPayload?.transaction || !suiPayload?.signature) {
         return { isValid: false, invalidReason: "invalid_payload", payer: "" };
+      }
+
+      // Method gate: this facilitator implements the `address-balance` method.
+      // A declared (requirements) or echoed (accepted) method naming anything
+      // else is rejected up front; the gasless-shape step below derives the
+      // effective method from the decoded bytes themselves.
+      for (const method of [
+        requirements.extra?.assetTransferMethod,
+        payload.accepted.extra?.assetTransferMethod,
+      ]) {
+        if (method !== undefined && method !== "address-balance") {
+          return {
+            isValid: false,
+            invalidReason: "invalid_payload",
+            invalidMessage: `unsupported assetTransferMethod: ${String(method)} (this facilitator implements address-balance)`,
+            payer: "",
+          };
+        }
       }
 
       // Step 2: signature is valid AND the recovered address is the tx sender.

--- a/typescript/packages/mechanisms/sui/src/exact/index.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/index.ts
@@ -1,0 +1,1 @@
+export { ExactSuiScheme } from "./client/scheme";

--- a/typescript/packages/mechanisms/sui/src/exact/server/index.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/server/index.ts
@@ -1,0 +1,1 @@
+export { ExactSuiScheme } from "./scheme";

--- a/typescript/packages/mechanisms/sui/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/server/scheme.ts
@@ -80,8 +80,8 @@ export class ExactSuiScheme implements SchemeNetworkServer {
 
   /**
    * Build payment requirements for this scheme/network combination. Passes
-   * through facilitator extras (e.g. `buildUrl`) and, when `extra.outputs` is
-   * declared, asserts the spec invariant `sum(outputs) == amount`.
+   * through facilitator extras (e.g. `assetTransferMethod`) and, when
+   * `extra.outputs` is declared, asserts the spec invariant `sum(outputs) == amount`.
    *
    * @param paymentRequirements - The base payment requirements
    * @param supportedKind - The supported kind from the facilitator's /supported

--- a/typescript/packages/mechanisms/sui/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/server/scheme.ts
@@ -1,0 +1,154 @@
+// Portions copyright 2026 Danny Devs (https://github.com/Danny-Devs/x402-sui), Apache-2.0
+
+import type {
+  AssetAmount,
+  MoneyParser,
+  Network,
+  PaymentRequirements,
+  Price,
+  SchemeNetworkServer,
+  SupportedKind,
+} from "@x402/core/types";
+import { convertToTokenAmount } from "../../utils";
+import { USDC_DECIMALS, getUsdcCoinType } from "../../constants";
+import type { SuiOutput } from "../../types";
+
+/**
+ * Sui server implementation for the Exact payment scheme.
+ * Handles price parsing (money chain → atomic USDC) and requirements enhancement.
+ */
+export class ExactSuiScheme implements SchemeNetworkServer {
+  readonly scheme = "exact";
+  private moneyParsers: MoneyParser[] = [];
+
+  /**
+   * Register a custom money parser in the parser chain. Parsers are tried in
+   * registration order; returning null falls through to the next. The default
+   * USDC conversion is always the final fallback.
+   *
+   * @param parser - Custom function to convert amount to AssetAmount (or null to skip)
+   * @returns The scheme instance for chaining
+   */
+  registerMoneyParser(parser: MoneyParser): ExactSuiScheme {
+    this.moneyParsers.push(parser);
+    return this;
+  }
+
+  /**
+   * Parse a price into an asset amount. An AssetAmount passes through; Money
+   * (string | number) is parsed to a decimal, run through custom parsers, then
+   * falls back to USDC conversion on the network.
+   *
+   * @param price - The price to parse
+   * @param network - The CAIP-2 network identifier
+   * @returns Promise resolving to the parsed asset amount
+   */
+  async parsePrice(price: Price, network: Network): Promise<AssetAmount> {
+    if (typeof price === "object" && price !== null && "amount" in price) {
+      if (!price.asset) {
+        throw new Error(`Asset address must be specified for AssetAmount on network ${network}`);
+      }
+      return { amount: price.amount, asset: price.asset, extra: price.extra || {} };
+    }
+
+    const amount = this.parseMoneyToDecimal(price);
+
+    for (const parser of this.moneyParsers) {
+      const result = await parser(amount, network);
+      if (result !== null) {
+        return result;
+      }
+    }
+
+    return this.defaultMoneyConversion(amount, network);
+  }
+
+  /**
+   * Return the decimal precision of the asset for a network. USDC is 6 dp on
+   * every Sui network; non-USDC assets must pass an explicit `AssetAmount` —
+   * decimals are not queried on-chain.
+   *
+   * @param asset - The asset coin type
+   * @param network - The CAIP-2 network identifier
+   * @returns Number of decimal places
+   */
+  getAssetDecimals(asset: string, network: Network): number {
+    void asset;
+    void network;
+    return USDC_DECIMALS;
+  }
+
+  /**
+   * Build payment requirements for this scheme/network combination. Passes
+   * through facilitator extras (e.g. `buildUrl`) and, when `extra.outputs` is
+   * declared, asserts the spec invariant `sum(outputs) == amount`.
+   *
+   * @param paymentRequirements - The base payment requirements
+   * @param supportedKind - The supported kind from the facilitator's /supported
+   * @param facilitatorExtensions - Extension keys supported by the facilitator
+   * @returns Enhanced payment requirements
+   */
+  enhancePaymentRequirements(
+    paymentRequirements: PaymentRequirements,
+    supportedKind: SupportedKind,
+    facilitatorExtensions: string[],
+  ): Promise<PaymentRequirements> {
+    void facilitatorExtensions;
+
+    const extra: Record<string, unknown> = {
+      ...paymentRequirements.extra,
+      ...supportedKind.extra,
+    };
+
+    const outputs = extra.outputs as SuiOutput[] | undefined;
+    if (Array.isArray(outputs) && outputs.length > 0) {
+      const total = outputs.reduce((s, o) => s + BigInt(o.amount), 0n);
+      if (total !== BigInt(paymentRequirements.amount)) {
+        return Promise.reject(
+          new Error(
+            `invalid_payment_requirements: outputs sum ${total} ≠ amount ${paymentRequirements.amount}`,
+          ),
+        );
+      }
+    }
+
+    return Promise.resolve({ ...paymentRequirements, extra });
+  }
+
+  /**
+   * Parse Money (string | number) to a decimal number. Handles "$1.50", "1.50",
+   * "1.50 USDC", 1.50, etc.
+   *
+   * @param money - The money value to parse
+   * @returns Decimal number
+   */
+  private parseMoneyToDecimal(money: string | number): number {
+    if (typeof money === "number") {
+      return money;
+    }
+
+    const cleanMoney = money
+      .replace(/^\$/, "")
+      .replace(/\s*(USDC|USD|SUI)\s*$/i, "")
+      .trim();
+    const amount = parseFloat(cleanMoney);
+
+    if (isNaN(amount)) {
+      throw new Error(`Invalid money format: ${money}`);
+    }
+
+    return amount;
+  }
+
+  /**
+   * Default money conversion — to atomic USDC on the network.
+   *
+   * @param amount - The decimal amount (e.g., 1.50)
+   * @param network - The CAIP-2 network identifier
+   * @returns AssetAmount in USDC
+   */
+  private defaultMoneyConversion(amount: number, network: Network): AssetAmount {
+    const tokenAmount = convertToTokenAmount(amount.toString(), USDC_DECIMALS);
+    return { amount: tokenAmount, asset: getUsdcCoinType(network), extra: {} };
+  }
+}

--- a/typescript/packages/mechanisms/sui/src/index.ts
+++ b/typescript/packages/mechanisms/sui/src/index.ts
@@ -1,0 +1,14 @@
+// Exact scheme exports
+export * from "./exact";
+
+// Types
+export * from "./types";
+
+// Constants
+export * from "./constants";
+
+// Signer utilities
+export * from "./signer";
+
+// Utils
+export * from "./utils";

--- a/typescript/packages/mechanisms/sui/src/signer.ts
+++ b/typescript/packages/mechanisms/sui/src/signer.ts
@@ -130,9 +130,9 @@ export function toFacilitatorSuiSigner(
   config?: FacilitatorSuiSignerConfig,
   keypair?: Signer,
 ): FacilitatorSuiSigner {
-  const clientCache = new Map<string, SuiJsonRpcClient>();
+  const clientCache = new Map<string, SuiGrpcClient>();
 
-  const getClient = (network: string): SuiJsonRpcClient => {
+  const getClient = (network: string): SuiGrpcClient => {
     const cached = clientCache.get(network);
     if (cached) return cached;
 
@@ -140,6 +140,18 @@ export function toFacilitatorSuiSigner(
     const client = createSuiClient(network as Network, rpcUrl);
     clientCache.set(network, client);
     return client;
+  };
+
+  // A transaction-lookup MISS (never committed) surfaces as a gRPC NOT_FOUND
+  // status or the core client's "Transaction <digest> not found" throw — that
+  // means "not executed". Any OTHER transport error (unavailable, timeout) must
+  // PROPAGATE: reading it as "not executed" would let the replay guard pass an
+  // already-settled payment and double-serve a merchant.
+  const isNotFound = (error: unknown): boolean => {
+    const code = (error as { code?: unknown } | null)?.code;
+    if (typeof code === "string" && code.toUpperCase().includes("NOT_FOUND")) return true;
+    const message = (error as { message?: unknown } | null)?.message;
+    return typeof message === "string" && /not found/i.test(message);
   };
 
   return {
@@ -159,20 +171,42 @@ export function toFacilitatorSuiSigner(
       network: string,
     ): Promise<DryRunTransactionBlockResponse> {
       const client = getClient(network);
-      return await client.dryRunTransactionBlock({
-        transactionBlock: transactionBytes,
+      const sim = await client.simulateTransaction<{ balanceChanges: true }>({
+        transaction: fromBase64(transactionBytes),
+        include: { balanceChanges: true },
       });
+
+      // Adapt the gRPC simulate result into the JSON-RPC DryRun shape the untouched
+      // facilitator scheme + `matchBalanceChanges` consume: `effects.status.status`
+      // ("success" | "failure"), `effects.status.error`, and `balanceChanges[]` as
+      // `{ owner: { AddressOwner }, coinType, amount }`. A gRPC balance change is
+      // inherently per-ADDRESS (a flat `address`, no owner-kind field), so every
+      // entry maps to an AddressOwner — the API surfaces no object/shared/immutable
+      // owner kind to preserve. (`matchBalanceChanges` still skips an empty address.)
+      const tx = sim.$kind === "Transaction" ? sim.Transaction : sim.FailedTransaction;
+      const success = sim.$kind === "Transaction" && tx.status.success === true;
+      const error = tx.status.success === false ? tx.status.error.message : undefined;
+
+      return {
+        effects: {
+          status: { status: success ? "success" : "failure", error },
+        },
+        balanceChanges: tx.balanceChanges.map(change => ({
+          coinType: change.coinType,
+          amount: change.amount,
+          owner: { AddressOwner: change.address },
+        })),
+      } as unknown as DryRunTransactionBlockResponse;
     },
 
     async isTransactionExecuted(digest: string, network: string): Promise<boolean> {
       const client = getClient(network);
       try {
-        const tx = await client.getTransactionBlock({ digest });
-        return tx?.digest === digest;
-      } catch {
-        // An unknown digest (never committed) makes the node return an error — the
-        // transaction is not on-chain. Treat any lookup failure as "not executed".
-        return false;
+        await client.getTransaction({ digest });
+        return true;
+      } catch (error) {
+        if (isNotFound(error)) return false;
+        throw error;
       }
     },
 
@@ -182,30 +216,32 @@ export function toFacilitatorSuiSigner(
       network: string,
     ): Promise<string> {
       const client = getClient(network);
+      const signatures = Array.isArray(signature) ? signature : [signature];
 
-      const result = await client.executeTransactionBlock({
-        transactionBlock: transaction,
-        signature,
-        options: {
-          showEffects: true,
-        },
+      // Broadcast over gRPC. Re-broadcasting an already-executed gasless tx THROWS
+      // (unlike JSON-RPC) — that throw propagates to the scheme's settle, which
+      // treats it as a race and re-checks the chain. No retry/swallow here.
+      const result = await client.executeTransaction({
+        transaction: fromBase64(transaction),
+        signatures,
       });
 
-      if (result.effects?.status?.status !== "success") {
+      const tx = result.$kind === "Transaction" ? result.Transaction : result.FailedTransaction;
+      if (tx.status.success !== true) {
         throw new Error(
-          `Transaction execution failed: ${result.effects?.status?.error || "unknown error"}`,
+          `Transaction execution failed: ${
+            tx.status.success === false ? tx.status.error.message : "unknown error"
+          }`,
         );
       }
-
-      return result.digest;
+      return tx.digest;
     },
 
     async waitForTransaction(digest: string, network: string): Promise<void> {
       const client = getClient(network);
-      await client.waitForTransaction({
-        digest,
-        options: { showEffects: true },
-      });
+      // The gRPC client's native wait shares the base CoreClient poll implementation
+      // with the JSON-RPC client, so its patience matches the previous transport.
+      await client.waitForTransaction({ digest });
     },
   };
 }

--- a/typescript/packages/mechanisms/sui/src/signer.ts
+++ b/typescript/packages/mechanisms/sui/src/signer.ts
@@ -1,0 +1,235 @@
+// Portions copyright 2026 Danny Devs (https://github.com/Danny-Devs/x402-sui), Apache-2.0
+
+import type { SuiJsonRpcClient, DryRunTransactionBlockResponse } from "@mysten/sui/jsonRpc";
+import type { SuiGrpcClient } from "@mysten/sui/grpc";
+import type { Signer } from "@mysten/sui/cryptography";
+import type { Transaction } from "@mysten/sui/transactions";
+import { fromBase64, toBase64 } from "@mysten/sui/utils";
+import { verifyTransactionSignature } from "@mysten/sui/verify";
+import type { Network } from "@x402/core/types";
+import { createSuiClient } from "./utils";
+
+/**
+ * Client-side signer for creating and signing Sui transactions.
+ * Any Sui signer works: Ed25519Keypair, Secp256k1Keypair, browser wallet adapter.
+ */
+export interface ClientSuiSigner {
+  /**
+   * The sender's Sui address.
+   */
+  readonly address: string;
+
+  /**
+   * Sign a transaction without executing it.
+   *
+   * @param transaction - The Transaction to sign
+   * @returns Signature and serialized transaction bytes (both Base64-encoded)
+   */
+  signTransaction(transaction: Transaction): Promise<{ signature: string; bytes: string }>;
+}
+
+/**
+ * Facilitator-side signer for verifying, simulating, and broadcasting Sui
+ * transactions. Encapsulates SuiClient operations. On the gasless path there is
+ * no sponsor key — the facilitator only relays the payer's already-signed bytes.
+ */
+export interface FacilitatorSuiSigner {
+  /**
+   * Get all addresses this facilitator can broadcast from. Empty on the gasless
+   * path (keyless broadcast — there is no sponsor key).
+   *
+   * @returns Array of Sui addresses
+   */
+  getAddresses(): readonly string[];
+
+  /**
+   * Verify a signature over transaction bytes and recover the signer's address.
+   * Supports Ed25519, Secp256k1, and Secp256r1 signatures.
+   *
+   * @param transactionBytes - Base64-encoded transaction bytes
+   * @param signature - Base64-encoded signature
+   * @param network - CAIP-2 network identifier
+   * @returns The recovered signer's Sui address
+   */
+  verifySignature(transactionBytes: string, signature: string, network: string): Promise<string>;
+
+  /**
+   * Dry-run a transaction to check it would succeed. Returns the full
+   * DryRunTransactionBlockResponse including `balanceChanges`.
+   *
+   * @param transactionBytes - Base64-encoded transaction bytes
+   * @param network - CAIP-2 network identifier
+   * @returns Dry-run result with balance changes, effects, and events
+   */
+  simulateTransaction(
+    transactionBytes: string,
+    network: string,
+  ): Promise<DryRunTransactionBlockResponse>;
+
+  /**
+   * Look up whether a transaction digest is already committed on-chain. This is the
+   * stateless replay guard: simulation is NOT sufficient for gasless Address-Balance
+   * transactions (they carry no object inputs, so re-simulating already-executed bytes
+   * still succeeds). The facilitator computes the digest from the signed bytes and
+   * asks the chain directly.
+   *
+   * @param digest - The transaction digest to look up
+   * @param network - CAIP-2 network identifier
+   * @returns `true` when the digest is already committed on-chain, `false` otherwise
+   */
+  isTransactionExecuted(digest: string, network: string): Promise<boolean>;
+
+  /**
+   * Execute a signed transaction on-chain.
+   *
+   * @param transaction - Base64-encoded transaction bytes
+   * @param signature - Base64-encoded signature(s): a single string, or an array
+   * @param network - CAIP-2 network identifier
+   * @returns Transaction digest
+   */
+  executeTransaction(
+    transaction: string,
+    signature: string | string[],
+    network: string,
+  ): Promise<string>;
+
+  /**
+   * Wait for transaction finality.
+   *
+   * @param digest - Transaction digest to wait for
+   * @param network - CAIP-2 network identifier
+   */
+  waitForTransaction(digest: string, network: string): Promise<void>;
+}
+
+/**
+ * Configuration for the facilitator signer.
+ */
+export interface FacilitatorSuiSignerConfig {
+  /**
+   * Optional custom RPC URL applied to every network.
+   */
+  rpcUrl?: string;
+
+  /**
+   * Optional per-network RPC URL mapping (keyed by CAIP-2 id).
+   */
+  rpcUrls?: Record<string, string>;
+}
+
+/**
+ * Create a FacilitatorSuiSigner from optional RPC config and an optional keypair.
+ * The keypair is only needed for the classic sponsored `Coin<T>` path; the
+ * gasless path is keyless and needs none.
+ *
+ * @param config - Optional configuration (custom RPC URLs)
+ * @param keypair - Optional keypair (only for the classic sponsored path)
+ * @returns A FacilitatorSuiSigner instance
+ */
+export function toFacilitatorSuiSigner(
+  config?: FacilitatorSuiSignerConfig,
+  keypair?: Signer,
+): FacilitatorSuiSigner {
+  const clientCache = new Map<string, SuiJsonRpcClient>();
+
+  const getClient = (network: string): SuiJsonRpcClient => {
+    const cached = clientCache.get(network);
+    if (cached) return cached;
+
+    const rpcUrl = config?.rpcUrls?.[network] ?? config?.rpcUrl;
+    const client = createSuiClient(network as Network, rpcUrl);
+    clientCache.set(network, client);
+    return client;
+  };
+
+  return {
+    getAddresses(): readonly string[] {
+      if (!keypair) return [];
+      return [keypair.toSuiAddress()];
+    },
+
+    async verifySignature(transactionBytes: string, signature: string, _: string): Promise<string> {
+      const txBytes = fromBase64(transactionBytes);
+      const publicKey = await verifyTransactionSignature(txBytes, signature);
+      return publicKey.toSuiAddress();
+    },
+
+    async simulateTransaction(
+      transactionBytes: string,
+      network: string,
+    ): Promise<DryRunTransactionBlockResponse> {
+      const client = getClient(network);
+      return await client.dryRunTransactionBlock({
+        transactionBlock: transactionBytes,
+      });
+    },
+
+    async isTransactionExecuted(digest: string, network: string): Promise<boolean> {
+      const client = getClient(network);
+      try {
+        const tx = await client.getTransactionBlock({ digest });
+        return tx?.digest === digest;
+      } catch {
+        // An unknown digest (never committed) makes the node return an error — the
+        // transaction is not on-chain. Treat any lookup failure as "not executed".
+        return false;
+      }
+    },
+
+    async executeTransaction(
+      transaction: string,
+      signature: string | string[],
+      network: string,
+    ): Promise<string> {
+      const client = getClient(network);
+
+      const result = await client.executeTransactionBlock({
+        transactionBlock: transaction,
+        signature,
+        options: {
+          showEffects: true,
+        },
+      });
+
+      if (result.effects?.status?.status !== "success") {
+        throw new Error(
+          `Transaction execution failed: ${result.effects?.status?.error || "unknown error"}`,
+        );
+      }
+
+      return result.digest;
+    },
+
+    async waitForTransaction(digest: string, network: string): Promise<void> {
+      const client = getClient(network);
+      await client.waitForTransaction({
+        digest,
+        options: { showEffects: true },
+      });
+    },
+  };
+}
+
+/**
+ * Convert any Sui keypair to a ClientSuiSigner. Works with Ed25519Keypair,
+ * Secp256k1Keypair, etc. Signs but never executes — the facilitator broadcasts.
+ *
+ * @param keypair - Any Sui cryptographic keypair
+ * @param client - A Sui client (JSON-RPC or gRPC) for building transactions
+ * @returns A ClientSuiSigner instance
+ */
+export function toClientSuiSigner(
+  keypair: Signer,
+  client: SuiJsonRpcClient | SuiGrpcClient,
+): ClientSuiSigner {
+  return {
+    address: keypair.toSuiAddress(),
+
+    async signTransaction(transaction: Transaction): Promise<{ signature: string; bytes: string }> {
+      const txBytes = await transaction.build({ client });
+      const { signature } = await keypair.signTransaction(txBytes);
+      const bytes = toBase64(txBytes);
+      return { signature, bytes };
+    },
+  };
+}

--- a/typescript/packages/mechanisms/sui/src/types.ts
+++ b/typescript/packages/mechanisms/sui/src/types.ts
@@ -45,10 +45,10 @@ export type ExactSuiExtra = {
   outputs?: SuiOutput[];
 
   /**
-   * Absolute https URL of a facilitator convenience endpoint that returns
-   * unsigned gasless transaction bytes for these terms. The client MUST verify
-   * the returned bytes before signing (see scheme_exact_sui.md "Prebuilt
-   * Transactions").
+   * The asset transfer method of the payment. OPTIONAL; when present the
+   * payment MUST use the declared method (see scheme_exact_sui.md "Method
+   * selection rules"). `"address-balance"` is the gasless path this package
+   * implements; `"coin"` is the classic gas-paying path.
    */
-  buildUrl?: string;
+  assetTransferMethod?: "address-balance" | "coin";
 };

--- a/typescript/packages/mechanisms/sui/src/types.ts
+++ b/typescript/packages/mechanisms/sui/src/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Sui-specific payload for the Exact payment scheme.
+ * A signed-but-not-executed transaction, per the Sui spec — the client signs and
+ * the facilitator broadcasts during settlement. Both fields are Base64.
+ */
+export type ExactSuiPayload = {
+  /**
+   * Base64-encoded signature over the transaction bytes (Ed25519/Secp256k1/Secp256r1).
+   */
+  signature: string;
+
+  /**
+   * Base64-encoded Sui transaction bytes (BCS-serialized TransactionData).
+   */
+  transaction: string;
+};
+
+/**
+ * A single declared settlement leg of a payment. `amount` is the atomic-unit
+ * amount credited to `to`, as a decimal string. The payer's transaction MUST
+ * credit each declared `to` EXACTLY this `amount` (see scheme_exact_sui.md
+ * "Declared Outputs").
+ */
+export type SuiOutput = {
+  /**
+   * Recipient address (an AddressOwner of the asset).
+   */
+  to: string;
+
+  /**
+   * Atomic-unit amount credited to `to`, as a decimal string.
+   */
+  amount: string;
+};
+
+/**
+ * The OPTIONAL Sui-scheme additions to `PaymentRequirements.extra`. Absent for
+ * the default single-recipient wire shape.
+ */
+export type ExactSuiExtra = {
+  /**
+   * The declared fee split. When present, `sum(outputs[].amount) == amount` and
+   * the payer's transaction must match these recipients/amounts EXACTLY.
+   */
+  outputs?: SuiOutput[];
+
+  /**
+   * Absolute https URL of a facilitator convenience endpoint that returns
+   * unsigned gasless transaction bytes for these terms. The client MUST verify
+   * the returned bytes before signing (see scheme_exact_sui.md "Prebuilt
+   * Transactions").
+   */
+  buildUrl?: string;
+};

--- a/typescript/packages/mechanisms/sui/src/utils.ts
+++ b/typescript/packages/mechanisms/sui/src/utils.ts
@@ -1,6 +1,6 @@
 // Portions copyright 2026 Danny Devs (https://github.com/Danny-Devs/x402-sui), Apache-2.0
 
-import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import type { BalanceChange } from "@mysten/sui/jsonRpc";
 import { normalizeStructTag } from "@mysten/sui/utils";
 import type { Network, PaymentRequirements } from "@x402/core/types";
@@ -10,21 +10,28 @@ import {
   SUI_MAINNET_CAIP2,
   SUI_TESTNET_CAIP2,
   SUI_DEVNET_CAIP2,
+  MAINNET_RPC_URL,
+  TESTNET_RPC_URL,
+  DEVNET_RPC_URL,
 } from "./constants";
 
 /**
- * Create a JSON-RPC Sui client for the specified network. The facilitator uses
- * this for `dryRunTransactionBlock` (simulation) and `executeTransactionBlock`
- * (settlement). The gasless PTB builder uses a gRPC client instead (see the
- * client scheme), because gasless eligibility resolves over the gRPC transport.
+ * Create a gRPC Sui client for the specified network. The facilitator uses this
+ * for `simulateTransaction` (verification), `executeTransaction` (settlement),
+ * `getTransaction` (the replay guard), and `waitForTransaction`. gRPC is the
+ * transport where the gasless Address-Balance path resolves, and the only one
+ * Mysten's public fullnodes still serve (the JSON-RPC endpoints are retired).
  *
  * @param network - CAIP-2 network identifier (e.g., "sui:testnet")
- * @param customRpcUrl - Optional custom RPC URL override
- * @returns SuiJsonRpcClient configured for the specified network
+ * @param customRpcUrl - Optional custom gRPC base URL override
+ * @returns SuiGrpcClient configured for the specified network
  */
-export function createSuiClient(network: Network, customRpcUrl?: string): SuiJsonRpcClient {
+export function createSuiClient(network: Network, customRpcUrl?: string): SuiGrpcClient {
   const ref = suiNetworkRef(network);
-  return new SuiJsonRpcClient({ url: customRpcUrl ?? getJsonRpcFullnodeUrl(ref), network: ref });
+  const baseUrl =
+    customRpcUrl ??
+    { mainnet: MAINNET_RPC_URL, testnet: TESTNET_RPC_URL, devnet: DEVNET_RPC_URL }[ref];
+  return new SuiGrpcClient({ network: ref, baseUrl });
 }
 
 /**

--- a/typescript/packages/mechanisms/sui/src/utils.ts
+++ b/typescript/packages/mechanisms/sui/src/utils.ts
@@ -1,0 +1,180 @@
+// Portions copyright 2026 Danny Devs (https://github.com/Danny-Devs/x402-sui), Apache-2.0
+
+import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
+import type { BalanceChange } from "@mysten/sui/jsonRpc";
+import { normalizeStructTag } from "@mysten/sui/utils";
+import type { Network, PaymentRequirements } from "@x402/core/types";
+import type { SuiOutput } from "./types";
+import {
+  SUI_ADDRESS_REGEX,
+  SUI_MAINNET_CAIP2,
+  SUI_TESTNET_CAIP2,
+  SUI_DEVNET_CAIP2,
+} from "./constants";
+
+/**
+ * Create a JSON-RPC Sui client for the specified network. The facilitator uses
+ * this for `dryRunTransactionBlock` (simulation) and `executeTransactionBlock`
+ * (settlement). The gasless PTB builder uses a gRPC client instead (see the
+ * client scheme), because gasless eligibility resolves over the gRPC transport.
+ *
+ * @param network - CAIP-2 network identifier (e.g., "sui:testnet")
+ * @param customRpcUrl - Optional custom RPC URL override
+ * @returns SuiJsonRpcClient configured for the specified network
+ */
+export function createSuiClient(network: Network, customRpcUrl?: string): SuiJsonRpcClient {
+  const ref = suiNetworkRef(network);
+  return new SuiJsonRpcClient({ url: customRpcUrl ?? getJsonRpcFullnodeUrl(ref), network: ref });
+}
+
+/**
+ * Map a CAIP-2 Sui network id to the SDK's network reference.
+ *
+ * @param network - CAIP-2 network identifier (e.g., "sui:testnet")
+ * @returns The SDK network ref ("mainnet" | "testnet" | "devnet")
+ */
+export function suiNetworkRef(network: Network): "mainnet" | "testnet" | "devnet" {
+  switch (network) {
+    case SUI_MAINNET_CAIP2:
+      return "mainnet";
+    case SUI_TESTNET_CAIP2:
+      return "testnet";
+    case SUI_DEVNET_CAIP2:
+      return "devnet";
+    default:
+      throw new Error(`Unsupported Sui network: ${network}`);
+  }
+}
+
+/**
+ * Validate a fully zero-padded Sui address (0x + 64 hex chars). Short-form
+ * addresses like "0x2" must be normalized to full length first.
+ *
+ * @param address - Hex-encoded Sui address
+ * @returns true if the address matches the full-length format
+ */
+export function validateSuiAddress(address: string): boolean {
+  return SUI_ADDRESS_REGEX.test(address);
+}
+
+/**
+ * Compare two Sui coin types for equality after normalization (leading zeros,
+ * casing, formatting).
+ *
+ * @param a - First coin type
+ * @param b - Second coin type
+ * @returns true if the coin types are equivalent
+ */
+export function coinTypesEqual(a: string, b: string): boolean {
+  return normalizeStructTag(a) === normalizeStructTag(b);
+}
+
+/**
+ * Convert a decimal amount string to a token's smallest units. Uses toFixed to
+ * avoid scientific notation (e.g. 1e-7) leaking into the result.
+ *
+ * @param decimalAmount - The decimal amount (e.g., "0.10")
+ * @param decimals - The number of decimals for the token (e.g., 6 for USDC)
+ * @returns The amount in smallest units as a string
+ */
+export function convertToTokenAmount(decimalAmount: string, decimals: number): string {
+  const trimmed = decimalAmount.trim();
+  if (trimmed.startsWith("-")) {
+    throw new Error(`Negative amounts not allowed: ${decimalAmount}`);
+  }
+  const amount = parseFloat(trimmed);
+  if (isNaN(amount)) {
+    throw new Error(`Invalid amount: ${decimalAmount}`);
+  }
+  const [intPart, decPart = ""] = amount.toFixed(decimals).split(".");
+  const paddedDec = decPart.padEnd(decimals, "0").slice(0, decimals);
+  const tokenAmount = (intPart + paddedDec).replace(/^0+/, "") || "0";
+  return tokenAmount;
+}
+
+/**
+ * Resolve the declared outputs of a requirements object: the explicit
+ * `extra.outputs` when present, otherwise the implicit single output
+ * `[{ to: payTo, amount }]`.
+ *
+ * @param requirements - The payment requirements
+ * @returns The ordered list of declared `{ to, amount }` outputs
+ */
+export function outputsOf(requirements: PaymentRequirements): SuiOutput[] {
+  const declared = requirements.extra?.outputs as SuiOutput[] | undefined;
+  if (Array.isArray(declared) && declared.length > 0) {
+    return declared;
+  }
+  return [{ to: requirements.payTo, amount: requirements.amount }];
+}
+
+/**
+ * Extract the AddressOwner of a `BalanceChange.owner`. Only AddressOwner credits
+ * count as payment recipients; ObjectOwner / Shared / Immutable are ignored.
+ *
+ * @param owner - The owner field from a BalanceChange
+ * @returns The address string, or "" when not an AddressOwner
+ */
+export function addressOwnerOf(owner: BalanceChange["owner"]): string {
+  if (owner && typeof owner === "object" && "AddressOwner" in owner) {
+    return owner.AddressOwner;
+  }
+  return "";
+}
+
+/**
+ * The exact-fee matcher. Given simulation `balanceChanges`, the asset, the
+ * declared outputs, and the payer, return the list of problems (empty = clean):
+ *   - every declared output is credited EXACTLY its amount (AddressOwner only),
+ *   - no UNDECLARED address receives any of the asset (the skim cheat-vector),
+ *   - the payer is debited EXACTLY the sum of the declared outputs.
+ *
+ * This is the V2 Sui scheme's heart: the exact-fee, no-skim balance-change check.
+ *
+ * @param balanceChanges - The asset balance changes from a dry-run/simulation
+ * @param asset - The required coin type
+ * @param outputs - The declared `{ to, amount }` outputs
+ * @param payer - The payer (signer) address
+ * @returns A list of mismatch descriptions; empty when the split matches exactly
+ */
+export function matchBalanceChanges(
+  balanceChanges: readonly BalanceChange[],
+  asset: string,
+  outputs: SuiOutput[],
+  payer: string,
+): string[] {
+  const net = new Map<string, bigint>();
+  for (const bc of balanceChanges) {
+    if (!coinTypesEqual(bc.coinType, asset)) continue;
+    const address = addressOwnerOf(bc.owner);
+    if (!address) continue; // skip non-AddressOwner changes
+    const key = address.toLowerCase();
+    net.set(key, (net.get(key) ?? 0n) + BigInt(bc.amount));
+  }
+
+  const problems: string[] = [];
+  let total = 0n;
+  const declared = new Set<string>();
+  for (const o of outputs) {
+    const key = o.to.toLowerCase();
+    declared.add(key);
+    const got = net.get(key) ?? 0n;
+    const want = BigInt(o.amount);
+    if (got !== want) problems.push(`output ${o.to.slice(0, 12)}… expected +${want} got ${got}`);
+    total += want;
+  }
+
+  // No UNDECLARED positive recipient of the asset.
+  for (const [addr, delta] of net) {
+    if (addr === payer.toLowerCase()) continue;
+    if (delta > 0n && !declared.has(addr)) {
+      problems.push(`undeclared recipient ${addr.slice(0, 12)}… received +${delta}`);
+    }
+  }
+
+  // The payer is debited EXACTLY the total of the declared outputs.
+  const payerDelta = net.get(payer.toLowerCase()) ?? 0n;
+  if (payerDelta !== -total) problems.push(`payer expected -${total} got ${payerDelta}`);
+
+  return problems;
+}

--- a/typescript/packages/mechanisms/sui/test/fixtures/fixtures.ts
+++ b/typescript/packages/mechanisms/sui/test/fixtures/fixtures.ts
@@ -1,0 +1,123 @@
+// AUTO-GENERATED fixtures for the @x402/sui unit tests — committed so the default
+// test run is fully network-free. Generated ONCE by `test/fixtures/gen.ts` against
+// Sui testnet (signed gasless Address-Balance payments + one gas-paying object-write
+// transaction; the balanceChanges are the real dry-run output). Regenerate with a
+// funded key; see gen.ts.
+//
+
+import { SUI_TESTNET_CAIP2, USDC_TESTNET } from "../../src/constants";
+
+/** The funded payer that signed every fixture (Sui testnet). */
+export const PAYER = "0x087aa862ca645c0b94400c49e11b491011fca35db837361ccfc4c6f69d356e86";
+
+/** Throwaway recipients minted at generation time. */
+export const RECIPIENT_1 = "0xa071949ae86e2d817e1675988a619a41fff34203dfab23defdc5b3033378a557";
+export const RECIPIENT_2 = "0xc2995dd3edace45879f773527c46c510a5c84258e25af7cfc216644c4a5c96bd";
+
+export const NETWORK = SUI_TESTNET_CAIP2;
+export const ASSET = USDC_TESTNET;
+
+/** A real signed, gasless, single-output payment (10000 atomic USDC to RECIPIENT_1). */
+export const VALID_SINGLE = {
+  transaction:
+    "AAACACCgcZSa6G4tgX4WdZiKYZpB//NCA9+rI979xbMDM3ilVwIAECcAAAAAAAAAB6Hsf8AKb0DblpOtFBXQwZOtOQZJRCjPJSYhA3vXEX4pBHVzZGMEVVNEQwAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgdiYWxhbmNlDHJlZGVlbV9mdW5kcwEHoex/wApvQNuWk60UFdDBk605BklEKM8lJiEDe9cRfikEdXNkYwRVU0RDAAEBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIHYmFsYW5jZQpzZW5kX2Z1bmRzAQeh7H/ACm9A25aTrRQV0MGTrTkGSUQozyUmIQN71xF+KQR1c2RjBFVTREMAAgMAAAAAAQAACHqoYspkXAuUQAxJ4RtJEBH8o124NzYcz8TG9p01boYACHqoYspkXAuUQAxJ4RtJEBH8o124NzYcz8TG9p01boYAAAAAAAAAAAAAAAAAAAAAAgFnBAAAAAAAAAFoBAAAAAAAAAAAIEx4razyovWtgPJ+19VKpp06ePHKZ/3vns9XVPW4u3ewWCqrzA==",
+  signature:
+    "AHCT5WJvtWEAbWRM4j7+KlQo0Fj5RcBNRFZyS3v5DnztcP0YxBBYayl3pICbPcW5We55Lr1tT5LaN7cTOLb9hA0eLBUhjBcukNXOW1y0WQWY5tEWP9PMUDd/jQX+PmYWHA==",
+  sender: PAYER,
+} as const;
+
+/** The dry-run balanceChanges captured for VALID_SINGLE (JSON-RPC shape). */
+export const VALID_SINGLE_BALANCE_CHANGES = [
+  {
+    coinType: "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC",
+    owner: { AddressOwner: "0x087aa862ca645c0b94400c49e11b491011fca35db837361ccfc4c6f69d356e86" },
+    amount: "-10000",
+  },
+  {
+    coinType: "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC",
+    owner: { AddressOwner: "0xa071949ae86e2d817e1675988a619a41fff34203dfab23defdc5b3033378a557" },
+    amount: "10000",
+  },
+];
+
+/** A real signed, gasless, two-output split (9800 to RECIPIENT_1, 200 to RECIPIENT_2). */
+export const VALID_SPLIT = {
+  transaction:
+    "AAAEACCgcZSa6G4tgX4WdZiKYZpB//NCA9+rI979xbMDM3ilVwAgwpld0+2s5Fh593NSfEbFEKXIQljiWvfPwhZkTEpclr0CAEgmAAAAAAAAAAeh7H/ACm9A25aTrRQV0MGTrTkGSUQozyUmIQN71xF+KQR1c2RjBFVTREMAAAIAyAAAAAAAAAAAB6Hsf8AKb0DblpOtFBXQwZOtOQZJRCjPJSYhA3vXEX4pBHVzZGMEVVNEQwAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgdiYWxhbmNlDHJlZGVlbV9mdW5kcwEHoex/wApvQNuWk60UFdDBk605BklEKM8lJiEDe9cRfikEdXNkYwRVU0RDAAEBAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIHYmFsYW5jZQpzZW5kX2Z1bmRzAQeh7H/ACm9A25aTrRQV0MGTrTkGSUQozyUmIQN71xF+KQR1c2RjBFVTREMAAgMAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACB2JhbGFuY2UMcmVkZWVtX2Z1bmRzAQeh7H/ACm9A25aTrRQV0MGTrTkGSUQozyUmIQN71xF+KQR1c2RjBFVTREMAAQEDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgdiYWxhbmNlCnNlbmRfZnVuZHMBB6Hsf8AKb0DblpOtFBXQwZOtOQZJRCjPJSYhA3vXEX4pBHVzZGMEVVNEQwACAwIAAAABAQAIeqhiymRcC5RADEnhG0kQEfyjXbg3NhzPxMb2nTVuhgAIeqhiymRcC5RADEnhG0kQEfyjXbg3NhzPxMb2nTVuhgAAAAAAAAAAAAAAAAAAAAACAWcEAAAAAAAAAWgEAAAAAAAAAAAgTHitrPKi9a2A8n7X1UqmnTp48cpn/e+ez1dU9bi7d7BMm5o6",
+  signature:
+    "APaG9nSW0qAx8Lg3/J6a6IxQgUpMl6GeSGTDZ9T1Gblqc/OshkBtgVokLFHIGlGj00038AFtxsKstaVEc+Sf8AMeLBUhjBcukNXOW1y0WQWY5tEWP9PMUDd/jQX+PmYWHA==",
+  sender: PAYER,
+} as const;
+
+/** The dry-run balanceChanges captured for VALID_SPLIT (JSON-RPC shape). */
+export const VALID_SPLIT_BALANCE_CHANGES = [
+  {
+    coinType: "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC",
+    owner: { AddressOwner: "0x087aa862ca645c0b94400c49e11b491011fca35db837361ccfc4c6f69d356e86" },
+    amount: "-10000",
+  },
+  {
+    coinType: "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC",
+    owner: { AddressOwner: "0xa071949ae86e2d817e1675988a619a41fff34203dfab23defdc5b3033378a557" },
+    amount: "9800",
+  },
+  {
+    coinType: "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC",
+    owner: { AddressOwner: "0xc2995dd3edace45879f773527c46c510a5c84258e25af7cfc216644c4a5c96bd" },
+    amount: "200",
+  },
+];
+
+/**
+ * A real GAS-PAYING object-write transaction (coin split + transfer). It violates
+ * every gasless-shape rule at once: non-zero gasPrice, non-empty gasPayment, and a
+ * non-allowlisted command — used to fixture the facilitator's step-3 rejection.
+ */
+export const BAD_GAS_PAYING_TX =
+  "AAACAAgBAAAAAAAAAAAgdtgT4eT48gvZTnAlKOJMbTgr6JeIBFVQ4PKDKYfPU5UCAgABAQAAAQEDAAAAAAEBAAh6qGLKZFwLlEAMSeEbSRAR/KNduDc2HM/ExvadNW6GAYeTp0xeISkdiyqe4BFeW5gZN49jaNmko2eH/uwXGVf2ufebNQAAAAAgygG4vx5T2QDmwme4r01LEy9xQXIEGwnN4e8ZWdbqsIYIeqhiymRcC5RADEnhG0kQEfyjXbg3NhzPxMb2nTVuhugDAAAAAAAA4JctAAAAAAAA";
+
+/**
+ * The COIN-OBJECT payer that signed the coin-only fixture below — a fresh address
+ * funded with USDC as a classic `Coin<T>` OBJECT (zero Address Balance). This is the
+ * COMMON real-world case: anyone who just received USDC via a classic coin transfer.
+ */
+export const COIN_ONLY_PAYER = "0x1e5c9282e118ffccc232f7cad4856cc03a2b73d51043d482fbaab9d94c66896e";
+
+/**
+ * A REAL signed gasless payment built by THIS package's client for a coin-object payer
+ * (10000 atomic USDC to RECIPIENT_1). The `tx.balance({ type, balance })` intent
+ * resolves a `Coin<T>` source to the PTB `[SplitCoins, coin::into_balance,
+ * balance::send_funds, coin::send_funds]` — `gasPrice = 0`, `gasPayment = []`. The
+ * OLD command allowlist wrongly rejected this ("disallowed command: SplitCoins"), so
+ * the facilitator refused payloads its own client builds.
+ */
+export const COIN_ONLY = {
+  transaction:
+    "AAAEACCgcZSa6G4tgX4WdZiKYZpB//NCA9+rI979xbMDM3ilVwEAIqs/0eGgPT1l//kHd24x3021kdf5L2LsrojUzgqXJ2vT95s1AAAAACD3jMirePnjvLMEgfnJak5PZyncOrjlcbum2QOtcOXDPwAIECcAAAAAAAAAIB5ckoLhGP/MwjL3ytSFbMA6K3PVEEPUgvuqudlMZoluBAIBAQABAQIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACBGNvaW4MaW50b19iYWxhbmNlAQeh7H/ACm9A25aTrRQV0MGTrTkGSUQozyUmIQN71xF+KQR1c2RjBFVTREMAAQMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACB2JhbGFuY2UKc2VuZF9mdW5kcwEHoex/wApvQNuWk60UFdDBk605BklEKM8lJiEDe9cRfikEdXNkYwRVU0RDAAIDAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgRjb2luCnNlbmRfZnVuZHMBB6Hsf8AKb0DblpOtFBXQwZOtOQZJRCjPJSYhA3vXEX4pBHVzZGMEVVNEQwACAQEAAQMAHlySguEY/8zCMvfK1IVswDorc9UQQ9SC+6q52UxmiW4AHlySguEY/8zCMvfK1IVswDorc9UQQ9SC+6q52UxmiW4AAAAAAAAAAAAAAAAAAAAAAgFoBAAAAAAAAAFpBAAAAAAAAAAAIEx4razyovWtgPJ+19VKpp06ePHKZ/3vns9XVPW4u3ewotX1Qg==",
+  signature:
+    "AMYZO2xXvCtau1ii1A77MB/CA9/kV4dd4UCFphmcbjaza647Ia6AhrTJKy41tu+CIDxqHvxINs7F/IKQKSJq3Ae5mTYEVwFgtslyCYJtsM4lTqzm0BkSXHk6Mepd7hB4Ew==",
+  sender: COIN_ONLY_PAYER,
+} as const;
+
+/** The dry-run balanceChanges captured for COIN_ONLY (JSON-RPC shape). */
+export const COIN_ONLY_BALANCE_CHANGES = [
+  {
+    coinType: "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC",
+    owner: { AddressOwner: "0x1e5c9282e118ffccc232f7cad4856cc03a2b73d51043d482fbaab9d94c66896e" },
+    amount: "-10000",
+  },
+  {
+    coinType: "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC",
+    owner: { AddressOwner: "0xa071949ae86e2d817e1675988a619a41fff34203dfab23defdc5b3033378a557" },
+    amount: "10000",
+  },
+];
+
+/**
+ * A PTB with GASLESS gas fields (`gasPrice = 0`, `gasPayment = []`) carrying a single
+ * `TransferObjects` command — the object-leak vector. The gasless-shape guard MUST
+ * still reject it (`disallowed command: TransferObjects`) even though the gas fields
+ * look gasless: only `SplitCoins`/`MergeCoins` coin-plumbing is tolerated.
+ */
+export const TRANSFER_OBJECTS_TX =
+  "AAACAQCHk6dMXiEpHYsqnuARXluYGTePY2jZpKNnh/7sFxlX9tX3mzUAAAAAIApKxRpfoVEEuCcpwzmvKMq73RdbNRF0OPMurO4V2XLoACCgcZSa6G4tgX4WdZiKYZpB//NCA9+rI979xbMDM3ilVwEBAQEAAAEBAAh6qGLKZFwLlEAMSeEbSRAR/KNduDc2HM/ExvadNW6GAAh6qGLKZFwLlEAMSeEbSRAR/KNduDc2HM/ExvadNW6GAAAAAAAAAAAAAAAAAAAAAAIBaAQAAAAAAAABaQQAAAAAAAAAACBMeK2s8qL1rYDyftfVSqadOnjxymf9757PV1T1uLt3sCep+Qk=";

--- a/typescript/packages/mechanisms/sui/test/fixtures/gen.ts
+++ b/typescript/packages/mechanisms/sui/test/fixtures/gen.ts
@@ -1,0 +1,118 @@
+// Fixture generator for the @x402/sui unit tests. Builds + signs REAL gasless
+// Address-Balance payment transactions against Sui testnet ONCE, then prints the
+// base64 `{ transaction, signature }` and the expected balanceChanges so they can
+// be committed as constants in `fixtures.ts`. The unit tests replay these with a
+// mock FacilitatorSuiSigner, so the default test run is fully network-free.
+//
+// Usage (one-time, with a funded testnet key in SUI_CLIENT_PRIVATE_KEY):
+//   SUI_CLIENT_PRIVATE_KEY=suiprivkey1... npx tsx test/fixtures/gen.ts
+//
+// It mints a fresh throwaway recipient set, builds the gasless PTBs, signs them,
+// dry-runs to capture the balanceChanges, and emits a TS module to stdout.
+
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
+import { Transaction } from "@mysten/sui/transactions";
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
+import { toBase64 } from "@mysten/sui/utils";
+import { USDC_TESTNET } from "../../src/constants";
+
+const GRPC = "https://fullnode.testnet.sui.io:443";
+
+/**
+ * Build, sign, and dry-run a gasless payment for the given outputs.
+ *
+ * @param signer - The funded payer keypair
+ * @param grpc - The gRPC client (gasless build transport)
+ * @param jsonRpc - The JSON-RPC client (dry-run for balanceChanges)
+ * @param outputs - The declared `{ to, amount }` outputs
+ * @returns The fixture payload (signature, transaction, sender, balanceChanges)
+ */
+async function buildFixture(
+  signer: Ed25519Keypair,
+  grpc: SuiGrpcClient,
+  jsonRpc: SuiJsonRpcClient,
+  outputs: { to: string; amount: string }[],
+): Promise<unknown> {
+  const tx = new Transaction();
+  tx.setSender(signer.toSuiAddress());
+  for (const o of outputs) {
+    tx.moveCall({
+      target: "0x2::balance::send_funds",
+      typeArguments: [USDC_TESTNET],
+      arguments: [
+        tx.balance({ type: USDC_TESTNET, balance: BigInt(o.amount) }),
+        tx.pure.address(o.to),
+      ],
+    });
+  }
+  tx.setGasBudget(0n);
+  const built = await tx.build({ client: grpc });
+  const transaction = toBase64(built);
+  const { signature } = await signer.signTransaction(built);
+  const sim = await jsonRpc.dryRunTransactionBlock({ transactionBlock: transaction });
+  return {
+    sender: signer.toSuiAddress(),
+    transaction,
+    signature,
+    balanceChanges: sim.balanceChanges,
+    status: sim.effects?.status,
+  };
+}
+
+/**
+ * Build a gas-PAYING object-write transaction (a coin split + transfer) and return
+ * its base64 bytes. This single fixture violates every gasless-shape rule at once:
+ * it carries a non-zero `gasPrice`, a non-empty `gasPayment`, and a non-allowlisted
+ * command (object write) — so it fixtures the facilitator's step-3 rejection.
+ *
+ * @param signer - The payer keypair (sender)
+ * @param grpc - The gRPC build client
+ * @returns Base64-encoded transaction bytes
+ */
+async function buildGasPaying(signer: Ed25519Keypair, grpc: SuiGrpcClient): Promise<string> {
+  const r = Ed25519Keypair.generate().toSuiAddress();
+  const tx = new Transaction();
+  tx.setSender(signer.toSuiAddress());
+  const [coin] = tx.splitCoins(tx.gas, [tx.pure.u64(1n)]);
+  tx.transferObjects([coin], tx.pure.address(r));
+  const built = await tx.build({ client: grpc });
+  return toBase64(built);
+}
+
+/**
+ * Entry point: build the valid 1-output and 2-output fixtures and print them.
+ *
+ * @returns A promise that resolves once the fixtures are printed
+ */
+async function main(): Promise<void> {
+  const priv = process.env.SUI_CLIENT_PRIVATE_KEY;
+  if (!priv) {
+    throw new Error("SUI_CLIENT_PRIVATE_KEY (funded testnet key) is required");
+  }
+  const { secretKey } = decodeSuiPrivateKey(priv);
+  const signer = Ed25519Keypair.fromSecretKey(secretKey);
+  const grpc = new SuiGrpcClient({ network: "testnet", baseUrl: GRPC });
+  const jsonRpc = new SuiJsonRpcClient({
+    url: getJsonRpcFullnodeUrl("testnet"),
+    network: "testnet",
+  });
+
+  const r1 = Ed25519Keypair.generate().toSuiAddress();
+  const r2 = Ed25519Keypair.generate().toSuiAddress();
+
+  const single = await buildFixture(signer, grpc, jsonRpc, [{ to: r1, amount: "10000" }]);
+  const split = await buildFixture(signer, grpc, jsonRpc, [
+    { to: r1, amount: "9800" },
+    { to: r2, amount: "200" },
+  ]);
+  const gasPaying = await buildGasPaying(signer, grpc);
+
+  console.log(JSON.stringify({ single, split, gasPaying, recipients: { r1, r2 } }, null, 2));
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/typescript/packages/mechanisms/sui/test/integrations/exact-sui.test.ts
+++ b/typescript/packages/mechanisms/sui/test/integrations/exact-sui.test.ts
@@ -6,7 +6,6 @@
 
 import { beforeAll, describe, expect, it } from "vitest";
 import { SuiGrpcClient } from "@mysten/sui/grpc";
-import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
 import { Transaction } from "@mysten/sui/transactions";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
 import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
@@ -120,15 +119,14 @@ describe("Sui exact — live testnet integration", () => {
   // coin::send_funds]; the facilitator must ACCEPT it — a too-strict allowlist that
   // rejected SplitCoins would refuse the payloads its own client produces.
   it("settles a COIN-OBJECT payer (zero Address Balance) end-to-end", async () => {
-    const jsonRpc = new SuiJsonRpcClient({
-      url: getJsonRpcFullnodeUrl("testnet"),
-      network: "testnet",
-    });
+    const rpc = toFacilitatorSuiSigner();
     const funder = Ed25519Keypair.fromSecretKey(decodeSuiPrivateKey(CLIENT_KEY!).secretKey);
 
     // Mint a fresh payer funded with USDC as a COIN OBJECT (+ a little SUI for parity)
     // and ZERO Address Balance, by withdrawing from the funder's Address Balance into a
-    // Coin and transferring it.
+    // Coin and transferring it. The payer is coin-object-only BY CONSTRUCTION (a fresh
+    // address receiving one Coin<USDC>); the `SplitCoins` command assertion below is the
+    // proof — an Address-Balance source would build `redeem_funds` instead and fail it.
     const coinPayer = new Ed25519Keypair();
     const coinPayerAddr = coinPayer.toSuiAddress();
     const fundTx = new Transaction();
@@ -142,21 +140,11 @@ describe("Sui exact — live testnet integration", () => {
       arguments: [bal],
     });
     fundTx.transferObjects([coin], fundTx.pure.address(coinPayerAddr));
-    const fundBytes = await fundTx.build({ client: jsonRpc });
+    const fundBytes = await fundTx.build({ client: grpc });
     const { signature: fundSig } = await funder.signTransaction(fundBytes);
-    const fundRes = await jsonRpc.executeTransactionBlock({
-      transactionBlock: toBase64(fundBytes),
-      signature: fundSig,
-      options: { showEffects: true },
-    });
-    expect(fundRes.effects?.status?.status).toBe("success");
-    await jsonRpc.waitForTransaction({ digest: fundRes.digest, options: { showEffects: true } });
-
-    // Confirm the payer is coin-object-only (zero Address Balance).
-    const payerBal = await jsonRpc.getBalance({ owner: coinPayerAddr, coinType: USDC_TESTNET });
-    expect((payerBal as unknown as { fundsInAddressBalance: string }).fundsInAddressBalance).toBe(
-      "0",
-    );
+    const fundDigest = await rpc.executeTransaction(toBase64(fundBytes), fundSig, NETWORK);
+    expect(fundDigest).toMatch(/^[A-Za-z0-9]+$/);
+    await rpc.waitForTransaction(fundDigest, NETWORK);
 
     const coinClient = new ExactSuiClient(toClientSuiSigner(coinPayer, grpc));
     const requirements = reqs({ payTo: Ed25519Keypair.generate().toSuiAddress() });
@@ -182,20 +170,14 @@ describe("Sui exact — live testnet integration", () => {
   // ── replay guard: an already-executed payment is rejected on re-verify; re-settle
   // is idempotent (simulation is NOT a replay guard for gasless Address Balances) ───
   it("rejects a replay on re-verify and re-settles idempotently", async () => {
-    const jsonRpc = new SuiJsonRpcClient({
-      url: getJsonRpcFullnodeUrl("testnet"),
-      network: "testnet",
-    });
+    const rpc = toFacilitatorSuiSigner();
     const requirements = reqs();
     const payload = (await client.createPaymentPayload(2, requirements)) as PaymentPayload;
     payload.accepted = requirements;
 
     const settle = await facilitator.settle(payload, requirements);
     expect(settle.success, settle.errorMessage).toBe(true);
-    await jsonRpc.waitForTransaction({
-      digest: settle.transaction,
-      options: { showEffects: true },
-    });
+    await rpc.waitForTransaction(settle.transaction, NETWORK);
 
     // Re-verify the SAME payload — now rejected as already-executed (the replay hole).
     const replay = await facilitator.verify(payload, requirements);

--- a/typescript/packages/mechanisms/sui/test/integrations/exact-sui.test.ts
+++ b/typescript/packages/mechanisms/sui/test/integrations/exact-sui.test.ts
@@ -1,0 +1,256 @@
+// Live testnet integration suite (env-gated, exactly like @x402/aptos). Runs ONLY
+// via `pnpm test:integration` with a funded `SUI_CLIENT_PRIVATE_KEY`; the default
+// `pnpm test` excludes this file. Exercises the real client→server→facilitator
+// flow on Sui testnet: build a gasless payment, verify the exact-fee match, settle
+// (keyless broadcast), and assert idempotent re-settle + the cheat/expiry guards.
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from "@mysten/sui/jsonRpc";
+import { Transaction } from "@mysten/sui/transactions";
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { decodeSuiPrivateKey } from "@mysten/sui/cryptography";
+import { toBase64, fromBase64 } from "@mysten/sui/utils";
+import type { Network, PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import { ExactSuiScheme as ExactSuiClient } from "../../src/exact/client/scheme";
+import { ExactSuiScheme as ExactSuiServer } from "../../src/exact/server/scheme";
+import { ExactSuiScheme as ExactSuiFacilitator } from "../../src/exact/facilitator/scheme";
+import { toClientSuiSigner, toFacilitatorSuiSigner } from "../../src/signer";
+import { TESTNET_RPC_URL, USDC_TESTNET } from "../../src/constants";
+
+const NETWORK: Network = "sui:testnet";
+const CLIENT_KEY = process.env.SUI_CLIENT_PRIVATE_KEY;
+
+if (!CLIENT_KEY) {
+  throw new Error("SUI_CLIENT_PRIVATE_KEY (funded testnet key) is required for integration tests");
+}
+
+function reqs(over: Partial<PaymentRequirements> = {}): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: NETWORK,
+    asset: USDC_TESTNET,
+    amount: "10000",
+    payTo: Ed25519Keypair.generate().toSuiAddress(),
+    maxTimeoutSeconds: 60,
+    extra: {},
+    ...over,
+  };
+}
+
+describe("Sui exact — live testnet integration", () => {
+  let client: ExactSuiClient;
+  let facilitator: ExactSuiFacilitator;
+  let payer: string;
+  let grpc: SuiGrpcClient;
+
+  beforeAll(() => {
+    const { secretKey } = decodeSuiPrivateKey(CLIENT_KEY);
+    const keypair = Ed25519Keypair.fromSecretKey(secretKey);
+    payer = keypair.toSuiAddress();
+    grpc = new SuiGrpcClient({ network: "testnet", baseUrl: TESTNET_RPC_URL });
+    client = new ExactSuiClient(toClientSuiSigner(keypair, grpc));
+    facilitator = new ExactSuiFacilitator(toFacilitatorSuiSigner());
+  });
+
+  it("parsePrice produces atomic USDC requirements", async () => {
+    const server = new ExactSuiServer();
+    const price = await server.parsePrice("$0.01", NETWORK);
+    expect(price.amount).toBe("10000");
+    expect(price.asset).toBe(USDC_TESTNET);
+  });
+
+  it("builds a gasless single-output payment that verifies and settles", async () => {
+    const requirements = reqs();
+    const payload = (await client.createPaymentPayload(2, requirements)) as PaymentPayload;
+    payload.accepted = requirements;
+
+    const verify = await facilitator.verify(payload, requirements);
+    expect(verify.isValid, verify.invalidMessage).toBe(true);
+    expect(verify.payer).toBe(payer);
+
+    const settle = await facilitator.settle(payload, requirements);
+    expect(settle.success, settle.errorMessage).toBe(true);
+    expect(settle.transaction).toMatch(/^[A-Za-z0-9]+$/);
+    console.log("single-output settled digest:", settle.transaction);
+
+    // Idempotent re-settle: same signed tx → same digest, no double charge.
+    const resettle = await facilitator.settle(payload, requirements);
+    expect(resettle.transaction).toBe(settle.transaction);
+  });
+
+  it("builds a gasless two-output split that verifies and settles", async () => {
+    const r1 = Ed25519Keypair.generate().toSuiAddress();
+    const r2 = Ed25519Keypair.generate().toSuiAddress();
+    const requirements = reqs({
+      payTo: r1,
+      extra: {
+        outputs: [
+          { to: r1, amount: "9800" },
+          { to: r2, amount: "200" },
+        ],
+      },
+    });
+    const payload = (await client.createPaymentPayload(2, requirements)) as PaymentPayload;
+    payload.accepted = requirements;
+
+    const verify = await facilitator.verify(payload, requirements);
+    expect(verify.isValid, verify.invalidMessage).toBe(true);
+
+    const settle = await facilitator.settle(payload, requirements);
+    expect(settle.success, settle.errorMessage).toBe(true);
+    console.log("two-output settled digest:", settle.transaction);
+  });
+
+  it("rejects a cheat: a payment whose recipient differs from the requirements", async () => {
+    // Build for one payTo, then verify against DIFFERENT requirements.
+    const built = reqs();
+    const payload = (await client.createPaymentPayload(2, built)) as PaymentPayload;
+    payload.accepted = built;
+
+    const tampered = reqs({ payTo: Ed25519Keypair.generate().toSuiAddress() });
+    const verify = await facilitator.verify(payload, tampered);
+    expect(verify.isValid).toBe(false);
+    expect(verify.invalidReason).toBe("invalid_exact_sui_payload_recipient_mismatch");
+  });
+
+  // ── coin-object payer (zero Address Balance) settles end-to-end ──────────────────
+  // The COMMON case: a payer holding USDC as a classic Coin<T> object, not an Address
+  // Balance. The client builds [SplitCoins, coin::into_balance, balance::send_funds,
+  // coin::send_funds]; the facilitator must ACCEPT it — a too-strict allowlist that
+  // rejected SplitCoins would refuse the payloads its own client produces.
+  it("settles a COIN-OBJECT payer (zero Address Balance) end-to-end", async () => {
+    const jsonRpc = new SuiJsonRpcClient({
+      url: getJsonRpcFullnodeUrl("testnet"),
+      network: "testnet",
+    });
+    const funder = Ed25519Keypair.fromSecretKey(decodeSuiPrivateKey(CLIENT_KEY!).secretKey);
+
+    // Mint a fresh payer funded with USDC as a COIN OBJECT (+ a little SUI for parity)
+    // and ZERO Address Balance, by withdrawing from the funder's Address Balance into a
+    // Coin and transferring it.
+    const coinPayer = new Ed25519Keypair();
+    const coinPayerAddr = coinPayer.toSuiAddress();
+    const fundTx = new Transaction();
+    fundTx.setSender(funder.toSuiAddress());
+    const [gas] = fundTx.splitCoins(fundTx.gas, [fundTx.pure.u64(50_000_000n)]);
+    fundTx.transferObjects([gas], fundTx.pure.address(coinPayerAddr));
+    const bal = fundTx.balance({ type: USDC_TESTNET, balance: 20_000n });
+    const coin = fundTx.moveCall({
+      target: "0x2::coin::from_balance",
+      typeArguments: [USDC_TESTNET],
+      arguments: [bal],
+    });
+    fundTx.transferObjects([coin], fundTx.pure.address(coinPayerAddr));
+    const fundBytes = await fundTx.build({ client: jsonRpc });
+    const { signature: fundSig } = await funder.signTransaction(fundBytes);
+    const fundRes = await jsonRpc.executeTransactionBlock({
+      transactionBlock: toBase64(fundBytes),
+      signature: fundSig,
+      options: { showEffects: true },
+    });
+    expect(fundRes.effects?.status?.status).toBe("success");
+    await jsonRpc.waitForTransaction({ digest: fundRes.digest, options: { showEffects: true } });
+
+    // Confirm the payer is coin-object-only (zero Address Balance).
+    const payerBal = await jsonRpc.getBalance({ owner: coinPayerAddr, coinType: USDC_TESTNET });
+    expect((payerBal as unknown as { fundsInAddressBalance: string }).fundsInAddressBalance).toBe(
+      "0",
+    );
+
+    const coinClient = new ExactSuiClient(toClientSuiSigner(coinPayer, grpc));
+    const requirements = reqs({ payTo: Ed25519Keypair.generate().toSuiAddress() });
+    const payload = (await coinClient.createPaymentPayload(2, requirements)) as PaymentPayload;
+    payload.accepted = requirements;
+
+    // The built PTB is the coin-source shape — proving the path under test.
+    const cmds = Transaction.from(
+      fromBase64((payload.payload as { transaction: string }).transaction),
+    )
+      .getData()
+      .commands.map(c => c.$kind);
+    expect(cmds[0]).toBe("SplitCoins");
+
+    const verify = await facilitator.verify(payload, requirements);
+    expect(verify.isValid, verify.invalidMessage).toBe(true);
+
+    const settle = await facilitator.settle(payload, requirements);
+    expect(settle.success, settle.errorMessage).toBe(true);
+    console.log("coin-only payer settled digest:", settle.transaction);
+  }, 60_000); // funds a coin-object payer + settles = two on-chain round trips
+
+  // ── replay guard: an already-executed payment is rejected on re-verify; re-settle
+  // is idempotent (simulation is NOT a replay guard for gasless Address Balances) ───
+  it("rejects a replay on re-verify and re-settles idempotently", async () => {
+    const jsonRpc = new SuiJsonRpcClient({
+      url: getJsonRpcFullnodeUrl("testnet"),
+      network: "testnet",
+    });
+    const requirements = reqs();
+    const payload = (await client.createPaymentPayload(2, requirements)) as PaymentPayload;
+    payload.accepted = requirements;
+
+    const settle = await facilitator.settle(payload, requirements);
+    expect(settle.success, settle.errorMessage).toBe(true);
+    await jsonRpc.waitForTransaction({
+      digest: settle.transaction,
+      options: { showEffects: true },
+    });
+
+    // Re-verify the SAME payload — now rejected as already-executed (the replay hole).
+    const replay = await facilitator.verify(payload, requirements);
+    expect(replay.isValid).toBe(false);
+    expect(replay.invalidReason).toBe("invalid_transaction_state");
+
+    // Re-settle the SAME payload — idempotent success returning the original digest.
+    const resettle = await facilitator.settle(payload, requirements);
+    expect(resettle.success).toBe(true);
+    expect(resettle.transaction).toBe(settle.transaction);
+  }, 60_000); // settle + finality + re-verify + re-settle = several on-chain round trips
+
+  // ── buildUrl pre-sign guard: dry-runs prebuilt bytes and refuses to sign bytes
+  // that pay a hidden recipient (the whole threat model of a prebuilt path) ─────────
+  it("refuses to sign buildUrl bytes that pay a hidden recipient", async () => {
+    const declaredPayTo = Ed25519Keypair.generate().toSuiAddress();
+    const attacker = Ed25519Keypair.generate().toSuiAddress();
+
+    // A MALICIOUS facilitator returns gasless bytes paying the ATTACKER, not payTo.
+    const evil = new Transaction();
+    evil.setSender(payer);
+    evil.moveCall({
+      target: "0x2::balance::send_funds",
+      typeArguments: [USDC_TESTNET],
+      arguments: [
+        evil.balance({ type: USDC_TESTNET, balance: 10_000n }),
+        evil.pure.address(attacker),
+      ],
+    });
+    evil.setGasBudget(0n);
+    const evilBytes = toBase64(await evil.build({ client: grpc }));
+
+    // Stub fetch ONLY for the buildUrl (the guard requires an https URL); every other
+    // request — crucially the JSON-RPC dry-run the guard itself makes — passes through.
+    const realFetch = globalThis.fetch;
+    const evilUrl = "https://evil.example/build";
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url === evilUrl) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ transaction: evilBytes }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+      return realFetch(input, init);
+    }) as typeof fetch;
+    try {
+      const requirements = reqs({ payTo: declaredPayTo, extra: { buildUrl: evilUrl } });
+      await expect(client.createPaymentPayload(2, requirements)).rejects.toThrow(
+        /do not pay the declared split|undeclared recipient|expected \+10000/,
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/typescript/packages/mechanisms/sui/test/integrations/exact-sui.test.ts
+++ b/typescript/packages/mechanisms/sui/test/integrations/exact-sui.test.ts
@@ -208,49 +208,15 @@ describe("Sui exact — live testnet integration", () => {
     expect(resettle.transaction).toBe(settle.transaction);
   }, 60_000); // settle + finality + re-verify + re-settle = several on-chain round trips
 
-  // ── buildUrl pre-sign guard: dry-runs prebuilt bytes and refuses to sign bytes
-  // that pay a hidden recipient (the whole threat model of a prebuilt path) ─────────
-  it("refuses to sign buildUrl bytes that pay a hidden recipient", async () => {
-    const declaredPayTo = Ed25519Keypair.generate().toSuiAddress();
-    const attacker = Ed25519Keypair.generate().toSuiAddress();
-
-    // A MALICIOUS facilitator returns gasless bytes paying the ATTACKER, not payTo.
-    const evil = new Transaction();
-    evil.setSender(payer);
-    evil.moveCall({
-      target: "0x2::balance::send_funds",
-      typeArguments: [USDC_TESTNET],
-      arguments: [
-        evil.balance({ type: USDC_TESTNET, balance: 10_000n }),
-        evil.pure.address(attacker),
-      ],
+  // ── method gate: a declared method other than address-balance is binding and
+  // rejected before any build or signature (spec "Method selection rules") ──────────
+  it("refuses to build when requirements declare the coin method", async () => {
+    const requirements = reqs({
+      payTo: Ed25519Keypair.generate().toSuiAddress(),
+      extra: { assetTransferMethod: "coin" },
     });
-    evil.setGasBudget(0n);
-    const evilBytes = toBase64(await evil.build({ client: grpc }));
-
-    // Stub fetch ONLY for the buildUrl (the guard requires an https URL); every other
-    // request — crucially the JSON-RPC dry-run the guard itself makes — passes through.
-    const realFetch = globalThis.fetch;
-    const evilUrl = "https://evil.example/build";
-    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-      if (url === evilUrl) {
-        return Promise.resolve(
-          new Response(JSON.stringify({ transaction: evilBytes }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-        );
-      }
-      return realFetch(input, init);
-    }) as typeof fetch;
-    try {
-      const requirements = reqs({ payTo: declaredPayTo, extra: { buildUrl: evilUrl } });
-      await expect(client.createPaymentPayload(2, requirements)).rejects.toThrow(
-        /do not pay the declared split|undeclared recipient|expected \+10000/,
-      );
-    } finally {
-      globalThis.fetch = realFetch;
-    }
+    await expect(client.createPaymentPayload(2, requirements)).rejects.toThrow(
+      /unsupported assetTransferMethod: coin/,
+    );
   });
 });

--- a/typescript/packages/mechanisms/sui/test/unit/constants.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/constants.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  SUI_MAINNET_CAIP2,
+  SUI_TESTNET_CAIP2,
+  SUI_DEVNET_CAIP2,
+  SUI_ADDRESS_REGEX,
+  USDC_MAINNET,
+  USDC_TESTNET,
+  USDC_DECIMALS,
+  MIN_GASLESS_TRANSFER,
+  GASLESS_ALLOWED_TARGETS,
+  GASLESS_ALLOWED_NON_MOVECALL,
+  getUsdcCoinType,
+  normalizeMoveTarget,
+} from "../../src/constants";
+
+describe("Sui Constants", () => {
+  describe("Network identifiers", () => {
+    it("uses the merged-spec CAIP-2 forms", () => {
+      expect(SUI_MAINNET_CAIP2).toBe("sui:mainnet");
+      expect(SUI_TESTNET_CAIP2).toBe("sui:testnet");
+      expect(SUI_DEVNET_CAIP2).toBe("sui:devnet");
+    });
+  });
+
+  describe("SUI_ADDRESS_REGEX", () => {
+    it("matches a full-length 0x + 64 hex address", () => {
+      expect(
+        SUI_ADDRESS_REGEX.test(
+          "0x0000000000000000000000000000000000000000000000000000000000000001",
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects short-form, missing-prefix, and bad-char addresses", () => {
+      expect(SUI_ADDRESS_REGEX.test("0x2")).toBe(false);
+      expect(SUI_ADDRESS_REGEX.test("a".repeat(64))).toBe(false);
+      expect(SUI_ADDRESS_REGEX.test("0x" + "g".repeat(64))).toBe(false);
+      expect(SUI_ADDRESS_REGEX.test("0x" + "a".repeat(65))).toBe(false);
+    });
+  });
+
+  describe("Default USDC", () => {
+    it("pins Circle native USDC on each network with 6 decimals", () => {
+      expect(USDC_MAINNET).toMatch(/::usdc::USDC$/);
+      expect(USDC_TESTNET).toMatch(/::usdc::USDC$/);
+      expect(USDC_DECIMALS).toBe(6);
+    });
+  });
+
+  describe("MIN_GASLESS_TRANSFER", () => {
+    it("is 0.01 USDC in atomic units, as a bigint", () => {
+      expect(MIN_GASLESS_TRANSFER).toBe(10_000n);
+      expect(typeof MIN_GASLESS_TRANSFER).toBe("bigint");
+    });
+  });
+
+  describe("GASLESS_ALLOWED_TARGETS", () => {
+    const f = "0x0000000000000000000000000000000000000000000000000000000000000002";
+
+    it("contains EXACTLY the four gasless ops that exist on-chain", () => {
+      // Verified via sui_getNormalizedMoveFunction on testnet AND mainnet.
+      expect([...GASLESS_ALLOWED_TARGETS].sort()).toEqual(
+        [
+          `${f}::balance::send_funds`,
+          `${f}::balance::redeem_funds`,
+          `${f}::coin::send_funds`,
+          `${f}::coin::into_balance`,
+        ].sort(),
+      );
+    });
+
+    it("does NOT contain the phantom ops (they do not exist on-chain)", () => {
+      // `0x2::balance::withdrawal_split` and `0x2::balance::into_balance` are MISSING on
+      // testnet and mainnet (sui_getNormalizedMoveFunction → no function found).
+      expect(GASLESS_ALLOWED_TARGETS.has(`${f}::balance::withdrawal_split`)).toBe(false);
+      expect(GASLESS_ALLOWED_TARGETS.has(`${f}::balance::into_balance`)).toBe(false);
+    });
+
+    it("does not contain a non-allowlisted op", () => {
+      expect(GASLESS_ALLOWED_TARGETS.has(`${f}::transfer::public_transfer`)).toBe(false);
+    });
+  });
+
+  describe("GASLESS_ALLOWED_NON_MOVECALL", () => {
+    it("tolerates only the coin-plumbing commands", () => {
+      // A coin-object payer's PTB carries SplitCoins/MergeCoins; TransferObjects (the
+      // object-leak vector) and every other command stay out.
+      expect([...GASLESS_ALLOWED_NON_MOVECALL].sort()).toEqual(["MergeCoins", "SplitCoins"]);
+      expect(GASLESS_ALLOWED_NON_MOVECALL.has("TransferObjects")).toBe(false);
+    });
+  });
+
+  describe("getUsdcCoinType", () => {
+    it("returns the network USDC for mainnet/testnet", () => {
+      expect(getUsdcCoinType(SUI_MAINNET_CAIP2)).toBe(USDC_MAINNET);
+      expect(getUsdcCoinType(SUI_TESTNET_CAIP2)).toBe(USDC_TESTNET);
+    });
+
+    it("throws on devnet (no default asset) and unsupported networks", () => {
+      expect(() => getUsdcCoinType(SUI_DEVNET_CAIP2)).toThrow("No default USDC");
+      expect(() => getUsdcCoinType("eip155:1")).toThrow("No default USDC");
+    });
+  });
+
+  describe("normalizeMoveTarget", () => {
+    it("pads the package address of the short 0x2 form", () => {
+      expect(normalizeMoveTarget("0x2", "balance", "send_funds")).toBe(
+        "0x0000000000000000000000000000000000000000000000000000000000000002::balance::send_funds",
+      );
+    });
+  });
+});

--- a/typescript/packages/mechanisms/sui/test/unit/facilitator-verify.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/facilitator-verify.test.ts
@@ -114,6 +114,37 @@ describe("ExactSuiFacilitator.verify() — step 1: version / scheme / network / 
   });
 });
 
+describe("ExactSuiFacilitator.verify() — assetTransferMethod gate", () => {
+  it("rejects requirements declaring the coin method", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({}));
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements({ extra: { assetTransferMethod: "coin" } }),
+    );
+    expect(r.isValid).toBe(false);
+    expect(r.invalidReason).toBe("invalid_payload");
+    expect(r.invalidMessage).toMatch(/unsupported assetTransferMethod: coin/);
+  });
+
+  it("rejects an echoed coin method in accepted.extra", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({}));
+    const p = buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature);
+    p.accepted.extra = { assetTransferMethod: "coin" };
+    const r = await f.verify(p, requirements());
+    expect(r.isValid).toBe(false);
+    expect(r.invalidReason).toBe("invalid_payload");
+  });
+
+  it("accepts a declared address-balance method (full happy path)", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ balanceChanges: VALID_SINGLE_BALANCE_CHANGES }));
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements({ extra: { assetTransferMethod: "address-balance" } }),
+    );
+    expect(r.isValid).toBe(true);
+  });
+});
+
 describe("ExactSuiFacilitator.verify() — step 2: signature binding", () => {
   it("rejects when signature verification throws", async () => {
     const f = new ExactSuiFacilitator(mockSigner({ recoverThrows: true }));
@@ -297,9 +328,9 @@ describe("ExactSuiFacilitator.verify() — step 5: balance-change match", () => 
 });
 
 describe("ExactSuiFacilitator metadata", () => {
-  it("getExtra is undefined (gasless is sponsor-free)", () => {
+  it("getExtra announces the address-balance method", () => {
     const f = new ExactSuiFacilitator(mockSigner({}));
-    expect(f.getExtra(NETWORK)).toBeUndefined();
+    expect(f.getExtra(NETWORK)).toEqual({ assetTransferMethod: "address-balance" });
   });
 
   it("caipFamily is sui:*", () => {

--- a/typescript/packages/mechanisms/sui/test/unit/facilitator-verify.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/facilitator-verify.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect } from "vitest";
+import type { DryRunTransactionBlockResponse } from "@mysten/sui/jsonRpc";
+import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import { ExactSuiScheme as ExactSuiFacilitator } from "../../src/exact/facilitator/scheme";
+import type { FacilitatorSuiSigner } from "../../src/signer";
+import {
+  VALID_SINGLE,
+  VALID_SINGLE_BALANCE_CHANGES,
+  VALID_SPLIT,
+  VALID_SPLIT_BALANCE_CHANGES,
+  BAD_GAS_PAYING_TX,
+  COIN_ONLY,
+  COIN_ONLY_BALANCE_CHANGES,
+  COIN_ONLY_PAYER,
+  TRANSFER_OBJECTS_TX,
+  PAYER,
+  RECIPIENT_1,
+  RECIPIENT_2,
+  ASSET,
+  NETWORK,
+} from "../fixtures/fixtures";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A mock FacilitatorSuiSigner that replays a configured recovered-payer and a
+// configured dry-run result, so verify() runs fully OFFLINE. `verifySignature`
+// returns the captured payer (the real signature recovers to PAYER on-chain);
+// `simulateTransaction` returns the captured balanceChanges + status.
+// ─────────────────────────────────────────────────────────────────────────────
+function mockSigner(opts: {
+  payer?: string;
+  recoverThrows?: boolean;
+  balanceChanges?: unknown[];
+  status?: "success" | "failure";
+  statusError?: string;
+  /** When true, isTransactionExecuted() returns true (the already-executed replay). */
+  alreadyExecuted?: boolean;
+  /** Captures the digest passed to executeTransaction() for idempotency assertions. */
+  onExecute?: (digest: string) => void;
+}): FacilitatorSuiSigner {
+  return {
+    getAddresses: () => [],
+    verifySignature: async () => {
+      if (opts.recoverThrows) throw new Error("Signature verification failed");
+      return opts.payer ?? PAYER;
+    },
+    isTransactionExecuted: async () => opts.alreadyExecuted ?? false,
+    simulateTransaction: async () =>
+      ({
+        effects: {
+          status: { status: opts.status ?? "success", error: opts.statusError },
+        },
+        balanceChanges: opts.balanceChanges ?? [],
+      }) as unknown as DryRunTransactionBlockResponse,
+    executeTransaction: async () => {
+      opts.onExecute?.("0xdigest");
+      return "0xdigest";
+    },
+    waitForTransaction: async () => {},
+  };
+}
+
+function buildPayload(tx: string, sig: string, network = NETWORK): PaymentPayload {
+  return {
+    x402Version: 2,
+    accepted: { scheme: "exact", network } as PaymentRequirements,
+    payload: { transaction: tx, signature: sig },
+  } as PaymentPayload;
+}
+
+function requirements(over: Partial<PaymentRequirements> = {}): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: NETWORK,
+    asset: ASSET,
+    amount: "10000",
+    payTo: RECIPIENT_1,
+    maxTimeoutSeconds: 60,
+    extra: {},
+    ...over,
+  };
+}
+
+describe("ExactSuiFacilitator.verify() — step 1: version / scheme / network / shape", () => {
+  it("rejects a non-2 x402Version", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({}));
+    const p = buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature);
+    p.x402Version = 1;
+    const r = await f.verify(p, requirements());
+    expect(r.isValid).toBe(false);
+    expect(r.invalidReason).toBe("invalid_x402_version");
+  });
+
+  it("rejects a non-exact scheme", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({}));
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements({ scheme: "upto" }),
+    );
+    expect(r.invalidReason).toBe("invalid_scheme");
+  });
+
+  it("rejects a network mismatch", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({}));
+    const p = buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature, "sui:mainnet");
+    const r = await f.verify(p, requirements({ network: NETWORK }));
+    expect(r.invalidReason).toBe("invalid_network");
+  });
+
+  it("rejects a malformed payload (missing signature)", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({}));
+    const p = buildPayload(VALID_SINGLE.transaction, "");
+    const r = await f.verify(p, requirements());
+    expect(r.invalidReason).toBe("invalid_payload");
+  });
+});
+
+describe("ExactSuiFacilitator.verify() — step 2: signature binding", () => {
+  it("rejects when signature verification throws", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ recoverThrows: true }));
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements(),
+    );
+    expect(r.invalidReason).toBe("invalid_exact_sui_payload_signature");
+  });
+
+  it("rejects when the recovered address ≠ the tx sender", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ payer: RECIPIENT_2 }));
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements(),
+    );
+    expect(r.invalidReason).toBe("invalid_exact_sui_payload_signature");
+    expect(r.invalidMessage).toMatch(/≠ tx sender/);
+  });
+});
+
+describe("ExactSuiFacilitator.verify() — step 3: gasless BCS shape", () => {
+  // BAD_GAS_PAYING_TX is a real gas-paying object-write tx: non-zero gasPrice,
+  // non-empty gasPayment, AND a non-allowlisted command. The facilitator checks
+  // gasPrice first, so it rejects on that branch — the single fixture proves the
+  // whole gasless-shape guard fires (the per-branch order is asserted by the
+  // gasPrice message; a gasless tx can never carry a gas coin, so the price and
+  // payment violations are inseparable on real bytes).
+  it("rejects a gas-paying tx (non-zero gasPrice — the gasless-shape guard)", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ payer: PAYER }));
+    const r = await f.verify(buildPayload(BAD_GAS_PAYING_TX, "c2ln"), requirements());
+    expect(r.invalidReason).toBe("invalid_payload");
+    expect(r.invalidMessage).toMatch(/non-zero gasPrice/);
+  });
+});
+
+describe("ExactSuiFacilitator.verify() — step 3: coin-object plumbing", () => {
+  // A coin-object payer (the COMMON case: zero Address Balance) gets a PTB the SDK
+  // builds as [SplitCoins, coin::into_balance, balance::send_funds, coin::send_funds].
+  // The OLD allowlist rejected it ("disallowed command: SplitCoins") — the facilitator
+  // refusing its own client's payloads. It must now PASS the gasless-shape guard while
+  // a TransferObjects PTB (the object-leak vector) still REJECTS.
+  function coinOnlyReqs(): PaymentRequirements {
+    return requirements({ payTo: RECIPIENT_1, amount: "10000" });
+  }
+
+  it("ACCEPTS a coin-only payer's [SplitCoins, into_balance, send_funds, …] PTB", async () => {
+    const f = new ExactSuiFacilitator(
+      mockSigner({ payer: COIN_ONLY_PAYER, balanceChanges: COIN_ONLY_BALANCE_CHANGES }),
+    );
+    const r = await f.verify(
+      buildPayload(COIN_ONLY.transaction, COIN_ONLY.signature),
+      coinOnlyReqs(),
+    );
+    expect(r.isValid, r.invalidMessage).toBe(true);
+    expect(r.payer).toBe(COIN_ONLY_PAYER);
+  });
+
+  it("REJECTS a gasless-fielded TransferObjects PTB (the object-leak vector)", async () => {
+    // TRANSFER_OBJECTS_TX's sender is PAYER, so the mock must recover PAYER to reach
+    // the command-shape check (otherwise step 2 rejects on sender≠signer first).
+    const f = new ExactSuiFacilitator(mockSigner({ payer: PAYER }));
+    const r = await f.verify(buildPayload(TRANSFER_OBJECTS_TX, "c2ln"), coinOnlyReqs());
+    expect(r.invalidReason).toBe("invalid_payload");
+    expect(r.invalidMessage).toMatch(/disallowed command: TransferObjects/);
+  });
+});
+
+describe("ExactSuiFacilitator.verify() — step 4: replay guard", () => {
+  // PROVEN on-chain: a gasless tx has no object inputs, so re-simulating ALREADY-
+  // EXECUTED bytes still SUCCEEDS — simulation is NOT a replay guard. The stateless
+  // guard computes the digest from the signed bytes and asks the chain directly.
+  it("REJECTS an already-executed transaction (the replay) with invalid_transaction_state", async () => {
+    const f = new ExactSuiFacilitator(
+      mockSigner({ alreadyExecuted: true, balanceChanges: VALID_SINGLE_BALANCE_CHANGES }),
+    );
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements(),
+    );
+    expect(r.isValid).toBe(false);
+    expect(r.invalidReason).toBe("invalid_transaction_state");
+    expect(r.invalidMessage).toMatch(/already executed/);
+  });
+
+  it("ACCEPTS a not-yet-executed transaction (the replay guard does not false-positive)", async () => {
+    const f = new ExactSuiFacilitator(
+      mockSigner({ alreadyExecuted: false, balanceChanges: VALID_SINGLE_BALANCE_CHANGES }),
+    );
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements(),
+    );
+    expect(r.isValid, r.invalidMessage).toBe(true);
+  });
+});
+
+describe("ExactSuiFacilitator.verify() — step 5: simulation", () => {
+  it("rejects when simulation fails (expired/insufficient)", async () => {
+    const f = new ExactSuiFacilitator(
+      mockSigner({ status: "failure", statusError: "InsufficientGas" }),
+    );
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements(),
+    );
+    expect(r.invalidReason).toBe("invalid_transaction_state");
+  });
+});
+
+describe("ExactSuiFacilitator.verify() — step 5: balance-change match", () => {
+  it("ACCEPTS a valid single-output payment (happy path)", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ balanceChanges: VALID_SINGLE_BALANCE_CHANGES }));
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements(),
+    );
+    expect(r.isValid).toBe(true);
+    expect(r.payer).toBe(PAYER);
+  });
+
+  it("ACCEPTS a valid two-output split (happy path)", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ balanceChanges: VALID_SPLIT_BALANCE_CHANGES }));
+    const reqs = requirements({
+      payTo: RECIPIENT_1,
+      extra: {
+        outputs: [
+          { to: RECIPIENT_1, amount: "9800" },
+          { to: RECIPIENT_2, amount: "200" },
+        ],
+      },
+    });
+    const r = await f.verify(buildPayload(VALID_SPLIT.transaction, VALID_SPLIT.signature), reqs);
+    expect(r.isValid).toBe(true);
+  });
+
+  it("rejects a single-output recipient mismatch", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ balanceChanges: VALID_SINGLE_BALANCE_CHANGES }));
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements({ payTo: RECIPIENT_2 }), // expected RECIPIENT_2, got RECIPIENT_1
+    );
+    expect(r.invalidReason).toBe("invalid_exact_sui_payload_recipient_mismatch");
+  });
+
+  it("rejects a declared-outputs mismatch (wrong split amount)", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ balanceChanges: VALID_SPLIT_BALANCE_CHANGES }));
+    const reqs = requirements({
+      extra: {
+        outputs: [
+          { to: RECIPIENT_1, amount: "9000" }, // chain credited 9800
+          { to: RECIPIENT_2, amount: "1000" },
+        ],
+      },
+    });
+    const r = await f.verify(buildPayload(VALID_SPLIT.transaction, VALID_SPLIT.signature), reqs);
+    expect(r.invalidReason).toBe("invalid_exact_sui_payload_outputs_mismatch");
+  });
+
+  it("rejects an undeclared recipient (skim cheat) under declared outputs", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ balanceChanges: VALID_SPLIT_BALANCE_CHANGES }));
+    // Declare only RECIPIENT_1 (9800) but amount=10000 — RECIPIENT_2 is undeclared,
+    // and the outputs would not sum to amount, so this is a declared-outputs case.
+    const reqs = requirements({
+      amount: "9800",
+      extra: { outputs: [{ to: RECIPIENT_1, amount: "9800" }] },
+    });
+    const r = await f.verify(buildPayload(VALID_SPLIT.transaction, VALID_SPLIT.signature), reqs);
+    expect(r.invalidReason).toBe("invalid_exact_sui_payload_outputs_mismatch");
+    expect(r.invalidMessage).toMatch(/undeclared recipient/);
+  });
+
+  it("rejects an asset mismatch (no credit in the required asset)", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ balanceChanges: VALID_SINGLE_BALANCE_CHANGES }));
+    const r = await f.verify(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements({ asset: "0xdeadbeef::other::OTHER" }),
+    );
+    expect(r.invalidReason).toBe("invalid_exact_sui_payload_recipient_mismatch");
+  });
+});
+
+describe("ExactSuiFacilitator metadata", () => {
+  it("getExtra is undefined (gasless is sponsor-free)", () => {
+    const f = new ExactSuiFacilitator(mockSigner({}));
+    expect(f.getExtra(NETWORK)).toBeUndefined();
+  });
+
+  it("caipFamily is sui:*", () => {
+    const f = new ExactSuiFacilitator(mockSigner({}));
+    expect(f.caipFamily).toBe("sui:*");
+  });
+
+  it("getSigners reflects the broadcast identities (empty when keyless)", () => {
+    const f = new ExactSuiFacilitator(mockSigner({}));
+    expect(f.getSigners(NETWORK)).toEqual([]);
+  });
+});
+
+describe("ExactSuiFacilitator.settle()", () => {
+  it("does not broadcast when verification fails", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ recoverThrows: true }));
+    const r = await f.settle(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements(),
+    );
+    expect(r.success).toBe(false);
+    expect(r.transaction).toBe("");
+    expect(r.errorReason).toBe("invalid_exact_sui_payload_signature");
+  });
+
+  it("returns the digest on a verified settle", async () => {
+    const f = new ExactSuiFacilitator(mockSigner({ balanceChanges: VALID_SINGLE_BALANCE_CHANGES }));
+    const r = await f.settle(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements(),
+    );
+    expect(r.success).toBe(true);
+    expect(r.transaction).toBe("0xdigest");
+    expect(r.payer).toBe(PAYER);
+  });
+
+  it("is idempotent: an already-executed tx settles to its real digest WITHOUT re-broadcasting", async () => {
+    let broadcast = false;
+    const f = new ExactSuiFacilitator(
+      mockSigner({ alreadyExecuted: true, onExecute: () => (broadcast = true) }),
+    );
+    const r = await f.settle(
+      buildPayload(VALID_SINGLE.transaction, VALID_SINGLE.signature),
+      requirements(),
+    );
+    expect(r.success).toBe(true);
+    // The real on-chain digest of VALID_SINGLE's signed bytes (computed offline).
+    expect(r.transaction).toBe("DdzsqjvRMntkoeCg1UMzAt93iE4ug9p485YgprUnAPmS");
+    expect(broadcast).toBe(false); // never re-broadcasts an executed tx
+    expect(r.payer).toBe(PAYER);
+  });
+});

--- a/typescript/packages/mechanisms/sui/test/unit/index.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/index.test.ts
@@ -89,14 +89,14 @@ describe("@x402/sui server scheme — enhancePaymentRequirements", () => {
   };
   const kind = { x402Version: 2, scheme: "exact", network: TESTNET };
 
-  it("passes facilitator extras through (e.g. buildUrl)", async () => {
+  it("passes facilitator extras through (e.g. assetTransferMethod)", async () => {
     const server = new ExactSuiServer();
     const r = await server.enhancePaymentRequirements(
       base,
-      { ...kind, extra: { buildUrl: "https://f.example/build" } },
+      { ...kind, extra: { assetTransferMethod: "address-balance" } },
       [],
     );
-    expect(r.extra.buildUrl).toBe("https://f.example/build");
+    expect(r.extra.assetTransferMethod).toBe("address-balance");
   });
 
   it("accepts declared outputs that sum to amount", async () => {

--- a/typescript/packages/mechanisms/sui/test/unit/index.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/index.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from "vitest";
+import type { Network, PaymentRequirements } from "@x402/core/types";
+import { ExactSuiScheme as ExactSuiServer } from "../../src/exact/server/scheme";
+import {
+  convertToTokenAmount,
+  coinTypesEqual,
+  validateSuiAddress,
+  outputsOf,
+  matchBalanceChanges,
+  suiNetworkRef,
+} from "../../src/utils";
+import { USDC_TESTNET, USDC_MAINNET } from "../../src/constants";
+import {
+  VALID_SINGLE_BALANCE_CHANGES,
+  VALID_SPLIT_BALANCE_CHANGES,
+  PAYER,
+  RECIPIENT_1,
+  RECIPIENT_2,
+  ASSET,
+} from "../fixtures/fixtures";
+
+const TESTNET: Network = "sui:testnet";
+
+describe("@x402/sui server scheme — parsePrice", () => {
+  let server: ExactSuiServer;
+
+  it("converts dollar/decimal/number money to atomic USDC (6 dp)", async () => {
+    server = new ExactSuiServer();
+    for (const [input, expected] of [
+      ["$1.00", "1000000"],
+      ["1.50", "1500000"],
+      [2.5, "2500000"],
+      ["$4.02", "4020000"], // float-rounding guard
+    ] as const) {
+      const r = await server.parsePrice(input, TESTNET);
+      expect(r.amount).toBe(expected);
+      expect(r.asset).toBe(USDC_TESTNET);
+    }
+  });
+
+  it("passes an AssetAmount straight through", async () => {
+    server = new ExactSuiServer();
+    const r = await server.parsePrice(
+      { amount: "5000000", asset: "0xabc::t::T", extra: { foo: "bar" } },
+      TESTNET,
+    );
+    expect(r.amount).toBe("5000000");
+    expect(r.asset).toBe("0xabc::t::T");
+    expect(r.extra?.foo).toBe("bar");
+  });
+
+  it("uses the mainnet USDC default on mainnet", async () => {
+    server = new ExactSuiServer();
+    const r = await server.parsePrice("$0.10", "sui:mainnet");
+    expect(r.asset).toBe(USDC_MAINNET);
+    expect(r.amount).toBe("100000");
+  });
+
+  it("rejects a price string on devnet (no default asset)", async () => {
+    server = new ExactSuiServer();
+    await expect(server.parsePrice("$1.00", "sui:devnet")).rejects.toThrow("No default USDC");
+  });
+
+  it("runs custom money parsers before the USDC fallback", async () => {
+    server = new ExactSuiServer();
+    server.registerMoneyParser(async amount => {
+      if (amount > 100) return { amount: String(amount), asset: "0xbig::t::T", extra: {} };
+      return null;
+    });
+    expect((await server.parsePrice(150, TESTNET)).asset).toBe("0xbig::t::T");
+    expect((await server.parsePrice(50, TESTNET)).asset).toBe(USDC_TESTNET);
+  });
+
+  it("reports asset decimals as 6", () => {
+    server = new ExactSuiServer();
+    expect(server.getAssetDecimals(USDC_TESTNET, TESTNET)).toBe(6);
+  });
+});
+
+describe("@x402/sui server scheme — enhancePaymentRequirements", () => {
+  const base: PaymentRequirements = {
+    scheme: "exact",
+    network: TESTNET,
+    asset: USDC_TESTNET,
+    amount: "10000",
+    payTo: RECIPIENT_1,
+    maxTimeoutSeconds: 60,
+    extra: {},
+  };
+  const kind = { x402Version: 2, scheme: "exact", network: TESTNET };
+
+  it("passes facilitator extras through (e.g. buildUrl)", async () => {
+    const server = new ExactSuiServer();
+    const r = await server.enhancePaymentRequirements(
+      base,
+      { ...kind, extra: { buildUrl: "https://f.example/build" } },
+      [],
+    );
+    expect(r.extra.buildUrl).toBe("https://f.example/build");
+  });
+
+  it("accepts declared outputs that sum to amount", async () => {
+    const server = new ExactSuiServer();
+    const withOutputs: PaymentRequirements = {
+      ...base,
+      extra: {
+        outputs: [
+          { to: RECIPIENT_1, amount: "9800" },
+          { to: RECIPIENT_2, amount: "200" },
+        ],
+      },
+    };
+    const r = await server.enhancePaymentRequirements(withOutputs, kind, []);
+    expect((r.extra.outputs as unknown[]).length).toBe(2);
+  });
+
+  it("rejects declared outputs that do NOT sum to amount", async () => {
+    const server = new ExactSuiServer();
+    const bad: PaymentRequirements = {
+      ...base,
+      extra: { outputs: [{ to: RECIPIENT_1, amount: "9000" }] }, // sums to 9000 ≠ 10000
+    };
+    await expect(server.enhancePaymentRequirements(bad, kind, [])).rejects.toThrow(
+      "invalid_payment_requirements",
+    );
+  });
+});
+
+describe("@x402/sui utils", () => {
+  it("convertToTokenAmount avoids scientific notation and rejects negatives", () => {
+    expect(convertToTokenAmount("0.0000001", 6)).toBe("0"); // truncates below 1 unit
+    expect(convertToTokenAmount("0.1", 6)).toBe("100000");
+    expect(() => convertToTokenAmount("-1", 6)).toThrow("Negative");
+  });
+
+  it("coinTypesEqual normalizes leading zeros", () => {
+    expect(
+      coinTypesEqual(
+        "0x2::sui::SUI",
+        "0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI",
+      ),
+    ).toBe(true);
+  });
+
+  it("validateSuiAddress requires the full 64-hex form", () => {
+    expect(validateSuiAddress(PAYER)).toBe(true);
+    expect(validateSuiAddress("0x2")).toBe(false);
+  });
+
+  it("suiNetworkRef maps CAIP-2 to the SDK ref and throws otherwise", () => {
+    expect(suiNetworkRef(TESTNET)).toBe("testnet");
+    expect(suiNetworkRef("sui:mainnet")).toBe("mainnet");
+    expect(() => suiNetworkRef("eip155:1")).toThrow("Unsupported");
+  });
+
+  it("outputsOf defaults to a single payTo output when extra.outputs is absent", () => {
+    const reqs: PaymentRequirements = {
+      scheme: "exact",
+      network: TESTNET,
+      asset: USDC_TESTNET,
+      amount: "10000",
+      payTo: RECIPIENT_1,
+      maxTimeoutSeconds: 60,
+      extra: {},
+    };
+    expect(outputsOf(reqs)).toEqual([{ to: RECIPIENT_1, amount: "10000" }]);
+  });
+
+  it("outputsOf returns the declared split when present", () => {
+    const reqs: PaymentRequirements = {
+      scheme: "exact",
+      network: TESTNET,
+      asset: USDC_TESTNET,
+      amount: "10000",
+      payTo: RECIPIENT_1,
+      maxTimeoutSeconds: 60,
+      extra: {
+        outputs: [
+          { to: RECIPIENT_1, amount: "9800" },
+          { to: RECIPIENT_2, amount: "200" },
+        ],
+      },
+    };
+    expect(outputsOf(reqs)).toHaveLength(2);
+  });
+});
+
+describe("@x402/sui matchBalanceChanges (the exact-fee matcher, on real fixtures)", () => {
+  it("accepts the single-output fixture against its declared output", () => {
+    const problems = matchBalanceChanges(
+      VALID_SINGLE_BALANCE_CHANGES,
+      ASSET,
+      [{ to: RECIPIENT_1, amount: "10000" }],
+      PAYER,
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it("accepts the two-output split fixture against its declared outputs", () => {
+    const problems = matchBalanceChanges(
+      VALID_SPLIT_BALANCE_CHANGES,
+      ASSET,
+      [
+        { to: RECIPIENT_1, amount: "9800" },
+        { to: RECIPIENT_2, amount: "200" },
+      ],
+      PAYER,
+    );
+    expect(problems).toEqual([]);
+  });
+
+  it("flags an output credited the wrong amount", () => {
+    const problems = matchBalanceChanges(
+      VALID_SINGLE_BALANCE_CHANGES,
+      ASSET,
+      [{ to: RECIPIENT_1, amount: "9999" }],
+      PAYER,
+    );
+    expect(problems.join(";")).toMatch(/expected \+9999 got 10000/);
+  });
+
+  it("flags an undeclared recipient (the skim cheat-vector)", () => {
+    // Declare only RECIPIENT_1 against the SPLIT changes — RECIPIENT_2 is undeclared.
+    const problems = matchBalanceChanges(
+      VALID_SPLIT_BALANCE_CHANGES,
+      ASSET,
+      [{ to: RECIPIENT_1, amount: "9800" }],
+      PAYER,
+    );
+    expect(problems.join(";")).toMatch(/undeclared recipient/);
+  });
+
+  it("flags a payer-debit mismatch", () => {
+    const problems = matchBalanceChanges(
+      VALID_SINGLE_BALANCE_CHANGES,
+      ASSET,
+      // Declared total 5000 but the payer was debited 10000 on-chain.
+      [{ to: RECIPIENT_1, amount: "5000" }],
+      PAYER,
+    );
+    expect(problems.join(";")).toMatch(/payer expected -5000 got -10000/);
+  });
+
+  it("ignores balance changes of a different asset", () => {
+    const problems = matchBalanceChanges(
+      VALID_SINGLE_BALANCE_CHANGES,
+      "0xdeadbeef::other::OTHER",
+      [{ to: RECIPIENT_1, amount: "10000" }],
+      PAYER,
+    );
+    // No matching-asset credit → output short + payer debit short.
+    expect(problems.length).toBeGreaterThan(0);
+  });
+});

--- a/typescript/packages/mechanisms/sui/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/signer.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { toFacilitatorSuiSigner, toClientSuiSigner } from "../../src/signer";
+
+describe("Sui Signer", () => {
+  describe("toFacilitatorSuiSigner", () => {
+    it("has no addresses without a keypair (keyless gasless path)", () => {
+      const signer = toFacilitatorSuiSigner();
+      expect(signer.getAddresses()).toHaveLength(0);
+    });
+
+    it("reports the keypair address when one is provided (classic path)", () => {
+      const kp = Ed25519Keypair.generate();
+      const signer = toFacilitatorSuiSigner(undefined, kp);
+      expect(signer.getAddresses()).toEqual([kp.toSuiAddress()]);
+    });
+
+    it("implements every required method", () => {
+      const signer = toFacilitatorSuiSigner();
+      expect(typeof signer.verifySignature).toBe("function");
+      expect(typeof signer.simulateTransaction).toBe("function");
+      expect(typeof signer.executeTransaction).toBe("function");
+      expect(typeof signer.waitForTransaction).toBe("function");
+    });
+  });
+
+  describe("toClientSuiSigner", () => {
+    it("exposes the keypair address and a signTransaction method", () => {
+      const kp = Ed25519Keypair.generate();
+      // The client is only used inside signTransaction; a typed stub suffices here.
+      const signer = toClientSuiSigner(kp, {} as never);
+      expect(signer.address).toBe(kp.toSuiAddress());
+      expect(typeof signer.signTransaction).toBe("function");
+    });
+  });
+});

--- a/typescript/packages/mechanisms/sui/test/unit/types.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/types.test.ts
@@ -19,15 +19,15 @@ describe("Sui Types", () => {
   });
 
   describe("ExactSuiExtra", () => {
-    it("allows optional outputs and buildUrl", () => {
+    it("allows optional outputs and assetTransferMethod", () => {
       const withOutputs: ExactSuiExtra = {
         outputs: [{ to: "0x1", amount: "9000" }],
-        buildUrl: "https://facilitator.example/build",
+        assetTransferMethod: "address-balance",
       };
       const empty: ExactSuiExtra = {};
       expect(withOutputs.outputs).toHaveLength(1);
       expect(empty.outputs).toBeUndefined();
-      expect(empty.buildUrl).toBeUndefined();
+      expect(empty.assetTransferMethod).toBeUndefined();
     });
   });
 });

--- a/typescript/packages/mechanisms/sui/test/unit/types.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/types.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import type { ExactSuiPayload, SuiOutput, ExactSuiExtra } from "../../src/types";
+
+describe("Sui Types", () => {
+  describe("ExactSuiPayload", () => {
+    it("accepts a signature + transaction pair", () => {
+      const payload: ExactSuiPayload = { signature: "c2ln", transaction: "dHg=" };
+      expect(typeof payload.signature).toBe("string");
+      expect(typeof payload.transaction).toBe("string");
+    });
+  });
+
+  describe("SuiOutput", () => {
+    it("carries a recipient and a decimal-string amount", () => {
+      const o: SuiOutput = { to: "0x1", amount: "10000" };
+      expect(o.to).toBe("0x1");
+      expect(o.amount).toBe("10000");
+    });
+  });
+
+  describe("ExactSuiExtra", () => {
+    it("allows optional outputs and buildUrl", () => {
+      const withOutputs: ExactSuiExtra = {
+        outputs: [{ to: "0x1", amount: "9000" }],
+        buildUrl: "https://facilitator.example/build",
+      };
+      const empty: ExactSuiExtra = {};
+      expect(withOutputs.outputs).toHaveLength(1);
+      expect(empty.outputs).toBeUndefined();
+      expect(empty.buildUrl).toBeUndefined();
+    });
+  });
+});

--- a/typescript/packages/mechanisms/sui/tsconfig.json
+++ b/typescript/packages/mechanisms/sui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/typescript/packages/mechanisms/sui/tsup.config.ts
+++ b/typescript/packages/mechanisms/sui/tsup.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "tsup";
+
+const baseConfig = {
+  entry: {
+    index: "src/index.ts",
+    "exact/client/index": "src/exact/client/index.ts",
+    "exact/server/index": "src/exact/server/index.ts",
+    "exact/facilitator/index": "src/exact/facilitator/index.ts",
+  },
+  dts: {
+    resolve: true,
+  },
+  sourcemap: true,
+  target: "es2020",
+};
+
+export default defineConfig([
+  {
+    ...baseConfig,
+    format: "esm",
+    outDir: "dist/esm",
+    clean: true,
+  },
+  {
+    ...baseConfig,
+    format: "cjs",
+    outDir: "dist/cjs",
+    clean: false,
+  },
+]);

--- a/typescript/packages/mechanisms/sui/vitest.config.ts
+++ b/typescript/packages/mechanisms/sui/vitest.config.ts
@@ -1,0 +1,15 @@
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig(({ mode }) => ({
+  test: {
+    env: loadEnv(mode, process.cwd(), ""),
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/test/integrations/**", // Exclude integration tests from default run
+    ],
+  },
+  plugins: [tsconfigPaths({ projects: ["."] })],
+}));

--- a/typescript/packages/mechanisms/sui/vitest.integration.config.ts
+++ b/typescript/packages/mechanisms/sui/vitest.integration.config.ts
@@ -1,0 +1,11 @@
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig(({ mode }) => ({
+  test: {
+    env: loadEnv(mode, process.cwd(), ""),
+    include: ["test/integrations/**/*.test.ts"], // Only include integration tests
+  },
+  plugins: [tsconfigPaths({ projects: ["."] })],
+}));

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1634,6 +1634,61 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.18.0)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
 
+  packages/mechanisms/sui:
+    dependencies:
+      '@mysten/sui':
+        specifier: ^2.17.0
+        version: 2.21.0(typescript@5.9.2)
+      '@x402/core':
+        specifier: workspace:~
+        version: link:../../core
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.34.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.19.17
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0)(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.49.0(eslint@9.34.0)(typescript@5.9.2)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.34.0
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0)
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.34.0)
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint@9.34.0)(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.2
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@22.19.17)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.2)(vite@6.3.5(@types/node@22.19.17)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
   packages/mechanisms/svm:
     dependencies:
       '@solana-program/compute-budget':
@@ -1915,6 +1970,20 @@ importers:
         version: 5.9.2
 
 packages:
+
+  '@0no-co/graphql.web@1.3.2':
+    resolution: {integrity: sha512-Q1+pRlLhE31GOY/2c9BAEnFTNxO7Awtc6fhhEDlxyCBQ2N0IhD32cPVvPChrK9mwBNSgRdW/sF1kd2e0ojHj1Q==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+
+  '@0no-co/graphqlsp@1.17.3':
+    resolution: {integrity: sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0
 
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
@@ -2609,6 +2678,26 @@ packages:
     resolution: {integrity: sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==}
     engines: {node: '>=18'}
 
+  '@gql.tada/cli-utils@1.9.2':
+    resolution: {integrity: sha512-cVNs4v8ewLRYJfyAsaHbiAmd5Hm+zXEMvMhBksH58ZU87d6f8crsp2CQG6QtIqnJJw1q0CBWfWTZepGWNcL3QA==}
+    peerDependencies:
+      '@0no-co/graphqlsp': ^1.16.0
+      '@gql.tada/svelte-support': 1.0.3
+      '@gql.tada/vue-support': 1.0.3
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@gql.tada/svelte-support':
+        optional: true
+      '@gql.tada/vue-support':
+        optional: true
+
+  '@gql.tada/internal@1.2.1':
+    resolution: {integrity: sha512-1kPMv9KRpD6mfVwtXK+iy43U/gi4bpr4ganfhPLD0TjxpbuVJm7CtZ9wMFdwy3FjLBFN2QhwscNnL7lRPHg4vg==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
@@ -3024,6 +3113,16 @@ packages:
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
     engines: {node: '>= 18'}
 
+  '@mysten/bcs@2.1.0':
+    resolution: {integrity: sha512-rIR/cDAqDfBDxmYEZXppN/on8gmh1OW0dYi/Bk2kMBZcYMTaBaEtEX1VR6g7HicVxuMbFAIP0/SQkdH7J9Y5dQ==}
+
+  '@mysten/sui@2.21.0':
+    resolution: {integrity: sha512-A/goX3VpYeUX4qplRGS1t9NwEO5VclZEA7qPpYPq1/h6CwqwVTUcqliM7AslZFAyejbd8jVVVQgPyIXw8e7G2Q==}
+    engines: {node: '>=22'}
+
+  '@mysten/utils@0.4.0':
+    resolution: {integrity: sha512-nHlXECBl9kE+AHF/aw5a7JVNizae8Kb71A4H18BV/sXd5/l2BaWNGWVatq05fzJo3hF78AWorDxa++1TgcBKWw==}
+
   '@near-js/crypto@2.5.1':
     resolution: {integrity: sha512-Kb+bbnUrfvuzzed9hpLRpcIlCMOaQlw/7BxlZPCq8DggVaK1m0nKR1DHQs2cV0Q0WSKSk2UrFJho1dxeKL5alg==}
     peerDependencies:
@@ -3216,6 +3315,10 @@ packages:
 
   '@noble/curves@2.0.1':
     resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
     engines: {node: '>= 20.19.0'}
 
   '@noble/ed25519@2.3.0':
@@ -3586,6 +3689,9 @@ packages:
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
+  '@scure/bip32@2.2.0':
+    resolution: {integrity: sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==}
+
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
 
@@ -3594,6 +3700,9 @@ packages:
 
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@scure/bip39@2.2.0':
+    resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
 
   '@signinwithethereum/siwe-parser@4.1.0':
     resolution: {integrity: sha512-aS+bU5QpTQgMpC6HjQHuKJpltUrkyGUVNuhuBLARa39wF1B+m05/4bgnf2qrEcgQONfU36A2Nbn3ibmwhHkc2Q==}
@@ -6753,6 +6862,12 @@ packages:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
 
+  gql.tada@1.11.2:
+    resolution: {integrity: sha512-oBr7ShA5/TmcwOO7BZgN1SynX2rBU+/ltysB0zXc+NCBF+9YOg6MRzJcTfLjIqDKdcE3LGxpOl0l9hBbxmyzmA==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -6766,6 +6881,10 @@ packages:
 
   graphql@16.11.0:
     resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   gtoken@7.1.0:
@@ -9186,6 +9305,14 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   valtio@1.13.2:
     resolution: {integrity: sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==}
     engines: {node: '>=12.20.0'}
@@ -9586,6 +9713,16 @@ packages:
         optional: true
 
 snapshots:
+
+  '@0no-co/graphql.web@1.3.2(graphql@16.14.2)':
+    optionalDependencies:
+      graphql: 16.14.2
+
+  '@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.9.2)':
+    dependencies:
+      '@gql.tada/internal': 1.2.1(graphql@16.14.2)(typescript@5.9.2)
+      graphql: 16.14.2
+      typescript: 5.9.2
 
   '@adraffy/ens-normalize@1.10.1': {}
 
@@ -10590,9 +10727,26 @@ snapshots:
   '@google-cloud/promisify@4.1.0':
     optional: true
 
+  '@gql.tada/cli-utils@1.9.2(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.9.2))(graphql@16.14.2)(typescript@5.9.2)':
+    dependencies:
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.9.2)
+      '@gql.tada/internal': 1.2.1(graphql@16.14.2)(typescript@5.9.2)
+      graphql: 16.14.2
+      typescript: 5.9.2
+
+  '@gql.tada/internal@1.2.1(graphql@16.14.2)(typescript@5.9.2)':
+    dependencies:
+      '@0no-co/graphql.web': 1.3.2(graphql@16.14.2)
+      graphql: 16.14.2
+      typescript: 5.9.2
+
   '@graphql-typed-document-node/core@3.2.0(graphql@16.11.0)':
     dependencies:
       graphql: 16.11.0
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
+    dependencies:
+      graphql: 16.14.2
 
   '@grpc/grpc-js@1.12.6':
     dependencies:
@@ -11162,6 +11316,37 @@ snapshots:
 
   '@msgpack/msgpack@3.1.3': {}
 
+  '@mysten/bcs@2.1.0':
+    dependencies:
+      '@mysten/utils': 0.4.0
+      '@scure/base': 2.2.0
+
+  '@mysten/sui@2.21.0(typescript@5.9.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      '@mysten/bcs': 2.1.0
+      '@mysten/utils': 0.4.0
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@protobuf-ts/grpcweb-transport': 2.11.1
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      '@scure/base': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      gql.tada: 1.11.2(graphql@16.14.2)(typescript@5.9.2)
+      graphql: 16.14.2
+      poseidon-lite: 0.2.1
+      valibot: 1.4.2(typescript@5.9.2)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
+
+  '@mysten/utils@0.4.0':
+    dependencies:
+      '@scure/base': 2.2.0
+
   '@near-js/crypto@2.5.1(@near-js/types@2.5.1)(@near-js/utils@2.5.1(@near-js/types@2.5.1))':
     dependencies:
       '@near-js/types': 2.5.1
@@ -11301,6 +11486,10 @@ snapshots:
   '@noble/curves@2.0.1':
     dependencies:
       '@noble/hashes': 2.0.1
+
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
 
   '@noble/ed25519@2.3.0': {}
 
@@ -12119,6 +12308,12 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@scure/bip32@2.2.0':
+    dependencies:
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
+
   '@scure/bip39@1.3.0':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -12133,6 +12328,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
+
+  '@scure/bip39@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@signinwithethereum/siwe-parser@4.1.0':
     dependencies:
@@ -17425,6 +17625,18 @@ snapshots:
       p-cancelable: 2.1.1
       responselike: 2.0.1
 
+  gql.tada@1.11.2(graphql@16.14.2)(typescript@5.9.2):
+    dependencies:
+      '@0no-co/graphql.web': 1.3.2(graphql@16.14.2)
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.9.2)
+      '@gql.tada/cli-utils': 1.9.2(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.9.2))(graphql@16.14.2)(typescript@5.9.2)
+      '@gql.tada/internal': 1.2.1(graphql@16.14.2)(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - graphql
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
@@ -17438,6 +17650,8 @@ snapshots:
       - encoding
 
   graphql@16.11.0: {}
+
+  graphql@16.14.2: {}
 
   gtoken@7.1.0:
     dependencies:
@@ -20255,6 +20469,10 @@ snapshots:
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
+
+  valibot@1.4.2(typescript@5.9.2):
+    optionalDependencies:
+      typescript: 5.9.2
 
   valtio@1.13.2(@types/react@19.1.12)(react@19.2.1):
     dependencies:


### PR DESCRIPTION
A `@x402/sui` mechanism package implementing the `exact` scheme for Sui, mirroring `@x402/aptos` in shape.

The headline: on Sui this payment is **gasless**. It rides Sui's **Address Balances** (protocol v125), so the transaction carries `gasPayment: []` and `gasPrice: 0` and is built entirely from protocol-allowlisted stablecoin operations.

No gas token, no sponsor, no gas-station round trip, no coin-object storage cost — the spec's entire Sponsored Transactions appendix is unnecessary on this path. The classic `Coin<T>` construction stays supported as the fallback for amounts below the protocol's `0.01` minimum.

This implements [`scheme_exact_sui.md`](specs/schemes/exact/scheme_exact_sui.md) and follows up on **#340** — @phdargen's invitation to land a v2-native Sui mechanism. The spec amendment ships as its **own PR (#2615)**; this PR carries only the implementation — the two review together.

cc @bmwill for spec-conformance.

---

## Structure

Mirrors `@x402/aptos` one-to-one — same `SchemeNetworkClient` / `SchemeNetworkServer` / `SchemeNetworkFacilitator` split, package layout, configs, and exports map. No changes to core. The payload is spec-exact: `{ signature, transaction }` (base64 signature, base64-BCS transaction).

```
typescript/packages/mechanisms/sui/
  src/{constants,types,signer,utils,index}.ts
  src/exact/{client,server,facilitator}/{scheme,index}.ts
  test/unit/{constants,types,signer,index,facilitator-verify}.test.ts
  test/integrations/exact-sui.test.ts      (env-gated, like aptos)
  test/fixtures/{gen,fixtures}.ts          (real testnet-signed fixtures)
```

---

## How the facilitator verifies a payment

Seven checks, each with a typed `invalidReason` and a dedicated unit test:

1. **Protocol envelope** — x402 version 2, scheme `exact`, matching network, and a well-formed `{ signature, transaction }` payload.
2. **Signature binds the payer** — the signature verifies over the transaction *and* the recovered address is the transaction's `sender`, so the debit can only come from the signer.
3. **Gasless shape** — the decoded transaction must carry `gasPrice: 0` and `gasPayment: []`, and every command must be an allowlisted stablecoin call (`0x2::balance::{send_funds,redeem_funds}`, `0x2::coin::{send_funds,into_balance}`) or native `SplitCoins` / `MergeCoins` change-making. `TransferObjects` and everything else is rejected. With zero gas and no object writes, there's no facilitator gas to drain and nothing to grief.
4. **Replay guard** — the digest is recomputed from the signed bytes and looked up on-chain; an already-committed transaction is refused. *(Simulation can't be the guard here: a gasless tx has no object inputs, so replaying executed bytes still simulates clean.)*
5. **Expiry** — the dry-run must succeed; a TTL-expired transaction fails at this step.
6. **Exact balance match** — every declared output (`extra.outputs`, defaulting to a single `payTo`) is credited to the cent, the payer is debited exactly `amount`, and no undeclared recipient of the asset is allowed.

Settlement is **executed-first and idempotent**: an already-committed tx returns its original digest without re-broadcasting; otherwise it re-verifies (defence in depth), broadcasts keylessly, and waits for finality. There is no `getExtra()` step — gasless is sponsor-free, which is simpler than the Aptos/SVM mechanisms and a feature in its own right.

---

## Tests

**67 unit tests, fully network-free** (`pnpm --filter @x402/sui test`) — every rejection branch (bad version / scheme / network, malformed payload, bad signature, sender ≠ signer, the gasless-shape guard, the `assetTransferMethod` gate, the coin-object plumbing accept and the `TransferObjects` reject, the already-executed replay, simulation failure, recipient mismatch, outputs mismatch, undeclared-recipient skim, payer-debit mismatch, asset mismatch), plus single- and two-output happy paths and the idempotent settle. Fixtures are **real testnet-signed** transactions captured once by `test/fixtures/gen.ts`.

**7 integration tests on live testnet** (`test:integration`, gated on `SUI_CLIENT_PRIVATE_KEY`) — full client → server → facilitator round-trips for single-output, two-output split, idempotent re-settle, a cheat rejection, a coin-object payer settling end-to-end, the replay rejection, and the `assetTransferMethod` gate refusing a declared `coin` method.

**Live conformance evidence** (Sui testnet, settled for this submission):

| Scenario | Digest | On-chain effect |
| --- | --- | --- |
| Gasless single-output | `AUEMarkDbo1L4xW4e9K5pRMorXtaQwWXgK6XviBQmcVo` | `gasPrice=0`, `gasPayment=[]`; USDC −10000 / +10000 |
| Gasless two-output split | `61HtkapYg1DaFnuZhDZCsrWLxcAyaYDc4ZaF7TzcqnaC` | `gasPrice=0`, `gasPayment=[]`; USDC −10000 / +200 / +9800 |

Both are verifiable on any public testnet fullnode via `sui_getTransactionBlock`: zero gas price, empty gas payment, and balance changes matching the declared outputs exactly.

---

## Credits & provenance

Builds on @Danny-Devs's [`x402-sui`](https://github.com/Danny-Devs/x402-sui) (Apache-2.0) — the signer, utils, constants, and server scheme derive from his work, adapted to `@mysten/sui` 2.17 (gRPC for the gasless build, JSON-RPC for simulate / execute) and the `@x402/core` interfaces. Derived files carry an Apache-2.0 §4 header and the commits are co-authored to him.

| Area | Source |
| --- | --- |
| signer / utils / constants / server scheme / test harness | @Danny-Devs `x402-sui` (Apache-2.0), adapted |
| gasless multi-output builder, exact-fee matcher, `assetTransferMethod` gate, cheat / replay cases | @Sceat (contributed here) |
| net-new | version guard, BCS command-shape allowlist, `getAssetDecimals`, the 7-step verify, idempotent keyless settle |
| spec + Address-Balances follow-up | @bmwill (Mysten) |
| the Transaction + Address-Balance APIs this rides on | `@mysten/sui` — thanks @hayes-mysten |

---

## AI assistance disclosure (per CONTRIBUTING)

Most of this implementation was AI-generated (Claude Fable 5 + Opus 4.8) and then reviewed through multiple consensus rounds. Every payment, signature, and settlement path was checked against the spec and exercised on live testnet with real USDC before submission — the unit-test assertions derive from **on-chain effects** (committed real dry-run `balanceChanges` and signed transactions), not from generated expectations. Hallucinated code doesn't settle USDC on-chain; the digests above are the proof.

---

## Local gauntlet

```
pnpm install --frozen-lockfile
pnpm --filter @x402/core --filter @x402/sui build
pnpm --filter @x402/sui test                                      # 64 passed
pnpm --filter @x402/sui lint:check
pnpm --filter @x402/sui format:check
SUI_CLIENT_PRIVATE_KEY=… pnpm --filter @x402/sui test:integration  # 7 passed (testnet)
```

## Checklist

- [x] Formatted and linted (`lint:check` + `format:check` green)
- [x] All new and existing tests pass (64 unit + 7 testnet integration)
- [x] My commits are signed (required for merge)
- [x] Changeset added (`typescript/.changeset/sui-exact-mechanism.md`)

cc @phdargen @bmwill @CarsonRoscoe @hayes-mysten @Danny-Devs

