### PR TITLE
spec(exact): verify() must be fail-closed relative to settle() -- three-case negative matrix

### DIFF
--- a/specs/schemes/exact/scheme_exact.md
+++ b/specs/schemes/exact/scheme_exact.md
@@ -39,3 +39,54 @@ While implementation details vary by network, facilitators MUST enforce security
 - Simulation verification: SHOULD simulate via emulation during `/verify` to confirm expected balance changes.
 
 Network-specific rules are in per-network documents: `scheme_exact_svm.md` (Solana), `scheme_exact_stellar.md` (Stellar), `scheme_exact_evm.md` (EVM), `scheme_exact_sui.md` (SUI), `scheme_exact_ton.md` (TON).
+
+## `verify()` must be fail-closed relative to `settle()`
+
+`verify()` is the facilitator's last opportunity to reject a payment before it sponsors fees and submits the transaction to consensus. It MUST return `isValid: false` for every condition that would cause `settle()` to fail on-chain.
+
+A `verify()` that validates transfer semantics (amounts, destinations, scheme version) but skips security-critical pre-conditions is unsafe: the facilitator sponsors fees and network round-trips for transactions the ledger will reject.
+
+### Three negative cases every `exact` mechanism MUST handle
+
+These apply to all networks regardless of signing scheme:
+
+**1. Payer signature invalid**
+
+`verify()` MUST reject transactions where the inferred payer did not produce a valid signature over the frozen transaction body. This includes:
+
+- A transaction signed with the wrong private key
+- An unsigned (serialized but never signed) transaction body
+
+A facilitator that does not verify the payer's signature will: (a) add its own fee-payer signature and submit; (b) receive `INVALID_SIGNATURE` (or equivalent) from the ledger; (c) have paid fees for a payment that was always going to fail on consensus.
+
+**2. Recipient cannot receive the asset**
+
+`verify()` SHOULD reject transactions where `payTo` cannot receive the specified asset. Common cases:
+
+- HTS, SPL, or Stellar asset not associated or opted-in to the receiver account
+- Receiver account inactive or not yet initialized for the token
+
+Preflight via the network's REST API or RPC is the reliable data source. Do not rely on fields that network nodes have stopped returning reliably; always use an authoritative off-chain query (e.g. Mirror Node for Hedera, JSON-RPC for EVM, Solana `getAccountInfo` for SVM).
+
+**3. Payer balance insufficient**
+
+`verify()` SHOULD reject transactions where the payer does not hold at least `requirements.amount` of the specified asset at verify time. An on-chain balance query via the network's REST or RPC API is the minimum reliable source.
+
+### Consequence of skipping any case
+
+| Missing check | `verify()` result | `settle()` result |
+|---|---|---|
+| Payer signature | `isValid: true` | `INVALID_SIGNATURE` / equivalent |
+| Recipient not provisioned | `isValid: true` | `TOKEN_NOT_ASSOCIATED_TO_ACCOUNT` / equivalent |
+| Payer balance | `isValid: true` | `INSUFFICIENT_BALANCE` / equivalent |
+
+In all three cases the facilitator has already sponsored a fee for a payment that was undeliverable at verify time.
+
+### Error reason conventions
+
+Mechanism-specific `invalidReason` values SHOULD follow the pattern:
+
+- `invalid_exact_{mechanism}_payload_signature_invalid`: payer did not sign the frozen body
+- `invalid_exact_{mechanism}_payload_preflight_failed`: recipient provisioning or balance check failed
+
+Per-mechanism documents SHOULD document the specific reason strings and the data source used for each check.


### PR DESCRIPTION
## What

Adds a normative  fail-closed section to .

## Why

#2701 identified that the Hedera  passes unsigned and wrong-key transactions because it validates transfer semantics but skips payer-signature verification and recipient-association preflight. #2707 fixes the Hedera implementation. But the invariant itself is not stated anywhere in the top-level  spec, so every new non-EVM mechanism can silently reproduce the same class of bug.

This PR adds the cross-mechanism normative text so the property is owned at the spec level, not rediscovered per-mechanism.

## Changes

 gains a new section:

- **Invariant**:  MUST return  for every condition that would cause  to fail at consensus.
- **Three mandatory negative cases** every  mechanism MUST handle:
  1. Payer signature invalid (wrong key, unsigned body)
  2. Recipient cannot receive the asset (unassociated token, inactive account)
  3. Payer balance insufficient
- **Consequence table** showing what happens for each missing check (verify passes, settle fails).
- **Error reason conventions** (, ) for per-mechanism docs to adopt.

## Relationship to other work

- Complements #2707 (Hedera implementation fix for the same three cases).
- Complements #2666 (settlement-receipt conformance vectors on the settle() side).
- No code changes; spec-only.

## Acceptance criteria

- [ ]  states that  MUST be fail-closed for the three cases
- [ ] Error reason conventions are documented so per-mechanism docs can adopt them
- [ ] No changes to implementation files
