### PR TITLE
docs: add GPT-5.5 x402 Gateway ecosystem listing

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/gpt55-token-gateway/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/gpt55-token-gateway/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "GPT-5.5 x402 Gateway",
+  "description": "OpenAI-compatible GPT-5.5 and deterministic seller tools behind x402 payments. Offers 100+ paid HTTP endpoints, MCP metadata, Bazaar discovery, and Base USDC settlement for agents and scripts without API-key onboarding.",
+  "logoUrl": "/logos/gpt55-token-gateway.svg",
+  "websiteUrl": "https://gpt55.558686.xyz",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/gpt55-token-gateway.svg
+++ b/typescript/site/public/logos/gpt55-token-gateway.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 80" role="img" aria-labelledby="title desc">
+  <title id="title">GPT-5.5 x402 Gateway</title>
+  <desc id="desc">Wordmark for the GPT-5.5 x402 Gateway ecosystem listing.</desc>
+  <rect width="240" height="80" rx="10" fill="#0B0F14"/>
+  <rect x="14" y="14" width="52" height="52" rx="8" fill="#0052FF"/>
+  <path d="M27 28h26v6H34v6h17v6H34v8h-7V28Z" fill="#FFFFFF"/>
+  <path d="M78 28h86v8H78v-8Zm0 17h54v7H78v-7Z" fill="#FFFFFF"/>
+  <text x="78" y="65" fill="#8AA7FF" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700">x402 Base USDC</text>
+  <text x="169" y="36" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="22" font-weight="700">GPT55</text>
+  <circle cx="218" cy="58" r="7" fill="#22C55E"/>
+</svg>


### PR DESCRIPTION
## Description\n\nAdds GPT-5.5 x402 Gateway to the x402 ecosystem site as a Services/Endpoints listing. The service exposes OpenAI-compatible GPT-5.5 and deterministic seller tooling over x402, with MCP metadata, Bazaar discovery, and Base USDC settlement.\n\nListing URL: https://gpt55.558686.xyz\n\n## Tests\n\n- `jq . typescript/site/app/ecosystem/partners-data/gpt55-token-gateway/metadata.json`\n- Parsed the new metadata JSON and SVG with Python stdlib checks; verified required fields and logo path.\n- `git diff --check`\n- Verified live pricing metadata from `https://gpt55.558686.xyz/pricing.json`: Base USDC settlement, 106 endpoint entries, payTo `0x1f0130669ca6fd02e025a984cc038f139df19a2f`.\n\n## Checklist\n\n- [x] I have formatted and linted my code\n- [x] All new and existing tests pass\n- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits\n- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)\n\nDocs-only ecosystem metadata change; no changelog fragment needed.