### PR TITLE
mcp interop fixes

### DIFF
--- a/e2e/servers/mcp-python/main.py
+++ b/e2e/servers/mcp-python/main.py
@@ -42,7 +42,10 @@ def main() -> None:
     from mcp.server.fastmcp import FastMCP
 
     from x402 import ResourceConfig, ResourceInfo, x402ResourceServer
-    from x402.extensions.bazaar import DeclareMcpDiscoveryConfig, declare_mcp_discovery_extension
+    from x402.extensions.bazaar import (
+        DeclareMcpDiscoveryConfig,
+        declare_mcp_discovery_extension,
+    )
     from x402.http import FacilitatorConfig, HTTPFacilitatorClient
     from x402.mcp import create_payment_wrapper
     from x402.mechanisms.evm.exact import register_exact_evm_server
@@ -62,64 +65,53 @@ def main() -> None:
     # Initialize (fetches supported kinds from facilitator)
     resource_server.initialize()
 
-    weather_accepts = []
+    # Expose one paid tool per protocol family
+    def register_weather_tool(tool_name: str, network: str, pay_to: str) -> None:
+        accepts = resource_server.build_payment_requirements(
+            ResourceConfig(
+                scheme="exact",
+                network=network,
+                pay_to=pay_to,
+                price="$0.001",
+            )
+        )
+        discovery = declare_mcp_discovery_extension(
+            DeclareMcpDiscoveryConfig(
+                tool_name=tool_name,
+                description="Get current weather for a city",
+                transport="sse",
+                input_schema={
+                    "properties": {
+                        "city": {"type": "string", "description": "City name"}
+                    },
+                    "required": ["city"],
+                },
+                example={"city": "San Francisco"},
+            )
+        )
+        wrapper = create_payment_wrapper(
+            resource_server,
+            accepts=accepts,
+            resource=ResourceInfo(
+                url=f"mcp://tool/{tool_name}",
+                description="Get current weather for a city",
+                mime_type="application/json",
+            ),
+            extensions=discovery,
+        )
+
+        @mcp.tool(
+            name=tool_name,
+            description="Get current weather for a city. Requires payment of $0.001.",
+        )
+        @wrapper
+        async def _get_weather(city: str) -> str:
+            return json.dumps(get_weather_data(city))
+
     if EVM_PAYEE_ADDRESS:
-        weather_accepts.extend(
-            resource_server.build_payment_requirements(
-                ResourceConfig(
-                    scheme="exact",
-                    network=EVM_NETWORK,
-                    pay_to=EVM_PAYEE_ADDRESS,
-                    price="$0.001",
-                )
-            )
-        )
+        register_weather_tool("get_weather", EVM_NETWORK, EVM_PAYEE_ADDRESS)
     if TVM_PAYEE_ADDRESS:
-        weather_accepts.extend(
-            resource_server.build_payment_requirements(
-                ResourceConfig(
-                    scheme="exact",
-                    network=TVM_NETWORK,
-                    pay_to=TVM_PAYEE_ADDRESS,
-                    price="$0.001",
-                )
-            )
-        )
-
-    # Declare Bazaar discovery metadata for the weather tool
-    weather_discovery = declare_mcp_discovery_extension(
-        DeclareMcpDiscoveryConfig(
-            tool_name="get_weather",
-            description="Get current weather for a city",
-            transport="sse",
-            input_schema={
-                "properties": {"city": {"type": "string", "description": "City name"}},
-                "required": ["city"],
-            },
-            example={"city": "San Francisco"},
-        )
-    )
-
-    # Create payment wrapper for the weather tool
-    weather_wrapper = create_payment_wrapper(
-        resource_server,
-        accepts=weather_accepts,
-        resource=ResourceInfo(
-            url="mcp://tool/get_weather",
-            description="Get current weather for a city",
-            mime_type="application/json",
-        ),
-        extensions=weather_discovery,
-    )
-
-    @mcp.tool(
-        name="get_weather",
-        description="Get current weather for a city. Requires payment of $0.001.",
-    )
-    @weather_wrapper
-    async def get_weather(city: str) -> str:
-        """Return weather data as JSON string."""
-        return json.dumps(get_weather_data(city))
+        register_weather_tool("get_weather_tvm", TVM_NETWORK, TVM_PAYEE_ADDRESS)
 
     @mcp.tool(name="ping", description="A free health check tool")
     def ping() -> str:
