### PR TITLE
feat(go/svm): support server-provided recent blockhash

### DIFF
--- a/go/.changes/unreleased/added-20260629-svm-recent-blockhash.yaml
+++ b/go/.changes/unreleased/added-20260629-svm-recent-blockhash.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Support server-provided recent blockhashes for Go SVM exact payment challenges
+time: 2026-06-29T00:00:00+09:00

--- a/go/mechanisms/svm/README.md
+++ b/go/mechanisms/svm/README.md
@@ -34,8 +34,18 @@ github.com/x402-foundation/x402/go/v2/mechanisms/svm/exact/server
 
 **Exports:**
 - `NewExactSvmScheme()` - Creates server-side SVM exact payment mechanism
+- `NewExactSvmScheme(&svm.ServerConfig{RPCURL: "https://api.devnet.solana.com"})` - Optionally embeds a recent blockhash in the 402 challenge
 - Used for building payment requirements and parsing prices
 - Supports custom money parsers via `RegisterMoneyParser()`
+
+```go
+import svm "github.com/x402-foundation/x402/go/v2/mechanisms/svm"
+import svmserver "github.com/x402-foundation/x402/go/v2/mechanisms/svm/exact/server"
+
+scheme := svmserver.NewExactSvmScheme(&svm.ServerConfig{
+	RPCURL: "https://api.devnet.solana.com",
+})
+```
 
 #### For Facilitators
 

