### PR TITLE
fix(py): cache SVM exact mint metadata

### DIFF
--- a/python/x402/changelog.d/2216.bugfix.md
+++ b/python/x402/changelog.d/2216.bugfix.md
@@ -1,0 +1,1 @@
+Cache SVM exact client mint metadata to avoid repeated mint RPC fetches.

--- a/python/x402/mechanisms/svm/exact/client.py
+++ b/python/x402/mechanisms/svm/exact/client.py
@@ -26,9 +26,8 @@ from ..constants import (
     MEMO_PROGRAM_ADDRESS,
     NETWORK_CONFIGS,
     SCHEME_EXACT,
-    TOKEN_2022_PROGRAM_ADDRESS,
-    TOKEN_PROGRAM_ADDRESS,
 )
+from ..mint_cache import MintMetadataCache, get_cached_mint_metadata
 from ..signer import ClientSvmSigner
 from ..types import ExactSvmPayload
 from ..utils import derive_ata, normalize_network
@@ -56,6 +55,7 @@ class ExactSvmScheme:
         self._signer = signer
         self._custom_rpc_url = rpc_url
         self._clients: dict[str, SolanaClient] = {}
+        self._mint_cache: MintMetadataCache = {}
 
     def _get_client(self, network: str) -> SolanaClient:
         """Get or create RPC client for network.
@@ -112,31 +112,9 @@ class ExactSvmScheme:
         mint = Pubkey.from_string(requirements.asset)
         payer_pubkey = Pubkey.from_string(self._signer.address)
 
-        # Fetch token mint info to get decimals and program
-        mint_info = client.get_account_info(mint)
-        if not mint_info.value:
-            raise ValueError(f"Token mint not found: {requirements.asset}")
-
-        # Determine token program from mint owner
-        mint_owner = str(mint_info.value.owner)
-        if mint_owner == TOKEN_PROGRAM_ADDRESS:
-            token_program = Pubkey.from_string(TOKEN_PROGRAM_ADDRESS)
-        elif mint_owner == TOKEN_2022_PROGRAM_ADDRESS:
-            token_program = Pubkey.from_string(TOKEN_2022_PROGRAM_ADDRESS)
-        else:
-            raise ValueError(f"Unknown token program: {mint_owner}")
-
-        # Parse mint data to get decimals
-        # SPL Token Mint layout:
-        #   0-3:   mintAuthorityOption (4 bytes)
-        #   4-35:  mintAuthority (32 bytes)
-        #   36-43: supply (8 bytes, u64)
-        #   44:    decimals (1 byte, u8)
-        #   45:    isInitialized (1 byte)
-        #   46-49: freezeAuthorityOption (4 bytes)
-        #   50-81: freezeAuthority (32 bytes)
-        mint_data = mint_info.value.data
-        decimals = mint_data[44]
+        mint_metadata = get_cached_mint_metadata(client, network, mint, self._mint_cache)
+        token_program = mint_metadata.token_program
+        decimals = mint_metadata.decimals
 
         # Derive ATAs
         source_ata_str = derive_ata(self._signer.address, requirements.asset, str(token_program))

--- a/python/x402/mechanisms/svm/exact/v1/client.py
+++ b/python/x402/mechanisms/svm/exact/v1/client.py
@@ -26,9 +26,8 @@ from ...constants import (
     MEMO_PROGRAM_ADDRESS,
     NETWORK_CONFIGS,
     SCHEME_EXACT,
-    TOKEN_2022_PROGRAM_ADDRESS,
-    TOKEN_PROGRAM_ADDRESS,
 )
+from ...mint_cache import MintMetadataCache, get_cached_mint_metadata
 from ...signer import ClientSvmSigner
 from ...types import ExactSvmPayload
 from ...utils import derive_ata, normalize_network
@@ -60,6 +59,7 @@ class ExactSvmSchemeV1:
         self._signer = signer
         self._custom_rpc_url = rpc_url
         self._clients: dict[str, SolanaClient] = {}
+        self._mint_cache: MintMetadataCache = {}
 
     def _get_client(self, network: str) -> SolanaClient:
         """Get or create RPC client for network.
@@ -116,24 +116,9 @@ class ExactSvmSchemeV1:
         mint = Pubkey.from_string(requirements.asset)
         payer_pubkey = Pubkey.from_string(self._signer.address)
 
