### PR TITLE
conformance: x402 core conformance-vector set + stdlib runner (#2178)

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,75 @@
+<!--
+Copyright 2026 Michael K. Saleme
+SPDX-License-Identifier: Apache-2.0
+-->
+# x402 Conformance Vectors
+
+An open, dependency-free conformance-vector set for x402 implementations —
+delivering the open-source conformance harness proposed in **#2178**.
+
+A protocol with governance but no conformance vectors is a promise, not a
+guarantee: two implementations can each claim x402 compliance and still diverge
+on the same request. These vectors let an implementer *prove* conformance.
+
+## What a vector is
+
+A vector is **data**, not a reference implementation — a normative x402
+requirement plus the request that exercises it:
+
+```json
+{
+  "id": "X4-001",
+  "title": "402 Payment Challenge Headers Present",
+  "category": "payment_challenge",
+  "requirement": "HC-1: Payment protocol must return complete challenge",
+  "method": "GET",
+  "request": { "path": "/" },
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding."
+}
+```
+
+The schema is `schema.json`. This set carries **52 vectors** across the x402
+core conformance surface: payment-challenge structure, recipient/amount
+integrity, session security, spending limits, facilitator trust, information
+disclosure, cross-chain confusion, identity verification, replay / double-spend,
+authorization bypass, settlement finality, and protocol abuse.
+
+## Running it against your implementation
+
+```bash
+# validate the vector set (offline, no network)
+python conformance/run_conformance.py --validate
+
+# replay every vector against your x402 endpoint and report the response
+python conformance/run_conformance.py --url https://your-x402-endpoint --report report.json
+```
+
+The runner is stdlib-only (no dependencies). It replays each vector's request
+and pairs the normative requirement with your implementation's observed
+response, so conformance can be judged per requirement in CI or review.
+
+## Scope and roadmap
+
+- **This set: x402 core (52 vectors).** Vectors are generated from the
+  open-source [`agent-security-harness`](https://pypi.org/project/agent-security-harness/)
+  (Apache-2.0) so they stay faithful to a maintained test suite; provenance is
+  recorded in each vector's `source` field.
+- **Planned:** optional machine-checkable `assert` blocks (status / header /
+  body predicates) so the runner can auto-judge deterministic vectors, and an
+  x402 **extension** conformance set (e.g. request-integrity / spend-governance)
+  contributed alongside the relevant extension spec.
+
+## Provenance & license
+
+Contributed by **Michael K. Saleme** (ORCID
+[0009-0003-6736-1900](https://orcid.org/0009-0003-6736-1900)). Vectors are
+derived from the Apache-2.0 `agent-security-harness`; methodology at Zenodo
+[10.5281/zenodo.19343034](https://doi.org/10.5281/zenodo.19343034). Licensed
+Apache-2.0, matching this repository.
+
+Building these vectors against a reference x402 hardening implementation
+surfaced three real fail-open defects (a credential-release check trusting an
+attacker-controlled flag, a scope check that failed open on an omitted field,
+and an SSRF blocklist that missed most of the RFC1918 `172.16/12` range) — all
+disclosed and guarded. That is what a conformance suite is for.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -68,8 +68,10 @@ derived from the Apache-2.0 `agent-security-harness`; methodology at Zenodo
 [10.5281/zenodo.19343034](https://doi.org/10.5281/zenodo.19343034). Licensed
 Apache-2.0, matching this repository.
 
-Building these vectors against a reference x402 hardening implementation
-surfaced three real fail-open defects (a credential-release check trusting an
-attacker-controlled flag, a scope check that failed open on an omitted field,
-and an SSRF blocklist that missed most of the RFC1918 `172.16/12` range) — all
-disclosed and guarded. That is what a conformance suite is for.
+While building the harness these vectors come from, adversarial review of **its
+own reference verifier** caught three fail-open defects *in that harness code* —
+a credential-release check trusting a self-asserted flag, a scope check that
+failed open on an omitted field, and an SSRF blocklist that missed most of the
+RFC1918 `172.16/12` range — each fixed and guarded by a negative test before
+release. Fail-open is easy to ship even in code written to catch it; that is
+exactly why machine-checkable conformance vectors are worth having.

--- a/conformance/run_conformance.py
+++ b/conformance/run_conformance.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright 2026 Michael K. Saleme
+# SPDX-License-Identifier: Apache-2.0
+"""x402 conformance-vector runner (stdlib-only, no dependencies).
+
+A conformance vector is *data*: a normative x402 requirement plus the request
+that exercises it. This runner either validates the vector set or replays it
+against a live x402 implementation and reports how the implementation responds,
+so you can judge conformance against each requirement.
+
+Usage:
+    python run_conformance.py --validate                 # schema-check all vectors
+    python run_conformance.py --url https://your-x402    # replay against your endpoint
+    python run_conformance.py --url https://your-x402 --report out.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+VECTORS_DIR = HERE / "vectors"
+
+_REQUIRED = {
+    "id": str, "title": str, "category": str, "requirement": str,
+    "method": str, "request": dict, "normative": str, "expected": str,
+}
+_METHODS = {"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"}
+
+
+def load_vectors() -> list[tuple[Path, dict]]:
+    return [(p, json.loads(p.read_text())) for p in sorted(VECTORS_DIR.rglob("*.json"))]
+
+
+def validate(vecs: list[tuple[Path, dict]]) -> list[str]:
+    """Minimal, dependency-free check against schema.json's core constraints."""
+    errs: list[str] = []
+    seen: set[str] = set()
+    for path, v in vecs:
+        for key, typ in _REQUIRED.items():
+            if key not in v:
+                errs.append(f"{path.name}: missing '{key}'")
+            elif not isinstance(v[key], typ):
+                errs.append(f"{path.name}: '{key}' must be {typ.__name__}")
+        if v.get("normative") not in ("MUST", "SHOULD"):
+            errs.append(f"{path.name}: 'normative' must be MUST or SHOULD")
+        if v.get("method", "").upper() not in _METHODS:
+            errs.append(f"{path.name}: unknown method '{v.get('method')}'")
+        vid = v.get("id")
+        if vid in seen:
+            errs.append(f"{path.name}: duplicate id '{vid}'")
+        seen.add(vid)
+    return errs
+
+
+def replay(target: str, vec: dict) -> dict:
+    req = vec.get("request", {})
+    path = req.get("path", "/") or "/"
+    url = target.rstrip("/") + (path if path.startswith("/") else "/" + path)
+    method = vec.get("method", "GET").upper()
+    body = req.get("body")
+    if isinstance(body, (dict, list)):
+        data = json.dumps(body).encode()
+    elif isinstance(body, str):
+        data = body.encode()
+    else:
+        data = None
+    request = urllib.request.Request(url, data=data, method=method,
+                                     headers={k: str(v) for k, v in (req.get("headers") or {}).items()})
+    try:
+        with urllib.request.urlopen(request, timeout=15) as resp:
+            return {"status": resp.status, "headers": dict(resp.headers)}
+    except urllib.error.HTTPError as e:
+        return {"status": e.code, "headers": dict(e.headers)}
+    except Exception as e:  # transport failure
+        return {"error": str(e)[:160]}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="x402 conformance-vector runner (stdlib-only)")
+    ap.add_argument("--validate", action="store_true", help="schema-check all vectors and exit")
+    ap.add_argument("--url", help="replay vectors against a live x402 implementation")
+    ap.add_argument("--report", help="write a JSON report to this path")
+    args = ap.parse_args()
+
+    vecs = load_vectors()
+    if not vecs:
+        print(f"no vectors found under {VECTORS_DIR}", file=sys.stderr)
+        sys.exit(1)
+
+    # Always validate first (also the whole job for --validate / no --url).
+    errs = validate(vecs)
+    if errs:
+        print("INVALID:")
+        for e in errs:
+            print("  " + e)
+        sys.exit(1)
+    print(f"OK — {len(vecs)} vectors valid")
+    if args.validate or not args.url:
+        return
+
+    # Live replay + conformance report.
+    results = []
+    print(f"\nReplaying {len(vecs)} vectors against {args.url}\n")
+    for _, v in vecs:
+        obs = replay(args.url, v)
+        outcome = obs.get("status", obs.get("error"))
+        results.append({"id": v["id"], "category": v["category"], "normative": v["normative"],
+                        "requirement": v["requirement"], "observed": obs})
+        print(f"  {v['id']} [{v['normative']}] {v['category']}: {v['requirement'][:58]} -> {outcome}")
+    if args.report:
+        Path(args.report).write_text(json.dumps(
+            {"target": args.url, "count": len(results), "results": results}, indent=2))
+        print(f"\nreport written to {args.report}")
+
+
+if __name__ == "__main__":
+    main()

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "x402 conformance vector",
+  "description": "A single x402 conformance vector: a normative requirement plus the request that exercises it.",
+  "type": "object",
+  "required": ["id", "title", "category", "requirement", "method", "request", "normative", "expected"],
+  "additionalProperties": true,
+  "properties": {
+    "id": { "type": "string", "pattern": "^X4-[0-9]+$" },
+    "title": { "type": "string" },
+    "category": { "type": "string" },
+    "requirement": {
+      "type": "string",
+      "description": "The normative conformance requirement this vector exercises."
+    },
+    "method": {
+      "type": "string",
+      "enum": ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"]
+    },
+    "request": {
+      "type": "object",
+      "description": "The request that exercises the requirement.",
+      "properties": {
+        "path": { "type": "string" },
+        "headers": { "type": "object" },
+        "body": {}
+      }
+    },
+    "owasp_asi": { "type": "string" },
+    "severity": { "type": "string" },
+    "impact": { "type": "string" },
+    "normative": { "type": "string", "enum": ["MUST", "SHOULD"] },
+    "expected": {
+      "type": "string",
+      "description": "What a conformant implementation does; a divergent response is a finding."
+    },
+    "source": { "type": "string" }
+  }
+}

--- a/conformance/vectors/x402-core/X4-001.json
+++ b/conformance/vectors/x402-core/X4-001.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-001",
+  "title": "402 Payment Challenge Headers Present",
+  "category": "payment_challenge",
+  "requirement": "HC-1: Payment protocol must return complete challenge",
+  "method": "GET",
+  "request": {
+    "path": "/"
+  },
+  "owasp_asi": "ASI03",
+  "severity": "high",
+  "impact": "service_denial",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-001"
+}

--- a/conformance/vectors/x402-core/X4-002.json
+++ b/conformance/vectors/x402-core/X4-002.json
@@ -1,0 +1,22 @@
+{
+  "id": "X4-002",
+  "title": "Malformed Payment Authorization Rejection",
+  "category": "payment_challenge",
+  "requirement": "HC-2: Server must validate payment authorization format",
+  "method": "GET",
+  "request": {
+    "variants": [
+      "empty",
+      "garbage",
+      "truncated_b64",
+      "null_bytes",
+      "oversized"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-002"
+}

--- a/conformance/vectors/x402-core/X4-003.json
+++ b/conformance/vectors/x402-core/X4-003.json
@@ -1,0 +1,22 @@
+{
+  "id": "X4-003",
+  "title": "Unsupported Currency Rejection",
+  "category": "payment_challenge",
+  "requirement": "HC-3: Server must validate payment currency matches requirement",
+  "method": "GET",
+  "request": {
+    "currencies_tested": [
+      "ETH",
+      "BTC",
+      "EURC",
+      "DAI",
+      "FAKE_TOKEN"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "medium",
+  "impact": "overpayment",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-003"
+}

--- a/conformance/vectors/x402-core/X4-004.json
+++ b/conformance/vectors/x402-core/X4-004.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-004",
+  "title": "Recipient Address Consistency (Dynamic Routing)",
+  "category": "recipient_manipulation",
+  "requirement": "Twelve Numbers: payTo address must be stable and verifiable",
+  "method": "GET",
+  "request": {
+    "n_requests": 5
+  },
+  "owasp_asi": "ASI09",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-004"
+}

--- a/conformance/vectors/x402-core/X4-005.json
+++ b/conformance/vectors/x402-core/X4-005.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-005",
+  "title": "Payment to Wrong Recipient Address",
+  "category": "recipient_manipulation",
+  "requirement": "HC-4: Server must verify payment recipient matches its own address",
+  "method": "GET",
+  "request": {
+    "attacker_recipient": "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead"
+  },
+  "owasp_asi": "ASI09",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-005"
+}

--- a/conformance/vectors/x402-core/X4-006.json
+++ b/conformance/vectors/x402-core/X4-006.json
@@ -1,0 +1,23 @@
+{
+  "id": "X4-006",
+  "title": "Invalid Recipient Address Rejection",
+  "category": "recipient_manipulation",
+  "requirement": "HC-5: Server must validate recipient address format",
+  "method": "GET",
+  "request": {
+    "addresses_tested": [
+      "0x0000000000000000000000000000000000000000",
+      "0xffffffffffffffffffffffffffffffffffffffff",
+      "0x1234",
+      "0xgggggggggggggggggggggggggggggggggggggggg",
+      "not_an_address",
+      ""
+    ]
+  },
+  "owasp_asi": "ASI09",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-006"
+}

--- a/conformance/vectors/x402-core/X4-007.json
+++ b/conformance/vectors/x402-core/X4-007.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-007",
+  "title": "Session Token Security Check",
+  "category": "session_security",
+  "requirement": "Harm Test: session tokens must not leak sensitive data",
+  "method": "GET",
+  "request": {
+    "authorization": "fake_payment_auth"
+  },
+  "owasp_asi": "ASI03",
+  "severity": "medium",
+  "impact": "session_hijack",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-007"
+}

--- a/conformance/vectors/x402-core/X4-008.json
+++ b/conformance/vectors/x402-core/X4-008.json
@@ -1,0 +1,22 @@
+{
+  "id": "X4-008",
+  "title": "Fabricated Session Token Rejection",
+  "category": "session_security",
+  "requirement": "HC-6: Server must cryptographically verify session tokens",
+  "method": "GET",
+  "request": {
+    "variants": [
+      "random_bytes",
+      "fake_jwt",
+      "empty",
+      "sql_injection",
+      "zero_bytes"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "high",
+  "impact": "session_hijack",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-008"
+}

--- a/conformance/vectors/x402-core/X4-009.json
+++ b/conformance/vectors/x402-core/X4-009.json
@@ -1,0 +1,17 @@
+{
+  "id": "X4-009",
+  "title": "Expired Session Token Rejection",
+  "category": "session_security",
+  "requirement": "HC-7: Server must enforce session token expiration",
+  "method": "GET",
+  "request": {
+    "token_type": "expired_jwt",
+    "exp": "1 hour ago"
+  },
+  "owasp_asi": "ASI03",
+  "severity": "high",
+  "impact": "session_hijack",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-009"
+}

--- a/conformance/vectors/x402-core/X4-010.json
+++ b/conformance/vectors/x402-core/X4-010.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-010",
+  "title": "Session / Response Data Leakage Check",
+  "category": "session_security",
+  "requirement": "Harm Test: responses must not leak sensitive operational data",
+  "method": "GET",
+  "request": {
+    "path": "/"
+  },
+  "owasp_asi": "ASI06",
+  "severity": "medium",
+  "impact": "info_leak",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-010"
+}

--- a/conformance/vectors/x402-core/X4-011.json
+++ b/conformance/vectors/x402-core/X4-011.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-011",
+  "title": "Rapid Payment Request Rate Limiting",
+  "category": "spending_limits",
+  "requirement": "Twelve Numbers: rate limits prevent budget exhaustion attacks",
+  "method": "GET",
+  "request": {
+    "n_requests": 20
+  },
+  "owasp_asi": "ASI08",
+  "severity": "medium",
+  "impact": "overpayment",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-011"
+}

--- a/conformance/vectors/x402-core/X4-012.json
+++ b/conformance/vectors/x402-core/X4-012.json
@@ -1,0 +1,20 @@
+{
+  "id": "X4-012",
+  "title": "Underpayment Attempt Rejection",
+  "category": "spending_limits",
+  "requirement": "HC-8: Server must verify payment amount matches or exceeds requirement",
+  "method": "GET",
+  "request": {
+    "amounts_tried": [
+      "0",
+      "1",
+      "100"
+    ]
+  },
+  "owasp_asi": "ASI09",
+  "severity": "high",
+  "impact": "overpayment",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-012"
+}

--- a/conformance/vectors/x402-core/X4-013.json
+++ b/conformance/vectors/x402-core/X4-013.json
@@ -1,0 +1,17 @@
+{
+  "id": "X4-013",
+  "title": "Budget Exhaustion Burst Test",
+  "category": "spending_limits",
+  "requirement": "Twelve Numbers: burst protection prevents agent budget exhaustion",
+  "method": "GET",
+  "request": {
+    "n_burst": 50,
+    "n_workers": 10
+  },
+  "owasp_asi": "ASI08",
+  "severity": "medium",
+  "impact": "overpayment",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-013"
+}

--- a/conformance/vectors/x402-core/X4-014.json
+++ b/conformance/vectors/x402-core/X4-014.json
@@ -1,0 +1,21 @@
+{
+  "id": "X4-014",
+  "title": "Fake Facilitator Header Injection",
+  "category": "facilitator_trust",
+  "requirement": "HC-9: Server must only trust pre-configured facilitator(s)",
+  "method": "GET",
+  "request": {
+    "fake_facilitators": [
+      "https://evil.com/verify",
+      "http://localhost:9999/fake-verify",
+      "https://attacker.io/x402-facilitator",
+      ""
+    ]
+  },
+  "owasp_asi": "ASI09",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-014"
+}

--- a/conformance/vectors/x402-core/X4-015.json
+++ b/conformance/vectors/x402-core/X4-015.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-015",
+  "title": "Non-Existent Facilitator Verification Claim",
+  "category": "facilitator_trust",
+  "requirement": "Falsification Requirement: facilitator identity must be independently verified",
+  "method": "GET",
+  "request": {
+    "fake_verification": true
+  },
+  "owasp_asi": "ASI09",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-015"
+}

--- a/conformance/vectors/x402-core/X4-016.json
+++ b/conformance/vectors/x402-core/X4-016.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-016",
+  "title": "Facilitator Timeout / Unreachable Handling",
+  "category": "facilitator_trust",
+  "requirement": "HC-10: Server must fail-closed when facilitator is unreachable",
+  "method": "GET",
+  "request": {
+    "facilitator": "non-routable TEST-NET address"
+  },
+  "owasp_asi": "ASI08",
+  "severity": "high",
+  "impact": "service_denial",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-016"
+}

--- a/conformance/vectors/x402-core/X4-017.json
+++ b/conformance/vectors/x402-core/X4-017.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-017",
+  "title": "402 Response Information Leakage",
+  "category": "information_disclosure",
+  "requirement": "Harm Test: 402 responses must not expose internal infrastructure details",
+  "method": "GET",
+  "request": {
+    "path": "/"
+  },
+  "owasp_asi": "ASI06",
+  "severity": "medium",
+  "impact": "info_leak",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-017"
+}

--- a/conformance/vectors/x402-core/X4-018.json
+++ b/conformance/vectors/x402-core/X4-018.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-018",
+  "title": "Error Message Information Disclosure",
+  "category": "information_disclosure",
+  "requirement": "HC-11: Error responses must not expose internal details",
+  "method": "GET",
+  "request": {
+    "n_payloads": 5
+  },
+  "owasp_asi": "ASI06",
+  "severity": "medium",
+  "impact": "info_leak",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-018"
+}

