### PR TITLE
feat(stellar): add registerExactStellarScheme() convenience export

### DIFF
--- a/typescript/.changeset/stellar-register-exact-scheme.md
+++ b/typescript/.changeset/stellar-register-exact-scheme.md
@@ -1,0 +1,5 @@
+---
+'@x402/stellar': minor
+---
+
+Add `registerExactStellarScheme()` convenience export to `@x402/stellar/exact/server` and `@x402/stellar/exact/client`, mirroring `@x402/evm`'s `registerExactEvmScheme()`. Previously, integrating Stellar required callers to know the `stellar:*` CAIP-2 wildcard and call the resource server/client's `.register()` method directly, unlike EVM which hides this behind a one-line wrapper.

--- a/typescript/packages/mechanisms/stellar/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/client/index.ts
@@ -1,1 +1,3 @@
 export { ExactStellarScheme } from "./scheme";
+export { registerExactStellarScheme } from "./register";
+export type { StellarClientConfig } from "./register";

--- a/typescript/packages/mechanisms/stellar/src/exact/client/register.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/client/register.ts
@@ -1,0 +1,71 @@
+import { x402Client, PaymentPolicy } from "@x402/core/client";
+import { Network } from "@x402/core/types";
+import { ExactStellarScheme } from "./scheme";
+import { STELLAR_WILDCARD_CAIP2 } from "../../constants";
+import { ClientStellarSigner } from "../../signer";
+import { RpcConfig } from "../../utils";
+
+/**
+ * Configuration options for registering Stellar schemes to an x402Client
+ */
+export interface StellarClientConfig {
+  /**
+   * The Stellar signer to use for creating payment payloads
+   */
+  signer: ClientStellarSigner;
+
+  /**
+   * Optional RPC configuration (e.g. a custom RPC URL)
+   */
+  rpcConfig?: RpcConfig;
+
+  /**
+   * Optional policies to apply to the client
+   */
+  policies?: PaymentPolicy[];
+
+  /**
+   * Optional specific networks to register.
+   * If not provided, registers wildcard support (stellar:*).
+   */
+  networks?: Network[];
+}
+
+/**
+ * Registers the Stellar exact payment scheme to an x402Client instance.
+ *
+ * @param client - The x402Client instance to register schemes to
+ * @param config - Configuration for Stellar client registration
+ * @returns The client instance for chaining
+ *
+ * @example
+ * ```typescript
+ * import { registerExactStellarScheme } from "@x402/stellar/exact/client";
+ * import { x402Client } from "@x402/core/client";
+ *
+ * const client = new x402Client();
+ * registerExactStellarScheme(client, { signer });
+ * ```
+ */
+export function registerExactStellarScheme(
+  client: x402Client,
+  config: StellarClientConfig,
+): x402Client {
+  const stellarScheme = new ExactStellarScheme(config.signer, config.rpcConfig);
+
+  if (config.networks && config.networks.length > 0) {
+    config.networks.forEach(network => {
+      client.register(network, stellarScheme);
+    });
+  } else {
+    client.register(STELLAR_WILDCARD_CAIP2, stellarScheme);
+  }
+
+  if (config.policies) {
+    config.policies.forEach(policy => {
+      client.registerPolicy(policy);
+    });
+  }
+
+  return client;
+}

--- a/typescript/packages/mechanisms/stellar/src/exact/server/index.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/server/index.ts
@@ -1,1 +1,3 @@
 export { ExactStellarScheme } from "./scheme";
+export { registerExactStellarScheme } from "./register";
+export type { StellarResourceServerConfig } from "./register";

