### PR TITLE
docs(svm): add `upto` SVM scheme specification

### DIFF
--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -14,73 +14,61 @@
 resource is consumed. Same target use cases as the generic spec: LLM token
 billing, per-byte metering, dynamic compute pricing.
 
-The hard part on Solana: a normal signed transfer commits to an *exact* amount
+A normal signed transfer commits to an *exact* amount
 and exact instruction data, so the server cannot lower the amount after the
 client signs without invalidating the signature. `upto` therefore requires an
 authorization that commits the client to a **ceiling** and lets the
-**facilitator** choose the actual amount at settlement. SVM offers two
-mechanisms that decouple "client authorizes a max" from "facilitator executes
-the actual," expressed here as two **profiles**.
+**operator** choose the actual amount at settlement. On SVM this is realized with
+an on-chain **payment channel**: the client escrows the ceiling, and the operator
+settles the actual amount against it with a single signed voucher.
+
+The **operator** is the party that co-signs the channel `open` as fee payer and
+submits settlement — the **server itself, or a facilitator it delegates to**
+(advertised as `extra.feePayer`). Nothing in `upto` requires a *separate*
+facilitator: a server can self-facilitate, running verify and settle directly.
+"Server/facilitator" below denotes whichever fills the operator role.
 
 ## 2. Mapping the five core requirements to SVM
 
-| Requirement (generic spec) | EVM mechanism | SVM mechanism (this spec) |
-|---|---|---|
-| Single-use authorization | Permit2 nonce | `payment-channel`: `finalize` makes the channel terminal (`ChannelStatus::Finalized`). `permit`: a one-shot nonce PDA consumed at settle. |
-| Time-bound validity (`validAfter`, `deadline`) | Permit2 `deadline` + witness `validAfter` | Authorization `validAfter` + `expiresAt`; `expiresAt` is also signed into the on-chain voucher / permit message. |
-| Recipient binding | Permit2 witness `to` | `payment-channel`: `channel.payee` + `distribution_hash` fixed at open. `permit`: `payTo` signed into the permit message and enforced by the program. |
-| Maximum amount enforcement | `permitted.amount` ceiling | `payment-channel`: on-chain `deposit` ceiling, `cumulative_amount ≤ deposit`. `permit`: `maxAmount` signed into the permit message, `actual ≤ maxAmount` enforced by the program. |
-| Phase-dependent amount semantics | `amount` = max at verify, actual at settle | Identical. `amount` in `PaymentRequirements` is the max during verification and the actual charge during settlement. |
+| Requirement (generic spec) | SVM mechanism |
+|---|---|
+| Single-use authorization | `finalize` makes the channel terminal (`ChannelStatus::Finalized`). |
+| Time-bound validity (`validAfter`, `expiresAt`) | Authorization `validAfter` + `expiresAt`; `expiresAt` is also signed into the on-chain voucher. |
+| Recipient binding | `channel.payee` + `distribution_hash` fixed at open. |
+| Maximum amount enforcement | On-chain `deposit` ceiling, `cumulative_amount ≤ deposit`. |
+| Phase-dependent amount semantics | `amount` in `PaymentRequirements` is the max during verification and the actual charge during settlement. |
 
-The facilitator MUST always verify against the client-signed ceiling, never
-against the settlement-time `amount`.
+The server/facilitator MUST always verify against the client-signed ceiling,
+never against the settlement-time `amount`.
 
-## 3. Profiles
+## 3. Payment-channel profile
 
-A server advertises one or more profiles in `extra.profiles`. The client picks
-one and signals it back in the payload's `profile` field.
-
-### 3.1 `payment-channel` (normative, v1)
-
-Backed by the on-chain payment-channels program (a `pay-kit`-controlled program;
-program id `CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX` on the current
-deployment). The escrow **deposit is the ceiling**; a single signed voucher
-settles the actual amount; `finalize` closes the channel and refunds the unused
+v1 defines a single profile, `payment-channel`, carried in the payload's
+`profile` field. It is backed by the on-chain payment-channels program
+(advertised via `extra.channelProgram`; a canonical deployment is assumed when
+omitted). The escrow **deposit is the ceiling**; a single signed voucher settles
+the actual amount; `finalize` closes the channel and refunds the unused
 remainder to the payer in the same transaction.
 
-Strengths: every requirement is enforced on-chain by a program we control. The
-facilitator cannot overcharge (capped by `deposit`), cannot redirect funds
+Strengths: every requirement is enforced on-chain by the program. The
+operator cannot overcharge (capped by `deposit`), cannot redirect funds
 (`channel.payee` / `distribution_hash` are fixed at open), and cannot replay
-(channel is terminal after `finalize`).
+(channel is terminal after `finalize`). Conversely, because the channel's
+`authorizedSigner` is the operator (and the operator is the `settle_and_finalize`
+merchant), the operator can settle and finalize **at any time** — collecting the
+metered amount and refunding the client's unused deposit — without the client's
+cooperation. The channel-account rent is fronted by the operator: the `open`
+instruction's `rentPayer` account (the operator's own key) funds the PDA and
+escrow-ATA rent, and `finalize` **refunds it to that `rentPayer`** — so the
+client moves only stablecoin and never needs SOL. The operator can finalize a
+stale channel at will, reclaiming the rent it fronted; its only exposure is the
+cheap finalize transaction.
 
 Cost: the client locks `max` in escrow for the lifetime of the request, and the
-flow needs two on-chain transactions (open, then settle-and-finalize). Channel
-rent is reclaimed at finalize.
-
-### 3.2 `permit` (optional, v2 — requires a new program)
-
-Backed by an Ed25519-signed one-shot delegated transfer — the closest analog to
-EVM's `permitWitnessTransferFrom`. The client `approve`s a program-owned
-delegate on its token account (reusable across requests, like a one-time Permit2
-approval), then signs an off-chain **permit message** committing to a ceiling and
-a witness. At settlement the facilitator submits one transaction; a small
-on-chain program verifies the Ed25519 signature (via the Ed25519 precompile +
-instructions sysvar, the same pattern the payment-channels program already uses
-for vouchers), checks the witness, enforces `actual ≤ maxAmount`, transfers the
-actual amount to `payTo`, and consumes a nonce PDA for replay protection.
-
-Strengths: no escrow lockup; a single settlement transaction; reusable approval.
-Matches EVM ergonomics.
-
-Cost: requires a new, audited on-chain program. Until that program ships and is
-audited, `payment-channel` is the only normative profile.
-
-> Multi-delegator is explicitly **not** an `upto` backend. Its `FixedDelegation`
-> is a standing, multi-pull cap that binds the *delegatee* (operator), not the
-> final `payTo`, and offers no on-chain single-use guarantee. It is the right
-> primitive for `session`/streaming, not for one-shot `upto`. Using it here
-> would downgrade the recipient-binding and single-use requirements to
-> "trust the facilitator," defeating the scheme.
+flow needs two on-chain transactions (open, then settle-and-finalize). The
+channel-account rent is funded by the operator (the `open` `rentPayer` account)
+and reclaimed at finalize; the client supplies only the stablecoin deposit and
+never needs SOL.
 
 ## 4. Wire format
 
