### PR TITLE
docs: add Attestify OS to third-party extensions

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -5,8 +5,9 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 
 | Name | Description | Languages | Links |
 | ---- | ----------- | --------- | ----- |
-| [World AgentKit](https://docs.world.org/agents/agent-kit/integrate) | Verify human-backed agents | TypeScript | [GitHub](https://github.com/worldcoin/agentkit) · [npm](https://www.npmjs.com/package/@worldcoin/agentkit) |
+| [Attestify OS](https://attestify-os.vercel.app) | Governed execution and financial control plane for AI agents. Adds tenant API keys, USDC budget enforcement, policy governance, SLA enforcement, heuristic verification scoring, and cryptographic receipts on every run — settled on Base. Ships an MCP-compatible server for governed, payment-gated agent task execution over x402. | TypeScript | [GitHub](https://github.com/attestifyagent/attestify-os) · [MCP](https://github.com/attestifyagent/attestify-mcp) |
 | [OMATrust](https://docs.omatrust.org/integrations/x402/overview) | Onchain EAS reputation from x402 signed offers and receipts | TypeScript | [GitHub](https://github.com/oma3dao/developer-docs) · [npm](https://www.npmjs.com/package/@oma3/omatrust) |
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |
+| [World AgentKit](https://docs.world.org/agents/agent-kit/integrate) | Verify human-backed agents | TypeScript | [GitHub](https://github.com/worldcoin/agentkit) · [npm](https://www.npmjs.com/package/@worldcoin/agentkit) |
 | [x402r](https://x402r.org) | Non-custodial refund and arbitration protocol | Typescript | [GitHub](https://github.com/BackTrackCo/x402r-sdk) · [npm](https://www.npmjs.com/package/@x402r/sdk ) |
 | [zauth](https://zauthx402.com) | Monitoring, verification, and refund SDK | TypeScript | [GitHub](https://github.com/zauthofficial/zauthSDK) · [npm](https://www.npmjs.com/package/@zauthx402/sdk) |


### PR DESCRIPTION
## What is Attestify OS?

Attestify OS is a governed execution and financial control plane for AI agents, built natively on x402.

It extends x402 beyond payment gating into the full governance layer that production AI agent deployments need:

- **Tenant API key issuance** — per-tenant keys with scoped access to execution lanes
- **USDC budget enforcement** — per-tenant and per-run spend limits enforced before execution
- **Policy governance** — operator-defined policies (allowed actions, required verification grade, risk thresholds)
- **SLA enforcement** — max latency, min verification grade, min reputation score, max price — evaluated on every run with breach recorded per-receipt
- **Heuristic verification scoring** — every run scored 0–1 with a grade (A–F) and risk flags
- **Cryptographic receipts** — hash-chained, tamper-evident receipt on every execution, settled on Base (eip155:8453)
- **Reputation scoring** — per-lane and per-session reputation computed from receipt history
- **MCP server** (`attestify-mcp`) — any MCP-compatible client can execute governed, payment-gated agent tasks over x402

## Live endpoints

- **Endpoint:** https://attestify-os.vercel.app
- **x402 discovery:** https://attestify-os.vercel.app/.well-known/x402.json
- **OpenAPI spec:** https://attestify-os.vercel.app/openapi.json
- **Capabilities:** https://attestify-os.vercel.app/api/capabilities

## Why third-party extensions?

Attestify OS adds a full governance and financial control layer on top of the x402 payment flow — it is infrastructure that extends what x402 can do for agent deployments, not a facilitator or a client SDK. It sits in the same category as OMATrust (reputation), PEAC Protocol (verifiable receipts), and World AgentKit (agent verification).

## Links

- GitHub: https://github.com/attestifyagent/attestify-os
- MCP package: https://github.com/attestifyagent/attestify-mcp