### PR TITLE
feat(extensions): add VCX reference implementation

### DIFF
--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -90,6 +90,18 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      canonicalize:
+        specifier: ^2.0.0
+        version: 2.1.0
+      did-jwt:
+        specifier: ^8.0.0
+        version: 8.0.18
+      did-jwt-vc:
+        specifier: ^4.0.0
+        version: 4.0.16
+      did-resolver:
+        specifier: ^4.1.0
+        version: 4.1.0
       jose:
         specifier: ^5.9.6
         version: 5.10.0
@@ -4369,6 +4381,9 @@ packages:
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
     engines: {node: '>= 18'}
 
+  '@multiformats/base-x@4.0.1':
+    resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -4815,6 +4830,9 @@ packages:
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
@@ -7201,6 +7219,10 @@ packages:
   caniuse-lite@1.0.30001735:
     resolution: {integrity: sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==}
 
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
+
   chai@5.3.1:
     resolution: {integrity: sha512-48af6xm9gQK8rhIcOxWwdGzIervm8BVTin+yRp9HEvU20BtVZ2lBywlIJBzwaDtvo0FvjeL7QdCADoUoqIbV3A==}
     engines: {node: '>=18'}
@@ -7575,6 +7597,16 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  did-jwt-vc@4.0.16:
+    resolution: {integrity: sha512-is7/e2KdLwtDP3JTnf9sLhUeBQF9AhyGjBuJAAVs5U2Uf8CBchRwDycztHQJCx1voBabVprrmAa9NJMd+qWcSA==}
+    engines: {node: '>=18'}
+
+  did-jwt@8.0.18:
+    resolution: {integrity: sha512-yS3Y+aUKjYqRFrgR/RY77NuOOqS7SFfvfFH4THhWD6+hkxeUZcKQSsdNZ12QR1Vd48yP9exwae2wzbuOZn0NqQ==}
+
+  did-resolver@4.1.0:
+    resolution: {integrity: sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==}
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
@@ -9132,6 +9164,11 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multibase@4.0.6:
+    resolution: {integrity: sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==}
+    engines: {node: '>=12.0.0', npm: '>=6.0.0'}
+    deprecated: This module has been superseded by the multiformats module
 
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
@@ -12551,6 +12588,8 @@ snapshots:
 
   '@msgpack/msgpack@3.1.3': {}
 
+  '@multiformats/base-x@4.0.1': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.4.5
@@ -13412,6 +13451,8 @@ snapshots:
   '@scure/base@1.1.9': {}
 
   '@scure/base@1.2.6': {}
+
+  '@scure/base@2.2.0': {}
 
   '@scure/bip32@1.4.0':
     dependencies:
@@ -18002,7 +18043,7 @@ snapshots:
       '@noble/hashes': 1.7.0
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
-      uint8arrays: 3.1.0
+      uint8arrays: 3.1.1
 
   '@walletconnect/safe-json@1.0.0': {}
 
@@ -19185,6 +19226,8 @@ snapshots:
 
   caniuse-lite@1.0.30001735: {}
 
+  canonicalize@2.1.0: {}
+
   chai@5.3.1:
     dependencies:
       assertion-error: 2.0.1
@@ -19497,6 +19540,25 @@ snapshots:
   detect-browser@5.3.0: {}
 
   detect-libc@2.1.2: {}
+
+  did-jwt-vc@4.0.16:
+    dependencies:
+      did-jwt: 8.0.18
+      did-resolver: 4.1.0
+
+  did-jwt@8.0.18:
+    dependencies:
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 2.2.0
+      canonicalize: 2.1.0
+      did-resolver: 4.1.0
+      multibase: 4.0.6
+      multiformats: 9.9.0
+      uint8arrays: 3.1.1
+
+  did-resolver@4.1.0: {}
 
   diff@4.0.4: {}
 
@@ -21650,6 +21712,10 @@ snapshots:
   ms@2.1.2: {}
 
   ms@2.1.3: {}
+
+  multibase@4.0.6:
+    dependencies:
+      '@multiformats/base-x': 4.0.1
 
   multiformats@9.9.0: {}
 

--- a/typescript/.changeset/vcx-extension.md
+++ b/typescript/.changeset/vcx-extension.md
@@ -1,0 +1,75 @@
+---
+"@x402/extensions": minor
+---
+
+Add VCX (Verifiable Credential Exchange) — a new identity extension under
+`@x402/extensions/vcx` matching the spec at `specs/extensions/vcx.md`
+(originally proposed on x402-foundation/x402#2400).
+
+VCX adds a `VCX` HTTP header carrying a three-layer identity envelope
+(Principal VC + Agent DID + Payment Source) and integrates via the
+standard `onPaymentRequired` / `onProtectedRequest` v2 extension
+lifecycle hooks. Verifiers run a four-step verification (principal
+credential JWS + revocation + trust list + hash pinning, agent
+delegation conditions, envelope-to-payment binding, settlement
+passthrough). Implements every v1.0 spec MUST in §6–§17 with the
+explicit §18 v1.1 carve-outs (ETSI Trusted List, full DID Method
+Registry expansion, OHTTP, `onAfterSettle` correlation,
+settlement-attestation profile).
+
+Public surface (importable from `@x402/extensions/vcx` or via the
+package root barrel):
+
+- Extension factories: `createVCXResourceServerExtension`,
+  `createVCXClientExtension`, `declareVCXExtension`
+- Verification: `verifyEnvelope` (with `VerifyEnvelopeOptions` covering
+  `paymentAmount`, `dailyLimitStore`, `strictDelegationConditions`,
+  `statusListCache`, `trustListCache`, `fetchImpl`)
+- Envelope: `buildIdentityEnvelope`, `buildEnvelopeFromRequirements`,
+  `canonicalEnvelope`, `envelopeDigest`
+- Revocation: `checkCredentialStatus`, `InMemoryStatusListCache`
+- Trust list: `resolveAcceptedIssuers`, `verifyDidDocumentHash`,
+  `InMemoryTrustListCache`
+- Resolver: `getDidResolver`, `buildHardenedWebResolver`,
+  `configureDidWebResolver`, `didWebToUrl`
+- Credentials: `createVCXIssuer`, `issueCredential` (supports
+  `format: "jwt-vc" | "sd-jwt-vc"` with `selectivelyDisclosable: string[]`)
+- SD-JWT VC primitives: `verifySdJwtVcPresentation`, `buildDisclosure`,
+  `disclosureHash`, `parseDisclosure`, `parseSdJwt`,
+  `buildSdIssuerSubject`, `composeSdJwt`
+- Identity primitives: `generateEd25519KeyPair`, `publicKeyToDidKey`,
+  `buildDid`, `createAgent`, `buildDelegation`,
+  `buildCredentialSubject`, `meetsKycRequirement`
+- Storage: `InMemoryNonceStorage`, `NoOpNonceStorage`, plus the
+  `NonceStorage` and `DailyLimitStore` interfaces
+- Header transport: `VCX_HEADER_NAME`, `encodeVCXHeader`,
+  `parseVCXHeader`
+- Schema: `buildVCXEnvelopeSchema`
+
+New runtime dependencies:
+
+- `did-jwt` (^8.0.0, Apache 2.0) — JWS for VCs and SD-JWT VCs
+- `did-jwt-vc` (^4.0.0, Apache 2.0) — W3C VC JWT issuance/verification
+- `did-resolver` (^4.1.0, Apache 2.0) — DID resolution glue
+- `canonicalize` (^2.0.0, MIT) — RFC 8785 JCS for envelope/document
+  digest computation
+
+Spec MUSTs implemented:
+
+§6 envelope (vcxPresent + credentialFormat + delegationProofFormat),
+§6.4 envelopeDigest, §7.1 did:key, §7.2 did:web with full TLS
+hardening (HTTPS-only, cert validation, no cross-host redirect),
+§8.1 inline + §8.2 well-known JWS-signed trust list + didDocumentHash
+pinning, §9.1–§9.4 four-step verification, §10 vc-embedded delegation,
+§11.1 short-lived + §11.2 Bitstring Status List v1.0 revocation,
+§12 all three disclosure tiers including Tier 1 SD-JWT VC with
+cryptographic disclosure-proof verification, §13.1 transactionId
+uniqueness, §13.2 envelope-to-payment binding, §13.4 fail-closed on
+unknown delegation conditions, §17 JCS canonicalization.
+
+Notes on the SD-JWT VC layer: the v1.0 reference impl is self-contained
+(~250 LOC under `src/vcx/envelope/sdjwtvc.ts`), supporting the
+presentation flow VCX uses. Scope is deliberately narrow — no
+key-binding-JWT verification, no recursive disclosures, no
+array-element disclosures. A future PR MAY swap to `@sd-jwt/core`
+without changing the public `verifySdJwtVcPresentation` signature.

--- a/typescript/packages/extensions/NOTICE
+++ b/typescript/packages/extensions/NOTICE
@@ -1,0 +1,29 @@
+Apache-2.0 License
+
+Copyright 2024 Coinbase
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This package implements the following public standards and conventions:
+
+  - RFC 8785  — JSON Canonicalization Scheme (JCS)
+  - FIPS 180-4 — SHA-256
+  - W3C Verifiable Credentials Data Model 1.1
+  - W3C Bitstring Status List v1.0
+  - W3C Decentralized Identifiers (DID) Core; did:key and did:web methods
+  - SD-JWT VC (IETF draft)
+  - RFC 7515 — JSON Web Signature (JWS)
+  - The multihash / OCI-style "sha256:<lowercase-hex>" content-digest convention
+
+These standards are implemented independently. This NOTICE does not assert any
+relationship with, or derivation from, any third-party implementation of them.

--- a/typescript/packages/extensions/package.json
+++ b/typescript/packages/extensions/package.json
@@ -47,6 +47,10 @@
     "@scure/base": "^1.2.6",
     "@x402/core": "workspace:~",
     "ajv": "^8.17.1",
+    "canonicalize": "^2.0.0",
+    "did-jwt": "^8.0.0",
+    "did-jwt-vc": "^4.0.0",
+    "did-resolver": "^4.1.0",
     "jose": "^5.9.6",
     "@signinwithethereum/siwe": "^4.1.0",
     "tweetnacl": "^1.0.3",
@@ -112,6 +116,16 @@
       "require": {
         "types": "./dist/cjs/builder-code/index.d.ts",
         "default": "./dist/cjs/builder-code/index.js"
+      }
+    },
+    "./vcx": {
+      "import": {
+        "types": "./dist/esm/vcx/index.d.mts",
+        "default": "./dist/esm/vcx/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/vcx/index.d.ts",
+        "default": "./dist/cjs/vcx/index.js"
       }
     }
   },

--- a/typescript/packages/extensions/src/index.ts
+++ b/typescript/packages/extensions/src/index.ts
@@ -23,3 +23,7 @@ export * from "./erc20-approval-gas-sponsoring";
 
 // Builder Code extension (ERC-8021)
 export * from "./builder-code";
+
+// VCX (Verifiable Credential Exchange) extension — spec: specs/extensions/vcx.md
+export * from "./vcx";
+export { createVCXResourceServerExtension, createVCXClientExtension } from "./vcx";

--- a/typescript/packages/extensions/src/vcx/canonicalize.d.ts
+++ b/typescript/packages/extensions/src/vcx/canonicalize.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Local ambient declaration for the `canonicalize` npm package (RFC 8785
+ * JCS reference implementation, MIT). Provides the type the package
+ * itself ships in some versions but not others; harmless when the real
+ * types are present.
+ */
+declare module "canonicalize" {
+  /**
+   * Produce the RFC 8785 (JCS) canonical JSON serialization of a value.
+   *
+   * @param value - The value to canonicalize.
+   * @returns The canonical JSON string, or undefined for unsupported input.
+   */
+  function canonicalize(value: unknown): string | undefined;
+  export default canonicalize;
+}

--- a/typescript/packages/extensions/src/vcx/client.ts
+++ b/typescript/packages/extensions/src/vcx/client.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ClientExtension } from "@x402/core/client";
+import { buildEnvelopeFromRequirements } from "./envelope/builder";
+import { encodeVCXHeader, VCX_HEADER_NAME } from "./header";
+import { VCX_EXTENSION_KEY } from "./declare";
+import type { IdentityRequirements, PrincipalClaims, PaymentSourceLayer } from "./types";
+import type { AgentIdentity } from "./identity/agent";
+
+export interface CreateVCXClientExtensionOptions {
+  /** Pre-issued W3C VC JWT (or SD-JWT VC presentation) for the principal. */
+  principalCredential: string;
+  /** Principal DID. MUST equal `credentialSubject.id` of the credential. */
+  principalDid: string;
+  /** Claims the principal is willing to disclose at Tier 1 / Tier 2. */
+  principalClaims: PrincipalClaims;
+  /** Agent identity (typically created via `createAgent(name)`). */
+  agent: AgentIdentity;
+  /** Payment source binding the envelope to the x402 payment sender. */
+  paymentSource: PaymentSourceLayer;
+  /**
+   * Delegation proof. Defaults to `principalCredential` for the v1
+   * `vc-embedded` profile (spec §10), in which the delegation lives inside
+   * the credential's `credentialSubject.delegatedTo`.
+   */
+  delegationProof?: string;
+}
+
+/**
+ * Build the VCX client extension for registration with the x402 v2 client.
+ *
+ * On any 402 response whose `extensions` declares VCX, the extension
+ * constructs an identity envelope from the configured principal credential,
+ * agent identity, and payment source, then attaches it as the `VCX`
+ * header on the resumed request.
+ *
+ * @example
+ * ```typescript
+ * import { createVCXClientExtension, createAgent } from "@x402/vcx";
+ *
+ * const vcx = createVCXClientExtension({
+ *   principalCredential: myCredentialJwt,
+ *   principalDid: "did:web:paypal.com:user/abc",
+ *   principalClaims: { kycLevel: "IdentityVerified", ageOver18: true },
+ *   agent: createAgent("my-payment-agent"),
+ *   paymentSource: {
+ *     accountId: "eip155:8453:0xA11CE...",
+ *     sourceId: "0xA11CE...",
+ *     network: "eip155:8453",
+ *   },
+ * });
+ *
+ * const client = new x402HTTPClient(...).registerExtension(vcx);
+ * ```
+ *
+ * @param options - Principal credential, principal DID, disclosed claims,
+ *   agent identity, payment-source binding, and optional delegation proof
+ *   used to construct the identity envelope.
+ * @returns A client extension that attaches the VCX identity header when a
+ *   402 response declares the VCX extension.
+ */
+export function createVCXClientExtension(
+  options: CreateVCXClientExtensionOptions,
+): ClientExtension {
+  return {
+    key: VCX_EXTENSION_KEY,
+    transportHooks: {
+      http: {
+        onPaymentRequired: async (
+          _declaration: unknown,
+          context: unknown,
+        ): Promise<{ headers: Record<string, string> } | void> => {
+          const ctx = context as {
+            paymentRequired: { extensions?: Record<string, unknown> };
+          };
+
+          const declared = ctx.paymentRequired.extensions?.[VCX_EXTENSION_KEY] as
+            | { info?: IdentityRequirements }
+            | undefined;
+
+          if (!declared?.info) return;
+
+          const envelope = buildEnvelopeFromRequirements(
+            {
+              credentialJwt: options.principalCredential,
+              principalDid: options.principalDid,
+              principalClaims: options.principalClaims,
+              agentDid: options.agent.did,
+              agentName: options.agent.name,
+              delegationProof: options.delegationProof ?? options.principalCredential,
+              paymentSource: options.paymentSource,
+            },
+            declared.info,
+          );
+
+          return {
+            headers: { [VCX_HEADER_NAME]: encodeVCXHeader(envelope) },
+          };
+        },
+      },
+    },
+  };
+}

--- a/typescript/packages/extensions/src/vcx/credential/index.ts
+++ b/typescript/packages/extensions/src/vcx/credential/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { createVCXIssuer, issueCredential } from "./issuer";
+export {
+  getDidResolver,
+  configureDidWebResolver,
+  buildHardenedWebResolver,
+  didWebToUrl,
+} from "./resolver";
+export type { DidWebHardeningConfig } from "./resolver";
+export { resolveAcceptedIssuers, verifyDidDocumentHash, InMemoryTrustListCache } from "./trustlist";
+export type {
+  TrustListEntry,
+  TrustListCache,
+  CachedTrustList,
+  ResolveAcceptedIssuersOptions,
+} from "./trustlist";

--- a/typescript/packages/extensions/src/vcx/credential/issuer.ts
+++ b/typescript/packages/extensions/src/vcx/credential/issuer.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createVerifiableCredentialJwt } from "did-jwt-vc";
+import { EdDSASigner } from "did-jwt";
+import type { Issuer } from "did-jwt-vc";
+import type { IssuerConfig, VCXCredentialSubject } from "../types";
+import { buildSdIssuerSubject, composeSdJwt } from "../envelope/sdjwtvc";
+
+/**
+ * Default credential lifetime (24 hours). Matches the short-lived
+ * revocation profile in spec §11.1; long-lived issuance MUST set
+ * `expiresInSeconds` above 86400 AND attach a `credentialStatus` per
+ * spec §11.2 (issuer's responsibility — the SDK doesn't auto-construct
+ * Bitstring Status List entries).
+ */
+const DEFAULT_EXPIRES_IN_SECONDS = 24 * 60 * 60;
+
+/**
+ * Build a did-jwt-vc {@link Issuer} from a VCX issuer configuration,
+ * decoding the hex-encoded Ed25519 private key into an EdDSA signer.
+ *
+ * @param config - The issuer configuration, including its DID and hex private key.
+ * @returns An {@link Issuer} ready to sign verifiable credentials.
+ */
+export function createVCXIssuer(config: IssuerConfig): Issuer {
+  const privateKeyBytes = Uint8Array.from(Buffer.from(config.privateKeyHex, "hex"));
+  return {
+    did: config.did,
+    signer: EdDSASigner(privateKeyBytes),
+    alg: "EdDSA",
+  };
+}
+
+export interface IssueCredentialOptions {
+  issuerConfig: IssuerConfig;
+  subject: VCXCredentialSubject;
+  expiresInSeconds?: number;
+  /**
+   * Credential serialisation format per spec §6.1. Defaults to `"jwt-vc"`.
+   * `"sd-jwt-vc"` emits an SD-JWT VC presentation suitable for spec §12
+   * Tier 1 selective disclosure; the issuer-signed payload commits to
+   * digests of every claim listed in `selectivelyDisclosable`, and the
+   * returned string includes the matching disclosures.
+   */
+  format?: "jwt-vc" | "sd-jwt-vc";
+  /**
+   * Subject claim names that should be selectively disclosable when
+   * `format === "sd-jwt-vc"`. Each listed claim is replaced in the
+   * issuer-signed payload with a `_sd` digest commitment; the matching
+   * `[salt, name, value]` disclosure is appended to the SD-JWT format.
+   * Claims not listed here are always disclosed (treated as plain
+   * fields). Ignored when `format === "jwt-vc"`.
+   */
+  selectivelyDisclosable?: readonly string[];
+}
+
+/**
+ * Issue a signed X402 identity verifiable credential for the given
+ * subject. Emits a standard `jwt-vc` by default, or an `sd-jwt-vc` with
+ * selective-disclosure digest commitments when requested, returning the
+ * serialised credential alongside its computed expiry and format.
+ *
+ * @param opts - The issuance options.
+ * @param opts.issuerConfig - The issuer configuration used to sign the credential.
+ * @param opts.subject - The credential subject to embed.
+ * @param opts.expiresInSeconds - Credential lifetime in seconds; defaults to 24 hours.
+ * @param opts.format - The serialisation format (`"jwt-vc"` or `"sd-jwt-vc"`); defaults to `"jwt-vc"`.
+ * @param opts.selectivelyDisclosable - Subject claim names to make selectively disclosable under `sd-jwt-vc`.
+ * @returns The serialised credential, its ISO 8601 expiry, and the emitted format.
+ */
+export async function issueCredential(
+  opts: IssueCredentialOptions,
+): Promise<{ jwt: string; expiresAt: string; format: "jwt-vc" | "sd-jwt-vc" }> {
+  const issuer = createVCXIssuer(opts.issuerConfig);
+  const now = Math.floor(Date.now() / 1000);
+  const expiresIn = opts.expiresInSeconds ?? DEFAULT_EXPIRES_IN_SECONDS;
+  const expiresAt = new Date((now + expiresIn) * 1000).toISOString();
+  const format = opts.format ?? "jwt-vc";
+
+  if (format === "jwt-vc") {
+    const vcPayload = {
+      sub: opts.subject.id,
+      nbf: now,
+      exp: now + expiresIn,
+      vc: {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://x402.org/credentials/identity/v1",
+        ],
+        type: ["VerifiableCredential", "X402IdentityCredential"],
+        credentialSubject: opts.subject,
+      },
+    };
+    const jwt = await createVerifiableCredentialJwt(vcPayload, issuer);
+    return { jwt, expiresAt, format };
+  }
+
+  // SD-JWT VC path. Split the subject into base (always-disclosed)
+  // and disclosable; the issuer-signed payload sees the base subject
+  // plus a `_sd` array of digest commitments for the disclosable
+  // claims. Disclosures are concatenated onto the JWT with `~`.
+  const { issuerSubject, disclosures } = buildSdIssuerSubject({
+    subject: opts.subject as unknown as Record<string, unknown>,
+    selectivelyDisclosable: opts.selectivelyDisclosable ?? [],
+  });
+  const vcPayload = {
+    sub: opts.subject.id,
+    nbf: now,
+    exp: now + expiresIn,
+    vc: {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://x402.org/credentials/identity/v1",
+      ],
+      type: ["VerifiableCredential", "X402IdentityCredential"],
+      credentialSubject: issuerSubject,
+    },
+  };
+  const jwt = await createVerifiableCredentialJwt(vcPayload, issuer);
+  return { jwt: composeSdJwt(jwt, disclosures), expiresAt, format };
+}

