### PR TITLE
feat(svm): idempotent create-ATA for first-time recipients in exact scheme (v1+v2)

### DIFF
--- a/typescript/.changeset/svm-idempotent-ata-create.md
+++ b/typescript/.changeset/svm-idempotent-ata-create.md
@@ -1,0 +1,5 @@
+---
+'@x402/svm': minor
+---
+
+Support first-time token recipients in the exact SVM scheme (#2395). When the destination associated token account does not exist yet, the client (v1 and v2) now prepends a `CreateAssociatedTokenIdempotent` instruction funded by the facilitator fee payer — only when the ATA is actually missing, so the repeat-payment layout is unchanged. The facilitator static path (v1 and v2) accepts exactly one optional create-ATA at index 2 (TransferChecked shifts to index 3) and pins every field of it — idempotent discriminator byte, six-account layout, funder == fee payer, owner == payTo, mint == asset, system program, token program == the transfer's, and derived ATA == the transfer destination — so the only account the facilitator can be made to rent-fund is the one it is being paid into. New error reasons: `invalid_exact_svm_payload_create_ata_{not_idempotent,account_count,funder_mismatch,owner_mismatch,mint_mismatch,system_program_mismatch,token_program_mismatch,destination_mismatch}`.

--- a/typescript/packages/mechanisms/svm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/client/scheme.ts
@@ -5,11 +5,13 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import {
   findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
   getTransferCheckedInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
 } from "@solana-program/token-2022";
 import {
   appendTransactionMessageInstructions,
+  createNoopSigner,
   createTransactionMessage,
   getBase64EncodedWireTransaction,
   partiallySignTransactionMessageWithSigners,
@@ -18,6 +20,7 @@ import {
   setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
   type Address,
+  type Instruction,
 } from "@solana/kit";
 import type { PaymentPayload, PaymentRequirements, SchemeNetworkClient } from "@x402/core/types";
 import {
@@ -108,6 +111,27 @@ export class ExactSvmScheme implements SchemeNetworkClient {
       throw new Error("feePayer is required in paymentRequirements.extra for SVM transactions");
     }
 
+    // If the recipient has never held this token, the destination ATA does not
+    // exist yet and TransferChecked would fail with InvalidAccountData (#2395).
+    // Prepend an idempotent create funded by the facilitator fee payer — only
+    // when the ATA is actually missing, so the common repeat-payment layout is
+    // unchanged. The facilitator statically pins every field of this
+    // instruction, and the idempotent discriminator makes a lost race with a
+    // concurrent creation harmless.
+    const prefixInstructions: Instruction[] = [];
+    const destinationInfo = await rpc.getAccountInfo(destinationATA, { encoding: "base64" }).send();
+    if (!destinationInfo.value) {
+      prefixInstructions.push(
+        getCreateAssociatedTokenIdempotentInstruction({
+          payer: createNoopSigner(feePayer),
+          ata: destinationATA,
+          owner: paymentRequirements.payTo as Address,
+          mint: paymentRequirements.asset as Address,
+          tokenProgram: tokenProgramAddress,
+        }),
+      );
+    }
+
     const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
     const sellerMemo = paymentRequirements.extra?.memo as string | undefined;
@@ -140,7 +164,7 @@ export class ExactSvmScheme implements SchemeNetworkClient {
           getSetComputeUnitLimitInstruction({ units: DEFAULT_COMPUTE_UNIT_LIMIT }),
           tx,
         ),
-      tx => appendTransactionMessageInstructions([transferIx, memoIx], tx),
+      tx => appendTransactionMessageInstructions([...prefixInstructions, transferIx, memoIx], tx),
       tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
     );
 

--- a/typescript/packages/mechanisms/svm/src/exact/createAta.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/createAta.ts
@@ -1,0 +1,116 @@
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  TOKEN_2022_PROGRAM_ADDRESS,
+} from "@solana-program/token-2022";
+
+/** The System Program, pinned as `account[4]` of a create-ATA instruction. */
+export const SYSTEM_PROGRAM_ADDRESS = "11111111111111111111111111111111";
+
+/**
+ * Single-byte instruction discriminator for CreateAssociatedTokenIdempotent.
+ * The legacy non-idempotent Create carries empty data (and a 7-account layout
+ * including the rent sysvar), so pinning the data to exactly this byte is what
+ * rejects a non-idempotent create being slipped into the same slot.
+ */
+export const CREATE_ATA_IDEMPOTENT_DISCRIMINATOR = 1;
+
+/**
+ * Minimal structural view of a decompiled instruction, shared by the v1 and v2
+ * facilitator schemes (whose concrete instruction types differ only in generics).
+ */
+export type DecompiledInstructionLike = {
+  programAddress: { toString(): string };
+  accounts?: ReadonlyArray<{ address: { toString(): string } }>;
+  data?: Readonly<Uint8Array>;
+};
+
+/**
+ * Whether an instruction targets the Associated Token Account program.
+ *
+ * @param instruction - A decompiled top-level instruction
+ * @returns True when the instruction's program is the ATA program
+ */
+export function isAssociatedTokenProgramInstruction(
+  instruction: DecompiledInstructionLike,
+): boolean {
+  return instruction.programAddress.toString() === ASSOCIATED_TOKEN_PROGRAM_ADDRESS.toString();
+}
+
+/**
+ * Accounts of a validated CreateAssociatedTokenIdempotent instruction that the
+ * caller must additionally pin against the parsed TransferChecked instruction:
+ * `ata` must equal the transfer destination (which the static path already
+ * requires to be the ATA derived from payTo/tokenProgram/mint), and
+ * `tokenProgram` must equal the transfer's token program. The token program is
+ * an ATA derivation seed, so without that last pin a Token-2022 create could
+ * point the rent at a different derived address than the one being paid.
+ */
+export type CreateAtaAccounts = {
+  ata: string;
+  tokenProgram: string;
+};
+
+/**
+ * Statically validate an optional CreateAssociatedTokenIdempotent instruction
+ * at index 2 of an exact-SVM payment transaction (see #2395).
+ *
+ * The fee payer (facilitator) funds the rent in the gasless flow, so every
+ * degree of freedom must be pinned or a client could make the facilitator
+ * rent-fund an arbitrary (owner, mint) ATA unrelated to the payment:
+ *
+ * - data == exactly the single idempotent discriminator byte `0x01`
+ * - exactly six accounts: [funder, ata, owner, mint, systemProgram, tokenProgram]
+ * - funder  == requirements.extra.feePayer
+ * - owner   == requirements.payTo
+ * - mint    == requirements.asset
+ * - systemProgram == the System Program
+ * - tokenProgram  ∈ {Token, Token-2022}
+ *
+ * @param instruction - The decompiled instruction at index 2
+ * @param expected - Pinned values from the payment requirements
+ * @param expected.payTo - The payment recipient (ATA owner)
+ * @param expected.asset - The payment mint
+ * @param expected.feePayer - The facilitator fee payer funding the rent
+ * @returns The `{ ata, tokenProgram }` accounts on success, or an
+ *   `invalidReason` string when any pin fails
+ */
+export function validateCreateAtaIdempotentInstruction(
+  instruction: DecompiledInstructionLike,
+  expected: { payTo: string; asset: string; feePayer: string },
+): CreateAtaAccounts | { invalidReason: string } {
+  const data = instruction.data;
+  if (!data || data.length !== 1 || data[0] !== CREATE_ATA_IDEMPOTENT_DISCRIMINATOR) {
+    return { invalidReason: "invalid_exact_svm_payload_create_ata_not_idempotent" };
+  }
+
+  const accounts = instruction.accounts ?? [];
+  if (accounts.length !== 6) {
+    return { invalidReason: "invalid_exact_svm_payload_create_ata_account_count" };
+  }
+
+  const [funder, ata, owner, mint, systemProgram, tokenProgram] = accounts.map(account =>
+    account.address.toString(),
+  );
+
+  if (funder !== expected.feePayer) {
+    return { invalidReason: "invalid_exact_svm_payload_create_ata_funder_mismatch" };
+  }
+  if (owner !== expected.payTo) {
+    return { invalidReason: "invalid_exact_svm_payload_create_ata_owner_mismatch" };
+  }
+  if (mint !== expected.asset) {
+    return { invalidReason: "invalid_exact_svm_payload_create_ata_mint_mismatch" };
+  }
+  if (systemProgram !== SYSTEM_PROGRAM_ADDRESS) {
+    return { invalidReason: "invalid_exact_svm_payload_create_ata_system_program_mismatch" };
+  }
+  if (
+    tokenProgram !== TOKEN_PROGRAM_ADDRESS.toString() &&
+    tokenProgram !== TOKEN_2022_PROGRAM_ADDRESS.toString()
+  ) {
+    return { invalidReason: "invalid_exact_svm_payload_create_ata_token_program_mismatch" };
+  }
+
+  return { ata, tokenProgram };
+}

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -37,6 +37,10 @@ import {
   getTokenPayerFromTransaction,
   transactionMessageHash,
 } from "../../utils";
+import {
+  isAssociatedTokenProgramInstruction,
+  validateCreateAtaIdempotentInstruction,
+} from "../createAta";
 import { verifySmartWalletTransaction, verifyPostSettlement } from "./smartWalletVerification";
 
 /**
@@ -554,15 +558,19 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     const decompiled = decompileTransactionMessage(compiled);
     const instructions = decompiled.instructions ?? [];
 
-    // Allow 3-7 instructions:
+    // Allow 3-7 instructions (8 when an idempotent create-ATA is present):
     // - 3 instructions: ComputeLimit + ComputePrice + TransferChecked
     // - 4 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse or Memo
     // - 5 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse + Lighthouse or Memo
     // - 6 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse + Lighthouse + Memo
     // - 7 instructions: + a third wallet-injected Lighthouse (Phantom, see #2097)
+    // An optional CreateAssociatedTokenIdempotent at index 2 (first payment to a
+    // payTo/mint whose ATA does not exist yet, see #2395) shifts TransferChecked
+    // to index 3 and raises each bound by one.
     // See: https://github.com/x402-foundation/x402/issues/828
     //  and: https://github.com/x402-foundation/x402/issues/2097
-    if (instructions.length < 3 || instructions.length > 7) {
+    //  and: https://github.com/x402-foundation/x402/issues/2395
+    if (instructions.length < 3 || instructions.length > 8) {
       return {
         isValid: false,
         invalidReason: "invalid_exact_svm_payload_transaction_instructions_length",
@@ -592,8 +600,39 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       };
     }
 
+    // Step 3b: Optional idempotent create-ATA at index 2 (#2395).
+    // When the recipient has never held the token, the client prepends a
+    // CreateAssociatedTokenIdempotent funded by the facilitator fee payer.
+    // Every field is pinned so the only ATA the facilitator can be made to
+    // rent-fund is the exact account it is being paid into; the remaining two
+    // pins (ata == transfer destination, tokenProgram == transfer program) are
+    // asserted after the transfer instruction is parsed below.
+    let transferIndex = 2;
+    let createAtaAccounts: { ata: string; tokenProgram: string } | null = null;
+    if (instructions.length >= 4 && isAssociatedTokenProgramInstruction(instructions[2] as never)) {
+      const result = validateCreateAtaIdempotentInstruction(instructions[2] as never, {
+        payTo: requirements.payTo,
+        asset: requirements.asset,
+        feePayer: requirements.extra!.feePayer as string,
+      });
+      if ("invalidReason" in result) {
+        return { isValid: false, invalidReason: result.invalidReason, payer };
+      }
+      createAtaAccounts = result;
+      transferIndex = 3;
+    }
+
+    // Without a create-ATA the original 3-7 instruction bound still applies.
+    if (!createAtaAccounts && instructions.length > 7) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_svm_payload_transaction_instructions_length",
+        payer,
+      };
+    }
+
     // Step 4: Verify Transfer Instruction
-    const transferIx = instructions[2];
+    const transferIx = instructions[transferIndex];
     const programAddress = transferIx.programAddress.toString();
 
     if (
@@ -671,6 +710,28 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       };
     }
 
+    // Step 4b: Pin the create-ATA instruction to the parsed transfer (#2395).
+    // ata must be the transfer destination (already proven equal to the ATA
+    // derived from payTo/tokenProgram/mint above), and the token program must
+    // be the transfer's — the token program is a derivation seed, so this is
+    // what keeps the derived-destination check sound for Token-2022.
+    if (createAtaAccounts) {
+      if (createAtaAccounts.tokenProgram !== programAddress) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_svm_payload_create_ata_token_program_mismatch",
+          payer,
+        };
+      }
+      if (createAtaAccounts.ata !== destATA) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_svm_payload_create_ata_destination_mismatch",
+          payer,
+        };
+      }
+    }
+
     // Verify transfer amount meets requirements
     const amount = parsedTransfer.data.amount;
     if (amount !== BigInt(requirements.amount)) {
@@ -683,7 +744,7 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
 
     // Step 5: Verify optional instructions (if present)
     // Allowed optional programs: Lighthouse (wallet protection) and Memo (uniqueness)
-    const optionalInstructions = instructions.slice(3);
+    const optionalInstructions = instructions.slice(transferIndex + 1);
     const invalidReasonByIndex = [
       "invalid_exact_svm_payload_unknown_fourth_instruction",
       "invalid_exact_svm_payload_unknown_fifth_instruction",

--- a/typescript/packages/mechanisms/svm/src/exact/v1/client/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/client/scheme.ts
@@ -5,11 +5,13 @@ import {
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import {
   findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
   getTransferCheckedInstruction,
   TOKEN_2022_PROGRAM_ADDRESS,
 } from "@solana-program/token-2022";
 import {
   appendTransactionMessageInstructions,
+  createNoopSigner,
   createTransactionMessage,
   getBase64EncodedWireTransaction,
   partiallySignTransactionMessageWithSigners,
@@ -18,6 +20,7 @@ import {
   setTransactionMessageFeePayer,
   setTransactionMessageLifetimeUsingBlockhash,
   type Address,
+  type Instruction,
 } from "@solana/kit";
 import type {
   Network,
@@ -117,6 +120,27 @@ export class ExactSvmSchemeV1 implements SchemeNetworkClient {
       throw new Error("feePayer is required in paymentRequirements.extra for SVM transactions");
     }
 
+    // If the recipient has never held this token, the destination ATA does not
+    // exist yet and TransferChecked would fail with InvalidAccountData (#2395).
+    // Prepend an idempotent create funded by the facilitator fee payer — only
+    // when the ATA is actually missing, so the common repeat-payment layout is
+    // unchanged. The facilitator statically pins every field of this
+    // instruction, and the idempotent discriminator makes a lost race with a
+    // concurrent creation harmless.
+    const prefixInstructions: Instruction[] = [];
+    const destinationInfo = await rpc.getAccountInfo(destinationATA, { encoding: "base64" }).send();
+    if (!destinationInfo.value) {
+      prefixInstructions.push(
+        getCreateAssociatedTokenIdempotentInstruction({
+          payer: createNoopSigner(feePayer),
+          ata: destinationATA,
+          owner: selectedV1.payTo as Address,
+          mint: selectedV1.asset as Address,
+          tokenProgram: tokenProgramAddress,
+        }),
+      );
+    }
+
     const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
     const sellerMemo = selectedV1.extra?.memo as string | undefined;
@@ -149,7 +173,7 @@ export class ExactSvmSchemeV1 implements SchemeNetworkClient {
           getSetComputeUnitLimitInstruction({ units: DEFAULT_COMPUTE_UNIT_LIMIT }),
           tx,
         ),
-      tx => appendTransactionMessageInstructions([transferIx, memoIx], tx),
+      tx => appendTransactionMessageInstructions([...prefixInstructions, transferIx, memoIx], tx),
       tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
     );
 

--- a/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
@@ -38,6 +38,10 @@ import {
   getTokenPayerFromTransaction,
   transactionMessageHash,
 } from "../../../utils";
+import {
+  isAssociatedTokenProgramInstruction,
+  validateCreateAtaIdempotentInstruction,
+} from "../../createAta";
 
 /**
  * SVM facilitator implementation for the Exact payment scheme (V1).
@@ -157,13 +161,17 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
     const decompiled = decompileTransactionMessage(compiled);
     const instructions = decompiled.instructions ?? [];
 
-    // Allow 3-6 instructions:
+    // Allow 3-6 instructions (7 when an idempotent create-ATA is present):
     // - 3 instructions: ComputeLimit + ComputePrice + TransferChecked
     // - 4 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse or Memo
     // - 5 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse + Lighthouse or Memo
     // - 6 instructions: ComputeLimit + ComputePrice + TransferChecked + Lighthouse + Lighthouse + Memo
+    // An optional CreateAssociatedTokenIdempotent at index 2 (first payment to a
+    // payTo/mint whose ATA does not exist yet, see #2395) shifts TransferChecked
+    // to index 3 and raises each bound by one.
     // See: https://github.com/x402-foundation/x402/issues/828
-    if (instructions.length < 3 || instructions.length > 6) {
+    //  and: https://github.com/x402-foundation/x402/issues/2395
+    if (instructions.length < 3 || instructions.length > 7) {
       return {
         isValid: false,
         invalidReason: "invalid_exact_svm_payload_transaction_instructions_length",
@@ -193,8 +201,36 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
       };
     }
 
+    // Step 3b: Optional idempotent create-ATA at index 2 (#2395).
+    // Same pinning as the v2 scheme: the facilitator fee payer funds the rent,
+    // so every field is validated; the ata/tokenProgram pins against the parsed
+    // transfer are asserted after the transfer instruction is parsed below.
+    let transferIndex = 2;
+    let createAtaAccounts: { ata: string; tokenProgram: string } | null = null;
+    if (instructions.length >= 4 && isAssociatedTokenProgramInstruction(instructions[2] as never)) {
+      const result = validateCreateAtaIdempotentInstruction(instructions[2] as never, {
+        payTo: requirements.payTo,
+        asset: requirements.asset,
+        feePayer: requirementsV1.extra!.feePayer as string,
+      });
+      if ("invalidReason" in result) {
+        return { isValid: false, invalidReason: result.invalidReason, payer };
+      }
+      createAtaAccounts = result;
+      transferIndex = 3;
+    }
+
+    // Without a create-ATA the original 3-6 instruction bound still applies.
+    if (!createAtaAccounts && instructions.length > 6) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_svm_payload_transaction_instructions_length",
+        payer,
+      };
+    }
+
     // Step 4: Verify Transfer Instruction
-    const transferIx = instructions[2];
+    const transferIx = instructions[transferIndex];
     const programAddress = transferIx.programAddress.toString();
 
     if (
@@ -272,6 +308,27 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
       };
     }
 
+    // Step 4b: Pin the create-ATA instruction to the parsed transfer (#2395).
+    // ata must be the transfer destination and the token program must be the
+    // transfer's — the token program is a derivation seed, so this is what
+    // keeps the derived-destination check sound for Token-2022.
+    if (createAtaAccounts) {
+      if (createAtaAccounts.tokenProgram !== programAddress) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_svm_payload_create_ata_token_program_mismatch",
+          payer,
+        };
+      }
+      if (createAtaAccounts.ata !== destATA) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_svm_payload_create_ata_destination_mismatch",
+          payer,
+        };
+      }
+    }
+
     // Verify transfer amount exactly matches requirements
     const amount = parsedTransfer.data.amount;
     if (amount !== BigInt(requirementsV1.maxAmountRequired)) {
@@ -284,7 +341,7 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
 
     // Step 5: Verify optional instructions (if present)
     // Allowed optional programs: Lighthouse (wallet protection) and Memo (uniqueness)
-    const optionalInstructions = instructions.slice(3);
+    const optionalInstructions = instructions.slice(transferIndex + 1);
     const invalidReasonByIndex = [
       "invalid_exact_svm_payload_unknown_fourth_instruction",
       "invalid_exact_svm_payload_unknown_fifth_instruction",

--- a/typescript/packages/mechanisms/svm/test/fixtures/ata-create-fixtures-token2022.json
+++ b/typescript/packages/mechanisms/svm/test/fixtures/ata-create-fixtures-token2022.json
@@ -1,0 +1,114 @@
+{
+  "SPDX-License-Identifier": "Apache-2.0",
+  "copyright": "Copyright 2026 Antoni Jagodka (DrVelvetFog). Contributed under Apache-2.0.",
+  "note": "Token-2022 companion to chopmob-cloud's ata-create-fixtures.json (#2798). Exercises the token-program derivation seed in both directions. payment_mint is PYUSD, a live Token-2022 mint on Solana mainnet; transfer_destination is the ATA derived under Token-2022 and reproduces from (payTo, Token-2022 program, mint).",
+  "context": {
+    "payTo": "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+    "payment_mint": "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
+    "transfer_token_program": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+    "fee_payer": "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9",
+    "transfer_destination": "5AJ5PmLBPTY9JkKPSkSdNrghd1iqoWh1U55g3ByVG41y",
+    "system_program": "11111111111111111111111111111111"
+  },
+  "assertions": [
+    "program == ATA program",
+    "data == 0x01",
+    "accounts length == 6",
+    "account[1] == transfer_destination",
+    "account[2] == payTo",
+    "account[3] == payment_mint",
+    "account[5] == transfer_token_program",
+    "account[0] == fee_payer",
+    "account[4] == System Program"
+  ],
+  "fixtures": [
+    {
+      "id": "fixture-pos-02-token2022",
+      "description": "legit Token-2022 payment (PYUSD): create-ATA derived under Token-2022 (account[5]=Token-2022), account[1] the Token-2022 ATA. Accepts only if the validator derives the destination parametrically on the token program rather than hardcoding SPL Token.",
+      "instruction": {
+        "program_id": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+        "data_b64": "AQ==",
+        "data_hex": "01",
+        "accounts": [
+          {
+            "pubkey": "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9",
+            "is_signer": true,
+            "is_writable": true
+          },
+          {
+            "pubkey": "5AJ5PmLBPTY9JkKPSkSdNrghd1iqoWh1U55g3ByVG41y",
+            "is_signer": false,
+            "is_writable": true
+          },
+          {
+            "pubkey": "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "11111111111111111111111111111111",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+            "is_signer": false,
+            "is_writable": false
+          }
+        ]
+      },
+      "expected_verdict": "ACCEPT",
+      "failed_assertions": []
+    },
+    {
+      "id": "fixture-neg-04-cross-program-create",
+      "description": "transfer is under Token-2022 (PYUSD) but the create-ATA names SPL Token in account[5]. account[1] is left as the correct Token-2022 destination so only the token-program pin fails; on-chain this would rent-fund the SPL-derived ATA (6v1NJ9vKgoG2v7BJXjcZhBtdsMk33bSYsUX51DV3Jw17) instead of the paid Token-2022 ATA (5AJ5PmLBPTY9JkKPSkSdNrghd1iqoWh1U55g3ByVG41y).",
+      "instruction": {
+        "program_id": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+        "data_b64": "AQ==",
+        "data_hex": "01",
+        "accounts": [
+          {
+            "pubkey": "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9",
+            "is_signer": true,
+            "is_writable": true
+          },
+          {
+            "pubkey": "5AJ5PmLBPTY9JkKPSkSdNrghd1iqoWh1U55g3ByVG41y",
+            "is_signer": false,
+            "is_writable": true
+          },
+          {
+            "pubkey": "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "11111111111111111111111111111111",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "is_signer": false,
+            "is_writable": false
+          }
+        ]
+      },
+      "expected_verdict": "REJECT",
+      "failed_assertions": [
+        "account[5] == transfer_token_program"
+      ]
+    }
+  ]
+}

--- a/typescript/packages/mechanisms/svm/test/fixtures/ata-create-fixtures.json
+++ b/typescript/packages/mechanisms/svm/test/fixtures/ata-create-fixtures.json
@@ -1,0 +1,209 @@
+{
+  "SPDX-License-Identifier": "Apache-2.0",
+  "copyright": "Copyright 2026 Christopher Hopley / AlgoVoi (chopmob-cloud). Contributed under Apache-2.0.",
+  "context": {
+    "payTo": "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+    "payment_mint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "transfer_token_program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "fee_payer": "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9",
+    "transfer_destination": "DNDTCnZkNk358qDFZd9unHtnrc73SsXcpVWtwJJMrR4B",
+    "system_program": "11111111111111111111111111111111"
+  },
+  "assertions": [
+    "program == ATA program",
+    "data == 0x01",
+    "accounts length == 6",
+    "account[1] == transfer_destination",
+    "account[2] == payTo",
+    "account[3] == payment_mint",
+    "account[5] == transfer_token_program",
+    "account[0] == fee_payer",
+    "account[4] == System Program"
+  ],
+  "fixtures": [
+    {
+      "id": "fixture-pos-01",
+      "description": "correct idempotent create, all seven assertions hold",
+      "instruction": {
+        "program_id": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+        "data_b64": "AQ==",
+        "data_hex": "01",
+        "accounts": [
+          {
+            "pubkey": "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9",
+            "is_signer": true,
+            "is_writable": true
+          },
+          {
+            "pubkey": "DNDTCnZkNk358qDFZd9unHtnrc73SsXcpVWtwJJMrR4B",
+            "is_signer": false,
+            "is_writable": true
+          },
+          {
+            "pubkey": "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "11111111111111111111111111111111",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "is_signer": false,
+            "is_writable": false
+          }
+        ]
+      },
+      "expected_verdict": "ACCEPT",
+      "failed_assertions": []
+    },
+    {
+      "id": "fixture-neg-01-legacy-create",
+      "description": "legacy non-idempotent Create (empty instruction data)",
+      "instruction": {
+        "program_id": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+        "data_b64": "",
+        "data_hex": "",
+        "accounts": [
+          {
+            "pubkey": "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9",
+            "is_signer": true,
+            "is_writable": true
+          },
+          {
+            "pubkey": "DNDTCnZkNk358qDFZd9unHtnrc73SsXcpVWtwJJMrR4B",
+            "is_signer": false,
+            "is_writable": true
+          },
+          {
+            "pubkey": "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "11111111111111111111111111111111",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "SysvarRent111111111111111111111111111111111",
+            "is_signer": false,
+            "is_writable": false
+          }
+        ]
+      },
+      "expected_verdict": "REJECT",
+      "failed_assertions": [
+        "data == 0x01",
+        "accounts length == 6"
+      ]
+    },
+    {
+      "id": "fixture-neg-02-tampered-destination",
+      "description": "account[1] tampered to a different ATA, not the derived TransferChecked destination",
+      "instruction": {
+        "program_id": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+        "data_b64": "AQ==",
+        "data_hex": "01",
+        "accounts": [
+          {
+            "pubkey": "AKnL4NNf3DGWZJS6cPknBuEGnVsV4A4m5tgebLHaRSZ9",
+            "is_signer": true,
+            "is_writable": true
+          },
+          {
+            "pubkey": "FHPASu6WrzXmbm5NbAQy9BxwX5naUHKn5z8ycurGoSX",
+            "is_signer": false,
+            "is_writable": true
+          },
+          {
+            "pubkey": "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "11111111111111111111111111111111",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "is_signer": false,
+            "is_writable": false
+          }
+        ]
+      },
+      "expected_verdict": "REJECT",
+      "failed_assertions": [
+        "account[1] == transfer_destination"
+      ]
+    },
+    {
+      "id": "fixture-neg-03-sender-funder",
+      "description": "otherwise-correct idempotent create funded by the sender, not the fee payer",
+      "instruction": {
+        "program_id": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+        "data_b64": "AQ==",
+        "data_hex": "01",
+        "accounts": [
+          {
+            "pubkey": "9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu",
+            "is_signer": true,
+            "is_writable": true
+          },
+          {
+            "pubkey": "DNDTCnZkNk358qDFZd9unHtnrc73SsXcpVWtwJJMrR4B",
+            "is_signer": false,
+            "is_writable": true
+          },
+          {
+            "pubkey": "GyGKxMyg1p9SsHfm15MkNUu1u9TN2JtTspcdmrtGUdse",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "11111111111111111111111111111111",
+            "is_signer": false,
+            "is_writable": false
+          },
+          {
+            "pubkey": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+            "is_signer": false,
+            "is_writable": false
+          }
+        ]
+      },
+      "expected_verdict": "REJECT",
+      "failed_assertions": [
+        "account[0] == fee_payer"
+      ]
+    }
+  ]
+}

--- a/typescript/packages/mechanisms/svm/test/unit/createAta.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/createAta.test.ts
@@ -1,0 +1,339 @@
+import {
+  decompileTransactionMessage,
+  generateKeyPairSigner,
+  getCompiledTransactionMessageDecoder,
+  type Address,
+} from "@solana/kit";
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ADDRESS,
+  TOKEN_2022_PROGRAM_ADDRESS,
+} from "@solana-program/token-2022";
+import type { PaymentRequirements } from "@x402/core/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SOLANA_DEVNET_CAIP2, USDC_DEVNET_ADDRESS } from "../../src/constants";
+import {
+  SYSTEM_PROGRAM_ADDRESS,
+  validateCreateAtaIdempotentInstruction,
+} from "../../src/exact/createAta";
+import type { FacilitatorSvmSigner } from "../../src/signer";
+
+const FIXED_BLOCKHASH = "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF";
+
+let mockAtaMap: Record<string, Address> = {};
+let destinationAtaExists = true;
+
+const mockRpc = {
+  getLatestBlockhash: vi.fn(() => ({
+    send: vi.fn().mockResolvedValue({ value: { blockhash: FIXED_BLOCKHASH } }),
+  })),
+  getAccountInfo: vi.fn(() => ({
+    send: vi.fn().mockImplementation(async () => ({
+      value: destinationAtaExists ? { data: ["", "base64"] } : null,
+    })),
+  })),
+};
+
+vi.mock("../../src/utils", async () => {
+  const actual = await vi.importActual<typeof import("../../src/utils")>("../../src/utils");
+  return {
+    ...actual,
+    createRpcClient: vi.fn(() => mockRpc),
+  };
+});
+
+vi.mock("@solana-program/token-2022", async () => {
+  const actual = await vi.importActual<typeof import("@solana-program/token-2022")>(
+    "@solana-program/token-2022",
+  );
+  return {
+    ...actual,
+    fetchMint: vi.fn().mockResolvedValue({
+      programAddress: TOKEN_PROGRAM_ADDRESS,
+      data: { decimals: 6 },
+    }),
+    findAssociatedTokenPda: vi.fn().mockImplementation(async args => {
+      const owner = String(args.owner);
+      const ata = mockAtaMap[owner];
+      if (!ata) {
+        throw new Error(`Missing ATA mock for owner ${owner}`);
+      }
+      return [ata, 255] as const;
+    }),
+  };
+});
+
+/** Build a structurally valid create-ATA instruction view for the validator. */
+function makeCreateIx(overrides?: {
+  data?: number[];
+  accounts?: string[];
+}): Parameters<typeof validateCreateAtaIdempotentInstruction>[0] {
+  const accounts = overrides?.accounts ?? [
+    "FeePayer1111111111111111111111111111",
+    "DerivedAta11111111111111111111111111",
+    "PayTo1111111111111111111111111111111",
+    USDC_DEVNET_ADDRESS,
+    SYSTEM_PROGRAM_ADDRESS,
+    TOKEN_PROGRAM_ADDRESS.toString(),
+  ];
+  return {
+    programAddress: { toString: () => ASSOCIATED_TOKEN_PROGRAM_ADDRESS.toString() },
+    accounts: accounts.map(address => ({ address: { toString: () => address } })),
+    data: new Uint8Array(overrides?.data ?? [1]),
+  };
+}
+
+const EXPECTED = {
+  payTo: "PayTo1111111111111111111111111111111",
+  asset: USDC_DEVNET_ADDRESS,
+  feePayer: "FeePayer1111111111111111111111111111",
+};
+
+describe("validateCreateAtaIdempotentInstruction", () => {
+  it("accepts a fully pinned idempotent create and returns ata/tokenProgram", () => {
+    const result = validateCreateAtaIdempotentInstruction(makeCreateIx(), EXPECTED);
+    expect(result).toEqual({
+      ata: "DerivedAta11111111111111111111111111",
+      tokenProgram: TOKEN_PROGRAM_ADDRESS.toString(),
+    });
+  });
+
+  it("rejects the legacy non-idempotent Create (empty data)", () => {
+    const result = validateCreateAtaIdempotentInstruction(makeCreateIx({ data: [] }), EXPECTED);
+    expect(result).toEqual({
+      invalidReason: "invalid_exact_svm_payload_create_ata_not_idempotent",
+    });
+  });
+
+  it("rejects a Create with explicit 0x00 discriminator", () => {
+    const result = validateCreateAtaIdempotentInstruction(makeCreateIx({ data: [0] }), EXPECTED);
+    expect(result).toEqual({
+      invalidReason: "invalid_exact_svm_payload_create_ata_not_idempotent",
+    });
+  });
+
+  it("rejects a seven-account layout (legacy create with rent sysvar)", () => {
+    const base = makeCreateIx();
+    const accounts = [...(base.accounts ?? [])];
+    accounts.push({ address: { toString: () => "SysvarRent111111111111111111111111111111111" } });
+    const result = validateCreateAtaIdempotentInstruction({ ...base, accounts }, EXPECTED);
+    expect(result).toEqual({
+      invalidReason: "invalid_exact_svm_payload_create_ata_account_count",
+    });
+  });
+
+  it("rejects a funder other than the fee payer", () => {
+    const ix = makeCreateIx({
+      accounts: [
+        "Sender111111111111111111111111111111", // sender pays rent instead of fee payer
+        "DerivedAta11111111111111111111111111",
+        "PayTo1111111111111111111111111111111",
+        USDC_DEVNET_ADDRESS,
+        SYSTEM_PROGRAM_ADDRESS,
+        TOKEN_PROGRAM_ADDRESS.toString(),
+      ],
+    });
+    expect(validateCreateAtaIdempotentInstruction(ix, EXPECTED)).toEqual({
+      invalidReason: "invalid_exact_svm_payload_create_ata_funder_mismatch",
+    });
+  });
+
+  it("rejects an owner other than payTo", () => {
+    const ix = makeCreateIx({
+      accounts: [
+        "FeePayer1111111111111111111111111111",
+        "DerivedAta11111111111111111111111111",
+        "Attacker11111111111111111111111111111",
+        USDC_DEVNET_ADDRESS,
+        SYSTEM_PROGRAM_ADDRESS,
+        TOKEN_PROGRAM_ADDRESS.toString(),
+      ],
+    });
+    expect(validateCreateAtaIdempotentInstruction(ix, EXPECTED)).toEqual({
+      invalidReason: "invalid_exact_svm_payload_create_ata_owner_mismatch",
+    });
+  });
+
+  it("rejects a mint other than the payment asset", () => {
+    const ix = makeCreateIx({
+      accounts: [
+        "FeePayer1111111111111111111111111111",
+        "DerivedAta11111111111111111111111111",
+        "PayTo1111111111111111111111111111111",
+        "OtherMint111111111111111111111111111",
+        SYSTEM_PROGRAM_ADDRESS,
+        TOKEN_PROGRAM_ADDRESS.toString(),
+      ],
+    });
+    expect(validateCreateAtaIdempotentInstruction(ix, EXPECTED)).toEqual({
+      invalidReason: "invalid_exact_svm_payload_create_ata_mint_mismatch",
+    });
+  });
+
+  it("rejects an unknown token program", () => {
+    const ix = makeCreateIx({
+      accounts: [
+        "FeePayer1111111111111111111111111111",
+        "DerivedAta11111111111111111111111111",
+        "PayTo1111111111111111111111111111111",
+        USDC_DEVNET_ADDRESS,
+        SYSTEM_PROGRAM_ADDRESS,
+        "FakeTokenProgram11111111111111111111",
+      ],
+    });
+    expect(validateCreateAtaIdempotentInstruction(ix, EXPECTED)).toEqual({
+      invalidReason: "invalid_exact_svm_payload_create_ata_token_program_mismatch",
+    });
+  });
+
+  it("accepts Token-2022 as the pinned token program", () => {
+    const ix = makeCreateIx({
+      accounts: [
+        "FeePayer1111111111111111111111111111",
+        "DerivedAta11111111111111111111111111",
+        "PayTo1111111111111111111111111111111",
+        USDC_DEVNET_ADDRESS,
+        SYSTEM_PROGRAM_ADDRESS,
+        TOKEN_2022_PROGRAM_ADDRESS.toString(),
+      ],
+    });
+    expect(validateCreateAtaIdempotentInstruction(ix, EXPECTED)).toEqual({
+      ata: "DerivedAta11111111111111111111111111",
+      tokenProgram: TOKEN_2022_PROGRAM_ADDRESS.toString(),
+    });
+  });
+});
+
+describe("client create-ATA inclusion (#2395)", () => {
+  beforeEach(() => {
+    mockAtaMap = {};
+    destinationAtaExists = true;
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Build a client payment payload against the mocked RPC and return the
+   * decompiled instruction list.
+   */
+  async function buildAndDecompile() {
+    const { ExactSvmScheme } = await import("../../src/exact/client/scheme");
+    const { decodeTransactionFromPayload } = await import("../../src/utils");
+
+    const clientSigner = await generateKeyPairSigner();
+    const feePayer = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const destAta = await generateKeyPairSigner();
+
+    mockAtaMap = {
+      [clientSigner.address]: clientSigner.address as Address,
+      [payTo.address]: destAta.address as Address,
+    };
+
+    const requirements: PaymentRequirements = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: feePayer.address },
+    };
+
+    const client = new ExactSvmScheme(clientSigner);
+    const payload = await client.createPaymentPayload(2, requirements);
+    const tx = decodeTransactionFromPayload(payload.payload as { transaction: string });
+    const compiled = getCompiledTransactionMessageDecoder().decode(tx.messageBytes);
+    const decompiled = decompileTransactionMessage(compiled);
+    return {
+      instructions: decompiled.instructions ?? [],
+      clientSigner,
+      feePayer,
+      payTo,
+      destAta,
+      requirements,
+      payload,
+    };
+  }
+
+  it("keeps the classic 4-instruction layout when the destination ATA exists", async () => {
+    destinationAtaExists = true;
+    const { instructions } = await buildAndDecompile();
+    expect(instructions.map(ix => ix.programAddress.toString())).not.toContain(
+      ASSOCIATED_TOKEN_PROGRAM_ADDRESS.toString(),
+    );
+    expect(instructions.length).toBe(4);
+  });
+
+  it("inserts a pinned idempotent create at index 2 when the ATA is missing", async () => {
+    destinationAtaExists = false;
+    const { instructions, feePayer, payTo, destAta } = await buildAndDecompile();
+
+    expect(instructions.length).toBe(5);
+    const createIx = instructions[2] as {
+      programAddress: { toString(): string };
+      accounts?: ReadonlyArray<{ address: { toString(): string } }>;
+      data?: Readonly<Uint8Array>;
+    };
+    expect(createIx.programAddress.toString()).toBe(ASSOCIATED_TOKEN_PROGRAM_ADDRESS.toString());
+    expect(Array.from(createIx.data ?? [])).toEqual([1]);
+
+    const accounts = (createIx.accounts ?? []).map(a => a.address.toString());
+    expect(accounts).toEqual([
+      feePayer.address, // funder == fee payer (facilitator-funded rent)
+      destAta.address, // ata == transfer destination
+      payTo.address, // owner == payTo
+      USDC_DEVNET_ADDRESS, // mint == payment asset
+      SYSTEM_PROGRAM_ADDRESS,
+      TOKEN_PROGRAM_ADDRESS.toString(), // token program == transfer's program
+    ]);
+
+    // TransferChecked shifted to index 3
+    expect(instructions[3].programAddress.toString()).toBe(TOKEN_PROGRAM_ADDRESS.toString());
+  });
+
+  it("is accepted by the facilitator static path, and rejected when the funder pin fails", async () => {
+    destinationAtaExists = false;
+    const { payload, requirements, clientSigner, feePayer } = await buildAndDecompile();
+
+    const { ExactSvmScheme: FacilitatorScheme } = await import(
+      "../../src/exact/facilitator/scheme"
+    );
+
+    const makeSigner = (addresses: string[]): FacilitatorSvmSigner =>
+      ({
+        getAddresses: vi.fn().mockReturnValue(addresses),
+        signTransaction: vi.fn().mockResolvedValue("signedTransaction=="),
+        simulateTransaction: vi.fn().mockResolvedValue({ value: { err: null } }),
+      }) as unknown as FacilitatorSvmSigner;
+
+    const fullPayload = {
+      x402Version: 2,
+      resource: { url: "http://example.com", description: "", mimeType: "application/json" },
+      accepted: requirements,
+      payload: payload.payload,
+    } as never;
+
+    // Accept: requirements feePayer matches the create-ATA funder
+    const facilitator = new FacilitatorScheme(makeSigner([feePayer.address]));
+    const ok = await facilitator.verify(fullPayload, requirements);
+    expect(ok.invalidReason).toBeUndefined();
+    expect(ok.isValid).toBe(true);
+    expect(ok.payer).toBe(clientSigner.address);
+
+    // Reject: same transaction verified against a different fee payer —
+    // the funder pin must fail before any rent could be redirected.
+    const otherFeePayer = await generateKeyPairSigner();
+    const otherRequirements = {
+      ...requirements,
+      extra: { feePayer: otherFeePayer.address },
+    } as PaymentRequirements;
+    const otherFacilitator = new FacilitatorScheme(makeSigner([otherFeePayer.address]));
+    const rejected = await otherFacilitator.verify(
+      { ...(fullPayload as object), accepted: otherRequirements } as never,
+      otherRequirements,
+    );
+    expect(rejected.isValid).toBe(false);
+    expect(rejected.invalidReason).toBe("invalid_exact_svm_payload_create_ata_funder_mismatch");
+  });
+});

--- a/typescript/packages/mechanisms/svm/test/unit/createAtaFixtures.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/createAtaFixtures.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { validateCreateAtaIdempotentInstruction } from "../../src/exact/createAta";
+
+/**
+ * Byte-fixture suite for the optional index-2 CreateAssociatedTokenIdempotent
+ * instruction (#2395 / #2798).
+ *
+ * Fixture sets (both contributed on the PR under Apache-2.0, SPDX headers kept
+ * inside the JSON files):
+ * - ata-create-fixtures.json — chopmob-cloud: 1 ACCEPT + 3 REJECT (SPL Token)
+ * - ata-create-fixtures-token2022.json — DrVelvetFog: 1 ACCEPT + 1 REJECT
+ *   driving the token-program derivation seed (PYUSD, a live Token-2022 mint)
+ *
+ * Each fixture is evaluated against the FULL static-path pin set: the shared
+ * validator (`validateCreateAtaIdempotentInstruction`) plus the two caller
+ * pins the facilitator applies after parsing the transfer —
+ * tokenProgram == the transfer's token program and ata == the transfer
+ * destination. neg-02 (tampered destination) intentionally passes the isolated
+ * validator — that function never reads `account[1]` — and only rejects at the
+ * caller's destination pin, exercising the transitive guard
+ * (ata == transfer destination == derived ATA). Pointing it at the validator
+ * alone would read as a false accept.
+ */
+
+type Fixture = {
+  id: string;
+  description: string;
+  instruction: {
+    program_id: string;
+    data_b64: string;
+    accounts: Array<{ pubkey: string }>;
+  };
+  expected_verdict: "ACCEPT" | "REJECT";
+};
+
+type FixtureFile = {
+  context: {
+    payTo: string;
+    payment_mint: string;
+    transfer_token_program: string;
+    fee_payer: string;
+    transfer_destination: string;
+  };
+  fixtures: Fixture[];
+};
+
+/** Reason each REJECT fixture must fail with, against the real error codes. */
+const EXPECTED_REASONS: Record<string, string> = {
+  "fixture-neg-01-legacy-create": "invalid_exact_svm_payload_create_ata_not_idempotent",
+  "fixture-neg-02-tampered-destination":
+    "invalid_exact_svm_payload_create_ata_destination_mismatch",
+  "fixture-neg-03-sender-funder": "invalid_exact_svm_payload_create_ata_funder_mismatch",
+  "fixture-neg-04-cross-program-create":
+    "invalid_exact_svm_payload_create_ata_token_program_mismatch",
+};
+
+function loadFixtureFile(name: string): FixtureFile {
+  return JSON.parse(readFileSync(join(__dirname, "..", "fixtures", name), "utf8")) as FixtureFile;
+}
+
+/** Adapt a JSON fixture instruction to the validator's decompiled-instruction shape. */
+function toInstruction(fixture: Fixture) {
+  return {
+    programAddress: { toString: () => fixture.instruction.program_id },
+    accounts: fixture.instruction.accounts.map(account => ({
+      address: { toString: () => account.pubkey },
+    })),
+    data: Uint8Array.from(Buffer.from(fixture.instruction.data_b64, "base64")),
+  };
+}
+
+/**
+ * Run the full static-path pin set: shared validator, then the facilitator's
+ * caller pins (token program == transfer's, ata == transfer destination).
+ */
+function verdictFor(
+  fixture: Fixture,
+  context: FixtureFile["context"],
+): { verdict: "ACCEPT" | "REJECT"; reason?: string } {
+  const result = validateCreateAtaIdempotentInstruction(toInstruction(fixture), {
+    payTo: context.payTo,
+    asset: context.payment_mint,
+    feePayer: context.fee_payer,
+  });
+  if ("invalidReason" in result) {
+    return { verdict: "REJECT", reason: result.invalidReason };
+  }
+  if (result.tokenProgram !== context.transfer_token_program) {
+    return {
+      verdict: "REJECT",
+      reason: "invalid_exact_svm_payload_create_ata_token_program_mismatch",
+    };
+  }
+  if (result.ata !== context.transfer_destination) {
+    return {
+      verdict: "REJECT",
+      reason: "invalid_exact_svm_payload_create_ata_destination_mismatch",
+    };
+  }
+  return { verdict: "ACCEPT" };
+}
+
+for (const file of ["ata-create-fixtures.json", "ata-create-fixtures-token2022.json"]) {
+  describe(`byte fixtures: ${file}`, () => {
+    const { context, fixtures } = loadFixtureFile(file);
+
+    for (const fixture of fixtures) {
+      it(`${fixture.id} — ${fixture.expected_verdict}`, () => {
+        const { verdict, reason } = verdictFor(fixture, context);
+        expect(verdict).toBe(fixture.expected_verdict);
+        if (fixture.expected_verdict === "REJECT") {
+          expect(reason).toBe(EXPECTED_REASONS[fixture.id]);
+        }
+      });
+    }
+  });
+}

--- a/typescript/packages/mechanisms/svm/test/unit/duplicateTx.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/duplicateTx.test.ts
@@ -29,6 +29,11 @@ const mockRpc = {
       value: { blockhash: blockhashes[blockhashIndex++] },
     }),
   })),