--- a/conformance/vectors/x402-core/X4-019.json
+++ b/conformance/vectors/x402-core/X4-019.json
@@ -1,0 +1,25 @@
+{
+  "id": "X4-019",
+  "title": "Wrong Network Payment Rejection",
+  "category": "cross_chain_confusion",
+  "requirement": "HC-12: Server must validate payment network matches requirement",
+  "method": "GET",
+  "request": {
+    "networks_tested": [
+      "polygon",
+      "ethereum",
+      "arbitrum",
+      "optimism",
+      "avalanche",
+      "solana",
+      "bitcoin"
+    ],
+    "expected_network": "1"
+  },
+  "owasp_asi": "ASI09",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-019"
+}

--- a/conformance/vectors/x402-core/X4-020.json
+++ b/conformance/vectors/x402-core/X4-020.json
@@ -1,0 +1,25 @@
+{
+  "id": "X4-020",
+  "title": "Wrong Token Type Payment Rejection",
+  "category": "cross_chain_confusion",
+  "requirement": "HC-13: Server must validate payment currency matches requirement",
+  "method": "GET",
+  "request": {
+    "tokens_tested": [
+      "EURC",
+      "USDT",
+      "DAI",
+      "WETH",
+      "WBTC",
+      "FAKE_TOKEN",
+      ""
+    ],
+    "expected_currency": "1"
+  },
+  "owasp_asi": "ASI09",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-020"
+}

