### PR TITLE
feat(go): add offer-receipt helpers

### DIFF
--- a/go/.changes/unreleased/added-20260617-150234.yaml
+++ b/go/.changes/unreleased/added-20260617-150234.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Add Go offer-receipt helpers for extracting signed offers and receipts from extension data
+time: 2026-06-17T15:02:34.000000+09:00

--- a/go/extensions/README.md
+++ b/go/extensions/README.md
@@ -206,6 +206,18 @@ paymentWrapper := mcp402.NewPaymentWrapper(resourceServer, mcp402.PaymentWrapper
 
 The Bazaar extension just facilitates the data exchange between servers and facilitators - the implementation is yours.
 
+### Offer-Receipt (Signed Offers and Receipts)
+
+**Import Path:**
+```
+github.com/x402-foundation/x402/go/v2/extensions/offerreceipt
+```
+
+**Purpose:**
+- Clients can extract signed offers from `PaymentRequired.extensions`
+- Clients can extract signed receipts from `SettleResponse.extensions`
+- Helpers decode payloads and compare receipt fields without verifying signatures
+
 ### Future Extensions
 
 Extensions can serve many purposes. Planned extensions include:
@@ -404,4 +416,3 @@ extensions/
 - **[Main README](../README.md)** - Package overview
 - **[SERVER.md](../SERVER.md)** - Using extensions in servers
 - **[FACILITATOR.md](../FACILITATOR.md)** - Extracting extensions in facilitators
-

--- a/go/extensions/offerreceipt/README.md
+++ b/go/extensions/offerreceipt/README.md
@@ -1,0 +1,19 @@
+# Offer-Receipt Extension Helpers
+
+Helpers for reading `offer-receipt` extension artifacts in Go.
+
+This package extracts signed offers and receipts from x402 extension maps, decodes EIP-712 and JWS payloads, matches signed offers to `accepts[]` entries, and checks whether a receipt payload matches an accepted offer.
+
+It does not verify cryptographic signatures, resolve JWS `kid` values, or decide signer authorization.
+
+```go
+offers, err := offerreceipt.ExtractOffersFromPaymentRequired(paymentRequired)
+if err != nil {
+    return err
+}
+
+decoded, err := offerreceipt.DecodeSignedOffers(offers)
+if err != nil {
+    return err
+}
+```

--- a/go/extensions/offerreceipt/doc.go
+++ b/go/extensions/offerreceipt/doc.go
@@ -1,0 +1,5 @@
+// Package offerreceipt provides helpers for the x402 offer-receipt extension.
+//
+// The helpers extract signed offers and receipts from extension maps and compare
+// their payload fields. They do not verify signatures or signer authorization.
+package offerreceipt

--- a/go/extensions/offerreceipt/extract.go
+++ b/go/extensions/offerreceipt/extract.go
@@ -1,0 +1,140 @@
+package offerreceipt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	x402 "github.com/x402-foundation/x402/go/v2"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+// ExtractOffersFromPaymentRequired extracts signed offers from a PaymentRequired response.
+func ExtractOffersFromPaymentRequired(required types.PaymentRequired) ([]SignedOffer, error) {
+	if required.Extensions == nil {
+		return []SignedOffer{}, nil
+	}
+
+	ext, err := extractExtension(required.Extensions)
+	if err != nil || ext == nil {
+		return []SignedOffer{}, err
+	}
+	if ext.Info.Offers == nil {
+		return []SignedOffer{}, nil
+	}
+
+	return ext.Info.Offers, nil
+}
+
+// ExtractReceiptFromSettleResponse extracts a signed receipt from a settle response.
+func ExtractReceiptFromSettleResponse(response x402.SettleResponse) (*SignedReceipt, error) {
+	return ExtractReceiptFromExtensions(response.Extensions)
+}
+
+// ExtractReceiptFromExtensions extracts a signed receipt from an extensions map.
+func ExtractReceiptFromExtensions(extensions map[string]interface{}) (*SignedReceipt, error) {
+	if extensions == nil {
+		return nil, nil
+	}
+
+	ext, err := extractExtension(extensions)
+	if err != nil || ext == nil {
+		return nil, err
+	}
+
+	return ext.Info.Receipt, nil
+}
+
+// DecodeSignedOffers extracts payloads from signed offers.
+func DecodeSignedOffers(offers []SignedOffer) ([]DecodedOffer, error) {
+	decoded := make([]DecodedOffer, 0, len(offers))
+	for _, offer := range offers {
+		payload, err := ExtractOfferPayload(offer)
+		if err != nil {
+			return nil, err
+		}
+		decoded = append(decoded, DecodedOffer{
+			OfferPayload: payload,
+			SignedOffer:  offer,
+			Format:       offer.Format,
+			AcceptIndex:  offer.AcceptIndex,
+		})
+	}
+	return decoded, nil
+}
+
+// ExtractOfferPayload returns the signed offer payload without verifying the signature.
+func ExtractOfferPayload(offer SignedOffer) (OfferPayload, error) {
+	switch offer.Format {
+	case FormatEIP712:
+		if offer.Payload == nil {
+			return OfferPayload{}, errors.New("offer-receipt: eip712 offer missing payload")
+		}
+		return *offer.Payload, nil
+	case FormatJWS:
+		var payload OfferPayload
+		if err := extractJWSPayload(offer.Signature, &payload); err != nil {
+			return OfferPayload{}, fmt.Errorf("offer-receipt: decode jws offer payload: %w", err)
+		}
+		return payload, nil
+	default:
+		return OfferPayload{}, fmt.Errorf("offer-receipt: unsupported offer format %q", offer.Format)
+	}
+}
+
+// ExtractReceiptPayload returns the signed receipt payload without verifying the signature.
+func ExtractReceiptPayload(receipt SignedReceipt) (ReceiptPayload, error) {
+	switch receipt.Format {
+	case FormatEIP712:
+		if receipt.Payload == nil {
+			return ReceiptPayload{}, errors.New("offer-receipt: eip712 receipt missing payload")
+		}
+		return *receipt.Payload, nil
+	case FormatJWS:
+		var payload ReceiptPayload
+		if err := extractJWSPayload(receipt.Signature, &payload); err != nil {
+			return ReceiptPayload{}, fmt.Errorf("offer-receipt: decode jws receipt payload: %w", err)
+		}
+		return payload, nil
+	default:
+		return ReceiptPayload{}, fmt.Errorf("offer-receipt: unsupported receipt format %q", receipt.Format)
+	}
+}
+
+func extractExtension(extensions map[string]interface{}) (*offerReceiptExtension, error) {
+	extRaw, ok := extensions[OFFER_RECEIPT]
+	if !ok {
+		return nil, nil
+	}
+
+	extJSON, err := json.Marshal(extRaw)
+	if err != nil {
+		return nil, fmt.Errorf("offer-receipt: marshal extension: %w", err)
+	}
+
+	var ext offerReceiptExtension
+	if err := json.Unmarshal(extJSON, &ext); err != nil {
+		return nil, fmt.Errorf("offer-receipt: unmarshal extension: %w", err)
+	}
+
+	return &ext, nil
+}
+
+func extractJWSPayload(jws string, target interface{}) error {
+	parts := strings.Split(jws, ".")
+	if len(parts) != 3 {
+		return errors.New("invalid jws compact serialization")
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(payloadJSON, target); err != nil {
+		return err
+	}
+	return nil
+}

--- a/go/extensions/offerreceipt/match.go
+++ b/go/extensions/offerreceipt/match.go
@@ -1,0 +1,98 @@
+package offerreceipt
+
+import (
+	"strings"
+	"time"
+
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+const DefaultMaxReceiptAgeSeconds int64 = 3600
+
+// FindAcceptsObjectFromSignedOffer finds the payment requirements matching a signed offer.
+func FindAcceptsObjectFromSignedOffer(
+	offer SignedOffer,
+	accepts []types.PaymentRequirements,
+) (*types.PaymentRequirements, error) {
+	payload, err := ExtractOfferPayload(offer)
+	if err != nil {
+		return nil, err
+	}
+
+	decoded := DecodedOffer{
+		OfferPayload: payload,
+		SignedOffer:  offer,
+		Format:       offer.Format,
+		AcceptIndex:  offer.AcceptIndex,
+	}
+
+	return FindAcceptsObjectFromDecodedOffer(decoded, accepts), nil
+}
+
+// FindAcceptsObjectFromDecodedOffer finds the payment requirements matching a decoded offer.
+func FindAcceptsObjectFromDecodedOffer(
+	offer DecodedOffer,
+	accepts []types.PaymentRequirements,
+) *types.PaymentRequirements {
+	if offer.AcceptIndex != nil && *offer.AcceptIndex >= 0 && *offer.AcceptIndex < len(accepts) {
+		if offerMatchesRequirements(offer.OfferPayload, accepts[*offer.AcceptIndex]) {
+			return &accepts[*offer.AcceptIndex]
+		}
+	}
+
+	for i := range accepts {
+		if offerMatchesRequirements(offer.OfferPayload, accepts[i]) {
+			return &accepts[i]
+		}
+	}
+
+	return nil
+}
+
+// VerifyReceiptMatchesOffer checks receipt payload consistency with an accepted offer.
+//
+// This does not verify the receipt signature or signer authorization.
+func VerifyReceiptMatchesOffer(
+	receipt SignedReceipt,
+	offer DecodedOffer,
+	payerAddresses []string,
+	maxAgeSeconds int64,
+	now time.Time,
+) (bool, error) {
+	payload, err := ExtractReceiptPayload(receipt)
+	if err != nil {
+		return false, err
+	}
+
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if maxAgeSeconds <= 0 {
+		maxAgeSeconds = DefaultMaxReceiptAgeSeconds
+	}
+
+	age := now.Unix() - payload.IssuedAt
+
+	return payload.ResourceURL == offer.ResourceURL &&
+		payload.Network == offer.Network &&
+		payerMatches(payload.Payer, payerAddresses) &&
+		age >= 0 &&
+		age < maxAgeSeconds, nil
+}
+
+func offerMatchesRequirements(payload OfferPayload, requirements types.PaymentRequirements) bool {
+	return requirements.Network == payload.Network &&
+		requirements.Scheme == payload.Scheme &&
+		requirements.Asset == payload.Asset &&
+		requirements.PayTo == payload.PayTo &&
+		requirements.Amount == payload.Amount
+}
+
+func payerMatches(payer string, payerAddresses []string) bool {
+	for _, address := range payerAddresses {
+		if strings.EqualFold(payer, address) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/extensions/offerreceipt/offerreceipt_test.go
+++ b/go/extensions/offerreceipt/offerreceipt_test.go
@@ -1,0 +1,359 @@
+package offerreceipt_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	x402 "github.com/x402-foundation/x402/go/v2"
+	"github.com/x402-foundation/x402/go/v2/extensions/offerreceipt"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+func TestExtractOffersFromPaymentRequired(t *testing.T) {
+	t.Run("returns empty when extensions are nil", func(t *testing.T) {
+		offers, err := offerreceipt.ExtractOffersFromPaymentRequired(types.PaymentRequired{})
+
+		require.NoError(t, err)
+		assert.Empty(t, offers)
+	})
+
+	t.Run("returns empty when extension is absent", func(t *testing.T) {
+		offers, err := offerreceipt.ExtractOffersFromPaymentRequired(types.PaymentRequired{
+			Extensions: map[string]interface{}{"other": map[string]interface{}{}},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, offers)
+	})
+
+	t.Run("extracts signed offers", func(t *testing.T) {
+		index := 0
+		expected := offerreceipt.SignedOffer{
+			Format:      offerreceipt.FormatEIP712,
+			AcceptIndex: &index,
+			Payload:     &testOfferPayload,
+			Signature:   "0xsig",
+		}
+
+		offers, err := offerreceipt.ExtractOffersFromPaymentRequired(types.PaymentRequired{
+			Extensions: map[string]interface{}{
+				offerreceipt.OFFER_RECEIPT: map[string]interface{}{
+					"info": map[string]interface{}{
+						"offers": []offerreceipt.SignedOffer{expected},
+					},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, offers, 1)
+		assert.Equal(t, expected, offers[0])
+	})
+}
+
+func TestExtractReceiptFromSettleResponse(t *testing.T) {
+	t.Run("returns nil when extension is absent", func(t *testing.T) {
+		receipt, err := offerreceipt.ExtractReceiptFromSettleResponse(x402.SettleResponse{})
+
+		require.NoError(t, err)
+		assert.Nil(t, receipt)
+	})
+
+	t.Run("extracts signed receipt", func(t *testing.T) {
+		expected := offerreceipt.SignedReceipt{
+			Format:    offerreceipt.FormatEIP712,
+			Payload:   &testReceiptPayload,
+			Signature: "0xsig",
+		}
+
+		receipt, err := offerreceipt.ExtractReceiptFromSettleResponse(x402.SettleResponse{
+			Extensions: map[string]interface{}{
+				offerreceipt.OFFER_RECEIPT: map[string]interface{}{
+					"info": map[string]interface{}{
+						"receipt": expected,
+					},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, receipt)
+		assert.Equal(t, expected, *receipt)
+	})
+}
+
+func TestExtractOfferPayload(t *testing.T) {
+	t.Run("returns eip712 payload", func(t *testing.T) {
+		payload, err := offerreceipt.ExtractOfferPayload(offerreceipt.SignedOffer{
+			Format:    offerreceipt.FormatEIP712,
+			Payload:   &testOfferPayload,
+			Signature: "0xsig",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, testOfferPayload, payload)
+	})
+
+	t.Run("decodes jws payload", func(t *testing.T) {
+		payload, err := offerreceipt.ExtractOfferPayload(offerreceipt.SignedOffer{
+			Format:    offerreceipt.FormatJWS,
+			Signature: compactJWS(t, testOfferPayload),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, testOfferPayload, payload)
+	})
+
+	t.Run("rejects malformed jws", func(t *testing.T) {
+		_, err := offerreceipt.ExtractOfferPayload(offerreceipt.SignedOffer{
+			Format:    offerreceipt.FormatJWS,
+			Signature: "not-a-jws",
+		})
+
+		require.Error(t, err)
+	})
+
+	t.Run("rejects eip712 without payload", func(t *testing.T) {
+		_, err := offerreceipt.ExtractOfferPayload(offerreceipt.SignedOffer{
+			Format:    offerreceipt.FormatEIP712,
+			Signature: "0xsig",
+		})
+
+		require.Error(t, err)
+	})
+}
+
+func TestExtractReceiptPayload(t *testing.T) {
+	t.Run("returns eip712 payload", func(t *testing.T) {
+		payload, err := offerreceipt.ExtractReceiptPayload(offerreceipt.SignedReceipt{
+			Format:    offerreceipt.FormatEIP712,
+			Payload:   &testReceiptPayload,
+			Signature: "0xsig",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, testReceiptPayload, payload)
+	})
+
+	t.Run("decodes jws payload", func(t *testing.T) {
+		payload, err := offerreceipt.ExtractReceiptPayload(offerreceipt.SignedReceipt{
+			Format:    offerreceipt.FormatJWS,
+			Signature: compactJWS(t, testReceiptPayload),
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, testReceiptPayload, payload)
+	})
+}
+
+func TestDecodeSignedOffers(t *testing.T) {
+	index := 0
+	decoded, err := offerreceipt.DecodeSignedOffers([]offerreceipt.SignedOffer{
+		{
+			Format:      offerreceipt.FormatEIP712,
+			AcceptIndex: &index,
+			Payload:     &testOfferPayload,
+			Signature:   "0xsig",
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, decoded, 1)
+	assert.Equal(t, testOfferPayload, decoded[0].OfferPayload)
+	assert.Equal(t, offerreceipt.FormatEIP712, decoded[0].Format)
+	assert.Equal(t, &index, decoded[0].AcceptIndex)
+}
+
+func TestFindAcceptsObjectFromSignedOffer(t *testing.T) {
+	accepts := []types.PaymentRequirements{
+		{
+			Scheme:  "exact",
+			Network: "eip155:84532",
+			Asset:   "0xother",
+			PayTo:   "0xpayee",
+			Amount:  "10000",
+		},
+		{
+			Scheme:  testOfferPayload.Scheme,
+			Network: testOfferPayload.Network,
+			Asset:   testOfferPayload.Asset,
+			PayTo:   testOfferPayload.PayTo,
+			Amount:  testOfferPayload.Amount,
+		},
+	}
+
+	t.Run("uses valid accept index", func(t *testing.T) {
+		index := 1
+		match, err := offerreceipt.FindAcceptsObjectFromSignedOffer(offerreceipt.SignedOffer{
+			Format:      offerreceipt.FormatEIP712,
+			AcceptIndex: &index,
+			Payload:     &testOfferPayload,
+			Signature:   "0xsig",
+		}, accepts)
+
+		require.NoError(t, err)
+		require.NotNil(t, match)
+		assert.Equal(t, accepts[1], *match)
+	})
+
+	t.Run("falls back when accept index is stale", func(t *testing.T) {
+		index := 0
+		match, err := offerreceipt.FindAcceptsObjectFromSignedOffer(offerreceipt.SignedOffer{
+			Format:      offerreceipt.FormatEIP712,
+			AcceptIndex: &index,
+			Payload:     &testOfferPayload,
+			Signature:   "0xsig",
+		}, accepts)
+
+		require.NoError(t, err)
+		require.NotNil(t, match)
+		assert.Equal(t, accepts[1], *match)
+	})
+
+	t.Run("returns nil when no accepts match", func(t *testing.T) {
+		payload := testOfferPayload
+		payload.Amount = "999"
+
+		match, err := offerreceipt.FindAcceptsObjectFromSignedOffer(offerreceipt.SignedOffer{
+			Format:    offerreceipt.FormatEIP712,
+			Payload:   &payload,
+			Signature: "0xsig",
+		}, accepts)
+
+		require.NoError(t, err)
+		assert.Nil(t, match)
+	})
+}
+
+func TestVerifyReceiptMatchesOffer(t *testing.T) {
+	now := time.Unix(1_700_000_100, 0)
+	offer := offerreceipt.DecodedOffer{
+		OfferPayload: testOfferPayload,
+		Format:       offerreceipt.FormatEIP712,
+	}
+	receipt := offerreceipt.SignedReceipt{
+		Format: offerreceipt.FormatEIP712,
+		Payload: &offerreceipt.ReceiptPayload{
+			Version:     1,
+			Network:     testOfferPayload.Network,
+			ResourceURL: testOfferPayload.ResourceURL,
+			Payer:       "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+			IssuedAt:    now.Unix() - 30,
+		},
+		Signature: "0xsig",
+	}
+
+	t.Run("returns true for matching receipt", func(t *testing.T) {
+		ok, err := offerreceipt.VerifyReceiptMatchesOffer(
+			receipt,
+			offer,
+			[]string{"0x857B06519e91e3A54538791bDBb0e22373E36B66"},
+			3600,
+			now,
+		)
+
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("returns false for wrong payer", func(t *testing.T) {
+		ok, err := offerreceipt.VerifyReceiptMatchesOffer(
+			receipt,
+			offer,
+			[]string{"0x0000000000000000000000000000000000000000"},
+			3600,
+			now,
+		)
+
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("returns false for expired receipt", func(t *testing.T) {
+		ok, err := offerreceipt.VerifyReceiptMatchesOffer(
+			receipt,
+			offer,
+			[]string{"0x857b06519E91e3A54538791bDbb0E22373e36b66"},
+			10,
+			now,
+		)
+
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("returns false for future issuedAt", func(t *testing.T) {
+		futureReceipt := receipt
+		payload := *receipt.Payload
+		payload.IssuedAt = now.Unix() + 30
+		futureReceipt.Payload = &payload
+
+		ok, err := offerreceipt.VerifyReceiptMatchesOffer(
+			futureReceipt,
+			offer,
+			[]string{"0x857b06519E91e3A54538791bDbb0E22373e36b66"},
+			3600,
+			now,
+		)
+
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("returns false for wrong resource", func(t *testing.T) {
+		wrongReceipt := receipt
+		payload := *receipt.Payload
+		payload.ResourceURL = "https://api.example.com/other"
+		wrongReceipt.Payload = &payload
+
+		ok, err := offerreceipt.VerifyReceiptMatchesOffer(
+			wrongReceipt,
+			offer,
+			[]string{"0x857b06519E91e3A54538791bDbb0E22373e36b66"},
+			3600,
+			now,
+		)
+
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}
+
+var testOfferPayload = offerreceipt.OfferPayload{
+	Version:     1,
+	ResourceURL: "https://api.example.com/premium-data",
+	Scheme:      "exact",
+	Network:     "eip155:8453",
+	Asset:       "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+	PayTo:       "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+	Amount:      "10000",
+	ValidUntil:  1_703_123_516,
+}
+
+var testReceiptPayload = offerreceipt.ReceiptPayload{
+	Version:     1,
+	Network:     "eip155:8453",
+	ResourceURL: "https://api.example.com/premium-data",
+	Payer:       "0x857b06519E91e3A54538791bDbb0E22373e36b66",
+	IssuedAt:    1_703_123_456,
+	Transaction: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+}
+
+func compactJWS(t *testing.T, payload interface{}) string {
+	t.Helper()
+
+	headerJSON, err := json.Marshal(map[string]string{"alg": "ES256K", "kid": "did:web:api.example.com#key-1"})
+	require.NoError(t, err)
+
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	header := base64.RawURLEncoding.EncodeToString(headerJSON)
+	body := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	return header + "." + body + ".sig"
+}

--- a/go/extensions/offerreceipt/types.go
+++ b/go/extensions/offerreceipt/types.go
@@ -1,0 +1,66 @@
+package offerreceipt
+
+// OFFER_RECEIPT is the extension identifier for signed offers and receipts.
+const OFFER_RECEIPT = "offer-receipt"
+
+// SignatureFormat identifies the signature envelope used by a signed artifact.
+type SignatureFormat string
+
+const (
+	FormatEIP712 SignatureFormat = "eip712"
+	FormatJWS    SignatureFormat = "jws"
+)
+
+// OfferPayload contains the canonical signed offer fields.
+type OfferPayload struct {
+	Version     int    `json:"version"`
+	ResourceURL string `json:"resourceUrl"`
+	Scheme      string `json:"scheme"`
+	Network     string `json:"network"`
+	Asset       string `json:"asset"`
+	PayTo       string `json:"payTo"`
+	Amount      string `json:"amount"`
+	ValidUntil  int64  `json:"validUntil,omitempty"`
+}
+
+// ReceiptPayload contains the canonical signed receipt fields.
+type ReceiptPayload struct {
+	Version     int    `json:"version"`
+	Network     string `json:"network"`
+	ResourceURL string `json:"resourceUrl"`
+	Payer       string `json:"payer"`
+	IssuedAt    int64  `json:"issuedAt"`
+	Transaction string `json:"transaction,omitempty"`
+}
+
+// SignedOffer is the transmitted signed offer artifact.
+type SignedOffer struct {
+	Format      SignatureFormat `json:"format"`
+	Payload     *OfferPayload   `json:"payload,omitempty"`
+	Signature   string          `json:"signature"`
+	AcceptIndex *int            `json:"acceptIndex,omitempty"`
+}
+
+// SignedReceipt is the transmitted signed receipt artifact.
+type SignedReceipt struct {
+	Format    SignatureFormat `json:"format"`
+	Payload   *ReceiptPayload `json:"payload,omitempty"`
+	Signature string          `json:"signature"`
+}
+
+// DecodedOffer combines a signed offer with its extracted payload.
+type DecodedOffer struct {
+	OfferPayload
+	SignedOffer SignedOffer
+	Format      SignatureFormat
+	AcceptIndex *int
+}
+
+type offerReceiptExtension struct {
+	Info offerReceiptInfo `json:"info"`
+}
+
+type offerReceiptInfo struct {
+	Offers  []SignedOffer  `json:"offers,omitempty"`
+	Receipt *SignedReceipt `json:"receipt,omitempty"`
+}


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

## Summary

Adds a small Go helper package for the `offer-receipt` extension.

This PR focuses on client/tooling helpers only:
- extract signed offers from `PaymentRequired.extensions`
- extract signed receipts from `SettleResponse.extensions`
- decode EIP-712 and JWS artifact payloads
- match signed offers to `accepts[]`
- check whether a receipt payload matches an accepted offer

It intentionally does not verify cryptographic signatures, resolve JWS `kid` values, or decide signer authorization. Those checks are separate from payload extraction/matching and are still evolving in the offer-receipt spec discussions.

## Changes

- Added `go/extensions/offerreceipt`
- Added typed offer/receipt payload and signed artifact structs
- Added extraction and matching helpers
- Added focused unit tests
- Documented the helper package in `go/extensions/README.md`
- Added a Go changelog fragment


## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

```bash
GOCACHE=/tmp/go-build-cache go test ./extensions/offerreceipt
GOCACHE=/tmp/go-build-cache go test ./extensions/...
GOCACHE=/tmp/go-build-cache go test ./...
GOCACHE=/tmp/go-build-cache make build
GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache make lint
GOCACHE=/tmp/go-build-cache make fmt
```

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 