### PR TITLE
Make the facilitator's receiverAuthorizer optional in batch-settlement

### DIFF
--- a/examples/typescript/facilitator/batch-settlement/README.md
+++ b/examples/typescript/facilitator/batch-settlement/README.md
@@ -11,17 +11,19 @@ This example can use separate keys for relaying transactions and authorizing rec
 | Env var                               | Role                                                                       | Onchain effect                                                                                   |
 | ------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `EVM_PRIVATE_KEY`                     | **Relayer** — submits transactions                                         | Pays gas for `deposit` / `claimWithSignature` / `settle` / `refundWithSignature`                 |
-| `EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY` | **Receiver authorizer** — signs `ClaimBatch` and `Refund` EIP-712 messages | Address is committed into the channel identity for any server that delegates to this facilitator |
+| `EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY` | **Receiver authorizer** (optional) — signs `ClaimBatch` and `Refund` EIP-712 messages | When set, address is committed into the channel identity for any server that delegates to this facilitator |
 
-If `EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY` is omitted, the relayer key is reused for both roles. In production, keep them separate so the receiver-authorizer key (which controls how much gets claimed) can be rotated independently of the gas-paying hot wallet.
+If `EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY` is omitted, this example registers `BatchSettlementEvmScheme` without an authorizer signer: no `receiverAuthorizer` is advertised in `/supported`, and servers must supply their own claim/refund authorizer signatures. Set this key only when you want servers to delegate authorization to this facilitator; in production, keep it separate from the relayer so the authorizer key (which controls how much gets claimed) can be rotated independently of the gas-paying hot wallet.
 
-> The receiver-authorizer address is advertised under `kinds[].extra.receiverAuthorizer` in `GET /supported`. **Servers that delegate authorization to this facilitator bind that address into their channel config** — rotating the authorizer key requires opening new channels, so treat this address as long-lived.
+> When configured, the receiver-authorizer address is advertised under `kinds[].extra.receiverAuthorizer` in `GET /supported`. **Servers that delegate authorization to this facilitator bind that address into their channel config** — rotating the authorizer key requires opening new channels, so treat this address as long-lived.
+
+> ⚠️ A facilitator that advertises a `receiverAuthorizer` (so servers can delegate to it) MUST authenticate that each cooperative refund request originates from the service that created the channel (e.g. SIWX, JWT, or an API credential bound at channel creation). This example does **not** implement that check, so it is for local testing only. Leave `EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY` unset unless you are explicitly testing delegated authorization.
 
 ## Prerequisites
 
 - Node.js v20+, pnpm v10
 - Base Sepolia ETH on the **relayer** address (gas)
-- Optional: a separate funded address for the **authorizer** (no gas required if relayer is separate)
+- Optional: a separate **authorizer** key (`EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY`; no gas required)
 
 ## Setup
 
