### PR TITLE
Add Onchain Safety to ecosystem partners

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/onchain-safety/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/onchain-safety/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Onchain Safety",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/onchain-safety.svg",
+  "description": "Multi-chain token-safety for AI agents: rug/honeypot verdicts, exit-safety, wallet reputation, and AI-incident lookups — pay-per-call via x402 across PulseChain, Monad, Base, and BSC",
+  "websiteUrl": "https://onchain.wick.pics"
+}

--- a/typescript/site/public/logos/onchain-safety.svg
+++ b/typescript/site/public/logos/onchain-safety.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="13" fill="#0b0f0d"/>
+  <path d="M32 11 L53 32 L32 53 L11 32 Z" fill="none" stroke="#00ff88" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M22.5 32.5 l6.5 6.5 l12.5 -14" fill="none" stroke="#00ff88" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Adds **Onchain Safety** (onchain.wick.pics) under Services/Endpoints.

Live x402 v2 service — 12 pay-per-call endpoints (USDC on Base): multi-chain token-safety verdicts, fresh-pool rug radar, exit-safety/liquidity depth, ownership/privilege reads, wallet approval + reputation scans, and an AI-incident/vendor-risk lookup. Chain coverage includes PulseChain and Monad alongside Base/BSC.

- Discovery: https://onchain.wick.pics/.well-known/x402.json
- OpenAPI: https://onchain.wick.pics/openapi.json
- Mainnet settlement proof: https://basescan.org/tx/0x6ba9df138435fe0014d95a98864be4b6aa729251af6f81c4ae8bdd52613dc05e
- Listed on x402scan and 402index (domain-verified); MCP server @wickpics/onchain-safety-mcp on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)