### PR TITLE
docs: add PipRail to third-party SDKs

### DIFF
--- a/docs/dev-tools/third-party-sdks.md
+++ b/docs/dev-tools/third-party-sdks.md
@@ -6,5 +6,6 @@ description: "Community-maintained x402 SDKs."
 | Name | Description | Languages | Links |
 | ---- | ----------- | --------- | ----- |
 | [Mogami](https://mogami.gitbook.io/mogami) | Java x402 stack | Java | [GitHub](https://github.com/mogami-tech/) |
+| [PipRail](https://piprail.com) | Multi-chain x402 SDK + MCP server; backendless self-custody (verify against your own RPC) | TypeScript | [GitHub](https://github.com/piprail/piprail) |
 | [x402-rs](https://github.com/x402-rs/x402-rs/blob/main/README.md) | Rust toolkit for x402 | Rust | [GitHub](https://github.com/x402-rs/x402-rs) |
 | [x402-rails](https://github.com/quiknode-labs/x402-rails/blob/main/README.md) | x402 for Rails applications by Quicknode | Ruby | [GitHub](https://github.com/quiknode-labs/x402-rails) |


### PR DESCRIPTION
Adds **PipRail** to the Third-Party SDKs list.

PipRail is an MIT-licensed TypeScript x402 SDK (+ an MCP server) covering EVM, Solana, TON, Tron, NEAR, Sui, Aptos, Algorand, Stellar, and XRPL via a single `chain` parameter. It is backendless — the resource server verifies payments against its own RPC rather than a facilitator, which the spec permits (trust-minimizing principle / self-hosted verification).

- Repo: https://github.com/piprail/piprail
- npm: `@piprail/sdk`, `@piprail/mcp`
- Site/docs: https://piprail.com · https://docs.piprail.com

Docs-only change (one table row), so no changelog fragment per CONTRIBUTING. Row inserted alphabetically.

_AI-assisted: drafted with an AI coding agent and reviewed by me before submitting._