--- a/go/mechanisms/svm/exact/client/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/client/duplicate_tx_test.go
@@ -31,6 +31,15 @@ func mockSolanaRPCHandler(t *testing.T, blockhashFunc func() string) http.Handle
 }
 
 func mockSolanaRPCHandlerWithAccountInfoCount(t *testing.T, blockhashFunc func() string, accountInfoCalls *int32) http.HandlerFunc {
+	return mockSolanaRPCHandlerWithCounts(t, blockhashFunc, nil, accountInfoCalls)
+}
+
+func mockSolanaRPCHandlerWithCounts(
+	t *testing.T,
+	blockhashFunc func() string,
+	blockhashCalls *int32,
+	accountInfoCalls *int32,
+) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			Method string        `json:"method"`
@@ -65,6 +74,9 @@ func mockSolanaRPCHandlerWithAccountInfoCount(t *testing.T, blockhashFunc func()
 
 		switch req.Method {
 		case "getLatestBlockhash":
+			if blockhashCalls != nil {
+				atomic.AddInt32(blockhashCalls, 1)
+			}
 			blockhash := blockhashFunc()
 			writeResult(map[string]interface{}{
 				"context": map[string]interface{}{"slot": 1234},
@@ -197,6 +209,106 @@ func TestMintMetadataCacheAvoidsRepeatedMintRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&accountInfoCalls))
+}
+
+func TestRecentBlockhashResolution(t *testing.T) {
+	t.Run("uses server-provided recentBlockhash", func(t *testing.T) {
+		var blockhashCalls int32
+		var accountInfoCalls int32
+		server := httptest.NewServer(mockSolanaRPCHandlerWithCounts(t, func() string {
+			return fixedBlockhashAlt
+		}, &blockhashCalls, &accountInfoCalls))
+		defer server.Close()
+
+		signer := &mockClientSigner{keypair: solana.NewWallet().PrivateKey}
+		client := NewExactSvmScheme(signer, &svm.ClientConfig{RPCURL: server.URL})
+
+		requirements := types.PaymentRequirements{
+			Scheme:            "exact",
+			Network:           "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+			Asset:             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+			Amount:            "100000",
+			PayTo:             solana.NewWallet().PublicKey().String(),
+			MaxTimeoutSeconds: 3600,
+			Extra: map[string]interface{}{
+				"feePayer":        solana.NewWallet().PublicKey().String(),
+				"recentBlockhash": fixedBlockhash,
+			},
+		}
+
+		payload, err := client.CreatePaymentPayload(context.Background(), requirements)
+		require.NoError(t, err)
+
+		decoded, err := svm.DecodeTransaction(payload.Payload["transaction"].(string))
+		require.NoError(t, err)
+
+		assert.Equal(t, solana.MustHashFromBase58(fixedBlockhash), decoded.Message.RecentBlockhash)
+		assert.Equal(t, int32(0), atomic.LoadInt32(&blockhashCalls))
+		assert.Equal(t, int32(1), atomic.LoadInt32(&accountInfoCalls))
+	})
+
+	t.Run("falls back to RPC when recentBlockhash is absent", func(t *testing.T) {
+		var blockhashCalls int32
+		server := httptest.NewServer(mockSolanaRPCHandlerWithCounts(t, func() string {
+			return fixedBlockhashAlt
+		}, &blockhashCalls, nil))
+		defer server.Close()
+
+		signer := &mockClientSigner{keypair: solana.NewWallet().PrivateKey}
+		client := NewExactSvmScheme(signer, &svm.ClientConfig{RPCURL: server.URL})
+
+		requirements := types.PaymentRequirements{
+			Scheme:            "exact",
+			Network:           "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+			Asset:             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+			Amount:            "100000",
+			PayTo:             solana.NewWallet().PublicKey().String(),
+			MaxTimeoutSeconds: 3600,
+			Extra: map[string]interface{}{
+				"feePayer": solana.NewWallet().PublicKey().String(),
+			},
+		}
+
+		payload, err := client.CreatePaymentPayload(context.Background(), requirements)
+		require.NoError(t, err)
+
+		decoded, err := svm.DecodeTransaction(payload.Payload["transaction"].(string))
+		require.NoError(t, err)
+
+		assert.Equal(t, solana.MustHashFromBase58(fixedBlockhashAlt), decoded.Message.RecentBlockhash)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&blockhashCalls))
+	})
+
+	t.Run("rejects malformed recentBlockhash", func(t *testing.T) {
+		var blockhashCalls int32
+		var accountInfoCalls int32
+		server := httptest.NewServer(mockSolanaRPCHandlerWithCounts(t, func() string {
+			return fixedBlockhashAlt
+		}, &blockhashCalls, &accountInfoCalls))
+		defer server.Close()
+
+		signer := &mockClientSigner{keypair: solana.NewWallet().PrivateKey}
+		client := NewExactSvmScheme(signer, &svm.ClientConfig{RPCURL: server.URL})
+
+		requirements := types.PaymentRequirements{
+			Scheme:            "exact",
+			Network:           "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+			Asset:             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+			Amount:            "100000",
+			PayTo:             solana.NewWallet().PublicKey().String(),
+			MaxTimeoutSeconds: 3600,
+			Extra: map[string]interface{}{
+				"feePayer":        solana.NewWallet().PublicKey().String(),
+				"recentBlockhash": "not-a-blockhash",
+			},
+		}
+
+		_, err := client.CreatePaymentPayload(context.Background(), requirements)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ErrInvalidRecentBlockhash)
+		assert.Equal(t, int32(0), atomic.LoadInt32(&blockhashCalls))
+		assert.Equal(t, int32(1), atomic.LoadInt32(&accountInfoCalls))
+	})
 }
 
 func TestFixedBlockhashProducesDistinctTransactions(t *testing.T) {

--- a/go/mechanisms/svm/exact/client/errors.go
+++ b/go/mechanisms/svm/exact/client/errors.go
@@ -14,6 +14,7 @@ const (
 	ErrInvalidFeePayerAddress       = "invalid_exact_solana_client_invalid_fee_payer_address"
 	ErrFailedToDecodeMintData       = "invalid_exact_solana_client_failed_to_decode_mint_data"
 	ErrFailedToGetLatestBlockhash   = "invalid_exact_solana_client_failed_to_get_latest_blockhash"
+	ErrInvalidRecentBlockhash       = "invalid_exact_solana_client_invalid_recent_blockhash"
 	ErrFailedToBuildComputeLimitIx  = "invalid_exact_solana_client_failed_to_build_compute_limit_instruction"
 	ErrFailedToBuildComputePriceIx  = "invalid_exact_solana_client_failed_to_build_compute_price_instruction"
 	ErrFailedToBuildTransferIx      = "invalid_exact_solana_client_failed_to_build_transfer_instruction"

--- a/go/mechanisms/svm/exact/client/scheme.go
+++ b/go/mechanisms/svm/exact/client/scheme.go
@@ -127,12 +127,10 @@ func (c *ExactSvmScheme) CreatePaymentPayload(
 		return types.PaymentPayload{}, fmt.Errorf(ErrInvalidFeePayerAddress+": %w", err)
 	}
 
-	// Get latest blockhash
-	latestBlockhash, err := rpcClient.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
+	recentBlockhash, err := c.resolveRecentBlockhash(ctx, rpcClient, requirements)
 	if err != nil {
-		return types.PaymentPayload{}, fmt.Errorf(ErrFailedToGetLatestBlockhash+": %w", err)
+		return types.PaymentPayload{}, err
 	}
-	recentBlockhash := latestBlockhash.Value.Blockhash
 
 	// Build compute budget instructions
 	cuLimit, err := computebudget.NewSetComputeUnitLimitInstructionBuilder().
@@ -221,4 +219,24 @@ func (c *ExactSvmScheme) CreatePaymentPayload(
 		X402Version: 2,
 		Payload:     svmPayload.ToMap(),
 	}, nil
+}
+
+func (c *ExactSvmScheme) resolveRecentBlockhash(
+	ctx context.Context,
+	rpcClient *rpc.Client,
+	requirements types.PaymentRequirements,
+) (solana.Hash, error) {
+	if blockhash, ok := requirements.Extra["recentBlockhash"].(string); ok && blockhash != "" {
+		recentBlockhash, err := solana.HashFromBase58(blockhash)
+		if err != nil {
+			return solana.Hash{}, fmt.Errorf(ErrInvalidRecentBlockhash+": %w", err)
+		}
+		return recentBlockhash, nil
+	}
+
+	latestBlockhash, err := rpcClient.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
+	if err != nil {
+		return solana.Hash{}, fmt.Errorf(ErrFailedToGetLatestBlockhash+": %w", err)
+	}
+	return latestBlockhash.Value.Blockhash, nil
 }

--- a/go/mechanisms/svm/exact/server/scheme.go
+++ b/go/mechanisms/svm/exact/server/scheme.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gagliardetto/solana-go/rpc"
 	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/svm"
 	"github.com/x402-foundation/x402/go/v2/types"
@@ -15,12 +16,18 @@ import (
 // ExactSvmScheme implements the SchemeNetworkServer interface for SVM (Solana) exact payments (V2)
 type ExactSvmScheme struct {
 	moneyParsers []x402.MoneyParser
+	config       *svm.ServerConfig
 }
 
 // NewExactSvmScheme creates a new ExactSvmScheme
-func NewExactSvmScheme() *ExactSvmScheme {
+func NewExactSvmScheme(config ...*svm.ServerConfig) *ExactSvmScheme {
+	var cfg *svm.ServerConfig
+	if len(config) > 0 {
+		cfg = config[0]
+	}
 	return &ExactSvmScheme{
 		moneyParsers: []x402.MoneyParser{},
+		config:       cfg,
 	}
 }
 
@@ -240,6 +247,8 @@ func (s *ExactSvmScheme) EnhancePaymentRequirements(
 		}
 	}
 
+	s.enrichRecentBlockhash(ctx, requirements.Extra)
+
 	// Copy extensions from supportedKind if provided
 	if supportedKind.Extra != nil {
 		for _, key := range extensionKeys {
@@ -250,4 +259,18 @@ func (s *ExactSvmScheme) EnhancePaymentRequirements(
 	}
 
 	return requirements, nil
+}
+
+func (s *ExactSvmScheme) enrichRecentBlockhash(ctx context.Context, extra map[string]interface{}) {
+	if s.config == nil || s.config.RPCURL == "" {
+		return
+	}
+
+	latestBlockhash, err := rpc.New(s.config.RPCURL).GetLatestBlockhash(ctx, rpc.CommitmentFinalized)
+	if err != nil {
+		return
+	}
+
+	extra["recentBlockhash"] = latestBlockhash.Value.Blockhash.String()
+	extra["lastValidBlockHeight"] = strconv.FormatUint(latestBlockhash.Value.LastValidBlockHeight, 10)
 }

--- a/go/mechanisms/svm/exact/server/server_blockhash_test.go
+++ b/go/mechanisms/svm/exact/server/server_blockhash_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/x402-foundation/x402/go/v2/mechanisms/svm"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+const testBlockhash = "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF"
+
+func mockBlockhashRPC(t *testing.T, blockhash string, fail bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string      `json:"method"`
+			ID     interface{} `json:"id"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		w.Header().Set("Content-Type", "application/json")
+		if fail {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"error": map[string]interface{}{
+					"code":    -32000,
+					"message": "blockhash unavailable",
+				},
+			})
+			return
+		}
+
+		require.Equal(t, "getLatestBlockhash", req.Method)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result": map[string]interface{}{
+				"context": map[string]interface{}{"slot": 1234},
+				"value": map[string]interface{}{
+					"blockhash":            blockhash,
+					"lastValidBlockHeight": 12345678,
+				},
+			},
+		})
+	}
+}
+
+func TestEnhancePaymentRequirementsRecentBlockhash(t *testing.T) {
+	baseRequirements := func() types.PaymentRequirements {
+		return types.PaymentRequirements{
+			Scheme:            "exact",
+			Network:           "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+			Asset:             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+			Amount:            "100000",
+			PayTo:             "GsbwXfJraMomNxBcjK7xK2xQx5MQgQUF2k3wEX2Q9z3w",
+			MaxTimeoutSeconds: 300,
+			Extra:             map[string]interface{}{"memo": "pi_3abc123def456"},
+		}
+	}
+	supportedKind := types.SupportedKind{
+		X402Version: 2,
+		Scheme:      "exact",
+		Network:     "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+		Extra:       map[string]interface{}{"feePayer": "FeePay3r1111111111111111111111111111111111"},
+	}
+
+	t.Run("embeds blockhash fields when RPC is configured", func(t *testing.T) {
+		rpcServer := httptest.NewServer(mockBlockhashRPC(t, testBlockhash, false))
+		defer rpcServer.Close()
+
+		server := NewExactSvmScheme(&svm.ServerConfig{RPCURL: rpcServer.URL})
+		requirements, err := server.EnhancePaymentRequirements(
+			context.Background(),
+			baseRequirements(),
+			supportedKind,
+			nil,
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, supportedKind.Extra["feePayer"], requirements.Extra["feePayer"])
+		assert.Equal(t, "pi_3abc123def456", requirements.Extra["memo"])
+		assert.Equal(t, testBlockhash, requirements.Extra["recentBlockhash"])
+		assert.Equal(t, "12345678", requirements.Extra["lastValidBlockHeight"])
+	})
+
+	t.Run("omits blockhash fields without RPC config", func(t *testing.T) {
+		server := NewExactSvmScheme()
+		requirements, err := server.EnhancePaymentRequirements(
+			context.Background(),
+			baseRequirements(),
+			supportedKind,
+			nil,
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, supportedKind.Extra["feePayer"], requirements.Extra["feePayer"])
+		assert.NotContains(t, requirements.Extra, "recentBlockhash")
+		assert.NotContains(t, requirements.Extra, "lastValidBlockHeight")
+	})
+
+	t.Run("omits blockhash fields on RPC failure", func(t *testing.T) {
+		rpcServer := httptest.NewServer(mockBlockhashRPC(t, testBlockhash, true))
+		defer rpcServer.Close()
+
+		server := NewExactSvmScheme(&svm.ServerConfig{RPCURL: rpcServer.URL})
+		requirements, err := server.EnhancePaymentRequirements(
+			context.Background(),
+			baseRequirements(),
+			supportedKind,
+			nil,
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, supportedKind.Extra["feePayer"], requirements.Extra["feePayer"])
+		assert.NotContains(t, requirements.Extra, "recentBlockhash")
+		assert.NotContains(t, requirements.Extra, "lastValidBlockHeight")
+	})
+}

--- a/go/mechanisms/svm/types.go
+++ b/go/mechanisms/svm/types.go
@@ -75,6 +75,11 @@ type ClientConfig struct {
 	RPCURL string // Custom RPC URL
 }
 
+// ServerConfig contains optional server configuration.
+type ServerConfig struct {
+	RPCURL string // Custom RPC URL for challenge enrichment
+}
+
 // ToMap converts an ExactSvmPayload to a map for JSON marshaling
 func (p *ExactSvmPayload) ToMap() map[string]interface{} {
 	return map[string]interface{}{


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

<!--
Please provide a clear and concise description of what the changes are, and why they are needed.
Include a link to the issue this PR addresses, if applicable (e.g. "Closes #123").
-->

Adds Go SVM exact parity for the server-provided recent blockhash behavior introduced in TypeScript PR #2693.

Go SVM exact clients previously always fetched their own recent blockhash in `go/mechanisms/svm/exact/client/scheme.go`, while the server challenge in `go/mechanisms/svm/exact/server/scheme.go` only added `feePayer`. This PR lets resource servers optionally embed a recent blockhash observed by their RPC, saving a client RPC round-trip and reducing blockhash-view mismatch.

### Changes

- Adds optional `svm.ServerConfig{RPCURL}` for Go SVM exact servers.
- Best-effort adds `extra.recentBlockhash` and `extra.lastValidBlockHeight` to payment requirements when server RPC is configured.
- Updates the Go SVM exact client to prefer `extra.recentBlockhash` when present, with existing `GetLatestBlockhash` behavior as fallback.
- Adds a dedicated invalid blockhash error code.
- Adds focused client/server tests and README docs.
- Adds a Go changelog fragment.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

```console
GOCACHE=/tmp/go-build-cache go test ./mechanisms/svm/exact/client
GOCACHE=/tmp/go-build-cache go test ./mechanisms/svm/...
GOCACHE=/tmp/go-build-cache make fmt
GOCACHE=/tmp/go-build-cache make test
GOCACHE=/tmp/go-build-cache make build
GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache make lint
git diff --check
```

## Related

- Follows TypeScript PR #2693 

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 