### PR TITLE
fix(typescript): reject non-canonical high-s EIP-3009 ECDSA signatures (#2386 parity)

### DIFF
--- a/typescript/.changeset/reject-non-canonical-eip3009-signatures.md
+++ b/typescript/.changeset/reject-non-canonical-eip3009-signatures.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Harden the exact-scheme EIP-3009 facilitator verify path to reject non-canonical (high-s) ECDSA signatures before settlement (EIP-2 / SEC1 §4.1.4), instead of relying on the token's on-chain `InvalidSignatureS` revert. Not all ERC-3009 tokens enforce low-s, and the alternate `(r, n-s, v^1)` signature can read as a distinct authorization at the facilitator's retry/cache layer. Adds the exported `isCanonicalEcdsaSignature` helper and the `ErrInvalidSignatureS` (`invalid_exact_evm_non_canonical_signature`) reason. TypeScript parity for #2386 (Go: #2454).

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -5,7 +5,7 @@ import {
   SettleResponse,
   VerifyResponse,
 } from "@x402/core/types";
-import { getAddress, Hex, isAddressEqual, parseErc6492Signature } from "viem";
+import { getAddress, Hex, isAddressEqual, parseErc6492Signature, size } from "viem";
 import { authorizationTypes } from "../../constants";
 import { FacilitatorEvmSigner } from "../../signer";
 import { getEvmChainId } from "../../utils";
@@ -19,6 +19,29 @@ import {
   parseEip3009TransferError,
   simulateEip3009TransferResult,
 } from "./eip3009-utils";
+
+// secp256k1 group order N halved (SEC1 §4.1.4 / EIP-2 low-s upper bound). Mirrors the
+// Go `secp256k1HalfN` used by `evm.IsCanonicalECDSASignature` (#2454, #2386).
+const SECP256K1_N_HALF = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0n;
+
+/**
+ * Returns true if `signature` is a canonical (low-s, `s <= n/2` per EIP-2) 65-byte ECDSA
+ * signature. Non-65-byte signatures (ERC-1271 / ERC-6492 wrappers) are not plain ECDSA and
+ * return false, so callers must gate on length before treating `false` as "reject". Mirrors
+ * Go `evm.IsCanonicalECDSASignature`.
+ *
+ * @param signature - The signature to inspect, as a hex string.
+ * @returns True if a canonical low-s 65-byte ECDSA signature; false otherwise (including any non-65-byte signature).
+ */
+export function isCanonicalEcdsaSignature(signature: Hex): boolean {
+  if (size(signature) !== 65) return false;
+  // s is bytes [32, 64) of the r || s || v layout. Read it directly (mirrors Go
+  // `new(big.Int).SetBytes(signature[32:64])`) rather than viem `parseSignature`, which
+  // also validates the v byte and would throw on a malformed v — that belongs to the
+  // later signature check, not this canonicalization gate.
+  const s = BigInt(`0x${signature.slice(2 + 64, 2 + 128)}`);
+  return s <= SECP256K1_N_HALF;
+}
 
 export interface VerifyEIP3009Options {
   /** Run onchain simulation. Defaults to true. */
@@ -152,6 +175,21 @@ export async function verifyEIP3009(
   }
 
   if (!isCounterfactual) {
+    // EIP-2 / SEC1 §4.1.4 hardening: reject non-canonical (high-s) plain ECDSA
+    // signatures before the typed-data check, so malleability is caught pre-broadcast
+    // rather than relying on the token's on-chain InvalidSignatureS revert. Not all
+    // ERC-3009 tokens enforce low-s, and the alternate (r, n-s, v^1) can read as a
+    // distinct authorization at the facilitator's retry/cache layer. Plain ECDSA
+    // signatures are 65 bytes; ERC-1271 / ERC-6492 wrappers have other lengths and are
+    // skipped. Mirrors the Go fix in #2454 (#2386).
+    if (size(innerSignature) === 65 && !isCanonicalEcdsaSignature(innerSignature)) {
+      return {
+        isValid: false,
+        invalidReason: Errors.ErrInvalidSignatureS,
+        payer,
+      };
+    }
+
     // For deployed addresses (plain EOA, smart contract, 7702 EOA): verify the
     // signature using a strict primitive that mirrors on-chain SignatureChecker
     // semantics — ecrecover when no code, strict EIP-1271 when code is present.

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
@@ -12,6 +12,7 @@ export const ErrNetworkMismatch = "invalid_exact_evm_network_mismatch";
 export const ErrMissingEip712Domain = "invalid_exact_evm_missing_eip712_domain";
 export const ErrRecipientMismatch = "invalid_exact_evm_recipient_mismatch";
 export const ErrInvalidSignature = "invalid_exact_evm_signature";
+export const ErrInvalidSignatureS = "invalid_exact_evm_non_canonical_signature";
 export const ErrValidBeforeExpired = "invalid_exact_evm_payload_authorization_valid_before";
 export const ErrValidAfterInFuture = "invalid_exact_evm_payload_authorization_valid_after";
 export const ErrInvalidAuthorizationValue = "invalid_exact_evm_authorization_value";

--- a/typescript/packages/mechanisms/evm/test/unit/exact/canonical-signature.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/canonical-signature.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import type { Hex } from "viem";
+import { isCanonicalEcdsaSignature } from "../../../src/exact/facilitator/eip3009";
+
+// secp256k1 n/2 (EIP-2 low-s upper bound) — the boundary value, which is canonical.
+const N_HALF = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0n;
+
+// Build a 65-byte ECDSA signature (r || s || v) with a chosen s value. r and v are
+// arbitrary here — isCanonicalEcdsaSignature only inspects s.
+function sigWithS(s: bigint, v = "1b"): Hex {
+  const r = "11".repeat(32);
+  return `0x${r}${s.toString(16).padStart(64, "0")}${v}`;
+}
+
+describe("isCanonicalEcdsaSignature", () => {
+  it("accepts a low-s signature (s < n/2)", () => {
+    expect(isCanonicalEcdsaSignature(sigWithS(N_HALF - 1n))).toBe(true);
+  });
+
+  it("accepts the boundary s == n/2 (canonical per EIP-2)", () => {
+    expect(isCanonicalEcdsaSignature(sigWithS(N_HALF))).toBe(true);
+  });
+
+  it("rejects a high-s signature (s > n/2, malleable)", () => {
+    expect(isCanonicalEcdsaSignature(sigWithS(N_HALF + 1n))).toBe(false);
+  });
+
+  it("returns false for non-65-byte signatures (ERC-1271 / ERC-6492 wrappers are skipped)", () => {
+    expect(isCanonicalEcdsaSignature("0x010203")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

TypeScript parity for #2386 — reject non-canonical (high-s) EIP-3009 ECDSA signatures in the `exact` scheme facilitator verify path **before** settlement, instead of relying on the token's on-chain `InvalidSignatureS` revert. Mirrors the Go fix in #2454 (@wnjoon).

Per #2386's defense-in-depth argument: not all ERC-3009 tokens enforce low-s, and the malleable alternate `(r, n-s, v^1)` can read as a distinct authorization at the facilitator's retry/cache layer. Catching it pre-broadcast also avoids burning gas on a doomed `transferWithAuthorization`.

## Changes (`@x402/evm`)

- `exact/facilitator/eip3009.ts`: add `isCanonicalEcdsaSignature(signature)` (EIP-2 / SEC1 §4.1.4, `s <= n/2`) and gate it inside `verifyEIP3009` for plain **65-byte** ECDSA signatures, before `verifyTypedDataSignature`. ERC-1271 / ERC-6492 wrapper signatures have other lengths and are skipped.
- `exact/facilitator/errors.ts`: add `ErrInvalidSignatureS = "invalid_exact_evm_non_canonical_signature"` — same symbol name and wire value as the Go const in #2454 (character-identical parity).
- unit tests + changeset.

## Parity notes

- Error const **name** (`ErrInvalidSignatureS`) and **wire value** (`invalid_exact_evm_non_canonical_signature`) match #2454's Go exactly.
- `s` is read directly from bytes `[32, 64)` of `r || s || v` (mirrors Go `new(big.Int).SetBytes(signature[32:64])`) rather than via `viem.parseSignature`, which additionally validates the `v` byte and would throw on a malformed `v` — that belongs to the later signature check, not this canonicalization gate.

## Scope

`Refs #2386` (not `closes`) — this is the **TypeScript** port. Go is done in #2454; the **Python** parity (`python/x402/mechanisms/evm/verify.py`) is still open as a separate follow-up.

## Verification

`pnpm --filter @x402/evm test` → all unit tests pass, including the new `canonical-signature.test.ts` (low-s / boundary `s == n/2` / high-s / non-65-byte). Commit is SSH-signed.
