### PR TITLE
docs+spec: clarify signer authorization in offer-receipt extension (#2462)

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -6,7 +6,7 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 | Name | Description | Languages | Links |
 | ---- | ----------- | --------- | ----- |
 | [World AgentKit](https://docs.world.org/agents/agent-kit/integrate) | Verify human-backed agents | TypeScript | [GitHub](https://github.com/worldcoin/agentkit) · [npm](https://www.npmjs.com/package/@worldcoin/agentkit) |
-| [OMATrust](https://docs.omatrust.org/integrations/x402/overview) | Onchain EAS reputation from x402 signed offers and receipts | TypeScript | [GitHub](https://github.com/oma3dao/developer-docs) · [npm](https://www.npmjs.com/package/@oma3/omatrust) |
+| [OMATrust](https://www.omatrust.org/x402) | Key authorizations for Signed Offers and Receipts | TypeScript | [GitHub](https://github.com/oma3dao/omatrust-sdk) · [npm](https://www.npmjs.com/package/@oma3/omatrust) |
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |
 | [x402r](https://x402r.org) | Non-custodial refund and arbitration protocol | Typescript | [GitHub](https://github.com/BackTrackCo/x402r-sdk) · [npm](https://www.npmjs.com/package/@x402r/sdk ) |
 | [zauth](https://zauthx402.com) | Monitoring, verification, and refund SDK | TypeScript | [GitHub](https://github.com/zauthofficial/zauthSDK) · [npm](https://www.npmjs.com/package/@zauthx402/sdk) |

--- a/docs/extensions/offer-receipt.mdx
+++ b/docs/extensions/offer-receipt.mdx
@@ -41,7 +41,7 @@ Both formats produce equivalent proof artifacts. Clients and verifiers handle bo
 
 This example uses EIP-712 signing with a raw private key from an environment variable. This is the simplest way to get started.
 
-> **Not for Production:** Storing private keys in environment variables is acceptable for local development and testing. For production deployments, use a key management service (KMS), hardware security module (HSM), or a managed wallet provider. See [Production Key Management](#production-key-management) below.
+> **Key Security:** Storing private keys in environment variables works for production as long as you keep them secret and rotate them regularly. For higher security guarantees, use a key management service (KMS), hardware security module (HSM), or a managed wallet provider. See [Production Key Management](#production-key-management) below for options. When rotating keys, use a signer-authorization service (see [Ecosystem Trust Providers](#ecosystem-trust-providers)) to maintain verifiable continuity of authorization.
 
 > **Signing Key ≠ Payment Address:** The signing key used for offers and receipts should be a dedicated signing key, not the wallet that receives payments (`payTo`). Separating signing from payment receipt limits exposure if the signing key is compromised.
 
@@ -55,7 +55,8 @@ EVM_ADDRESS=0xYourPaymentWalletAddress
 
 # Private key for signing offers and receipts (EIP-712)
 # This should be a DEDICATED SIGNING KEY, not the payment wallet's key
-# For production deployments, do not store private keys in an environment variable
+# Keep your private key secret and rotate it in accordance with your security policy and key storage mechanism
+# Use a key-binding service to maintain authorization continuity
 SIGNING_PRIVATE_KEY=0xYourDedicatedSigningPrivateKey
 
 # x402 facilitator URL
@@ -80,7 +81,7 @@ import { privateKeyToAccount } from "viem/accounts";
 config();
 
 const evmAddress = process.env.EVM_ADDRESS as `0x${string}`;
-const signingPrivateKey = process.env.SIGNING_PRIVATE_KEY as `0x${string}`; // not for production
+const signingPrivateKey = process.env.SIGNING_PRIVATE_KEY as `0x${string}`;
 const facilitatorUrl = process.env.FACILITATOR_URL!;
 
 // Create EIP-712 signer from the dedicated signing key
@@ -158,7 +159,7 @@ EVM_ADDRESS=0xYourPaymentWalletAddress
 FACILITATOR_URL=https://x402.org/facilitator
 
 # Base64-encoded PKCS#8 private key (EC P-256)
-# For production deployments, do not store private keys in an environment variable
+# Keep secret and consider using more secure key store mechanisms
 SIGNING_PRIVATE_KEY=base64EncodedPrivateKey
 
 # Your server's domain (URL-encoded for did:web)
@@ -178,7 +179,7 @@ import {
 } from "@x402/extensions/offer-receipt";
 
 const serverDomain = process.env.SERVER_DOMAIN!;
-const signingPrivateKey = process.env.SIGNING_PRIVATE_KEY!; // not for production
+const signingPrivateKey = process.env.SIGNING_PRIVATE_KEY!;
 
 const did = `did:web:${serverDomain}`;
 const kid = `${did}#key-1`;
@@ -284,9 +285,11 @@ Both payloads are signed using the format configured on the server (EIP-712 or J
 
 ## Production Key Management
 
-> The examples above use environment variables for signing keys. This is fine for development but not for production. Private keys in environment variables can leak through process inspection, logging, crash dumps, and container metadata endpoints.
+Environment variables are not ideal for storing signing keys, but if you use them keep them secret and rotate them periodically. The main risks are leaking through process inspection, logging, crash dumps, or container metadata endpoints — standard operational security applies.
 
-For production, use a signing backend that keeps keys in secure hardware or managed infrastructure. The extension's signer interface is pluggable — you only need to implement the `sign()` function (for JWS) or `signTypedData()` function (for EIP-712) using your provider's SDK. The `OfferReceiptIssuer` interface handles the rest.
+For higher security guarantees, use a signing backend that keeps keys in secure hardware or managed infrastructure. The extension's signer interface is pluggable — you only need to implement the `sign()` function (for JWS) or `signTypedData()` function (for EIP-712) using your provider's SDK. The `OfferReceiptIssuer` interface handles the rest.
+
+**Key rotation:** When you rotate signing keys (whether stored in environment variables or KMS), previously-issued offers and receipts remain valid as long as verifiers can confirm the old key was authorized at issuance time. Use a signer-authorization service (see [Ecosystem Trust Providers](#ecosystem-trust-providers)) to record key-binding attestations that survive rotation.
 
 When using a managed wallet provider, you won't have access to the raw private key. Instead, you call the provider's signing API. Here's what the EIP-712 setup looks like with a server wallet (conceptual example):
 
@@ -329,9 +332,19 @@ If you're using EIP-712 signing, you can host a `did.json` as well — list your
 
 This is a W3C standard mechanism and is sufficient for many use cases. However, the DID document is mutable — if you remove the key later, verifiers checking at that point won't find it.
 
-### Additional Binding Mechanisms
+### Signer Authorization Approaches
 
-For production services that need stronger guarantees — immutable onchain attestations, DNS-based verification, temporal anchoring, or key lifecycle management (expiration, rotation, revocation) — third parties offer additional trust layers on top of `did.json`.
+The following approaches can establish that a signing key is authorized for your service. They differ in durability — specifically whether authorization evidence survives key rotation and whether it provides temporally immutable proof.
+
+| Approach | Description |
+|----------|-------------|
+| `did:web` + `did.json` | Host your signing key at `/.well-known/did.json`. Simple and self-service. However, the document is mutable and current-state only — once a key is removed during rotation, there is no record it was previously authorized. Does not support key rotation history or temporal immutability. |
+| DNS TXT records | Bind your signing key to your domain via DNS. Easy to automate. Same limitation as `did:web` — mutable, no history. Does not support key rotation history or temporal immutability. |
+| [OMATrust](https://docs.omatrust.org/integrations/x402/overview) | On-chain signer-authorization attestations with timestamps. Authorization evidence persists regardless of key rotation or DID document changes. Supports key rotation history and temporal immutability. |
+
+> **Adding to this table:** Solutions that provide signer-authorization evidence for x402 signed artifacts are welcome. To be listed, describe how the approach handles key rotation and whether it provides temporally immutable proof of authorization. Open a PR or issue against this repository.
+
+These mechanisms are not optional — verifiers need at least one way to confirm your signing key is authorized for your service. The choice depends on your durability requirements.
 
 ## Client-Side: Extracting Offers and Receipts
 
@@ -406,6 +419,7 @@ Signed offers and receipts are portable, verifiable artifacts. Clients can:
 - **Store them for auditing** — receipts create a verifiable trail of service delivery
 - **Use them in dispute resolution** — offers prove the server committed to terms; receipts prove delivery
 - **Share them with aggregators** — trust scoring engines can verify the signatures independently
+- **Submit them to trust providers** — services like [OMATrust](https://docs.omatrust.org/integrations/x402/overview) can embed receipts into user reviews, and [PEAC Protocol](https://x402.peacprotocol.org) can record them as payment evidence attestation chains
 
 ## Working Examples
 

--- a/docs/getting-started/quickstart-for-sellers.mdx
+++ b/docs/getting-started/quickstart-for-sellers.mdx
@@ -1063,6 +1063,12 @@ Learn more about the discovery layer in the [Bazaar documentation](/extensions/b
 * If you run into trouble, check out the examples in the [repo](https://github.com/x402-foundation/x402/tree/main/examples) for more context and full code.
 * Run `npm install` or `go mod tidy` to install dependencies
 
+### 6. Enable Signed Offers & Receipts
+
+The [Signed Offers & Receipts extension](/extensions/offer-receipt) adds cryptographic proof-of-interaction to your payment flows. When enabled, your server automatically signs **offers** on every `402` response (committing to payment terms) and a **receipt** on every `200` response (confirming service delivery).
+
+This creates portable, verifiable artifacts that clients and third parties can use for auditing, dispute resolution, and increasing the reputation of your service. See the [full setup guide](/extensions/offer-receipt) for installation, configuration, and signer authorization options.
+
 ---
 
 ## Running on Mainnet
@@ -1262,7 +1268,7 @@ See [Network Support](/core-concepts/network-and-token-support) for the full lis
 
 * Check out the [Advanced Example](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/advanced) for a more complex payment flow
 * Explore [Advanced Concepts](/advanced-concepts/lifecycle-hooks) like lifecycle hooks for custom logic before/after verification/settlement
-* Explore [Extensions](/extensions/bazaar) like Bazaar for service discovery
+* Explore Extensions like [Bazaar](/extensions/bazaar) for service discovery and [Signed Offers & Receipts](/extensions/offer-receipt) for verifiable trust and reputation
 * Get started as a [buyer](/getting-started/quickstart-for-buyers)
 
 For questions or support, join our [Discord](https://discord.gg/cdp).

--- a/specs/extensions/extension-offer-and-receipt.md
+++ b/specs/extensions/extension-offer-and-receipt.md
@@ -384,6 +384,8 @@ For the optional `transaction` field, implementations MUST set unused fields to 
 7. Confirm `issuedAt` (from the payload) is within acceptable verifier policy
 8. If `transaction` is present, verifiers MAY check the blockchain to confirm the transaction exists
 
+When verifying a receipt outside the immediate x402 payment session (e.g., for reputation, auditing, or dispute resolution), verifiers SHOULD evaluate signer authorization as of the receipt's `issuedAt` time, not merely at the time of verification. Revocation or removal of a signing key from a mutable authorization source SHOULD be treated as prospective — it prevents future reliance on that key but does not by itself prove the key was unauthorized at `issuedAt`.
+
 
 **6. Protocol Integration Examples**
 

--- a/specs/extensions/extension-offer-and-receipt.md
+++ b/specs/extensions/extension-offer-and-receipt.md
@@ -234,10 +234,18 @@ For the optional `validUntil` field, implementations MUST set unused fields to `
 
 **4.5.1 Signer Authorization**
 
+Verifiers MUST distinguish between signature validity and signer authorization. A valid signature proves that a specific key signed the artifact. It does not prove that the key was authorized to sign on behalf of the service identified by `resourceUrl`.
+
+Without authorization verification, an attacker can generate a valid key pair, sign an offer or receipt for any `resourceUrl`, and present it as legitimate — the signature will verify, but the key has no relationship to the service.
+
 Verifiers MUST confirm that the signing key is authorized to act on behalf of the service identified by `resourceUrl`. This specification does not mandate a specific authorization mechanism. Common approaches include:
 
-- **`payTo` address signing**: The simplest approach — the service signs with the private key corresponding to the `payTo` address. Verifiers accept the signature if the recovered signer matches `payTo`.
-- **External key registry**: An external system (e.g., DID documents, on-chain attestations, or other key binding mechanisms) maps the signing key or `kid` to the service identity.
+- **`payTo` address signing**: The simplest approach — the service signs with the private key corresponding to the `payTo` address. Verifiers accept the signature if the recovered signer matches `payTo`. Note: coupling payment receipt and signing into a single key increases risk if the key is compromised. Production deployments SHOULD use a dedicated signing key separate from the `payTo` address.
+- **DID document (`did:web`)**: The service publishes the signing key in a [DID document](https://www.w3.org/TR/did-core/) at `/.well-known/did.json` associated with the `resourceUrl` domain. Verifiers resolve the DID URL in `kid` and confirm the key is listed in `verificationMethod`. See the [W3C DID Core specification](https://www.w3.org/TR/did-core/) and the [did:web method specification](https://w3c-ccg.github.io/did-method-web/).
+- **DNS TXT records**: The service publishes a TXT record at `_controllers.<domain>` binding the signing key to the service domain. The TXT value begins with a version prefix followed by one or more controller identifiers in DID format, separated by semicolons: `v=1;controller=did:pkh:eip155:1:<address>;controller=did:jwk:<base64url-encoded-public-jwk>`. Multiple `controller` values indicate co-controllers. The domain holder SHOULD enable DNSSEC, and verifiers SHOULD validate DNSSEC when available.
+- **External key registry**: An external system (e.g., on-chain attestations, transparency logs, or other key binding mechanisms) maps the signing key or `kid` to the service identity. See the [x402 Offer & Receipt documentation](https://x402.org/extensions/offer-receipt#signer-authorization-approaches) for a comparison of approaches.
+
+Mutable authorization sources (DID documents, DNS records) reflect current state only. Applications that verify offers or receipts after key rotation SHOULD preserve or reference temporally immutable authorization evidence (e.g., on-chain attestations, transparency logs) to confirm the key was authorized at issuance time.
 
 **4.6 Offer Expiration**
 


### PR DESCRIPTION
## Description

Addresses https://github.com/x402-foundation/x402/issues/2462

This PR makes two related changes:

**1. Spec: clarify signer authorization (§4.5.1, §5.5)**

- §4.5.1 now distinguishes signature validity from signer authorization and describes an attack vector where a valid signature alone is insufficient. Lists concrete authorization mechanisms (`payTo` signing, `did:web`, DNS TXT, external registries) and notes that mutable sources don't provide durable historical evidence after key rotation.
- §5.5 adds guidance that when receipts are verified outside the immediate payment session, authorization should be evaluated as of `issuedAt`, not at verification time. Key revocation is treated as prospective.

**2. Docs: expand offer-receipt guidance for sellers**

- `docs/extensions/offer-receipt.mdx` — Adds a "Signer Authorization Approaches" table comparing mechanisms by durability, updates key management guidance to address rotation workflows.
- `docs/getting-started/quickstart-for-sellers.mdx` — Adds step 6 pointing sellers to the Signed Offers & Receipts extension.
- `docs/dev-tools/third-party-extensions.md` — Updates OMATrust description to reflect signer-authorization focus.

## Tests

Documentation and specification changes only — no code changes. Verified markdown renders correctly and all internal links resolve.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)