### PR TITLE
feat(evm): add Igra mainnet (eip155:38833) default stablecoin

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -109,6 +109,7 @@ When you use `"$0.01"` syntax, x402 needs to know which stablecoin to use. The f
 | HPP Sepolia | `eip155:181228` | `0x401eCb1D350407f13ba348573E5630B83638E30D` | Bridged USDC | 6 | EIP-3009 |
 | XDC Network | `eip155:50` | `0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1` | USDC | 6 | EIP-3009 |
 | XDC Apothem Testnet | `eip155:51` | `0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4` | USDC | 6 | EIP-3009 |
+| Igra | `eip155:38833` | `0xA5b8BF902b2844dA17d4506cc827F7F1681735E7` | USDC | 6 | Permit2 |
 
 
 

--- a/go/.changes/unreleased/added-igra-mainnet-default-stablecoin.yaml
+++ b/go/.changes/unreleased/added-igra-mainnet-default-stablecoin.yaml
@@ -1,0 +1,3 @@
+kind: added
+body: Add Igra mainnet (eip155:38833) default stablecoin USDC via Permit2
+time: 2026-07-06T12:00:00.000000+00:00

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -88,6 +88,7 @@ var (
 	ChainIDHPPSepolia    = big.NewInt(181228)
 	ChainIDXDC           = big.NewInt(50)
 	ChainIDXDCApothem    = big.NewInt(51)
+	ChainIDIgra          = big.NewInt(38833)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -289,6 +290,17 @@ var (
 				Name:     "USDC",
 				Version:  "2",
 				Decimals: DefaultDecimals,
+			},
+		},
+		// Igra Mainnet (uses Permit2 instead of EIP-3009, no EIP-2612)
+		"eip155:38833": {
+			ChainID: ChainIDIgra,
+			DefaultAsset: AssetInfo{
+				Address:             "0xA5b8BF902b2844dA17d4506cc827F7F1681735E7", // USDC on Igra
+				Name:                "USDC",
+				Version:             "1",
+				Decimals:            DefaultDecimals,
+				AssetTransferMethod: AssetTransferMethodPermit2,
 			},
 		},
 	}

--- a/python/x402/changelog.d/add-igra-mainnet-default-stablecoin.feature.md
+++ b/python/x402/changelog.d/add-igra-mainnet-default-stablecoin.feature.md
@@ -1,0 +1,1 @@
+Add Igra mainnet (eip155:38833) default stablecoin USDC via Permit2

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -595,6 +595,17 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "decimals": 6,
         },
     },
+    # Igra Mainnet (uses Permit2 instead of EIP-3009, no EIP-2612)
+    "eip155:38833": {
+        "chain_id": 38833,
+        "default_asset": {
+            "address": "0xA5b8BF902b2844dA17d4506cc827F7F1681735E7",
+            "name": "USDC",
+            "version": "1",
+            "decimals": 6,
+            "asset_transfer_method": "permit2",
+        },
+    },
 }
 
 # V1 legacy constants are in x402.mechanisms.evm.v1.constants

--- a/typescript/.changeset/add-igra-mainnet-default-stablecoin.md
+++ b/typescript/.changeset/add-igra-mainnet-default-stablecoin.md
@@ -1,0 +1,5 @@
+---
+'@x402/evm': patch
+---
+
+Add Igra mainnet (eip155:38833) default stablecoin USDC via Permit2

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -159,6 +159,13 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     version: "2",
     decimals: 6,
   }, // XDC Apothem testnet USDC (Bridged USDC Standard, EIP-3009 supported)
+  "eip155:38833": {
+    address: "0xA5b8BF902b2844dA17d4506cc827F7F1681735E7",
+    name: "USDC",
+    version: "1",
+    decimals: 6,
+    assetTransferMethod: "permit2",
+  }, // Igra mainnet USDC (no EIP-3009, no EIP-2612)
 };
 
 /**


### PR DESCRIPTION
## Description

Add Igra Network (chain ID 38833) as a supported chain with USDC as the default stablecoin across TypeScript, Go, and Python SDKs.

- **CAIP-2**: `eip155:38833`
- **Token**: USDC — `0xA5b8BF902b2844dA17d4506cc827F7F1681735E7` (6 decimals)
- **Transfer method**: Permit2 (token has no EIP-3009 or EIP-2612)
- **Explorer**: https://explorer.igralabs.com

All five x402 canonical contracts are deployed at their deterministic addresses on Igra mainnet.

## Tests

- `go test ./mechanisms/evm/...` — all pass
- TypeScript and Python changes are data-only (network config entries);  CI will validate

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes