### PR TITLE
docs(svm): add `batch-settlement` SVM scheme specification

### DIFF
--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -28,10 +28,11 @@ The x402 roles map to the payment-channel program as follows:
 - **Server**: resource provider; receives funds at `payTo`; owns per-channel
   offchain state, including the accepted cumulative watermark and latest
   voucher.
-- **Receiver authorizer**: server-controlled Ed25519 key advertised as
+- **Receiver authorizer**: optional server-controlled Ed25519 key advertised as
   `extra.receiverAuthorizer`. It authenticates server-approved cooperative
-  refund requests to the facilitator. It is an offchain x402 role and is not
-  recorded in the payment-channel account.
+  close requests to the facilitator. It is an offchain x402 role and is not
+  recorded in the payment-channel account. It is not required for unilateral
+  refund or rent recovery.
 - **Facilitator / sponsor**: account advertised as `extra.feePayer`; sponsors
   transaction fees and channel rent. It is the transaction fee payer and channel
   `rent_payer`, and occupies the channel `payee` lifecycle-authority seat with a
@@ -66,7 +67,7 @@ claim promptly.
 | Monotonic amount | Server-owned offchain watermark plus onchain `settled < maxClaimableAmount <= deposit` at redemption. |
 | Batched redemption | One `settle` per channel, packed transaction-size permitting; `distribute` pays settled deltas. |
 | Recipient binding | `distribution_hash` fixed at `open` sends funds to `payTo`; program re-checks it at `distribute`. |
-| Recovery of unused deposit | Server-authorized `settle_and_seal` + `distribute` for full cooperative close; `request_close` / `seal` / `withdraw_payer` for payer-forced close. |
+| Recovery of unused deposit | Client-signed `request_close`, followed after the grace period by permissionless `seal` + `distribute`; an optional server authorization can replace this with immediate cooperative `settle_and_seal` + `distribute`. |
 
 ## 3. Payment-Channel Method
 
@@ -114,16 +115,31 @@ to rediscover the channels it sponsored as specified in section 6. Token
 payouts and the return of unused escrow are completed by `distribute` and are
 not delayed by the later `reclaim` of PDA rent.
 
-For an x402 cooperative refund, the facilitator MUST additionally require a
-valid refund authorization from `extra.receiverAuthorizer`. That signature
-authenticates the server's HTTP request; it does not replace the facilitator's
-onchain `payee` signature or the client's voucher signature. The facilitator
-MUST bind `receiverAuthorizer` to the authenticated resource server and `payTo`
-through trusted configuration or an authenticated registration established no
-later than channel opening. It MUST NOT trust a receiver-authorizer key merely
-because it appears in `PaymentRequirements` or a settlement request. The
-trusted receiver authorizer is fixed for the channel lifetime; changing it
-requires cooperatively closing the channel and opening a new one.
+For an x402 immediate cooperative close, the facilitator MUST authenticate the
+resource server and bind that identity to `payTo` and the channel. It MAY do so
+with a valid `CloseAuthorization` signed by `extra.receiverAuthorizer`, or with
+facilitator-specific out-of-band authentication established no later than the
+channel's first deposit. Neither mechanism replaces the facilitator's onchain
+`payee` signature or the client's voucher signature. The facilitator MUST NOT
+trust a receiver-authorizer key or claimed server identity merely because it
+appears in `PaymentRequirements` or a settlement request. Any trusted binding
+is fixed for the channel lifetime; changing it requires closing the channel and
+opening a new one.
+
+For out-of-band authentication, the facilitator MUST record the authenticated
+server principal that submitted or sponsored the first deposit together with
+the derived `channelId` and verified `payTo`. It MUST require that same principal
+on an immediate cooperative-close request. This mechanism is facilitator-local;
+the interoperable wire fallback remains payer-signed forced close.
+
+The facilitator MUST accept a refund without a receiver authorizer. In that
+case, the client supplies a payer-signed `request_close` transaction, the
+facilitator adds its fee-payer signature and broadcasts it, and the facilitator
+or another permissionless crank finalizes the channel after the grace period.
+The facilitator MAY use the immediate cooperative path when it receives the
+server's latest valid voucher through an authenticated request under that
+binding. Out-of-band authentication is an optimization and is not required for
+interoperability.
 
 If the client invokes `request_close`, the channel enters `Closing` and regular
 `settle` is no longer available. Only the `payee` can apply a final voucher with
@@ -155,17 +171,22 @@ and `SettlementResponse` types are defined in
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
+| `paymentFlow` | string | yes | MUST be `"escrow"`, because the deposit settles before the resource handler and later vouchers authorize asynchronous claims. |
 | `feePayer` | string | yes | Base58 sponsor key set as channel `rent_payer` and zero-share `payee`. Co-signs setup/top-up transactions as transaction fee payer and signs channel lifecycle transactions. |
-| `receiverAuthorizer` | string | yes | Base58 server-controlled Ed25519 key that authenticates cooperative refund requests to the facilitator. It is not a payment-channel account field. |
-| `withdrawDelay` | number | yes | Server-defined forced-close grace period in seconds. The client MUST encode this exact value as the program `grace_period`; the verifier MUST reject any other value. |
+| `receiverAuthorizer` | string | no | Base58 server-controlled Ed25519 key that authenticates an optional immediate cooperative close to the facilitator. It is not a payment-channel account field. |
+| `withdrawDelay` | number | yes | Forced-close grace period in seconds. MUST be an integer from `900` through `2592000` (15 minutes through 30 days), MUST be `>= maxTimeoutSeconds`, and MUST be encoded exactly as the program `grace_period`. |
+| `tokenProgram` | string | yes | SPL Token (`Tokenkeg...`) or Token-2022 (`TokenzQ...`) program that owns `asset`. The client and facilitator MUST verify it against the onchain mint owner. |
+| `memo` | string | no | Seller-defined UTF-8 payment reference for the setup transaction's Memo instruction. Maximum 256 bytes. |
 | `recentBlockhash` | string | no | Pre-fetched blockhash the client MAY use to build an `open` or `top_up` transaction without an RPC round trip. The client MUST refresh it if it is no longer valid. |
+| `lastValidBlockHeight` | string | no | Last block height at which `recentBlockhash` is valid, as a decimal string. Informational; MAY be ignored. Ignored when `recentBlockhash` is absent. |
 | `recentSlot` | number | no | Recent slot the client MAY use as `channelConfig.openSlot` when it does not fetch its own slot. The program still enforces the open-slot window. |
 | `channelState` | object | no | Corrective-only server channel snapshot for cumulative amount resynchronization. |
 | `voucherState` | object | no | Corrective-only signed voucher proof for cumulative amount resynchronization. |
 
-`recentBlockhash` and `recentSlot` are transaction-construction hints only. They
-are not persistent channel configuration and are not included in the voucher
-message. A client MAY ignore either hint and obtain a fresher value from an RPC.
+`recentBlockhash`, `lastValidBlockHeight`, and `recentSlot` are
+transaction-construction hints only. They are not persistent channel
+configuration and are not included in the voucher message. A client MAY ignore
+the hints and obtain fresher values from an RPC.
 
 The x402 wire format does not expose program-specific split arrays. The client
 derives the payment-channel accounts and distribution from the x402 fields:
@@ -196,10 +217,14 @@ Example:
   "payTo": "<server-receiver>",
   "maxTimeoutSeconds": 300,
   "extra": {
+    "paymentFlow": "escrow",
     "feePayer": "<facilitator-fee-payer>",
-    "receiverAuthorizer": "<server-refund-authorizer>",
+    "receiverAuthorizer": "<server-close-authorizer>",
     "withdrawDelay": 3600,
+    "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "memo": "invoice-123",
     "recentBlockhash": "<recent-blockhash>",
+    "lastValidBlockHeight": "321000000",
     "recentSlot": 341000000
   }
 }
@@ -217,11 +242,12 @@ may expose those program fields with language-specific casing.
 | x402 wire field | Payment-channels program notation |
 |---|---|
 | `PaymentRequirements.extra.feePayer` | `Channel.rent_payer` and zero-share `Channel.payee` |
-| `PaymentRequirements.extra.receiverAuthorizer` | No program field; trusted server key for offchain refund authorization |
+| `PaymentRequirements.extra.receiverAuthorizer` | No program field; optional trusted server key for offchain close authorization |
+| `PaymentRequirements.extra.tokenProgram` | `open.token_program` / `top_up.token_program`; MUST equal the onchain owner of `Channel.mint` |
 | `channelConfig.payer` | `Channel.payer` |
 | `channelConfig.payerAuthorizer` | `Channel.authorized_signer` |
 | `channelConfig.receiver` | Sole `DistributionEntry.recipient` with `bps = 10000`; the `Channel.payee` implicit remainder is always zero |
-| `channelConfig.receiverAuthorizer` | No program field; MUST equal `PaymentRequirements.extra.receiverAuthorizer` |
+| `channelConfig.receiverAuthorizer` | No program field; when supplied, MUST equal `PaymentRequirements.extra.receiverAuthorizer` |
 | `channelConfig.token` | `Channel.mint` |
 | `channelConfig.withdrawDelay` | `Channel.grace_period` |
 | `channelConfig.salt` | `Channel.salt` |
@@ -241,15 +267,15 @@ may expose those program fields with language-specific casing.
 | `payer` | string | Client wallet and channel payer. MUST NOT equal `feePayer`, because the program requires distinct payer and payee accounts. |
 | `payerAuthorizer` | string | Client-controlled Ed25519 voucher signer; maps to channel `authorized_signer`. MAY equal `payer` but MUST NOT equal `feePayer`. |
 | `receiver` | string | MUST equal `payTo`. |
-| `receiverAuthorizer` | string | MUST equal `extra.receiverAuthorizer`. This key authenticates cooperative refund requests offchain and is not a channel PDA seed or program account field. |
+| `receiverAuthorizer` | string | Optional. When supplied, MUST equal `extra.receiverAuthorizer`. This key authenticates cooperative close requests offchain and is not a channel PDA seed or program account field. |
 | `token` | string | MUST equal `asset`; maps to channel `mint`. |
 | `withdrawDelay` | number | MUST equal `extra.withdrawDelay`; maps to channel `grace_period`. |
 | `salt` | string | Decimal `u64` channel salt. |
 | `openSlot` | number | `u64` slot encoded in `open` and used as a channel PDA seed. |
 
-The client MUST determine the token program from the onchain owner of
-`channelConfig.token`; it MUST NOT accept an unverified token-program value from
-the server.
+The client and facilitator MUST confirm `extra.tokenProgram` equals the onchain
+owner of `channelConfig.token`; neither role may trust the server-provided value
+without that check.
 
 `channelId` is the program-derived address:
 
@@ -299,17 +325,17 @@ The signed message is exactly:
 This is the payment-channels program voucher layout (`VOUCHER_MAGIC`,
 `channel_id`, `cumulative_amount`, `expires_at`), 50 bytes total.
 
-`RefundAuthorization`:
+`CloseAuthorization`:
 
 | Field | Type | Notes |
 |---|---|---|
 | `validBefore` | number | Integer Unix seconds. The server MUST set it no later than its current time plus `maxTimeoutSeconds`; the facilitator MUST require `now < validBefore <= now + maxTimeoutSeconds`. |
-| `signature` | string | Base58 Ed25519 signature by `extra.receiverAuthorizer` over the digest below. |
+| `signature` | string | Base58 Ed25519 signature by the receiver authorizer bound to the server through `extra.receiverAuthorizer` or a trusted out-of-band registration. |
 
 The receiver authorizer signs the SHA-256 digest of this exact byte sequence:
 
 ```text
-UTF8("x402:batch-settlement:svm:refund:v1") || 0x00 ||
+UTF8("x402:batch-settlement:svm:close:v1") || 0x00 ||
 u16(len(network)).le || UTF8(network) ||
 programId[32] ||
 feePayer[32] ||
@@ -339,9 +365,10 @@ program deployment, facilitator, channel, voucher watermark, or expiry.
 ### 4.3 Client `PaymentPayload` Variants
 
 The client payload is a tagged union on `payload.type`. `/verify` accepts all
-three variants. `/settle` accepts `deposit` directly; the server enriches
-`refund` with a `RefundAuthorization` before forwarding it as specified in
-section 4.5. A `voucher` is accepted offchain by the server.
+three variants. `/settle` accepts `deposit` and `refund` directly. The server
+MAY enrich `refund` with its latest accepted voucher and, when needed, a
+`CloseAuthorization` before forwarding it as specified in section 4.5. A
+`voucher` is accepted offchain by the server.
 
 **`deposit`** opens a channel or tops up an existing channel and authorizes the
 current request:
@@ -365,10 +392,13 @@ current request:
     "payTo": "<server-receiver>",
     "maxTimeoutSeconds": 300,
     "extra": {
+      "paymentFlow": "escrow",
       "feePayer": "<facilitator-fee-payer>",
-      "receiverAuthorizer": "<server-refund-authorizer>",
+      "receiverAuthorizer": "<server-close-authorizer>",
       "withdrawDelay": 3600,
+      "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
       "recentBlockhash": "<recent-blockhash>",
+      "lastValidBlockHeight": "321000000",
       "recentSlot": 341000000
     }
   },
@@ -378,7 +408,7 @@ current request:
       "payer": "<client-wallet>",
       "payerAuthorizer": "<client-voucher-signer>",
       "receiver": "<server-receiver>",
-      "receiverAuthorizer": "<server-refund-authorizer>",
+      "receiverAuthorizer": "<server-close-authorizer>",
       "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "withdrawDelay": 3600,
       "salt": "42",
@@ -418,10 +448,13 @@ transaction:
     "payTo": "<server-receiver>",
     "maxTimeoutSeconds": 300,
     "extra": {
+      "paymentFlow": "escrow",
       "feePayer": "<facilitator-fee-payer>",
-      "receiverAuthorizer": "<server-refund-authorizer>",
+      "receiverAuthorizer": "<server-close-authorizer>",
       "withdrawDelay": 3600,
+      "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
       "recentBlockhash": "<recent-blockhash>",
+      "lastValidBlockHeight": "321000000",
       "recentSlot": 341000000
     }
   },
@@ -431,7 +464,7 @@ transaction:
       "payer": "<client-wallet>",
       "payerAuthorizer": "<client-voucher-signer>",
       "receiver": "<server-receiver>",
-      "receiverAuthorizer": "<server-refund-authorizer>",
+      "receiverAuthorizer": "<server-close-authorizer>",
       "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "withdrawDelay": 3600,
       "salt": "42",
@@ -447,17 +480,21 @@ transaction:
 }
 ```
 
-**`refund`** requests immediate cooperative closure and the return of all
-unspent escrow. It is a payment operation, not a paid resource request, so the
-application resource handler MUST be bypassed. The request MUST NOT contain an
-`amount`: the payment-channel program supports only a full refund of
-`deposit - settled`, and the closed channel cannot be reused.
+**`refund`** is retained as the cross-binding wire discriminator for a channel
+close. The client MUST provide a payer-signed `request_close` transaction. This
+is a payment operation, not a paid resource request, so the application
+resource handler MUST be bypassed. The request MUST NOT contain an `amount`:
+the payment-channel program supports only the return of all unused escrow, and
+the closed channel cannot be reused. A client MAY also provide a voucher as a
+hint for an immediate cooperative close, but the facilitator MUST NOT apply it
+unless an authenticated server confirms it is the latest accepted voucher.
 
 | Field | Type | Notes |
 |---|---|---|
 | `type` | string | `"refund"` |
 | `channelConfig` | `ChannelConfig` | Full channel configuration. |
-| `voucher` | `BatchVoucher` | Zero-charge voucher whose `maxClaimableAmount` equals the server's current `chargedCumulativeAmount`. |
+| `transaction` | string | Base64 client-signed `request_close` transaction. The transaction MUST set `extra.feePayer` as its Solana fee payer so the facilitator can co-sign and broadcast it. |
+| `voucher` | `BatchVoucher` | Optional latest accepted voucher. It is used only when supplied or confirmed by an authenticated server for immediate cooperative close. |
 
 ```json
 {
@@ -470,10 +507,12 @@ application resource handler MUST be bypassed. The request MUST NOT contain an
     "payTo": "<server-receiver>",
     "maxTimeoutSeconds": 300,
     "extra": {
+      "paymentFlow": "escrow",
       "feePayer": "<facilitator-fee-payer>",
-      "receiverAuthorizer": "<server-refund-authorizer>",
       "withdrawDelay": 3600,
+      "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
       "recentBlockhash": "<recent-blockhash>",
+      "lastValidBlockHeight": "321000000",
       "recentSlot": 341000000
     }
   },
@@ -483,18 +522,12 @@ application resource handler MUST be bypassed. The request MUST NOT contain an
       "payer": "<client-wallet>",
       "payerAuthorizer": "<client-voucher-signer>",
       "receiver": "<server-receiver>",
-      "receiverAuthorizer": "<server-refund-authorizer>",
       "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "withdrawDelay": 3600,
       "salt": "42",
       "openSlot": 341000000
     },
-    "voucher": {
-      "channelId": "<channel-pda>",
-      "maxClaimableAmount": "5000",
-      "expiresAt": 0,
-      "signature": "<base58-ed25519-zero-charge-voucher-signature>"
-    }
+    "transaction": "<base64-client-signed-request-close-transaction>"
   }
 }
 ```
@@ -506,7 +539,7 @@ application resource handler MUST be bypassed. The request MUST NOT contain an
 | `success` | boolean | yes | Whether acceptance or settlement succeeded. |
 | `errorReason` | string | no | Omitted on success. |
 | `payer` | string | no | Channel `payer`. |
-| `transaction` | string | yes | Onchain signature for deposit/top-up/refund/claim/settle operations; empty string for offchain voucher acceptance. |
+| `transaction` | string | yes | Onchain signature for deposit/top-up/refund-initiation/cooperative-close/claim/settle operations; empty string for offchain voucher acceptance. |
 | `network` | string | yes | CAIP-2 network identifier. |
 | `amount` | string | no | Amount moved onchain; empty for voucher acceptance and `claim`. |
 | `extra.commitmentId` | string | no | MUST be non-empty for voucher acceptance, e.g. `channelId:maxClaimableAmount`. |
@@ -554,10 +587,13 @@ The standard x402 `POST /verify` and `POST /settle` request envelope contains
 `paymentPayload.payload` MUST be one of the client-authored `deposit`, `voucher`,
 or `refund` variants in section 4.3. The facilitator validates the wire fields,
 voucher signature, derived channel PDA, and onchain channel state and, for
-`deposit`, the client-signed transaction. For `refund`, it additionally confirms
-that the voucher is redeemable or already reflected in `Channel.settled`, the
-channel is `Open` or is still within its `Closing` grace period, and the payer's
-canonical refund ATA is healthy.
+`deposit` and `refund`, the client-signed transaction. For `refund`, it
+additionally confirms that the transaction is an exact payer-authorized
+`request_close` for the derived channel, the channel is `Open` or is still
+within its `Closing` grace period, and the payer's canonical return ATA is
+healthy. If a voucher is present, the facilitator MAY validate it during
+verification, but MUST only apply it after authenticating the server through a
+trusted request context or a valid `CloseAuthorization`.
 
 | Response field | Type | Required | Notes |
 |---|---|---|---|
@@ -600,7 +636,7 @@ instruction it invokes:
 | `voucher` | Client | Accept an offchain authorization; no funds move. | None |
 | `claim` | Server | Advance accounting; no funds move to the receiver. | `settle` |
 | `settle` | Server | Move earned funds to the receiver. | `distribute` |
-| `refund` | Client, then server-enriched | Apply any final voucher, close the channel, and return all unspent escrow. | `settle_and_seal` + sealed `distribute` |
+| `refund` | Client, optionally server-enriched | Start a payer-forced close; after the grace period, finalize and return all unused escrow, or use an authenticated immediate cooperative close. | `request_close` then `seal` + sealed `distribute`, or `settle_and_seal` + sealed `distribute` |
 
 The examples in this subsection show the inner `paymentPayload.payload`; the
 caller MUST wrap each one in the standard request envelope defined above.
@@ -624,23 +660,23 @@ server-authored or server-enriched variants are:
 | Settle | `channels[].channelConfig` | `ChannelConfig` | Full configuration used to derive accounts, validate the channel, and reconstruct the distribution. |
 | Refund | `type` | string | `"refund"` |
 | Refund | `channelConfig` | `ChannelConfig` | Client-provided channel configuration. |
-| Refund | `voucher` | `BatchVoucher` | Client's zero-charge voucher at the server's current cumulative charge. |
-| Refund | `refundAuthorization` | `RefundAuthorization` | Server signature authorizing this full cooperative close. |
+| Refund | `transaction` | string | Client-signed `request_close` transaction forwarded to the facilitator. |
+| Immediate cooperative close | `voucher` | `BatchVoucher` | Latest accepted client voucher supplied or confirmed by the authenticated server. |
+| Immediate cooperative close | `closeAuthorization` | `CloseAuthorization` | Optional server signature authorizing the immediate cooperative close. Omit when trusted out-of-band request authentication supplies the server binding. |
 
 The server forwards a client-authored `deposit` unchanged. It MAY settle
 `voucher` locally by storing the commitment and producing the response in
 section 4.4.
 
 For `refund`, the server MUST serialize processing with every paid request and
-other refund for the channel. It MUST require
-`voucher.maxClaimableAmount == chargedCumulativeAmount`, verify the client
-voucher, bypass the resource handler, and obtain successful facilitator
-verification. It then creates a fresh `RefundAuthorization` with
-`extra.receiverAuthorizer`, atomically marks the channel refund-pending through
-`validBefore`, and forwards the enriched payload. Once it signs, the server MUST
-reject new paid requests for the channel until the refund confirms or the
-authorization expires; otherwise a delayed valid authorization could close
-after a later charge:
+other close for the channel, bypass the resource handler, and forward the
+client-signed `request_close` transaction after successful facilitator
+verification. For the unilateral path, once the request-close transaction
+confirms, the server MUST reject new paid requests for the channel. The server
+MAY instead provide the latest voucher through a facilitator-authenticated
+request for an immediate cooperative close. When the facilitator does not
+authenticate the request out of band, the server MUST also create a fresh
+`CloseAuthorization` with `extra.receiverAuthorizer`:
 
 ```json
 {
@@ -649,35 +685,50 @@ after a later charge:
     "payer": "<client-wallet>",
     "payerAuthorizer": "<client-voucher-signer>",
     "receiver": "<server-receiver>",
-    "receiverAuthorizer": "<server-refund-authorizer>",
+    "receiverAuthorizer": "<server-close-authorizer>",
     "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
     "withdrawDelay": 3600,
     "salt": "42",
     "openSlot": 341000000
   },
+  "transaction": "<base64-client-signed-request-close-transaction>",
   "voucher": {
     "channelId": "<channel-pda>",
     "maxClaimableAmount": "5000",
     "expiresAt": 0,
-    "signature": "<base58-ed25519-zero-charge-voucher-signature>"
+    "signature": "<base58-ed25519-latest-voucher-signature>"
   },
-  "refundAuthorization": {
+  "closeAuthorization": {
     "validBefore": 1785341100,
-    "signature": "<base58-server-refund-authorization-signature>"
+    "signature": "<base58-server-close-authorization-signature>"
   }
 }
 ```
 
-The facilitator MUST validate `refundAuthorization` against the trusted
-receiver-authorizer binding, reject it at or after `validBefore`, and construct
-the transaction itself. When `Channel.settled <
-voucher.maxClaimableAmount`, it emits the voucher's Ed25519 precompile
-instruction immediately followed by `settle_and_seal` with `has_voucher = 1`.
-When the values are equal, it invokes `settle_and_seal` with `has_voucher = 0`;
-submitting an equal voucher onchain would fail the program's strict monotonicity
-check. Any other relationship MUST be rejected. It then invokes sealed
-`distribute` in the same transaction, verifies the confirmed onchain result,
-and returns the full amount `deposit - settled` transferred to the payer.
+If the server supplied a cooperative voucher, the facilitator MUST authenticate
+the server either from its trusted request context or by validating
+`closeAuthorization` against the trusted receiver-authorizer binding. It MUST
+reject a supplied `CloseAuthorization` at or after `validBefore`, and MUST
+validate the voucher against the channel. When
+`Channel.settled < voucher.maxClaimableAmount`, it emits the
+voucher's Ed25519 precompile instruction immediately followed by
+`settle_and_seal` with `has_voucher = 1`. When the values are equal, it invokes
+`settle_and_seal` with `has_voucher = 0`; submitting an equal voucher onchain
+would fail the program's strict monotonicity check. Any other relationship
+MUST be rejected. It then invokes sealed `distribute` in the same transaction,
+verifies the confirmed onchain result, and returns the full amount
+`deposit - settled` transferred to the payer.
+
+Without a valid cooperative authorization, the facilitator MUST validate and
+co-sign the client's `request_close` transaction with `extra.feePayer`,
+broadcast it, and confirm that the channel entered `Closing`. It MUST NOT
+fabricate or apply a final voucher. After `Channel.closure_started_at +
+Channel.grace_period`, the facilitator MUST schedule and attempt `seal` followed
+by sealed `distribute`, returning `deposit - settled` to the payer. If another
+permissionless crank completes either transition first, the facilitator MUST
+treat the observed terminal state as success. Eligible PDA rent is recovered
+by the same worker through `reclaim`; none of these asynchronous transactions
+is part of the initial HTTP refund response.
 
 The server initiates asynchronous accounting with a `claim` payload. Each
 claim carries the full channel configuration needed to derive and validate the
@@ -694,7 +745,7 @@ instruction:
           "payer": "<client-wallet-1>",
           "payerAuthorizer": "<client-voucher-signer-1>",
           "receiver": "<server-receiver>",
-          "receiverAuthorizer": "<server-refund-authorizer>",
+          "receiverAuthorizer": "<server-close-authorizer>",
           "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
           "withdrawDelay": 3600,
           "salt": "42",
@@ -712,7 +763,7 @@ instruction:
           "payer": "<client-wallet-2>",
           "payerAuthorizer": "<client-voucher-signer-2>",
           "receiver": "<server-receiver>",
-          "receiverAuthorizer": "<server-refund-authorizer>",
+          "receiverAuthorizer": "<server-close-authorizer>",
           "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
           "withdrawDelay": 3600,
           "salt": "43",
@@ -748,7 +799,7 @@ a `settle` payload:
         "payer": "<client-wallet-1>",
         "payerAuthorizer": "<client-voucher-signer-1>",
         "receiver": "<server-receiver>",
-        "receiverAuthorizer": "<server-refund-authorizer>",
+        "receiverAuthorizer": "<server-close-authorizer>",
         "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         "withdrawDelay": 3600,
         "salt": "42",
@@ -761,7 +812,7 @@ a `settle` payload:
         "payer": "<client-wallet-2>",
         "payerAuthorizer": "<client-voucher-signer-2>",
         "receiver": "<server-receiver>",
-        "receiverAuthorizer": "<server-refund-authorizer>",
+        "receiverAuthorizer": "<server-close-authorizer>",
         "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         "withdrawDelay": 3600,
         "salt": "43",
@@ -823,40 +874,48 @@ Deposit (`amount` is the amount deposited or topped up):
 }
 ```
 
-Refund (`amount` is the full unspent escrow returned to the payer):
+Refund initiation (`amount` is empty because the grace period may still be
+running):
 
 ```json
 {
   "success": true,
-  "transaction": "<base58-transaction-signature>",
+  "transaction": "<base58-request-close-transaction-signature>",
   "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
   "payer": "<client-wallet>",
-  "amount": "95000",
+  "amount": "",
   "extra": {
     "channelState": {
       "channelId": "<channel-pda>",
-      "balance": "0",
+      "balance": "100000",
       "totalClaimed": "5000",
-      "withdrawRequestedAt": 0,
+      "withdrawRequestedAt": 1785341100,
       "chargedCumulativeAmount": "5000"
     }
   }
 }
 ```
 
-After successful refund, the server MUST mark the channel closed and reject
-further paid requests for that channel. A later session MUST open a new channel
-with a new `openSlot`. If settlement fails, the server MUST retain the
-refund-pending state until `refundAuthorization.validBefore` before it may
-resume paid requests.
+The facilitator MUST return the request-close signature after it confirms the
+channel entered `Closing`; it MUST NOT claim that the refund amount has moved
+until a later `seal`/`distribute` cleanup confirms it. For this unilateral path,
+the server MUST mark the channel close-pending and reject further paid
+requests. A later session MUST open a new channel with a new `openSlot`.
+
+When the immediate cooperative shortcut is used, the response instead contains
+the final cooperative-close signature and `amount = deposit - settled`; the
+server marks the channel closed after confirmation.
 
 #### `GET /supported`
 
-The facilitator advertises its SVM transaction fee payer. The server MUST copy
-this value into `PaymentRequirements.extra.feePayer` and MUST set
-`PaymentRequirements.extra.receiverAuthorizer` to the server key covered by its
-trusted facilitator registration. The receiver authorizer is server-owned and
-is therefore not advertised by the facilitator:
+The facilitator advertises the `escrow` payment flow and its SVM transaction
+fee payer. The server MUST copy these values into
+`PaymentRequirements.extra.paymentFlow` and `extra.feePayer`, then set
+`extra.tokenProgram` from the selected asset's verified mint owner. The server
+MAY also set `extra.receiverAuthorizer` to a key covered by a trusted
+facilitator registration when it wants signed immediate cooperative closes.
+The receiver authorizer is server-owned and is therefore not advertised by the
+facilitator:
 
 ```json
 {
@@ -866,6 +925,7 @@ is therefore not advertised by the facilitator:
       "scheme": "batch-settlement",
       "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "extra": {
+        "paymentFlow": "escrow",
         "feePayer": "<facilitator-fee-payer>"
       }
     }
