### PR TITLE
fix e2e exit hang

### DIFF
--- a/e2e/clients/httpx/uv.lock
+++ b/e2e/clients/httpx/uv.lock
@@ -2329,7 +2329,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/mcp-python/uv.lock
+++ b/e2e/clients/mcp-python/uv.lock
@@ -2260,7 +2260,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/clients/requests/uv.lock
+++ b/e2e/clients/requests/uv.lock
@@ -2329,7 +2329,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/facilitators/python/uv.lock
+++ b/e2e/facilitators/python/uv.lock
@@ -3300,7 +3300,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/mock-facilitator/index.ts
+++ b/e2e/mock-facilitator/index.ts
@@ -83,6 +83,27 @@ function sendJson(res: http.ServerResponse, statusCode: number, body: unknown) {
 
 const supportedResponse = buildSupportedResponse();
 
+let shuttingDown = false;
+
+function shutdown() {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  const forceExitTimeout = setTimeout(() => process.exit(1), 5_000);
+  forceExitTimeout.unref();
+
+  server.close(error => {
+    clearTimeout(forceExitTimeout);
+    if (error) {
+      console.error("Failed to close mock facilitator:", error);
+      process.exit(1);
+    }
+    process.exit(0);
+  });
+}
+
 const server = http.createServer((req, res) => {
   const url = new URL(req.url || "/", `http://localhost:${PORT}`);
 
@@ -93,6 +114,12 @@ const server = http.createServer((req, res) => {
 
   if (req.method === "GET" && url.pathname === "/health") {
     sendJson(res, 200, { status: "ok" });
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === "/close") {
+    sendJson(res, 200, { status: "shutting down" });
+    setImmediate(shutdown);
     return;
   }
 
@@ -119,3 +146,6 @@ server.listen(PORT, () => {
   console.log(`Mock facilitator listening on port ${PORT}`);
   console.log("Facilitator listening");
 });
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/e2e/servers/fastapi/uv.lock
+++ b/e2e/servers/fastapi/uv.lock
@@ -3300,7 +3300,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/flask/uv.lock
+++ b/e2e/servers/flask/uv.lock
@@ -2494,7 +2494,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/servers/mcp-python/uv.lock
+++ b/e2e/servers/mcp-python/uv.lock
@@ -2260,7 +2260,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.14.0"
+version = "2.15.0"
 source = { editable = "../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/e2e/src/logger.ts
+++ b/e2e/src/logger.ts
@@ -44,11 +44,14 @@ class Logger {
     }
   }
 
-  close(): void {
-    if (this.logStream) {
-      this.logStream.end();
-      this.logStream = null;
+  close(): Promise<void> {
+    if (!this.logStream) {
+      return Promise.resolve();
     }
+
+    const stream = this.logStream;
+    this.logStream = null;
+    return new Promise(resolve => stream.end(resolve));
   }
 }
 
@@ -60,7 +63,7 @@ let globalLogger: Logger | null = null;
  */
 export function config(options: LoggerConfig): void {
   if (globalLogger) {
-    globalLogger.close();
+    void globalLogger.close();
   }
   globalLogger = new Logger(options);
 }
@@ -111,9 +114,9 @@ export function createComboLogger(comboIndex: number, serverName: string, facili
 /**
  * Close the logger and its file streams
  */
-export function close(): void {
+export async function close(): Promise<void> {
   if (globalLogger) {
-    globalLogger.close();
+    await globalLogger.close();
     globalLogger = null;
   }
 } 

--- a/e2e/test.ts
+++ b/e2e/test.ts
@@ -660,6 +660,51 @@ function envFlagDefaultTrue(value: string | undefined): boolean {
   return !['0', 'false', 'no', 'off'].includes(value.toLowerCase());
 }
 
+function waitForChildProcess(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise(resolve => {
+    const onClose = () => {
+      clearTimeout(timeout);
+      resolve(true);
+    };
+    const timeout = setTimeout(() => {
+      child.removeListener('close', onClose);
+      resolve(false);
+    }, timeoutMs);
+
+    child.once('close', onClose);
+  });
+}
+
+async function stopMockFacilitator(child: ChildProcess, url: string): Promise<void> {
+  try {
+    const response = await fetch(`${url}/close`, {
+      method: 'POST',
+      signal: AbortSignal.timeout(2_000),
+    });
+    await response.text();
+  } catch (error) {
+    verboseLog(`Mock facilitator graceful shutdown failed: ${String(error)}`);
+  }
+
+  if (await waitForChildProcess(child, 3_000)) {
+    return;
+  }
+
+  child.kill('SIGTERM');
+  if (await waitForChildProcess(child, 3_000)) {
+    return;
+  }
+
+  child.kill('SIGKILL');
+  await waitForChildProcess(child, 2_000);
+  child.stdout?.destroy();
+  child.stderr?.destroy();
+}
+
 async function runTest() {
   // Show help if requested
   if (parsedArgs.showHelp) {
@@ -1231,7 +1276,7 @@ async function runTest() {
   const mockFacilitatorPort = allocatePort();
   log(`\n🎭 Starting mock facilitator on port ${mockFacilitatorPort}...`);
   const mockFacilitatorProcess: ChildProcess = spawn(
-    'npx', ['tsx', 'index.ts'],
+    process.execPath, ['--import', 'tsx', 'index.ts'],
     {
       cwd: join(process.cwd(), 'mock-facilitator'),
       env: {
@@ -1270,7 +1315,7 @@ async function runTest() {
   );
   if (!mockHealthy) {
     log('❌ Failed to start mock facilitator');
-    mockFacilitatorProcess.kill();
+    await stopMockFacilitator(mockFacilitatorProcess, mockFacilitatorUrl);
     process.exit(1);
   }
   log(`  ✅ Mock facilitator ready at ${mockFacilitatorUrl}`);
@@ -1829,8 +1874,10 @@ async function runTest() {
     facilitatorStopPromises.push(manager.stop());
   }
   log('  🛑 Stopping mock facilitator');
-  mockFacilitatorProcess.kill();
-  await Promise.all(facilitatorStopPromises);
+  await Promise.all([
+    stopMockFacilitator(mockFacilitatorProcess, mockFacilitatorUrl),
+    ...facilitatorStopPromises,
+  ]);
 
   // Calculate totals
   const passed = testResults.filter(r => r.passed).length;
@@ -1993,12 +2040,13 @@ async function runTest() {
   }
 
   // Close logger
-  closeLogger();
-
-  if (failed > 0 || discoveryFailed) {
-    process.exit(1);
-  }
+  await closeLogger();
+  process.exit(failed > 0 || discoveryFailed ? 1 : 0);
 }
 
 // Run the test
-runTest().catch(error => errorLog(error));
+runTest().catch(async error => {
+  errorLog(String(error));
+  await closeLogger();
+  process.exit(1);
+});

--- a/scripts/tag-go-release.py
+++ b/scripts/tag-go-release.py
@@ -191,40 +191,38 @@ def assert_head_matches_release_main(root: Path, remote: str) -> None:
     print(f"HEAD matches {remote}/{RELEASE_BRANCH} ({head[:12]}).")
 
 
-def release_tags(version: str) -> list[tuple[str, str | None]]:
-    """Return ``(tag, message)`` pairs. A ``None`` message means a lightweight tag."""
+def release_tags(version: str) -> list[tuple[str, str]]:
+    """Return ``(tag, message)`` pairs for the release tags."""
     return [
         (
             f"go-x402@v{version}",
             f"Released x402 in go as version v{version}",
         ),
-        (f"go/v{version}", None),
+        (
+            f"go/v{version}",
+            f"go module release v{version}",
+        ),
     ]
 
 
-def create_tag(root: Path, tag: str, message: str | None, *, sign: bool) -> None:
-    if message is None:
-        git_run(root, ["tag", tag])
-        return
-
+def create_tag(root: Path, tag: str, message: str, *, sign: bool) -> None:
     sign_flag = "-s" if sign else "-a"
-    git_run(root, ["tag", sign_flag, "-a", tag, "-m", message])
+    git_run(root, ["tag", sign_flag, tag, "-m", message])
 
 
 def print_plan(
     version: str,
     remote: str,
-    tags: list[tuple[str, str | None]],
+    tags: list[tuple[str, str]],
     local: set[str],
     remote_existing: set[str],
 ) -> None:
     print(f"Go SDK release version: {version}")
     print(f"Release remote: {remote}")
     print("Tags:")
-    for tag, message in tags:
-        kind = "lightweight" if message is None else "annotated"
+    for tag, _ in tags:
         marker = existing_marker(tag, local, remote_existing, remote)
-        print(f"  - {tag} ({kind}){marker}")
+        print(f"  - {tag} (annotated){marker}")
 
 
 def main() -> int:


### PR DESCRIPTION
Fix the e2e post-summary hang at its source by making the mock facilitator terminate cleanly and awaiting its child process, then force the runner to return the computed exit code after logs are flushed. 