### PR TITLE
fix(go): verify Transfer event after exact/eip3009 settle

### DIFF
--- a/go/.changes/unreleased/fixed-20260629-103231.yaml
+++ b/go/.changes/unreleased/fixed-20260629-103231.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Verify matching ERC-20 Transfer logs when Go exact/eip3009 settlement receipts include logs
+time: 2026-06-29T10:32:31+09:00

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -348,6 +348,20 @@ var (
 	// Legacy: Combined ABI (deprecated, use specific ABIs above)
 	TransferWithAuthorizationABI = TransferWithAuthorizationVRSABI
 
+	// ERC20TransferEventABI for parsing Transfer event logs
+	ERC20TransferEventABI = []byte(`[
+		{
+			"anonymous": false,
+			"inputs": [
+				{"indexed": true, "name": "from", "type": "address"},
+				{"indexed": true, "name": "to", "type": "address"},
+				{"indexed": false, "name": "value", "type": "uint256"}
+			],
+			"name": "Transfer",
+			"type": "event"
+		}
+	]`)
+
 	// ABI for authorizationState check
 	AuthorizationStateABI = []byte(`[
 		{

--- a/go/mechanisms/evm/exact/facilitator/eip3009.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
 	"github.com/x402-foundation/x402/go/v2/types"
@@ -234,6 +236,20 @@ func (f *ExactEvmScheme) settleEIP3009(
 
 	if receipt.Status != evm.TxStatusSuccess {
 		return nil, x402.NewSettleError(ErrTransactionFailed, verifyResp.Payer, network, txHash, "")
+	}
+
+	if receipt.Logs != nil {
+		transferMatched, err := verifyEIP3009TransferEvent(receipt.Logs, common.HexToAddress(tokenAddress), expectedTransferEvent{
+			From:  parsedAuthorization.From,
+			To:    parsedAuthorization.To,
+			Value: parsedAuthorization.Value,
+		})
+		if err != nil {
+			return nil, x402.NewSettleError(ErrTransferEventMismatch, verifyResp.Payer, network, txHash, err.Error())
+		}
+		if !transferMatched {
+			return nil, x402.NewSettleError(ErrTransferEventMismatch, verifyResp.Payer, network, txHash, "")
+		}
 	}
 
 	return &x402.SettleResponse{

--- a/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	goethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
 )
@@ -28,6 +29,54 @@ type EIP3009SignatureClassification struct {
 	IsSmartWallet bool
 	IsUndeployed  bool
 	SigData       *evm.ERC6492SignatureData
+}
+
+type expectedTransferEvent struct {
+	From  common.Address
+	To    common.Address
+	Value *big.Int
+}
+
+// verifyEIP3009TransferEvent checks for a matching ERC-20 Transfer event in receipt logs.
+func verifyEIP3009TransferEvent(
+	logs []*goethtypes.Log,
+	tokenAddress common.Address,
+	expected expectedTransferEvent,
+) (bool, error) {
+	contractABI, err := abi.JSON(strings.NewReader(string(evm.ERC20TransferEventABI)))
+	if err != nil {
+		return false, fmt.Errorf("parse transfer event ABI: %w", err)
+	}
+
+	transferEvent := contractABI.Events["Transfer"]
+	for _, receiptLog := range logs {
+		if receiptLog == nil ||
+			receiptLog.Address != tokenAddress ||
+			len(receiptLog.Topics) != 3 ||
+			receiptLog.Topics[0] != transferEvent.ID {
+			continue
+		}
+
+		values, err := contractABI.Unpack("Transfer", receiptLog.Data)
+		if err != nil {
+			continue
+		}
+		if len(values) != 1 {
+			continue
+		}
+		value, ok := values[0].(*big.Int)
+		if !ok {
+			continue
+		}
+
+		from := common.BytesToAddress(receiptLog.Topics[1].Bytes())
+		to := common.BytesToAddress(receiptLog.Topics[2].Bytes())
+		if from == expected.From && to == expected.To && value.Cmp(expected.Value) == 0 {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // ParseEIP3009Authorization parses authorization fields into contract-call arguments.

--- a/go/mechanisms/evm/exact/facilitator/eip3009_settle_erc6492_test.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_settle_erc6492_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	goethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
@@ -21,6 +22,7 @@ import (
 // wallet whose validator rejects the inner signature.
 type settleMockSigner struct {
 	codeByAddress map[string][]byte
+	receipt       *evm.TransactionReceipt
 	// writeErr, when set, is returned from WriteContract so settle classifies the reverted
 	// transfer via parseEIP3009TransferError instead of submitting it successfully.
 	writeErr error
@@ -48,6 +50,9 @@ func (m *settleMockSigner) SendTransaction(ctx context.Context, to string, data 
 }
 
 func (m *settleMockSigner) WaitForTransactionReceipt(ctx context.Context, txHash string) (*evm.TransactionReceipt, error) {
+	if m.receipt != nil {
+		return m.receipt, nil
+	}
 	return &evm.TransactionReceipt{Status: evm.TxStatusSuccess, TxHash: txHash}, nil
 }
 
@@ -185,5 +190,94 @@ func TestSettleEIP3009_SubmitsTransferAfterDeploy(t *testing.T) {
 	}
 	if !resp.Success {
 		t.Fatalf("expected resp.Success = true, got %+v", resp)
+	}
+}
+
+func TestSettleEIP3009_RejectsTransferEventMismatch(t *testing.T) {
+	const (
+		factory = "0xca11bde05977b3631167028862be2a173976ca11"
+		payer   = "0x1234567890123456789012345678901234567890"
+		token   = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+	)
+	payload, requirements := counterfactualErc6492Payload(t)
+	txHash := "0x" + strings.Repeat("ab", 32)
+	signer := &settleMockSigner{
+		codeByAddress: map[string][]byte{
+			strings.ToLower(token): {0x60, 0x60},
+			strings.ToLower(payer): {},
+		},
+		receipt: &evm.TransactionReceipt{
+			Status: evm.TxStatusSuccess,
+			TxHash: txHash,
+			Logs: []*goethtypes.Log{
+				makeTransferLog(
+					common.HexToAddress(token),
+					common.HexToAddress(payer),
+					common.HexToAddress(requirements.PayTo),
+					big.NewInt(1),
+				),
+			},
+		},
+	}
+	scheme := NewExactEvmScheme(signer, &ExactEvmSchemeConfig{
+		EIP6492AllowedFactories: []string{factory},
+	})
+
+	resp, err := scheme.Settle(context.Background(), payload, requirements, nil)
+	if err == nil {
+		t.Fatalf("expected transfer event mismatch error, got success: %+v", resp)
+	}
+
+	se := &x402.SettleError{}
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *x402.SettleError, got %T: %v", err, err)
+	}
+	if se.ErrorReason != ErrTransferEventMismatch {
+		t.Fatalf("expected reason %q, got %q", ErrTransferEventMismatch, se.ErrorReason)
+	}
+	if se.Transaction != txHash {
+		t.Fatalf("expected transaction %q, got %q", txHash, se.Transaction)
+	}
+}
+
+func TestSettleEIP3009_AcceptsMatchingTransferEvent(t *testing.T) {
+	const (
+		factory = "0xca11bde05977b3631167028862be2a173976ca11"
+		payer   = "0x1234567890123456789012345678901234567890"
+		token   = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+	)
+	payload, requirements := counterfactualErc6492Payload(t)
+	txHash := "0x" + strings.Repeat("ab", 32)
+	signer := &settleMockSigner{
+		codeByAddress: map[string][]byte{
+			strings.ToLower(token): {0x60, 0x60},
+			strings.ToLower(payer): {},
+		},
+		receipt: &evm.TransactionReceipt{
+			Status: evm.TxStatusSuccess,
+			TxHash: txHash,
+			Logs: []*goethtypes.Log{
+				makeTransferLog(
+					common.HexToAddress(token),
+					common.HexToAddress(payer),
+					common.HexToAddress(requirements.PayTo),
+					big.NewInt(1_000_000),
+				),
+			},
+		},
+	}
+	scheme := NewExactEvmScheme(signer, &ExactEvmSchemeConfig{
+		EIP6492AllowedFactories: []string{factory},
+	})
+
+	resp, err := scheme.Settle(context.Background(), payload, requirements, nil)
+	if err != nil {
+		t.Fatalf("expected settle success, got error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected resp.Success = true, got %+v", resp)
+	}
+	if resp.Transaction != txHash {
+		t.Fatalf("expected transaction %q, got %q", txHash, resp.Transaction)
 	}
 }

--- a/go/mechanisms/evm/exact/facilitator/eip3009_transfer_event_test.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_transfer_event_test.go
@@ -1,0 +1,106 @@
+package facilitator
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	goethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var transferEventTopic = crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))
+
+func makeTransferLog(token common.Address, from common.Address, to common.Address, value *big.Int) *goethtypes.Log {
+	return &goethtypes.Log{
+		Address: token,
+		Topics: []common.Hash{
+			transferEventTopic,
+			common.BytesToHash(common.LeftPadBytes(from.Bytes(), 32)),
+			common.BytesToHash(common.LeftPadBytes(to.Bytes(), 32)),
+		},
+		Data: common.LeftPadBytes(value.Bytes(), 32),
+	}
+}
+
+func TestVerifyEIP3009TransferEvent(t *testing.T) {
+	token := common.HexToAddress("0xE7C3D8C9a439feDe00D2600032D5dB0Be71C3c29")
+	otherToken := common.HexToAddress("0x0000000000000000000000000000000000000bad")
+	payer := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	receiver := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	attacker := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	value := big.NewInt(1000)
+
+	tests := []struct {
+		name string
+		logs []*goethtypes.Log
+		want bool
+	}{
+		{
+			name: "matches canonical Transfer event",
+			logs: []*goethtypes.Log{
+				makeTransferLog(token, payer, receiver, value),
+			},
+			want: true,
+		},
+		{
+			name: "ignores unrelated logs",
+			logs: []*goethtypes.Log{
+				makeTransferLog(otherToken, attacker, receiver, big.NewInt(999)),
+				makeTransferLog(token, payer, receiver, value),
+			},
+			want: true,
+		},
+		{
+			name: "rejects different value",
+			logs: []*goethtypes.Log{
+				makeTransferLog(token, payer, receiver, big.NewInt(1)),
+			},
+		},
+		{
+			name: "rejects different recipient",
+			logs: []*goethtypes.Log{
+				makeTransferLog(token, payer, attacker, value),
+			},
+		},
+		{
+			name: "rejects different sender",
+			logs: []*goethtypes.Log{
+				makeTransferLog(token, attacker, receiver, value),
+			},
+		},
+		{
+			name: "rejects different token",
+			logs: []*goethtypes.Log{
+				makeTransferLog(otherToken, payer, receiver, value),
+			},
+		},
+		{
+			name: "rejects empty logs",
+			logs: []*goethtypes.Log{},
+		},
+		{
+			name: "address comparison is normalized",
+			logs: []*goethtypes.Log{
+				makeTransferLog(common.HexToAddress("0xe7c3d8c9a439fede00d2600032d5db0be71c3c29"), payer, receiver, value),
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := verifyEIP3009TransferEvent(tt.logs, token, expectedTransferEvent{
+				From:  payer,
+				To:    receiver,
+				Value: value,
+			})
+			if err != nil {
+				t.Fatalf("verifyEIP3009TransferEvent() error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("verifyEIP3009TransferEvent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go/mechanisms/evm/exact/facilitator/errors.go
+++ b/go/mechanisms/evm/exact/facilitator/errors.go
@@ -36,6 +36,7 @@ const (
 	ErrFailedToExecuteTransfer = "invalid_exact_evm_failed_to_execute_transfer"
 	ErrFailedToGetReceipt      = "invalid_exact_evm_failed_to_get_receipt"
 	ErrTransactionFailed       = "invalid_exact_evm_transaction_failed"
+	ErrTransferEventMismatch   = "invalid_exact_evm_transfer_event_mismatch"
 
 	// Smart wallet errors (shared by EIP-3009 and Permit2)
 	ErrUndeployedSmartWallet       = "invalid_exact_evm_payload_undeployed_smart_wallet"

--- a/go/mechanisms/evm/types.go
+++ b/go/mechanisms/evm/types.go
@@ -290,9 +290,10 @@ type TypedDataField struct {
 
 // TransactionReceipt represents the receipt of a mined transaction
 type TransactionReceipt struct {
-	Status      uint64 `json:"status"`
-	BlockNumber uint64 `json:"blockNumber"`
-	TxHash      string `json:"transactionHash"`
+	Status      uint64            `json:"status"`
+	BlockNumber uint64            `json:"blockNumber"`
+	TxHash      string            `json:"transactionHash"`
+	Logs        []*goethtypes.Log `json:"logs,omitempty"`
 }
 
 // AssetInfo contains information about an ERC20 token

--- a/go/test/integration/evm_test.go
+++ b/go/test/integration/evm_test.go
@@ -277,6 +277,7 @@ func (s *realFacilitatorEvmSigner) WaitForTransactionReceipt(ctx context.Context
 				Status:      status,
 				BlockNumber: receipt.BlockNumber.Uint64(),
 				TxHash:      receipt.TxHash.Hex(),
+				Logs:        receipt.Logs,
 			}, nil
 		}
 
@@ -973,6 +974,7 @@ func (s *permit2FacilitatorEvmSigner) WaitForTransactionReceipt(ctx context.Cont
 				Status:      status,
 				BlockNumber: receipt.BlockNumber.Uint64(),
 				TxHash:      receipt.TxHash.Hex(),
+				Logs:        receipt.Logs,
 			}, nil
 		}
 


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

This ports the defensive exact/eip3009 post-settle receipt check from TypeScript PR #2385 to the Go SDK in a backward-compatible way.

`settleEIP3009` previously treated `receipt.Status == TxStatusSuccess` as sufficient proof that the expected ERC-20 transfer happened. A successful receipt only proves the transaction did not revert; it does not prove the expected token emitted a matching `Transfer(from, to, value)` event.

Go's `FacilitatorEvmSigner` interface returns the repository's lightweight `TransactionReceipt`, and existing user-provided signers may still return status-only receipts. To avoid false negatives for those implementations, this change adds optional receipt logs and verifies the Transfer event only when logs are present.

### Changes

- Added optional `Logs` to `go/mechanisms/evm.TransactionReceipt`.
- Added `ErrTransferEventMismatch` with the TypeScript parity wire string `invalid_exact_evm_transfer_event_mismatch`.
- Added exact/eip3009 Transfer log verification against the expected token, payer, recipient, and amount.
- Preserved the transaction hash on Transfer event mismatch settlement errors.
- Populated logs in in-repo integration signer receipt adapters that already receive go-ethereum receipts.
- Added focused tests for matching logs, unrelated logs, mismatched fields, empty logs, and settle-level success/failure paths.
- Added a Go changelog fragment.

### Compatibility

This does not change the `FacilitatorEvmSigner` interface. Existing signers that return receipts without logs keep the current status-only behavior. Signers that populate `TransactionReceipt.Logs` opt into the stronger Transfer event check.

## Related

- TypeScript parity PR: https://github.com/x402-foundation/x402/pull/2385

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

- `GOCACHE=/tmp/go-build-cache go test ./mechanisms/evm/exact/facilitator`
- `GOCACHE=/tmp/go-build-cache go test ./...`
- `GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache make verify`
- `GOCACHE=/tmp/go-build-cache make build`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 
