### PR TITLE
Add Lagoon Tech Systems to ecosystem (CIV Commodity Data + Webpage-to-Markdown)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/civ-commodity-data/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/civ-commodity-data/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "CIV Commodity Data",
+  "description": "x402-paid HTTP API for cocoa, coffee, sugar, cotton, and cashew commodity data. First-mover Côte d'Ivoire farmgate prices (CCC and CCA decrees, FCFA/kg), ICE Futures US settlements (CC, KC, SB, CT), CFTC COT positioning, and historical trends. 19 endpoints across 5 commodities, $0.01–$0.10 USDC on Base. Machine-readable real public data, no API keys. Listed on x402scan.",
+  "logoUrl": "/logos/lagoon-tech-commodity-data.svg",
+  "websiteUrl": "https://data.lagoontechsystems.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/app/ecosystem/partners-data/webpage-to-markdown/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/webpage-to-markdown/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Webpage-to-Markdown",
+  "description": "x402-paid HTTP API that converts any webpage URL into clean, agent-ready Markdown (Readability + Turndown). POST a URL, pay $0.005 USDC on Base, receive structured Markdown. No API keys. Built for agent-context construction. Listed on x402scan.",
+  "logoUrl": "/logos/lagoon-tech-x402-md.svg",
+  "websiteUrl": "https://x402-md.lagoontechsystems.com",
+  "category": "Services/Endpoints"
+}

--- a/typescript/site/public/logos/lagoon-tech-commodity-data.svg
+++ b/typescript/site/public/logos/lagoon-tech-commodity-data.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="CIV Commodity Data by Lagoon Tech">
+  <defs>
+    <linearGradient id="cd-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0d1a14"/>
+      <stop offset="1" stop-color="#1c4d35"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="64" fill="url(#cd-bg)"/>
+  <g font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif" text-anchor="middle">
+    <text x="256" y="200" font-size="56" font-weight="700" fill="#9adfb3" letter-spacing="6">CIV</text>
+    <text x="256" y="312" font-size="108" font-weight="700" fill="#ecfdf0" letter-spacing="-3">data</text>
+  </g>
+  <g transform="translate(256 400)">
+    <rect x="-90" y="-8" width="20" height="20" fill="#9adfb3"/>
+    <rect x="-60" y="-14" width="20" height="26" fill="#c0e8ce"/>
+    <rect x="-30" y="-22" width="20" height="34" fill="#ecfdf0"/>
+    <rect x="0"   y="-16" width="20" height="28" fill="#c0e8ce"/>
+    <rect x="30"  y="-28" width="20" height="40" fill="#9adfb3"/>
+    <rect x="60"  y="-12" width="20" height="24" fill="#ecfdf0"/>
+  </g>
+</svg>

--- a/typescript/site/public/logos/lagoon-tech-x402-md.svg
+++ b/typescript/site/public/logos/lagoon-tech-x402-md.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Webpage-to-Markdown by Lagoon Tech">
+  <defs>
+    <linearGradient id="lg-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b1620"/>
+      <stop offset="1" stop-color="#1a3247"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="64" fill="url(#lg-bg)"/>
+  <g font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif" text-anchor="middle">
+    <text x="256" y="220" font-size="120" font-weight="700" fill="#eaf3fb" letter-spacing="-4">URL</text>
+    <text x="256" y="290" font-size="40" font-weight="500" fill="#5fb2e8" letter-spacing="2">→</text>
+    <text x="256" y="360" font-size="80" font-weight="700" fill="#5fb2e8" letter-spacing="-2">md</text>
+  </g>
+  <g transform="translate(256 430)">
+    <circle cx="-32" cy="0" r="6" fill="#5fb2e8"/>
+    <circle cx="0"   cy="0" r="6" fill="#eaf3fb"/>
+    <circle cx="32"  cy="0" r="6" fill="#5fb2e8"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Add Lagoon Tech Systems to the ecosystem

Two live x402 seller services from **Lagoon Tech Systems** (Abidjan, Côte d'Ivoire), both on **Base mainnet** via the CDP facilitator, x402 **v2**, USDC, no API keys:

- **CIV Commodity Data** — https://data.lagoontechsystems.com — pay-per-call Côte d'Ivoire & global soft-commodity data (cocoa, coffee, sugar, cotton, cashew): CCC/CCA farmgate floor decrees, ICE Futures US settlements, CFTC COT positioning, and history. **19 paid endpoints**, $0.01–$0.10.
- **Webpage-to-Markdown** — https://x402-md.lagoontechsystems.com — convert any URL into clean, agent-ready Markdown (Readability + Turndown). $0.005/call.

Both serve `/openapi.json` (OpenAPI 3.1 with `x-payment-info`) and a spec-compliant HTTP 402, and are listed on x402scan. Category: **Services/Endpoints**.

Adds 2 `partners-data/*/metadata.json` files + 2 logos. (Supersedes coinbase/x402#187, which was opened against the non-canonical repo.)