--- a/typescript/packages/extensions/src/vcx/credential/resolver.ts
+++ b/typescript/packages/extensions/src/vcx/credential/resolver.ts
@@ -1,0 +1,304 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Resolver } from "did-resolver";
+import type { DIDResolutionResult, DIDResolver, VerificationMethod } from "did-resolver";
+import { base58btcDecode, base58Encode } from "../identity/base58";
+
+/**
+ * Configuration knobs for the hardened `did:web` resolver (spec §7.2).
+ * These are read at resolver-construction time; pass via
+ * {@link configureDidWebResolver} before the first {@link getDidResolver}
+ * call, or call `configureDidWebResolver` then re-acquire.
+ */
+export interface DidWebHardeningConfig {
+  /**
+   * Override the fetch implementation. Defaults to the global `fetch`.
+   * Primarily for testing — production deployments may also wrap to add
+   * timeouts, retries, or proxy routing.
+   */
+  fetchImpl?: typeof fetch;
+  /**
+   * Maximum number of same-host redirects to follow before giving up.
+   * Defaults to 0; spec §7.2 doesn't require redirect-following at all,
+   * and most issuers serve `did.json` directly. Cross-host redirects are
+   * ALWAYS rejected regardless of this number.
+   */
+  maxSameHostRedirects?: number;
+}
+
+let cachedResolver: Resolver | null = null;
+let activeHardeningConfig: DidWebHardeningConfig = {};
+
+/**
+ * Override the `did:web` hardening config. Invalidates the cached
+ * resolver so the next {@link getDidResolver} call rebuilds with the
+ * new config. Use this in tests to inject a mock fetch.
+ *
+ * @param config - The hardening configuration to apply on the next resolver build.
+ */
+export function configureDidWebResolver(config: DidWebHardeningConfig): void {
+  activeHardeningConfig = { ...config };
+  cachedResolver = null;
+}
+
+/**
+ * Return a cached DID resolver wired for the `did:key` and hardened
+ * `did:web` methods, building it on first use from the active hardening
+ * config and reusing it on subsequent calls.
+ *
+ * @returns The shared {@link Resolver} instance.
+ */
+export function getDidResolver(): Resolver {
+  if (cachedResolver) return cachedResolver;
+
+  cachedResolver = new Resolver({
+    key: resolveDidKey,
+    web: buildHardenedWebResolver(activeHardeningConfig),
+  });
+
+  return cachedResolver;
+}
+
+/**
+ * Build a hardened `did:web` resolver per spec §7.2:
+ *
+ * - HTTPS-only (reject any URL whose scheme is not `https:`).
+ * - Default Node `fetch` TLS chain + expiry + hostname validation
+ *   (`rejectUnauthorized` is true by default and MUST NOT be disabled).
+ * - No cross-host redirects: each 3xx Location MUST resolve to the same
+ *   hostname as the original DID, else fail with a clear error.
+ *
+ * Replaces the unmodified `web-did-resolver` registration the SDK used
+ * through v0.4. The shape `DIDResolver` is unchanged so consumers see
+ * no API difference.
+ *
+ * @param config - Optional hardening configuration (fetch override, redirect limit).
+ * @returns A {@link DIDResolver} that resolves `did:web` identifiers safely.
+ */
+export function buildHardenedWebResolver(config: DidWebHardeningConfig = {}): DIDResolver {
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const maxRedirects = config.maxSameHostRedirects ?? 0;
+
+  return async (did, _parsed, _resolver, options): Promise<DIDResolutionResult> => {
+    let url: URL;
+    try {
+      url = didWebToUrl(did);
+    } catch (err) {
+      return webError("invalidDid", err instanceof Error ? err.message : String(err));
+    }
+    if (url.protocol !== "https:") {
+      return webError(
+        "notFound",
+        `did:web resolution refused: ${url.protocol} is not https (spec §7.2)`,
+      );
+    }
+    const originalHostname = url.hostname;
+
+    let response: Response;
+    try {
+      response = await fetchWithSameHostRedirects({
+        url,
+        originalHostname,
+        fetchImpl,
+        maxRedirects,
+      });
+    } catch (err) {
+      return webError("notFound", err instanceof Error ? err.message : String(err));
+    }
+
+    if (!response.ok) {
+      return webError("notFound", `HTTP ${response.status} from ${url.toString()}`);
+    }
+
+    let didDocument: Record<string, unknown>;
+    try {
+      didDocument = (await response.json()) as Record<string, unknown>;
+    } catch (err) {
+      return webError(
+        "notFound",
+        `did.json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (didDocument.id !== did) {
+      return webError(
+        "notFound",
+        `did:web document.id "${String(didDocument.id)}" does not match resolved DID "${did}"`,
+      );
+    }
+
+    return {
+      didResolutionMetadata: {
+        contentType: options.accept || "application/did+json",
+      },
+      didDocument: didDocument as DIDResolutionResult["didDocument"],
+      didDocumentMetadata: {},
+    };
+  };
+}
+
+/**
+ * Construct the HTTPS URL for a `did:web` per the DID method
+ * specification: `did:web:DOMAIN[:PATH...]` →
+ * `https://DOMAIN[/PATH...]/did.json`, or
+ * `https://DOMAIN/.well-known/did.json` when there is no path. Domain
+ * may be URL-encoded (`%3A` for the port colon).
+ *
+ * @param did - The `did:web` identifier to translate.
+ * @returns The HTTPS URL of the corresponding `did.json` document.
+ */
+export function didWebToUrl(did: string): URL {
+  if (!did.startsWith("did:web:")) {
+    throw new Error(`Not a did:web identifier: ${did}`);
+  }
+  const identifier = did.slice("did:web:".length);
+  if (identifier.length === 0) {
+    throw new Error(`did:web identifier is empty`);
+  }
+  const segments = identifier.split(":");
+  const domain = decodeURIComponent(segments[0]);
+  const path = segments.slice(1).map(decodeURIComponent);
+  const pathPart = path.length === 0 ? "/.well-known/did.json" : `/${path.join("/")}/did.json`;
+  // URL constructor will throw on malformed domains; let that propagate.
+  return new URL(`https://${domain}${pathPart}`);
+}
+
+/**
+ * Fetch a URL while following only same-host HTTPS redirects up to a
+ * limit. Any cross-host redirect, non-HTTPS redirect, missing `Location`
+ * header, or exceeding the redirect limit throws (spec §7.2).
+ *
+ * @param args - The fetch parameters.
+ * @param args.url - The initial URL to fetch.
+ * @param args.originalHostname - The hostname redirects must stay within.
+ * @param args.fetchImpl - The fetch implementation to use.
+ * @param args.maxRedirects - The maximum number of same-host redirects to follow.
+ * @returns The final non-redirect {@link Response}.
+ */
+async function fetchWithSameHostRedirects(args: {
+  url: URL;
+  originalHostname: string;
+  fetchImpl: typeof fetch;
+  maxRedirects: number;
+}): Promise<Response> {
+  let currentUrl = args.url;
+  for (let attempt = 0; attempt <= args.maxRedirects; attempt += 1) {
+    const response = await args.fetchImpl(currentUrl.toString(), {
+      redirect: "manual",
+    });
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location) {
+        throw new Error(
+          `${response.status} redirect from ${currentUrl.toString()} with no Location header`,
+        );
+      }
+      const next = new URL(location, currentUrl);
+      if (next.protocol !== "https:") {
+        throw new Error(`did:web redirect refused: ${next.protocol} is not https (spec §7.2)`);
+      }
+      if (next.hostname !== args.originalHostname) {
+        throw new Error(
+          `did:web cross-host redirect refused: ${currentUrl.hostname} → ${next.hostname} (spec §7.2)`,
+        );
+      }
+      currentUrl = next;
+      continue;
+    }
+    return response;
+  }
+  throw new Error(`did:web exceeded the maxSameHostRedirects limit (${args.maxRedirects})`);
+}
+
+/**
+ * Build a failed `did:web` {@link DIDResolutionResult} carrying an error
+ * code and human-readable message with a null DID document.
+ *
+ * @param error - The resolution error code.
+ * @param message - The human-readable error message.
+ * @returns A resolution result representing the failure.
+ */
+function webError(error: string, message: string): DIDResolutionResult {
+  return {
+    didResolutionMetadata: { error, message },
+    didDocument: null,
+    didDocumentMetadata: {},
+  };
+}
+
+const resolveDidKey: DIDResolver = async (
+  did,
+  parsed,
+  _resolver,
+  options,
+): Promise<DIDResolutionResult> => {
+  try {
+    const multicodecPublicKey = base58btcDecode(parsed.id);
+    if (
+      multicodecPublicKey.length !== 34 ||
+      multicodecPublicKey[0] !== 0xed ||
+      multicodecPublicKey[1] !== 0x01
+    ) {
+      return notFound("Only Ed25519 did:key identifiers are supported");
+    }
+
+    const publicKey = multicodecPublicKey.slice(2);
+    const keyId = `${did}#${parsed.id}`;
+    const verificationMethod: VerificationMethod = {
+      id: keyId,
+      type: "Ed25519VerificationKey2020",
+      controller: did,
+      publicKeyBase58: base58Encode(publicKey),
+      publicKeyMultibase: parsed.id,
+    };
+
+    return {
+      didResolutionMetadata: {
+        contentType: options.accept || "application/did+json",
+      },
+      didDocument: {
+        id: did,
+        verificationMethod: [verificationMethod],
+        authentication: [keyId],
+        assertionMethod: [keyId],
+        capabilityInvocation: [keyId],
+        capabilityDelegation: [keyId],
+      },
+      didDocumentMetadata: {},
+    };
+  } catch (err) {
+    return notFound(err instanceof Error ? err.message : String(err));
+  }
+};
+
+/**
+ * Build a `notFound` {@link DIDResolutionResult} carrying the given
+ * message with a null DID document.
+ *
+ * @param message - The human-readable error message.
+ * @returns A resolution result representing the not-found failure.
+ */
+function notFound(message: string): DIDResolutionResult {
+  return {
+    didResolutionMetadata: {
+      error: "notFound",
+      message,
+    },
+    didDocument: null,
+    didDocumentMetadata: {},
+  };
+}

--- a/typescript/packages/extensions/src/vcx/credential/trustlist.ts
+++ b/typescript/packages/extensions/src/vcx/credential/trustlist.ts
@@ -1,0 +1,303 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import { verifyJWT } from "did-jwt";
+import type { Resolvable } from "did-resolver";
+import { jcsSha256 } from "../envelope/canonicalize";
+
+/**
+ * One entry in a trust list. `did` is the issuer DID the verifier
+ * should accept; the optional `didDocumentHash` (per spec §8.2) pins
+ * the resolved DID document by content hash so a DNS / BGP / TLS-MITM
+ * attacker cannot substitute a malicious DID document even if they
+ * control the issuer's domain transiently.
+ */
+export interface TrustListEntry {
+  did: string;
+  didDocumentHash?: string;
+}
+
+const DEFAULT_TRUST_LIST_TTL_SECONDS = 60 * 60;
+
+export interface CachedTrustList {
+  entries: TrustListEntry[];
+  /** Epoch milliseconds. Reads past this point MUST refetch. */
+  expiresAt: number;
+}
+
+/**
+ * Pluggable cache for resolved well-known trust lists. The default
+ * {@link InMemoryTrustListCache} is fine for single-process verifiers;
+ * multi-instance verifiers SHOULD provide a shared store so a trust
+ * list update applied to one instance propagates.
+ */
+export interface TrustListCache {
+  get(ref: string): CachedTrustList | undefined;
+  set(ref: string, entries: TrustListEntry[], ttlSeconds: number): void;
+}
+
+/**
+ * In-memory {@link TrustListCache} suitable for single-process verifiers.
+ * Entries are evicted lazily on read once their TTL has elapsed.
+ */
+export class InMemoryTrustListCache implements TrustListCache {
+  private readonly store = new Map<string, CachedTrustList>();
+
+  /**
+   * Look up a cached trust list, evicting and returning `undefined` when
+   * the entry has expired.
+   *
+   * @param ref - The trust-list reference key.
+   * @returns The cached trust list, or `undefined` if missing or expired.
+   */
+  get(ref: string): CachedTrustList | undefined {
+    const entry = this.store.get(ref);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(ref);
+      return undefined;
+    }
+    return entry;
+  }
+
+  /**
+   * Store a trust list under a reference key with a TTL, computing its
+   * absolute expiry timestamp.
+   *
+   * @param ref - The trust-list reference key.
+   * @param entries - The resolved trust-list entries to cache.
+   * @param ttlSeconds - How long the entry remains valid, in seconds.
+   */
+  set(ref: string, entries: TrustListEntry[], ttlSeconds: number): void {
+    this.store.set(ref, {
+      entries,
+      expiresAt: Date.now() + ttlSeconds * 1000,
+    });
+  }
+}
+
+export interface ResolveAcceptedIssuersOptions {
+  resolver: Resolvable;
+  cache?: TrustListCache;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Resolve each `acceptedIssuers` reference (spec §8) to a flat list of
+ * {@link TrustListEntry}. Three transports are supported in v1:
+ *
+ * - **§8.1 inline DID URI** (`did:web:...`, `did:key:z...`): returned
+ *   as-is with no `didDocumentHash` pin.
+ * - **§8.2 well-known JWS-signed JSON** (HTTPS URL): fetched, the JWS
+ *   verified against the publisher's DID, and the embedded `issuers`
+ *   array (with optional `didDocumentHash`) returned.
+ * - **§8.3 ETSI Trusted List**: deferred to v1.1. Returns an explicit
+ *   "deferred" error so a verifier configured with one fails-closed
+ *   rather than silently accepting.
+ *
+ * @param refs - The `acceptedIssuers` references to resolve.
+ * @param options - Resolution options (resolver, optional cache and fetch).
+ * @returns The flattened list of resolved {@link TrustListEntry} values.
+ */
+export async function resolveAcceptedIssuers(
+  refs: readonly string[],
+  options: ResolveAcceptedIssuersOptions,
+): Promise<TrustListEntry[]> {
+  const entries: TrustListEntry[] = [];
+  for (const ref of refs) {
+    if (ref.startsWith("did:")) {
+      entries.push({ did: ref });
+      continue;
+    }
+    if (ref.startsWith("https://")) {
+      if (ref.endsWith(".xml") || /\/etsi\//i.test(ref)) {
+        throw new Error(
+          `Trust-list reference appears to be ETSI (${ref}); ETSI Trusted List transport (spec §8.3) is deferred to v1.1`,
+        );
+      }
+      const resolved = await fetchWellKnownTrustList(ref, options);
+      entries.push(...resolved);
+      continue;
+    }
+    if (ref.startsWith("http://")) {
+      throw new Error(`Trust-list reference MUST be HTTPS (spec §8.2); got ${ref}`);
+    }
+    throw new Error(
+      `Unrecognised acceptedIssuers reference shape: ${ref}. Expected inline DID URI, https://.../.well-known/vcx-trust-list, or ETSI URL.`,
+    );
+  }
+  return entries;
+}
+
+/**
+ * Fetch and validate a well-known JWS-signed trust list (spec §8.2),
+ * returning its entries. Serves a cached copy when available; otherwise
+ * fetches the JWS, verifies it against the resolver, checks that the body
+ * issuer matches the JWS issuer and the validity window, validates each
+ * entry, caches the result per `Cache-Control: max-age`, and returns it.
+ *
+ * @param ref - The HTTPS URL of the well-known trust list.
+ * @param options - Resolution options (resolver, optional cache and fetch).
+ * @returns The validated trust-list entries.
+ */
+async function fetchWellKnownTrustList(
+  ref: string,
+  options: ResolveAcceptedIssuersOptions,
+): Promise<TrustListEntry[]> {
+  const cache = options.cache;
+  const cached = cache?.get(ref);
+  if (cached) return cached.entries;
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const response = await fetchImpl(ref);
+  if (!response.ok) {
+    throw new Error(`Trust-list fetch ${ref} returned HTTP ${response.status}`);
+  }
+  const jws = (await response.text()).trim();
+  const ttlSeconds = parseCacheControlMaxAge(response.headers.get("cache-control"));
+
+  // Verify the JWS against any DID in the resolver. did-jwt's verifyJWT
+  // resolves the `iss` claim from the JWT payload, looks up keys in the
+  // DID document, and verifies. Throws on failure.
+  let verified: Awaited<ReturnType<typeof verifyJWT>>;
+  try {
+    verified = await verifyJWT(jws, { resolver: options.resolver });
+  } catch (err) {
+    throw new Error(
+      `Trust-list JWS verification failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const payload = verified.payload as {
+    issuer?: unknown;
+    issuers?: unknown;
+    validFrom?: unknown;
+    validUntil?: unknown;
+  };
+
+  // The publisher DID in the body MUST match the JWS issuer; otherwise
+  // an attacker could repackage a different publisher's trust list and
+  // claim it as their own.
+  if (payload.issuer !== verified.issuer) {
+    throw new Error(
+      `Trust-list body.issuer (${String(payload.issuer)}) does not match JWS iss (${verified.issuer})`,
+    );
+  }
+
+  // Enforce validity window (spec §8.2 doesn't pin format but documents
+  // validFrom/validUntil in the example). Strict ISO 8601 timestamps.
+  const now = Date.now();
+  if (typeof payload.validFrom === "string") {
+    const ms = Date.parse(payload.validFrom);
+    if (Number.isFinite(ms) && ms > now) {
+      throw new Error(`Trust-list validFrom (${payload.validFrom}) is in the future`);
+    }
+  }
+  if (typeof payload.validUntil === "string") {
+    const ms = Date.parse(payload.validUntil);
+    if (Number.isFinite(ms) && ms <= now) {
+      throw new Error(`Trust-list validUntil (${payload.validUntil}) has passed`);
+    }
+  }
+
+  if (!Array.isArray(payload.issuers)) {
+    throw new Error("Trust-list body.issuers MUST be an array");
+  }
+  const entries: TrustListEntry[] = [];
+  for (const raw of payload.issuers) {
+    if (!raw || typeof raw !== "object") {
+      throw new Error("Each trust-list issuers entry MUST be an object");
+    }
+    const obj = raw as { did?: unknown; didDocumentHash?: unknown };
+    if (typeof obj.did !== "string" || obj.did.length === 0) {
+      throw new Error("Each trust-list issuers entry MUST have a string `did`");
+    }
+    const entry: TrustListEntry = { did: obj.did };
+    if (obj.didDocumentHash !== undefined) {
+      if (typeof obj.didDocumentHash !== "string") {
+        throw new Error(
+          `Trust-list entry didDocumentHash MUST be a string; got ${typeof obj.didDocumentHash}`,
+        );
+      }
+      if (!/^sha256:[0-9a-f]{64}$/.test(obj.didDocumentHash)) {
+        throw new Error(
+          `Trust-list entry didDocumentHash MUST be "sha256:<lowercase-hex>"; got ${obj.didDocumentHash}`,
+        );
+      }
+      entry.didDocumentHash = obj.didDocumentHash;
+    }
+    entries.push(entry);
+  }
+  cache?.set(ref, entries, ttlSeconds);
+  return entries;
+}
+
+/**
+ * After Step 1's JWS check, when the trust-list entry for the resolved
+ * issuer publishes a `didDocumentHash`, recompute the hash by
+ * resolving the issuer DID and JCS-canonicalizing the returned DID
+ * document. If the hash differs, the resolved document was tampered
+ * (or rotated without an updated trust-list publication) and the
+ * envelope MUST be rejected (spec §8.2 / §13.3).
+ *
+ * @param opts - The hash-pinning inputs.
+ * @param opts.issuerDid - The issuer DID whose document is re-resolved.
+ * @param opts.expectedHash - The pinned `sha256:<hex>` document hash to match.
+ * @param opts.resolver - The resolver used to re-fetch the DID document.
+ * @returns `{ ok: true }` on match, otherwise `{ ok: false, reason }`.
+ */
+export async function verifyDidDocumentHash(opts: {
+  issuerDid: string;
+  expectedHash: string;
+  resolver: Resolvable;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  let result: Awaited<ReturnType<Resolvable["resolve"]>>;
+  try {
+    result = await opts.resolver.resolve(opts.issuerDid);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `Failed to resolve issuer DID ${opts.issuerDid} for hash pinning: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (!result.didDocument) {
+    return {
+      ok: false,
+      reason: `Issuer DID ${opts.issuerDid} resolved to no document (${result.didResolutionMetadata.error ?? "unknown"})`,
+    };
+  }
+  const computed = jcsSha256(result.didDocument);
+  if (computed !== opts.expectedHash) {
+    return {
+      ok: false,
+      reason: `didDocumentHash mismatch for ${opts.issuerDid}: expected ${opts.expectedHash}, computed ${computed}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Parse the `max-age` directive from a `Cache-Control` header value,
+ * falling back to the default trust-list TTL when the header is absent,
+ * malformed, or negative.
+ *
+ * @param header - The raw `Cache-Control` header value, or `null`.
+ * @returns The cache lifetime in seconds.
+ */
+function parseCacheControlMaxAge(header: string | null): number {
+  if (!header) return DEFAULT_TRUST_LIST_TTL_SECONDS;
+  const match = header.match(/max-age=(\d+)/i);
+  if (!match) return DEFAULT_TRUST_LIST_TTL_SECONDS;
+  const n = Number(match[1]);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_TRUST_LIST_TTL_SECONDS;
+}

--- a/typescript/packages/extensions/src/vcx/declare.ts
+++ b/typescript/packages/extensions/src/vcx/declare.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IdentityRequirements, DisclosureTier, KycLevel } from "./types";
+import { buildVCXEnvelopeSchema, type VCXEnvelopeSchema } from "./schema";
+
+/** Extension key registered with the x402 v2 runtime (spec §4). */
+export const VCX_EXTENSION_KEY = "vcx";
+
+/** Protocol version this implementation speaks. */
+const VCX_PROTOCOL_VERSION = "x402-vcx-v1" as const;
+
+export interface DeclareVCXOptions {
+  disclosureTier: DisclosureTier;
+  requiredClaims?: string[];
+  minKycLevel?: KycLevel;
+  /**
+   * Trust-list references. Each entry MUST resolve to a set of issuer DIDs
+   * via one of the transports defined in spec §8: a literal DID URI, a URL
+   * to a `/.well-known/vcx-trust-list` endpoint, or a URL to an ETSI
+   * Trusted List.
+   */
+  acceptedIssuers: string[];
+  /** Protocol version override. Defaults to `"x402-vcx-v1"`. */
+  protocol?: typeof VCX_PROTOCOL_VERSION;
+}
+
+/**
+ * Extension declaration object returned by `declareVCXExtension`. Stored on
+ * the route declaration and consumed at request time by the server extension.
+ */
+export interface VCXDeclaration {
+  info: IdentityRequirements;
+  schema: VCXEnvelopeSchema;
+  _options: DeclareVCXOptions;
+}
+
+/**
+ * Declare the VCX extension on a route.
+ *
+ * @example
+ * ```typescript
+ * const routes = {
+ *   "GET /premium/data": {
+ *     accepts: [{ scheme: "exact", price: "$0.01", network: "eip155:8453" }],
+ *     extensions: declareVCXExtension({
+ *       disclosureTier: 1,
+ *       requiredClaims: ["kycLevel", "ageOver18"],
+ *       minKycLevel: "IdentityVerified",
+ *       acceptedIssuers: ["did:web:paypal.com"],
+ *     }),
+ *   },
+ * };
+ * ```
+ *
+ * @param options - Disclosure tier, required claims, minimum KYC level,
+ *   accepted issuer trust-list references, and optional protocol override
+ *   that define the identity requirements advertised to clients.
+ * @returns A declaration object keyed by the VCX extension key, carrying the
+ *   identity requirements, envelope JSON Schema, and the raw options.
+ */
+export function declareVCXExtension(options: DeclareVCXOptions): Record<string, VCXDeclaration> {
+  // Conditional spread so optional fields are absent when undefined, rather
+  // than serialised as explicit-undefined keys.
+  const info: IdentityRequirements = {
+    protocol: options.protocol ?? VCX_PROTOCOL_VERSION,
+    disclosureTier: options.disclosureTier,
+    acceptedIssuers: options.acceptedIssuers,
+    ...(options.requiredClaims !== undefined && {
+      requiredClaims: options.requiredClaims,
+    }),
+    ...(options.minKycLevel !== undefined && {
+      minKycLevel: options.minKycLevel,
+    }),
+  };
+
+  return {
+    [VCX_EXTENSION_KEY]: {
+      info,
+      schema: buildVCXEnvelopeSchema(),
+      _options: options,
+    },
+  };
+}

--- a/typescript/packages/extensions/src/vcx/envelope/builder.ts
+++ b/typescript/packages/extensions/src/vcx/envelope/builder.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { randomUUID } from "crypto";
+import type {
+  IdentityEnvelope,
+  PrincipalClaims,
+  PaymentSourceLayer,
+  DisclosureTier,
+  IdentityRequirements,
+  CredentialFormat,
+  DelegationProofFormat,
+} from "../types";
+
+export interface BuildEnvelopeOpts {
+  credentialJwt: string;
+  principalDid: string;
+  principalClaims: PrincipalClaims;
+  agentDid: string;
+  agentName: string;
+  delegationProof: string;
+  paymentSource: PaymentSourceLayer;
+  disclosureTier?: DisclosureTier;
+  requiredClaims?: string[];
+  /**
+   * Credential serialisation format per spec §6.1. Defaults to `"jwt-vc"`.
+   * Callers that issue an SD-JWT VC presentation MUST pass `"sd-jwt-vc"`;
+   * Tier 1 verification of those presentations requires SDK v1.0.0+.
+   */
+  credentialFormat?: CredentialFormat;
+  /**
+   * Delegation-proof profile per spec §6.2. Defaults to `"vc-embedded"`,
+   * which is the only profile permitted by spec §10 in v1.
+   */
+  delegationProofFormat?: DelegationProofFormat;
+}
+
+/**
+ * Build a VCX identity envelope from the principal credential, agent
+ * delegation, and payment-source inputs. Selectively discloses principal
+ * claims according to the requested disclosure tier (spec §6).
+ *
+ * @param opts - The envelope build inputs.
+ * @param opts.credentialJwt - The principal's credential serialization.
+ * @param opts.principalDid - The principal's DID.
+ * @param opts.principalClaims - The full set of principal claims available
+ *   for disclosure.
+ * @param opts.agentDid - The delegated agent's DID.
+ * @param opts.agentName - The delegated agent's human-readable name.
+ * @param opts.delegationProof - The delegation proof authorizing the agent.
+ * @param opts.paymentSource - The payment-source layer bound into the
+ *   envelope.
+ * @param opts.disclosureTier - The disclosure tier governing which
+ *   principal claims are revealed. Defaults to tier 1.
+ * @param opts.requiredClaims - Claim names to disclose under tier 1.
+ * @param opts.credentialFormat - Credential serialization format (spec
+ *   §6.1). Defaults to `"jwt-vc"`.
+ * @param opts.delegationProofFormat - Delegation-proof profile (spec §6.2).
+ *   Defaults to `"vc-embedded"`.
+ * @returns The assembled identity envelope.
+ */
+export function buildIdentityEnvelope(opts: BuildEnvelopeOpts): IdentityEnvelope {
+  const disclosed = selectDisclosedClaims(
+    opts.principalClaims,
+    opts.disclosureTier ?? 1,
+    opts.requiredClaims,
+  );
+
+  return {
+    version: "1.0",
+    protocol: "x402-vcx-v1",
+    transactionId: randomUUID(),
+    vcxPresent: true,
+    principal: {
+      credentialFormat: opts.credentialFormat ?? "jwt-vc",
+      credentialJwt: opts.credentialJwt,
+      did: opts.principalDid,
+      disclosed,
+    },
+    agent: {
+      did: opts.agentDid,
+      name: opts.agentName,
+      delegationProofFormat: opts.delegationProofFormat ?? "vc-embedded",
+      delegationProof: opts.delegationProof,
+    },
+    paymentSource: opts.paymentSource,
+  };
+}
+
+/**
+ * Build an identity envelope, deriving the disclosure tier and required
+ * claims from a verifier's stated {@link IdentityRequirements} rather than
+ * passing them explicitly.
+ *
+ * @param opts - The envelope build inputs, excluding the disclosure tier
+ *   and required claims (which are taken from `requirements`).
+ * @param requirements - The verifier's identity requirements supplying the
+ *   disclosure tier and required claims.
+ * @returns The assembled identity envelope.
+ */
+export function buildEnvelopeFromRequirements(
+  opts: Omit<BuildEnvelopeOpts, "disclosureTier" | "requiredClaims">,
+  requirements: IdentityRequirements,
+): IdentityEnvelope {
+  return buildIdentityEnvelope({
+    ...opts,
+    disclosureTier: requirements.disclosureTier,
+    requiredClaims: requirements.requiredClaims,
+  });
+}
+
+/**
+ * Select which principal claims to disclose for a given disclosure tier.
+ * Tier 0 discloses nothing, tier 2 discloses everything, and tier 1
+ * discloses only the requested required claims (or everything when no
+ * required claims are specified).
+ *
+ * @param claims - The full set of principal claims available.
+ * @param tier - The disclosure tier governing the selection.
+ * @param requiredClaims - Claim names to disclose under tier 1.
+ * @returns The subset of claims to embed in the envelope.
+ */
+function selectDisclosedClaims(
+  claims: PrincipalClaims,
+  tier: DisclosureTier,
+  requiredClaims?: string[],
+): PrincipalClaims {
+  if (tier === 0) return {};
+
+  if (tier === 2) return { ...claims };
+
+  if (!requiredClaims || requiredClaims.length === 0) return { ...claims };
+
+  const disclosed: PrincipalClaims = {};
+  for (const key of requiredClaims) {
+    if (key in claims) {
+      disclosed[key] = claims[key];
+    }
+  }
+  return disclosed;
+}

--- a/typescript/packages/extensions/src/vcx/envelope/canonicalize.ts
+++ b/typescript/packages/extensions/src/vcx/envelope/canonicalize.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import canonicalize from "canonicalize";
+import { createHash } from "crypto";
+import type { IdentityEnvelope } from "../types";
+
+/**
+ * JCS-canonicalize an arbitrary JSON-shaped value per spec §17 / RFC 8785
+ * and return the UTF-8 bytes. Used internally by {@link canonicalEnvelope}
+ * and by the didDocumentHash check in `src/credential/trustlist.ts`.
+ *
+ * @param value - The JSON-shaped value to canonicalize.
+ * @returns The UTF-8 bytes of the JCS-canonical JSON serialization.
+ */
+export function canonicalJsonBytes(value: unknown): Uint8Array {
+  const json = canonicalize(value);
+  if (typeof json !== "string") {
+    throw new Error("JCS canonicalization returned non-string");
+  }
+  return new TextEncoder().encode(json);
+}
+
+/**
+ * `"sha256:" + lowercase-hex SHA-256` over the JCS-canonical bytes. The
+ * canonical VCX digest format (spec §6.4 envelopeDigest, §8.2
+ * didDocumentHash, §17.3 future digest sites).
+ *
+ * @param value - The JSON-shaped value to hash.
+ * @returns The `"sha256:"`-prefixed lowercase-hex SHA-256 digest of the
+ *   JCS-canonical bytes.
+ */
+export function jcsSha256(value: unknown): string {
+  const bytes = canonicalJsonBytes(value);
+  return "sha256:" + createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * JCS-canonicalize the envelope per spec §17 and return the UTF-8 bytes.
+ *
+ * The output is byte-deterministic across implementations that conform to
+ * RFC 8785. Two envelopes with identical content but different JSON key
+ * insertion order MUST produce identical output.
+ *
+ * @param envelope - The identity envelope to canonicalize.
+ * @returns The UTF-8 bytes of the envelope's JCS-canonical JSON
+ *   serialization.
+ */
+export function canonicalEnvelope(envelope: IdentityEnvelope): Uint8Array {
+  return canonicalJsonBytes(envelope);
+}
+
+/**
+ * Compute the content-addressable envelope digest per spec §6.4.
+ *
+ * Returns `"sha256:" + lowercase-hex SHA-256` over the JCS-canonical bytes.
+ * Suitable for embedding in facilitator settle-time receipts (spec §16.1)
+ * and any other audit-time correlation surface.
+ *
+ * @param envelope - The identity envelope to digest.
+ * @returns The `"sha256:"`-prefixed lowercase-hex SHA-256 envelope digest.
+ */
+export function envelopeDigest(envelope: IdentityEnvelope): string {
+  return jcsSha256(envelope);
+}

--- a/typescript/packages/extensions/src/vcx/envelope/index.ts
+++ b/typescript/packages/extensions/src/vcx/envelope/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { buildIdentityEnvelope, buildEnvelopeFromRequirements } from "./builder";
+export type { BuildEnvelopeOpts } from "./builder";
+
+export { verifyEnvelope } from "./verifier";
+export type { VerifyEnvelopeOptions } from "./verifier";
+
+export { canonicalEnvelope, envelopeDigest } from "./canonicalize";
+
+export { checkCredentialStatus, InMemoryStatusListCache } from "./revocation";
+export type {
+  StatusListCache,
+  CachedStatusList,
+  RevocationCheckResult,
+  CheckCredentialStatusOptions,
+} from "./revocation";
+
+export {
+  verifySdJwtVcPresentation,
+  buildDisclosure,
+  disclosureHash,
+  parseDisclosure,
+  parseSdJwt,
+  buildSdIssuerSubject,
+  composeSdJwt,
+} from "./sdjwtvc";
+export type { Disclosure, VerifiedSdJwtVc } from "./sdjwtvc";

--- a/typescript/packages/extensions/src/vcx/envelope/revocation.ts
+++ b/typescript/packages/extensions/src/vcx/envelope/revocation.ts
@@ -1,0 +1,426 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gunzipSync } from "zlib";
+import { verifyCredential } from "did-jwt-vc";
+import type { Resolvable } from "did-resolver";
+
+/**
+ * Maximum lifetime for the short-lived revocation profile (spec §11.1):
+ * 24 hours, after which a credential MUST carry a `credentialStatus`
+ * field per the status-list profile (§11.2).
+ */
+const SHORT_LIVED_MAX_SECONDS = 24 * 60 * 60;
+
+/**
+ * Default cache TTL for status-list fetches when the response carries no
+ * `Cache-Control: max-age=…`. Set to one hour per spec §11.2.
+ */
+const DEFAULT_STATUS_LIST_TTL_SECONDS = 60 * 60;
+
+/**
+ * In-memory cache entry shape.
+ */
+export interface CachedStatusList {
+  /** Decoded, decompressed bitstring bytes. */
+  bitstring: Uint8Array;
+  /** Epoch milliseconds. Reads past this point MUST refetch. */
+  expiresAt: number;
+}
+
+/**
+ * Pluggable cache for fetched Bitstring Status List bytes (spec §11.2).
+ * The default `InMemoryStatusListCache` is suitable for single-process
+ * deployments; multi-instance verifiers SHOULD provide a shared store
+ * (Redis, distributed cache) so a revocation event applied to one
+ * instance's cache doesn't leave another instance accepting the same
+ * credential until its independent TTL expires.
+ */
+export interface StatusListCache {
+  get(url: string): CachedStatusList | undefined;
+  set(url: string, bitstring: Uint8Array, ttlSeconds: number): void;
+}
+
+/**
+ * In-process {@link StatusListCache} backed by a `Map`. Entries expire on
+ * read once their TTL elapses. Suitable for single-process verifiers; not
+ * shared across instances.
+ */
+export class InMemoryStatusListCache implements StatusListCache {
+  private readonly store = new Map<string, CachedStatusList>();
+
+  /**
+   * Return the cached status list for a URL, or `undefined` when absent or
+   * expired. Expired entries are evicted on access.
+   *
+   * @param url - The status-list credential URL to look up.
+   * @returns The cached entry, or `undefined` when missing or expired.
+   */
+  get(url: string): CachedStatusList | undefined {
+    const entry = this.store.get(url);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(url);
+      return undefined;
+    }
+    return entry;
+  }
+
+  /**
+   * Store decoded status-list bytes for a URL with the given TTL.
+   *
+   * @param url - The status-list credential URL to cache under.
+   * @param bitstring - The decoded, decompressed status-list bytes.
+   * @param ttlSeconds - Time-to-live in seconds before the entry expires.
+   */
+  set(url: string, bitstring: Uint8Array, ttlSeconds: number): void {
+    this.store.set(url, {
+      bitstring,
+      expiresAt: Date.now() + ttlSeconds * 1000,
+    });
+  }
+}
+
+/**
+ * Result of a revocation check. `ok: false` always carries a reason
+ * suitable for inclusion in the verifier's step-1 error message.
+ */
+export type RevocationCheckResult = { ok: true } | { ok: false; reason: string };
+
+export interface CheckCredentialStatusOptions {
+  /** Issuer DID of the verified principal credential (spec §11.2). */
+  issuerDid: string;
+  /** Resolver shared with the verifier. */
+  resolver: Resolvable;
+  /** Cache. Defaults to a new {@link InMemoryStatusListCache} per call. */
+  cache?: StatusListCache;
+  /**
+   * Override the fetch function (testing). Defaults to global `fetch`.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Run the spec §11 revocation check against a verified credential's JWT
+ * payload. Detects the short-lived (§11.1) vs status-list (§11.2)
+ * profile and enforces the relevant MUSTs.
+ *
+ * @param payload - The `payload` field returned by did-jwt-vc's
+ *   verifyCredential. Must include `nbf` and `exp` (epoch seconds) and
+ *   the W3C VC body under `vc`.
+ * @param options - Revocation-check options (issuer DID, resolver, cache,
+ *   and fetch override).
+ * @returns `{ ok: true }` when the credential is not revoked, or
+ *   `{ ok: false, reason }` describing the failure.
+ */
+export async function checkCredentialStatus(
+  payload: unknown,
+  options: CheckCredentialStatusOptions,
+): Promise<RevocationCheckResult> {
+  const nbf = readEpochClaim(payload, "nbf");
+  const exp = readEpochClaim(payload, "exp");
+  if (nbf === undefined || exp === undefined) {
+    return {
+      ok: false,
+      reason:
+        "Credential JWT MUST carry both `nbf` and `exp` claims for revocation-profile detection (spec §11)",
+    };
+  }
+
+  const credentialStatus = readCredentialStatus(payload);
+  const lifetimeSeconds = exp - nbf;
+
+  // Spec §11.1 short-lived profile: lifetime ≤ 24h AND no
+  // `credentialStatus`. Reject either deviation.
+  if (lifetimeSeconds <= SHORT_LIVED_MAX_SECONDS) {
+    if (credentialStatus !== undefined) {
+      return {
+        ok: false,
+        reason:
+          "Short-lived credential (lifetime ≤ 24h) MUST NOT carry a credentialStatus field (spec §11.1)",
+      };
+    }
+    return { ok: true };
+  }
+
+  // Spec §11.2 status-list profile. credentialStatus MUST be present.
+  if (credentialStatus === undefined) {
+    return {
+      ok: false,
+      reason: `Long-lived credential (lifetime ${lifetimeSeconds}s > 24h) MUST carry a credentialStatus field per Bitstring Status List v1.0 (spec §11.2)`,
+    };
+  }
+  if (credentialStatus.type !== "BitstringStatusListEntry") {
+    return {
+      ok: false,
+      reason: `credentialStatus.type MUST be "BitstringStatusListEntry"; got ${JSON.stringify(credentialStatus.type)}`,
+    };
+  }
+  if (credentialStatus.statusPurpose !== "revocation") {
+    return {
+      ok: false,
+      reason: `credentialStatus.statusPurpose MUST be "revocation" in v1; got ${JSON.stringify(credentialStatus.statusPurpose)}`,
+    };
+  }
+  if (typeof credentialStatus.statusListCredential !== "string") {
+    return {
+      ok: false,
+      reason: "credentialStatus.statusListCredential MUST be a string URL",
+    };
+  }
+  const statusListIndex = parseStatusListIndex(credentialStatus.statusListIndex);
+  if (statusListIndex === undefined) {
+    return {
+      ok: false,
+      reason: `credentialStatus.statusListIndex MUST be a non-negative integer string; got ${JSON.stringify(credentialStatus.statusListIndex)}`,
+    };
+  }
+
+  const cache = options.cache ?? new InMemoryStatusListCache();
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  let bitstring: Uint8Array;
+  const cached = cache.get(credentialStatus.statusListCredential);
+  if (cached) {
+    bitstring = cached.bitstring;
+  } else {
+    let fetchResult: FetchedStatusList;
+    try {
+      fetchResult = await fetchAndVerifyStatusList({
+        url: credentialStatus.statusListCredential,
+        expectedIssuerDid: options.issuerDid,
+        resolver: options.resolver,
+        fetchImpl,
+      });
+    } catch (err) {
+      return {
+        ok: false,
+        reason: `Failed to fetch / verify status list at ${credentialStatus.statusListCredential}: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+    cache.set(credentialStatus.statusListCredential, fetchResult.bitstring, fetchResult.ttlSeconds);
+    bitstring = fetchResult.bitstring;
+  }
+
+  let bit: number;
+  try {
+    bit = getBit(bitstring, statusListIndex);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `Failed to read bit ${statusListIndex} from status list: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (bit === 1) {
+    return {
+      ok: false,
+      reason: `Credential is revoked (status list bit ${statusListIndex} is set)`,
+    };
+  }
+  return { ok: true };
+}
+
+interface FetchedStatusList {
+  bitstring: Uint8Array;
+  ttlSeconds: number;
+}
+
+/**
+ * Fetch a status-list credential, verify its JWS against the resolver,
+ * confirm the issuer matches the credential issuer, and decode the
+ * embedded bitstring (spec §11.2).
+ *
+ * @param args - The fetch-and-verify inputs.
+ * @param args.url - The status-list credential URL to fetch.
+ * @param args.expectedIssuerDid - The DID the status-list issuer MUST equal.
+ * @param args.resolver - The DID resolver used to verify the status-list JWS.
+ * @param args.fetchImpl - The fetch implementation to use.
+ * @returns The decoded bitstring and the cache TTL derived from the
+ *   response headers.
+ */
+async function fetchAndVerifyStatusList(args: {
+  url: string;
+  expectedIssuerDid: string;
+  resolver: Resolvable;
+  fetchImpl: typeof fetch;
+}): Promise<FetchedStatusList> {
+  const response = await args.fetchImpl(args.url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const body = await response.text();
+  const ttlSeconds = parseCacheControlMaxAge(response.headers.get("cache-control"));
+
+  // The status list credential is itself a JWT-encoded W3C VC. Verify
+  // the JWS against the configured resolver; this is what the §11.2
+  // "verify JWS against the status-list issuer's DID" MUST refers to.
+  const verified = await verifyCredential(body, args.resolver);
+  if (!verified.verified) {
+    throw new Error("status list JWS verification failed");
+  }
+
+  // Spec §17 open question (v1 simplifying assumption): status-list
+  // issuer MUST equal the credential issuer. v1.1 may relax via a
+  // delegation-of-issuance profile.
+  const statusListIssuer = readIssuer(verified.verifiableCredential.issuer);
+  if (statusListIssuer !== args.expectedIssuerDid) {
+    throw new Error(
+      `status list issuer ${statusListIssuer ?? "(missing)"} MUST equal the credential issuer ${args.expectedIssuerDid} in v1`,
+    );
+  }
+
+  // credentialSubject.encodedList per Bitstring Status List v1.0 §3.
+  const subject = verified.verifiableCredential.credentialSubject as
+    | { encodedList?: unknown; type?: unknown }
+    | undefined;
+  if (!subject || subject.type !== "BitstringStatusList") {
+    throw new Error(
+      `status list credentialSubject.type MUST be "BitstringStatusList"; got ${JSON.stringify(subject?.type)}`,
+    );
+  }
+  if (typeof subject.encodedList !== "string") {
+    throw new Error("status list credentialSubject.encodedList MUST be a string");
+  }
+  const bitstring = decodeEncodedList(subject.encodedList);
+
+  return { bitstring, ttlSeconds };
+}
+
+/**
+ * Read a finite numeric epoch-seconds claim from a JWT payload.
+ *
+ * @param payload - The JWT payload to read from.
+ * @param key - The claim name to read (`"nbf"` or `"exp"`).
+ * @returns The numeric claim value, or `undefined` when absent or not a
+ *   finite number.
+ */
+function readEpochClaim(payload: unknown, key: "nbf" | "exp"): number | undefined {
+  const value = (payload as Record<string, unknown> | null | undefined)?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+interface CredentialStatusObject {
+  type?: unknown;
+  statusPurpose?: unknown;
+  statusListIndex?: unknown;
+  statusListCredential?: unknown;
+}
+
+/**
+ * Extract the `vc.credentialStatus` object from a JWT payload, if present.
+ *
+ * @param payload - The JWT payload to read from.
+ * @returns The credential-status object, or `undefined` when absent or not
+ *   an object.
+ */
+function readCredentialStatus(payload: unknown): CredentialStatusObject | undefined {
+  const vc = (payload as { vc?: unknown }).vc as { credentialStatus?: unknown } | undefined;
+  const status = vc?.credentialStatus;
+  if (!status || typeof status !== "object") return undefined;
+  return status as CredentialStatusObject;
+}
+
+/**
+ * Normalize a W3C VC `issuer` field (string or `{ id }` object) to its DID
+ * string.
+ *
+ * @param issuer - The raw issuer value (string or object with `id`).
+ * @returns The issuer DID string, or `undefined` when it cannot be
+ *   determined.
+ */
+function readIssuer(issuer: unknown): string | undefined {
+  if (typeof issuer === "string") return issuer;
+  const id = (issuer as { id?: unknown } | null | undefined)?.id;
+  return typeof id === "string" ? id : undefined;
+}
+
+/**
+ * Parse a `statusListIndex` into a non-negative safe integer, accepting
+ * either a decimal-digit string or a number.
+ *
+ * @param raw - The raw status-list index value.
+ * @returns The parsed non-negative integer, or `undefined` when invalid.
+ */
+function parseStatusListIndex(raw: unknown): number | undefined {
+  if (typeof raw === "string") {
+    if (!/^\d+$/.test(raw)) return undefined;
+    const n = Number(raw);
+    return Number.isSafeInteger(n) ? n : undefined;
+  }
+  if (typeof raw === "number" && Number.isSafeInteger(raw) && raw >= 0) {
+    return raw;
+  }
+  return undefined;
+}
+
+/**
+ * Derive a cache TTL in seconds from a `Cache-Control` header's `max-age`
+ * directive, falling back to the default when absent or unparseable.
+ *
+ * @param header - The raw `Cache-Control` header value, or `null`.
+ * @returns The TTL in seconds.
+ */
+function parseCacheControlMaxAge(header: string | null): number {
+  if (!header) return DEFAULT_STATUS_LIST_TTL_SECONDS;
+  const match = header.match(/max-age=(\d+)/i);
+  if (!match) return DEFAULT_STATUS_LIST_TTL_SECONDS;
+  const n = Number(match[1]);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_STATUS_LIST_TTL_SECONDS;
+}
+
+/**
+ * Decode the `encodedList` per Bitstring Status List v1.0 §3.4: a
+ * multibase-prefixed (typically `u` for base64url-no-pad) GZIP-compressed
+ * bitstring. Returns the decompressed bytes.
+ *
+ * @param encoded - The multibase-prefixed, GZIP-compressed encoded list.
+ * @returns The decompressed bitstring bytes.
+ */
+function decodeEncodedList(encoded: string): Uint8Array {
+  if (encoded.length === 0) {
+    throw new Error("encodedList is empty");
+  }
+  const prefix = encoded[0];
+  const body = encoded.slice(1);
+  let raw: Buffer;
+  if (prefix === "u") {
+    raw = Buffer.from(body, "base64url");
+  } else {
+    throw new Error(`Unsupported multibase prefix "${prefix}"; v1 supports base64url (\`u\`) only`);
+  }
+  // GZIP-decompress per Bitstring Status List v1.0 §3.4.
+  return new Uint8Array(gunzipSync(raw));
+}
+
+/**
+ * MSB-first bit access into the decoded bitstring per Bitstring Status
+ * List v1.0 §3.1 (the bit at position `i` is bit `7 - (i % 8)` of byte
+ * `floor(i / 8)`).
+ *
+ * @param bitstring - The decoded status-list bytes.
+ * @param index - The zero-based bit position to read.
+ * @returns The bit value (0 or 1) at the given index.
+ */
+function getBit(bitstring: Uint8Array, index: number): number {
+  const byteIdx = Math.floor(index / 8);
+  if (byteIdx >= bitstring.length) {
+    throw new Error(
+      `statusListIndex ${index} is beyond the bitstring (${bitstring.length} bytes / ${bitstring.length * 8} bits)`,
+    );
+  }
+  const bitIdx = index % 8;
+  return (bitstring[byteIdx] >> (7 - bitIdx)) & 1;
+}

--- a/typescript/packages/extensions/src/vcx/envelope/sdjwtvc.ts
+++ b/typescript/packages/extensions/src/vcx/envelope/sdjwtvc.ts
@@ -1,0 +1,316 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+import { createHash, randomBytes } from "crypto";
+import { verifyJWT } from "did-jwt";
+import type { Resolvable } from "did-resolver";
+
+/**
+ * Initial in-house SD-JWT VC implementation for spec §12 Tier 1.
+ *
+ * Why not `@sd-jwt/core`? The v1.0 SDK roadmap called for it, but the
+ * package's exact v0.x API surface couldn't be verified against the
+ * public npm registry from the development environment this code was
+ * authored in. Shipping a small (~200 LOC) self-contained
+ * implementation that we can statically verify line-by-line is safer
+ * for a v1.0 reference impl than shipping API guesses. A follow-up PR
+ * MAY swap this for `@sd-jwt/core` (or `@sd-jwt/sd-jwt-vc`) with the
+ * `verifySdJwtVcPresentation` signature unchanged.
+ *
+ * The scope is intentionally narrow: support for the SD-JWT VC
+ * presentation flow as VCX uses it. Out of scope here (and deferred
+ * to a future PR):
+ *
+ * - Key-binding JWT verification (the trailing `~<kb-jwt>` segment).
+ *   We parse-and-ignore; VCX v1 does not require it.
+ * - Recursive / nested disclosures (SD-JWT v06+ allows disclosures
+ *   pointing at other disclosures).
+ * - Array element disclosures (`[salt, value]` 2-element arrays for
+ *   array-element revelation, vs the 3-element `[salt, name, value]`
+ *   we handle).
+ *
+ * Spec references throughout: draft-ietf-oauth-selective-disclosure-jwt
+ * for the SD-JWT base format and draft-ietf-oauth-sd-jwt-vc for the
+ * VC layer on top.
+ */
+
+export interface Disclosure {
+  salt: string;
+  name: string;
+  value: unknown;
+}
+
+/**
+ * Build a disclosure: a base64url-encoded JSON array
+ * `[salt, name, value]`. The SHA-256 hash of this base64url string
+ * (ASCII bytes) is what the issuer puts into the `_sd` array of the
+ * SD-JWT payload; the disclosure itself is transmitted alongside the
+ * JWT separated by `~`.
+ *
+ * @param name - The claim name being disclosed.
+ * @param value - The claim value being disclosed.
+ * @param salt - Optional explicit salt; a random 16-byte base64url salt is
+ *   generated when omitted.
+ * @returns The base64url-encoded `[salt, name, value]` disclosure string.
+ */
+export function buildDisclosure(name: string, value: unknown, salt?: string): string {
+  const actualSalt = salt ?? randomBytes(16).toString("base64url");
+  const json = JSON.stringify([actualSalt, name, value]);
+  return Buffer.from(json, "utf8").toString("base64url");
+}
+
+/**
+ * Hash a disclosure string per SD-JWT: SHA-256 over the ASCII bytes
+ * of the base64url-encoded disclosure, output base64url-encoded.
+ *
+ * @param disclosure - The base64url-encoded disclosure string to hash.
+ * @returns The base64url-encoded SHA-256 digest of the disclosure.
+ */
+export function disclosureHash(disclosure: string): string {
+  return createHash("sha256").update(disclosure, "ascii").digest("base64url");
+}
+
+/**
+ * Decode a base64url disclosure back into its `[salt, name, value]` parts.
+ *
+ * @param disclosure - The base64url-encoded disclosure string to decode.
+ * @returns The decoded salt, name, and value.
+ */
+export function parseDisclosure(disclosure: string): Disclosure {
+  let json: string;
+  try {
+    json = Buffer.from(disclosure, "base64url").toString("utf8");
+  } catch (err) {
+    throw new Error(
+      `Disclosure is not valid base64url: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  let arr: unknown;
+  try {
+    arr = JSON.parse(json);
+  } catch (err) {
+    throw new Error(
+      `Disclosure is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!Array.isArray(arr) || arr.length !== 3) {
+    throw new Error(
+      "Disclosure MUST be a 3-element array [salt, name, value] for object-property disclosures",
+    );
+  }
+  if (typeof arr[0] !== "string" || typeof arr[1] !== "string") {
+    throw new Error("Disclosure salt and name MUST be strings");
+  }
+  return { salt: arr[0], name: arr[1], value: arr[2] };
+}
+
+/**
+ * Parse SD-JWT format: `<JWT>~<disclosure1>~<disclosure2>~...[~<kb-jwt>]`.
+ * The trailing key-binding JWT is identified by its 2-dot JWT shape and
+ * captured separately. Empty trailing segments (from the canonical
+ * trailing `~`) are dropped.
+ *
+ * @param sdjwt - The SD-JWT presentation string to parse.
+ * @returns The issuer JWT, the list of disclosure strings, and the
+ *   optional trailing key-binding JWT.
+ */
+export function parseSdJwt(sdjwt: string): {
+  jwt: string;
+  disclosures: string[];
+  keyBindingJwt?: string;
+} {
+  if (typeof sdjwt !== "string" || !sdjwt.includes("~")) {
+    throw new Error("SD-JWT MUST contain at least one ~ separator");
+  }
+  const parts = sdjwt.split("~");
+  const jwt = parts[0];
+  const tail = parts.slice(1);
+  // Drop trailing empties (e.g. "<jwt>~<d>~" canonical form).
+  while (tail.length > 0 && tail[tail.length - 1] === "") tail.pop();
+  let keyBindingJwt: string | undefined;
+  if (tail.length > 0 && tail[tail.length - 1].split(".").length === 3) {
+    keyBindingJwt = tail.pop();
+  }
+  return { jwt, disclosures: tail, keyBindingJwt };
+}
+
+export interface VerifiedSdJwtVc {
+  /**
+   * The verified JWT payload from the issuer-signed portion. Includes
+   * non-disclosable claims as-is, plus the `_sd` digest array and any
+   * `_sd_alg` field. Disclosed claim values are NOT spliced back into
+   * this object — they're returned separately in `disclosed`.
+   */
+  payload: Record<string, unknown>;
+  /** Issuer DID resolved from the JWT `iss` claim. */
+  issuer: string;
+  /**
+   * Verified disclosed claims, keyed by name. Every entry here has been
+   * cryptographically validated against the issuer-signed `_sd` digests;
+   * a holder cannot inject an undisclosed claim.
+   */
+  disclosed: Record<string, unknown>;
+}
+
+/**
+ * Verify an SD-JWT VC presentation per draft-ietf-oauth-sd-jwt-vc:
+ *
+ * 1. Split the presentation on `~`.
+ * 2. Verify the issuer JWT's JWS against the configured resolver.
+ * 3. Reject if `_sd_alg` is present and not `sha-256` (the only algorithm
+ *    VCX v1.0 supports).
+ * 4. Collect `_sd` digests from the top-level payload and from the
+ *    `vc.credentialSubject` block (both placements are seen in the
+ *    wild; VCX issuers use the `vc.credentialSubject` placement).
+ * 5. For each disclosure, compute its SHA-256 hash. Reject if any
+ *    disclosure's hash isn't in the `_sd` set (i.e. a holder appended
+ *    a disclosure the issuer didn't commit to).
+ * 6. Return the verified disclosed claims as a flat name→value map.
+ *
+ * @param opts - The verification inputs.
+ * @param opts.sdjwt - The SD-JWT VC presentation string to verify.
+ * @param opts.resolver - The DID resolver used to verify the issuer JWS.
+ * @returns The verified payload, issuer DID, and disclosed claims.
+ */
+export async function verifySdJwtVcPresentation(opts: {
+  sdjwt: string;
+  resolver: Resolvable;
+}): Promise<VerifiedSdJwtVc> {
+  const { jwt, disclosures } = parseSdJwt(opts.sdjwt);
+
+  let verified;
+  try {
+    verified = await verifyJWT(jwt, { resolver: opts.resolver });
+  } catch (err) {
+    throw new Error(
+      `SD-JWT VC: issuer JWT verification failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const payload = verified.payload as Record<string, unknown>;
+
+  // _sd_alg defaults to sha-256 per spec; v1.0 supports only this value.
+  const sdAlg = payload._sd_alg;
+  if (sdAlg !== undefined && sdAlg !== "sha-256") {
+    throw new Error(`SD-JWT VC: _sd_alg MUST be "sha-256" in v1; got ${JSON.stringify(sdAlg)}`);
+  }
+
+  const sdDigests = collectSdDigests(payload);
+
+  const disclosed: Record<string, unknown> = {};
+  for (const d of disclosures) {
+    const h = disclosureHash(d);
+    if (!sdDigests.has(h)) {
+      throw new Error(
+        `SD-JWT VC: disclosure hash ${h} not present in issuer _sd commitments (forged disclosure)`,
+      );
+    }
+    const parsed = parseDisclosure(d);
+    disclosed[parsed.name] = parsed.value;
+  }
+
+  return {
+    payload,
+    issuer: verified.issuer,
+    disclosed,
+  };
+}
+
+/**
+ * Collect every `_sd` digest commitment from a JWT payload. VCX issuers
+ * place `_sd` inside `vc.credentialSubject` (so the disclosures map to
+ * credential subject fields), but generic SD-JWT placement at the top
+ * level is also accepted.
+ *
+ * @param payload - The verified issuer JWT payload to scan for `_sd`
+ *   commitments.
+ * @returns The set of `_sd` digest strings found in the payload.
+ */
+function collectSdDigests(payload: Record<string, unknown>): Set<string> {
+  const set = new Set<string>();
+  addStringArrayToSet(payload._sd, set);
+  const vc = payload.vc as { credentialSubject?: Record<string, unknown> } | undefined;
+  if (vc?.credentialSubject) {
+    addStringArrayToSet(vc.credentialSubject._sd, set);
+  }
+  return set;
+}
+
+/**
+ * Add every string element of `raw` to `set`, ignoring `raw` entirely when
+ * it is not an array and skipping any non-string elements.
+ *
+ * @param raw - The candidate value expected to be an array of strings.
+ * @param set - The set to add the string elements into.
+ */
+function addStringArrayToSet(raw: unknown, set: Set<string>): void {
+  if (!Array.isArray(raw)) return;
+  for (const v of raw) {
+    if (typeof v === "string") set.add(v);
+  }
+}
+
+/**
+ * Helper for tests / issuer-side code: given a base credential subject
+ * object and a list of selectively-disclosable field names, build the
+ * matching SD-JWT VC issuer payload (with `_sd` digests in place of
+ * the disclosable values) and the disclosure strings.
+ *
+ * The caller then signs the payload (via did-jwt's `createJWT` or
+ * did-jwt-vc's `createVerifiableCredentialJwt`) and assembles the
+ * SD-JWT format `<jwt>~<d1>~<d2>~...`.
+ *
+ * @param opts - The issuer-subject build inputs.
+ * @param opts.subject - The base credential subject object.
+ * @param opts.selectivelyDisclosable - Field names to make selectively
+ *   disclosable (replaced by `_sd` digests in the issuer subject).
+ * @returns The issuer subject (with `_sd` digests) and the matching
+ *   disclosure strings.
+ */
+export function buildSdIssuerSubject(opts: {
+  subject: Record<string, unknown>;
+  selectivelyDisclosable: readonly string[];
+}): {
+  issuerSubject: Record<string, unknown>;
+  disclosures: string[];
+} {
+  const issuerSubject: Record<string, unknown> = {};
+  const disclosures: string[] = [];
+  const sdHashes: string[] = [];
+  for (const [name, value] of Object.entries(opts.subject)) {
+    if (opts.selectivelyDisclosable.includes(name)) {
+      const d = buildDisclosure(name, value);
+      disclosures.push(d);
+      sdHashes.push(disclosureHash(d));
+    } else {
+      issuerSubject[name] = value;
+    }
+  }
+  if (sdHashes.length > 0) {
+    issuerSubject._sd = sdHashes;
+    issuerSubject._sd_alg = "sha-256";
+  }
+  return { issuerSubject, disclosures };
+}
+
+/**
+ * Concatenate a JWT and its disclosures into the canonical SD-JWT
+ * format. Convenience for issuer-side composition; verification accepts
+ * the same shape.
+ *
+ * @param jwt - The issuer-signed JWT.
+ * @param disclosures - The disclosure strings to append.
+ * @returns The canonical `<jwt>~<d1>~<d2>~...~` SD-JWT string.
+ */
+export function composeSdJwt(jwt: string, disclosures: readonly string[]): string {
+  return [jwt, ...disclosures].join("~") + "~";
+}

--- a/typescript/packages/extensions/src/vcx/envelope/verifier.ts
+++ b/typescript/packages/extensions/src/vcx/envelope/verifier.ts
@@ -1,0 +1,713 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { verifyCredential } from "did-jwt-vc";
+import { getDidResolver } from "../credential/resolver";
+import { meetsKycRequirement } from "../identity/principal";
+import {
+  resolveAcceptedIssuers,
+  verifyDidDocumentHash,
+  type TrustListCache,
+} from "../credential/trustlist";
+import type { DailyLimitStore } from "../storage";
+import { checkCredentialStatus, type StatusListCache } from "./revocation";
+import { verifySdJwtVcPresentation } from "./sdjwtvc";
+import type { Resolvable } from "did-resolver";
+import type {
+  IdentityEnvelope,
+  IdentityRequirements,
+  VerificationResult,
+  FullVerificationResult,
+  VCXCredentialSubject,
+} from "../types";
+
+/**
+ * Additional context the verifier needs to enforce the full §9.2
+ * delegation conditions. Each field is optional so the v0.2 call site
+ * (`verifyEnvelope(env, req, sender)`) still type-checks; when a
+ * delegation includes `maxPerTransaction` but the caller didn't supply
+ * `paymentAmount`, the verifier fails-closed (cannot enforce a MUST →
+ * MUST reject).
+ */
+export interface VerifyEnvelopeOptions {
+  /**
+   * The amount being charged on the matching x402 payment payload, as a
+   * decimal string in the scheme's smallest unit (matching the units
+   * `delegatedTo.conditions.maxPerTransaction` is expressed in). Required
+   * whenever the credential's delegation carries `maxPerTransaction`.
+   */
+  paymentAmount?: string;
+  /**
+   * Stateful store for `delegatedTo.conditions.maxDaily` (spec §9.2).
+   * No default implementation; see {@link DailyLimitStore} for guidance.
+   */
+  dailyLimitStore?: DailyLimitStore;
+  /**
+   * When true, missing context that prevents enforcement of a present
+   * delegation condition causes a verification failure. When false
+   * (default), the verifier logs a `console.warn` and skips that specific
+   * check. Production deployments in regulated environments SHOULD set
+   * `strictDelegationConditions: true`.
+   */
+  strictDelegationConditions?: boolean;
+  /**
+   * Cache for fetched Bitstring Status List bodies (spec §11.2). When
+   * omitted, the verifier instantiates a fresh
+   * {@link InMemoryStatusListCache} per call — fine for tests but a
+   * production deployment SHOULD pass a long-lived cache so consecutive
+   * verifications against the same status list don't refetch.
+   */
+  statusListCache?: StatusListCache;
+  /**
+   * Cache for resolved well-known trust lists (spec §8.2). Same
+   * production-vs-test tradeoff as `statusListCache`.
+   */
+  trustListCache?: TrustListCache;
+  /**
+   * Override the `fetch` used to retrieve status lists. Defaults to the
+   * global `fetch`. Primarily for testing — production verifiers can
+   * also wrap `fetch` to add timeouts, retries, or proxy routing.
+   */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Whitelist of keys permitted inside `delegatedTo.conditions` (spec §9.2,
+ * with the fail-closed rule normatively enforced by §13.4). Any other
+ * key in the conditions object causes the verifier to reject the
+ * envelope, even if every recognised condition would otherwise pass.
+ */
+const KNOWN_CONDITION_KEYS = new Set([
+  "maxPerTransaction",
+  "maxDaily",
+  "allowedNetworks",
+  "allowedAssets",
+  "expiresAt",
+]);
+
+/**
+ * Maximum delegation lifetime per spec §9.2 (30 days from credential
+ * issuance). v1.1 may add a profile relaxing this for verified
+ * institutional principals; v1 verifiers MUST enforce it unconditionally.
+ */
+const MAX_DELEGATION_LIFETIME_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * Verify a VCX identity envelope against a verifier's requirements,
+ * running the four ordered checks of spec §6: principal credential,
+ * agent delegation, payment-source binding, and payment settlement.
+ * Returns on the first failing step.
+ *
+ * @param envelope - The identity envelope to verify.
+ * @param requirements - The verifier's identity requirements (accepted
+ *   issuers, minimum KYC level, required claims).
+ * @param paymentSender - The address/identifier that actually originated
+ *   the x402 payment, bound against the envelope's payment source.
+ * @param options - Additional verification context (payment amount, daily
+ *   limit store, strict-conditions flag, caches, and fetch override).
+ * @returns The full verification result, including each step's outcome.
+ */
+export async function verifyEnvelope(
+  envelope: IdentityEnvelope,
+  requirements: IdentityRequirements,
+  paymentSender: string,
+  options: VerifyEnvelopeOptions = {},
+): Promise<FullVerificationResult> {
+  const steps: VerificationResult[] = [];
+
+  // Envelope shape precondition (spec §6): vcxPresent MUST be the literal
+  // true. A missing or wrong-typed value indicates either a malformed
+  // envelope or a sender on a non-VCX protocol; reject before touching the
+  // credential.
+  if ((envelope as { vcxPresent?: unknown }).vcxPresent !== true) {
+    steps.push({
+      step: "principal_credential",
+      success: false,
+      error: "Envelope vcxPresent field MUST be the literal true (spec §6)",
+    });
+    return { valid: false, steps };
+  }
+
+  // Step 1: Principal Credential — verifies the JWS and returns the
+  // verified credentialSubject so Step 2 doesn't have to re-parse the JWT.
+  const step1 = await verifyPrincipalCredential(envelope, requirements, options);
+  steps.push(step1.result);
+  if (!step1.result.success || !step1.subject) {
+    return { valid: false, steps };
+  }
+
+  // Step 2: Agent Delegation
+  const step2 = await verifyAgentDelegation({
+    envelope,
+    subject: step1.subject,
+    credentialNbf: step1.credentialNbf,
+    options,
+  });
+  steps.push(step2);
+  if (!step2.success) return { valid: false, steps };
+
+  // Step 3: Payment Source Binding
+  const step3 = verifyPaymentSourceBinding(envelope, paymentSender);
+  steps.push(step3);
+  if (!step3.success) return { valid: false, steps };
+
+  // Step 4: Payment Settlement (delegated to x402 v2 core; this step is a
+  // placeholder so the result shape stays consistent. The server extension
+  // is responsible for marking step 4 as success only when x402 settlement
+  // has actually reported success.)
+  steps.push({ step: "payment_settlement", success: true });
+
+  return { valid: true, steps };
+}
+
+interface Step1Result {
+  result: VerificationResult;
+  subject?: VCXCredentialSubject;
+  /**
+   * `nbf` claim from the JWT-encoded VC (epoch seconds). Step 2 uses
+   * this as the issuance baseline for the 30-day `expiresAt` cap. May
+   * be undefined if the credential omits `nbf`, in which case Step 2
+   * cannot enforce the cap and rejects per the spec MUST.
+   */
+  credentialNbf?: number;
+}
+
+/**
+ * Step 1 of {@link verifyEnvelope}: verify the principal credential's JWS,
+ * resolve and match the issuer against the trust list (with optional
+ * didDocumentHash pinning), run the revocation check, and confirm the
+ * subject, KYC level, and disclosed/required claims (spec §6.1, §8, §11).
+ *
+ * @param envelope - The identity envelope being verified.
+ * @param requirements - The verifier's identity requirements.
+ * @param options - Additional verification context (caches, fetch override).
+ * @returns The step result plus, on success, the verified credential
+ *   subject and its `nbf` issuance baseline for step 2.
+ */
+async function verifyPrincipalCredential(
+  envelope: IdentityEnvelope,
+  requirements: IdentityRequirements,
+  options: VerifyEnvelopeOptions,
+): Promise<Step1Result> {
+  const result: VerificationResult = {
+    step: "principal_credential",
+    success: false,
+  };
+
+  // Spec §6.1: credentialFormat MUST be present and MUST be one of the
+  // two enum values. v0.2.0 verifies "jwt-vc" only; "sd-jwt-vc" is
+  // typed-and-accepted by the envelope shape but its verification path
+  // is deferred to v1.0.0 (PR #6 in the v1.0 roadmap).
+  const format = (envelope.principal as { credentialFormat?: unknown }).credentialFormat;
+  if (format !== "jwt-vc" && format !== "sd-jwt-vc") {
+    result.error = `principal.credentialFormat MUST be "jwt-vc" or "sd-jwt-vc" (spec §6.1); got ${
+      typeof format === "string" ? `"${format}"` : String(format)
+    }`;
+    return { result };
+  }
+  try {
+    const resolver = getDidResolver();
+    const normalized = await verifyAndNormalize(envelope, resolver, format);
+    if (!normalized.ok) {
+      result.error = normalized.error;
+      return { result };
+    }
+    const { issuer, payload, subject, disclosed, credentialNbf } = normalized;
+
+    // Spec §8: resolve each acceptedIssuers reference (inline DID,
+    // well-known JWS-signed URL, or ETSI URL) to a flat entry list.
+    let trustList;
+    try {
+      trustList = await resolveAcceptedIssuers(requirements.acceptedIssuers, {
+        resolver,
+        cache: options.trustListCache,
+        fetchImpl: options.fetchImpl,
+      });
+    } catch (err) {
+      result.error = `Trust-list resolution failed: ${err instanceof Error ? err.message : String(err)}`;
+      return { result };
+    }
+    const matchedEntry = trustList.find(e => e.did === issuer);
+    if (!matchedEntry) {
+      result.error = `Issuer ${issuer} not in resolved trust list (${trustList.length} entries)`;
+      return { result };
+    }
+
+    // Spec §8.2 didDocumentHash pinning: when the trust list publishes
+    // a hash, the resolved DID document MUST match exactly. This
+    // neutralizes DNS/BGP/TLS-MITM substitution attacks against
+    // `did:web` issuers (spec §13.3).
+    if (matchedEntry.didDocumentHash) {
+      const hashCheck = await verifyDidDocumentHash({
+        issuerDid: issuer,
+        expectedHash: matchedEntry.didDocumentHash,
+        resolver,
+      });
+      if (!hashCheck.ok) {
+        result.error = hashCheck.reason;
+        return { result };
+      }
+    }
+
+    // Spec §11 revocation check (short-lived vs Bitstring Status List
+    // v1.0 profile detected from `nbf`/`exp` and `credentialStatus`).
+    const revocation = await checkCredentialStatus(payload, {
+      issuerDid: issuer,
+      resolver,
+      cache: options.statusListCache,
+      fetchImpl: options.fetchImpl,
+    });
+    if (!revocation.ok) {
+      result.error = revocation.reason;
+      return { result };
+    }
+
+    if (subject.id !== envelope.principal.did) {
+      result.error = `Credential subject ${subject.id} does not match envelope principal ${envelope.principal.did}`;
+      return { result };
+    }
+
+    // Fail-closed KYC check: when the verifier requires a minimum KYC level,
+    // a credential missing or not-a-string kycLevel MUST be rejected.
+    if (requirements.minKycLevel) {
+      if (
+        typeof subject.kycLevel !== "string" ||
+        !meetsKycRequirement(subject.kycLevel, requirements.minKycLevel)
+      ) {
+        const actual = typeof subject.kycLevel === "string" ? subject.kycLevel : "(missing)";
+        result.error = `Credential kycLevel "${actual}" does not meet minimum ${requirements.minKycLevel}`;
+        return { result };
+      }
+    }
+
+    // Disclosed-claim check. For jwt-vc, the disclosed values must
+    // equal the corresponding credentialSubject fields (plain-claim
+    // path). For sd-jwt-vc, the values were already cryptographically
+    // validated against the issuer's _sd digests by
+    // verifySdJwtVcPresentation; we just check the envelope's reported
+    // disclosed values match what the presentation actually disclosed.
+    if (format === "sd-jwt-vc") {
+      for (const [claim, disclosedValue] of Object.entries(envelope.principal.disclosed)) {
+        if (!(claim in disclosed)) {
+          result.error = `Disclosed claim "${claim}" was not actually disclosed by the SD-JWT VC presentation`;
+          return { result };
+        }
+        if (!claimsEqual(disclosedValue, disclosed[claim])) {
+          result.error = `Disclosed claim "${claim}" value (${JSON.stringify(disclosedValue)}) does not match the SD-JWT VC disclosure (${JSON.stringify(disclosed[claim])})`;
+          return { result };
+        }
+      }
+    } else {
+      const subjectClaims = subject as unknown as Record<string, unknown>;
+      for (const [claim, disclosedValue] of Object.entries(envelope.principal.disclosed)) {
+        if (!(claim in subjectClaims)) {
+          result.error = `Disclosed claim "${claim}" is not present in credential`;
+          return { result };
+        }
+        if (!claimsEqual(disclosedValue, subjectClaims[claim])) {
+          result.error = `Disclosed claim "${claim}" does not match credential`;
+          return { result };
+        }
+      }
+    }
+
+    if (requirements.requiredClaims) {
+      for (const claim of requirements.requiredClaims) {
+        if (!(claim in envelope.principal.disclosed)) {
+          result.error = `Required claim "${claim}" not disclosed`;
+          return { result };
+        }
+      }
+    }
+
+    result.success = true;
+    return { result, subject, credentialNbf };
+  } catch (err) {
+    result.error = `Credential verification error: ${err instanceof Error ? err.message : String(err)}`;
+    return { result };
+  }
+}
+
+interface NormalizedCredential {
+  ok: true;
+  issuer: string;
+  payload: Record<string, unknown>;
+  subject: VCXCredentialSubject;
+  /**
+   * Verified disclosed claims (sd-jwt-vc only). Empty for jwt-vc.
+   */
+  disclosed: Record<string, unknown>;
+  credentialNbf?: number;
+}
+
+/**
+ * Verify the principal credential by format and normalize the result into
+ * a common shape. For `sd-jwt-vc` this verifies the SD-JWT VC presentation
+ * and overlays the verified disclosures; for `jwt-vc` it uses did-jwt-vc's
+ * `verifyCredential`.
+ *
+ * @param envelope - The identity envelope whose principal credential is
+ *   verified.
+ * @param resolver - The DID resolver used to verify the credential JWS.
+ * @param format - The credential serialization format to verify.
+ * @returns The normalized credential (issuer, payload, subject, disclosed
+ *   claims, `nbf`) on success, or an error result.
+ */
+async function verifyAndNormalize(
+  envelope: IdentityEnvelope,
+  resolver: Resolvable,
+  format: "jwt-vc" | "sd-jwt-vc",
+): Promise<NormalizedCredential | { ok: false; error: string }> {
+  if (format === "sd-jwt-vc") {
+    let v;
+    try {
+      v = await verifySdJwtVcPresentation({
+        sdjwt: envelope.principal.credentialJwt,
+        resolver,
+      });
+    } catch (err) {
+      return {
+        ok: false,
+        error: `Credential verification error: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+    // Build a synthetic VCXCredentialSubject from the issuer-signed
+    // base (vc.credentialSubject minus the _sd digests) overlaid with
+    // the verified disclosures. Fields needed downstream (id, kycLevel,
+    // delegatedTo) may live in either the base or the disclosures
+    // depending on the issuer's framing.
+    const vc = v.payload.vc as { credentialSubject?: Record<string, unknown> } | undefined;
+    const baseSubject = { ...(vc?.credentialSubject ?? {}) };
+    delete baseSubject._sd;
+    delete baseSubject._sd_alg;
+    const subject = { ...baseSubject, ...v.disclosed } as unknown as VCXCredentialSubject;
+    return {
+      ok: true,
+      issuer: v.issuer,
+      payload: v.payload,
+      subject,
+      disclosed: v.disclosed,
+      credentialNbf: readEpochClaim(v.payload, "nbf"),
+    };
+  }
+  // jwt-vc: existing did-jwt-vc verifyCredential path.
+  const verified = await verifyCredential(envelope.principal.credentialJwt, resolver);
+  if (!verified.verified) {
+    return { ok: false, error: "Credential JWT signature verification failed" };
+  }
+  const issuerRaw = verified.verifiableCredential.issuer;
+  const issuer = typeof issuerRaw === "string" ? issuerRaw : (issuerRaw as { id?: string })?.id;
+  if (!issuer) {
+    return { ok: false, error: "Verified credential has no issuer" };
+  }
+  const subject = verified.verifiableCredential.credentialSubject as VCXCredentialSubject;
+  return {
+    ok: true,
+    issuer,
+    payload: (verified as { payload?: Record<string, unknown> }).payload ?? {},
+    subject,
+    disclosed: {},
+    credentialNbf: readEpochClaim(
+      (verified as { payload?: Record<string, unknown> }).payload,
+      "nbf",
+    ),
+  };
+}
+
+/**
+ * Read a finite numeric epoch-seconds claim from a JWT payload.
+ *
+ * @param payload - The JWT payload to read from, if any.
+ * @param key - The claim name to read (`"nbf"` or `"exp"`).
+ * @returns The numeric claim value, or `undefined` when absent or not a
+ *   finite number.
+ */
+function readEpochClaim(
+  payload: Record<string, unknown> | undefined,
+  key: "nbf" | "exp",
+): number | undefined {
+  const value = payload?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Step 2 of {@link verifyEnvelope}: verify the agent delegation embedded in
+ * the credential subject. Enforces the `vc-embedded` proof format, agent-DID
+ * and payment-source binding, the fail-closed condition whitelist, the
+ * `expiresAt` 30-day cap, and the per-transaction / network / asset / daily
+ * limits (spec §9.2, §10, §13.4).
+ *
+ * @param args - The delegation-verification inputs.
+ * @param args.envelope - The identity envelope being verified.
+ * @param args.subject - The verified credential subject carrying the
+ *   delegation.
+ * @param args.credentialNbf - The credential's `nbf` issuance baseline used
+ *   for the 30-day cap.
+ * @param args.options - Additional verification context (payment amount,
+ *   daily limit store, strict-conditions flag).
+ * @returns The step result, successful only when every present condition is
+ *   satisfied.
+ */
+async function verifyAgentDelegation(args: {
+  envelope: IdentityEnvelope;
+  subject: VCXCredentialSubject;
+  credentialNbf: number | undefined;
+  options: VerifyEnvelopeOptions;
+}): Promise<VerificationResult> {
+  const { envelope, subject, credentialNbf, options } = args;
+  const step: VerificationResult = {
+    step: "agent_delegation",
+    success: false,
+  };
+
+  // Spec §6.2 / §10: delegationProofFormat MUST be "vc-embedded" in v1.
+  // Reserved values (ucan, cacao, hdp) are not permitted; v1 verifiers
+  // MUST reject any other value rather than attempt to interpret it.
+  const proofFormat = (envelope.agent as { delegationProofFormat?: unknown }).delegationProofFormat;
+  if (proofFormat !== "vc-embedded") {
+    step.error = `agent.delegationProofFormat MUST be "vc-embedded" in v1 (spec §10); got ${
+      typeof proofFormat === "string" ? `"${proofFormat}"` : String(proofFormat)
+    }`;
+    return step;
+  }
+
+  if (!subject.delegatedTo) {
+    step.error = "Credential does not contain delegation";
+    return step;
+  }
+
+  if (subject.delegatedTo.agentDid !== envelope.agent.did) {
+    step.error = `Delegated agent DID ${subject.delegatedTo.agentDid} does not match envelope agent ${envelope.agent.did}`;
+    return step;
+  }
+
+  if (
+    subject.delegatedTo.paymentSource &&
+    subject.delegatedTo.paymentSource !== envelope.paymentSource.accountId
+  ) {
+    step.error = `Delegated payment source ${subject.delegatedTo.paymentSource} does not match envelope ${envelope.paymentSource.accountId}`;
+    return step;
+  }
+
+  const conditions = subject.delegatedTo.conditions;
+  if (!conditions) {
+    // No conditions block means no expiresAt, which is a spec MUST.
+    step.error = "Delegation has no conditions block; spec §9.2 requires `expiresAt` to be present";
+    return step;
+  }
+
+  // Spec §13.4: fail-closed on any condition key the verifier doesn't
+  // recognise. A future-version restriction silently ignored grants
+  // unbounded authority on this deployment.
+  for (const key of Object.keys(conditions)) {
+    if (!KNOWN_CONDITION_KEYS.has(key)) {
+      step.error = `Unknown delegation condition "${key}"; spec §13.4 requires fail-closed on unrecognised keys`;
+      return step;
+    }
+  }
+
+  // §9.2: expiresAt MUST be present, valid, in the future, and ≤ 30
+  // days after the credential's `nbf` (issuance baseline).
+  const expiresAt = conditions.expiresAt;
+  if (typeof expiresAt !== "string" || expiresAt.length === 0) {
+    step.error = "Delegation conditions.expiresAt MUST be present (spec §9.2)";
+    return step;
+  }
+  const expiresAtMs = Date.parse(expiresAt);
+  if (Number.isNaN(expiresAtMs)) {
+    step.error = "Delegation expiresAt is not a valid ISO 8601 timestamp";
+    return step;
+  }
+  if (expiresAtMs <= Date.now()) {
+    step.error = "Delegation has expired";
+    return step;
+  }
+  if (credentialNbf === undefined) {
+    step.error = "Cannot enforce spec §9.2 30-day expiresAt cap: credential JWT has no `nbf` claim";
+    return step;
+  }
+  const maxExpiresAtMs = (credentialNbf + MAX_DELEGATION_LIFETIME_SECONDS) * 1000;
+  if (expiresAtMs > maxExpiresAtMs) {
+    step.error = `Delegation expiresAt (${expiresAt}) exceeds the 30-day cap from credential issuance (spec §9.2)`;
+    return step;
+  }
+
+  // §9.2 maxPerTransaction: MUST enforce against payment amount when
+  // present. If amount unavailable, fail-closed (cannot satisfy a MUST).
+  if (conditions.maxPerTransaction !== undefined) {
+    if (options.paymentAmount === undefined) {
+      step.error =
+        "Delegation conditions.maxPerTransaction is set but no paymentAmount was provided to the verifier (spec §9.2 MUST)";
+      return step;
+    }
+    let limit: bigint;
+    let amount: bigint;
+    try {
+      limit = BigInt(conditions.maxPerTransaction);
+      amount = BigInt(options.paymentAmount);
+    } catch {
+      step.error = `Delegation maxPerTransaction (${conditions.maxPerTransaction}) or paymentAmount (${options.paymentAmount}) is not a parseable decimal integer`;
+      return step;
+    }
+    if (amount > limit) {
+      step.error = `Payment amount ${amount.toString()} exceeds delegation maxPerTransaction ${limit.toString()}`;
+      return step;
+    }
+  }
+
+  // §9.2 allowedNetworks: MUST enforce against envelope.paymentSource.network
+  // when present. Envelope-layer comparison; no payment-details thread.
+  if (conditions.allowedNetworks !== undefined) {
+    if (!Array.isArray(conditions.allowedNetworks)) {
+      step.error = "Delegation conditions.allowedNetworks MUST be an array of CAIP-2 strings";
+      return step;
+    }
+    if (!conditions.allowedNetworks.includes(envelope.paymentSource.network)) {
+      step.error = `Payment-source network ${envelope.paymentSource.network} is not in delegation allowedNetworks [${conditions.allowedNetworks.join(", ")}]`;
+      return step;
+    }
+  }
+
+  // §9.2 allowedAssets: MUST enforce against envelope.paymentSource.asset
+  // when present. Absent asset + present allowedAssets → reject.
+  if (conditions.allowedAssets !== undefined) {
+    if (!Array.isArray(conditions.allowedAssets)) {
+      step.error =
+        "Delegation conditions.allowedAssets MUST be an array of CAIP-19 strings or contract addresses";
+      return step;
+    }
+    if (envelope.paymentSource.asset === undefined) {
+      step.error =
+        "Delegation conditions.allowedAssets is set but envelope.paymentSource.asset is absent (spec §9.2)";
+      return step;
+    }
+    if (!conditions.allowedAssets.includes(envelope.paymentSource.asset)) {
+      step.error = `Payment-source asset ${envelope.paymentSource.asset} is not in delegation allowedAssets [${conditions.allowedAssets.join(", ")}]`;
+      return step;
+    }
+  }
+
+  // §9.2 maxDaily: requires a stateful DailyLimitStore. No default
+  // store is shipped (see DailyLimitStore docstring); warn-and-skip
+  // unless strict mode is on.
+  if (conditions.maxDaily !== undefined) {
+    if (!options.dailyLimitStore) {
+      if (options.strictDelegationConditions) {
+        step.error =
+          "Delegation conditions.maxDaily is set but no dailyLimitStore was provided and strictDelegationConditions is true (spec §9.2)";
+        return step;
+      }
+      console.warn(
+        "VCX: delegation carries maxDaily but no DailyLimitStore configured; skipping the check (set strictDelegationConditions: true to fail-closed)",
+      );
+    } else {
+      if (options.paymentAmount === undefined) {
+        step.error =
+          "Delegation conditions.maxDaily is set but no paymentAmount was provided to the verifier";
+        return step;
+      }
+      let limit: bigint;
+      try {
+        limit = BigInt(conditions.maxDaily);
+      } catch {
+        step.error = `Delegation maxDaily (${conditions.maxDaily}) is not a parseable decimal integer`;
+        return step;
+      }
+      const newTotal = await options.dailyLimitStore.addAndGetTotal({
+        principalDid: envelope.principal.did,
+        agentDid: envelope.agent.did,
+        amount: options.paymentAmount,
+      });
+      let total: bigint;
+      try {
+        total = BigInt(newTotal);
+      } catch {
+        step.error = `DailyLimitStore.addAndGetTotal returned non-integer ${newTotal}`;
+        return step;
+      }
+      if (total > limit) {
+        step.error = `Daily total ${total.toString()} (including this request) exceeds delegation maxDaily ${limit.toString()}`;
+        return step;
+      }
+    }
+  }
+
+  step.success = true;
+  return step;
+}
+
+/**
+ * Step 3 of {@link verifyEnvelope}: bind the envelope's payment source to
+ * the actual payment sender. Confirms `sourceId` matches the sender and
+ * that it also matches the address component of `accountId`, closing the
+ * gap where step 2 trusts `accountId` while step 3 trusts `sourceId`.
+ *
+ * @param envelope - The identity envelope being verified.
+ * @param paymentSender - The address/identifier that originated the payment.
+ * @returns The step result, successful only when both bindings match.
+ */
+function verifyPaymentSourceBinding(
+  envelope: IdentityEnvelope,
+  paymentSender: string,
+): VerificationResult {
+  const step: VerificationResult = {
+    step: "payment_source_binding",
+    success: false,
+  };
+
+  const sourceId = envelope.paymentSource.sourceId.toLowerCase();
+  const sender = paymentSender.toLowerCase();
+
+  if (sourceId !== sender) {
+    step.error = `Payment source ${envelope.paymentSource.sourceId} does not match payment sender ${paymentSender}`;
+    return step;
+  }
+
+  // Bind sourceId to accountId. For CAIP-10 IDs the address is the last
+  // `:`-separated segment; for non-CAIP rail-specific URIs the whole accountId
+  // is compared. Without this check, an attacker can satisfy the delegation
+  // constraint (Step 2 uses accountId) with one wallet while paying from
+  // another (Step 3 uses sourceId), defeating the integrity guarantee that
+  // the credential authorised payment from this specific source.
+  const accountIdSegments = envelope.paymentSource.accountId.split(":");
+  const accountIdAddress = accountIdSegments[accountIdSegments.length - 1].toLowerCase();
+  if (accountIdAddress !== sourceId) {
+    step.error = `paymentSource.sourceId ${envelope.paymentSource.sourceId} does not match the address component of paymentSource.accountId ${envelope.paymentSource.accountId}`;
+    return step;
+  }
+
+  step.success = true;
+  return step;
+}
+
+/**
+ * Compare two disclosed claim values for equality. Uses `Object.is` for
+ * primitives and a stable JSON-stringify comparison for objects.
+ *
+ * @param left - The first claim value to compare.
+ * @param right - The second claim value to compare.
+ * @returns `true` when the values are considered equal.
+ */
+function claimsEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (!left || !right) return false;
+  if (typeof left !== "object" || typeof right !== "object") return false;
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+}

--- a/typescript/packages/extensions/src/vcx/header.ts
+++ b/typescript/packages/extensions/src/vcx/header.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { IdentityEnvelope } from "./types";
+
+/** HTTP header carrying the VCX identity envelope (spec §6). */
+export const VCX_HEADER_NAME = "VCX";
+
+/**
+ * Encode an identity envelope as a base64 string suitable for the VCX header.
+ *
+ * @param envelope - The VCX identity envelope to serialise.
+ * @returns The base64-encoded JSON representation of the envelope.
+ */
+export function encodeVCXHeader(envelope: IdentityEnvelope): string {
+  return Buffer.from(JSON.stringify(envelope)).toString("base64");
+}
+
+/**
+ * Decode the VCX header value back into an identity envelope.
+ *
+ * @param headerValue - The base64-encoded VCX header value to decode.
+ * @returns The decoded identity envelope.
+ * @throws If the input is not valid base64 JSON.
+ */
+export function parseVCXHeader(headerValue: string): IdentityEnvelope {
+  const decoded = Buffer.from(headerValue, "base64").toString("utf8");
+  return JSON.parse(decoded) as IdentityEnvelope;
+}

--- a/typescript/packages/extensions/src/vcx/identity/agent.ts
+++ b/typescript/packages/extensions/src/vcx/identity/agent.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generateEd25519KeyPair, type Ed25519KeyPair } from "./did";
+import type { AgentDelegation, DelegationConditions } from "../types";
+
+export interface AgentIdentity {
+  did: string;
+  name: string;
+  privateKeyHex: string;
+  keyPair: Ed25519KeyPair;
+}
+
+/**
+ * Create a new agent identity by generating a fresh Ed25519 key pair and
+ * associating it with a human-readable name. The resulting identity's DID
+ * is the key pair's `did:key`.
+ *
+ * @param name - A human-readable label for the agent.
+ * @returns The agent identity, including its DID, name, and key material.
+ */
+export function createAgent(name: string): AgentIdentity {
+  const keyPair = generateEd25519KeyPair();
+  return {
+    did: keyPair.did,
+    name,
+    privateKeyHex: keyPair.privateKeyHex,
+    keyPair,
+  };
+}
+
+/**
+ * Build an agent delegation record describing the agent a principal
+ * delegates to, along with the optional payment source and conditions
+ * that constrain the delegation.
+ *
+ * @param opts - The delegation parameters.
+ * @param opts.agentDid - The DID of the agent being delegated to.
+ * @param opts.paymentSource - Optional payment source authorised for the delegation.
+ * @param opts.conditions - Optional conditions constraining the delegation.
+ * @returns The assembled agent delegation record.
+ */
+export function buildDelegation(opts: {
+  agentDid: string;
+  paymentSource?: string;
+  conditions?: DelegationConditions;
+}): AgentDelegation {
+  return {
+    agentDid: opts.agentDid,
+    paymentSource: opts.paymentSource,
+    conditions: opts.conditions,
+  };
+}

--- a/typescript/packages/extensions/src/vcx/identity/base58.ts
+++ b/typescript/packages/extensions/src/vcx/identity/base58.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const BASE58_BTC_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+const BASE58_BTC_LOOKUP = new Map(
+  [...BASE58_BTC_ALPHABET].map((character, index) => [character, index]),
+);
+
+/**
+ * Encode bytes as a base58btc multibase string, prefixing the result
+ * with the `z` multibase code point per the multibase specification.
+ *
+ * @param bytes - The raw bytes to encode.
+ * @returns The `z`-prefixed base58btc multibase string.
+ */
+export function base58btcEncode(bytes: Uint8Array): string {
+  return `z${base58Encode(bytes)}`;
+}
+
+/**
+ * Decode a base58btc multibase string back to its raw bytes, requiring
+ * and stripping the leading `z` multibase code point.
+ *
+ * @param value - The `z`-prefixed base58btc multibase string.
+ * @returns The decoded raw bytes.
+ */
+export function base58btcDecode(value: string): Uint8Array {
+  if (!value.startsWith("z")) {
+    throw new Error("Expected base58btc multibase value");
+  }
+  return base58Decode(value.slice(1));
+}
+
+/**
+ * Encode bytes as a base58 string using the Bitcoin alphabet, preserving
+ * leading zero bytes as leading `1` characters.
+ *
+ * @param bytes - The raw bytes to encode.
+ * @returns The base58-encoded string.
+ */
+export function base58Encode(bytes: Uint8Array): string {
+  let zeroes = 0;
+  while (zeroes < bytes.length && bytes[zeroes] === 0) zeroes += 1;
+  if (zeroes === bytes.length) return "1".repeat(zeroes);
+
+  const digits = [0];
+  for (let byteIndex = zeroes; byteIndex < bytes.length; byteIndex += 1) {
+    const byte = bytes[byteIndex];
+    let carry = byte;
+    for (let i = 0; i < digits.length; i += 1) {
+      const value = digits[i] * 256 + carry;
+      digits[i] = value % 58;
+      carry = Math.floor(value / 58);
+    }
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = Math.floor(carry / 58);
+    }
+  }
+
+  let encoded = "1".repeat(zeroes);
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    encoded += BASE58_BTC_ALPHABET[digits[i]];
+  }
+  return encoded;
+}
+
+/**
+ * Decode a base58 string (Bitcoin alphabet) back to its raw bytes,
+ * restoring leading `1` characters as leading zero bytes. Throws on any
+ * character outside the base58 alphabet.
+ *
+ * @param value - The base58-encoded string.
+ * @returns The decoded raw bytes.
+ */
+function base58Decode(value: string): Uint8Array {
+  if (value.length === 0) return new Uint8Array();
+
+  let zeroes = 0;
+  while (zeroes < value.length && value[zeroes] === "1") zeroes += 1;
+
+  const bytes = [0];
+  for (let valueIndex = zeroes; valueIndex < value.length; valueIndex += 1) {
+    const digit = BASE58_BTC_LOOKUP.get(value[valueIndex]);
+    if (digit === undefined) {
+      throw new Error("Invalid base58btc character");
+    }
+
+    let carry = digit;
+    for (let i = 0; i < bytes.length; i += 1) {
+      const next = bytes[i] * 58 + carry;
+      bytes[i] = next & 0xff;
+      carry = next >> 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  for (let i = 0; i < zeroes; i += 1) {
+    bytes.push(0);
+  }
+
+  return Uint8Array.from(bytes.reverse());
+}

--- a/typescript/packages/extensions/src/vcx/identity/did.ts
+++ b/typescript/packages/extensions/src/vcx/identity/did.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import crypto from "crypto";
+import { base58btcEncode } from "./base58";
+
+export interface Ed25519KeyPair {
+  publicKey: Uint8Array;
+  privateKey: Uint8Array;
+  did: string;
+  privateKeyHex: string;
+}
+
+/**
+ * Generate a fresh Ed25519 key pair and derive its `did:key` identifier.
+ * The raw 32-byte public and private keys are extracted from the encoded
+ * SPKI/PKCS#8 output, and the private key is also exposed as hex.
+ *
+ * @returns The generated key pair with its raw keys, `did:key`, and hex private key.
+ */
+export function generateEd25519KeyPair(): Ed25519KeyPair {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519", {
+    publicKeyEncoding: { type: "spki", format: "der" },
+    privateKeyEncoding: { type: "pkcs8", format: "der" },
+  });
+
+  const rawPublic = publicKey.subarray(publicKey.length - 32);
+  const rawPrivate = privateKey.subarray(privateKey.length - 32);
+
+  return {
+    publicKey: rawPublic,
+    privateKey: rawPrivate,
+    did: publicKeyToDidKey(rawPublic),
+    privateKeyHex: Buffer.from(rawPrivate).toString("hex"),
+  };
+}
+
+/**
+ * Derive the `did:key` identifier for a raw Ed25519 public key by
+ * prepending the Ed25519 multicodec prefix (`0xed 0x01`) and encoding the
+ * result as a base58btc multibase string.
+ *
+ * @param publicKey - The raw 32-byte Ed25519 public key.
+ * @returns The `did:key:z...` identifier.
+ */
+export function publicKeyToDidKey(publicKey: Uint8Array): string {
+  const multicodecPrefix = new Uint8Array([0xed, 0x01]);
+  const multicodecKey = new Uint8Array(multicodecPrefix.length + publicKey.length);
+  multicodecKey.set(multicodecPrefix);
+  multicodecKey.set(publicKey, multicodecPrefix.length);
+
+  return `did:key:${base58btcEncode(multicodecKey)}`;
+}
+
+/**
+ * Build a `did:web` identifier from a domain and a URL-style path,
+ * translating path separators (`/`) into the `:` segment delimiter
+ * required by the did:web method.
+ *
+ * @param domain - The host (and optional encoded port) for the DID.
+ * @param path - A URL-style path such as `user/abc`.
+ * @returns The `did:web:...` identifier.
+ */
+export function buildDid(domain: string, path: string): string {
+  // did:web encodes path segments with `:`, not `/`. Translate so callers
+  // can pass familiar URL-style paths like "user/abc".
+  const colonPath = path.split("/").join(":");
+  return `did:web:${domain}:${colonPath}`;
+}

--- a/typescript/packages/extensions/src/vcx/identity/index.ts
+++ b/typescript/packages/extensions/src/vcx/identity/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { generateEd25519KeyPair, publicKeyToDidKey, buildDid } from "./did";
+export type { Ed25519KeyPair } from "./did";
+
+export { buildCredentialSubject, meetsKycRequirement } from "./principal";
+export type { PrincipalIdentity } from "./principal";
+
+export { createAgent, buildDelegation } from "./agent";
+export type { AgentIdentity } from "./agent";

--- a/typescript/packages/extensions/src/vcx/identity/principal.ts
+++ b/typescript/packages/extensions/src/vcx/identity/principal.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  KYC_LEVEL_ORDER,
+  type KycLevel,
+  type PrincipalClaims,
+  type VCXCredentialSubject,
+  type AgentDelegation,
+} from "../types";
+
+export interface PrincipalIdentity {
+  did: string;
+  claims: PrincipalClaims;
+}
+
+/**
+ * Assemble a VCX credential subject from a principal's DID, identity
+ * claims, and an agent delegation. Missing KYC level defaults to
+ * `"Unverified"`.
+ *
+ * @param opts - The inputs used to build the subject.
+ * @param opts.principalDid - The DID of the principal that owns the credential.
+ * @param opts.claims - The principal's identity claims.
+ * @param opts.delegation - The agent delegation to embed as `delegatedTo`.
+ * @returns The assembled VCX credential subject.
+ */
+export function buildCredentialSubject(opts: {
+  principalDid: string;
+  claims: PrincipalClaims;
+  delegation: AgentDelegation;
+}): VCXCredentialSubject {
+  return {
+    id: opts.principalDid,
+    kycLevel: opts.claims.kycLevel ?? "Unverified",
+    emailVerified: opts.claims.emailVerified,
+    paymentsEnabled: opts.claims.paymentsEnabled,
+    accountType: opts.claims.accountType,
+    ageOver18: opts.claims.ageOver18,
+    jurisdiction: opts.claims.jurisdiction,
+    delegatedTo: opts.delegation,
+  };
+}
+
+/**
+ * Determine whether an actual KYC level satisfies a required level by
+ * comparing their positions in the canonical KYC ordering.
+ *
+ * @param actual - The KYC level the principal currently holds.
+ * @param required - The minimum KYC level demanded.
+ * @returns `true` when the actual level meets or exceeds the required level.
+ */
+export function meetsKycRequirement(actual: KycLevel, required: KycLevel): boolean {
+  return KYC_LEVEL_ORDER[actual] >= KYC_LEVEL_ORDER[required];
+}

--- a/typescript/packages/extensions/src/vcx/index.ts
+++ b/typescript/packages/extensions/src/vcx/index.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Protocol types
+export type {
+  IdentityRequirements,
+  KycLevel,
+  PrincipalClaims,
+  PrincipalLayer,
+  CredentialFormat,
+  AgentDelegation,
+  DelegationConditions,
+  AgentLayer,
+  DelegationProofFormat,
+  PaymentSourceLayer,
+  PaymentDetails,
+  IdentityEnvelope,
+  VerificationStep,
+  VerificationResult,
+  FullVerificationResult,
+  VCXCredentialSubject,
+  IssuerConfig,
+} from "./types";
+
+export { DisclosureTier, KYC_LEVEL_ORDER } from "./types";
+
+// Identity primitives
+export {
+  generateEd25519KeyPair,
+  publicKeyToDidKey,
+  buildDid,
+  buildCredentialSubject,
+  meetsKycRequirement,
+  createAgent,
+  buildDelegation,
+} from "./identity";
+export type { Ed25519KeyPair, PrincipalIdentity, AgentIdentity } from "./identity";
+
+// Credentials
+export {
+  createVCXIssuer,
+  issueCredential,
+  getDidResolver,
+  configureDidWebResolver,
+  buildHardenedWebResolver,
+  didWebToUrl,
+  resolveAcceptedIssuers,
+  verifyDidDocumentHash,
+  InMemoryTrustListCache,
+} from "./credential";
+export type {
+  DidWebHardeningConfig,
+  TrustListEntry,
+  TrustListCache,
+  CachedTrustList,
+  ResolveAcceptedIssuersOptions,
+} from "./credential";
+
+// Envelope
+export {
+  buildIdentityEnvelope,
+  buildEnvelopeFromRequirements,
+  verifyEnvelope,
+  canonicalEnvelope,
+  envelopeDigest,
+  checkCredentialStatus,
+  InMemoryStatusListCache,
+  verifySdJwtVcPresentation,
+  buildDisclosure,
+  disclosureHash,
+  parseDisclosure,
+  parseSdJwt,
+  buildSdIssuerSubject,
+  composeSdJwt,
+} from "./envelope";
+export type {
+  BuildEnvelopeOpts,
+  VerifyEnvelopeOptions,
+  StatusListCache,
+  CachedStatusList,
+  RevocationCheckResult,
+  CheckCredentialStatusOptions,
+  Disclosure,
+  VerifiedSdJwtVc,
+} from "./envelope";
+
+// V2 extension declaration
+export { declareVCXExtension, VCX_EXTENSION_KEY } from "./declare";
+export type { DeclareVCXOptions, VCXDeclaration } from "./declare";
+
+// V2 extension factories
+export { createVCXResourceServerExtension } from "./server";
+export type { CreateVCXResourceServerExtensionOptions, VCXRequestContext } from "./server";
+
+export { createVCXClientExtension } from "./client";
+export type { CreateVCXClientExtensionOptions } from "./client";
+
+// VCX header transport
+export { VCX_HEADER_NAME, encodeVCXHeader, parseVCXHeader } from "./header";
+
+// Replay-protection storage + daily-limit storage
+export { InMemoryNonceStorage, NoOpNonceStorage, DEFAULT_NONCE_FRESHNESS_MS } from "./storage";
+export type { NonceStorage, DailyLimitStore } from "./storage";
+
+// JSON Schema for the envelope
+export { buildVCXEnvelopeSchema } from "./schema";
+export type { VCXEnvelopeSchema } from "./schema";

--- a/typescript/packages/extensions/src/vcx/schema.ts
+++ b/typescript/packages/extensions/src/vcx/schema.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JSON Schema for the VCX identity envelope as v0.2+ accepts it.
+ *
+ * Emitted with the extension declaration so clients and external tooling
+ * can validate envelopes against the contract the verifier enforces.
+ *
+ * The schema mirrors the v1.0 spec MUSTs: `credentialFormat` (§6.1) is an
+ * enum of `{jwt-vc, sd-jwt-vc}`; `delegationProofFormat` (§6.2 / §10) is
+ * the literal `vc-embedded` in v1; `vcxPresent` (§6) is the literal
+ * boolean `true`.
+ */
+export interface VCXEnvelopeSchema {
+  $schema: string;
+  type: "object";
+  properties: Record<string, unknown>;
+  required: string[];
+}
+
+/**
+ * Build the JSON Schema describing the VCX identity envelope contract.
+ *
+ * @returns The JSON Schema object emitted alongside the extension
+ *   declaration for client-side and external envelope validation.
+ */
+export function buildVCXEnvelopeSchema(): VCXEnvelopeSchema {
+  return {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    properties: {
+      version: { type: "string", const: "1.0" },
+      protocol: { type: "string", const: "x402-vcx-v1" },
+      transactionId: { type: "string", format: "uuid" },
+      vcxPresent: { type: "boolean", const: true },
+      principal: {
+        type: "object",
+        properties: {
+          credentialFormat: { type: "string", enum: ["jwt-vc", "sd-jwt-vc"] },
+          credentialJwt: { type: "string" },
+          did: { type: "string" },
+          disclosed: { type: "object" },
+        },
+        required: ["credentialFormat", "credentialJwt", "did", "disclosed"],
+      },
+      agent: {
+        type: "object",
+        properties: {
+          did: { type: "string" },
+          name: { type: "string" },
+          delegationProofFormat: { type: "string", const: "vc-embedded" },
+          delegationProof: { type: "string" },
+        },
+        required: ["did", "name", "delegationProofFormat", "delegationProof"],
+      },
+      paymentSource: {
+        type: "object",
+        properties: {
+          accountId: { type: "string" },
+          sourceId: { type: "string" },
+          network: { type: "string" },
+          asset: { type: "string" },
+        },
+        required: ["accountId", "sourceId", "network"],
+      },
+    },
+    required: [
+      "version",
+      "protocol",
+      "transactionId",
+      "vcxPresent",
+      "principal",
+      "agent",
+      "paymentSource",
+    ],
+  };
+}

--- a/typescript/packages/extensions/src/vcx/server.ts
+++ b/typescript/packages/extensions/src/vcx/server.ts
@@ -1,0 +1,250 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ResourceServerExtension } from "@x402/core/types";
+import { verifyEnvelope } from "./envelope/verifier";
+import { parseVCXHeader, VCX_HEADER_NAME } from "./header";
+import { VCX_EXTENSION_KEY, type VCXDeclaration } from "./declare";
+import { type NonceStorage, type DailyLimitStore, DEFAULT_NONCE_FRESHNESS_MS } from "./storage";
+import type { IdentityEnvelope, FullVerificationResult, PaymentDetails } from "./types";
+
+/**
+ * Request context surface VCX needs during `onProtectedRequest`. A thin
+ * subset of the x402 v2 HTTP request context, sufficient for header lookup
+ * (and re-exposed to user-supplied `extractPaymentSender`).
+ */
+export interface VCXRequestContext {
+  /** Case-insensitive header lookup. Returns undefined when absent. */
+  getHeader: (name: string) => string | undefined;
+}
+
+export interface CreateVCXResourceServerExtensionOptions {
+  /**
+   * Extract payment details (sender + amount + asset + network) from the
+   * request context. Used for Step 3 envelope-to-payment binding
+   * (spec §9.3 / §13.2) and for Step 2 `maxPerTransaction` /
+   * `allowedNetworks` / `allowedAssets` / `maxDaily` enforcement
+   * (spec §9.2).
+   *
+   * Preferred over {@link extractPaymentSender} from v0.3 onward. Pass
+   * this when registering on a route whose declared
+   * `delegatedTo.conditions` may include `maxPerTransaction` or
+   * `maxDaily` — without it, those checks fail-closed under
+   * `strictDelegationConditions: true` or warn-and-skip otherwise.
+   *
+   * The implementation is scheme-specific:
+   *
+   * - `exact_evm`: decode `X-PAYMENT`, read
+   *   `payload.authorization.from`, `payload.authorization.value`, and
+   *   the asset address from the payment requirements.
+   * - `exact_solana`: read the transaction fee-payer, the SystemProgram
+   *   transfer amount, and the asset (typically SOL or a token mint).
+   */
+  extractPaymentDetails?: (ctx: VCXRequestContext) => PaymentDetails | Promise<PaymentDetails>;
+
+  /**
+   * Extract the payment sender identifier from the request context. Used
+   * for the Step 3 envelope-to-payment binding check (spec §9.3 / §13.2).
+   *
+   * @deprecated Prefer {@link extractPaymentDetails}, which also supplies
+   * the amount/asset/network needed for spec §9.2 condition enforcement.
+   * Callers that use only `extractPaymentSender` on a route whose
+   * credential carries `maxPerTransaction` will see the verifier
+   * fail-closed (with `strictDelegationConditions: true`) or warn-and-skip
+   * those specific checks. Kept for back-compat in v0.x; will be removed
+   * in v2.0.
+   */
+  extractPaymentSender?: (ctx: VCXRequestContext) => string | Promise<string>;
+
+  /**
+   * Storage for transactionId uniqueness enforcement (spec §13.1).
+   * REQUIRED in this revision — pass `new InMemoryNonceStorage()` for
+   * single-process deployments or a shared-store implementation
+   * (Redis, distributed cache) for multi-instance verifiers. There is no
+   * default — the prior `NoOpNonceStorage` default silently disabled
+   * replay protection and was non-conformant with the spec.
+   */
+  nonceStorage: NonceStorage;
+
+  /**
+   * Override the freshness window applied to the `transactionId` nonce.
+   * Defaults to spec §13.1's 300 seconds.
+   */
+  nonceFreshnessMs?: number;
+
+  /**
+   * Store for `delegatedTo.conditions.maxDaily` enforcement (spec §9.2).
+   * No default implementation is shipped; see {@link DailyLimitStore}.
+   * When a credential carries `maxDaily` but this option is unset, the
+   * verifier logs a `console.warn` and skips the check — unless
+   * `strictDelegationConditions: true`, in which case it fails-closed.
+   */
+  dailyLimitStore?: DailyLimitStore;
+
+  /**
+   * When true, missing context that prevents enforcement of a present
+   * delegation condition causes the verifier to fail-closed. Production
+   * deployments in regulated environments SHOULD set this to true.
+   * Default: false.
+   */
+  strictDelegationConditions?: boolean;
+
+  /**
+   * Invoked after every verification (success or failure) for audit
+   * logging (spec §16).
+   */
+  onVerify?: (envelope: IdentityEnvelope, verification: FullVerificationResult) => void;
+}
+
+/**
+ * Build the VCX server extension for registration with the x402 v2
+ * `x402HTTPResourceServer`.
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   createVCXResourceServerExtension,
+ *   InMemoryNonceStorage,
+ * } from "@x402/vcx";
+ *
+ * const vcx = createVCXResourceServerExtension({
+ *   extractPaymentSender: (ctx) => {
+ *     const raw = ctx.getHeader("X-PAYMENT");
+ *     if (!raw) return "";
+ *     const payload = JSON.parse(Buffer.from(raw, "base64").toString("utf8"));
+ *     return payload?.payload?.authorization?.from ?? "";
+ *   },
+ *   nonceStorage: new InMemoryNonceStorage(),
+ * });
+ *
+ * const server = new x402HTTPResourceServer(resourceServer, routes)
+ *   .registerExtension(vcx);
+ * ```
+ *
+ * @param options - Payment-detail/sender extractors, replay-protection
+ *   nonce storage, optional nonce freshness window, optional daily-limit
+ *   store, the strict-delegation-conditions toggle, and an optional
+ *   post-verification audit callback.
+ * @returns A resource-server extension that parses and verifies the VCX
+ *   identity header on each protected request, aborting on failure.
+ */
+export function createVCXResourceServerExtension(
+  options: CreateVCXResourceServerExtensionOptions,
+): ResourceServerExtension {
+  const freshnessMs = options.nonceFreshnessMs ?? DEFAULT_NONCE_FRESHNESS_MS;
+
+  return {
+    key: VCX_EXTENSION_KEY,
+
+    enrichPaymentRequiredResponse: async declaration => {
+      const decl = declaration as VCXDeclaration;
+      return { info: decl.info, schema: decl.schema };
+    },
+
+    transportHooks: {
+      http: {
+        onProtectedRequest: async (
+          declaration: unknown,
+          context: unknown,
+          _: unknown,
+        ): Promise<void | { abort: true; reason: string }> => {
+          const decl = declaration as VCXDeclaration;
+          const ctx = context as {
+            adapter: { getHeader: (name: string) => string | undefined };
+          };
+
+          const adapterCtx: VCXRequestContext = {
+            getHeader: name =>
+              ctx.adapter.getHeader(name) ?? ctx.adapter.getHeader(name.toLowerCase()),
+          };
+
+          const headerValue = adapterCtx.getHeader(VCX_HEADER_NAME);
+          if (!headerValue) {
+            return abort("missing VCX header");
+          }
+
+          let envelope: IdentityEnvelope;
+          try {
+            envelope = parseVCXHeader(headerValue);
+          } catch (err) {
+            return abort(`malformed envelope: ${err instanceof Error ? err.message : String(err)}`);
+          }
+
+          let paymentDetails: PaymentDetails;
+          try {
+            if (options.extractPaymentDetails) {
+              paymentDetails = await options.extractPaymentDetails(adapterCtx);
+            } else if (options.extractPaymentSender) {
+              paymentDetails = {
+                sender: await options.extractPaymentSender(adapterCtx),
+              };
+            } else {
+              return abort(
+                "configuration error: one of extractPaymentDetails or extractPaymentSender MUST be provided",
+              );
+            }
+          } catch (err) {
+            return abort(
+              `payment-details extractor threw: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+
+          const verification = await verifyEnvelope(envelope, decl.info, paymentDetails.sender, {
+            paymentAmount: paymentDetails.amount,
+            dailyLimitStore: options.dailyLimitStore,
+            strictDelegationConditions: options.strictDelegationConditions ?? false,
+          });
+
+          options.onVerify?.(envelope, verification);
+
+          if (!verification.valid) {
+            const failed = verification.steps.find(s => !s.success);
+            return abort(
+              `verification failed at ${failed?.step ?? "unknown"}: ${failed?.error ?? "no error message"}`,
+            );
+          }
+
+          // Verify-then-record: only consume the nonce on successful
+          // verification, so a failed verify doesn't poison the cache and
+          // an attacker can't grief a victim by replaying their envelope
+          // once to mark the nonce used.
+          const replayed = await options.nonceStorage.checkAndRecord(
+            envelope.transactionId,
+            freshnessMs,
+          );
+          if (replayed) {
+            return abort(
+              `transactionId ${envelope.transactionId} already processed within the freshness window`,
+            );
+          }
+
+          return undefined;
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Build an abort result that rejects the protected request, prefixing the
+ * reason with `VCX:` for log attribution.
+ *
+ * @param reason - Human-readable explanation of why the request was rejected.
+ * @returns An abort directive carrying the namespaced reason.
+ */
+function abort(reason: string): { abort: true; reason: string } {
+  return { abort: true, reason: `VCX: ${reason}` };
+}

--- a/typescript/packages/extensions/src/vcx/storage.ts
+++ b/typescript/packages/extensions/src/vcx/storage.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default freshness window for transactionId uniqueness checks (spec §13.1).
+ * 300 seconds = 5 minutes.
+ */
+export const DEFAULT_NONCE_FRESHNESS_MS = 300_000;
+
+/**
+ * Storage interface for transactionId uniqueness enforcement (spec §13.1).
+ *
+ * The VCX server extension uses this to reject envelopes whose
+ * `transactionId` has been processed within the freshness window. A
+ * load-balanced verifier without shared state defeats this check —
+ * production implementations must use a store consistent across the
+ * deployment surface (Redis, distributed cache, etc.).
+ */
+export interface NonceStorage {
+  /**
+   * Atomically check whether the nonce has been seen within the freshness
+   * window, and record it if not.
+   *
+   * @returns `true` if the nonce was already present (the verifier MUST
+   *   reject the request), `false` if it was newly recorded.
+   */
+  checkAndRecord(nonce: string, freshnessWindowMs: number): Promise<boolean>;
+}
+
+/**
+ * In-memory NonceStorage. Suitable for single-process deployments and tests.
+ * Not suitable for production with multiple verifier instances.
+ */
+export class InMemoryNonceStorage implements NonceStorage {
+  private readonly seen = new Map<string, number>();
+
+  /**
+   * Check whether the nonce was seen within the freshness window, recording
+   * it when newly observed.
+   *
+   * @param nonce - The transactionId nonce to check and record.
+   * @param freshnessWindowMs - How long, in milliseconds, a recorded nonce
+   *   remains in effect before it is eligible for eviction.
+   * @returns `true` if the nonce was already present (reject the request),
+   *   `false` if it was newly recorded.
+   */
+  async checkAndRecord(nonce: string, freshnessWindowMs: number): Promise<boolean> {
+    const now = Date.now();
+    this.evictExpired(now, freshnessWindowMs);
+    if (this.seen.has(nonce)) return true;
+    this.seen.set(nonce, now);
+    return false;
+  }
+
+  /**
+   * Drop recorded nonces older than the freshness window to bound memory use.
+   *
+   * @param now - The current timestamp in milliseconds.
+   * @param freshnessWindowMs - The freshness window in milliseconds; nonces
+   *   recorded before `now - freshnessWindowMs` are evicted.
+   */
+  private evictExpired(now: number, freshnessWindowMs: number): void {
+    const cutoff = now - freshnessWindowMs;
+    for (const [nonce, recordedAt] of this.seen) {
+      if (recordedAt < cutoff) this.seen.delete(nonce);
+    }
+  }
+}
+
+/**
+ * No-op NonceStorage. Always reports the nonce as new. Used when the
+ * verifier explicitly opts out of replay protection — non-conformant with
+ * spec §13.1.
+ */
+export class NoOpNonceStorage implements NonceStorage {
+  /**
+   * Always report the nonce as new, performing no replay tracking.
+   *
+   * @returns `false` always, signalling the nonce is treated as unseen.
+   */
+  async checkAndRecord(): Promise<boolean> {
+    return false;
+  }
+}
+
+/**
+ * Storage interface for `delegatedTo.conditions.maxDaily` enforcement
+ * (spec §9.2). Unlike `maxPerTransaction` (a per-request comparison),
+ * `maxDaily` requires stateful tracking of every settled amount for a
+ * given principal+agent pair within a rolling 24-hour window.
+ *
+ * No default implementation is shipped: the storage surface depends
+ * heavily on the deployment topology (single-process Map, Redis,
+ * relational DB, etc.) and on how the verifier observes settled amounts
+ * (which depends on the x402 settlement-callback wiring). Verifiers that
+ * register VCX without a `DailyLimitStore` and receive a credential
+ * carrying `maxDaily` will, by default, log a warning and skip the
+ * check; pass `strictDelegationConditions: true` to fail-closed instead.
+ */
+export interface DailyLimitStore {
+  /**
+   * Atomically add `amount` to the rolling-window total for the given
+   * principal+agent pair and return the resulting total.
+   *
+   * The window is 24 hours from the first-recorded amount in the window;
+   * implementations MAY use a sliding window with sub-second granularity
+   * or a calendar-day window aligned to the verifier's timezone. The
+   * spec does not currently pin one; the v1.1 revision may.
+   *
+   * @returns the new total after the addition. Compare against
+   *   `delegatedTo.conditions.maxDaily` (decimal string, same scale as
+   *   the payment amount) to decide whether to accept the request.
+   */
+  addAndGetTotal(opts: { principalDid: string; agentDid: string; amount: string }): Promise<string>;
+}

--- a/typescript/packages/extensions/src/vcx/types.ts
+++ b/typescript/packages/extensions/src/vcx/types.ts
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// ---------------------------------------------------------------------------
+// VCX Protocol Types — x402 v2 Extension
+// Spec: specs/vcx.md
+// ---------------------------------------------------------------------------
+
+// --- Disclosure Tiers ---
+
+export enum DisclosureTier {
+  IssuerOnly = 0,
+  SelectiveClaims = 1,
+  FullDisclosure = 2,
+}
+
+// --- Identity Requirements (server → client, in 402 response extensions) ---
+
+export interface IdentityRequirements {
+  protocol: "x402-vcx-v1";
+  disclosureTier: DisclosureTier;
+  requiredClaims?: string[];
+  minKycLevel?: KycLevel;
+  acceptedIssuers: string[];
+}
+
+// --- KYC Levels ---
+
+export type KycLevel = "Unverified" | "EmailVerified" | "IdentityVerified" | "BusinessVerified";
+
+export const KYC_LEVEL_ORDER: Record<KycLevel, number> = {
+  Unverified: 0,
+  EmailVerified: 1,
+  IdentityVerified: 2,
+  BusinessVerified: 3,
+};
+
+// --- Principal Layer ---
+
+export interface PrincipalClaims {
+  [key: string]: unknown;
+  kycLevel?: KycLevel;
+  ageOver18?: boolean;
+  jurisdiction?: string;
+  paymentsEnabled?: boolean;
+  emailVerified?: boolean;
+  accountType?: string;
+}
+
+/**
+ * Permitted credential serialisation formats per spec §6.1.
+ *
+ * - `jwt-vc` — plain JWT-based W3C VC. Used for Tier 0 (IssuerOnly) and
+ *   Tier 2 (FullDisclosure) per §12.
+ * - `sd-jwt-vc` — SD-JWT VC presentation per draft-ietf-oauth-sd-jwt-vc.
+ *   Used for Tier 1 (SelectiveClaims). Verification is deferred to the
+ *   v1.0.0 SDK release; envelopes setting this format on a pre-1.0.0
+ *   verifier MUST be rejected at Step 1.
+ */
+export type CredentialFormat = "jwt-vc" | "sd-jwt-vc";
+
+export interface PrincipalLayer {
+  credentialFormat: CredentialFormat;
+  credentialJwt: string;
+  did: string;
+  disclosed: PrincipalClaims;
+}
+
+// --- Agent Layer ---
+
+export interface AgentDelegation {
+  agentDid: string;
+  paymentSource?: string;
+  conditions?: DelegationConditions;
+}
+
+export interface DelegationConditions {
+  maxPerTransaction?: string;
+  maxDaily?: string;
+  allowedNetworks?: string[];
+  allowedAssets?: string[];
+  expiresAt?: string;
+}
+
+/**
+ * Delegation-proof profile discriminator per spec §6.2 / §10.
+ *
+ * v1 normative profile is `"vc-embedded"` (delegation inside the principal's
+ * VC under `credentialSubject.delegatedTo`). Reserved values from §10
+ * (`ucan`, `cacao`, `hdp`) are intentionally absent from this union: v1
+ * verifiers MUST reject any other value, and accepting them at the type
+ * level would invite a builder to emit one.
+ */
+export type DelegationProofFormat = "vc-embedded";
+
+export interface AgentLayer {
+  did: string;
+  name: string;
+  delegationProofFormat: DelegationProofFormat;
+  delegationProof: string;
+}
+
+// --- Payment Source Layer ---
+
+export interface PaymentSourceLayer {
+  accountId: string;
+  sourceId: string;
+  network: string;
+  asset?: string;
+}
+
+// --- Payment Details (verifier input, spec §9.2 / §9.3) ---
+
+/**
+ * Payment-payload-derived inputs the verifier needs to enforce both
+ * Step 3 envelope-to-payment binding (sender) and Step 2 delegation
+ * conditions (amount). Extracted by the integrator from the x402
+ * payment payload, since the extraction path is scheme-specific.
+ *
+ * `network` and `asset` are intentionally absent: spec §9.2 enforces
+ * `allowedNetworks` / `allowedAssets` against the envelope's
+ * `paymentSource.network` / `paymentSource.asset` fields, not against
+ * the payment payload, so the verifier reads them from the envelope
+ * itself.
+ */
+export interface PaymentDetails {
+  /** The sender / from-address on the x402 payment payload. */
+  sender: string;
+  /**
+   * The amount being charged on the matching payment payload, as a
+   * decimal string in the scheme's smallest unit. REQUIRED whenever the
+   * credential's delegation carries `maxPerTransaction` or `maxDaily`.
+   */
+  amount?: string;
+}
+
+// --- Identity Envelope ---
+
+export interface IdentityEnvelope {
+  version: "1.0";
+  protocol: "x402-vcx-v1";
+  transactionId: string;
+  /**
+   * Passive-observer flag per spec §6 envelope table. Always the literal
+   * `true` in v1; the field exists so indexers and analytics can flag
+   * VCX-attested traffic without dereferencing principal claims.
+   */
+  vcxPresent: true;
+  principal: PrincipalLayer;
+  agent: AgentLayer;
+  paymentSource: PaymentSourceLayer;
+}
+
+// --- Verification ---
+
+export type VerificationStep =
+  | "principal_credential"
+  | "agent_delegation"
+  | "payment_source_binding"
+  | "payment_settlement";
+
+export interface VerificationResult {
+  step: VerificationStep;
+  success: boolean;
+  error?: string;
+}
+
+export interface FullVerificationResult {
+  valid: boolean;
+  steps: VerificationResult[];
+}
+
+// --- Credential Subject (for W3C VC issuance) ---
+
+export interface VCXCredentialSubject {
+  id: string;
+  kycLevel: KycLevel;
+  emailVerified?: boolean;
+  paymentsEnabled?: boolean;
+  accountType?: string;
+  ageOver18?: boolean;
+  jurisdiction?: string;
+  delegatedTo: AgentDelegation;
+}
+
+// --- Issuer Configuration ---
+
+export interface IssuerConfig {
+  privateKeyHex: string;
+  did: string;
+}

--- a/typescript/packages/extensions/test/vcx-canonicalize.test.ts
+++ b/typescript/packages/extensions/test/vcx-canonicalize.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { canonicalEnvelope, envelopeDigest } from "../src/vcx";
+import type { IdentityEnvelope } from "../src/vcx";
+
+const baseEnvelope: IdentityEnvelope = {
+  version: "1.0",
+  protocol: "x402-vcx-v1",
+  transactionId: "00000000-0000-4000-8000-000000000001",
+  vcxPresent: true,
+  principal: {
+    credentialFormat: "jwt-vc",
+    credentialJwt: "stub.jwt.value",
+    did: "did:web:paypal.com:user/abc",
+    disclosed: { kycLevel: "IdentityVerified", ageOver18: true },
+  },
+  agent: {
+    did: "did:key:zAgent",
+    name: "test-agent",
+    delegationProofFormat: "vc-embedded",
+    delegationProof: "stub.jwt.value",
+  },
+  paymentSource: {
+    accountId: "eip155:8453:0xA11CE",
+    sourceId: "0xA11CE",
+    network: "eip155:8453",
+  },
+};
+
+describe("envelopeDigest", () => {
+  it("is byte-deterministic across different key insertion orders at every nesting level", () => {
+    // Construct a logically-identical envelope by reversing property
+    // insertion order at every nesting level. JCS MUST sort keys, so the
+    // digest MUST be the same.
+    //
+    // Note: an earlier version of this test used
+    // `JSON.stringify(env, Object.keys(env).reverse())` for the reorder,
+    // but `JSON.stringify`'s array-replacer is an *allowlist* applied at
+    // every level — top-level-only keys would filter out the nested
+    // `principal`/`agent`/`paymentSource` fields entirely, masking the
+    // property the test is supposed to exercise.
+    const reordered: IdentityEnvelope = {
+      paymentSource: {
+        network: baseEnvelope.paymentSource.network,
+        sourceId: baseEnvelope.paymentSource.sourceId,
+        accountId: baseEnvelope.paymentSource.accountId,
+      },
+      agent: {
+        delegationProof: baseEnvelope.agent.delegationProof,
+        delegationProofFormat: baseEnvelope.agent.delegationProofFormat,
+        name: baseEnvelope.agent.name,
+        did: baseEnvelope.agent.did,
+      },
+      principal: {
+        disclosed: {
+          ageOver18: baseEnvelope.principal.disclosed.ageOver18,
+          kycLevel: baseEnvelope.principal.disclosed.kycLevel,
+        },
+        did: baseEnvelope.principal.did,
+        credentialJwt: baseEnvelope.principal.credentialJwt,
+        credentialFormat: baseEnvelope.principal.credentialFormat,
+      },
+      vcxPresent: true,
+      transactionId: baseEnvelope.transactionId,
+      protocol: baseEnvelope.protocol,
+      version: baseEnvelope.version,
+    };
+    expect(envelopeDigest(baseEnvelope)).toBe(envelopeDigest(reordered));
+  });
+
+  it("returns sha256:hex format with 64-char hex body", () => {
+    const digest = envelopeDigest(baseEnvelope);
+    expect(digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  it("changes when any envelope field changes (avalanche check)", () => {
+    const original = envelopeDigest(baseEnvelope);
+    const mutated = envelopeDigest({
+      ...baseEnvelope,
+      transactionId: "00000000-0000-4000-8000-000000000002",
+    });
+    expect(original).not.toBe(mutated);
+  });
+
+  it("changes when a nested principal claim changes", () => {
+    const original = envelopeDigest(baseEnvelope);
+    const mutated = envelopeDigest({
+      ...baseEnvelope,
+      principal: {
+        ...baseEnvelope.principal,
+        disclosed: { ...baseEnvelope.principal.disclosed, ageOver18: false },
+      },
+    });
+    expect(original).not.toBe(mutated);
+  });
+});
+
+describe("canonicalEnvelope", () => {
+  it("returns UTF-8 bytes that parse back to the input shape", () => {
+    const bytes = canonicalEnvelope(baseEnvelope);
+    const json = new TextDecoder().decode(bytes);
+    const parsed = JSON.parse(json) as IdentityEnvelope;
+    expect(parsed.transactionId).toBe(baseEnvelope.transactionId);
+    expect(parsed.principal.credentialFormat).toBe("jwt-vc");
+    expect(parsed.vcxPresent).toBe(true);
+  });
+
+  it("emits keys in sorted order (JCS requirement)", () => {
+    const bytes = canonicalEnvelope(baseEnvelope);
+    const json = new TextDecoder().decode(bytes);
+    // Top-level keys MUST appear sorted: agent, paymentSource, principal,
+    // protocol, transactionId, vcxPresent, version.
+    const topLevelKeyOrder = json.match(
+      /"(agent|paymentSource|principal|protocol|transactionId|vcxPresent|version)"\s*:/g,
+    );
+    expect(topLevelKeyOrder).toEqual([
+      '"agent":',
+      '"paymentSource":',
+      '"principal":',
+      '"protocol":',
+      '"transactionId":',
+      '"vcxPresent":',
+      '"version":',
+    ]);
+  });
+});

--- a/typescript/packages/extensions/test/vcx-client.test.ts
+++ b/typescript/packages/extensions/test/vcx-client.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// AUTHORED OFFLINE — first CI run is the verification step.
+
+import { describe, it, expect } from "vitest";
+import {
+  createVCXClientExtension,
+  declareVCXExtension,
+  VCX_EXTENSION_KEY,
+  VCX_HEADER_NAME,
+  parseVCXHeader,
+  createAgent,
+  buildCredentialSubject,
+  buildDelegation,
+  issueCredential,
+  DisclosureTier,
+} from "../src/vcx";
+import { trustedIssuer, principalDid, principalClaims, paymentSource } from "./vcx-test-utils";
+
+/**
+ * Issues a credential and builds a VCX client extension wired to a fresh agent,
+ * delegation, and the shared test payment source.
+ *
+ * @returns The configured client extension, the agent, and the issued credential JWT.
+ */
+async function buildClientWithCredential() {
+  const agent = createAgent("client-test-agent");
+  const delegation = buildDelegation({
+    agentDid: agent.did,
+    paymentSource: paymentSource.accountId,
+    conditions: {
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    },
+  });
+  const subject = buildCredentialSubject({
+    principalDid,
+    claims: principalClaims,
+    delegation,
+  });
+  const { jwt } = await issueCredential({
+    issuerConfig: trustedIssuer,
+    subject,
+  });
+  const ext = createVCXClientExtension({
+    principalCredential: jwt,
+    principalDid,
+    principalClaims,
+    agent,
+    paymentSource,
+  });
+  return { ext, agent, jwt };
+}
+
+const declarationFor = (opts = {}) =>
+  declareVCXExtension({
+    disclosureTier: DisclosureTier.SelectiveClaims,
+    requiredClaims: ["kycLevel", "ageOver18"],
+    minKycLevel: "IdentityVerified",
+    acceptedIssuers: [trustedIssuer.did],
+    ...opts,
+  });
+
+describe("createVCXClientExtension", () => {
+  it("returns an extension registered under the VCX key", async () => {
+    const { ext } = await buildClientWithCredential();
+    expect(ext.key).toBe(VCX_EXTENSION_KEY);
+    expect(ext.transportHooks?.http).toBeDefined();
+  });
+
+  describe("onPaymentRequired", () => {
+    it("returns void when the 402 has no VCX extension declared", async () => {
+      const { ext } = await buildClientWithCredential();
+      const result = await ext.transportHooks!.http!.onPaymentRequired!(undefined, {
+        paymentRequired: { extensions: {} },
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it("returns a VCX header when the extension is declared", async () => {
+      const { ext } = await buildClientWithCredential();
+      const declared = declarationFor();
+      const result = (await ext.transportHooks!.http!.onPaymentRequired!(undefined, {
+        paymentRequired: { extensions: declared },
+      })) as { headers: Record<string, string> } | undefined;
+
+      expect(result?.headers[VCX_HEADER_NAME]).toBeTypeOf("string");
+    });
+
+    it("constructs an envelope matching the declared requirements", async () => {
+      const { ext, agent } = await buildClientWithCredential();
+      const declared = declarationFor();
+      const result = (await ext.transportHooks!.http!.onPaymentRequired!(undefined, {
+        paymentRequired: { extensions: declared },
+      })) as { headers: Record<string, string> };
+
+      const envelope = parseVCXHeader(result.headers[VCX_HEADER_NAME]);
+      expect(envelope.version).toBe("1.0");
+      expect(envelope.protocol).toBe("x402-vcx-v1");
+      expect(envelope.principal.did).toBe(principalDid);
+      expect(envelope.agent.did).toBe(agent.did);
+      expect(envelope.paymentSource).toEqual(paymentSource);
+      expect(envelope.principal.disclosed).toEqual({
+        kycLevel: "IdentityVerified",
+        ageOver18: true,
+      });
+    });
+
+    it("uses delegationProof override when provided, defaulting to principalCredential otherwise", async () => {
+      const { jwt, agent } = await buildClientWithCredential();
+      const overrideExt = createVCXClientExtension({
+        principalCredential: jwt,
+        principalDid,
+        principalClaims,
+        agent,
+        paymentSource,
+        delegationProof: "explicit.override.proof",
+      });
+
+      const declared = declarationFor();
+      const result = (await overrideExt.transportHooks!.http!.onPaymentRequired!(undefined, {
+        paymentRequired: { extensions: declared },
+      })) as { headers: Record<string, string> };
+
+      const envelope = parseVCXHeader(result.headers[VCX_HEADER_NAME]);
+      expect(envelope.agent.delegationProof).toBe("explicit.override.proof");
+    });
+
+    it("produces a unique transactionId per invocation", async () => {
+      const { ext } = await buildClientWithCredential();
+      const declared = declarationFor();
+      const first = (await ext.transportHooks!.http!.onPaymentRequired!(undefined, {
+        paymentRequired: { extensions: declared },
+      })) as { headers: Record<string, string> };
+      const second = (await ext.transportHooks!.http!.onPaymentRequired!(undefined, {
+        paymentRequired: { extensions: declared },
+      })) as { headers: Record<string, string> };
+
+      const e1 = parseVCXHeader(first.headers[VCX_HEADER_NAME]);
+      const e2 = parseVCXHeader(second.headers[VCX_HEADER_NAME]);
+      expect(e1.transactionId).not.toBe(e2.transactionId);
+    });
+  });
+});

--- a/typescript/packages/extensions/test/vcx-credential.test.ts
+++ b/typescript/packages/extensions/test/vcx-credential.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// AUTHORED OFFLINE — first CI run is the verification step.
+
+import { describe, it, expect } from "vitest";
+import {
+  createVCXIssuer,
+  issueCredential,
+  getDidResolver,
+  generateEd25519KeyPair,
+  buildCredentialSubject,
+  buildDelegation,
+} from "../src/vcx";
+import { trustedIssuer, principalDid } from "./vcx-test-utils";
+
+describe("createVCXIssuer", () => {
+  it("returns an Issuer with did, signer function, and EdDSA algorithm", () => {
+    const issuer = createVCXIssuer(trustedIssuer);
+    expect(issuer.did).toBe(trustedIssuer.did);
+    expect(issuer.alg).toBe("EdDSA");
+    expect(typeof issuer.signer).toBe("function");
+  });
+});
+
+describe("issueCredential", () => {
+  it("produces a JWT with the expected header, payload, and expiry", async () => {
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: { kycLevel: "IdentityVerified", ageOver18: true },
+      delegation: buildDelegation({ agentDid: "did:key:zAgent" }),
+    });
+
+    const { jwt, expiresAt } = await issueCredential({
+      issuerConfig: trustedIssuer,
+      subject,
+      expiresInSeconds: 3600,
+    });
+
+    const parts = jwt.split(".");
+    expect(parts.length).toBe(3);
+
+    const header = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8"));
+    expect(header.alg).toBe("EdDSA");
+
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8"));
+    expect(payload.sub).toBe(principalDid);
+    expect(payload.iss).toBe(trustedIssuer.did);
+    expect(payload.vc.type).toContain("X402IdentityCredential");
+    expect(payload.vc.credentialSubject.kycLevel).toBe("IdentityVerified");
+
+    const expiresAtMs = Date.parse(expiresAt);
+    const driftMs = Math.abs(expiresAtMs - (Date.now() + 3600 * 1000));
+    expect(driftMs).toBeLessThan(5000);
+  });
+
+  it("rejects when private key hex is empty", async () => {
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: {},
+      delegation: buildDelegation({ agentDid: "did:key:zAgent" }),
+    });
+    await expect(
+      issueCredential({
+        issuerConfig: { did: trustedIssuer.did, privateKeyHex: "" },
+        subject,
+      }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("getDidResolver", () => {
+  it("resolves a did:key identifier produced by generateEd25519KeyPair", async () => {
+    const kp = generateEd25519KeyPair();
+    const resolver = getDidResolver();
+    const result = await resolver.resolve(kp.did);
+    expect(result.didDocument?.id).toBe(kp.did);
+    expect((result.didDocument?.verificationMethod ?? []).length).toBeGreaterThan(0);
+  });
+
+  it("returns the same resolver instance on subsequent calls", () => {
+    expect(getDidResolver()).toBe(getDidResolver());
+  });
+
+  it("returns notFound for a malformed did:key identifier", async () => {
+    const resolver = getDidResolver();
+    const result = await resolver.resolve("did:key:zNotAValidMulticodecKey");
+    expect(result.didResolutionMetadata.error).toBe("notFound");
+  });
+});

--- a/typescript/packages/extensions/test/vcx-e2e.test.ts
+++ b/typescript/packages/extensions/test/vcx-e2e.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// AUTHORED OFFLINE — first CI run is the verification step.
+// End-to-end flow: client extension produces VCX header → server extension
+// verifies it. Mirrors what the x402 v2 runtime will do in production.
+
+import { describe, it, expect } from "vitest";
+import {
+  createVCXClientExtension,
+  createVCXResourceServerExtension,
+  declareVCXExtension,
+  VCX_EXTENSION_KEY,
+  VCX_HEADER_NAME,
+  parseVCXHeader,
+  InMemoryNonceStorage,
+  createAgent,
+  buildCredentialSubject,
+  buildDelegation,
+  issueCredential,
+  DisclosureTier,
+  type VCXRequestContext,
+} from "../src/vcx";
+import { trustedIssuer, principalDid, principalClaims, paymentSource } from "./vcx-test-utils";
+
+/**
+ * Issues a credential and returns a VCX client extension for the end-to-end flow.
+ *
+ * @returns The configured VCX client extension.
+ */
+async function setupClient() {
+  const agent = createAgent("e2e-agent");
+  const delegation = buildDelegation({
+    agentDid: agent.did,
+    paymentSource: paymentSource.accountId,
+    conditions: {
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    },
+  });
+  const subject = buildCredentialSubject({
+    principalDid,
+    claims: principalClaims,
+    delegation,
+  });
+  const { jwt } = await issueCredential({
+    issuerConfig: trustedIssuer,
+    subject,
+  });
+  return createVCXClientExtension({
+    principalCredential: jwt,
+    principalDid,
+    principalClaims,
+    agent,
+    paymentSource,
+  });
+}
+
+const declared = declareVCXExtension({
+  disclosureTier: DisclosureTier.SelectiveClaims,
+  requiredClaims: ["kycLevel", "ageOver18"],
+  minKycLevel: "IdentityVerified",
+  acceptedIssuers: [trustedIssuer.did],
+});
+
+const extractFromPayment = (ctx: VCXRequestContext): string => {
+  const raw = ctx.getHeader("X-PAYMENT");
+  if (!raw) return "";
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64").toString("utf8")) as {
+      payload?: { authorization?: { from?: string } };
+    };
+    return parsed.payload?.authorization?.from ?? "";
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * Builds a server request context whose adapter exposes the given VCX header and
+ * a base64 X-PAYMENT header carrying the supplied sender address.
+ *
+ * @param vcxHeader - The VCX header value to return for the `vcx` header lookup.
+ * @param sender - The payment sender address to embed in the X-PAYMENT header.
+ * @returns A context object with an `adapter.getHeader` lookup.
+ */
+function buildServerContext(vcxHeader: string, sender: string) {
+  const paymentHeader = Buffer.from(
+    JSON.stringify({ payload: { authorization: { from: sender } } }),
+  ).toString("base64");
+  return {
+    adapter: {
+      getHeader: (name: string): string | undefined => {
+        const lower = name.toLowerCase();
+        if (lower === "vcx") return vcxHeader;
+        if (lower === "x-payment") return paymentHeader;
+        return undefined;
+      },
+    },
+  };
+}
+
+describe("VCX end-to-end via extension factories", () => {
+  it("client produces a header that the server accepts", async () => {
+    const clientExt = await setupClient();
+    const serverExt = createVCXResourceServerExtension({
+      extractPaymentSender: extractFromPayment,
+      nonceStorage: new InMemoryNonceStorage(),
+    });
+
+    const clientResult = (await clientExt.transportHooks!.http!.onPaymentRequired!(undefined, {
+      paymentRequired: { extensions: declared },
+    })) as { headers: Record<string, string> };
+
+    const headerValue = clientResult.headers[VCX_HEADER_NAME];
+    expect(headerValue).toBeTypeOf("string");
+
+    const result = await serverExt.transportHooks!.http!.onProtectedRequest!(
+      declared[VCX_EXTENSION_KEY],
+      buildServerContext(headerValue, paymentSource.sourceId),
+      {},
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("server aborts on a tampered envelope at principal_credential", async () => {
+    const clientExt = await setupClient();
+    const serverExt = createVCXResourceServerExtension({
+      extractPaymentSender: extractFromPayment,
+      nonceStorage: new InMemoryNonceStorage(),
+    });
+
+    const clientResult = (await clientExt.transportHooks!.http!.onPaymentRequired!(undefined, {
+      paymentRequired: { extensions: declared },
+    })) as { headers: Record<string, string> };
+
+    const envelope = parseVCXHeader(clientResult.headers[VCX_HEADER_NAME]);
+    envelope.principal.disclosed.ageOver18 = false;
+    const tamperedHeader = Buffer.from(JSON.stringify(envelope)).toString("base64");
+
+    const result = await serverExt.transportHooks!.http!.onProtectedRequest!(
+      declared[VCX_EXTENSION_KEY],
+      buildServerContext(tamperedHeader, paymentSource.sourceId),
+      {},
+    );
+    expect(result).toEqual({
+      abort: true,
+      reason: expect.stringMatching(/principal_credential/),
+    });
+  });
+});

--- a/typescript/packages/extensions/test/vcx-envelope.test.ts
+++ b/typescript/packages/extensions/test/vcx-envelope.test.ts
@@ -1,0 +1,631 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// AUTHORED OFFLINE — first CI run is the verification step.
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildIdentityEnvelope,
+  buildEnvelopeFromRequirements,
+  verifyEnvelope,
+  buildCredentialSubject,
+  buildDelegation,
+  createAgent,
+  issueCredential,
+  DisclosureTier,
+} from "../src/vcx";
+import {
+  trustedIssuer,
+  principalDid,
+  principalClaims,
+  paymentSource,
+  requirements,
+  newIssuer,
+} from "./vcx-test-utils";
+
+describe("buildIdentityEnvelope", () => {
+  const baseOpts = {
+    credentialJwt: "stub.jwt.value",
+    principalDid,
+    principalClaims,
+    agentDid: "did:key:zAgent",
+    agentName: "test-agent",
+    delegationProof: "stub.jwt.value",
+    paymentSource,
+  };
+
+  it("constructs a 3-layer envelope with required protocol metadata", () => {
+    const env = buildIdentityEnvelope({
+      ...baseOpts,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: ["kycLevel"],
+    });
+    expect(env.version).toBe("1.0");
+    expect(env.protocol).toBe("x402-vcx-v1");
+    expect(env.transactionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(env.vcxPresent).toBe(true);
+    expect(env.principal.did).toBe(principalDid);
+    expect(env.principal.credentialJwt).toBe("stub.jwt.value");
+    expect(env.principal.credentialFormat).toBe("jwt-vc");
+    expect(env.principal.disclosed).toEqual({ kycLevel: "IdentityVerified" });
+    expect(env.agent).toEqual({
+      did: "did:key:zAgent",
+      name: "test-agent",
+      delegationProofFormat: "vc-embedded",
+      delegationProof: "stub.jwt.value",
+    });
+    expect(env.paymentSource).toEqual(paymentSource);
+  });
+
+  it("propagates a non-default credentialFormat", () => {
+    const env = buildIdentityEnvelope({
+      ...baseOpts,
+      credentialFormat: "sd-jwt-vc",
+    });
+    expect(env.principal.credentialFormat).toBe("sd-jwt-vc");
+  });
+
+  it("discloses nothing at IssuerOnly tier", () => {
+    const env = buildIdentityEnvelope({
+      ...baseOpts,
+      disclosureTier: DisclosureTier.IssuerOnly,
+    });
+    expect(env.principal.disclosed).toEqual({});
+  });
+
+  it("discloses all claims at FullDisclosure tier", () => {
+    const env = buildIdentityEnvelope({
+      ...baseOpts,
+      disclosureTier: DisclosureTier.FullDisclosure,
+    });
+    expect(env.principal.disclosed).toEqual(principalClaims);
+  });
+
+  it("discloses only requiredClaims at SelectiveClaims tier", () => {
+    const env = buildIdentityEnvelope({
+      ...baseOpts,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: ["kycLevel", "ageOver18"],
+    });
+    expect(env.principal.disclosed).toEqual({
+      kycLevel: "IdentityVerified",
+      ageOver18: true,
+    });
+  });
+
+  it("produces a unique transactionId per call", () => {
+    const a = buildIdentityEnvelope(baseOpts);
+    const b = buildIdentityEnvelope(baseOpts);
+    expect(a.transactionId).not.toBe(b.transactionId);
+  });
+});
+
+describe("buildEnvelopeFromRequirements", () => {
+  it("applies disclosureTier and requiredClaims from the requirements object", () => {
+    const env = buildEnvelopeFromRequirements(
+      {
+        credentialJwt: "x",
+        principalDid,
+        principalClaims,
+        agentDid: "did:key:zAgent",
+        agentName: "a",
+        delegationProof: "x",
+        paymentSource,
+      },
+      requirements,
+    );
+    expect(env.principal.disclosed).toEqual({
+      kycLevel: "IdentityVerified",
+      ageOver18: true,
+    });
+  });
+});
+
+/**
+ * Issues a credential and builds a valid identity envelope, allowing delegation
+ * conditions and the payment source to be overridden for failure-path tests.
+ *
+ * @param overrides - Optional overrides for the scenario.
+ * @param overrides.conditions - Delegation conditions to embed instead of the default expiry-only block.
+ * @param overrides.paymentSourceOverride - Payment source to use in place of the shared fixture.
+ * @returns The built envelope, the agent, and the issued credential JWT.
+ */
+async function buildValidScenario(overrides?: {
+  conditions?: Record<string, unknown>;
+  paymentSourceOverride?: typeof paymentSource;
+}) {
+  const agent = createAgent("verify-agent");
+  // Presence-check rather than `??` so a test can pass `conditions: undefined`
+  // to exercise the no-conditions delegation path; `??` would swap it for the
+  // default block and make that case impossible to express.
+  const conditions = (
+    overrides && "conditions" in overrides
+      ? overrides.conditions
+      : { expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString() }
+  ) as Record<string, unknown>;
+  const delegation = buildDelegation({
+    agentDid: agent.did,
+    paymentSource: (overrides?.paymentSourceOverride ?? paymentSource).accountId,
+    // Cast to bypass DelegationConditions strict typing for tests that need
+    // to inject unknown keys to exercise the §13.4 fail-closed path.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    conditions: conditions as any,
+  });
+  const subject = buildCredentialSubject({ principalDid, claims: principalClaims, delegation });
+  const { jwt } = await issueCredential({ issuerConfig: trustedIssuer, subject });
+  const envelope = buildIdentityEnvelope({
+    credentialJwt: jwt,
+    principalDid,
+    principalClaims,
+    agentDid: agent.did,
+    agentName: agent.name,
+    delegationProof: jwt,
+    paymentSource: overrides?.paymentSourceOverride ?? paymentSource,
+    disclosureTier: DisclosureTier.SelectiveClaims,
+    requiredClaims: requirements.requiredClaims,
+  });
+  return { envelope, agent, jwt };
+}
+
+describe("verifyEnvelope", () => {
+  it("passes for a valid envelope from a trusted issuer", async () => {
+    const { envelope } = await buildValidScenario();
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(true);
+    expect(result.steps).toHaveLength(4);
+    expect(result.steps.map(s => s.step)).toEqual([
+      "principal_credential",
+      "agent_delegation",
+      "payment_source_binding",
+      "payment_settlement",
+    ]);
+    expect(result.steps.every(s => s.success)).toBe(true);
+  });
+
+  it("rejects a forged credential signature", async () => {
+    const { envelope } = await buildValidScenario();
+    const parts = envelope.principal.credentialJwt.split(".");
+    const sig = parts[2];
+    parts[2] = sig.slice(0, -1) + (sig.endsWith("A") ? "B" : "A");
+    envelope.principal.credentialJwt = parts.join(".");
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].step).toBe("principal_credential");
+    expect(result.steps[0].success).toBe(false);
+  });
+
+  it("rejects when issuer is not in acceptedIssuers", async () => {
+    const untrusted = newIssuer();
+    const agent = createAgent("untrusted-issuer-agent");
+    const delegation = buildDelegation({
+      agentDid: agent.did,
+      paymentSource: paymentSource.accountId,
+      conditions: { expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString() },
+    });
+    const subject = buildCredentialSubject({ principalDid, claims: principalClaims, delegation });
+    const { jwt } = await issueCredential({ issuerConfig: untrusted, subject });
+    const envelope = buildIdentityEnvelope({
+      credentialJwt: jwt,
+      principalDid,
+      principalClaims,
+      agentDid: agent.did,
+      agentName: agent.name,
+      delegationProof: jwt,
+      paymentSource,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: requirements.requiredClaims,
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].step).toBe("principal_credential");
+    expect(result.steps[0].error ?? "").toMatch(/not in resolved trust list/);
+  });
+
+  it("rejects when envelope.agent.did does not match credential.delegatedTo.agentDid", async () => {
+    const { envelope } = await buildValidScenario();
+    envelope.agent.did = "did:key:zMismatchedAgent";
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.success).toBe(false);
+  });
+
+  it("rejects when payment sender does not match payment source", async () => {
+    const { envelope } = await buildValidScenario();
+    const result = await verifyEnvelope(envelope, requirements, "0xWRONGSENDER");
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "payment_source_binding");
+    expect(step?.success).toBe(false);
+    // Verifier short-circuits on first failure; settlement step MUST NOT appear.
+    expect(result.steps.find(s => s.step === "payment_settlement")).toBeUndefined();
+  });
+
+  it("rejects an expired delegation", async () => {
+    const agent = createAgent("expired-agent");
+    const delegation = buildDelegation({
+      agentDid: agent.did,
+      paymentSource: paymentSource.accountId,
+      conditions: { expiresAt: new Date(Date.now() - 1000).toISOString() },
+    });
+    const subject = buildCredentialSubject({ principalDid, claims: principalClaims, delegation });
+    const { jwt } = await issueCredential({ issuerConfig: trustedIssuer, subject });
+    const envelope = buildIdentityEnvelope({
+      credentialJwt: jwt,
+      principalDid,
+      principalClaims,
+      agentDid: agent.did,
+      agentName: agent.name,
+      delegationProof: jwt,
+      paymentSource,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: requirements.requiredClaims,
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.success).toBe(false);
+    expect(step?.error ?? "").toMatch(/expired/i);
+  });
+
+  it("rejects when a disclosed claim does not match the credential", async () => {
+    const { envelope } = await buildValidScenario();
+    envelope.principal.disclosed.ageOver18 = false;
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].step).toBe("principal_credential");
+    expect(result.steps[0].error ?? "").toMatch(/match credential|disclosed/i);
+  });
+
+  // Regression: B1 from the v0.1 prep security review. Attack scenario:
+  // delegation authorises payments from accountId X; attacker constructs an
+  // envelope that keeps accountId=X (passes Step 2) but uses a different
+  // sourceId Y, then pays from Y (passes Step 3's first sub-check). Without
+  // the accountId↔sourceId binding, the verifier accepts; with it, rejects.
+  it("rejects when sourceId does not match the accountId address component (B1 binding)", async () => {
+    const { envelope } = await buildValidScenario();
+    // Reassign a fresh object rather than mutating the shared paymentSource
+    // fixture in place — an in-place mutation here leaks into every later test.
+    envelope.paymentSource = {
+      ...envelope.paymentSource,
+      sourceId: "0xATTACKER000000000000000000000000000FACE",
+    };
+    const result = await verifyEnvelope(
+      envelope,
+      requirements,
+      "0xATTACKER000000000000000000000000000FACE",
+    );
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "payment_source_binding");
+    expect(step?.success).toBe(false);
+    expect(step?.error ?? "").toMatch(/address component/i);
+  });
+
+  it("rejects when envelope vcxPresent is missing", async () => {
+    const { envelope } = await buildValidScenario();
+    delete (envelope as { vcxPresent?: unknown }).vcxPresent;
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].step).toBe("principal_credential");
+    expect(result.steps[0].error ?? "").toMatch(/vcxPresent/);
+  });
+
+  it("rejects when envelope vcxPresent is not the literal true", async () => {
+    const { envelope } = await buildValidScenario();
+    (envelope as { vcxPresent: unknown }).vcxPresent = "true";
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].error ?? "").toMatch(/vcxPresent/);
+  });
+
+  it("rejects when principal.credentialFormat is missing", async () => {
+    const { envelope } = await buildValidScenario();
+    delete (envelope.principal as { credentialFormat?: unknown }).credentialFormat;
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].step).toBe("principal_credential");
+    expect(result.steps[0].error ?? "").toMatch(/credentialFormat/);
+  });
+
+  it("rejects when principal.credentialFormat is out of enum", async () => {
+    const { envelope } = await buildValidScenario();
+    (envelope.principal as { credentialFormat: unknown }).credentialFormat = "ld-vc";
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].error ?? "").toMatch(/credentialFormat/);
+  });
+
+  it("rejects credentialFormat=sd-jwt-vc when the credential is not a valid SD-JWT VC", async () => {
+    const { envelope } = await buildValidScenario();
+    // The fixture credential is a plain JWT, not an SD-JWT VC (no `~` separators),
+    // so the now-implemented SD-JWT VC path must reject it.
+    envelope.principal.credentialFormat = "sd-jwt-vc";
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].error ?? "").toMatch(/SD-JWT/i);
+  });
+
+  it("rejects when agent.delegationProofFormat is missing", async () => {
+    const { envelope } = await buildValidScenario();
+    delete (envelope.agent as { delegationProofFormat?: unknown }).delegationProofFormat;
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.success).toBe(false);
+    expect(step?.error ?? "").toMatch(/delegationProofFormat/);
+  });
+
+  it("rejects when agent.delegationProofFormat is a reserved-but-non-v1 value", async () => {
+    const { envelope } = await buildValidScenario();
+    (envelope.agent as { delegationProofFormat: unknown }).delegationProofFormat = "ucan";
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/delegationProofFormat/);
+  });
+
+  // Regression: B2 from the v0.1 prep security review. When minKycLevel is
+  // set, a credential whose subject omits kycLevel MUST be rejected
+  // (fail-closed), not silently allowed.
+  it("rejects when minKycLevel is set but credential lacks kycLevel (B2 fail-closed)", async () => {
+    const agent = createAgent("b2-fail-closed-agent");
+    // Bypass buildCredentialSubject (which would default kycLevel to "Unverified")
+    // to simulate an issuer that omits the field entirely.
+    const customSubject = {
+      id: principalDid,
+      delegatedTo: {
+        agentDid: agent.did,
+        paymentSource: paymentSource.accountId,
+        conditions: {
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        },
+      },
+      // kycLevel intentionally omitted
+    };
+    const { jwt } = await issueCredential({
+      issuerConfig: trustedIssuer,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      subject: customSubject as any,
+    });
+    const envelope = buildIdentityEnvelope({
+      credentialJwt: jwt,
+      principalDid,
+      principalClaims: {},
+      agentDid: agent.did,
+      agentName: agent.name,
+      delegationProof: jwt,
+      paymentSource,
+      disclosureTier: DisclosureTier.IssuerOnly,
+    });
+    const result = await verifyEnvelope(
+      envelope,
+      {
+        protocol: "x402-vcx-v1",
+        disclosureTier: DisclosureTier.IssuerOnly,
+        minKycLevel: "IdentityVerified",
+        acceptedIssuers: [trustedIssuer.did],
+      },
+      paymentSource.sourceId,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].step).toBe("principal_credential");
+    expect(result.steps[0].error ?? "").toMatch(/kycLevel/i);
+  });
+});
+
+// v0.3 §9.2 full delegation enforcement: every condition's happy path and
+// every failure path. Reads against verifier.ts:verifyAgentDelegation.
+describe("verifyEnvelope — v0.3 §9.2 delegation conditions", () => {
+  const validExpiresAt = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+  it("rejects an unknown condition key (§13.4 fail-closed)", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: { expiresAt: validExpiresAt(), geoFence: "EU" },
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/geoFence|Unknown delegation condition/);
+  });
+
+  it("rejects a delegation with no conditions block", async () => {
+    const { envelope } = await buildValidScenario({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      conditions: undefined as any,
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/conditions/i);
+  });
+
+  it("rejects when expiresAt is missing from conditions", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: { maxPerTransaction: "1000" },
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      paymentAmount: "500",
+    });
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/expiresAt/);
+  });
+
+  it("rejects expiresAt beyond the 30-day cap from credential nbf", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: {
+        expiresAt: new Date(Date.now() + 31 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/30-day/);
+  });
+
+  it("rejects when maxPerTransaction is set but paymentAmount was not supplied", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: { expiresAt: validExpiresAt(), maxPerTransaction: "1000" },
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/maxPerTransaction.*paymentAmount/i);
+  });
+
+  it("rejects when payment amount exceeds maxPerTransaction", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: { expiresAt: validExpiresAt(), maxPerTransaction: "1000" },
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      paymentAmount: "1500",
+    });
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/exceeds delegation maxPerTransaction/);
+  });
+
+  it("accepts when payment amount equals maxPerTransaction (BigInt boundary)", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: { expiresAt: validExpiresAt(), maxPerTransaction: "1000" },
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      paymentAmount: "1000",
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects when paymentSource.network is not in allowedNetworks", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: {
+        expiresAt: validExpiresAt(),
+        allowedNetworks: ["eip155:1"], // mainnet, but envelope is on Base (8453)
+      },
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/allowedNetworks/);
+  });
+
+  it("accepts when paymentSource.network is in allowedNetworks", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: {
+        expiresAt: validExpiresAt(),
+        allowedNetworks: ["eip155:1", paymentSource.network],
+      },
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects when allowedAssets is set but envelope.paymentSource.asset is absent", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: {
+        expiresAt: validExpiresAt(),
+        allowedAssets: ["0xUSDC"],
+      },
+    });
+    // paymentSource fixture has no `asset` field → reject
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/allowedAssets.*absent|asset is absent/);
+  });
+
+  it("rejects when paymentSource.asset is not in allowedAssets", async () => {
+    const paymentSourceWithAsset = { ...paymentSource, asset: "0xWBTC" };
+    const { envelope } = await buildValidScenario({
+      conditions: {
+        expiresAt: validExpiresAt(),
+        allowedAssets: ["0xUSDC", "0xUSDT"],
+      },
+      paymentSourceOverride: paymentSourceWithAsset,
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/allowedAssets/);
+  });
+
+  it("accepts when paymentSource.asset is in allowedAssets", async () => {
+    const paymentSourceWithAsset = { ...paymentSource, asset: "0xUSDC" };
+    const { envelope } = await buildValidScenario({
+      conditions: {
+        expiresAt: validExpiresAt(),
+        allowedAssets: ["0xUSDC", "0xUSDT"],
+      },
+      paymentSourceOverride: paymentSourceWithAsset,
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects maxDaily with no store under strictDelegationConditions", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: { expiresAt: validExpiresAt(), maxDaily: "10000" },
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      paymentAmount: "500",
+      strictDelegationConditions: true,
+    });
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/maxDaily.*dailyLimitStore/);
+  });
+
+  it("warn-and-skips maxDaily with no store when not strict", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: { expiresAt: validExpiresAt(), maxDaily: "10000" },
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      paymentAmount: "500",
+    });
+    expect(result.valid).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("rejects when DailyLimitStore total exceeds maxDaily", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: { expiresAt: validExpiresAt(), maxDaily: "1000" },
+    });
+    const store = {
+      addAndGetTotal: async () => "1500",
+    };
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      paymentAmount: "500",
+      dailyLimitStore: store,
+    });
+    expect(result.valid).toBe(false);
+    const step = result.steps.find(s => s.step === "agent_delegation");
+    expect(step?.error ?? "").toMatch(/Daily total.*exceeds.*maxDaily/);
+  });
+
+  it("accepts when DailyLimitStore total is within maxDaily", async () => {
+    const { envelope } = await buildValidScenario({
+      conditions: { expiresAt: validExpiresAt(), maxDaily: "10000" },
+    });
+    const store = {
+      addAndGetTotal: async () => "750",
+    };
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      paymentAmount: "500",
+      dailyLimitStore: store,
+    });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/typescript/packages/extensions/test/vcx-identity.test.ts
+++ b/typescript/packages/extensions/test/vcx-identity.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// AUTHORED OFFLINE — first CI run is the verification step.
+
+import { describe, it, expect } from "vitest";
+import {
+  generateEd25519KeyPair,
+  publicKeyToDidKey,
+  buildDid,
+  createAgent,
+  buildDelegation,
+  buildCredentialSubject,
+  meetsKycRequirement,
+} from "../src/vcx";
+
+describe("generateEd25519KeyPair", () => {
+  it("produces 32-byte Ed25519 keys and a valid did:key", () => {
+    const kp = generateEd25519KeyPair();
+    expect(kp.publicKey).toBeInstanceOf(Uint8Array);
+    expect(kp.publicKey.length).toBe(32);
+    expect(kp.privateKey.length).toBe(32);
+    expect(kp.did).toMatch(/^did:key:z[1-9A-HJ-NP-Za-km-z]+$/);
+    expect(kp.privateKeyHex).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces a different keypair on each call", () => {
+    const a = generateEd25519KeyPair();
+    const b = generateEd25519KeyPair();
+    expect(a.did).not.toBe(b.did);
+    expect(a.privateKeyHex).not.toBe(b.privateKeyHex);
+  });
+});
+
+describe("publicKeyToDidKey", () => {
+  it("is deterministic for a given public key", () => {
+    const kp = generateEd25519KeyPair();
+    expect(publicKeyToDidKey(kp.publicKey)).toBe(kp.did);
+    expect(publicKeyToDidKey(kp.publicKey)).toBe(publicKeyToDidKey(kp.publicKey));
+  });
+
+  it("produces distinct DIDs for distinct keys", () => {
+    const a = generateEd25519KeyPair();
+    const b = generateEd25519KeyPair();
+    expect(publicKeyToDidKey(a.publicKey)).not.toBe(publicKeyToDidKey(b.publicKey));
+  });
+});
+
+describe("buildDid", () => {
+  it("formats a did:web identifier from domain and path", () => {
+    expect(buildDid("example.com", "user/abc")).toBe("did:web:example.com:user:abc");
+  });
+});
+
+describe("createAgent", () => {
+  it("creates an agent with a did:key and preserves the provided name", () => {
+    const agent = createAgent("payment-bot");
+    expect(agent.name).toBe("payment-bot");
+    expect(agent.did).toMatch(/^did:key:z/);
+    expect(agent.privateKeyHex).toMatch(/^[0-9a-f]{64}$/);
+    expect(agent.keyPair.did).toBe(agent.did);
+  });
+
+  it("creates a unique agent per call (independent keys)", () => {
+    const a = createAgent("x");
+    const b = createAgent("x");
+    expect(a.did).not.toBe(b.did);
+  });
+});
+
+describe("buildDelegation", () => {
+  it("passes through agentDid, paymentSource, and conditions", () => {
+    const d = buildDelegation({
+      agentDid: "did:key:zAgent",
+      paymentSource: "eip155:1:0xabc",
+      conditions: {
+        maxPerTransaction: "1000",
+        allowedNetworks: ["eip155:1"],
+        expiresAt: "2026-12-31T23:59:59Z",
+      },
+    });
+    expect(d.agentDid).toBe("did:key:zAgent");
+    expect(d.paymentSource).toBe("eip155:1:0xabc");
+    expect(d.conditions?.maxPerTransaction).toBe("1000");
+    expect(d.conditions?.allowedNetworks).toEqual(["eip155:1"]);
+  });
+
+  it("permits missing optional fields", () => {
+    const d = buildDelegation({ agentDid: "did:key:zAgent" });
+    expect(d.agentDid).toBe("did:key:zAgent");
+    expect(d.paymentSource).toBeUndefined();
+    expect(d.conditions).toBeUndefined();
+  });
+});
+
+describe("buildCredentialSubject", () => {
+  it("constructs a W3C VC subject from claims and delegation", () => {
+    const subject = buildCredentialSubject({
+      principalDid: "did:web:example.com:user/1",
+      claims: { kycLevel: "IdentityVerified", ageOver18: true, emailVerified: true },
+      delegation: { agentDid: "did:key:zAgent" },
+    });
+    expect(subject.id).toBe("did:web:example.com:user/1");
+    expect(subject.kycLevel).toBe("IdentityVerified");
+    expect(subject.ageOver18).toBe(true);
+    expect(subject.emailVerified).toBe(true);
+    expect(subject.delegatedTo.agentDid).toBe("did:key:zAgent");
+  });
+
+  it("defaults kycLevel to Unverified when not provided", () => {
+    const subject = buildCredentialSubject({
+      principalDid: "did:web:example.com:user/1",
+      claims: {},
+      delegation: { agentDid: "did:key:zAgent" },
+    });
+    expect(subject.kycLevel).toBe("Unverified");
+  });
+});
+
+describe("meetsKycRequirement", () => {
+  it("returns true when actual KYC meets or exceeds the required level", () => {
+    expect(meetsKycRequirement("EmailVerified", "EmailVerified")).toBe(true);
+    expect(meetsKycRequirement("IdentityVerified", "EmailVerified")).toBe(true);
+    expect(meetsKycRequirement("BusinessVerified", "IdentityVerified")).toBe(true);
+  });
+
+  it("returns false when actual KYC is below the required level", () => {
+    expect(meetsKycRequirement("Unverified", "EmailVerified")).toBe(false);
+    expect(meetsKycRequirement("EmailVerified", "IdentityVerified")).toBe(false);
+  });
+});

--- a/typescript/packages/extensions/test/vcx-resolver.test.ts
+++ b/typescript/packages/extensions/test/vcx-resolver.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildHardenedWebResolver, didWebToUrl } from "../src/vcx";
+
+// Stand-in for the `parsed` arg the did-resolver runtime passes; the
+// hardened resolver doesn't read it, so an empty placeholder is enough.
+const dummyParsed = {
+  did: "",
+  didUrl: "",
+  method: "web",
+  id: "",
+} as unknown as Parameters<ReturnType<typeof buildHardenedWebResolver>>[1];
+
+const dummyOptions = { accept: "application/did+json" };
+const dummyResolver = {} as Parameters<ReturnType<typeof buildHardenedWebResolver>>[2];
+
+/**
+ * Builds a 200 JSON `Response` with the DID-document content type for the given body.
+ *
+ * @param body - The value to JSON-serialize as the response body.
+ * @param init - Optional response init overrides merged over the defaults.
+ * @returns A `Response` carrying the serialized body.
+ */
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/did+json" },
+    ...init,
+  });
+}
+
+describe("didWebToUrl", () => {
+  it("maps a domain-only did:web to /.well-known/did.json", () => {
+    expect(didWebToUrl("did:web:example.com").toString()).toBe(
+      "https://example.com/.well-known/did.json",
+    );
+  });
+
+  it("maps a path-bearing did:web to /path/segments/did.json", () => {
+    expect(didWebToUrl("did:web:example.com:users:alice").toString()).toBe(
+      "https://example.com/users/alice/did.json",
+    );
+  });
+
+  it("URL-decodes a port-bearing domain (%3A)", () => {
+    expect(didWebToUrl("did:web:example.com%3A8443:users:alice").toString()).toBe(
+      "https://example.com:8443/users/alice/did.json",
+    );
+  });
+
+  it("rejects identifiers that don't start with did:web:", () => {
+    expect(() => didWebToUrl("did:key:zAbc")).toThrow();
+  });
+
+  it("rejects an empty identifier", () => {
+    expect(() => didWebToUrl("did:web:")).toThrow();
+  });
+});
+
+describe("buildHardenedWebResolver — happy path", () => {
+  it("returns the DID document on a 200 with matching id", async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({
+        id: "did:web:example.com",
+        verificationMethod: [],
+      })) as unknown as typeof fetch;
+    const resolver = buildHardenedWebResolver({ fetchImpl });
+    const result = await resolver("did:web:example.com", dummyParsed, dummyResolver, dummyOptions);
+    expect(result.didResolutionMetadata.error).toBeUndefined();
+    expect(result.didDocument?.id).toBe("did:web:example.com");
+  });
+});
+
+describe("buildHardenedWebResolver — TLS / scheme hardening (§7.2)", () => {
+  it("rejects a redirect to http://", async () => {
+    let callCount = 0;
+    const fetchImpl = (async (): Promise<Response> => {
+      callCount += 1;
+      return new Response("", {
+        status: 301,
+        headers: { location: "http://example.com/users/alice/did.json" },
+      });
+    }) as unknown as typeof fetch;
+    const resolver = buildHardenedWebResolver({
+      fetchImpl,
+      maxSameHostRedirects: 1,
+    });
+    const result = await resolver(
+      "did:web:example.com:users:alice",
+      dummyParsed,
+      dummyResolver,
+      dummyOptions,
+    );
+    expect(result.didResolutionMetadata.error).toBe("notFound");
+    expect(result.didResolutionMetadata.message ?? "").toMatch(/redirect refused: http/);
+    expect(callCount).toBe(1);
+  });
+
+  it("rejects a cross-host redirect", async () => {
+    const fetchImpl = (async (): Promise<Response> => {
+      return new Response("", {
+        status: 302,
+        headers: { location: "https://attacker.test/users/alice/did.json" },
+      });
+    }) as unknown as typeof fetch;
+    const resolver = buildHardenedWebResolver({
+      fetchImpl,
+      maxSameHostRedirects: 5,
+    });
+    const result = await resolver(
+      "did:web:example.com:users:alice",
+      dummyParsed,
+      dummyResolver,
+      dummyOptions,
+    );
+    expect(result.didResolutionMetadata.error).toBe("notFound");
+    expect(result.didResolutionMetadata.message ?? "").toMatch(/cross-host redirect refused/);
+  });
+
+  it("follows a same-host redirect within the redirect budget", async () => {
+    let call = 0;
+    const fetchImpl = (async (url: RequestInfo | URL): Promise<Response> => {
+      call += 1;
+      const u = typeof url === "string" ? url : url.toString();
+      if (call === 1) {
+        // First request → 301 to same host, different path
+        return new Response("", {
+          status: 301,
+          headers: { location: "/users/alice/did-v2.json" },
+        });
+      }
+      if (u.endsWith("/users/alice/did-v2.json")) {
+        return jsonResponse({ id: "did:web:example.com:users:alice" });
+      }
+      return new Response("not found", { status: 404 });
+    }) as unknown as typeof fetch;
+    const resolver = buildHardenedWebResolver({
+      fetchImpl,
+      maxSameHostRedirects: 1,
+    });
+    const result = await resolver(
+      "did:web:example.com:users:alice",
+      dummyParsed,
+      dummyResolver,
+      dummyOptions,
+    );
+    expect(result.didResolutionMetadata.error).toBeUndefined();
+    expect(result.didDocument?.id).toBe("did:web:example.com:users:alice");
+    expect(call).toBe(2);
+  });
+
+  it("rejects when the redirect budget is exhausted", async () => {
+    const fetchImpl = (async (): Promise<Response> => {
+      return new Response("", {
+        status: 301,
+        headers: { location: "/again/did.json" },
+      });
+    }) as unknown as typeof fetch;
+    const resolver = buildHardenedWebResolver({
+      fetchImpl,
+      maxSameHostRedirects: 2,
+    });
+    const result = await resolver("did:web:example.com", dummyParsed, dummyResolver, dummyOptions);
+    expect(result.didResolutionMetadata.error).toBe("notFound");
+    expect(result.didResolutionMetadata.message ?? "").toMatch(/maxSameHostRedirects/);
+  });
+
+  it("rejects a 3xx with no Location header", async () => {
+    const fetchImpl = (async () => new Response("", { status: 301 })) as unknown as typeof fetch;
+    const resolver = buildHardenedWebResolver({
+      fetchImpl,
+      maxSameHostRedirects: 1,
+    });
+    const result = await resolver("did:web:example.com", dummyParsed, dummyResolver, dummyOptions);
+    expect(result.didResolutionMetadata.error).toBe("notFound");
+    expect(result.didResolutionMetadata.message ?? "").toMatch(/no Location header/);
+  });
+});
+
+describe("buildHardenedWebResolver — body validation", () => {
+  it("rejects when the response is not 2xx", async () => {
+    const fetchImpl = (async () =>
+      new Response("server exploded", { status: 500 })) as unknown as typeof fetch;
+    const resolver = buildHardenedWebResolver({ fetchImpl });
+    const result = await resolver("did:web:example.com", dummyParsed, dummyResolver, dummyOptions);
+    expect(result.didResolutionMetadata.error).toBe("notFound");
+    expect(result.didResolutionMetadata.message ?? "").toMatch(/HTTP 500/);
+  });
+
+  it("rejects when the response body is not JSON", async () => {
+    const fetchImpl = (async () =>
+      new Response("<html></html>", { status: 200 })) as unknown as typeof fetch;
+    const resolver = buildHardenedWebResolver({ fetchImpl });
+    const result = await resolver("did:web:example.com", dummyParsed, dummyResolver, dummyOptions);
+    expect(result.didResolutionMetadata.error).toBe("notFound");
+    expect(result.didResolutionMetadata.message ?? "").toMatch(/not valid JSON/);
+  });
+
+  it("rejects when the document.id does not match the resolved DID", async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({ id: "did:web:other.com" })) as unknown as typeof fetch;
+    const resolver = buildHardenedWebResolver({ fetchImpl });
+    const result = await resolver("did:web:example.com", dummyParsed, dummyResolver, dummyOptions);
+    expect(result.didResolutionMetadata.error).toBe("notFound");
+    expect(result.didResolutionMetadata.message ?? "").toMatch(/document\.id.*does not match/);
+  });
+});

--- a/typescript/packages/extensions/test/vcx-revocation.test.ts
+++ b/typescript/packages/extensions/test/vcx-revocation.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildIdentityEnvelope,
+  buildCredentialSubject,
+  buildDelegation,
+  createAgent,
+  verifyEnvelope,
+  InMemoryStatusListCache,
+  DisclosureTier,
+} from "../src/vcx";
+import {
+  trustedIssuer,
+  principalDid,
+  principalClaims,
+  paymentSource,
+  requirements,
+  newIssuer,
+} from "./vcx-test-utils";
+import {
+  STATUS_LIST_URL,
+  buildEncodedList,
+  issueStatusListCredential,
+  issueLongLivedCredential,
+  issueShortLivedCredentialWithStatus,
+  mockStatusListFetch,
+} from "./vcx-test-utils";
+
+const validExpiresAt = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+/**
+ * Build a long-lived credential scenario: an identity envelope plus a matching
+ * signed status list credential with the given revoked indices.
+ *
+ * @param opts - Options for the scenario.
+ * @param opts.statusListIndex - The status list index assigned to the credential.
+ * @param opts.revokedIndices - The indices marked revoked in the status list.
+ * @returns The envelope, agent, credential JWT, and status list JWT.
+ */
+async function buildLongLivedScenario(opts: { statusListIndex: number; revokedIndices: number[] }) {
+  const agent = createAgent("revocation-test-agent");
+  const delegation = buildDelegation({
+    agentDid: agent.did,
+    paymentSource: paymentSource.accountId,
+    conditions: { expiresAt: validExpiresAt() },
+  });
+  const subject = buildCredentialSubject({
+    principalDid,
+    claims: principalClaims,
+    delegation,
+  });
+  const jwt = await issueLongLivedCredential({
+    issuerConfig: trustedIssuer,
+    subject,
+    statusListIndex: opts.statusListIndex,
+  });
+  const envelope = buildIdentityEnvelope({
+    credentialJwt: jwt,
+    principalDid,
+    principalClaims,
+    agentDid: agent.did,
+    agentName: agent.name,
+    delegationProof: jwt,
+    paymentSource,
+    disclosureTier: DisclosureTier.SelectiveClaims,
+    requiredClaims: requirements.requiredClaims,
+  });
+  const statusListJwt = await issueStatusListCredential({
+    issuerConfig: trustedIssuer,
+    encodedList: buildEncodedList({ revokedIndices: opts.revokedIndices }),
+  });
+  return { envelope, agent, jwt, statusListJwt };
+}
+
+describe("checkCredentialStatus — short-lived profile (§11.1)", () => {
+  it("rejects a short-lived credential that carries a credentialStatus field", async () => {
+    const agent = createAgent("short-lived-with-status-agent");
+    const delegation = buildDelegation({
+      agentDid: agent.did,
+      paymentSource: paymentSource.accountId,
+      conditions: { expiresAt: validExpiresAt() },
+    });
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation,
+    });
+    const jwt = await issueShortLivedCredentialWithStatus({
+      issuerConfig: trustedIssuer,
+      subject,
+    });
+    const envelope = buildIdentityEnvelope({
+      credentialJwt: jwt,
+      principalDid,
+      principalClaims,
+      agentDid: agent.did,
+      agentName: agent.name,
+      delegationProof: jwt,
+      paymentSource,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: requirements.requiredClaims,
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].step).toBe("principal_credential");
+    expect(result.steps[0].error ?? "").toMatch(/Short-lived.*credentialStatus/);
+  });
+});
+
+describe("checkCredentialStatus — Bitstring Status List v1.0 (§11.2)", () => {
+  it("accepts a long-lived credential whose status bit is 0", async () => {
+    const { envelope, statusListJwt } = await buildLongLivedScenario({
+      statusListIndex: 42,
+      revokedIndices: [],
+    });
+    const fetchMock = mockStatusListFetch({ body: statusListJwt });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      fetchImpl: fetchMock,
+    });
+    expect(result.valid).toBe(true);
+    expect(fetchMock.calls).toBe(1);
+  });
+
+  it("rejects a long-lived credential whose status bit is 1 (revoked)", async () => {
+    const { envelope, statusListJwt } = await buildLongLivedScenario({
+      statusListIndex: 42,
+      revokedIndices: [42],
+    });
+    const fetchMock = mockStatusListFetch({ body: statusListJwt });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      fetchImpl: fetchMock,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].error ?? "").toMatch(/revoked/);
+  });
+
+  it("rejects a long-lived credential with no credentialStatus field", async () => {
+    const agent = createAgent("long-lived-no-status-agent");
+    const delegation = buildDelegation({
+      agentDid: agent.did,
+      paymentSource: paymentSource.accountId,
+      conditions: { expiresAt: validExpiresAt() },
+    });
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation,
+    });
+    // Issue with 48h lifetime but no credentialStatus override → uses
+    // the helper's default, which DOES set credentialStatus. To exercise
+    // the missing-status path we must drop the override after the fact.
+    // Easier: build the long-lived JWT then mutate. But did-jwt-vc would
+    // re-sign. Cleanest: use issueShortLivedCredentialWithStatus's helper
+    // pattern but with no status. Build it inline instead.
+    const { createVerifiableCredentialJwt } = await import("did-jwt-vc");
+    const { EdDSASigner } = await import("did-jwt");
+    const issuer = {
+      did: trustedIssuer.did,
+      signer: EdDSASigner(Uint8Array.from(Buffer.from(trustedIssuer.privateKeyHex, "hex"))),
+      alg: "EdDSA",
+    };
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await createVerifiableCredentialJwt(
+      {
+        sub: subject.id,
+        nbf: now,
+        exp: now + 48 * 60 * 60,
+        vc: {
+          "@context": ["https://www.w3.org/2018/credentials/v1"],
+          type: ["VerifiableCredential", "X402IdentityCredential"],
+          credentialSubject: subject,
+        },
+      },
+      issuer,
+    );
+    const envelope = buildIdentityEnvelope({
+      credentialJwt: jwt,
+      principalDid,
+      principalClaims,
+      agentDid: agent.did,
+      agentName: agent.name,
+      delegationProof: jwt,
+      paymentSource,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: requirements.requiredClaims,
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].error ?? "").toMatch(/Long-lived.*credentialStatus/);
+  });
+
+  it("rejects a credentialStatus whose type is not BitstringStatusListEntry", async () => {
+    const agent = createAgent("wrong-status-type-agent");
+    const delegation = buildDelegation({
+      agentDid: agent.did,
+      paymentSource: paymentSource.accountId,
+      conditions: { expiresAt: validExpiresAt() },
+    });
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation,
+    });
+    const jwt = await issueLongLivedCredential({
+      issuerConfig: trustedIssuer,
+      subject,
+      statusListIndex: 0,
+      credentialStatusOverride: {
+        id: `${STATUS_LIST_URL}#0`,
+        type: "RevocationList2020Status", // legacy type, not accepted in v1
+        statusListIndex: "0",
+        statusListCredential: STATUS_LIST_URL,
+      },
+    });
+    const envelope = buildIdentityEnvelope({
+      credentialJwt: jwt,
+      principalDid,
+      principalClaims,
+      agentDid: agent.did,
+      agentName: agent.name,
+      delegationProof: jwt,
+      paymentSource,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: requirements.requiredClaims,
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].error ?? "").toMatch(/BitstringStatusListEntry/);
+  });
+
+  it("rejects a credentialStatus whose statusPurpose is not revocation", async () => {
+    const agent = createAgent("wrong-purpose-agent");
+    const delegation = buildDelegation({
+      agentDid: agent.did,
+      paymentSource: paymentSource.accountId,
+      conditions: { expiresAt: validExpiresAt() },
+    });
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation,
+    });
+    const jwt = await issueLongLivedCredential({
+      issuerConfig: trustedIssuer,
+      subject,
+      statusListIndex: 0,
+      credentialStatusOverride: {
+        id: `${STATUS_LIST_URL}#0`,
+        type: "BitstringStatusListEntry",
+        statusPurpose: "suspension", // v1 supports revocation only
+        statusListIndex: "0",
+        statusListCredential: STATUS_LIST_URL,
+      },
+    });
+    const envelope = buildIdentityEnvelope({
+      credentialJwt: jwt,
+      principalDid,
+      principalClaims,
+      agentDid: agent.did,
+      agentName: agent.name,
+      delegationProof: jwt,
+      paymentSource,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: requirements.requiredClaims,
+    });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId);
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].error ?? "").toMatch(/statusPurpose.*revocation/);
+  });
+
+  it("rejects a status list signed by a different issuer than the credential", async () => {
+    const otherIssuer = newIssuer();
+    const { envelope } = await buildLongLivedScenario({
+      statusListIndex: 0,
+      revokedIndices: [],
+    });
+    // Sign status list with a DIFFERENT issuer than the principal credential.
+    const statusListJwt = await issueStatusListCredential({
+      issuerConfig: otherIssuer,
+      encodedList: buildEncodedList({ revokedIndices: [] }),
+    });
+    const fetchMock = mockStatusListFetch({ body: statusListJwt });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      fetchImpl: fetchMock,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].error ?? "").toMatch(/status list issuer.*MUST equal/);
+  });
+
+  it("honours the cache: second verification of the same status list URL does not refetch", async () => {
+    const { envelope, statusListJwt } = await buildLongLivedScenario({
+      statusListIndex: 7,
+      revokedIndices: [],
+    });
+    const cache = new InMemoryStatusListCache();
+    const fetchMock = mockStatusListFetch({
+      body: statusListJwt,
+      cacheControl: "max-age=3600",
+    });
+    const first = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      fetchImpl: fetchMock,
+      statusListCache: cache,
+    });
+    expect(first.valid).toBe(true);
+    expect(fetchMock.calls).toBe(1);
+
+    // Build a second envelope referencing the same status list at a
+    // different index. Cache HIT should mean no second fetch.
+    const second = await buildLongLivedScenario({
+      statusListIndex: 8,
+      revokedIndices: [],
+    });
+    const secondResult = await verifyEnvelope(
+      second.envelope,
+      requirements,
+      paymentSource.sourceId,
+      { fetchImpl: fetchMock, statusListCache: cache },
+    );
+    expect(secondResult.valid).toBe(true);
+    expect(fetchMock.calls).toBe(1);
+  });
+
+  it("rejects when status list fetch returns non-2xx", async () => {
+    const { envelope } = await buildLongLivedScenario({
+      statusListIndex: 0,
+      revokedIndices: [],
+    });
+    // mockStatusListFetch returns 404 for any URL that isn't STATUS_LIST_URL;
+    // here we override by giving it the wrong base body — but the cleanest
+    // way to test the error path is just an empty fetch impl that 500s.
+    const failingFetch = async (): Promise<Response> =>
+      new Response("server exploded", { status: 500 });
+    const result = await verifyEnvelope(envelope, requirements, paymentSource.sourceId, {
+      fetchImpl: failingFetch as typeof fetch,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].error ?? "").toMatch(/HTTP 500|Failed to fetch/);
+  });
+});