@@ -896,10 +956,13 @@ signed recovery proof:
       "payTo": "<server-receiver>",
       "maxTimeoutSeconds": 300,
       "extra": {
+        "paymentFlow": "escrow",
         "feePayer": "<facilitator-fee-payer>",
-        "receiverAuthorizer": "<server-refund-authorizer>",
+        "receiverAuthorizer": "<server-close-authorizer>",
         "withdrawDelay": 3600,
+        "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
         "recentBlockhash": "<recent-blockhash>",
+        "lastValidBlockHeight": "321000000",
         "recentSlot": 341000000,
         "channelState": {
           "channelId": "<channel-pda>",
@@ -965,10 +1028,10 @@ not supported by this version of the scheme.
   and zero-share `payee` account positions. For `top_up`, it MUST NOT appear in
   the payment-channel instruction's account list. In either form it MUST NOT be
   invoked as a program or used by any other instruction.
-- `channelConfig.receiverAuthorizer` MUST equal
-  `extra.receiverAuthorizer`, and the facilitator MUST validate that key against
-  its trusted binding for the authenticated server and `payTo`. It is not a
-  required transaction signer or payment-channel instruction account.
+- When either receiver-authorizer field is supplied, the two values MUST be
+  equal, and the facilitator MUST validate that key against its trusted binding
+  for the authenticated server and `payTo`. It is not a required transaction
+  signer or payment-channel instruction account.
 
 ##### Top-level instruction layout
 
@@ -979,14 +1042,17 @@ The top-level instructions MUST consist only of the following ordered regions:
    instruction. If both are present, the limit MUST precede the price.
 2. Exactly one canonical payment-channels `open` or `top_up` instruction,
    matching the payload form selected by the decoded channel state.
-3. An optional suffix of at most three Lighthouse instructions, each invoking
-   `L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`.
+3. A suffix containing exactly one SPL Memo instruction
+   (`MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr`) and at most three Lighthouse
+   instructions (`L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`). The Memo data
+   MUST be `extra.memo` as UTF-8 when supplied, or otherwise a random nonce of
+   at least 16 bytes encoded as hexadecimal text.
 
 No other top-level instruction or program is allowed. In particular, a
-top-level associated-token-account instruction, SPL Memo instruction, arbitrary
-wallet program, second payment-channel instruction, or duplicate setup
-instruction MUST cause rejection. The payment-channels `open` instruction
-creates the escrow ATA internally.
+top-level associated-token-account instruction, arbitrary wallet program,
+second payment-channel instruction, or duplicate setup instruction MUST cause
+rejection. The payment-channels `open` instruction creates the escrow ATA
+internally.
 
 When present, Compute Budget instructions:
 
@@ -997,10 +1063,14 @@ When present, Compute Budget instructions:
 - MUST set a compute-unit price no greater than `5000000` microlamports per
   compute unit.
 
-Lighthouse instructions are allowed only for Phantom/Solflare assertions and
-MUST NOT reference `extra.feePayer` as an account. A sponsor MAY apply stricter
-local compute or priority-fee limits or reject all optional instructions, but it
-MUST NOT admit instructions outside this allowlist or relax these maxima.
+A sponsor MAY apply stricter local compute-unit, priority-fee, or
+required-signature caps, but MUST NOT relax the absolute maxima above.
+Lighthouse and Memo instructions are allowed only in the final suffix and
+MUST NOT reference `extra.feePayer` as an account or as the invoked program. If
+`extra.memo` is present, the facilitator MUST require exactly one Memo and an
+exact UTF-8 data match. A sponsor MAY reject all optional Lighthouse
+instructions, but MUST NOT reject the required Memo or admit instructions
+outside this allowlist.
 
 ##### Canonical `open`
 
@@ -1060,14 +1130,51 @@ Therefore `authorized_signer` MAY be effectively writable and a signer when
 because `payee == rent_payer`. Those prescribed unions MUST NOT cause rejection;
 no other privilege escalation is permitted.
 
-After static validation, the facilitator MUST simulate the exact transaction,
-reject a failed simulation, sign and broadcast it, and confirm its onchain
-effects before returning success. An expired blockhash or out-of-window
-`openSlot` MUST be rejected; the client must rebuild and re-sign with fresh
-values.
+Before co-signing an `open` or `top_up`, the facilitator MUST simulate the exact
+client-supplied transaction and confirm the eventual settlement path is usable
+for the bound mint, token program, payer return ATA, treasury, and `payTo`
+recipient ATA. It MAY use a facilitator-built composite simulation or targeted
+account checks in addition to the setup simulation, but it MUST reject before
+escrowing when a settlement account is missing, frozen, has the wrong owner or
+mint, or is otherwise unusable under the program rules. After confirmation it
+MUST re-read the channel and verify its status, deposit, mint, payer, payee,
+authorized signer, rent payer, grace period, open slot, and distribution against
+the payload and requirements before reporting settlement success.
 
-After confirmation, the server records the channel in its `ChannelStore` and
-accepts the voucher for the request under Phase 3.
+After a confirmed `open` or `top_up`, the server records the channel in its
+`ChannelStore` and accepts the request voucher under Phase 3.
+
+##### Canonical refund `request_close`
+
+The refund transaction MUST contain exactly one canonical payment-channels
+`request_close` instruction for the PDA derived from `channelConfig`. It MAY
+also contain the bounded Compute Budget prefix allowed above and a suffix with
+at most three Lighthouse instructions and at most one Memo. The suffix uses the
+same program and fee-payer-isolation rules as setup transactions; when
+`extra.memo` is present, a supplied Memo MUST match it. The instruction MUST
+use discriminator `5`, contain exactly these two accounts in order, and contain
+no remaining accounts:
+
+| Position | Account role | Required binding | Required privileges |
+|---:|---|---|---|
+| 0 | `payer` | `channelConfig.payer == Channel.payer` | read-only, signer |
+| 1 | `channel` | PDA derived from `channelConfig` | writable |
+
+The transaction MUST contain the payer signature and `extra.feePayer` as fee
+payer; no other signer or address lookup table is permitted. No instruction or
+program outside the prefix/suffix allowlist is permitted. The facilitator MUST
+verify that the channel is `Open` or `Closing`, that the payer and fee-payer
+bindings match the decoded channel, and that the transaction does not include
+`seal`, `settle_and_seal`, `distribute`, or any token transfer. The sponsor
+signature authorizes only the bounded network fee.
+
+If the channel is `Open`, the facilitator MUST simulate the exact transaction,
+reject a failed simulation, sign and broadcast it, and confirm that the channel
+entered `Closing` before returning success. An expired blockhash or
+out-of-window `openSlot` MUST be rejected; the client must rebuild and re-sign
+with fresh values. If the channel is already `Closing`, the facilitator MUST
+NOT rebroadcast; after revalidating the channel bindings, it returns the
+observed initiation state as the idempotent result.
 
 ### Phase 2 - Steady-State Request
 
@@ -1084,7 +1191,8 @@ The server is the sole owner of per-channel offchain state. A separate
 facilitator, if used, remains stateless for ordinary voucher acceptance; it only
 needs onchain state plus a voucher when it later settles.
 
-The server MUST serialize all paid-request and refund processing per channel.
+The server MUST serialize all paid-request and close processing per
+channel.
 The server stores `chargedCumulativeAmount`, `signedMaxClaimable`, the latest
 voucher signature and expiry, and a cached paid-response entry keyed by
 `("access", channelId, maxClaimableAmount)`. For every paid-request voucher,
@@ -1100,9 +1208,9 @@ the server MUST:
    channelConfig.payerAuthorizer`, `rent_payer == extra.feePayer`,
    `grace_period == channelConfig.withdrawDelay == extra.withdrawDelay`,
    `open_slot == channelConfig.openSlot`, and a distribution to `payTo`
-   matching section 4.1. Confirm `channelConfig.receiverAuthorizer ==
-   extra.receiverAuthorizer`. Reject if `payer` or `payerAuthorizer` equals
-   `feePayer`.
+   matching section 4.1. When `channelConfig.receiverAuthorizer` is supplied,
+   confirm it equals `extra.receiverAuthorizer`; otherwise both fields MUST be
+   absent. Reject if `payer` or `payerAuthorizer` equals `feePayer`.
 4. **Expiry, accounting for async settlement.** `expiresAt` is re-checked
    onchain when `settle` or `settle_and_seal` executes. Because redemption is
    delayed, the server MUST require either `expiresAt == 0` or
@@ -1143,28 +1251,31 @@ the request path:
 - **Settle (`type: "settle"`).** Call program `distribute` to pay the newly
   claimed delta to `payTo` and advance `payout_watermark`. The channel remains
   open.
-- **Refund (`type: "refund"`).** Verify the server's `RefundAuthorization`;
-  apply the final client voucher when it advances `settled`; sign
-  `settle_and_seal` as channel `payee`; and invoke sealed `distribute`.
-  `distribute` pays any remaining settled delta, returns the full
-  `deposit - settled` remainder to the payer, closes the escrow token account,
-  and moves the channel to its cleanup state.
+- **Refund (`type: "refund"`).** The facilitator broadcasts the client's
+  payer-signed `request_close` transaction with its fee-payer signature. After
+  the configured grace period, it or another permissionless crank calls `seal`
+  and sealed `distribute`. `distribute` pays any remaining settled delta,
+  returns the full `deposit - settled` remainder to the payer, closes the
+  escrow token account, and moves the channel to its cleanup state. If the
+  server supplies or confirms the final voucher through an authenticated
+  request, the facilitator MAY skip the wait and use `settle_and_seal` plus
+  sealed `distribute` immediately.
 - **Rent cleanup.** If final `distribute` leaves the channel in `Distributed`,
   anyone can later call `reclaim` after the open-slot window to return remaining
   PDA rent to `rent_payer`.
 
-The refund authorization is required for the x402 cooperative-refund flow. It
-does not remove the facilitator's independent lifecycle authority to close an
-abandoned channel at the current onchain watermark under its published rent
-recovery policy.
+The close authorization is required only for the optional immediate
+cooperative-close optimization. It does not remove the facilitator's
+independent permissionless lifecycle authority to finalize a forced close at
+the current onchain watermark under its published rent-recovery policy.
 
 The payer exits through the payment-channel program's forced-close path. The
 server SHOULD claim with enough buffer before `withdrawDelay` can elapse after
 the payer calls `request_close`. During the grace period, only the facilitator
-as `payee` can apply a final voucher and seal cooperatively. After the grace
-period, anyone can call `seal`; the payer can recover unspent deposit via
-`withdraw_payer` or sealed `distribute`, and vouchers not yet claimed are
-forfeited by the server.
+as `payee` can apply a final voucher and seal cooperatively, and only when the
+server has authenticated that close. After the grace period, anyone can call
+`seal`; the payer can recover unspent deposit via `withdraw_payer` or sealed
+`distribute`, and vouchers not yet claimed are forfeited by the server.
 
 ### Phase 5 - Duplicate and Concurrent Operation Handling
 
@@ -1176,13 +1287,14 @@ idempotency:
   `("access", channelId, maxClaimableAmount)` cache are the authoritative replay
   defense. The same authorization MUST NOT execute the resource handler more
   than once, regardless of whether a retry changes from `deposit` to `voucher`.
-- **Client-supplied deposit transactions.** The facilitator SHOULD maintain a
-  short-lived in-flight cache keyed by the exact serialized transaction or its
-  first signature. Concurrent `/settle` calls for the same transaction MUST be
-  coalesced to one broadcast and one result or rejected with
-  `duplicate_settlement`; they MUST NOT produce independent successful
+- **Client-supplied transactions.** For `deposit` and `refund`, the facilitator
+  SHOULD maintain a short-lived in-flight cache keyed by the exact serialized
+  transaction or its first signature. Concurrent `/settle` calls for the same
+  transaction MUST be coalesced to one broadcast and one result or rejected
+  with `duplicate_settlement`; they MUST NOT produce independent successful
   settlements. The entry MAY be evicted once the transaction's blockhash is no
-  longer valid.
+  longer valid. A refund retry after `request_close` confirms MUST return the
+  observed `Closing` state rather than attempt a second transition.
 - **Claims.** Program `settle` requires a strictly increasing watermark, so the
   same claim cannot advance accounting twice. A facilitator MAY coalesce
   in-flight `(channelId, maxClaimableAmount)` claims to avoid a predictable
@@ -1191,15 +1303,15 @@ idempotency:
   `settled`; a repeat cannot pay the same delta again. A facilitator MAY
   coalesce concurrent distributions for the same channel and observed
   watermark.
-- **Refunds.** A refund intentionally reuses the latest zero-charge voucher and
-  therefore occupies a distinct `("refund", channelId,
-  maxClaimableAmount)` namespace. The server and facilitator MUST cache the
-  refund result at least through `refundAuthorization.validBefore`; a retry
-  returns that result and never invokes a resource handler. Sealing and final
-  distribution make the channel terminal, so the authorization cannot refund
-  twice. Because the signature has no revocation nonce, the server MUST keep the
-  channel refund-pending and reject later charges until the authorization
-  expires or confirms.
+- **Refunds.** The facilitator MUST coalesce retries of the same
+  `request_close` transaction into one broadcast and one initiation result.
+  Once `Closing`, later retries return the observed channel state. A client
+  refund does not occupy the cooperative-close authorization namespace and does
+  not require a server signature. If the server supplies a cooperative close,
+  the latest voucher and its authorization occupy a distinct `("close",
+  channelId, maxClaimableAmount)` namespace; the server and facilitator MUST
+  cache that result through `closeAuthorization.validBefore` or the replay
+  window of the trusted out-of-band request authentication.
 - **Reclaim.** A channel can transition from `Distributed` to deallocated only
   once. Concurrent reclaim attempts require no additional replay mitigation;
   later attempts observe an absent account or invalid status.
@@ -1273,7 +1385,8 @@ request path. After startup or local state loss, a rent sponsor MUST:
    followed by `distribute` and, when necessary, `reclaim`.
 4. For a `Closing` channel, schedule a recheck at the grace deadline. During the
    grace period, the facilitator MAY apply a final voucher supplied by the
-   server; afterward the normal permissionless `seal` path applies.
+   server when it has a valid cooperative authorization; afterward the normal
+   permissionless `seal` path applies regardless of server availability.
 5. For a `Sealed` channel, submit or relay `distribute`. For a `Distributed`
    channel, schedule `reclaim` after the open-slot gate; recovered SOL always
    returns to the recorded `rent_payer`.
@@ -1292,6 +1405,10 @@ Standard x402 codes apply. The facilitator reports verification failures in
 
 - `invalid_batch_settlement_svm_payload_type` - payload `type` is not valid for
   the current verify or settle operation.
+- `invalid_batch_settlement_svm_payment_flow` - `extra.paymentFlow` is absent or
+  is not `"escrow"`.
+- `invalid_batch_settlement_svm_token_program` - `extra.tokenProgram` is not a
+  supported SPL token program or does not own the selected mint.
 - `invalid_batch_settlement_svm_voucher_signature` - signature invalid or
   `channelConfig.payerAuthorizer` does not match channel `authorized_signer`.
 - `invalid_batch_settlement_svm_channel_id_mismatch` - `channelId` does not
@@ -1301,16 +1418,20 @@ Standard x402 codes apply. The facilitator reports verification failures in
 - `invalid_batch_settlement_svm_receiver_authorizer_mismatch` -
   `channelConfig.receiverAuthorizer` does not match
   `extra.receiverAuthorizer` or the facilitator's trusted server binding.
-- `invalid_batch_settlement_svm_refund_authorization` - refund authorization is
-  malformed, expired, signed by the wrong receiver authorizer, or does not bind
-  the exact refund request.
-- `invalid_batch_settlement_svm_refund_amount_unsupported` - refund payload
-  contains an `amount`; this scheme supports full cooperative close only.
-- `invalid_batch_settlement_svm_refund_state` - channel cannot be cooperatively
-  closed, the zero-charge voucher does not equal server state, or its watermark
-  is behind the channel's onchain `settled` value.
+- `invalid_batch_settlement_svm_close_authorization` - close authorization is
+  malformed, expired, signed by the wrong receiver authorizer, does not bind the
+  exact cooperative-close request, or the out-of-band request principal does
+  not match the server principal bound at deposit.
+- `invalid_batch_settlement_svm_close_amount_unsupported` - the `"refund"`
+  wire payload contains an `amount`; this scheme supports only returning the
+  full unused escrow.
+- `invalid_batch_settlement_svm_close_state` - the channel cannot be closed, or
+  an optional cooperative voucher does not equal server state or is behind the
+  channel's onchain `settled` value.
 - `invalid_batch_settlement_svm_withdraw_delay_mismatch` - channel grace period
   does not match `extra.withdrawDelay`.
+- `invalid_batch_settlement_svm_withdraw_delay_out_of_range` - `withdrawDelay`
+  is outside `900..=2592000` seconds or is shorter than `maxTimeoutSeconds`.
 - `invalid_batch_settlement_svm_cumulative_amount_mismatch` - corrective 402:
   client's cumulative voucher does not match server state.
 - `invalid_batch_settlement_svm_cumulative_exceeds_deposit` - voucher exceeds
@@ -1319,8 +1440,15 @@ Standard x402 codes apply. The facilitator reports verification failures in
   before redemption.
 - `invalid_batch_settlement_svm_setup_transaction` - setup transaction fails the
   sponsor safety checks.
-- `duplicate_settlement` - the same client-supplied setup transaction is already
-  being settled.
+- `invalid_batch_settlement_svm_settlement_simulation` - setup or
+  settlement-readiness simulation/checks failed before accepting the deposit.
+- `invalid_batch_settlement_svm_channel_state` - confirmed channel state does
+  not match the payload and challenge-bound requirements.
+- `invalid_batch_settlement_svm_refund_transaction` - refund transaction is not
+  a valid payer-signed `request_close` for the derived channel or contains an
+  unauthorized instruction.
+- `duplicate_settlement` - the same client-supplied setup or refund transaction
+  is already being settled.
 
 ## 8. Security Properties
 
@@ -1334,14 +1462,17 @@ Standard x402 codes apply. The facilitator reports verification failures in
   `channelConfig.payerAuthorizer`, so the facilitator can close a channel but
   cannot advance `settled` without a client-signed voucher. The committed
   distribution prevents payout redirection.
-- **Authenticated cooperative refunds.** The facilitator constructs and signs
-  the close transaction only after verifying a domain-separated authorization
-  from the receiver authorizer trusted for the server and `payTo`. The key
-  supplied in an untrusted request is not itself a trust anchor. The client
-  voucher independently binds the final cumulative spend.
-- **Full-close refunds.** Cooperative refund first locks the final `settled`
-  watermark, then returns exactly `deposit - settled` and closes the escrow.
-  Partial refunds and channel reuse after refund are not supported.
+- **Optional authenticated cooperative closes.** The facilitator uses the
+  authenticated server request only for the immediate cooperative shortcut. A
+  key or principal supplied in an untrusted request is not itself a trust
+  anchor: the facilitator binds a receiver-authorizer key through trusted
+  registration, or records the authenticated server principal, `channelId`, and
+  `payTo` at deposit. The client voucher independently binds the final
+  cumulative spend.
+- **Committed value is preserved at close.** Both forced and cooperative close
+  paths pay any settled delta to `payTo`, return exactly `deposit - settled` to
+  the payer, and close the escrow. Partial unused-escrow returns and channel
+  reuse after close are not supported.
 - **Facilitator rent recovery.** Because the facilitator is channel `payee`, it
   can run `settle_and_seal` with `has_voucher = 0`, then `distribute` and
   `reclaim`, without client or server cooperation. Abandoned channels cannot
@@ -1351,12 +1482,13 @@ Standard x402 codes apply. The facilitator reports verification failures in
   client. The server MUST bound its exposure by claiming promptly and SHOULD
   treat unclaimed voucher value as facilitator credit risk. During a
   client-initiated grace period, only the facilitator can apply the final
-  voucher and seal cooperatively.
+  voucher, and only after authenticating the server.
 - **No replay / no rollback.** Server offchain watermark plus onchain
   `settled` monotonicity reject old vouchers. Paid-request equality is accepted
-  only as an idempotent replay of a cached access response. Refunds use a
-  separate operation namespace, a time-bounded server authorization, and a
-  terminal onchain transition.
+  only as an idempotent replay of a cached access response. Refund initiation
+  is idempotent by the client-signed `request_close` transaction; optional
+  cooperative closes use a separate operation namespace and a terminal onchain
+  transition.
 - **Bounded sponsor exposure.** Client-supplied transactions have a static
   instruction allowlist, exact signer and account layouts, no address lookup
   tables, bounded compute-unit limit and price, and transaction simulation.
@@ -1364,7 +1496,8 @@ Standard x402 codes apply. The facilitator reports verification failures in
   authorizes network fees only.
 - **Client escape hatch.** `withdrawDelay` is fixed at `open`; if the server
   does not settle, the payer can start forced close and recover unspent escrow
-  after the grace period.
+  after the grace period. The protocol bounds that delay to 15 minutes through
+  30 days and never shorter than the HTTP completion window.
 - **Time-bounded commitments.** Nonzero voucher `expiresAt` is checked both at
   server acceptance and onchain redemption. `expiresAt == 0` means no voucher
   expiry; in that case the channel's forced-close path bounds the commitment.

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -28,10 +28,6 @@ The x402 roles map to the payment-channel program as follows:
 - **Server**: resource provider; receives funds at `payTo`; owns per-channel
   offchain state, including the accepted cumulative watermark and latest
   voucher.
-- **Receiver authorizer**: lifecycle key advertised as
-  `extra.receiverAuthorizer`; recorded as channel `payee`; signs cooperative
-  close/refund operations. It MUST equal `extra.feePayer` so the rent sponsor
-  can close abandoned channels and recover its rent.
 - **Facilitator / sponsor**: account advertised as `extra.feePayer`; sponsors
   transaction fees and channel rent. It is the transaction fee payer and channel
   `rent_payer`, and occupies the channel `payee` lifecycle-authority seat with a
@@ -53,7 +49,7 @@ the facilitator:
   watermark, but it cannot create a nonzero claim or redirect funds.
 
 A facilitator that closes before the latest client voucher is claimed freezes
-the watermark and causes the unclaimed remainder to be refunded to the client.
+the watermark and causes the unclaimed remainder to be returned to the client.
 The server MUST treat unclaimed voucher value as facilitator credit risk and
 claim promptly.
 
@@ -66,13 +62,13 @@ claim promptly.
 | Monotonic amount | Server-owned offchain watermark plus onchain `settled < maxClaimableAmount <= deposit` at redemption. |
 | Batched redemption | One `settle` per channel, packed transaction-size permitting; `distribute` pays settled deltas. |
 | Recipient binding | `distribution_hash` fixed at `open` sends funds to `payTo`; program re-checks it at `distribute`. |
-| Refund of unused deposit | `settle_and_seal` + `distribute` for cooperative close; `request_close` / `seal` / `withdraw_payer` for payer-forced close. |
+| Recovery of unused deposit | `request_close` / `seal` / `withdraw_payer` for payer-forced close. |
 
 ## 3. Payment-Channel Method
 
 SVM `batch-settlement` defines a single payment method backed by the
-payment-channels program. Because there is only one method, the wire format does
-not include `extra.profiles` or `extra.assetTransferMethod`.
+payment-channels program, so the wire format does not include
+`extra.assetTransferMethod`.
 
 The canonical program id is a network/SDK constant, not a server-provided wire
 field. For the current mainnet deployment:
@@ -95,10 +91,10 @@ The current program lifecycle is:
    valid voucher.
 3. `distribute`: permissionlessly pays the newly settled delta to `payTo` and
    advances `payout_watermark`. While the channel is still open, it does not
-   refund the payer or close the escrow.
-4. `settle_and_seal`: receiver-authorizer-signed cooperative close. It may apply
-   a final voucher, locks the watermark, and moves the channel to `Sealed`.
-5. Sealed `distribute`: pays any final settled delta, refunds
+   return unused escrow to the payer or close the escrow.
+4. `settle_and_seal`: `payee`-signed cooperative close. It may apply a final
+   voucher, locks the watermark, and moves the channel to `Sealed`.
+5. Sealed `distribute`: pays any final settled delta, returns
    `deposit - settled` to the payer, closes the escrow token account, and either
    deallocates the channel PDA immediately or marks it `Distributed`.
 6. `reclaim`: permissionless cleanup for `Distributed` channels after
@@ -111,14 +107,14 @@ to that address during the final `distribute` fast path or a later `reclaim`.
 Because the sponsor holds the `payee` lifecycle authority, it can seal and clean
 up an abandoned channel without a client or server signature. It MUST be able
 to rediscover the channels it sponsored as specified in section 6. Token
-payouts and client refunds are completed by `distribute` and are not delayed by
-the later `reclaim` of PDA rent.
+payouts and the return of unused escrow are completed by `distribute` and are
+not delayed by the later `reclaim` of PDA rent.
 
-If the client invokes `request_close`, only the `payee` can cooperatively
-`settle_and_seal` during the grace period. The server therefore depends on the
-facilitator to include its latest voucher before the deadline. After the grace
-period, anyone can call `seal`; the payer can recover unspent escrow through
-`withdraw_payer` or sealed `distribute`.
+If the client invokes `request_close`, the channel enters `Closing` and regular
+`settle` is no longer available. Only the `payee` can apply a final voucher with
+`settle_and_seal` during the grace period. After the grace period, anyone can
+call `seal`; the payer can recover unspent escrow through `withdraw_payer` or
+sealed `distribute`.
 
 ## 4. Wire Format
 
@@ -134,7 +130,7 @@ and `SettlementResponse` types are defined in
 |---|---|---|---|
 | `scheme` | string | yes | `"batch-settlement"` |
 | `network` | string | yes | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` |
-| `amount` | string | yes | Maximum per-request price in atomic units. The server MAY charge less and reports the actual charge in `SettlementResponse.extra.chargedAmount`. |
+| `amount` | string | yes | Fixed per-request price in atomic units. |
 | `asset` | string | yes | Concrete SPL / Token-2022 mint pubkey, not a symbol. |
 | `payTo` | string | yes | Base58 final payment receiver. Normally a server cold wallet. |
 | `maxTimeoutSeconds` | number | yes | HTTP completion window. |
@@ -144,8 +140,7 @@ and `SettlementResponse` types are defined in
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `feePayer` | string | yes | Base58 sponsor key set as channel `rent_payer` and zero-share `payee`. Co-signs setup/top-up transactions as transaction fee payer and signs cooperative close/refund transactions. |
-| `receiverAuthorizer` | string | yes | Base58 lifecycle-authority key set as channel `payee`. MUST equal `feePayer`, so rent recovery never depends on a separate server key. |
+| `feePayer` | string | yes | Base58 sponsor key set as channel `rent_payer` and zero-share `payee`. Co-signs setup/top-up transactions as transaction fee payer and signs channel lifecycle transactions. |
 | `withdrawDelay` | number | yes | Server-defined forced-close grace period in seconds. The client MUST encode this exact value as the program `grace_period`; the verifier MUST reject any other value. |
 | `recentBlockhash` | string | no | Pre-fetched blockhash the client MAY use to build an `open` or `top_up` transaction without an RPC round trip. The client MUST refresh it if it is no longer valid. |
 | `recentSlot` | number | no | Recent slot the client MAY use as `channelConfig.openSlot` when it does not fetch its own slot. The program still enforces the open-slot window. |
@@ -186,7 +181,6 @@ Example:
   "maxTimeoutSeconds": 300,
   "extra": {
     "feePayer": "<facilitator-fee-payer>",
-    "receiverAuthorizer": "<facilitator-fee-payer>",
     "withdrawDelay": 3600,
     "recentBlockhash": "<recent-blockhash>",
     "recentSlot": 341000000
@@ -209,7 +203,6 @@ may expose those program fields with language-specific casing.
 | `channelConfig.payer` | `Channel.payer` |
 | `channelConfig.payerAuthorizer` | `Channel.authorized_signer` |
 | `channelConfig.receiver` | Sole `DistributionEntry.recipient` with `bps = 10000`; the `Channel.payee` implicit remainder is always zero |
-| `channelConfig.receiverAuthorizer` | `Channel.payee` |
 | `channelConfig.token` | `Channel.mint` |
 | `channelConfig.withdrawDelay` | `Channel.grace_period` |
 | `channelConfig.salt` | `Channel.salt` |
@@ -226,10 +219,9 @@ may expose those program fields with language-specific casing.
 
 | Field | Type | Notes |
 |---|---|---|
-| `payer` | string | Client wallet and channel payer. MUST NOT equal `receiverAuthorizer`, because the program requires distinct payer and payee accounts. |
-| `payerAuthorizer` | string | Client-controlled Ed25519 voucher signer; maps to channel `authorized_signer`. MAY equal `payer` but MUST NOT equal `receiverAuthorizer` / `feePayer`. |
+| `payer` | string | Client wallet and channel payer. MUST NOT equal `feePayer`, because the program requires distinct payer and payee accounts. |
+| `payerAuthorizer` | string | Client-controlled Ed25519 voucher signer; maps to channel `authorized_signer`. MAY equal `payer` but MUST NOT equal `feePayer`. |
 | `receiver` | string | MUST equal `payTo`. |
-| `receiverAuthorizer` | string | MUST equal `extra.receiverAuthorizer == extra.feePayer`; maps to channel `payee`. |
 | `token` | string | MUST equal `asset`; maps to channel `mint`. |
 | `withdrawDelay` | number | MUST equal `extra.withdrawDelay`; maps to channel `grace_period`. |
 | `salt` | string | Decimal `u64` channel salt. |
@@ -246,7 +238,7 @@ find_program_address(
   [
     "channel",
     channelConfig.payer,
-    channelConfig.receiverAuthorizer,
+    PaymentRequirements.extra.feePayer,
     channelConfig.token,
     channelConfig.payerAuthorizer,
     u64(channelConfig.salt).to_le_bytes(),
@@ -263,7 +255,7 @@ For a new channel, the `open` instruction MUST encode:
 - `grace_period == channelConfig.withdrawDelay`
 - `open_slot == channelConfig.openSlot`
 - `rent_payer == PaymentRequirements.extra.feePayer`
-- `payee == channelConfig.receiverAuthorizer`
+- `payee == PaymentRequirements.extra.feePayer`
 - `authorized_signer == channelConfig.payerAuthorizer`
 - `mint == channelConfig.token`
 - the distribution derived from `channelConfig.receiver` as specified in
@@ -295,13 +287,12 @@ This is the payment-channels program voucher layout (`VOUCHER_MAGIC`,
 | `balance` | string | Current `Channel.deposit` ceiling in atomic units. |
 | `totalClaimed` | string | Current onchain `Channel.settled` watermark. |
 | `withdrawRequestedAt` | number | `Channel.closure_started_at`, or `0` when no forced close is pending. |
-| `chargedCumulativeAmount` | string | Server-owned offchain cumulative actual charge. Present only when the response is authored by the server. |
+| `chargedCumulativeAmount` | string | Server-owned offchain cumulative fixed charge. Present only when the response is authored by the server. |
 
 ### 4.3 Client `PaymentPayload` Variants
 
-The client payload is a tagged union on `payload.type`. `/verify` accepts all
-three variants. `/settle` accepts `deposit` and `voucher` directly; the server
-enriches `refund` before settlement as specified in section 4.5.
+The client payload is a tagged union on `payload.type`. `/verify` and `/settle`
+accept the `deposit` and `voucher` variants.
 
 **`deposit`** opens a channel or tops up an existing channel and authorizes the
 current request:
@@ -326,7 +317,6 @@ current request:
     "maxTimeoutSeconds": 300,
     "extra": {
       "feePayer": "<facilitator-fee-payer>",
-      "receiverAuthorizer": "<facilitator-fee-payer>",
       "withdrawDelay": 3600,
       "recentBlockhash": "<recent-blockhash>",
       "recentSlot": 341000000
@@ -338,7 +328,6 @@ current request:
       "payer": "<client-wallet>",
       "payerAuthorizer": "<client-voucher-signer>",
       "receiver": "<server-receiver>",
-      "receiverAuthorizer": "<facilitator-fee-payer>",
       "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "withdrawDelay": 3600,
       "salt": "42",
@@ -379,7 +368,6 @@ transaction:
     "maxTimeoutSeconds": 300,
     "extra": {
       "feePayer": "<facilitator-fee-payer>",
-      "receiverAuthorizer": "<facilitator-fee-payer>",
       "withdrawDelay": 3600,
       "recentBlockhash": "<recent-blockhash>",
       "recentSlot": 341000000
@@ -391,7 +379,6 @@ transaction:
       "payer": "<client-wallet>",
       "payerAuthorizer": "<client-voucher-signer>",
       "receiver": "<server-receiver>",
-      "receiverAuthorizer": "<facilitator-fee-payer>",
       "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "withdrawDelay": 3600,
       "salt": "42",
@@ -407,57 +394,6 @@ transaction:
 }
 ```
 
-**`refund`** requests cooperative closure and a full refund of the unspent
-escrow. The application resource handler is bypassed. Its voucher is
-zero-charge: `maxClaimableAmount` MUST equal the server's current
-`chargedCumulativeAmount`.
-
-| Field | Type | Notes |
-|---|---|---|
-| `type` | string | `"refund"` |
-| `channelConfig` | `ChannelConfig` | Full channel configuration. |
-| `voucher` | `BatchVoucher` | Zero-charge voucher at the server's current cumulative charge. |
-
-```json
-{
-  "x402Version": 2,
-  "accepted": {
-    "scheme": "batch-settlement",
-    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-    "amount": "1000",
-    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-    "payTo": "<server-receiver>",
-    "maxTimeoutSeconds": 300,
-    "extra": {
-      "feePayer": "<facilitator-fee-payer>",
-      "receiverAuthorizer": "<facilitator-fee-payer>",
-      "withdrawDelay": 3600,
-      "recentBlockhash": "<recent-blockhash>",
-      "recentSlot": 341000000
-    }
-  },
-  "payload": {
-    "type": "refund",
-    "channelConfig": {
-      "payer": "<client-wallet>",
-      "payerAuthorizer": "<client-voucher-signer>",
-      "receiver": "<server-receiver>",
-      "receiverAuthorizer": "<facilitator-fee-payer>",
-      "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      "withdrawDelay": 3600,
-      "salt": "42",
-      "openSlot": 341000000
-    },
-    "voucher": {
-      "channelId": "<channel-pda>",
-      "maxClaimableAmount": "3200",
-      "expiresAt": 0,
-      "signature": "<base58-ed25519-zero-charge-voucher-signature>"
-    }
-  }
-}
-```
-
 ### 4.4 `SettlementResponse` (in `PAYMENT-RESPONSE`)
 
 | Field | Type | Required | Notes |
@@ -465,11 +401,11 @@ zero-charge: `maxClaimableAmount` MUST equal the server's current
 | `success` | boolean | yes | Whether acceptance or settlement succeeded. |
 | `errorReason` | string | no | Omitted on success. |
 | `payer` | string | no | Channel `payer`. |
-| `transaction` | string | yes | Onchain signature for deposit/top-up/refund/claim/settle operations; empty string for offchain voucher acceptance. |
+| `transaction` | string | yes | Onchain signature for deposit/top-up/claim/settle operations; empty string for offchain voucher acceptance. |
 | `network` | string | yes | CAIP-2 network identifier. |
 | `amount` | string | no | Amount moved onchain; empty for voucher acceptance and `claim`. |
 | `extra.commitmentId` | string | no | MUST be non-empty for voucher acceptance, e.g. `channelId:maxClaimableAmount`. |
-| `extra.chargedAmount` | string | no | Actual per-request charge committed offchain. |
+| `extra.chargedAmount` | string | no | Fixed per-request charge; MUST equal `PaymentRequirements.amount`. |
 | `extra.channelState` | `ChannelState` | no | Current channel snapshot. |
 
 Scheme-specific response fields are nested under `extra`.
@@ -484,13 +420,13 @@ A successful voucher-only response is:
   "amount": "",
   "extra": {
     "commitmentId": "<channel-pda>:5000",
-    "chargedAmount": "700",
+    "chargedAmount": "1000",
     "channelState": {
       "channelId": "<channel-pda>",
       "balance": "100000",
-      "totalClaimed": "3200",
+      "totalClaimed": "3000",
       "withdrawRequestedAt": 0,
-      "chargedCumulativeAmount": "4700"
+      "chargedCumulativeAmount": "5000"
     }
   }
 }
@@ -510,8 +446,8 @@ The standard x402 `POST /verify` and `POST /settle` request envelope contains
 
 #### `POST /verify`
 
-`paymentPayload.payload` MUST be one of the client-authored `deposit`,
-`voucher`, or `refund` variants in section 4.3. The facilitator validates the
+`paymentPayload.payload` MUST be one of the client-authored `deposit` or
+`voucher` variants in section 4.3. The facilitator validates the
 wire fields, voucher signature, derived channel PDA, onchain channel state, and,
 for `deposit`, the client-signed transaction.
 
@@ -542,8 +478,7 @@ A successful response is:
 
 The facilitator MUST return `isValid: false` with `invalidReason` when
 verification fails. The server MAY verify ordinary voucher payloads locally
-when its onchain snapshot is fresh; `deposit` and `refund` MUST be sent to the
-facilitator.
+when its onchain snapshot is fresh; `deposit` MUST be sent to the facilitator.
 
 #### `POST /settle`
 
@@ -556,22 +491,17 @@ instruction it invokes:
 | `voucher` | Client | Accept an offchain authorization; no funds move. | None |
 | `claim` | Server | Advance accounting; no funds move to the receiver. | `settle` |
 | `settle` | Server | Move earned funds to the receiver. | `distribute` |
-| `refund` | Client, then server-enriched | Cooperatively close and return unspent escrow to the payer. | `settle_and_seal` + `distribute` |
 
 The examples in this subsection show the inner `paymentPayload.payload`; the
 caller MUST wrap each one in the standard request envelope defined above.
 
 The `deposit` and `voucher` settle payloads are the client variants from
-section 4.3. The server-authored or server-enriched variants are:
+section 4.3. The server-authored variants are:
 
 | Payload | Field | Type | Notes |
 |---|---|---|---|
-| Refund | `type` | string | `"refund"` |
-| Refund | `channelConfig` | `ChannelConfig` | Client-provided channel configuration. |
-| Refund | `voucher` | `BatchVoucher` | Client's zero-charge voucher. |
-| Refund | `transaction` | string | Base64 transaction containing `settle_and_seal` and sealed `distribute`, prepared for `feePayer` to sign as transaction fee payer and channel `payee`. |
 | Claim | `type` | string | `"claim"` |
-| Claim | `claims` | array | One or more voucher claims. |
+| Claim | `claims` | array | One to four voucher claims. |
 | Claim | `claims[].voucher.channelConfig` | `ChannelConfig` | Full channel configuration. |
 | Claim | `claims[].voucher.channelId` | string | Channel PDA. |
 | Claim | `claims[].voucher.maxClaimableAmount` | string | Cumulative amount for program `settle`. |
@@ -584,33 +514,7 @@ section 4.3. The server-authored or server-enriched variants are:
 
 The server forwards a client-authored `deposit` unchanged. It MAY settle
 `voucher` locally by storing the commitment and producing the response in
-section 4.4. Before forwarding `refund`, the server MUST build the cooperative
-close transaction and add `transaction`. The facilitator MUST validate the
-complete transaction, then sign as both transaction `feePayer` and channel
-`payee` before broadcasting it:
-
-```json
-{
-  "type": "refund",
-  "channelConfig": {
-    "payer": "<client-wallet>",
-    "payerAuthorizer": "<client-voucher-signer>",
-    "receiver": "<server-receiver>",
-    "receiverAuthorizer": "<facilitator-fee-payer>",
-    "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-    "withdrawDelay": 3600,
-    "salt": "42",
-    "openSlot": 341000000
-  },
-  "voucher": {
-    "channelId": "<channel-pda>",
-    "maxClaimableAmount": "3200",
-    "expiresAt": 0,
-    "signature": "<base58-ed25519-zero-charge-voucher-signature>"
-  },
-  "transaction": "<base64-settle-and-seal-and-distribute-transaction-awaiting-facilitator-signature>"
-}
-```
+section 4.4.
 
 The server initiates asynchronous accounting with a `claim` payload. Each
 claim carries the full channel configuration needed to derive and validate the
@@ -627,7 +531,6 @@ instruction:
           "payer": "<client-wallet-1>",
           "payerAuthorizer": "<client-voucher-signer-1>",
           "receiver": "<server-receiver>",
-          "receiverAuthorizer": "<facilitator-fee-payer>",
           "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
           "withdrawDelay": 3600,
           "salt": "42",
@@ -645,7 +548,6 @@ instruction:
           "payer": "<client-wallet-2>",
           "payerAuthorizer": "<client-voucher-signer-2>",
           "receiver": "<server-receiver>",
-          "receiverAuthorizer": "<facilitator-fee-payer>",
           "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
           "withdrawDelay": 3600,
           "salt": "43",
@@ -661,8 +563,10 @@ instruction:
 }
 ```
 
-The facilitator MUST process every `claims[]` entry or fail the request; it
-MUST NOT silently truncate a batch. For each claim it emits an Ed25519
+`claims[]` MUST contain between one and four entries so the instruction pairs
+fit in a legacy Solana transaction without address lookup tables. The
+facilitator MUST process every entry or fail the request; it MUST NOT silently
+truncate a batch. For each claim it emits an Ed25519
 precompile instruction immediately followed by the program `settle`
 instruction.
 
@@ -679,7 +583,6 @@ a `settle` payload:
         "payer": "<client-wallet-1>",
         "payerAuthorizer": "<client-voucher-signer-1>",
         "receiver": "<server-receiver>",
-        "receiverAuthorizer": "<facilitator-fee-payer>",
         "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         "withdrawDelay": 3600,
         "salt": "42",
@@ -692,7 +595,6 @@ a `settle` payload:
         "payer": "<client-wallet-2>",
         "payerAuthorizer": "<client-voucher-signer-2>",
         "receiver": "<server-receiver>",
-        "receiverAuthorizer": "<facilitator-fee-payer>",
         "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         "withdrawDelay": 3600,
         "salt": "43",
@@ -741,31 +643,14 @@ Deposit (`amount` is the amount deposited or topped up):
   "payer": "<client-wallet>",
   "amount": "100000",
   "extra": {
+    "commitmentId": "<channel-pda>:1000",
+    "chargedAmount": "1000",
     "channelState": {
       "channelId": "<channel-pda>",
       "balance": "100000",
-      "totalClaimed": "3200",
-      "withdrawRequestedAt": 0
-    }
-  }
-}
-```
-
-Refund (`amount` is the amount returned to the payer):
-
-```json
-{
-  "success": true,
-  "transaction": "<base58-transaction-signature>",
-  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
-  "payer": "<client-wallet>",
-  "amount": "96800",
-  "extra": {
-    "channelState": {
-      "channelId": "<channel-pda>",
-      "balance": "0",
-      "totalClaimed": "3200",
-      "withdrawRequestedAt": 0
+      "totalClaimed": "0",
+      "withdrawRequestedAt": 0,
+      "chargedCumulativeAmount": "1000"
     }
   }
 }
@@ -774,8 +659,7 @@ Refund (`amount` is the amount returned to the payer):
 #### `GET /supported`
 
 The facilitator advertises its SVM transaction fee payer. The server MUST copy
-this value into both `PaymentRequirements.extra.feePayer` and
-`PaymentRequirements.extra.receiverAuthorizer`:
+this value into `PaymentRequirements.extra.feePayer`:
 
 ```json
 {
@@ -816,19 +700,18 @@ signed recovery proof:
       "maxTimeoutSeconds": 300,
       "extra": {
         "feePayer": "<facilitator-fee-payer>",
-        "receiverAuthorizer": "<facilitator-fee-payer>",
         "withdrawDelay": 3600,
         "recentBlockhash": "<recent-blockhash>",
         "recentSlot": 341000000,
         "channelState": {
           "channelId": "<channel-pda>",
           "balance": "100000",
-          "totalClaimed": "500",
+          "totalClaimed": "2000",
           "withdrawRequestedAt": 0,
-          "chargedCumulativeAmount": "3200"
+          "chargedCumulativeAmount": "3000"
         },
         "voucherState": {
-          "signedMaxClaimable": "3200",
+          "signedMaxClaimable": "3000",
           "expiresAt": 0,
           "signature": "<base58-ed25519-voucher-signature>"
         }
@@ -854,12 +737,10 @@ client MUST fetch a fresh value and rebuild the transaction. The facilitator
 MUST reject an expired transaction blockhash and an `openSlot` outside the
 program's accepted window.
 
-For `open`, the client MUST require `extra.receiverAuthorizer ==
-extra.feePayer` and set `payee = extra.feePayer`,
-`authorized_signer = channelConfig.payerAuthorizer`, `rent_payer =
-extra.feePayer`, `mint = channelConfig.token`, `grace_period =
-channelConfig.withdrawDelay`, `open_slot = channelConfig.openSlot`, and
-`deposit = payload.deposit.amount`.
+For `open`, the client MUST set `payee = extra.feePayer`, `authorized_signer =
+channelConfig.payerAuthorizer`, `rent_payer = extra.feePayer`,
+`mint = channelConfig.token`, `grace_period = channelConfig.withdrawDelay`,
+`open_slot = channelConfig.openSlot`, and `deposit = payload.deposit.amount`.
 
 The sponsor MUST validate the full compiled setup transaction before co-signing,
 not only the payment-channel instruction. It MUST resolve address lookup tables,
@@ -900,8 +781,7 @@ voucher signature and expiry, and a cached response keyed by
 2. Confirm `channelId` matches the PDA derived from `channelConfig` and the
    canonical payment-channels program id.
 3. Confirm the channel exists, is `Open`, has `mint == channelConfig.token ==
-   asset`, `payee == channelConfig.receiverAuthorizer ==
-   extra.receiverAuthorizer == extra.feePayer`, `authorized_signer ==
+   asset`, `payee == extra.feePayer`, `authorized_signer ==
    channelConfig.payerAuthorizer`, `rent_payer == extra.feePayer`,
    `grace_period == channelConfig.withdrawDelay == extra.withdrawDelay`,
    `open_slot == channelConfig.openSlot`, and a distribution to `payTo`
@@ -921,9 +801,8 @@ voucher signature and expiry, and a cached response keyed by
      rejected.
    - A fresh voucher MUST have `maxClaimableAmount ==
      chargedCumulativeAmount + PaymentRequirements.amount`.
-7. Execute the resource handler and determine `chargedAmount`, which MUST be
-   greater than zero and less than or equal to `PaymentRequirements.amount`.
-   Only after the handler succeeds, atomically add `chargedAmount` to
+7. Execute the resource handler. Only after it succeeds, set `chargedAmount =
+   PaymentRequirements.amount`, atomically add `chargedAmount` to
    `chargedCumulativeAmount`, store `signedMaxClaimable`, the voucher and the
    cached response, and return `PAYMENT-RESPONSE` with `transaction == ""`,
    `extra.commitmentId`, `extra.chargedAmount`, and `extra.channelState`. If the
@@ -942,29 +821,28 @@ the request path:
 
 - **Claim (`type: "claim"`).** For each channel, build an Ed25519 precompile
   instruction for the latest stored voucher followed by program `settle`. Pack
-  as many channels into one transaction as the transaction size permits; do not
-  silently drop channels from a full batch. Program `settle` advances onchain
-  `settled` to the voucher's exact `maxClaimableAmount`.
+  no more than four channels into one transaction and do not silently drop
+  channels from a full batch. Program `settle` advances onchain `settled` to
+  the voucher's exact `maxClaimableAmount`.
 - **Settle (`type: "settle"`).** Call program `distribute` to pay the newly
   claimed delta to `payTo` and advance `payout_watermark`. The channel remains
   open.
-- **Cooperative close/refund.** For a `refund` payload or server-initiated
-  close, the facilitator signs `settle_and_seal` as `payee`, applying the final
-  voucher when it advances the watermark (or using `has_voucher = 0` when no
-  claim is needed). `distribute` then pays any remaining settled delta, refunds
-  `deposit - settled` to the payer, closes the escrow token account, and moves
-  the channel to its cleanup state.
+- **Channel close.** Cooperative close is a payment-channel lifecycle operation,
+  not an x402 wire payload. The facilitator MAY sign `settle_and_seal` as
+  `payee` under its lifecycle policy. `distribute` then pays any remaining
+  settled delta, returns `deposit - settled` to the payer, closes the escrow
+  token account, and moves the channel to its cleanup state.
 - **Rent cleanup.** If final `distribute` leaves the channel in `Distributed`,
   anyone can later call `reclaim` after the open-slot window to return remaining
   PDA rent to `rent_payer`.
 
-The server SHOULD claim with enough buffer before `withdrawDelay` can elapse
-after a client starts forced close. If the payer calls `request_close`, only the
-facilitator as `payee` can `settle_and_seal` during the grace period, using a
-final voucher supplied by the server. After the grace period, anyone can call
-`seal`; the payer can then recover unspent deposit via `withdraw_payer` or the
-sealed `distribute` refund branch, and vouchers not yet claimed are forfeited by
-the server.
+The payer exits through the payment-channel program's forced-close path. The
+server SHOULD claim with enough buffer before `withdrawDelay` can elapse after
+the payer calls `request_close`. During the grace period, only the facilitator
+as `payee` can apply a final voucher and seal cooperatively. After the grace
+period, anyone can call `seal`; the payer can recover unspent deposit via
+`withdraw_payer` or sealed `distribute`, and vouchers not yet claimed are
+forfeited by the server.
 
 ## 6. Asynchronous Recovery and Channel Discovery
 
@@ -1058,9 +936,8 @@ Standard x402 codes apply. The facilitator reports verification failures in
   `channelConfig.payerAuthorizer` does not match channel `authorized_signer`.
 - `invalid_batch_settlement_svm_channel_id_mismatch` - `channelId` does not
   match the canonical PDA derivation.
-- `invalid_batch_settlement_svm_receiver_authorizer_mismatch` - channel `payee`
-  does not match `extra.receiverAuthorizer`, or `receiverAuthorizer` does not
-  equal `feePayer`.
+- `invalid_batch_settlement_svm_fee_payer_mismatch` - channel `payee` or
+  `rent_payer` does not match `extra.feePayer`.
 - `invalid_batch_settlement_svm_withdraw_delay_mismatch` - channel grace period
   does not match `extra.withdrawDelay`.
 - `invalid_batch_settlement_svm_cumulative_amount_mismatch` - corrective 402:
@@ -1078,7 +955,7 @@ Standard x402 codes apply. The facilitator reports verification failures in
   and sets the exact cumulative maximum signed by the client.
 - **No redirection.** `distribution_hash` is fixed at `open` and re-checked at
   `distribute`; the derived distribution sends settled funds to `payTo`.
-- **Authenticated claims.** The wire `extra.feePayer` address is recorded as
+- **Authenticated vouchers.** The wire `extra.feePayer` address is recorded as
   program `Channel.rent_payer` and zero-share `Channel.payee`. Program
   `Channel.authorized_signer` instead comes from wire
   `channelConfig.payerAuthorizer`, so the facilitator can close a channel but
@@ -1089,7 +966,7 @@ Standard x402 codes apply. The facilitator reports verification failures in
   `reclaim`, without client or server cooperation. Abandoned channels cannot
   permanently lock sponsored rent.
 - **Facilitator early-close exposure.** Closing before the latest voucher is
-  claimed freezes the onchain watermark and refunds the remainder to the
+  claimed freezes the onchain watermark and returns the remainder to the
   client. The server MUST bound its exposure by claiming promptly and SHOULD
   treat unclaimed voucher value as facilitator credit risk. During a
   client-initiated grace period, only the facilitator can apply the final
@@ -1103,11 +980,9 @@ Standard x402 codes apply. The facilitator reports verification failures in
 - **Time-bounded commitments.** Nonzero voucher `expiresAt` is checked both at
   server acceptance and onchain redemption. `expiresAt == 0` means no voucher
   expiry; in that case the channel's forced-close path bounds the commitment.
-- **Metering trust.** Each voucher authorizes at most the advertised
-  `PaymentRequirements.amount` above the previously reported actual cumulative
-  charge. The client trusts the server to claim no more than the reported
-  `chargedCumulativeAmount`; the server trusts itself to redeem before voucher
-  expiry or forced-close expiry.
+- **Fixed pricing.** Each fresh voucher increases the cumulative authorization
+  by exactly `PaymentRequirements.amount`. The server trusts itself to redeem
+  before voucher expiry or forced-close expiry.
 
 ## 9. Out of Scope
 

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -171,10 +171,11 @@ and `SettlementResponse` types are defined in
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `paymentFlow` | string | yes | MUST be `"escrow"`, because the deposit settles before the resource handler and later vouchers authorize asynchronous claims. |
+| `paymentFlow` | string | no | When present, MUST be `"authorization"`. The scheme resolves to the protocol-default `authorization` flow: read-only verification runs before the resource handler, and `/settle` commits the voucher — and broadcasts any `deposit` transaction — after it. |
 | `feePayer` | string | yes | Base58 sponsor key set as channel `rent_payer` and zero-share `payee`. Co-signs setup/top-up transactions as transaction fee payer and signs channel lifecycle transactions. |
 | `receiverAuthorizer` | string | no | Base58 server-controlled Ed25519 key that authenticates an optional immediate cooperative close to the facilitator. It is not a payment-channel account field. |
-| `withdrawDelay` | number | yes | Forced-close grace period in seconds. MUST be an integer from `900` through `2592000` (15 minutes through 30 days), MUST be `>= maxTimeoutSeconds`, and MUST be encoded exactly as the program `grace_period`. |
+| `withdrawDelay` | number | yes | Forced-close grace period in seconds. MUST be an integer from `900` through `2592000` (15 minutes through 30 days), MUST be `>= maxTimeoutSeconds`, and MUST be encoded exactly as the program `grace_period`. The payment-channels program accepts any positive `grace_period`; this range is an x402 conformance bound, so verifying facilitators MUST enforce it and reject out-of-range requirements. |
+| `settlementBufferSeconds` | number | no | Positive-integer voucher-expiry margin in seconds used in the Phase 3 expiry bound (section 5). Defaults to `60` when omitted. A server or facilitator requiring a larger margin MUST advertise it here so the client can compute an acceptable `expiresAt` from the 402 alone. |
 | `tokenProgram` | string | yes | SPL Token (`Tokenkeg...`) or Token-2022 (`TokenzQ...`) program that owns `asset`. The client and facilitator MUST verify it against the onchain mint owner. |
 | `memo` | string | no | Seller-defined UTF-8 payment reference for the setup transaction's Memo instruction. Maximum 256 bytes. |
 | `recentBlockhash` | string | no | Pre-fetched blockhash the client MAY use to build an `open` or `top_up` transaction without an RPC round trip. The client MUST refresh it if it is no longer valid. |
@@ -216,7 +217,6 @@ Example:
   "payTo": "<server-receiver>",
   "maxTimeoutSeconds": 300,
   "extra": {
-    "paymentFlow": "escrow",
     "feePayer": "<facilitator-fee-payer>",
     "receiverAuthorizer": "<server-close-authorizer>",
     "withdrawDelay": 3600,
@@ -390,7 +390,6 @@ current request:
     "payTo": "<server-receiver>",
     "maxTimeoutSeconds": 300,
     "extra": {
-      "paymentFlow": "escrow",
       "feePayer": "<facilitator-fee-payer>",
       "receiverAuthorizer": "<server-close-authorizer>",
       "withdrawDelay": 3600,
@@ -445,7 +444,6 @@ transaction:
     "payTo": "<server-receiver>",
     "maxTimeoutSeconds": 300,
     "extra": {
-      "paymentFlow": "escrow",
       "feePayer": "<facilitator-fee-payer>",
       "receiverAuthorizer": "<server-close-authorizer>",
       "withdrawDelay": 3600,
@@ -503,7 +501,6 @@ unless an authenticated server confirms it is the latest accepted voucher.
     "payTo": "<server-receiver>",
     "maxTimeoutSeconds": 300,
     "extra": {
-      "paymentFlow": "escrow",
       "feePayer": "<facilitator-fee-payer>",
       "withdrawDelay": 3600,
       "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
@@ -903,10 +900,12 @@ server marks the channel closed after confirmation.
 
 #### `GET /supported`
 
-The facilitator advertises the `escrow` payment flow and its SVM transaction
-fee payer. The server MUST copy these values into
-`PaymentRequirements.extra.paymentFlow` and `extra.feePayer`, then set
-`extra.tokenProgram` from the selected asset's verified mint owner. The server
+The facilitator advertises its SVM transaction fee payer. The server MUST copy
+that value into `PaymentRequirements.extra.feePayer`, then set
+`extra.tokenProgram` from the selected asset's verified mint owner. The scheme
+resolves to the protocol-default `authorization` payment flow, so
+`extra.paymentFlow` is normally omitted; when either party emits it, the value
+MUST be `"authorization"`. The server
 MAY also set `extra.receiverAuthorizer` to a key covered by a trusted
 facilitator registration when it wants signed immediate cooperative closes.
 The receiver authorizer is server-owned and is therefore not advertised by the
@@ -920,7 +919,6 @@ facilitator:
       "scheme": "batch-settlement",
       "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "extra": {
-        "paymentFlow": "escrow",
         "feePayer": "<facilitator-fee-payer>"
       }
     }
@@ -951,7 +949,6 @@ signed recovery proof:
       "payTo": "<server-receiver>",
       "maxTimeoutSeconds": 300,
       "extra": {
-        "paymentFlow": "escrow",
         "feePayer": "<facilitator-fee-payer>",
         "receiverAuthorizer": "<server-close-authorizer>",
         "withdrawDelay": 3600,
@@ -975,6 +972,18 @@ signed recovery proof:
   ]
 }
 ```
+
+Before adopting the corrective state, the client MUST verify
+`voucherState.signature` against its own `payerAuthorizer` key as an Ed25519
+signature over the 50-byte voucher message of section 4.2, reconstructed from
+the derived `channelId`, `maxClaimableAmount = voucherState.signedMaxClaimable`,
+and `expiresAt = voucherState.expiresAt`. The client MUST reject the snapshot
+when the signature does not verify or when
+`channelState.chargedCumulativeAmount` exceeds `voucherState.signedMaxClaimable`.
+Only after these checks does the client adopt `chargedCumulativeAmount` as its
+new cumulative base and retry. When the server has no accepted voucher for the
+channel, it omits `voucherState` and the client resynchronizes from onchain
+state instead.
 
 ## 5. Phases
 
@@ -1135,8 +1144,10 @@ MUST re-read the channel and verify its status, deposit, mint, payer, payee,
 authorized signer, rent payer, grace period, open slot, and distribution against
 the payload and requirements before reporting settlement success.
 
-After a confirmed `open` or `top_up`, the server records the channel in its
-`ChannelStore` and accepts the request voucher under Phase 3.
+Under the `authorization` flow, the `open` or `top_up` transaction is broadcast
+by the post-handler `/settle`, after the statically validated `deposit` request
+passes Phase 3 and the resource handler succeeds. After the transaction
+confirms, the server records the channel in its `ChannelStore`.
 
 ##### Canonical refund `request_close`
 
@@ -1208,8 +1219,12 @@ the server MUST:
 4. **Expiry, accounting for async settlement.** `expiresAt` is re-checked
    onchain when `settle` or `settle_and_seal` executes. Because redemption is
    delayed, the server MUST require either `expiresAt == 0` or
-   `expiresAt >= now + withdrawDelay + a settlement buffer`. A voucher that
-   could expire before redemption MUST be rejected.
+   `expiresAt >= now + withdrawDelay + settlementBufferSeconds`, where
+   `settlementBufferSeconds` is `extra.settlementBufferSeconds` when advertised
+   and `60` otherwise. The server and the verifying facilitator MUST NOT
+   require a larger margin than that advertised bound, so the client can always
+   compute a passing `expiresAt` from the 402 alone. A voucher that could
+   expire before redemption MUST be rejected.
 5. Enforce the deposit cap: `maxClaimableAmount <= channel.deposit`.
 6. Enforce replay protection and the per-request ceiling:
    - A previously accepted `("access", channelId, maxClaimableAmount)` is an
@@ -1225,6 +1240,16 @@ the server MUST:
    cached response, and return `PAYMENT-RESPONSE` with `transaction == ""`,
    `extra.commitmentId`, `extra.chargedAmount`, and `extra.channelState`. If the
    handler fails, state MUST remain unchanged so the client can retry.
+
+For a `deposit` payload, the `open` or `top_up` transaction is broadcast by the
+post-handler `/settle`, so the checks above run against the statically
+validated transaction: for `open`, the step-3 bindings and the step-5 cap are
+evaluated against the transaction's instruction fields with
+`deposit = payload.deposit.amount`; for `top_up`, against the existing onchain
+channel with its deposit increased by `payload.deposit.amount`. The server
+accepts the risk that a validated deposit transaction later fails to confirm;
+because earlier vouchers were capped by the confirmed deposit, that exposure is
+bounded by the single request's `amount`.
 
 On any failure, the server returns `402` without serving the resource. If the
 server has local channel state and the client submits the wrong cumulative
@@ -1399,8 +1424,8 @@ Standard x402 codes apply. The facilitator reports verification failures in
 
 - `invalid_batch_settlement_svm_payload_type` - payload `type` is not valid for
   the current verify or settle operation.
-- `invalid_batch_settlement_svm_payment_flow` - `extra.paymentFlow` is absent or
-  is not `"escrow"`.
+- `invalid_batch_settlement_svm_payment_flow` - `extra.paymentFlow` is present
+  and is not `"authorization"`.
 - `invalid_batch_settlement_svm_token_program` - `extra.tokenProgram` is not a
   supported SPL token program or does not own the selected mint.
 - `invalid_batch_settlement_svm_voucher_signature` - signature invalid or

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -1,0 +1,263 @@
+# SVM `batch-settlement` Scheme: High-Throughput Channel Payments on Solana
+
+> Status: **draft**. Companion to the network-agnostic
+> [`scheme_batch_settlement.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/batch-settlement/scheme_batch_settlement.md)
+> and the EVM profile
+> [`scheme_batch_settlement_evm.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md).
+> This document specifies how the `batch-settlement` scheme is realized on Solana
+> Virtual Machine (SVM) networks.
+
+## 1. Purpose
+
+`batch-settlement` is the high-throughput x402 scheme: a client **deposits once**
+into an escrow channel, then signs a stream of **cumulative Ed25519 vouchers**
+(one per request). The server verifies each voucher **off-chain** and serves the
+resource immediately — no on-chain transaction in the request path — and the
+operator **redeems the latest voucher per channel later, in batches**. This
+amortizes one on-chain settlement across many paid requests, so per-request cost
+and latency approach zero.
+
+Where `upto` settles **at most once** per authorization, `batch-settlement` is
+its multi-voucher generalization: the channel is long-lived and each request
+advances a monotonic cumulative counter. On SVM this is the same model as the MPP
+**`session`** intent, surfaced over the x402 wire and backed by the **same**
+payment-channels program and 48-byte voucher already used by
+[`upto`](../upto/scheme_upto_svm.md).
+
+## 2. Mapping the core requirements to SVM
+
+| Requirement (generic spec) | EVM mechanism | SVM mechanism (this spec) |
+|---|---|---|
+| One-time escrow deposit | ERC-20 `approve` + channel contract | `payment-channels` program: `open` deposits the escrow and fixes `payee` / `authorizedSigner` / `distribution_hash`. |
+| Per-request authorization | Cumulative signed voucher | 48-byte Ed25519 voucher `channel_id ‖ cumulative_amount_le ‖ expires_at_le`, signed by the channel's `authorizedSigner`. |
+| Monotonic amount | `cumulativeAmount` strictly increases | Off-chain watermark in the `ChannelStore` (`cumulative`), capped by on-chain `deposit`; on-chain `SettlementWatermarks.settled` enforces it at redemption. |
+| Batched redemption | One `claim` per channel, up to N | `settle` per channel draws the voucher's **exact** cumulative; multiple channels packed per transaction (tx-size-bounded). |
+| Recipient binding | Channel `recipient` fixed at open | `channel.payee` + `distribution_hash` fixed at `open`. |
+| Refund of unused deposit | `close` / cooperative close | `settle_and_finalize` + `distribute`: pays the settled amount and refunds `deposit − settled` to the payer, closing the channel. |
+
+**Decisive SVM divergence.** The SVM `settle` instruction draws the voucher's
+**exact** cumulative (`settled = voucher.cumulativeAmount`, after
+`settled < cumulative ≤ deposit`), not EVM's "claim up to a ceiling." So an SVM
+voucher commits the **actual** cumulative charged, and EVM's `claim`/`settle`
+split maps to our `settle` (advance the on-chain watermark) and `distribute`
+(sweep settled funds to `payee`/splits) instructions. Consequently v1 ships a
+**fixed per-request price** (each request advances the cumulative by exactly the
+advertised `amount`); dynamic pricing below the advertised amount would need a
+commit round-trip and is deferred.
+
+## 3. Profile
+
+A server advertises supported profiles in `extra.profiles`. v1 defines a single
+normative profile:
+
+### 3.1 `payment-channel` (normative, v1)
+
+Backed by the on-chain payment-channels program (a `pay-kit`-controlled program;
+program id `CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX` on the current
+deployment). The escrow **deposit is the ceiling**; the client signs cumulative
+vouchers off-chain; the operator settles the latest voucher per channel in
+batches and finalizes with a refund of the unused remainder.
+
+Unlike `upto`, where the **operator** is the `authorizedSigner` (it fills in
+`actual ≤ ceiling` after metering), here the **client** is the `authorizedSigner`
+— the client signs each cumulative voucher itself (this is the `session` /
+client-voucher model). The operator only ever submits on-chain `settle` /
+`distribute` / `finalize`; it can never exceed the on-chain `deposit` or redirect
+funds away from the fixed `payee`.
+
+Strengths: per-request cost approaches zero (no on-chain tx per request); every
+guarantee is enforced by a program we control. Cost: the client locks the
+deposit for the channel's lifetime, and the operator must settle before the
+forced-close grace period elapses to capture funds.
+
+## 4. Wire format
+
+`batch-settlement` reuses the x402 v2 transport: a `402` response carries
+`PAYMENT-REQUIRED`; each paid request carries `PAYMENT-SIGNATURE`; the response
+carries `PAYMENT-RESPONSE`. Only the `scheme` value and the payload shape change
+relative to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
+`SettlementResponse` types are defined in
+[`x402-specification-v2.md`](../../x402-specification-v2.md).
+
+### 4.1 `PaymentRequirements` (in `PAYMENT-REQUIRED.accepts[]`)
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `scheme` | string | ✓ | `"batch-settlement"` |
+| `network` | string | ✓ | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (mainnet), `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (devnet) |
+| `amount` | string | ✓ | Per-request price, base units (fixed in v1) |
+| `asset` | string | ✓ | SPL mint address (or a known symbol like `"USDC"`) |
+| `payTo` | string | ✓ | Base58 channel payee |
+| `maxTimeoutSeconds` | number | ✓ | Completion window |
+| `extra` | object | ✓ | See below |
+
+`extra` (`BatchExtra`):
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `profiles` | string[] | ✓ | Subset of `["payment-channel"]`, in server preference order |
+| `channelProgram` | string | ✓ | Channel program id (base58) |
+| `gracePeriodSeconds` | number | ✓ | Forced-close grace period (non-zero) |
+| `feePayer` | string | ✓ | Operator key that sponsors fees (co-signs/broadcasts `open`) and submits settlement (base58) |
+| `decimals` | number | – | Token decimals |
+| `tokenProgram` | string | – | `Tokenkeg…` or `TokenzQ…` (Token-2022); the client SHOULD verify it against the on-chain mint owner |
+| `recentBlockhash` | string | – | Pre-fetched blockhash so the client can build `open`/`topUp` without an extra RPC round-trip |
+| `suggestedDeposit` | string | – | Suggested initial deposit (base units) |
+| `minimumDeposit` | string | – | HTTP-enforced minimum initial deposit (base units) |
+| `minVoucherDelta` | string | – | Minimum cumulative increment between accepted vouchers (base units) |
+| `distributionSplits` | `{recipient, shareBps}[]` | – | Merchant-side splits committed at open; payee gets the remainder |
+
+### 4.2 `BatchPayload` (in `PAYMENT-SIGNATURE.payload`)
+
+A tagged union on `type`:
+
+**`deposit`** — open a channel (or top up) and authorize the first voucher:
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | string | `"deposit"` |
+| `channelConfig` | object | `{payer, payee, mint, authorizedSigner, salt, depositAmount, gracePeriodSeconds, distributionSplits[]}`. The channel id is the PDA `["channel", payer, payee, mint, authorizedSigner, salt]`. |
+| `transaction` | string | Base64 client-signed `open`/`topUp` transaction for the operator to co-sign as fee payer + broadcast |
+| `voucher` | object? | First cumulative `BatchVoucher` (omitted on a pure top-up) |
+
+**`voucher`** — steady-state paid request (no on-chain transaction):
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | string | `"voucher"` |
+| `channelId` | string | Channel PDA (base58) |
+| `voucher` | object | A new cumulative `BatchVoucher` |
+
+**`refund`** — cooperative close (the application route is bypassed):
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | string | `"refund"` |
+| `channelId` | string | Channel PDA (base58) |
+| `voucher` | object? | Optional final voucher to settle before refunding |
+
+`BatchVoucher`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `channelId` | string | Channel PDA (base58) |
+| `cumulativeAmount` | string | Cumulative authorized total (base units), monotonically increasing |
+| `expiresAt` | number | Voucher expiry (Unix seconds); MUST be a future time |
+| `signer` | string | Base58 voucher signer = the channel's `authorizedSigner` (the client) |
+| `signature` | string | Base58 Ed25519 signature over the 48-byte voucher payload |
+
+The signed message is exactly `channel_id (32) ‖ cumulative_amount (u64 le) ‖
+expires_at (i64 le)`, identical to `upto` and the MPP `session` voucher.
+
+### 4.3 `SettlementResponse` (in `PAYMENT-RESPONSE`)
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `success` | boolean | ✓ | |
+| `errorReason` | string | – | Omitted on success |
+| `payer` | string | – | Channel `payer` |
+| `transaction` | string | ✓ | On-chain signature; **empty `""` for an off-chain voucher acceptance** (the common case) |
+| `network` | string | ✓ | CAIP-2 |
+| `amount` | string | ✓ | Amount moved on-chain (`""` for voucher-only) |
+| `chargedAmount` | string | – | The per-request charge committed off-chain |
+| `channelState` | object | – | `{channelId, deposit, settled, paidOut, status}` snapshot |
+
+## 5. Phases
+
+### Phase 1 — Open (once per channel)
+
+The client builds an `open` transaction depositing `depositAmount` (≥
+`extra.minimumDeposit`), with `authorizedSigner = payer` (client-voucher model),
+`payee = payTo`, and `distributionSplits` matching `extra.distributionSplits`.
+The client sends a `deposit` payload carrying the base64 client-signed
+transaction plus the first cumulative voucher.
+
+The operator MUST validate the `open` transaction before co-signing as fee payer
+(the SOL-drain guard, reused from `upto`): exactly one instruction, the expected
+program id and `open` discriminator, and accounts/args matching `channelConfig`.
+It then co-signs, broadcasts, confirms, binds the on-chain channel into its
+`ChannelStore`, and accepts the first voucher (Phase 3). Only then is the
+resource served.
+
+### Phase 2 — Steady state (per request)
+
+The client increments the cumulative total by the per-request `amount`, signs a
+new `BatchVoucher`, and sends a `voucher` payload. No on-chain transaction. The
+operator accepts the voucher off-chain (Phase 3) and serves immediately.
+
+### Phase 3 — Voucher acceptance (before serving)
+
+For every voucher the operator MUST, via `core::session::accept_voucher`:
+
+1. Verify the Ed25519 `signature` over the 48-byte message against `signer`, and
+   confirm `signer` equals the channel's `authorizedSigner`.
+2. Confirm `expiresAt > now` (reject expired vouchers).
+3. Enforce **monotonicity**: `cumulativeAmount` ≥ the stored watermark.
+4. Enforce the **deposit cap**: `cumulativeAmount ≤ channel.deposit`.
+5. Enforce `minVoucherDelta` (if set) on the increment over the previous
+   cumulative.
+6. **Idempotent replay**: a voucher equal to the current watermark is accepted as
+   a no-op (the same request retried), not double-charged.
+7. Atomically advance the stored cumulative (compare-and-set).
+
+On any failure the operator returns `402` without serving the resource. A
+successful acceptance returns `200` with a `PAYMENT-RESPONSE` carrying an empty
+`transaction` and the `chargedAmount`.
+
+### Phase 4 — Batched settlement (operator-driven, out of band)
+
+The operator redeems accumulated vouchers asynchronously — **not** in the request
+path:
+
+- `settle_batch(channel_ids)`: for each channel, build `[ed25519_verify(latest
+  voucher), settle]` from the stored highest voucher and pack as many channels as
+  fit per transaction (tx-size-bounded; the implementation caps at
+  `MAX_CHANNELS_PER_SETTLE_TX = 3`, and logs any channel dropped from a batch —
+  no silent truncation). `settle` advances on-chain `SettlementWatermarks.settled`
+  to the voucher's exact cumulative.
+- `distribute(channel_id)`: sweep settled-but-unpaid funds to `payee` and the
+  committed `distributionSplits`.
+- `settle_and_finalize` + `distribute` on a `refund` payload (or when closing):
+  settle the final voucher, pay out, refund `deposit − settled` to the payer, and
+  close the channel.
+
+The operator MUST settle before the forced-close `gracePeriodSeconds` elapses
+after a client requests close, or it forfeits the unsettled remainder.
+
+## 6. Error codes
+
+Standard x402 codes apply. Scheme-specific failures surface as `402` with an
+`errorReason`:
+
+- voucher signature invalid / signer ≠ `authorizedSigner`
+- voucher expired (`expiresAt ≤ now`)
+- non-monotonic cumulative (below the watermark)
+- cumulative exceeds the on-chain `deposit`
+- increment below `minVoucherDelta`
+- `open` transaction failed the SOL-drain guard (rejected before co-signing)
+
+## 7. Security properties
+
+- **No overcharge.** Each voucher is capped on-chain by `deposit`; `settle` draws
+  the voucher's exact cumulative and can never exceed it.
+- **No redirection.** `channel.payee` / `distribution_hash` are fixed at `open`.
+- **No replay / no rollback.** Off-chain monotonic watermark plus on-chain
+  monotonic `SettlementWatermarks.settled`; an old voucher cannot settle after a
+  newer one.
+- **No fee-payer drain.** The operator validates the `open` transaction (single
+  instruction, correct program/discriminator/accounts) before co-signing as fee
+  payer.
+- **Time-bounded.** `expiresAt` is checked off-chain at acceptance and signed into
+  the on-chain voucher, so a stale voucher cannot settle.
+- **Bounded loss.** The client trusts the operator to settle before grace; the
+  operator trusts the client only up to the escrowed `deposit`. Everything above
+  the deposit, the destination, and replay are enforced cryptographically /
+  on-chain.
+
+## 8. Out of scope (follow-ups)
+
+- Automatic background channel manager (settle/distribute cadence) and
+  forced-close watchdog (settle before grace elapses); durable `ChannelStore`.
+- Metered / dynamic per-request pricing below the advertised `amount` (needs the
+  commit round-trip; SVM `settle` draws the voucher's exact cumulative).
+- `secp256r1` / passkey delegated voucher signers.

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -175,7 +175,6 @@ and `SettlementResponse` types are defined in
 | `feePayer` | string | yes | Base58 sponsor key set as channel `rent_payer` and zero-share `payee`. Co-signs setup/top-up transactions as transaction fee payer and signs channel lifecycle transactions. |
 | `receiverAuthorizer` | string | no | Base58 server-controlled Ed25519 key that authenticates an optional immediate cooperative close to the facilitator. It is not a payment-channel account field. |
 | `withdrawDelay` | number | yes | Forced-close grace period in seconds. MUST be an integer from `900` through `2592000` (15 minutes through 30 days), MUST be `>= maxTimeoutSeconds`, and MUST be encoded exactly as the program `grace_period`. The payment-channels program accepts any positive `grace_period`; this range is an x402 conformance bound, so verifying facilitators MUST enforce it and reject out-of-range requirements. |
-| `settlementBufferSeconds` | number | no | Positive-integer voucher-expiry margin in seconds used in the Phase 3 expiry bound (section 5). Defaults to `60` when omitted. A server or facilitator requiring a larger margin MUST advertise it here so the client can compute an acceptable `expiresAt` from the 402 alone. |
 | `tokenProgram` | string | yes | SPL Token (`Tokenkeg...`) or Token-2022 (`TokenzQ...`) program that owns `asset`. The client and facilitator MUST verify it against the onchain mint owner. |
 | `memo` | string | no | Seller-defined UTF-8 payment reference for the setup transaction's Memo instruction. Maximum 256 bytes. |
 | `recentBlockhash` | string | no | Pre-fetched blockhash the client MAY use to build an `open` or `top_up` transaction without an RPC round trip. The client MUST refresh it if it is no longer valid. |
@@ -252,7 +251,7 @@ may expose those program fields with language-specific casing.
 | `channelConfig.openSlot` | `Channel.open_slot` |
 | `voucher.channelId` | `VoucherArgs.channel_id` |
 | `voucher.maxClaimableAmount` | `VoucherArgs.cumulative_amount` |
-| `voucher.expiresAt` | `VoucherArgs.expires_at`; `0` disables voucher expiry |
+| `voucher.expiresAt` | `VoucherArgs.expires_at`; MUST be `0` in this scheme |
 | `channelState.balance` | `Channel.deposit` |
 | `channelState.totalClaimed` | `Channel.settled` |
 | `channelState.withdrawRequestedAt` | `Channel.closure_started_at` |
@@ -311,7 +310,7 @@ For a new channel, the `open` instruction MUST encode:
 |---|---|---|
 | `channelId` | string | Channel PDA (base58). |
 | `maxClaimableAmount` | string | Cumulative authorized total in atomic units; maps to program `cumulative_amount`. |
-| `expiresAt` | number | Unix seconds. `0` means no voucher expiry; otherwise the program enforces `now < expiresAt` at `settle` / `settle_and_seal`. |
+| `expiresAt` | number | MUST be `0` (no voucher expiry). The field stays in the signed message for program compatibility; the forced-close grace period alone bounds the redemption window. |
 | `signature` | string | Base58 Ed25519 signature by `channelConfig.payerAuthorizer`. |
 
 The signed message is exactly:
@@ -644,7 +643,7 @@ server-authored or server-enriched variants are:
 | Claim | `claims[].voucher.channelConfig` | `ChannelConfig` | Full channel configuration. |
 | Claim | `claims[].voucher.channelId` | string | Channel PDA. |
 | Claim | `claims[].voucher.maxClaimableAmount` | string | Cumulative amount for program `settle`. |
-| Claim | `claims[].voucher.expiresAt` | number | Voucher expiry. |
+| Claim | `claims[].voucher.expiresAt` | number | MUST be `0`. |
 | Claim | `claims[].signature` | string | Base58 Ed25519 voucher signature. |
 | Settle | `type` | string | `"settle"` |
 | Settle | `channels` | array | One or more channels to distribute. |
@@ -1199,7 +1198,7 @@ needs onchain state plus a voucher when it later settles.
 The server MUST serialize all paid-request and close processing per
 channel.
 The server stores `chargedCumulativeAmount`, `signedMaxClaimable`, the latest
-voucher signature and expiry, and a cached paid-response entry keyed by
+voucher signature, and a cached paid-response entry keyed by
 `("access", channelId, maxClaimableAmount)`. For every paid-request voucher,
 the server MUST:
 
@@ -1216,15 +1215,12 @@ the server MUST:
    matching section 4.1. When `channelConfig.receiverAuthorizer` is supplied,
    confirm it equals `extra.receiverAuthorizer`; otherwise both fields MUST be
    absent. Reject if `payer` or `payerAuthorizer` equals `feePayer`.
-4. **Expiry, accounting for async settlement.** `expiresAt` is re-checked
-   onchain when `settle` or `settle_and_seal` executes. Because redemption is
-   delayed, the server MUST require either `expiresAt == 0` or
-   `expiresAt >= now + withdrawDelay + settlementBufferSeconds`, where
-   `settlementBufferSeconds` is `extra.settlementBufferSeconds` when advertised
-   and `60` otherwise. The server and the verifying facilitator MUST NOT
-   require a larger margin than that advertised bound, so the client can always
-   compute a passing `expiresAt` from the 402 alone. A voucher that could
-   expire before redemption MUST be rejected.
+4. **No voucher expiry.** The client MUST sign `expiresAt = 0`, and the
+   server and facilitator MUST reject any voucher with nonzero `expiresAt`.
+   The forced-close grace period already bounds the redemption window after a
+   payer `request_close`; a per-voucher expiry would add a second clock the
+   server has to beat and could make an accepted voucher unredeemable while
+   the channel is still open, after the resource has been served.
 5. Enforce the deposit cap: `maxClaimableAmount <= channel.deposit`.
 6. Enforce replay protection and the per-request ceiling:
    - A previously accepted `("access", channelId, maxClaimableAmount)` is an
@@ -1455,10 +1451,8 @@ Standard x402 codes apply. The facilitator reports verification failures in
   client's cumulative voucher does not match server state.
 - `invalid_batch_settlement_svm_cumulative_exceeds_deposit` - voucher exceeds
   escrowed deposit.
-- `invalid_batch_settlement_svm_expiry_window_too_short` - voucher may expire
-  before redemption.
-- `invalid_batch_settlement_svm_settlement_buffer` - `extra.settlementBufferSeconds`
-  is present and is not a positive integer.
+- `invalid_batch_settlement_svm_voucher_expiry` - voucher `expiresAt` is
+  nonzero; this scheme requires non-expiring vouchers.
 - `invalid_batch_settlement_svm_setup_transaction` - setup transaction fails the
   sponsor safety checks.
 - `invalid_batch_settlement_svm_settlement_simulation` - setup or
@@ -1519,12 +1513,13 @@ Standard x402 codes apply. The facilitator reports verification failures in
   does not settle, the payer can start forced close and recover unspent escrow
   after the grace period. The protocol bounds that delay to 15 minutes through
   30 days and never shorter than the HTTP completion window.
-- **Time-bounded commitments.** Nonzero voucher `expiresAt` is checked both at
-  server acceptance and onchain redemption. `expiresAt == 0` means no voucher
-  expiry; in that case the channel's forced-close path bounds the commitment.
+- **Single settlement clock.** Vouchers never expire (`expiresAt` is fixed at
+  `0`); the channel's forced-close path alone bounds the commitment. The server
+  beats one clock — the grace period after a payer `request_close` — and an
+  accepted voucher can never become unredeemable while the channel is open.
 - **Fixed pricing.** Each fresh voucher increases the cumulative authorization
   by exactly `PaymentRequirements.amount`. The server trusts itself to redeem
-  before voucher expiry or forced-close expiry.
+  before forced-close expiry.
 
 ## 9. Out of Scope
 

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -30,7 +30,7 @@ payment-channels program and 48-byte voucher already used by
 |---|---|---|
 | One-time escrow deposit | ERC-20 `approve` + channel contract | `payment-channels` program: `open` deposits the escrow and fixes `payee` / `authorizedSigner` / `distribution_hash`. |
 | Per-request authorization | Cumulative signed voucher | 48-byte Ed25519 voucher `channel_id ‖ cumulative_amount_le ‖ expires_at_le`, signed by the channel's `authorizedSigner`. |
-| Monotonic amount | `cumulativeAmount` strictly increases | Off-chain watermark in the `ChannelStore` (`cumulative`), capped by on-chain `deposit`; on-chain `SettlementWatermarks.settled` enforces it at redemption. |
+| Monotonic amount | `cumulativeAmount` strictly increases | Off-chain watermark in the **server's** `ChannelStore` (`cumulative`), capped by on-chain `deposit`; on-chain `SettlementWatermarks.settled` enforces it at redemption. |
 | Batched redemption | One `claim` per channel, up to N | `settle` per channel draws the voucher's **exact** cumulative; multiple channels packed per transaction (tx-size-bounded). |
 | Recipient binding | Channel `recipient` fixed at open | `channel.payee` + `distribution_hash` fixed at `open`. |
 | Refund of unused deposit | `close` / cooperative close | `settle_and_finalize` + `distribute`: pays the settled amount and refunds `deposit − settled` to the payer, closing the channel. |
@@ -98,7 +98,7 @@ relative to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
 | `scheme` | string | ✓ | `"batch-settlement"` |
 | `network` | string | ✓ | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (mainnet), `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (devnet) |
 | `amount` | string | ✓ | Per-request price, base units (fixed in v1) |
-| `asset` | string | ✓ | SPL mint address (or a known symbol like `"USDC"`) |
+| `asset` | string | ✓ | The concrete SPL / Token-2022 mint pubkey (base58), e.g. USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` — not a symbol |
 | `payTo` | string | ✓ | Base58 recipient. Realized as the channel `payee` when the server self-facilitates (`payTo == operator`), or as a `distributionSplits` entry when a separate facilitator is the `payee`. |
 | `maxTimeoutSeconds` | number | ✓ | Completion window |
 | `extra` | object | ✓ | See below |
@@ -170,9 +170,13 @@ expires_at (i64 le)`, identical to `upto` and the MPP `session` voucher.
 | `payer` | string | – | Channel `payer` |
 | `transaction` | string | ✓ | On-chain signature; **empty `""` for an off-chain voucher acceptance** (the common case) |
 | `network` | string | ✓ | CAIP-2 |
-| `amount` | string | ✓ | Amount moved on-chain (`""` for voucher-only) |
-| `chargedAmount` | string | – | The per-request charge committed off-chain |
-| `channelState` | object | – | `{channelId, deposit, settled, paidOut, status}` snapshot |
+| `amount` | string | – | Amount moved on-chain (`""` / omitted for a voucher-only acceptance) — optional, per the core `SettleResponse` |
+| `extra.chargedAmount` | string | – | The per-request charge committed off-chain |
+| `extra.channelState` | object | – | `{channelId, deposit, settled, paidOut, status}` snapshot |
+
+Scheme-specific fields are nested under `extra` and `amount` is optional, matching
+the core `SettleResponse` and the EVM `batch-settlement` profile
+(`extra.chargedAmount`, `extra.channelState`).
 
 ## 5. Phases
 
@@ -186,12 +190,19 @@ matching `extra.distributionSplits`.
 The client sends a `deposit` payload carrying the base64 client-signed
 transaction plus the first cumulative voucher.
 
-The operator MUST validate the `open` transaction before co-signing as fee payer
-(the SOL-drain guard, reused from `upto`): exactly one instruction, the expected
-program id and `open` discriminator, and accounts/args matching `channelConfig`.
-It then co-signs, broadcasts, confirms, binds the on-chain channel into its
-`ChannelStore`, and accepts the first voucher (Phase 3). Only then is the
-resource served.
+The operator MUST validate the **full compiled** `open` transaction before
+co-signing as fee payer — not only the payment-channel instruction. Following the
+`exact` SVM scheme's fee-payer guard
+([`scheme_exact_svm.md`](../exact/scheme_exact_svm.md)): resolve any
+address-lookup tables; allow only the expected instruction set (the channel
+`open`, plus an optional ComputeBudget instruction); confirm the program id and
+`open` discriminator and that accounts/args match `channelConfig`; and confirm
+the fee payer (the operator) is never used as an authority, source, or writable
+account except to pay transaction fees. Anything else is rejected before
+broadcasting, so a malicious client cannot make the operator co-sign more than
+fee payment. The operator then co-signs, broadcasts, confirms, binds the on-chain
+channel into the server's `ChannelStore`, and accepts the first voucher
+(Phase 3). Only then is the resource served.
 
 ### Phase 2 — Steady state (per request)
 
@@ -201,42 +212,68 @@ operator accepts the voucher off-chain (Phase 3) and serves immediately.
 
 ### Phase 3 — Voucher acceptance (before serving)
 
-For every voucher the operator MUST, via `core::session::accept_voucher`:
+For every voucher the operator MUST (the off-chain watermark and channel snapshot
+are the **resource server's** per-channel state — a separate facilitator, if used,
+stays stateless for this verification, per x402):
 
 1. Verify the Ed25519 `signature` over the 48-byte message against `signer`, and
    confirm `signer` equals the channel's `authorizedSigner`.
-2. Confirm `expiresAt > now` (reject expired vouchers).
-3. Enforce **monotonicity**: `cumulativeAmount` ≥ the stored watermark.
+2. **Expiry, accounting for async settlement.** `expiresAt` is re-checked
+   **on-chain** when `settle` / `settleAndFinalize` execute (the program rejects
+   `expires_at != 0 && now ≥ expires_at`), not only at HTTP acceptance. Because
+   redemption is batched and out-of-band, the operator MUST require `expiresAt`
+   to outlast the redemption window: either `expiresAt == 0` (the program treats
+   `0` as no-expiry, so the channel is time-bounded only by its forced-close
+   grace period) or `expiresAt ≥ now + gracePeriodSeconds + a settlement buffer`.
+   A voucher whose `expiresAt` could lapse before settlement MUST be rejected —
+   it would be served but never redeemable.
+3. Enforce **monotonicity**: reject any `cumulativeAmount` **below** the stored
+   watermark — a stale or replayed voucher. The `cumulativeAmount` is itself the
+   per-request nonce: each served response maps one-to-one to a unique cumulative
+   level, so replay protection is intrinsic to the amount.
 4. Enforce the **deposit cap**: `cumulativeAmount ≤ channel.deposit`.
-5. Enforce `minVoucherDelta` (if set) on the increment over the previous
-   cumulative.
-6. **Idempotent replay**: a voucher equal to the current watermark is accepted as
-   a no-op (the same request retried), not double-charged.
-7. Atomically advance the stored cumulative (compare-and-set).
+5. **Charge-worthy (new) request** — `cumulativeAmount > watermark`: in
+   fixed-price v1 the increment MUST equal the advertised price exactly
+   (`cumulativeAmount == watermark + amount`, and ≥ `minVoucherDelta` when set).
+   The operator atomically advances the stored watermark (compare-and-set),
+   serves the resource, and caches the response keyed by
+   `(channelId, cumulativeAmount)`.
+6. **Idempotent retry** — `cumulativeAmount == watermark`: necessarily a retry of
+   the request already paid for at that level (a genuinely new request carries a
+   strictly higher cumulative). The operator returns the **cached response** for
+   that `(channelId, cumulativeAmount)` and does **not** serve a fresh resource,
+   re-charge, or advance the watermark. Accepting an equal voucher MUST NOT
+   produce a new response — otherwise a client could replay its latest voucher to
+   buy further responses without paying.
 
-On any failure the operator returns `402` without serving the resource. A
-successful acceptance returns `200` with a `PAYMENT-RESPONSE` carrying an empty
-`transaction` and the `chargedAmount`.
+On any failure the operator returns `402` without serving the resource. A fresh
+acceptance (step 5) returns `200` with a `PAYMENT-RESPONSE` carrying an empty
+`transaction` and the `chargedAmount`; an idempotent retry (step 6) replays that
+cached `200` response.
 
 ### Phase 4 — Batched settlement (operator-driven, out of band)
 
 The operator redeems accumulated vouchers asynchronously — **not** in the request
 path:
 
-- `settle_batch(channel_ids)`: for each channel, build `[ed25519_verify(latest
-  voucher), settle]` from the stored highest voucher and pack as many channels as
-  fit per transaction (tx-size-bounded; the implementation caps at
-  `MAX_CHANNELS_PER_SETTLE_TX = 3`, and logs any channel dropped from a batch —
-  no silent truncation). `settle` advances on-chain `SettlementWatermarks.settled`
-  to the voucher's exact cumulative.
-- `distribute(channel_id)`: sweep settled-but-unpaid funds to `payee` and the
+- **Batched `settle`.** For each channel the operator builds
+  `[ed25519_verify(latest voucher), settle]` from the stored highest voucher and
+  packs as many channels into one transaction as fit (**transaction-size-bounded**
+  — a few per transaction today, more as the runtime allows). Any channel dropped
+  from a full batch MUST be logged (no silent truncation). `settle` advances
+  on-chain `SettlementWatermarks.settled` to the voucher's exact cumulative.
+- **`distribute`.** Sweep settled-but-unpaid funds to the `payee` and the
   committed `distributionSplits`.
-- `settle_and_finalize` + `distribute` on a `refund` payload (or when closing):
-  settle the final voucher, pay out, refund `deposit − settled` to the payer, and
-  close the channel.
+- **`settle_and_finalize` + `distribute`** on a `refund` payload (or when
+  closing): settle the final voucher, pay out, refund `deposit − settled` to the
+  payer, and close the channel.
 
 The operator MUST settle before the forced-close `gracePeriodSeconds` elapses
-after a client requests close, or it forfeits the unsettled remainder.
+after a client requests close, or it forfeits the unsettled remainder. Because
+redemption is asynchronous, the operator SHOULD settle with a comfortable buffer
+ahead of that deadline, and SHOULD advertise a `gracePeriodSeconds` long enough
+to cover its batch cadence — consistent with the `expiresAt` window in §5
+Phase 3.
 
 ## 6. Error codes
 
@@ -258,13 +295,17 @@ Standard x402 codes apply. Scheme-specific failures surface as `402` with an
 - **No replay / no rollback.** Off-chain monotonic watermark plus on-chain
   monotonic `SettlementWatermarks.settled`; an old voucher cannot settle after a
   newer one.
-- **No fee-payer drain.** The operator validates the `open` transaction (single
-  instruction, correct program/discriminator/accounts) before co-signing as fee
-  payer.
-- **Time-bounded.** `expiresAt` is checked off-chain at acceptance and enforced
-  on-chain at settle. Because the **client** signs each voucher (it is the
-  `authorizedSigner`), `expiresAt` is a genuine client commitment here — unlike
-  `upto`, where the operator signs and the field is operator-attested.
+- **No fee-payer drain.** The operator validates the full compiled `open`
+  transaction before co-signing — allowed instruction set only, address-lookup
+  tables resolved, and the fee payer never used as an authority, source, or
+  writable account except to pay fees (§5 Phase 1).
+- **Time-bounded.** `expiresAt` is checked off-chain at acceptance and re-checked
+  on-chain at `settle`/`settleAndFinalize`. Because the **client** signs each
+  voucher (it is the `authorizedSigner`), `expiresAt` is a genuine client
+  commitment here — unlike `upto`, where the operator signs and the field is
+  operator-attested. Since redemption is asynchronous, the operator only accepts
+  vouchers whose `expiresAt` is `0` (no-expiry) or outlasts the settlement window
+  (§5 Phase 3), so an accepted voucher cannot expire before it is redeemed.
 - **Bounded loss.** The client trusts the operator to settle before grace; the
   operator trusts the client only up to the escrowed `deposit`. Everything above
   the deposit, the destination, and replay are enforced cryptographically /

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -178,12 +178,11 @@ and `SettlementResponse` types are defined in
 | `tokenProgram` | string | yes | SPL Token (`Tokenkeg...`) or Token-2022 (`TokenzQ...`) program that owns `asset`. The client and facilitator MUST verify it against the onchain mint owner. |
 | `memo` | string | no | Seller-defined UTF-8 payment reference for the setup transaction's Memo instruction. Maximum 256 bytes. |
 | `recentBlockhash` | string | no | Pre-fetched blockhash the client MAY use to build an `open` or `top_up` transaction without an RPC round trip. The client MUST refresh it if it is no longer valid. |
-| `lastValidBlockHeight` | string | no | Last block height at which `recentBlockhash` is valid, as a decimal string. Informational; MAY be ignored. Ignored when `recentBlockhash` is absent. |
 | `recentSlot` | number | no | Recent slot the client MAY use as `channelConfig.openSlot` when it does not fetch its own slot. The program still enforces the open-slot window. |
 | `channelState` | object | no | Corrective-only server channel snapshot for cumulative amount resynchronization. |
 | `voucherState` | object | no | Corrective-only signed voucher proof for cumulative amount resynchronization. |
 
-`recentBlockhash`, `lastValidBlockHeight`, and `recentSlot` are
+`recentBlockhash` and `recentSlot` are
 transaction-construction hints only. They are not persistent channel
 configuration and are not included in the voucher message. A client MAY ignore
 the hints and obtain fresher values from an RPC.
@@ -224,7 +223,6 @@ Example:
     "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
     "memo": "invoice-123",
     "recentBlockhash": "<recent-blockhash>",
-    "lastValidBlockHeight": "321000000",
     "recentSlot": 341000000
   }
 }
@@ -398,7 +396,6 @@ current request:
       "withdrawDelay": 3600,
       "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
       "recentBlockhash": "<recent-blockhash>",
-      "lastValidBlockHeight": "321000000",
       "recentSlot": 341000000
     }
   },
@@ -454,7 +451,6 @@ transaction:
       "withdrawDelay": 3600,
       "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
       "recentBlockhash": "<recent-blockhash>",
-      "lastValidBlockHeight": "321000000",
       "recentSlot": 341000000
     }
   },
@@ -512,7 +508,6 @@ unless an authenticated server confirms it is the latest accepted voucher.
       "withdrawDelay": 3600,
       "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
       "recentBlockhash": "<recent-blockhash>",
-      "lastValidBlockHeight": "321000000",
       "recentSlot": 341000000
     }
   },
@@ -962,7 +957,6 @@ signed recovery proof:
         "withdrawDelay": 3600,
         "tokenProgram": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
         "recentBlockhash": "<recent-blockhash>",
-        "lastValidBlockHeight": "321000000",
         "recentSlot": 341000000,
         "channelState": {
           "channelId": "<channel-pda>",

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -1,9 +1,7 @@
 # SVM `batch-settlement` Scheme: High-Throughput Channel Payments on Solana
 
 > Status: **draft**. Companion to the network-agnostic
-> [`scheme_batch_settlement.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/batch-settlement/scheme_batch_settlement.md)
-> and the EVM profile
-> [`scheme_batch_settlement_evm.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md).
+> [`scheme_batch_settlement.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/batch-settlement/scheme_batch_settlement.md).
 > This document specifies how the `batch-settlement` scheme is realized on
 > Solana Virtual Machine (SVM) networks.
 
@@ -30,29 +28,45 @@ The x402 roles map to the payment-channel program as follows:
 - **Server**: resource provider; receives funds at `payTo`; owns per-channel
   offchain state, including the accepted cumulative watermark and latest
   voucher.
-- **Receiver authorizer**: server-controlled hot key advertised as
+- **Receiver authorizer**: lifecycle key advertised as
   `extra.receiverAuthorizer`; recorded as channel `payee`; signs cooperative
-  close/refund operations. It does not need to receive the settled funds.
+  close/refund operations. It MUST equal `extra.feePayer` so the rent sponsor
+  can close abandoned channels and recover its rent.
 - **Facilitator / sponsor**: account advertised as `extra.feePayer`; sponsors
   transaction fees and channel rent. It is the transaction fee payer and channel
-  `rent_payer`, but it is not a payment authority.
+  `rent_payer`, and occupies the channel `payee` lifecycle-authority seat with a
+  zero share of settled funds. The server MAY self-facilitate.
 
-`payTo` is the server's payment receiver, typically a cold wallet. If
-`payTo != receiverAuthorizer`, the channel distribution sends 100% of settled
-funds to `payTo`, leaving the channel `payee` with a zero implicit remainder.
-If `payTo == receiverAuthorizer`, the client MAY omit recipients and let the
-payee receive the implicit 100% remainder.
+`payTo` is the server's payment receiver, typically a cold wallet. The channel
+distribution always sends 100% of settled funds to `payTo` through one explicit
+recipient and leaves the channel `payee` with a zero implicit remainder, even
+when both roles use the same address.
+
+This authority split prevents rent lock without granting payment authority to
+the facilitator:
+
+- The facilitator, as `payee`, can run `settle_and_seal` with
+  `has_voucher = 0`, then `distribute` and `reclaim`, even if the client and
+  server disappear. A client/server pair cannot strand the rent it sponsored.
+- Only the client-controlled `payerAuthorizer` can sign a voucher that advances
+  the settled watermark. The facilitator can close at the current onchain
+  watermark, but it cannot create a nonzero claim or redirect funds.
+
+A facilitator that closes before the latest client voucher is claimed freezes
+the watermark and causes the unclaimed remainder to be refunded to the client.
+The server MUST treat unclaimed voucher value as facilitator credit risk and
+claim promptly.
 
 ## 2. Mapping the Core Requirements to SVM
 
-| Requirement (generic spec) | EVM mechanism | SVM mechanism |
-|---|---|---|
-| One-time escrow deposit | Token authorization plus channel contract | Payment-channels `open` deposits escrow, records `withdrawDelay`, fixes `payee`, `authorized_signer`, `rent_payer`, and commits `distribution_hash`. |
-| Per-request authorization | Cumulative signed voucher | Ed25519 voucher signed by `payerAuthorizer` over `0x56 0x01 || channelId || cumulativeAmount || expiresAt`. |
-| Monotonic amount | `maxClaimableAmount` increases | Server-owned offchain watermark plus onchain `settled < cumulativeAmount <= deposit` at redemption. |
-| Batched redemption | Claim many channels | One `settle` per channel, packed transaction-size permitting; `distribute` pays settled deltas. |
-| Recipient binding | Receiver fixed in channel config | `distribution_hash` fixed at `open` sends funds to `payTo`; program re-checks it at `distribute`. |
-| Refund of unused deposit | Cooperative refund or timed withdrawal | `settle_and_seal` + `distribute` for cooperative close; `request_close` / `seal` / `withdraw_payer` for payer-forced close. |
+| Requirement (generic spec) | SVM mechanism |
+|---|---|
+| One-time escrow deposit | Payment-channels `open` deposits escrow, records `withdrawDelay`, fixes `payee`, `authorized_signer`, `rent_payer`, and commits `distribution_hash`. |
+| Per-request authorization | Ed25519 voucher signed by `payerAuthorizer` over `0x56 0x01 || channelId || maxClaimableAmount || expiresAt`. |
+| Monotonic amount | Server-owned offchain watermark plus onchain `settled < maxClaimableAmount <= deposit` at redemption. |
+| Batched redemption | One `settle` per channel, packed transaction-size permitting; `distribute` pays settled deltas. |
+| Recipient binding | `distribution_hash` fixed at `open` sends funds to `payTo`; program re-checks it at `distribute`. |
+| Refund of unused deposit | `settle_and_seal` + `distribute` for cooperative close; `request_close` / `seal` / `withdraw_payer` for payer-forced close. |
 
 ## 3. Payment-Channel Method
 
@@ -91,6 +105,21 @@ The current program lifecycle is:
    `clock.slot > open_slot + OPEN_SLOT_WINDOW`; it returns remaining PDA rent to
    the recorded `rent_payer`.
 
+The address carried on the x402 wire as `extra.feePayer` is recorded by the
+program as both `Channel.rent_payer` and zero-share `Channel.payee`. Rent returns
+to that address during the final `distribute` fast path or a later `reclaim`.
+Because the sponsor holds the `payee` lifecycle authority, it can seal and clean
+up an abandoned channel without a client or server signature. It MUST be able
+to rediscover the channels it sponsored as specified in section 6. Token
+payouts and client refunds are completed by `distribute` and are not delayed by
+the later `reclaim` of PDA rent.
+
+If the client invokes `request_close`, only the `payee` can cooperatively
+`settle_and_seal` during the grace period. The server therefore depends on the
+facilitator to include its latest voucher before the deadline. After the grace
+period, anyone can call `seal`; the payer can recover unspent escrow through
+`withdraw_payer` or sealed `distribute`.
+
 ## 4. Wire Format
 
 `batch-settlement` reuses the x402 v2 transport: a `402` response carries
@@ -105,7 +134,7 @@ and `SettlementResponse` types are defined in
 |---|---|---|---|
 | `scheme` | string | yes | `"batch-settlement"` |
 | `network` | string | yes | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` |
-| `amount` | string | yes | Fixed per-request price in base units. |
+| `amount` | string | yes | Maximum per-request price in atomic units. The server MAY charge less and reports the actual charge in `SettlementResponse.extra.chargedAmount`. |
 | `asset` | string | yes | Concrete SPL / Token-2022 mint pubkey, not a symbol. |
 | `payTo` | string | yes | Base58 final payment receiver. Normally a server cold wallet. |
 | `maxTimeoutSeconds` | number | yes | HTTP completion window. |
@@ -115,39 +144,35 @@ and `SettlementResponse` types are defined in
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `feePayer` | string | yes | Base58 sponsor key that co-signs channel setup/top-up/settlement transactions as transaction fee payer and funds channel rent as `rent_payer`. |
-| `receiverAuthorizer` | string | yes | Base58 server-controlled key set as channel `payee`; signs cooperative close/refund transactions. |
+| `feePayer` | string | yes | Base58 sponsor key set as channel `rent_payer` and zero-share `payee`. Co-signs setup/top-up transactions as transaction fee payer and signs cooperative close/refund transactions. |
+| `receiverAuthorizer` | string | yes | Base58 lifecycle-authority key set as channel `payee`. MUST equal `feePayer`, so rent recovery never depends on a separate server key. |
 | `withdrawDelay` | number | yes | Server-defined forced-close grace period in seconds. The client MUST encode this exact value as the program `grace_period`; the verifier MUST reject any other value. |
-| `tokenProgram` | string | yes | `Tokenkeg...` or `TokenzQ...` (Token-2022); the client SHOULD verify it against the onchain mint owner. |
-| `recentBlockhash` | string | no | Pre-fetched blockhash so the client can build setup transactions without an RPC round trip. |
-| `recentSlot` | number | no | Recent slot the client MAY use as `openSlot` when it does not fetch its own slot. The program still enforces the slot window. |
-| `suggestedDeposit` | string | no | Suggested initial deposit in base units. |
-| `minimumDeposit` | string | no | HTTP-enforced minimum initial deposit in base units. |
-| `minVoucherDelta` | string | no | Minimum cumulative increment between accepted vouchers in base units. |
+| `recentBlockhash` | string | no | Pre-fetched blockhash the client MAY use to build an `open` or `top_up` transaction without an RPC round trip. The client MUST refresh it if it is no longer valid. |
+| `recentSlot` | number | no | Recent slot the client MAY use as `channelConfig.openSlot` when it does not fetch its own slot. The program still enforces the open-slot window. |
 | `channelState` | object | no | Corrective-only server channel snapshot for cumulative amount resynchronization. |
 | `voucherState` | object | no | Corrective-only signed voucher proof for cumulative amount resynchronization. |
+
+`recentBlockhash` and `recentSlot` are transaction-construction hints only. They
+are not persistent channel configuration and are not included in the voucher
+message. A client MAY ignore either hint and obtain a fresher value from an RPC.
 
 The x402 wire format does not expose program-specific split arrays. The client
 derives the payment-channel accounts and distribution from the x402 fields:
 
 ```text
 rent_payer = extra.feePayer
-payee = extra.receiverAuthorizer
+payee = extra.feePayer
 authorized_signer = channelConfig.payerAuthorizer
 grace_period = extra.withdrawDelay
 
-if payTo == extra.receiverAuthorizer:
-  recipients = []
-  payee_implicit_remainder_bps = 10000
-else:
-  recipients = [{ recipient: payTo, bps: 10000 }]
-  payee_implicit_remainder_bps = 0
+recipients = [{ recipient: payTo, bps: 10000 }]
+payee_implicit_remainder_bps = 0
 ```
 
 Any facilitator commercial fee is outside this wire contract or included in the
 server's pricing. The channel distribution for this scheme MUST NOT assign any
-portion of settled funds away from `payTo`, except when `payTo` is itself the
-channel payee via the implicit remainder path.
+portion of settled funds away from `payTo`. The explicit single-entry
+distribution is REQUIRED even when `payTo == extra.feePayer`.
 
 Example:
 
@@ -157,66 +182,62 @@ Example:
   "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
   "amount": "1000",
   "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  "payTo": "<server-cold-wallet>",
+  "payTo": "<server-receiver>",
   "maxTimeoutSeconds": 300,
   "extra": {
-    "feePayer": "<facilitator>",
-    "receiverAuthorizer": "<server-hot-wallet>",
+    "feePayer": "<facilitator-fee-payer>",
+    "receiverAuthorizer": "<facilitator-fee-payer>",
     "withdrawDelay": 3600,
-    "tokenProgram": "<token-program>",
-    "recentBlockhash": "<cached>",
-    "recentSlot": 341000000,
-    "suggestedDeposit": "100000",
-    "minimumDeposit": "10000"
+    "recentBlockhash": "<recent-blockhash>",
+    "recentSlot": 341000000
   }
 }
 ```
 
-### 4.2 `BatchPayload` (in `PAYMENT-SIGNATURE.payload`)
+### 4.2 Shared Wire Objects and Program Mapping
 
-A tagged union on `type`:
+The wire format uses network-neutral x402 names even when the SVM program uses
+different instruction or account notation:
 
-**`deposit`** - open a channel or top up an existing channel and authorize the
-current request:
+In this section, camelCase names identify x402 wire fields. Snake_case names
+identify the payment-channels program's Rust account fields; generated clients
+may expose those program fields with language-specific casing.
 
-| Field | Type | Notes |
-|---|---|---|
-| `type` | string | `"deposit"` |
-| `channelConfig` | object | See `ChannelConfig` below. |
-| `transaction` | string | Base64 client-signed `open` or `top_up` transaction for the sponsor to co-sign and broadcast. |
-| `voucher` | object | New cumulative `BatchVoucher` for the request being paid. |
-
-**`voucher`** - steady-state paid request with no onchain transaction:
-
-| Field | Type | Notes |
-|---|---|---|
-| `type` | string | `"voucher"` |
-| `channelId` | string | Channel PDA (base58). |
-| `voucher` | object | New cumulative `BatchVoucher`. |
-
-**`refund`** - cooperative close; the application resource handler is bypassed:
-
-| Field | Type | Notes |
-|---|---|---|
-| `type` | string | `"refund"` |
-| `channelId` | string | Channel PDA (base58). |
-| `voucher` | object | Zero-charge voucher whose `cumulativeAmount` equals the server's current watermark. |
-| `amount` | string | Optional requested refund amount; omitted means full unspent remainder. |
+| x402 wire field | Payment-channels program notation |
+|---|---|
+| `PaymentRequirements.extra.feePayer` | `Channel.rent_payer` and zero-share `Channel.payee` |
+| `channelConfig.payer` | `Channel.payer` |
+| `channelConfig.payerAuthorizer` | `Channel.authorized_signer` |
+| `channelConfig.receiver` | Sole `DistributionEntry.recipient` with `bps = 10000`; the `Channel.payee` implicit remainder is always zero |
+| `channelConfig.receiverAuthorizer` | `Channel.payee` |
+| `channelConfig.token` | `Channel.mint` |
+| `channelConfig.withdrawDelay` | `Channel.grace_period` |
+| `channelConfig.salt` | `Channel.salt` |
+| `channelConfig.openSlot` | `Channel.open_slot` |
+| `voucher.channelId` | `VoucherArgs.channel_id` |
+| `voucher.maxClaimableAmount` | `VoucherArgs.cumulative_amount` |
+| `voucher.expiresAt` | `VoucherArgs.expires_at`; `0` disables voucher expiry |
+| `channelState.balance` | `Channel.deposit` |
+| `channelState.totalClaimed` | `Channel.settled` |
+| `channelState.withdrawRequestedAt` | `Channel.closure_started_at` |
+| `channelState.chargedCumulativeAmount` | Server-owned offchain cumulative charge |
 
 `ChannelConfig`:
 
 | Field | Type | Notes |
 |---|---|---|
-| `payer` | string | Client wallet and channel payer. |
-| `payerAuthorizer` | string | Client-controlled Ed25519 voucher signer; maps to channel `authorized_signer`. MAY equal `payer`. |
-| `receiver` | string | MUST equal `payTo`. Included so the client can verify the derived distribution. |
-| `receiverAuthorizer` | string | MUST equal `extra.receiverAuthorizer`; maps to channel `payee`. |
-| `mint` | string | MUST equal `asset`. |
-| `tokenProgram` | string | MUST equal `extra.tokenProgram`. |
+| `payer` | string | Client wallet and channel payer. MUST NOT equal `receiverAuthorizer`, because the program requires distinct payer and payee accounts. |
+| `payerAuthorizer` | string | Client-controlled Ed25519 voucher signer; maps to channel `authorized_signer`. MAY equal `payer` but MUST NOT equal `receiverAuthorizer` / `feePayer`. |
+| `receiver` | string | MUST equal `payTo`. |
+| `receiverAuthorizer` | string | MUST equal `extra.receiverAuthorizer == extra.feePayer`; maps to channel `payee`. |
+| `token` | string | MUST equal `asset`; maps to channel `mint`. |
+| `withdrawDelay` | number | MUST equal `extra.withdrawDelay`; maps to channel `grace_period`. |
 | `salt` | string | Decimal `u64` channel salt. |
 | `openSlot` | number | `u64` slot encoded in `open` and used as a channel PDA seed. |
-| `depositAmount` | string | Initial deposit or top-up amount in base units. |
-| `withdrawDelay` | number | MUST equal `extra.withdrawDelay`. |
+
+The client MUST determine the token program from the onchain owner of
+`channelConfig.token`; it MUST NOT accept an unverified token-program value from
+the server.
 
 `channelId` is the program-derived address:
 
@@ -226,7 +247,7 @@ find_program_address(
     "channel",
     channelConfig.payer,
     channelConfig.receiverAuthorizer,
-    channelConfig.mint,
+    channelConfig.token,
     channelConfig.payerAuthorizer,
     u64(channelConfig.salt).to_le_bytes(),
     u64(channelConfig.openSlot).to_le_bytes()
@@ -235,52 +256,587 @@ find_program_address(
 )
 ```
 
-The `open` instruction MUST encode:
+For a new channel, the `open` instruction MUST encode:
 
 - `salt == channelConfig.salt`
-- `deposit == channelConfig.depositAmount`
-- `grace_period == extra.withdrawDelay`
+- `deposit == deposit.amount`
+- `grace_period == channelConfig.withdrawDelay`
 - `open_slot == channelConfig.openSlot`
-- `rent_payer == extra.feePayer`
-- `payee == extra.receiverAuthorizer`
+- `rent_payer == PaymentRequirements.extra.feePayer`
+- `payee == channelConfig.receiverAuthorizer`
 - `authorized_signer == channelConfig.payerAuthorizer`
-- the distribution derived from `payTo` as specified in section 4.1
+- `mint == channelConfig.token`
+- the distribution derived from `channelConfig.receiver` as specified in
+  section 4.1
 
 `BatchVoucher`:
 
 | Field | Type | Notes |
 |---|---|---|
 | `channelId` | string | Channel PDA (base58). |
-| `cumulativeAmount` | string | Cumulative authorized total in base units. |
+| `maxClaimableAmount` | string | Cumulative authorized total in atomic units; maps to program `cumulative_amount`. |
 | `expiresAt` | number | Unix seconds. `0` means no voucher expiry; otherwise the program enforces `now < expiresAt` at `settle` / `settle_and_seal`. |
-| `signer` | string | Base58 voucher signer. MUST equal `channelConfig.payerAuthorizer` / channel `authorized_signer`. |
-| `signature` | string | Base58 Ed25519 signature over the voucher payload. |
+| `signature` | string | Base58 Ed25519 signature by `channelConfig.payerAuthorizer`. |
 
 The signed message is exactly:
 
 ```text
-0x56 0x01 || channelId || u64(cumulativeAmount).le || i64(expiresAt).le
+0x56 0x01 || channelId || u64(maxClaimableAmount).le || i64(expiresAt).le
 ```
 
 This is the payment-channels program voucher layout (`VOUCHER_MAGIC`,
 `channel_id`, `cumulative_amount`, `expires_at`), 50 bytes total.
 
-### 4.3 `SettlementResponse` (in `PAYMENT-RESPONSE`)
+`ChannelState`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `channelId` | string | Channel PDA (base58). |
+| `balance` | string | Current `Channel.deposit` ceiling in atomic units. |
+| `totalClaimed` | string | Current onchain `Channel.settled` watermark. |
+| `withdrawRequestedAt` | number | `Channel.closure_started_at`, or `0` when no forced close is pending. |
+| `chargedCumulativeAmount` | string | Server-owned offchain cumulative actual charge. Present only when the response is authored by the server. |
+
+### 4.3 Client `PaymentPayload` Variants
+
+The client payload is a tagged union on `payload.type`. `/verify` accepts all
+three variants. `/settle` accepts `deposit` and `voucher` directly; the server
+enriches `refund` before settlement as specified in section 4.5.
+
+**`deposit`** opens a channel or tops up an existing channel and authorizes the
+current request:
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | string | `"deposit"` |
+| `channelConfig` | `ChannelConfig` | Full channel configuration. |
+| `voucher` | `BatchVoucher` | Cumulative authorization for the current request. |
+| `deposit.amount` | string | Amount to deposit or top up in atomic units. |
+| `deposit.transaction` | string | Base64 client-signed `open` or `top_up` transaction for the facilitator to validate, co-sign, and broadcast. |
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "batch-settlement",
+    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "amount": "1000",
+    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "payTo": "<server-receiver>",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "feePayer": "<facilitator-fee-payer>",
+      "receiverAuthorizer": "<facilitator-fee-payer>",
+      "withdrawDelay": 3600,
+      "recentBlockhash": "<recent-blockhash>",
+      "recentSlot": 341000000
+    }
+  },
+  "payload": {
+    "type": "deposit",
+    "channelConfig": {
+      "payer": "<client-wallet>",
+      "payerAuthorizer": "<client-voucher-signer>",
+      "receiver": "<server-receiver>",
+      "receiverAuthorizer": "<facilitator-fee-payer>",
+      "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "withdrawDelay": 3600,
+      "salt": "42",
+      "openSlot": 341000000
+    },
+    "voucher": {
+      "channelId": "<channel-pda>",
+      "maxClaimableAmount": "1000",
+      "expiresAt": 0,
+      "signature": "<base58-ed25519-signature>"
+    },
+    "deposit": {
+      "amount": "100000",
+      "transaction": "<base64-client-signed-open-or-top-up-transaction>"
+    }
+  }
+}
+```
+
+**`voucher`** authorizes a steady-state paid request without an onchain
+transaction:
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | string | `"voucher"` |
+| `channelConfig` | `ChannelConfig` | Full channel configuration. |
+| `voucher` | `BatchVoucher` | New cumulative voucher. |
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "batch-settlement",
+    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "amount": "1000",
+    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "payTo": "<server-receiver>",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "feePayer": "<facilitator-fee-payer>",
+      "receiverAuthorizer": "<facilitator-fee-payer>",
+      "withdrawDelay": 3600,
+      "recentBlockhash": "<recent-blockhash>",
+      "recentSlot": 341000000
+    }
+  },
+  "payload": {
+    "type": "voucher",
+    "channelConfig": {
+      "payer": "<client-wallet>",
+      "payerAuthorizer": "<client-voucher-signer>",
+      "receiver": "<server-receiver>",
+      "receiverAuthorizer": "<facilitator-fee-payer>",
+      "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "withdrawDelay": 3600,
+      "salt": "42",
+      "openSlot": 341000000
+    },
+    "voucher": {
+      "channelId": "<channel-pda>",
+      "maxClaimableAmount": "5000",
+      "expiresAt": 0,
+      "signature": "<base58-ed25519-signature>"
+    }
+  }
+}
+```
+
+**`refund`** requests cooperative closure and a full refund of the unspent
+escrow. The application resource handler is bypassed. Its voucher is
+zero-charge: `maxClaimableAmount` MUST equal the server's current
+`chargedCumulativeAmount`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | string | `"refund"` |
+| `channelConfig` | `ChannelConfig` | Full channel configuration. |
+| `voucher` | `BatchVoucher` | Zero-charge voucher at the server's current cumulative charge. |
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "batch-settlement",
+    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "amount": "1000",
+    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "payTo": "<server-receiver>",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "feePayer": "<facilitator-fee-payer>",
+      "receiverAuthorizer": "<facilitator-fee-payer>",
+      "withdrawDelay": 3600,
+      "recentBlockhash": "<recent-blockhash>",
+      "recentSlot": 341000000
+    }
+  },
+  "payload": {
+    "type": "refund",
+    "channelConfig": {
+      "payer": "<client-wallet>",
+      "payerAuthorizer": "<client-voucher-signer>",
+      "receiver": "<server-receiver>",
+      "receiverAuthorizer": "<facilitator-fee-payer>",
+      "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "withdrawDelay": 3600,
+      "salt": "42",
+      "openSlot": 341000000
+    },
+    "voucher": {
+      "channelId": "<channel-pda>",
+      "maxClaimableAmount": "3200",
+      "expiresAt": 0,
+      "signature": "<base58-ed25519-zero-charge-voucher-signature>"
+    }
+  }
+}
+```
+
+### 4.4 `SettlementResponse` (in `PAYMENT-RESPONSE`)
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `success` | boolean | yes |  |
+| `success` | boolean | yes | Whether acceptance or settlement succeeded. |
 | `errorReason` | string | no | Omitted on success. |
 | `payer` | string | no | Channel `payer`. |
-| `transaction` | string | yes | Onchain signature for deposit/top-up/refund/settlement operations; empty string for offchain voucher acceptance. |
-| `network` | string | yes | CAIP-2. |
-| `amount` | string | no | Amount moved onchain; empty or omitted for voucher-only acceptance. |
-| `extra.commitmentId` | string | no | Non-empty commitment identifier for voucher-only acceptance, e.g. `channelId:cumulativeAmount`. |
-| `extra.chargedAmount` | string | no | Per-request charge committed offchain. |
-| `extra.channelState` | object | no | `{channelId, deposit, chargedCumulativeAmount, settled, paidOut, status}` snapshot. |
+| `transaction` | string | yes | Onchain signature for deposit/top-up/refund/claim/settle operations; empty string for offchain voucher acceptance. |
+| `network` | string | yes | CAIP-2 network identifier. |
+| `amount` | string | no | Amount moved onchain; empty for voucher acceptance and `claim`. |
+| `extra.commitmentId` | string | no | MUST be non-empty for voucher acceptance, e.g. `channelId:maxClaimableAmount`. |
+| `extra.chargedAmount` | string | no | Actual per-request charge committed offchain. |
+| `extra.channelState` | `ChannelState` | no | Current channel snapshot. |
 
-Scheme-specific fields are nested under `extra`, matching the EVM
-`batch-settlement` profile.
+Scheme-specific response fields are nested under `extra`.
+A successful voucher-only response is:
+
+```json
+{
+  "success": true,
+  "transaction": "",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "payer": "<client-wallet>",
+  "amount": "",
+  "extra": {
+    "commitmentId": "<channel-pda>:5000",
+    "chargedAmount": "700",
+    "channelState": {
+      "channelId": "<channel-pda>",
+      "balance": "100000",
+      "totalClaimed": "3200",
+      "withdrawRequestedAt": 0,
+      "chargedCumulativeAmount": "4700"
+    }
+  }
+}
+```
+
+### 4.5 Facilitator Interface
+
+The standard x402 `POST /verify` and `POST /settle` request envelope contains
+`x402Version`, `paymentPayload`, and `paymentRequirements`. For every request,
+`paymentPayload.accepted` MUST equal `paymentRequirements`.
+
+| Request field | Type | Required | Notes |
+|---|---|---|---|
+| `x402Version` | number | yes | MUST be `2`. |
+| `paymentPayload` | `PaymentPayload` | yes | Its inner `payload` is one of the variants defined below. |
+| `paymentRequirements` | `PaymentRequirements` | yes | The selected requirements from the server's `PaymentRequired`. |
+
+#### `POST /verify`
+
+`paymentPayload.payload` MUST be one of the client-authored `deposit`,
+`voucher`, or `refund` variants in section 4.3. The facilitator validates the
+wire fields, voucher signature, derived channel PDA, onchain channel state, and,
+for `deposit`, the client-signed transaction.
+
+| Response field | Type | Required | Notes |
+|---|---|---|---|
+| `isValid` | boolean | yes | Whether the payload is valid. |
+| `invalidReason` | string | no | Machine-readable reason when invalid. |
+| `payer` | string | no | Channel payer when recoverable from the payload. |
+| `extra.channelId` | string | no | Derived channel PDA. |
+| `extra.balance` | string | no | Onchain `Channel.deposit`. |
+| `extra.totalClaimed` | string | no | Onchain `Channel.settled`. |
+| `extra.withdrawRequestedAt` | number | no | Onchain `Channel.closure_started_at`. |
+
+A successful response is:
+
+```json
+{
+  "isValid": true,
+  "payer": "<client-wallet>",
+  "extra": {
+    "channelId": "<channel-pda>",
+    "balance": "1000000",
+    "totalClaimed": "500000",
+    "withdrawRequestedAt": 0
+  }
+}
+```
+
+The facilitator MUST return `isValid: false` with `invalidReason` when
+verification fails. The server MAY verify ordinary voucher payloads locally
+when its onchain snapshot is fresh; `deposit` and `refund` MUST be sent to the
+facilitator.
+
+#### `POST /settle`
+
+Each wire `type` names the effect of the payload, not the payment-channels
+instruction it invokes:
+
+| Wire `payload.type` | Author | Effect | SVM program instruction |
+|---|---|---|---|
+| `deposit` | Client | Open a channel or add escrow. | `open` / `top_up` |
+| `voucher` | Client | Accept an offchain authorization; no funds move. | None |
+| `claim` | Server | Advance accounting; no funds move to the receiver. | `settle` |
+| `settle` | Server | Move earned funds to the receiver. | `distribute` |
+| `refund` | Client, then server-enriched | Cooperatively close and return unspent escrow to the payer. | `settle_and_seal` + `distribute` |
+
+The examples in this subsection show the inner `paymentPayload.payload`; the
+caller MUST wrap each one in the standard request envelope defined above.
+
+The `deposit` and `voucher` settle payloads are the client variants from
+section 4.3. The server-authored or server-enriched variants are:
+
+| Payload | Field | Type | Notes |
+|---|---|---|---|
+| Refund | `type` | string | `"refund"` |
+| Refund | `channelConfig` | `ChannelConfig` | Client-provided channel configuration. |
+| Refund | `voucher` | `BatchVoucher` | Client's zero-charge voucher. |
+| Refund | `transaction` | string | Base64 transaction containing `settle_and_seal` and sealed `distribute`, prepared for `feePayer` to sign as transaction fee payer and channel `payee`. |
+| Claim | `type` | string | `"claim"` |
+| Claim | `claims` | array | One or more voucher claims. |
+| Claim | `claims[].voucher.channelConfig` | `ChannelConfig` | Full channel configuration. |
+| Claim | `claims[].voucher.channelId` | string | Channel PDA. |
+| Claim | `claims[].voucher.maxClaimableAmount` | string | Cumulative amount for program `settle`. |
+| Claim | `claims[].voucher.expiresAt` | number | Voucher expiry. |
+| Claim | `claims[].signature` | string | Base58 Ed25519 voucher signature. |
+| Settle | `type` | string | `"settle"` |
+| Settle | `channels` | array | One or more channels to distribute. |
+| Settle | `channels[].channelId` | string | Channel PDA. |
+| Settle | `channels[].channelConfig` | `ChannelConfig` | Full configuration used to derive accounts, validate the channel, and reconstruct the distribution. |
+
+The server forwards a client-authored `deposit` unchanged. It MAY settle
+`voucher` locally by storing the commitment and producing the response in
+section 4.4. Before forwarding `refund`, the server MUST build the cooperative
+close transaction and add `transaction`. The facilitator MUST validate the
+complete transaction, then sign as both transaction `feePayer` and channel
+`payee` before broadcasting it:
+
+```json
+{
+  "type": "refund",
+  "channelConfig": {
+    "payer": "<client-wallet>",
+    "payerAuthorizer": "<client-voucher-signer>",
+    "receiver": "<server-receiver>",
+    "receiverAuthorizer": "<facilitator-fee-payer>",
+    "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "withdrawDelay": 3600,
+    "salt": "42",
+    "openSlot": 341000000
+  },
+  "voucher": {
+    "channelId": "<channel-pda>",
+    "maxClaimableAmount": "3200",
+    "expiresAt": 0,
+    "signature": "<base58-ed25519-zero-charge-voucher-signature>"
+  },
+  "transaction": "<base64-settle-and-seal-and-distribute-transaction-awaiting-facilitator-signature>"
+}
+```
+
+The server initiates asynchronous accounting with a `claim` payload. Each
+claim carries the full channel configuration needed to derive and validate the
+channel plus the voucher signature needed to construct the Ed25519 precompile
+instruction:
+
+```json
+{
+  "type": "claim",
+  "claims": [
+    {
+      "voucher": {
+        "channelConfig": {
+          "payer": "<client-wallet-1>",
+          "payerAuthorizer": "<client-voucher-signer-1>",
+          "receiver": "<server-receiver>",
+          "receiverAuthorizer": "<facilitator-fee-payer>",
+          "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "withdrawDelay": 3600,
+          "salt": "42",
+          "openSlot": 341000000
+        },
+        "channelId": "<channel-pda-1>",
+        "maxClaimableAmount": "5000",
+        "expiresAt": 0
+      },
+      "signature": "<base58-ed25519-voucher-signature-1>"
+    },
+    {
+      "voucher": {
+        "channelConfig": {
+          "payer": "<client-wallet-2>",
+          "payerAuthorizer": "<client-voucher-signer-2>",
+          "receiver": "<server-receiver>",
+          "receiverAuthorizer": "<facilitator-fee-payer>",
+          "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "withdrawDelay": 3600,
+          "salt": "43",
+          "openSlot": 341000050
+        },
+        "channelId": "<channel-pda-2>",
+        "maxClaimableAmount": "7000",
+        "expiresAt": 0
+      },
+      "signature": "<base58-ed25519-voucher-signature-2>"
+    }
+  ]
+}
+```
+
+The facilitator MUST process every `claims[]` entry or fail the request; it
+MUST NOT silently truncate a batch. For each claim it emits an Ed25519
+precompile instruction immediately followed by the program `settle`
+instruction.
+
+After claims advance onchain accounting, the server initiates distribution with
+a `settle` payload:
+
+```json
+{
+  "type": "settle",
+  "channels": [
+    {
+      "channelId": "<channel-pda-1>",
+      "channelConfig": {
+        "payer": "<client-wallet-1>",
+        "payerAuthorizer": "<client-voucher-signer-1>",
+        "receiver": "<server-receiver>",
+        "receiverAuthorizer": "<facilitator-fee-payer>",
+        "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "withdrawDelay": 3600,
+        "salt": "42",
+        "openSlot": 341000000
+      }
+    },
+    {
+      "channelId": "<channel-pda-2>",
+      "channelConfig": {
+        "payer": "<client-wallet-2>",
+        "payerAuthorizer": "<client-voucher-signer-2>",
+        "receiver": "<server-receiver>",
+        "receiverAuthorizer": "<facilitator-fee-payer>",
+        "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "withdrawDelay": 3600,
+        "salt": "43",
+        "openSlot": 341000050
+      }
+    }
+  ]
+}
+```
+
+The facilitator invokes `distribute` for every `channels[]` entry and MUST
+process every entry or fail the request. It MUST confirm each transaction
+onchain before returning success.
+
+Successful responses have operation-specific `amount` semantics:
+
+Claim (`amount` is empty because no funds move):
+
+```json
+{
+  "success": true,
+  "transaction": "<base58-transaction-signature>",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "amount": ""
+}
+```
+
+Settle (`amount` is the total transferred to the receiver across the batch):
+
+```json
+{
+  "success": true,
+  "transaction": "<base58-transaction-signature>",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "amount": "5000"
+}
+```
+
+Deposit (`amount` is the amount deposited or topped up):
+
+```json
+{
+  "success": true,
+  "transaction": "<base58-transaction-signature>",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "payer": "<client-wallet>",
+  "amount": "100000",
+  "extra": {
+    "channelState": {
+      "channelId": "<channel-pda>",
+      "balance": "100000",
+      "totalClaimed": "3200",
+      "withdrawRequestedAt": 0
+    }
+  }
+}
+```
+
+Refund (`amount` is the amount returned to the payer):
+
+```json
+{
+  "success": true,
+  "transaction": "<base58-transaction-signature>",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "payer": "<client-wallet>",
+  "amount": "96800",
+  "extra": {
+    "channelState": {
+      "channelId": "<channel-pda>",
+      "balance": "0",
+      "totalClaimed": "3200",
+      "withdrawRequestedAt": 0
+    }
+  }
+}
+```
+
+#### `GET /supported`
+
+The facilitator advertises its SVM transaction fee payer. The server MUST copy
+this value into both `PaymentRequirements.extra.feePayer` and
+`PaymentRequirements.extra.receiverAuthorizer`:
+
+```json
+{
+  "kinds": [
+    {
+      "x402Version": 2,
+      "scheme": "batch-settlement",
+      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "extra": {
+        "feePayer": "<facilitator-fee-payer>"
+      }
+    }
+  ],
+  "extensions": [],
+  "signers": {
+    "solana:*": ["<facilitator-fee-payer>"]
+  }
+}
+```
+
+### 4.6 Corrective `PaymentRequired`
+
+When the client's cumulative amount does not match server state, the server
+SHOULD return `invalid_batch_settlement_svm_cumulative_amount_mismatch` with a
+signed recovery proof:
+
+```json
+{
+  "x402Version": 2,
+  "error": "invalid_batch_settlement_svm_cumulative_amount_mismatch",
+  "accepts": [
+    {
+      "scheme": "batch-settlement",
+      "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      "amount": "1000",
+      "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "payTo": "<server-receiver>",
+      "maxTimeoutSeconds": 300,
+      "extra": {
+        "feePayer": "<facilitator-fee-payer>",
+        "receiverAuthorizer": "<facilitator-fee-payer>",
+        "withdrawDelay": 3600,
+        "recentBlockhash": "<recent-blockhash>",
+        "recentSlot": 341000000,
+        "channelState": {
+          "channelId": "<channel-pda>",
+          "balance": "100000",
+          "totalClaimed": "500",
+          "withdrawRequestedAt": 0,
+          "chargedCumulativeAmount": "3200"
+        },
+        "voucherState": {
+          "signedMaxClaimable": "3200",
+          "expiresAt": 0,
+          "signature": "<base58-ed25519-voucher-signature>"
+        }
+      }
+    }
+  ]
+}
+```
 
 ## 5. Phases
 
@@ -292,10 +848,18 @@ sponsor later signs as transaction fee payer. For `open`, the sponsor also signs
 as program `rent_payer`, because the payment-channels program debits SOL from
 that account to fund the channel PDA and escrow ATA rent.
 
-For `open`, the client MUST set `payee = extra.receiverAuthorizer`,
+The client MAY use `extra.recentBlockhash` and `extra.recentSlot` to avoid an
+RPC round trip while constructing the transaction. If either hint is stale, the
+client MUST fetch a fresh value and rebuild the transaction. The facilitator
+MUST reject an expired transaction blockhash and an `openSlot` outside the
+program's accepted window.
+
+For `open`, the client MUST require `extra.receiverAuthorizer ==
+extra.feePayer` and set `payee = extra.feePayer`,
 `authorized_signer = channelConfig.payerAuthorizer`, `rent_payer =
