### PR TITLE
docs: clarify mainnet facilitator setup

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -18,4 +18,4 @@ The table below lists selected production options; it is not an exhaustive catal
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
 
-For testnet development, the [x402.org facilitator](/core-concepts/network-and-token-support#x402org-facilitator) requires no setup. 
+For testnet development, the [x402.org facilitator](/core-concepts/network-and-token-support#x402org-facilitator) requires no setup. It is not intended for mainnet routes; use a production facilitator or self-hosted facilitator for production networks.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -126,6 +126,7 @@ Yes. Programmatic wallets (e.g., **CDP Wallet API**, **viem**, **ethers‑v6** H
 #### My test works on Base Sepolia but fails on Base mainnet—what changed?
 
 * Ensure you set `network: "eip155:8453"` (Base mainnet) instead of `"eip155:84532"` (Base Sepolia).
+* If you are still using `https://x402.org/facilitator`, switch to a production facilitator. The default x402.org facilitator is for testnet development and does not support Base mainnet (`eip155:8453`), which can surface as a route-configuration error after changing only the network.
 * Confirm your wallet has _mainnet_ USDC.
 * Gas fees are higher on mainnet; fund the wallet with a small amount of ETH for gas.
 

--- a/docs/getting-started/quickstart-for-sellers.mdx
+++ b/docs/getting-started/quickstart-for-sellers.mdx
@@ -1120,6 +1120,8 @@ For mainnet, use a production facilitator. See [Facilitators](/dev-tools/facilit
   </Tab>
 </Tabs>
 
+Do not reuse `https://x402.org/facilitator` for mainnet routes. The default x402.org facilitator is intended for testnet development only.
+
 ### 2. Update Your Network Identifier
 
 Change from testnet to mainnet network identifiers:


### PR DESCRIPTION
﻿## Description

Clarifies the mainnet facilitator path for sellers moving from Base Sepolia to Base mainnet.

- warns in the seller quickstart not to reuse the default `https://x402.org/facilitator` for Base mainnet routes
- adds the same troubleshooting note to the FAQ
- makes the facilitator listing explicit that x402.org is for testnet development, not production routes

Closes #2591

## Tests

- `git diff --check`
- verified the commit has a valid SSH signature locally

`mint dev` was not run because the Mintlify CLI is not installed in this environment.

## Checklist

- [x] I have formatted and linted my code (`git diff --check`; docs-only)
- [x] All new and existing tests pass (docs-only; no SDK tests required)
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)