### PR TITLE
fix next e2e build

### DIFF
--- a/e2e/servers/next/build.sh
+++ b/e2e/servers/next/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# TypeScript build handled by pnpm at root level
-# This file is intentionally empty
-exit 0
-
+set -e
+export FACILITATOR_URL="${FACILITATOR_URL:-http://localhost:4022}"
+pnpm build

--- a/e2e/servers/next/next.config.ts
+++ b/e2e/servers/next/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
     root: monorepoRoot,
   },
   outputFileTracingRoot: monorepoRoot,
+  serverExternalPackages: ["@keetanetwork/keetanet-client", "@keetanetwork/asn1-napi-rs"],
 };
 
 export default nextConfig;

--- a/e2e/servers/next/package.json
+++ b/e2e/servers/next/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "NODE_NO_WARNINGS=1 next dev -p ${PORT:-4021}",
     "build": "next build",
-    "start": "next start",
+    "start": "NODE_NO_WARNINGS=1 next start -p ${PORT:-4021}",
     "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
     "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
     "lint": "eslint . --ext .ts --fix",

--- a/e2e/servers/next/run.sh
+++ b/e2e/servers/next/run.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-pnpm dev 
+pnpm start


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

- Fixes the e2e next server's build, which was broken by the native @keetanetwork/asn1-napi-rs addon that Turbopack can't bundle (added via @x402/keeta), by marking the Keeta packages as serverExternalPackages
- makes `build.sh` run a `next build` and `run.sh` serve the compiled output via `next start`, so build regressions are caught in CI and the server starts deterministically instead of JIT-compiling under `next dev`

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 