-extra.feePayer`, `grace_period = extra.withdrawDelay`, and `open_slot =
-channelConfig.openSlot`.
+extra.feePayer`, `mint = channelConfig.token`, `grace_period =
+channelConfig.withdrawDelay`, `open_slot = channelConfig.openSlot`, and
+`deposit = payload.deposit.amount`.
 
 The sponsor MUST validate the full compiled setup transaction before co-signing,
 not only the payment-channel instruction. It MUST resolve address lookup tables,
@@ -303,18 +867,22 @@ allow only the expected instruction set (payment-channel `open` or `top_up`,
 optional associated-token-account creation required by `open`, and bounded
 ComputeBudget instructions), confirm the canonical program id and instruction
 arguments, and confirm `feePayer` is not used as an authority, source, or
-writable account except for transaction fees and the intended channel/escrow
-rent. Anything else MUST be rejected before broadcasting.
+sender of token value. It MAY appear only in its prescribed transaction-fee,
+`rent_payer`, and zero-share `payee` roles, and MAY be writable only for fees
+and the intended channel/escrow rent. Anything else MUST be rejected before
+broadcasting.
 
 After confirmation, the server records the channel in its `ChannelStore` and
 accepts the voucher for the request under Phase 3.
 
 ### Phase 2 - Steady-State Request
 