@@ -98,7 +86,7 @@ to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
 | `scheme` | string | ✓ | `"upto"` |
 | `network` | string | ✓ | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (mainnet), `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (devnet) |
 | `amount` | string | ✓ | **Phase-dependent**: max authorized at verification; actual charge at settlement. Base units. |
-| `asset` | string | ✓ | SPL mint address (or `"SOL"` — discouraged for `upto`; stablecoins recommended) |
+| `asset` | string | ✓ | SPL mint address (e.g. USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) |
 | `payTo` | string | ✓ | Base58 recipient |
 | `maxTimeoutSeconds` | number | ✓ | Completion window; also the basis for the authorization `expiresAt` |
 | `extra` | object | ✓ | See below |
@@ -107,14 +95,14 @@ to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `profiles` | string[] | ✓ | Subset of `["payment-channel","permit"]`, in server preference order |
+| `profiles` | string[] | ✓ | `["payment-channel"]` (the only v1 profile) |
 | `feePayer` | string | ✓ | Base58 operator key that sponsors fees (co-signs the setup transaction as fee payer) and settles |
-| `channelProgram` | string | – | Channel/permit program id; defaults to the canonical deployment |
+| `channelProgram` | string | – | Channel program id; defaults to the canonical deployment |
 | `decimals` | number | ✓ | Token decimals |
 | `tokenProgram` | string | ✓ | `Tokenkeg…` or `TokenzQ…` (Token-2022); the client SHOULD verify it against the on-chain mint owner |
 | `recentBlockhash` | string | – | Pre-fetched blockhash so the client can build setup transactions without an extra RPC round-trip |
 | `validAfter` | number | – | Earliest activation time (Unix seconds); default = now |
-| `splits` | `{recipient,bps}[]` | – | `payment-channel` only; distributed at finalize |
+| `splits` | `{recipient,bps}[]` | – | Distribution splits sealed at open; distributed at finalize |
 
 ### 4.2 `UptoPayload` (in `PAYMENT-SIGNATURE.payload`)
 
@@ -122,21 +110,21 @@ Common fields:
 
 | Field | Type | Notes |
 |---|---|---|
-| `profile` | string | `"payment-channel"` or `"permit"` |
+| `profile` | string | `"payment-channel"` (the only v1 profile) |
 | `from` | string | Payer wallet (base58) |
 | `maxAmount` | string | The signed ceiling (base units). MUST equal verification-phase `amount`. |
 | `expiresAt` | number | Deadline (Unix seconds); signed into the on-chain message |
 | `validAfter` | number | Activation time (Unix seconds) |
 | `nonce` | string | Unique per authorization |
 
-`payment-channel` profile adds:
+Plus the channel fields:
 
 | Field | Type | Notes |
 |---|---|---|
 | `channelId` | string | Channel PDA (base58) |
 | `deposit` | string | On-chain escrow = the ceiling; MUST equal `maxAmount` |
-| `authorizedSigner` | string | The **operator/facilitator** key (base58). The operator — not the client — signs the single settlement voucher (see §5 Phase 2). |
-| `openTransaction` | string | Base64 signed `open` transaction for the facilitator to broadcast if the channel is not yet open (pull-style). Omitted if the client already broadcast `open` (push-style) and `signature` is set. |
+| `authorizedSigner` | string | The **operator** key (base58) — the server's or facilitator's pubkey, equal to `extra.feePayer`. The operator — not the client — signs the single settlement voucher (see §5 Phase 2); as the channel `authorizedSigner`/merchant it alone can settle and finalize the channel. |
+| `openTransaction` | string | Base64 signed `open` transaction for the server/facilitator to broadcast if the channel is not yet open (pull-style). Omitted if the client already broadcast `open` (push-style) and `signature` is set. |
 | `signature` | string | Base58 signature of the broadcast `open` transaction (push) |
 
 > The voucher is **not** carried in the payload. Because the actual amount is
@@ -144,28 +132,7 @@ Common fields:
 > on-chain `deposit` ceiling plus the fixed `payee`, the operator (set as the
 > channel's `authorizedSigner` at open) signs the single voucher for the metered
 > amount at settlement. This keeps `upto` a single HTTP round-trip with a
-> handler-determined amount, matching the EVM trust model where the server fills
-> in `actual ≤ ceiling`.
-
-`permit` profile adds:
-
-| Field | Type | Notes |
-|---|---|---|
-| `tokenAccount` | string | Payer ATA being delegated (base58) |
-| `approveTransaction` | string | Base64 signed `approve` transaction for the facilitator to broadcast if no sufficient delegation exists |
-| `permitSignature` | string | Base58 Ed25519 signature by `from` over the permit message |
-
-Permit message (Borsh, signed by `from`):
-
-```
-nonce_pda: [u8;32]          // PDA(["upto", from, mint, nonce])
-mint:      [u8;32]
-pay_to:    [u8;32]
-facilitator:[u8;32]
-max_amount: u64 (le)
-valid_after: i64 (le)
-expires_at: i64 (le)
-```
+> handler-determined amount: the server fills in `actual ≤ ceiling`.
 
 ### 4.3 `SettlementResponse` (in `PAYMENT-RESPONSE`)
 
@@ -180,38 +147,34 @@ expires_at: i64 (le)
 
 ## 5. Phases
 
-### Phase 1 — Setup (gas/approval)
+### Phase 1 — Setup
 
-- `payment-channel`: the client builds an `open` transaction depositing
-  `maxAmount`. Push: the client broadcasts it and sends `signature`. Pull: the
-  client sends `openTransaction` and the facilitator broadcasts it (the
-  facilitator may co-sign as fee payer, matching `exact`'s fee-sponsorship).
-- `permit`: the client ensures a program-owned delegate is approved on
-  `tokenAccount` for at least `maxAmount`. If absent, the facilitator returns
-  `412 Precondition Failed` with `errorReason = APPROVAL_REQUIRED` and the
-  required `approve` transaction, mirroring EVM's `PERMIT2_ALLOWANCE_REQUIRED`.
+The client builds an `open` transaction depositing `maxAmount`, naming the
+operator as the open's `rentPayer` so the operator funds the channel rent (the
+client supplies only the stablecoin deposit). Push: the client broadcasts it and
+sends `signature`. Pull: the client sends `openTransaction` and the
+server/facilitator broadcasts it, co-signing as fee payer **and** as `rentPayer`
+(one operator signature covers both, matching `exact`'s fee-sponsorship).
 
 ### Phase 2 — Authorization signature
 
-- `payment-channel` (normative v1): the client's signature on the `open`
-  transaction **is** the authorization — it commits the `deposit` ceiling, the
-  `payee`, and the `mint`, with `authorizedSigner` set to the **operator**. The
-  client does not sign a voucher. After metering, the operator signs the single
-  voucher for `cumulativeAmount = actual` (Ed25519 over
-  `channel_id ‖ cumulative_amount_le ‖ expires_at_le`) and settles it. The
-  client is protected by the on-chain ceiling (the operator cannot exceed
-  `deposit`) and the fixed `payee` (the operator cannot redirect) — the same
-  trust model as EVM `upto`, in a single round-trip.
-- `permit`: sign the permit message with `from`.
+The client's signature on the `open` transaction **is** the authorization — it
+commits the `deposit` ceiling, the `payee`, and the `mint`, with
+`authorizedSigner` set to the **operator**. The client does not sign a voucher.
+After metering, the operator signs the single voucher for
+`cumulativeAmount = actual` (Ed25519 over
+`channel_id ‖ cumulative_amount_le ‖ expires_at_le`) and settles it. The client
+is protected by the on-chain ceiling (the operator cannot exceed `deposit`) and
+the fixed `payee` (the operator cannot redirect), in a single round-trip.
 
 ### Phase 3 — Verification (before serving the resource)
 
-The facilitator MUST, in order:
+The server/facilitator MUST, in order:
 
 1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
 2. Confirm `network`, `asset` (mint), `tokenProgram`, and `payTo` match the requirements.
-3. Confirm `feePayer` in `extra` is this server's key.
-4. `payment-channel`: confirm the channel exists (or the `openTransaction` is valid and broadcastable), `channel.deposit ≥ maxAmount`, `channel.payee` and `distribution_hash` match `payTo`/`splits`, `channel.status == Open`, and `channel.mint == asset`. `permit`: recover `permitSignature`, confirm signer is `from`; confirm the delegate allowance and the payer token balance both cover `maxAmount`.
+3. Confirm `feePayer` in `extra` is the operator's own key (the server's, or the facilitator's it delegates to).
+4. Confirm the channel exists (or the `openTransaction` is valid and broadcastable), `channel.deposit ≥ maxAmount`, `channel.payee` and `distribution_hash` match `payTo`/`splits`, `channel.status == Open`, `channel.mint == asset`, **`channel.authorizedSigner == operator`** (so the operator alone can settle and finalize), and the open's **`rentPayer == operator`** (the operator funds and reclaims the rent it co-signs for). An `open` naming any other authorized signer or rentPayer MUST be rejected before co-signing.
 5. Validate `validAfter ≤ now ≤ expiresAt`.
 6. Simulate the settlement instruction(s).
 
@@ -221,39 +184,41 @@ precondition) without serving the resource.
 ### Phase 4 — Settlement (after serving the resource)
 
 At settlement `paymentRequirements.amount` carries the **actual** metered amount.
-The facilitator MUST:
+The server/facilitator MUST:
 
 1. Re-verify the authorization against the **signed ceiling**
    (`maxAmount` / `deposit`), NOT against `paymentRequirements.amount`.
 2. Assert `paymentRequirements.amount ≤ maxAmount`. On violation, fail with
    `invalid_upto_svm_payload_settlement_exceeds_amount`.
-3. Execute:
-   - `payment-channel`: `settle_and_finalize` with the single voucher for the
-     actual cumulative amount, then `distribute` to `payTo`/`splits`. Finalize
-     refunds `deposit − actual` to the payer and closes the channel.
-   - `permit`: submit the verify+settle transaction; the program checks the
-     Ed25519 signature and witness, enforces `actual ≤ maxAmount`, transfers
-     `actual` to `payTo`, and consumes the nonce PDA.
-4. A `0`-amount settlement requires no transfer. `payment-channel` still
-   finalizes (full refund, channel closed); `permit` still consumes the nonce.
-   `transaction` MAY be empty when no token movement occurred.
+3. `settle_and_finalize` with the single voucher for the actual cumulative
+   amount, then `distribute` to `payTo`/`splits`. Finalize refunds
+   `deposit − actual` to the payer and closes the channel.
+4. A `0`-amount settlement requires no transfer; the channel still finalizes
+   (full refund, channel closed). `transaction` MAY be empty when no token
+   movement occurred.
 
 ## 6. Error codes
 
 Standard x402 codes apply. Scheme-specific:
 
 - `invalid_upto_svm_payload_settlement_exceeds_amount` — actual > signed ceiling.
-- `APPROVAL_REQUIRED` (`permit`, with `412`) — delegate approval missing/insufficient.
-- `CHANNEL_REQUIRED` (`payment-channel`, with `412`) — no open channel and no broadcastable `openTransaction`.
+- `CHANNEL_REQUIRED` (with `412`) — no open channel and no broadcastable `openTransaction`.
 
 ## 7. Security properties
 
-- **No overcharge.** `payment-channel`: capped by on-chain `deposit`. `permit`:
-  capped by the signed `maxAmount` enforced inside the program.
-- **No redirection.** `payment-channel`: `channel.payee`/`distribution_hash`
-  fixed at open. `permit`: `payTo` is in the signed message and checked on-chain.
-- **No replay.** `payment-channel`: terminal `ChannelStatus::Finalized` plus
-  monotonic `SettlementWatermarks.settled`. `permit`: one-shot nonce PDA.
+- **No overcharge.** Capped by the on-chain `deposit`.
+- **No redirection.** `channel.payee`/`distribution_hash` fixed at open.
+- **No replay.** Terminal `ChannelStatus::Finalized` plus monotonic
+  `SettlementWatermarks.settled`.
+- **No operator griefing.** The channel's `authorizedSigner` is the operator,
+  which is also the `settle_and_finalize` merchant, so the operator can always
+  settle the metered amount, refund the client's unused deposit, and close the
+  channel without the client. The operator fronts the channel rent (the `open`
+  `rentPayer` account is its own key) and reclaims it at finalize, so the client
+  never needs SOL and cannot strand the operator's funds — the operator's only
+  exposure is the finalize transaction it elects to send. The server/facilitator
+  MUST reject any `open` whose `authorizedSigner` or `rentPayer` is not the
+  operator before co-signing (§5 Phase 3).
 - **Time-bounded.** `validAfter`/`expiresAt` checked off-chain at verify and
   signed into the on-chain message so a stale authorization cannot settle.
 - **Trust model.** As in the generic spec, the client trusts the server to meter
@@ -262,6 +227,6 @@ Standard x402 codes apply. Scheme-specific:
 
 ## 8. Out of scope
 
-Multi-settlement streaming and recurring auto-pay are served by the `session`
-and `subscription` intents, not `upto`. `upto` settles **at most once** per
-authorization.
+Multi-settlement streaming — a long-lived channel reused across many requests —
+is served by the [`batch-settlement`](../batch-settlement/scheme_batch_settlement_svm.md)
+scheme, not `upto`. `upto` settles **at most once** per authorization.

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -88,12 +88,10 @@ The v1 flow uses these program instructions:
 
 The fee/rent sponsor is `extra.feePayer`. It funds the channel PDA and escrow
 ATA rent at `open`; that rent is returned to the recorded `rent_payer` during
-final cleanup (`distribute` fast path, or later `reclaim`). A sponsor SHOULD
-keep or reconstruct an index of channels it opened, for example from `Opened`
-events or channel accounts whose `rent_payer` equals its key, so it can reclaim
-rent for channels that were distributed before the reclaim gate elapsed. This is
-operational bookkeeping; token payouts and client refunds are not delayed by
-`reclaim`.
+final cleanup (`distribute` fast path, or later `reclaim`). A sponsor MAY keep a
+local channel index, but it MUST be able to rediscover the channels it funded
+onchain as specified in [Asynchronous Recovery and Channel Discovery](#6-asynchronous-recovery-and-channel-discovery).
+Token payouts and client refunds are not delayed by `reclaim`.
 
 The client has an escape hatch if the server never settles. The client can call
 `request_close`, which moves the channel to `Closing` and starts the
@@ -366,7 +364,96 @@ The server/facilitator MUST:
 the channel to its cleanup state. `SettlementResponse.transaction` MUST identify
 the confirmed transaction containing that final `distribute`.
 
-## 6. Error Codes
+## 6. Asynchronous Recovery and Channel Discovery
+
+Channel discovery is onchain. A client can discover channels for which it
+provided the deposit by querying channel accounts whose `payer` equals the
+client key. A facilitator or other fee/rent sponsor can discover every channel
+for which it fronted rent by querying accounts whose `rent_payer` equals its
+key. A server can similarly query `payee` or `authorized_signer` to find
+channels it is able to settle. Local storage is therefore an optimization, not
+the source of truth for channel lifecycle or rent recovery.
+
+Implementations MAY retain a local index for request correlation, worker leases,
+and response history. They MUST be able to rebuild the onchain portion of that
+index after local state loss, including at worker startup and periodically while
+they sponsor rent or operate channels.
+
+### 6.1 Discovery RPC
+
+Implementations MUST use `getProgramAccounts` against the canonical
+payment-channels program for the selected network. The channel account layout
+targeted by this version is fixed at 256 bytes. Its public-key field offsets are:
+
+| Channel field | Offset | Discovery use |
+|---|---:|---|
+| `payer` | 88 | Client deposit/channel recovery |
+| `payee` | 120 | Server/operator channel recovery |
+| `authorized_signer` | 152 | Server settlement-authority recovery |
+| `rent_payer` | 216 | Facilitator/sponsor rent recovery |
+
+For example, a facilitator discovers channels for which it paid rent using a
+base58-encoded public key in a `memcmp` filter:
+
+```json
+{
+  "encoding": "base64",
+  "commitment": "confirmed",
+  "filters": [
+    { "dataSize": 256 },
+    { "memcmp": { "offset": 216, "bytes": "<feePayer>" } }
+  ]
+}
+```
+
+The client uses the same request with `offset: 88` and its payer key. An
+implementation MAY add one of the other listed filters to narrow its result
+set. It MUST decode each returned account with the program's supported channel
+codec and reject an account whose owner, discriminator, version, length, or PDA
+does not match the selected program and its decoded channel fields. In
+particular, the implementation MUST rederive the PDA from `payer`, `payee`,
+`mint`, `authorized_signer`, `salt`, and `open_slot` before treating the account
+as a recovered channel. Implementations MUST NOT rely on these byte offsets for
+an unsupported future channel-account version.
+
+### 6.2 Asynchronous recovery flow
+
+The scan is asynchronous maintenance work, not part of the paid HTTP request.
+An implementation that has lost its local state, or that resumes after a
+restart, MUST perform the following flow:
+
+1. Query and decode its matching channel accounts as described above, then
+   upsert the validated account address and its current status into a local work
+   queue. The queue is disposable; a later scan is always able to reconstruct
+   it from chain state.
+2. Before submitting an action, refetch the channel and revalidate its status.
+   Multiple workers and normal user activity can change a channel between the
+   scan and submission. A transition failure caused by stale state MUST cause
+   the worker to refetch and reclassify the channel, rather than assuming that
+   cleanup failed.
+3. For an `Open` channel, the server may resume settlement only when it has
+   recovered the application metering result and can obtain the required
+   `receiverAuthorizer` signatures. Otherwise it MUST NOT invent a nonzero
+   charge. The server may perform the no-voucher, zero-charge close path; the
+   client may instead begin its `request_close` escape hatch.
+4. For a `Closing` channel, schedule a recheck when the recorded grace period
+   expires. The server can still settle during that period; after it, the normal
+   `seal`, payer withdrawal, and distribution path applies.
+5. For a `Sealed` channel, submit or relay the remaining distribution/withdrawal
+   actions permitted by the channel state. For a `Distributed` channel, schedule
+   `reclaim` after its open-slot reclaim gate. `reclaim` is permissionless, but
+   the program returns the recovered SOL rent only to the recorded `rent_payer`.
+
+A fee/rent sponsor has discovery and relay capability, not payment authority:
+it cannot create a nonzero settlement or close a channel by itself without the
+server-controlled `receiverAuthorizer` authorization required elsewhere in this
+spec. Likewise, onchain recovery does not reconstruct application-specific
+metering, request/response correlation, or an unpersisted settlement voucher.
+Those records MAY be kept offchain; if they are lost, the server MUST take the
+conservative no-charge or client-initiated close path rather than charging based
+on a guess.
+
+## 7. Error Codes
 
 Standard x402 codes apply. Scheme-specific:
 
@@ -376,7 +463,7 @@ Standard x402 codes apply. Scheme-specific:
   `openTransaction` that can be co-signed, broadcast, and confirmed before
   serving the resource.
 
-## 7. Security Properties
+## 8. Security Properties
 
 - **No overcharge.** Capped by the onchain `deposit`; verifier requires
   `deposit == maxAmount`.
@@ -404,7 +491,7 @@ Standard x402 codes apply. Scheme-specific:
   server to meter honestly within the ceiling. The ceiling, recipient, and
   replay properties are enforced by signatures and the onchain program.
 
-## 8. Out of Scope
+## 9. Out of Scope
 
 Multi-settlement streaming or long-lived channels reused across many requests
 are served by [`batch-settlement`](../batch-settlement/scheme_batch_settlement.md)

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -144,17 +144,40 @@ Common fields:
 | `maxAmount` | string | The signed ceiling (base units). MUST equal verification-phase `amount`. |
 | `expiresAt` | number | Deadline (Unix seconds); signed into the on-chain message |
 | `validAfter` | number | Activation time (Unix seconds) |
-| `nonce` | string | Unique per authorization |
+| `nonce` | string | Unique per authorization. For `payment-channel`, interpreted as the decimal `u64` `salt` encoded in the `open` instruction. |
 
 Plus the channel fields:
 
 | Field | Type | Notes |
 |---|---|---|
-| `channelId` | string | Channel PDA (base58) |
+| `channelId` | string | Channel PDA (base58), derived before `open` from the fields below |
 | `deposit` | string | On-chain escrow = the ceiling; MUST equal `maxAmount` |
 | `authorizedSigner` | string | The **operator** key (base58) — the server's or facilitator's pubkey, equal to `extra.feePayer` **and** to `channel.payee`. The operator — not the client — signs the single settlement voucher (see §5 Phase 2); because it is also the channel `payee` (the `settle_and_finalize` merchant) it alone can settle and finalize the channel. |
-| `openTransaction` | string | Base64 signed `open` transaction for the server/facilitator to broadcast if the channel is not yet open (pull-style). Omitted if the client already broadcast `open` (push-style) and `signature` is set. |
-| `signature` | string | Base58 signature of the broadcast `open` transaction (push) |
+| `openTransaction` | string | Base64 client-signed `open` transaction for the server/facilitator to co-sign and broadcast if the channel is not yet open. |
+
+`channelId` is the program-derived address:
+
+```text
+find_program_address(
+  [
+    "channel",
+    from,
+    channel_payee,
+    asset,
+    authorizedSigner,
+    u64(nonce).to_le_bytes()
+  ],
+  extra.channelProgram
+)
+```
+
+For this profile, `channel_payee == authorizedSigner == extra.feePayer`. Because
+the channel address is a PDA, the client knows `channelId` before the channel is
+opened. The client MUST derive it before signing `openTransaction`, include the
+same PDA as the writable `channel` account in the `open` instruction, and set
+`payload.channelId` to that address. The server/facilitator MUST rederive the
+PDA from the decoded `openTransaction` and reject the payload if it differs from
+either the decoded `channel` account or `payload.channelId`.
 
 > The voucher is **not** carried in the payload. Because the actual amount is
 > only known after the resource is consumed, and the client's protection is the
@@ -180,10 +203,10 @@ Plus the channel fields:
 
 The client builds an `open` transaction depositing `maxAmount`, naming the
 operator as the open's `rentPayer` so the operator funds the channel rent (the
-client supplies only the stablecoin deposit). Push: the client broadcasts it and
-sends `signature`. Pull: the client sends `openTransaction` and the
-server/facilitator broadcasts it, co-signing as fee payer **and** as `rentPayer`
-(one operator signature covers both, matching `exact`'s fee-sponsorship).
+client supplies only the stablecoin deposit). The client sends
+`openTransaction`; the server/facilitator co-signs it as fee payer **and** as
+`rentPayer`, then broadcasts it (one operator signature covers both, matching
+`exact`'s fee-sponsorship).
 
 ### Phase 2 — Authorization signature
 

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -122,7 +122,6 @@ to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
 | `profiles` | string[] | ✓ | `["payment-channel"]` (the only v1 profile) |
 | `feePayer` | string | ✓ | Base58 operator key that sponsors fees (co-signs the setup transaction as fee payer) and settles |
 | `channelProgram` | string | ✓ | Base58 payment-channels program id. Clients and facilitators MUST reject unsupported program ids for the selected `network`. |
-| `decimals` | number | ✓ | Token decimals |
 | `tokenProgram` | string | ✓ | `Tokenkeg…` or `TokenzQ…` (Token-2022); the client SHOULD verify it against the on-chain mint owner |
 | `recentBlockhash` | string | – | Pre-fetched blockhash so the client can build setup transactions without an extra RPC round-trip |
 | `validAfter` | number | – | Earliest activation time (Unix seconds); default = now |

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -10,155 +10,153 @@
 ## 1. Purpose
 
 `upto` lets a client authorize a **maximum** amount while the server settles for
-**actual** usage (`actual ≤ max`), with the final charge determined after the
+**actual** usage (`actual <= max`), with the final charge determined after the
 resource is consumed. Same target use cases as the generic spec: LLM token
-billing, per-byte metering, dynamic compute pricing.
+billing, per-byte metering, and dynamic compute pricing.
 
-A normal signed transfer commits to an *exact* amount
-and exact instruction data, so the server cannot lower the amount after the
-client signs without invalidating the signature. `upto` therefore requires an
-authorization that commits the client to a **ceiling** and lets the
-**operator** choose the actual amount at settlement. On SVM this is realized with
-an on-chain **payment channel**: the client escrows the ceiling, and the operator
-settles the actual amount against it with a single signed voucher.
+A normal signed SVM transfer commits to an exact amount and exact instruction
+data, so the server cannot lower the amount after the client signs without
+invalidating the signature. SVM `upto` therefore uses the
+[payment-channels program](https://github.com/solana-foundation/payment-channels):
+the client escrows the ceiling in an onchain channel, and the server later
+settles the actual amount with a signed cumulative voucher.
 
-The **operator** is the party that co-signs the channel `open` as fee payer and
-submits settlement — the **server itself, or a facilitator it delegates to**
-(advertised as `extra.facilitatorAddress`). When `extra.facilitatorAddress` is
-omitted, the operator is `payTo`, so the server self-facilitates by running
-verify and settle directly. "Server/facilitator" below denotes whichever fills
-the operator role.
+The x402 roles map to the payment-channel program as follows:
 
-The operator fills every channel role that must act without the client: the
-`open` fee payer and `rentPayer`, the voucher `authorizedSigner`, **and the
-channel `payee`** — which the program requires as the `settle_and_finalize`
-signer (the program checks `merchant == channel.payee`). The x402 `payTo` (the
-resource server's revenue address) is realized as a **program-enforced
-distribution split** fixed at `open`: when the server self-facilitates it simply
-*is* the operator/payee and receives the settled amount directly; when a
-separate facilitator is the operator, `payTo` is a locked split recipient and
-`extra.facilitatorFee` is the facilitator's basis-point share, paid through the
-payee's implicit remainder. This is why a third-party facilitator needs no
-program change — the x402 fields map to the payment-channel program's native
-split support.
+- **Client**: channel `payer`; signs the `open` transaction and funds the
+  stablecoin deposit.
+- **Server**: resource provider; receives funds at `payTo`; determines the
+  actual metered charge after serving the resource.
+- **Receiver authorizer**: server-controlled hot key advertised as
+  `extra.receiverAuthorizer`; set as both channel `payee` and
+  `authorized_signer`; signs the settlement voucher and the cooperative close
+  instruction. It does not need to hold SOL or token funds.
+- **Facilitator / sponsor**: account advertised as `extra.feePayer`; sponsors
+  transaction fees and channel rent by co-signing the channel `open` as
+  transaction fee payer and program `rent_payer`. The server MAY self-facilitate
+  by using its own key as `feePayer`.
+
+This keeps the facilitator out of the payment authority path. A third-party
+facilitator cannot close or refund the channel on its own, because
+`settle_and_seal` requires the channel `payee` signature and vouchers must be
+signed by `authorized_signer`; in this scheme both are `receiverAuthorizer`.
 
 ## 2. Mapping the five core requirements to SVM
 
 | Requirement (generic spec) | SVM mechanism |
 |---|---|
-| Single-use authorization | `finalize` makes the channel terminal (`ChannelStatus::Finalized`). |
-| Time-bound validity (`validAfter`, `expiresAt`) | `expiresAt` is signed by the operator into the on-chain voucher and enforced by the program (settle rejected once `now ≥ expiresAt`); `validAfter` is off-chain verify-time policy only. Neither is client-bound — the client signs only `open`. |
-| Recipient binding | `channel.payee` (the operator) + `distribution_hash` (the `payTo` / `facilitatorFee` split) fixed at open; the program re-checks the distribution at `distribute`. |
-| Maximum amount enforcement | On-chain `deposit` ceiling, `cumulative_amount ≤ deposit`; the verifier pins `deposit == maxAmount` so the ceiling is exact, not advisory. |
+| Single-use authorization | The x402 authorization is a one-request channel. Settlement uses `settle_and_seal` followed by a final `distribute`; after sealing and final distribution, the authorization cannot be used again for `upto`. |
+| Time-bound validity (`validAfter`, `expiresAt`) | `expiresAt` is signed by `receiverAuthorizer` into the voucher and enforced by the program (`now < expiresAt`). Although the program supports `expires_at == 0` as no expiry, SVM `upto` MUST reject `expiresAt == 0`. `validAfter` is offchain verify-time policy. Neither value is client-bound; the client signs only `open`. |
+| Recipient binding | The `open` transaction fixes `distribution_hash`. For this scheme the distribution sends 100% of settled funds to `payTo`, unless `payTo == receiverAuthorizer`, where the channel payee's implicit remainder is sufficient. The program re-checks the distribution at `distribute`. |
+| Maximum amount enforcement | Onchain `deposit` is the ceiling and vouchers must satisfy `settled < cumulative_amount <= deposit`; the verifier pins `deposit == maxAmount` so the x402 ceiling is exact, not advisory. |
 | Phase-dependent amount semantics | `amount` in `PaymentRequirements` is the max during verification and the actual charge during settlement. |
 
-The server/facilitator MUST always verify against the client-signed ceiling,
-never against the settlement-time `amount`.
+The facilitator MUST always verify against the client-signed ceiling, never
+against the settlement-time `amount`.
 
-## 3. Payment-channel asset transfer method
+## 3. Payment-channel Method
 
-SVM `upto` defines a single asset transfer method, `payment-channel`, carried in
-`extra.assetTransferMethod`. It is backed by the on-chain payment-channels
-program (advertised via `extra.channelProgram`). The escrow **deposit is the
-ceiling**; a single operator-signed
-voucher locks the actual amount via `settle_and_finalize`, and `distribute` then
-moves the funds — paying out the sealed `payTo` / facilitator-fee distribution,
-refunding the unused `deposit − actual` to the payer, returning the fronted rent
-to the operator, and closing (tombstoning) the channel. Note
-`settle_and_finalize`/`finalize` only
-advance channel *status*; the token movement, refund, and close all happen in
-`distribute` (the two can be bundled in one transaction).
+SVM `upto` v1 defines a single payment method backed by the payment-channels
+program. Because there is only one method, the wire format does not include an
+`extra.assetTransferMethod` discriminator.
 
-Strengths: every requirement is enforced on-chain by the program. The operator
-cannot overcharge (capped by `deposit`), cannot redirect funds (the `payTo` /
-facilitator-fee distribution and `distribution_hash` are fixed at open and
-re-checked by the program at `distribute`), and cannot replay (channel is
-terminal after `finalize`).
-Conversely, because the operator is the channel `payee` (hence the
-`settle_and_finalize` merchant) **and** the voucher `authorizedSigner`, it can
-settle and finalize **at any time** — locking the metered amount, refunding the
-client's unused deposit, and closing the channel — without the client's
-cooperation. The channel-account rent is fronted by the operator: the `open`
-instruction's `rentPayer` account (the operator's own key) funds the PDA and
-escrow-ATA rent, and `distribute` **returns it to that `rentPayer`** on close —
-so the client moves only stablecoin and never needs SOL. The operator can settle
-a stale channel at will, reclaiming the rent it fronted; its only exposure is the
-cheap settle-and-finalize + distribute transaction.
+The canonical program id is a network/SDK constant, not a server-provided wire
+field. For the current mainnet deployment:
 
-Cost: the client locks `max` in escrow for the lifetime of the request, and the
-flow needs two on-chain transactions (open, then settle-and-finalize). The
-channel-account rent is funded by the operator (the `open` `rentPayer` account)
-and reclaimed at finalize; the client supplies only the stablecoin deposit and
-never needs SOL.
+```text
+CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX
+```
 
-The program stores `rentPayer` in channel state, so rent can only be returned to
-the account that funded it. A server/facilitator that sponsors rent SHOULD keep
-or reconstruct an index of channels it opened, for example from `Opened` events
-or channel accounts where `rentPayer` equals the operator. It can then close
-stale channels and reclaim rent by finalizing and distributing them; a no-charge
-cleanup uses the no-voucher `settle_and_finalize` path followed by `distribute`.
-This indexing is operational bookkeeping, not a trust assumption.
+Implementations MUST target the canonical payment-channels program id for the
+selected `network` and MUST NOT trust or negotiate a `channelProgram` value from
+`extra`. Program documentation and instruction references live in the
+[payment-channels repository](https://github.com/solana-foundation/payment-channels).
 
-> **Reference-implementation status.** The v1 reference implements the
-> **self-facilitating** case (`operator == payTo`), where the operator is both
-> the settlement authority (`channel.payee`) and the recipient. Separate-facilitator
-> operation — where `payTo` is a program-enforced distribution split and the
-> facilitator is the `channel.payee` — is specified (§4.1) but not yet implemented;
-> the reference rejects an open whose `payTo` is not the operator.
+The v1 flow uses these program instructions:
 
-## 4. Wire format
+1. `open`: creates a channel PDA, escrows `maxAmount`, stores
+   `grace_period == extra.withdrawDelay`, and commits the payout distribution.
+2. `settle_and_seal`: payee-signed cooperative close. It optionally applies the
+   final voucher, locks the settled watermark, and moves the channel to
+   `Sealed`.
+3. `distribute`: pays `payTo`, refunds `deposit - actual` to the client, closes
+   the escrow token account, and either deallocates the channel PDA immediately
+   or marks it `Distributed` until `reclaim` is allowed.
+4. `reclaim`: permissionless cleanup for `Distributed` channels once
+   `clock.slot > open_slot + OPEN_SLOT_WINDOW`; it returns the remaining PDA
+   rent to the recorded `rent_payer`.
 
-`upto` reuses the x402 v2 transport: a `402` response carries `PAYMENT-REQUIRED`;
-the paid retry carries `PAYMENT-SIGNATURE`; the response carries
-`PAYMENT-RESPONSE`. Only the `scheme` value and the payload shape change relative
-to `exact`.
+The fee/rent sponsor is `extra.feePayer`. It funds the channel PDA and escrow
+ATA rent at `open`; that rent is returned to the recorded `rent_payer` during
+final cleanup (`distribute` fast path, or later `reclaim`). A sponsor SHOULD
+keep or reconstruct an index of channels it opened, for example from `Opened`
+events or channel accounts whose `rent_payer` equals its key, so it can reclaim
+rent for channels that were distributed before the reclaim gate elapsed. This is
+operational bookkeeping; token payouts and client refunds are not delayed by
+`reclaim`.
+
+The client has an escape hatch if the server never settles. The client can call
+`request_close`, which moves the channel to `Closing` and starts the
+`withdrawDelay` grace period fixed at `open`. The server can still
+`settle_and_seal` during that grace period. After the grace period, anyone can
+call `seal`; the payer can then call `withdraw_payer` to recover
+`deposit - settled`, and `distribute`/`reclaim` can finish cleanup.
+
+## 4. Wire Format
+
+`upto` reuses the x402 v2 transport: a `402` response carries
+`PAYMENT-REQUIRED`; the paid retry carries `PAYMENT-SIGNATURE`; the response
+carries `PAYMENT-RESPONSE`. Only the `scheme` value and payload shape differ
+from `exact`.
 
 ### 4.1 `PaymentRequirements` (in `PAYMENT-REQUIRED.accepts[]`)
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `scheme` | string | ✓ | `"upto"` |
-| `network` | string | ✓ | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (mainnet), `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (devnet) |
-| `amount` | string | ✓ | **Phase-dependent**: max authorized at verification; actual charge at settlement. Base units. |
-| `asset` | string | ✓ | SPL mint address (e.g. USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) |
-| `payTo` | string | ✓ | Base58 final recipient. When the server self-facilitates, `payTo` is also the operator/channel `payee`. When `extra.facilitatorAddress` is present, `payTo` is realized as a program-enforced distribution split and the facilitator is the operator/channel `payee`. |
-| `maxTimeoutSeconds` | number | ✓ | Completion window; also the basis for the authorization `expiresAt` |
-| `extra` | object | ✓ | See below |
+| `scheme` | string | yes | `"upto"` |
+| `network` | string | yes | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` |
+| `amount` | string | yes | Phase-dependent: max authorized at verification; actual charge at settlement. Base units. |
+| `asset` | string | yes | SPL mint address, e.g. USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
+| `payTo` | string | yes | Base58 final payment recipient. This is normally a server cold wallet, not the hot `receiverAuthorizer`. |
+| `maxTimeoutSeconds` | number | yes | Completion window; basis for `expiresAt` |
+| `extra` | object | yes | See below |
 
 `extra`:
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `assetTransferMethod` | string | ✓ | MUST be `"payment-channel"`. This value selects the remaining `extra` fields in this table. |
-| `facilitatorAddress` | string | – | Base58 operator key. If omitted, `payTo` is the operator. If present, this key sponsors fees/rent, co-signs the setup transaction, and settles. |
-| `facilitatorFee` | number | – | Facilitator fee in basis points of the settled amount. Default `0`. MUST be an integer `0..10000`. MUST be omitted or `0` when `facilitatorAddress` is omitted. |
-| `channelProgram` | string | ✓ | Base58 payment-channels program id. Clients and facilitators MUST reject unsupported program ids for the selected `network`. |
-| `tokenProgram` | string | ✓ | `Tokenkeg…` or `TokenzQ…` (Token-2022); the client SHOULD verify it against the on-chain mint owner |
-| `recentBlockhash` | string | – | Pre-fetched blockhash so the client can build setup transactions without an extra RPC round-trip |
-| `validAfter` | number | – | Earliest activation time (Unix seconds); default = now |
+| `feePayer` | string | yes | Base58 sponsor key that co-signs `open` as transaction fee payer and channel `rent_payer`, and co-signs settlement transactions as fee payer. MAY equal `receiverAuthorizer` for self-facilitation. |
+| `receiverAuthorizer` | string | yes | Base58 server-controlled key set as channel `payee` and `authorized_signer`; signs vouchers and `settle_and_seal`. |
+| `withdrawDelay` | number | yes | Server-defined `grace_period` in seconds. The client MUST encode this exact value in `open`; the verifier MUST reject any other value. MUST be an integer greater than zero. |
+| `tokenProgram` | string | yes | `Tokenkeg...` or `TokenzQ...` (Token-2022); the client SHOULD verify it against the onchain mint owner. |
+| `recentBlockhash` | string | no | Pre-fetched blockhash so the client can build `openTransaction` without an RPC round trip. |
+| `recentSlot` | number | no | Recent slot the client MAY use as `openSlot` when it does not fetch its own slot. The `open` instruction still enforces the program's slot window. |
+| `validAfter` | number | no | Earliest activation time (Unix seconds); default = now. |
 
 The x402 wire format does not expose program-specific split arrays. The client
-derives the payment-channel distribution from `payTo`, `facilitatorAddress`, and
-`facilitatorFee`:
+derives the payment-channel accounts and distribution from the x402 fields:
 
 ```text
