### PR TITLE
Add AgentServices to ecosystem (Services/Endpoints)

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AgentCourt",
+  "category": "Infrastructure & Tooling",
+  "logoUrl": "",
+  "description": "Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. The Evaluator layer for ERC-8183. Non-custodial, open source, MIT. x402-native at $0.05/dispute.",
+  "websiteUrl": "https://github.com/vbkotecha/agentcourt-api"
+}

--- a/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentcourt/metadata.json
@@ -1,7 +1,0 @@
-{
-  "name": "AgentCourt",
-  "category": "Infrastructure & Tooling",
-  "logoUrl": "",
-  "description": "Policy-driven dispute resolution API for agent commerce. 7 templates, 39 rules, <500ms deterministic rulings. The Evaluator layer for ERC-8183. Non-custodial, open source, MIT. x402-native at $0.05/dispute.",
-  "websiteUrl": "https://github.com/vbkotecha/agentcourt-api"
-}

--- a/typescript/site/app/ecosystem/partners-data/agentservices/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/agentservices/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "AgentServices",
+  "category": "Services/Endpoints",
+  "logoUrl": "/logos/agentservices.png",
+  "description": "50+ paid APIs for AI agents — crypto market data, DeFi yields, on-chain analytics, whale tracking, web search, marketing intelligence, portfolio analysis, and LLM inference gateway. USDC on Base via x402. 36 MCP tools. Live on mainnet.",
+  "websiteUrl": "https://agentservices.to"
+}


### PR DESCRIPTION
Adds **AgentServices** to the ecosystem directory under **Services/Endpoints**.

- Website: https://agentservices.to
- x402 manifest: https://agentservices.to/.well-known/x402
- MCP server: https://agentservices.to/mcp (36 tools)
- 50 services, 38 paid ($0.003-$0.25 per call)
- Builder Code: bc_9dtr4mh9
- USDC on Base mainnet
- Live since July 2026

AgentServices is a paid API platform for AI agents — crypto market data, DeFi yields, on-chain analytics, whale tracking, web search, marketing intelligence, portfolio analysis, deep research, and an LLM inference gateway (gpt-5.4/5.5). All paid endpoints use x402 protocol with USDC on Base.

Also on the Official MCP Registry (`to.agentservices/agentservices`) and indexed on Agent402.