### PR TITLE
patch py datetime

### DIFF
--- a/e2e/facilitators/python/main.py
+++ b/e2e/facilitators/python/main.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel
 from solders.keypair import Keypair
 
 from x402 import x402Facilitator
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from x402.extensions.bazaar import DiscoveryResource, extract_discovery_info
 from x402.extensions.eip2612_gas_sponsoring import EIP2612_GAS_SPONSORING
@@ -226,7 +226,7 @@ def _handle_after_verify(ctx: Any) -> None:
                         if hasattr(ctx.requirements, "model_dump")
                         else ctx.requirements
                     ],
-                    last_updated=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+                    last_updated=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
                     description=discovered.description,
                     mime_type=discovered.mime_type,
                     service_name=discovered.service_name,

--- a/e2e/facilitators/python/uv.lock
+++ b/e2e/facilitators/python/uv.lock
@@ -3115,7 +3115,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.12.0"
+version = "2.13.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },


### PR DESCRIPTION
## Description

e2e/facilitators/python/main.py used `datetime.UTC`, which was only added in Python 3.11

Updated to use `timezone.utc`, which works on 3.10+ aligning with the project's `requires-python = ">=3.10"`

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 