-operator = extra.facilitatorAddress ?? payTo
-facilitator_fee_bps = extra.facilitatorFee ?? 0
-pay_to_bps = 10000 - facilitator_fee_bps
-channel.payee = operator
-channel.authorizedSigner = operator
+rent_payer = extra.feePayer
+payee = extra.receiverAuthorizer
+authorized_signer = extra.receiverAuthorizer
+grace_period = extra.withdrawDelay
+
+if payTo == extra.receiverAuthorizer:
+  recipients = []
+  payee_implicit_remainder_bps = 10000
+else:
+  recipients = [{ recipient: payTo, bps: 10000 }]
+  payee_implicit_remainder_bps = 0
 ```
 
-If `operator == payTo` and `facilitator_fee_bps == 0`, the client MAY omit the
-program `recipients` array because the channel payee receives the implicit
-remainder. If `operator != payTo`, the client MUST encode `payTo` as a
-recipient with `pay_to_bps`; the facilitator receives the implicit remainder as
-its fee. The server/facilitator MUST rederive this distribution and verify that
-the decoded `openTransaction` seals the matching `distribution_hash`.
+Any facilitator commercial fee is outside this wire contract or included in the
+server's pricing. The channel distribution for `upto` MUST NOT assign any
+portion of the settled amount away from `payTo`, except when `payTo` is itself
+the channel payee via the implicit remainder path above.
 
-Examples:
-
-Self-facilitating server (`operator == payTo`):
+Example: server self-facilitates while using a hot receiver key and cold payout
+wallet:
 
 ```json
 {
@@ -166,18 +164,20 @@ Self-facilitating server (`operator == payTo`):
   "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
   "amount": "10000",
   "asset": "<mint>",
-  "payTo": "<merchant/operator>",
+  "payTo": "<server-cold-wallet>",
   "maxTimeoutSeconds": 300,
   "extra": {
-    "assetTransferMethod": "payment-channel",
-    "channelProgram": "CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX",
+    "feePayer": "<server-hot-wallet>",
+    "receiverAuthorizer": "<server-hot-wallet>",
+    "withdrawDelay": 3600,
     "tokenProgram": "<token-program>",
-    "recentBlockhash": "<cached>"
+    "recentBlockhash": "<cached>",
+    "recentSlot": 341000000
   }
 }
 ```
 
-Separate facilitator (`operator == extra.facilitatorAddress`):
+Example: server uses an external facilitator for fee/rent sponsorship:
 
 ```json
 {
@@ -185,47 +185,33 @@ Separate facilitator (`operator == extra.facilitatorAddress`):
   "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
   "amount": "10000",
   "asset": "<mint>",
-  "payTo": "<merchant>",
+  "payTo": "<server-cold-wallet>",
   "maxTimeoutSeconds": 300,
   "extra": {
-    "assetTransferMethod": "payment-channel",
-    "facilitatorAddress": "<operator>",
-    "facilitatorFee": 0,
-    "channelProgram": "CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX",
+    "feePayer": "<facilitator>",
+    "receiverAuthorizer": "<server-hot-wallet>",
+    "withdrawDelay": 3600,
     "tokenProgram": "<token-program>",
-    "recentBlockhash": "<cached>"
+    "recentBlockhash": "<cached>",
+    "recentSlot": 341000000
   }
 }
 ```
-
-`channelProgram` is discovery, not a trust anchor. The client consumes it to
-derive the channel address and build the `open` transaction; the
-server/facilitator consumes it to verify and settle the channel. Implementations
-MUST maintain a supported-program set per `network` and reject any
-`channelProgram` outside that set. The server/facilitator MUST verify that the
-`openTransaction`, settlement, and distribution instructions target exactly
-`extra.channelProgram`.
 
 ### 4.2 `UptoPayload` (in `PAYMENT-SIGNATURE.payload`)
 
-Common fields:
-
 | Field | Type | Notes |
 |---|---|---|
-| `from` | string | Payer wallet (base58) |
-| `maxAmount` | string | The signed ceiling (base units). MUST equal verification-phase `amount`. |
-| `expiresAt` | number | Deadline (Unix seconds); signed into the on-chain message |
-| `validAfter` | number | Activation time (Unix seconds) |
-| `nonce` | string | Unique per authorization. For `payment-channel`, interpreted as the decimal `u64` `salt` encoded in the `open` instruction. |
-
-Plus the channel fields:
-
-| Field | Type | Notes |
-|---|---|---|
-| `channelId` | string | Channel PDA (base58), derived before `open` from the fields below |
-| `deposit` | string | On-chain escrow = the ceiling; MUST equal `maxAmount` |
-| `authorizedSigner` | string | The **operator** key (base58): `extra.facilitatorAddress` when present, otherwise `payTo`. It MUST equal `channel.payee`. The operator — not the client — signs the single settlement voucher (see §5 Phase 2); because it is also the channel `payee` (the `settle_and_finalize` merchant) it alone can settle and finalize the channel. |
-| `openTransaction` | string | Base64 partially signed `open` transaction. The client signature is present; the operator signature is still required for the transaction fee payer and `rentPayer` before broadcast. |
+| `from` | string | Payer wallet (base58). |
+| `maxAmount` | string | Signed ceiling in base units. MUST equal verification-phase `amount`. |
+| `expiresAt` | number | Nonzero deadline (Unix seconds); signed into the server voucher. |
+| `validAfter` | number | Activation time (Unix seconds). |
+| `nonce` | string | Unique decimal `u64` salt encoded in the `open` instruction. |
+| `openSlot` | number | `u64` slot encoded in the `open` instruction and used as a channel PDA seed. |
+| `channelId` | string | Channel PDA (base58), derived before `open` from the fields below. |
+| `deposit` | string | Onchain escrow amount. MUST equal `maxAmount`. |
+| `authorizedSigner` | string | MUST equal `extra.receiverAuthorizer`; included for explicit payload validation. |
+| `openTransaction` | string | Base64 partially signed `open` transaction. The client signature is present; the `feePayer`/`rent_payer` signature is still required before broadcast. |
 
 `channelId` is the program-derived address:
 
@@ -234,177 +220,193 @@ find_program_address(
   [
     "channel",
     from,
-    channel_payee,
+    extra.receiverAuthorizer,
     asset,
-    authorizedSigner,
-    u64(nonce).to_le_bytes()
+    extra.receiverAuthorizer,
+    u64(nonce).to_le_bytes(),
+    u64(openSlot).to_le_bytes()
   ],
-  extra.channelProgram
+  CANONICAL_PAYMENT_CHANNELS_PROGRAM_ID
 )
 ```
 
-For `payment-channel`, `channel_payee == authorizedSigner == operator`, where
-`operator = extra.facilitatorAddress ?? payTo`.
-Because the channel address is a PDA, the client knows `channelId` before the
-channel is opened. The client MUST derive it before signing `openTransaction`,
-include the same PDA as the writable `channel` account in the `open`
-instruction, and set `payload.channelId` to that address. The
-server/facilitator MUST rederive the PDA from the decoded `openTransaction` and
-reject the payload if it differs from either the decoded `channel` account or
-`payload.channelId`.
+The client MUST derive `channelId` before signing `openTransaction`, include the
+same PDA as the writable `channel` account in the `open` instruction, and set
+`payload.channelId` to that address. The server/facilitator MUST rederive the
+PDA from the decoded `openTransaction` and reject the payload if it differs from
+either the decoded `channel` account or `payload.channelId`.
 
-> The voucher is **not** carried in the payload. Because the actual amount is
-> only known after the resource is consumed, and the client's protection is the
-> on-chain `deposit` ceiling plus the fixed `payee`, the operator (set as the
-> channel's `authorizedSigner` at open) signs the single voucher for the metered
-> amount at settlement. This keeps `upto` a single HTTP round-trip with a
-> handler-determined amount: the server fills in `actual ≤ ceiling`.
+The `open` instruction MUST encode:
+
+- `salt == u64(payload.nonce)`
+- `deposit == payload.maxAmount`
+- `grace_period == extra.withdrawDelay`
+- `open_slot == payload.openSlot`
+- `rent_payer == extra.feePayer`
+- `payee == extra.receiverAuthorizer`
+- `authorized_signer == extra.receiverAuthorizer`
+- the distribution derived from `payTo` as specified in section 4.1
+
+The voucher is not carried in the client payload. After metering, the server
+signs an Ed25519 voucher with `receiverAuthorizer`. The signed message is:
+
+```text
+0x56 0x01 || channelId || u64(cumulativeAmount).le || i64(expiresAt).le
+```
+
+where `cumulativeAmount == actual` for `upto`. The voucher is supplied to the
+program through the Ed25519 native-program instruction immediately preceding
+`settle_and_seal`.
 
 ### 4.3 `SettlementResponse` (in `PAYMENT-RESPONSE`)
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `success` | boolean | ✓ | |
-| `errorReason` | string | – | Omitted on success |
-| `payer` | string | – | `from` |
-| `transaction` | string | ✓ | Base58 transaction signature (tx hash) for the confirmed transaction that finalizes and distributes the channel. MUST NOT be empty, including when `amount` is `0`. |
-| `network` | string | ✓ | CAIP-2 |
-| `amount` | string | ✓ | Actual base units charged (may be `0`) |
+| `success` | boolean | yes |  |
+| `errorReason` | string | no | Omitted on success. |
+| `payer` | string | no | `from`. |
+| `transaction` | string | yes | Base58 transaction signature for the confirmed transaction containing the final `distribute` instruction. MUST NOT be empty, including when `amount` is `0`. |
+| `network` | string | yes | CAIP-2. |
+| `amount` | string | yes | Actual base units charged, which MAY be `0`. |
+
+If final `distribute` marks the channel `Distributed` because the reclaim gate
+has not elapsed, the later `reclaim` transaction is not the x402 settlement
+transaction. `distribute` is sufficient for x402 success because it moves the
+settled funds, refunds the client, and closes the escrow token account.
 
 ## 5. Phases
 
-### Phase 1 — Setup
+### Phase 1 - Setup
 
-The client builds an `open` transaction depositing `maxAmount`, naming the
-operator as the open's `rentPayer` so the operator funds the channel rent (the
-client supplies only the stablecoin deposit). Rent is paid during `open`: the
-payment-channels program requires the `rentPayer` account to be a signer because
-the instruction transfers SOL from that account to fund the channel PDA and
-escrow ATA rent. Merely naming the operator as `rentPayer` is not sufficient.
+The server returns `feePayer`, `receiverAuthorizer`, and `withdrawDelay` in the
+402 response. The client builds an `open` transaction against the canonical
+payment-channels program, deposits `maxAmount`, sets `rent_payer` to
+`extra.feePayer`, sets `payee` and `authorized_signer` to
+`extra.receiverAuthorizer`, and signs as channel `payer`.
 
