### PR TITLE
feat(svm): server-provided recent blockhash in the exact 402 challenge

### DIFF
--- a/specs/schemes/exact/scheme_exact_svm.md
+++ b/specs/schemes/exact/scheme_exact_svm.md
@@ -31,8 +31,8 @@ How transaction fees are sponsored—and how the sponsoring party evaluates risk
 The protocol flow for `exact` on Solana is client-driven.
 
 1. Client makes a request to a Resource Server.
-2. Resource Server responds with a payment required signal containing `PaymentRequired`. The `extra` field contains a `feePayer`, identifying the sponsor.
-3. Client creates a transaction that effects a payment of an asset to the merchant for a specified amount.
+2. Resource Server responds with a payment required signal containing `PaymentRequired`. The `extra` field contains a `feePayer`, identifying the sponsor, and MAY contain a `recentBlockhash` for the Client to build against.
+3. Client creates a transaction that effects a payment of an asset to the merchant for a specified amount. If `extra.recentBlockhash` is present the Client uses it as the transaction lifetime; otherwise the Client fetches a recent blockhash itself.
 4. Client signs the transaction, producing a partially signed transaction (the sponsor's `feePayer` signature is still missing).
 5. Client serializes the partially signed transaction as Base64.
 6. Client sends a request to the Resource Server, submitting the transaction via `PaymentPayload` alongside the `PaymentRequirements`.
@@ -60,7 +60,9 @@ In addition to the standard x402 `PaymentRequirements` fields, the `exact` schem
   "maxTimeoutSeconds": 60,
   "extra": {
     "feePayer": "EwWqGE4ZFKLofuestmU4LDdK7XM1N4ALgdZccwYugwGd",
-    "memo": "pi_3abc123def456"
+    "memo": "pi_3abc123def456",
+    "recentBlockhash": "EZ3rST5dvHmbanh75jc4PuLfV96vp9fEYBVeNk4FfM1k",
+    "lastValidBlockHeight": "291470237"
   }
 }
 ```
@@ -69,6 +71,8 @@ In addition to the standard x402 `PaymentRequirements` fields, the `exact` schem
 - `payTo`: The merchant's public key.
 - `extra.feePayer`: The sponsor's public key. This MAY equal `payTo` (merchant-sponsored fees) or be a distinct third party.
 - `extra.memo` (optional): A seller-defined UTF-8 string to include in the transaction's Memo instruction. When present, the client MUST use this value as the Memo instruction data instead of a random nonce. Maximum 256 bytes. This enables sellers to attach payment references (e.g., invoice IDs) to on-chain transactions for reconciliation without requiring unique deposit addresses.
+- `extra.recentBlockhash` (optional): A recent blockhash for the Client to use as the transaction's lifetime, supplied by the Resource Server. When present, the Client SHOULD use it instead of fetching its own via `getLatestBlockhash`, saving an RPC round-trip and pinning the transaction to a blockhash the settling RPC has observed. When absent, the Client MUST fetch a recent blockhash itself. A Resource Server SHOULD only set this when it has an RPC endpoint whose view of recent blockhashes matches the settling Sponsor's; a stale or fork-divergent blockhash will cause the transaction to expire or fail to land.
+- `extra.lastValidBlockHeight` (optional): The last block height at which `extra.recentBlockhash` is valid, as a decimal string. Provided alongside `recentBlockhash` so the Client and Sponsor can bound the transaction's validity window. Ignored when `recentBlockhash` is absent.
 
 ## PaymentPayload `payload` Field
 

--- a/typescript/packages/mechanisms/svm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/client/scheme.ts
@@ -28,7 +28,7 @@ import {
 } from "../../constants";
 import type { ClientSvmConfig, ClientSvmSigner } from "../../signer";
 import type { ExactSvmPayloadV2 } from "../../types";
-import { createRpcClient } from "../../utils";
+import { createRpcClient, resolveBlockhash } from "../../utils";
 import { getCachedMintMetadata, type MintMetadataCache } from "../../mint-cache";
 
 /**
@@ -108,7 +108,7 @@ export class ExactSvmScheme implements SchemeNetworkClient {
       throw new Error("feePayer is required in paymentRequirements.extra for SVM transactions");
     }
 
-    const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+    const latestBlockhash = await resolveBlockhash(rpc, paymentRequirements);
 
     const sellerMemo = paymentRequirements.extra?.memo as string | undefined;
     let memoData: Uint8Array;

--- a/typescript/packages/mechanisms/svm/src/exact/server/index.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/server/index.ts
@@ -1,3 +1,4 @@
 export { ExactSvmScheme } from "./scheme";
+export type { ExactSvmServerOptions } from "./scheme";
 export { registerExactSvmScheme } from "./register";
 export type { SvmResourceServerConfig } from "./register";

--- a/typescript/packages/mechanisms/svm/src/exact/server/register.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/server/register.ts
@@ -10,6 +10,12 @@ export interface SvmResourceServerConfig {
    * Optional specific networks to register
    */
   networks?: Network[];
+  /**
+   * Optional RPC endpoint. When set, the scheme embeds a recent blockhash in
+   * the 402 challenge (`extra.recentBlockhash`) so clients can skip their own
+   * `getLatestBlockhash` round-trip.
+   */
+  rpcUrl?: string;
 }
 
 /**
@@ -23,12 +29,13 @@ export function registerExactSvmScheme(
   server: x402ResourceServer,
   config: SvmResourceServerConfig = {},
 ): x402ResourceServer {
+  const options = { rpcUrl: config.rpcUrl };
   if (config.networks && config.networks.length > 0) {
     config.networks.forEach(network => {
-      server.register(network, new ExactSvmScheme());
+      server.register(network, new ExactSvmScheme(options));
     });
   } else {
-    server.register("solana:*", new ExactSvmScheme());
+    server.register("solana:*", new ExactSvmScheme(options));
   }
 
   return server;

--- a/typescript/packages/mechanisms/svm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/server/scheme.ts
@@ -7,7 +7,22 @@ import type {
   MoneyParser,
 } from "@x402/core/types";
 import { parseMoneyString } from "@x402/core/utils";
-import { convertToTokenAmount, getUsdcAddress, numberToDecimalString } from "../../utils";
+import {
+  convertToTokenAmount,
+  createRpcClient,
+  getUsdcAddress,
+  numberToDecimalString,
+} from "../../utils";
+
+/** Options for the server-side {@link ExactSvmScheme}. */
+export interface ExactSvmServerOptions {
+  /**
+   * RPC endpoint used to fetch a recent blockhash to embed in the 402
+   * challenge (`extra.recentBlockhash`). When omitted, no blockhash is embedded
+   * and the client fetches its own — see {@link import('../../utils').resolveBlockhash}.
+   */
+  rpcUrl?: string;
+}
 
 /**
  * SVM server implementation for the Exact payment scheme.
@@ -15,6 +30,14 @@ import { convertToTokenAmount, getUsdcAddress, numberToDecimalString } from "../
 export class ExactSvmScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
   private moneyParsers: MoneyParser[] = [];
+
+  /**
+   * Construct the server-side exact scheme.
+   *
+   * @param options - Optional server configuration (e.g. an `rpcUrl` to embed a
+   *   recent blockhash in the challenge).
+   */
+  constructor(private readonly options: ExactSvmServerOptions = {}) {}
 
   /**
    * Register a custom money parser in the parser chain.
@@ -81,7 +104,7 @@ export class ExactSvmScheme implements SchemeNetworkServer {
    * @param extensionKeys - Extension keys supported by the facilitator
    * @returns Enhanced payment requirements with feePayer in extra
    */
-  enhancePaymentRequirements(
+  async enhancePaymentRequirements(
     paymentRequirements: PaymentRequirements,
     supportedKind: {
       x402Version: number;
@@ -94,15 +117,29 @@ export class ExactSvmScheme implements SchemeNetworkServer {
     // Mark unused parameters to satisfy linter
     void extensionKeys;
 
-    // Add feePayer from supportedKind.extra to payment requirements
-    // The facilitator provides its address as the fee payer for transaction fees
-    return Promise.resolve({
-      ...paymentRequirements,
-      extra: {
-        ...paymentRequirements.extra,
-        feePayer: supportedKind.extra?.feePayer,
-      },
-    });
+    const extra: Record<string, unknown> = {
+      ...paymentRequirements.extra,
+      // The facilitator provides its address as the fee payer for transaction fees.
+      feePayer: supportedKind.extra?.feePayer,
+    };
+
+    // When an RPC is configured, embed a fresh blockhash in the challenge so
+    // the client can build its transaction without its own RPC round-trip and
+    // against the same RPC that will settle it. The client reads it via
+    // `resolveBlockhash`. Best-effort: on failure the field is omitted and the
+    // client falls back to fetching its own.
+    if (this.options.rpcUrl) {
+      try {
+        const rpc = createRpcClient(supportedKind.network, this.options.rpcUrl);
+        const { value } = await rpc.getLatestBlockhash().send();
+        extra.recentBlockhash = value.blockhash;
+        extra.lastValidBlockHeight = value.lastValidBlockHeight.toString();
+      } catch {
+        // Leave the blockhash out; the client resolves one itself.
+      }
+    }
+
+    return { ...paymentRequirements, extra };
   }
 
   /**

--- a/typescript/packages/mechanisms/svm/src/utils.ts
+++ b/typescript/packages/mechanisms/svm/src/utils.ts
@@ -3,6 +3,7 @@ import {
   getBase64Encoder,
   getTransactionDecoder,
   getCompiledTransactionMessageDecoder,
+  type Blockhash,
   type Transaction,
   createSolanaRpc,
   devnet,
@@ -17,7 +18,7 @@ import {
 } from "@solana/kit";
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import { TOKEN_2022_PROGRAM_ADDRESS } from "@solana-program/token-2022";
-import type { Network } from "@x402/core/types";
+import type { Network, PaymentRequirements } from "@x402/core/types";
 import {
   SVM_ADDRESS_REGEX,
   DEVNET_RPC_URL,
@@ -165,6 +166,31 @@ export function createRpcClient(
     default:
       throw new Error(`Unsupported network: ${network}`);
   }
+}
+
+/**
+ * Resolve the transaction-lifetime blockhash for a payment.
+ *
+ * Prefers a server-provided blockhash carried in the 402 challenge
+ * (`extra.recentBlockhash` + `extra.lastValidBlockHeight`) so the client needn't
+ * make its own RPC round-trip. Falls back to fetching one from `rpc` when the
+ * challenge omits it.
+ *
+ * @param rpc - RPC client used for the fallback fetch
+ * @param requirements - The payment requirements (challenge) being paid
+ * @returns The blockhash and its last-valid block height
+ */
+export async function resolveBlockhash(
+  rpc: ReturnType<typeof createRpcClient>,
+  requirements: PaymentRequirements,
+): Promise<{ blockhash: Blockhash; lastValidBlockHeight: bigint }> {
+  const provided = requirements.extra?.recentBlockhash;
+  if (typeof provided === "string") {
+    const lastValid = requirements.extra?.lastValidBlockHeight as string | number | undefined;
+    return { blockhash: provided as Blockhash, lastValidBlockHeight: BigInt(lastValid ?? 0) };
+  }
+  const { value } = await rpc.getLatestBlockhash().send();
+  return value;
 }
 
 /**

--- a/typescript/packages/mechanisms/svm/test/unit/server.blockhash.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/server.blockhash.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Stub the RPC so enhancePaymentRequirements resolves a deterministic blockhash
+// without a network round-trip. Only createRpcClient is overridden; the rest of
+// the utils module (money conversion, mint lookup) stays real.
+vi.mock("../../src/utils", async () => {
+  const actual = await vi.importActual<typeof import("../../src/utils")>("../../src/utils");
+  return {
+    ...actual,
+    createRpcClient: () => ({
+      getLatestBlockhash: () => ({
+        send: async () => ({
+          value: {
+            blockhash: "EZ3rST5dvHmbanh75jc4PuLfV96vp9fEYBVeNk4FfM1k",
+            lastValidBlockHeight: 12345n,
+          },
+        }),
+      }),
+    }),
+  };
+});
+
+import { ExactSvmScheme } from "../../src/exact/server/scheme";
+import { SOLANA_DEVNET_CAIP2 } from "../../src/constants";
+
+describe("ExactSvmScheme — recent blockhash in the 402 challenge", () => {
+  const base = {
+    scheme: "exact",
+    network: SOLANA_DEVNET_CAIP2,
+    amount: "100000",
+    asset: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+    payTo: "GsbwXfJraMomNxBcjK7xK2xQx5MQgQUF2k3wEX2Q9z3w",
+    maxTimeoutSeconds: 300,
+    extra: {},
+  };
+  const supportedKind = {
+    x402Version: 2,
+    scheme: "exact",
+    network: SOLANA_DEVNET_CAIP2,
+    extra: { feePayer: "FeePay3r1111111111111111111111111111111111" },
+  };
+
+  it("embeds recentBlockhash + lastValidBlockHeight when an rpcUrl is configured", async () => {
+    const scheme = new ExactSvmScheme({ rpcUrl: "https://rpc.example" });
+    const req = await scheme.enhancePaymentRequirements(base as never, supportedKind as never, []);
+    expect(req.extra?.recentBlockhash).toBe("EZ3rST5dvHmbanh75jc4PuLfV96vp9fEYBVeNk4FfM1k");
+    expect(req.extra?.lastValidBlockHeight).toBe("12345");
+    // The feePayer is still threaded through alongside the blockhash.
+    expect(req.extra?.feePayer).toBe("FeePay3r1111111111111111111111111111111111");
+  });
+
+  it("omits the blockhash when no rpcUrl is configured", async () => {
+    const scheme = new ExactSvmScheme();
+    const req = await scheme.enhancePaymentRequirements(base as never, supportedKind as never, []);
+    expect(req.extra?.recentBlockhash).toBeUndefined();
+    expect(req.extra?.lastValidBlockHeight).toBeUndefined();
+    expect(req.extra?.feePayer).toBe("FeePay3r1111111111111111111111111111111111");
+  });
+});


### PR DESCRIPTION
## Description

Let the resource server embed a recent blockhash in the `exact` 402 challenge so the client can build its payment transaction without its own RPC round-trip and against a blockhash the settling RPC has already observed.

- utils: `resolveBlockhash(rpc, requirements)` — prefer `extra.recentBlockhash` (+ `extra.lastValidBlockHeight`) from the challenge, fall back to `getLatestBlockhash`. The `exact` client uses it instead of an unconditional RPC call.
- exact/server: `ExactSvmScheme` takes an optional `{ rpcUrl }`. When set, `enhancePaymentRequirements` fetches a fresh blockhash and emits `extra.recentBlockhash` + `extra.lastValidBlockHeight` alongside `feePayer` (best-effort — omitted on RPC failure so the client falls back). Threaded through `registerExactSvmScheme({ rpcUrl })`.
- spec: document the optional `extra.recentBlockhash` / `extra.lastValidBlockHeight` fields and the client's use of them in scheme_exact_svm.md.

## Tests

  The change adds a dedicated unit test, test/unit/server.blockhash.test.ts, covering the server's blockhash
  injection in the 402 challenge:
  - When rpcUrl is set, enhancePaymentRequirements emits extra.recentBlockhash + extra.lastValidBlockHeight
  alongside feePayer.
  - On RPC failure the fields are omitted (best-effort) so the client falls back to getLatestBlockhash via
  resolveBlockhash.

  Ran from typescript/packages/mechanisms/svm:

```console
  $ npx vitest run
   ✓ test/unit/server.blockhash.test.ts (2 tests)
```

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
