### PR TITLE
Add HPP facilitator to the facilitators directory

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -13,6 +13,7 @@ The table below lists selected production options; it is not an exhaustive catal
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
 | [Corbits](https://corbits.dev) | Production-grade multi-network, multi-token facilitator supporting EVM and Solana |
 | [Dexter](https://dexter.cash/facilitator) | Free public x402 facilitator across Solana and EVM chains with no fees and no account required |
+| [HPP Facilitator](https://docs.hpp.io/x402/facilitator) | Gasless, public x402 facilitator for HPP Mainnet and Sepolia |
 | [Meridian](https://mrdn.finance) | Multi-chain facilitator with developer-first features |
 | [Mogami Facilitator](https://facilitator.mogami.tech) | Free, developer-focused facilitator for Base with optional self-hosted Docker deployment |
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |


### PR DESCRIPTION
Adds a directory entry for the HPP Facilitator — the first-party, gasless x402 facilitator operated by the HPP team, live on HPP Mainnet and Sepolia.

- Live: https://facilitator.hpp.io (eip155:190415) and https://facilitator-sepolia.hpp.io (eip155:181228) — `/supported`, `/verify`, `/settle` over HTTPS with CORS
- Token: USDC.e ("Bridged USDC", `0x401eCb1D350407f13ba348573E5630B83638E30D`) on both chains
- Schemes: `exact` (EIP-3009) and `upto` (Permit2), with gasless EIP-2612 sponsoring so payers never hold native gas
- On-chain proof (mainnet): `0xe7941c7ecdcf97f701f286afe0030fa407362f6e55d35de0578c29414b92366b` (0.01 USDC.e settled through the live service)
- HPP Mainnet (190415) and HPP Sepolia (181228) are already recognized by the `@x402` SDK (#2309)
- Docs: https://docs.hpp.io/x402/facilitator
