### PR TITLE
Hardened Hedera facilitator verify

### DIFF
--- a/e2e/facilitators/typescript/index.ts
+++ b/e2e/facilitators/typescript/index.ts
@@ -232,7 +232,7 @@ if (process.env.HEDERA_ACCOUNT_ID && process.env.HEDERA_PRIVATE_KEY) {
       buildHederaClient,
       hederaKey,
     ),
-    verifyPayerSignature: createHederaVerifyPayerSignature(buildHederaClient),
+    verifyPayerSignature: createHederaVerifyPayerSignature(),
     preflightTransfer: createHederaPreflightTransfer(),
   });
   console.info(`Hedera Facilitator account: ${hederaAccountId}`);

--- a/e2e/facilitators/typescript/index.ts
+++ b/e2e/facilitators/typescript/index.ts
@@ -49,6 +49,7 @@ import {
   createHederaClient,
   createHederaPreflightTransfer,
   createHederaSignAndSubmitTransaction,
+  createHederaVerifyPayerSignature,
   toFacilitatorHederaSigner,
 } from "@x402/hedera";
 import { ExactHederaScheme } from "@x402/hedera/exact/facilitator";
@@ -231,7 +232,8 @@ if (process.env.HEDERA_ACCOUNT_ID && process.env.HEDERA_PRIVATE_KEY) {
       buildHederaClient,
       hederaKey,
     ),
-    preflightTransfer: createHederaPreflightTransfer(buildHederaClient),
+    verifyPayerSignature: createHederaVerifyPayerSignature(buildHederaClient),
+    preflightTransfer: createHederaPreflightTransfer(),
   });
   console.info(`Hedera Facilitator account: ${hederaAccountId}`);
 }

--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
         version: 1.2.6
       '@signinwithethereum/siwe':
         specifier: ^4.1.0
-        version: 4.1.0(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
+        version: 4.1.0(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))
       '@x402/core':
         specifier: workspace:~
         version: link:../core
@@ -1421,9 +1421,12 @@ importers:
 
   ../typescript/packages/mechanisms/hedera:
     dependencies:
+      '@hiero-ledger/proto':
+        specifier: 2.31.0
+        version: 2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.0.1)(strip-ansi@7.1.2)
       '@hiero-ledger/sdk':
