### PR TITLE
docs: note accepts[] parse behavior for multi-network challenges

### DIFF
--- a/typescript/.changeset/fix-legacy-fetch-compatible-accepts.md
+++ b/typescript/.changeset/fix-legacy-fetch-compatible-accepts.md
@@ -1,0 +1,5 @@
+---
+"x402-fetch": patch
+---
+
+Skip incompatible payment requirements in legacy fetch 402 responses.

--- a/typescript/packages/legacy/x402-fetch/src/index.test.ts
+++ b/typescript/packages/legacy/x402-fetch/src/index.test.ts
@@ -108,6 +108,59 @@ describe("fetchWithPayment()", () => {
     } as RequestInitWithRetry);
   });
 
+  it("should ignore incompatible payment requirements and use a compatible option", async () => {
+    const paymentHeader = "payment-header-value";
+    const successResponse = createResponse(200, { data: "success" });
+    const incompatiblePaymentRequirement = {
+      ...validPaymentRequirements[0],
+      network: "eip155:480",
+    };
+
+    const { createPaymentHeader, selectPaymentRequirements } = await import("x402/client");
+    (createPaymentHeader as ReturnType<typeof vi.fn>).mockResolvedValue(paymentHeader);
+    mockFetch
+      .mockResolvedValueOnce(
+        createResponse(402, {
+          accepts: [incompatiblePaymentRequirement, validPaymentRequirements[0]],
+          x402Version: 1,
+        }),
+      )
+      .mockResolvedValueOnce(successResponse);
+
+    const result = await wrappedFetch("https://api.example.com");
+
+    expect(result).toBe(successResponse);
+    expect(selectPaymentRequirements).toHaveBeenCalledWith(
+      validPaymentRequirements,
+      undefined,
+      "exact",
+    );
+    expect(createPaymentHeader).toHaveBeenCalledWith(
+      mockWalletClient,
+      1,
+      validPaymentRequirements[0],
+      undefined,
+    );
+  });
+
+  it("should reject with a clear error when no payment requirements are compatible", async () => {
+    const incompatiblePaymentRequirement = {
+      ...validPaymentRequirements[0],
+      network: "eip155:480",
+    };
+
+    mockFetch.mockResolvedValueOnce(
+      createResponse(402, {
+        accepts: [incompatiblePaymentRequirement],
+        x402Version: 1,
+      }),
+    );
+
+    await expect(wrappedFetch("https://api.example.com")).rejects.toThrow(
+      "No compatible payment requirements found",
+    );
+  });
+
   it("should not retry if already retried", async () => {
     const errorResponse = createResponse(402, {
       accepts: validPaymentRequirements,

--- a/typescript/packages/legacy/x402-fetch/src/index.ts
+++ b/typescript/packages/legacy/x402-fetch/src/index.ts
@@ -70,7 +70,14 @@ export function wrapFetchWithPayment(
       x402Version: number;
       accepts: unknown[];
     };
-    const parsedPaymentRequirements = accepts.map(x => PaymentRequirementsSchema.parse(x));
+    const parsedPaymentRequirements = accepts.flatMap(x => {
+      const parsed = PaymentRequirementsSchema.safeParse(x);
+      return parsed.success ? [parsed.data] : [];
+    });
+
+    if (parsedPaymentRequirements.length === 0) {
+      throw new Error("No compatible payment requirements found");
+    }
 
     const network = isMultiNetworkSigner(walletClient)
       ? undefined


### PR DESCRIPTION
Adds a resource server compatibility note for multi-network `accepts[]` arrays to `docs/guides/`.

The legacy **v1** `x402-fetch` client (via `x402/types`) eagerly parses every entry in the `accepts[]` array with `PaymentRequirementsSchema.parse()`. If any entry uses a `network` value not in the schema's enum, the entire parse throws — preventing payment even for valid entries.

**v2 `@x402/fetch` (via `@x402/core`) already tolerates CAIP-2 and unknown networks** — this note is for resource servers that still need to serve the deployed v1 buyer base.

See #2729 for the tracking issue.

AI-assisted draft, human-reviewed and corrected before submission.