--- a/conformance/vectors/x402-core/X4-021.json
+++ b/conformance/vectors/x402-core/X4-021.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-021",
+  "title": "Operator Attestation Presence (OATR)",
+  "category": "identity_verification",
+  "requirement": "HC-14: x402 endpoints must present verifiable operator identity via OATR attestation",
+  "method": "GET",
+  "request": {
+    "path": "/"
+  },
+  "owasp_asi": "ASI04",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-021"
+}

--- a/conformance/vectors/x402-core/X4-022.json
+++ b/conformance/vectors/x402-core/X4-022.json
@@ -1,0 +1,17 @@
+{
+  "id": "X4-022",
+  "title": "Attestation-Domain Binding (OATR)",
+  "category": "identity_verification",
+  "requirement": "HC-15: Attestation audience must bind to the serving domain to prevent replay",
+  "method": "GET",
+  "request": {
+    "path": "/",
+    "target_url": "http://mock"
+  },
+  "owasp_asi": "ASI04",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-022"
+}

--- a/conformance/vectors/x402-core/X4-023.json
+++ b/conformance/vectors/x402-core/X4-023.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-023",
+  "title": "Attestation Revocation Check (OATR)",
+  "category": "identity_verification",
+  "requirement": "HC-16: Revocation checking must be available to reject compromised operator keys",
+  "method": "GET",
+  "request": {
+    "revocation_url": "http://mock/.well-known/oatr-revocation.json"
+  },
+  "owasp_asi": "ASI04",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-023"
+}