-The client increments the cumulative total by the fixed per-request `amount`,
-signs a new `BatchVoucher`, and sends a `voucher` payload. No onchain
-transaction is required in the request path. The server verifies and stores the
-voucher under Phase 3, then serves immediately.
+Using the last authenticated `PAYMENT-RESPONSE`, the client sets
+`maxClaimableAmount = channelState.chargedCumulativeAmount +
+PaymentRequirements.amount`, signs a new `BatchVoucher`, and sends a `voucher`
+payload. No onchain transaction is required in the request path. The server
+verifies and stores the voucher under Phase 3, then serves immediately.
+For a new channel, `chargedCumulativeAmount` starts at zero.
 
 ### Phase 3 - Voucher Acceptance (before serving)
 
@@ -322,81 +890,177 @@ The server is the sole owner of per-channel offchain state. A separate
 facilitator, if used, remains stateless for ordinary voucher acceptance; it only
 needs onchain state plus a voucher when it later settles.
 
-For every voucher, the server MUST:
+The server stores `chargedCumulativeAmount`, `signedMaxClaimable`, the latest
+voucher signature and expiry, and a cached response keyed by
+`(channelId, maxClaimableAmount)`. For every voucher, the server MUST:
 
-1. Verify the Ed25519 signature over the 50-byte message and confirm `signer`
-   equals the channel `authorized_signer` / `channelConfig.payerAuthorizer`.
+1. Verify the Ed25519 signature over the 50-byte message using
+   `channelConfig.payerAuthorizer` and confirm that key equals the channel
+   `authorized_signer`.
 2. Confirm `channelId` matches the PDA derived from `channelConfig` and the
    canonical payment-channels program id.