-        specifier: 2.80.0
-        version: 2.80.0(bn.js@5.2.1)(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
+        specifier: 2.85.0
+        version: 2.85.0(bn.js@5.2.3)(bufferutil@4.0.9)(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
       '@x402/core':
         specifier: workspace:~
         version: link:../../core
@@ -2803,6 +2806,9 @@ importers:
 
 packages:
 
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+
   '@adraffy/ens-normalize@1.11.0':
     resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
 
@@ -3868,60 +3874,6 @@ packages:
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
     engines: {node: '>=14'}
 
-  '@ethersproject/abi@5.8.0':
-    resolution: {integrity: sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==}
-
-  '@ethersproject/abstract-provider@5.8.0':
-    resolution: {integrity: sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==}
-
-  '@ethersproject/abstract-signer@5.8.0':
-    resolution: {integrity: sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==}
-
-  '@ethersproject/address@5.8.0':
-    resolution: {integrity: sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==}
-
-  '@ethersproject/base64@5.8.0':
-    resolution: {integrity: sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==}
-
-  '@ethersproject/bignumber@5.8.0':
-    resolution: {integrity: sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==}
-
-  '@ethersproject/bytes@5.8.0':
-    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
-
-  '@ethersproject/constants@5.8.0':
-    resolution: {integrity: sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==}
-
-  '@ethersproject/hash@5.8.0':
-    resolution: {integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==}
-
-  '@ethersproject/keccak256@5.8.0':
-    resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
-
-  '@ethersproject/logger@5.8.0':
-    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
-
-  '@ethersproject/networks@5.8.0':
-    resolution: {integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==}
-
-  '@ethersproject/properties@5.8.0':
-    resolution: {integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==}
-
-  '@ethersproject/rlp@5.8.0':
-    resolution: {integrity: sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==}
-
-  '@ethersproject/signing-key@5.8.0':
-    resolution: {integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==}
-
-  '@ethersproject/strings@5.8.0':
-    resolution: {integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==}
-
-  '@ethersproject/transactions@5.8.0':
-    resolution: {integrity: sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==}
-
-  '@ethersproject/web@5.8.0':
-    resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
-
   '@evanhahn/lottie-web-light@5.8.1':
     resolution: {integrity: sha512-U0G1tt3/UEYnyCNNslWPi1dB7X1xQ9aoSip+B3GTKO/Bns8yz/p39vBkRSN9d25nkbHuCsbjky2coQftj5YVKw==}
 
@@ -4018,8 +3970,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hiero-ledger/cryptography@1.16.0-beta.3':
-    resolution: {integrity: sha512-7+R/HKGq6LiqUZ1agn52sQS6J3+VXBWvqIMUCIU1EVdbEPQDPoVPJYEd7dDreBCLIcjBRcHVjDc9wbi+ar2rsA==}
+  '@hiero-ledger/cryptography@1.19.0':
+    resolution: {integrity: sha512-6CN34QzPGpegFpQGw1dI77N+75ICdLPSSpcBQ35tyKiNruh6KjE9L0R0th5kcn5sdFw8CwHOPwDQ4+HaSyW0Yw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       expo-crypto: '*'
@@ -4027,21 +3979,21 @@ packages:
       expo-crypto:
         optional: true
 
-  '@hiero-ledger/proto@2.26.0-beta.3':
-    resolution: {integrity: sha512-2UhTKX2RbL2LC8XcgetFa4iS5d8cELY/8PmFolj750z4CoQu2YOchZTqNTdI431qR9uAx3aBVSf+mx/YBYIUNA==}
+  '@hiero-ledger/proto@2.31.0':
+    resolution: {integrity: sha512-6Uq9cSK1lqhMsP/Zwz3liKIzn5QtN2dvt/7EET00/LdubYxYqVxREs8SCtYbgOlzMy34n1Hl6eNeEDDFpkQhMg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       debug: 4.4.1
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       strip-ansi: 7.1.2
 
-  '@hiero-ledger/sdk@2.80.0':
-    resolution: {integrity: sha512-9FHNPduWl27eNI2Gns0O6GJTqcEJ11lBTML84A7D8albCErVXaUVsnRrASafH+Xfq1dqK5dwsNHRwu8WtM3zVQ==}
+  '@hiero-ledger/sdk@2.85.0':
+    resolution: {integrity: sha512-o9xmNHeIt7D2ZuetLTSJlrUI9S7dsEzaut61lOxIbne+9fDxGyYfkNrZaf65rOp2e/SltdwQMOseXyFXUdFqVg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.3
 
   '@hono/node-server@1.19.5':
     resolution: {integrity: sha512-iBuhh+uaaggeAuf+TftcjZyWh2GEgZcVGXkNtskLVoWaXhnJtC5HLHrU8W1KHDoucqO1MswwglmkWLFyiDn4WQ==}
@@ -4718,6 +4670,9 @@ packages:
     resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
 
@@ -4749,6 +4704,10 @@ packages:
 
   '@noble/ed25519@3.1.0':
     resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -4834,20 +4793,11 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
-
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
-
   '@protobufjs/eventemitter@1.1.1':
     resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
-
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
 
   '@protobufjs/fetch@1.1.1':
     resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
@@ -4863,9 +4813,6 @@ packages:
 
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
-
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
@@ -6737,6 +6684,9 @@ packages:
   '@types/node@22.16.0':
     resolution: {integrity: sha512-B2egV9wALML1JCpv3VQoQ+yesQKAmNMBIAY7OteVrikcOcAkWm+dGL6qpeCktPjAv6N1JLnhbNiqS35UpFyBsQ==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
 
@@ -7289,6 +7239,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -7529,11 +7482,11 @@ packages:
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
 
+  bignumber.js@11.1.2:
+    resolution: {integrity: sha512-9idDyC15Vpk+53w4OfxEu2PqHSKFQUffrH1oTvnkJ9fduTJ032tpuI2sxS04oCzocklokWUZmWVEkTEQdLmUOQ==}
+
   bignumber.js@11.1.4:
     resolution: {integrity: sha512-AJ9dSeaUGj2xu7tEwmdqb51dqdb633xo4njI9K8ZFfcLrNr0XN8/EPkkZUNaF9fkCblGt2zVwZymesUdGynEkQ==}
-
-  bignumber.js@9.1.1:
-    resolution: {integrity: sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -7554,11 +7507,11 @@ packages:
   bn.js@4.12.2:
     resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
 
-  bn.js@5.2.1:
-    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
-
   bn.js@5.2.2:
     resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -8509,6 +8462,10 @@ packages:
 
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
+
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
+    engines: {node: '>=14.0.0'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -10307,12 +10264,16 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
-    engines: {node: '>=12.0.0'}
-
   protobufjs@7.6.4:
     resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.2.0:
+    resolution: {integrity: sha512-oI+GC9iPxrQEr6wragljFKH46/r3rNsm6eg7F2fp6kBUMnf6/mesDRdBuF4gK+OyaKJ8N4C1B9s9cCeYdqFikg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -10446,10 +10407,10 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-native-get-random-values@1.11.0:
-    resolution: {integrity: sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==}
+  react-native-get-random-values@2.0.0:
+    resolution: {integrity: sha512-wx7/aPqsUIiWsG35D+MsUJd8ij96e3JKddklSdrdZUrheTx89gPtz3Q2yl9knBArj5u26Cl23T88ai+Q0vypdQ==}
     peerDependencies:
-      react-native: '>=0.56'
+      react-native: '>=0.81'
 
   react-native@0.85.2:
     resolution: {integrity: sha512-GFWEPwLYirfj5X8gMtXOWtqX0cqUEURRHETZfFk37VCa4++izrKvGvv24anvuyulXV87NAhVkfNw93rLg3HByw==}
@@ -11140,6 +11101,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -11249,6 +11213,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -11807,6 +11774,8 @@ packages:
         optional: true
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.10.1': {}
 
   '@adraffy/ens-normalize@1.11.0': {}
 
@@ -13123,129 +13092,6 @@ snapshots:
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
 
-  '@ethersproject/abi@5.8.0':
-    dependencies:
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
-  '@ethersproject/abstract-provider@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/networks': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/web': 5.8.0
-
-  '@ethersproject/abstract-signer@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-
-  '@ethersproject/address@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-
-  '@ethersproject/base64@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-
-  '@ethersproject/bignumber@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      bn.js: 5.2.2
-
-  '@ethersproject/bytes@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/constants@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-
-  '@ethersproject/hash@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
-  '@ethersproject/keccak256@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      js-sha3: 0.8.0
-
-  '@ethersproject/logger@5.8.0': {}
-
-  '@ethersproject/networks@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/properties@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/rlp@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/signing-key@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      bn.js: 5.2.2
-      elliptic: 6.6.1
-      hash.js: 1.1.7
-
-  '@ethersproject/strings@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/transactions@5.8.0':
-    dependencies:
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-
-  '@ethersproject/web@5.8.0':
-    dependencies:
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
   '@evanhahn/lottie-web-light@5.8.1': {}
 
   '@farcaster/frame-sdk@0.1.12(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)':
@@ -13412,31 +13258,31 @@ snapshots:
   '@grpc/proto-loader@0.7.15':
     dependencies:
       lodash.camelcase: 4.3.0
-      long: 5.3.1
-      protobufjs: 7.5.4
+      long: 5.3.2
+      protobufjs: 7.6.4
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
-      long: 5.3.1
+      long: 5.3.2
       protobufjs: 7.6.4
       yargs: 17.7.2
 
-  '@hiero-ledger/cryptography@1.16.0-beta.3(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))':
+  '@hiero-ledger/cryptography@1.19.0(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))':
     dependencies:
       '@noble/curves': 1.8.1
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       asn1js: 3.0.6
-      bignumber.js: 9.1.1
-      bn.js: 5.2.1
+      bignumber.js: 11.1.2
+      bn.js: 5.2.3
       buffer: 6.0.3
       crypto-js: 4.2.0
       debug: 4.4.1
       forge-light: 1.1.4
       js-base64: 3.7.7
-      react-native-get-random-values: 1.11.0(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
+      react-native-get-random-values: 2.0.0(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
       spark-md5: 3.0.2
       strip-ansi: 7.1.2
       tweetnacl: 1.0.3
@@ -13445,42 +13291,50 @@ snapshots:
       - react-native
       - supports-color
 
-  '@hiero-ledger/proto@2.26.0-beta.3(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)':
+  '@hiero-ledger/proto@2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.0.1)(strip-ansi@7.1.2)':
     dependencies:
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       debug: 4.4.1
       long: 5.3.1
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       strip-ansi: 7.1.2
 
-  '@hiero-ledger/sdk@2.80.0(bn.js@5.2.1)(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))':
+  '@hiero-ledger/proto@2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.2.0)(strip-ansi@7.1.2)':
     dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@grpc/grpc-js': 1.12.6
-      '@hiero-ledger/cryptography': 1.16.0-beta.3(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
-      '@hiero-ledger/proto': 2.26.0-beta.3(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
-      bignumber.js: 9.1.1
-      bn.js: 5.2.1
+      debug: 4.4.1
+      long: 5.3.1
+      protobufjs: 8.2.0
+      strip-ansi: 7.1.2
+
+  '@hiero-ledger/sdk@2.85.0(bn.js@5.2.3)(bufferutil@4.0.9)(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)':
+    dependencies:
+      '@grpc/grpc-js': 1.12.6
+      '@hiero-ledger/cryptography': 1.19.0(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
+      '@hiero-ledger/proto': 2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.2.0)(strip-ansi@7.1.2)
+      ansi-regex: 6.2.2
+      ansi-styles: 6.2.3
+      bignumber.js: 11.1.2
+      bn.js: 5.2.3
       crypto-js: 4.2.0
       debug: 4.4.1
+      ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       js-base64: 3.7.4
       long: 5.3.1
       pino: 10.1.0
       pino-pretty: 13.0.0
-      protobufjs: 7.5.4
+      protobufjs: 8.2.0
       rfc4648: 1.5.3
       strip-ansi: 7.1.2
       utf8: 3.0.0
     transitivePeerDependencies:
+      - bufferutil
       - expo-crypto
       - react-native
       - supports-color
+      - utf-8-validate
 
   '@hono/node-server@1.19.5(hono@4.10.2)':
     dependencies:
@@ -14109,6 +13963,10 @@ snapshots:
 
   '@noble/ciphers@2.1.1': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -14138,6 +13996,8 @@ snapshots:
   '@noble/ed25519@3.0.1': {}
 
   '@noble/ed25519@3.1.0': {}
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
 
@@ -14212,18 +14072,9 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
-
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
-
   '@protobufjs/eventemitter@1.1.1': {}
-
-  '@protobufjs/fetch@1.1.0':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/fetch@1.1.1':
     dependencies:
@@ -14236,8 +14087,6 @@ snapshots:
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
-
-  '@protobufjs/utf8@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
 
@@ -14963,10 +14812,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       apg-js: 4.4.0
 
-  '@signinwithethereum/siwe@4.1.0(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
+  '@signinwithethereum/siwe@4.1.0(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71))':
     dependencies:
       '@signinwithethereum/siwe-parser': 4.1.0
     optionalDependencies:
+      ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       viem: 2.48.11(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.71)
 
   '@sinclair/typebox@0.27.10': {}
@@ -17353,6 +17203,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/prompts@2.4.9':
     dependencies:
       '@types/node': 22.16.0
@@ -19128,6 +18982,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  aes-js@4.0.0-beta.5: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -19402,9 +19258,9 @@ snapshots:
 
   big.js@6.2.2: {}
 
-  bignumber.js@11.1.4: {}
+  bignumber.js@11.1.2: {}
 
-  bignumber.js@9.1.1: {}
+  bignumber.js@11.1.4: {}
 
   bignumber.js@9.3.1: {}
 
@@ -19422,9 +19278,9 @@ snapshots:
 
   bn.js@4.12.2: {}
 
-  bn.js@5.2.1: {}
-
   bn.js@5.2.2: {}
+
+  bn.js@5.2.3: {}
 
   body-parser@1.20.3:
     dependencies:
@@ -20676,6 +20532,19 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
+  ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   event-target-shim@5.0.1: {}
 
   eventemitter2@6.4.9: {}
@@ -21134,7 +21003,7 @@ snapshots:
 
   google-gax@4.6.1:
     dependencies:
-      '@grpc/grpc-js': 1.12.6
+      '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       '@types/long': 4.0.2
       abort-controller: 3.0.0
@@ -21143,7 +21012,7 @@ snapshots:
       node-fetch: 2.7.0
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
-      protobufjs: 7.5.4
+      protobufjs: 7.6.4
       retry-request: 7.0.2
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -22892,23 +22761,8 @@ snapshots:
 
   proto3-json-serializer@2.0.2:
     dependencies:
-      protobufjs: 7.5.4
+      protobufjs: 7.6.4
     optional: true
-
-  protobufjs@7.5.4:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.16.0
-      long: 5.3.1
 
   protobufjs@7.6.4:
     dependencies:
@@ -22921,6 +22775,26 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.16.0
+      long: 5.3.2
+
+  protobufjs@8.0.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.16.0
+      long: 5.3.2
+
+  protobufjs@8.2.0:
+    dependencies:
       '@types/node': 22.16.0
       long: 5.3.2
 
@@ -23075,7 +22949,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-native-get-random-values@1.11.0(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10)):
+  react-native-get-random-values@2.0.0(react-native@0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10)):
     dependencies:
       fast-base64-decode: 1.0.0
       react-native: 0.85.2(@babel/core@7.28.4)(@types/react@19.2.2)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10)
@@ -23967,6 +23841,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsup@8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.1):
@@ -24112,6 +23988,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   uncrypto@0.1.3: {}
+
+  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 

--- a/examples/typescript/facilitator/advanced/all_networks.ts
+++ b/examples/typescript/facilitator/advanced/all_networks.ts
@@ -235,7 +235,7 @@ if (hederaAccountId && hederaPrivateKey) {
       buildHederaClient,
       hederaKey,
     ),
-    verifyPayerSignature: createHederaVerifyPayerSignature(buildHederaClient),
+    verifyPayerSignature: createHederaVerifyPayerSignature(),
     preflightTransfer: createHederaPreflightTransfer(),
   });
   facilitator.register(HEDERA_NETWORK, new ExactHederaScheme(hederaSigner));

--- a/examples/typescript/facilitator/advanced/all_networks.ts
+++ b/examples/typescript/facilitator/advanced/all_networks.ts
@@ -36,6 +36,7 @@ import {
   createHederaClient,
   createHederaPreflightTransfer,
   createHederaSignAndSubmitTransaction,
+  createHederaVerifyPayerSignature,
   toFacilitatorHederaSigner,
 } from "@x402/hedera";
 import { ExactHederaScheme } from "@x402/hedera/exact/facilitator";
@@ -234,7 +235,8 @@ if (hederaAccountId && hederaPrivateKey) {
       buildHederaClient,
       hederaKey,
     ),
-    preflightTransfer: createHederaPreflightTransfer(buildHederaClient),
+    verifyPayerSignature: createHederaVerifyPayerSignature(buildHederaClient),
+    preflightTransfer: createHederaPreflightTransfer(),
   });
   facilitator.register(HEDERA_NETWORK, new ExactHederaScheme(hederaSigner));
   console.info(`Hedera Facilitator account: ${hederaAccountId}`);

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
         version: 1.2.6
       '@signinwithethereum/siwe':
         specifier: ^4.1.0
-        version: 4.2.0(viem@2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: 4.2.0(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@x402/core':
         specifier: workspace:~
         version: link:../core
@@ -940,9 +940,12 @@ importers:
 
   ../../typescript/packages/mechanisms/hedera:
     dependencies:
+      '@hiero-ledger/proto':
+        specifier: 2.31.0
+        version: 2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.0.1)(strip-ansi@7.1.2)
       '@hiero-ledger/sdk':
-        specifier: 2.80.0
-        version: 2.80.0(bn.js@5.2.1)(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
+        specifier: 2.85.0
+        version: 2.85.0(bn.js@5.2.3)(bufferutil@4.0.9)(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
       '@x402/core':
         specifier: workspace:~
         version: link:../../core
@@ -3386,6 +3389,9 @@ importers:
 
 packages:
 
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+
   '@adraffy/ens-normalize@1.11.0':
     resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
 
@@ -3959,60 +3965,6 @@ packages:
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
     engines: {node: '>=14'}
 
-  '@ethersproject/abi@5.8.0':
-    resolution: {integrity: sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==}
-
-  '@ethersproject/abstract-provider@5.8.0':
-    resolution: {integrity: sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==}
-
-  '@ethersproject/abstract-signer@5.8.0':
-    resolution: {integrity: sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==}
-
-  '@ethersproject/address@5.8.0':
-    resolution: {integrity: sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==}
-
-  '@ethersproject/base64@5.8.0':
-    resolution: {integrity: sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==}
-
-  '@ethersproject/bignumber@5.8.0':
-    resolution: {integrity: sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==}
-
-  '@ethersproject/bytes@5.8.0':
-    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
-
-  '@ethersproject/constants@5.8.0':
-    resolution: {integrity: sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==}
-
-  '@ethersproject/hash@5.8.0':
-    resolution: {integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==}
-
-  '@ethersproject/keccak256@5.8.0':
-    resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
-
-  '@ethersproject/logger@5.8.0':
-    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
-
-  '@ethersproject/networks@5.8.0':
-    resolution: {integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==}
-
-  '@ethersproject/properties@5.8.0':
-    resolution: {integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==}
-
-  '@ethersproject/rlp@5.8.0':
-    resolution: {integrity: sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==}
-
-  '@ethersproject/signing-key@5.8.0':
-    resolution: {integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==}
-
-  '@ethersproject/strings@5.8.0':
-    resolution: {integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==}
-
-  '@ethersproject/transactions@5.8.0':
-    resolution: {integrity: sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==}
-
-  '@ethersproject/web@5.8.0':
-    resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
-
   '@evanhahn/lottie-web-light@5.8.1':
     resolution: {integrity: sha512-U0G1tt3/UEYnyCNNslWPi1dB7X1xQ9aoSip+B3GTKO/Bns8yz/p39vBkRSN9d25nkbHuCsbjky2coQftj5YVKw==}
 
@@ -4100,8 +4052,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hiero-ledger/cryptography@1.16.0-beta.3':
-    resolution: {integrity: sha512-7+R/HKGq6LiqUZ1agn52sQS6J3+VXBWvqIMUCIU1EVdbEPQDPoVPJYEd7dDreBCLIcjBRcHVjDc9wbi+ar2rsA==}
+  '@hiero-ledger/cryptography@1.19.0':
+    resolution: {integrity: sha512-6CN34QzPGpegFpQGw1dI77N+75ICdLPSSpcBQ35tyKiNruh6KjE9L0R0th5kcn5sdFw8CwHOPwDQ4+HaSyW0Yw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       expo-crypto: '*'
@@ -4109,21 +4061,21 @@ packages:
       expo-crypto:
         optional: true
 
-  '@hiero-ledger/proto@2.26.0-beta.3':
-    resolution: {integrity: sha512-2UhTKX2RbL2LC8XcgetFa4iS5d8cELY/8PmFolj750z4CoQu2YOchZTqNTdI431qR9uAx3aBVSf+mx/YBYIUNA==}
+  '@hiero-ledger/proto@2.31.0':
+    resolution: {integrity: sha512-6Uq9cSK1lqhMsP/Zwz3liKIzn5QtN2dvt/7EET00/LdubYxYqVxREs8SCtYbgOlzMy34n1Hl6eNeEDDFpkQhMg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       debug: 4.4.1
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       strip-ansi: 7.1.2
 
-  '@hiero-ledger/sdk@2.80.0':
-    resolution: {integrity: sha512-9FHNPduWl27eNI2Gns0O6GJTqcEJ11lBTML84A7D8albCErVXaUVsnRrASafH+Xfq1dqK5dwsNHRwu8WtM3zVQ==}
+  '@hiero-ledger/sdk@2.85.0':
+    resolution: {integrity: sha512-o9xmNHeIt7D2ZuetLTSJlrUI9S7dsEzaut61lOxIbne+9fDxGyYfkNrZaf65rOp2e/SltdwQMOseXyFXUdFqVg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.3
 
   '@hono/node-server@1.19.0':
     resolution: {integrity: sha512-1k8/8OHf5VIymJEcJyVksFpT+AQ5euY0VA5hUkCnlKpD4mr8FSbvXaHblxeTTEr90OaqWzAkQaqD80qHZQKxBA==}
@@ -4561,6 +4513,9 @@ packages:
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
 
@@ -4589,6 +4544,10 @@ packages:
 
   '@noble/ed25519@3.1.0':
     resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -4670,20 +4629,11 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
-
   '@protobufjs/codegen@2.0.5':
     resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
-
   '@protobufjs/eventemitter@1.1.1':
     resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
-
-  '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
 
   '@protobufjs/fetch@1.1.1':
     resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
@@ -4699,9 +4649,6 @@ packages:
 
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
-
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
@@ -6390,6 +6337,9 @@ packages:
   '@types/node@22.17.2':
     resolution: {integrity: sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
@@ -6968,6 +6918,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -7017,10 +6970,6 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.0:
-    resolution: {integrity: sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==}
-    engines: {node: '>=12'}
-
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -7032,10 +6981,6 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-
-  ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -7218,11 +7163,11 @@ packages:
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
 
+  bignumber.js@11.1.2:
+    resolution: {integrity: sha512-9idDyC15Vpk+53w4OfxEu2PqHSKFQUffrH1oTvnkJ9fduTJ032tpuI2sxS04oCzocklokWUZmWVEkTEQdLmUOQ==}
+
   bignumber.js@11.1.4:
     resolution: {integrity: sha512-AJ9dSeaUGj2xu7tEwmdqb51dqdb633xo4njI9K8ZFfcLrNr0XN8/EPkkZUNaF9fkCblGt2zVwZymesUdGynEkQ==}
-
-  bignumber.js@9.1.1:
-    resolution: {integrity: sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -7239,11 +7184,11 @@ packages:
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
 
-  bn.js@5.2.1:
-    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
-
   bn.js@5.2.2:
     resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
@@ -8062,6 +8007,10 @@ packages:
 
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
+
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
+    engines: {node: '>=14.0.0'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -9812,12 +9761,16 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
-    engines: {node: '>=12.0.0'}
-
   protobufjs@7.6.4:
     resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.2.0:
+    resolution: {integrity: sha512-oI+GC9iPxrQEr6wragljFKH46/r3rNsm6eg7F2fp6kBUMnf6/mesDRdBuF4gK+OyaKJ8N4C1B9s9cCeYdqFikg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -9932,10 +9885,10 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-native-get-random-values@1.11.0:
-    resolution: {integrity: sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==}
+  react-native-get-random-values@2.0.0:
+    resolution: {integrity: sha512-wx7/aPqsUIiWsG35D+MsUJd8ij96e3JKddklSdrdZUrheTx89gPtz3Q2yl9knBArj5u26Cl23T88ai+Q0vypdQ==}
     peerDependencies:
-      react-native: '>=0.56'
+      react-native: '>=0.81'
 
   react-native@0.85.2:
     resolution: {integrity: sha512-GFWEPwLYirfj5X8gMtXOWtqX0cqUEURRHETZfFk37VCa4++izrKvGvv24anvuyulXV87NAhVkfNw93rLg3HByw==}
@@ -10381,10 +10334,6 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
-
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
@@ -10595,6 +10544,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -10746,6 +10698,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -11295,6 +11250,8 @@ packages:
         optional: true
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.10.1': {}
 
   '@adraffy/ens-normalize@1.11.0': {}
 
@@ -11955,129 +11912,6 @@ snapshots:
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
 
-  '@ethersproject/abi@5.8.0':
-    dependencies:
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
-  '@ethersproject/abstract-provider@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/networks': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/web': 5.8.0
-
-  '@ethersproject/abstract-signer@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-
-  '@ethersproject/address@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-
-  '@ethersproject/base64@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-
-  '@ethersproject/bignumber@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      bn.js: 5.2.2
-
-  '@ethersproject/bytes@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/constants@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-
-  '@ethersproject/hash@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
-  '@ethersproject/keccak256@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      js-sha3: 0.8.0
-
-  '@ethersproject/logger@5.8.0': {}
-
-  '@ethersproject/networks@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/properties@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/rlp@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/signing-key@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      bn.js: 5.2.2
-      elliptic: 6.6.1
-      hash.js: 1.1.7
-
-  '@ethersproject/strings@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/transactions@5.8.0':
-    dependencies:
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-
-  '@ethersproject/web@5.8.0':
-    dependencies:
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
   '@evanhahn/lottie-web-light@5.8.1': {}
 
   '@farcaster/miniapp-core@0.4.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
@@ -12228,31 +12062,31 @@ snapshots:
   '@grpc/proto-loader@0.7.15':
     dependencies:
       lodash.camelcase: 4.3.0
-      long: 5.3.1
-      protobufjs: 7.5.4
+      long: 5.3.2
+      protobufjs: 7.6.4
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
-      long: 5.3.1
+      long: 5.3.2
       protobufjs: 7.6.4
       yargs: 17.7.2
 
-  '@hiero-ledger/cryptography@1.16.0-beta.3(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))':
+  '@hiero-ledger/cryptography@1.19.0(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))':
     dependencies:
       '@noble/curves': 1.8.1
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       asn1js: 3.0.6
-      bignumber.js: 9.1.1
-      bn.js: 5.2.1
+      bignumber.js: 11.1.2
+      bn.js: 5.2.3
       buffer: 6.0.3
       crypto-js: 4.2.0
       debug: 4.4.1
       forge-light: 1.1.4
       js-base64: 3.7.7
-      react-native-get-random-values: 1.11.0(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
+      react-native-get-random-values: 2.0.0(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
       spark-md5: 3.0.2
       strip-ansi: 7.1.2
       tweetnacl: 1.0.3
@@ -12261,42 +12095,50 @@ snapshots:
       - react-native
       - supports-color
 
-  '@hiero-ledger/proto@2.26.0-beta.3(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)':
+  '@hiero-ledger/proto@2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.0.1)(strip-ansi@7.1.2)':
     dependencies:
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       debug: 4.4.1
       long: 5.3.1
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       strip-ansi: 7.1.2
 
-  '@hiero-ledger/sdk@2.80.0(bn.js@5.2.1)(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))':
+  '@hiero-ledger/proto@2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.2.0)(strip-ansi@7.1.2)':
     dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@grpc/grpc-js': 1.12.6
-      '@hiero-ledger/cryptography': 1.16.0-beta.3(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
-      '@hiero-ledger/proto': 2.26.0-beta.3(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
-      bignumber.js: 9.1.1
-      bn.js: 5.2.1
+      debug: 4.4.1
+      long: 5.3.1
+      protobufjs: 8.2.0
+      strip-ansi: 7.1.2
+
+  '@hiero-ledger/sdk@2.85.0(bn.js@5.2.3)(bufferutil@4.0.9)(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)':
+    dependencies:
+      '@grpc/grpc-js': 1.12.6
+      '@hiero-ledger/cryptography': 1.19.0(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
+      '@hiero-ledger/proto': 2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.2.0)(strip-ansi@7.1.2)
+      ansi-regex: 6.2.2
+      ansi-styles: 6.2.3
+      bignumber.js: 11.1.2
+      bn.js: 5.2.3
       crypto-js: 4.2.0
       debug: 4.4.1
+      ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       js-base64: 3.7.4
       long: 5.3.1
       pino: 10.1.0
       pino-pretty: 13.0.0
-      protobufjs: 7.5.4
+      protobufjs: 8.2.0
       rfc4648: 1.5.3
       strip-ansi: 7.1.2
       utf8: 3.0.0
     transitivePeerDependencies:
+      - bufferutil
       - expo-crypto
       - react-native
       - supports-color
+      - utf-8-validate
 
   '@hono/node-server@1.19.0(hono@4.10.7)':
     dependencies:
@@ -12423,7 +12265,7 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
+      strip-ansi: 7.1.2
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
@@ -12804,6 +12646,10 @@ snapshots:
 
   '@noble/ciphers@2.2.0': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -12831,6 +12677,8 @@ snapshots:
   '@noble/ed25519@2.3.0': {}
 
   '@noble/ed25519@3.1.0': {}
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
 
@@ -12903,18 +12751,9 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
-
   '@protobufjs/codegen@2.0.5': {}
 
-  '@protobufjs/eventemitter@1.1.0': {}
-
   '@protobufjs/eventemitter@1.1.1': {}
-
-  '@protobufjs/fetch@1.1.0':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
 
   '@protobufjs/fetch@1.1.1':
     dependencies:
@@ -12927,8 +12766,6 @@ snapshots:
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
-
-  '@protobufjs/utf8@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
 
@@ -13688,10 +13525,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       apg-js: 4.4.0
 
-  '@signinwithethereum/siwe@4.2.0(viem@2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@signinwithethereum/siwe@4.2.0(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@signinwithethereum/siwe-parser': 4.2.0
     optionalDependencies:
+      ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       viem: 2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
 
   '@sinclair/typebox@0.27.10': {}
@@ -17085,6 +16923,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -19013,6 +18855,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  aes-js@4.0.0-beta.5: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.1
@@ -19066,8 +18910,6 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.0: {}
-
   ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
@@ -19075,8 +18917,6 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
-
-  ansi-styles@6.2.1: {}
 
   ansi-styles@6.2.3: {}
 
@@ -19268,9 +19108,9 @@ snapshots:
 
   big.js@6.2.2: {}
 
-  bignumber.js@11.1.4: {}
+  bignumber.js@11.1.2: {}
 
-  bignumber.js@9.1.1: {}
+  bignumber.js@11.1.4: {}
 
   bignumber.js@9.3.1: {}
 
@@ -19286,9 +19126,9 @@ snapshots:
 
   bn.js@4.12.3: {}
 
-  bn.js@5.2.1: {}
-
   bn.js@5.2.2: {}
+
+  bn.js@5.2.3: {}
 
   body-parser@1.20.3:
     dependencies:
@@ -20437,6 +20277,19 @@ snapshots:
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
 
+  ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   event-target-shim@5.0.1: {}
 
   eventemitter2@6.4.9: {}
@@ -20886,7 +20739,7 @@ snapshots:
 
   google-gax@4.6.1:
     dependencies:
-      '@grpc/grpc-js': 1.12.6
+      '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       '@types/long': 4.0.2
       abort-controller: 3.0.0
@@ -20895,7 +20748,7 @@ snapshots:
       node-fetch: 2.7.0
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
-      protobufjs: 7.5.4
+      protobufjs: 7.6.4
       retry-request: 7.0.2
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -22601,23 +22454,8 @@ snapshots:
 
   proto3-json-serializer@2.0.2:
     dependencies:
-      protobufjs: 7.5.4
+      protobufjs: 7.6.4
     optional: true
-
-  protobufjs@7.5.4:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/node': 22.17.2
-      long: 5.3.1
 
   protobufjs@7.6.4:
     dependencies:
@@ -22630,6 +22468,26 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.17.2
+      long: 5.3.2
+
+  protobufjs@8.0.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.17.2
+      long: 5.3.2
+
+  protobufjs@8.2.0:
+    dependencies:
       '@types/node': 22.17.2
       long: 5.3.2
 
@@ -22755,7 +22613,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-native-get-random-values@1.11.0(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10)):
+  react-native-get-random-values@2.0.0(react-native@0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10)):
     dependencies:
       fast-base64-decode: 1.0.0
       react-native: 0.85.2(@babel/core@7.28.3)(@types/react@19.2.1)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10)
@@ -23415,10 +23273,6 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.1.0:
-    dependencies:
-      ansi-regex: 6.2.0
-
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
@@ -23617,6 +23471,8 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@1.14.1: {}
+
+  tslib@2.7.0: {}
 
   tslib@2.8.1: {}
 
@@ -23822,6 +23678,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
+
+  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 
@@ -24383,7 +24241,7 @@ snapshots:
 
   wrap-ansi@8.1.0:
     dependencies:
-      ansi-styles: 6.2.1
+      ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
 

--- a/specs/schemes/exact/scheme_exact_hedera.md
+++ b/specs/schemes/exact/scheme_exact_hedera.md
@@ -149,11 +149,12 @@ A facilitator verifying an `exact`‑scheme Hedera payment MUST enforce all of t
   - The net amount to `payTo` is not exactly equal to `PaymentRequirements.amount`, or
   - The client is sending more than `PaymentRequirements.amount` in total for the specified `asset`.
 
-### 6. General validity and replay protection
+### 6. Payer signature, general validity, and replay protection
 
+- The facilitator MUST verify that the inferred payer actually signed the frozen transaction body before sponsoring it. The facilitator fetches the payer's onchain account key (e.g. via a consensus-node `AccountInfoQuery`) and checks that the transaction carries a valid signature satisfying that key, including KeyList/threshold accounts. A transaction signed with the wrong key, or left unsigned, MUST be rejected (reason `invalid_exact_hedera_payload_signature_invalid`). Without this check a payload that fails at settlement with `INVALID_SIGNATURE` would otherwise pass verification.
 - The transaction MUST:
   - Not have been previously submitted/observed (implementations SHOULD perform idempotency / replay checks where possible).
-- The facilitator SHOULD simulate or pre‑check the transaction using Hedera APIs where available to ensure:
+- The facilitator SHOULD pre‑check the transaction to ensure:
   - The client has sufficient balance of the `asset` to cover the transfer.
   - The transaction is expected to succeed on chain (no obvious `INSUFFICIENT_BALANCE`, invalid token association, or similar failures).
 

--- a/typescript/.changeset/hedera-verify-hardening.md
+++ b/typescript/.changeset/hedera-verify-hardening.md
@@ -2,8 +2,14 @@
 "@x402/hedera": minor
 ---
 
-Hardened the exact Hedera facilitator `verify()` path so a payment that passes verification is the same one that succeeds at settlement (security fix for unsigned / wrong-key payloads and unassociated recipients).
+**[Breaking for facilitator implementers]** Hardened the exact Hedera facilitator `verify()` path so it closes the unsigned/wrong-key and unassociated-recipient gaps between verify and settle. (This is not full verify⇒settle parity: paused/frozen/KYC, custom fees, and expiry remain out of scope.)
 
-`verify()` now (1) confirms the inferred payer actually signed the frozen transaction body by fetching the payer's onchain account key and checking the signature — including KeyList/threshold accounts — and (2) pre-checks balance and token association against the Hedera Mirror Node REST API, which is the reliable data source (consensus-node token data is no longer dependable). Both run unconditionally and fail closed.
+`verify()` now (1) confirms every debited sender actually signed the frozen transaction body — including KeyList/threshold accounts — by reading the payer's onchain account key from the free Hedera Mirror Node REST API, and (2) pre-checks balance and token association for each sender against the Mirror Node (the reliable data source, since consensus-node token data is no longer dependable). Both run unconditionally and fail closed. The whole verify path is now Mirror-Node-only and requires no operator-funded queries.
 
-Breaking change to `FacilitatorHederaSigner`: `verifyPayerSignature` is a new required capability and `preflightTransfer` is now required (was optional). Use the new `createHederaVerifyPayerSignature(buildClient)` default and `createHederaPreflightTransfer(config?)`, whose signature changed from `(buildClient)` to an optional `{ mirrorNodeUrl? }`.
+Migration for `FacilitatorHederaSigner` implementers:
+
+- `verifyPayerSignature` and `preflightTransfer` are now both required (previously optional/absent). Custom signers will fail to compile until both are wired, and an unwired `verifyPayerSignature` fails closed at runtime by rejecting all payments.
+- `createHederaVerifyPayerSignature` no longer takes a client factory. Its signature is now `createHederaVerifyPayerSignature(config?: { mirrorNodeUrl?: string })`; it reads the payer key from the Mirror Node instead of a paid `AccountInfoQuery`, so the verify-only operator setup is no longer needed.
+- `createHederaPreflightTransfer(buildClient)` → `createHederaPreflightTransfer(config?: { mirrorNodeUrl?: string })`. This is a silent change: callers still passing a client factory put a function where a config object is expected, so `mirrorNodeUrl` is `undefined` and it silently falls back to the public Mirror Node.
+
+Bumped `@hiero-ledger/sdk` to `2.85.0` and added `@hiero-ledger/proto` `2.31.0` (kept in lockstep, since the SDK pins that proto version). No breaking changes for this package's API surface; the SDK bump is a minor (non-major) version, so the re-exported SDK primitives are unaffected.

--- a/typescript/.changeset/hedera-verify-hardening.md
+++ b/typescript/.changeset/hedera-verify-hardening.md
@@ -1,0 +1,9 @@
+---
+"@x402/hedera": minor
+---
+
+Hardened the exact Hedera facilitator `verify()` path so a payment that passes verification is the same one that succeeds at settlement (security fix for unsigned / wrong-key payloads and unassociated recipients).
+
+`verify()` now (1) confirms the inferred payer actually signed the frozen transaction body by fetching the payer's onchain account key and checking the signature — including KeyList/threshold accounts — and (2) pre-checks balance and token association against the Hedera Mirror Node REST API, which is the reliable data source (consensus-node token data is no longer dependable). Both run unconditionally and fail closed.
+
+Breaking change to `FacilitatorHederaSigner`: `verifyPayerSignature` is a new required capability and `preflightTransfer` is now required (was optional). Use the new `createHederaVerifyPayerSignature(buildClient)` default and `createHederaPreflightTransfer(config?)`, whose signature changed from `(buildClient)` to an optional `{ mirrorNodeUrl? }`.

--- a/typescript/packages/mechanisms/hedera/package.json
+++ b/typescript/packages/mechanisms/hedera/package.json
@@ -42,6 +42,7 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.5"
   },
+  "//": "@hiero-ledger/proto must stay pinned in lockstep with @hiero-ledger/sdk (see src/signer.ts).",
   "dependencies": {
     "@x402/core": "workspace:~",
     "@hiero-ledger/proto": "2.31.0",

--- a/typescript/packages/mechanisms/hedera/package.json
+++ b/typescript/packages/mechanisms/hedera/package.json
@@ -44,7 +44,8 @@
   },
   "dependencies": {
     "@x402/core": "workspace:~",
-    "@hiero-ledger/sdk": "2.80.0"
+    "@hiero-ledger/proto": "2.31.0",
+    "@hiero-ledger/sdk": "2.85.0"
   },
   "exports": {
     ".": {

--- a/typescript/packages/mechanisms/hedera/src/constants.ts
+++ b/typescript/packages/mechanisms/hedera/src/constants.ts
@@ -9,6 +9,16 @@ export const HEDERA_MAINNET_CAIP2 = "hedera:mainnet";
 export const HEDERA_TESTNET_CAIP2 = "hedera:testnet";
 
 /**
+ * Hedera Mirror Node REST API base URL for Mainnet.
+ */
+export const HEDERA_MAINNET_MIRROR_NODE_URL = "https://mainnet-public.mirrornode.hedera.com";
+
+/**
+ * Hedera Mirror Node REST API base URL for Testnet.
+ */
+export const HEDERA_TESTNET_MIRROR_NODE_URL = "https://testnet.mirrornode.hedera.com";
+
+/**
  * Asset id used by x402 to represent native HBAR.
  */
 export const HBAR_ASSET_ID = "0.0.0";

--- a/typescript/packages/mechanisms/hedera/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/hedera/src/exact/facilitator/scheme.ts
@@ -137,7 +137,8 @@ export class ExactHederaScheme implements SchemeNetworkFacilitator {
       inspected.hbarTransfers,
       requirements,
     ) as HederaTransferEntry[];
-    const payer = this.inferPayer(payerTransfers);
+    const payers = this.inferPayers(payerTransfers);
+    const payer = payers[0]?.accountId ?? "";
 
     // Phase 4: alias policy check
     const payToValidation = await this.validatePayToPolicy(requirements);
@@ -145,68 +146,73 @@ export class ExactHederaScheme implements SchemeNetworkFacilitator {
       return payToValidation;
     }
 
-    // Phase 5: payer signature verification (fail-closed).
-    // Runs before preflight to avoid wasted Mirror Node calls on bad signatures.
-    // Precondition: Phase 3 transfer-semantics guarantees `payer` is non-empty
-    // (the payload must contain at least one debited account for `asset`).
-    let signature: { ok: boolean; reason?: string; message?: string };
-    try {
-      signature = await this.signer.verifyPayerSignature({
-        payer,
-        transaction: transactionBase64,
-        network: requirements.network,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_hedera_payload_signature_invalid",
-        invalidMessage: message,
-        payer,
-      };
-    }
-    if (!signature.ok) {
-      const invalidMessage = signature.reason
-        ? `${signature.reason}${signature.message ? `: ${signature.message}` : ""}`
-        : signature.message;
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_hedera_payload_signature_invalid",
-        invalidMessage,
-        payer,
-      };
+    // Phase 5: payer signature verification (fail-closed), checked before
+    // preflight so an unsigned/wrong-key payload is rejected first.
+    // Spec §4 allows multiple sending accounts, so every debited sender must
+    // have signed. Precondition: Phase 3 transfer-semantics guarantees at
+    // least one debited account for `asset`, so `payers` is non-empty.
+    for (const sender of payers) {
+      let signature: { ok: boolean; reason?: string; message?: string };
+      try {
+        signature = await this.signer.verifyPayerSignature({
+          payer: sender.accountId,
+          transaction: transactionBase64,
+          network: requirements.network,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_hedera_payload_signature_invalid",
+          invalidMessage: message,
+          payer,
+        };
+      }
+      if (!signature.ok) {
+        const invalidMessage = signature.reason
+          ? `${signature.reason}${signature.message ? `: ${signature.message}` : ""}`
+          : signature.message;
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_hedera_payload_signature_invalid",
+          invalidMessage,
+          payer,
+        };
+      }
     }
 
     // Phase 6: onchain preflight (balance + token association), fail-closed.
-    // Spec §6 — never throws out of verify.
-    let preflight: { ok: boolean; reason?: string; message?: string };
-    try {
-      preflight = await this.signer.preflightTransfer({
-        payer,
-        payTo: requirements.payTo,
-        asset: requirements.asset,
-        amount: requirements.amount,
-        network: requirements.network,
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_hedera_payload_preflight_failed",
-        invalidMessage: message,
-        payer,
-      };
-    }
-    if (!preflight.ok) {
-      const invalidMessage = preflight.reason
-        ? `${preflight.reason}${preflight.message ? `: ${preflight.message}` : ""}`
-        : preflight.message;
-      return {
-        isValid: false,
-        invalidReason: "invalid_exact_hedera_payload_preflight_failed",
-        invalidMessage,
-        payer,
-      };
+    // Each sender only funds their own debited portion, so preflight runs per sender with that sender's amount.
+    for (const sender of payers) {
+      let preflight: { ok: boolean; reason?: string; message?: string };
+      try {
+        preflight = await this.signer.preflightTransfer({
+          payer: sender.accountId,
+          payTo: requirements.payTo,
+          asset: requirements.asset,
+          amount: sender.amount,
+          network: requirements.network,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_hedera_payload_preflight_failed",
+          invalidMessage: message,
+          payer,
+        };
+      }
+      if (!preflight.ok) {
+        const invalidMessage = preflight.reason
+          ? `${preflight.reason}${preflight.message ? `: ${preflight.message}` : ""}`
+          : preflight.message;
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_hedera_payload_preflight_failed",
+          invalidMessage,
+          payer,
+        };
+      }
     }
 
     return {
@@ -310,13 +316,27 @@ export class ExactHederaScheme implements SchemeNetworkFacilitator {
   }
 
   /**
-   * Best-effort payer inference from debited transfer entries.
+   * Infers every debited sender from the asset transfers, summing each
+   * account's debited magnitude. Spec §4 permits multiple sending accounts,
+   * so all of them are returned (each funds only their own portion).
    *
    * @param transfers - Asset transfers
-   * @returns Payer account id
+   * @returns Distinct debited accounts with their absolute debited amount
    */
-  private inferPayer(transfers: HederaTransferEntry[]): string {
-    return transfers.find(entry => BigInt(entry.amount) < 0n)?.accountId ?? "";
+  private inferPayers(
+    transfers: HederaTransferEntry[],
+  ): Array<{ accountId: string; amount: string }> {
+    const debited = new Map<string, bigint>();
+    for (const entry of transfers) {
+      const amount = BigInt(entry.amount);
+      if (amount < 0n) {
+        debited.set(entry.accountId, (debited.get(entry.accountId) ?? 0n) + amount);
+      }
+    }
+    return [...debited.entries()].map(([accountId, amount]) => ({
+      accountId,
+      amount: (-amount).toString(),
+    }));
   }
 
   /**

--- a/typescript/packages/mechanisms/hedera/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/hedera/src/exact/facilitator/scheme.ts
@@ -145,40 +145,68 @@ export class ExactHederaScheme implements SchemeNetworkFacilitator {
       return payToValidation;
     }
 
-    // Phase 5: optional onchain preflight (balance + token association).
-    // Spec §6 — advisory, never throws out of verify.
+    // Phase 5: payer signature verification (fail-closed).
+    // Runs before preflight to avoid wasted Mirror Node calls on bad signatures.
     // Precondition: Phase 3 transfer-semantics guarantees `payer` is non-empty
     // (the payload must contain at least one debited account for `asset`).
-    if (typeof this.signer.preflightTransfer === "function") {
-      let preflight: { ok: boolean; reason?: string; message?: string };
-      try {
-        preflight = await this.signer.preflightTransfer({
-          payer,
-          payTo: requirements.payTo,
-          asset: requirements.asset,
-          amount: requirements.amount,
-          network: requirements.network,
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return {
-          isValid: false,
-          invalidReason: "invalid_exact_hedera_payload_preflight_failed",
-          invalidMessage: message,
-          payer,
-        };
-      }
-      if (!preflight.ok) {
-        const invalidMessage = preflight.reason
-          ? `${preflight.reason}${preflight.message ? `: ${preflight.message}` : ""}`
-          : preflight.message;
-        return {
-          isValid: false,
-          invalidReason: "invalid_exact_hedera_payload_preflight_failed",
-          invalidMessage,
-          payer,
-        };
-      }
+    let signature: { ok: boolean; reason?: string; message?: string };
+    try {
+      signature = await this.signer.verifyPayerSignature({
+        payer,
+        transaction: transactionBase64,
+        network: requirements.network,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_hedera_payload_signature_invalid",
+        invalidMessage: message,
+        payer,
+      };
+    }
+    if (!signature.ok) {
+      const invalidMessage = signature.reason
+        ? `${signature.reason}${signature.message ? `: ${signature.message}` : ""}`
+        : signature.message;
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_hedera_payload_signature_invalid",
+        invalidMessage,
+        payer,
+      };
+    }
+
+    // Phase 6: onchain preflight (balance + token association), fail-closed.
+    // Spec §6 — never throws out of verify.
+    let preflight: { ok: boolean; reason?: string; message?: string };
+    try {
+      preflight = await this.signer.preflightTransfer({
+        payer,
+        payTo: requirements.payTo,
+        asset: requirements.asset,
+        amount: requirements.amount,
+        network: requirements.network,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_hedera_payload_preflight_failed",
+        invalidMessage: message,
+        payer,
+      };
+    }
+    if (!preflight.ok) {
+      const invalidMessage = preflight.reason
+        ? `${preflight.reason}${preflight.message ? `: ${preflight.message}` : ""}`
+        : preflight.message;
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_hedera_payload_preflight_failed",
+        invalidMessage,
+        payer,
+      };
     }
 
     return {

--- a/typescript/packages/mechanisms/hedera/src/preflight.ts
+++ b/typescript/packages/mechanisms/hedera/src/preflight.ts
@@ -82,7 +82,9 @@ export function createHederaPreflightTransfer(
     const required = BigInt(amount);
 
     if (isHbarAsset(asset)) {
-      const account = await fetchJson<MirrorAccount>(`${baseUrl}/api/v1/accounts/${payer}`);
+      const account = await fetchJson<MirrorAccount>(
+        `${baseUrl}/api/v1/accounts/${encodeURIComponent(payer)}`,
+      );
       const held = BigInt(account.balance.balance);
       if (held < required) {
         return {
@@ -95,7 +97,7 @@ export function createHederaPreflightTransfer(
     }
 
     const payerTokens = await fetchJson<MirrorTokensResponse>(
-      `${baseUrl}/api/v1/accounts/${payer}/tokens?token.id=${asset}`,
+      `${baseUrl}/api/v1/accounts/${encodeURIComponent(payer)}/tokens?token.id=${encodeURIComponent(asset)}`,
     );
     const held = payerTokens.tokens[0] ? BigInt(payerTokens.tokens[0].balance) : 0n;
     if (held < required) {
@@ -123,7 +125,7 @@ export function createHederaPreflightTransfer(
  * @param network - CAIP-2 network identifier
  * @returns Mirror Node REST API base URL
  */
-function mirrorNodeUrlForNetwork(network: string): string {
+export function mirrorNodeUrlForNetwork(network: string): string {
   if (network === HEDERA_MAINNET_CAIP2) {
     return HEDERA_MAINNET_MIRROR_NODE_URL;
   }
@@ -144,13 +146,15 @@ function mirrorNodeUrlForNetwork(network: string): string {
  */
 async function isPayToAssociated(baseUrl: string, payTo: string, asset: string): Promise<boolean> {
   const direct = await fetchJson<MirrorTokensResponse>(
-    `${baseUrl}/api/v1/accounts/${payTo}/tokens?token.id=${asset}`,
+    `${baseUrl}/api/v1/accounts/${encodeURIComponent(payTo)}/tokens?token.id=${encodeURIComponent(asset)}`,
   );
   if (direct.tokens.length > 0) {
     return true;
   }
 
-  const account = await fetchJson<MirrorAccount>(`${baseUrl}/api/v1/accounts/${payTo}`);
+  const account = await fetchJson<MirrorAccount>(
+    `${baseUrl}/api/v1/accounts/${encodeURIComponent(payTo)}`,
+  );
   const maxAuto = account.max_automatic_token_associations;
   if (maxAuto === -1) {
     return true;
@@ -179,7 +183,7 @@ async function isPayToAssociated(baseUrl: string, payTo: string, asset: string):
  * @param url - Fully-qualified Mirror Node URL
  * @returns Parsed JSON body
  */
-async function fetchJson<T>(url: string): Promise<T> {
+export async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`Mirror Node request failed with status ${response.status}`);

--- a/typescript/packages/mechanisms/hedera/src/preflight.ts
+++ b/typescript/packages/mechanisms/hedera/src/preflight.ts
@@ -1,10 +1,9 @@
 import {
-  AccountBalanceQuery,
-  AccountId,
-  AccountInfoQuery,
-  Client,
-  TokenId,
-} from "@hiero-ledger/sdk";
+  HEDERA_MAINNET_CAIP2,
+  HEDERA_MAINNET_MIRROR_NODE_URL,
+  HEDERA_TESTNET_CAIP2,
+  HEDERA_TESTNET_MIRROR_NODE_URL,
+} from "./constants";
 import { isHbarAsset } from "./utils";
 
 /**
@@ -28,78 +27,162 @@ export type HederaPreflightResult = {
 };
 
 /**
- * Builds a `preflightTransfer` implementation backed by the Hiero SDK.
+ * Optional configuration for the default Mirror Node preflight implementation.
+ */
+export type HederaPreflightConfig = {
+  /**
+   * Mirror Node REST API base URL (no trailing slash). Defaults to the public
+   * Mirror Node for the request's CAIP-2 network.
+   */
+  mirrorNodeUrl?: string;
+};
+
+/**
+ * Account fields read from the Mirror Node `/accounts/{id}` endpoint.
+ */
+type MirrorAccount = {
+  balance: { balance: number };
+  max_automatic_token_associations: number;
+};
+
+/**
+ * A token relationship entry from the Mirror Node `/accounts/{id}/tokens` endpoint.
+ */
+type MirrorTokenRelationship = {
+  token_id: string;
+  balance: number;
+  automatic_association: boolean;
+};
+
+/**
+ * Paged response from the Mirror Node `/accounts/{id}/tokens` endpoint.
+ */
+type MirrorTokensResponse = {
+  tokens: MirrorTokenRelationship[];
+  links: { next: string | null };
+};
+
+/**
+ * Builds a `preflightTransfer` implementation backed by the Hedera Mirror Node
+ * REST API.
  *
- * Checks the payer has sufficient balance of `asset` and that `payTo` is
- * either associated with `asset` or has an available auto-association slot.
- * Implements the SHOULD in `specs/schemes/exact/scheme_exact_hedera.md` §6.
+ * The Mirror Node is the reliable source for balance and token-association
+ * data; consensus-node token queries no longer return that data dependably.
+ * Checks that the payer holds enough of `asset` and that `payTo` is either
+ * associated with `asset` or has an available auto-association slot.
  *
- * The caller supplies `buildClient(network)` — responsible for SDK client
- * construction and operator setup (and node-URL selection, if any). The
- * returned function closes the client in a `finally` block.
- *
- * @param buildClient - Factory that produces an SDK client for a given CAIP-2 network
+ * @param config - Optional Mirror Node configuration
  * @returns A function suitable for `FacilitatorHederaSigner.preflightTransfer`
  */
 export function createHederaPreflightTransfer(
-  buildClient: (network: string) => Client,
+  config: HederaPreflightConfig = {},
 ): (params: HederaPreflightParams) => Promise<HederaPreflightResult> {
   return async ({ payer, payTo, asset, amount, network }) => {
-    const client = buildClient(network);
-    try {
-      const required = BigInt(amount);
-      const balance = await new AccountBalanceQuery()
-        .setAccountId(AccountId.fromString(payer))
-        .execute(client);
+    const baseUrl = config.mirrorNodeUrl ?? mirrorNodeUrlForNetwork(network);
+    const required = BigInt(amount);
 
-      if (isHbarAsset(asset)) {
-        const payerTinybars = BigInt(balance.hbars.toTinybars().toString());
-        if (payerTinybars < required) {
-          return {
-            ok: false,
-            reason: "insufficient_balance",
-            message: `payer has ${payerTinybars} tinybars, needs ${required}`,
-          };
-        }
-        return { ok: true };
-      }
-
-      const tokenId = TokenId.fromString(asset);
-      const payerTokenBal = balance.tokens?.get(tokenId);
-      const held = payerTokenBal ? BigInt(payerTokenBal.toString()) : 0n;
+    if (isHbarAsset(asset)) {
+      const account = await fetchJson<MirrorAccount>(`${baseUrl}/api/v1/accounts/${payer}`);
+      const held = BigInt(account.balance.balance);
       if (held < required) {
         return {
           ok: false,
           reason: "insufficient_balance",
-          message: `payer holds ${held} of ${asset}, needs ${required}`,
+          message: `payer has ${held} tinybars, needs ${required}`,
         };
       }
+      return { ok: true };
+    }
 
-      const payToInfo = await new AccountInfoQuery()
-        .setAccountId(AccountId.fromString(payTo))
-        .execute(client);
-      const alreadyAssociated = payToInfo.tokenRelationships?.get(tokenId) !== undefined;
-      if (alreadyAssociated) {
-        return { ok: true };
-      }
-      const maxAuto = payToInfo.maxAutomaticTokenAssociations?.toNumber() ?? 0;
-      if (maxAuto === -1) {
-        return { ok: true };
-      }
-      const currentAuto = payToInfo.tokenRelationships
-        ? Array.from(payToInfo.tokenRelationships.values()).filter(r => r.automaticAssociation)
-            .length
-        : 0;
-      if (maxAuto > 0 && currentAuto < maxAuto) {
-        return { ok: true };
-      }
+    const payerTokens = await fetchJson<MirrorTokensResponse>(
+      `${baseUrl}/api/v1/accounts/${payer}/tokens?token.id=${asset}`,
+    );
+    const held = payerTokens.tokens[0] ? BigInt(payerTokens.tokens[0].balance) : 0n;
+    if (held < required) {
       return {
         ok: false,
-        reason: "pay_to_not_associated",
-        message: `payTo ${payTo} is not associated with ${asset} and has no auto-association slots`,
+        reason: "insufficient_balance",
+        message: `payer holds ${held} of ${asset}, needs ${required}`,
       };
-    } finally {
-      client.close();
     }
+
+    if (await isPayToAssociated(baseUrl, payTo, asset)) {
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      reason: "pay_to_not_associated",
+      message: `payTo ${payTo} is not associated with ${asset} and has no auto-association slots`,
+    };
   };
+}
+
+/**
+ * Resolves the public Mirror Node base URL for a CAIP-2 network.
+ *
+ * @param network - CAIP-2 network identifier
+ * @returns Mirror Node REST API base URL
+ */
+function mirrorNodeUrlForNetwork(network: string): string {
+  if (network === HEDERA_MAINNET_CAIP2) {
+    return HEDERA_MAINNET_MIRROR_NODE_URL;
+  }
+  if (network === HEDERA_TESTNET_CAIP2) {
+    return HEDERA_TESTNET_MIRROR_NODE_URL;
+  }
+  throw new Error(`Unsupported Hedera network: ${network}`);
+}
+
+/**
+ * Determines whether `payTo` can receive `asset`: either it is already
+ * associated, or it has a free auto-association slot.
+ *
+ * @param baseUrl - Mirror Node REST API base URL
+ * @param payTo - Destination account id
+ * @param asset - HTS token id
+ * @returns True when a transfer of `asset` to `payTo` will not fail association
+ */
+async function isPayToAssociated(baseUrl: string, payTo: string, asset: string): Promise<boolean> {
+  const direct = await fetchJson<MirrorTokensResponse>(
+    `${baseUrl}/api/v1/accounts/${payTo}/tokens?token.id=${asset}`,
+  );
+  if (direct.tokens.length > 0) {
+    return true;
+  }
+
+  const account = await fetchJson<MirrorAccount>(`${baseUrl}/api/v1/accounts/${payTo}`);
+  const maxAuto = account.max_automatic_token_associations;
+  if (maxAuto === -1) {
+    return true;
+  }
+  if (maxAuto === 0) {
+    return false;
+  }
+
+  let consumed = 0;
+  let next: string | null = `/api/v1/accounts/${payTo}/tokens`;
+  while (next) {
+    const page: MirrorTokensResponse = await fetchJson<MirrorTokensResponse>(`${baseUrl}${next}`);
+    consumed += page.tokens.filter(token => token.automatic_association).length;
+    if (consumed >= maxAuto) {
+      return false;
+    }
+    next = page.links?.next ?? null;
+  }
+  return consumed < maxAuto;
+}
+
+/**
+ * Fetches and parses a JSON response from the Mirror Node, throwing on a
+ * non-2xx status so the scheme reports preflight failure.
+ *
+ * @param url - Fully-qualified Mirror Node URL
+ * @returns Parsed JSON body
+ */
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Mirror Node request failed with status ${response.status}`);
+  }
+  return (await response.json()) as T;
 }

--- a/typescript/packages/mechanisms/hedera/src/signer.ts
+++ b/typescript/packages/mechanisms/hedera/src/signer.ts
@@ -1,7 +1,7 @@
 import type { PaymentRequirements } from "@x402/core/types";
+import { proto } from "@hiero-ledger/proto";
 import {
   AccountId,
-  AccountInfoQuery,
   Client,
   Hbar,
   Key,
@@ -14,6 +14,7 @@ import {
   TransferTransaction,
 } from "@hiero-ledger/sdk";
 import { HEDERA_MAINNET_CAIP2, HEDERA_TESTNET_CAIP2 } from "./constants";
+import { fetchJson, mirrorNodeUrlForNetwork } from "./preflight";
 import { assertSupportedHederaNetwork, isHbarAsset } from "./utils";
 
 /**
@@ -268,49 +269,102 @@ function keySignsTransaction(key: Key, tx: Transaction): boolean {
   }
   if (key instanceof KeyList) {
     const keys = key.toArray();
-    const threshold = key.threshold ?? keys.length;
+    // A non-positive or absent threshold means every key in the list must sign.
+    const threshold = key.threshold && key.threshold > 0 ? key.threshold : keys.length;
     return keys.filter(k => keySignsTransaction(k, tx)).length >= threshold;
   }
   return false;
 }
 
 /**
- * Builds a `verifyPayerSignature` implementation backed by the Hiero SDK.
+ * Optional configuration for the default Mirror Node verify implementation.
+ */
+export type HederaVerifyConfig = {
+  /**
+   * Mirror Node REST API base URL (no trailing slash). Defaults to the public
+   * Mirror Node for the request's CAIP-2 network.
+   */
+  mirrorNodeUrl?: string;
+};
+
+/**
+ * Account key as returned by the Mirror Node `/accounts/{id}` endpoint.
+ */
+type MirrorAccountKey = {
+  key: { _type: "ED25519" | "ECDSA_SECP256K1" | "ProtobufEncoded"; key: string } | null;
+};
+
+/**
+ * Converts a Mirror Node `key` field into a Hedera SDK `Key`.
  *
- * Fetches the payer's onchain account key via `AccountInfoQuery` (consensus
- * nodes reliably return keys) and verifies that the frozen transaction body
- * carries a valid signature satisfying that key — including KeyList/threshold
- * accounts. Binds the signature to the payer account, so a transaction signed
- * with the wrong key (or left unsigned) is rejected.
+ * Simple keys are parsed directly; threshold / KeyList accounts arrive as a
+ * hex-encoded protobuf (`ProtobufEncoded`) and are rebuilt via the SDK's
+ * internal `Key._fromProtobufKey`, the only entry point that reconstructs a
+ * `Key` from its protobuf form.
  *
- * The caller supplies `buildClient(network)` — responsible for SDK client
- * construction and operator setup so the query fee can be paid. The returned
- * function closes the client in a `finally` block.
+ * @param mirrorKey - The `key` object from the Mirror Node account response
+ * @returns Parsed SDK `Key`, or `null` when the key is missing or unrecognized
+ */
+function parseMirrorKey(mirrorKey: MirrorAccountKey["key"]): Key | null {
+  if (!mirrorKey || typeof mirrorKey.key !== "string" || mirrorKey.key.length === 0) {
+    return null;
+  }
+  switch (mirrorKey._type) {
+    case "ED25519":
+      return PublicKey.fromStringED25519(mirrorKey.key);
+    case "ECDSA_SECP256K1":
+      return PublicKey.fromStringECDSA(mirrorKey.key);
+    case "ProtobufEncoded": {
+      const decoded = proto.Key.decode(Buffer.from(mirrorKey.key, "hex"));
+      // `_fromProtobufKey` is an internal static on the SDK `Key` base class; it
+      // is the only way to rebuild a KeyList/threshold `Key` from its protobuf.
+      return (Key as unknown as { _fromProtobufKey(key: proto.IKey): Key })._fromProtobufKey(
+        decoded,
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Builds a `verifyPayerSignature` implementation backed by the Hedera Mirror
+ * Node REST API.
  *
- * @param buildClient - Factory that produces an SDK client for a given CAIP-2 network
+ * Reads the payer's onchain account key from the free Mirror Node (the same
+ * source as `createHederaPreflightTransfer`) and verifies that the frozen
+ * transaction body carries a valid signature satisfying that key — including
+ * KeyList/threshold accounts. Binds the signature to the payer account, so a
+ * transaction signed with the wrong key (or left unsigned) is rejected.
+ *
+ * @param config - Optional Mirror Node configuration
  * @returns A function suitable for `FacilitatorHederaSigner.verifyPayerSignature`
  */
 export function createHederaVerifyPayerSignature(
-  buildClient: (network: string) => Client,
+  config: HederaVerifyConfig = {},
 ): FacilitatorHederaSigner["verifyPayerSignature"] {
   return async ({ payer, transaction, network }) => {
     const tx = Transaction.fromBytes(Buffer.from(transaction, "base64"));
-    const client = buildClient(network);
-    try {
-      const info = await new AccountInfoQuery()
-        .setAccountId(AccountId.fromString(payer))
-        .execute(client);
-      if (keySignsTransaction(info.key, tx)) {
-        return { ok: true };
-      }
+    const baseUrl = config.mirrorNodeUrl ?? mirrorNodeUrlForNetwork(network);
+    const account = await fetchJson<MirrorAccountKey>(
+      `${baseUrl}/api/v1/accounts/${encodeURIComponent(payer)}`,
+    );
+    const key = parseMirrorKey(account.key);
+    if (!key) {
       return {
         ok: false,
         reason: "signature_invalid",
-        message: `payer ${payer} did not sign the transaction`,
+        message: "could not resolve payer key",
       };
-    } finally {
-      client.close();
     }
+    if (keySignsTransaction(key, tx)) {
+      return { ok: true };
+    }
+    return {
+      ok: false,
+      reason: "signature_invalid",
+      message: `payer ${payer} did not sign the transaction`,
+    };
   };
 }
 

--- a/typescript/packages/mechanisms/hedera/src/signer.ts
+++ b/typescript/packages/mechanisms/hedera/src/signer.ts
@@ -1,9 +1,13 @@
 import type { PaymentRequirements } from "@x402/core/types";
 import {
   AccountId,
+  AccountInfoQuery,
   Client,
   Hbar,
+  Key,
+  KeyList,
   PrivateKey,
+  PublicKey,
   TokenId,
   Transaction,
   TransactionId,
@@ -71,6 +75,28 @@ export type FacilitatorHederaSigner = {
   ): Promise<{ transactionId: string }>;
 
   /**
+   * Verify that the inferred payer actually signed the frozen transaction body.
+   *
+   * Required verify-time capability, called unconditionally by the scheme (it
+   * cannot be silently skipped), mirroring EVM's `verifyTypedData`. The default
+   * `createHederaVerifyPayerSignature` fetches the payer's onchain account key
+   * and verifies the signature against it; on `{ ok: false }` or a thrown error
+   * the scheme fails closed with `invalid_exact_hedera_payload_signature_invalid`.
+   *
+   * @param params - Signature verification parameters
+   * @param params.payer - Payer account id (inferred from decoded transfers)
+   * @param params.transaction - Base64-encoded transaction the payer should have signed
+   * @param params.network - CAIP-2 network identifier
+   * @returns `{ ok: true }` when the payer signed, otherwise
+   *          `{ ok: false, reason?, message? }`
+   */
+  verifyPayerSignature(params: {
+    payer: string;
+    transaction: string;
+    network: string;
+  }): Promise<{ ok: boolean; reason?: string; message?: string }>;
+
+  /**
    * Optional account resolution hook (used for alias policy).
    *
    * @param accountIdOrAlias - payTo field value
@@ -80,15 +106,13 @@ export type FacilitatorHederaSigner = {
   resolveAccount?(accountIdOrAlias: string, network: string): Promise<HederaAccountResolution>;
 
   /**
-   * Optional pre-settlement check that the transfer is expected to succeed
-   * on chain. Implements the SHOULD in
-   * `specs/schemes/exact/scheme_exact_hedera.md` §6 — verify payer balance
-   * and recipient token association / auto-association capacity.
+   * Pre-settlement check that the transfer is expected to succeed on chain.
+   * Implements the SHOULD in `specs/schemes/exact/scheme_exact_hedera.md` §6 —
+   * verify payer balance and recipient token association / auto-association
+   * capacity.
    *
-   * The hook is advisory: if it throws or is unreachable, the scheme treats
-   * the check as failed and reports `invalid_exact_hedera_payload_preflight_failed`,
-   * but verify itself never throws. There is an inherent verify→settle race
-   * (balance may change between calls) — this is best-effort.
+   * Required verify-time capability, called unconditionally by the scheme.
+   * The scheme fails closed with `invalid_exact_hedera_payload_preflight_failed` on `{ ok: false }` or a thrown error.
    *
    * @param params - Preflight parameters
    * @param params.payer - Payer account id (inferred from decoded transfers)
@@ -99,7 +123,7 @@ export type FacilitatorHederaSigner = {
    * @returns `{ ok: true }` when the transfer is expected to succeed,
    *          otherwise `{ ok: false, reason?, message? }`
    */
-  preflightTransfer?(params: {
+  preflightTransfer(params: {
     payer: string;
     payTo: string;
     asset: string;
@@ -223,6 +247,67 @@ export function createHederaSignAndSubmitTransaction(
       const response = await signed.execute(client);
       await response.getReceipt(client);
       return { transactionId: response.transactionId.toString() };
+    } finally {
+      client.close();
+    }
+  };
+}
+
+/**
+ * Returns true when `key` (a single key, or a KeyList whose threshold is met)
+ * has produced a valid signature over `tx`. Recurses into nested KeyLists so
+ * threshold and multi-key accounts are handled.
+ *
+ * @param key - Account key fetched from the network
+ * @param tx - Frozen, signed transaction to verify against
+ * @returns Whether the key's signing requirement is satisfied by `tx`
+ */
+function keySignsTransaction(key: Key, tx: Transaction): boolean {
+  if (key instanceof PublicKey) {
+    return key.verifyTransaction(tx);
+  }
+  if (key instanceof KeyList) {
+    const keys = key.toArray();
+    const threshold = key.threshold ?? keys.length;
+    return keys.filter(k => keySignsTransaction(k, tx)).length >= threshold;
+  }
+  return false;
+}
+
+/**
+ * Builds a `verifyPayerSignature` implementation backed by the Hiero SDK.
+ *
+ * Fetches the payer's onchain account key via `AccountInfoQuery` (consensus
+ * nodes reliably return keys) and verifies that the frozen transaction body
+ * carries a valid signature satisfying that key — including KeyList/threshold
+ * accounts. Binds the signature to the payer account, so a transaction signed
+ * with the wrong key (or left unsigned) is rejected.
+ *
+ * The caller supplies `buildClient(network)` — responsible for SDK client
+ * construction and operator setup so the query fee can be paid. The returned
+ * function closes the client in a `finally` block.
+ *
+ * @param buildClient - Factory that produces an SDK client for a given CAIP-2 network
+ * @returns A function suitable for `FacilitatorHederaSigner.verifyPayerSignature`
+ */
+export function createHederaVerifyPayerSignature(
+  buildClient: (network: string) => Client,
+): FacilitatorHederaSigner["verifyPayerSignature"] {
+  return async ({ payer, transaction, network }) => {
+    const tx = Transaction.fromBytes(Buffer.from(transaction, "base64"));
+    const client = buildClient(network);
+    try {
+      const info = await new AccountInfoQuery()
+        .setAccountId(AccountId.fromString(payer))
+        .execute(client);
+      if (keySignsTransaction(info.key, tx)) {
+        return { ok: true };
+      }
+      return {
+        ok: false,
+        reason: "signature_invalid",
+        message: `payer ${payer} did not sign the transaction`,
+      };
     } finally {
       client.close();
     }

--- a/typescript/packages/mechanisms/hedera/src/signer.ts
+++ b/typescript/packages/mechanisms/hedera/src/signer.ts
@@ -1,4 +1,7 @@
 import type { PaymentRequirements } from "@x402/core/types";
+// `@hiero-ledger/proto` must stay pinned in lockstep with `@hiero-ledger/sdk`
+// `parseMirrorKey` below relies on the SDK's internal `Key._fromProtobufKey`,
+// so re-check its availability whenever either dependency is bumped.
 import { proto } from "@hiero-ledger/proto";
 import {
   AccountId,
@@ -295,6 +298,13 @@ type MirrorAccountKey = {
 };
 
 /**
+ * Thrown when the Hedera SDK no longer exposes the internal
+ * `Key._fromProtobufKey` that {@link parseMirrorKey} relies on to rebuild
+ * KeyList/threshold keys, e.g. after an SDK upgrade renames or removes it.
+ */
+class ProtobufKeyReconstructionError extends Error {}
+
+/**
  * Converts a Mirror Node `key` field into a Hedera SDK `Key`.
  *
  * Simple keys are parsed directly; threshold / KeyList accounts arrive as a
@@ -304,6 +314,8 @@ type MirrorAccountKey = {
  *
  * @param mirrorKey - The `key` object from the Mirror Node account response
  * @returns Parsed SDK `Key`, or `null` when the key is missing or unrecognized
+ * @throws {ProtobufKeyReconstructionError} If the SDK no longer exposes
+ * `Key._fromProtobufKey`
  */
 function parseMirrorKey(mirrorKey: MirrorAccountKey["key"]): Key | null {
   if (!mirrorKey || typeof mirrorKey.key !== "string" || mirrorKey.key.length === 0) {
@@ -318,9 +330,17 @@ function parseMirrorKey(mirrorKey: MirrorAccountKey["key"]): Key | null {
       const decoded = proto.Key.decode(Buffer.from(mirrorKey.key, "hex"));
       // `_fromProtobufKey` is an internal static on the SDK `Key` base class; it
       // is the only way to rebuild a KeyList/threshold `Key` from its protobuf.
-      return (Key as unknown as { _fromProtobufKey(key: proto.IKey): Key })._fromProtobufKey(
-        decoded,
-      );
+      // Guarded explicitly so a future SDK rename/removal surfaces a
+      // diagnosable error instead of silently failing signature checks.
+      const fromProtobufKey = (Key as unknown as { _fromProtobufKey?: (key: proto.IKey) => Key })
+        ._fromProtobufKey;
+      if (typeof fromProtobufKey !== "function") {
+        throw new ProtobufKeyReconstructionError(
+          "@hiero-ledger/sdk Key._fromProtobufKey is unavailable; check the " +
+            "@hiero-ledger/sdk / @hiero-ledger/proto version pins in package.json",
+        );
+      }
+      return fromProtobufKey(decoded);
     }
     default:
       return null;
@@ -349,7 +369,19 @@ export function createHederaVerifyPayerSignature(
     const account = await fetchJson<MirrorAccountKey>(
       `${baseUrl}/api/v1/accounts/${encodeURIComponent(payer)}`,
     );
-    const key = parseMirrorKey(account.key);
+    let key: Key | null;
+    try {
+      key = parseMirrorKey(account.key);
+    } catch (error) {
+      if (error instanceof ProtobufKeyReconstructionError) {
+        return {
+          ok: false,
+          reason: "signature_unverifiable",
+          message: error.message,
+        };
+      }
+      throw error;
+    }
     if (!key) {
       return {
         ok: false,

--- a/typescript/packages/mechanisms/hedera/test/integrations/exact-hedera.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/integrations/exact-hedera.test.ts
@@ -21,6 +21,7 @@ import {
   type FacilitatorHederaSigner,
   createClientHederaSigner,
   createHederaSignAndSubmitTransaction,
+  createHederaVerifyPayerSignature,
 } from "../../src/signer";
 import { createHederaPreflightTransfer } from "../../src/preflight";
 import { ExactHederaScheme as ExactHederaClient } from "../../src/exact/client/scheme";
@@ -97,6 +98,10 @@ describe("Hedera integration", () => {
         return { transactionId: signed.transactionId?.toString() ?? "" };
       },
       resolveAccount: async () => ({ exists: true, isAlias: false }),
+      // Local flow exercises the in-memory finalizer without network access,
+      // so verify-time capabilities are stubbed to pass.
+      verifyPayerSignature: async () => ({ ok: true }),
+      preflightTransfer: async () => ({ ok: true }),
     };
   }
 
@@ -116,7 +121,8 @@ describe("Hedera integration", () => {
         feePayerPrivateKey,
       ),
       resolveAccount: async () => ({ exists: true, isAlias: false }),
-      preflightTransfer: createHederaPreflightTransfer(buildClient),
+      verifyPayerSignature: createHederaVerifyPayerSignature(buildClient),
+      preflightTransfer: createHederaPreflightTransfer(),
     };
   }
 
@@ -490,11 +496,13 @@ describe("Hedera integration", () => {
           parsedLiveClientPrivateKey,
           { network },
         );
-        // Disable preflight so settlement reaches execute()+getReceipt() and
-        // surfaces the real on-chain failure instead of being caught upstream.
+        // Stub the verify-time capabilities to pass so settlement reaches
+        // execute()+getReceipt() and surfaces the real on-chain failure instead
+        // of being caught upstream during verify.
         const liveSigner: FacilitatorHederaSigner = {
           ...createLiveNetworkSigner(liveFeePayerAccount!, parsedLiveFeePayerPrivateKey),
-          preflightTransfer: undefined,
+          verifyPayerSignature: async () => ({ ok: true }),
+          preflightTransfer: async () => ({ ok: true }),
         };
         const hederaFacilitator = new ExactHederaFacilitator(liveSigner);
         const facilitator = new x402Facilitator().register(network, hederaFacilitator);

--- a/typescript/packages/mechanisms/hedera/test/integrations/exact-hedera.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/integrations/exact-hedera.test.ts
@@ -121,7 +121,7 @@ describe("Hedera integration", () => {
         feePayerPrivateKey,
       ),
       resolveAccount: async () => ({ exists: true, isAlias: false }),
-      verifyPayerSignature: createHederaVerifyPayerSignature(buildClient),
+      verifyPayerSignature: createHederaVerifyPayerSignature(),
       preflightTransfer: createHederaPreflightTransfer(),
     };
   }

--- a/typescript/packages/mechanisms/hedera/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/unit/facilitator.test.ts
@@ -43,6 +43,8 @@ function createSigner() {
       transactionId: "0.0.5001@1700000001.000000000",
     })),
     resolveAccount: vi.fn(async () => ({ exists: true, isAlias: false })),
+    verifyPayerSignature: vi.fn(async () => ({ ok: true })),
+    preflightTransfer: vi.fn(async () => ({ ok: true })),
   };
 }
 
@@ -623,12 +625,76 @@ describe("ExactHedera facilitator scheme", () => {
       expect(settled.errorMessage).toContain("pay_to_not_associated");
       expect(signer.signAndSubmitTransaction).not.toHaveBeenCalled();
     });
+  });
 
-    it("is a no-op when hook is not defined", async () => {
+  describe("verifyPayerSignature", () => {
+    async function buildValidPayload(): Promise<PaymentPayload> {
+      return {
+        ...basePayload,
+        payload: {
+          transaction: await createTransferTransactionBase64({
+            feePayer: "0.0.5001",
+            payer: "0.0.9001",
+            payTo: "0.0.7001",
+            asset: "0.0.6001",
+            amount: "1000",
+          }),
+        },
+      };
+    }
+
+    it("passes payer/transaction/network to the capability", async () => {
       const signer = createSigner();
       const scheme = new ExactHederaScheme(signer);
-      const result = await scheme.verify(await buildValidPayload(), baseRequirements);
+      const payload = await buildValidPayload();
+      const result = await scheme.verify(payload, baseRequirements);
       expect(result.isValid).toBe(true);
+      expect(signer.verifyPayerSignature).toHaveBeenCalledWith({
+        payer: "0.0.9001",
+        transaction: payload.payload.transaction,
+        network: "hedera:testnet",
+      });
+    });
+
+    it("fails verify when the capability returns ok:false", async () => {
+      const signer = {
+        ...createSigner(),
+        verifyPayerSignature: vi.fn(async () => ({
+          ok: false,
+          reason: "signature_invalid",
+          message: "payer 0.0.9001 did not sign the transaction",
+        })),
+      };
+      const scheme = new ExactHederaScheme(signer);
+      const result = await scheme.verify(await buildValidPayload(), baseRequirements);
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("invalid_exact_hedera_payload_signature_invalid");
+      expect(result.invalidMessage).toContain("signature_invalid");
+      expect(result.payer).toBe("0.0.9001");
+    });
+
+    it("fails verify when the capability throws", async () => {
+      const signer = {
+        ...createSigner(),
+        verifyPayerSignature: vi.fn(async () => {
+          throw new Error("account info query unreachable");
+        }),
+      };
+      const scheme = new ExactHederaScheme(signer);
+      const result = await scheme.verify(await buildValidPayload(), baseRequirements);
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("invalid_exact_hedera_payload_signature_invalid");
+      expect(result.invalidMessage).toContain("account info query unreachable");
+    });
+
+    it("skips preflight when signature verification fails", async () => {
+      const signer = {
+        ...createSigner(),
+        verifyPayerSignature: vi.fn(async () => ({ ok: false, reason: "signature_invalid" })),
+      };
+      const scheme = new ExactHederaScheme(signer);
+      await scheme.verify(await buildValidPayload(), baseRequirements);
+      expect(signer.preflightTransfer).not.toHaveBeenCalled();
     });
   });
 

--- a/typescript/packages/mechanisms/hedera/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/unit/facilitator.test.ts
@@ -698,6 +698,77 @@ describe("ExactHedera facilitator scheme", () => {
     });
   });
 
+  describe("multi-sender payloads", () => {
+    async function buildMultiSenderPayload(): Promise<PaymentPayload> {
+      const tx = new TransferTransaction();
+      const tokenId = TokenId.fromString("0.0.6001");
+      tx.addTokenTransfer(tokenId, AccountId.fromString("0.0.9001"), "-600");
+      tx.addTokenTransfer(tokenId, AccountId.fromString("0.0.9002"), "-400");
+      tx.addTokenTransfer(tokenId, AccountId.fromString("0.0.7001"), "1000");
+      tx.setTransactionId(TransactionId.generate(AccountId.fromString("0.0.5001")));
+      await tx.freezeWith(Client.forTestnet());
+      return {
+        ...basePayload,
+        payload: { transaction: Buffer.from(tx.toBytes()).toString("base64") },
+      };
+    }
+
+    it("verifies the signature of every debited sender", async () => {
+      const signer = createSigner();
+      const scheme = new ExactHederaScheme(signer);
+
+      const result = await scheme.verify(await buildMultiSenderPayload(), baseRequirements);
+      expect(result.isValid).toBe(true);
+      expect(signer.verifyPayerSignature).toHaveBeenCalledTimes(2);
+      expect(signer.verifyPayerSignature).toHaveBeenCalledWith(
+        expect.objectContaining({ payer: "0.0.9001" }),
+      );
+      expect(signer.verifyPayerSignature).toHaveBeenCalledWith(
+        expect.objectContaining({ payer: "0.0.9002" }),
+      );
+    });
+
+    it("preflights each sender with their own debited amount", async () => {
+      const signer = createSigner();
+      const scheme = new ExactHederaScheme(signer);
+
+      const result = await scheme.verify(await buildMultiSenderPayload(), baseRequirements);
+      expect(result.isValid).toBe(true);
+      expect(signer.preflightTransfer).toHaveBeenCalledWith({
+        payer: "0.0.9001",
+        payTo: "0.0.7001",
+        asset: "0.0.6001",
+        amount: "600",
+        network: "hedera:testnet",
+      });
+      expect(signer.preflightTransfer).toHaveBeenCalledWith({
+        payer: "0.0.9002",
+        payTo: "0.0.7001",
+        asset: "0.0.6001",
+        amount: "400",
+        network: "hedera:testnet",
+      });
+    });
+
+    it("fails verify when a second sender did not sign", async () => {
+      const signer = {
+        ...createSigner(),
+        verifyPayerSignature: vi.fn(async ({ payer }: { payer: string }) =>
+          payer === "0.0.9002"
+            ? { ok: false, reason: "signature_invalid", message: `payer ${payer} did not sign` }
+            : { ok: true },
+        ),
+      };
+      const scheme = new ExactHederaScheme(signer);
+
+      const result = await scheme.verify(await buildMultiSenderPayload(), baseRequirements);
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("invalid_exact_hedera_payload_signature_invalid");
+      expect(result.invalidMessage).toContain("0.0.9002");
+      expect(signer.preflightTransfer).not.toHaveBeenCalled();
+    });
+  });
+
   describe("settle on-chain receipt handling", () => {
     async function buildValidPayload(): Promise<PaymentPayload> {
       return {

--- a/typescript/packages/mechanisms/hedera/test/unit/preflight.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/unit/preflight.test.ts
@@ -1,223 +1,247 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const balanceExecute = vi.fn();
-const infoExecute = vi.fn();
-const setBalanceAccountId = vi.fn(function (this: unknown) {
-  return this;
-});
-const setInfoAccountId = vi.fn(function (this: unknown) {
-  return this;
-});
-
-vi.mock("@hiero-ledger/sdk", async () => {
-  const actual = await vi.importActual<typeof import("@hiero-ledger/sdk")>("@hiero-ledger/sdk");
-  class AccountBalanceQuery {
-    setAccountId = setBalanceAccountId;
-    execute = balanceExecute;
-  }
-  class AccountInfoQuery {
-    setAccountId = setInfoAccountId;
-    execute = infoExecute;
-  }
-  return { ...actual, AccountBalanceQuery, AccountInfoQuery };
-});
-
-// Import after mock is registered.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHederaPreflightTransfer } from "../../src/preflight";
 
+const BASE = "https://mirror.test";
 const HBAR = "0.0.0";
 const TOKEN = "0.0.6001";
+const PAYER = "0.0.9001";
+const PAY_TO = "0.0.7001";
 
-function fakeClient() {
-  return { close: vi.fn() } as unknown as import("@hiero-ledger/sdk").Client;
+function mockFetch(handler: (url: string) => unknown): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    const body = handler(url);
+    if (body === undefined) {
+      return { ok: false, status: 404, json: async () => ({}) } as unknown as Response;
+    }
+    return { ok: true, status: 200, json: async () => body } as unknown as Response;
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
 }
 
-function hbarBalance(tinybars: bigint) {
-  return {
-    hbars: { toTinybars: () => ({ toString: () => tinybars.toString() }) },
-    tokens: undefined,
-  };
+function preflight(params: { payer?: string; payTo?: string; asset: string; amount: string }) {
+  return createHederaPreflightTransfer({ mirrorNodeUrl: BASE })({
+    payer: params.payer ?? PAYER,
+    payTo: params.payTo ?? PAY_TO,
+    asset: params.asset,
+    amount: params.amount,
+    network: "hedera:testnet",
+  });
 }
 
-function tokenBalance(tokenId: string, amount: bigint) {
-  return {
-    hbars: { toTinybars: () => ({ toString: () => "0" }) },
-    tokens: {
-      get: (tid: { toString(): string }) =>
-        tid.toString() === tokenId ? { toString: () => amount.toString() } : undefined,
-    },
-  };
-}
-
-function accountInfo(opts: { tokens?: Array<{ id: string; auto: boolean }>; maxAuto?: number }) {
-  const entries = opts.tokens ?? [];
-  const relationships = new Map<string, { automaticAssociation: boolean }>();
-  for (const e of entries) {
-    relationships.set(e.id, { automaticAssociation: e.auto });
-  }
-  return {
-    // Real SDK uses Map<TokenId, TokenRelationship>; we key by string and
-    // normalize TokenId via toString() on lookups from the helper.
-    tokenRelationships: {
-      get: (tid: { toString(): string }) => relationships.get(tid.toString()),
-      values: () => relationships.values(),
-    },
-    maxAutomaticTokenAssociations: { toNumber: () => opts.maxAuto ?? 0 },
-  };
-}
-
-describe("createHederaPreflightTransfer", () => {
-  let client: ReturnType<typeof fakeClient>;
-  let build: ReturnType<typeof vi.fn>;
-
+describe("createHederaPreflightTransfer (Mirror Node)", () => {
   beforeEach(() => {
-    balanceExecute.mockReset();
-    infoExecute.mockReset();
-    setBalanceAccountId.mockClear();
-    setInfoAccountId.mockClear();
-    client = fakeClient();
-    build = vi.fn(() => client);
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("HBAR: ok when payer balance >= amount", async () => {
-    balanceExecute.mockResolvedValue(hbarBalance(5000n));
-    const preflight = createHederaPreflightTransfer(build);
-    const r = await preflight({
-      payer: "0.0.9001",
-      payTo: "0.0.7001",
-      asset: HBAR,
-      amount: "1000",
-      network: "hedera:testnet",
-    });
+    const fetchFn = mockFetch(url =>
+      url.endsWith(`/accounts/${PAYER}`)
+        ? { balance: { balance: 5000 }, max_automatic_token_associations: 0 }
+        : undefined,
+    );
+    const r = await preflight({ asset: HBAR, amount: "1000" });
     expect(r).toEqual({ ok: true });
-    expect((client as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalled();
+    expect(fetchFn).toHaveBeenCalledWith(`${BASE}/api/v1/accounts/${PAYER}`);
   });
 
   it("HBAR: insufficient_balance when payer short", async () => {
-    balanceExecute.mockResolvedValue(hbarBalance(500n));
-    const preflight = createHederaPreflightTransfer(build);
-    const r = await preflight({
-      payer: "0.0.9001",
-      payTo: "0.0.7001",
-      asset: HBAR,
-      amount: "1000",
-      network: "hedera:testnet",
-    });
+    mockFetch(url =>
+      url.endsWith(`/accounts/${PAYER}`)
+        ? { balance: { balance: 500 }, max_automatic_token_associations: 0 }
+        : undefined,
+    );
+    const r = await preflight({ asset: HBAR, amount: "1000" });
     expect(r.ok).toBe(false);
     expect(r.reason).toBe("insufficient_balance");
     expect(r.message).toContain("500");
   });
 
   it("HTS: insufficient token balance", async () => {
-    balanceExecute.mockResolvedValue(tokenBalance(TOKEN, 100n));
-    const preflight = createHederaPreflightTransfer(build);
-    const r = await preflight({
-      payer: "0.0.9001",
-      payTo: "0.0.7001",
-      asset: TOKEN,
-      amount: "1000",
-      network: "hedera:testnet",
-    });
+    mockFetch(url =>
+      url.includes(`/accounts/${PAYER}/tokens`)
+        ? {
+            tokens: [{ token_id: TOKEN, balance: 100, automatic_association: false }],
+            links: { next: null },
+          }
+        : undefined,
+    );
+    const r = await preflight({ asset: TOKEN, amount: "1000" });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("insufficient_balance");
+  });
+
+  it("HTS: insufficient_balance when payer holds none of the token", async () => {
+    mockFetch(url =>
+      url.includes(`/accounts/${PAYER}/tokens`) ? { tokens: [], links: { next: null } } : undefined,
+    );
+    const r = await preflight({ asset: TOKEN, amount: "1000" });
     expect(r.ok).toBe(false);
     expect(r.reason).toBe("insufficient_balance");
   });
 
   it("HTS: ok when payTo already associated", async () => {
-    balanceExecute.mockResolvedValue(tokenBalance(TOKEN, 5000n));
-    infoExecute.mockResolvedValue(
-      accountInfo({ tokens: [{ id: TOKEN, auto: false }], maxAuto: 0 }),
-    );
-    const preflight = createHederaPreflightTransfer(build);
-    const r = await preflight({
-      payer: "0.0.9001",
-      payTo: "0.0.7001",
-      asset: TOKEN,
-      amount: "1000",
-      network: "hedera:testnet",
+    mockFetch(url => {
+      if (url.includes(`/accounts/${PAYER}/tokens`)) {
+        return {
+          tokens: [{ token_id: TOKEN, balance: 5000, automatic_association: false }],
+          links: { next: null },
+        };
+      }
+      if (url.includes(`/accounts/${PAY_TO}/tokens`)) {
+        return {
+          tokens: [{ token_id: TOKEN, balance: 0, automatic_association: false }],
+          links: { next: null },
+        };
+      }
+      return undefined;
     });
+    const r = await preflight({ asset: TOKEN, amount: "1000" });
     expect(r).toEqual({ ok: true });
   });
 
   it("HTS: ok when payTo has unlimited auto-association (-1)", async () => {
-    balanceExecute.mockResolvedValue(tokenBalance(TOKEN, 5000n));
-    infoExecute.mockResolvedValue(accountInfo({ tokens: [], maxAuto: -1 }));
-    const preflight = createHederaPreflightTransfer(build);
-    const r = await preflight({
-      payer: "0.0.9001",
-      payTo: "0.0.7001",
-      asset: TOKEN,
-      amount: "1000",
-      network: "hedera:testnet",
+    mockFetch(url => {
+      if (url.includes(`/accounts/${PAYER}/tokens`)) {
+        return {
+          tokens: [{ token_id: TOKEN, balance: 5000, automatic_association: false }],
+          links: { next: null },
+        };
+      }
+      if (url.includes(`/accounts/${PAY_TO}/tokens`)) {
+        return { tokens: [], links: { next: null } };
+      }
+      if (url.endsWith(`/accounts/${PAY_TO}`)) {
+        return { balance: { balance: 0 }, max_automatic_token_associations: -1 };
+      }
+      return undefined;
     });
+    const r = await preflight({ asset: TOKEN, amount: "1000" });
     expect(r).toEqual({ ok: true });
   });
 
-  it("HTS: ok when payTo has available auto-association slot", async () => {
-    balanceExecute.mockResolvedValue(tokenBalance(TOKEN, 5000n));
-    infoExecute.mockResolvedValue(
-      accountInfo({ tokens: [{ id: "0.0.9999", auto: true }], maxAuto: 3 }),
-    );
-    const preflight = createHederaPreflightTransfer(build);
-    const r = await preflight({
-      payer: "0.0.9001",
-      payTo: "0.0.7001",
-      asset: TOKEN,
-      amount: "1000",
-      network: "hedera:testnet",
+  it("HTS: ok when payTo has an available auto-association slot", async () => {
+    mockFetch(url => {
+      if (url.includes(`/accounts/${PAYER}/tokens`)) {
+        return {
+          tokens: [{ token_id: TOKEN, balance: 5000, automatic_association: false }],
+          links: { next: null },
+        };
+      }
+      if (url.includes(`/accounts/${PAY_TO}/tokens?token.id=`)) {
+        return { tokens: [], links: { next: null } };
+      }
+      if (url.includes(`/accounts/${PAY_TO}/tokens`)) {
+        return {
+          tokens: [{ token_id: "0.0.1", balance: 1, automatic_association: true }],
+          links: { next: null },
+        };
+      }
+      if (url.endsWith(`/accounts/${PAY_TO}`)) {
+        return { balance: { balance: 0 }, max_automatic_token_associations: 3 };
+      }
+      return undefined;
     });
+    const r = await preflight({ asset: TOKEN, amount: "1000" });
     expect(r).toEqual({ ok: true });
   });
 
   it("HTS: pay_to_not_associated when no association and no slots", async () => {
-    balanceExecute.mockResolvedValue(tokenBalance(TOKEN, 5000n));
-    infoExecute.mockResolvedValue(accountInfo({ tokens: [], maxAuto: 0 }));
-    const preflight = createHederaPreflightTransfer(build);
-    const r = await preflight({
-      payer: "0.0.9001",
-      payTo: "0.0.7001",
-      asset: TOKEN,
-      amount: "1000",
-      network: "hedera:testnet",
+    mockFetch(url => {
+      if (url.includes(`/accounts/${PAYER}/tokens`)) {
+        return {
+          tokens: [{ token_id: TOKEN, balance: 5000, automatic_association: false }],
+          links: { next: null },
+        };
+      }
+      if (url.includes(`/accounts/${PAY_TO}/tokens`)) {
+        return { tokens: [], links: { next: null } };
+      }
+      if (url.endsWith(`/accounts/${PAY_TO}`)) {
+        return { balance: { balance: 0 }, max_automatic_token_associations: 0 };
+      }
+      return undefined;
     });
+    const r = await preflight({ asset: TOKEN, amount: "1000" });
     expect(r.ok).toBe(false);
     expect(r.reason).toBe("pay_to_not_associated");
   });
 
   it("HTS: pay_to_not_associated when auto slots fully consumed", async () => {
-    balanceExecute.mockResolvedValue(tokenBalance(TOKEN, 5000n));
-    infoExecute.mockResolvedValue(
-      accountInfo({
-        tokens: [
-          { id: "0.0.1", auto: true },
-          { id: "0.0.2", auto: true },
-        ],
-        maxAuto: 2,
-      }),
-    );
-    const preflight = createHederaPreflightTransfer(build);
-    const r = await preflight({
-      payer: "0.0.9001",
-      payTo: "0.0.7001",
-      asset: TOKEN,
-      amount: "1000",
-      network: "hedera:testnet",
+    mockFetch(url => {
+      if (url.includes(`/accounts/${PAYER}/tokens`)) {
+        return {
+          tokens: [{ token_id: TOKEN, balance: 5000, automatic_association: false }],
+          links: { next: null },
+        };
+      }
+      if (url.includes(`/accounts/${PAY_TO}/tokens?token.id=`)) {
+        return { tokens: [], links: { next: null } };
+      }
+      if (url.includes(`/accounts/${PAY_TO}/tokens`)) {
+        return {
+          tokens: [
+            { token_id: "0.0.1", balance: 1, automatic_association: true },
+            { token_id: "0.0.2", balance: 1, automatic_association: true },
+          ],
+          links: { next: null },
+        };
+      }
+      if (url.endsWith(`/accounts/${PAY_TO}`)) {
+        return { balance: { balance: 0 }, max_automatic_token_associations: 2 };
+      }
+      return undefined;
     });
+    const r = await preflight({ asset: TOKEN, amount: "1000" });
     expect(r.ok).toBe(false);
     expect(r.reason).toBe("pay_to_not_associated");
   });
 
-  it("closes the client even when a query throws", async () => {
-    balanceExecute.mockRejectedValue(new Error("mirror down"));
-    const preflight = createHederaPreflightTransfer(build);
-    await expect(
-      preflight({
-        payer: "0.0.9001",
-        payTo: "0.0.7001",
-        asset: HBAR,
-        amount: "1000",
-        network: "hedera:testnet",
-      }),
-    ).rejects.toThrow("mirror down");
-    expect((client as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalled();
+  it("HTS: follows links.next when counting consumed auto-association slots", async () => {
+    const fetchFn = mockFetch(url => {
+      if (url.includes(`/accounts/${PAYER}/tokens`)) {
+        return {
+          tokens: [{ token_id: TOKEN, balance: 5000, automatic_association: false }],
+          links: { next: null },
+        };
+      }
+      if (url.includes(`/accounts/${PAY_TO}/tokens?token.id=`)) {
+        return { tokens: [], links: { next: null } };
+      }
+      if (url.includes("page=2")) {
+        return {
+          tokens: [{ token_id: "0.0.3", balance: 1, automatic_association: true }],
+          links: { next: null },
+        };
+      }
+      if (url.includes(`/accounts/${PAY_TO}/tokens`)) {
+        return {
+          tokens: [
+            { token_id: "0.0.1", balance: 1, automatic_association: true },
+            { token_id: "0.0.2", balance: 1, automatic_association: true },
+          ],
+          links: { next: `/api/v1/accounts/${PAY_TO}/tokens?page=2` },
+        };
+      }
+      if (url.endsWith(`/accounts/${PAY_TO}`)) {
+        return { balance: { balance: 0 }, max_automatic_token_associations: 5 };
+      }
+      return undefined;
+    });
+    const r = await preflight({ asset: TOKEN, amount: "1000" });
+    expect(r).toEqual({ ok: true });
+    expect(fetchFn).toHaveBeenCalledWith(`${BASE}/api/v1/accounts/${PAY_TO}/tokens?page=2`);
+  });
+
+  it("throws when the Mirror Node returns a non-2xx status", async () => {
+    mockFetch(() => undefined);
+    await expect(preflight({ asset: HBAR, amount: "1000" })).rejects.toThrow(
+      "Mirror Node request failed",
+    );
   });
 });

--- a/typescript/packages/mechanisms/hedera/test/unit/preflight.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/unit/preflight.test.ts
@@ -238,6 +238,22 @@ describe("createHederaPreflightTransfer (Mirror Node)", () => {
     expect(fetchFn).toHaveBeenCalledWith(`${BASE}/api/v1/accounts/${PAY_TO}/tokens?page=2`);
   });
 
+  it("encodes interpolated path segments before hitting the Mirror Node", async () => {
+    const weirdAsset = "0.0.6001 evil/path";
+    const fetchFn = mockFetch(url =>
+      url.includes("/tokens")
+        ? {
+            tokens: [{ token_id: weirdAsset, balance: 5000, automatic_association: false }],
+            links: { next: null },
+          }
+        : undefined,
+    );
+    await preflight({ asset: weirdAsset, amount: "1000" });
+    const requestedUrl = String(fetchFn.mock.calls[0][0]);
+    expect(requestedUrl).toContain(`token.id=${encodeURIComponent(weirdAsset)}`);
+    expect(requestedUrl).not.toContain(" ");
+  });
+
   it("throws when the Mirror Node returns a non-2xx status", async () => {
     mockFetch(() => undefined);
     await expect(preflight({ asset: HBAR, amount: "1000" })).rejects.toThrow(

--- a/typescript/packages/mechanisms/hedera/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/unit/signer.test.ts
@@ -4,6 +4,7 @@ import {
   AccountId,
   Client,
   Hbar,
+  Key,
   KeyList,
   PrivateKey,
   TokenId,
@@ -389,6 +390,26 @@ describe("createHederaVerifyPayerSignature", () => {
     const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("signature_invalid");
+  });
+
+  it("fails closed with a diagnosable reason if the SDK's internal Key._fromProtobufKey is unavailable", async () => {
+    const key1 = PrivateKey.generateED25519();
+    const key2 = PrivateKey.generateED25519();
+    const transaction = await buildTransaction([key1, key2]);
+    const keyList = new KeyList([key1.publicKey, key2.publicKey], 2);
+    mockMirrorKey({ _type: "ProtobufEncoded", key: keyListToProtobufHex(keyList) });
+    const verify = createHederaVerifyPayerSignature({ mirrorNodeUrl: "https://mirror.test" });
+
+    const original = (Key as unknown as { _fromProtobufKey?: unknown })._fromProtobufKey;
+    (Key as unknown as { _fromProtobufKey?: unknown })._fromProtobufKey = undefined;
+    try {
+      const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("signature_unverifiable");
+      expect(result.message).toContain("_fromProtobufKey");
+    } finally {
+      (Key as unknown as { _fromProtobufKey?: unknown })._fromProtobufKey = original;
+    }
   });
 
   it("fails when the Mirror Node returns no key", async () => {

--- a/typescript/packages/mechanisms/hedera/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/unit/signer.test.ts
@@ -1,15 +1,36 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const infoExecute = vi.fn();
+const setInfoAccountId = vi.fn(function (this: unknown) {
+  return this;
+});
+
+vi.mock("@hiero-ledger/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@hiero-ledger/sdk")>("@hiero-ledger/sdk");
+  class AccountInfoQuery {
+    setAccountId = setInfoAccountId;
+    execute = infoExecute;
+  }
+  return { ...actual, AccountInfoQuery };
+});
+
 import {
   AccountId,
   Client,
   Hbar,
+  type Key,
+  KeyList,
   PrivateKey,
   TokenId,
   TopicCreateTransaction,
   TransactionId,
   TransferTransaction,
 } from "@hiero-ledger/sdk";
-import { createClientHederaSigner, createHederaSignAndSubmitTransaction } from "../../src/signer";
+import {
+  createClientHederaSigner,
+  createHederaSignAndSubmitTransaction,
+  createHederaVerifyPayerSignature,
+} from "../../src/signer";
 import { inspectHederaTransaction } from "../../src/utils";
 import { HEDERA_TESTNET_USDC } from "../../src/constants";
 
@@ -271,5 +292,110 @@ describe("createHederaSignAndSubmitTransaction", () => {
     await expect(submit(base64, feePayerAccount, "hedera:testnet")).rejects.toThrow(
       /expected TransferTransaction/,
     );
+  });
+});
+
+describe("createHederaVerifyPayerSignature", () => {
+  const PAYER = "0.0.9001";
+  const PAY_TO = "0.0.7001";
+  const FEE_PAYER = "0.0.5001";
+
+  function fakeClient(): Client {
+    return { close: vi.fn() } as unknown as Client;
+  }
+
+  async function buildTransaction(
+    signers: PrivateKey[],
+  ): Promise<{ transaction: string; client: Client }> {
+    const tx = new TransferTransaction();
+    tx.addHbarTransfer(AccountId.fromString(PAYER), Hbar.fromTinybars("-1000"));
+    tx.addHbarTransfer(AccountId.fromString(PAY_TO), Hbar.fromTinybars("1000"));
+    tx.setTransactionId(TransactionId.generate(AccountId.fromString(FEE_PAYER)));
+    await tx.freezeWith(Client.forTestnet());
+    for (const signer of signers) {
+      await tx.sign(signer);
+    }
+    return {
+      transaction: Buffer.from(tx.toBytes()).toString("base64"),
+      client: fakeClient(),
+    };
+  }
+
+  function withKey(key: Key, client: Client): (network: string) => Client {
+    infoExecute.mockResolvedValue({ key });
+    return () => client;
+  }
+
+  beforeEach(() => {
+    infoExecute.mockReset();
+    setInfoAccountId.mockClear();
+  });
+
+  it("ok when the payer signed with their account key", async () => {
+    const key = PrivateKey.generateED25519();
+    const { transaction, client } = await buildTransaction([key]);
+    const verify = createHederaVerifyPayerSignature(withKey(key.publicKey, client));
+
+    const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
+    expect(result).toEqual({ ok: true });
+    expect((client as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalled();
+  });
+
+  it("fails when signed with a different key", async () => {
+    const signingKey = PrivateKey.generateED25519();
+    const accountKey = PrivateKey.generateED25519();
+    const { transaction, client } = await buildTransaction([signingKey]);
+    const verify = createHederaVerifyPayerSignature(withKey(accountKey.publicKey, client));
+
+    const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("signature_invalid");
+  });
+
+  it("fails for an unsigned transaction", async () => {
+    const accountKey = PrivateKey.generateED25519();
+    const { transaction, client } = await buildTransaction([]);
+    const verify = createHederaVerifyPayerSignature(withKey(accountKey.publicKey, client));
+
+    const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("signature_invalid");
+  });
+
+  it("ok when a KeyList threshold is met", async () => {
+    const key1 = PrivateKey.generateED25519();
+    const key2 = PrivateKey.generateED25519();
+    const key3 = PrivateKey.generateED25519();
+    const { transaction, client } = await buildTransaction([key1, key2]);
+    const keyList = new KeyList([key1.publicKey, key2.publicKey, key3.publicKey], 2);
+    const verify = createHederaVerifyPayerSignature(withKey(keyList, client));
+
+    const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("fails when a KeyList threshold is not met", async () => {
+    const key1 = PrivateKey.generateED25519();
+    const key2 = PrivateKey.generateED25519();
+    const key3 = PrivateKey.generateED25519();
+    const { transaction, client } = await buildTransaction([key1]);
+    const keyList = new KeyList([key1.publicKey, key2.publicKey, key3.publicKey], 2);
+    const verify = createHederaVerifyPayerSignature(withKey(keyList, client));
+
+    const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("signature_invalid");
+  });
+
+  it("closes the client even when the account query throws", async () => {
+    const client = fakeClient();
+    infoExecute.mockRejectedValue(new Error("account info down"));
+    const { transaction } = await buildTransaction([PrivateKey.generateED25519()]);
+    const verify = createHederaVerifyPayerSignature(() => client);
+
+    await expect(verify({ payer: PAYER, transaction, network: "hedera:testnet" })).rejects.toThrow(
+      "account info down",
+    );
+    expect((client as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalled();
   });
 });

--- a/typescript/packages/mechanisms/hedera/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/unit/signer.test.ts
@@ -1,24 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const infoExecute = vi.fn();
-const setInfoAccountId = vi.fn(function (this: unknown) {
-  return this;
-});
-
-vi.mock("@hiero-ledger/sdk", async () => {
-  const actual = await vi.importActual<typeof import("@hiero-ledger/sdk")>("@hiero-ledger/sdk");
-  class AccountInfoQuery {
-    setAccountId = setInfoAccountId;
-    execute = infoExecute;
-  }
-  return { ...actual, AccountInfoQuery };
-});
-
+import { proto } from "@hiero-ledger/proto";
 import {
   AccountId,
   Client,
   Hbar,
-  type Key,
   KeyList,
   PrivateKey,
   TokenId,
@@ -300,13 +285,9 @@ describe("createHederaVerifyPayerSignature", () => {
   const PAY_TO = "0.0.7001";
   const FEE_PAYER = "0.0.5001";
 
-  function fakeClient(): Client {
-    return { close: vi.fn() } as unknown as Client;
-  }
+  type MirrorKey = { _type: "ED25519" | "ECDSA_SECP256K1" | "ProtobufEncoded"; key: string } | null;
 
-  async function buildTransaction(
-    signers: PrivateKey[],
-  ): Promise<{ transaction: string; client: Client }> {
+  async function buildTransaction(signers: PrivateKey[]): Promise<string> {
     const tx = new TransferTransaction();
     tx.addHbarTransfer(AccountId.fromString(PAYER), Hbar.fromTinybars("-1000"));
     tx.addHbarTransfer(AccountId.fromString(PAY_TO), Hbar.fromTinybars("1000"));
@@ -315,37 +296,57 @@ describe("createHederaVerifyPayerSignature", () => {
     for (const signer of signers) {
       await tx.sign(signer);
     }
-    return {
-      transaction: Buffer.from(tx.toBytes()).toString("base64"),
-      client: fakeClient(),
-    };
+    return Buffer.from(tx.toBytes()).toString("base64");
   }
 
-  function withKey(key: Key, client: Client): (network: string) => Client {
-    infoExecute.mockResolvedValue({ key });
-    return () => client;
+  // Serializes a KeyList to the hex-encoded protobuf the Mirror Node returns
+  // for threshold / KeyList accounts (`_type: "ProtobufEncoded"`).
+  function keyListToProtobufHex(keyList: KeyList): string {
+    const protoKey = (keyList as unknown as { _toProtobufKey(): proto.IKey })._toProtobufKey();
+    return Buffer.from(proto.Key.encode(protoKey).finish()).toString("hex");
+  }
+
+  function mockMirrorKey(key: MirrorKey): ReturnType<typeof vi.fn> {
+    const fn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ key }) }));
+    global.fetch = fn as unknown as typeof fetch;
+    return fn;
   }
 
   beforeEach(() => {
-    infoExecute.mockReset();
-    setInfoAccountId.mockClear();
+    vi.restoreAllMocks();
   });
 
-  it("ok when the payer signed with their account key", async () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("ok when the payer signed with their ED25519 account key", async () => {
     const key = PrivateKey.generateED25519();
-    const { transaction, client } = await buildTransaction([key]);
-    const verify = createHederaVerifyPayerSignature(withKey(key.publicKey, client));
+    const transaction = await buildTransaction([key]);
+    const fetchFn = mockMirrorKey({ _type: "ED25519", key: key.publicKey.toStringRaw() });
+    const verify = createHederaVerifyPayerSignature({ mirrorNodeUrl: "https://mirror.test" });
 
     const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
     expect(result).toEqual({ ok: true });
-    expect((client as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalled();
+    expect(fetchFn).toHaveBeenCalledWith(`https://mirror.test/api/v1/accounts/${PAYER}`);
+  });
+
+  it("ok when the payer signed with their ECDSA account key", async () => {
+    const key = PrivateKey.generateECDSA();
+    const transaction = await buildTransaction([key]);
+    mockMirrorKey({ _type: "ECDSA_SECP256K1", key: key.publicKey.toStringRaw() });
+    const verify = createHederaVerifyPayerSignature({ mirrorNodeUrl: "https://mirror.test" });
+
+    const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
+    expect(result).toEqual({ ok: true });
   });
 
   it("fails when signed with a different key", async () => {
     const signingKey = PrivateKey.generateED25519();
     const accountKey = PrivateKey.generateED25519();
-    const { transaction, client } = await buildTransaction([signingKey]);
-    const verify = createHederaVerifyPayerSignature(withKey(accountKey.publicKey, client));
+    const transaction = await buildTransaction([signingKey]);
+    mockMirrorKey({ _type: "ED25519", key: accountKey.publicKey.toStringRaw() });
+    const verify = createHederaVerifyPayerSignature({ mirrorNodeUrl: "https://mirror.test" });
 
     const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
     expect(result.ok).toBe(false);
@@ -354,8 +355,9 @@ describe("createHederaVerifyPayerSignature", () => {
 
   it("fails for an unsigned transaction", async () => {
     const accountKey = PrivateKey.generateED25519();
-    const { transaction, client } = await buildTransaction([]);
-    const verify = createHederaVerifyPayerSignature(withKey(accountKey.publicKey, client));
+    const transaction = await buildTransaction([]);
+    mockMirrorKey({ _type: "ED25519", key: accountKey.publicKey.toStringRaw() });
+    const verify = createHederaVerifyPayerSignature({ mirrorNodeUrl: "https://mirror.test" });
 
     const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
     expect(result.ok).toBe(false);
@@ -366,9 +368,10 @@ describe("createHederaVerifyPayerSignature", () => {
     const key1 = PrivateKey.generateED25519();
     const key2 = PrivateKey.generateED25519();
     const key3 = PrivateKey.generateED25519();
-    const { transaction, client } = await buildTransaction([key1, key2]);
+    const transaction = await buildTransaction([key1, key2]);
     const keyList = new KeyList([key1.publicKey, key2.publicKey, key3.publicKey], 2);
-    const verify = createHederaVerifyPayerSignature(withKey(keyList, client));
+    mockMirrorKey({ _type: "ProtobufEncoded", key: keyListToProtobufHex(keyList) });
+    const verify = createHederaVerifyPayerSignature({ mirrorNodeUrl: "https://mirror.test" });
 
     const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
     expect(result).toEqual({ ok: true });
@@ -378,24 +381,38 @@ describe("createHederaVerifyPayerSignature", () => {
     const key1 = PrivateKey.generateED25519();
     const key2 = PrivateKey.generateED25519();
     const key3 = PrivateKey.generateED25519();
-    const { transaction, client } = await buildTransaction([key1]);
+    const transaction = await buildTransaction([key1]);
     const keyList = new KeyList([key1.publicKey, key2.publicKey, key3.publicKey], 2);
-    const verify = createHederaVerifyPayerSignature(withKey(keyList, client));
+    mockMirrorKey({ _type: "ProtobufEncoded", key: keyListToProtobufHex(keyList) });
+    const verify = createHederaVerifyPayerSignature({ mirrorNodeUrl: "https://mirror.test" });
 
     const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("signature_invalid");
   });
 
-  it("closes the client even when the account query throws", async () => {
-    const client = fakeClient();
-    infoExecute.mockRejectedValue(new Error("account info down"));
-    const { transaction } = await buildTransaction([PrivateKey.generateED25519()]);
-    const verify = createHederaVerifyPayerSignature(() => client);
+  it("fails when the Mirror Node returns no key", async () => {
+    const transaction = await buildTransaction([PrivateKey.generateED25519()]);
+    mockMirrorKey(null);
+    const verify = createHederaVerifyPayerSignature({ mirrorNodeUrl: "https://mirror.test" });
+
+    const result = await verify({ payer: PAYER, transaction, network: "hedera:testnet" });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("signature_invalid");
+    expect(result.message).toContain("could not resolve payer key");
+  });
+
+  it("throws when the Mirror Node request fails", async () => {
+    const transaction = await buildTransaction([PrivateKey.generateED25519()]);
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    const verify = createHederaVerifyPayerSignature({ mirrorNodeUrl: "https://mirror.test" });
 
     await expect(verify({ payer: PAYER, transaction, network: "hedera:testnet" })).rejects.toThrow(
-      "account info down",
+      "Mirror Node request failed",
     );
-    expect((client as unknown as { close: ReturnType<typeof vi.fn> }).close).toHaveBeenCalled();
   });
 });

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: 1.2.6
       '@signinwithethereum/siwe':
         specifier: ^4.1.0
-        version: 4.1.0(viem@2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: 4.1.0(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@x402/core':
         specifier: workspace:~
         version: link:../core
@@ -1390,9 +1390,12 @@ importers:
 
   packages/mechanisms/hedera:
     dependencies:
+      '@hiero-ledger/proto':
+        specifier: 2.31.0
+        version: 2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.0.1)(strip-ansi@7.1.2)
       '@hiero-ledger/sdk':
-        specifier: 2.80.0
-        version: 2.80.0(bn.js@5.2.1)(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
+        specifier: 2.85.0
+        version: 2.85.0(bn.js@5.2.3)(bufferutil@4.0.9)(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)
       '@x402/core':
         specifier: workspace:~
         version: link:../../core
@@ -1818,6 +1821,9 @@ importers:
         version: 5.9.2
 
 packages:
+
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
@@ -2968,60 +2974,6 @@ packages:
     resolution: {integrity: sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==}
     engines: {node: '>=14'}
 
-  '@ethersproject/abi@5.8.0':
-    resolution: {integrity: sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==}
-
-  '@ethersproject/abstract-provider@5.8.0':
-    resolution: {integrity: sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==}
-
-  '@ethersproject/abstract-signer@5.8.0':
-    resolution: {integrity: sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==}
-
-  '@ethersproject/address@5.8.0':
-    resolution: {integrity: sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==}
-
-  '@ethersproject/base64@5.8.0':
-    resolution: {integrity: sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==}
-
-  '@ethersproject/bignumber@5.8.0':
-    resolution: {integrity: sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==}
-
-  '@ethersproject/bytes@5.8.0':
-    resolution: {integrity: sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==}
-
-  '@ethersproject/constants@5.8.0':
-    resolution: {integrity: sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==}
-
-  '@ethersproject/hash@5.8.0':
-    resolution: {integrity: sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==}
-
-  '@ethersproject/keccak256@5.8.0':
-    resolution: {integrity: sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==}
-
-  '@ethersproject/logger@5.8.0':
-    resolution: {integrity: sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==}
-
-  '@ethersproject/networks@5.8.0':
-    resolution: {integrity: sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==}
-
-  '@ethersproject/properties@5.8.0':
-    resolution: {integrity: sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==}
-
-  '@ethersproject/rlp@5.8.0':
-    resolution: {integrity: sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==}
-
-  '@ethersproject/signing-key@5.8.0':
-    resolution: {integrity: sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==}
-
-  '@ethersproject/strings@5.8.0':
-    resolution: {integrity: sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==}
-
-  '@ethersproject/transactions@5.8.0':
-    resolution: {integrity: sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==}
-
-  '@ethersproject/web@5.8.0':
-    resolution: {integrity: sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==}
-
   '@evanhahn/lottie-web-light@5.8.1':
     resolution: {integrity: sha512-U0G1tt3/UEYnyCNNslWPi1dB7X1xQ9aoSip+B3GTKO/Bns8yz/p39vBkRSN9d25nkbHuCsbjky2coQftj5YVKw==}
 
@@ -3123,8 +3075,8 @@ packages:
     peerDependencies:
       react: '>= 16 || ^19.0.0-rc'
 
-  '@hiero-ledger/cryptography@1.16.0-beta.3':
-    resolution: {integrity: sha512-7+R/HKGq6LiqUZ1agn52sQS6J3+VXBWvqIMUCIU1EVdbEPQDPoVPJYEd7dDreBCLIcjBRcHVjDc9wbi+ar2rsA==}
+  '@hiero-ledger/cryptography@1.19.0':
+    resolution: {integrity: sha512-6CN34QzPGpegFpQGw1dI77N+75ICdLPSSpcBQ35tyKiNruh6KjE9L0R0th5kcn5sdFw8CwHOPwDQ4+HaSyW0Yw==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       expo-crypto: '*'
@@ -3132,21 +3084,21 @@ packages:
       expo-crypto:
         optional: true
 
-  '@hiero-ledger/proto@2.26.0-beta.3':
-    resolution: {integrity: sha512-2UhTKX2RbL2LC8XcgetFa4iS5d8cELY/8PmFolj750z4CoQu2YOchZTqNTdI431qR9uAx3aBVSf+mx/YBYIUNA==}
+  '@hiero-ledger/proto@2.31.0':
+    resolution: {integrity: sha512-6Uq9cSK1lqhMsP/Zwz3liKIzn5QtN2dvt/7EET00/LdubYxYqVxREs8SCtYbgOlzMy34n1Hl6eNeEDDFpkQhMg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       debug: 4.4.1
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       strip-ansi: 7.1.2
 
-  '@hiero-ledger/sdk@2.80.0':
-    resolution: {integrity: sha512-9FHNPduWl27eNI2Gns0O6GJTqcEJ11lBTML84A7D8albCErVXaUVsnRrASafH+Xfq1dqK5dwsNHRwu8WtM3zVQ==}
+  '@hiero-ledger/sdk@2.85.0':
+    resolution: {integrity: sha512-o9xmNHeIt7D2ZuetLTSJlrUI9S7dsEzaut61lOxIbne+9fDxGyYfkNrZaf65rOp2e/SltdwQMOseXyFXUdFqVg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      bn.js: 5.2.1
+      bn.js: 5.2.3
 
   '@hono/node-server@1.19.1':
     resolution: {integrity: sha512-h44e5s+ByUriaRIbeS/C74O8v90m0A95luyYQGMF7KEn96KkYMXO7bZAwombzTpjQTU4e0TkU8U1WBIXlwuwtA==}
@@ -3656,6 +3608,9 @@ packages:
     resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
 
@@ -3687,6 +3642,10 @@ packages:
 
   '@noble/ed25519@3.1.0':
     resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -5530,6 +5489,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
@@ -6104,6 +6066,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -6350,11 +6315,11 @@ packages:
     resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
     engines: {node: '>= 10.0.0'}
 
+  bignumber.js@11.1.2:
+    resolution: {integrity: sha512-9idDyC15Vpk+53w4OfxEu2PqHSKFQUffrH1oTvnkJ9fduTJ032tpuI2sxS04oCzocklokWUZmWVEkTEQdLmUOQ==}
+
   bignumber.js@11.1.4:
     resolution: {integrity: sha512-AJ9dSeaUGj2xu7tEwmdqb51dqdb633xo4njI9K8ZFfcLrNr0XN8/EPkkZUNaF9fkCblGt2zVwZymesUdGynEkQ==}
-
-  bignumber.js@9.1.1:
-    resolution: {integrity: sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -6373,9 +6338,6 @@ packages:
 
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
-
-  bn.js@5.2.1:
-    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
 
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
@@ -7280,6 +7242,10 @@ packages:
 
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
+
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
+    engines: {node: '>=14.0.0'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -9204,6 +9170,14 @@ packages:
     resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
     engines: {node: '>=12.0.0'}
 
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+    engines: {node: '>=12.0.0'}
+
+  protobufjs@8.2.0:
+    resolution: {integrity: sha512-oI+GC9iPxrQEr6wragljFKH46/r3rNsm6eg7F2fp6kBUMnf6/mesDRdBuF4gK+OyaKJ8N4C1B9s9cCeYdqFikg==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -9324,10 +9298,10 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-native-get-random-values@1.11.0:
-    resolution: {integrity: sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==}
+  react-native-get-random-values@2.0.0:
+    resolution: {integrity: sha512-wx7/aPqsUIiWsG35D+MsUJd8ij96e3JKddklSdrdZUrheTx89gPtz3Q2yl9knBArj5u26Cl23T88ai+Q0vypdQ==}
     peerDependencies:
-      react-native: '>=0.56'
+      react-native: '>=0.81'
 
   react-native@0.85.0:
     resolution: {integrity: sha512-z2ltUAS9xzdL4HQeG7wpsYMv2o35R4D8qZwbXu0SbeamZ4+ZIBxc84Ay4Vb6fRExBpsT06aZFV+W030W9JxDFQ==}
@@ -10027,6 +10001,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -10170,6 +10147,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -10728,6 +10708,8 @@ packages:
         optional: true
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.10.1': {}
 
   '@adraffy/ens-normalize@1.11.1': {}
 
@@ -12303,129 +12285,6 @@ snapshots:
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
 
-  '@ethersproject/abi@5.8.0':
-    dependencies:
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/hash': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
-  '@ethersproject/abstract-provider@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/networks': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/transactions': 5.8.0
-      '@ethersproject/web': 5.8.0
-
-  '@ethersproject/abstract-signer@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-provider': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-
-  '@ethersproject/address@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-
-  '@ethersproject/base64@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-
-  '@ethersproject/bignumber@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      bn.js: 5.2.3
-
-  '@ethersproject/bytes@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/constants@5.8.0':
-    dependencies:
-      '@ethersproject/bignumber': 5.8.0
-
-  '@ethersproject/hash@5.8.0':
-    dependencies:
-      '@ethersproject/abstract-signer': 5.8.0
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
-  '@ethersproject/keccak256@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      js-sha3: 0.8.0
-
-  '@ethersproject/logger@5.8.0': {}
-
-  '@ethersproject/networks@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/properties@5.8.0':
-    dependencies:
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/rlp@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/signing-key@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      bn.js: 5.2.3
-      elliptic: 6.6.1
-      hash.js: 1.1.7
-
-  '@ethersproject/strings@5.8.0':
-    dependencies:
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/logger': 5.8.0
-
-  '@ethersproject/transactions@5.8.0':
-    dependencies:
-      '@ethersproject/address': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/constants': 5.8.0
-      '@ethersproject/keccak256': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@ethersproject/signing-key': 5.8.0
-
-  '@ethersproject/web@5.8.0':
-    dependencies:
-      '@ethersproject/base64': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/logger': 5.8.0
-      '@ethersproject/properties': 5.8.0
-      '@ethersproject/strings': 5.8.0
-
   '@evanhahn/lottie-web-light@5.8.1': {}
 
   '@farcaster/frame-sdk@0.1.9(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
@@ -12602,14 +12461,14 @@ snapshots:
   '@grpc/proto-loader@0.7.15':
     dependencies:
       lodash.camelcase: 4.3.0
-      long: 5.3.1
+      long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
-      long: 5.3.1
+      long: 5.3.2
       protobufjs: 7.6.1
       yargs: 17.7.2
 
@@ -12617,20 +12476,20 @@ snapshots:
     dependencies:
       react: 19.2.6
 
-  '@hiero-ledger/cryptography@1.16.0-beta.3(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))':
+  '@hiero-ledger/cryptography@1.19.0(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))':
     dependencies:
       '@noble/curves': 1.8.1
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       asn1js: 3.0.6
-      bignumber.js: 9.1.1
-      bn.js: 5.2.1
+      bignumber.js: 11.1.2
+      bn.js: 5.2.3
       buffer: 6.0.3
       crypto-js: 4.2.0
       debug: 4.4.1
       forge-light: 1.1.4
       js-base64: 3.7.7
-      react-native-get-random-values: 1.11.0(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
+      react-native-get-random-values: 2.0.0(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
       spark-md5: 3.0.2
       strip-ansi: 7.1.2
       tweetnacl: 1.0.3
@@ -12639,42 +12498,50 @@ snapshots:
       - react-native
       - supports-color
 
-  '@hiero-ledger/proto@2.26.0-beta.3(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)':
+  '@hiero-ledger/proto@2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.0.1)(strip-ansi@7.1.2)':
     dependencies:
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       debug: 4.4.1
       long: 5.3.1
-      protobufjs: 7.5.4
+      protobufjs: 8.0.1
       strip-ansi: 7.1.2
 
-  '@hiero-ledger/sdk@2.80.0(bn.js@5.2.1)(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))':
+  '@hiero-ledger/proto@2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.2.0)(strip-ansi@7.1.2)':
     dependencies:
-      '@ethersproject/abi': 5.8.0
-      '@ethersproject/bignumber': 5.8.0
-      '@ethersproject/bytes': 5.8.0
-      '@ethersproject/rlp': 5.8.0
-      '@grpc/grpc-js': 1.12.6
-      '@hiero-ledger/cryptography': 1.16.0-beta.3(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
-      '@hiero-ledger/proto': 2.26.0-beta.3(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
-      bignumber.js: 9.1.1
-      bn.js: 5.2.1
+      debug: 4.4.1
+      long: 5.3.1
+      protobufjs: 8.2.0
+      strip-ansi: 7.1.2
+
+  '@hiero-ledger/sdk@2.85.0(bn.js@5.2.3)(bufferutil@4.0.9)(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)':
+    dependencies:
+      '@grpc/grpc-js': 1.12.6
+      '@hiero-ledger/cryptography': 1.19.0(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10))
+      '@hiero-ledger/proto': 2.31.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@8.2.0)(strip-ansi@7.1.2)
+      ansi-regex: 6.2.2
+      ansi-styles: 6.2.3
+      bignumber.js: 11.1.2
+      bn.js: 5.2.3
       crypto-js: 4.2.0
       debug: 4.4.1
+      ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       js-base64: 3.7.4
       long: 5.3.1
       pino: 10.1.0
       pino-pretty: 13.0.0
-      protobufjs: 7.5.4
+      protobufjs: 8.2.0
       rfc4648: 1.5.3
       strip-ansi: 7.1.2
       utf8: 3.0.0
     transitivePeerDependencies:
+      - bufferutil
       - expo-crypto
       - react-native
       - supports-color
+      - utf-8-validate
 
   '@hono/node-server@1.19.1(hono@4.10.7)':
     dependencies:
@@ -13232,6 +13099,10 @@ snapshots:
 
   '@noble/ciphers@2.1.1': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -13261,6 +13132,8 @@ snapshots:
   '@noble/ed25519@3.0.0': {}
 
   '@noble/ed25519@3.1.0': {}
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
 
@@ -14315,10 +14188,11 @@ snapshots:
       '@noble/hashes': 1.8.0
       apg-js: 4.4.0
 
-  '@signinwithethereum/siwe@4.1.0(viem@2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@signinwithethereum/siwe@4.1.0(ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(viem@2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@signinwithethereum/siwe-parser': 4.1.0
     optionalDependencies:
+      ethers: 6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       viem: 2.48.11(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
 
   '@sinclair/typebox@0.27.10': {}
@@ -16291,6 +16165,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -18213,6 +18091,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  aes-js@4.0.0-beta.5: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -18485,9 +18365,9 @@ snapshots:
     dependencies:
       bindings: 1.5.0
 
-  bignumber.js@11.1.4: {}
+  bignumber.js@11.1.2: {}
 
-  bignumber.js@9.1.1: {}
+  bignumber.js@11.1.4: {}
 
   bignumber.js@9.3.1: {}
 
@@ -18506,8 +18386,6 @@ snapshots:
   bn.js@4.11.8: {}
 
   bn.js@4.12.3: {}
-
-  bn.js@5.2.1: {}
 
   bn.js@5.2.3: {}
 
@@ -19646,6 +19524,19 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
+
+  ethers@6.16.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   event-target-shim@5.0.1: {}
 
@@ -21914,7 +21805,7 @@ snapshots:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/node': 22.19.17
-      long: 5.3.1
+      long: 5.3.2
 
   protobufjs@7.6.1:
     dependencies:
@@ -21928,6 +21819,26 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.17
+      long: 5.3.2
+
+  protobufjs@8.0.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.17
+      long: 5.3.2
+
+  protobufjs@8.2.0:
+    dependencies:
       '@types/node': 22.19.17
       long: 5.3.2
 
@@ -22064,7 +21975,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-native-get-random-values@1.11.0(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10)):
+  react-native-get-random-values@2.0.0(react-native@0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10)):
     dependencies:
       fast-base64-decode: 1.0.0
       react-native: 0.85.0(@babel/core@7.28.3)(bufferutil@4.0.9)(react@19.2.6)(utf-8-validate@5.0.10)
@@ -22950,6 +22861,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsup@8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1):
@@ -23122,6 +23035,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   uncrypto@0.1.3: {}
+
+  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 

--- a/typescript/site/app/facilitator/index.ts
+++ b/typescript/site/app/facilitator/index.ts
@@ -17,10 +17,12 @@ import {
 } from "@x402/extensions";
 import { BuilderCodeFacilitatorExtension } from "@x402/extensions/builder-code";
 import {
+  AccountId as HederaAccountId,
   PrivateKey as HederaPrivateKey,
   createHederaClient,
   createHederaPreflightTransfer,
   createHederaSignAndSubmitTransaction,
+  createHederaVerifyPayerSignature,
   toFacilitatorHederaSigner,
 } from "@x402/hedera";
 import { ExactHederaScheme } from "@x402/hedera/exact/facilitator";
@@ -208,7 +210,11 @@ async function createFacilitator(): Promise<x402Facilitator> {
       process.env.FACILITATOR_HEDERA_PRIVATE_KEY,
     );
     const hederaFeePayer = process.env.FACILITATOR_HEDERA_ACCOUNT_ID;
-    const buildHederaClient = (network: string) => createHederaClient(network);
+    const buildHederaClient = (network: string) => {
+      const client = createHederaClient(network);
+      client.setOperator(HederaAccountId.fromString(hederaFeePayer), hederaFeePayerKey);
+      return client;
+    };
 
     const hederaSigner = toFacilitatorHederaSigner({
       getAddresses: () => [hederaFeePayer],
@@ -216,7 +222,8 @@ async function createFacilitator(): Promise<x402Facilitator> {
         buildHederaClient,
         hederaFeePayerKey,
       ),
-      preflightTransfer: createHederaPreflightTransfer(buildHederaClient),
+      verifyPayerSignature: createHederaVerifyPayerSignature(buildHederaClient),
+      preflightTransfer: createHederaPreflightTransfer(),
     });
 
     facilitator.register(

--- a/typescript/site/app/facilitator/index.ts
+++ b/typescript/site/app/facilitator/index.ts
@@ -222,7 +222,7 @@ async function createFacilitator(): Promise<x402Facilitator> {
         buildHederaClient,
         hederaFeePayerKey,
       ),
-      verifyPayerSignature: createHederaVerifyPayerSignature(buildHederaClient),
+      verifyPayerSignature: createHederaVerifyPayerSignature(),
       preflightTransfer: createHederaPreflightTransfer(),
     });
 


### PR DESCRIPTION
## Description

Hardened the exact Hedera facilitator `verify()` path so a payment that passes verification is the same one that succeeds at settlement (security fix for unsigned / wrong-key payloads and unassociated recipients).

`verify()` now (1) confirms the inferred payer actually signed the frozen transaction body by fetching the payer's onchain account key and checking the signature — including KeyList/threshold accounts — and (2) pre-checks balance and token association against the Hedera Mirror Node REST API, which is the reliable data source (consensus-node token data is no longer dependable). Both run unconditionally and fail closed.

Breaking change to `FacilitatorHederaSigner`: `verifyPayerSignature` is a new required capability and `preflightTransfer` is now required (was optional). Use the new `createHederaVerifyPayerSignature(buildClient)` default and `createHederaPreflightTransfer(config?)`, whose signature changed from `(buildClient)` to an optional `{ mirrorNodeUrl? }`.

Closes https://github.com/x402-foundation/x402/issues/2701

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 