### PR TITLE
Add Sui facilitator to the facilitators directory

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -29,6 +29,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
 | [Solvador](https://solvador.com) | Multi-network facilitator with broad mainnet coverage across EVM plus Solana and NEAR, supporting multiple schemes and extensions |
+| [Sui Facilitator (UIG Studios)](https://github.com/DrVelvetFog/sui-x402-facilitator) | Non-custodial, zero-fee x402 facilitator for Sui mainnet and testnet with USDC support |
 | [T54 XRPL Facilitator](https://xrpl-x402.t54.ai) | x402 facilitator for the XRP Ledger, covering mainnet and testnet with XRP and RLUSD support |
 
 For testnet development, the [x402.org facilitator](/core-concepts/network-and-token-support#x402org-facilitator) requires no setup. It is not intended for mainnet routes; use a production facilitator, a self-hosted facilitator, or [self-facilitation](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/self-facilitation) for production networks.


### PR DESCRIPTION
Adds a directory entry for a non-custodial, zero-fee x402 facilitator for Sui — the first facilitator to settle x402 payments on Sui. The `exact` scheme for Sui is specified in this repo but had no live facilitator until now.

- Live: https://sui-facilitator.onrender.com (`/supported`, `/verify`, `/settle`); serves `sui:mainnet` and `sui:testnet`
- Source (Apache-2.0): https://github.com/DrVelvetFog/sui-x402-facilitator
- On-chain proof: first mainnet settlement `HenUMqpDgdiAo9CsYc4mcoPpZYFMxDH8YVgEnVtAr5B9` ($0.01 USDC settled through the live service)

Non-custodial: it relays the payer's own signed transaction; it holds no keys and cannot redirect funds.

Note: the `exact` Sui scheme spec defines `sui:mainnet` but no testnet network id. This facilitator advertises `sui:testnet` (CAIP-2 style) — happy to align if the foundation blesses a canonical id.

Disclosure: the facilitator implementation and this PR were prepared with AI assistance and reviewed before submission.