### PR TITLE
Add yen402 to the facilitators directory

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -28,5 +28,6 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | [Mogami Facilitator](https://facilitator.mogami.tech) | Free, developer-focused facilitator for Base with optional self-hosted Docker deployment |
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
+| [yen402](https://yen402.com) | Free, open facilitator for JPYC (yen stablecoin) on Polygon and Kaia. No API key or account; gas sponsored |
 
 For testnet development, the [x402.org facilitator](/core-concepts/network-and-token-support#x402org-facilitator) requires no setup. It is not intended for mainnet routes; use a production facilitator, a self-hosted facilitator, or [self-facilitation](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/self-facilitation) for production networks.


### PR DESCRIPTION
Adds a directory entry for **yen402** — a free, open x402 facilitator for **JPYC**, the yen stablecoin (Japan's first FSA-licensed one, under the Payment Services Act). JPYC is not currently represented anywhere in this repo.

- **Live:** https://yen402.com — `/supported`, `/verify`, `/settle` over HTTPS with CORS. No API key, no account, no fees; gas is sponsored.
- **Networks:** Polygon (`eip155:137`), Kaia (`eip155:8217`), Polygon Amoy (`eip155:80002`, testnet)
- **Token:** JPYC `0xe7c3d8c9a439fede00d2600032d5db0be71c3c29` — same address on every chain, 18 decimals, EIP-3009
- **Scheme:** `exact` (EIP-3009 `transferWithAuthorization`), x402 v2 and v1
- **On-chain proof (Polygon mainnet):** [`0xebb1cdc5…836462`](https://polygonscan.com/tx/0xebb1cdc5126323f8a119fffd1a3897140daed8acd660526d1fbe64a54b836462) — 10 JPYC settled through the live service **with no API key**, block 90142523
- **Source:** https://github.com/kakedashi3/x402-jpyc (MIT, self-hostable)

`/supported` reports what the facilitator can *actually* do, read from the chain rather than from a config file: `available` per network is derived from the facilitator wallet's live gas balance, and `/settle` returns `insufficient_facilitator_gas` rather than failing at the moment money moves. Ethereum and Avalanche are deliberately not offered — L1 gas dwarfs the micropayments x402 exists for.

Independent open-source project. Not affiliated with JPYC Inc.

---

**AI disclosure (per CONTRIBUTING):** the facilitator's recent redesign was written with AI assistance; this PR — a one-line directory entry — was drafted with it as well. I reviewed the change, and the on-chain settlement above is a live end-to-end verification of the service being listed.