-3. Confirm the channel exists, is `Open`, has `mint == asset`,
-   `payee == extra.receiverAuthorizer`, `authorized_signer ==
+3. Confirm the channel exists, is `Open`, has `mint == channelConfig.token ==
+   asset`, `payee == channelConfig.receiverAuthorizer ==
+   extra.receiverAuthorizer == extra.feePayer`, `authorized_signer ==
    channelConfig.payerAuthorizer`, `rent_payer == extra.feePayer`,
-   `grace_period == extra.withdrawDelay`, `open_slot ==
-   channelConfig.openSlot`, and a distribution to `payTo` matching section 4.1.
+   `grace_period == channelConfig.withdrawDelay == extra.withdrawDelay`,
+   `open_slot == channelConfig.openSlot`, and a distribution to `payTo`
+   matching section 4.1. Reject if `payer` or `payerAuthorizer` equals
+   `feePayer`.
 4. **Expiry, accounting for async settlement.** `expiresAt` is re-checked
    onchain when `settle` or `settle_and_seal` executes. Because redemption is
    delayed, the server MUST require either `expiresAt == 0` or
    `expiresAt >= now + withdrawDelay + a settlement buffer`. A voucher that
    could expire before redemption MUST be rejected.
-5. Enforce deposit cap: `cumulativeAmount <= channel.deposit`.
-6. Enforce monotonicity against the server's stored watermark:
-   - `cumulativeAmount < watermark`: reject as stale.
-   - `cumulativeAmount == watermark`: idempotent retry only. Return the cached
-     response for `(channelId, cumulativeAmount)` and do not execute the
-     resource handler again.
-   - `cumulativeAmount > watermark`: fresh charge.
-     `cumulativeAmount == watermark + PaymentRequirements.amount` and the
-     increment is at least `minVoucherDelta` when set.
-7. For a fresh charge, atomically advance the stored watermark, store the latest
-   voucher, serve the resource, and return `PAYMENT-RESPONSE` with
-   `transaction == ""`, `extra.commitmentId`, `extra.chargedAmount`, and
-   `extra.channelState`.
+5. Enforce the deposit cap: `maxClaimableAmount <= channel.deposit`.
+6. Enforce replay protection and the per-request ceiling:
+   - A previously accepted `(channelId, maxClaimableAmount)` is an idempotent
+     retry. Return its cached response and do not execute the resource handler
+     again.
+   - Any other `maxClaimableAmount <= signedMaxClaimable` is stale and MUST be
+     rejected.
+   - A fresh voucher MUST have `maxClaimableAmount ==
+     chargedCumulativeAmount + PaymentRequirements.amount`.
+7. Execute the resource handler and determine `chargedAmount`, which MUST be
+   greater than zero and less than or equal to `PaymentRequirements.amount`.
+   Only after the handler succeeds, atomically add `chargedAmount` to
+   `chargedCumulativeAmount`, store `signedMaxClaimable`, the voucher and the
+   cached response, and return `PAYMENT-RESPONSE` with `transaction == ""`,
+   `extra.commitmentId`, `extra.chargedAmount`, and `extra.channelState`. If the
+   handler fails, state MUST remain unchanged so the client can retry.
 
 On any failure, the server returns `402` without serving the resource. If the
 server has local channel state and the client submits the wrong cumulative
 amount, the server SHOULD return a corrective 402 with
-`accepts[].extra.channelState` and `accepts[].extra.voucherState`, following the
-EVM profile's recovery convention.
+`accepts[].extra.channelState` and `accepts[].extra.voucherState`, as shown in
+section 4.6.
 
 ### Phase 4 - Batched Redemption (out of band)
 
 The server or facilitator redeems accumulated vouchers asynchronously, outside
 the request path:
 
-- **Settle.** For each channel, build an Ed25519 precompile instruction for the
-  latest stored voucher followed by `settle`. Pack as many channels into one
-  transaction as the transaction size permits; do not silently drop channels
-  from a full batch. `settle` advances onchain `settled` to the voucher's exact
-  cumulative amount.
-- **Distribute while open.** Call `distribute` to pay the newly settled delta to
-  `payTo` and advance `payout_watermark`. The channel remains open.
+- **Claim (`type: "claim"`).** For each channel, build an Ed25519 precompile
+  instruction for the latest stored voucher followed by program `settle`. Pack
+  as many channels into one transaction as the transaction size permits; do not
+  silently drop channels from a full batch. Program `settle` advances onchain
+  `settled` to the voucher's exact `maxClaimableAmount`.
+- **Settle (`type: "settle"`).** Call program `distribute` to pay the newly
+  claimed delta to `payTo` and advance `payout_watermark`. The channel remains
+  open.
 - **Cooperative close/refund.** For a `refund` payload or server-initiated
-  close, `receiverAuthorizer` signs `settle_and_seal` with the final voucher
-  (or no voucher for a zero-charge close), then `distribute` pays any remaining
-  settled delta, refunds `deposit - settled` to the payer, closes the escrow
-  token account, and moves the channel to its cleanup state.
+  close, the facilitator signs `settle_and_seal` as `payee`, applying the final
+  voucher when it advances the watermark (or using `has_voucher = 0` when no
+  claim is needed). `distribute` then pays any remaining settled delta, refunds
+  `deposit - settled` to the payer, closes the escrow token account, and moves
+  the channel to its cleanup state.
 - **Rent cleanup.** If final `distribute` leaves the channel in `Distributed`,
   anyone can later call `reclaim` after the open-slot window to return remaining
   PDA rent to `rent_payer`.
 
-The server SHOULD redeem with enough buffer before `withdrawDelay` can elapse
-after a client starts forced close. If the payer calls `request_close`, the
-server can still `settle_and_seal` during the grace period. After the grace
-period, anyone can call `seal`; the payer can then recover unspent deposit via
-`withdraw_payer` or the sealed `distribute` refund branch, and vouchers not yet
-settled are forfeited by the server.
+The server SHOULD claim with enough buffer before `withdrawDelay` can elapse
+after a client starts forced close. If the payer calls `request_close`, only the
+facilitator as `payee` can `settle_and_seal` during the grace period, using a
+final voucher supplied by the server. After the grace period, anyone can call
+`seal`; the payer can then recover unspent deposit via `withdraw_payer` or the
+sealed `distribute` refund branch, and vouchers not yet claimed are forfeited by
+the server.
 
-## 6. Error Codes
+## 6. Asynchronous Recovery and Channel Discovery
 
-Standard x402 codes apply. Scheme-specific failures surface as `402` with an
-`errorReason`:
+Channel discovery is onchain for lifecycle and rent recovery. A client can
+discover channels whose `payer` equals its wallet. A facilitator can discover
+every channel for which it fronted rent by querying `rent_payer` or, equivalently
+in this scheme, `payee`. The server still requires durable offchain storage for
+the accepted charge watermark, unclaimed voucher, request correlation, and
+cached responses; those values cannot be reconstructed from channel accounts.
 
-- `invalid_batch_settlement_svm_voucher_signature` - signature invalid or signer
-  does not match channel `authorized_signer`.
+Implementations MAY retain a local lifecycle index, but a facilitator MUST be
+able to rebuild the onchain portion after local state loss, at startup, and
+periodically while it sponsors rent.
+
+### 6.1 `getProgramAccounts` Discovery
+
+Implementations MUST call `getProgramAccounts` against the canonical
+payment-channels program for the selected network. This specification targets
+the current 256-byte channel account layout, whose public-key offsets are:
+
+| Channel field | Offset | Discovery use |
+|---|---:|---|
+| `payer` | 88 | Client deposit/channel recovery |
+| `payee` | 120 | Facilitator lifecycle recovery; equals `feePayer` in this scheme |
+| `authorized_signer` | 152 | Client voucher-authorizer recovery |
+| `rent_payer` | 216 | Facilitator rent recovery; equals `feePayer` in this scheme |
+
+For example, a facilitator discovers channels for which it paid rent using a
+base58-encoded key in a `memcmp` filter:
+
+```json
+{
+  "encoding": "base64",
+  "commitment": "confirmed",
+  "filters": [
+    { "dataSize": 256 },
+    { "memcmp": { "offset": 216, "bytes": "<facilitator-fee-payer>" } }
+  ]
+}
+```
+
+The client uses the same filter with offset `88` and its payer key. A
+facilitator MAY additionally filter `payee` at offset `120`; because `payee ==
+rent_payer == feePayer`, the two fields provide equivalent identities in valid
+channels for this scheme.
+
+Every returned account MUST be decoded with the supported payment-channels
+codec. The implementation MUST reject an account whose owner, discriminator,
+version, data length, or PDA does not match the selected program and decoded
+channel fields. It MUST rederive the PDA from `payer`, `payee`, `mint`,
+`authorized_signer`, `salt`, and `open_slot` before accepting the account.
+Implementations MUST NOT reuse these byte offsets for an unsupported future
+channel-account version.
+
+### 6.2 Recovery Flow
+
+Discovery and cleanup are asynchronous maintenance, not part of the paid HTTP
+request path. After startup or local state loss, a rent sponsor MUST:
+
+1. Query and decode matching channels, then upsert their addresses and statuses
+   into a disposable local work queue.
+2. Refetch and revalidate a channel immediately before acting. If another worker
+   or user changes its status, refetch and reclassify it instead of treating the
+   stale transition failure as permanent.
+3. For an `Open` channel, allow the server a policy-defined notice or idle
+   timeout to submit its latest voucher. The facilitator MAY then close at the
+   current onchain watermark using `settle_and_seal` with `has_voucher = 0`,
+   followed by `distribute` and, when necessary, `reclaim`.
+4. For a `Closing` channel, schedule a recheck at the grace deadline. During the
+   grace period, the facilitator MAY apply a final voucher supplied by the
+   server; afterward the normal permissionless `seal` path applies.
+5. For a `Sealed` channel, submit or relay `distribute`. For a `Distributed`
+   channel, schedule `reclaim` after the open-slot gate; recovered SOL always
+   returns to the recorded `rent_payer`.
+
+Onchain recovery does not recreate an unclaimed voucher or the server's
+`chargedCumulativeAmount`. If those records are lost, the server MUST NOT invent
+a charge. The facilitator's conservative recovery action is to close at the
+current onchain `settled` watermark and return the remainder to the payer.
+
+## 7. Error Codes
+
+Standard x402 codes apply. The facilitator reports verification failures in
+`VerifyResponse.invalidReason` and settlement failures in
+`SettlementResponse.errorReason`; a resource server returning a corrective
+`PaymentRequired` uses `error`. Scheme-specific codes are:
+
+- `invalid_batch_settlement_svm_payload_type` - payload `type` is not valid for
+  the current verify or settle operation.
+- `invalid_batch_settlement_svm_voucher_signature` - signature invalid or
+  `channelConfig.payerAuthorizer` does not match channel `authorized_signer`.
 - `invalid_batch_settlement_svm_channel_id_mismatch` - `channelId` does not
   match the canonical PDA derivation.
 - `invalid_batch_settlement_svm_receiver_authorizer_mismatch` - channel `payee`
-  does not match `extra.receiverAuthorizer`.
+  does not match `extra.receiverAuthorizer`, or `receiverAuthorizer` does not
+  equal `feePayer`.
 - `invalid_batch_settlement_svm_withdraw_delay_mismatch` - channel grace period
   does not match `extra.withdrawDelay`.
 - `invalid_batch_settlement_svm_cumulative_amount_mismatch` - corrective 402:
@@ -408,18 +1072,28 @@ Standard x402 codes apply. Scheme-specific failures surface as `402` with an
 - `invalid_batch_settlement_svm_setup_transaction` - setup transaction fails the
   sponsor safety checks.
 
-## 7. Security Properties
+## 8. Security Properties
 
-- **No overcharge.** Onchain `settle` rejects vouchers above `deposit` and sets
-  the exact cumulative amount signed by the client.
+- **Bounded authorization.** Onchain `settle` rejects vouchers above `deposit`
+  and sets the exact cumulative maximum signed by the client.
 - **No redirection.** `distribution_hash` is fixed at `open` and re-checked at
   `distribute`; the derived distribution sends settled funds to `payTo`.
-- **Facilitator isolation.** `feePayer` sponsors fees/rent only. It is not
-  `payee` and not `authorized_signer`, so it cannot sign vouchers or
-  cooperative closes.
-- **Server-controlled close.** `receiverAuthorizer` is the channel `payee`, so a
-  hot server key can sign `settle_and_seal` while funds still route to cold
-  `payTo`.
+- **Authenticated claims.** The wire `extra.feePayer` address is recorded as
+  program `Channel.rent_payer` and zero-share `Channel.payee`. Program
+  `Channel.authorized_signer` instead comes from wire
+  `channelConfig.payerAuthorizer`, so the facilitator can close a channel but
+  cannot advance `settled` without a client-signed voucher. The committed
+  distribution prevents payout redirection.
+- **Facilitator rent recovery.** Because the facilitator is channel `payee`, it
+  can run `settle_and_seal` with `has_voucher = 0`, then `distribute` and
+  `reclaim`, without client or server cooperation. Abandoned channels cannot
+  permanently lock sponsored rent.
+- **Facilitator early-close exposure.** Closing before the latest voucher is
+  claimed freezes the onchain watermark and refunds the remainder to the
+  client. The server MUST bound its exposure by claiming promptly and SHOULD
+  treat unclaimed voucher value as facilitator credit risk. During a
+  client-initiated grace period, only the facilitator can apply the final
+  voucher and seal cooperatively.
 - **No replay / no rollback.** Server offchain watermark plus onchain
   `settled` monotonicity reject old vouchers. Equality is accepted only as an
   idempotent replay of a cached response.
@@ -429,14 +1103,14 @@ Standard x402 codes apply. Scheme-specific failures surface as `402` with an
 - **Time-bounded commitments.** Nonzero voucher `expiresAt` is checked both at
   server acceptance and onchain redemption. `expiresAt == 0` means no voucher
   expiry; in that case the channel's forced-close path bounds the commitment.
-- **Metering trust.** Each fresh request charges the advertised
-  `PaymentRequirements.amount`. The client trusts the server to return the
-  resource once the voucher is accepted; the server trusts itself to redeem
-  before voucher expiry or forced-close expiry.
+- **Metering trust.** Each voucher authorizes at most the advertised
+  `PaymentRequirements.amount` above the previously reported actual cumulative
+  charge. The client trusts the server to claim no more than the reported
+  `chargedCumulativeAmount`; the server trusts itself to redeem before voucher
+  expiry or forced-close expiry.
 
-## 8. Out of Scope
+## 9. Out of Scope
 
-- Dynamic per-request pricing below `PaymentRequirements.amount`.
-- A durable background channel manager, redemption scheduler, and forced-close
-  watchdog.
+- A prescribed persistence backend, worker topology, or scheduling architecture
+  for the required asynchronous maintenance.
 - Delegated passkey or secp256r1 voucher signers.

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -28,6 +28,10 @@ The x402 roles map to the payment-channel program as follows:
 - **Server**: resource provider; receives funds at `payTo`; owns per-channel
   offchain state, including the accepted cumulative watermark and latest
   voucher.
+- **Receiver authorizer**: server-controlled Ed25519 key advertised as
+  `extra.receiverAuthorizer`. It authenticates server-approved cooperative
+  refund requests to the facilitator. It is an offchain x402 role and is not
+  recorded in the payment-channel account.
 - **Facilitator / sponsor**: account advertised as `extra.feePayer`; sponsors
   transaction fees and channel rent. It is the transaction fee payer and channel
   `rent_payer`, and occupies the channel `payee` lifecycle-authority seat with a
@@ -58,11 +62,11 @@ claim promptly.
 | Requirement (generic spec) | SVM mechanism |
 |---|---|
 | One-time escrow deposit | Payment-channels `open` deposits escrow, records `withdrawDelay`, fixes `payee`, `authorized_signer`, `rent_payer`, and commits `distribution_hash`. |
-| Per-request authorization | Ed25519 voucher signed by `payerAuthorizer` over `0x56 0x01 || channelId || maxClaimableAmount || expiresAt`. |
+| Per-request authorization | Ed25519 voucher signed by `payerAuthorizer` over `0x56 0x01 \|\| channelId \|\| maxClaimableAmount \|\| expiresAt`. |
 | Monotonic amount | Server-owned offchain watermark plus onchain `settled < maxClaimableAmount <= deposit` at redemption. |
 | Batched redemption | One `settle` per channel, packed transaction-size permitting; `distribute` pays settled deltas. |
 | Recipient binding | `distribution_hash` fixed at `open` sends funds to `payTo`; program re-checks it at `distribute`. |
-| Recovery of unused deposit | `request_close` / `seal` / `withdraw_payer` for payer-forced close. |
+| Recovery of unused deposit | Server-authorized `settle_and_seal` + `distribute` for full cooperative close; `request_close` / `seal` / `withdraw_payer` for payer-forced close. |
 
 ## 3. Payment-Channel Method
 
@@ -110,6 +114,17 @@ to rediscover the channels it sponsored as specified in section 6. Token
 payouts and the return of unused escrow are completed by `distribute` and are
 not delayed by the later `reclaim` of PDA rent.
 
+For an x402 cooperative refund, the facilitator MUST additionally require a
+valid refund authorization from `extra.receiverAuthorizer`. That signature
+authenticates the server's HTTP request; it does not replace the facilitator's
+onchain `payee` signature or the client's voucher signature. The facilitator
+MUST bind `receiverAuthorizer` to the authenticated resource server and `payTo`
+through trusted configuration or an authenticated registration established no
+later than channel opening. It MUST NOT trust a receiver-authorizer key merely
+because it appears in `PaymentRequirements` or a settlement request. The
+trusted receiver authorizer is fixed for the channel lifetime; changing it
+requires cooperatively closing the channel and opening a new one.
+
 If the client invokes `request_close`, the channel enters `Closing` and regular
 `settle` is no longer available. Only the `payee` can apply a final voucher with
 `settle_and_seal` during the grace period. After the grace period, anyone can
@@ -141,6 +156,7 @@ and `SettlementResponse` types are defined in
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `feePayer` | string | yes | Base58 sponsor key set as channel `rent_payer` and zero-share `payee`. Co-signs setup/top-up transactions as transaction fee payer and signs channel lifecycle transactions. |
+| `receiverAuthorizer` | string | yes | Base58 server-controlled Ed25519 key that authenticates cooperative refund requests to the facilitator. It is not a payment-channel account field. |
 | `withdrawDelay` | number | yes | Server-defined forced-close grace period in seconds. The client MUST encode this exact value as the program `grace_period`; the verifier MUST reject any other value. |
 | `recentBlockhash` | string | no | Pre-fetched blockhash the client MAY use to build an `open` or `top_up` transaction without an RPC round trip. The client MUST refresh it if it is no longer valid. |
 | `recentSlot` | number | no | Recent slot the client MAY use as `channelConfig.openSlot` when it does not fetch its own slot. The program still enforces the open-slot window. |
@@ -181,6 +197,7 @@ Example:
   "maxTimeoutSeconds": 300,
   "extra": {
     "feePayer": "<facilitator-fee-payer>",
+    "receiverAuthorizer": "<server-refund-authorizer>",
     "withdrawDelay": 3600,
     "recentBlockhash": "<recent-blockhash>",
     "recentSlot": 341000000
@@ -200,9 +217,11 @@ may expose those program fields with language-specific casing.
 | x402 wire field | Payment-channels program notation |
 |---|---|
 | `PaymentRequirements.extra.feePayer` | `Channel.rent_payer` and zero-share `Channel.payee` |
+| `PaymentRequirements.extra.receiverAuthorizer` | No program field; trusted server key for offchain refund authorization |
 | `channelConfig.payer` | `Channel.payer` |
 | `channelConfig.payerAuthorizer` | `Channel.authorized_signer` |
 | `channelConfig.receiver` | Sole `DistributionEntry.recipient` with `bps = 10000`; the `Channel.payee` implicit remainder is always zero |
+| `channelConfig.receiverAuthorizer` | No program field; MUST equal `PaymentRequirements.extra.receiverAuthorizer` |
 | `channelConfig.token` | `Channel.mint` |
 | `channelConfig.withdrawDelay` | `Channel.grace_period` |
 | `channelConfig.salt` | `Channel.salt` |
@@ -222,6 +241,7 @@ may expose those program fields with language-specific casing.
 | `payer` | string | Client wallet and channel payer. MUST NOT equal `feePayer`, because the program requires distinct payer and payee accounts. |
 | `payerAuthorizer` | string | Client-controlled Ed25519 voucher signer; maps to channel `authorized_signer`. MAY equal `payer` but MUST NOT equal `feePayer`. |
 | `receiver` | string | MUST equal `payTo`. |
+| `receiverAuthorizer` | string | MUST equal `extra.receiverAuthorizer`. This key authenticates cooperative refund requests offchain and is not a channel PDA seed or program account field. |
 | `token` | string | MUST equal `asset`; maps to channel `mint`. |
 | `withdrawDelay` | number | MUST equal `extra.withdrawDelay`; maps to channel `grace_period`. |
 | `salt` | string | Decimal `u64` channel salt. |
@@ -279,6 +299,33 @@ The signed message is exactly:
 This is the payment-channels program voucher layout (`VOUCHER_MAGIC`,
 `channel_id`, `cumulative_amount`, `expires_at`), 50 bytes total.
 
+`RefundAuthorization`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `validBefore` | number | Integer Unix seconds. The server MUST set it no later than its current time plus `maxTimeoutSeconds`; the facilitator MUST require `now < validBefore <= now + maxTimeoutSeconds`. |
+| `signature` | string | Base58 Ed25519 signature by `extra.receiverAuthorizer` over the digest below. |
+
+The receiver authorizer signs the SHA-256 digest of this exact byte sequence:
+
+```text
+UTF8("x402:batch-settlement:svm:refund:v1") || 0x00 ||
+u16(len(network)).le || UTF8(network) ||
+programId[32] ||
+feePayer[32] ||
+channelId[32] ||
+u64(maxClaimableAmount).le ||
+i64(voucherExpiresAt).le ||
+i64(validBefore).le
+```
+
+`network` is the canonical CAIP-2 identifier from `PaymentRequirements`;
+`programId` is the canonical payment-channels program id for that network; and
+`feePayer`, `channelId`, and the voucher fields are decoded to their canonical
+binary forms. The length is the number of UTF-8 bytes in `network`. This domain
+separation prevents the signature from authorizing another operation, network,
+program deployment, facilitator, channel, voucher watermark, or expiry.
+
 `ChannelState`:
 
 | Field | Type | Notes |
@@ -291,8 +338,10 @@ This is the payment-channels program voucher layout (`VOUCHER_MAGIC`,
 
 ### 4.3 Client `PaymentPayload` Variants
 
-The client payload is a tagged union on `payload.type`. `/verify` and `/settle`
-accept the `deposit` and `voucher` variants.
+The client payload is a tagged union on `payload.type`. `/verify` accepts all
+three variants. `/settle` accepts `deposit` directly; the server enriches
+`refund` with a `RefundAuthorization` before forwarding it as specified in
+section 4.5. A `voucher` is accepted offchain by the server.
 
 **`deposit`** opens a channel or tops up an existing channel and authorizes the
 current request:
@@ -317,6 +366,7 @@ current request:
     "maxTimeoutSeconds": 300,
     "extra": {
       "feePayer": "<facilitator-fee-payer>",
+      "receiverAuthorizer": "<server-refund-authorizer>",
       "withdrawDelay": 3600,
       "recentBlockhash": "<recent-blockhash>",
       "recentSlot": 341000000
@@ -328,6 +378,7 @@ current request:
       "payer": "<client-wallet>",
       "payerAuthorizer": "<client-voucher-signer>",
       "receiver": "<server-receiver>",
+      "receiverAuthorizer": "<server-refund-authorizer>",
       "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "withdrawDelay": 3600,
       "salt": "42",
@@ -368,6 +419,7 @@ transaction:
     "maxTimeoutSeconds": 300,
     "extra": {
       "feePayer": "<facilitator-fee-payer>",
+      "receiverAuthorizer": "<server-refund-authorizer>",
       "withdrawDelay": 3600,
       "recentBlockhash": "<recent-blockhash>",
       "recentSlot": 341000000
@@ -379,6 +431,7 @@ transaction:
       "payer": "<client-wallet>",
       "payerAuthorizer": "<client-voucher-signer>",
       "receiver": "<server-receiver>",
+      "receiverAuthorizer": "<server-refund-authorizer>",
       "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
       "withdrawDelay": 3600,
       "salt": "42",
@@ -394,6 +447,58 @@ transaction:
 }
 ```
 
+**`refund`** requests immediate cooperative closure and the return of all
+unspent escrow. It is a payment operation, not a paid resource request, so the
+application resource handler MUST be bypassed. The request MUST NOT contain an
+`amount`: the payment-channel program supports only a full refund of
+`deposit - settled`, and the closed channel cannot be reused.
+
+| Field | Type | Notes |
+|---|---|---|
+| `type` | string | `"refund"` |
+| `channelConfig` | `ChannelConfig` | Full channel configuration. |
+| `voucher` | `BatchVoucher` | Zero-charge voucher whose `maxClaimableAmount` equals the server's current `chargedCumulativeAmount`. |
+
+```json
+{
+  "x402Version": 2,
+  "accepted": {
+    "scheme": "batch-settlement",
+    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "amount": "1000",
+    "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "payTo": "<server-receiver>",
+    "maxTimeoutSeconds": 300,
+    "extra": {
+      "feePayer": "<facilitator-fee-payer>",
+      "receiverAuthorizer": "<server-refund-authorizer>",
+      "withdrawDelay": 3600,
+      "recentBlockhash": "<recent-blockhash>",
+      "recentSlot": 341000000
+    }
+  },
+  "payload": {
+    "type": "refund",
+    "channelConfig": {
+      "payer": "<client-wallet>",
+      "payerAuthorizer": "<client-voucher-signer>",
+      "receiver": "<server-receiver>",
+      "receiverAuthorizer": "<server-refund-authorizer>",
+      "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "withdrawDelay": 3600,
+      "salt": "42",
+      "openSlot": 341000000
+    },
+    "voucher": {
+      "channelId": "<channel-pda>",
+      "maxClaimableAmount": "5000",
+      "expiresAt": 0,
+      "signature": "<base58-ed25519-zero-charge-voucher-signature>"
+    }
+  }
+}
+```
+
 ### 4.4 `SettlementResponse` (in `PAYMENT-RESPONSE`)
 
 | Field | Type | Required | Notes |
@@ -401,7 +506,7 @@ transaction:
 | `success` | boolean | yes | Whether acceptance or settlement succeeded. |
 | `errorReason` | string | no | Omitted on success. |
 | `payer` | string | no | Channel `payer`. |
-| `transaction` | string | yes | Onchain signature for deposit/top-up/claim/settle operations; empty string for offchain voucher acceptance. |
+| `transaction` | string | yes | Onchain signature for deposit/top-up/refund/claim/settle operations; empty string for offchain voucher acceptance. |
 | `network` | string | yes | CAIP-2 network identifier. |
 | `amount` | string | no | Amount moved onchain; empty for voucher acceptance and `claim`. |
 | `extra.commitmentId` | string | no | MUST be non-empty for voucher acceptance, e.g. `channelId:maxClaimableAmount`. |
@@ -446,10 +551,13 @@ The standard x402 `POST /verify` and `POST /settle` request envelope contains
 
 #### `POST /verify`
 
-`paymentPayload.payload` MUST be one of the client-authored `deposit` or
-`voucher` variants in section 4.3. The facilitator validates the
-wire fields, voucher signature, derived channel PDA, onchain channel state, and,
-for `deposit`, the client-signed transaction.
+`paymentPayload.payload` MUST be one of the client-authored `deposit`, `voucher`,
+or `refund` variants in section 4.3. The facilitator validates the wire fields,
+voucher signature, derived channel PDA, and onchain channel state and, for
+`deposit`, the client-signed transaction. For `refund`, it additionally confirms
+that the voucher is redeemable or already reflected in `Channel.settled`, the
+channel is `Open` or is still within its `Closing` grace period, and the payer's
+canonical refund ATA is healthy.
 
 | Response field | Type | Required | Notes |
 |---|---|---|---|
@@ -478,7 +586,8 @@ A successful response is:
 
 The facilitator MUST return `isValid: false` with `invalidReason` when
 verification fails. The server MAY verify ordinary voucher payloads locally
-when its onchain snapshot is fresh; `deposit` MUST be sent to the facilitator.
+when its onchain snapshot is fresh; `deposit` and `refund` MUST be sent to the
+facilitator.
 
 #### `POST /settle`
 
@@ -491,12 +600,14 @@ instruction it invokes:
 | `voucher` | Client | Accept an offchain authorization; no funds move. | None |
 | `claim` | Server | Advance accounting; no funds move to the receiver. | `settle` |
 | `settle` | Server | Move earned funds to the receiver. | `distribute` |
+| `refund` | Client, then server-enriched | Apply any final voucher, close the channel, and return all unspent escrow. | `settle_and_seal` + sealed `distribute` |
 
 The examples in this subsection show the inner `paymentPayload.payload`; the
 caller MUST wrap each one in the standard request envelope defined above.
 
-The `deposit` and `voucher` settle payloads are the client variants from
-section 4.3. The server-authored variants are:
+The `deposit` settle payload is the client variant from section 4.3. A `voucher`
+is stored and answered by the server without a facilitator settlement. The
+server-authored or server-enriched variants are:
 
 | Payload | Field | Type | Notes |
 |---|---|---|---|
@@ -511,10 +622,62 @@ section 4.3. The server-authored variants are:
 | Settle | `channels` | array | One or more channels to distribute. |
 | Settle | `channels[].channelId` | string | Channel PDA. |
 | Settle | `channels[].channelConfig` | `ChannelConfig` | Full configuration used to derive accounts, validate the channel, and reconstruct the distribution. |
+| Refund | `type` | string | `"refund"` |
+| Refund | `channelConfig` | `ChannelConfig` | Client-provided channel configuration. |
+| Refund | `voucher` | `BatchVoucher` | Client's zero-charge voucher at the server's current cumulative charge. |
+| Refund | `refundAuthorization` | `RefundAuthorization` | Server signature authorizing this full cooperative close. |
 
 The server forwards a client-authored `deposit` unchanged. It MAY settle
 `voucher` locally by storing the commitment and producing the response in
 section 4.4.
+
+For `refund`, the server MUST serialize processing with every paid request and
+other refund for the channel. It MUST require
+`voucher.maxClaimableAmount == chargedCumulativeAmount`, verify the client
+voucher, bypass the resource handler, and obtain successful facilitator
+verification. It then creates a fresh `RefundAuthorization` with
+`extra.receiverAuthorizer`, atomically marks the channel refund-pending through
+`validBefore`, and forwards the enriched payload. Once it signs, the server MUST
+reject new paid requests for the channel until the refund confirms or the
+authorization expires; otherwise a delayed valid authorization could close
+after a later charge:
+
+```json
+{
+  "type": "refund",
+  "channelConfig": {
+    "payer": "<client-wallet>",
+    "payerAuthorizer": "<client-voucher-signer>",
+    "receiver": "<server-receiver>",
+    "receiverAuthorizer": "<server-refund-authorizer>",
+    "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "withdrawDelay": 3600,
+    "salt": "42",
+    "openSlot": 341000000
+  },
+  "voucher": {
+    "channelId": "<channel-pda>",
+    "maxClaimableAmount": "5000",
+    "expiresAt": 0,
+    "signature": "<base58-ed25519-zero-charge-voucher-signature>"
+  },
+  "refundAuthorization": {
+    "validBefore": 1785341100,
+    "signature": "<base58-server-refund-authorization-signature>"
+  }
+}
+```
+
+The facilitator MUST validate `refundAuthorization` against the trusted
+receiver-authorizer binding, reject it at or after `validBefore`, and construct
+the transaction itself. When `Channel.settled <
+voucher.maxClaimableAmount`, it emits the voucher's Ed25519 precompile
+instruction immediately followed by `settle_and_seal` with `has_voucher = 1`.
+When the values are equal, it invokes `settle_and_seal` with `has_voucher = 0`;
+submitting an equal voucher onchain would fail the program's strict monotonicity
+check. Any other relationship MUST be rejected. It then invokes sealed
+`distribute` in the same transaction, verifies the confirmed onchain result,
+and returns the full amount `deposit - settled` transferred to the payer.
 
 The server initiates asynchronous accounting with a `claim` payload. Each
 claim carries the full channel configuration needed to derive and validate the