--- a/typescript/packages/extensions/test/vcx-sdjwtvc.test.ts
+++ b/typescript/packages/extensions/test/vcx-sdjwtvc.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildDisclosure,
+  buildIdentityEnvelope,
+  buildCredentialSubject,
+  buildDelegation,
+  composeSdJwt,
+  createAgent,
+  disclosureHash,
+  DisclosureTier,
+  issueCredential,
+  parseDisclosure,
+  parseSdJwt,
+  verifyEnvelope,
+  verifySdJwtVcPresentation,
+  getDidResolver,
+} from "../src/vcx";
+import {
+  trustedIssuer,
+  principalDid,
+  principalClaims,
+  paymentSource,
+  requirements,
+} from "./vcx-test-utils";
+
+const validExpiresAt = () => new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+describe("SD-JWT format primitives", () => {
+  it("round-trips a disclosure: build → hash matches; parse → original values", () => {
+    const d = buildDisclosure("ageOver18", true, "fixed-salt-123");
+    const parsed = parseDisclosure(d);
+    expect(parsed.salt).toBe("fixed-salt-123");
+    expect(parsed.name).toBe("ageOver18");
+    expect(parsed.value).toBe(true);
+    // Same disclosure → same hash (idempotent).
+    expect(disclosureHash(d)).toBe(disclosureHash(d));
+  });
+
+  it("rejects a malformed disclosure (non-array JSON)", () => {
+    const garbage = Buffer.from('{"not":"an array"}', "utf8").toString("base64url");
+    expect(() => parseDisclosure(garbage)).toThrow(/3-element array/);
+  });
+
+  it("parses SD-JWT format: <jwt>~<d1>~<d2>~", () => {
+    const composed = composeSdJwt("h.p.s", ["d1", "d2"]);
+    expect(composed).toBe("h.p.s~d1~d2~");
+    const parsed = parseSdJwt(composed);
+    expect(parsed.jwt).toBe("h.p.s");
+    expect(parsed.disclosures).toEqual(["d1", "d2"]);
+    expect(parsed.keyBindingJwt).toBeUndefined();
+  });
+
+  it("captures a trailing KB-JWT (3-part JWT shape) separately from disclosures", () => {
+    // A KB-JWT is a compact JWS: exactly three parts (header.payload.signature).
+    const parsed = parseSdJwt("h.p.s~d1~d2~kb.payload.sig");
+    expect(parsed.jwt).toBe("h.p.s");
+    expect(parsed.disclosures).toEqual(["d1", "d2"]);
+    expect(parsed.keyBindingJwt).toBe("kb.payload.sig");
+  });
+});
+
+describe("issueCredential — sd-jwt-vc format", () => {
+  it("returns a string in SD-JWT format with one ~ per disclosure", async () => {
+    const agent = createAgent("sd-jwt-issuance-agent");
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation: buildDelegation({
+        agentDid: agent.did,
+        paymentSource: paymentSource.accountId,
+        conditions: { expiresAt: validExpiresAt() },
+      }),
+    });
+    const { jwt: sdjwt, format } = await issueCredential({
+      issuerConfig: trustedIssuer,
+      subject,
+      format: "sd-jwt-vc",
+      selectivelyDisclosable: ["ageOver18", "jurisdiction"],
+    });
+    expect(format).toBe("sd-jwt-vc");
+    const parsed = parseSdJwt(sdjwt);
+    // Two disclosable claims → at least two disclosures (jurisdiction
+    // may be absent from principalClaims, in which case it's skipped).
+    expect(parsed.disclosures.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("verifySdJwtVcPresentation", () => {
+  it("returns disclosed claim values for a valid presentation", async () => {
+    const agent = createAgent("sd-jwt-verify-agent");
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation: buildDelegation({
+        agentDid: agent.did,
+        paymentSource: paymentSource.accountId,
+        conditions: { expiresAt: validExpiresAt() },
+      }),
+    });
+    const { jwt: sdjwt } = await issueCredential({
+      issuerConfig: trustedIssuer,
+      subject,
+      format: "sd-jwt-vc",
+      selectivelyDisclosable: ["ageOver18"],
+    });
+    const result = await verifySdJwtVcPresentation({
+      sdjwt,
+      resolver: getDidResolver(),
+    });
+    expect(result.issuer).toBe(trustedIssuer.did);
+    expect(result.disclosed.ageOver18).toBe(true);
+  });
+
+  it("rejects a presentation with a forged disclosure (hash not in _sd)", async () => {
+    const agent = createAgent("sd-jwt-forged-agent");
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation: buildDelegation({
+        agentDid: agent.did,
+        paymentSource: paymentSource.accountId,
+        conditions: { expiresAt: validExpiresAt() },
+      }),
+    });
+    const { jwt: sdjwt } = await issueCredential({
+      issuerConfig: trustedIssuer,
+      subject,
+      format: "sd-jwt-vc",
+      selectivelyDisclosable: ["ageOver18"],
+    });
+    // Append an attacker-constructed disclosure that the issuer never
+    // committed to: claims "vipStatus: platinum".
+    const forged = buildDisclosure("vipStatus", "platinum");
+    const parsed = parseSdJwt(sdjwt);
+    const tampered = composeSdJwt(parsed.jwt, [...parsed.disclosures, forged]);
+    await expect(
+      verifySdJwtVcPresentation({ sdjwt: tampered, resolver: getDidResolver() }),
+    ).rejects.toThrow(/not present in issuer _sd commitments|forged disclosure/);
+  });
+
+  it("rejects when the issuer JWT signature is broken", async () => {
+    const agent = createAgent("sd-jwt-tamper-agent");
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation: buildDelegation({
+        agentDid: agent.did,
+        paymentSource: paymentSource.accountId,
+        conditions: { expiresAt: validExpiresAt() },
+      }),
+    });
+    const { jwt: sdjwt } = await issueCredential({
+      issuerConfig: trustedIssuer,
+      subject,
+      format: "sd-jwt-vc",
+      selectivelyDisclosable: ["ageOver18"],
+    });
+    const parsed = parseSdJwt(sdjwt);
+    // Flip one character of the JWT signature.
+    const jwtParts = parsed.jwt.split(".");
+    const sig = jwtParts[2];
+    jwtParts[2] = sig.slice(0, -1) + (sig.endsWith("A") ? "B" : "A");
+    const tampered = composeSdJwt(jwtParts.join("."), parsed.disclosures);
+    await expect(
+      verifySdJwtVcPresentation({ sdjwt: tampered, resolver: getDidResolver() }),
+    ).rejects.toThrow(/issuer JWT verification failed/);
+  });
+});
+
+describe("verifyEnvelope — sd-jwt-vc end-to-end (§12 Tier 1)", () => {
+  it("accepts an envelope built from a valid SD-JWT VC presentation", async () => {
+    const agent = createAgent("e2e-sd-jwt-vc-agent");
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation: buildDelegation({
+        agentDid: agent.did,
+        paymentSource: paymentSource.accountId,
+        conditions: { expiresAt: validExpiresAt() },
+      }),
+    });
+    const { jwt: sdjwt } = await issueCredential({
+      issuerConfig: trustedIssuer,
+      subject,
+      format: "sd-jwt-vc",
+      selectivelyDisclosable: ["ageOver18"],
+    });
+    const envelope = buildIdentityEnvelope({
+      credentialFormat: "sd-jwt-vc",
+      credentialJwt: sdjwt,
+      principalDid,
+      principalClaims: { ageOver18: true },
+      agentDid: agent.did,
+      agentName: agent.name,
+      delegationProof: sdjwt,
+      paymentSource,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: ["ageOver18"],
+    });
+    const result = await verifyEnvelope(
+      envelope,
+      { ...requirements, requiredClaims: ["ageOver18"] },
+      paymentSource.sourceId,
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects when the envelope claims a disclosed value the SD-JWT VC didn't actually disclose", async () => {
+    const agent = createAgent("e2e-sd-jwt-vc-mismatch-agent");
+    const subject = buildCredentialSubject({
+      principalDid,
+      claims: principalClaims,
+      delegation: buildDelegation({
+        agentDid: agent.did,
+        paymentSource: paymentSource.accountId,
+        conditions: { expiresAt: validExpiresAt() },
+      }),
+    });
+    const { jwt: sdjwt } = await issueCredential({
+      issuerConfig: trustedIssuer,
+      subject,
+      format: "sd-jwt-vc",
+      selectivelyDisclosable: ["ageOver18"],
+    });
+    const envelope = buildIdentityEnvelope({
+      credentialFormat: "sd-jwt-vc",
+      credentialJwt: sdjwt,
+      principalDid,
+      principalClaims: { ageOver18: false }, // claim the opposite of what's disclosed
+      agentDid: agent.did,
+      agentName: agent.name,
+      delegationProof: sdjwt,
+      paymentSource,
+      disclosureTier: DisclosureTier.SelectiveClaims,
+      requiredClaims: ["ageOver18"],
+    });
+    const result = await verifyEnvelope(
+      envelope,
+      { ...requirements, requiredClaims: ["ageOver18"] },
+      paymentSource.sourceId,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.steps[0].step).toBe("principal_credential");
+    expect(result.steps[0].error ?? "").toMatch(/does not match the SD-JWT VC disclosure/);
+  });
+});

