### PR TITLE
fix(evm): emit spec-compliant authorization_value_mismatch error for cross-SDK parity

### DIFF
--- a/typescript/.changeset/evm-authorization-value-mismatch-parity.md
+++ b/typescript/.changeset/evm-authorization-value-mismatch-parity.md
@@ -1,0 +1,6 @@
+---
+'@x402/evm': patch
+'x402': patch
+---
+
+Align the exact EVM authorization-value-mismatch error code across SDKs. The `@x402/evm` facilitator now emits the spec-documented `invalid_exact_evm_payload_authorization_value_mismatch` reason when an authorization value does not match the required amount, matching the Go facilitator (the previous `invalid_exact_evm_authorization_value` string was not in the spec error registry). The legacy `x402` `ErrorReasons` enum now accepts this reason so responses from the Python/Go facilitators no longer fail TypeScript schema validation.

--- a/typescript/packages/legacy/x402/src/types/verify/x402Specs.ts
+++ b/typescript/packages/legacy/x402/src/types/verify/x402Specs.ts
@@ -17,6 +17,7 @@ export const ErrorReasons = [
   "invalid_exact_evm_payload_authorization_valid_after",
   "invalid_exact_evm_payload_authorization_valid_before",
   "invalid_exact_evm_payload_authorization_value",
+  "invalid_exact_evm_payload_authorization_value_mismatch",
   "invalid_exact_evm_payload_signature",
   "invalid_exact_evm_payload_undeployed_smart_wallet",
   "invalid_exact_evm_payload_recipient_mismatch",

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -205,7 +205,7 @@ export async function verifyEIP3009(
   if (BigInt(eip3009Payload.authorization.value) !== BigInt(requirements.amount)) {
     return {
       isValid: false,
-      invalidReason: Errors.ErrInvalidAuthorizationValue,
+      invalidReason: Errors.ErrAuthorizationValueMismatch,
       payer,
     };
   }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/errors.ts
@@ -15,6 +15,8 @@ export const ErrInvalidSignature = "invalid_exact_evm_signature";
 export const ErrValidBeforeExpired = "invalid_exact_evm_payload_authorization_valid_before";
 export const ErrValidAfterInFuture = "invalid_exact_evm_payload_authorization_valid_after";
 export const ErrInvalidAuthorizationValue = "invalid_exact_evm_authorization_value";
+export const ErrAuthorizationValueMismatch =
+  "invalid_exact_evm_payload_authorization_value_mismatch";
 export const ErrUndeployedSmartWallet = "invalid_exact_evm_payload_undeployed_smart_wallet";
 export const ErrTransactionFailed = "invalid_exact_evm_transaction_failed";
 

--- a/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
@@ -274,7 +274,8 @@ describe("ExactEvmScheme (Facilitator)", () => {
       const result = await facilitator.verify(fullPayload, modifiedRequirements);
 
       expect(result.isValid).toBe(false);
-      // Verification should fail (amount mismatch or other validation error)
+      // Must emit the spec-documented, cross-SDK code (matches the Go facilitator)
+      expect(result.invalidReason).toBe(Errors.ErrAuthorizationValueMismatch);
     });
 
     it("should include payer in response", async () => {


### PR DESCRIPTION
Closes #2742.

## Problem

The `@x402/evm` facilitator and the Go facilitator emit **different error codes for the identical check** (authorization value ≠ required amount):

- **Go** [`go/mechanisms/evm/exact/facilitator/eip3009.go:62`] → `invalid_exact_evm_payload_authorization_value_mismatch` (present in the spec error registry)
- **TypeScript** [`typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts:205`] → `invalid_exact_evm_authorization_value` — **not** in the spec registry

The TS string also violates the `errors.ts` header contract ("These strings must be character-for-character identical to the Go constants ... to maintain cross-SDK parity"). Go's own `ErrInvalidAuthorizationValue` (the non-`mismatch` string) is defined but never emitted, so `…_authorization_value_mismatch` is the only correct reason for this condition.

Separately — the case in the linked issue — the legacy `x402` package validates facilitator responses with `z.enum(ErrorReasons)`, and that enum was missing the documented reason. A TypeScript client therefore rejected an otherwise-valid response from the Python/Go facilitators as a schema error.

## Fix

- `@x402/evm`: emit `ErrAuthorizationValueMismatch` from the EIP-3009 value check; add the constant (kept `ErrInvalidAuthorizationValue`, still referenced by the v1 path).
- legacy `x402`: add `invalid_exact_evm_payload_authorization_value_mismatch` to `ErrorReasons`.
- Tighten the existing exact-facilitator unit test to assert the emitted reason (it previously only checked `isValid === false`).
- Changeset (patch for both packages).

## Verification

- `@x402/evm` unit suite: **728/728 pass** (`pnpm test` after building deps).
- Prettier clean on all changed files.

---

*Disclosure: drafted with AI assistance (Claude Code). I verified the diff, the cross-SDK behavior, and the tests.*
