### PR TITLE
fix(evm): clarify client signer shape

### DIFF
--- a/typescript/packages/mechanisms/evm/src/signer.ts
+++ b/typescript/packages/mechanisms/evm/src/signer.ts
@@ -3,13 +3,9 @@ import type { Log } from "viem";
 /**
  * ClientEvmSigner - Used by x402 clients to sign payment authorizations.
  *
- * Typically a viem WalletClient extended with publicActions:
+ * Typically a viem LocalAccount:
  * ```typescript
- * const client = createWalletClient({
- *   account: privateKeyToAccount('0x...'),
- *   chain: baseSepolia,
- *   transport: http(),
- * }).extend(publicActions);
+ * const account = privateKeyToAccount('0x...');
  * ```
  *
  * Or composed via `toClientEvmSigner(account, publicClient)`.
@@ -107,13 +103,11 @@ export type FacilitatorEvmSigner = {
  * Use this when your signer (e.g., `privateKeyToAccount`) doesn't have
  * `readContract`. The `publicClient` provides the on-chain read capability.
  *
- * Alternatively, use a WalletClient extended with publicActions directly:
+ * Alternatively, use a local account with an explicit public client:
  * ```typescript
- * const signer = createWalletClient({
- *   account: privateKeyToAccount('0x...'),
- *   chain: baseSepolia,
- *   transport: http(),
- * }).extend(publicActions);
+ * const account = privateKeyToAccount('0x...');
+ * const publicClient = createPublicClient({ chain: baseSepolia, transport: http() });
+ * const signer = toClientEvmSigner(account, publicClient);
  * ```
  *
  * @param signer - A signer with `address` and `signTypedData` (and optionally `readContract`)


### PR DESCRIPTION
## Summary
- allow `toClientEvmSigner` to compose from viem WalletClient-style `account.address`
- validate missing signer address with an actionable error before payment signing
- update EVM signer docs and add unit coverage for WalletClient-style input

Fixes #2631.

## Validation
- `node .../prettier@3.5.2/.../prettier.cjs --write typescript/packages/mechanisms/evm/src/signer.ts typescript/packages/mechanisms/evm/test/unit/signer.test.ts`
- `git diff --check`
- Blocked: `CI=true corepack pnpm install --filter @x402/evm...` failed fetching tarballs from the configured npm mirror (`https://mirrors.tencentyun.com/npm/...`) with `TypeError: fetch failed`.
- Blocked: direct Vitest startup fails before tests run because Rollup optional native package `@rollup/rollup-linux-x64-gnu` is missing from the existing install.
