### PR TITLE
ecosystem: add Solana Token Intelligence (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/token-intel/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/token-intel/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Solana Token Intelligence",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/token-intel.svg",
+  "description": "Agent-native token safety API: one x402 micropayment ($0.02 USDC on Base) returns a fused risk read on any Solana token — mint/freeze authorities, holder concentration, dev holdings, organic volume score, liquidity — with a synthesized verdict and red/green flags. No API key, no account; full OpenAPI + bazaar discovery schemas.",
+  "websiteUrl": "https://token-intel-x402.echolonius.deno.net"
+}

--- a/typescript/site/public/logos/token-intel.svg
+++ b/typescript/site/public/logos/token-intel.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <rect width="256" height="256" rx="48" fill="#14213d"/>
+  <rect x="56" y="128" width="28" height="72" rx="6" fill="#7df9aa"/>
+  <rect x="100" y="96" width="28" height="104" rx="6" fill="#7df9aa"/>
+  <rect x="144" y="64" width="28" height="136" rx="6" fill="#4ade80"/>
+  <rect x="188" y="112" width="28" height="88" rx="6" fill="#fca5a5"/>
+  <circle cx="202" cy="76" r="22" fill="none" stroke="#7df9aa" stroke-width="10"/>
+  <line x1="217" y1="93" x2="236" y2="112" stroke="#7df9aa" stroke-width="12" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds **Solana Token Intelligence** to the ecosystem page under Services/Endpoints.

- **Live service:** https://token-intel-x402.echolonius.deno.net (x402 v2, Base mainnet USDC, $0.02/call via the keyless PayAI facilitator)
- **What it does:** one micropayment returns a fused safety read on any Solana token — mint/freeze authority status, holder concentration, dev holdings, organic-volume score, liquidity — synthesized into a 0–100 score, verdict, and red/green flags. Built for agents: no API key, no account, nothing to steal server-side.
- **Discovery-conformant:** serves `/openapi.json` + `/.well-known/x402` with bazaar input/output schemas; registered on x402scan and 402index. `npx -y @agentcash/discovery token-intel-x402.echolonius.deno.net` audits clean.
- **Source:** https://github.com/Echolonius/token-intel-x402

Entry follows the existing format (metadata.json + SVG logo). Commit is signed (created via GitHub API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018p8jtKC5g7uUMrjGCWksqu