-The client therefore sends a partially signed `openTransaction`; the
-server/facilitator validates it, co-signs it as transaction fee payer **and** as
-`rentPayer`, then broadcasts it (one operator signature covers both, matching
-`exact`'s fee-sponsorship). Without the operator signature, the transaction is
-invalid and cannot charge rent to the operator.
+The client sends only a partially signed `openTransaction`. The
+server/facilitator validates it, signs it as transaction fee payer and as
+program `rent_payer`, broadcasts it during verification, and waits until the
+channel account is confirmed `Open` before the protected resource is served.
+The open transaction MUST NOT be deferred until settlement.
 
-`openTransaction` is consumed during verification, before the protected resource
-is served. The server/facilitator MUST NOT defer broadcasting `openTransaction`
-until settlement. If the channel is not already open, verification MUST co-sign
-and broadcast `openTransaction`, wait until the channel account is confirmed
-`Open`, and then continue with the checks below.
+### Phase 2 - Authorization
 
-### Phase 2 — Authorization signature
+The client's signature on `openTransaction` is the client's authorization: it
+commits the deposit ceiling, mint, `withdrawDelay`, `openSlot`, and fixed
+distribution to `payTo`.
 
-The client's signature on the `open` transaction **is** the authorization — it
-commits the `deposit` ceiling, the `mint`, and the sealed distribution
-(`distribution_hash` over the `payTo` / `facilitatorFee` distribution), with
-`payee` and `authorizedSigner` set to the **operator**. The client does not sign
-a voucher. After metering, the operator signs the single voucher for
-`cumulativeAmount = actual` (Ed25519 over
-`channel_id ‖ cumulative_amount_le ‖ expires_at_le`) and settles it. The client
-is protected by the on-chain ceiling (the operator cannot exceed `deposit`) and
-the sealed distribution (the operator cannot redirect or shortchange `payTo`),
-in a single round-trip.
+The server's later settlement authorization is separate. The
+`receiverAuthorizer` key signs the voucher for the actual amount and signs the
+`settle_and_seal` transaction. That transaction may be constructed by the server
+or by the facilitator, but the `receiverAuthorizer` signature MUST cover the
+`settle_and_seal` instruction before the facilitator co-signs and broadcasts.
+This signature also authenticates the otherwise unauthenticated facilitator
+`settle/` HTTP request: the facilitator MUST NOT settle, seal, or refund a
+channel unless the submitted settlement is authorized by `receiverAuthorizer`.
 
-### Phase 3 — Verification (before serving the resource)
+### Phase 3 - Verification (before serving the resource)
 
 The server/facilitator MUST, in order:
 
 1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
-2. Confirm `extra.assetTransferMethod == "payment-channel"` and `network`, `asset` (mint), `tokenProgram`, `channelProgram`, and `payTo` match the requirements.
-3. Determine `operator = extra.facilitatorAddress ?? payTo`. If
-   `facilitatorAddress` is present, confirm it is the facilitator's own key. If
-   `facilitatorAddress` is absent, confirm the server self-facilitates as
-   `payTo`. Confirm `extra.facilitatorFee` is absent or an integer basis-point
-   value in `0..10000`, and that it is `0` when `facilitatorAddress` is absent.
+2. Confirm `network`, `asset` (mint), `tokenProgram`, and `payTo` match the
+   selected requirements.
+3. Confirm `extra.feePayer` is the sponsor key that will co-sign the
+   transaction, `extra.receiverAuthorizer` is the server's configured receiver
+   authorizer, and `extra.withdrawDelay` is an integer greater than zero.
 4. Confirm the channel is open:
-   - If it does not yet exist, validate that `openTransaction` targets
-     `extra.channelProgram`, names `rentPayer == operator` with `rentPayer`
-     marked as a required signer, names no other payee or authorized signer than
-     the operator, seals the distribution derived from `payTo` and
-     `facilitatorFee`, and is otherwise valid for the requirements; then
-     co-sign, broadcast, and wait until the channel account is confirmed `Open`.
-   - After the channel is open, confirm **`channel.deposit == maxAmount`**
-     (exact, not `≥`: `topUp` can raise an open channel's deposit, so only
-     equality keeps the x402 ceiling enforced rather than advisory),
-     `distribution_hash` matches the intended `payTo` / `facilitatorFee`
-     distribution (so `payTo`'s payout is locked on-chain),
-     `channel.status == Open`,
-     `channel.mint == asset`, and
-     **`channel.payee == channel.authorizedSigner == operator`** (so the
-     operator is both the voucher signer and the `settle_and_finalize` merchant,
-     and alone can settle and finalize).
-5. Validate `validAfter ≤ now ≤ expiresAt`.
-6. Simulate the settlement instruction(s).
+   - If it does not yet exist, validate that `openTransaction` targets the
+     canonical payment-channels program, names `rent_payer == extra.feePayer`
+     with `rent_payer` marked as a required signer, names
+     `payee == authorized_signer == extra.receiverAuthorizer`, encodes
+     `grace_period == extra.withdrawDelay`, encodes
+     `open_slot == payload.openSlot`, seals the distribution derived from
+     `payTo`, and is otherwise valid for the requirements; then co-sign,
+     broadcast, and wait until the channel account is confirmed `Open`.
+   - After the channel is open, confirm `channel.deposit == maxAmount` (exact,
+     not `>=`: `top_up` can raise an open channel's deposit, so equality keeps
+     the x402 ceiling enforced), `channel.status == Open`,
+     `channel.mint == asset`, `channel.rent_payer == extra.feePayer`,
+     `channel.payee == channel.authorized_signer == extra.receiverAuthorizer`,
+     `channel.open_slot == payload.openSlot`, and `distribution_hash` matches
+     the intended `payTo` distribution.
+5. Confirm `payload.channelId` equals the PDA derived from `from`, `asset`,
+   `extra.receiverAuthorizer`, `nonce`, and `openSlot` under the canonical
+   program id.
+6. Validate `validAfter <= now < expiresAt` and reject `expiresAt == 0`.
+7. Simulate the expected settlement instructions before accepting the payment.
 
-On failure the server returns `402` (or `412` for the approval/open
-precondition) without serving the resource.
+On failure the server returns `402` (or `412` for the open precondition) without
+serving the resource.
 
-### Phase 4 — Settlement (after serving the resource)
+### Phase 4 - Settlement (after serving the resource)
 
-At settlement `paymentRequirements.amount` carries the **actual** metered amount.
+At settlement, `paymentRequirements.amount` carries the actual metered amount.
 The server/facilitator MUST:
 
-1. Re-verify the authorization against the **signed ceiling**
-   (`maxAmount` / `deposit`), NOT against `paymentRequirements.amount`.
-2. Assert `paymentRequirements.amount ≤ maxAmount`. On violation, fail with
+1. Re-verify the authorization against the signed ceiling (`maxAmount` /
+   `deposit`), not against `paymentRequirements.amount`.
+2. Assert `paymentRequirements.amount <= maxAmount`. On violation, fail with
    `invalid_upto_svm_payload_settlement_exceeds_amount`.
-3. `settle_and_finalize` with the single operator-signed voucher for the actual
-   cumulative amount — this only locks `settled` and flips status to
-   `Finalized`. Then `distribute`, which is what actually pays out
-   the sealed `payTo` / facilitator-fee distribution, refunds
-   `deposit − actual` to the payer, returns the rent to the operator
-   (`rentPayer`), and closes (tombstones) the channel. The two instructions MAY
-   be bundled in one transaction. `SettlementResponse.transaction` MUST identify
-   the confirmed transaction containing the final `distribute` instruction; if
-   settlement and distribution are not bundled, this is the `distribute`
-   transaction because it moves the settled `amount` to the sealed `payTo` /
-   facilitator-fee distribution and closes the channel.
-4. A `0`-amount settlement uses the **no-voucher** path: `settle_and_finalize`
-   with `has_voucher = 0` (a `cumulative_amount = 0` voucher is invalid — the
-   watermark must advance strictly above the initial `settled = 0`), then
-   `distribute` to refund the full deposit and close.
-   `SettlementResponse.transaction` MUST be the signature of that confirmed
-   close/refund transaction.
+3. Require server authorization from `receiverAuthorizer`:
+   - For `actual > 0`, a voucher signed by `receiverAuthorizer` for
+     `cumulativeAmount == actual` and the agreed `expiresAt`.
+   - For `actual == 0`, no voucher; the `settle_and_seal` instruction uses
+     `has_voucher = 0`.
+   In both cases, the `settle_and_seal` transaction MUST be signed by
+   `receiverAuthorizer` as channel `payee`.
+4. Co-sign as transaction `feePayer`, broadcast the final transaction, and
+   confirm a successful `distribute`. The usual bundle is Ed25519 precompile
+   (for nonzero actual), `settle_and_seal`, then `distribute`.
 
-## 6. Error codes
+`settle_and_seal` only locks the settled watermark and moves status to
+`Sealed`. `distribute` is the instruction that pays `payTo`, refunds
+`deposit - actual` to the payer, closes the escrow token account, and advances
+the channel to its cleanup state. `SettlementResponse.transaction` MUST identify
+the confirmed transaction containing that final `distribute`.
+
+## 6. Error Codes
 
 Standard x402 codes apply. Scheme-specific:
 
-- `invalid_upto_svm_payload_settlement_exceeds_amount` — actual > signed ceiling.
-- `CHANNEL_REQUIRED` (with `412`) — no open channel and no valid `openTransaction` that can be co-signed, broadcast, and confirmed before serving the resource.
+- `invalid_upto_svm_payload_settlement_exceeds_amount` - actual amount exceeds
+  the signed ceiling.
+- `CHANNEL_REQUIRED` (with `412`) - no open channel and no valid
+  `openTransaction` that can be co-signed, broadcast, and confirmed before
+  serving the resource.
 
-## 7. Security properties
+## 7. Security Properties
 
-- **No overcharge.** Capped by the on-chain `deposit`.
-- **No redirection.** `channel.payee` (the operator) and `distribution_hash`
-  (the `payTo` / facilitator-fee distribution) are fixed at open and re-checked
-  by the program at `distribute`, so the operator cannot redirect or shortchange
-  `payTo`.
-- **No replay.** Terminal `ChannelStatus::Finalized` plus monotonic
-  `SettlementWatermarks.settled`.
-- **No operator griefing.** The operator is the channel `payee` (so it is the
-  `settle_and_finalize` merchant, which the program requires to equal
-  `channel.payee`) **and** the voucher `authorizedSigner`, so it can always
-  settle the metered amount, refund the client's unused deposit, and — via
-  `distribute` — close the channel and reclaim the rent it fronted, all without
-  the client. The client never needs SOL and cannot strand the operator's funds;
-  the operator's only exposure is the settle-and-finalize + distribute
-  transaction it elects to send. The server/facilitator MUST reject any `open`
-  whose `payee`, `authorizedSigner`, or `rentPayer` is not the operator before
-  co-signing (§5 Phase 3).
-- **Time-bounded.** `expiresAt` is signed by the operator into the voucher and
-  enforced on-chain (the program rejects a settle once `now ≥ expiresAt`);
-  `validAfter` is off-chain verify-time policy only. These bind the *operator's*
-  voucher rather than the client (who signs only `open`): they bound when a
-  metered settlement may land, not a client-side commitment.
-- **Trust model.** As in the generic spec, the client trusts the server to meter
-  honestly within the ceiling. Everything above the ceiling, the destination,
-  and replay are enforced cryptographically/on-chain.
+- **No overcharge.** Capped by the onchain `deposit`; verifier requires
+  `deposit == maxAmount`.
+- **No redirection.** The distribution fixed at `open` sends settled funds to
+  `payTo`, and the program re-checks `distribution_hash` at `distribute`.
+- **Authenticated settlement.** A third-party facilitator is only `feePayer` /
+  `rent_payer`. It cannot sign vouchers or `settle_and_seal`; those require the
+  server-controlled `receiverAuthorizer`.
+- **No replay.** Vouchers are scoped to `channelId`, monotonic in
+  `cumulativeAmount`, and the x402 flow seals and distributes the channel once
+  for the request. `openSlot` is part of the channel PDA derivation for the
+  current program version.
+- **Client gaslessness.** The client supplies the stablecoin deposit and signs
+  `open`; `feePayer` signs the transaction and funds SOL fees/rent. The
+  verifier MUST ensure the client-signed `open` cannot debit `feePayer` beyond
+  fees and the intended channel/escrow rent.
+- **Client escape hatch.** `withdrawDelay` is server-defined and fixed at
+  `open`. If the server does not settle, the payer can start forced close with
+  `request_close`, wait the grace period, then recover unspent deposit through
+  `seal` and `withdraw_payer` / `distribute`.
+- **Time-bounded settlement.** `expiresAt` is enforced by the program for
+  nonzero vouchers; `validAfter` is offchain verification policy. These bound
+  when a metered settlement may land, but they are not client-signed terms.
+- **Metering trust.** As in the generic `upto` spec, the client trusts the
+  server to meter honestly within the ceiling. The ceiling, recipient, and
+  replay properties are enforced by signatures and the onchain program.
 
-## 8. Out of scope
+## 8. Out of Scope
 
-Multi-settlement streaming — a long-lived channel reused across many requests —
-is served by the [`batch-settlement`](../batch-settlement/scheme_batch_settlement_svm.md)
-scheme, not `upto`. `upto` settles **at most once** per authorization.
+Multi-settlement streaming or long-lived channels reused across many requests
+are served by [`batch-settlement`](../batch-settlement/scheme_batch_settlement.md)
+or a session-oriented payment-channel protocol, not `upto`. `upto` settles at
+most once per authorization.

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -1,0 +1,267 @@
+# SVM `upto` Scheme: Usage-Based Payment Authorization on Solana
+
+> Status: **draft**. Companion to the network-agnostic
+> [`scheme_upto.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/upto/scheme_upto.md)
+> and the EVM profile
+> [`scheme_upto_evm.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/upto/scheme_upto_evm.md).
+> This document specifies how the `upto` scheme is realized on Solana Virtual
+> Machine (SVM) networks.
+
+## 1. Purpose
+
+`upto` lets a client authorize a **maximum** amount while the server settles for
+**actual** usage (`actual ≤ max`), with the final charge determined after the
+resource is consumed. Same target use cases as the generic spec: LLM token
+billing, per-byte metering, dynamic compute pricing.
+
+The hard part on Solana: a normal signed transfer commits to an *exact* amount
+and exact instruction data, so the server cannot lower the amount after the
+client signs without invalidating the signature. `upto` therefore requires an
+authorization that commits the client to a **ceiling** and lets the
+**facilitator** choose the actual amount at settlement. SVM offers two
+mechanisms that decouple "client authorizes a max" from "facilitator executes
+the actual," expressed here as two **profiles**.
+
+## 2. Mapping the five core requirements to SVM
+
+| Requirement (generic spec) | EVM mechanism | SVM mechanism (this spec) |
+|---|---|---|
+| Single-use authorization | Permit2 nonce | `payment-channel`: `finalize` makes the channel terminal (`ChannelStatus::Finalized`). `permit`: a one-shot nonce PDA consumed at settle. |
+| Time-bound validity (`validAfter`, `deadline`) | Permit2 `deadline` + witness `validAfter` | Authorization `validAfter` + `expiresAt`; `expiresAt` is also signed into the on-chain voucher / permit message. |
+| Recipient binding | Permit2 witness `to` | `payment-channel`: `channel.payee` + `distribution_hash` fixed at open. `permit`: `payTo` signed into the permit message and enforced by the program. |
+| Maximum amount enforcement | `permitted.amount` ceiling | `payment-channel`: on-chain `deposit` ceiling, `cumulative_amount ≤ deposit`. `permit`: `maxAmount` signed into the permit message, `actual ≤ maxAmount` enforced by the program. |
+| Phase-dependent amount semantics | `amount` = max at verify, actual at settle | Identical. `amount` in `PaymentRequirements` is the max during verification and the actual charge during settlement. |
+
+The facilitator MUST always verify against the client-signed ceiling, never
+against the settlement-time `amount`.
+
+## 3. Profiles
+
+A server advertises one or more profiles in `extra.profiles`. The client picks
+one and signals it back in the payload's `profile` field.
+
+### 3.1 `payment-channel` (normative, v1)
+
+Backed by the on-chain payment-channels program (a `pay-kit`-controlled program;
+program id `CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX` on the current
+deployment). The escrow **deposit is the ceiling**; a single signed voucher
+settles the actual amount; `finalize` closes the channel and refunds the unused
+remainder to the payer in the same transaction.
+
+Strengths: every requirement is enforced on-chain by a program we control. The
+facilitator cannot overcharge (capped by `deposit`), cannot redirect funds
+(`channel.payee` / `distribution_hash` are fixed at open), and cannot replay
+(channel is terminal after `finalize`).
+
+Cost: the client locks `max` in escrow for the lifetime of the request, and the
+flow needs two on-chain transactions (open, then settle-and-finalize). Channel
+rent is reclaimed at finalize.
+
+### 3.2 `permit` (optional, v2 — requires a new program)
+
+Backed by an Ed25519-signed one-shot delegated transfer — the closest analog to
+EVM's `permitWitnessTransferFrom`. The client `approve`s a program-owned
+delegate on its token account (reusable across requests, like a one-time Permit2
+approval), then signs an off-chain **permit message** committing to a ceiling and
+a witness. At settlement the facilitator submits one transaction; a small
+on-chain program verifies the Ed25519 signature (via the Ed25519 precompile +
+instructions sysvar, the same pattern the payment-channels program already uses
+for vouchers), checks the witness, enforces `actual ≤ maxAmount`, transfers the
+actual amount to `payTo`, and consumes a nonce PDA for replay protection.
+
+Strengths: no escrow lockup; a single settlement transaction; reusable approval.
+Matches EVM ergonomics.
+
+Cost: requires a new, audited on-chain program. Until that program ships and is
+audited, `payment-channel` is the only normative profile.
+
+> Multi-delegator is explicitly **not** an `upto` backend. Its `FixedDelegation`
+> is a standing, multi-pull cap that binds the *delegatee* (operator), not the
+> final `payTo`, and offers no on-chain single-use guarantee. It is the right
+> primitive for `session`/streaming, not for one-shot `upto`. Using it here
+> would downgrade the recipient-binding and single-use requirements to
+> "trust the facilitator," defeating the scheme.
+
+## 4. Wire format
+
+`upto` reuses the x402 v2 transport: a `402` response carries `PAYMENT-REQUIRED`;
+the paid retry carries `PAYMENT-SIGNATURE`; the response carries
+`PAYMENT-RESPONSE`. Only the `scheme` value and the payload shape change relative
+to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
+`SettlementResponse` types are defined in
+[`x402-specification-v2.md`](../../x402-specification-v2.md).
+
+### 4.1 `PaymentRequirements` (in `PAYMENT-REQUIRED.accepts[]`)
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `scheme` | string | ✓ | `"upto"` |
+| `network` | string | ✓ | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (mainnet), `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (devnet) |
+| `amount` | string | ✓ | **Phase-dependent**: max authorized at verification; actual charge at settlement. Base units. |
+| `asset` | string | ✓ | SPL mint address (or `"SOL"` — discouraged for `upto`; stablecoins recommended) |
+| `payTo` | string | ✓ | Base58 recipient |
+| `maxTimeoutSeconds` | number | ✓ | Completion window; also the basis for the authorization `expiresAt` |
+| `extra` | object | ✓ | See below |
+
+`extra`:
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `profiles` | string[] | ✓ | Subset of `["payment-channel","permit"]`, in server preference order |
+| `feePayer` | string | ✓ | Base58 operator key that sponsors fees (co-signs the setup transaction as fee payer) and settles |
+| `channelProgram` | string | – | Channel/permit program id; defaults to the canonical deployment |
+| `decimals` | number | ✓ | Token decimals |
+| `tokenProgram` | string | ✓ | `Tokenkeg…` or `TokenzQ…` (Token-2022); the client SHOULD verify it against the on-chain mint owner |
+| `recentBlockhash` | string | – | Pre-fetched blockhash so the client can build setup transactions without an extra RPC round-trip |
+| `validAfter` | number | – | Earliest activation time (Unix seconds); default = now |
+| `splits` | `{recipient,bps}[]` | – | `payment-channel` only; distributed at finalize |
+
+### 4.2 `UptoPayload` (in `PAYMENT-SIGNATURE.payload`)
+
+Common fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| `profile` | string | `"payment-channel"` or `"permit"` |
+| `from` | string | Payer wallet (base58) |
+| `maxAmount` | string | The signed ceiling (base units). MUST equal verification-phase `amount`. |
+| `expiresAt` | number | Deadline (Unix seconds); signed into the on-chain message |
+| `validAfter` | number | Activation time (Unix seconds) |
+| `nonce` | string | Unique per authorization |
+
+`payment-channel` profile adds:
+
+| Field | Type | Notes |
+|---|---|---|
+| `channelId` | string | Channel PDA (base58) |
+| `deposit` | string | On-chain escrow = the ceiling; MUST equal `maxAmount` |
+| `authorizedSigner` | string | The **operator/facilitator** key (base58). The operator — not the client — signs the single settlement voucher (see §5 Phase 2). |
+| `openTransaction` | string | Base64 signed `open` transaction for the facilitator to broadcast if the channel is not yet open (pull-style). Omitted if the client already broadcast `open` (push-style) and `signature` is set. |
+| `signature` | string | Base58 signature of the broadcast `open` transaction (push) |
+
+> The voucher is **not** carried in the payload. Because the actual amount is
+> only known after the resource is consumed, and the client's protection is the
+> on-chain `deposit` ceiling plus the fixed `payee`, the operator (set as the
+> channel's `authorizedSigner` at open) signs the single voucher for the metered
+> amount at settlement. This keeps `upto` a single HTTP round-trip with a
+> handler-determined amount, matching the EVM trust model where the server fills
+> in `actual ≤ ceiling`.
+
+`permit` profile adds:
+
+| Field | Type | Notes |
+|---|---|---|
+| `tokenAccount` | string | Payer ATA being delegated (base58) |
+| `approveTransaction` | string | Base64 signed `approve` transaction for the facilitator to broadcast if no sufficient delegation exists |
+| `permitSignature` | string | Base58 Ed25519 signature by `from` over the permit message |
+
+Permit message (Borsh, signed by `from`):
+
+```
+nonce_pda: [u8;32]          // PDA(["upto", from, mint, nonce])
+mint:      [u8;32]
+pay_to:    [u8;32]
+facilitator:[u8;32]
+max_amount: u64 (le)
+valid_after: i64 (le)
+expires_at: i64 (le)
+```
+
+### 4.3 `SettlementResponse` (in `PAYMENT-RESPONSE`)
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `success` | boolean | ✓ | |
+| `errorReason` | string | – | Omitted on success |
+| `payer` | string | – | `from` |
+| `transaction` | string | ✓ | Settle (or settle-and-finalize) signature; empty string if the actual charge is `0` |
+| `network` | string | ✓ | CAIP-2 |
+| `amount` | string | ✓ | Actual base units charged (may be `0`) |
+
+## 5. Phases
+
+### Phase 1 — Setup (gas/approval)
+
+- `payment-channel`: the client builds an `open` transaction depositing
+  `maxAmount`. Push: the client broadcasts it and sends `signature`. Pull: the
+  client sends `openTransaction` and the facilitator broadcasts it (the
+  facilitator may co-sign as fee payer, matching `exact`'s fee-sponsorship).
+- `permit`: the client ensures a program-owned delegate is approved on
+  `tokenAccount` for at least `maxAmount`. If absent, the facilitator returns
+  `412 Precondition Failed` with `errorReason = APPROVAL_REQUIRED` and the
+  required `approve` transaction, mirroring EVM's `PERMIT2_ALLOWANCE_REQUIRED`.
+
+### Phase 2 — Authorization signature
+
+- `payment-channel` (normative v1): the client's signature on the `open`
+  transaction **is** the authorization — it commits the `deposit` ceiling, the
+  `payee`, and the `mint`, with `authorizedSigner` set to the **operator**. The
+  client does not sign a voucher. After metering, the operator signs the single
+  voucher for `cumulativeAmount = actual` (Ed25519 over
+  `channel_id ‖ cumulative_amount_le ‖ expires_at_le`) and settles it. The
+  client is protected by the on-chain ceiling (the operator cannot exceed
+  `deposit`) and the fixed `payee` (the operator cannot redirect) — the same
+  trust model as EVM `upto`, in a single round-trip.
+- `permit`: sign the permit message with `from`.
+
+### Phase 3 — Verification (before serving the resource)
+
+The facilitator MUST, in order:
+
+1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
+2. Confirm `network`, `asset` (mint), `tokenProgram`, and `payTo` match the requirements.
+3. Confirm `feePayer` in `extra` is this server's key.
+4. `payment-channel`: confirm the channel exists (or the `openTransaction` is valid and broadcastable), `channel.deposit ≥ maxAmount`, `channel.payee` and `distribution_hash` match `payTo`/`splits`, `channel.status == Open`, and `channel.mint == asset`. `permit`: recover `permitSignature`, confirm signer is `from`; confirm the delegate allowance and the payer token balance both cover `maxAmount`.
+5. Validate `validAfter ≤ now ≤ expiresAt`.
+6. Simulate the settlement instruction(s).
+
+On failure the server returns `402` (or `412` for the approval/open
+precondition) without serving the resource.
+
+### Phase 4 — Settlement (after serving the resource)
+
+At settlement `paymentRequirements.amount` carries the **actual** metered amount.
+The facilitator MUST:
+
+1. Re-verify the authorization against the **signed ceiling**
+   (`maxAmount` / `deposit`), NOT against `paymentRequirements.amount`.
+2. Assert `paymentRequirements.amount ≤ maxAmount`. On violation, fail with
+   `invalid_upto_svm_payload_settlement_exceeds_amount`.
+3. Execute:
+   - `payment-channel`: `settle_and_finalize` with the single voucher for the
+     actual cumulative amount, then `distribute` to `payTo`/`splits`. Finalize
+     refunds `deposit − actual` to the payer and closes the channel.
+   - `permit`: submit the verify+settle transaction; the program checks the
+     Ed25519 signature and witness, enforces `actual ≤ maxAmount`, transfers
+     `actual` to `payTo`, and consumes the nonce PDA.
+4. A `0`-amount settlement requires no transfer. `payment-channel` still
+   finalizes (full refund, channel closed); `permit` still consumes the nonce.
+   `transaction` MAY be empty when no token movement occurred.
+
+## 6. Error codes
+
+Standard x402 codes apply. Scheme-specific:
+
+- `invalid_upto_svm_payload_settlement_exceeds_amount` — actual > signed ceiling.
+- `APPROVAL_REQUIRED` (`permit`, with `412`) — delegate approval missing/insufficient.
+- `CHANNEL_REQUIRED` (`payment-channel`, with `412`) — no open channel and no broadcastable `openTransaction`.
+
+## 7. Security properties
+
+- **No overcharge.** `payment-channel`: capped by on-chain `deposit`. `permit`:
+  capped by the signed `maxAmount` enforced inside the program.
+- **No redirection.** `payment-channel`: `channel.payee`/`distribution_hash`
+  fixed at open. `permit`: `payTo` is in the signed message and checked on-chain.
+- **No replay.** `payment-channel`: terminal `ChannelStatus::Finalized` plus
+  monotonic `SettlementWatermarks.settled`. `permit`: one-shot nonce PDA.
+- **Time-bounded.** `validAfter`/`expiresAt` checked off-chain at verify and
+  signed into the on-chain message so a stale authorization cannot settle.
+- **Trust model.** As in the generic spec, the client trusts the server to meter
+  honestly within the ceiling. Everything above the ceiling, the destination,
+  and replay are enforced cryptographically/on-chain.
+
+## 8. Out of scope
+
+Multi-settlement streaming and recurring auto-pay are served by the `session`
+and `subscription` intents, not `upto`. `upto` settles **at most once** per
+authorization.

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -99,9 +99,7 @@ never needs SOL.
 `upto` reuses the x402 v2 transport: a `402` response carries `PAYMENT-REQUIRED`;
 the paid retry carries `PAYMENT-SIGNATURE`; the response carries
 `PAYMENT-RESPONSE`. Only the `scheme` value and the payload shape change relative
-to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
-`SettlementResponse` types are defined in
-[`x402-specification-v2.md`](../../x402-specification-v2.md).
+to `exact`.
 
 ### 4.1 `PaymentRequirements` (in `PAYMENT-REQUIRED.accepts[]`)
 

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -28,18 +28,37 @@ The x402 roles map to the payment-channel program as follows:
 - **Server**: resource provider; receives funds at `payTo`; determines the
   actual metered charge after serving the resource.
 - **Receiver authorizer**: server-controlled hot key advertised as
-  `extra.receiverAuthorizer`; set as both channel `payee` and
-  `authorized_signer`; signs the settlement voucher and the cooperative close
-  instruction. It does not need to hold SOL or token funds.
+  `extra.receiverAuthorizer`; set as channel `authorized_signer`; signs the
+  settlement voucher that authorizes any nonzero charge. It does not need to
+  hold SOL or token funds, and it never signs a transaction: the voucher
+  message binds only values known at build time, so signing it requires no
+  fresh blockhash.
 - **Facilitator / sponsor**: account advertised as `extra.feePayer`; sponsors
   transaction fees and channel rent by co-signing the channel `open` as
-  transaction fee payer and program `rent_payer`. The server MAY self-facilitate
-  by using its own key as `feePayer`.
+  transaction fee payer and program `rent_payer`, and is set as the channel
+  `payee` with a zero share of the distribution. The server MAY
+  self-facilitate by using its own key as `feePayer`.
 
-This keeps the facilitator out of the payment authority path. A third-party
-facilitator cannot close or refund the channel on its own, because
-`settle_and_seal` requires the channel `payee` signature and vouchers must be
-signed by `authorized_signer`; in this scheme both are `receiverAuthorizer`.
+The facilitator-as-zero-share-payee shape splits channel authority in two:
+
+- The facilitator, as `payee`, holds the **lifecycle** authority: it signs
+  `settle_and_seal` and can therefore always drive a channel to closure and
+  recover the rent it fronted (`settle_and_seal` with `has_voucher = 0`, then
+  `distribute`, then `reclaim`), even if the client and server both
+  disappear. A client/server pair cannot strand the facilitator's rent by
+  leaving a channel open.
+- The server, as `authorized_signer`, holds the **payment** authority: every
+  nonzero settlement requires a voucher signed by `receiverAuthorizer`, the
+  distribution committed at `open` sends 100% of settled funds to `payTo`,
+  and the payer refund is program-bound to the client. The facilitator can
+  close a channel at its current settled watermark; it cannot redirect funds
+  or settle any nonzero amount on its own.
+
+The residual trust assumption is facilitator honesty and liveness at closure:
+a facilitator that seals early (`has_voucher = 0`) freezes the watermark, and
+the unsettled remainder is refunded to the client. The server MUST therefore
+treat unsettled voucher value as facilitator credit risk and settle promptly.
+See [Security Properties](#8-security-properties).
 
 ## 2. Mapping the five core requirements to SVM
 
@@ -47,7 +66,7 @@ signed by `authorized_signer`; in this scheme both are `receiverAuthorizer`.
 |---|---|
 | Single-use authorization | The x402 authorization is a one-request channel. Settlement uses `settle_and_seal` followed by a final `distribute`; after sealing and final distribution, the authorization cannot be used again for `upto`. |
 | Time-bound validity (`validAfter`, `expiresAt`) | `expiresAt` is signed by `receiverAuthorizer` into the voucher and enforced by the program (`now < expiresAt`). Although the program supports `expires_at == 0` as no expiry, SVM `upto` MUST reject `expiresAt == 0`. `validAfter` is offchain verify-time policy. Neither value is client-bound; the client signs only `open`. |
-| Recipient binding | The `open` transaction fixes `distribution_hash`. For this scheme the distribution sends 100% of settled funds to `payTo`, unless `payTo == receiverAuthorizer`, where the channel payee's implicit remainder is sufficient. The program re-checks the distribution at `distribute`. |
+| Recipient binding | The `open` transaction fixes `distribution_hash`. For this scheme the distribution is always the single explicit entry `[{ recipient: payTo, bps: 10000 }]`; the channel payee (the facilitator) holds the implicit remainder, which is zero. The program re-checks the distribution at `distribute`. |
 | Maximum amount enforcement | Onchain `deposit` is the ceiling and vouchers must satisfy `settled < cumulative_amount <= deposit`; the verifier pins `deposit == maxAmount` so the x402 ceiling is exact, not advisory. |
 | Phase-dependent amount semantics | `amount` in `PaymentRequirements` is the max during verification and the actual charge during settlement. |
 
@@ -76,9 +95,9 @@ The v1 flow uses these program instructions:
 
 1. `open`: creates a channel PDA, escrows `maxAmount`, stores
    `grace_period == extra.withdrawDelay`, and commits the payout distribution.
-2. `settle_and_seal`: payee-signed cooperative close. It optionally applies the
-   final voucher, locks the settled watermark, and moves the channel to
-   `Sealed`.
+2. `settle_and_seal`: payee-signed (facilitator-signed) cooperative close. It
+   optionally applies the final server voucher, locks the settled watermark,
+   and moves the channel to `Sealed`.
 3. `distribute`: pays `payTo`, refunds `deposit - actual` to the client, closes
    the escrow token account, and either deallocates the channel PDA immediately
    or marks it `Distributed` until `reclaim` is allowed.
@@ -88,17 +107,24 @@ The v1 flow uses these program instructions:
 
 The fee/rent sponsor is `extra.feePayer`. It funds the channel PDA and escrow
 ATA rent at `open`; that rent is returned to the recorded `rent_payer` during
-final cleanup (`distribute` fast path, or later `reclaim`). A sponsor MAY keep a
+final cleanup (`distribute` fast path, or later `reclaim`). Because the
+sponsor is also the channel `payee`, it never depends on the client or the
+server to reach that cleanup: it can seal an abandoned channel itself with a
+zero-charge `settle_and_seal` and recover its rent. A sponsor MAY keep a
 local channel index, but it MUST be able to rediscover the channels it funded
 onchain as specified in [Asynchronous Recovery and Channel Discovery](#6-asynchronous-recovery-and-channel-discovery).
 Token payouts and client refunds are not delayed by `reclaim`.
 
 The client has an escape hatch if the server never settles. The client can call
 `request_close`, which moves the channel to `Closing` and starts the
-`withdrawDelay` grace period fixed at `open`. The server can still
-`settle_and_seal` during that grace period. After the grace period, anyone can
-call `seal`; the payer can then call `withdraw_payer` to recover
-`deposit - settled`, and `distribute`/`reclaim` can finish cleanup.
+`withdrawDelay` grace period fixed at `open`. During that grace period only
+the payee — the facilitator — can act: it can still `settle_and_seal`,
+carrying the server's final voucher if the server has produced one. The
+server cannot rescue an unsettled voucher by itself during `Closing`
+(`settle` requires `Open`), so it depends on the facilitator's liveness for
+mid-grace settlement. After the grace period, anyone can call `seal`; the
+payer can then call `withdraw_payer` to recover `deposit - settled`, and
+`distribute`/`reclaim` can finish cleanup.
 
 ## 4. Wire Format
 
@@ -123,8 +149,8 @@ from `exact`.
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `feePayer` | string | yes | Base58 sponsor key that co-signs `open` as transaction fee payer and channel `rent_payer`, and co-signs settlement transactions as fee payer. MAY equal `receiverAuthorizer` for self-facilitation. |
-| `receiverAuthorizer` | string | yes | Base58 server-controlled key set as channel `payee` and `authorized_signer`; signs vouchers and `settle_and_seal`. |
+| `feePayer` | string | yes | Base58 sponsor key set as channel `payee` (zero share) and `rent_payer`. Co-signs `open` as transaction fee payer, and signs settlement transactions as both fee payer and channel `payee`. MAY equal `receiverAuthorizer` for self-facilitation. |
+| `receiverAuthorizer` | string | yes | Base58 server-controlled key set as channel `authorized_signer`; signs settlement vouchers. |
 | `withdrawDelay` | number | yes | Server-defined `grace_period` in seconds. The client MUST encode this exact value in `open`; the verifier MUST reject any other value. MUST be an integer greater than zero. |
 | `tokenProgram` | string | yes | `Tokenkeg...` or `TokenzQ...` (Token-2022); the client SHOULD verify it against the onchain mint owner. |
 | `recentBlockhash` | string | no | Pre-fetched blockhash so the client can build `openTransaction` without an RPC round trip. |
@@ -136,22 +162,22 @@ derives the payment-channel accounts and distribution from the x402 fields:
 
 ```text
 rent_payer = extra.feePayer
-payee = extra.receiverAuthorizer
+payee = extra.feePayer            # facilitator: zero-share payee
 authorized_signer = extra.receiverAuthorizer
 grace_period = extra.withdrawDelay
 
-if payTo == extra.receiverAuthorizer:
-  recipients = []
-  payee_implicit_remainder_bps = 10000
-else:
-  recipients = [{ recipient: payTo, bps: 10000 }]
-  payee_implicit_remainder_bps = 0
+recipients = [{ recipient: payTo, bps: 10000 }]
+payee_implicit_remainder_bps = 0
 ```
+
+The explicit single-entry distribution is REQUIRED in all cases, including
+when `payTo` equals `extra.receiverAuthorizer` or `extra.feePayer`: the payee
+implicit remainder MUST be zero so that the facilitator in the payee seat has
+no claim on settled funds.
 
 Any facilitator commercial fee is outside this wire contract or included in the
 server's pricing. The channel distribution for `upto` MUST NOT assign any
-portion of the settled amount away from `payTo`, except when `payTo` is itself
-the channel payee via the implicit remainder path above.
+portion of the settled amount away from `payTo`.
 
 Example: server self-facilitates while using a hot receiver key and cold payout
 wallet:
@@ -218,9 +244,9 @@ find_program_address(
   [
     "channel",
     from,
-    extra.receiverAuthorizer,
+    extra.feePayer,           # payee seed slot
     asset,
-    extra.receiverAuthorizer,
+    extra.receiverAuthorizer, # authorized_signer seed slot
     u64(nonce).to_le_bytes(),
     u64(openSlot).to_le_bytes()
   ],
@@ -241,9 +267,9 @@ The `open` instruction MUST encode:
 - `grace_period == extra.withdrawDelay`
 - `open_slot == payload.openSlot`
 - `rent_payer == extra.feePayer`
-- `payee == extra.receiverAuthorizer`
+- `payee == extra.feePayer`
 - `authorized_signer == extra.receiverAuthorizer`
-- the distribution derived from `payTo` as specified in section 4.1
+- the single-entry 100% `payTo` distribution specified in section 4.1
 
 The voucher is not carried in the client payload. After metering, the server
 signs an Ed25519 voucher with `receiverAuthorizer`. The signed message is:
@@ -278,9 +304,9 @@ settled funds, refunds the client, and closes the escrow token account.
 
 The server returns `feePayer`, `receiverAuthorizer`, and `withdrawDelay` in the
 402 response. The client builds an `open` transaction against the canonical
-payment-channels program, deposits `maxAmount`, sets `rent_payer` to
-`extra.feePayer`, sets `payee` and `authorized_signer` to
-`extra.receiverAuthorizer`, and signs as channel `payer`.
+payment-channels program, deposits `maxAmount`, sets `payee` and `rent_payer`
+to `extra.feePayer`, sets `authorized_signer` to `extra.receiverAuthorizer`,
+and signs as channel `payer`.
 
 The client sends only a partially signed `openTransaction`. The
 server/facilitator validates it, signs it as transaction fee payer and as
@@ -294,14 +320,17 @@ The client's signature on `openTransaction` is the client's authorization: it
 commits the deposit ceiling, mint, `withdrawDelay`, `openSlot`, and fixed
 distribution to `payTo`.
 
-The server's later settlement authorization is separate. The
-`receiverAuthorizer` key signs the voucher for the actual amount and signs the
-`settle_and_seal` transaction. That transaction may be constructed by the server
-or by the facilitator, but the `receiverAuthorizer` signature MUST cover the
-`settle_and_seal` instruction before the facilitator co-signs and broadcasts.
-This signature also authenticates the otherwise unauthenticated facilitator
-`settle/` HTTP request: the facilitator MUST NOT settle, seal, or refund a
-channel unless the submitted settlement is authorized by `receiverAuthorizer`.
+The server's later settlement authorization is separate and voucher-only. For
+a nonzero actual amount, the `receiverAuthorizer` key signs the Ed25519
+voucher; the facilitator constructs the `settle_and_seal` transaction itself,
+signs it as channel `payee` and transaction fee payer, and broadcasts it. The
+server never signs a settlement transaction. The voucher signature
+authenticates the otherwise unauthenticated facilitator `settle/` HTTP
+request: the facilitator MUST NOT settle a nonzero amount unless the
+submitted voucher is signed by `receiverAuthorizer`. The zero-charge close
+(`has_voucher = 0`) carries no server authorization: it moves no settled
+funds, refunds the full deposit to the client, and is the facilitator's own
+cleanup authority.
 
 ### Phase 3 - Verification (before serving the resource)
 
@@ -315,23 +344,24 @@ The server/facilitator MUST, in order:
    authorizer, and `extra.withdrawDelay` is an integer greater than zero.
 4. Confirm the channel is open:
    - If it does not yet exist, validate that `openTransaction` targets the
-     canonical payment-channels program, names `rent_payer == extra.feePayer`
-     with `rent_payer` marked as a required signer, names
-     `payee == authorized_signer == extra.receiverAuthorizer`, encodes
-     `grace_period == extra.withdrawDelay`, encodes
-     `open_slot == payload.openSlot`, seals the distribution derived from
-     `payTo`, and is otherwise valid for the requirements; then co-sign,
+     canonical payment-channels program, names
+     `payee == rent_payer == extra.feePayer` with `rent_payer` marked as a
+     required signer, names `authorized_signer == extra.receiverAuthorizer`,
+     encodes `grace_period == extra.withdrawDelay`, encodes
+     `open_slot == payload.openSlot`, seals the single-entry 100% `payTo`
+     distribution, and is otherwise valid for the requirements; then co-sign,
      broadcast, and wait until the channel account is confirmed `Open`.
    - After the channel is open, confirm `channel.deposit == maxAmount` (exact,
      not `>=`: `top_up` can raise an open channel's deposit, so equality keeps
      the x402 ceiling enforced), `channel.status == Open`,
-     `channel.mint == asset`, `channel.rent_payer == extra.feePayer`,
-     `channel.payee == channel.authorized_signer == extra.receiverAuthorizer`,
+     `channel.mint == asset`,
+     `channel.payee == channel.rent_payer == extra.feePayer`,
+     `channel.authorized_signer == extra.receiverAuthorizer`,
      `channel.open_slot == payload.openSlot`, and `distribution_hash` matches
      the intended `payTo` distribution.
-5. Confirm `payload.channelId` equals the PDA derived from `from`, `asset`,
-   `extra.receiverAuthorizer`, `nonce`, and `openSlot` under the canonical
-   program id.
+5. Confirm `payload.channelId` equals the PDA derived from `from`,
+   `extra.feePayer`, `asset`, `extra.receiverAuthorizer`, `nonce`, and
+   `openSlot` under the canonical program id.
 6. Validate `validAfter <= now < expiresAt` and reject `expiresAt == 0`.
 7. Simulate the expected settlement instructions before accepting the payment.
 
@@ -347,16 +377,18 @@ The server/facilitator MUST:
    `deposit`), not against `paymentRequirements.amount`.
 2. Assert `paymentRequirements.amount <= maxAmount`. On violation, fail with
    `invalid_upto_svm_payload_settlement_exceeds_amount`.
-3. Require server authorization from `receiverAuthorizer`:
+3. Require server authorization for any nonzero charge:
    - For `actual > 0`, a voucher signed by `receiverAuthorizer` for
      `cumulativeAmount == actual` and the agreed `expiresAt`.
-   - For `actual == 0`, no voucher; the `settle_and_seal` instruction uses
-     `has_voucher = 0`.
+   - For `actual == 0`, no voucher and no server authorization; the
+     `settle_and_seal` instruction uses `has_voucher = 0`.
    In both cases, the `settle_and_seal` transaction MUST be signed by
-   `receiverAuthorizer` as channel `payee`.
-4. Co-sign as transaction `feePayer`, broadcast the final transaction, and
-   confirm a successful `distribute`. The usual bundle is Ed25519 precompile
-   (for nonzero actual), `settle_and_seal`, then `distribute`.
+   `extra.feePayer` as channel `payee`; the server signs nothing but the
+   voucher.
+4. Sign as transaction `feePayer` and channel `payee`, broadcast the final
+   transaction, and confirm a successful `distribute`. The usual bundle is
+   Ed25519 precompile (for nonzero actual), `settle_and_seal`, then
+   `distribute`.
 
 `settle_and_seal` only locks the settled watermark and moves status to
 `Sealed`. `distribute` is the instruction that pays `payTo`, refunds
@@ -369,10 +401,11 @@ the confirmed transaction containing that final `distribute`.
 Channel discovery is onchain. A client can discover channels for which it
 provided the deposit by querying channel accounts whose `payer` equals the
 client key. A facilitator or other fee/rent sponsor can discover every channel
-for which it fronted rent by querying accounts whose `rent_payer` equals its
-key. A server can similarly query `payee` or `authorized_signer` to find
-channels it is able to settle. Local storage is therefore an optimization, not
-the source of truth for channel lifecycle or rent recovery.
+for which it fronted rent by querying accounts whose `rent_payer` (or,
+equivalently in this scheme, `payee`) equals its key. A server can query
+`authorized_signer` to find channels it is able to settle. Local storage is
+therefore an optimization, not the source of truth for channel lifecycle or
+rent recovery.
 
 Implementations MAY retain a local index for request correlation, worker leases,
 and response history. They MUST be able to rebuild the onchain portion of that
@@ -388,7 +421,7 @@ targeted by this version is fixed at 256 bytes. Its public-key field offsets are
 | Channel field | Offset | Discovery use |
 |---|---:|---|
 | `payer` | 88 | Client deposit/channel recovery |
-| `payee` | 120 | Server/operator channel recovery |
+| `payee` | 120 | Facilitator/sponsor lifecycle recovery (`payee == feePayer` in this scheme) |
 | `authorized_signer` | 152 | Server settlement-authority recovery |
 | `rent_payer` | 216 | Facilitator/sponsor rent recovery |
 
@@ -432,22 +465,29 @@ restart, MUST perform the following flow:
    the worker to refetch and reclassify the channel, rather than assuming that
    cleanup failed.
 3. For an `Open` channel, the server may resume settlement only when it has
-   recovered the application metering result and can obtain the required
-   `receiverAuthorizer` signatures. Otherwise it MUST NOT invent a nonzero
-   charge. The server may perform the no-voucher, zero-charge close path; the
-   client may instead begin its `request_close` escape hatch.
+   recovered the application metering result and can produce the required
+   `receiverAuthorizer` voucher. Otherwise it MUST NOT invent a nonzero
+   charge. The facilitator, as payee, may perform the no-voucher, zero-charge
+   close path (`settle_and_seal` with `has_voucher = 0`, then `distribute`,
+   then `reclaim`) on its own; before doing so it SHOULD apply a
+   policy-defined notice or timeout that gives the server a chance to submit
+   a final voucher. The client may instead begin its `request_close` escape
+   hatch.
 4. For a `Closing` channel, schedule a recheck when the recorded grace period
-   expires. The server can still settle during that period; after it, the normal
+   expires. The facilitator can still `settle_and_seal` during that period,
+   carrying the server's final voucher if one exists; after it, the normal
    `seal`, payer withdrawal, and distribution path applies.
 5. For a `Sealed` channel, submit or relay the remaining distribution/withdrawal
    actions permitted by the channel state. For a `Distributed` channel, schedule
    `reclaim` after its open-slot reclaim gate. `reclaim` is permissionless, but
    the program returns the recovered SOL rent only to the recorded `rent_payer`.
 
-A fee/rent sponsor has discovery and relay capability, not payment authority:
-it cannot create a nonzero settlement or close a channel by itself without the
-server-controlled `receiverAuthorizer` authorization required elsewhere in this
-spec. Likewise, onchain recovery does not reconstruct application-specific
+A fee/rent sponsor has discovery, relay, and lifecycle capability, but no
+payment authority: as `payee` it can close a channel at its current settled
+watermark, but it cannot create a nonzero settlement or redirect funds — those
+require the server-controlled `receiverAuthorizer` voucher and the
+distribution committed at `open`. Likewise, onchain recovery does not
+reconstruct application-specific
 metering, request/response correlation, or an unpersisted settlement voucher.
 Those records MAY be kept offchain; if they are lost, the server MUST take the
 conservative no-charge or client-initiated close path rather than charging based
@@ -469,9 +509,27 @@ Standard x402 codes apply. Scheme-specific:
   `deposit == maxAmount`.
 - **No redirection.** The distribution fixed at `open` sends settled funds to
   `payTo`, and the program re-checks `distribution_hash` at `distribute`.
-- **Authenticated settlement.** A third-party facilitator is only `feePayer` /
-  `rent_payer`. It cannot sign vouchers or `settle_and_seal`; those require the
-  server-controlled `receiverAuthorizer`.
+- **Authenticated settlement.** A third-party facilitator is `feePayer` /
+  `rent_payer` / zero-share `payee`. It cannot sign vouchers, so it cannot
+  settle any nonzero amount; that requires the server-controlled
+  `receiverAuthorizer`. Its `settle_and_seal` authority only freezes the
+  watermark and triggers the program-fixed payout to `payTo` and refund to
+  the client.
+- **Facilitator rent recovery.** Because the facilitator is the channel
+  `payee`, it can always run `settle_and_seal` (`has_voucher = 0`), then
+  `distribute`, then `reclaim` on its own. A colluding client/server pair
+  cannot strand the facilitator's rent by opening channels and leaving them
+  unsealed.
+- **Facilitator early-close exposure (server side).** A facilitator that
+  seals before the server settles freezes the watermark, and the unsettled
+  remainder is refunded to the client — a facilitator colluding with the
+  client could claw back payment for a served resource. The server already
+  trusts the facilitator to co-sign and broadcast its settlements; this
+  extends that trust to settlement liveness. The server MUST bound its
+  exposure by settling promptly after serving the resource, and SHOULD treat
+  unsettled voucher value as facilitator credit risk. During a
+  client-initiated `Closing` grace period, only the facilitator can commit
+  the final voucher.
 - **No replay.** Vouchers are scoped to `channelId`, monotonic in
   `cumulativeAmount`, and the x402 flow seals and distributes the channel once
   for the request. `openSlot` is part of the channel PDA derivation for the

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -57,8 +57,8 @@ never against the settlement-time `amount`.
 
 v1 defines a single profile, `payment-channel`, carried in the payload's
 `profile` field. It is backed by the on-chain payment-channels program
-(advertised via `extra.channelProgram`; a canonical deployment is assumed when
-omitted). The escrow **deposit is the ceiling**; a single operator-signed
+(advertised via `extra.channelProgram`). The escrow **deposit is the ceiling**;
+a single operator-signed
 voucher locks the actual amount via `settle_and_finalize`, and `distribute` then
 moves the funds — paying out the `payTo`/`splits`, refunding the unused
 `deposit − actual` to the payer, returning the fronted rent to the operator, and
@@ -121,12 +121,20 @@ to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
 |---|---|---|---|
 | `profiles` | string[] | ✓ | `["payment-channel"]` (the only v1 profile) |
 | `feePayer` | string | ✓ | Base58 operator key that sponsors fees (co-signs the setup transaction as fee payer) and settles |
-| `channelProgram` | string | – | Channel program id; defaults to the canonical deployment |
+| `channelProgram` | string | ✓ | Base58 payment-channels program id. Clients and facilitators MUST reject unsupported program ids for the selected `network`. |
 | `decimals` | number | ✓ | Token decimals |
 | `tokenProgram` | string | ✓ | `Tokenkeg…` or `TokenzQ…` (Token-2022); the client SHOULD verify it against the on-chain mint owner |
 | `recentBlockhash` | string | – | Pre-fetched blockhash so the client can build setup transactions without an extra RPC round-trip |
 | `validAfter` | number | – | Earliest activation time (Unix seconds); default = now |
 | `splits` | `{recipient,bps}[]` | – | Distribution splits sealed at open; distributed at finalize |
+
+`channelProgram` is discovery, not a trust anchor. The client consumes it to
+derive the channel address and build the `open` transaction; the
+server/facilitator consumes it to verify and settle the channel. Implementations
+MUST maintain a supported-program set per `network` and reject any
+`channelProgram` outside that set. The server/facilitator MUST verify that the
+`openTransaction`, settlement, and distribution instructions target exactly
+`extra.channelProgram`.
 
 ### 4.2 `UptoPayload` (in `PAYMENT-SIGNATURE.payload`)
 
@@ -197,9 +205,9 @@ in a single round-trip.
 The server/facilitator MUST, in order:
 
 1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
-2. Confirm `network`, `asset` (mint), `tokenProgram`, and `payTo` match the requirements.
+2. Confirm `network`, `asset` (mint), `tokenProgram`, `channelProgram`, and `payTo` match the requirements.
 3. Confirm `feePayer` in `extra` is the operator's own key (the server's, or the facilitator's it delegates to).
-4. Confirm the channel exists (or the `openTransaction` is valid and broadcastable), **`channel.deposit == maxAmount`** (exact, not `≥`: `topUp` can raise an open channel's deposit, so only equality keeps the x402 ceiling enforced rather than advisory), `distribution_hash` matches the intended `payTo`/`splits` (so `payTo`'s payout is locked on-chain), `channel.status == Open`, `channel.mint == asset`, **`channel.payee == channel.authorizedSigner == operator`** (so the operator is both the voucher signer and the `settle_and_finalize` merchant, and alone can settle and finalize), and the open's **`rentPayer == operator`** (the operator funds and reclaims the rent it co-signs for). An `open` naming any other payee, authorized signer, or rentPayer MUST be rejected before co-signing.
+4. Confirm the channel exists (or the `openTransaction` is valid and broadcastable), targets `extra.channelProgram`, **`channel.deposit == maxAmount`** (exact, not `≥`: `topUp` can raise an open channel's deposit, so only equality keeps the x402 ceiling enforced rather than advisory), `distribution_hash` matches the intended `payTo`/`splits` (so `payTo`'s payout is locked on-chain), `channel.status == Open`, `channel.mint == asset`, **`channel.payee == channel.authorizedSigner == operator`** (so the operator is both the voucher signer and the `settle_and_finalize` merchant, and alone can settle and finalize), and the open's **`rentPayer == operator`** (the operator funds and reclaims the rent it co-signs for). An `open` naming any other payee, authorized signer, or rentPayer MUST be rejected before co-signing.
 5. Validate `validAfter ≤ now ≤ expiresAt`.
 6. Simulate the settlement instruction(s).
 

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -24,9 +24,10 @@ settles the actual amount against it with a single signed voucher.
 
 The **operator** is the party that co-signs the channel `open` as fee payer and
 submits settlement — the **server itself, or a facilitator it delegates to**
-(advertised as `extra.feePayer`). Nothing in `upto` requires a *separate*
-facilitator: a server can self-facilitate, running verify and settle directly.
-"Server/facilitator" below denotes whichever fills the operator role.
+(advertised as `extra.facilitatorAddress`). When `extra.facilitatorAddress` is
+omitted, the operator is `payTo`, so the server self-facilitates by running
+verify and settle directly. "Server/facilitator" below denotes whichever fills
+the operator role.
 
 The operator fills every channel role that must act without the client: the
 `open` fee payer and `rentPayer`, the voucher `authorizedSigner`, **and the
@@ -35,10 +36,11 @@ signer (the program checks `merchant == channel.payee`). The x402 `payTo` (the
 resource server's revenue address) is realized as a **program-enforced
 distribution split** fixed at `open`: when the server self-facilitates it simply
 *is* the operator/payee and receives the settled amount directly; when a
-separate facilitator is the operator, `payTo` is a locked split recipient the
-facilitator cannot redirect or shortchange (the facilitator MAY keep a fee via
-the payee's implicit remainder). This is why a third-party facilitator needs no
-program change — see §3 and §5.
+separate facilitator is the operator, `payTo` is a locked split recipient and
+`extra.facilitatorFee` is the facilitator's basis-point share, paid through the
+payee's implicit remainder. This is why a third-party facilitator needs no
+program change — the x402 fields map to the payment-channel program's native
+split support.
 
 ## 2. Mapping the five core requirements to SVM
 
@@ -46,7 +48,7 @@ program change — see §3 and §5.
 |---|---|
 | Single-use authorization | `finalize` makes the channel terminal (`ChannelStatus::Finalized`). |
 | Time-bound validity (`validAfter`, `expiresAt`) | `expiresAt` is signed by the operator into the on-chain voucher and enforced by the program (settle rejected once `now ≥ expiresAt`); `validAfter` is off-chain verify-time policy only. Neither is client-bound — the client signs only `open`. |
-| Recipient binding | `channel.payee` (the operator) + `distribution_hash` (the `payTo`/`splits`) fixed at open; the program re-checks the splits at `distribute`. |
+| Recipient binding | `channel.payee` (the operator) + `distribution_hash` (the `payTo` / `facilitatorFee` split) fixed at open; the program re-checks the distribution at `distribute`. |
 | Maximum amount enforcement | On-chain `deposit` ceiling, `cumulative_amount ≤ deposit`; the verifier pins `deposit == maxAmount` so the ceiling is exact, not advisory. |
 | Phase-dependent amount semantics | `amount` in `PaymentRequirements` is the max during verification and the actual charge during settlement. |
 
@@ -60,16 +62,18 @@ SVM `upto` defines a single asset transfer method, `payment-channel`, carried in
 program (advertised via `extra.channelProgram`). The escrow **deposit is the
 ceiling**; a single operator-signed
 voucher locks the actual amount via `settle_and_finalize`, and `distribute` then
-moves the funds — paying out the `payTo`/`splits`, refunding the unused
-`deposit − actual` to the payer, returning the fronted rent to the operator, and
-closing (tombstoning) the channel. Note `settle_and_finalize`/`finalize` only
+moves the funds — paying out the sealed `payTo` / facilitator-fee distribution,
+refunding the unused `deposit − actual` to the payer, returning the fronted rent
+to the operator, and closing (tombstoning) the channel. Note
+`settle_and_finalize`/`finalize` only
 advance channel *status*; the token movement, refund, and close all happen in
 `distribute` (the two can be bundled in one transaction).
 
 Strengths: every requirement is enforced on-chain by the program. The operator
-cannot overcharge (capped by `deposit`), cannot redirect funds (the `payTo`
-split and `distribution_hash` are fixed at open and re-checked by the program at
-`distribute`), and cannot replay (channel is terminal after `finalize`).
+cannot overcharge (capped by `deposit`), cannot redirect funds (the `payTo` /
+facilitator-fee distribution and `distribution_hash` are fixed at open and
+re-checked by the program at `distribute`), and cannot replay (channel is
+terminal after `finalize`).
 Conversely, because the operator is the channel `payee` (hence the
 `settle_and_finalize` merchant) **and** the voucher `authorizedSigner`, it can
 settle and finalize **at any time** — locking the metered amount, refunding the
@@ -117,7 +121,7 @@ to `exact`.
 | `network` | string | ✓ | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (mainnet), `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (devnet) |
 | `amount` | string | ✓ | **Phase-dependent**: max authorized at verification; actual charge at settlement. Base units. |
 | `asset` | string | ✓ | SPL mint address (e.g. USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) |
-| `payTo` | string | ✓ | Base58 recipient. Realized on-chain as the channel `payee` when the server self-facilitates (`payTo == operator`), or as a program-enforced distribution split when a separate facilitator is the `payee`. |
+| `payTo` | string | ✓ | Base58 final recipient. When the server self-facilitates, `payTo` is also the operator/channel `payee`. When `extra.facilitatorAddress` is present, `payTo` is realized as a program-enforced distribution split and the facilitator is the operator/channel `payee`. |
 | `maxTimeoutSeconds` | number | ✓ | Completion window; also the basis for the authorization `expiresAt` |
 | `extra` | object | ✓ | See below |
 
@@ -126,12 +130,73 @@ to `exact`.
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `assetTransferMethod` | string | ✓ | MUST be `"payment-channel"`. This value selects the remaining `extra` fields in this table. |
-| `feePayer` | string | ✓ | Base58 operator key that sponsors fees (co-signs the setup transaction as fee payer) and settles |
+| `facilitatorAddress` | string | – | Base58 operator key. If omitted, `payTo` is the operator. If present, this key sponsors fees/rent, co-signs the setup transaction, and settles. |
+| `facilitatorFee` | number | – | Facilitator fee in basis points of the settled amount. Default `0`. MUST be an integer `0..10000`. MUST be omitted or `0` when `facilitatorAddress` is omitted. |
 | `channelProgram` | string | ✓ | Base58 payment-channels program id. Clients and facilitators MUST reject unsupported program ids for the selected `network`. |
 | `tokenProgram` | string | ✓ | `Tokenkeg…` or `TokenzQ…` (Token-2022); the client SHOULD verify it against the on-chain mint owner |
 | `recentBlockhash` | string | – | Pre-fetched blockhash so the client can build setup transactions without an extra RPC round-trip |
 | `validAfter` | number | – | Earliest activation time (Unix seconds); default = now |
-| `splits` | `{recipient,bps}[]` | – | Distribution splits sealed at open; distributed at finalize |
+
+The x402 wire format does not expose program-specific split arrays. The client
+derives the payment-channel distribution from `payTo`, `facilitatorAddress`, and
+`facilitatorFee`:
+
+```text
+operator = extra.facilitatorAddress ?? payTo
+facilitator_fee_bps = extra.facilitatorFee ?? 0
+pay_to_bps = 10000 - facilitator_fee_bps
+channel.payee = operator
+channel.authorizedSigner = operator
+```
+
+If `operator == payTo` and `facilitator_fee_bps == 0`, the client MAY omit the
+program `recipients` array because the channel payee receives the implicit
+remainder. If `operator != payTo`, the client MUST encode `payTo` as a
+recipient with `pay_to_bps`; the facilitator receives the implicit remainder as
+its fee. The server/facilitator MUST rederive this distribution and verify that
+the decoded `openTransaction` seals the matching `distribution_hash`.
+
+Examples:
+
+Self-facilitating server (`operator == payTo`):
+
+```json
+{
+  "scheme": "upto",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "amount": "10000",
+  "asset": "<mint>",
+  "payTo": "<merchant/operator>",
+  "maxTimeoutSeconds": 300,
+  "extra": {
+    "assetTransferMethod": "payment-channel",
+    "channelProgram": "CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX",
+    "tokenProgram": "<token-program>",
+    "recentBlockhash": "<cached>"
+  }
+}
+```
+
+Separate facilitator (`operator == extra.facilitatorAddress`):
+
+```json
+{
+  "scheme": "upto",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "amount": "10000",
+  "asset": "<mint>",
+  "payTo": "<merchant>",
+  "maxTimeoutSeconds": 300,
+  "extra": {
+    "assetTransferMethod": "payment-channel",
+    "facilitatorAddress": "<operator>",
+    "facilitatorFee": 0,
+    "channelProgram": "CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX",
+    "tokenProgram": "<token-program>",
+    "recentBlockhash": "<cached>"
+  }
+}
+```
 
 `channelProgram` is discovery, not a trust anchor. The client consumes it to
 derive the channel address and build the `open` transaction; the
@@ -159,7 +224,7 @@ Plus the channel fields:
 |---|---|---|
 | `channelId` | string | Channel PDA (base58), derived before `open` from the fields below |
 | `deposit` | string | On-chain escrow = the ceiling; MUST equal `maxAmount` |
-| `authorizedSigner` | string | The **operator** key (base58) — the server's or facilitator's pubkey, equal to `extra.feePayer` **and** to `channel.payee`. The operator — not the client — signs the single settlement voucher (see §5 Phase 2); because it is also the channel `payee` (the `settle_and_finalize` merchant) it alone can settle and finalize the channel. |
+| `authorizedSigner` | string | The **operator** key (base58): `extra.facilitatorAddress` when present, otherwise `payTo`. It MUST equal `channel.payee`. The operator — not the client — signs the single settlement voucher (see §5 Phase 2); because it is also the channel `payee` (the `settle_and_finalize` merchant) it alone can settle and finalize the channel. |
 | `openTransaction` | string | Base64 partially signed `open` transaction. The client signature is present; the operator signature is still required for the transaction fee payer and `rentPayer` before broadcast. |
 
 `channelId` is the program-derived address:
@@ -178,7 +243,8 @@ find_program_address(
 )
 ```
 
-For `payment-channel`, `channel_payee == authorizedSigner == extra.feePayer`.
+For `payment-channel`, `channel_payee == authorizedSigner == operator`, where
+`operator = extra.facilitatorAddress ?? payTo`.
 Because the channel address is a PDA, the client knows `channelId` before the
 channel is opened. The client MUST derive it before signing `openTransaction`,
 include the same PDA as the writable `channel` account in the `open`
@@ -232,9 +298,10 @@ and broadcast `openTransaction`, wait until the channel account is confirmed
 
 The client's signature on the `open` transaction **is** the authorization — it
 commits the `deposit` ceiling, the `mint`, and the sealed distribution
-(`distribution_hash` over `payTo`/`splits`), with `payee` and `authorizedSigner`
-set to the **operator**. The client does not sign a voucher. After metering, the
-operator signs the single voucher for `cumulativeAmount = actual` (Ed25519 over
+(`distribution_hash` over the `payTo` / `facilitatorFee` distribution), with
+`payee` and `authorizedSigner` set to the **operator**. The client does not sign
+a voucher. After metering, the operator signs the single voucher for
+`cumulativeAmount = actual` (Ed25519 over
 `channel_id ‖ cumulative_amount_le ‖ expires_at_le`) and settles it. The client
 is protected by the on-chain ceiling (the operator cannot exceed `deposit`) and
 the sealed distribution (the operator cannot redirect or shortchange `payTo`),
@@ -246,18 +313,24 @@ The server/facilitator MUST, in order:
 
 1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
 2. Confirm `extra.assetTransferMethod == "payment-channel"` and `network`, `asset` (mint), `tokenProgram`, `channelProgram`, and `payTo` match the requirements.
-3. Confirm `feePayer` in `extra` is the operator's own key (the server's, or the facilitator's it delegates to).
+3. Determine `operator = extra.facilitatorAddress ?? payTo`. If
+   `facilitatorAddress` is present, confirm it is the facilitator's own key. If
+   `facilitatorAddress` is absent, confirm the server self-facilitates as
+   `payTo`. Confirm `extra.facilitatorFee` is absent or an integer basis-point
+   value in `0..10000`, and that it is `0` when `facilitatorAddress` is absent.
 4. Confirm the channel is open:
    - If it does not yet exist, validate that `openTransaction` targets
      `extra.channelProgram`, names `rentPayer == operator` with `rentPayer`
      marked as a required signer, names no other payee or authorized signer than
-     the operator, and is otherwise valid for the requirements; then co-sign,
-     broadcast, and wait until the channel account is confirmed `Open`.
+     the operator, seals the distribution derived from `payTo` and
+     `facilitatorFee`, and is otherwise valid for the requirements; then
+     co-sign, broadcast, and wait until the channel account is confirmed `Open`.
    - After the channel is open, confirm **`channel.deposit == maxAmount`**
      (exact, not `≥`: `topUp` can raise an open channel's deposit, so only
      equality keeps the x402 ceiling enforced rather than advisory),
-     `distribution_hash` matches the intended `payTo`/`splits` (so `payTo`'s
-     payout is locked on-chain), `channel.status == Open`,
+     `distribution_hash` matches the intended `payTo` / `facilitatorFee`
+     distribution (so `payTo`'s payout is locked on-chain),
+     `channel.status == Open`,
      `channel.mint == asset`, and
      **`channel.payee == channel.authorizedSigner == operator`** (so the
      operator is both the voucher signer and the `settle_and_finalize` merchant,
@@ -280,13 +353,14 @@ The server/facilitator MUST:
 3. `settle_and_finalize` with the single operator-signed voucher for the actual
    cumulative amount — this only locks `settled` and flips status to
    `Finalized`. Then `distribute`, which is what actually pays out
-   `payTo`/`splits`, refunds `deposit − actual` to the payer, returns the rent to
-   the operator (`rentPayer`), and closes (tombstones) the channel. The two
-   instructions MAY be bundled in one transaction. `SettlementResponse.transaction`
-   MUST identify the confirmed transaction containing the final `distribute`
-   instruction; if settlement and distribution are not bundled, this is the
-   `distribute` transaction because it moves the settled `amount` to the sealed
-   `payTo`/`splits` distribution and closes the channel.
+   the sealed `payTo` / facilitator-fee distribution, refunds
+   `deposit − actual` to the payer, returns the rent to the operator
+   (`rentPayer`), and closes (tombstones) the channel. The two instructions MAY
+   be bundled in one transaction. `SettlementResponse.transaction` MUST identify
+   the confirmed transaction containing the final `distribute` instruction; if
+   settlement and distribution are not bundled, this is the `distribute`
+   transaction because it moves the settled `amount` to the sealed `payTo` /
+   facilitator-fee distribution and closes the channel.
 4. A `0`-amount settlement uses the **no-voucher** path: `settle_and_finalize`
    with `has_voucher = 0` (a `cumulative_amount = 0` voucher is invalid — the
    watermark must advance strictly above the initial `settled = 0`), then
@@ -305,8 +379,9 @@ Standard x402 codes apply. Scheme-specific:
 
 - **No overcharge.** Capped by the on-chain `deposit`.
 - **No redirection.** `channel.payee` (the operator) and `distribution_hash`
-  (the `payTo`/`splits`) are fixed at open and re-checked by the program at
-  `distribute`, so the operator cannot redirect or shortchange `payTo`.
+  (the `payTo` / facilitator-fee distribution) are fixed at open and re-checked
+  by the program at `distribute`, so the operator cannot redirect or shortchange
+  `payTo`.
 - **No replay.** Terminal `ChannelStatus::Finalized` plus monotonic
   `SettlementWatermarks.settled`.
 - **No operator griefing.** The operator is the channel `payee` (so it is the

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -153,7 +153,7 @@ Plus the channel fields:
 | `channelId` | string | Channel PDA (base58), derived before `open` from the fields below |
 | `deposit` | string | On-chain escrow = the ceiling; MUST equal `maxAmount` |
 | `authorizedSigner` | string | The **operator** key (base58) — the server's or facilitator's pubkey, equal to `extra.feePayer` **and** to `channel.payee`. The operator — not the client — signs the single settlement voucher (see §5 Phase 2); because it is also the channel `payee` (the `settle_and_finalize` merchant) it alone can settle and finalize the channel. |
-| `openTransaction` | string | Base64 client-signed `open` transaction for the server/facilitator to co-sign and broadcast if the channel is not yet open. |
+| `openTransaction` | string | Base64 partially signed `open` transaction. The client signature is present; the operator signature is still required for the transaction fee payer and `rentPayer` before broadcast. |
 
 `channelId` is the program-derived address:
 
@@ -193,7 +193,7 @@ either the decoded `channel` account or `payload.channelId`.
 | `success` | boolean | ✓ | |
 | `errorReason` | string | – | Omitted on success |
 | `payer` | string | – | `from` |
-| `transaction` | string | ✓ | Settle (or settle-and-finalize) signature; empty string if the actual charge is `0` |
+| `transaction` | string | ✓ | Base58 transaction signature (tx hash) for the confirmed transaction that finalizes and distributes the channel. MUST NOT be empty, including when `amount` is `0`. |
 | `network` | string | ✓ | CAIP-2 |
 | `amount` | string | ✓ | Actual base units charged (may be `0`) |
 
@@ -203,10 +203,16 @@ either the decoded `channel` account or `payload.channelId`.
 
 The client builds an `open` transaction depositing `maxAmount`, naming the
 operator as the open's `rentPayer` so the operator funds the channel rent (the
-client supplies only the stablecoin deposit). The client sends
-`openTransaction`; the server/facilitator co-signs it as fee payer **and** as
+client supplies only the stablecoin deposit). Rent is paid during `open`: the
+payment-channels program requires the `rentPayer` account to be a signer because
+the instruction transfers SOL from that account to fund the channel PDA and
+escrow ATA rent. Merely naming the operator as `rentPayer` is not sufficient.
+
+The client therefore sends a partially signed `openTransaction`; the
+server/facilitator validates it, co-signs it as transaction fee payer **and** as
 `rentPayer`, then broadcasts it (one operator signature covers both, matching
-`exact`'s fee-sponsorship).
+`exact`'s fee-sponsorship). Without the operator signature, the transaction is
+invalid and cannot charge rent to the operator.
 
 ### Phase 2 — Authorization signature
 
@@ -227,7 +233,7 @@ The server/facilitator MUST, in order:
 1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
 2. Confirm `network`, `asset` (mint), `tokenProgram`, `channelProgram`, and `payTo` match the requirements.
 3. Confirm `feePayer` in `extra` is the operator's own key (the server's, or the facilitator's it delegates to).
-4. Confirm the channel exists (or the `openTransaction` is valid and broadcastable), targets `extra.channelProgram`, **`channel.deposit == maxAmount`** (exact, not `≥`: `topUp` can raise an open channel's deposit, so only equality keeps the x402 ceiling enforced rather than advisory), `distribution_hash` matches the intended `payTo`/`splits` (so `payTo`'s payout is locked on-chain), `channel.status == Open`, `channel.mint == asset`, **`channel.payee == channel.authorizedSigner == operator`** (so the operator is both the voucher signer and the `settle_and_finalize` merchant, and alone can settle and finalize), and the open's **`rentPayer == operator`** (the operator funds and reclaims the rent it co-signs for). An `open` naming any other payee, authorized signer, or rentPayer MUST be rejected before co-signing.
+4. Confirm the channel exists (or the `openTransaction` is valid and broadcastable), targets `extra.channelProgram`, **`channel.deposit == maxAmount`** (exact, not `≥`: `topUp` can raise an open channel's deposit, so only equality keeps the x402 ceiling enforced rather than advisory), `distribution_hash` matches the intended `payTo`/`splits` (so `payTo`'s payout is locked on-chain), `channel.status == Open`, `channel.mint == asset`, **`channel.payee == channel.authorizedSigner == operator`** (so the operator is both the voucher signer and the `settle_and_finalize` merchant, and alone can settle and finalize), and the open's **`rentPayer == operator`** with `rentPayer` marked as a required signer (the operator funds and reclaims the rent it co-signs for). An `open` naming any other payee, authorized signer, or rentPayer, or naming `rentPayer` without requiring the operator signature, MUST be rejected before co-signing.
 5. Validate `validAfter ≤ now ≤ expiresAt`.
 6. Simulate the settlement instruction(s).
 
@@ -248,12 +254,17 @@ The server/facilitator MUST:
    `Finalized`. Then `distribute`, which is what actually pays out
    `payTo`/`splits`, refunds `deposit − actual` to the payer, returns the rent to
    the operator (`rentPayer`), and closes (tombstones) the channel. The two
-   instructions MAY be bundled in one transaction.
+   instructions MAY be bundled in one transaction. `SettlementResponse.transaction`
+   MUST identify the confirmed transaction containing the final `distribute`
+   instruction; if settlement and distribution are not bundled, this is the
+   `distribute` transaction because it moves the settled `amount` to the sealed
+   `payTo`/`splits` distribution and closes the channel.
 4. A `0`-amount settlement uses the **no-voucher** path: `settle_and_finalize`
    with `has_voucher = 0` (a `cumulative_amount = 0` voucher is invalid — the
    watermark must advance strictly above the initial `settled = 0`), then
-   `distribute` to refund the full deposit and close. `transaction` MAY be empty
-   when no token movement occurred.
+   `distribute` to refund the full deposit and close.
+   `SettlementResponse.transaction` MUST be the signature of that confirmed
+   close/refund transaction.
 
 ## 6. Error codes
 

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -334,6 +334,101 @@ cleanup authority.
 
 ### Phase 3 - Verification (before serving the resource)
 
+#### Client-supplied `openTransaction` acceptance policy
+
+The facilitator adds its `feePayer` signature to transaction bytes constructed
+by the client. Before signing, it MUST statically inspect the complete message
+and enforce the rules in this section. Simulation or eventual onchain failure
+MUST NOT replace these checks: either occurs only after the facilitator's
+signature has already authorized the transaction.
+
+These rules apply only to the client-supplied `openTransaction`. The settlement
+transaction is constructed by the facilitator and is governed by Phase 4.
+
+##### Message and signer rules
+
+- The message MAY be legacy or version `0`, but it MUST NOT contain Address
+  Lookup Table lookups. The canonical `open` fits entirely in static account
+  keys, and rejecting lookups ensures that every program and account is visible
+  before the facilitator signs.
+- The transaction fee payer MUST equal `extra.feePayer`.
+- The complete required-signer set MUST equal the distinct addresses in
+  `{ payload.from, extra.feePayer }`. No other signature may be required.
+- The `payload.from` signature MUST be present and valid before the facilitator
+  signs. The facilitator MUST add or replace only its own `extra.feePayer`
+  signature slot.
+- Outside the canonical `open` account positions defined below,
+  `extra.feePayer` MUST NOT appear in any instruction's account list or as an
+  invoked program. If two requirements-bound roles intentionally have the same
+  address (for example `feePayer == receiverAuthorizer`), each occurrence in
+  its prescribed `open` position is permitted.
+
+##### Top-level instruction layout
+
+The top-level instructions MUST consist only of the following ordered regions:
+
+1. An optional Compute Budget prefix containing at most one
+   `SetComputeUnitLimit` instruction and at most one `SetComputeUnitPrice`
+   instruction. If both are present, `SetComputeUnitLimit` MUST precede
+   `SetComputeUnitPrice`.
+2. Exactly one payment-channels `open` instruction.
+3. An optional suffix of at most three Lighthouse instructions, each invoking
+   `L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`.
+
+No other top-level instruction or program is allowed. In particular, another
+payment-channels instruction, an SPL Memo instruction, an arbitrary wallet
+program, or a duplicate `open` MUST cause rejection.
+
+When present, Compute Budget instructions:
+
+- MUST invoke `ComputeBudget111111111111111111111111111111`;
+- MUST use only discriminator `2` (`SetComputeUnitLimit`, exactly 5 data bytes)
+  or discriminator `3` (`SetComputeUnitPrice`, exactly 9 data bytes);
+- MUST set a compute-unit limit no greater than `400000`; and
+- MUST set a compute-unit price no greater than `5000000` microlamports per
+  compute unit (5 lamports per compute unit).
+
+Lighthouse instructions are allowed only for Phantom/Solflare transaction
+assertions and MUST NOT reference `extra.feePayer` as an account. A sponsor MAY
+apply a stricter local policy, including rejecting all optional instructions,
+but MUST NOT admit instructions outside this allowlist or relax the limits
+above.
+
+##### Canonical `open` instruction
+
+The `open` instruction MUST invoke the canonical payment-channels program for
+the selected network, use discriminator `1`, contain exactly the following 14
+account positions in order, and contain no remaining accounts:
+
+| Position | Account role | Required binding | Required privileges |
+|---:|---|---|---|
+| 0 | `payer` | `payload.from` | writable, signer |
+| 1 | `rent_payer` | `extra.feePayer` | writable, signer |
+| 2 | `payee` | `extra.feePayer` | read-only role |
+| 3 | `mint` | `requirements.asset` | read-only |
+| 4 | `authorized_signer` | `extra.receiverAuthorizer` | read-only role |
+| 5 | `channel` | `payload.channelId` | writable |
+| 6 | `payer_token_account` | ATA derived from `payload.from`, `asset`, and `extra.tokenProgram` | writable |
+| 7 | `channel_token_account` | ATA derived from `payload.channelId`, `asset`, and `extra.tokenProgram` | writable |
+| 8 | `token_program` | `extra.tokenProgram` | read-only |
+| 9 | `system_program` | `11111111111111111111111111111111` | read-only |
+| 10 | `rent` | `SysvarRent111111111111111111111111111111111` | read-only |
+| 11 | `associated_token_program` | `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL` | read-only |
+| 12 | `event_authority` | canonical event-authority PDA for the payment-channels program | read-only |
+| 13 | `self_program` | canonical payment-channels program id | read-only |
+
+Solana message compilation deduplicates equal public keys and unions their
+privileges. Therefore a read-only role at position 2 or 4 MAY be effectively
+writable and/or a signer when it equals another requirements-bound role (as
+`payee == rent_payer` always does in this profile); that expected privilege
+union MUST NOT itself cause rejection. No account outside the writable roles in
+the table (including an intentional equal-key union) may be writable.
+
+The facilitator MUST fully decode the canonical `open` instruction data, reject
+truncated data or trailing bytes, and enforce every field binding defined in
+section 4.2, including the exact deposit, salt, open slot, grace period,
+distribution, and rederived channel PDA.
+
 The server/facilitator MUST, in order:
 
 1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
@@ -343,14 +438,9 @@ The server/facilitator MUST, in order:
    transaction, `extra.receiverAuthorizer` is the server's configured receiver
    authorizer, and `extra.withdrawDelay` is an integer greater than zero.
 4. Confirm the channel is open:
-   - If it does not yet exist, validate that `openTransaction` targets the
-     canonical payment-channels program, names
-     `payee == rent_payer == extra.feePayer` with `rent_payer` marked as a
-     required signer, names `authorized_signer == extra.receiverAuthorizer`,
-     encodes `grace_period == extra.withdrawDelay`, encodes
-     `open_slot == payload.openSlot`, seals the single-entry 100% `payTo`
-     distribution, and is otherwise valid for the requirements; then co-sign,
-     broadcast, and wait until the channel account is confirmed `Open`.
+   - If it does not yet exist, validate `openTransaction` against the complete
+     acceptance policy above; then co-sign, broadcast, and wait until the
+     channel account is confirmed `Open`.
    - After the channel is open, confirm `channel.deposit == maxAmount` (exact,
      not `>=`: `top_up` can raise an open channel's deposit, so equality keeps
      the x402 ceiling enforced), `channel.status == Open`,
@@ -536,8 +626,9 @@ Standard x402 codes apply. Scheme-specific:
   current program version.
 - **Client gaslessness.** The client supplies the stablecoin deposit and signs
   `open`; `feePayer` signs the transaction and funds SOL fees/rent. The
-  verifier MUST ensure the client-signed `open` cannot debit `feePayer` beyond
-  fees and the intended channel/escrow rent.
+  verifier MUST enforce the Phase 3 `openTransaction` acceptance policy so the
+  client-signed transaction cannot debit `feePayer` beyond fees and the
+  intended channel/escrow rent.
 - **Client escape hatch.** `withdrawDelay` is server-defined and fixed at
   `open`. If the server does not settle, the payer can start forced close with
   `request_close`, wait the grace period, then recover unspent deposit through

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -28,14 +28,26 @@ submits settlement — the **server itself, or a facilitator it delegates to**
 facilitator: a server can self-facilitate, running verify and settle directly.
 "Server/facilitator" below denotes whichever fills the operator role.
 
+The operator fills every channel role that must act without the client: the
+`open` fee payer and `rentPayer`, the voucher `authorizedSigner`, **and the
+channel `payee`** — which the program requires as the `settle_and_finalize`
+signer (the program checks `merchant == channel.payee`). The x402 `payTo` (the
+resource server's revenue address) is realized as a **program-enforced
+distribution split** fixed at `open`: when the server self-facilitates it simply
+*is* the operator/payee and receives the settled amount directly; when a
+separate facilitator is the operator, `payTo` is a locked split recipient the
+facilitator cannot redirect or shortchange (the facilitator MAY keep a fee via
+the payee's implicit remainder). This is why a third-party facilitator needs no
+program change — see §3 and §5.
+
 ## 2. Mapping the five core requirements to SVM
 
 | Requirement (generic spec) | SVM mechanism |
 |---|---|
 | Single-use authorization | `finalize` makes the channel terminal (`ChannelStatus::Finalized`). |
-| Time-bound validity (`validAfter`, `expiresAt`) | Authorization `validAfter` + `expiresAt`; `expiresAt` is also signed into the on-chain voucher. |
-| Recipient binding | `channel.payee` + `distribution_hash` fixed at open. |
-| Maximum amount enforcement | On-chain `deposit` ceiling, `cumulative_amount ≤ deposit`. |
+| Time-bound validity (`validAfter`, `expiresAt`) | `expiresAt` is signed by the operator into the on-chain voucher and enforced by the program (settle rejected once `now ≥ expiresAt`); `validAfter` is off-chain verify-time policy only. Neither is client-bound — the client signs only `open`. |
+| Recipient binding | `channel.payee` (the operator) + `distribution_hash` (the `payTo`/`splits`) fixed at open; the program re-checks the splits at `distribute`. |
+| Maximum amount enforcement | On-chain `deposit` ceiling, `cumulative_amount ≤ deposit`; the verifier pins `deposit == maxAmount` so the ceiling is exact, not advisory. |
 | Phase-dependent amount semantics | `amount` in `PaymentRequirements` is the max during verification and the actual charge during settlement. |
 
 The server/facilitator MUST always verify against the client-signed ceiling,
@@ -46,23 +58,28 @@ never against the settlement-time `amount`.
 v1 defines a single profile, `payment-channel`, carried in the payload's
 `profile` field. It is backed by the on-chain payment-channels program
 (advertised via `extra.channelProgram`; a canonical deployment is assumed when
-omitted). The escrow **deposit is the ceiling**; a single signed voucher settles
-the actual amount; `finalize` closes the channel and refunds the unused
-remainder to the payer in the same transaction.
+omitted). The escrow **deposit is the ceiling**; a single operator-signed
+voucher locks the actual amount via `settle_and_finalize`, and `distribute` then
+moves the funds — paying out the `payTo`/`splits`, refunding the unused
+`deposit − actual` to the payer, returning the fronted rent to the operator, and
+closing (tombstoning) the channel. Note `settle_and_finalize`/`finalize` only
+advance channel *status*; the token movement, refund, and close all happen in
+`distribute` (the two can be bundled in one transaction).
 
-Strengths: every requirement is enforced on-chain by the program. The
-operator cannot overcharge (capped by `deposit`), cannot redirect funds
-(`channel.payee` / `distribution_hash` are fixed at open), and cannot replay
-(channel is terminal after `finalize`). Conversely, because the channel's
-`authorizedSigner` is the operator (and the operator is the `settle_and_finalize`
-merchant), the operator can settle and finalize **at any time** — collecting the
-metered amount and refunding the client's unused deposit — without the client's
+Strengths: every requirement is enforced on-chain by the program. The operator
+cannot overcharge (capped by `deposit`), cannot redirect funds (the `payTo`
+split and `distribution_hash` are fixed at open and re-checked by the program at
+`distribute`), and cannot replay (channel is terminal after `finalize`).
+Conversely, because the operator is the channel `payee` (hence the
+`settle_and_finalize` merchant) **and** the voucher `authorizedSigner`, it can
+settle and finalize **at any time** — locking the metered amount, refunding the
+client's unused deposit, and closing the channel — without the client's
 cooperation. The channel-account rent is fronted by the operator: the `open`
 instruction's `rentPayer` account (the operator's own key) funds the PDA and
-escrow-ATA rent, and `finalize` **refunds it to that `rentPayer`** — so the
-client moves only stablecoin and never needs SOL. The operator can finalize a
-stale channel at will, reclaiming the rent it fronted; its only exposure is the
-cheap finalize transaction.
+escrow-ATA rent, and `distribute` **returns it to that `rentPayer`** on close —
+so the client moves only stablecoin and never needs SOL. The operator can settle
+a stale channel at will, reclaiming the rent it fronted; its only exposure is the
+cheap settle-and-finalize + distribute transaction.
 
 Cost: the client locks `max` in escrow for the lifetime of the request, and the
 flow needs two on-chain transactions (open, then settle-and-finalize). The
@@ -87,7 +104,7 @@ to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
 | `network` | string | ✓ | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (mainnet), `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (devnet) |
 | `amount` | string | ✓ | **Phase-dependent**: max authorized at verification; actual charge at settlement. Base units. |
 | `asset` | string | ✓ | SPL mint address (e.g. USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) |
-| `payTo` | string | ✓ | Base58 recipient |
+| `payTo` | string | ✓ | Base58 recipient. Realized on-chain as the channel `payee` when the server self-facilitates (`payTo == operator`), or as a program-enforced distribution split when a separate facilitator is the `payee`. |
 | `maxTimeoutSeconds` | number | ✓ | Completion window; also the basis for the authorization `expiresAt` |
 | `extra` | object | ✓ | See below |
 
@@ -123,7 +140,7 @@ Plus the channel fields:
 |---|---|---|
 | `channelId` | string | Channel PDA (base58) |
 | `deposit` | string | On-chain escrow = the ceiling; MUST equal `maxAmount` |
-| `authorizedSigner` | string | The **operator** key (base58) — the server's or facilitator's pubkey, equal to `extra.feePayer`. The operator — not the client — signs the single settlement voucher (see §5 Phase 2); as the channel `authorizedSigner`/merchant it alone can settle and finalize the channel. |
+| `authorizedSigner` | string | The **operator** key (base58) — the server's or facilitator's pubkey, equal to `extra.feePayer` **and** to `channel.payee`. The operator — not the client — signs the single settlement voucher (see §5 Phase 2); because it is also the channel `payee` (the `settle_and_finalize` merchant) it alone can settle and finalize the channel. |
 | `openTransaction` | string | Base64 signed `open` transaction for the server/facilitator to broadcast if the channel is not yet open (pull-style). Omitted if the client already broadcast `open` (push-style) and `signature` is set. |
 | `signature` | string | Base58 signature of the broadcast `open` transaction (push) |
 
@@ -159,13 +176,14 @@ server/facilitator broadcasts it, co-signing as fee payer **and** as `rentPayer`
 ### Phase 2 — Authorization signature
 
 The client's signature on the `open` transaction **is** the authorization — it
-commits the `deposit` ceiling, the `payee`, and the `mint`, with
-`authorizedSigner` set to the **operator**. The client does not sign a voucher.
-After metering, the operator signs the single voucher for
-`cumulativeAmount = actual` (Ed25519 over
+commits the `deposit` ceiling, the `mint`, and the sealed distribution
+(`distribution_hash` over `payTo`/`splits`), with `payee` and `authorizedSigner`
+set to the **operator**. The client does not sign a voucher. After metering, the
+operator signs the single voucher for `cumulativeAmount = actual` (Ed25519 over
 `channel_id ‖ cumulative_amount_le ‖ expires_at_le`) and settles it. The client
 is protected by the on-chain ceiling (the operator cannot exceed `deposit`) and
-the fixed `payee` (the operator cannot redirect), in a single round-trip.
+the sealed distribution (the operator cannot redirect or shortchange `payTo`),
+in a single round-trip.
 
 ### Phase 3 — Verification (before serving the resource)
 
@@ -174,7 +192,7 @@ The server/facilitator MUST, in order:
 1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
 2. Confirm `network`, `asset` (mint), `tokenProgram`, and `payTo` match the requirements.
 3. Confirm `feePayer` in `extra` is the operator's own key (the server's, or the facilitator's it delegates to).
-4. Confirm the channel exists (or the `openTransaction` is valid and broadcastable), `channel.deposit ≥ maxAmount`, `channel.payee` and `distribution_hash` match `payTo`/`splits`, `channel.status == Open`, `channel.mint == asset`, **`channel.authorizedSigner == operator`** (so the operator alone can settle and finalize), and the open's **`rentPayer == operator`** (the operator funds and reclaims the rent it co-signs for). An `open` naming any other authorized signer or rentPayer MUST be rejected before co-signing.
+4. Confirm the channel exists (or the `openTransaction` is valid and broadcastable), **`channel.deposit == maxAmount`** (exact, not `≥`: `topUp` can raise an open channel's deposit, so only equality keeps the x402 ceiling enforced rather than advisory), `distribution_hash` matches the intended `payTo`/`splits` (so `payTo`'s payout is locked on-chain), `channel.status == Open`, `channel.mint == asset`, **`channel.payee == channel.authorizedSigner == operator`** (so the operator is both the voucher signer and the `settle_and_finalize` merchant, and alone can settle and finalize), and the open's **`rentPayer == operator`** (the operator funds and reclaims the rent it co-signs for). An `open` naming any other payee, authorized signer, or rentPayer MUST be rejected before co-signing.
 5. Validate `validAfter ≤ now ≤ expiresAt`.
 6. Simulate the settlement instruction(s).
 
@@ -190,12 +208,17 @@ The server/facilitator MUST:
    (`maxAmount` / `deposit`), NOT against `paymentRequirements.amount`.
 2. Assert `paymentRequirements.amount ≤ maxAmount`. On violation, fail with
    `invalid_upto_svm_payload_settlement_exceeds_amount`.
-3. `settle_and_finalize` with the single voucher for the actual cumulative
-   amount, then `distribute` to `payTo`/`splits`. Finalize refunds
-   `deposit − actual` to the payer and closes the channel.
-4. A `0`-amount settlement requires no transfer; the channel still finalizes
-   (full refund, channel closed). `transaction` MAY be empty when no token
-   movement occurred.
+3. `settle_and_finalize` with the single operator-signed voucher for the actual
+   cumulative amount — this only locks `settled` and flips status to
+   `Finalized`. Then `distribute`, which is what actually pays out
+   `payTo`/`splits`, refunds `deposit − actual` to the payer, returns the rent to
+   the operator (`rentPayer`), and closes (tombstones) the channel. The two
+   instructions MAY be bundled in one transaction.
+4. A `0`-amount settlement uses the **no-voucher** path: `settle_and_finalize`
+   with `has_voucher = 0` (a `cumulative_amount = 0` voucher is invalid — the
+   watermark must advance strictly above the initial `settled = 0`), then
+   `distribute` to refund the full deposit and close. `transaction` MAY be empty
+   when no token movement occurred.
 
 ## 6. Error codes
 
@@ -207,20 +230,26 @@ Standard x402 codes apply. Scheme-specific:
 ## 7. Security properties
 
 - **No overcharge.** Capped by the on-chain `deposit`.
-- **No redirection.** `channel.payee`/`distribution_hash` fixed at open.
+- **No redirection.** `channel.payee` (the operator) and `distribution_hash`
+  (the `payTo`/`splits`) are fixed at open and re-checked by the program at
+  `distribute`, so the operator cannot redirect or shortchange `payTo`.
 - **No replay.** Terminal `ChannelStatus::Finalized` plus monotonic
   `SettlementWatermarks.settled`.
-- **No operator griefing.** The channel's `authorizedSigner` is the operator,
-  which is also the `settle_and_finalize` merchant, so the operator can always
-  settle the metered amount, refund the client's unused deposit, and close the
-  channel without the client. The operator fronts the channel rent (the `open`
-  `rentPayer` account is its own key) and reclaims it at finalize, so the client
-  never needs SOL and cannot strand the operator's funds — the operator's only
-  exposure is the finalize transaction it elects to send. The server/facilitator
-  MUST reject any `open` whose `authorizedSigner` or `rentPayer` is not the
-  operator before co-signing (§5 Phase 3).
-- **Time-bounded.** `validAfter`/`expiresAt` checked off-chain at verify and
-  signed into the on-chain message so a stale authorization cannot settle.
+- **No operator griefing.** The operator is the channel `payee` (so it is the
+  `settle_and_finalize` merchant, which the program requires to equal
+  `channel.payee`) **and** the voucher `authorizedSigner`, so it can always
+  settle the metered amount, refund the client's unused deposit, and — via
+  `distribute` — close the channel and reclaim the rent it fronted, all without
+  the client. The client never needs SOL and cannot strand the operator's funds;
+  the operator's only exposure is the settle-and-finalize + distribute
+  transaction it elects to send. The server/facilitator MUST reject any `open`
+  whose `payee`, `authorizedSigner`, or `rentPayer` is not the operator before
+  co-signing (§5 Phase 3).
+- **Time-bounded.** `expiresAt` is signed by the operator into the voucher and
+  enforced on-chain (the program rejects a settle once `now ≥ expiresAt`);
+  `validAfter` is off-chain verify-time policy only. These bind the *operator's*
+  voucher rather than the client (who signs only `open`): they bound when a
+  metered settlement may land, not a client-side commitment.
 - **Trust model.** As in the generic spec, the client trusts the server to meter
   honestly within the ceiling. Everything above the ceiling, the destination,
   and replay are enforced cryptographically/on-chain.

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -87,6 +87,13 @@ channel-account rent is funded by the operator (the `open` `rentPayer` account)
 and reclaimed at finalize; the client supplies only the stablecoin deposit and
 never needs SOL.
 
+> **Reference-implementation status.** The v1 reference implements the
+> **self-facilitating** case (`operator == payTo`), where the operator is both
+> the settlement authority (`channel.payee`) and the recipient. Separate-facilitator
+> operation — where `payTo` is a program-enforced distribution split and the
+> facilitator is the `channel.payee` — is specified (§4.1) but not yet implemented;
+> the reference rejects an open whose `payTo` is not the operator.
+
 ## 4. Wire format
 
 `upto` reuses the x402 v2 transport: a `402` response carries `PAYMENT-REQUIRED`;

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -53,12 +53,12 @@ program change — see §3 and §5.
 The server/facilitator MUST always verify against the client-signed ceiling,
 never against the settlement-time `amount`.
 
-## 3. Payment-channel profile
+## 3. Payment-channel asset transfer method
 
-v1 defines a single profile, `payment-channel`, carried in the payload's
-`profile` field. It is backed by the on-chain payment-channels program
-(advertised via `extra.channelProgram`). The escrow **deposit is the ceiling**;
-a single operator-signed
+SVM `upto` defines a single asset transfer method, `payment-channel`, carried in
+`extra.assetTransferMethod`. It is backed by the on-chain payment-channels
+program (advertised via `extra.channelProgram`). The escrow **deposit is the
+ceiling**; a single operator-signed
 voucher locks the actual amount via `settle_and_finalize`, and `distribute` then
 moves the funds — paying out the `payTo`/`splits`, refunding the unused
 `deposit − actual` to the payer, returning the fronted rent to the operator, and
@@ -117,7 +117,7 @@ to `exact`.
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `profiles` | string[] | ✓ | `["payment-channel"]` (the only v1 profile) |
+| `assetTransferMethod` | string | ✓ | MUST be `"payment-channel"`. This value selects the remaining `extra` fields in this table. |
 | `feePayer` | string | ✓ | Base58 operator key that sponsors fees (co-signs the setup transaction as fee payer) and settles |
 | `channelProgram` | string | ✓ | Base58 payment-channels program id. Clients and facilitators MUST reject unsupported program ids for the selected `network`. |
 | `tokenProgram` | string | ✓ | `Tokenkeg…` or `TokenzQ…` (Token-2022); the client SHOULD verify it against the on-chain mint owner |
@@ -139,7 +139,6 @@ Common fields:
 
 | Field | Type | Notes |
 |---|---|---|
-| `profile` | string | `"payment-channel"` (the only v1 profile) |
 | `from` | string | Payer wallet (base58) |
 | `maxAmount` | string | The signed ceiling (base units). MUST equal verification-phase `amount`. |
 | `expiresAt` | number | Deadline (Unix seconds); signed into the on-chain message |
@@ -171,13 +170,14 @@ find_program_address(
 )
 ```
 
-For this profile, `channel_payee == authorizedSigner == extra.feePayer`. Because
-the channel address is a PDA, the client knows `channelId` before the channel is
-opened. The client MUST derive it before signing `openTransaction`, include the
-same PDA as the writable `channel` account in the `open` instruction, and set
-`payload.channelId` to that address. The server/facilitator MUST rederive the
-PDA from the decoded `openTransaction` and reject the payload if it differs from
-either the decoded `channel` account or `payload.channelId`.
+For `payment-channel`, `channel_payee == authorizedSigner == extra.feePayer`.
+Because the channel address is a PDA, the client knows `channelId` before the
+channel is opened. The client MUST derive it before signing `openTransaction`,
+include the same PDA as the writable `channel` account in the `open`
+instruction, and set `payload.channelId` to that address. The
+server/facilitator MUST rederive the PDA from the decoded `openTransaction` and
+reject the payload if it differs from either the decoded `channel` account or
+`payload.channelId`.
 
 > The voucher is **not** carried in the payload. Because the actual amount is
 > only known after the resource is consumed, and the client's protection is the
@@ -231,7 +231,7 @@ in a single round-trip.
 The server/facilitator MUST, in order:
 
 1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
-2. Confirm `network`, `asset` (mint), `tokenProgram`, `channelProgram`, and `payTo` match the requirements.
+2. Confirm `extra.assetTransferMethod == "payment-channel"` and `network`, `asset` (mint), `tokenProgram`, `channelProgram`, and `payTo` match the requirements.
 3. Confirm `feePayer` in `extra` is the operator's own key (the server's, or the facilitator's it delegates to).
 4. Confirm the channel exists (or the `openTransaction` is valid and broadcastable), targets `extra.channelProgram`, **`channel.deposit == maxAmount`** (exact, not `≥`: `topUp` can raise an open channel's deposit, so only equality keeps the x402 ceiling enforced rather than advisory), `distribution_hash` matches the intended `payTo`/`splits` (so `payTo`'s payout is locked on-chain), `channel.status == Open`, `channel.mint == asset`, **`channel.payee == channel.authorizedSigner == operator`** (so the operator is both the voucher signer and the `settle_and_finalize` merchant, and alone can settle and finalize), and the open's **`rentPayer == operator`** with `rentPayer` marked as a required signer (the operator funds and reclaims the rent it co-signs for). An `open` naming any other payee, authorized signer, or rentPayer, or naming `rentPayer` without requiring the operator signature, MUST be rejected before co-signing.
 5. Validate `validAfter ≤ now ≤ expiresAt`.

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -214,6 +214,12 @@ server/facilitator validates it, co-signs it as transaction fee payer **and** as
 `exact`'s fee-sponsorship). Without the operator signature, the transaction is
 invalid and cannot charge rent to the operator.
 
+`openTransaction` is consumed during verification, before the protected resource
+is served. The server/facilitator MUST NOT defer broadcasting `openTransaction`
+until settlement. If the channel is not already open, verification MUST co-sign
+and broadcast `openTransaction`, wait until the channel account is confirmed
+`Open`, and then continue with the checks below.
+
 ### Phase 2 — Authorization signature
 
 The client's signature on the `open` transaction **is** the authorization — it
@@ -233,7 +239,21 @@ The server/facilitator MUST, in order:
 1. Confirm `payload.maxAmount` equals verification-phase `requirements.amount`.
 2. Confirm `extra.assetTransferMethod == "payment-channel"` and `network`, `asset` (mint), `tokenProgram`, `channelProgram`, and `payTo` match the requirements.
 3. Confirm `feePayer` in `extra` is the operator's own key (the server's, or the facilitator's it delegates to).
-4. Confirm the channel exists (or the `openTransaction` is valid and broadcastable), targets `extra.channelProgram`, **`channel.deposit == maxAmount`** (exact, not `≥`: `topUp` can raise an open channel's deposit, so only equality keeps the x402 ceiling enforced rather than advisory), `distribution_hash` matches the intended `payTo`/`splits` (so `payTo`'s payout is locked on-chain), `channel.status == Open`, `channel.mint == asset`, **`channel.payee == channel.authorizedSigner == operator`** (so the operator is both the voucher signer and the `settle_and_finalize` merchant, and alone can settle and finalize), and the open's **`rentPayer == operator`** with `rentPayer` marked as a required signer (the operator funds and reclaims the rent it co-signs for). An `open` naming any other payee, authorized signer, or rentPayer, or naming `rentPayer` without requiring the operator signature, MUST be rejected before co-signing.
+4. Confirm the channel is open:
+   - If it does not yet exist, validate that `openTransaction` targets
+     `extra.channelProgram`, names `rentPayer == operator` with `rentPayer`
+     marked as a required signer, names no other payee or authorized signer than
+     the operator, and is otherwise valid for the requirements; then co-sign,
+     broadcast, and wait until the channel account is confirmed `Open`.
+   - After the channel is open, confirm **`channel.deposit == maxAmount`**
+     (exact, not `≥`: `topUp` can raise an open channel's deposit, so only
+     equality keeps the x402 ceiling enforced rather than advisory),
+     `distribution_hash` matches the intended `payTo`/`splits` (so `payTo`'s
+     payout is locked on-chain), `channel.status == Open`,
+     `channel.mint == asset`, and
+     **`channel.payee == channel.authorizedSigner == operator`** (so the
+     operator is both the voucher signer and the `settle_and_finalize` merchant,
+     and alone can settle and finalize).
 5. Validate `validAfter ≤ now ≤ expiresAt`.
 6. Simulate the settlement instruction(s).
 
@@ -271,7 +291,7 @@ The server/facilitator MUST:
 Standard x402 codes apply. Scheme-specific:
 
 - `invalid_upto_svm_payload_settlement_exceeds_amount` — actual > signed ceiling.
-- `CHANNEL_REQUIRED` (with `412`) — no open channel and no broadcastable `openTransaction`.
+- `CHANNEL_REQUIRED` (with `412`) — no open channel and no valid `openTransaction` that can be co-signed, broadcast, and confirmed before serving the resource.
 
 ## 7. Security properties
 

--- a/specs/schemes/upto/scheme_upto_svm.md
+++ b/specs/schemes/upto/scheme_upto_svm.md
@@ -87,6 +87,14 @@ channel-account rent is funded by the operator (the `open` `rentPayer` account)
 and reclaimed at finalize; the client supplies only the stablecoin deposit and
 never needs SOL.
 
+The program stores `rentPayer` in channel state, so rent can only be returned to
+the account that funded it. A server/facilitator that sponsors rent SHOULD keep
+or reconstruct an index of channels it opened, for example from `Opened` events
+or channel accounts where `rentPayer` equals the operator. It can then close
+stale channels and reclaim rent by finalizing and distributing them; a no-charge
+cleanup uses the no-voucher `settle_and_finalize` path followed by `distribute`.
+This indexing is operational bookkeeping, not a trust assumption.
+
 > **Reference-implementation status.** The v1 reference implements the
 > **self-facilitating** case (`operator == payTo`), where the operator is both
 > the settlement authority (`channel.payee`) and the recipient. Separate-facilitator


### PR DESCRIPTION
## Description

Adds the **SVM profile of the `upto` scheme** — `specs/schemes/upto/scheme_upto_svm.md` — the per-network companion to the network-agnostic [`scheme_upto.md`](specs/schemes/upto/scheme_upto.md) and the EVM profile [`scheme_upto_evm.md`](specs/schemes/upto/scheme_upto_evm.md).

`upto` lets a client authorize a **maximum** while the server settles for **actual** usage (`actual ≤ max`). On SVM this is realized via two profiles: a normative `payment-channel` profile (escrow deposit = ceiling, single operator-signed voucher, `settle_and_finalize` + refund) and an optional future `permit` profile. The spec maps the five core `upto` requirements onto SVM mechanisms and specifies the wire format, phases, error codes, and security properties.

Authored per the repo's [`authoring-specs`](.agents/skills/authoring-specs/SKILL.md) guidance: v2 transport/headers, CAIP-2 networks, atomic units, scheme data in `extra` (e.g. `feePayer`, `channelProgram`), and references to the core `x402-specification-v2.md` types.

## Tests

Documentation-only change (no code). N/A.

## Checklist

- [x] My commits are signed (required for merge) <!-- verify before merge -->
- [x] I added a changelog fragment for user-facing changes <!-- docs-only: skipped per template -->
