### PR TITLE
fix(python/flask): use sync server in payment_middleware_from_config

### DIFF
--- a/python/x402/changelog.d/2810.bugfix.md
+++ b/python/x402/changelog.d/2810.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `flask_payment_middleware_from_config`, which raised `TypeError` at construction because it built the async `x402ResourceServer` for the sync Flask middleware; it now uses `x402ResourceServerSync`.

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -555,9 +555,13 @@ def payment_middleware_from_config(
     Returns:
         PaymentMiddleware instance.
     """
-    from ...server import x402ResourceServer
+    # Flask's PaymentMiddleware drives x402HTTPResourceServerSync, which rejects a
+    # server whose verify_payment is async. Use the sync server; the async
+    # x402ResourceServer would raise TypeError at construction. (The FastAPI
+    # factory correctly uses the async x402ResourceServer for its async server.)
+    from ...server import x402ResourceServerSync
 
-    server = x402ResourceServer(facilitator_client)
+    server = x402ResourceServerSync(facilitator_client)
 
     if schemes:
         for registration in schemes:

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -863,3 +863,26 @@ class TestFlaskMiddlewareIntegration:
                 assert response.get_json() == {
                     "error": "Facilitator settle returned invalid data: {'success': true}"
                 }
+
+
+def test_payment_middleware_from_config_builds_with_sync_server():
+    """flask_payment_middleware_from_config must construct without raising.
+
+    Regression: the factory used to instantiate the async x402ResourceServer,
+    which x402HTTPResourceServerSync rejects at construction with TypeError
+    ("requires a sync server"). It must use x402ResourceServerSync instead,
+    mirroring how the FastAPI factory uses the async server for its async path.
+    """
+    from x402.http.middleware.flask import payment_middleware_from_config
+
+    app = Flask(__name__)
+    facilitator = MagicMock()
+
+    # Must not raise TypeError about async methods on a sync server.
+    middleware = payment_middleware_from_config(
+        app,
+        {"/api/protected": {"price": "$0.01", "pay_to": "0x" + "1" * 40}},
+        facilitator_client=facilitator,
+    )
+
+    assert middleware is not None


### PR DESCRIPTION
## What

`flask_payment_middleware_from_config` (the Flask convenience factory) instantiates the **async** `x402ResourceServer` and passes it to `PaymentMiddleware`, which builds `x402HTTPResourceServerSync`. The sync HTTP server rejects a server whose `verify_payment` is a coroutine:

```python
# x402_http_server.py (x402HTTPResourceServerSync.__init__)
if verify_method and inspect.iscoroutinefunction(verify_method):
    raise TypeError("x402HTTPResourceServerSync requires a sync server ... "
                    "Use x402ResourceServerSync instead of x402ResourceServer ...")
```

So the factory raises `TypeError` at construction and is unusable — it fails 100% of the time.

## Fix

Use `x402ResourceServerSync` in the Flask factory, mirroring how the FastAPI factory correctly uses the async `x402ResourceServer` for its async `x402HTTPResourceServer`. One-line import/instantiation change; `register()` is defined on the shared base so scheme registration is unaffected.

The package's own `__init__.py` docstring already shows the correct sync usage (`server = x402ResourceServerSync(facilitator_client)`), confirming intent.

## Tests

Added `test_payment_middleware_from_config_builds_with_sync_server` — constructs via the factory and asserts it does not raise. Previously this raised `TypeError`; now passes. Full flask middleware suite: 40 passed. ruff clean.

AI disclosure: found via a systematic cross-SDK scan and implemented with AI assistance (Claude); reviewed and tested locally by me.