@@ -531,6 +694,7 @@ instruction:
           "payer": "<client-wallet-1>",
           "payerAuthorizer": "<client-voucher-signer-1>",
           "receiver": "<server-receiver>",
+          "receiverAuthorizer": "<server-refund-authorizer>",
           "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
           "withdrawDelay": 3600,
           "salt": "42",
@@ -548,6 +712,7 @@ instruction:
           "payer": "<client-wallet-2>",
           "payerAuthorizer": "<client-voucher-signer-2>",
           "receiver": "<server-receiver>",
+          "receiverAuthorizer": "<server-refund-authorizer>",
           "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
           "withdrawDelay": 3600,
           "salt": "43",
@@ -583,6 +748,7 @@ a `settle` payload:
         "payer": "<client-wallet-1>",
         "payerAuthorizer": "<client-voucher-signer-1>",
         "receiver": "<server-receiver>",
+        "receiverAuthorizer": "<server-refund-authorizer>",
         "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         "withdrawDelay": 3600,
         "salt": "42",
@@ -595,6 +761,7 @@ a `settle` payload:
         "payer": "<client-wallet-2>",
         "payerAuthorizer": "<client-voucher-signer-2>",
         "receiver": "<server-receiver>",
+        "receiverAuthorizer": "<server-refund-authorizer>",
         "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         "withdrawDelay": 3600,
         "salt": "43",
