### PR TITLE
fix(evm): reject wallet clients with clear error

### DIFF
--- a/typescript/packages/mechanisms/evm/README.md
+++ b/typescript/packages/mechanisms/evm/README.md
@@ -24,7 +24,7 @@ This package provides three main components for handling x402 payments on EVM-co
 
 **Client:**
 - `ExactEvmClient` - V2 client implementation using EIP-3009
-- `toClientEvmSigner(account)` - Converts viem accounts to x402 signers
+- `toClientEvmSigner(account, publicClient?)` - Converts viem LocalAccount values to x402 signers
 - `ClientEvmSigner` - TypeScript type for client signers
 
 **Facilitator:**
@@ -79,8 +79,15 @@ This package provides three main components for handling x402 payments on EVM-co
 
 ```typescript
 import { x402Client } from "@x402/core/client";
-import { ExactEvmClient } from "@x402/evm";
+import { ExactEvmClient, toClientEvmSigner } from "@x402/evm";
 import { ExactEvmClientV1 } from "@x402/evm/v1";
+import { createPublicClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { baseSepolia } from "viem/chains";
+
+const account = privateKeyToAccount("0x...");
+const publicClient = createPublicClient({ chain: baseSepolia, transport: http() });
+const signer = toClientEvmSigner(account, publicClient);
 
 const client = new x402Client()
   .register("eip155:*", new ExactEvmClient(signer))
@@ -91,8 +98,9 @@ const client = new x402Client()
 ### Extension RPC Configuration (Optional)
 
 `ExactEvmClient` only requires signer support for `address` + `signTypedData`.
-Permit2 extension enrichment (EIP-2612 / ERC-20 approval gas sponsoring) can
-optionally use explicit RPC config when signer read/fee helpers are unavailable.
+`toClientEvmSigner(account, publicClient)` composes a LocalAccount with optional
+read/fee helpers for Permit2 extension enrichment (EIP-2612 / ERC-20 approval
+gas sponsoring).
 
 No chain-default RPC fallback is applied by the SDK.
 

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -4,7 +4,8 @@ import {
   PaymentPayloadResult,
   PaymentPayloadContext,
 } from "@x402/core/types";
-import { ClientEvmSigner } from "../../signer";
+import { assertClientEvmSigner } from "../../signer";
+import type { ClientEvmSigner } from "../../signer";
 import { AssetTransferMethod } from "../../types";
 import { createEIP3009Payload } from "./eip3009";
 import { createPermit2Payload } from "./permit2";
@@ -41,7 +42,9 @@ export class ExactEvmScheme implements SchemeNetworkClient {
   constructor(
     private readonly signer: ClientEvmSigner,
     private readonly options?: ExactEvmSchemeOptions,
-  ) {}
+  ) {
+    assertClientEvmSigner(signer);
+  }
 
   /**
    * Creates a payment payload for the Exact scheme.

--- a/typescript/packages/mechanisms/evm/src/signer.ts
+++ b/typescript/packages/mechanisms/evm/src/signer.ts
@@ -3,13 +3,9 @@ import type { Log } from "viem";
 /**
  * ClientEvmSigner - Used by x402 clients to sign payment authorizations.
  *
- * Typically a viem WalletClient extended with publicActions:
+ * Typically a viem LocalAccount:
  * ```typescript