--- a/typescript/packages/extensions/test/vcx-server.test.ts
+++ b/typescript/packages/extensions/test/vcx-server.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// AUTHORED OFFLINE — first CI run is the verification step.
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  createVCXResourceServerExtension,
+  declareVCXExtension,
+  VCX_EXTENSION_KEY,
+  encodeVCXHeader,
+  InMemoryNonceStorage,
+  buildIdentityEnvelope,
+  buildCredentialSubject,
+  buildDelegation,
+  createAgent,
+  issueCredential,
+  DisclosureTier,
+  type VCXRequestContext,
+} from "../src/vcx";
+import {
+  trustedIssuer,
+  principalDid,
+  principalClaims,
+  paymentSource,
+  requirements,
+} from "./vcx-test-utils";
+
+/**
+ * Build a fully valid VCX identity envelope (agent, delegation, credential)
+ * for use as the happy-path fixture in server extension tests.
+ *
+ * @returns A signed, verifiable VCX identity envelope.
+ */
+async function buildValidEnvelope() {
+  const agent = createAgent("server-test-agent");
+  const delegation = buildDelegation({
+    agentDid: agent.did,
+    paymentSource: paymentSource.accountId,
+    conditions: {
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    },
+  });
+  const subject = buildCredentialSubject({
+    principalDid,
+    claims: principalClaims,
+    delegation,
+  });
+  const { jwt } = await issueCredential({
+    issuerConfig: trustedIssuer,
+    subject,
+  });
+  return buildIdentityEnvelope({
+    credentialJwt: jwt,
+    principalDid,
+    principalClaims,
+    agentDid: agent.did,
+    agentName: agent.name,
+    delegationProof: jwt,
+    paymentSource,
+    disclosureTier: DisclosureTier.SelectiveClaims,
+    requiredClaims: requirements.requiredClaims,
+  });
+}
+
+/**
+ * Encode a mock base64 X-PAYMENT header carrying the given payment sender address.
+ *
+ * @param sender - The payment sender address to embed in the authorization payload.
+ * @returns A base64-encoded X-PAYMENT header value.
+ */
+function encodePaymentHeader(sender: string): string {
+  return Buffer.from(JSON.stringify({ payload: { authorization: { from: sender } } })).toString(
+    "base64",
+  );
+}
+
+// Realistic extract function — mirrors the JSDoc example in src/server.ts.
+const extractFromPayment = (ctx: VCXRequestContext): string => {
+  const raw = ctx.getHeader("X-PAYMENT");
+  if (!raw) return "";
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64").toString("utf8")) as {
+      payload?: { authorization?: { from?: string } };
+    };
+    return parsed.payload?.authorization?.from ?? "";
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * Build a mock request context whose adapter serves the given VCX and
+ * X-PAYMENT headers, for driving the onProtectedRequest hook.
+ *
+ * @param vcxHeader - The VCX header value to serve, or undefined to omit it.
+ * @param sender - The payment sender address encoded into the X-PAYMENT header.
+ * @returns A mock request context with a header-resolving adapter.
+ */
+function makeContext(vcxHeader: string | undefined, sender: string = paymentSource.sourceId) {
+  const paymentHeader = encodePaymentHeader(sender);
+  return {
+    adapter: {
+      getHeader: (name: string): string | undefined => {
+        const lower = name.toLowerCase();
+        if (lower === "vcx") return vcxHeader;
+        if (lower === "x-payment") return paymentHeader;
+        return undefined;
+      },
+    },
+  };
+}
+
+const declarationFor = (overrides: Partial<Parameters<typeof declareVCXExtension>[0]> = {}) =>
+  declareVCXExtension({
+    disclosureTier: DisclosureTier.SelectiveClaims,
+    requiredClaims: ["kycLevel", "ageOver18"],
+    minKycLevel: "IdentityVerified",
+    acceptedIssuers: [trustedIssuer.did],
+    ...overrides,
+  })[VCX_EXTENSION_KEY];
+
+const newServerExtension = (
+  overrides: Partial<Parameters<typeof createVCXResourceServerExtension>[0]> = {},
+) =>
+  createVCXResourceServerExtension({
+    extractPaymentSender: extractFromPayment,
+    nonceStorage: new InMemoryNonceStorage(),
+    ...overrides,
+  });
+
+describe("createVCXResourceServerExtension", () => {
+  it("returns an extension registered under the VCX key", () => {
+    const ext = newServerExtension();
+    expect(ext.key).toBe(VCX_EXTENSION_KEY);
+    expect(ext.transportHooks?.http).toBeDefined();
+  });
+
+  describe("enrichPaymentRequiredResponse", () => {
+    it("returns the declaration's info and schema", async () => {
+      const ext = newServerExtension();
+      const decl = declarationFor();
+      const enriched = (await ext.enrichPaymentRequiredResponse!(decl, {} as never)) as {
+        info: unknown;
+        schema: unknown;
+      };
+      expect(enriched.info).toEqual(decl.info);
+      expect(enriched.schema).toEqual(decl.schema);
+    });
+  });
+
+  describe("onProtectedRequest", () => {
+    it("aborts when the VCX header is missing", async () => {
+      const ext = newServerExtension();
+      const result = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext(undefined),
+        {},
+      );
+      expect(result).toEqual({
+        abort: true,
+        reason: expect.stringMatching(/missing VCX header/i),
+      });
+    });
+
+    it("aborts when the VCX header is malformed", async () => {
+      const ext = newServerExtension();
+      const result = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext("not-base64-or-json-at-all"),
+        {},
+      );
+      expect(result).toEqual({
+        abort: true,
+        reason: expect.stringMatching(/malformed envelope/i),
+      });
+    });
+
+    it("aborts when verification fails (wrong payment sender)", async () => {
+      const envelope = await buildValidEnvelope();
+      const headerValue = encodeVCXHeader(envelope);
+      const ext = newServerExtension();
+      const result = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext(headerValue, "0xWRONGSENDER"),
+        {},
+      );
+      expect(result).toEqual({
+        abort: true,
+        reason: expect.stringMatching(/payment_source_binding/i),
+      });
+    });
+
+    it("aborts on transactionId replay within the freshness window", async () => {
+      const envelope = await buildValidEnvelope();
+      const headerValue = encodeVCXHeader(envelope);
+      const ext = newServerExtension();
+
+      // First request succeeds and records the nonce.
+      const first = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext(headerValue),
+        {},
+      );
+      expect(first).toBeUndefined();
+
+      // Second identical request aborts as replay.
+      const second = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext(headerValue),
+        {},
+      );
+      expect(second).toEqual({
+        abort: true,
+        reason: expect.stringMatching(/already processed within the freshness window/i),
+      });
+    });
+
+    it("does NOT consume the nonce when verification fails (verify-then-record)", async () => {
+      const envelope = await buildValidEnvelope();
+      const headerValue = encodeVCXHeader(envelope);
+      const ext = newServerExtension();
+
+      // First request fails verification — nonce must remain unused.
+      const failed = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext(headerValue, "0xWRONGSENDER"),
+        {},
+      );
+      expect(failed).toEqual({
+        abort: true,
+        reason: expect.stringMatching(/payment_source_binding/i),
+      });
+
+      // Second request with the same envelope but correct sender should succeed —
+      // the failed attempt above did not poison the nonce cache.
+      const success = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext(headerValue),
+        {},
+      );
+      expect(success).toBeUndefined();
+    });
+
+    it("aborts when extractPaymentSender throws", async () => {
+      const ext = newServerExtension({
+        extractPaymentSender: () => {
+          throw new Error("scheme decoder unavailable");
+        },
+      });
+      const envelope = await buildValidEnvelope();
+      const headerValue = encodeVCXHeader(envelope);
+      const result = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext(headerValue),
+        {},
+      );
+      expect(result).toEqual({
+        abort: true,
+        reason: expect.stringMatching(/extractor threw/i),
+      });
+    });
+
+    it("succeeds and invokes onVerify when the envelope is valid", async () => {
+      const envelope = await buildValidEnvelope();
+      const headerValue = encodeVCXHeader(envelope);
+      const onVerify = vi.fn();
+      const ext = newServerExtension({ onVerify });
+      const result = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext(headerValue),
+        {},
+      );
+      expect(result).toBeUndefined();
+      expect(onVerify).toHaveBeenCalledTimes(1);
+      const [verifiedEnvelope, verification] = onVerify.mock.calls[0];
+      expect(verifiedEnvelope.transactionId).toBe(envelope.transactionId);
+      expect(verification.valid).toBe(true);
+    });
+
+    it("invokes onVerify even when verification fails", async () => {
+      const envelope = await buildValidEnvelope();
+      const headerValue = encodeVCXHeader(envelope);
+      const onVerify = vi.fn();
+      const ext = newServerExtension({ onVerify });
+      const result = await ext.transportHooks!.http!.onProtectedRequest!(
+        declarationFor(),
+        makeContext(headerValue, "0xWRONGSENDER"),
+        {},
+      );
+      expect(result).toEqual({
+        abort: true,
+        reason: expect.stringMatching(/payment_source_binding/i),
+      });
+      expect(onVerify).toHaveBeenCalledTimes(1);
+      expect(onVerify.mock.calls[0][1].valid).toBe(false);
+    });
+  });
+});

