### PR TITLE
Feat/x402 trace trust ecosystem

### DIFF
--- a/typescript/site/app/ecosystem/partners-data/x402-trace-trust/metadata.json
+++ b/typescript/site/app/ecosystem/partners-data/x402-trace-trust/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "x402-trace-trust",
+  "category": "Infrastructure & Tooling",
+  "logoUrl": "/logos/x402-trace-trust.svg",
+  "description": "TRACE trust scoring extension for x402 payments. Evaluates agent reputation via TRACE API before processing payments — blocks untrusted agents (Sybil, collusion) with HTTP 402.",
+  "websiteUrl": "https://github.com/trace-api/trace-api/tree/main/sdk-python/x402_trace_trust",
+  "packageUrl": "https://pypi.org/project/x402-trace-trust/"
+}

--- a/typescript/site/public/logos/x402-trace-trust.svg
+++ b/typescript/site/public/logos/x402-trace-trust.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10b981;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#059669;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#grad)"/>
+  <text x="64" y="88" font-family="system-ui, sans-serif" font-size="56" font-weight="700" fill="white" text-anchor="middle">TR</text>
+</svg>


### PR DESCRIPTION
## Description

Add `x402-trace-trust` to ecosystem partners directory.

Standalone PyPI package (`x402-trace-trust`) providing TRACE trust scoring as an x402 `ResourceServerExtension`. Evaluates agent reputation via TRACE API before payment settlement — blocks untrusted agents (Sybil, collusion, low score) with HTTP 402.

- PyPI: https://pypi.org/project/x402-trace-trust/
- Source: https://github.com/trace-api/trace-api/tree/main/sdk-python/x402_trace_trust
- Usage: `pip install x402-trace-trust` → `extensions=[TraceTrustExtension(api_key="sk_trace_...")]`

## Tests

- Package builds and passes `twine check`
- Unit tests pass locally: `pytest tests/test_extension.py`
- Integration verified against x402 Python SDK

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] I added a changelog fragment for user-facing changes (N/A - docs-only ecosystem addition)