### PR TITLE
fix: warn at startup when ResourceInfo description/tags exceed CDP facilitator limits

### DIFF
--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -144,9 +144,24 @@ export interface RouteConfig {
 
   // HTTP-specific metadata
   resource?: string;
+  /**
+   * Human-readable description of this resource.
+   *
+   * Keep concise: the CDP facilitator enforces an undocumented payload-size limit and returns a
+   * generic 400 "invalid paymentPayload" (not a field-specific error) when the combined
+   * ResourceInfo payload is too large. Descriptions over ~200 characters have been observed to
+   * trigger this. See: https://github.com/x402-foundation/x402/issues/2679
+   */
   description?: string;
   mimeType?: string;
   serviceName?: string;
+  /**
+   * Searchable tags for this resource.
+   *
+   * The CDP facilitator silently rejects payloads with more than 8 tags, returning a generic
+   * 400 "invalid paymentPayload" error rather than a tag-count-specific message. Keep to 8 or
+   * fewer. See: https://github.com/x402-foundation/x402/issues/2679
+   */
   tags?: string[];
   iconUrl?: string;
   customPaywallHtml?: string;

--- a/typescript/packages/extensions/src/bazaar/startupValidation.ts
+++ b/typescript/packages/extensions/src/bazaar/startupValidation.ts
@@ -13,8 +13,14 @@ export { checkIfBazaarNeeded } from "@x402/core/server";
 
 /**
  * Empirical limits observed for the CDP facilitator (https://github.com/x402-foundation/x402/issues/2679).
- * The CDP facilitator returns a generic 400 "invalid paymentPayload" when ResourceInfo
- * fields exceed these values, with no field-specific error message.
+ *
+ * The facilitator behaves like a combined ResourceInfo payload-size budget rather than
+ * two independent caps: exceeding it returns a generic 400 "invalid paymentPayload" with
+ * no field-specific message. Empirically the tag count is the sharper lever: a ~450-char
+ * description can settle on its own, yet the same description paired with 14 tags trips the
+ * limit, and trimming to 8 tags clears it without shortening the description. The values
+ * below are conservative heuristics for being near the budget; tags <= 8 is the most
+ * reliable single fix.
  */
 const CDP_MAX_TAGS = 8;
 const CDP_MAX_DESCRIPTION_LENGTH = 200;
@@ -39,9 +45,10 @@ export function validateResourceInfoLimits(routes: RoutesConfig): void {
     if (Array.isArray(config.tags) && config.tags.length > CDP_MAX_TAGS) {
       console.warn(
         `x402: Route "${pattern}" declares ${config.tags.length} tags. ` +
-          `The CDP facilitator silently rejects payloads with more than ${CDP_MAX_TAGS} tags ` +
-          `(returns generic 400 "invalid paymentPayload" — not a tag-count error). ` +
-          `Trim to ${CDP_MAX_TAGS} or fewer. See: https://github.com/x402-foundation/x402/issues/2679`,
+          `The CDP facilitator silently rejects payloads over its combined ResourceInfo budget ` +
+          `(a generic 400 "invalid paymentPayload", not a tag-count error), and tag count is the ` +
+          `sharpest lever. Trim to ${CDP_MAX_TAGS} or fewer. ` +
+          `See: https://github.com/x402-foundation/x402/issues/2679`,
       );
     }
     if (
@@ -50,8 +57,11 @@ export function validateResourceInfoLimits(routes: RoutesConfig): void {
     ) {
       console.warn(
         `x402: Route "${pattern}" description is ${config.description.length} characters. ` +
-          `The CDP facilitator may reject large ResourceInfo payloads with a generic ` +
-          `400 "invalid paymentPayload" error. Keep descriptions under ${CDP_MAX_DESCRIPTION_LENGTH} characters. ` +
+          `The CDP facilitator enforces a combined ResourceInfo payload budget and may reject ` +
+          `large payloads with a generic 400 "invalid paymentPayload" error. A long description ` +
+          `can settle on its own but is more likely to trip the limit alongside many tags, so ` +
+          `reducing tags to ${CDP_MAX_TAGS} or fewer is the most reliable fix; keeping descriptions ` +
+          `under ${CDP_MAX_DESCRIPTION_LENGTH} characters is a conservative default. ` +
           `See: https://github.com/x402-foundation/x402/issues/2679`,
       );
     }

--- a/typescript/packages/extensions/src/bazaar/startupValidation.ts
+++ b/typescript/packages/extensions/src/bazaar/startupValidation.ts
@@ -31,7 +31,9 @@ const CDP_MAX_DESCRIPTION_LENGTH = 200;
  */
 export function validateResourceInfoLimits(routes: RoutesConfig): void {
   const entries: [string, { description?: string; tags?: string[] }][] =
-    "accepts" in routes ? [["*", routes as { description?: string; tags?: string[] }]] : Object.entries(routes);
+    "accepts" in routes
+      ? [["*", routes as { description?: string; tags?: string[] }]]
+      : Object.entries(routes);
 
   for (const [pattern, config] of entries) {
     if (Array.isArray(config.tags) && config.tags.length > CDP_MAX_TAGS) {
@@ -42,7 +44,10 @@ export function validateResourceInfoLimits(routes: RoutesConfig): void {
           `Trim to ${CDP_MAX_TAGS} or fewer. See: https://github.com/x402-foundation/x402/issues/2679`,
       );
     }
-    if (typeof config.description === "string" && config.description.length > CDP_MAX_DESCRIPTION_LENGTH) {
+    if (
+      typeof config.description === "string" &&
+      config.description.length > CDP_MAX_DESCRIPTION_LENGTH
+    ) {
       console.warn(
         `x402: Route "${pattern}" description is ${config.description.length} characters. ` +
           `The CDP facilitator may reject large ResourceInfo payloads with a generic ` +

--- a/typescript/packages/extensions/src/bazaar/startupValidation.ts
+++ b/typescript/packages/extensions/src/bazaar/startupValidation.ts
@@ -11,6 +11,48 @@ import { validateDiscoveryExtension, validateDiscoveryExtensionSpec } from "./fa
 
 export { checkIfBazaarNeeded } from "@x402/core/server";
 
+/**
+ * Empirical limits observed for the CDP facilitator (https://github.com/x402-foundation/x402/issues/2679).
+ * The CDP facilitator returns a generic 400 "invalid paymentPayload" when ResourceInfo
+ * fields exceed these values, with no field-specific error message.
+ */
+const CDP_MAX_TAGS = 8;
+const CDP_MAX_DESCRIPTION_LENGTH = 200;
+
+/**
+ * Warn at startup when ResourceInfo fields on a route exceed the empirical CDP
+ * facilitator limits that cause generic 400 "invalid paymentPayload" errors.
+ *
+ * The CDP facilitator does not return a field-specific error when these limits
+ * are exceeded; it returns the same top-level "invalid paymentPayload" pattern
+ * mismatch as any other payload schema error (issue #2679).
+ *
+ * @param routes - Route configuration to check
+ */
+export function validateResourceInfoLimits(routes: RoutesConfig): void {
+  const entries: [string, { description?: string; tags?: string[] }][] =
+    "accepts" in routes ? [["*", routes as { description?: string; tags?: string[] }]] : Object.entries(routes);
+
+  for (const [pattern, config] of entries) {
+    if (Array.isArray(config.tags) && config.tags.length > CDP_MAX_TAGS) {
+      console.warn(
+        `x402: Route "${pattern}" declares ${config.tags.length} tags. ` +
+          `The CDP facilitator silently rejects payloads with more than ${CDP_MAX_TAGS} tags ` +
+          `(returns generic 400 "invalid paymentPayload" — not a tag-count error). ` +
+          `Trim to ${CDP_MAX_TAGS} or fewer. See: https://github.com/x402-foundation/x402/issues/2679`,
+      );
+    }
+    if (typeof config.description === "string" && config.description.length > CDP_MAX_DESCRIPTION_LENGTH) {
+      console.warn(
+        `x402: Route "${pattern}" description is ${config.description.length} characters. ` +
+          `The CDP facilitator may reject large ResourceInfo payloads with a generic ` +
+          `400 "invalid paymentPayload" error. Keep descriptions under ${CDP_MAX_DESCRIPTION_LENGTH} characters. ` +
+          `See: https://github.com/x402-foundation/x402/issues/2679`,
+      );
+    }
+  }
+}
+
 const HTTP_VERB_RE = /^(GET|POST|PUT|PATCH|DELETE|HEAD)\b/i;
 
 /**


### PR DESCRIPTION
## Problem

The CDP facilitator returns a generic `400 'paymentPayload' is invalid: must match one of [x402V2Pay...]` when `ResourceInfo.description` is too long or `ResourceInfo.tags` has more than 8 items. The error does not name the offending field, so developers face a long debugging cycle (report: #2679).

Root cause (diagnosed by @GTCC777 in #2679): the CDP facilitator enforces an undocumented payload-size limit on the `ResourceInfo` block echoed in the client `PaymentPayload`. Exceeding it produces the same top-level pattern-mismatch error as any other payload schema failure.

Empirical limits from #2679:
- **tags**: 14 items fail; 8 items pass
- **description**: ~450 characters with 14 tags fails; concise description passes

## Changes

**`typescript/packages/core/src/http/x402HTTPResourceServer.ts`**

Add JSDoc on `RouteConfig.description` and `RouteConfig.tags` documenting the empirical CDP limits and linking to #2679. Surfaces in IDE tooling at the point where the developer sets the field.

**`typescript/packages/extensions/src/bazaar/startupValidation.ts`**

Add `validateResourceInfoLimits(routes)` that warns at middleware startup if a route exceeds the empirical limits. Fires at the same startup phase as the existing `validateBazaarRouteExtensions` check, before any payment request is attempted.

Example warning:
```
x402: Route "GET /api/scan/crypto" declares 14 tags. The CDP facilitator silently rejects
payloads with more than 8 tags (returns generic 400 "invalid paymentPayload" -- not a
tag-count error). Trim to 8 or fewer. See: https://github.com/x402-foundation/x402/issues/2679
```

## Notes

- Constants (`CDP_MAX_TAGS = 8`, `CDP_MAX_DESCRIPTION_LENGTH = 200`) are empirical; can be updated if Coinbase publishes the enforced limits.
- No breaking changes: warn-only, does not throw.
- Python middleware equivalent can follow in a separate PR if maintainers want parity.
