### PR TITLE
fix(python): infer bazaar method during startup validation

### DIFF
--- a/python/x402/changelog.d/2626.bugfix.md
+++ b/python/x402/changelog.d/2626.bugfix.md
@@ -1,0 +1,1 @@
+Fixed startup-time bazaar validation for declared discovery extensions whose HTTP method is inferred from route keys.

--- a/python/x402/http/middleware/_bazaar_utils.py
+++ b/python/x402/http/middleware/_bazaar_utils.py
@@ -6,6 +6,7 @@ used by both FastAPI and Flask middleware.
 
 from __future__ import annotations
 
+import copy
 import warnings
 from typing import Any
 
@@ -92,7 +93,7 @@ def validate_bazaar_extensions(routes: RoutesConfig) -> None:
         if not extensions or "bazaar" not in extensions:
             continue
 
-        bazaar_ext = extensions["bazaar"]
+        bazaar_ext = _with_method_from_route_pattern(pattern, extensions["bazaar"])
         if (
             not isinstance(bazaar_ext, dict)
             or "info" not in bazaar_ext
@@ -123,3 +124,40 @@ def validate_bazaar_extensions(routes: RoutesConfig) -> None:
                 )
         except Exception:
             pass
+
+
+def _with_method_from_route_pattern(pattern: str, bazaar_ext: Any) -> Any:
+    """Return a validation copy with HTTP method inferred from a route key.
+
+    ``declare_discovery_extension`` intentionally omits ``info.input.method`` so
+    framework middleware can infer it from route keys such as ``GET /weather``.
+    Startup validation runs before request-time enrichment, so it needs the same
+    route-key inference to avoid warning on valid declarations.
+    """
+    if not isinstance(bazaar_ext, dict):
+        return bazaar_ext
+
+    method = _method_from_route_pattern(pattern)
+    if method is None:
+        return bazaar_ext
+
+    ext = copy.deepcopy(bazaar_ext)
+    info = ext.setdefault("info", {})
+    if not isinstance(info, dict):
+        return bazaar_ext
+
+    input_info = info.setdefault("input", {})
+    if not isinstance(input_info, dict):
+        return bazaar_ext
+
+    input_info.setdefault("method", method)
+    return ext
+
+
+def _method_from_route_pattern(pattern: str) -> str | None:
+    parts = pattern.split(None, 1)
+    if len(parts) != 2:
+        return None
+
+    method = parts[0].upper()
+    return method if method != "*" else None

--- a/python/x402/tests/unit/http/test_bazaar_extension_validation.py
+++ b/python/x402/tests/unit/http/test_bazaar_extension_validation.py
@@ -85,6 +85,28 @@ class TestFastAPIBazaarExtensionValidation:
         bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
         assert len(bazaar_warnings) == 0
 
+    def test_declared_extension_without_method_uses_route_key(self):
+        """Startup validation should infer method for declared discovery extensions."""
+        from x402.extensions.bazaar import declare_discovery_extension
+        from x402.http.middleware.fastapi import _validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions=declare_discovery_extension(
+                    input={"query": "test"},
+                    input_schema={"properties": {"query": {"type": "string"}}},
+                ),
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0
+
     def test_invalid_extension_emits_warning(self):
         """A route with schema requiring fields absent from info should emit a warning."""
         from x402.http.middleware.fastapi import _validate_bazaar_extensions


### PR DESCRIPTION
## Description

Fixes #2604.

`declare_discovery_extension()` intentionally omits `info.input.method` so framework middleware can infer it from route keys such as `GET /weather`. Startup-time bazaar validation ran before request-time enrichment, so valid declared discovery extensions emitted warnings like `input: method is a required property`.

This change validates a copy of the bazaar extension with the HTTP method inferred from the route pattern, matching the runtime behavior without mutating the route config.

## Tests

- `PYTHONPATH=/home/ubuntu/x402-foundation-x402/python /tmp/x402-pytest-venv/bin/python -m pytest x402/tests/unit/http/test_bazaar_extension_validation.py x402/tests/unit/extensions/bazaar/test_server.py`
- Result: `43 passed, 3 skipped`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

---

AI assistance was used to inspect the existing code paths, draft the test, and run local verification. I reviewed the final diff and test output.