@@ -656,10 +823,40 @@ Deposit (`amount` is the amount deposited or topped up):
 }
 ```
 
+Refund (`amount` is the full unspent escrow returned to the payer):
+
+```json
+{
+  "success": true,
+  "transaction": "<base58-transaction-signature>",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "payer": "<client-wallet>",
+  "amount": "95000",
+  "extra": {
+    "channelState": {
+      "channelId": "<channel-pda>",
+      "balance": "0",
+      "totalClaimed": "5000",
+      "withdrawRequestedAt": 0,
+      "chargedCumulativeAmount": "5000"
+    }
+  }
+}
+```
+
+After successful refund, the server MUST mark the channel closed and reject
+further paid requests for that channel. A later session MUST open a new channel
+with a new `openSlot`. If settlement fails, the server MUST retain the
+refund-pending state until `refundAuthorization.validBefore` before it may
+resume paid requests.
+
 #### `GET /supported`
 
 The facilitator advertises its SVM transaction fee payer. The server MUST copy
-this value into `PaymentRequirements.extra.feePayer`:
+this value into `PaymentRequirements.extra.feePayer` and MUST set
+`PaymentRequirements.extra.receiverAuthorizer` to the server key covered by its
+trusted facilitator registration. The receiver authorizer is server-owned and
+is therefore not advertised by the facilitator:
 
 ```json
 {
@@ -700,6 +897,7 @@ signed recovery proof:
       "maxTimeoutSeconds": 300,
       "extra": {
         "feePayer": "<facilitator-fee-payer>",
+        "receiverAuthorizer": "<server-refund-authorizer>",
         "withdrawDelay": 3600,
         "recentBlockhash": "<recent-blockhash>",
         "recentSlot": 341000000,
@@ -742,16 +940,131 @@ channelConfig.payerAuthorizer`, `rent_payer = extra.feePayer`,
 `mint = channelConfig.token`, `grace_period = channelConfig.withdrawDelay`,
 `open_slot = channelConfig.openSlot`, and `deposit = payload.deposit.amount`.
 
-The sponsor MUST validate the full compiled setup transaction before co-signing,
-not only the payment-channel instruction. It MUST resolve address lookup tables,
-allow only the expected instruction set (payment-channel `open` or `top_up`,
-optional associated-token-account creation required by `open`, and bounded
-ComputeBudget instructions), confirm the canonical program id and instruction
-arguments, and confirm `feePayer` is not used as an authority, source, or
-sender of token value. It MAY appear only in its prescribed transaction-fee,
-`rent_payer`, and zero-share `payee` roles, and MAY be writable only for fees
-and the intended channel/escrow rent. Anything else MUST be rejected before
-broadcasting.
+The sponsor adds its signature to transaction bytes constructed by the client.
+Before signing, it MUST statically validate the complete compiled message under
+the acceptance policy below. Simulation or eventual onchain failure MUST NOT
+replace these checks because either occurs only after the sponsor's signature
+has authorized fee and, for `open`, rent expenditure. Smart-wallet wrappers are
+not supported by this version of the scheme.
+
+#### Client-supplied transaction acceptance policy
+
+##### Message and signer rules
+
+- The message MAY be legacy or version `0`, but it MUST NOT contain Address
+  Lookup Table lookups. The canonical `open` and `top_up` forms fit in static
+  account keys.
+- The transaction fee payer MUST equal `extra.feePayer`.
+- The complete required-signer set MUST equal the distinct addresses in
+  `{ channelConfig.payer, extra.feePayer }`. No other signature may be required.
+- The payer signature MUST be present and valid before the sponsor signs. The
+  sponsor MUST add or replace only its own `extra.feePayer` signature slot.
+- `channelConfig.payer` and `channelConfig.payerAuthorizer` MUST NOT equal
+  `extra.feePayer`.
+- For `open`, `extra.feePayer` MAY appear only in its canonical `rent_payer`
+  and zero-share `payee` account positions. For `top_up`, it MUST NOT appear in
+  the payment-channel instruction's account list. In either form it MUST NOT be
+  invoked as a program or used by any other instruction.
+- `channelConfig.receiverAuthorizer` MUST equal
+  `extra.receiverAuthorizer`, and the facilitator MUST validate that key against
+  its trusted binding for the authenticated server and `payTo`. It is not a
+  required transaction signer or payment-channel instruction account.
+
+##### Top-level instruction layout
+
+The top-level instructions MUST consist only of the following ordered regions:
+
+1. An optional Compute Budget prefix containing at most one
+   `SetComputeUnitLimit` instruction and at most one `SetComputeUnitPrice`
+   instruction. If both are present, the limit MUST precede the price.
+2. Exactly one canonical payment-channels `open` or `top_up` instruction,
+   matching the payload form selected by the decoded channel state.
+3. An optional suffix of at most three Lighthouse instructions, each invoking
+   `L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`.
+
+No other top-level instruction or program is allowed. In particular, a
+top-level associated-token-account instruction, SPL Memo instruction, arbitrary
+wallet program, second payment-channel instruction, or duplicate setup
+instruction MUST cause rejection. The payment-channels `open` instruction
+creates the escrow ATA internally.
+
+When present, Compute Budget instructions:
+
+- MUST invoke `ComputeBudget111111111111111111111111111111`;
+- MUST use only discriminator `2` (`SetComputeUnitLimit`, exactly 5 data bytes)
+  or discriminator `3` (`SetComputeUnitPrice`, exactly 9 data bytes);
+- MUST set a compute-unit limit no greater than `400000`; and
+- MUST set a compute-unit price no greater than `5000000` microlamports per
+  compute unit.
+
+Lighthouse instructions are allowed only for Phantom/Solflare assertions and
+MUST NOT reference `extra.feePayer` as an account. A sponsor MAY apply stricter
+local compute or priority-fee limits or reject all optional instructions, but it
+MUST NOT admit instructions outside this allowlist or relax these maxima.
+
+##### Canonical `open`
+
+The `open` instruction MUST invoke the canonical payment-channels program, use
+discriminator `1`, contain exactly these 14 accounts in order, and contain no
+remaining accounts:
+
+| Position | Account role | Required binding | Required privileges |
+|---:|---|---|---|
+| 0 | `payer` | `channelConfig.payer` | writable, signer |
+| 1 | `rent_payer` | `extra.feePayer` | writable, signer |
+| 2 | `payee` | `extra.feePayer` | read-only role |
+| 3 | `mint` | `asset == channelConfig.token` | read-only |
+| 4 | `authorized_signer` | `channelConfig.payerAuthorizer` | read-only role |
+| 5 | `channel` | `voucher.channelId` | writable |
+| 6 | `payer_token_account` | Canonical ATA for `payer`, `mint`, and the mint's token program | writable |
+| 7 | `channel_token_account` | Canonical ATA for `channel`, `mint`, and the mint's token program | writable |
+| 8 | `token_program` | Onchain owner of `mint`; supported SPL Token or Token-2022 program | read-only |
+| 9 | `system_program` | `11111111111111111111111111111111` | read-only |
+| 10 | `rent` | `SysvarRent111111111111111111111111111111111` | read-only |
+| 11 | `associated_token_program` | `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL` | read-only |
+| 12 | `event_authority` | Canonical event-authority PDA for the payment-channels program | read-only |
+| 13 | `self_program` | Canonical payment-channels program id | read-only |
+
+The facilitator MUST fully decode the instruction data, reject truncated data or
+trailing bytes, and enforce the exact salt, deposit, grace period, open slot,
+single-recipient distribution, and PDA derivation specified in sections 4.1 and
+4.2. It MUST confirm the payer has sufficient tokens for the deposit and the
+sponsor has sufficient SOL for the transaction fee plus the channel PDA and
+escrow ATA rent. The sponsor's signature authorizes no other SOL or token debit.
+
+##### Canonical `top_up`
+
+The `top_up` instruction MUST invoke the canonical payment-channels program, use
+discriminator `3`, contain exactly these six accounts in order, and contain no
+remaining accounts:
+
+| Position | Account role | Required binding | Required privileges |
+|---:|---|---|---|
+| 0 | `payer` | `channelConfig.payer` | writable, signer |
+| 1 | `channel` | `voucher.channelId` | writable |
+| 2 | `payer_token_account` | Canonical ATA for `payer`, `mint`, and the mint's token program | writable |
+| 3 | `channel_token_account` | Canonical escrow ATA for `channel`, `mint`, and the mint's token program | writable |
+| 4 | `mint` | `asset == channelConfig.token` | read-only |
+| 5 | `token_program` | Onchain owner of `mint`; supported SPL Token or Token-2022 program | read-only |
+
+The facilitator MUST confirm the decoded amount equals
+`payload.deposit.amount`; the channel is `Open`; and every immutable channel
+field and the committed distribution match the payload and requirements. It
+MUST confirm the payer has sufficient tokens. In this form `extra.feePayer`
+authorizes only the bounded transaction fee and MUST NOT be an instruction
+account, authority, source, or delegate.
+
+Solana message compilation deduplicates equal keys and unions privileges.
+Therefore `authorized_signer` MAY be effectively writable and a signer when
+`payerAuthorizer == payer`, and `payee` is effectively writable and a signer
+because `payee == rent_payer`. Those prescribed unions MUST NOT cause rejection;
+no other privilege escalation is permitted.
+
+After static validation, the facilitator MUST simulate the exact transaction,
+reject a failed simulation, sign and broadcast it, and confirm its onchain
+effects before returning success. An expired blockhash or out-of-window
+`openSlot` MUST be rejected; the client must rebuild and re-sign with fresh
+values.
 
 After confirmation, the server records the channel in its `ChannelStore` and
 accepts the voucher for the request under Phase 3.
@@ -771,9 +1084,11 @@ The server is the sole owner of per-channel offchain state. A separate
 facilitator, if used, remains stateless for ordinary voucher acceptance; it only
 needs onchain state plus a voucher when it later settles.
 
+The server MUST serialize all paid-request and refund processing per channel.
 The server stores `chargedCumulativeAmount`, `signedMaxClaimable`, the latest
-voucher signature and expiry, and a cached response keyed by
-`(channelId, maxClaimableAmount)`. For every voucher, the server MUST:
+voucher signature and expiry, and a cached paid-response entry keyed by
+`("access", channelId, maxClaimableAmount)`. For every paid-request voucher,
+the server MUST:
 
 1. Verify the Ed25519 signature over the 50-byte message using
    `channelConfig.payerAuthorizer` and confirm that key equals the channel
@@ -785,7 +1100,8 @@ voucher signature and expiry, and a cached response keyed by
    channelConfig.payerAuthorizer`, `rent_payer == extra.feePayer`,
    `grace_period == channelConfig.withdrawDelay == extra.withdrawDelay`,
    `open_slot == channelConfig.openSlot`, and a distribution to `payTo`
-   matching section 4.1. Reject if `payer` or `payerAuthorizer` equals
+   matching section 4.1. Confirm `channelConfig.receiverAuthorizer ==
+   extra.receiverAuthorizer`. Reject if `payer` or `payerAuthorizer` equals
    `feePayer`.
 4. **Expiry, accounting for async settlement.** `expiresAt` is re-checked
    onchain when `settle` or `settle_and_seal` executes. Because redemption is
@@ -794,9 +1110,9 @@ voucher signature and expiry, and a cached response keyed by
    could expire before redemption MUST be rejected.
 5. Enforce the deposit cap: `maxClaimableAmount <= channel.deposit`.
 6. Enforce replay protection and the per-request ceiling:
-   - A previously accepted `(channelId, maxClaimableAmount)` is an idempotent
-     retry. Return its cached response and do not execute the resource handler
-     again.
+   - A previously accepted `("access", channelId, maxClaimableAmount)` is an
+     idempotent retry. Return its cached response and do not execute the resource
+     handler again.
    - Any other `maxClaimableAmount <= signedMaxClaimable` is stale and MUST be
      rejected.
    - A fresh voucher MUST have `maxClaimableAmount ==
@@ -827,14 +1143,20 @@ the request path:
 - **Settle (`type: "settle"`).** Call program `distribute` to pay the newly
   claimed delta to `payTo` and advance `payout_watermark`. The channel remains
   open.
-- **Channel close.** Cooperative close is a payment-channel lifecycle operation,
-  not an x402 wire payload. The facilitator MAY sign `settle_and_seal` as
-  `payee` under its lifecycle policy. `distribute` then pays any remaining
-  settled delta, returns `deposit - settled` to the payer, closes the escrow
-  token account, and moves the channel to its cleanup state.
+- **Refund (`type: "refund"`).** Verify the server's `RefundAuthorization`;
+  apply the final client voucher when it advances `settled`; sign
+  `settle_and_seal` as channel `payee`; and invoke sealed `distribute`.
+  `distribute` pays any remaining settled delta, returns the full
+  `deposit - settled` remainder to the payer, closes the escrow token account,
+  and moves the channel to its cleanup state.
 - **Rent cleanup.** If final `distribute` leaves the channel in `Distributed`,
   anyone can later call `reclaim` after the open-slot window to return remaining
   PDA rent to `rent_payer`.
+
+The refund authorization is required for the x402 cooperative-refund flow. It
+does not remove the facilitator's independent lifecycle authority to close an
+abandoned channel at the current onchain watermark under its published rent
+recovery policy.
 
 The payer exits through the payment-channel program's forced-close path. The
 server SHOULD claim with enough buffer before `withdrawDelay` can elapse after
@@ -843,6 +1165,44 @@ as `payee` can apply a final voucher and seal cooperatively. After the grace
 period, anyone can call `seal`; the payer can recover unspent deposit via
 `withdraw_payer` or sealed `distribute`, and vouchers not yet claimed are
 forfeited by the server.
+
+### Phase 5 - Duplicate and Concurrent Operation Handling
+
+The cumulative voucher and payment-channel state machine prevent duplicate
+token movement, but HTTP retries still require explicit operation-level
+idempotency:
+
+- **Paid requests (`deposit` and `voucher`).** The server's per-channel lock and
+  `("access", channelId, maxClaimableAmount)` cache are the authoritative replay
+  defense. The same authorization MUST NOT execute the resource handler more
+  than once, regardless of whether a retry changes from `deposit` to `voucher`.
+- **Client-supplied deposit transactions.** The facilitator SHOULD maintain a
+  short-lived in-flight cache keyed by the exact serialized transaction or its
+  first signature. Concurrent `/settle` calls for the same transaction MUST be
+  coalesced to one broadcast and one result or rejected with
+  `duplicate_settlement`; they MUST NOT produce independent successful
+  settlements. The entry MAY be evicted once the transaction's blockhash is no
+  longer valid.
+- **Claims.** Program `settle` requires a strictly increasing watermark, so the
+  same claim cannot advance accounting twice. A facilitator MAY coalesce
+  in-flight `(channelId, maxClaimableAmount)` claims to avoid a predictable
+  second transaction failure; no durable duplicate cache is required.
+- **Open-channel distributions.** `distribute` advances `payout_watermark` to
+  `settled`; a repeat cannot pay the same delta again. A facilitator MAY
+  coalesce concurrent distributions for the same channel and observed
+  watermark.
+- **Refunds.** A refund intentionally reuses the latest zero-charge voucher and
+  therefore occupies a distinct `("refund", channelId,
+  maxClaimableAmount)` namespace. The server and facilitator MUST cache the
+  refund result at least through `refundAuthorization.validBefore`; a retry
+  returns that result and never invokes a resource handler. Sealing and final
+  distribution make the channel terminal, so the authorization cannot refund
+  twice. Because the signature has no revocation nonce, the server MUST keep the
+  channel refund-pending and reject later charges until the authorization
+  expires or confirms.
+- **Reclaim.** A channel can transition from `Distributed` to deallocated only
+  once. Concurrent reclaim attempts require no additional replay mitigation;
+  later attempts observe an absent account or invalid status.
 
 ## 6. Asynchronous Recovery and Channel Discovery
 
@@ -938,6 +1298,17 @@ Standard x402 codes apply. The facilitator reports verification failures in
   match the canonical PDA derivation.
 - `invalid_batch_settlement_svm_fee_payer_mismatch` - channel `payee` or
   `rent_payer` does not match `extra.feePayer`.
+- `invalid_batch_settlement_svm_receiver_authorizer_mismatch` -
+  `channelConfig.receiverAuthorizer` does not match
+  `extra.receiverAuthorizer` or the facilitator's trusted server binding.
+- `invalid_batch_settlement_svm_refund_authorization` - refund authorization is
+  malformed, expired, signed by the wrong receiver authorizer, or does not bind
+  the exact refund request.
+- `invalid_batch_settlement_svm_refund_amount_unsupported` - refund payload
+  contains an `amount`; this scheme supports full cooperative close only.
+- `invalid_batch_settlement_svm_refund_state` - channel cannot be cooperatively
+  closed, the zero-charge voucher does not equal server state, or its watermark
+  is behind the channel's onchain `settled` value.
 - `invalid_batch_settlement_svm_withdraw_delay_mismatch` - channel grace period
   does not match `extra.withdrawDelay`.
 - `invalid_batch_settlement_svm_cumulative_amount_mismatch` - corrective 402:
@@ -948,6 +1319,8 @@ Standard x402 codes apply. The facilitator reports verification failures in
   before redemption.
 - `invalid_batch_settlement_svm_setup_transaction` - setup transaction fails the
   sponsor safety checks.
+- `duplicate_settlement` - the same client-supplied setup transaction is already
+  being settled.
 
 ## 8. Security Properties
 
@@ -961,6 +1334,14 @@ Standard x402 codes apply. The facilitator reports verification failures in
   `channelConfig.payerAuthorizer`, so the facilitator can close a channel but
   cannot advance `settled` without a client-signed voucher. The committed
   distribution prevents payout redirection.
+- **Authenticated cooperative refunds.** The facilitator constructs and signs
+  the close transaction only after verifying a domain-separated authorization
+  from the receiver authorizer trusted for the server and `payTo`. The key
+  supplied in an untrusted request is not itself a trust anchor. The client
+  voucher independently binds the final cumulative spend.
+- **Full-close refunds.** Cooperative refund first locks the final `settled`
+  watermark, then returns exactly `deposit - settled` and closes the escrow.
+  Partial refunds and channel reuse after refund are not supported.
 - **Facilitator rent recovery.** Because the facilitator is channel `payee`, it
   can run `settle_and_seal` with `has_voucher = 0`, then `distribute` and
   `reclaim`, without client or server cooperation. Abandoned channels cannot
@@ -972,8 +1353,15 @@ Standard x402 codes apply. The facilitator reports verification failures in
   client-initiated grace period, only the facilitator can apply the final
   voucher and seal cooperatively.
 - **No replay / no rollback.** Server offchain watermark plus onchain
-  `settled` monotonicity reject old vouchers. Equality is accepted only as an
-  idempotent replay of a cached response.
+  `settled` monotonicity reject old vouchers. Paid-request equality is accepted
+  only as an idempotent replay of a cached access response. Refunds use a
+  separate operation namespace, a time-bounded server authorization, and a
+  terminal onchain transition.
+- **Bounded sponsor exposure.** Client-supplied transactions have a static
+  instruction allowlist, exact signer and account layouts, no address lookup
+  tables, bounded compute-unit limit and price, and transaction simulation.
+  Outside the prescribed `open` rent roles, the facilitator signature
+  authorizes network fees only.
 - **Client escape hatch.** `withdrawDelay` is fixed at `open`; if the server
   does not settle, the payer can start forced close and recover unspent escrow
   after the grace period.
@@ -988,4 +1376,6 @@ Standard x402 codes apply. The facilitator reports verification failures in
 
 - A prescribed persistence backend, worker topology, or scheduling architecture
   for the required asynchronous maintenance.
+- Smart-wallet-wrapped `open` or `top_up` transactions and simulation-based
+  acceptance of arbitrary wallet programs.
 - Delegated passkey or secp256r1 voucher signers.

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -52,23 +52,35 @@ normative profile:
 
 ### 3.1 `payment-channel` (normative, v1)
 
-Backed by the on-chain payment-channels program (a `pay-kit`-controlled program;
-program id `CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX` on the current
-deployment). The escrow **deposit is the ceiling**; the client signs cumulative
-vouchers off-chain; the operator settles the latest voucher per channel in
-batches and finalizes with a refund of the unused remainder.
+Backed by the on-chain payment-channels program (advertised via
+`extra.channelProgram`; a canonical deployment is assumed when omitted). The
+escrow **deposit is the ceiling**; the client signs cumulative vouchers
+off-chain; the operator settles the latest voucher per channel in batches and
+finalizes with a refund of the unused remainder.
 
 Unlike `upto`, where the **operator** is the `authorizedSigner` (it fills in
 `actual ≤ ceiling` after metering), here the **client** is the `authorizedSigner`
 — the client signs each cumulative voucher itself (this is the `session` /
-client-voucher model). The operator only ever submits on-chain `settle` /
-`distribute` / `finalize`; it can never exceed the on-chain `deposit` or redirect
-funds away from the fixed `payee`.
+client-voucher model). The operator fills the remaining channel roles: it is the
+fee payer, the `rentPayer`, **and the channel `payee`** — which the program
+requires as the `settle_and_finalize` merchant (`merchant == channel.payee`). The
+x402 `payTo` is realized as that `payee` when the server self-facilitates
+(`payTo == operator`), or as a program-enforced `distributionSplits` entry when a
+separate facilitator is the `payee`. The operator only ever submits on-chain
+`settle` / `distribute` / `finalize`; it can never exceed the on-chain `deposit`
+(the client signs the cumulative) or redirect funds away from the sealed
+distribution.
 
 Strengths: per-request cost approaches zero (no on-chain tx per request); every
-guarantee is enforced by a program we control. Cost: the client locks the
+requirement is enforced on-chain by the program. Cost: the client locks the
 deposit for the channel's lifetime, and the operator must settle before the
 forced-close grace period elapses to capture funds.
+
+> **Reference-implementation status.** The v1 reference implements the
+> **self-facilitating** case (`operator == payTo`), where the operator is both
+> the settlement authority (`channel.payee`) and the recipient. Separate-facilitator
+> operation — `payTo` as a program-enforced `distributionSplits` entry, the
+> facilitator as `channel.payee` — is specified but not yet implemented.
 
 ## 4. Wire format
 
@@ -87,7 +99,7 @@ relative to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
 | `network` | string | ✓ | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (mainnet), `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (devnet) |
 | `amount` | string | ✓ | Per-request price, base units (fixed in v1) |
 | `asset` | string | ✓ | SPL mint address (or a known symbol like `"USDC"`) |
-| `payTo` | string | ✓ | Base58 channel payee |
+| `payTo` | string | ✓ | Base58 recipient. Realized as the channel `payee` when the server self-facilitates (`payTo == operator`), or as a `distributionSplits` entry when a separate facilitator is the `payee`. |
 | `maxTimeoutSeconds` | number | ✓ | Completion window |
 | `extra` | object | ✓ | See below |
 
@@ -168,7 +180,9 @@ expires_at (i64 le)`, identical to `upto` and the MPP `session` voucher.
 
 The client builds an `open` transaction depositing `depositAmount` (≥
 `extra.minimumDeposit`), with `authorizedSigner = payer` (client-voucher model),
-`payee = payTo`, and `distributionSplits` matching `extra.distributionSplits`.
+`payee = operator` (the settlement authority — equal to `payTo` when the server
+self-facilitates; see §3.1), `rentPayer = operator`, and `distributionSplits`
+matching `extra.distributionSplits`.
 The client sends a `deposit` payload carrying the base64 client-signed
 transaction plus the first cumulative voucher.
 
@@ -247,8 +261,10 @@ Standard x402 codes apply. Scheme-specific failures surface as `402` with an
 - **No fee-payer drain.** The operator validates the `open` transaction (single
   instruction, correct program/discriminator/accounts) before co-signing as fee
   payer.
-- **Time-bounded.** `expiresAt` is checked off-chain at acceptance and signed into
-  the on-chain voucher, so a stale voucher cannot settle.
+- **Time-bounded.** `expiresAt` is checked off-chain at acceptance and enforced
+  on-chain at settle. Because the **client** signs each voucher (it is the
+  `authorizedSigner`), `expiresAt` is a genuine client commitment here — unlike
+  `upto`, where the operator signs and the field is operator-attested.
 - **Bounded loss.** The client trusts the operator to settle before grace; the
   operator trusts the client only up to the escrowed `deposit`. Everything above
   the deposit, the destination, and replay are enforced cryptographically /

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -4,317 +4,439 @@
 > [`scheme_batch_settlement.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/batch-settlement/scheme_batch_settlement.md)
 > and the EVM profile
 > [`scheme_batch_settlement_evm.md`](https://github.com/x402-foundation/x402/blob/main/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md).
-> This document specifies how the `batch-settlement` scheme is realized on Solana
-> Virtual Machine (SVM) networks.
+> This document specifies how the `batch-settlement` scheme is realized on
+> Solana Virtual Machine (SVM) networks.
 
 ## 1. Purpose
 
-`batch-settlement` is the high-throughput x402 scheme: a client **deposits once**
-into an escrow channel, then signs a stream of **cumulative Ed25519 vouchers**
-(one per request). The server verifies each voucher **off-chain** and serves the
-resource immediately — no on-chain transaction in the request path — and the
-operator **redeems the latest voucher per channel later, in batches**. This
-amortizes one on-chain settlement across many paid requests, so per-request cost
-and latency approach zero.
+`batch-settlement` is the high-throughput x402 scheme: a client deposits once
+into an escrow channel, then signs cumulative Ed25519 vouchers for individual
+requests. The server verifies each voucher offchain, stores the latest
+commitment, serves immediately, and later redeems the latest voucher onchain.
+This removes onchain settlement from the request path.
 
-Where `upto` settles **at most once** per authorization, `batch-settlement` is
-its multi-voucher generalization: the channel is long-lived and each request
-advances a monotonic cumulative counter. On SVM this is the same model as the MPP
-**`session`** intent, surfaced over the x402 wire and backed by the **same**
-payment-channels program and 48-byte voucher already used by
-[`upto`](../upto/scheme_upto_svm.md).
+On SVM this scheme is backed by the
+[payment-channels program](https://github.com/solana-foundation/payment-channels),
+the same program used by SVM `upto`. `upto` is a one-request channel that closes
+after one metered charge; `batch-settlement` keeps the channel open across many
+requests and advances a cumulative watermark.
 
-## 2. Mapping the core requirements to SVM
+The x402 roles map to the payment-channel program as follows:
 
-| Requirement (generic spec) | EVM mechanism | SVM mechanism (this spec) |
+- **Client**: channel `payer`; funds deposits and signs per-request vouchers
+  through `payerAuthorizer`.
+- **Payer authorizer**: client-controlled Ed25519 key recorded as channel
+  `authorized_signer`; signs cumulative vouchers. It MAY equal `payer`.
+- **Server**: resource provider; receives funds at `payTo`; owns per-channel
+  offchain state, including the accepted cumulative watermark and latest
+  voucher.
+- **Receiver authorizer**: server-controlled hot key advertised as
+  `extra.receiverAuthorizer`; recorded as channel `payee`; signs cooperative
+  close/refund operations. It does not need to receive the settled funds.
+- **Facilitator / sponsor**: account advertised as `extra.feePayer`; sponsors
+  transaction fees and channel rent. It is the transaction fee payer and channel
+  `rent_payer`, but it is not a payment authority.
+
+`payTo` is the server's payment receiver, typically a cold wallet. If
+`payTo != receiverAuthorizer`, the channel distribution sends 100% of settled
+funds to `payTo`, leaving the channel `payee` with a zero implicit remainder.
+If `payTo == receiverAuthorizer`, the client MAY omit recipients and let the
+payee receive the implicit 100% remainder.
+
+## 2. Mapping the Core Requirements to SVM
+
+| Requirement (generic spec) | EVM mechanism | SVM mechanism |
 |---|---|---|
-| One-time escrow deposit | ERC-20 `approve` + channel contract | `payment-channels` program: `open` deposits the escrow and fixes `payee` / `authorizedSigner` / `distribution_hash`. |
-| Per-request authorization | Cumulative signed voucher | 48-byte Ed25519 voucher `channel_id ‖ cumulative_amount_le ‖ expires_at_le`, signed by the channel's `authorizedSigner`. |
-| Monotonic amount | `cumulativeAmount` strictly increases | Off-chain watermark in the **server's** `ChannelStore` (`cumulative`), capped by on-chain `deposit`; on-chain `SettlementWatermarks.settled` enforces it at redemption. |
-| Batched redemption | One `claim` per channel, up to N | `settle` per channel draws the voucher's **exact** cumulative; multiple channels packed per transaction (tx-size-bounded). |
-| Recipient binding | Channel `recipient` fixed at open | `channel.payee` + `distribution_hash` fixed at `open`. |
-| Refund of unused deposit | `close` / cooperative close | `settle_and_finalize` + `distribute`: pays the settled amount and refunds `deposit − settled` to the payer, closing the channel. |
+| One-time escrow deposit | Token authorization plus channel contract | Payment-channels `open` deposits escrow, records `withdrawDelay`, fixes `payee`, `authorized_signer`, `rent_payer`, and commits `distribution_hash`. |
+| Per-request authorization | Cumulative signed voucher | Ed25519 voucher signed by `payerAuthorizer` over `0x56 0x01 || channelId || cumulativeAmount || expiresAt`. |
+| Monotonic amount | `maxClaimableAmount` increases | Server-owned offchain watermark plus onchain `settled < cumulativeAmount <= deposit` at redemption. |
+| Batched redemption | Claim many channels | One `settle` per channel, packed transaction-size permitting; `distribute` pays settled deltas. |
+| Recipient binding | Receiver fixed in channel config | `distribution_hash` fixed at `open` sends funds to `payTo`; program re-checks it at `distribute`. |
+| Refund of unused deposit | Cooperative refund or timed withdrawal | `settle_and_seal` + `distribute` for cooperative close; `request_close` / `seal` / `withdraw_payer` for payer-forced close. |
 
-**Decisive SVM divergence.** The SVM `settle` instruction draws the voucher's
-**exact** cumulative (`settled = voucher.cumulativeAmount`, after
-`settled < cumulative ≤ deposit`), not EVM's "claim up to a ceiling." So an SVM
-voucher commits the **actual** cumulative charged, and EVM's `claim`/`settle`
-split maps to our `settle` (advance the on-chain watermark) and `distribute`
-(sweep settled funds to `payee`/splits) instructions. Consequently v1 ships a
-**fixed per-request price** (each request advances the cumulative by exactly the
-advertised `amount`); dynamic pricing below the advertised amount would need a
-commit round-trip and is deferred.
+## 3. Payment-Channel Method
 
-## 3. Profile
+SVM `batch-settlement` defines a single payment method backed by the
+payment-channels program. Because there is only one method, the wire format does
+not include `extra.profiles` or `extra.assetTransferMethod`.
 
-A server advertises supported profiles in `extra.profiles`. v1 defines a single
-normative profile:
+The canonical program id is a network/SDK constant, not a server-provided wire
+field. For the current mainnet deployment:
 
-### 3.1 `payment-channel` (normative, v1)
+```text
+CHNLxYvVA28MJP9PrFuDXccuoGXAx7jBacfLEkahyGsX
+```
 
-Backed by the on-chain payment-channels program (advertised via
-`extra.channelProgram`; a canonical deployment is assumed when omitted). The
-escrow **deposit is the ceiling**; the client signs cumulative vouchers
-off-chain; the operator settles the latest voucher per channel in batches and
-finalizes with a refund of the unused remainder.
+Implementations MUST target the canonical payment-channels program id for the
+selected `network` and MUST NOT trust or negotiate a `channelProgram` value from
+`extra`. Program documentation and instruction references live in the
+[payment-channels repository](https://github.com/solana-foundation/payment-channels).
 
-Unlike `upto`, where the **operator** is the `authorizedSigner` (it fills in
-`actual ≤ ceiling` after metering), here the **client** is the `authorizedSigner`
-— the client signs each cumulative voucher itself (this is the `session` /
-client-voucher model). The operator fills the remaining channel roles: it is the
-fee payer, the `rentPayer`, **and the channel `payee`** — which the program
-requires as the `settle_and_finalize` merchant (`merchant == channel.payee`). The
-x402 `payTo` is realized as that `payee` when the server self-facilitates
-(`payTo == operator`), or as a program-enforced `distributionSplits` entry when a
-separate facilitator is the `payee`. The operator only ever submits on-chain
-`settle` / `distribute` / `finalize`; it can never exceed the on-chain `deposit`
-(the client signs the cumulative) or redirect funds away from the sealed
-distribution.
+The current program lifecycle is:
 
-Strengths: per-request cost approaches zero (no on-chain tx per request); every
-requirement is enforced on-chain by the program. Cost: the client locks the
-deposit for the channel's lifetime, and the operator must settle before the
-forced-close grace period elapses to capture funds.
+1. `open`: creates the channel PDA, escrows the deposit, stores
+   `grace_period == extra.withdrawDelay`, stores `open_slot`, and commits the
+   payout distribution.
+2. `settle`: permissionlessly advances the onchain `settled` watermark from a
+   valid voucher.
+3. `distribute`: permissionlessly pays the newly settled delta to `payTo` and
+   advances `payout_watermark`. While the channel is still open, it does not
+   refund the payer or close the escrow.
+4. `settle_and_seal`: receiver-authorizer-signed cooperative close. It may apply
+   a final voucher, locks the watermark, and moves the channel to `Sealed`.
+5. Sealed `distribute`: pays any final settled delta, refunds
+   `deposit - settled` to the payer, closes the escrow token account, and either
+   deallocates the channel PDA immediately or marks it `Distributed`.
+6. `reclaim`: permissionless cleanup for `Distributed` channels after
+   `clock.slot > open_slot + OPEN_SLOT_WINDOW`; it returns remaining PDA rent to
+   the recorded `rent_payer`.
 
-> **Reference-implementation status.** The v1 reference implements the
-> **self-facilitating** case (`operator == payTo`), where the operator is both
-> the settlement authority (`channel.payee`) and the recipient. Separate-facilitator
-> operation — `payTo` as a program-enforced `distributionSplits` entry, the
-> facilitator as `channel.payee` — is specified but not yet implemented.
-
-## 4. Wire format
+## 4. Wire Format
 
 `batch-settlement` reuses the x402 v2 transport: a `402` response carries
 `PAYMENT-REQUIRED`; each paid request carries `PAYMENT-SIGNATURE`; the response
-carries `PAYMENT-RESPONSE`. Only the `scheme` value and the payload shape change
-relative to `exact`. The core `PaymentRequirements`, `PaymentPayload`, and
-`SettlementResponse` types are defined in
+carries `PAYMENT-RESPONSE`. The core `PaymentRequirements`, `PaymentPayload`,
+and `SettlementResponse` types are defined in
 [`x402-specification-v2.md`](../../x402-specification-v2.md).
 
 ### 4.1 `PaymentRequirements` (in `PAYMENT-REQUIRED.accepts[]`)
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `scheme` | string | ✓ | `"batch-settlement"` |
-| `network` | string | ✓ | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (mainnet), `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (devnet) |
-| `amount` | string | ✓ | Per-request price, base units (fixed in v1) |
-| `asset` | string | ✓ | The concrete SPL / Token-2022 mint pubkey (base58), e.g. USDC `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` — not a symbol |
-| `payTo` | string | ✓ | Base58 recipient. Realized as the channel `payee` when the server self-facilitates (`payTo == operator`), or as a `distributionSplits` entry when a separate facilitator is the `payee`. |
-| `maxTimeoutSeconds` | number | ✓ | Completion window |
-| `extra` | object | ✓ | See below |
+| `scheme` | string | yes | `"batch-settlement"` |
+| `network` | string | yes | CAIP-2, e.g. `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` |
+| `amount` | string | yes | Fixed per-request price in base units. |
+| `asset` | string | yes | Concrete SPL / Token-2022 mint pubkey, not a symbol. |
+| `payTo` | string | yes | Base58 final payment receiver. Normally a server cold wallet. |
+| `maxTimeoutSeconds` | number | yes | HTTP completion window. |
+| `extra` | object | yes | See below. |
 
-`extra` (`BatchExtra`):
+`extra`:
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `profiles` | string[] | ✓ | Subset of `["payment-channel"]`, in server preference order |
-| `channelProgram` | string | ✓ | Channel program id (base58) |
-| `gracePeriodSeconds` | number | ✓ | Forced-close grace period (non-zero) |
-| `feePayer` | string | ✓ | Operator key that sponsors fees (co-signs/broadcasts `open`) and submits settlement (base58) |
-| `decimals` | number | – | Token decimals |
-| `tokenProgram` | string | – | `Tokenkeg…` or `TokenzQ…` (Token-2022); the client SHOULD verify it against the on-chain mint owner |
-| `recentBlockhash` | string | – | Pre-fetched blockhash so the client can build `open`/`topUp` without an extra RPC round-trip |
-| `suggestedDeposit` | string | – | Suggested initial deposit (base units) |
-| `minimumDeposit` | string | – | HTTP-enforced minimum initial deposit (base units) |
-| `minVoucherDelta` | string | – | Minimum cumulative increment between accepted vouchers (base units) |
-| `distributionSplits` | `{recipient, shareBps}[]` | – | Merchant-side splits committed at open; payee gets the remainder |
+| `feePayer` | string | yes | Base58 sponsor key that co-signs channel setup/top-up/settlement transactions as transaction fee payer and funds channel rent as `rent_payer`. |
+| `receiverAuthorizer` | string | yes | Base58 server-controlled key set as channel `payee`; signs cooperative close/refund transactions. |
+| `withdrawDelay` | number | yes | Server-defined forced-close grace period in seconds. The client MUST encode this exact value as the program `grace_period`; the verifier MUST reject any other value. |
+| `tokenProgram` | string | yes | `Tokenkeg...` or `TokenzQ...` (Token-2022); the client SHOULD verify it against the onchain mint owner. |
+| `recentBlockhash` | string | no | Pre-fetched blockhash so the client can build setup transactions without an RPC round trip. |
+| `recentSlot` | number | no | Recent slot the client MAY use as `openSlot` when it does not fetch its own slot. The program still enforces the slot window. |
+| `suggestedDeposit` | string | no | Suggested initial deposit in base units. |
+| `minimumDeposit` | string | no | HTTP-enforced minimum initial deposit in base units. |
+| `minVoucherDelta` | string | no | Minimum cumulative increment between accepted vouchers in base units. |
+| `channelState` | object | no | Corrective-only server channel snapshot for cumulative amount resynchronization. |
+| `voucherState` | object | no | Corrective-only signed voucher proof for cumulative amount resynchronization. |
+
+The x402 wire format does not expose program-specific split arrays. The client
+derives the payment-channel accounts and distribution from the x402 fields:
+
+```text
+rent_payer = extra.feePayer
+payee = extra.receiverAuthorizer
+authorized_signer = channelConfig.payerAuthorizer
+grace_period = extra.withdrawDelay
+
+if payTo == extra.receiverAuthorizer:
+  recipients = []
+  payee_implicit_remainder_bps = 10000
+else:
+  recipients = [{ recipient: payTo, bps: 10000 }]
+  payee_implicit_remainder_bps = 0
+```
+
+Any facilitator commercial fee is outside this wire contract or included in the
+server's pricing. The channel distribution for this scheme MUST NOT assign any
+portion of settled funds away from `payTo`, except when `payTo` is itself the
+channel payee via the implicit remainder path.
+
+Example:
+
+```json
+{
+  "scheme": "batch-settlement",
+  "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+  "amount": "1000",
+  "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  "payTo": "<server-cold-wallet>",
+  "maxTimeoutSeconds": 300,
+  "extra": {
+    "feePayer": "<facilitator>",
+    "receiverAuthorizer": "<server-hot-wallet>",
+    "withdrawDelay": 3600,
+    "tokenProgram": "<token-program>",
+    "recentBlockhash": "<cached>",
+    "recentSlot": 341000000,
+    "suggestedDeposit": "100000",
+    "minimumDeposit": "10000"
+  }
+}
+```
 
 ### 4.2 `BatchPayload` (in `PAYMENT-SIGNATURE.payload`)
 
 A tagged union on `type`:
 
-**`deposit`** — open a channel (or top up) and authorize the first voucher:
+**`deposit`** - open a channel or top up an existing channel and authorize the
+current request:
 
 | Field | Type | Notes |
 |---|---|---|
 | `type` | string | `"deposit"` |
-| `channelConfig` | object | `{payer, payee, mint, authorizedSigner, salt, depositAmount, gracePeriodSeconds, distributionSplits[]}`. The channel id is the PDA `["channel", payer, payee, mint, authorizedSigner, salt]`. |
-| `transaction` | string | Base64 client-signed `open`/`topUp` transaction for the operator to co-sign as fee payer + broadcast |
-| `voucher` | object? | First cumulative `BatchVoucher` (omitted on a pure top-up) |
+| `channelConfig` | object | See `ChannelConfig` below. |
+| `transaction` | string | Base64 client-signed `open` or `top_up` transaction for the sponsor to co-sign and broadcast. |
+| `voucher` | object | New cumulative `BatchVoucher` for the request being paid. |
 
-**`voucher`** — steady-state paid request (no on-chain transaction):
+**`voucher`** - steady-state paid request with no onchain transaction:
 
 | Field | Type | Notes |
 |---|---|---|
 | `type` | string | `"voucher"` |
-| `channelId` | string | Channel PDA (base58) |
-| `voucher` | object | A new cumulative `BatchVoucher` |
+| `channelId` | string | Channel PDA (base58). |
+| `voucher` | object | New cumulative `BatchVoucher`. |
 
-**`refund`** — cooperative close (the application route is bypassed):
+**`refund`** - cooperative close; the application resource handler is bypassed:
 
 | Field | Type | Notes |
 |---|---|---|
 | `type` | string | `"refund"` |
-| `channelId` | string | Channel PDA (base58) |
-| `voucher` | object? | Optional final voucher to settle before refunding |
+| `channelId` | string | Channel PDA (base58). |
+| `voucher` | object | Zero-charge voucher whose `cumulativeAmount` equals the server's current watermark. |
+| `amount` | string | Optional requested refund amount; omitted means full unspent remainder. |
+
+`ChannelConfig`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `payer` | string | Client wallet and channel payer. |
+| `payerAuthorizer` | string | Client-controlled Ed25519 voucher signer; maps to channel `authorized_signer`. MAY equal `payer`. |
+| `receiver` | string | MUST equal `payTo`. Included so the client can verify the derived distribution. |
+| `receiverAuthorizer` | string | MUST equal `extra.receiverAuthorizer`; maps to channel `payee`. |
+| `mint` | string | MUST equal `asset`. |
+| `tokenProgram` | string | MUST equal `extra.tokenProgram`. |
+| `salt` | string | Decimal `u64` channel salt. |
+| `openSlot` | number | `u64` slot encoded in `open` and used as a channel PDA seed. |
+| `depositAmount` | string | Initial deposit or top-up amount in base units. |
+| `withdrawDelay` | number | MUST equal `extra.withdrawDelay`. |
+
+`channelId` is the program-derived address:
+
+```text
+find_program_address(
+  [
+    "channel",
+    channelConfig.payer,
+    channelConfig.receiverAuthorizer,
+    channelConfig.mint,
+    channelConfig.payerAuthorizer,
+    u64(channelConfig.salt).to_le_bytes(),
+    u64(channelConfig.openSlot).to_le_bytes()
+  ],
+  CANONICAL_PAYMENT_CHANNELS_PROGRAM_ID
+)
+```
+
+The `open` instruction MUST encode:
+
+- `salt == channelConfig.salt`
+- `deposit == channelConfig.depositAmount`
+- `grace_period == extra.withdrawDelay`
+- `open_slot == channelConfig.openSlot`
+- `rent_payer == extra.feePayer`
+- `payee == extra.receiverAuthorizer`
+- `authorized_signer == channelConfig.payerAuthorizer`
+- the distribution derived from `payTo` as specified in section 4.1
 
 `BatchVoucher`:
 
 | Field | Type | Notes |
 |---|---|---|
-| `channelId` | string | Channel PDA (base58) |
-| `cumulativeAmount` | string | Cumulative authorized total (base units), monotonically increasing |
-| `expiresAt` | number | Voucher expiry (Unix seconds); MUST be a future time |
-| `signer` | string | Base58 voucher signer = the channel's `authorizedSigner` (the client) |
-| `signature` | string | Base58 Ed25519 signature over the 48-byte voucher payload |
+| `channelId` | string | Channel PDA (base58). |
+| `cumulativeAmount` | string | Cumulative authorized total in base units. |
+| `expiresAt` | number | Unix seconds. `0` means no voucher expiry; otherwise the program enforces `now < expiresAt` at `settle` / `settle_and_seal`. |
+| `signer` | string | Base58 voucher signer. MUST equal `channelConfig.payerAuthorizer` / channel `authorized_signer`. |
+| `signature` | string | Base58 Ed25519 signature over the voucher payload. |
 
-The signed message is exactly `channel_id (32) ‖ cumulative_amount (u64 le) ‖
-expires_at (i64 le)`, identical to `upto` and the MPP `session` voucher.
+The signed message is exactly:
+
+```text
+0x56 0x01 || channelId || u64(cumulativeAmount).le || i64(expiresAt).le
+```
+
+This is the payment-channels program voucher layout (`VOUCHER_MAGIC`,
+`channel_id`, `cumulative_amount`, `expires_at`), 50 bytes total.
 
 ### 4.3 `SettlementResponse` (in `PAYMENT-RESPONSE`)
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `success` | boolean | ✓ | |
-| `errorReason` | string | – | Omitted on success |
-| `payer` | string | – | Channel `payer` |
-| `transaction` | string | ✓ | On-chain signature; **empty `""` for an off-chain voucher acceptance** (the common case) |
-| `network` | string | ✓ | CAIP-2 |
-| `amount` | string | – | Amount moved on-chain (`""` / omitted for a voucher-only acceptance) — optional, per the core `SettleResponse` |
-| `extra.chargedAmount` | string | – | The per-request charge committed off-chain |
-| `extra.channelState` | object | – | `{channelId, deposit, settled, paidOut, status}` snapshot |
+| `success` | boolean | yes |  |
+| `errorReason` | string | no | Omitted on success. |
+| `payer` | string | no | Channel `payer`. |
+| `transaction` | string | yes | Onchain signature for deposit/top-up/refund/settlement operations; empty string for offchain voucher acceptance. |
+| `network` | string | yes | CAIP-2. |
+| `amount` | string | no | Amount moved onchain; empty or omitted for voucher-only acceptance. |
+| `extra.commitmentId` | string | no | Non-empty commitment identifier for voucher-only acceptance, e.g. `channelId:cumulativeAmount`. |
+| `extra.chargedAmount` | string | no | Per-request charge committed offchain. |
+| `extra.channelState` | object | no | `{channelId, deposit, chargedCumulativeAmount, settled, paidOut, status}` snapshot. |
 
-Scheme-specific fields are nested under `extra` and `amount` is optional, matching
-the core `SettleResponse` and the EVM `batch-settlement` profile
-(`extra.chargedAmount`, `extra.channelState`).
+Scheme-specific fields are nested under `extra`, matching the EVM
+`batch-settlement` profile.
 
 ## 5. Phases
 
-### Phase 1 — Open (once per channel)
+### Phase 1 - Open or Top Up
 
-The client builds an `open` transaction depositing `depositAmount` (≥
-`extra.minimumDeposit`), with `authorizedSigner = payer` (client-voucher model),
-`payee = operator` (the settlement authority — equal to `payTo` when the server
-self-facilitates; see §3.1), `rentPayer = operator`, and `distributionSplits`
-matching `extra.distributionSplits`.
-The client sends a `deposit` payload carrying the base64 client-signed
-transaction plus the first cumulative voucher.
+The client builds an `open` transaction for a new channel or a `top_up`
+transaction for an existing channel. The client signs as channel `payer`; the
+sponsor later signs as transaction fee payer. For `open`, the sponsor also signs
+as program `rent_payer`, because the payment-channels program debits SOL from
+that account to fund the channel PDA and escrow ATA rent.
 
-The operator MUST validate the **full compiled** `open` transaction before
-co-signing as fee payer — not only the payment-channel instruction. Following the
-`exact` SVM scheme's fee-payer guard
-([`scheme_exact_svm.md`](../exact/scheme_exact_svm.md)): resolve any
-address-lookup tables; allow only the expected instruction set (the channel
-`open`, plus an optional ComputeBudget instruction); confirm the program id and
-`open` discriminator and that accounts/args match `channelConfig`; and confirm
-the fee payer (the operator) is never used as an authority, source, or writable
-account except to pay transaction fees. Anything else is rejected before
-broadcasting, so a malicious client cannot make the operator co-sign more than
-fee payment. The operator then co-signs, broadcasts, confirms, binds the on-chain
-channel into the server's `ChannelStore`, and accepts the first voucher
-(Phase 3). Only then is the resource served.
+For `open`, the client MUST set `payee = extra.receiverAuthorizer`,
+`authorized_signer = channelConfig.payerAuthorizer`, `rent_payer =
+extra.feePayer`, `grace_period = extra.withdrawDelay`, and `open_slot =
+channelConfig.openSlot`.
 
-### Phase 2 — Steady state (per request)
+The sponsor MUST validate the full compiled setup transaction before co-signing,
+not only the payment-channel instruction. It MUST resolve address lookup tables,
+allow only the expected instruction set (payment-channel `open` or `top_up`,
+optional associated-token-account creation required by `open`, and bounded
+ComputeBudget instructions), confirm the canonical program id and instruction
+arguments, and confirm `feePayer` is not used as an authority, source, or
+writable account except for transaction fees and the intended channel/escrow
+rent. Anything else MUST be rejected before broadcasting.
 
-The client increments the cumulative total by the per-request `amount`, signs a
-new `BatchVoucher`, and sends a `voucher` payload. No on-chain transaction. The
-operator accepts the voucher off-chain (Phase 3) and serves immediately.
+After confirmation, the server records the channel in its `ChannelStore` and
+accepts the voucher for the request under Phase 3.
 
-### Phase 3 — Voucher acceptance (before serving)
+### Phase 2 - Steady-State Request
 
-For every voucher the operator MUST (the off-chain watermark and channel snapshot
-are the **resource server's** per-channel state — a separate facilitator, if used,
-stays stateless for this verification, per x402):
+The client increments the cumulative total by the fixed per-request `amount`,
+signs a new `BatchVoucher`, and sends a `voucher` payload. No onchain
+transaction is required in the request path. The server verifies and stores the
+voucher under Phase 3, then serves immediately.
 
-1. Verify the Ed25519 `signature` over the 48-byte message against `signer`, and
-   confirm `signer` equals the channel's `authorizedSigner`.
-2. **Expiry, accounting for async settlement.** `expiresAt` is re-checked
-   **on-chain** when `settle` / `settleAndFinalize` execute (the program rejects
-   `expires_at != 0 && now ≥ expires_at`), not only at HTTP acceptance. Because
-   redemption is batched and out-of-band, the operator MUST require `expiresAt`
-   to outlast the redemption window: either `expiresAt == 0` (the program treats
-   `0` as no-expiry, so the channel is time-bounded only by its forced-close
-   grace period) or `expiresAt ≥ now + gracePeriodSeconds + a settlement buffer`.
-   A voucher whose `expiresAt` could lapse before settlement MUST be rejected —
-   it would be served but never redeemable.
-3. Enforce **monotonicity**: reject any `cumulativeAmount` **below** the stored
-   watermark — a stale or replayed voucher. The `cumulativeAmount` is itself the
-   per-request nonce: each served response maps one-to-one to a unique cumulative
-   level, so replay protection is intrinsic to the amount.
-4. Enforce the **deposit cap**: `cumulativeAmount ≤ channel.deposit`.
-5. **Charge-worthy (new) request** — `cumulativeAmount > watermark`: in
-   fixed-price v1 the increment MUST equal the advertised price exactly
-   (`cumulativeAmount == watermark + amount`, and ≥ `minVoucherDelta` when set).
-   The operator atomically advances the stored watermark (compare-and-set),
-   serves the resource, and caches the response keyed by
-   `(channelId, cumulativeAmount)`.
-6. **Idempotent retry** — `cumulativeAmount == watermark`: necessarily a retry of
-   the request already paid for at that level (a genuinely new request carries a
-   strictly higher cumulative). The operator returns the **cached response** for
-   that `(channelId, cumulativeAmount)` and does **not** serve a fresh resource,
-   re-charge, or advance the watermark. Accepting an equal voucher MUST NOT
-   produce a new response — otherwise a client could replay its latest voucher to
-   buy further responses without paying.
+### Phase 3 - Voucher Acceptance (before serving)
 
-On any failure the operator returns `402` without serving the resource. A fresh
-acceptance (step 5) returns `200` with a `PAYMENT-RESPONSE` carrying an empty
-`transaction` and the `chargedAmount`; an idempotent retry (step 6) replays that
-cached `200` response.
+The server is the sole owner of per-channel offchain state. A separate
+facilitator, if used, remains stateless for ordinary voucher acceptance; it only
+needs onchain state plus a voucher when it later settles.
 
-### Phase 4 — Batched settlement (operator-driven, out of band)
+For every voucher, the server MUST:
 
-The operator redeems accumulated vouchers asynchronously — **not** in the request
-path:
+1. Verify the Ed25519 signature over the 50-byte message and confirm `signer`
+   equals the channel `authorized_signer` / `channelConfig.payerAuthorizer`.
+2. Confirm `channelId` matches the PDA derived from `channelConfig` and the
+   canonical payment-channels program id.
+3. Confirm the channel exists, is `Open`, has `mint == asset`,
+   `payee == extra.receiverAuthorizer`, `authorized_signer ==
+   channelConfig.payerAuthorizer`, `rent_payer == extra.feePayer`,
+   `grace_period == extra.withdrawDelay`, `open_slot ==
+   channelConfig.openSlot`, and a distribution to `payTo` matching section 4.1.
+4. **Expiry, accounting for async settlement.** `expiresAt` is re-checked
+   onchain when `settle` or `settle_and_seal` executes. Because redemption is
+   delayed, the server MUST require either `expiresAt == 0` or
+   `expiresAt >= now + withdrawDelay + a settlement buffer`. A voucher that
+   could expire before redemption MUST be rejected.
+5. Enforce deposit cap: `cumulativeAmount <= channel.deposit`.
+6. Enforce monotonicity against the server's stored watermark:
+   - `cumulativeAmount < watermark`: reject as stale.
+   - `cumulativeAmount == watermark`: idempotent retry only. Return the cached
+     response for `(channelId, cumulativeAmount)` and do not execute the
+     resource handler again.
+   - `cumulativeAmount > watermark`: fresh charge.
+     `cumulativeAmount == watermark + PaymentRequirements.amount` and the
+     increment is at least `minVoucherDelta` when set.
+7. For a fresh charge, atomically advance the stored watermark, store the latest
+   voucher, serve the resource, and return `PAYMENT-RESPONSE` with
+   `transaction == ""`, `extra.commitmentId`, `extra.chargedAmount`, and
+   `extra.channelState`.
 
-- **Batched `settle`.** For each channel the operator builds
-  `[ed25519_verify(latest voucher), settle]` from the stored highest voucher and
-  packs as many channels into one transaction as fit (**transaction-size-bounded**
-  — a few per transaction today, more as the runtime allows). Any channel dropped
-  from a full batch MUST be logged (no silent truncation). `settle` advances
-  on-chain `SettlementWatermarks.settled` to the voucher's exact cumulative.
-- **`distribute`.** Sweep settled-but-unpaid funds to the `payee` and the
-  committed `distributionSplits`.
-- **`settle_and_finalize` + `distribute`** on a `refund` payload (or when
-  closing): settle the final voucher, pay out, refund `deposit − settled` to the
-  payer, and close the channel.
+On any failure, the server returns `402` without serving the resource. If the
+server has local channel state and the client submits the wrong cumulative
+amount, the server SHOULD return a corrective 402 with
+`accepts[].extra.channelState` and `accepts[].extra.voucherState`, following the
+EVM profile's recovery convention.
 
-The operator MUST settle before the forced-close `gracePeriodSeconds` elapses
-after a client requests close, or it forfeits the unsettled remainder. Because
-redemption is asynchronous, the operator SHOULD settle with a comfortable buffer
-ahead of that deadline, and SHOULD advertise a `gracePeriodSeconds` long enough
-to cover its batch cadence — consistent with the `expiresAt` window in §5
-Phase 3.
+### Phase 4 - Batched Redemption (out of band)
 
-## 6. Error codes
+The server or facilitator redeems accumulated vouchers asynchronously, outside
+the request path:
+
+- **Settle.** For each channel, build an Ed25519 precompile instruction for the
+  latest stored voucher followed by `settle`. Pack as many channels into one
+  transaction as the transaction size permits; do not silently drop channels
+  from a full batch. `settle` advances onchain `settled` to the voucher's exact
+  cumulative amount.
+- **Distribute while open.** Call `distribute` to pay the newly settled delta to
+  `payTo` and advance `payout_watermark`. The channel remains open.
+- **Cooperative close/refund.** For a `refund` payload or server-initiated
+  close, `receiverAuthorizer` signs `settle_and_seal` with the final voucher
+  (or no voucher for a zero-charge close), then `distribute` pays any remaining
+  settled delta, refunds `deposit - settled` to the payer, closes the escrow
+  token account, and moves the channel to its cleanup state.
+- **Rent cleanup.** If final `distribute` leaves the channel in `Distributed`,
+  anyone can later call `reclaim` after the open-slot window to return remaining
+  PDA rent to `rent_payer`.
+
+The server SHOULD redeem with enough buffer before `withdrawDelay` can elapse
+after a client starts forced close. If the payer calls `request_close`, the
+server can still `settle_and_seal` during the grace period. After the grace
+period, anyone can call `seal`; the payer can then recover unspent deposit via
+`withdraw_payer` or the sealed `distribute` refund branch, and vouchers not yet
+settled are forfeited by the server.
+
+## 6. Error Codes
 
 Standard x402 codes apply. Scheme-specific failures surface as `402` with an
 `errorReason`:
 
-- voucher signature invalid / signer ≠ `authorizedSigner`
-- voucher expired (`expiresAt ≤ now`)
-- non-monotonic cumulative (below the watermark)
-- cumulative exceeds the on-chain `deposit`
-- increment below `minVoucherDelta`
-- `open` transaction failed the SOL-drain guard (rejected before co-signing)
+- `invalid_batch_settlement_svm_voucher_signature` - signature invalid or signer
+  does not match channel `authorized_signer`.
+- `invalid_batch_settlement_svm_channel_id_mismatch` - `channelId` does not
+  match the canonical PDA derivation.
+- `invalid_batch_settlement_svm_receiver_authorizer_mismatch` - channel `payee`
+  does not match `extra.receiverAuthorizer`.
+- `invalid_batch_settlement_svm_withdraw_delay_mismatch` - channel grace period
+  does not match `extra.withdrawDelay`.
+- `invalid_batch_settlement_svm_cumulative_amount_mismatch` - corrective 402:
+  client's cumulative voucher does not match server state.
+- `invalid_batch_settlement_svm_cumulative_exceeds_deposit` - voucher exceeds
+  escrowed deposit.
+- `invalid_batch_settlement_svm_expiry_window_too_short` - voucher may expire
+  before redemption.
+- `invalid_batch_settlement_svm_setup_transaction` - setup transaction fails the
+  sponsor safety checks.
 
-## 7. Security properties
+## 7. Security Properties
 
-- **No overcharge.** Each voucher is capped on-chain by `deposit`; `settle` draws
-  the voucher's exact cumulative and can never exceed it.
-- **No redirection.** `channel.payee` / `distribution_hash` are fixed at `open`.
-- **No replay / no rollback.** Off-chain monotonic watermark plus on-chain
-  monotonic `SettlementWatermarks.settled`; an old voucher cannot settle after a
-  newer one.
-- **No fee-payer drain.** The operator validates the full compiled `open`
-  transaction before co-signing — allowed instruction set only, address-lookup
-  tables resolved, and the fee payer never used as an authority, source, or
-  writable account except to pay fees (§5 Phase 1).
-- **Time-bounded.** `expiresAt` is checked off-chain at acceptance and re-checked
-  on-chain at `settle`/`settleAndFinalize`. Because the **client** signs each
-  voucher (it is the `authorizedSigner`), `expiresAt` is a genuine client
-  commitment here — unlike `upto`, where the operator signs and the field is
-  operator-attested. Since redemption is asynchronous, the operator only accepts
-  vouchers whose `expiresAt` is `0` (no-expiry) or outlasts the settlement window
-  (§5 Phase 3), so an accepted voucher cannot expire before it is redeemed.
-- **Bounded loss.** The client trusts the operator to settle before grace; the
-  operator trusts the client only up to the escrowed `deposit`. Everything above
-  the deposit, the destination, and replay are enforced cryptographically /
-  on-chain.
+- **No overcharge.** Onchain `settle` rejects vouchers above `deposit` and sets
+  the exact cumulative amount signed by the client.
+- **No redirection.** `distribution_hash` is fixed at `open` and re-checked at
+  `distribute`; the derived distribution sends settled funds to `payTo`.
+- **Facilitator isolation.** `feePayer` sponsors fees/rent only. It is not
+  `payee` and not `authorized_signer`, so it cannot sign vouchers or
+  cooperative closes.
+- **Server-controlled close.** `receiverAuthorizer` is the channel `payee`, so a
+  hot server key can sign `settle_and_seal` while funds still route to cold
+  `payTo`.
+- **No replay / no rollback.** Server offchain watermark plus onchain
+  `settled` monotonicity reject old vouchers. Equality is accepted only as an
+  idempotent replay of a cached response.
+- **Client escape hatch.** `withdrawDelay` is fixed at `open`; if the server
+  does not settle, the payer can start forced close and recover unspent escrow
+  after the grace period.
+- **Time-bounded commitments.** Nonzero voucher `expiresAt` is checked both at
+  server acceptance and onchain redemption. `expiresAt == 0` means no voucher
+  expiry; in that case the channel's forced-close path bounds the commitment.
+- **Metering trust.** Each fresh request charges the advertised
+  `PaymentRequirements.amount`. The client trusts the server to return the
+  resource once the voucher is accepted; the server trusts itself to redeem
+  before voucher expiry or forced-close expiry.
 
-## 8. Out of scope (follow-ups)
+## 8. Out of Scope
 
-- Automatic background channel manager (settle/distribute cadence) and
-  forced-close watchdog (settle before grace elapses); durable `ChannelStore`.
-- Metered / dynamic per-request pricing below the advertised `amount` (needs the
-  commit round-trip; SVM `settle` draws the voucher's exact cumulative).
-- `secp256r1` / passkey delegated voucher signers.
+- Dynamic per-request pricing below `PaymentRequirements.amount`.
+- A durable background channel manager, redemption scheduler, and forced-close
+  watchdog.
+- Delegated passkey or secp256r1 voucher signers.

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_svm.md
@@ -1457,6 +1457,8 @@ Standard x402 codes apply. The facilitator reports verification failures in
   escrowed deposit.
 - `invalid_batch_settlement_svm_expiry_window_too_short` - voucher may expire
   before redemption.
+- `invalid_batch_settlement_svm_settlement_buffer` - `extra.settlementBufferSeconds`
+  is present and is not a positive integer.
 - `invalid_batch_settlement_svm_setup_transaction` - setup transaction fails the
   sponsor safety checks.
 - `invalid_batch_settlement_svm_settlement_simulation` - setup or


### PR DESCRIPTION
## Summary

- Adds the SVM profile for long-lived `batch-settlement` payment channels.
- Specifies deposit/top-up validation, cumulative vouchers, batched claim/distribution, replay handling, and lifecycle recovery.
- Makes payer-signed `request_close` the interoperable refund path: the facilitator sponsors initiation and finalizes after a 15-minute to 30-day grace period. Authenticated cooperative close remains an optional fast path.
- Aligns setup with the current SVM `upto` profile: protocol-default `authorization` flow, verified token-program binding, Memo/block-height hints, settlement-readiness checks, and post-confirmation state binding.

## Validation

- All 16 JSON examples parse.
- Local Markdown links resolve.
- `git diff --check upstream/main...HEAD`.

## Checklist

- [x] Commits are SSH-signed
- [x] Documentation-only change; no changelog fragment

