### PR TITLE
fix(python): surface FastAPI settlement errors

### DIFF
--- a/python/x402/changelog.d/2603.bugfix.md
+++ b/python/x402/changelog.d/2603.bugfix.md
@@ -1,0 +1,1 @@
+Log unexpected FastAPI settlement exceptions and return HTTP 500 instead of an empty 402 response.

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -6,6 +6,7 @@ Provides payment-gated route protection for FastAPI applications.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -48,6 +49,8 @@ from ._bazaar_utils import (
 from ._bazaar_utils import (
     validate_bazaar_extensions as _validate_bazaar_extensions,
 )
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # FastAPI Adapter
@@ -375,7 +378,11 @@ def payment_middleware(
             except FacilitatorResponseError as error:
                 return _facilitator_error_response(error)
             except Exception:
-                return JSONResponse(content={}, status_code=402)
+                logger.exception("Unexpected error while settling x402 payment")
+                return JSONResponse(
+                    content={"error": "Internal server error during payment settlement"},
+                    status_code=500,
+                )
 
         # Fallthrough - should not happen
         return await call_next(request)

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -653,6 +653,60 @@ class TestFastAPIMiddlewareIntegration:
                     "error": "Facilitator settle returned invalid data: {'success': true}"
                 }
 
+    def test_unexpected_settlement_exception_returns_500_and_logs(self, caplog):
+        """Test that unexpected settlement exceptions are logged and return 500."""
+        app = FastAPI()
+
+        @app.get("/api/protected")
+        def protected_route():
+            return {"data": "Protected content"}
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request = AsyncMock(
+                return_value=HTTPProcessResult(
+                    type="payment-verified",
+                    payment_payload=payment_payload,
+                    payment_requirements=payment_requirements,
+                )
+            )
+            mock_http_server_instance.process_settlement = AsyncMock(
+                side_effect=RuntimeError("settlement transport crashed")
+            )
+            mock_http_server.return_value = mock_http_server_instance
+
+            @app.middleware("http")
+            async def x402_middleware(request: Request, call_next):
+                return await payment_middleware(
+                    routes, mock_server, sync_facilitator_on_start=False
+                )(request, call_next)
+
+            with caplog.at_level("ERROR", logger="x402.http.middleware.fastapi"):
+                with TestClient(app) as client:
+                    response = client.get("/api/protected")
+
+        assert response.status_code == 500
+        assert response.json() == {
+            "error": "Internal server error during payment settlement"
+        }
+        assert "Unexpected error while settling x402 payment" in caplog.text
+
 
 # =============================================================================
 # Concurrency Tests


### PR DESCRIPTION
## Summary
- Fixes #2603
- Log unexpected FastAPI settlement exceptions with `logger.exception`
- Return HTTP 500 with a minimal error body for unexpected settlement failures instead of an empty HTTP 402
- Preserve existing 402 behavior for normal settlement failures and 502 behavior for invalid facilitator responses
- Add a regression test and changelog fragment

## Verification
- `/tmp/x402-fastapi-test-venv/bin/python -m pytest python/x402/tests/unit/http/middleware/test_fastapi.py`
- `/tmp/x402-fastapi-test-venv/bin/python -m ruff check python/x402/http/middleware/fastapi.py python/x402/tests/unit/http/middleware/test_fastapi.py`
- `/tmp/x402-fastapi-test-venv/bin/python -m compileall -q python/x402/http/middleware/fastapi.py python/x402/tests/unit/http/middleware/test_fastapi.py`
- `git diff --check`