### PR TITLE
fix(ts): cache SVM exact mint metadata

### DIFF
--- a/typescript/.changeset/cache-svm-mint-metadata.md
+++ b/typescript/.changeset/cache-svm-mint-metadata.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": patch
+---
+
+Cache SVM exact client mint metadata to avoid repeated mint RPC fetches.

--- a/typescript/packages/mechanisms/svm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/client/scheme.ts
@@ -4,7 +4,6 @@ import {
 } from "@solana-program/compute-budget";
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import {
-  fetchMint,
   findAssociatedTokenPda,
   getTransferCheckedInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
@@ -30,12 +29,14 @@ import {
 import type { ClientSvmConfig, ClientSvmSigner } from "../../signer";
 import type { ExactSvmPayloadV2 } from "../../types";
 import { createRpcClient } from "../../utils";
+import { getCachedMintMetadata, type MintMetadataCache } from "../../mint-cache";
 
 /**
  * SVM client implementation for the Exact payment scheme.
  */
 export class ExactSvmScheme implements SchemeNetworkClient {
   readonly scheme = "exact";
+  private readonly mintCache: MintMetadataCache = new Map();
 
   /**
    * Creates a new ExactSvmClient instance.
@@ -62,8 +63,13 @@ export class ExactSvmScheme implements SchemeNetworkClient {
   ): Promise<Pick<PaymentPayload, "x402Version" | "payload">> {
     const rpc = createRpcClient(paymentRequirements.network, this.config?.rpcUrl);
 
-    const tokenMint = await fetchMint(rpc, paymentRequirements.asset as Address);
-    const tokenProgramAddress = tokenMint.programAddress;
+    const mintMetadata = await getCachedMintMetadata(
+      rpc,
+      paymentRequirements.network,
+      paymentRequirements.asset as Address,
+      this.mintCache,
+    );
+    const tokenProgramAddress = mintMetadata.programAddress;
 
     if (
       tokenProgramAddress.toString() !== TOKEN_PROGRAM_ADDRESS.toString() &&
@@ -91,7 +97,7 @@ export class ExactSvmScheme implements SchemeNetworkClient {
         destination: destinationATA,
         authority: this.signer,
         amount: BigInt(paymentRequirements.amount),
-        decimals: tokenMint.data.decimals,
+        decimals: mintMetadata.decimals,
       },
       { programAddress: tokenProgramAddress },
     );

--- a/typescript/packages/mechanisms/svm/src/exact/v1/client/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/client/scheme.ts
@@ -4,7 +4,6 @@ import {
 } from "@solana-program/compute-budget";
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import {
-  fetchMint,
   findAssociatedTokenPda,
   getTransferCheckedInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
@@ -36,12 +35,14 @@ import {
 import type { ClientSvmConfig, ClientSvmSigner } from "../../../signer";
 import type { ExactSvmPayloadV1 } from "../../../types";
 import { createRpcClient } from "../../../utils";
+import { getCachedMintMetadata, type MintMetadataCache } from "../../../mint-cache";
 
 /**
  * SVM client implementation for the Exact payment scheme (V1).
  */
 export class ExactSvmSchemeV1 implements SchemeNetworkClient {
   readonly scheme = "exact";
+  private readonly mintCache: MintMetadataCache = new Map();
 
   /**
    * Creates a new ExactSvmClientV1 instance.
@@ -71,8 +72,13 @@ export class ExactSvmSchemeV1 implements SchemeNetworkClient {
     const selectedV1 = paymentRequirements as unknown as PaymentRequirementsV1;
     const rpc = createRpcClient(selectedV1.network, this.config?.rpcUrl);
 
-    const tokenMint = await fetchMint(rpc, selectedV1.asset as Address);
-    const tokenProgramAddress = tokenMint.programAddress;
+    const mintMetadata = await getCachedMintMetadata(
+      rpc,
+      selectedV1.network,
+      selectedV1.asset as Address,
+      this.mintCache,
+    );
+    const tokenProgramAddress = mintMetadata.programAddress;
 
     if (
       tokenProgramAddress.toString() !== TOKEN_PROGRAM_ADDRESS.toString() &&
@@ -100,7 +106,7 @@ export class ExactSvmSchemeV1 implements SchemeNetworkClient {
         destination: destinationATA,
         authority: this.signer,
         amount: BigInt(selectedV1.maxAmountRequired),
-        decimals: tokenMint.data.decimals,
+        decimals: mintMetadata.decimals,
       },
       { programAddress: tokenProgramAddress },
     );

--- a/typescript/packages/mechanisms/svm/src/mint-cache.ts
+++ b/typescript/packages/mechanisms/svm/src/mint-cache.ts
@@ -1,0 +1,47 @@
+import { fetchMint } from "@solana-program/token-2022";
+import type { Address } from "@solana/kit";
+
+type Mint = Awaited<ReturnType<typeof fetchMint>>;
+
+export type MintMetadata = {
+  decimals: Mint["data"]["decimals"];
+  programAddress: Mint["programAddress"];
+};
+
+export type MintMetadataCache = Map<string, Promise<MintMetadata>>;
+
+/**
+ * Gets stable SPL mint metadata from cache, fetching it once per network and mint.
+ *
+ * @param rpc - Solana RPC client
+ * @param network - Payment requirements network
+ * @param asset - SPL mint address
+ * @param cache - Per-client mint metadata cache
+ * @returns Cached mint metadata
+ */
+export async function getCachedMintMetadata(
+  rpc: Parameters<typeof fetchMint>[0],
+  network: string,
+  asset: Address,
+  cache: MintMetadataCache,
+): Promise<MintMetadata> {
+  const key = `${network}:${asset}`;
+  let metadata = cache.get(key);
+
+  if (!metadata) {
+    metadata = fetchMint(rpc, asset).then(mint => ({
+      decimals: mint.data.decimals,
+      programAddress: mint.programAddress,
+    }));
+    cache.set(key, metadata);
+  }
+
+  try {
+    return await metadata;
+  } catch (error) {
+    if (cache.get(key) === metadata) {
+      cache.delete(key);
+    }
+    throw error;
+  }
+}

--- a/typescript/packages/mechanisms/svm/test/unit/duplicateTx.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/duplicateTx.test.ts
@@ -505,6 +505,82 @@ describe("Memo Uniqueness", () => {
   });
 });
 
+describe("mint metadata cache", () => {
+  beforeEach(() => {
+    blockhashes = [];
+    blockhashIndex = 0;
+    mockAtaMap = {};
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("caches mint metadata for repeated V2 payment payloads", async () => {
+    blockhashes = [FIXED_BLOCKHASH, FIXED_BLOCKHASH_ALT];
+
+    const { ExactSvmScheme } = await import("../../src/exact/client/scheme");
+    const { fetchMint } = await import("@solana-program/token-2022");
+
+    const clientSigner = await createSigner();
+    const feePayer = await createSigner();
+    const payTo = await createSigner();
+
+    const client = new ExactSvmScheme(clientSigner);
+    mockAtaMap = {
+      [clientSigner.address]: clientSigner.address as Address,
+      [payTo.address]: payTo.address as Address,
+    };
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: feePayer.address },
+    };
+
+    await client.createPaymentPayload(2, requirements);
+    await client.createPaymentPayload(2, requirements);
+
+    expect(fetchMint).toHaveBeenCalledTimes(1);
+    expect(mockRpc.getLatestBlockhash).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches mint metadata for repeated V1 payment payloads", async () => {
+    blockhashes = [FIXED_BLOCKHASH, FIXED_BLOCKHASH_ALT];
+
+    const { ExactSvmSchemeV1 } = await import("../../src/exact/v1/client/scheme");
+    const { fetchMint } = await import("@solana-program/token-2022");
+
+    const clientSigner = await createSigner();
+    const feePayer = await createSigner();
+    const payTo = await createSigner();
+
+    const client = new ExactSvmSchemeV1(clientSigner);
+    mockAtaMap = {
+      [clientSigner.address]: clientSigner.address as Address,
+      [payTo.address]: payTo.address as Address,
+    };
+
+    const requirements = {
+      scheme: "exact",
+      network: "solana-devnet",
+      asset: USDC_DEVNET_ADDRESS,
+      maxAmountRequired: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: feePayer.address },
+    };
+
+    await client.createPaymentPayload(1, requirements as never);
+    await client.createPaymentPayload(1, requirements as never);
+
+    expect(fetchMint).toHaveBeenCalledTimes(1);
+    expect(mockRpc.getLatestBlockhash).toHaveBeenCalledTimes(2);
+  });
+});
+
 // Verify that randomizing the fee-payer signature bytes (slot 0) — which the
 // facilitator overwrites before broadcast — does not change the cache key.
 describe("transactionMessageHash malleability resistance", () => {


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

- Cache SVM mint metadata per TypeScript exact client instance
- Reuse cached mint decimals and token program in both V1 and V2 SVM exact client payload creation
- Add unit coverage verifying repeated payload creation only fetches mint metadata once while still fetching a fresh blockhash per payment

SVM exact payment payload creation fetched mint metadata on every payment to derive the token program and decimals. Those fields are stable for a mint, so repeated payments from the same client can reuse them and avoid unnecessary RPC calls.

This follows up on #2216 for the TypeScript SDK.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

- `CI=true corepack pnpm --filter @x402/svm test -- --runInBand`
- `CI=true corepack pnpm --filter @x402/svm build`
- `CI=true corepack pnpm --filter @x402/svm lint:check`
- `git diff --check --cached`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 

## Related Issue

- Part of #2216