### PR TITLE
fix(fetch): preserve payment payload error cause

### DIFF
--- a/typescript/.changeset/fuzzy-mugs-happen.md
+++ b/typescript/.changeset/fuzzy-mugs-happen.md
@@ -1,0 +1,5 @@
+---
+"@x402/fetch": patch
+---
+
+Preserved the original error as the cause when payment payload creation fails.

--- a/typescript/packages/http/fetch/src/index.test.ts
+++ b/typescript/packages/http/fetch/src/index.test.ts
@@ -200,9 +200,10 @@ describe("wrapFetchWithPayment()", () => {
 
     mockFetch.mockResolvedValue(createResponse(402, validPaymentRequired));
 
-    await expect(wrappedFetch("https://api.example.com", { method: "GET" })).rejects.toThrow(
-      "Failed to create payment payload: Insufficient funds",
-    );
+    await expect(wrappedFetch("https://api.example.com", { method: "GET" })).rejects.toMatchObject({
+      message: "Failed to create payment payload: Insufficient funds",
+      cause: paymentError,
+    });
   });
 
   it("should reject with generic error message for unknown parsing errors", async () => {

--- a/typescript/packages/http/fetch/src/index.ts
+++ b/typescript/packages/http/fetch/src/index.ts
@@ -96,9 +96,17 @@ export function wrapFetchWithPayment(
     try {
       paymentPayload = await client.createPaymentPayload(paymentRequired);
     } catch (error) {
-      throw new Error(
-        `Failed to create payment payload: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      const message = `Failed to create payment payload: ${error instanceof Error ? error.message : "Unknown error"}`;
+      if (error instanceof Error) {
+        const wrappedError = new Error(message);
+        Object.defineProperty(wrappedError, "cause", {
+          configurable: true,
+          value: error,
+          writable: true,
+        });
+        throw wrappedError;
+      }
+      throw new Error(message);
     }
 
     // Encode payment header


### PR DESCRIPTION
## Summary

- preserve the original Error thrown by createPaymentPayload on the wrapped fetch error as cause
- keep the existing public error message for compatibility
- add a regression assertion that the original payment error remains available
- add a patch changeset for @x402/fetch

Fixes #2394

## Validation

- corepack pnpm --filter @x402/fetch lint:check
- corepack pnpm --filter @x402/fetch format:check
- git diff --check

Blocked checks:
- corepack pnpm --filter @x402/fetch test failed before running tests because Rollup could not load missing optional native package @rollup/rollup-linux-x64-gnu from the existing workspace install.
- corepack pnpm --filter @x402/fetch build failed for the same Rollup optional dependency blocker.
- direct tsc --noEmit in typescript/packages/http/fetch could not resolve workspace imports for @x402/core in this checkout state.

## Checklist

- [x] I have formatted and linted my code
- [ ] All new and existing tests pass
- [x] My commits are signed (verified by GitHub)
- [x] I added a changelog fragment for user-facing changes