--- a/typescript/packages/extensions/test/vcx-storage.test.ts
+++ b/typescript/packages/extensions/test/vcx-storage.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// AUTHORED OFFLINE — first CI run is the verification step.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { InMemoryNonceStorage, NoOpNonceStorage } from "../src/vcx";
+
+const WINDOW = 60_000;
+
+describe("InMemoryNonceStorage", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false on first sighting and true on immediate replay", async () => {
+    const store = new InMemoryNonceStorage();
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(false);
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(true);
+  });
+
+  it("treats distinct nonces independently", async () => {
+    const store = new InMemoryNonceStorage();
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(false);
+    expect(await store.checkAndRecord("nonce-b", WINDOW)).toBe(false);
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(true);
+    expect(await store.checkAndRecord("nonce-b", WINDOW)).toBe(true);
+  });
+
+  it("evicts entries older than the freshness window", async () => {
+    vi.useFakeTimers();
+    const store = new InMemoryNonceStorage();
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(false);
+
+    vi.advanceTimersByTime(WINDOW + 1);
+
+    // After the window elapses, the nonce should be fresh again.
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(false);
+  });
+
+  it("does not evict entries within the freshness window", async () => {
+    vi.useFakeTimers();
+    const store = new InMemoryNonceStorage();
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(false);
+
+    vi.advanceTimersByTime(WINDOW - 1);
+
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(true);
+  });
+});
+
+describe("NoOpNonceStorage", () => {
+  it("always reports nonces as new (disables replay protection)", async () => {
+    const store = new NoOpNonceStorage();
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(false);
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(false);
+    expect(await store.checkAndRecord("nonce-a", WINDOW)).toBe(false);
+  });
+});

