### PR TITLE
docs: add Data Market to live x402 services

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ go get github.com/x402-foundation/x402/go/v2
 
 Curated third-party SDKs, extensions, and facilitators are listed in the [Developer Tools docs](https://docs.x402.org/dev-tools/overview). For broader discovery of x402 services and integrations, see community-maintained directories such as [x402scan.com](https://x402scan.com), [Agentic.Market](https://agentic.market), [Pay.sh](https://pay.sh), and [app.ampersend.ai/discover](https://app.ampersend.ai/discover).
 
+**Live x402 Services:**
+- **[Data Market](https://data-market.alickzheng618.workers.dev)** — Curated structured datasets (weather, forex, crypto, reference data) for AI agents, pay-per-dataset via x402 on Base mainnet. [Source](https://github.com/al157/data-market)
+
 **Roadmap:** see [ROADMAP.md](https://github.com/x402-foundation/x402/blob/main/ROADMAP.md)
 
 **Documentation:** see [`docs/`](./docs/) for the published documentation source (Mintlify). Payment **schemes** include **`exact`**, **`upto`**, and **`batch-settlement`**; specifications live under [`specs/schemes/`](./specs/schemes/).


### PR DESCRIPTION
Adds Data Market — a live x402 service offering curated structured datasets for AI agents, pay-per-dataset on Base mainnet.

Source: https://github.com/al157/data-market