### PR TITLE
fix flask 3xx response bug

### DIFF
--- a/python/x402/changelog.d/2826.bugfix.md
+++ b/python/x402/changelog.d/2826.bugfix.md
@@ -1,0 +1,1 @@
+Fixed Flask middleware skipping settlement on 3xx responses, allowing paid content behind redirects to be delivered without onchain payment.

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -417,10 +417,7 @@ class PaymentMiddleware:
                     return []
 
                 # Check if successful response
-                if (
-                    response_wrapper.status_code is not None
-                    and 200 <= response_wrapper.status_code < 300
-                ):
+                if response_wrapper.status_code is not None and response_wrapper.status_code < 400:
                     # Extract settlement overrides from response headers and strip them
                     overrides = self._http_server._extract_settlement_overrides(
                         response_wrapper.headers,

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -11,7 +11,7 @@ import pytest
 
 # Skip all tests if flask not installed
 pytest.importorskip("flask")
-from flask import Flask
+from flask import Flask, redirect
 from werkzeug.datastructures import Headers, ImmutableMultiDict
 
 from x402.http.facilitator_client_base import FacilitatorResponseError
@@ -634,6 +634,55 @@ class TestFlaskMiddlewareIntegration:
                 assert response.status_code == 200
                 assert b"Protected content" in response.data
                 assert "PAYMENT-RESPONSE" in response.headers
+
+    def test_verified_payment_settles_on_redirect(self):
+        """Test that verified payment settles on 3xx redirect responses."""
+        app = Flask(__name__)
+
+        @app.route("/api/protected")
+        def protected_route():
+            return redirect("https://cdn.example/signed", 302)
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+            )
+            mock_http_server_instance.process_settlement.return_value = ProcessSettleResult(
+                success=True,
+                headers={"PAYMENT-RESPONSE": "settlement_encoded"},
+            )
+            mock_http_server.return_value = mock_http_server_instance
+
+            PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=False)
+
+            with app.test_client() as client:
+                response = client.get(
+                    "/api/protected",
+                    headers={"PAYMENT-SIGNATURE": "valid_payment"},
+                )
+                assert response.status_code == 302
+                assert response.headers["Location"] == "https://cdn.example/signed"
+                assert "PAYMENT-RESPONSE" in response.headers
+                mock_http_server_instance.process_settlement.assert_called_once()
 
     def test_settlement_failure_returns_402(self):
         """Test that settlement failure returns 402 with empty body and PAYMENT-RESPONSE header."""


### PR DESCRIPTION
## Description

In [python/x402/http/middleware/flask.py](https://github.com/x402-foundation/x402/compare/python/x402/http/middleware/flask.py), after the >= 400 cancellation gate already returns for error responses, the settlement gate is over-narrow:
```
if (
    response_wrapper.status_code is not None
    and 200 <= response_wrapper.status_code < 300  # bug: excludes 3xx
)
```

A 3xx response (e.g. 302 redirect) is neither >= 400 (so not cancelled) nor < 300 (so not settled). It falls through to `send_response(body_chunks) `and delivers content with zero settlement. FastAPI and all TS/Go adapters gate only on >= 400, settling everything below it.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 