### PR TITLE
Add AIServices to third-party extensions and SDKs

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -10,3 +10,5 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |
 | [x402r](https://x402r.org) | Non-custodial refund and arbitration protocol | Typescript | [GitHub](https://github.com/BackTrackCo/x402r-sdk) · [npm](https://www.npmjs.com/package/@x402r/sdk ) |
 | [zauth](https://zauthx402.com) | Monitoring, verification, and refund SDK | TypeScript | [GitHub](https://github.com/zauthofficial/zauthSDK) · [npm](https://www.npmjs.com/package/@zauthx402/sdk) |
+| [AIServices](https://aiservices.to) | Data APIs for AI agents — crypto prices, DeFi yields, technical indicators, fear-greed index, IP geolocation, URL metadata, and policy-driven dispute resolution | Python | [GitHub](https://github.com/vbkotecha/aiservices-api) · [Website](https://aiservices.to) |
+

--- a/docs/dev-tools/third-party-sdks.md
+++ b/docs/dev-tools/third-party-sdks.md
@@ -8,3 +8,4 @@ description: "Community-maintained x402 SDKs."
 | [Mogami](https://mogami.gitbook.io/mogami) | Java x402 stack | Java | [GitHub](https://github.com/mogami-tech/) |
 | [x402-rs](https://github.com/x402-rs/x402-rs/blob/main/README.md) | Rust toolkit for x402 | Rust | [GitHub](https://github.com/x402-rs/x402-rs) |
 | [x402-rails](https://github.com/quiknode-labs/x402-rails/blob/main/README.md) | x402 for Rails applications by Quicknode | Ruby | [GitHub](https://github.com/quiknode-labs/x402-rails) |
+| [AIServices Python SDK](https://github.com/vbkotecha/aiservices-api/tree/main/sdk) | Python client for x402 data APIs — crypto, DeFi, indicators, geo, metadata | Python | [GitHub](https://github.com/vbkotecha/aiservices-api) |

--- a/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AgentCourt",
+  "category": "Infrastructure & Tooling",
+  "logoUrl": "",
+  "description": "Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. The Evaluator layer for ERC-8183. Non-custodial, open source, MIT. x402-native at $0.05/dispute.",
+  "websiteUrl": "https://github.com/vbkotecha/agentcourt-api"
+}

--- a/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
@@ -1,7 +1,0 @@
-{
-  "name": "AgentCourt",
-  "category": "Infrastructure & Tooling",
-  "logoUrl": "",
-  "description": "Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. The Evaluator layer for ERC-8183. Non-custodial, open source, MIT. x402-native at $0.05/dispute.",
-  "websiteUrl": "https://github.com/vbkotecha/agentcourt-api"
-}


### PR DESCRIPTION
## What

Added **AIServices** (https://aiservices.to) to the x402 ecosystem pages:

1. **Third-Party Extensions** — AIServices is a live x402-enabled API platform providing data endpoints for AI agents: crypto prices, DeFi yields, technical indicators, fear-greed index, IP geolocation, URL metadata, and policy-driven dispute resolution (AgentCourt engine).

2. **Third-Party SDKs** — Added the AIServices Python SDK, a lightweight client for the x402 data APIs.

## Live endpoints

- Free: crypto prices, fear-greed index, IP geolocation
- Paid ($0.01-$0.05 via x402 USDC on Base): technical indicators, DeFi yields, URL metadata, dispute resolution

Base URL: `https://api.aiservices.to`

Already registered on: x402scan, x402Scout, CDP Bazaar, agent-tools.cloud

Repo: https://github.com/vbkotecha/aiservices-api