### PR TITLE
docs(facilitators): add Solvador to facilitators list

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -18,6 +18,6 @@ The table below lists selected production options; it is not an exhaustive catal
 | [Mogami Facilitator](https://facilitator.mogami.tech) | Free, developer-focused facilitator for Base with optional self-hosted Docker deployment |
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
-| [Solvador](https://solvador.com) | Multi-network facilitator with broad mainnet coverage across EVM and Solana, supporting multiple schemes and extensions |
+| [Solvador](https://solvador.com) | Multi-network facilitator with broad mainnet coverage across EVM plus Solana and NEAR, supporting multiple schemes and extensions |
 
 For testnet development, the [x402.org facilitator](/core-concepts/network-and-token-support#x402org-facilitator) requires no setup. It is not intended for mainnet routes; use a production facilitator or self-hosted facilitator for production networks.

--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -18,5 +18,6 @@ The table below lists selected production options; it is not an exhaustive catal
 | [Mogami Facilitator](https://facilitator.mogami.tech) | Free, developer-focused facilitator for Base with optional self-hosted Docker deployment |
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
+| [Solvador](https://solvador.com) | Multi-network facilitator with broad mainnet coverage across EVM and Solana, supporting multiple schemes and extensions |
 
 For testnet development, the [x402.org facilitator](/core-concepts/network-and-token-support#x402org-facilitator) requires no setup. It is not intended for mainnet routes; use a production facilitator or self-hosted facilitator for production networks.


### PR DESCRIPTION
## Description

Adds [Solvador](https://solvador.com) to the production facilitators table in `docs/dev-tools/facilitators.md`.

Solvador is an x402 payment facilitator offering broad mainnet coverage across EVM and Solana. Resource servers integrate by pointing to its API and authenticating with an API key, with transaction monitoring available through its dashboard.

## Tests

Docs-only change — no code paths affected. Verified the new table row renders correctly and follows the existing format, and that the table's alphabetical ordering is preserved.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)