### PR TITLE
Add x402 Data Gateway to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-data-gateway/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-data-gateway/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "x402 Data Gateway",
+  "description": "Pay-per-call USDC endpoints for autonomous agents, no auth or API keys. /enrich turns a bare domain into agent-ready company intelligence (identity, tech stack, social, contact, DNS/email infra, AI-readiness score); /extract and /read return clean structured JSON or LLM-ready Markdown for any URL; /scan is a static supply-chain security scan of a public GitHub repo before an agent installs it. Settles USDC directly on Base via x402 v2.",
+  "logoUrl": "/logos/x402-data-gateway.svg",
+  "websiteUrl": "https://x402-url-extractor-production.up.railway.app/",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/x402-data-gateway.svg
+++ b/typescript/site/public/logos/x402-data-gateway.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-label="x402 Data Gateway">
+  <rect width="120" height="120" rx="26" fill="#0B1020"/>
+  <rect x="6" y="6" width="108" height="108" rx="21" fill="none" stroke="#1E2A4A" stroke-width="2"/>
+  <!-- payment / data node glyph -->
+  <g stroke="#5B8DEF" stroke-width="5" fill="none" stroke-linecap="round">
+    <circle cx="34" cy="60" r="9" fill="#5B8DEF" stroke="none"/>
+    <circle cx="86" cy="38" r="7"/>
+    <circle cx="86" cy="82" r="7"/>
+    <line x1="42" y1="55" x2="80" y2="40"/>
+    <line x1="42" y1="65" x2="80" y2="80"/>
+  </g>
+  <text x="60" y="104" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="17" font-weight="700" fill="#9DB4E6" letter-spacing="1">402</text>
+</svg>


### PR DESCRIPTION
## Adding x402 Data Gateway to the ecosystem

A live, mainnet x402 v2 service of pay-per-call USDC endpoints for autonomous agents — no auth, no API keys, no subscription. Settles USDC directly to a self-custody wallet on Base.

**Category:** Services/Endpoints

**Endpoints (all live on Base mainnet, `eip155:8453`):**
- `GET /enrich?domain=` — bare domain → agent-ready company intelligence: identity, tech stack fingerprint, social profiles, contact surface, DNS/email infra (SPF/DMARC), and an AI-search-readiness score. The frictionless, pay-per-call alternative to signup-gated enrichment APIs.
- `GET /extract?url=` — URL → clean structured JSON (text, JSON-LD, OpenGraph, headings, links, AI-readiness signals).
- `GET /read?url=` — URL → LLM-ready Markdown.
- `GET /scan?repo=` — static supply-chain security scan of a public GitHub repo before an agent installs/runs it.

**Discovery / spec:**
- `/.well-known/x402` — advertises all resources with the Bazaar discovery extension.
- `/openapi.json` — OpenAPI 3 spec.
- Each unpaid route returns a standard HTTP 402 with full payment requirements.

**This PR adds:**
- `typescript/site/app/ecosystem/partners-data/x402-data-gateway/metadata.json`
- `typescript/site/public/logos/x402-data-gateway.svg`

### Requirements checklist (Services/Endpoints)
- [x] Working mainnet integration (Base, `eip155:8453`, x402 v2 / `@x402/express`)
- [x] API documentation (`/openapi.json`, `/.well-known/x402`, landing page)
- [x] Designed for high uptime (Railway, health-checked at `/healthz`)
