### PR TITLE
feat: add JMT x402 Agent Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,3 +154,5 @@ See `specs/schemes` for full scheme specifications; `specs/schemes/exact/scheme_
 Because a scheme is a logical way of moving money, the way a scheme is implemented can be different for different blockchains. (ex: the way you need to implement `exact` on Ethereum is very different from the way you need to implement `exact` on Solana).
 
 Clients and facilitators must explicitly support different `(scheme, network)` pairs in order to be able to create proper payloads and verify / settle payments.
+
+- [JMT x402 Agent Tools](https://jmt-x402-proxy.jmthomasofficial.workers.dev) — 25 paid x402 endpoints on Base mainnet: web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard. $0.001-$0.15/call USDC. Local LLM-powered.


### PR DESCRIPTION
## What

Adds JMT x402 Agent Tools — 25 paid x402 endpoints on Base mainnet.

## Service Details

- **URL:** https://jmt-x402-proxy.jmthomasofficial.workers.dev
- **Network:** Base mainnet (eip155:8453)
- **Endpoints:** 25 paid endpoints covering web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard
- **Price range:** $0.001-$0.15 per call
- **Currency:** USDC on Base
- **Wallet:** 0x624FaF18C78456C8Da5bf156Cd77c1A2033F21c5
- **Discovery:** /.well-known/x402, /openapi.json

## Verification

- [x] curl -I https://jmt-x402-proxy.jmthomasofficial.workers.dev/api/search returns 402
- [x] /.well-known/x402 returns valid x402 discovery document
- [x] /openapi.json has x-payment-info on all paid operations