### PR TITLE
Add AgentCourt — dispute resolution for x402 agent commerce

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AgentCourt",
+  "category": "Infrastructure & Tooling",
+  "logoUrl": "",
+  "description": "Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. The Evaluator layer for ERC-8183. Non-custodial, open source, MIT. x402-native at $0.05/dispute.",
+  "websiteUrl": "https://github.com/vbkotecha/agentcourt-api"
+}


### PR DESCRIPTION
## AgentCourt — Policy-Driven Dispute Resolution for Agent Commerce

AgentCourt is the dispute resolution layer for x402-based agent commerce. When an agent pays for a service via x402 and the transaction goes wrong (schema mismatch, non-delivery, SLA breach), AgentCourt evaluates evidence and issues a deterministic ruling in under 500ms.

### Stats
- **7 policy templates** (freelance, milestone, bug bounty, SLA, API quality, commerce, scope)
- **39 deterministic rules** with structured fact matching
- **$0.05 USDC per dispute** on Base mainnet via x402
- **Free tier**: 100 disputes/month
- **MIT licensed**, open source

### Live Endpoints
- API: https://agentcourt-api-production.up.railway.app/docs
- x402 manifest: https://agentcourt-api-production.up.railway.app/.well-known/x402
- GitHub: https://github.com/vbkotecha/agentcourt-api
- Landing: https://vbkotecha.github.io/agentcourt-api/

### Why AgentCourt belongs in the x402 ecosystem
- Only dispute resolution service in the x402 ecosystem
- x402-native pricing ($0.05/dispute, USDC on Base)
- Non-custodial (rulings through consequence, not escrow)
- Deterministic (same evidence = same ruling, every time)