--- a/typescript/packages/extensions/test/vcx-test-utils.ts
+++ b/typescript/packages/extensions/test/vcx-test-utils.ts
@@ -1,0 +1,270 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gzipSync } from "zlib";
+import { createVerifiableCredentialJwt, type Issuer } from "did-jwt-vc";
+import { EdDSASigner } from "did-jwt";
+import {
+  DisclosureTier,
+  generateEd25519KeyPair,
+  type IssuerConfig,
+  type PrincipalClaims,
+  type PaymentSourceLayer,
+  type IdentityRequirements,
+  type VCXCredentialSubject,
+} from "../src/vcx";
+
+// -----------------------------------------------------------------
+// Stable demo issuer + principal fixtures (formerly test/fixtures/keys.ts).
+// -----------------------------------------------------------------
+
+export const trustedIssuer: IssuerConfig = {
+  did: "did:key:z6MkehBvJQrFXNY3jYcRpXFjbhUrve8ap2a3vwZC91HPpNfE",
+  privateKeyHex: "ec647ec7c32eaabc40c6b3d5ccfc9da4ec034fcb52628d1f2c98d26560d69645",
+};
+
+export const principalDid = "did:web:demo.example:user:TEST123";
+
+export const principalClaims: PrincipalClaims = {
+  kycLevel: "IdentityVerified",
+  ageOver18: true,
+  emailVerified: true,
+  paymentsEnabled: true,
+  accountType: "PERSONAL",
+};
+
+export const paymentSource: PaymentSourceLayer = {
+  accountId: "eip155:8453:0xA11CE0000000000000000000000000000000FACE",
+  sourceId: "0xA11CE0000000000000000000000000000000FACE",
+  network: "eip155:8453",
+};
+
+export const requirements: IdentityRequirements = {
+  protocol: "x402-vcx-v1",
+  disclosureTier: DisclosureTier.SelectiveClaims,
+  requiredClaims: ["kycLevel", "ageOver18"],
+  minKycLevel: "IdentityVerified",
+  acceptedIssuers: [trustedIssuer.did],
+};
+
+/**
+ * Generate a fresh untrusted issuer for "not in acceptedIssuers" negative tests.
+ *
+ * @returns A new issuer config with a freshly generated Ed25519 keypair.
+ */
+export function newIssuer(): IssuerConfig {
+  const kp = generateEd25519KeyPair();
+  return { did: kp.did, privateKeyHex: kp.privateKeyHex };
+}
+
+// -----------------------------------------------------------------
+// Bitstring Status List v1.0 test helpers (formerly
+// test/fixtures/status-lists.ts).
+// -----------------------------------------------------------------
+
+const SECONDS = 1;
+const HOUR = 60 * 60 * SECONDS;
+const DAY = 24 * HOUR;
+
+/**
+ * Status-list URL the fixture credentials reference. Tests mock `fetch`
+ * to return the status list JWT for this URL.
+ */
+export const STATUS_LIST_URL = "https://example.test/credentials/status/1";
+
+/**
+ * Build a Bitstring Status List v1.0 `encodedList` value given the
+ * indices that should be revoked (bit set to 1). Default list size is
+ * smaller than the spec §13.6 recommended 131,072-bit minimum for test
+ * speed; production issuers use larger lists for herd-based privacy.
+ *
+ * @param opts - Options for building the encoded list.
+ * @param opts.revokedIndices - Bit indices to set to 1 (revoked).
+ * @param opts.sizeBits - Total bit length of the list (defaults to 16384).
+ * @returns The gzip-compressed, base64url-encoded status list with the multibase `u` prefix.
+ */
+export function buildEncodedList(opts: { revokedIndices: number[]; sizeBits?: number }): string {
+  const sizeBits = opts.sizeBits ?? 16384;
+  const bytes = new Uint8Array(Math.ceil(sizeBits / 8));
+  for (const idx of opts.revokedIndices) {
+    if (idx < 0 || idx >= sizeBits) {
+      throw new Error(`revokedIndex ${idx} is outside size ${sizeBits}`);
+    }
+    const byteIdx = Math.floor(idx / 8);
+    const bitIdx = idx % 8;
+    bytes[byteIdx] |= 1 << (7 - bitIdx);
+  }
+  const gz = gzipSync(Buffer.from(bytes));
+  return "u" + gz.toString("base64url");
+}
+
+/**
+ * Build a did-jwt-vc `Issuer` (EdDSA signer) from an issuer config.
+ *
+ * @param config - The issuer config holding the DID and hex private key.
+ * @returns A did-jwt-vc Issuer ready to sign credentials.
+ */
+function makeIssuer(config: IssuerConfig): Issuer {
+  const privateKeyBytes = Uint8Array.from(Buffer.from(config.privateKeyHex, "hex"));
+  return {
+    did: config.did,
+    signer: EdDSASigner(privateKeyBytes),
+    alg: "EdDSA",
+  };
+}
+
+/**
+ * Issue a signed Bitstring Status List credential JWT for the fixture status list URL.
+ *
+ * @param opts - Options for issuing the status list credential.
+ * @param opts.issuerConfig - The issuer that signs the status list credential.
+ * @param opts.encodedList - The encoded bitstring list to embed in the credential.
+ * @returns A signed status list credential JWT.
+ */
+export async function issueStatusListCredential(opts: {
+  issuerConfig: IssuerConfig;
+  encodedList: string;
+}): Promise<string> {
+  const issuer = makeIssuer(opts.issuerConfig);
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    sub: STATUS_LIST_URL,
+    nbf: now,
+    exp: now + 30 * DAY,
+    vc: {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/ns/credentials/status/v1",
+      ],
+      type: ["VerifiableCredential", "BitstringStatusListCredential"],
+      credentialSubject: {
+        id: `${STATUS_LIST_URL}#list`,
+        type: "BitstringStatusList",
+        statusPurpose: "revocation",
+        encodedList: opts.encodedList,
+      },
+    },
+  };
+  return createVerifiableCredentialJwt(payload, issuer);
+}
+
+/**
+ * Issue a long-lived identity credential JWT carrying a Bitstring Status List entry.
+ *
+ * @param opts - Options for issuing the long-lived credential.
+ * @param opts.issuerConfig - The issuer that signs the credential.
+ * @param opts.subject - The credential subject to embed.
+ * @param opts.statusListIndex - The status list index referenced by the credentialStatus entry.
+ * @param opts.lifetimeSeconds - Credential lifetime in seconds (defaults to 48 hours).
+ * @param opts.credentialStatusOverride - Replaces the default credentialStatus block when provided.
+ * @returns A signed long-lived credential JWT.
+ */
+export async function issueLongLivedCredential(opts: {
+  issuerConfig: IssuerConfig;
+  subject: VCXCredentialSubject;
+  statusListIndex: number;
+  lifetimeSeconds?: number;
+  credentialStatusOverride?: Record<string, unknown>;
+}): Promise<string> {
+  const issuer = makeIssuer(opts.issuerConfig);
+  const now = Math.floor(Date.now() / 1000);
+  const lifetimeSeconds = opts.lifetimeSeconds ?? 48 * HOUR;
+  const payload = {
+    sub: opts.subject.id,
+    nbf: now,
+    exp: now + lifetimeSeconds,
+    vc: {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://x402.org/credentials/identity/v1",
+      ],
+      type: ["VerifiableCredential", "X402IdentityCredential"],
+      credentialSubject: opts.subject,
+      credentialStatus: opts.credentialStatusOverride ?? {
+        id: `${STATUS_LIST_URL}#${opts.statusListIndex}`,
+        type: "BitstringStatusListEntry",
+        statusPurpose: "revocation",
+        statusListIndex: String(opts.statusListIndex),
+        statusListCredential: STATUS_LIST_URL,
+      },
+    },
+  };
+  return createVerifiableCredentialJwt(payload, issuer);
+}
+
+/**
+ * Issue a short-lived (12h) identity credential that improperly carries a
+ * credentialStatus field, used to exercise the short-lived-profile rejection path.
+ *
+ * @param opts - Options for issuing the short-lived credential.
+ * @param opts.issuerConfig - The issuer that signs the credential.
+ * @param opts.subject - The credential subject to embed.
+ * @returns A signed short-lived credential JWT that contains a credentialStatus block.
+ */
+export async function issueShortLivedCredentialWithStatus(opts: {
+  issuerConfig: IssuerConfig;
+  subject: VCXCredentialSubject;
+}): Promise<string> {
+  const issuer = makeIssuer(opts.issuerConfig);
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    sub: opts.subject.id,
+    nbf: now,
+    exp: now + 12 * HOUR,
+    vc: {
+      "@context": ["https://www.w3.org/2018/credentials/v1"],
+      type: ["VerifiableCredential", "X402IdentityCredential"],
+      credentialSubject: opts.subject,
+      credentialStatus: {
+        id: `${STATUS_LIST_URL}#5`,
+        type: "BitstringStatusListEntry",
+        statusPurpose: "revocation",
+        statusListIndex: "5",
+        statusListCredential: STATUS_LIST_URL,
+      },
+    },
+  };
+  return createVerifiableCredentialJwt(payload, issuer);
+}
+
+/**
+ * Build a `fetch` mock that serves the given body for the fixture status list
+ * URL and 404s for everything else, tracking the number of calls made.
+ *
+ * @param opts - Options for the fetch mock.
+ * @param opts.body - The response body returned for the status list URL.
+ * @param opts.cacheControl - Optional `cache-control` header value to include.
+ * @returns A fetch-compatible function exposing a `calls` counter.
+ */
+export function mockStatusListFetch(opts: {
+  body: string;
+  cacheControl?: string;
+}): typeof fetch & { calls: number } {
+  const fn = (async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    fn.calls += 1;
+    if (url === STATUS_LIST_URL) {
+      const headers = new Headers();
+      if (opts.cacheControl) {
+        headers.set("cache-control", opts.cacheControl);
+      }
+      return new Response(opts.body, { status: 200, headers });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch & { calls: number };
+  fn.calls = 0;
+  return fn;
+}

--- a/typescript/packages/extensions/test/vcx-trustlist.test.ts
+++ b/typescript/packages/extensions/test/vcx-trustlist.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Copyright 2026 PayPal Holdings, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, it, expect } from "vitest";
+import { createJWT, EdDSASigner } from "did-jwt";
+import {
+  resolveAcceptedIssuers,
+  verifyDidDocumentHash,
+  InMemoryTrustListCache,
+  getDidResolver,
+} from "../src/vcx";
+import { jcsSha256 } from "../src/vcx/envelope/canonicalize";
+import { trustedIssuer } from "./vcx-test-utils";
+
+const TRUST_LIST_URL = "https://trust.example.test/.well-known/vcx-trust-list";
+
+/**
+ * Build the signing options (issuer DID, EdDSA signer, alg) for the trusted
+ * fixture issuer, used to sign trust list JWSs.
+ *
+ * @returns The createJWT signer options for the trusted issuer.
+ */
+function issuerSignerOpts() {
+  const privateKeyBytes = Uint8Array.from(Buffer.from(trustedIssuer.privateKeyHex, "hex"));
+  return {
+    issuer: trustedIssuer.did,
+    signer: EdDSASigner(privateKeyBytes),
+    alg: "EdDSA",
+  };
+}
+
+/**
+ * Sign a trust list body into a JWS, defaulting the `iss` claim to the signer's issuer.
+ *
+ * @param body - The trust list body claims to sign.
+ * @param signerOverride - Optional signer options to use instead of the trusted issuer.
+ * @returns The signed trust list JWS.
+ */
+async function buildTrustListJws(
+  body: Record<string, unknown>,
+  signerOverride?: ReturnType<typeof issuerSignerOpts>,
+): Promise<string> {
+  return createJWT(
+    {
+      ...body,
+      iss: (signerOverride ?? issuerSignerOpts()).issuer,
+    },
+    signerOverride ?? issuerSignerOpts(),
+  );
+}
+
+/**
+ * Build a `fetch` mock that serves the given JWS for the trust list URL and
+ * 404s for everything else, tracking the number of calls made.
+ *
+ * @param opts - Options for the fetch mock.
+ * @param opts.jws - The JWS response body returned for the trust list URL.
+ * @param opts.cacheControl - Optional `cache-control` header value to include.
+ * @returns A fetch-compatible function exposing a `calls` counter.
+ */
+function mockFetch(opts: { jws: string; cacheControl?: string }): typeof fetch & { calls: number } {
+  const fn = (async (input: RequestInfo | URL): Promise<Response> => {
+    fn.calls += 1;
+    const url = typeof input === "string" ? input : input.toString();
+    if (url === TRUST_LIST_URL) {
+      const headers = new Headers();
+      if (opts.cacheControl) {
+        headers.set("cache-control", opts.cacheControl);
+      }
+      return new Response(opts.jws, { status: 200, headers });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch & { calls: number };
+  fn.calls = 0;
+  return fn;
+}
+
+describe("resolveAcceptedIssuers — inline DIDs (§8.1)", () => {
+  it("passes through inline DIDs without fetching", async () => {
+    const fetchMock = mockFetch({ jws: "unused" });
+    const entries = await resolveAcceptedIssuers(["did:web:paypal.com", "did:key:zAbc"], {
+      resolver: getDidResolver(),
+      fetchImpl: fetchMock,
+    });
+    expect(entries).toEqual([{ did: "did:web:paypal.com" }, { did: "did:key:zAbc" }]);
+    expect(fetchMock.calls).toBe(0);
+  });
+});
+
+describe("resolveAcceptedIssuers — well-known JWS (§8.2)", () => {
+  it("fetches, verifies, and parses a JWS-signed trust list", async () => {
+    const jws = await buildTrustListJws({
+      issuer: trustedIssuer.did,
+      validFrom: "2026-01-01T00:00:00Z",
+      validUntil: "2027-01-01T00:00:00Z",
+      issuers: [
+        { did: trustedIssuer.did },
+        {
+          did: "did:web:paypal.com:divisions:cards",
+          didDocumentHash:
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        },
+      ],
+    });
+    const fetchMock = mockFetch({ jws });
+    const entries = await resolveAcceptedIssuers([TRUST_LIST_URL], {
+      resolver: getDidResolver(),
+      fetchImpl: fetchMock,
+    });
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toEqual({ did: trustedIssuer.did });
+    expect(entries[1].didDocumentHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(fetchMock.calls).toBe(1);
+  });
+
+  it("rejects when body.issuer does not match JWS iss", async () => {
+    // Sign with trustedIssuer but claim a different `issuer` in the body.
+    const jws = await buildTrustListJws({
+      issuer: "did:web:attacker.test",
+      issuers: [{ did: "did:web:attacker.test" }],
+    });
+    const fetchMock = mockFetch({ jws });
+    await expect(
+      resolveAcceptedIssuers([TRUST_LIST_URL], {
+        resolver: getDidResolver(),
+        fetchImpl: fetchMock,
+      }),
+    ).rejects.toThrow(/body\.issuer.*does not match JWS iss/);
+  });
+
+  it("rejects an expired trust list (validUntil in the past)", async () => {
+    const jws = await buildTrustListJws({
+      issuer: trustedIssuer.did,
+      validFrom: "2025-01-01T00:00:00Z",
+      validUntil: "2025-12-31T00:00:00Z",
+      issuers: [{ did: trustedIssuer.did }],
+    });
+    const fetchMock = mockFetch({ jws });
+    await expect(
+      resolveAcceptedIssuers([TRUST_LIST_URL], {
+        resolver: getDidResolver(),
+        fetchImpl: fetchMock,
+      }),
+    ).rejects.toThrow(/validUntil.*has passed/);
+  });
+
+  it("rejects a malformed didDocumentHash format", async () => {
+    const jws = await buildTrustListJws({
+      issuer: trustedIssuer.did,
+      issuers: [
+        {
+          did: trustedIssuer.did,
+          didDocumentHash: "sha512:abc", // wrong algo tag
+        },
+      ],
+    });
+    const fetchMock = mockFetch({ jws });
+    await expect(
+      resolveAcceptedIssuers([TRUST_LIST_URL], {
+        resolver: getDidResolver(),
+        fetchImpl: fetchMock,
+      }),
+    ).rejects.toThrow(/didDocumentHash MUST be "sha256/);
+  });
+
+  it("honours the cache: same URL doesn't refetch on the second call", async () => {
+    const jws = await buildTrustListJws({
+      issuer: trustedIssuer.did,
+      issuers: [{ did: trustedIssuer.did }],
+    });
+    const fetchMock = mockFetch({ jws, cacheControl: "max-age=3600" });
+    const cache = new InMemoryTrustListCache();
+    await resolveAcceptedIssuers([TRUST_LIST_URL], {
+      resolver: getDidResolver(),
+      fetchImpl: fetchMock,
+      cache,
+    });
+    await resolveAcceptedIssuers([TRUST_LIST_URL], {
+      resolver: getDidResolver(),
+      fetchImpl: fetchMock,
+      cache,
+    });
+    expect(fetchMock.calls).toBe(1);
+  });
+});
+
+describe("resolveAcceptedIssuers — rejection paths", () => {
+  it("rejects http:// URLs", async () => {
+    await expect(
+      resolveAcceptedIssuers(["http://insecure.test/.well-known/vcx-trust-list"], {
+        resolver: getDidResolver(),
+      }),
+    ).rejects.toThrow(/MUST be HTTPS/);
+  });
+
+  it("returns the deferred-to-v1.1 error for ETSI URLs", async () => {
+    await expect(
+      resolveAcceptedIssuers(["https://example.test/etsi/trust-list.xml"], {
+        resolver: getDidResolver(),
+      }),
+    ).rejects.toThrow(/ETSI.*deferred to v1\.1/);
+  });
+
+  it("rejects unrecognised reference shapes", async () => {
+    await expect(
+      resolveAcceptedIssuers(["mailto:trust@example.test"], {
+        resolver: getDidResolver(),
+      }),
+    ).rejects.toThrow(/Unrecognised acceptedIssuers reference/);
+  });
+});
+
+describe("verifyDidDocumentHash (§8.2)", () => {
+  it("passes when the computed hash equals the expected hash (did:key)", async () => {
+    const resolver = getDidResolver();
+    const result = await resolver.resolve(trustedIssuer.did);
+    const expectedHash = jcsSha256(result.didDocument);
+    const check = await verifyDidDocumentHash({
+      issuerDid: trustedIssuer.did,
+      expectedHash,
+      resolver,
+    });
+    expect(check.ok).toBe(true);
+  });
+
+  it("rejects when the computed hash differs from the expected hash", async () => {
+    const resolver = getDidResolver();
+    const check = await verifyDidDocumentHash({
+      issuerDid: trustedIssuer.did,
+      expectedHash: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      resolver,
+    });
+    expect(check.ok).toBe(false);
+    if (!check.ok) {
+      expect(check.reason).toMatch(/mismatch/);
+    }
+  });
+});

--- a/typescript/packages/extensions/tsup.config.ts
+++ b/typescript/packages/extensions/tsup.config.ts
@@ -8,6 +8,7 @@ const baseConfig = {
     "offer-receipt/index": "src/offer-receipt/index.ts",
     "payment-identifier/index": "src/payment-identifier/index.ts",
     "builder-code/index": "src/builder-code/index.ts",
+    "vcx/index": "src/vcx/index.ts",
   },
   dts: {
     resolve: true,

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -99,6 +99,18 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      canonicalize:
+        specifier: ^2.0.0
+        version: 2.1.0
+      did-jwt:
+        specifier: ^8.0.0
+        version: 8.0.18
+      did-jwt-vc:
+        specifier: ^4.0.0
+        version: 4.0.16
+      did-resolver:
+        specifier: ^4.1.0
+        version: 4.1.0
       jose:
         specifier: ^5.9.6
         version: 5.10.0
@@ -3437,6 +3449,9 @@ packages:
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
     engines: {node: '>= 18'}
 
+  '@multiformats/base-x@4.0.1':
+    resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -3915,6 +3930,9 @@ packages:
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/base@2.2.0':
+    resolution: {integrity: sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==}
 
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
@@ -6367,6 +6385,10 @@ packages:
   caniuse-lite@1.0.30001739:
     resolution: {integrity: sha512-y+j60d6ulelrNSwpPyrHdl+9mJnQzHBr08xm48Qno0nSk4h3Qojh+ziv2qE6rXf4k3tadF4o1J/1tAbVm1NtnA==}
 
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -6790,6 +6812,16 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  did-jwt-vc@4.0.16:
+    resolution: {integrity: sha512-is7/e2KdLwtDP3JTnf9sLhUeBQF9AhyGjBuJAAVs5U2Uf8CBchRwDycztHQJCx1voBabVprrmAa9NJMd+qWcSA==}
+    engines: {node: '>=18'}
+
+  did-jwt@8.0.18:
+    resolution: {integrity: sha512-yS3Y+aUKjYqRFrgR/RY77NuOOqS7SFfvfFH4THhWD6+hkxeUZcKQSsdNZ12QR1Vd48yP9exwae2wzbuOZn0NqQ==}
+
+  did-resolver@4.1.0:
+    resolution: {integrity: sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==}
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
@@ -8507,6 +8539,11 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multibase@4.0.6:
+    resolution: {integrity: sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==}
+    engines: {node: '>=12.0.0', npm: '>=6.0.0'}
+    deprecated: This module has been superseded by the multiformats module
 
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
@@ -10603,7 +10640,7 @@ snapshots:
     dependencies:
       '@noble/ciphers': 2.1.1
       '@noble/curves': 2.0.1
-      '@noble/hashes': 2.0.1
+      '@noble/hashes': 2.2.0
       ajv: 8.17.1
       algo-msgpack-with-bigint: 2.1.1
       bn.js: 5.2.3
@@ -12970,6 +13007,8 @@ snapshots:
 
   '@msgpack/msgpack@3.1.3': {}
 
+  '@multiformats/base-x@4.0.1': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.5.0
@@ -14054,6 +14093,8 @@ snapshots:
   '@scure/base@1.1.9': {}
 
   '@scure/base@1.2.6': {}
+
+  '@scure/base@2.2.0': {}
 
   '@scure/bip32@1.4.0':
     dependencies:
@@ -18427,6 +18468,8 @@ snapshots:
 
   caniuse-lite@1.0.30001739: {}
 
+  canonicalize@2.1.0: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -18787,6 +18830,25 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
+
+  did-jwt-vc@4.0.16:
+    dependencies:
+      did-jwt: 8.0.18
+      did-resolver: 4.1.0
+
+  did-jwt@8.0.18:
+    dependencies:
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/base': 2.2.0
+      canonicalize: 2.1.0
+      did-resolver: 4.1.0
+      multibase: 4.0.6
+      multiformats: 9.9.0
+      uint8arrays: 3.1.1
+
+  did-resolver@4.1.0: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -20988,6 +21050,10 @@ snapshots:
   ms@2.1.2: {}
 
   ms@2.1.3: {}
+
+  multibase@4.0.6:
+    dependencies:
+      '@multiformats/base-x': 4.0.1
 
   multiformats@9.9.0: {}
 


### PR DESCRIPTION
## Summary

TypeScript **reference implementation** of the VCX (Verifiable Credential Exchange) identity extension for x402 v2.

This is the **implementation half** of #2544, split out so it can be reviewed independently of the normative spec. The spec lands in companion PR #2747.

## What's added

**Implementation** (`typescript/packages/extensions/src/vcx/`, 24 source files): subpath of `@x402/extensions` (minor bump 2.14.0 → 2.15.0). New runtime deps: `did-jwt`, `did-jwt-vc`, `did-resolver`, `canonicalize`. Public surface re-exported from package root + via the new `@x402/extensions/vcx` subpath.

**Tests** (`typescript/packages/extensions/test/vcx-*.test.ts`, 12 files + 1 test-utils): ~70 cases covering envelope shape, delegation enforcement, revocation, trust-list resolution, hash pinning, did:web TLS hardening, SD-JWT VC end-to-end.

**Changeset**: `@x402/extensions` minor.

## Spec MUSTs implemented

§6 envelope shape, §6.4 envelopeDigest, §7.1 did:key, §7.2 did:web with full TLS hardening, §8.1 inline + §8.2 well-known JWS trust list + didDocumentHash pinning, §9.1–§9.4 four-step verification, §10 vc-embedded delegation, §11.1 short-lived + §11.2 Bitstring Status List v1.0 revocation, §12 all three disclosure tiers (Tier 0/2 plain JWT VC + Tier 1 SD-JWT VC with cryptographic disclosure-proof verification), §13.1 transactionId uniqueness, §13.2 envelope-to-payment binding, §13.4 fail-closed on unknown delegation conditions, §17 JCS canonicalization.

## Test plan

- [ ] `pnpm install` clean on CI (4 new runtime deps resolve)
- [ ] `pnpm -F @x402/extensions build` clean (tsup produces dual CJS+ESM + the new `./vcx` subpath dist)
- [ ] `pnpm -F @x402/extensions test` clean (12 new vcx-*.test.ts files)
- [ ] Lint + format check clean

Local CI was not run against this branch because the contributor's development environment blocks the public npm registry. Foundation CI is the first real exercise. Static review found no obvious type or import errors; existing extension tests are unchanged.

## Notes on the SD-JWT VC layer

The §12 Tier 1 implementation is self-contained (~250 LOC under `src/vcx/envelope/sdjwtvc.ts`), supporting the presentation flow VCX uses. Scope is deliberately narrow: no key-binding-JWT verification, no recursive disclosures, no array-element disclosures. The original roadmap intended to use `@sd-jwt/core` (openwallet-foundation) — that path is still open as a follow-up that swaps the implementation without changing the public `verifySdJwtVcPresentation` signature.

## Disclosure: AI-assisted work

Per CONTRIBUTING.md: significant portions of this contribution were written with AI assistance (Claude Opus 4.7). Each commit, type definition, and test case was reviewed by the contributor before push. Cryptographic primitives (the SD-JWT VC layer, JCS canonicalization, the Bitstring Status List bit-decoding path, did:web TLS hardening) were given particular review attention. Foundation reviewers are explicitly encouraged to scrutinize these areas.

## Refs

- Spec PR: #2747
- Original combined PR: #2544
- Discussion: #2400