--- a/typescript/packages/mechanisms/stellar/src/exact/server/register.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/server/register.ts
@@ -1,0 +1,46 @@
+import { x402ResourceServer } from "@x402/core/server";
+import { Network } from "@x402/core/types";
+import { ExactStellarScheme } from "./scheme";
+import { STELLAR_WILDCARD_CAIP2 } from "../../constants";
+
+/**
+ * Configuration options for registering Stellar schemes to an x402ResourceServer
+ */
+export interface StellarResourceServerConfig {
+  /**
+   * Optional specific networks to register
+   * If not provided, registers wildcard support (stellar:*)
+   */
+  networks?: Network[];
+}
+
+/**
+ * Registers the Stellar exact payment scheme to an x402ResourceServer instance.
+ *
+ * @param server - The x402ResourceServer instance to register schemes to
+ * @param config - Configuration for Stellar resource server registration
+ * @returns The server instance for chaining
+ *
+ * @example
+ * ```typescript
+ * import { registerExactStellarScheme } from "@x402/stellar/exact/server";
+ * import { x402ResourceServer } from "@x402/core/server";
+ *
+ * const server = new x402ResourceServer(facilitatorClient);
+ * registerExactStellarScheme(server);
+ * ```
+ */
+export function registerExactStellarScheme(
+  server: x402ResourceServer,
+  config: StellarResourceServerConfig = {},
+): x402ResourceServer {
+  if (config.networks && config.networks.length > 0) {
+    config.networks.forEach(network => {
+      server.register(network, new ExactStellarScheme());
+    });
+  } else {
+    server.register(STELLAR_WILDCARD_CAIP2, new ExactStellarScheme());
+  }
+
+  return server;
+}

--- a/typescript/packages/mechanisms/stellar/test/unit/client-register.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/client-register.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { STELLAR_WILDCARD_CAIP2 } from "../../src/constants";
+import { registerExactStellarScheme } from "../../src/exact/client/register";
+import { ExactStellarScheme } from "../../src/exact/client/scheme";
+import type { ClientStellarSigner } from "../../src/signer";
+import type { x402Client, PaymentPolicy } from "@x402/core/client";
+
+const mockSigner: ClientStellarSigner = {
+  address: "GBBO4ZDDZTSM2IUKQYBAST3CFHNPFXECGEFTGWTA2WELR2BIWDK57UVE",
+  signAuthEntry: vi.fn(),
+};
+
+describe("registerExactStellarScheme (client)", () => {
+  it("registers the wildcard network when no networks are provided", () => {
+    const register = vi.fn();
+    const registerPolicy = vi.fn();
+    const client = { register, registerPolicy } as unknown as x402Client;
+
+    const result = registerExactStellarScheme(client, { signer: mockSigner });
+
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(register).toHaveBeenCalledWith(STELLAR_WILDCARD_CAIP2, expect.any(ExactStellarScheme));
+    expect(registerPolicy).not.toHaveBeenCalled();
+    expect(result).toBe(client);
+  });
+
+  it("registers each provided network instead of the wildcard, reusing one scheme instance", () => {
+    const register = vi.fn();
+    const client = { register, registerPolicy: vi.fn() } as unknown as x402Client;
+
+    registerExactStellarScheme(client, {
+      signer: mockSigner,
+      networks: ["stellar:pubnet", "stellar:testnet"],
+    });
+
+    expect(register).toHaveBeenCalledTimes(2);
+    const [firstNetwork, firstScheme] = register.mock.calls[0];
+    const [secondNetwork, secondScheme] = register.mock.calls[1];
+    expect(firstNetwork).toBe("stellar:pubnet");
+    expect(secondNetwork).toBe("stellar:testnet");
+    expect(firstScheme).toBeInstanceOf(ExactStellarScheme);
+    expect(firstScheme).toBe(secondScheme);
+  });
+
+  it("forwards rpcConfig to the underlying scheme", () => {
+    const register = vi.fn();
+    const client = { register, registerPolicy: vi.fn() } as unknown as x402Client;
+
+    registerExactStellarScheme(client, {
+      signer: mockSigner,
+      rpcConfig: { url: "https://custom-rpc.example.com" },
+    });
+
+    const [, scheme] = register.mock.calls[0];
+    expect(scheme).toEqual(
+      expect.objectContaining({
+        signer: mockSigner,
+        rpcConfig: { url: "https://custom-rpc.example.com" },
+      }),
+    );
+  });
+
+  it("registers provided policies", () => {
+    const registerPolicy = vi.fn();
+    const client = { register: vi.fn(), registerPolicy } as unknown as x402Client;
+    const policyA = vi.fn() as unknown as PaymentPolicy;
+    const policyB = vi.fn() as unknown as PaymentPolicy;
+
+    registerExactStellarScheme(client, { signer: mockSigner, policies: [policyA, policyB] });
+
+    expect(registerPolicy).toHaveBeenCalledTimes(2);
+    expect(registerPolicy).toHaveBeenNthCalledWith(1, policyA);
+    expect(registerPolicy).toHaveBeenNthCalledWith(2, policyB);
+  });
+});