@@ -135,7 +127,11 @@ def main() -> None:
         return JSONResponse(
             {
                 "status": "ok",
-                "tools": ["get_weather (paid: $0.001)", "ping (free)"],
+                "tools": [
+                    *(["get_weather (paid: $0.001)"] if EVM_PAYEE_ADDRESS else []),
+                    *(["get_weather_tvm (paid: $0.001)"] if TVM_PAYEE_ADDRESS else []),
+                    "ping (free)",
+                ],
                 "protocols": [
                     protocol
                     for protocol, enabled in {

--- a/e2e/servers/mcp-python/test.config.json
+++ b/e2e/servers/mcp-python/test.config.json
@@ -20,11 +20,14 @@
       "assetTransferMethod": "eip3009"
     },
     {
-      "path": "get_weather",
+      "path": "get_weather_tvm",
       "method": "tool",
-      "description": "Paid weather tool via MCP transport",
+      "toolName": "get_weather_tvm",
+      "mcpTransport": "sse",
+      "description": "Paid weather tool via MCP transport (TVM)",
       "requiresPayment": true,
-      "protocolFamily": "tvm"
+      "protocolFamily": "tvm",
+      "scheme": "exact"
     },
     {
       "path": "/health",

--- a/go/.changes/unreleased/fixed-20260703-173109.yaml
+++ b/go/.changes/unreleased/fixed-20260703-173109.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: MCP payment matching now selects the advertised `accepts` entry matching the payment payload instead of always using the first entry, so cross-SDK MCP flows advertising multiple requirements no longer fail when the payer selects a non-first option.
+time: 2026-07-03T17:31:09.645073+02:00

--- a/go/mcp/client.go
+++ b/go/mcp/client.go
@@ -165,9 +165,15 @@ func (c *X402MCPClient) CallTool(ctx context.Context, name string, args map[stri
 		}
 	}
 
+	// Select a supported requirement via the policy-aware selector
+	selected, err := c.paymentClient.SelectPaymentRequirements(paymentRequired.Accepts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select payment requirements: %w", err)
+	}
+
 	payload, err := c.paymentClient.CreatePaymentPayload(
 		ctx,
-		paymentRequired.Accepts[0],
+		selected,
 		paymentRequired.Resource,
 		paymentRequired.Extensions,
 	)
@@ -469,10 +475,15 @@ func CallPaidTool(
 		return buildResult(result, true), nil
 	}
 
-	// Create payment payload using the first requirement
+	// Select a supported requirement via the policy-aware selector
+	selected, err := x402Client.SelectPaymentRequirements(paymentRequired.Accepts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select payment requirements: %w", err)
+	}
+
 	paymentPayload, err := x402Client.CreatePaymentPayload(
 		ctx,
-		paymentRequired.Accepts[0],
+		selected,
 		paymentRequired.Resource,
 		paymentRequired.Extensions,
 	)

--- a/go/mcp/client_test.go
+++ b/go/mcp/client_test.go
@@ -491,6 +491,63 @@ func TestX402MCPClient_CallTool_AutoPaymentE2E(t *testing.T) {
 	}
 }
 
+func TestX402MCPClient_CallTool_SelectsSupportedNonFirstAccept(t *testing.T) {
+	// accepts[0] is on an unsupported network; the supported requirement is second.
+	// The client must select via SelectPaymentRequirements rather than accepts[0],
+	// otherwise CreatePaymentPayload fails for the unregistered first network.
+	paymentRequired := types.PaymentRequired{
+		X402Version: 2,
+		Accepts: []types.PaymentRequirements{
+			{Scheme: "exact", Network: "eip155:1", Amount: "1000", Asset: "USDC", PayTo: "0xrecipient", MaxTimeoutSeconds: 300},
+			{Scheme: "exact", Network: "eip155:84532", Amount: "1000", Asset: "USDC", PayTo: "0xrecipient", MaxTimeoutSeconds: 300},
+		},
+	}
+
+	structuredBytes, _ := json.Marshal(paymentRequired)
+	var structuredContent map[string]interface{}
+	if err := json.Unmarshal(structuredBytes, &structuredContent); err != nil {
+		t.Fatalf("Failed to unmarshal structured content: %v", err)
+	}
+
+	mockMCPCaller := &mockMCPCaller{
+		callToolResults: []MCPToolResult{
+			{IsError: true, StructuredContent: structuredContent},
+			{
+				Content: []MCPContentItem{{Type: "text", Text: "success"}},
+				IsError: false,
+				Meta: map[string]interface{}{
+					MCP_PAYMENT_RESPONSE_META_KEY: map[string]interface{}{
+						"success":     true,
+						"transaction": "0xtxhash",
+						"network":     "eip155:84532",
+					},
+				},
+			},
+		},
+	}
+
+	paymentClient := x402.Newx402Client()
+	// Only the second accept's network is supported.
+	paymentClient.Register("eip155:84532", &mockSchemeNetworkClient{scheme: "exact"})
+
+	x402Client := NewX402MCPClient(mockMCPCaller, paymentClient, Options{
+		AutoPayment: BoolPtr(true),
+	})
+
+	ctx := context.Background()
+	result, err := x402Client.CallTool(ctx, "paid_tool", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !result.PaymentMade {
+		t.Error("Expected PaymentMade to be true via the supported (second) accept")
+	}
+	if mockMCPCaller.callCount != 2 {
+		t.Errorf("Expected 2 calls to CallTool, got %d", mockMCPCaller.callCount)
+	}
+}
+
 func TestX402MCPClient_CallTool_HookAbort(t *testing.T) {
 	paymentRequired := types.PaymentRequired{
 		X402Version: 2,

--- a/go/mcp/server.go
+++ b/go/mcp/server.go
@@ -80,8 +80,15 @@ func (w *PaymentWrapper) Wrap(handler ToolHandler) ToolHandler {
 			return w.paymentRequiredResult(fmt.Sprintf("Invalid payment payload: %v", err)), nil
 		}
 
+		// Match the payload against the advertised accepts
+		matched := w.server.FindMatchingRequirements(w.config.Accepts, payload)
+		if matched == nil {
+			return w.paymentRequiredResult("No matching payment requirements found"), nil
+		}
+		requirements := *matched
+
 		// Verify payment -- return tool error result, NOT Go error
-		verifyResp, err := w.server.VerifyPayment(ctx, payload, w.config.Accepts[0])
+		verifyResp, err := w.server.VerifyPayment(ctx, payload, requirements)
 		if err != nil {
 			return w.paymentRequiredResult(
 				fmt.Sprintf("Payment verification error: %v", err)), nil
@@ -99,7 +106,7 @@ func (w *PaymentWrapper) Wrap(handler ToolHandler) ToolHandler {
 			hookCtx := ServerHookContext{
 				ToolName:            request.Params.Name,
 				Arguments:           args,
-				PaymentRequirements: w.config.Accepts[0],
+				PaymentRequirements: requirements,
 				PaymentPayload:      payload,
 			}
 			ok, err := (*w.config.Hooks.OnBeforeExecution)(hookCtx)
@@ -129,7 +136,7 @@ func (w *PaymentWrapper) Wrap(handler ToolHandler) ToolHandler {
 				ServerHookContext: ServerHookContext{
 					ToolName:            request.Params.Name,
 					Arguments:           args,
-					PaymentRequirements: w.config.Accepts[0],
+					PaymentRequirements: requirements,
 					PaymentPayload:      payload,
 				},
 				Result: mcpResult,
@@ -138,7 +145,7 @@ func (w *PaymentWrapper) Wrap(handler ToolHandler) ToolHandler {
 		}
 
 		// Settle payment -- return tool error result, NOT Go error
-		settleResp, err := w.server.SettlePayment(ctx, payload, w.config.Accepts[0], nil)
+		settleResp, err := w.server.SettlePayment(ctx, payload, requirements, nil)
 		if err != nil {
 			return w.settlementFailedResult(
 				fmt.Sprintf("Settlement error: %v", err)), nil
@@ -154,7 +161,7 @@ func (w *PaymentWrapper) Wrap(handler ToolHandler) ToolHandler {
 				ServerHookContext: ServerHookContext{
 					ToolName:            request.Params.Name,
 					Arguments:           args,
-					PaymentRequirements: w.config.Accepts[0],
+					PaymentRequirements: requirements,
 					PaymentPayload:      payload,
 				},
 				Settlement: *settleResp,

--- a/go/mcp/server_test.go
+++ b/go/mcp/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -622,6 +623,117 @@ func TestNewPaymentWrapper_NilExtensionsOmitted(t *testing.T) {
 	}
 	if _, ok := sc["extensions"]; ok {
 		t.Error("Expected 'extensions' key to be absent when Extensions is nil")
+	}
+}
+
+func TestNewPaymentWrapper_MatchesNonFirstAccept(t *testing.T) {
+	var verifiedReq types.PaymentRequirements
+	mockFacilitator := &mockFacilitatorClient{
+		verifyFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error) {
+			_ = json.Unmarshal(requirementsBytes, &verifiedReq)
+			return &x402.VerifyResponse{IsValid: true, Payer: "test-payer"}, nil
+		},
+	}
+	mockSchemeServer := &mockSchemeNetworkServer{scheme: "cash"}
+
+	server := x402.Newx402ResourceServer(
+		x402.WithFacilitatorClient(mockFacilitator),
+		x402.WithSchemeServer("x402:cash", mockSchemeServer),
+	)
+
+	ctx := context.Background()
+	if err := server.Initialize(ctx); err != nil {
+		t.Fatalf("Failed to initialize server: %v", err)
+	}
+
+	first := types.PaymentRequirements{Scheme: "cash", Network: "x402:cash", Amount: "1000", PayTo: "recipient-A"}
+	second := types.PaymentRequirements{Scheme: "cash", Network: "x402:cash", Amount: "2000", PayTo: "recipient-B"}
+
+	config := PaymentWrapperConfig{Accepts: []types.PaymentRequirements{first, second}}
+	wrapper := NewPaymentWrapper(server, config)
+	handler := func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "success"}},
+		}, nil
+	}
+	wrapped := wrapper.Wrap(handler)
+
+	// Client paid the SECOND requirement, not accepts[0].
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted:    second,
+		Payload:     map[string]interface{}{"signature": "~test-payer"},
+	}
+	req := makeCallToolRequest(map[string]interface{}{}, mcp.Meta{MCP_PAYMENT_META_KEY: payload})
+	result, err := wrapped(ctx, req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if result.IsError {
+		t.Error("Expected success result when payload matches a non-first accept")
+	}
+	if verifiedReq.PayTo != "recipient-B" || verifiedReq.Amount != "2000" {
+		t.Errorf("Expected verification against the matched (second) accept, got payTo=%q amount=%q",
+			verifiedReq.PayTo, verifiedReq.Amount)
+	}
+}
+
+func TestNewPaymentWrapper_NoMatchingAccept(t *testing.T) {
+	verifyCalled := false
+	mockFacilitator := &mockFacilitatorClient{
+		verifyFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error) {
+			verifyCalled = true
+			return &x402.VerifyResponse{IsValid: true, Payer: "test-payer"}, nil
+		},
+	}
+	mockSchemeServer := &mockSchemeNetworkServer{scheme: "cash"}
+
+	server := x402.Newx402ResourceServer(
+		x402.WithFacilitatorClient(mockFacilitator),
+		x402.WithSchemeServer("x402:cash", mockSchemeServer),
+	)
+
+	ctx := context.Background()
+	if err := server.Initialize(ctx); err != nil {
+		t.Fatalf("Failed to initialize server: %v", err)
+	}
+
+	config := PaymentWrapperConfig{
+		Accepts: []types.PaymentRequirements{
+			{Scheme: "cash", Network: "x402:cash", Amount: "1000", PayTo: "recipient-A"},
+		},
+	}
+	wrapper := NewPaymentWrapper(server, config)
+	handler := func(ctx context.Context, request *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{}, nil
+	}
+	wrapped := wrapper.Wrap(handler)
+
+	// Payload requirement matches none of the advertised accepts.
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted:    types.PaymentRequirements{Scheme: "cash", Network: "x402:cash", Amount: "9999", PayTo: "recipient-Z"},
+		Payload:     map[string]interface{}{"signature": "~test-payer"},
+	}
+	req := makeCallToolRequest(map[string]interface{}{}, mcp.Meta{MCP_PAYMENT_META_KEY: payload})
+	result, err := wrapped(ctx, req)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !result.IsError {
+		t.Error("Expected error result when no accept matches the payload")
+	}
+	if verifyCalled {
+		t.Error("Verification should not run when no accept matches")
+	}
+	sc, ok := result.StructuredContent.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected structuredContent to be a map, got %T", result.StructuredContent)
+	}
+	if errMsg, _ := sc["error"].(string); !strings.Contains(errMsg, "No matching payment requirements") {
+		t.Errorf("Expected a no-match error message, got %q", errMsg)
 	}
 }
 

--- a/python/x402/changelog.d/2774.bugfix.md
+++ b/python/x402/changelog.d/2774.bugfix.md
@@ -1,0 +1,1 @@
+Fixed cross-SDK MCP interop: the FastMCP payment wrapper now verifies and settles against the advertised `accepts` entry that matches the payment payload instead of always using the first entry, and omits `None` optional fields from serialized `PaymentRequired` results so stricter clients accept them.

--- a/python/x402/mcp/server.py
+++ b/python/x402/mcp/server.py
@@ -146,8 +146,8 @@ def create_payment_wrapper(
                 )
 
             # Match the payload against the advertised accepts
-            requirements = resource_server.find_matching_requirements(accepts, payload)
-            if requirements is None:
+            payment_requirements = resource_server.find_matching_requirements(accepts, payload)
+            if payment_requirements is None:
                 return _create_payment_required_result(
                     accepts,
                     tool_resource,
@@ -156,10 +156,10 @@ def create_payment_wrapper(
                 )
 
             if asyncio.iscoroutinefunction(resource_server.verify_payment):
-                verify_result = await resource_server.verify_payment(payload, requirements)
+                verify_result = await resource_server.verify_payment(payload, payment_requirements)
             else:
                 verify_result = await asyncio.to_thread(
-                    resource_server.verify_payment, payload, requirements
+                    resource_server.verify_payment, payload, payment_requirements
                 )
             if not verify_result.is_valid:
                 return _create_payment_required_result(
@@ -174,7 +174,7 @@ def create_payment_wrapper(
                 hook_ctx = ServerHookContext(
                     tool_name=tool_name,
                     arguments=kwargs,
-                    payment_requirements=requirements,
+                    payment_requirements=payment_requirements,
                     payment_payload=payload,
                 )
                 proceed = hooks.on_before_execution(hook_ctx)
@@ -232,7 +232,7 @@ def create_payment_wrapper(
                 after_ctx = AfterExecutionContext(
                     tool_name=tool_name,
                     arguments=kwargs,
-                    payment_requirements=requirements,
+                    payment_requirements=payment_requirements,
                     payment_payload=payload,
                     result=mcp_result,
                 )
@@ -245,10 +245,12 @@ def create_payment_wrapper(
 
             try:
                 if asyncio.iscoroutinefunction(resource_server.settle_payment):
-                    settle_result = await resource_server.settle_payment(payload, requirements)
+                    settle_result = await resource_server.settle_payment(
+                        payload, payment_requirements
+                    )
                 else:
                     settle_result = await asyncio.to_thread(
-                        resource_server.settle_payment, payload, requirements
+                        resource_server.settle_payment, payload, payment_requirements
                     )
                 if not settle_result.success:
                     return _create_settlement_failed_result(
@@ -256,7 +258,7 @@ def create_payment_wrapper(
                         tool_resource,
                         settle_result.error_reason or "Unknown settlement failure",
                         extensions,
-                        network=requirements.network,
+                        network=payment_requirements.network,
                     )
             except Exception as e:
                 return _create_settlement_failed_result(
@@ -264,7 +266,7 @@ def create_payment_wrapper(
                     tool_resource,
                     str(e),
                     extensions,
-                    network=requirements.network,
+                    network=payment_requirements.network,
                 )
 
             # OnAfterSettlement hook
@@ -272,7 +274,7 @@ def create_payment_wrapper(
                 settlement_ctx = SettlementContext(
                     tool_name=tool_name,
                     arguments=kwargs,
-                    payment_requirements=requirements,
+                    payment_requirements=payment_requirements,
                     payment_payload=payload,
                     settlement=settle_result,
                 )

--- a/python/x402/mcp/server.py
+++ b/python/x402/mcp/server.py
@@ -145,11 +145,21 @@ def create_payment_wrapper(
                     accepts, tool_resource, f"Invalid payment payload: {e}", extensions
                 )
 
+            # Match the payload against the advertised accepts
+            requirements = resource_server.find_matching_requirements(accepts, payload)
+            if requirements is None:
+                return _create_payment_required_result(
+                    accepts,
+                    tool_resource,
+                    "No matching payment requirements found",
+                    extensions,
+                )
+
             if asyncio.iscoroutinefunction(resource_server.verify_payment):
-                verify_result = await resource_server.verify_payment(payload, accepts[0])
+                verify_result = await resource_server.verify_payment(payload, requirements)
             else:
                 verify_result = await asyncio.to_thread(
-                    resource_server.verify_payment, payload, accepts[0]
+                    resource_server.verify_payment, payload, requirements
                 )
             if not verify_result.is_valid:
                 return _create_payment_required_result(
@@ -164,7 +174,7 @@ def create_payment_wrapper(
                 hook_ctx = ServerHookContext(
                     tool_name=tool_name,
                     arguments=kwargs,
-                    payment_requirements=accepts[0],
+                    payment_requirements=requirements,
                     payment_payload=payload,
                 )
                 proceed = hooks.on_before_execution(hook_ctx)
@@ -222,7 +232,7 @@ def create_payment_wrapper(
                 after_ctx = AfterExecutionContext(
                     tool_name=tool_name,
                     arguments=kwargs,
-                    payment_requirements=accepts[0],
+                    payment_requirements=requirements,
                     payment_payload=payload,
                     result=mcp_result,
                 )
@@ -235,10 +245,10 @@ def create_payment_wrapper(
 
             try:
                 if asyncio.iscoroutinefunction(resource_server.settle_payment):
-                    settle_result = await resource_server.settle_payment(payload, accepts[0])
+                    settle_result = await resource_server.settle_payment(payload, requirements)
                 else:
                     settle_result = await asyncio.to_thread(
-                        resource_server.settle_payment, payload, accepts[0]
+                        resource_server.settle_payment, payload, requirements
                     )
                 if not settle_result.success:
                     return _create_settlement_failed_result(
@@ -246,6 +256,7 @@ def create_payment_wrapper(
                         tool_resource,
                         settle_result.error_reason or "Unknown settlement failure",
                         extensions,
+                        network=requirements.network,
                     )
             except Exception as e:
                 return _create_settlement_failed_result(
@@ -253,6 +264,7 @@ def create_payment_wrapper(
                     tool_resource,
                     str(e),
                     extensions,
+                    network=requirements.network,
                 )
 
             # OnAfterSettlement hook
@@ -260,7 +272,7 @@ def create_payment_wrapper(
                 settlement_ctx = SettlementContext(
                     tool_name=tool_name,
                     arguments=kwargs,
-                    payment_requirements=accepts[0],
+                    payment_requirements=requirements,
                     payment_payload=payload,
                     settlement=settle_result,
                 )
@@ -272,7 +284,7 @@ def create_payment_wrapper(
                     pass
 
             # Return result with payment response in _meta
-            payment_response = settle_result.model_dump(by_alias=True)
+            payment_response = settle_result.model_dump(by_alias=True, exclude_none=True)
             response_meta = result_meta.copy()
             response_meta[MCP_PAYMENT_RESPONSE_META_KEY] = payment_response
             return CallToolResult(
@@ -346,12 +358,12 @@ def _create_payment_required_result(
     """Create a payment required CallToolResult."""
     from mcp.types import CallToolResult, TextContent
 
-    accepts_dicts = [req.model_dump(by_alias=True) for req in accepts]
+    accepts_dicts = [req.model_dump(by_alias=True, exclude_none=True) for req in accepts]
     payment_required: dict[str, Any] = {
         "x402Version": 2,
         "accepts": accepts_dicts,
         "error": error_message,
-        "resource": resource.model_dump(by_alias=True),
+        "resource": resource.model_dump(by_alias=True, exclude_none=True),
     }
     if extensions:
         payment_required["extensions"] = extensions
@@ -367,21 +379,23 @@ def _create_settlement_failed_result(
     resource: ResourceInfo,
     error_message: str,
     extensions: dict[str, Any] | None = None,
+    *,
+    network: str | None = None,
 ) -> Any:
     """Create a settlement failed CallToolResult."""
     from mcp.types import CallToolResult, TextContent
 
-    accepts_dicts = [req.model_dump(by_alias=True) for req in accepts]
+    accepts_dicts = [req.model_dump(by_alias=True, exclude_none=True) for req in accepts]
     error_data: dict[str, Any] = {
         "x402Version": 2,
         "accepts": accepts_dicts,
         "error": f"Payment settlement failed: {error_message}",
-        "resource": resource.model_dump(by_alias=True),
+        "resource": resource.model_dump(by_alias=True, exclude_none=True),
         MCP_PAYMENT_RESPONSE_META_KEY: {
             "success": False,
             "errorReason": error_message,
             "transaction": "",
-            "network": accepts[0].network,
+            "network": network or accepts[0].network,
         },
     }
     if extensions:

--- a/python/x402/mcp/server_async.py
+++ b/python/x402/mcp/server_async.py
@@ -301,7 +301,7 @@ def create_payment_wrapper(
             if result.meta is None:
                 result.meta = {}
             result.meta[MCP_PAYMENT_RESPONSE_META_KEY] = (
-                settle_result.model_dump(by_alias=True)
+                settle_result.model_dump(by_alias=True, exclude_none=True)
                 if hasattr(settle_result, "model_dump")
                 else settle_result
             )
@@ -341,7 +341,7 @@ async def _create_payment_required_result_async(
 
     # Convert to dict for structuredContent
     payment_required_dict = (
-        payment_required.model_dump(by_alias=True)
+        payment_required.model_dump(by_alias=True, exclude_none=True)
         if hasattr(payment_required, "model_dump")
         else payment_required
     )
@@ -391,7 +391,7 @@ async def _create_settlement_failed_result_async(
 
     # Merge paymentRequired with settlement failure (camelCase for wire format)
     error_data = (
-        payment_required.model_dump(by_alias=True)
+        payment_required.model_dump(by_alias=True, exclude_none=True)
         if hasattr(payment_required, "model_dump")
         else payment_required
     )

--- a/python/x402/mcp/server_sync.py
+++ b/python/x402/mcp/server_sync.py
@@ -182,7 +182,7 @@ def create_payment_wrapper_sync(
             if result.meta is None:
                 result.meta = {}
             result.meta[MCP_PAYMENT_RESPONSE_META_KEY] = (
-                settle_result.model_dump(by_alias=True)
+                settle_result.model_dump(by_alias=True, exclude_none=True)
                 if hasattr(settle_result, "model_dump")
                 else settle_result
             )
@@ -211,7 +211,7 @@ def _create_payment_required_result_sync(
     )
 
     payment_required_dict = (
-        payment_required.model_dump(by_alias=True)
+        payment_required.model_dump(by_alias=True, exclude_none=True)
         if hasattr(payment_required, "model_dump")
         else payment_required
     )
@@ -249,7 +249,7 @@ def _create_settlement_failed_result_sync(
     }
 
     error_data = (
-        payment_required.model_dump(by_alias=True)
+        payment_required.model_dump(by_alias=True, exclude_none=True)
         if hasattr(payment_required, "model_dump")
         else payment_required
     )

--- a/python/x402/mcp/tests/test_server_fastmcp.py
+++ b/python/x402/mcp/tests/test_server_fastmcp.py
@@ -8,7 +8,12 @@ import pytest
 from mcp.types import CallToolResult, TextContent
 from x402.mcp.constants import MCP_PAYMENT_META_KEY, MCP_PAYMENT_RESPONSE_META_KEY
 from x402.mcp.server import create_payment_wrapper
-from x402.schemas import PaymentPayload, PaymentRequirements, SettleResponse
+from x402.schemas import (
+    PaymentPayload,
+    PaymentRequirements,
+    ResourceInfo,
+    SettleResponse,
+)
 
 
 class MockFastMCPContext:
@@ -18,6 +23,24 @@ class MockFastMCPContext:
         self.request_context = SimpleNamespace(
             meta=SimpleNamespace(model_extra=meta),
         )
+
+
+def _matching_resource_server(**overrides):
+    """Mock resource server whose find_matching_requirements matches by scheme+network."""
+    resource_server = Mock()
+    resource_server.find_matching_requirements = Mock(
+        side_effect=lambda accepts, payload: next(
+            (
+                req
+                for req in accepts
+                if req.scheme == payload.accepted.scheme and req.network == payload.accepted.network
+            ),
+            None,
+        )
+    )
+    for name, value in overrides.items():
+        setattr(resource_server, name, value)
+    return resource_server
 
 
 @pytest.mark.asyncio
@@ -64,3 +87,124 @@ async def test_fastmcp_wrapper_preserves_call_tool_result_meta():
     assert result.content[0].text == "ok"
     assert result.meta["traceId"] == "trace-123"
     assert result.meta[MCP_PAYMENT_RESPONSE_META_KEY]["transaction"] == "0xtx123"
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_verifies_and_settles_against_matched_accept():
+    """The wrapper must use the requirement matched from payload.accepted, not accepts[0]."""
+    evm = PaymentRequirements(
+        scheme="exact",
+        network="eip155:84532",
+        amount="1000",
+        asset="USDC",
+        pay_to="0xevm",
+        max_timeout_seconds=300,
+    )
+    tvm = PaymentRequirements(
+        scheme="exact",
+        network="tvm:-3",
+        amount="1000",
+        asset="TON",
+        pay_to="0xtvm",
+        max_timeout_seconds=300,
+    )
+    # Client paid the second (TVM) requirement.
+    payload = PaymentPayload(
+        x402_version=2,
+        accepted=tvm.model_dump(by_alias=True),
+        payload={"signature": "0x123"},
+    )
+    resource_server = _matching_resource_server(
+        verify_payment=AsyncMock(return_value=Mock(is_valid=True)),
+        settle_payment=AsyncMock(
+            return_value=SettleResponse(success=True, transaction="0xtx123", network="tvm:-3")
+        ),
+    )
+
+    wrapper = create_payment_wrapper(resource_server, accepts=[evm, tvm])
+
+    @wrapper
+    async def paid_tool() -> str:
+        return "ok"
+
+    result = await paid_tool(
+        ctx=MockFastMCPContext({MCP_PAYMENT_META_KEY: payload.model_dump(by_alias=True)})
+    )
+
+    assert result.isError is False
+    assert resource_server.verify_payment.call_args.args[1].network == "tvm:-3"
+    assert resource_server.settle_payment.call_args.args[1].network == "tvm:-3"
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_returns_payment_required_when_no_accept_matches():
+    """A payload that matches none of the advertised accepts must not be verified."""
+    evm = PaymentRequirements(
+        scheme="exact",
+        network="eip155:84532",
+        amount="1000",
+        asset="USDC",
+        pay_to="0xevm",
+        max_timeout_seconds=300,
+    )
+    tvm = PaymentRequirements(
+        scheme="exact",
+        network="tvm:-3",
+        amount="1000",
+        asset="TON",
+        pay_to="0xtvm",
+        max_timeout_seconds=300,
+    )
+    payload = PaymentPayload(
+        x402_version=2,
+        accepted=tvm.model_dump(by_alias=True),
+        payload={"signature": "0x123"},
+    )
+    resource_server = _matching_resource_server(verify_payment=AsyncMock())
+
+    wrapper = create_payment_wrapper(resource_server, accepts=[evm])
+
+    @wrapper
+    async def paid_tool() -> str:
+        return "ok"
+
+    result = await paid_tool(
+        ctx=MockFastMCPContext({MCP_PAYMENT_META_KEY: payload.model_dump(by_alias=True)})
+    )
+
+    assert result.isError is True
+    resource_server.verify_payment.assert_not_called()
+    assert "No matching payment requirements" in result.structuredContent["error"]
+
+
+@pytest.mark.asyncio
+async def test_fastmcp_payment_required_omits_null_optional_fields():
+    """Unset optional fields must not serialize as explicit null (exclude_none)."""
+    requirements = PaymentRequirements(
+        scheme="exact",
+        network="eip155:84532",
+        amount="1000",
+        asset="USDC",
+        pay_to="0xrecipient",
+        max_timeout_seconds=300,
+    )
+    resource_server = Mock()
+
+    wrapper = create_payment_wrapper(
+        resource_server,
+        accepts=[requirements],
+        resource=ResourceInfo(url="mcp://tool/get_weather"),
+    )
+
+    @wrapper
+    async def paid_tool() -> str:
+        return "ok"
+
+    # No payment in context -> payment required result.
+    result = await paid_tool(ctx=MockFastMCPContext({}))
+
+    assert result.isError is True
+    # Optional ResourceInfo fields (description, mimeType, ...) default to None and
+    # must be stripped rather than emitted as null.
+    assert result.structuredContent["resource"] == {"url": "mcp://tool/get_weather"}
+    assert all(value is not None for value in result.structuredContent["accepts"][0].values())

--- a/typescript/.changeset/forty-hats-repeat.md
+++ b/typescript/.changeset/forty-hats-repeat.md
@@ -1,0 +1,6 @@
+---
+'@x402/core': patch
+'@x402/mcp': patch
+---
+
+Fixed cross-SDK MCP interop: optional `PaymentRequired`/`ResourceInfo`/`PaymentPayload` wire fields serialized as explicit `null` by the Python and Go SDKs are now accepted and normalized to `undefined` instead of failing validation. The MCP client routes both result and error extraction through `parsePaymentRequired`, so 402 responses from other implementations reliably trigger auto-payment.

--- a/typescript/packages/core/src/schemas/index.ts
+++ b/typescript/packages/core/src/schemas/index.ts
@@ -67,13 +67,34 @@ export type Network = z.infer<typeof NetworkSchema>;
 // len() / len() otherwise diverge for multi-byte input).
 const PRINTABLE_ASCII_REGEX = /^[\x20-\x7e]+$/;
 
+// Optional wire fields accept explicit `null` from other implementations and normalize it to `undefined`
 export const ResourceInfoSchema = z.object({
   url: NonEmptyString,
-  description: z.string().optional(),
-  mimeType: z.string().optional(),
-  serviceName: z.string().min(1).max(32).regex(PRINTABLE_ASCII_REGEX).optional(),
-  tags: z.array(z.string().min(1).max(32).regex(PRINTABLE_ASCII_REGEX)).max(5).optional(),
-  iconUrl: z.string().max(2048).optional(),
+  description: z
+    .string()
+    .nullish()
+    .transform(v => v ?? undefined),
+  mimeType: z
+    .string()
+    .nullish()
+    .transform(v => v ?? undefined),
+  serviceName: z
+    .string()
+    .min(1)
+    .max(32)
+    .regex(PRINTABLE_ASCII_REGEX)
+    .nullish()
+    .transform(v => v ?? undefined),
+  tags: z
+    .array(z.string().min(1).max(32).regex(PRINTABLE_ASCII_REGEX))
+    .max(5)
+    .nullish()
+    .transform(v => v ?? undefined),
+  iconUrl: z
+    .string()
+    .max(2048)
+    .nullish()
+    .transform(v => v ?? undefined),
 });
 export type ResourceInfo = z.infer<typeof ResourceInfoSchema>;
 
@@ -148,7 +169,10 @@ export type PaymentRequirementsV2 = z.infer<typeof PaymentRequirementsV2Schema>;
  */
 export const PaymentRequiredV2Schema = z.object({
   x402Version: z.literal(2),
-  error: z.string().optional(),
+  error: z
+    .string()
+    .nullish()
+    .transform(v => v ?? undefined),
   resource: ResourceInfoSchema,
   accepts: z.array(PaymentRequirementsV2Schema).min(1),
   extensions: OptionalAny,
@@ -161,7 +185,7 @@ export type PaymentRequiredV2 = z.infer<typeof PaymentRequiredV2Schema>;
  */
 export const PaymentPayloadV2Schema = z.object({
   x402Version: z.literal(2),
-  resource: ResourceInfoSchema.optional(),
+  resource: ResourceInfoSchema.nullish().transform(v => v ?? undefined),
   accepted: PaymentRequirementsV2Schema,
   payload: Any,
   extensions: OptionalAny,

--- a/typescript/packages/core/test/unit/schemas/schemas.test.ts
+++ b/typescript/packages/core/test/unit/schemas/schemas.test.ts
@@ -264,6 +264,60 @@ describe("x402 Schemas", () => {
         const result = PaymentPayloadV2Schema.safeParse(withoutResource);
         expect(result.success).toBe(true);
       });
+
+      it("should accept null resource and normalize it to undefined", () => {
+        const result = PaymentPayloadV2Schema.safeParse({
+          ...validPaymentPayloadV2,
+          resource: null,
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.resource).toBeUndefined();
+        }
+      });
+    });
+
+    describe("Nullable optional field normalization", () => {
+      it("should accept explicit null for optional ResourceInfo fields and normalize to undefined", () => {
+        const result = PaymentRequiredV2Schema.safeParse({
+          ...validPaymentRequiredV2,
+          resource: {
+            url: "https://api.example.com/premium-data",
+            description: null,
+            mimeType: null,
+            serviceName: null,
+            tags: null,
+            iconUrl: null,
+          },
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.resource.description).toBeUndefined();
+          expect(result.data.resource.mimeType).toBeUndefined();
+          expect(result.data.resource.serviceName).toBeUndefined();
+          expect(result.data.resource.tags).toBeUndefined();
+          expect(result.data.resource.iconUrl).toBeUndefined();
+        }
+      });
+
+      it("should accept explicit null for PaymentRequiredV2 error and normalize to undefined", () => {
+        const result = PaymentRequiredV2Schema.safeParse({
+          ...validPaymentRequiredV2,
+          error: null,
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.error).toBeUndefined();
+        }
+      });
+
+      it("should still reject a resource missing the required url", () => {
+        const result = PaymentRequiredV2Schema.safeParse({
+          ...validPaymentRequiredV2,
+          resource: { url: null },
+        });
+        expect(result.success).toBe(false);
+      });
     });
 
     describe("V2 Type Guards", () => {

--- a/typescript/packages/mcp/src/client/x402MCPClient.ts
+++ b/typescript/packages/mcp/src/client/x402MCPClient.ts
@@ -5,7 +5,7 @@ import type {
   Network,
   SchemeNetworkClient,
 } from "@x402/core/types";
-import { isPaymentRequired } from "@x402/core/schemas";
+import { parsePaymentRequired } from "@x402/core/schemas";
 import { x402Client } from "@x402/core/client";
 import type { x402ClientConfig } from "@x402/core/client";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -624,11 +624,11 @@ export class x402MCPClient {
     const paymentRequired = this.extractPaymentRequiredFromResult(result);
     const recoveryResult = paymentPayload.accepted
       ? await this._paymentClient.handlePaymentResponse({
-          paymentPayload,
-          requirements: paymentPayload.accepted,
-          ...(paymentResponse ? { settleResponse: paymentResponse } : {}),
-          ...(paymentRequired ? { paymentRequired } : {}),
-        })
+        paymentPayload,
+        requirements: paymentPayload.accepted,
+        ...(paymentResponse ? { settleResponse: paymentResponse } : {}),
+        ...(paymentRequired ? { paymentRequired } : {}),
+      })
       : undefined;
 
     // A paid attempt can return a corrective 402. Scheme hooks recover local
@@ -809,11 +809,9 @@ export class x402MCPClient {
    * @returns PaymentRequired if found, null otherwise
    */
   private extractPaymentRequiredFromObject(obj: Record<string, unknown>): PaymentRequired | null {
-    if (isPaymentRequired(obj)) {
-      return obj as PaymentRequired;
-    }
-
-    return null;
+    // parsePaymentRequired yields the schema (V1 | V2) union; cast to the transport PaymentRequired type
+    const result = parsePaymentRequired(obj);
+    return result.success ? (result.data as PaymentRequired) : null;
   }
 
   /**
@@ -832,7 +830,9 @@ export class x402MCPClient {
       return null;
     }
 
-    return "x402" in error.data ? error.data.x402 : error.data;
+    const data = "x402" in error.data ? error.data.x402 : error.data;
+    const result = parsePaymentRequired(data);
+    return result.success ? (result.data as PaymentRequired) : null;
   }
 
 }

--- a/typescript/packages/mcp/src/utils/encoding.ts
+++ b/typescript/packages/mcp/src/utils/encoding.ts
@@ -1,4 +1,5 @@
 import type { PaymentPayload, PaymentRequired, SettleResponse } from "@x402/core/types";
+import { parsePaymentRequired } from "@x402/core/schemas";
 import {
   MCP_PAYMENT_META_KEY,
   MCP_PAYMENT_REQUIRED_CODE,
@@ -214,7 +215,9 @@ export function extractPaymentRequiredFromError(error: unknown): PaymentRequired
     return null;
   }
 
-  return data;
+  // parsePaymentRequired yields the schema (V1 | V2) union; cast to the transport PaymentRequired type
+  const result = parsePaymentRequired(data);
+  return result.success ? (result.data as PaymentRequired) : null;
 }
 
 /**

--- a/typescript/packages/mcp/test/unit/client.test.ts
+++ b/typescript/packages/mcp/test/unit/client.test.ts
@@ -596,6 +596,40 @@ describe("x402MCPClient response format interoperability", () => {
       expect(mockPaymentClient.createPaymentPayload).toHaveBeenCalledWith(mockPaymentRequired);
     });
 
+    it("should auto-pay when structuredContent has null optional resource fields", async () => {
+      // Other SDKs may serialize unset optional fields as explicit null. Before
+      // the schema normalization, strict parsing rejected these and the 402 was
+      // returned as ordinary tool data instead of triggering payment.
+      const paymentRequiredWithNulls = {
+        ...mockPaymentRequired,
+        error: null,
+        resource: {
+          url: "mcp://tool/test",
+          description: null,
+          mimeType: null,
+          serviceName: null,
+          tags: null,
+          iconUrl: null,
+        },
+      };
+
+      mockMcpClient.callTool
+        .mockResolvedValueOnce(
+          createStructuredContentDirectPaymentError(
+            paymentRequiredWithNulls as unknown as PaymentRequired,
+          ),
+        )
+        .mockResolvedValueOnce({
+          content: [{ type: "text", text: "success" }],
+          _meta: { "x402/payment-response": mockSettleResponse },
+        });
+
+      const result = await client.callTool("paid_tool");
+
+      expect(result.paymentMade).toBe(true);
+      expect(mockMcpClient.callTool).toHaveBeenCalledTimes(2);
+    });
+
     it("should parse structuredContent with direct PaymentRequired V1 (ethanniser/x402-mcp style)", async () => {
       mockMcpClient.callTool
         .mockResolvedValueOnce(createStructuredContentDirectPaymentError(mockPaymentRequiredV1))

--- a/typescript/packages/mcp/test/unit/utils.test.ts
+++ b/typescript/packages/mcp/test/unit/utils.test.ts
@@ -49,7 +49,7 @@ const mockPaymentRequired: PaymentRequired = {
       amount: "1000",
       asset: "0xtoken",
       payTo: "0xrecipient",
-      maxAmountRequired: "1000",
+      maxTimeoutSeconds: 60,
       extra: {},
     },
   ],


### PR DESCRIPTION
## Description

- cross-SDK MCP interop fix: don't emit null for optional fields but accept-and-normalize inbound null
- match against the client's selected `accept` instead of `accepts[0]`


## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 