--- a/conformance/vectors/x402-core/X4-024.json
+++ b/conformance/vectors/x402-core/X4-024.json
@@ -1,0 +1,17 @@
+{
+  "id": "X4-024",
+  "title": "Stale Manifest Acceptance (OATR)",
+  "category": "identity_verification",
+  "requirement": "HC-17: Clients/servers must reject manifests older than CACHE_TTL_MS (default 15min)",
+  "method": "POST",
+  "request": {
+    "stale_generated_at_ms": 1783088054974,
+    "ttl_exceeded_by_s": 300
+  },
+  "owasp_asi": "ASI04",
+  "severity": "medium",
+  "impact": "fund_theft",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-024"
+}

--- a/conformance/vectors/x402-core/X4-025.json
+++ b/conformance/vectors/x402-core/X4-025.json
@@ -1,0 +1,17 @@
+{
+  "id": "X4-025",
+  "title": "Forged Attestation Injection (OATR)",
+  "category": "identity_verification",
+  "requirement": "HC-18: Forged attestations with unknown issuers must be rejected",
+  "method": "GET",
+  "request": {
+    "forged_jwt_iss": "fake-issuer",
+    "forged_jwt_alg": "EdDSA"
+  },
+  "owasp_asi": "ASI04",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-025"
+}