--- a/typescript/packages/mechanisms/stellar/test/unit/server-register.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/server-register.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from "vitest";
+import { STELLAR_WILDCARD_CAIP2 } from "../../src/constants";
+import { registerExactStellarScheme } from "../../src/exact/server/register";
+import { ExactStellarScheme } from "../../src/exact/server/scheme";
+import type { x402ResourceServer } from "@x402/core/server";
+
+describe("registerExactStellarScheme (server)", () => {
+  it("registers the wildcard network when no networks are provided", () => {
+    const register = vi.fn();
+    const server = { register } as unknown as x402ResourceServer;
+
+    const result = registerExactStellarScheme(server);
+
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(register).toHaveBeenCalledWith(STELLAR_WILDCARD_CAIP2, expect.any(ExactStellarScheme));
+    expect(result).toBe(server);
+  });
+
+  it("registers each provided network instead of the wildcard", () => {
+    const register = vi.fn();
+    const server = { register } as unknown as x402ResourceServer;
+
+    registerExactStellarScheme(server, { networks: ["stellar:pubnet", "stellar:testnet"] });
+
+    expect(register).toHaveBeenCalledTimes(2);
+    expect(register).toHaveBeenNthCalledWith(1, "stellar:pubnet", expect.any(ExactStellarScheme));
+    expect(register).toHaveBeenNthCalledWith(2, "stellar:testnet", expect.any(ExactStellarScheme));
+  });
+});


### PR DESCRIPTION
## Description

`@x402/evm` and `@x402/svm` each export a `registerExact*Scheme(server/client, config?)` convenience wrapper that hides the CAIP-2 network wildcard and the raw scheme class from callers. `@x402/stellar` had no equivalent — integrating Stellar required knowing the `stellar:*` wildcard and calling `.register()`/`new ExactStellarScheme()` directly.

This adds `registerExactStellarScheme()` to `@x402/stellar/exact/server` and `@x402/stellar/exact/client`, mirroring the EVM/SVM implementations:

- Server: registers `ExactStellarScheme` on `stellar:*` (or specific `networks`, if provided)
- Client: constructs `ExactStellarScheme(signer, rpcConfig)` once, registers it on `stellar:*` (or specific `networks`), and applies any `policies`

No existing exports or behavior changed — both `index.ts` files only gained new export lines.

Closes #2759

## Before / After

**Server**

```ts
// Before
const resourceServer = new x402ResourceServer(facilitatorClient).register(
  "stellar:*",
  new ExactStellarScheme(),
);

// After
const resourceServer = registerExactStellarScheme(new x402ResourceServer(facilitatorClient));
```

**Client**

```ts
// Before
const client = new x402Client().register(
  "stellar:*",
  new ExactStellarScheme(signer, rpcConfig),
);

// After
const client = registerExactStellarScheme(new x402Client(), { signer, rpcConfig });
```

## Tests

Added `test/unit/server-register.test.ts` and `test/unit/client-register.test.ts` covering:
- Default wildcard (`stellar:*`) registration
- Registration against explicit `networks`
- `rpcConfig` forwarded to the underlying scheme
- `policies` registered on the client

Ran from `/typescript`:
- `pnpm --filter @x402/stellar build` — passes
- `pnpm --filter @x402/stellar test` — 163/163 passing (6 new)
- `pnpm --filter @x402/stellar lint:check` — clean
- `pnpm --filter @x402/stellar format:check` — clean

Also manually verified end-to-end against live Stellar testnet: both the before and after snippets above were run as real server/client apps against Stellar testnet. Each completed a full 402 challenge -> signed payment -> verify/settle via the hosted `x402.org` facilitator, confirmed on-chain (`successful: true` on Horizon testnet), with identical settlement behavior.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
