### PR TITLE
docs: add TWZRD to third-party extensions

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -10,3 +10,4 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |
 | [x402r](https://x402r.org) | Non-custodial refund and arbitration protocol | Typescript | [GitHub](https://github.com/BackTrackCo/x402r-sdk) · [npm](https://www.npmjs.com/package/@x402r/sdk ) |
 | [zauth](https://zauthx402.com) | Monitoring, verification, and refund SDK | TypeScript | [GitHub](https://github.com/zauthofficial/zauthSDK) · [npm](https://www.npmjs.com/package/@zauthx402/sdk) |
+| [TWZRD](https://intel.twzrd.xyz) | Pre-sign counterparty trust preflight for x402 clients (allow/warn/block + wash-flag refusal) | TypeScript | [GitHub](https://github.com/twzrd-sol/twzrd-trust) · [npm](https://www.npmjs.com/package/twzrd-x402-gate) |


### PR DESCRIPTION
Adds a row for TWZRD to `docs/dev-tools/third-party-extensions.md`, following the pattern of the existing vendor entries (#1047, #1616).

**What it is:** [twzrd-x402-gate](https://www.npmjs.com/package/twzrd-x402-gate) is a buyer-side counterparty trust preflight for x402 clients. It registers on the official client's `onBeforePaymentCreation` lifecycle hook (or wraps fetch for clients that compose over it) and returns allow/warn/block on the selected payment requirement - including wash-flag refusal for flagged merchants - before any payload is constructed or signed. Zero runtime dependencies, MIT.

Docs-only change; no changelog fragment per CONTRIBUTING.md.

Disclosure: this PR was prepared with AI assistance and human-reviewed; the linked package and its hook integration against `x402Client.onBeforePaymentCreation` are shipped and tested.

---
<sub>Resubmission of #2839 with a verified-signed commit. The original carried the identical docs change but an unsigned commit, which the `check-verified-commits` gate blocked; #2839 is being closed in favour of this one. Same author, same diff.</sub>