+  // Destination ATA exists by default, so no create-ATA instruction is added
+  // and the classic [compute, compute, transfer, memo] layout is preserved.
+  getAccountInfo: vi.fn(() => ({
+    send: vi.fn().mockResolvedValue({ value: { data: ["", "base64"] } }),
+  })),
 };
 
 vi.mock("../../src/utils", async () => {


### PR DESCRIPTION
Closes #2395

## Problem

The exact SVM client builds `TransferChecked` against the recipient's associated token account without ensuring it exists. The first payment to any `payTo`/mint whose ATA has never been created fails with `InstructionError: [.., InvalidAccountData]`.

As discussed in #2395, this cannot be fixed client-side alone: the facilitator's static path pins `instructions[2]` to `TransferChecked` and only exempts Lighthouse/Memo beyond it, so a prepended create-ATA trips `no_transfer_instruction`. This PR makes the coordinated client + facilitator change, for both v2 and v1.

## Design (as converged in the issue thread)

**Client (v1 + v2):** when the destination ATA does not exist (one `getAccountInfo` check), prepend a `CreateAssociatedTokenIdempotent` funded by the facilitator fee payer via `createNoopSigner`. The repeat-payment layout is byte-identical to today — the new instruction only appears for first-time recipients, and the idempotent discriminator makes a lost race with a concurrent creation harmless.

**Facilitator (v1 + v2) static path:** accept exactly one optional create-ATA at index 2, shifting `TransferChecked` to index 3 (instruction-count bounds raised by one only when it is present). Because the fee payer funds the rent in the gasless flow, every field is pinned — an unscoped allowance would let a client make the facilitator rent-fund arbitrary `(owner, mint)` ATAs (credit @DrVelvetFog for surfacing this):

| pin | value |
|---|---|
| program | ATA program |
| data | exactly `0x01` (idempotent; legacy `Create` is empty-data + 7 accounts) |
| accounts | exactly 6 |
| `account[0]` funder | `requirements.extra.feePayer` |
| `account[2]` owner | `payTo` |
| `account[3]` mint | `asset` |
| `account[4]` | System Program |
| `account[5]` token program | the transfer's token program (ATA derivation seed — keeps the check sound for Token-2022) |
| `account[1]` ata | the `TransferChecked` destination, itself required to equal the ATA derived from (`payTo`, token program, mint) |

The byte-level shape follows @chopmob-cloud's spec in the thread; their byte-validated positive/negative fixture set (`pos-01`, `neg-01-legacy-create`, `neg-02-tampered-destination`, `neg-03-sender-funder`) is offered under Apache-2.0 and will be added to this PR.

## Changes

- `src/exact/createAta.ts` (new): shared static validator for the optional create-ATA instruction
- `src/exact/client/scheme.ts`, `src/exact/v1/client/scheme.ts`: conditional idempotent create-ATA
- `src/exact/facilitator/scheme.ts`, `src/exact/v1/facilitator/scheme.ts`: optional index-2 create-ATA with full pinning
- `test/unit/createAta.test.ts` (new): validator pins (incl. legacy `Create`, funder≠feePayer, Token-2022), client layout with/without existing ATA, facilitator accept + funder-pin reject end-to-end
- changeset: `@x402/svm` minor

`pnpm build` clean, 206/206 tests pass, eslint clean.

## Open questions for maintainers

1. **Path 2 interplay:** create-ATA pin failures are currently *not* in `LAYOUT_RECOVERABLE_REASONS`, so they hard-fail rather than falling through to smart-wallet simulation. Smart wallets wrap transfers in CPI (their top-level ix is the wallet program, not the ATA program), so this shouldn't affect them — but happy to move them into the recoverable set if you prefer.
2. Whether the client should *always* include the idempotent create (deterministic layout, +1 RPC saved) instead of conditionally — conditional was chosen to keep the common path byte-identical.

## Notes

- Draft until maintainers confirm the intended shape (per the thread); @chopmob-cloud will land the byte fixtures here, and @DrVelvetFog offered to review the vectors.
- AI disclosure: implemented with AI assistance (Claude); design from the #2395 thread, all code reviewed and tested locally by me.