--- a/conformance/vectors/x402-core/X4-026.json
+++ b/conformance/vectors/x402-core/X4-026.json
@@ -1,0 +1,23 @@
+{
+  "id": "X4-026",
+  "title": "Payment Amount Rounding Attack (IEEE 754)",
+  "category": "advanced_payment",
+  "requirement": "HC-19: Payment amounts must use integer smallest-unit representation, reject floats",
+  "method": "GET",
+  "request": {
+    "rounding_payloads": [
+      "ieee754_classic",
+      "float_sum",
+      "sub_cent",
+      "large_with_fraction",
+      "scientific_notation",
+      "negative_epsilon"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "high",
+  "impact": "overpayment",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-026"
+}

--- a/conformance/vectors/x402-core/X4-027.json
+++ b/conformance/vectors/x402-core/X4-027.json
@@ -1,0 +1,17 @@
+{
+  "id": "X4-027",
+  "title": "Stale Payment Session Replay",
+  "category": "advanced_payment",
+  "requirement": "HC-20: Payment sessions must be time-bound; stale sessions must be rejected",
+  "method": "GET",
+  "request": {
+    "stale_session_id": "session_7093bd40200b0ba2",
+    "age_seconds": 7200
+  },
+  "owasp_asi": "ASI04",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-027"
+}

--- a/conformance/vectors/x402-core/X4-031.json
+++ b/conformance/vectors/x402-core/X4-031.json
@@ -1,0 +1,21 @@
+{
+  "id": "X4-031",
+  "title": "Multi-Hop Redirect Chain Attack",
+  "category": "protocol_abuse",
+  "requirement": "HC-21: Servers must not follow payment redirect chains from untrusted headers",
+  "method": "GET",
+  "request": {
+    "hop_chain": [
+      "https://facilitator-hop1.evil.test/verify",
+      "https://facilitator-hop2.evil.test/verify",
+      "https://final-redirect.evil.test/collect"
+    ],
+    "attacker_wallet": "0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1"
+  },
+  "owasp_asi": "ASI09",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-031"
+}

--- a/conformance/vectors/x402-core/X4-032.json
+++ b/conformance/vectors/x402-core/X4-032.json
@@ -1,0 +1,37 @@
+{
+  "id": "X4-032",
+  "title": "Currency Type Confusion",
+  "category": "protocol_abuse",
+  "requirement": "HC-22: Server must validate exact token contract, not just symbol name",
+  "method": "GET",
+  "request": {
+    "confusion_pairs": [
+      [
+        "USDC",
+        "EURC"
+      ],
+      [
+        "USDC",
+        "USDT"
+      ],
+      [
+        "USDC",
+        "DAI"
+      ],
+      [
+        "EURC",
+        "USDC"
+      ],
+      [
+        "USDC",
+        "USDbC"
+      ]
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-032"
+}

--- a/conformance/vectors/x402-core/X4-033.json
+++ b/conformance/vectors/x402-core/X4-033.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-033",
+  "title": "Payment Deadline Bypass",
+  "category": "protocol_abuse",
+  "requirement": "HC-23: Servers must reject payments with expired deadlines",
+  "method": "GET",
+  "request": {
+    "expired_deadline": 1783085654
+  },
+  "owasp_asi": "ASI03",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-033"
+}

--- a/conformance/vectors/x402-core/X4-034.json
+++ b/conformance/vectors/x402-core/X4-034.json
@@ -1,0 +1,21 @@
+{
+  "id": "X4-034",
+  "title": "Zero-Amount Payment Acceptance",
+  "category": "protocol_abuse",
+  "requirement": "HC-24: Servers must reject payments with zero or non-positive amounts",
+  "method": "GET",
+  "request": {
+    "zero_amounts": [
+      "0",
+      "0.0",
+      "0x0",
+      "0e0"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "high",
+  "impact": "service_denial",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-034"
+}

--- a/conformance/vectors/x402-core/X4-035.json
+++ b/conformance/vectors/x402-core/X4-035.json
@@ -1,0 +1,21 @@
+{
+  "id": "X4-035",
+  "title": "Negative Amount Payment",
+  "category": "protocol_abuse",
+  "requirement": "HC-25: Servers must reject payments with negative amounts (credit/refund attack)",
+  "method": "GET",
+  "request": {
+    "negative_amounts": [
+      "-1",
+      "-1000000",
+      "-0.01",
+      "-999999999999"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-035"
+}

--- a/conformance/vectors/x402-core/X4-036.json
+++ b/conformance/vectors/x402-core/X4-036.json
@@ -1,0 +1,22 @@
+{
+  "id": "X4-036",
+  "title": "Max uint256 Overflow Attack",
+  "category": "protocol_abuse",
+  "requirement": "HC-26: Servers must validate amounts fit within uint256 and reject overflows",
+  "method": "GET",
+  "request": {
+    "overflow_variants": [
+      "uint256_max",
+      "uint256_max_plus_one",
+      "uint256_double",
+      "negative_overflow",
+      "huge_decimal"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-036"
+}

--- a/conformance/vectors/x402-core/X4-037.json
+++ b/conformance/vectors/x402-core/X4-037.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-037",
+  "title": "Facilitator Impersonation",
+  "category": "trust_abuse",
+  "requirement": "HC-27: Facilitator identity must be cryptographically verified, not header-based",
+  "method": "GET",
+  "request": {
+    "impersonation_variants": 3
+  },
+  "owasp_asi": "ASI04",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-037"
+}

--- a/conformance/vectors/x402-core/X4-038.json
+++ b/conformance/vectors/x402-core/X4-038.json
@@ -1,0 +1,17 @@
+{
+  "id": "X4-038",
+  "title": "Double-Spend Detection",
+  "category": "trust_abuse",
+  "requirement": "HC-28: Servers must track payment nonces and reject duplicate submissions",
+  "method": "GET",
+  "request": {
+    "nonce": "a1bed042219646d59c5158c5fc879520",
+    "submitted_twice": true
+  },
+  "owasp_asi": "ASI03",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-038"
+}

--- a/conformance/vectors/x402-core/X4-039.json
+++ b/conformance/vectors/x402-core/X4-039.json
@@ -1,0 +1,25 @@
+{
+  "id": "X4-039",
+  "title": "Payment Proof Format Injection",
+  "category": "trust_abuse",
+  "requirement": "HC-29: Payment proof must be parsed safely; reject malformed/injected proofs",
+  "method": "GET",
+  "request": {
+    "injection_variants": [
+      "sql_injection",
+      "nosql_injection",
+      "json_nested_bomb",
+      "null_byte",
+      "unicode_rtl",
+      "template_injection",
+      "header_injection",
+      "path_traversal"
+    ]
+  },
+  "owasp_asi": "ASI07",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-039"
+}

--- a/conformance/vectors/x402-core/X4-040.json
+++ b/conformance/vectors/x402-core/X4-040.json
@@ -1,0 +1,22 @@
+{
+  "id": "X4-040",
+  "title": "Cross-Chain Payment Confusion",
+  "category": "network_attacks",
+  "requirement": "HC-30: Server must validate chain ID matches expected network in payment proof",
+  "method": "GET",
+  "request": {
+    "server_network": "1",
+    "wrong_networks": [
+      "base",
+      "base-sepolia",
+      "arbitrum",
+      "optimism"
+    ]
+  },
+  "owasp_asi": "ASI09",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-040"
+}

--- a/conformance/vectors/x402-core/X4-041.json
+++ b/conformance/vectors/x402-core/X4-041.json
@@ -1,0 +1,23 @@
+{
+  "id": "X4-041",
+  "title": "Settlement Callback URL SSRF",
+  "category": "network_attacks",
+  "requirement": "HC-31: Settlement callback URLs must be validated against allowlist, reject internal addresses",
+  "method": "GET",
+  "request": {
+    "ssrf_targets": [
+      "localhost",
+      "internal_ip",
+      "internal_dns",
+      "loopback_ipv6",
+      "dns_rebind",
+      "file_scheme"
+    ]
+  },
+  "owasp_asi": "ASI07",
+  "severity": "critical",
+  "impact": "info_leak",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-041"
+}

--- a/conformance/vectors/x402-core/X4-042.json
+++ b/conformance/vectors/x402-core/X4-042.json
@@ -1,0 +1,22 @@
+{
+  "id": "X4-042",
+  "title": "Payment Metadata Exfiltration",
+  "category": "network_attacks",
+  "requirement": "HC-32: Payment metadata must be sanitized; sensitive fields must not be echoed",
+  "method": "GET",
+  "request": {
+    "metadata_fields": [
+      "ssn",
+      "credit_card",
+      "api_key",
+      "internal_note",
+      "webhook"
+    ]
+  },
+  "owasp_asi": "ASI06",
+  "severity": "high",
+  "impact": "info_leak",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-042"
+}

--- a/conformance/vectors/x402-core/X4-043.json
+++ b/conformance/vectors/x402-core/X4-043.json
@@ -1,0 +1,17 @@
+{
+  "id": "X4-043",
+  "title": "Concurrent Payment Race Condition",
+  "category": "network_attacks",
+  "requirement": "HC-33: Payment processing must be atomic; concurrent duplicate nonces must resolve to single acceptance",
+  "method": "GET",
+  "request": {
+    "nonce": "c5660f5652014568acf8d149dfdfcc5b",
+    "concurrent_requests": 5
+  },
+  "owasp_asi": "ASI03",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-043"
+}

--- a/conformance/vectors/x402-core/X4-044.json
+++ b/conformance/vectors/x402-core/X4-044.json
@@ -1,0 +1,17 @@
+{
+  "id": "X4-044",
+  "title": "Payment Replay Against Different Endpoint",
+  "category": "network_attacks",
+  "requirement": "HC-34: Payment proofs must be bound to specific resource paths",
+  "method": "GET",
+  "request": {
+    "original_path": "/paid",
+    "replayed_to": "/admin"
+  },
+  "owasp_asi": "ASI04",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-044"
+}

--- a/conformance/vectors/x402-core/X4-045.json
+++ b/conformance/vectors/x402-core/X4-045.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-045",
+  "title": "Replay Same Payment Hash",
+  "category": "replay_double_spend",
+  "requirement": "HC-35: Payment hashes must be single-use; replay of consumed hash must be rejected",
+  "method": "GET",
+  "request": {
+    "payment_hash": "ae6d4a9baba123d16dccb6629f3e94bc880e66858f039ba6c87a1fd60d64c58a"
+  },
+  "owasp_asi": "ASI03",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-045"
+}

--- a/conformance/vectors/x402-core/X4-046.json
+++ b/conformance/vectors/x402-core/X4-046.json
@@ -1,0 +1,20 @@
+{
+  "id": "X4-046",
+  "title": "Duplicate Settlement Claim",
+  "category": "replay_double_spend",
+  "requirement": "HC-36: Only one settlement claim per payment nonce must be accepted",
+  "method": "GET",
+  "request": {
+    "nonce": "3efe0badd6164597879bdb34a25918b3",
+    "tx_hashes": [
+      "0x709b55bd3da0f5a838125bd0ee20c5bfdd7caba173912d4281cae816b79a201b",
+      "0x27ca64c092a959c7edc525ed45e845b1de6a7590d173fd2fad9133c8a779a1e3"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-046"
+}

--- a/conformance/vectors/x402-core/X4-047.json
+++ b/conformance/vectors/x402-core/X4-047.json
@@ -1,0 +1,19 @@
+{
+  "id": "X4-047",
+  "title": "Expired Auth Token Reuse",
+  "category": "authorization_bypass",
+  "requirement": "HC-37: Payment authorization tokens with past expiry must be rejected",
+  "method": "GET",
+  "request": {
+    "expired_variants": [
+      "expired_b64",
+      "expired_jwt"
+    ]
+  },
+  "owasp_asi": "ASI02",
+  "severity": "critical",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-047"
+}

--- a/conformance/vectors/x402-core/X4-048.json
+++ b/conformance/vectors/x402-core/X4-048.json
@@ -1,0 +1,21 @@
+{
+  "id": "X4-048",
+  "title": "Scope Escalation in Payment Context",
+  "category": "authorization_bypass",
+  "requirement": "HC-38: Payment proofs with escalated scope claims must be validated against authorized scope",
+  "method": "GET",
+  "request": {
+    "escalation_variants": [
+      "admin_scope",
+      "write_scope",
+      "wildcard_scope",
+      "elevated_amount"
+    ]
+  },
+  "owasp_asi": "ASI02",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-048"
+}

--- a/conformance/vectors/x402-core/X4-049.json
+++ b/conformance/vectors/x402-core/X4-049.json
@@ -1,0 +1,20 @@
+{
+  "id": "X4-049",
+  "title": "Premature Finality Claim",
+  "category": "settlement_finality",
+  "requirement": "HC-39: Server must verify sufficient block confirmations before granting access",
+  "method": "GET",
+  "request": {
+    "premature_variants": [
+      "zero_confirmations",
+      "pending_status",
+      "future_block"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-049"
+}

--- a/conformance/vectors/x402-core/X4-050.json
+++ b/conformance/vectors/x402-core/X4-050.json
@@ -1,0 +1,20 @@
+{
+  "id": "X4-050",
+  "title": "Settlement Race Condition",
+  "category": "settlement_finality",
+  "requirement": "HC-40: Resource access must not be granted until settlement is confirmed",
+  "method": "GET",
+  "request": {
+    "nonce": "76c40ee4a7fe4f6fbff51d20606d1363",
+    "settlement_statuses": [
+      "pending",
+      "confirming"
+    ]
+  },
+  "owasp_asi": "ASI03",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-050"
+}

--- a/conformance/vectors/x402-core/X4-051.json
+++ b/conformance/vectors/x402-core/X4-051.json
@@ -1,0 +1,20 @@
+{
+  "id": "X4-051",
+  "title": "L402-to-x402 Protocol Confusion",
+  "category": "cross_protocol_confusion",
+  "requirement": "HC-41: x402 endpoints must reject L402/LSAT authorization headers",
+  "method": "GET",
+  "request": {
+    "l402_variants": [
+      "l402_header",
+      "lsat_header",
+      "mixed_headers"
+    ]
+  },
+  "owasp_asi": "ASI09",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-051"
+}

--- a/conformance/vectors/x402-core/X4-052.json
+++ b/conformance/vectors/x402-core/X4-052.json
@@ -1,0 +1,20 @@
+{
+  "id": "X4-052",
+  "title": "Mixed Settlement Protocol Confusion",
+  "category": "cross_protocol_confusion",
+  "requirement": "HC-42: x402 settlement must reject Lightning/HTLC-style proofs",
+  "method": "GET",
+  "request": {
+    "mixed_variants": [
+      "lightning_preimage",
+      "bolt11_invoice",
+      "htlc_settlement"
+    ]
+  },
+  "owasp_asi": "ASI09",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-052"
+}

--- a/conformance/vectors/x402-core/X4-053.json
+++ b/conformance/vectors/x402-core/X4-053.json
@@ -1,0 +1,22 @@
+{
+  "id": "X4-053",
+  "title": "Payment Metadata Side Channel",
+  "category": "metadata_exfiltration",
+  "requirement": "HC-43: Error responses must not vary in size/timing based on payment amount validation",
+  "method": "GET",
+  "request": {
+    "test_amounts": [
+      "valid_small",
+      "valid_large",
+      "boundary",
+      "negative",
+      "overflow"
+    ]
+  },
+  "owasp_asi": "ASI06",
+  "severity": "medium",
+  "impact": "info_leak",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-053"
+}

--- a/conformance/vectors/x402-core/X4-054.json
+++ b/conformance/vectors/x402-core/X4-054.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-054",
+  "title": "Payment Correlation Attack",
+  "category": "metadata_exfiltration",
+  "requirement": "HC-44: Responses must not contain persistent identifiers that correlate independent payment requests",
+  "method": "GET",
+  "request": {
+    "num_requests": 3
+  },
+  "owasp_asi": "ASI06",
+  "severity": "medium",
+  "impact": "info_leak",
+  "normative": "SHOULD",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-054"
+}

--- a/conformance/vectors/x402-core/X4-055.json
+++ b/conformance/vectors/x402-core/X4-055.json
@@ -1,0 +1,16 @@
+{
+  "id": "X4-055",
+  "title": "Cascading Payment Approval Chain",
+  "category": "agent_autonomy",
+  "requirement": "HC-45: Responses must not embed or trigger cascading payment requirements without explicit agent consent",
+  "method": "GET",
+  "request": {
+    "path": "/paid"
+  },
+  "owasp_asi": "ASI02",
+  "severity": "high",
+  "impact": "fund_theft",
+  "normative": "MUST",
+  "expected": "A conformant x402 implementation satisfies the stated requirement; a divergent response is a finding.",
+  "source": "agent-security-harness (Apache-2.0) :: x402_harness.py :: X4-055"
+}


### PR DESCRIPTION
## Summary

An open, dependency-free **x402 conformance-vector set** — delivering the open-source conformance harness proposed in #2178.

A protocol with governance but no conformance vectors is a promise, not a guarantee: two implementations can each claim x402 compliance and still diverge on the same request. This set lets an implementer *prove* conformance.

## What's here (`conformance/`)

- **52 core conformance vectors** (`vectors/x402-core/`) — each a normative x402 requirement plus the request that exercises it (payment-challenge structure, recipient/amount integrity, session security, spending limits, facilitator trust, info disclosure, cross-chain confusion, replay/double-spend, authorization bypass, settlement finality, protocol abuse).
- **`run_conformance.py`** — stdlib-only runner (no dependencies): `--validate` (offline schema check) and `--url` (replay each vector against your endpoint and report the response against each requirement).
- **`schema.json`** — the vector schema.

## Design

Vectors are **data, not a reference implementation** — you test *your* x402 code against them. They're generated from the Apache-2.0 [`agent-security-harness`](https://pypi.org/project/agent-security-harness/) so they stay faithful to a maintained suite (provenance in each vector's `source`).

Roadmap (in the README): optional machine-checkable `assert` blocks for auto-judging deterministic vectors, and an extension conformance set alongside the relevant extension spec.

## Why it matters

While building the harness these vectors come from, adversarial review of its *own reference verifier* caught three fail-open defects **in that harness code** (a credential-release check trusting a self-asserted flag, a scope check that failed open on an omitted field, and an SSRF blocklist that missed most of the RFC1918 `172.16/12` range) — each fixed and guarded by a negative test before release. Fail-open is easy to ship even in code written to catch it; that is exactly why machine-checkable conformance vectors are worth having.

Apache-2.0, matching this repo. Happy to align vectors to your preferred layout/schema.