- * const client = createWalletClient({
- *   account: privateKeyToAccount('0x...'),
- *   chain: baseSepolia,
- *   transport: http(),
- * }).extend(publicActions);
+ * const account = privateKeyToAccount("0x...");
  * ```
  *
  * Or composed via `toClientEvmSigner(account, publicClient)`.
@@ -56,6 +52,29 @@ export type ClientEvmSigner = {
    */
   estimateFeesPerGas?(): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }>;
 };
+
+/**
+ * Asserts that a value has the minimal client signer shape expected by x402 EVM clients.
+ *
+ * A viem WalletClient stores its account at `walletClient.account.address`; pass the LocalAccount
+ * itself, or compose one with `toClientEvmSigner(account, publicClient)`.
+ *
+ * @param signer - Value to validate before using it as a ClientEvmSigner
+ */
+export function assertClientEvmSigner(signer: unknown): asserts signer is ClientEvmSigner {
+  const candidate = signer as Partial<ClientEvmSigner> | undefined;
+  const address = candidate?.address;
+
+  if (typeof address !== "string" || !address.startsWith("0x")) {
+    throw new Error(
+      "ClientEvmSigner must expose an `address` string. Pass a viem LocalAccount from `privateKeyToAccount(...)`, or wrap it with `toClientEvmSigner(account, publicClient)` instead of passing a WalletClient.",
+    );
+  }
+
+  if (typeof candidate?.signTypedData !== "function") {
+    throw new Error("ClientEvmSigner must expose a `signTypedData` function.");
+  }
+}
 
 /**
  * FacilitatorEvmSigner - Used by x402 facilitators to verify and settle payments
@@ -107,15 +126,6 @@ export type FacilitatorEvmSigner = {
  * Use this when your signer (e.g., `privateKeyToAccount`) doesn't have
  * `readContract`. The `publicClient` provides the on-chain read capability.
  *
- * Alternatively, use a WalletClient extended with publicActions directly:
- * ```typescript
- * const signer = createWalletClient({
- *   account: privateKeyToAccount('0x...'),
- *   chain: baseSepolia,
- *   transport: http(),
- * }).extend(publicActions);
- * ```
- *
  * @param signer - A signer with `address` and `signTypedData` (and optionally `readContract`)
  * @param publicClient - A client with optional read/nonce/fee helpers
  * @param publicClient.readContract - The readContract method from the public client
@@ -145,6 +155,8 @@ export function toClientEvmSigner(
     estimateFeesPerGas?(): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }>;
   },
 ): ClientEvmSigner {
+  assertClientEvmSigner(signer);
+
   const readContract = signer.readContract ?? publicClient?.readContract.bind(publicClient);
 
   const result: ClientEvmSigner = {

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -28,6 +28,19 @@ describe("ExactEvmScheme (Client)", () => {
       expect(client).toBeDefined();
       expect(client.scheme).toBe("exact");
     });
+
+    it("should reject WalletClient-like values without top-level address", () => {
+      const walletClientLike = {
+        account: {
+          address: "0x1234567890123456789012345678901234567890",
+        },
+        signTypedData: vi.fn().mockResolvedValue("0xmocksignature123456789"),
+      };
+
+      expect(() => new ExactEvmScheme(walletClientLike as never)).toThrow(
+        "Pass a viem LocalAccount",
+      );
+    });
   });
 
   describe("createPaymentPayload", () => {

--- a/typescript/packages/mechanisms/evm/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/signer.test.ts
@@ -41,6 +41,19 @@ describe("EVM Signer Converters", () => {
       expect(result.address).toBe(mockAccount.address);
       expect(result.readContract).toBeUndefined();
     });
+
+    it("should reject WalletClient-like values without top-level address", () => {
+      const walletClientLike = {
+        account: {
+          address: "0x1234567890123456789012345678901234567890",
+        },
+        signTypedData: async () => "0xsignature" as `0x${string}`,
+      };
+
+      expect(() => toClientEvmSigner(walletClientLike as never)).toThrow(
+        "Pass a viem LocalAccount",
+      );
+    });
   });
 
   describe("toFacilitatorEvmSigner", () => {


### PR DESCRIPTION
## Summary

Fixes #2631 by making the EVM client signer requirement fail early with an actionable error when a viem WalletClient-like value is passed without a top-level `address`.

Changes:
- Adds `assertClientEvmSigner()` for the minimal `address` + `signTypedData` client signer shape.
- Validates the signer in `toClientEvmSigner()` and `ExactEvmScheme` construction.
- Updates the `@x402/evm` README and signer docstring to show a viem LocalAccount with `toClientEvmSigner(account, publicClient)` instead of implying that a WalletClient can be passed directly.
- Adds unit coverage for WalletClient-like values that only expose `account.address`.

## Validation

- `git diff --check`

Blocked local package test:
- `corepack pnpm --filter @x402/evm test` could not run in this environment because `vitest` is not installed and the workspace has no local `node_modules` for this package (`sh: 1: vitest: not found`). I did not run a full workspace install or retry registry downloads.
