### PR TITLE
fix(py): return 500 (not empty 402) on unexpected settlement error in FastAPI middleware

### DIFF
--- a/python/x402/changelog.d/2603.bugfix.md
+++ b/python/x402/changelog.d/2603.bugfix.md
@@ -1,0 +1,1 @@
+FastAPI middleware now returns `500` (and logs the exception) when the settlement path raises an unexpected error, instead of a silent empty-body `402` that could prompt a paying client to retry.

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -6,6 +6,7 @@ Provides payment-gated route protection for FastAPI applications.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
@@ -48,6 +49,8 @@ from ._bazaar_utils import (
 from ._bazaar_utils import (
     validate_bazaar_extensions as _validate_bazaar_extensions,
 )
+
+logger = logging.getLogger(__name__)
 
 # ============================================================================
 # FastAPI Adapter
@@ -375,7 +378,14 @@ def payment_middleware(
             except FacilitatorResponseError as error:
                 return _facilitator_error_response(error)
             except Exception:
-                return JSONResponse(content={}, status_code=402)
+                # An unexpected failure here (RPC outage, bug, etc.) is a server
+                # error, not "payment required". Returning 402 would tell a paying
+                # client/agent to retry and pay again into a broken endpoint.
+                logger.exception("Unexpected error during x402 settlement")
+                return JSONResponse(
+                    content={"error": "Internal Server Error"},
+                    status_code=500,
+                )
 
         # Fallthrough - should not happen
         return await call_next(request)

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -450,6 +450,55 @@ class TestFastAPIMiddlewareIntegration:
                 assert response.json() == {}
                 assert "PAYMENT-RESPONSE" in response.headers
 
+    def test_settlement_unexpected_exception_returns_500(self):
+        """Test that an unexpected settlement error returns 500, not an empty 402."""
+        app = FastAPI()
+
+        @app.get("/api/protected")
+        def protected_route():
+            return {"data": "Protected content"}
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request = AsyncMock(
+                return_value=HTTPProcessResult(
+                    type="payment-verified",
+                    payment_payload=payment_payload,
+                    payment_requirements=payment_requirements,
+                )
+            )
+            mock_http_server_instance.process_settlement = AsyncMock(
+                side_effect=RuntimeError("RPC node unreachable")
+            )
+            mock_http_server.return_value = mock_http_server_instance
+
+            @app.middleware("http")
+            async def x402_middleware(request: Request, call_next):
+                return await payment_middleware(
+                    routes, mock_server, sync_facilitator_on_start=False
+                )(request, call_next)
+
+            with TestClient(app) as client:
+                response = client.get("/api/protected")
+                assert response.status_code == 500
+                assert response.json() == {"error": "Internal Server Error"}
+
     def test_cancels_on_handler_error_status(self):
         """Test that handler 4xx/5xx triggers cancellation without settlement."""
         app = FastAPI()


### PR DESCRIPTION
## What

The FastAPI middleware's settlement `except Exception` returned an empty-body `402`, so an internal failure (RPC outage, bug) was indistinguishable from a genuine "payment required" — an autonomous client may retry and **pay again** into a broken endpoint. It now logs the exception and returns `500`. The genuine settlement-failure path (`if not settle_result.success`) still returns `402` unchanged.

Closes #2603.

## Changes
- `fastapi.py`: module logger + `logger.exception(...)` and `500` in the post-verification settlement catch-all.
- Test: `test_settlement_unexpected_exception_returns_500`.
- Towncrier changelog fragment.

## Scope
- Scoped to FastAPI per the issue. The same empty-402 catch-all also exists in `flask.py` (WSGI) — happy to include the parity fix here or as a follow-up (asked on the issue thread).
- Settle-path idempotency (raised on the issue) is out of scope for this PR.

## Verification
`uv run pytest tests/unit/http/middleware/test_fastapi.py` → 32 passed; `ruff check` clean.

---
AI-assisted (Claude Code), reviewed before submitting.