### PR TITLE
fix(core): return 400 for undecodable PAYMENT-SIGNATURE header

### DIFF
--- a/typescript/.changeset/malformed-payment-signature-400.md
+++ b/typescript/.changeset/malformed-payment-signature-400.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Return `400` instead of `402` when a request carries a `PAYMENT-SIGNATURE` header that cannot be decoded. The header was previously treated as absent (the decode error was swallowed with a `console.warn`), so a client that sent a corrupt payment header got the same `402 Payment Required` as a client that sent none, and could not tell the two apart. The HTTP transport spec maps a malformed payment payload to `400`, so a present-but-undecodable header now yields `400` with body `{ "error": "invalid_payload" }` and no facilitator `verify` call.

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -519,7 +519,20 @@ export class x402HTTPResourceServer {
     const paymentOptions = this.normalizePaymentOptions(routeConfig);
 
     // Check for payment header (v1 or v2)
-    const paymentPayload = this.extractPayment(adapter);
+    let paymentPayload: PaymentPayload | null;
+    try {
+      paymentPayload = this.extractPayment(adapter);
+    } catch {
+      // A present-but-undecodable header is a client error, not a missing payment.
+      return {
+        type: "payment-error",
+        response: {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+          body: { error: "invalid_payload" },
+        },
+      };
+    }
 
     // Create resource info, using config override if provided
     const resourceInfo = {
@@ -1016,18 +1029,15 @@ export class x402HTTPResourceServer {
    * Extract payment from HTTP headers (handles v1 and v2)
    *
    * @param adapter - HTTP adapter
-   * @returns Decoded payment payload or null
+   * @returns Decoded payment payload, or null when no payment header is present
+   * @throws If a payment header is present but cannot be decoded
    */
   private extractPayment(adapter: HTTPAdapter): PaymentPayload | null {
     // Check v2 header first (PAYMENT-SIGNATURE)
     const header = adapter.getHeader("payment-signature") || adapter.getHeader("PAYMENT-SIGNATURE");
 
     if (header) {
-      try {
-        return decodePaymentSignatureHeader(header);
-      } catch (error) {
-        console.warn("Failed to decode PAYMENT-SIGNATURE header:", error);
-      }
+      return decodePaymentSignatureHeader(header);
     }
 
     return null;

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -775,6 +775,71 @@ describe("x402HTTPResourceServer", () => {
       }
     });
 
+    it("should return 400 when PAYMENT-SIGNATURE is present but cannot be decoded", async () => {
+      const routes = {
+        "/api/test": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00" as Price,
+            network: "eip155:8453" as Network,
+          },
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+      const adapter = new MockHTTPAdapter({ "payment-signature": "not-base64!!" });
+      const context: HTTPRequestContext = {
+        adapter,
+        path: "/api/test",
+        method: "GET",
+      };
+
+      const result = await httpServer.processHTTPRequest(context);
+
+      expect(result.type).toBe("payment-error");
+      if (result.type === "payment-error") {
+        expect(result.response.status).toBe(400);
+        expect(result.response.body).toEqual({ error: "invalid_payload" });
+        expect(result.response.headers["PAYMENT-REQUIRED"]).toBeUndefined();
+      }
+      expect(mockFacilitator.verifyCalls.length).toBe(0);
+    });
+
+    it("should return 400 when PAYMENT-SIGNATURE is base64 but not valid JSON", async () => {
+      const routes = {
+        "/api/test": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00" as Price,
+            network: "eip155:8453" as Network,
+          },
+        },
+      };
+
+      const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+      const adapter = new MockHTTPAdapter({
+        "payment-signature": Buffer.from("{not json").toString("base64"),
+      });
+      const context: HTTPRequestContext = {
+        adapter,
+        path: "/api/test",
+        method: "GET",
+      };
+
+      const result = await httpServer.processHTTPRequest(context);
+
+      expect(result.type).toBe("payment-error");
+      if (result.type === "payment-error") {
+        expect(result.response.status).toBe(400);
+        expect(result.response.body).toEqual({ error: "invalid_payload" });
+      }
+      expect(mockFacilitator.verifyCalls.length).toBe(0);
+    });
+
     it("should include bazaar service metadata on PaymentRequired.resource", async () => {
       const routes = {
         "/api/weather": {


### PR DESCRIPTION
Fixes #2397.

`extractPayment()` swallowed a `PAYMENT-SIGNATURE` decode failure with a `console.warn` and returned `null`, so a request carrying a corrupt payment header took the same path as one carrying no header at all and got `402 Payment Required`. A client cannot tell "you didn't pay" apart from "your payment header is broken", and retries the same broken header.

`specs/transports-v2/http.md` maps this case to 400:

| x402 Error      | HTTP Status | Description                               |
| --------------- | ----------- | ----------------------------------------- |
| Invalid Payment | 400         | Malformed payment payload or requirements |

A present-but-undecodable header now returns `400` with `{ "error": "invalid_payload" }` — the spec's error name for a malformed payload — and no facilitator `verify` call. An absent header is unchanged: still `402` with `PAYMENT-REQUIRED`.

Both decode failure paths are covered by tests: a non-base64 header, and a base64 header that isn't valid JSON.

Prior art: #2439 by @peterxing took the same shape (throw from `extractPayment`, catch at the call site). This keeps that shape, drops the now-redundant `console.warn`, and reuses the spec error name instead of introducing a new one.

AI-assisted: implementation and tests were drafted with an AI coding agent and reviewed before opening.