@@ -51,7 +53,7 @@ Standard x402 facilitator endpoints: `POST /verify`, `POST /settle`, `GET /suppo
 
 `/verify` and `/settle` always return the onchain channel snapshot (`balance`, `totalClaimed`, `withdrawRequestedAt`, `refundNonce`) in the `extra` field — the resource server mirrors these into its session state.
 
-`GET /supported` advertises the receiver authorizer address:
+`GET /supported` includes `extra.receiverAuthorizer` only when `EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY` is set:
 
 ```json
 {

--- a/examples/typescript/facilitator/batch-settlement/README.md
+++ b/examples/typescript/facilitator/batch-settlement/README.md
@@ -8,9 +8,9 @@ See the [scheme specification](../../../../specs/schemes/batch-settlement/scheme
 
 This example can use separate keys for relaying transactions and authorizing receiver actions:
 
-| Env var                               | Role                                                                       | Onchain effect                                                                                   |
-| ------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `EVM_PRIVATE_KEY`                     | **Relayer** — submits transactions                                         | Pays gas for `deposit` / `claimWithSignature` / `settle` / `refundWithSignature`                 |
+| Env var                               | Role                                                                                  | Onchain effect                                                                                             |
+| ------------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `EVM_PRIVATE_KEY`                     | **Relayer** — submits transactions                                                    | Pays gas for `deposit` / `claimWithSignature` / `settle` / `refundWithSignature`                           |
 | `EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY` | **Receiver authorizer** (optional) — signs `ClaimBatch` and `Refund` EIP-712 messages | When set, address is committed into the channel identity for any server that delegates to this facilitator |
 
 If `EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY` is omitted, this example registers `BatchSettlementEvmScheme` without an authorizer signer: no `receiverAuthorizer` is advertised in `/supported`, and servers must supply their own claim/refund authorizer signatures. Set this key only when you want servers to delegate authorization to this facilitator; in production, keep it separate from the relayer so the authorizer key (which controls how much gets claimed) can be rotated independently of the gas-paying hot wallet.

--- a/examples/typescript/facilitator/batch-settlement/index.ts
+++ b/examples/typescript/facilitator/batch-settlement/index.ts
@@ -26,10 +26,9 @@ if (!process.env.EVM_PRIVATE_KEY) {
 
 const evmRpcUrl = process.env.EVM_RPC_URL ?? "https://sepolia.base.org";
 
-// Treat unset or blank like Go's envOr: `.env` often has `KEY=` which is "" not undefined.
+// Treat unset or blank as not configured 
 const receiverAuthorizerPrivateKey =
-  process.env.EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY?.trim() ||
-  process.env.EVM_PRIVATE_KEY;
+  process.env.EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY?.trim();
 
 // Initialize the EVM account from private key (submits transactions)
 const evmAccount = privateKeyToAccount(
@@ -37,20 +36,29 @@ const evmAccount = privateKeyToAccount(
   { nonceManager },
 );
 
-// Dedicated receiverAuthorizer (signs ClaimBatch / Refund EIP-712 messages)
-const authorizerAccount = privateKeyToAccount(
-  receiverAuthorizerPrivateKey as `0x${string}`,
-);
-const authorizerSigner: AuthorizerSigner = {
-  address: authorizerAccount.address,
-  signTypedData: (params) =>
-    authorizerAccount.signTypedData(
-      params as Parameters<typeof authorizerAccount.signTypedData>[0],
-    ),
-};
+// Optional receiverAuthorizer (signs ClaimBatch / Refund EIP-712 messages)
+let authorizerSigner: AuthorizerSigner | undefined;
+if (receiverAuthorizerPrivateKey) {
+  const authorizerAccount = privateKeyToAccount(
+    receiverAuthorizerPrivateKey as `0x${string}`,
+  );
+  authorizerSigner = {
+    address: authorizerAccount.address,
+    signTypedData: (params) =>
+      authorizerAccount.signTypedData(
+        params as Parameters<typeof authorizerAccount.signTypedData>[0],
+      ),
+  };
+}
 
 console.info(`EVM Facilitator account: ${evmAccount.address}`);
-console.info(`EVM Receiver Authorizer: ${authorizerSigner.address}`);
+if (authorizerSigner) {
+  console.info(`EVM Receiver Authorizer: ${authorizerSigner.address}`);
+} else {
+  console.info(
+    "EVM Receiver Authorizer: not configured",
+  );
+}
 
 // Create a Viem client with both wallet and public capabilities
 const viemClient = createWalletClient({

--- a/examples/typescript/facilitator/batch-settlement/index.ts
+++ b/examples/typescript/facilitator/batch-settlement/index.ts
@@ -26,7 +26,7 @@ if (!process.env.EVM_PRIVATE_KEY) {
 
 const evmRpcUrl = process.env.EVM_RPC_URL ?? "https://sepolia.base.org";
 
-// Treat unset or blank as not configured 
+// Treat unset or blank as not configured
 const receiverAuthorizerPrivateKey =
   process.env.EVM_RECEIVER_AUTHORIZER_PRIVATE_KEY?.trim();
 
@@ -55,9 +55,7 @@ console.info(`EVM Facilitator account: ${evmAccount.address}`);
 if (authorizerSigner) {
   console.info(`EVM Receiver Authorizer: ${authorizerSigner.address}`);
 } else {
-  console.info(
-    "EVM Receiver Authorizer: not configured",
-  );
+  console.info("EVM Receiver Authorizer: not configured");
 }
 
 // Create a Viem client with both wallet and public capabilities

--- a/examples/typescript/servers/batch-settlement/index.ts
+++ b/examples/typescript/servers/batch-settlement/index.ts
@@ -1,7 +1,12 @@
 import { HTTPFacilitatorClient } from "@x402/core/server";
 import { BatchSettlementEvmScheme } from "@x402/evm/batch-settlement/server";
 import { FileChannelStorage } from "@x402/evm/batch-settlement/server/file-storage";
-import { paymentMiddleware, setSettlementOverrides, x402ResourceServer } from "@x402/express";
+import {
+  paymentMiddlewareFromHTTPServer,
+  setSettlementOverrides,
+  x402HTTPResourceServer,
+  x402ResourceServer,
+} from "@x402/express";
 import { config } from "dotenv";
 import express from "express";
 import { privateKeyToAccount } from "viem/accounts";
@@ -74,42 +79,50 @@ const app = express();
 // Authorize up to this amount per request; optional usage-based override below bills actual usage.
 const maxPrice = "$0.01";
 
-app.use(
-  paymentMiddleware(
-    {
-      "GET /weather": {
-        accepts: {
-          scheme: "batch-settlement",
-          price: maxPrice,
-          network: NETWORK,
-          payTo: evmAddress,
-        },
-        description: "Weather data",
-        mimeType: "application/json",
-      },
+const httpServer = new x402HTTPResourceServer(resourceServer, {
+  "GET /weather": {
+    accepts: {
+      scheme: "batch-settlement",
+      price: maxPrice,
+      network: NETWORK,
+      payTo: evmAddress,
     },
-    resourceServer,
-  ),
-);
-
-app.get("/weather", (req, res) => {
-  const chargedPercent = 1 + Math.floor(Math.random() * 100);
-  setSettlementOverrides(res, { amount: `${chargedPercent}%` });
-
-  res.send({
-    report: {
-      weather: "sunny",
-      temperature: 70,
-    },
-  });
+    description: "Weather data",
+    mimeType: "application/json",
+  },
 });
 
-app.listen(4021, () => {
-  console.log("Batch-settlement server listening at http://localhost:4021");
-  console.log("  GET /weather");
-  if (receiverAuthorizerSigner) {
-    console.log(`  Receiver authorizer: local signer ${receiverAuthorizerSigner.address}`);
-  } else {
-    console.log("  Receiver authorizer: facilitator");
-  }
+async function main() {
+  // Fail fast on misconfiguration: this throws the capability error (and any
+  // HTTP route validation error) before the server starts accepting requests.
+  await httpServer.initialize();
+
+  app.use(paymentMiddlewareFromHTTPServer(httpServer, undefined, undefined, false));
+
+  app.get("/weather", (req, res) => {
+    const chargedPercent = 1 + Math.floor(Math.random() * 100);
+    setSettlementOverrides(res, { amount: `${chargedPercent}%` });
+
+    res.send({
+      report: {
+        weather: "sunny",
+        temperature: 70,
+      },
+    });
+  });
+
+  app.listen(4021, () => {
+    console.log("Batch-settlement server listening at http://localhost:4021");
+    console.log("  GET /weather");
+    if (receiverAuthorizerSigner) {
+      console.log(`  Receiver authorizer: local signer ${receiverAuthorizerSigner.address}`);
+    } else {
+      console.log("  Receiver authorizer: facilitator");
+    }
+  });
+}
+
+main().catch(err => {
+  console.error("Startup failed:", err);
+  process.exit(1);
 });

--- a/examples/typescript/servers/batch-settlement/index.ts
+++ b/examples/typescript/servers/batch-settlement/index.ts
@@ -92,6 +92,9 @@ const httpServer = new x402HTTPResourceServer(resourceServer, {
   },
 });
 
+/**
+ * Initializes facilitator capability checks and starts the batch-settlement server.
+ */
 async function main() {
   // Fail fast on misconfiguration: this throws the capability error (and any
   // HTTP route validation error) before the server starts accepting requests.

--- a/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
+++ b/specs/schemes/batch-settlement/scheme_batch_settlement_evm.md
@@ -459,7 +459,7 @@ Example facilitator response for a refund:
 
 ### GET /supported
 
-The facilitator declares a receiver authorizer whose role is to produce EIP-712 signatures for claims and refunds. The server may delegate to this address as its channel's `receiverAuthorizer`, or supply its own. Any address in `signers` may relay the resulting transactions.
+The facilitator MAY declare a receiver authorizer whose role is to produce EIP-712 signatures for claims and refunds. The server may delegate to this address as its channel's `receiverAuthorizer`, or supply its own. Any address in `signers` may relay the resulting transactions.
 
 ```json
 {
@@ -659,6 +659,8 @@ The recovery baseline is:
 3. **Cross-function replay prevention**: `Voucher`, `Refund`, and `ClaimBatch` use distinct EIP-712 type hashes so a signature for one cannot be replayed as another. Refunds additionally carry a per-channel nonce.
 
 4. **Voucher expiry via escrow depletion**: Vouchers carry no expiry field. A voucher remains claimable as long as `balance - totalClaimed > 0`; `finalizeWithdraw` and `refundWithSignature` close the claim window by draining available escrow. The ERC-3009 `validBefore`/`validAfter` fields bound only the deposit authorization, not the voucher.
+
+5. **Refund authorization when the facilitator is `receiverAuthorizer`**: A cooperative refund bypasses the timed-withdrawal delay, so it must carry receiver-side consent. When a server supplies its own `refundAuthorizerSignature` that signature is the consent. When the server delegates `receiverAuthorizer` to the facilitator, the faciltator MUST authenticate that each `refund` request originates from the service that created the channel (e.g. SIWX, JWT, or API credential bound at channel-creation time) and reject all others. A facilitator with no such authentication mechanism MUST NOT advertise a `receiverAuthorizer` in `/supported`.
 
 ---
 

--- a/typescript/.changeset/brown-mails-stop.md
+++ b/typescript/.changeset/brown-mails-stop.md
@@ -1,0 +1,5 @@
+---
+'@x402/evm': minor
+---
+
+Declares `receiverAuthorizer` in facilitator supported as optional. If a facilitator opts in to provide `receiverAuthorizer`, servers may delegate to it. Otherwise, they must provide their own.

--- a/typescript/.changeset/validate-facilitator-support-hook.md
+++ b/typescript/.changeset/validate-facilitator-support-hook.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": minor
+---
+
+Added an optional `validateFacilitatorSupport` hook to `SchemeNetworkServer` and wired it into `x402ResourceServer.initialize()`. After supported kinds are loaded, each registered scheme that the facilitator actually supports is asked to validate the advertised capabilities against its own configuration; any reported problems are aggregated and thrown so misconfigurations fail fast at server startup, not just on the first protected request.

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -612,53 +612,17 @@ export class x402ResourceServer {
     if (this.supportedResponsesMap.size === 0) {
       throw lastError
         ? new Error(
-          "Failed to initialize: no supported payment kinds loaded from any facilitator.",
-          {
-            cause: lastError,
-          },
-        )
+            "Failed to initialize: no supported payment kinds loaded from any facilitator.",
+            {
+              cause: lastError,
+            },
+          )
         : new Error(
-          "Failed to initialize: no supported payment kinds loaded from any facilitator.",
-        );
+            "Failed to initialize: no supported payment kinds loaded from any facilitator.",
+          );
     }
 
     this.validateFacilitatorCapabilities();
-  }
-
-  /**
-   * Validates that each registered scheme's configuration is compatible with the
-   * facilitator capabilities advertised for the scheme/network combinations it
-   * supports. Only schemes the facilitator actually supports are validated.
-   *
-   * @throws Error listing every capability problem when one or more schemes report one.
-   */
-  private validateFacilitatorCapabilities(): void {
-    const configErrors: string[] = [];
-
-    for (const [network, schemeMap] of this.registeredServerSchemes) {
-      for (const [scheme, server] of schemeMap) {
-        if (!server.validateFacilitatorSupport) continue;
-
-        for (const x402Version of this.supportedResponsesMap.keys()) {
-          const supportedKind = this.getSupportedKind(x402Version, network as Network, scheme);
-          if (!supportedKind) continue;
-
-          const extensions = this.getFacilitatorExtensions(x402Version, network as Network, scheme);
-          const problem = server.validateFacilitatorSupport(
-            network as Network,
-            supportedKind,
-            extensions,
-          );
-          if (problem) configErrors.push(`${scheme} on ${network}: ${problem}`);
-        }
-      }
-    }
-
-    if (configErrors.length > 0) {
-      throw new Error(
-        `x402 facilitator capability errors:\n${configErrors.map(e => `  - ${e}`).join("\n")}`,
-      );
-    }
   }
 
   /**
@@ -739,7 +703,7 @@ export class x402ResourceServer {
     if (!supportedKind) {
       throw new Error(
         `Facilitator does not support ${SchemeNetworkServer.scheme} on ${resourceConfig.network}. ` +
-        `Make sure to call initialize() to fetch supported kinds from facilitators.`,
+          `Make sure to call initialize() to fetch supported kinds from facilitators.`,
       );
     }
 
@@ -1373,6 +1337,42 @@ export class x402ResourceServer {
         throw new Error(
           `Unsupported x402 version: ${(paymentPayload as PaymentPayload).x402Version}`,
         );
+    }
+  }
+
+  /**
+   * Validates that each registered scheme's configuration is compatible with the
+   * facilitator capabilities advertised for the scheme/network combinations it
+   * supports. Only schemes the facilitator actually supports are validated.
+   *
+   * @throws Error listing every capability problem when one or more schemes report one.
+   */
+  private validateFacilitatorCapabilities(): void {
+    const configErrors: string[] = [];
+
+    for (const [network, schemeMap] of this.registeredServerSchemes) {
+      for (const [scheme, server] of schemeMap) {
+        if (!server.validateFacilitatorSupport) continue;
+
+        for (const x402Version of this.supportedResponsesMap.keys()) {
+          const supportedKind = this.getSupportedKind(x402Version, network as Network, scheme);
+          if (!supportedKind) continue;
+
+          const extensions = this.getFacilitatorExtensions(x402Version, network as Network, scheme);
+          const problem = server.validateFacilitatorSupport(
+            network as Network,
+            supportedKind,
+            extensions,
+          );
+          if (problem) configErrors.push(`${scheme} on ${network}: ${problem}`);
+        }
+      }
+    }
+
+    if (configErrors.length > 0) {
+      throw new Error(
+        `x402 facilitator capability errors:\n${configErrors.map(e => `  - ${e}`).join("\n")}`,
+      );
     }
   }
 

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -612,14 +612,52 @@ export class x402ResourceServer {
     if (this.supportedResponsesMap.size === 0) {
       throw lastError
         ? new Error(
-            "Failed to initialize: no supported payment kinds loaded from any facilitator.",
-            {
-              cause: lastError,
-            },
-          )
+          "Failed to initialize: no supported payment kinds loaded from any facilitator.",
+          {
+            cause: lastError,
+          },
+        )
         : new Error(
-            "Failed to initialize: no supported payment kinds loaded from any facilitator.",
+          "Failed to initialize: no supported payment kinds loaded from any facilitator.",
+        );
+    }
+
+    this.validateFacilitatorCapabilities();
+  }
+
+  /**
+   * Validates that each registered scheme's configuration is compatible with the
+   * facilitator capabilities advertised for the scheme/network combinations it
+   * supports. Only schemes the facilitator actually supports are validated.
+   *
+   * @throws Error listing every capability problem when one or more schemes report one.
+   */
+  private validateFacilitatorCapabilities(): void {
+    const configErrors: string[] = [];
+
+    for (const [network, schemeMap] of this.registeredServerSchemes) {
+      for (const [scheme, server] of schemeMap) {
+        if (!server.validateFacilitatorSupport) continue;
+
+        for (const x402Version of this.supportedResponsesMap.keys()) {
+          const supportedKind = this.getSupportedKind(x402Version, network as Network, scheme);
+          if (!supportedKind) continue;
+
+          const extensions = this.getFacilitatorExtensions(x402Version, network as Network, scheme);
+          const problem = server.validateFacilitatorSupport(
+            network as Network,
+            supportedKind,
+            extensions,
           );
+          if (problem) configErrors.push(`${scheme} on ${network}: ${problem}`);
+        }
+      }
+    }
+
+    if (configErrors.length > 0) {
+      throw new Error(
+        `x402 facilitator capability errors:\n${configErrors.map(e => `  - ${e}`).join("\n")}`,
+      );
     }
   }
 
@@ -701,7 +739,7 @@ export class x402ResourceServer {
     if (!supportedKind) {
       throw new Error(
         `Facilitator does not support ${SchemeNetworkServer.scheme} on ${resourceConfig.network}. ` +
-          `Make sure to call initialize() to fetch supported kinds from facilitators.`,
+        `Make sure to call initialize() to fetch supported kinds from facilitators.`,
       );
     }
 

--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -236,4 +236,21 @@ export interface SchemeNetworkServer {
     supportedKind: SupportedKind,
     facilitatorExtensions: string[],
   ): Promise<PaymentRequirements>;
+
+  /**
+   * Optional: validate that the facilitator's advertised capabilities for this
+   * scheme/network are sufficient given the scheme's own configuration. Invoked
+   * during initialize(), only when the facilitator supports the scheme.
+   *
+   * @param network - The network identifier being validated
+   * @param supportedKind - The facilitator's advertised kind for this scheme/network
+   * @param facilitatorExtensions - Extensions advertised by the facilitator
+   * @returns A human-readable problem message when the configuration cannot be
+   *   fulfilled, or void/undefined when valid.
+   */
+  validateFacilitatorSupport?(
+    network: Network,
+    supportedKind: SupportedKind,
+    facilitatorExtensions: string[],
+  ): string | void;
 }

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -316,6 +316,61 @@ describe("x402ResourceServer", () => {
     });
   });
 
+  describe("initialize - validateFacilitatorSupport", () => {
+    class ValidatingScheme extends MockSchemeNetworkServer {
+      public validateCalls = 0;
+      private problem: string | undefined;
+
+      constructor(scheme: string, problem: string | undefined) {
+        super(scheme);
+        this.problem = problem;
+      }
+
+      validateFacilitatorSupport(): string | void {
+        this.validateCalls++;
+        return this.problem;
+      }
+    }
+
+    /**
+     * Builds a facilitator advertising the `exact` scheme on Base.
+     *
+     * @returns Mock facilitator client supporting `exact` on `eip155:8453`.
+     */
+    function buildExactFacilitator(): MockFacilitatorClient {
+      return new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+      );
+    }
+
+    it("rejects when a registered scheme reports a capability problem", async () => {
+      const server = new x402ResourceServer(buildExactFacilitator());
+      server.register("eip155:8453" as Network, new ValidatingScheme("exact", "needs a signer"));
+
+      await expect(server.initialize()).rejects.toThrow(/exact on eip155:8453: needs a signer/);
+    });
+
+    it("resolves when the hook returns void", async () => {
+      const server = new x402ResourceServer(buildExactFacilitator());
+      const scheme = new ValidatingScheme("exact", undefined);
+      server.register("eip155:8453" as Network, scheme);
+
+      await expect(server.initialize()).resolves.not.toThrow();
+      expect(scheme.validateCalls).toBe(1);
+    });
+
+    it("skips the hook when the facilitator does not support the scheme/network", async () => {
+      const server = new x402ResourceServer(buildExactFacilitator());
+      const scheme = new ValidatingScheme("unsupported", "should not be reported");
+      server.register("eip155:8453" as Network, scheme);
+
+      await expect(server.initialize()).resolves.not.toThrow();
+      expect(scheme.validateCalls).toBe(0);
+    });
+  });
+
   describe("buildPaymentRequirements", () => {
     it("should build requirements from ResourceConfig", async () => {
       const mockClient = new MockFacilitatorClient(

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/README.md
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/README.md
@@ -185,7 +185,9 @@ const facilitator = new x402Facilitator().register(
 );
 ```
 
-The `authorizerSigner` produces the EIP-712 signatures advertised in `/supported.kinds[].extra.receiverAuthorizer`. Servers may delegate to it (see above) or supply their own. The `evmSigner` (the wallet account) submits transactions for `deposit`, `claimWithSignature`, `settle`, and `refundWithSignature` — anyone can submit a valid claim/refund tx, but only the configured signer here will be used by this facilitator.
+The optional `authorizerSigner` produces the EIP-712 signatures advertised in `/supported.kinds[].extra.receiverAuthorizer`. Servers may delegate to it (see above) or supply their own. The `evmSigner` (the wallet account) submits transactions for `deposit`, `claimWithSignature`, `settle`, and `refundWithSignature` — anyone can submit a valid claim/refund tx, but only the configured signer here will be used by this facilitator.
+
+A facilitator that advertises a `receiverAuthorizer` (so servers can delegate to it) must authenticate that each cooperative refund request originates from the service that created the channel (e.g. SIWX, JWT, or an API credential bound at channel-creation time). If the facilitator has no such authentication mechanism, omit `authorizerSigner` so no `receiverAuthorizer` is advertised in `/supported`; servers then supply their own authorizer signatures for claims and refunds.
 
 ## Supported Networks
 

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/errors.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/errors.ts
@@ -34,6 +34,7 @@ export const ErrReceiverAuthorizerMismatch =
 export const ErrWithdrawDelayMismatch = "invalid_batch_settlement_evm_withdraw_delay_mismatch";
 export const ErrAuthorizerAddressMismatch =
   "invalid_batch_settlement_evm_authorizer_address_mismatch";
+export const ErrAuthorizerNotConfigured = "invalid_batch_settlement_evm_authorizer_not_configured";
 export const ErrDepositSimulationFailed = "invalid_batch_settlement_evm_deposit_simulation_failed";
 
 // ERC-6492 counterfactual deployment errors (ERC-3009 deposit path). Wire values keep the

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/claim.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/claim.ts
@@ -37,7 +37,8 @@ export function buildVoucherClaimArgs(claims: BatchSettlementClaimPayload["claim
  * @param signer - Facilitator signer used to submit the claim transaction.
  * @param payload - Claim payload containing voucher claims and optional authorizer signature.
  * @param requirements - Payment requirements for network identification.
- * @param authorizerSigner - Dedicated key for producing `ClaimBatch` EIP-712 signatures.
+ * @param authorizerSigner - Optional dedicated key for producing `ClaimBatch` EIP-712 signatures.
+ *   When omitted, the payload must already carry a `claimAuthorizerSignature`.
  * @param dataSuffix - Optional hex suffix appended to the claim transaction.
  * @returns A {@link SettleResponse} with the transaction hash on success.
  */
@@ -45,7 +46,7 @@ export async function executeClaimWithSignature(
   signer: FacilitatorEvmSigner,
   payload: BatchSettlementClaimPayload,
   requirements: PaymentRequirements,
-  authorizerSigner: AuthorizerSigner,
+  authorizerSigner: AuthorizerSigner | undefined,
   dataSuffix?: `0x${string}`,
 ): Promise<SettleResponse> {
   const network = requirements.network;
@@ -54,6 +55,14 @@ export async function executeClaimWithSignature(
   let sig = payload.claimAuthorizerSignature;
 
   if (!sig) {
+    if (!authorizerSigner) {
+      return {
+        success: false,
+        errorReason: Errors.ErrAuthorizerNotConfigured,
+        transaction: "",
+        network,
+      };
+    }
     for (const claim of payload.claims) {
       if (
         getAddress(claim.voucher.channel.receiverAuthorizer) !==

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/refund.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/refund.ts
@@ -187,7 +187,8 @@ function buildRefundExtraFromPostState(
  * @param signer - Facilitator signer used to submit the onchain transactions.
  * @param payload - Refund payload with optional signatures, amount, and nonce.
  * @param requirements - Payment requirements for network identification.
- * @param authorizerSigner - Dedicated key for producing EIP-712 signatures.
+ * @param authorizerSigner - Optional dedicated key for producing EIP-712 signatures.
+ *   When omitted, the payload must already carry the required authorizer signatures.
  * @param dataSuffix - Optional hex suffix appended to the refund transaction.
  * @returns A {@link SettleResponse} with the transaction hash on success.
  */
@@ -195,7 +196,7 @@ export async function executeRefundWithSignature(
   signer: FacilitatorEvmSigner,
   payload: BatchSettlementEnrichedRefundPayload,
   requirements: PaymentRequirements,
-  authorizerSigner: AuthorizerSigner,
+  authorizerSigner: AuthorizerSigner | undefined,
   dataSuffix?: `0x${string}`,
 ): Promise<SettleResponse> {
   const network = requirements.network;
@@ -217,10 +218,21 @@ export async function executeRefundWithSignature(
     }
 
     const hasClientSig = payload.refundAuthorizerSignature !== undefined;
-    const authorizerMismatch =
-      getAddress(payload.channelConfig.receiverAuthorizer) !== getAddress(authorizerSigner.address);
 
-    if (!hasClientSig && authorizerMismatch) {
+    if (!hasClientSig && !authorizerSigner) {
+      return {
+        success: false,
+        errorReason: Errors.ErrAuthorizerNotConfigured,
+        transaction: "",
+        network,
+      };
+    }
+
+    if (
+      !hasClientSig &&
+      authorizerSigner &&
+      getAddress(payload.channelConfig.receiverAuthorizer) !== getAddress(authorizerSigner.address)
+    ) {
       return {
         success: false,
         errorReason: Errors.ErrAuthorizerAddressMismatch,
@@ -231,7 +243,13 @@ export async function executeRefundWithSignature(
 
     const refundSig =
       payload.refundAuthorizerSignature ??
-      (await signRefund(authorizerSigner, channelId, payload.amount, payload.refundNonce, network));
+      (await signRefund(
+        authorizerSigner!,
+        channelId,
+        payload.amount,
+        payload.refundNonce,
+        network,
+      ));
 
     const refundCalldata = encodeFunctionData({
       abi: batchSettlementABI,
@@ -249,6 +267,14 @@ export async function executeRefundWithSignature(
     if (payload.claims.length > 0) {
       let claimSig = payload.claimAuthorizerSignature;
       if (!claimSig) {
+        if (!authorizerSigner) {
+          return {
+            success: false,
+            errorReason: Errors.ErrAuthorizerNotConfigured,
+            transaction: "",
+            network,
+          };
+        }
         claimSig = await signClaimBatch(authorizerSigner, payload.claims, network);
       }
 

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/scheme.ts
@@ -51,13 +51,19 @@ export class BatchSettlementEvmScheme implements SchemeNetworkFacilitator {
   /**
    * Creates a facilitator scheme for verifying and settling batch-settlement payments.
    *
-   * @param signer - Facilitator EVM signer used for tx submission and onchain reads.
-   * @param authorizerSigner - Dedicated key for `claimWithSignature` / `refundWithSignature`.
+   * @param signer - Facilitator EVM signer(s) used for tx submission and onchain reads.
+   * @param authorizerSigner - Optional dedicated key that provides EIP-712 signatures for
+   *   `claimWithSignature` / `refundWithSignature`. When provided, the facilitator advertises
+   *   its address as `receiverAuthorizer` in `/supported` and signs missing authorizer
+   *   signatures using this key when the server omits them. A facilitator that advertises a
+   *   `receiverAuthorizer` for servers to delegate to must authenticate refund requests (see the
+   *   spec); when no such mechanism exists, omit this signer so no `receiverAuthorizer` is
+   *   advertised and servers supply their own signatures.
    * @param config - Optional configuration (e.g. ERC-6492 factory allowlist).
    */
   constructor(
     private readonly signer: FacilitatorEvmSigner,
-    private readonly authorizerSigner: AuthorizerSigner,
+    private readonly authorizerSigner?: AuthorizerSigner,
     config?: BatchSettlementEvmSchemeConfig,
   ) {
     this.config = {
@@ -69,12 +75,16 @@ export class BatchSettlementEvmScheme implements SchemeNetworkFacilitator {
    * Returns facilitator-specific extra fields to be merged into payment requirements.
    *
    * Exposes the configured `receiverAuthorizer` address so the server and client can
-   * embed it in `ChannelConfig`.
+   * embed it in `ChannelConfig`. Returns `undefined` when no authorizer signer is
+   * configured, signalling that servers must supply their own authorizer signatures.
    *
    * @param _ - Network identifier (unused).
-   * @returns Extra fields containing `receiverAuthorizer`.
+   * @returns Extra fields containing `receiverAuthorizer`, or `undefined`.
    */
   getExtra(_: string): { receiverAuthorizer: `0x${string}` } | undefined {
+    if (!this.authorizerSigner) {
+      return undefined;
+    }
     return { receiverAuthorizer: this.authorizerSigner.address };
   }
 

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/server/scheme.ts
@@ -308,17 +308,17 @@ export class BatchSettlementEvmScheme implements SchemeNetworkServer {
 
   /**
    * Fails server startup when this scheme delegates the receiver-authorizer role
-   * but the facilitator does not advertise a usable `receiverAuthorizer`. 
+   * but the facilitator does not advertise a usable `receiverAuthorizer`.
    *
    * @param network - The network identifier being validated.
    * @param supportedKind - The facilitator's advertised kind for this scheme/network.
-   * @param _facilitatorExtensions - Extensions advertised by the facilitator (unused).
+   * @param _ - Extensions advertised by the facilitator (unused).
    * @returns A problem message when delegation is impossible, or void when valid.
    */
   validateFacilitatorSupport(
     network: Network,
     supportedKind: SupportedKind,
-    _facilitatorExtensions: string[],
+    _: string[],
   ): string | void {
     if (this.receiverAuthorizerSigner) return;
 

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/server/scheme.ts
@@ -7,6 +7,7 @@ import {
   SchemeNetworkServer,
   SchemeServerHooks,
   MoneyParser,
+  SupportedKind,
 } from "@x402/core/types";
 import type { DeepReadonly } from "@x402/core/types";
 import type { SettleContext, SettleResultContext } from "@x402/core/server";
@@ -303,6 +304,36 @@ export class BatchSettlementEvmScheme implements SchemeNetworkServer {
           paymentRequirements.extra?.assetTransferMethod ?? assetInfo.assetTransferMethod,
       },
     };
+  }
+
+  /**
+   * Fails server startup when this scheme delegates the receiver-authorizer role
+   * but the facilitator does not advertise a usable `receiverAuthorizer`. 
+   *
+   * @param network - The network identifier being validated.
+   * @param supportedKind - The facilitator's advertised kind for this scheme/network.
+   * @param _facilitatorExtensions - Extensions advertised by the facilitator (unused).
+   * @returns A problem message when delegation is impossible, or void when valid.
+   */
+  validateFacilitatorSupport(
+    network: Network,
+    supportedKind: SupportedKind,
+    _facilitatorExtensions: string[],
+  ): string | void {
+    if (this.receiverAuthorizerSigner) return;
+
+    const advertised = supportedKind.extra?.receiverAuthorizer;
+    const hasValid =
+      typeof advertised === "string" &&
+      getAddress(advertised) !== "0x0000000000000000000000000000000000000000";
+
+    if (!hasValid) {
+      return (
+        `no receiverAuthorizerSigner is configured and the facilitator does not advertise a ` +
+        `receiverAuthorizer on ${network}. Configure a receiverAuthorizerSigner or use a ` +
+        `facilitator that advertises one.`
+      );
+    }
   }
 
   /**

--- a/typescript/packages/mechanisms/evm/test/unit/batch-settlement/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/batch-settlement/facilitator.test.ts
@@ -199,6 +199,11 @@ describe("BatchSettlementEvmScheme (Facilitator) — construction & metadata", (
     expect(scheme.getExtra(NETWORK)).toEqual({ receiverAuthorizer: authorizer.address });
   });
 
+  it("getExtra returns undefined when no authorizerSigner is configured", () => {
+    const scheme = new BatchSettlementEvmScheme(buildSigner());
+    expect(scheme.getExtra(NETWORK)).toBeUndefined();
+  });
+
   it("getSigners returns the facilitator addresses", () => {
     const scheme = new BatchSettlementEvmScheme(buildSigner(), authorizer);
     expect(scheme.getSigners(NETWORK)).toEqual([FACILITATOR_ADDRESS]);
@@ -1215,6 +1220,121 @@ describe("BatchSettlementEvmScheme (Facilitator) — settle routing", () => {
     );
     expect(result.success).toBe(false);
     expect(result.errorReason).toBe(Errors.ErrSettleTransactionFailed);
+  });
+});
+
+describe("BatchSettlementEvmScheme (Facilitator) — no authorizer configured", () => {
+  it("returns AuthorizerNotConfigured for a claim without a client signature", async () => {
+    const signer = buildSigner();
+    const scheme = new BatchSettlementEvmScheme(signer);
+    const config = buildChannelConfig();
+    const cp: BatchSettlementClaimPayload = {
+      type: "claim",
+      claims: [
+        {
+          voucher: { channel: config, maxClaimableAmount: "1000" },
+          signature: "0xcafe",
+          totalClaimed: "1000",
+        },
+      ],
+    };
+
+    const result = await scheme.settle(
+      envelopeSettle(cp as unknown as Record<string, unknown>),
+      makeRequirements(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(Errors.ErrAuthorizerNotConfigured);
+    expect(signer.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("submits a claim that carries a server-supplied authorizer signature", async () => {
+    const signer = buildSigner();
+    const scheme = new BatchSettlementEvmScheme(signer);
+    const config = buildChannelConfig();
+    const cp: BatchSettlementClaimPayload = {
+      type: "claim",
+      claimAuthorizerSignature: "0xserversig" as `0x${string}`,
+      claims: [
+        {
+          voucher: { channel: config, maxClaimableAmount: "1000" },
+          signature: "0xcafe",
+          totalClaimed: "1000",
+        },
+      ],
+    };
+
+    const result = await scheme.settle(
+      envelopeSettle(cp as unknown as Record<string, unknown>),
+      makeRequirements(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(signer.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: "claimWithSignature" }),
+    );
+  });
+
+  it("returns AuthorizerNotConfigured for a refund without a client signature", async () => {
+    const signer = buildSigner();
+    mockedMulticall.mockResolvedValue([
+      { status: "success", result: [10000n, 0n] },
+      { status: "success", result: [0n, 0n] },
+      { status: "success", result: 0n },
+    ]);
+    const scheme = new BatchSettlementEvmScheme(signer);
+    const config = buildChannelConfig();
+    const channelId = computeChannelId(config);
+    const rp: BatchSettlementEnrichedRefundPayload = {
+      type: "refund",
+      channelConfig: config,
+      voucher: { channelId, maxClaimableAmount: "0", signature: "0xdead" },
+      amount: "9000",
+      refundNonce: "0",
+      claims: [],
+    };
+
+    const result = await scheme.settle(
+      envelopeSettle(rp as unknown as Record<string, unknown>),
+      makeRequirements(),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(Errors.ErrAuthorizerNotConfigured);
+    expect(signer.writeContract).not.toHaveBeenCalled();
+  });
+
+  it("submits a refund that carries a server-supplied authorizer signature", async () => {
+    const signer = buildSigner();
+    mockedMulticall.mockResolvedValue([
+      { status: "success", result: [10000n, 0n] },
+      { status: "success", result: [0n, 0n] },
+      { status: "success", result: 0n },
+    ]);
+    const scheme = new BatchSettlementEvmScheme(signer);
+    const config = buildChannelConfig();
+    const channelId = computeChannelId(config);
+    const rp: BatchSettlementEnrichedRefundPayload = {
+      type: "refund",
+      channelConfig: config,
+      voucher: { channelId, maxClaimableAmount: "0", signature: "0xdead" },
+      amount: "9000",
+      refundNonce: "0",
+      refundAuthorizerSignature: "0xserversig" as `0x${string}`,
+      claims: [],
+    };
+
+    const result = await scheme.settle(
+      envelopeSettle(rp as unknown as Record<string, unknown>),
+      makeRequirements(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.amount).toBe("9000");
+    expect(signer.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: "refundWithSignature" }),
+    );
   });
 });
 

--- a/typescript/packages/mechanisms/evm/test/unit/batch-settlement/server.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/batch-settlement/server.test.ts
@@ -396,6 +396,47 @@ describe("BatchSettlementEvmScheme — enhancePaymentRequirements", () => {
   });
 });
 
+describe("BatchSettlementEvmScheme — validateFacilitatorSupport", () => {
+  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+  function supportedKind(extra?: Record<string, unknown>) {
+    return { x402Version: 2, scheme: "batch-settlement", network: NETWORK, extra };
+  }
+
+  it("returns a problem when no signer and the facilitator advertises no receiverAuthorizer", () => {
+    const server = new BatchSettlementEvmScheme(RECEIVER);
+    const problem = server.validateFacilitatorSupport(NETWORK, supportedKind(), []);
+    expect(problem).toMatch(/receiverAuthorizer/);
+  });
+
+  it("returns a problem when no signer and the facilitator advertises a zero receiverAuthorizer", () => {
+    const server = new BatchSettlementEvmScheme(RECEIVER);
+    const problem = server.validateFacilitatorSupport(
+      NETWORK,
+      supportedKind({ receiverAuthorizer: ZERO_ADDRESS }),
+      [],
+    );
+    expect(problem).toMatch(/receiverAuthorizer/);
+  });
+
+  it("returns void when the server has its own receiver-authorizer signer", () => {
+    const server = new BatchSettlementEvmScheme(RECEIVER, {
+      receiverAuthorizerSigner: buildAuthorizerSigner(),
+    });
+    expect(server.validateFacilitatorSupport(NETWORK, supportedKind(), [])).toBeUndefined();
+  });
+
+  it("returns void when the facilitator advertises a valid receiverAuthorizer", () => {
+    const server = new BatchSettlementEvmScheme(RECEIVER);
+    const problem = server.validateFacilitatorSupport(
+      NETWORK,
+      supportedKind({ receiverAuthorizer: RECEIVER_AUTHORIZER }),
+      [],
+    );
+    expect(problem).toBeUndefined();
+  });
+});
+
 describe("BatchSettlementEvmScheme — onBeforeVerify", () => {
   let server: BatchSettlementEvmScheme;
   let storage: InMemoryChannelStorage;

--- a/typescript/site/app/facilitator/index.ts
+++ b/typescript/site/app/facilitator/index.ts
@@ -6,7 +6,7 @@ import { toFacilitatorAptosSigner } from "@x402/aptos";
 import { ExactAptosScheme } from "@x402/aptos/exact/facilitator";
 import { x402Facilitator } from "@x402/core/facilitator";
 import { Network } from "@x402/core/types";
-import { type AuthorizerSigner, toFacilitatorEvmSigner } from "@x402/evm";
+import { toFacilitatorEvmSigner } from "@x402/evm";
 import { BatchSettlementEvmScheme } from "@x402/evm/batch-settlement/facilitator";
 import { ExactEvmScheme } from "@x402/evm/exact/facilitator";
 import { ExactEvmSchemeV1 } from "@x402/evm/exact/v1/facilitator";
@@ -107,12 +107,6 @@ async function createFacilitator(): Promise<x402Facilitator> {
     getCode: (args: { address: `0x${string}` }) => viemClient.getCode(args),
   });
 
-  const receiverAuthorizerSigner: AuthorizerSigner = {
-    address: evmAccount.address,
-    signTypedData: params =>
-      evmAccount.signTypedData(params as Parameters<typeof evmAccount.signTypedData>[0]),
-  };
-
   // Initialize the SVM account from private key
   const svmAccount = await createKeyPairSignerFromBytes(
     base58.decode(process.env.FACILITATOR_SVM_PRIVATE_KEY as string),
@@ -136,7 +130,7 @@ async function createFacilitator(): Promise<x402Facilitator> {
       new ExactEvmSchemeV1(evmSigner, { eip6492AllowedFactories }),
     )
     .register("eip155:84532", new UptoEvmScheme(evmSigner))
-    .register("eip155:84532", new BatchSettlementEvmScheme(evmSigner, receiverAuthorizerSigner))
+    .register("eip155:84532", new BatchSettlementEvmScheme(evmSigner))
     .register(
       "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
       new ExactSvmScheme(svmSigner, undefined, { enableSmartWalletVerification: true }),


### PR DESCRIPTION
## Description

- Declares receiverAuthorizer in facilitator supported as optional
- If a facilitator opts in to provide receiverAuthorizer, server may delegate to it. Otherwise, they must provide their own
- Added an optional `validateFacilitatorSupport` hook to `SchemeNetworkServer` and wired it into `x402ResourceServer.initialize()`. After supported kinds are loaded, each registered scheme that the facilitator actually supports is asked to validate the advertised capabilities against its own configuration; any reported problems are aggregated and thrown so misconfigurations fail fast at server startup, not lazily on the first protected request.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 