### PR TITLE
fix(python/bazaar): startup validation tolerates pre-enrichment method (#2604)

### DIFF
--- a/python/x402/changelog.d/2604.bugfix.md
+++ b/python/x402/changelog.d/2604.bugfix.md
@@ -1,0 +1,1 @@
+Startup-time bazaar extension validation no longer warns `'method' is a required property` for every route. `method` is injected by the resource-server enricher at request time, so the pre-enrichment info-vs-schema check now treats it as optional; other schema/info mismatches are still flagged.

--- a/python/x402/http/middleware/_bazaar_utils.py
+++ b/python/x402/http/middleware/_bazaar_utils.py
@@ -6,6 +6,7 @@ used by both FastAPI and Flask middleware.
 
 from __future__ import annotations
 
+import copy
 import warnings
 from typing import Any
 
@@ -55,6 +56,26 @@ def register_bazaar_extension(server: Any) -> None:
         server.register_extension(bazaar_resource_server_extension)
     except ImportError:
         pass
+
+
+def _without_required_method(bazaar_ext: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``bazaar_ext`` with ``method`` dropped from the schema's
+    ``input.required``.
+
+    ``method`` is injected into both info and schema by the resource-server enricher
+    (``enrich_declaration``) at request time, so a freshly *declared* extension omits
+    it. Treating it as optional for the startup (pre-enrichment) info-vs-schema check
+    avoids flagging every not-yet-enriched route, while any other schema/info mismatch
+    is still caught (#2604).
+    """
+    ext = copy.deepcopy(bazaar_ext)
+    try:
+        required = ext["schema"]["properties"]["input"]["required"]
+    except (KeyError, TypeError):
+        return ext
+    if isinstance(required, list) and "method" in required:
+        ext["schema"]["properties"]["input"]["required"] = [r for r in required if r != "method"]
+    return ext
 
 
 def validate_bazaar_extensions(routes: RoutesConfig) -> None:
@@ -114,7 +135,10 @@ def validate_bazaar_extensions(routes: RoutesConfig) -> None:
                     stacklevel=3,
                 )
                 continue
-            result = validate_discovery_extension(bazaar_ext)
+            # `method` is injected into info+schema by the resource-server enricher
+            # at request time, so at startup a declared extension legitimately omits
+            # it — validate with `method` treated as optional (#2604).
+            result = validate_discovery_extension(_without_required_method(bazaar_ext))
             if not result.valid:
                 warnings.warn(
                     f'x402: Route "{pattern}" has an invalid bazaar extension: '

--- a/python/x402/tests/unit/http/test_bazaar_extension_validation.py
+++ b/python/x402/tests/unit/http/test_bazaar_extension_validation.py
@@ -520,6 +520,52 @@ class TestSharedBazaarUtils:
         bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
         assert len(bazaar_warnings) == 0
 
+    def test_no_warning_on_declared_query_extension_pending_enrichment(self):
+        """#2604: a declared GET extension omits `method` (the resource-server enricher
+        injects it at request time), so startup validation must not warn about it."""
+        from x402.extensions.bazaar import declare_discovery_extension
+        from x402.http.middleware._bazaar_utils import validate_bazaar_extensions
+
+        routes = {
+            "GET /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions=declare_discovery_extension(
+                    input={"query": "x"},
+                    input_schema={"properties": {"query": {"type": "string"}}},
+                ),
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0
+
+    def test_no_warning_on_declared_body_extension_pending_enrichment(self):
+        """#2604: same as above for a POST/body declaration."""
+        from x402.extensions.bazaar import declare_discovery_extension
+        from x402.http.middleware._bazaar_utils import validate_bazaar_extensions
+
+        routes = {
+            "POST /api/data": RouteConfig(
+                accepts=[_make_payment_option()],
+                extensions=declare_discovery_extension(
+                    input={"name": "John"},
+                    input_schema={"properties": {"name": {"type": "string"}}},
+                    body_type="json",
+                ),
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            validate_bazaar_extensions(routes)
+
+        bazaar_warnings = [w for w in caught if "bazaar" in str(w.message).lower()]
+        assert len(bazaar_warnings) == 0
+
     def test_validate_warns_on_spec_violation(self):
         from x402.http.middleware._bazaar_utils import validate_bazaar_extensions
 


### PR DESCRIPTION
### Problem
The reference FastAPI e2e server logs `x402: Route "GET /…" has an invalid bazaar
extension: input: 'method' is a required property` for every protected route at
startup.

Root cause: `validate_bazaar_extensions` (middleware startup, `_bazaar_utils.py`)
runs the strict `validate_discovery_extension` (info-vs-schema) over the **declared**
route extensions. A declared extension's schema requires `method`, but `method` is —
by design — injected into both info and schema only by the resource-server enricher
(`enrich_declaration`) at request time. So a not-yet-enriched (declared) extension
fails the strict check at startup.

### Change
- In the startup validator, treat `method` as optional: validate a copy of the
  extension with `method` removed from `schema.properties.input.required`. Every
  other info-vs-schema mismatch is still flagged; only the expected pre-enrichment
  absence of `method` is tolerated.

`declare_discovery_extension`, `validate_discovery_extension`,
`validate_discovery_extension_spec`, and the enricher are unchanged — the existing
"method required" / "enrich then validate" tests stay green.

### Tests
- Two regression tests (`TestSharedBazaarUtils`) drive a real `declare_discovery_extension`
  (GET + POST) through `validate_bazaar_extensions` and assert no warning.

### How it was found
Surfaced while building a black-box conformance suite for x402 V2 endpoints
(x402-conformance), running against the reference FastAPI e2e server.

Closes #2604