### PR TITLE
docs(readme): replace flow.png with inline Mermaid sequence diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,29 @@ See `specs/` for full documentation of the x402 standard/
 ### Typical x402 flow
 
 x402 payments typically adhere to the following flow, but servers have a lot of flexibility. See `advanced` folders in `examples/`.
-![](./static/flow.png)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant RS as Resource Server
+    participant F as Facilitator
+    participant B as Blockchain
+    Note over F: Optional — server can verify and settle directly
+
+    C->>RS: GET /api
+    RS-->>C: 402 Payment Required (PAYMENT-REQUIRED header)
+    C->>C: Select PaymentRequirements, create PaymentPayload
+    C->>RS: GET /api + PAYMENT-SIGNATURE header
+    RS->>F: POST /verify (PaymentPayload + PaymentRequirements)
+    F-->>RS: Verification Response
+    RS->>RS: Fulfill request
+    RS->>F: POST /settle (PaymentPayload + PaymentRequirements)
+    F->>B: Submit transaction
+    B-->>F: Transaction confirmed
+    F-->>RS: Payment Execution Response
+    RS-->>C: 200 OK + PAYMENT-RESPONSE header + content
+```
 
 The following outlines the flow of a payment using the `x402` protocol. Note that steps (1) and (2) are optional if the client already knows the payment details accepted for a resource.
 


### PR DESCRIPTION
Closes #2678

Replaces the `static/flow.png` reference in README.md with an inline
Mermaid `sequenceDiagram`. The diagram mirrors the 12 numbered steps of
the existing "Typical x402 flow" prose immediately below it, so the two
stay in sync.

### Why

- Text-based source diffs cleanly in PR review when the protocol evolves.
- Renders natively on GitHub, including dark mode.
- Lives next to the prose it illustrates — easier for future contributors
  to keep aligned.

### Scope

- Single file changed: `README.md`.
- `static/flow.png` left in the repo for external link compatibility;
  no longer referenced from README. Happy to delete in a follow-up if
  maintainers prefer.
- No spec, SDK, or example changes.

### Verification

Rendered and verified against the 12-step prose description step-for-step.
No changes to the surrounding text.

### Checklist

- [x] No code changes — docs only, changelog fragment not required.
- [x] Commit is GPG-signed.

Used an AI assistant for the initial Mermaid syntax draft; reviewed and
verified manually before committing.