-        # Fetch token mint info to get decimals and program
-        mint_info = client.get_account_info(mint)
-        if not mint_info.value:
-            raise ValueError(f"Token mint not found: {requirements.asset}")
-
-        # Determine token program from mint owner
-        mint_owner = str(mint_info.value.owner)
-        if mint_owner == TOKEN_PROGRAM_ADDRESS:
-            token_program = Pubkey.from_string(TOKEN_PROGRAM_ADDRESS)
-        elif mint_owner == TOKEN_2022_PROGRAM_ADDRESS:
-            token_program = Pubkey.from_string(TOKEN_2022_PROGRAM_ADDRESS)
-        else:
-            raise ValueError(f"Unknown token program: {mint_owner}")
-
-        # Parse mint data to get decimals
-        # SPL Token Mint layout: decimals is at byte 44
-        mint_data = mint_info.value.data
-        decimals = mint_data[44]
+        mint_metadata = get_cached_mint_metadata(client, network, mint, self._mint_cache)
+        token_program = mint_metadata.token_program
+        decimals = mint_metadata.decimals
 
         # Derive ATAs
         source_ata_str = derive_ata(self._signer.address, requirements.asset, str(token_program))

--- a/python/x402/mechanisms/svm/mint_cache.py
+++ b/python/x402/mechanisms/svm/mint_cache.py
@@ -1,0 +1,51 @@
+"""Helpers for caching immutable SPL mint metadata."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from solders.pubkey import Pubkey
+
+from .constants import TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS
+
+
+@dataclass(frozen=True)
+class MintMetadata:
+    """Stable fields needed to build SPL token transfers."""
+
+    decimals: int
+    token_program: Pubkey
+
+
+MintMetadataCache = dict[tuple[str, str], MintMetadata]
+
+
+def get_cached_mint_metadata(
+    client: Any,
+    network: str,
+    mint: Pubkey,
+    cache: MintMetadataCache,
+) -> MintMetadata:
+    """Get cached mint decimals and token program, fetching once per network/mint."""
+    key = (network, str(mint))
+    cached = cache.get(key)
+    if cached:
+        return cached
+
+    mint_info = client.get_account_info(mint)
+    if not mint_info.value:
+        raise ValueError(f"Token mint not found: {mint}")
+
+    mint_owner = str(mint_info.value.owner)
+    if mint_owner == TOKEN_PROGRAM_ADDRESS:
+        token_program = Pubkey.from_string(TOKEN_PROGRAM_ADDRESS)
+    elif mint_owner == TOKEN_2022_PROGRAM_ADDRESS:
+        token_program = Pubkey.from_string(TOKEN_2022_PROGRAM_ADDRESS)
+    else:
+        raise ValueError(f"Unknown token program: {mint_owner}")
+
+    metadata = MintMetadata(
+        decimals=mint_info.value.data[44],
+        token_program=token_program,
+    )
+    cache[key] = metadata
+    return metadata

--- a/python/x402/tests/unit/mechanisms/svm/test_client.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_client.py
@@ -1,11 +1,20 @@
 """Tests for ExactSvmScheme client."""
 
-from solders.keypair import Keypair
+from unittest.mock import MagicMock, patch
 
-from x402.mechanisms.svm import SOLANA_DEVNET_CAIP2, USDC_DEVNET_ADDRESS
+from solders.hash import Hash
+from solders.keypair import Keypair
+from solders.pubkey import Pubkey
+
+from x402.mechanisms.svm import SOLANA_DEVNET_CAIP2, TOKEN_PROGRAM_ADDRESS, USDC_DEVNET_ADDRESS
 from x402.mechanisms.svm.exact import ExactSvmClientScheme
+from x402.mechanisms.svm.exact.v1 import ExactSvmSchemeV1
 from x402.mechanisms.svm.signers import KeypairSigner
 from x402.schemas import PaymentRequirements
+from x402.schemas.v1 import PaymentRequirementsV1
+
+FIXED_BLOCKHASH = "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF"
+FIXED_BLOCKHASH_ALT = "7ZCxc2SDhzV2bYgEQqdxTpweYJkpwshVSDtXuY7uPtjf"
 
 
 class TestExactSvmSchemeConstructor:
@@ -85,6 +94,86 @@ class TestCreatePaymentPayload:
         assert client.create_payment_payload is not None
         assert requirements.extra is not None
         assert requirements.extra.get("feePayer") is None
+
+
+class TestMintMetadataCache:
+    """Test mint metadata caching during payload creation."""
+
+    def _mock_rpc_client(self):
+        mock_client = MagicMock()
+
+        blockhashes = [
+            Hash.from_string(FIXED_BLOCKHASH),
+            Hash.from_string(FIXED_BLOCKHASH_ALT),
+        ]
+
+        def get_latest_blockhash():
+            mock_resp = MagicMock()
+            mock_resp.value.blockhash = blockhashes.pop(0)
+            return mock_resp
+
+        mock_client.get_latest_blockhash.side_effect = get_latest_blockhash
+
+        mock_account_info = MagicMock()
+        mock_account_info.value = MagicMock()
+        mock_account_info.value.owner = Pubkey.from_string(TOKEN_PROGRAM_ADDRESS)
+        mock_account_info.value.data = bytes(44) + bytes([6]) + bytes(37)
+        mock_client.get_account_info.return_value = mock_account_info
+
+        return mock_client
+
+    def test_v2_reuses_cached_mint_metadata(self):
+        """V2 should fetch mint metadata once for repeated same-network same-mint payments."""
+        signer = KeypairSigner(Keypair.from_seed(bytes([1] * 32)))
+        fee_payer = Keypair.from_seed(bytes([2] * 32))
+        pay_to = Keypair.from_seed(bytes([3] * 32))
+
+        client = ExactSvmClientScheme(signer)
+        rpc_client = self._mock_rpc_client()
+
+        requirements = PaymentRequirements(
+            scheme="exact",
+            network=SOLANA_DEVNET_CAIP2,
+            asset=USDC_DEVNET_ADDRESS,
+            amount="100000",
+            pay_to=str(pay_to.pubkey()),
+            max_timeout_seconds=3600,
+            extra={"feePayer": str(fee_payer.pubkey())},
+        )
+
+        with patch.object(client, "_get_client", return_value=rpc_client):
+            client.create_payment_payload(requirements)
+            client.create_payment_payload(requirements)
+
+        assert rpc_client.get_account_info.call_count == 1
+        assert rpc_client.get_latest_blockhash.call_count == 2
+
+    def test_v1_reuses_cached_mint_metadata(self):
+        """V1 should fetch mint metadata once for repeated same-network same-mint payments."""
+        signer = KeypairSigner(Keypair.from_seed(bytes([1] * 32)))
+        fee_payer = Keypair.from_seed(bytes([2] * 32))
+        pay_to = Keypair.from_seed(bytes([3] * 32))
+
+        client = ExactSvmSchemeV1(signer)
+        rpc_client = self._mock_rpc_client()
+
+        requirements = PaymentRequirementsV1(
+            scheme="exact",
+            network="solana-devnet",
+            resource="https://example.com",
+            asset=USDC_DEVNET_ADDRESS,
+            max_amount_required="100000",
+            pay_to=str(pay_to.pubkey()),
+            max_timeout_seconds=3600,
+            extra={"feePayer": str(fee_payer.pubkey())},
+        )
+
+        with patch.object(client, "_get_client", return_value=rpc_client):
+            client.create_payment_payload(requirements)
+            client.create_payment_payload(requirements)
+
+        assert rpc_client.get_account_info.call_count == 1
+        assert rpc_client.get_latest_blockhash.call_count == 2
 
 
 class TestClientSchemeAttributes:


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

- Cache SVM mint metadata per Python exact client instance
- Reuse cached mint decimals and token program in both V1 and V2 SVM exact client payload creation
- Add unit coverage verifying repeated payload creation only fetches mint metadata once while still fetching a fresh blockhash per payment

SVM exact payment payload creation fetched mint metadata on every payment to derive the token program and decimals. Those fields are stable for a mint, so repeated payments from the same client can reuse them and avoid unnecessary RPC calls.

This follows up on #2216 for the Python SDK.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

- `/tmp/x402-python-test-venv/bin/python -m pytest x402/tests/unit/mechanisms/svm/test_client.py`
- `/tmp/x402-python-test-venv/bin/python -m ruff check x402/mechanisms/svm/mint_cache.py x402/mechanisms/svm/exact/client.py x402/mechanisms/svm/exact/v1/client.py x402/tests/unit/mechanisms/svm/test_client.py`
- `/tmp/x402-python-test-venv/bin/python -m py_compile x402/mechanisms/svm/mint_cache.py x402/mechanisms/svm/exact/client.py x402/mechanisms/svm/exact/v1/client.py x402/tests/unit/mechanisms/svm/test_client.py`
- `git diff --cached --check`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 

## Related Issue

- Part of #2216