### PR TITLE
feat: add Triple Arbiter facilitator

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/triple-arbiter/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/triple-arbiter/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "Triple Arbiter",
+  "description": "x402 settlement facilitator + EAS-compatible threat-intel attestation issuer on Base mainnet. Non-custodial EIP-3009 USDC settlement with a 50 bps facilitator fee. Pairs settlement receipts with on-chain EAS attestations for agent-to-agent trust signals.",
+  "logoUrl": "/logos/triple-arbiter.svg",
+  "websiteUrl": "https://facilitator.eno.cx.ua",
+  "category": "Facilitators",
+  "facilitator": {
+    "baseUrl": "https://facilitator.eno.cx.ua",
+    "networks": ["base"],
+    "schemes": ["exact"],
+    "assets": ["EIP-3009"],
+    "supports": {
+      "verify": true,
+      "settle": true,
+      "supported": true,
+      "list": false
+    }
+  }
+}

--- a/typescript/site/public/logos/triple-arbiter.svg
+++ b/typescript/site/public/logos/triple-arbiter.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Triple Arbiter logo">
+  <rect width="256" height="256" rx="36" fill="#0b1220"/>
+  <g fill="none" stroke="#60a5fa" stroke-width="10" stroke-linecap="round" stroke-linejoin="round">
+    <polygon points="128,48 208,192 48,192"/>
+  </g>
+  <circle cx="128" cy="48" r="10" fill="#22d3ee"/>
+  <circle cx="208" cy="192" r="10" fill="#a78bfa"/>
+  <circle cx="48" cy="192" r="10" fill="#34d399"/>
+  <text x="128" y="230" text-anchor="middle" font-family="monospace" font-size="22" font-weight="700" fill="#f8fafc">x402 · EAS · UMA</text>
+</svg>


### PR DESCRIPTION
# Add Triple Arbiter facilitator to ecosystem

## Summary
Adds Triple Arbiter — an x402 settlement facilitator on Base mainnet that pairs EIP-3009 `transferWithAuthorization` USDC settlements with EAS-compatible threat-intel attestations.

## Category
`Facilitators`

## Key facts
- **Non-custodial** — facilitator never takes custody of user funds. Settlement is a direct USDC transfer from payer to merchant authorized via EIP-3009.
- **Fee** — 50 bps facilitator fee, $2 minimum transfer. ProsharkyHook (ISettlementHook at [`0x05E09a53e188DA1622AcFc9498703F0aE10f9202`](https://basescan.org/address/0x05E09a53e188DA1622AcFc9498703F0aE10f9202) on Base) adds optional 10 bps on-chain capture — 50% undercut vs Coinbase's 20 bps facilitator surcharge — with 2 bps auto-allocated to EAS attestation gas reserve.
- **Network** — Base mainnet (chain_id 8453), USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
- **Scheme / asset** — `exact` / `EIP-3009`
- **Discovery** — `/.well-known/x402-facilitator.json` served per spec
- **EAS attestations** — Triple Arbiter pairs each settlement receipt with an on-chain EAS attestation (UID emitted per settlement tx) on Base, queryable directly via the EAS indexer. Agents can use these on-chain attestation records to score counterparty reputation before settling and to detect revoked issuers.

## Verification
```
$ curl -s https://facilitator.eno.cx.ua/health
OK

$ curl -s https://facilitator.eno.cx.ua/.well-known/x402-facilitator.json | jq .
{
  "schema_ref": "https://docs.x402.org/schemas/facilitator/v1.json",
  "name": "Triple Arbiter",
  "facilitator": {
    "address": "0xbe5df0394dbd9cc19127cf93cd9b543f2eb63b97",
    "network": "base",
    "chain_id": 8453,
    "asset": "USDC",
    "asset_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
    "fee_bps": 50,
    "min_transfer_usd": "2.00",
    "custody": "none",
    "relay_pattern": "eip-3009-transferWithAuthorization"
  }
}
```

## Why it's distinct
Most facilitators ship settlement only. Triple Arbiter pairs each x402 settlement receipt with an optional EAS attestation (deprecation of compromised issuers, threat-intel feed for agent-to-agent trust), which is the non-obvious part of the integration — merchants can consume the attestation feed to filter requests before settlement.

## Files added
- `typescript/site/app/ecosystem/partners-data/triple-arbiter/metadata.json`
- `typescript/site/public/logos/triple-arbiter.svg`

## Tests
Facilitator endpoint verified live:
- `GET /health` → `200 OK`
- `GET /.well-known/x402-facilitator.json` → valid JSON matching x402 facilitator schema

## Checklist
- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [ ] I added a changelog fragment for user-facing changes (ecosystem listing — docs-only change)