### PR TITLE
Add AgentCourt — dispute resolution for x402 agent commerce

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AgentCourt",
+  "category": "Infrastructure & Tooling",
+  "logoUrl": "",
+  "description": "Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. Non-custodial, open source, MIT. x402-native at $0.05/dispute on Base mainnet.",
+  "websiteUrl": "https://agentcourt-api-production.up.railway.app"
+}


### PR DESCRIPTION
## AgentCourt — Dispute Resolution for x402 Agent Commerce

The dispute resolution layer for x402-based agent commerce. When an agent pays for a service and the transaction goes wrong, AgentCourt evaluates evidence and issues a deterministic ruling.

### Details
- **7 policy templates** (freelance, milestone, bug bounty, SLA, API quality, commerce, scope)
- **39 deterministic rules** with structured fact matching
- **$0.05 USDC per dispute** on Base mainnet via x402
- **Free tier**: 100 disputes/month
- **MIT licensed**, open source

### Links
- API: https://agentcourt-api-production.up.railway.app/docs
- x402 manifest: https://agentcourt-api-production.up.railway.app/.well-known/x402
- GitHub: https://github.com/vbkotecha/agentcourt-api