### PR TITLE
fix stellar tx fee

### DIFF
--- a/specs/schemes/exact/scheme_exact_stellar.md
+++ b/specs/schemes/exact/scheme_exact_stellar.md
@@ -34,7 +34,7 @@ The protocol flow for `exact` on Stellar is client-driven with facilitator-spons
 10. **Resource Server**, upon successful verification, forwards the payload to the facilitator's `/settle` endpoint.
     - NOTE: `/settle` MUST perform full verification independently and MUST NOT assume prior verification.
 11. **Facilitator** rebuilds the transaction with its own account as the source, preserving all operations and auth entries.
-12. **Facilitator** simulates the transaction to verify it succeeds and emits the expected transfer events.
+12. **Facilitator** simulates the transaction to verify it succeeds, emits the expected transfer events, and derives the settlement fee and fresh Soroban resource data (footprint and resource fee cap) from that simulation.
 13. **Facilitator** signs the rebuilt transaction with its own key and submits it to the Stellar network via RPC `sendTransaction`.
 14. **Facilitator** polls for transaction confirmation and responds with a `SettlementResponse` to the **Resource Server**.
 15. **Resource Server** grants the **Client** access to the resource in its response upon successful settlement.
@@ -145,6 +145,20 @@ These checks prevent the fee payer from being tricked into transferring their ow
 - The simulation MUST succeed without errors.
 - The simulation MUST emit events confirming the exact balance change specified in `requirements.amount`.
 
+## Transaction Fees
+
+In the sponsored flow (`areFeesSponsored: true`), the facilitator fully controls settlement fees. The facilitator MUST NOT use the client's fee bid when rebuilding the transaction.
+
+### Facilitator (MUST)
+
+- Derive the settlement fee from a fresh simulation at settle time: `simulationResourceFee + inclusionBuffer`, where the inclusion buffer MUST be at least **100 stroops**.
+- Refresh the Soroban resource data (footprint and `resourceFee` cap) from that same simulation before submitting.
+- Fully override the client's fee when rebuilding the transaction for submission.
+
+### Safety ceiling: `maxTransactionFeeStroops`
+
+Facilitator implementations MAY expose a `maxTransactionFeeStroops` configuration as a safety ceiling / circuit breaker (default: **50,000 stroops**, operator-overridable). If the simulation-derived settlement fee exceeds this ceiling, the facilitator MUST reject verification with `invalid_exact_stellar_payload_fee_exceeds_maximum`. This is not a per-transaction budget knob; normal transfers should fall well below the default ceiling.
+
 ## Settlement Logic
 
 Settlement is performed via the facilitator rebuilding and signing the transaction:
@@ -153,10 +167,13 @@ Settlement is performed via the facilitator rebuilding and signing the transacti
 
 1. Parse the client's signed transaction XDR.
 2. Extract all operations and authorization entries.
-3. Rebuild a new transaction with:
+3. Re-simulate the transaction and derive the settlement fee and fresh Soroban resource data from the simulation result.
+4. Rebuild a new transaction with:
    - **Source Account**: Facilitator's Stellar address (spends [sequence number] and pays fees)
    - **Operations**: Copied from the client's transaction
    - **Auth Entries**: Copied from the client's transaction
+   - **Fee**: Simulation-derived (`simulationResourceFee + inclusionBuffer`, buffer >= 100 stroops); MUST NOT use the client's fee
+   - **Soroban Data**: Refreshed from the settle-time simulation (footprint and `resourceFee` cap)
 
 ### Phase 2: Transaction Submission
 

--- a/typescript/.changeset/bumpy-pears-throw.md
+++ b/typescript/.changeset/bumpy-pears-throw.md
@@ -1,0 +1,5 @@
+---
+'@x402/stellar': minor
+---
+
+Fixed Stellar exact facilitator settlement to derive fees from settle-time simulation (BASE_FEE + resource fee) instead of the client bid, fixing SDK v16 resource-fee double-counting.

--- a/typescript/packages/mechanisms/stellar/README.md
+++ b/typescript/packages/mechanisms/stellar/README.md
@@ -40,7 +40,7 @@ This package provides three main components for handling x402 payments on Stella
 - `FacilitatorStellarSigner` - TypeScript type for facilitator signers
 
 > [!NOTE]
-> Facilitators currently always sponsor transaction fees (`areFeesSponsored: true`). A non-sponsored flow will be added later. See [spec](../../../specs/schemes/exact/scheme_exact_stellar.md#paymentrequirements-for-exact) for details.
+> Facilitators currently always sponsor transaction fees (`areFeesSponsored: true`). Settlement fees are derived from the settle-time simulation (`simulationResourceFee + inclusionBuffer`); `maxTransactionFeeStroops` is a safety ceiling, not a per-transaction budget. A non-sponsored flow will be added later. See [spec](../../../specs/schemes/exact/scheme_exact_stellar.md#paymentrequirements-for-exact) for details.
 
 **Server:**
 

--- a/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
@@ -8,6 +8,7 @@ import {
   rpc,
   TransactionBuilder,
   SignerKey,
+  BASE_FEE,
 } from "@stellar/stellar-sdk";
 import { Api } from "@stellar/stellar-sdk/rpc";
 import { STELLAR_WILDCARD_CAIP2 } from "../../constants";
@@ -51,10 +52,15 @@ const roundRobinSelectSigner = (): ((addresses: readonly string[]) => string) =>
  *
  * @param reason - The error reason code
  * @param payer - Optional payer address
+ * @param message - Optional human-readable detail for invalidMessage
  * @returns a `VerifyResponse` with `isValid: false` and the provided reason and (optional) payer
  */
-export function invalidVerifyResponse(reason: string, payer?: string): VerifyResponse {
-  return { isValid: false, invalidReason: reason, payer };
+export function invalidVerifyResponse(
+  reason: string,
+  payer?: string,
+  message?: string,
+): VerifyResponse {
+  return { isValid: false, invalidReason: reason, payer, invalidMessage: message };
 }
 
 /**
@@ -66,6 +72,12 @@ export function invalidVerifyResponse(reason: string, payer?: string): VerifyRes
 export function validVerifyResponse(payer: string): VerifyResponse {
   return { isValid: true, payer };
 }
+
+type VerifyResult = {
+  response: VerifyResponse;
+  /** Present only when simulation succeeded (used by settle to derive the fee + fresh Soroban data). */
+  simResponse?: Api.SimulateTransactionSuccessResponse;
+};
 
 /**
  * Stellar facilitator implementation for the Exact payment scheme.
@@ -89,7 +101,7 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
    * @param options - Configuration options
    * @param options.rpcConfig - Optional RPC configuration with custom RPC URL
    * @param options.areFeesSponsored - Indicates if fees are sponsored (default: true)
-   * @param options.maxTransactionFeeStroops - Maximum fee in stroops the facilitator will pay (default: 50_000)
+   * @param options.maxTransactionFeeStroops - Safety ceiling in stroops; verify rejects if the simulation-derived fee exceeds this (default: 50_000)
    * @param options.selectSigner - Callback to select which signer to use (default: round-robin)
    * @param options.feeBumpSigner - Optional signer used as fee source in a fee bump transaction wrapper.
    *   When provided, settle() wraps the inner transaction (signed by the selected signer) in a
@@ -109,7 +121,7 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
       rpcConfig?: RpcConfig;
       /** Indicates if fees are sponsored (default: true) */
       areFeesSponsored?: boolean;
-      /** Maximum fee in stroops the facilitator will pay (default: 50_000) */
+      /** Safety ceiling in stroops; verify rejects if the simulation-derived fee exceeds this (default: 50_000) */
       maxTransactionFeeStroops?: number;
       /** Optional callback to select which signer to use. Receives addresses array, returns selected address. Defaults to round-robin. */
       selectSigner?: (addresses: readonly string[]) => string;
@@ -172,165 +184,7 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
     payload: PaymentPayload,
     requirements: PaymentRequirements,
   ): Promise<VerifyResponse> {
-    let fromAddress: string | undefined;
-    try {
-      // Step 1: Validate protocol version, scheme, and network
-      if (payload.x402Version !== SUPPORTED_X402_VERSION) {
-        return invalidVerifyResponse("invalid_x402_version");
-      }
-
-      if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
-        return invalidVerifyResponse("unsupported_scheme");
-      }
-
-      if (requirements.network !== payload.accepted.network) {
-        return invalidVerifyResponse("network_mismatch");
-      }
-      if (!isStellarNetwork(requirements.network)) {
-        return invalidVerifyResponse("invalid_network");
-      }
-
-      const networkPassphrase = getNetworkPassphrase(requirements.network);
-      const server = getRpcClient(requirements.network, this.rpcConfig);
-
-      // Step 2: Parse and decode transaction
-      const stellarPayload = payload.payload as ExactStellarPayloadV2;
-      if (!stellarPayload || typeof stellarPayload.transaction !== "string") {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_malformed");
-      }
-
-      let transaction: Transaction;
-      try {
-        transaction = new Transaction(stellarPayload.transaction, networkPassphrase);
-      } catch (error) {
-        console.error("Error parsing transaction:", error);
-        return invalidVerifyResponse("invalid_exact_stellar_payload_malformed");
-      }
-
-      // Step 3: Validate transaction structure
-      if (transaction.operations.length !== 1) {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_wrong_operation");
-      }
-
-      const operation = transaction.operations[0];
-      if (operation.type !== "invokeHostFunction") {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_wrong_operation");
-      }
-
-      if (
-        this.signingAddresses.has(operation.source ?? "") ||
-        this.signingAddresses.has(transaction.source)
-      ) {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_unsafe_tx_or_op_source");
-      }
-
-      // Step 4: Extract and validate contract invocation details
-      const invokeOp = operation as Operation.InvokeHostFunction;
-      const func = invokeOp.func;
-
-      if (!func || func.switch().name !== "hostFunctionTypeInvokeContract") {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_wrong_operation");
-      }
-
-      // Step 5: Validate contract address and function name
-      const invokeContractArgs = func.invokeContract();
-      const contractAddress = Address.fromScAddress(
-        invokeContractArgs.contractAddress(),
-      ).toString();
-      const functionName = invokeContractArgs.functionName().toString();
-
-      const args = invokeContractArgs.args();
-      if (contractAddress !== requirements.asset) {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_wrong_asset");
-      }
-
-      if (functionName !== "transfer" || args.length !== 3) {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_wrong_function_name");
-      }
-
-      // Step 6: Extract and validate transfer arguments
-      fromAddress = scValToNative(args[0]) as string;
-      const toAddress = scValToNative(args[1]) as string;
-      const amount = scValToNative(args[2]) as bigint;
-
-      if (this.signingAddresses.has(fromAddress)) {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_facilitator_is_payer");
-      }
-
-      if (toAddress !== requirements.payTo) {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_wrong_recipient", fromAddress);
-      }
-
-      const expectedAmount = BigInt(requirements.amount);
-      if (amount !== expectedAmount) {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_wrong_amount", fromAddress);
-      }
-
-      // Step 7: Re-simulate to ensure transaction will succeed
-      const simResponse = await server.simulateTransaction(transaction);
-      if (!Api.isSimulationSuccess(simResponse)) {
-        const errorMsg = simResponse.error ? `: ${simResponse.error}` : "";
-        console.error("Simulation error:", errorMsg);
-        return invalidVerifyResponse(
-          "invalid_exact_stellar_payload_simulation_failed",
-          fromAddress,
-        );
-      }
-
-      // Step 8: Validate if the resource fees are within acceptable bounds
-      const clientFeeStroops = parseInt(transaction.fee, 10);
-      const minResourceFee = parseInt(simResponse.minResourceFee, 10);
-
-      // Fee must be at least the minimum required by simulation
-      if (clientFeeStroops < minResourceFee) {
-        return invalidVerifyResponse(
-          "invalid_exact_stellar_payload_fee_below_minimum",
-          fromAddress,
-        );
-      }
-
-      // Fee must not exceed the facilitator's maximum
-      if (clientFeeStroops > this.maxTransactionFeeStroops) {
-        return invalidVerifyResponse("invalid_exact_stellar_payload_fee_exceeds_maximum");
-      }
-
-      // Step 9: Validate simulation events for expected transfer only.
-      const eventValidation = this.validateSimulationEvents(
-        simResponse.events,
-        fromAddress,
-        requirements.payTo,
-        expectedAmount,
-        requirements.asset,
-      );
-      if (eventValidation) {
-        return eventValidation;
-      }
-
-      const latestLedger = await server.getLatestLedger();
-      const currentLedger = latestLedger.sequence;
-      const maxTimeoutSeconds = requirements.maxTimeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
-      const estimatedLedgerSeconds = await getEstimatedLedgerCloseTimeSeconds(requirements.network);
-      const maxLedgerOffset = Math.ceil(maxTimeoutSeconds / estimatedLedgerSeconds);
-      const maxLedger = currentLedger + maxLedgerOffset;
-
-      // Step 10: Validate auth entries (structure, credential type, expiration, facilitator safety, and signature status).
-      const authValidation = this.validateAuthEntries(
-        invokeOp,
-        this.signingAddresses,
-        fromAddress,
-        maxLedger,
-        transaction,
-        simResponse,
-      );
-      if (authValidation) {
-        return authValidation;
-      }
-
-      return validVerifyResponse(fromAddress);
-    } catch (error) {
-      console.error("Unexpected verification error:", error);
-      return invalidVerifyResponse("unexpected_verify_error", fromAddress);
-    }
+    return (await this._verify(payload, requirements)).response;
   }
 
   /**
@@ -351,7 +205,7 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
 
     try {
       // Step 1: Verify payment before settlement
-      const verifyResult = await this.verify(payload, requirements);
+      const { response: verifyResult, simResponse } = await this._verify(payload, requirements);
 
       if (!verifyResult.isValid) {
         return {
@@ -363,29 +217,27 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
         };
       }
 
-      payer = verifyResult.payer!;
-
-      // Step 2: Parse transaction envelope once to extract both transaction and Soroban data
-      const stellarPayload = payload.payload as ExactStellarPayloadV2;
-      const txEnvelope = xdr.TransactionEnvelope.fromXDR(stellarPayload.transaction, "base64");
-      const transaction = new Transaction(stellarPayload.transaction, networkPassphrase);
-      const sorobanData = txEnvelope.v1()?.tx()?.ext()?.sorobanData() || undefined;
-
-      // Validate Soroban data is present for Soroban transactions
-      if (!sorobanData) {
+      if (!simResponse) {
         return {
           success: false,
           network: payload.accepted.network,
           transaction: "",
-          errorReason: "invalid_exact_stellar_payload_malformed",
-          payer,
+          errorReason: "unexpected_settle_error",
+          payer: verifyResult.payer,
         };
       }
+
+      payer = verifyResult.payer!;
+
+      // Step 2: Parse transaction envelope to extract the operation
+      const stellarPayload = payload.payload as ExactStellarPayloadV2;
+      const transaction = new Transaction(stellarPayload.transaction, networkPassphrase);
+      const sorobanData = simResponse.transactionData.build();
 
       // Step 3: Extract operation
       const invokeOp = transaction.operations[0] as Operation.InvokeHostFunction;
 
-      // Step 4: Rebuild transaction with facilitator as source and facilitator-chosen fee
+      // Step 4: Rebuild transaction with facilitator as source and simulation-derived fee
       const signer = this.signerMap.get(this.selectSigner([...this.signingAddresses]));
       if (!signer) {
         return {
@@ -398,12 +250,10 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
       }
       const facilitatorAccount = await server.getAccount(signer.address);
 
-      // Use the minimum of the client's fee and the maximum cap
-      const clientFeeStroops = parseInt(transaction.fee, 10);
-      const maxFeeStroops = Math.min(clientFeeStroops, this.maxTransactionFeeStroops);
-
+      // SDK v16: `fee` is the inclusion buffer only; build() adds sorobanData.resourceFee()
+      // from the settle-time simulation, so tx.fee = BASE_FEE + minResourceFee.
       const rebuiltTx = new TransactionBuilder(facilitatorAccount, {
-        fee: maxFeeStroops.toString(),
+        fee: BASE_FEE,
         networkPassphrase,
         ledgerbounds: transaction.ledgerBounds,
         memo: transaction.memo,
@@ -445,7 +295,8 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
 
         const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
           this.feeBumpSigner.address,
-          maxFeeStroops.toString(), // Same as the inner transaction fee
+          // Same inclusion-only base fee; SDK adds the inner tx resource fee.
+          BASE_FEE,
           signedInnerTx,
           networkPassphrase,
         );
@@ -515,6 +366,192 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
         errorReason: "unexpected_settle_error",
         payer,
       };
+    }
+  }
+
+  /**
+   * Internal verification that also returns the simulation result for settlement.
+   *
+   * @param payload - The payment payload to verify
+   * @param requirements - The payment requirements
+   * @returns Verification response and optional simulation result
+   */
+  private async _verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResult> {
+    let fromAddress: string | undefined;
+    try {
+      // Step 1: Validate protocol version, scheme, and network
+      if (payload.x402Version !== SUPPORTED_X402_VERSION) {
+        return { response: invalidVerifyResponse("invalid_x402_version") };
+      }
+
+      if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
+        return { response: invalidVerifyResponse("unsupported_scheme") };
+      }
+
+      if (requirements.network !== payload.accepted.network) {
+        return { response: invalidVerifyResponse("network_mismatch") };
+      }
+      if (!isStellarNetwork(requirements.network)) {
+        return { response: invalidVerifyResponse("invalid_network") };
+      }
+
+      const networkPassphrase = getNetworkPassphrase(requirements.network);
+      const server = getRpcClient(requirements.network, this.rpcConfig);
+
+      // Step 2: Parse and decode transaction
+      const stellarPayload = payload.payload as ExactStellarPayloadV2;
+      if (!stellarPayload || typeof stellarPayload.transaction !== "string") {
+        return { response: invalidVerifyResponse("invalid_exact_stellar_payload_malformed") };
+      }
+
+      let transaction: Transaction;
+      try {
+        transaction = new Transaction(stellarPayload.transaction, networkPassphrase);
+      } catch (error) {
+        console.error("Error parsing transaction:", error);
+        return { response: invalidVerifyResponse("invalid_exact_stellar_payload_malformed") };
+      }
+
+      // Step 3: Validate transaction structure
+      if (transaction.operations.length !== 1) {
+        return { response: invalidVerifyResponse("invalid_exact_stellar_payload_wrong_operation") };
+      }
+
+      const operation = transaction.operations[0];
+      if (operation.type !== "invokeHostFunction") {
+        return { response: invalidVerifyResponse("invalid_exact_stellar_payload_wrong_operation") };
+      }
+
+      if (
+        this.signingAddresses.has(operation.source ?? "") ||
+        this.signingAddresses.has(transaction.source)
+      ) {
+        return {
+          response: invalidVerifyResponse("invalid_exact_stellar_payload_unsafe_tx_or_op_source"),
+        };
+      }
+
+      // Step 4: Extract and validate contract invocation details
+      const invokeOp = operation as Operation.InvokeHostFunction;
+      const func = invokeOp.func;
+
+      if (!func || func.switch().name !== "hostFunctionTypeInvokeContract") {
+        return { response: invalidVerifyResponse("invalid_exact_stellar_payload_wrong_operation") };
+      }
+
+      // Step 5: Validate contract address and function name
+      const invokeContractArgs = func.invokeContract();
+      const contractAddress = Address.fromScAddress(
+        invokeContractArgs.contractAddress(),
+      ).toString();
+      const functionName = invokeContractArgs.functionName().toString();
+
+      const args = invokeContractArgs.args();
+      if (contractAddress !== requirements.asset) {
+        return { response: invalidVerifyResponse("invalid_exact_stellar_payload_wrong_asset") };
+      }
+
+      if (functionName !== "transfer" || args.length !== 3) {
+        return {
+          response: invalidVerifyResponse("invalid_exact_stellar_payload_wrong_function_name"),
+        };
+      }
+
+      // Step 6: Extract and validate transfer arguments
+      fromAddress = scValToNative(args[0]) as string;
+      const toAddress = scValToNative(args[1]) as string;
+      const amount = scValToNative(args[2]) as bigint;
+
+      if (this.signingAddresses.has(fromAddress)) {
+        return {
+          response: invalidVerifyResponse("invalid_exact_stellar_payload_facilitator_is_payer"),
+        };
+      }
+
+      if (toAddress !== requirements.payTo) {
+        return {
+          response: invalidVerifyResponse(
+            "invalid_exact_stellar_payload_wrong_recipient",
+            fromAddress,
+          ),
+        };
+      }
+
+      const expectedAmount = BigInt(requirements.amount);
+      if (amount !== expectedAmount) {
+        return {
+          response: invalidVerifyResponse(
+            "invalid_exact_stellar_payload_wrong_amount",
+            fromAddress,
+          ),
+        };
+      }
+
+      // Step 7: Re-simulate to ensure transaction will succeed
+      const simResponse = await server.simulateTransaction(transaction);
+      if (!Api.isSimulationSuccess(simResponse)) {
+        const errorMsg = simResponse.error ? `: ${simResponse.error}` : "";
+        console.error("Simulation error:", errorMsg);
+        return {
+          response: invalidVerifyResponse(
+            "invalid_exact_stellar_payload_simulation_failed",
+            fromAddress,
+          ),
+        };
+      }
+
+      // Step 8: Validate the simulation-derived settlement fee against the safety ceiling
+      const minResourceFee = parseInt(simResponse.minResourceFee, 10);
+      const settlementFeeStroops = minResourceFee + parseInt(BASE_FEE, 10);
+      if (settlementFeeStroops > this.maxTransactionFeeStroops) {
+        return {
+          response: invalidVerifyResponse(
+            "invalid_exact_stellar_payload_fee_exceeds_maximum",
+            fromAddress,
+            `simulation-derived fee ${settlementFeeStroops} stroops exceeds ceiling ${this.maxTransactionFeeStroops} stroops`,
+          ),
+        };
+      }
+
+      // Step 9: Validate simulation events for expected transfer only.
+      const eventValidation = this.validateSimulationEvents(
+        simResponse.events,
+        fromAddress,
+        requirements.payTo,
+        expectedAmount,
+        requirements.asset,
+      );
+      if (eventValidation) {
+        return { response: eventValidation };
+      }
+
+      const latestLedger = await server.getLatestLedger();
+      const currentLedger = latestLedger.sequence;
+      const maxTimeoutSeconds = requirements.maxTimeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
+      const estimatedLedgerSeconds = await getEstimatedLedgerCloseTimeSeconds(requirements.network);
+      const maxLedgerOffset = Math.ceil(maxTimeoutSeconds / estimatedLedgerSeconds);
+      const maxLedger = currentLedger + maxLedgerOffset;
+
+      // Step 10: Validate auth entries (structure, credential type, expiration, facilitator safety, and signature status).
+      const authValidation = this.validateAuthEntries(
+        invokeOp,
+        this.signingAddresses,
+        fromAddress,
+        maxLedger,
+        transaction,
+        simResponse,
+      );
+      if (authValidation) {
+        return { response: authValidation };
+      }
+
+      return { response: validVerifyResponse(fromAddress), simResponse };
+    } catch (error) {
+      console.error("Unexpected verification error:", error);
+      return { response: invalidVerifyResponse("unexpected_verify_error", fromAddress) };
     }
   }
 

--- a/typescript/packages/mechanisms/stellar/test/unit/facilitator-settle.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/facilitator-settle.test.ts
@@ -6,6 +6,8 @@ import {
   SorobanDataBuilder,
   TransactionBuilder,
   FeeBumpTransaction,
+  Transaction,
+  BASE_FEE,
 } from "@stellar/stellar-sdk";
 import { Api } from "@stellar/stellar-sdk/rpc";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -15,6 +17,25 @@ import { createEd25519Signer } from "../../src/signer";
 import * as stellarUtils from "../../src/utils";
 import type { FacilitatorStellarSigner } from "../../src/signer";
 import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+
+function mockVerifySuccess(minResourceFee = "100") {
+  return {
+    response: {
+      isValid: true as const,
+      payer: "GBBO4ZDDZTSM2IUKQYBAST3CFHNPFXECGEFTGWTA2WELR2BIWDK57UVE",
+    },
+    simResponse: {
+      id: "test",
+      latestLedger: 123,
+      events: [],
+      _parsed: true,
+      transactionData: new SorobanDataBuilder().setResourceFee(minResourceFee),
+      minResourceFee,
+      cost: { cpuInsns: "0", memBytes: "0" },
+      results: [],
+    } as Api.SimulateTransactionSuccessResponse,
+  };
+}
 
 vi.mock("../../src/utils", async () => {
   const actual = await vi.importActual<typeof stellarUtils>("../../src/utils");
@@ -123,13 +144,11 @@ describe("ExactStellarScheme - Settle (randomly using 1-2 facilitator signers)",
     vi.mocked(stellarUtils.getNetworkPassphrase).mockReturnValue(StellarNetworks.TESTNET);
     vi.mocked(stellarUtils.getRpcUrl).mockReturnValue("https://soroban-testnet.stellar.org");
 
-    // Mock verify to pass for settle tests (verify is tested separately)
-    // The expiration check may reject the test transaction, so we mock verify for settle tests
-    // Note: This is reset in tests that need to test actual verify behavior
-    vi.spyOn(facilitator, "verify").mockImplementation(async () => ({
-      isValid: true,
-      payer: CLIENT_PUBLIC,
-    }));
+    // Mock _verify to pass for settle tests (verify is tested separately)
+    vi.spyOn(
+      facilitator as unknown as { _verify: typeof facilitator.verify },
+      "_verify",
+    ).mockImplementation(async () => mockVerifySuccess());
 
     // Mock signTransaction for all signers to return the mock signed XDR
     vi.spyOn(facilitatorSigner1, "signTransaction").mockResolvedValue({
@@ -144,7 +163,10 @@ describe("ExactStellarScheme - Settle (randomly using 1-2 facilitator signers)",
 
   describe("settlement failures", () => {
     it("should return error when verify fails", async () => {
-      vi.spyOn(facilitator, "verify").mockRestore();
+      vi.spyOn(
+        facilitator as unknown as { _verify: typeof facilitator.verify },
+        "_verify",
+      ).mockRestore();
       // Use requirements with wrong amount to make verify fail
       const invalidRequirements = {
         ...validRequirements,
@@ -311,6 +333,20 @@ describe("ExactStellarScheme - Settle (randomly using 1-2 facilitator signers)",
       expect(result.success).toBe(true);
       expect(mockServer.getTransaction).toHaveBeenCalledTimes(2);
     });
+
+    it("should set rebuilt transaction fee from simulation-derived resource fee plus inclusion buffer", async () => {
+      const minResourceFee = "100";
+      vi.spyOn(
+        facilitator as unknown as { _verify: typeof facilitator.verify },
+        "_verify",
+      ).mockImplementation(async () => mockVerifySuccess(minResourceFee));
+
+      await facilitator.settle(validPayload, validRequirements);
+
+      const rebuiltTxXdr = vi.mocked(facilitatorSigner1.signTransaction).mock.calls[0][0];
+      const rebuiltTx = new Transaction(rebuiltTxXdr, StellarNetworks.TESTNET);
+      expect(rebuiltTx.fee).toBe(String(parseInt(minResourceFee, 10) + parseInt(BASE_FEE, 10)));
+    });
   });
 
   describe("multi-signer tests", () => {
@@ -321,10 +357,10 @@ describe("ExactStellarScheme - Settle (randomly using 1-2 facilitator signers)",
         selectSigner: addrs => addrs[1],
       });
 
-      vi.spyOn(customFacilitator, "verify").mockResolvedValue({
-        isValid: true,
-        payer: CLIENT_PUBLIC,
-      });
+      vi.spyOn(
+        customFacilitator as unknown as { _verify: typeof customFacilitator.verify },
+        "_verify",
+      ).mockImplementation(async () => mockVerifySuccess());
 
       const result = await customFacilitator.settle(validPayload, validRequirements);
 
@@ -337,10 +373,10 @@ describe("ExactStellarScheme - Settle (randomly using 1-2 facilitator signers)",
     it("should use round-robin by default with multiple signers", async () => {
       const roundRobinFacilitator = new ExactStellarScheme(multiSigners);
 
-      vi.spyOn(roundRobinFacilitator, "verify").mockResolvedValue({
-        isValid: true,
-        payer: CLIENT_PUBLIC,
-      });
+      vi.spyOn(
+        roundRobinFacilitator as unknown as { _verify: typeof roundRobinFacilitator.verify },
+        "_verify",
+      ).mockImplementation(async () => mockVerifySuccess());
 
       const calledAddresses: string[] = [];
 
@@ -475,7 +511,10 @@ describe("ExactStellarScheme - Settle with feeBumpSigner", () => {
       });
 
     const facilitator = new ExactStellarScheme([facilitatorSigner1], { feeBumpSigner });
-    vi.spyOn(facilitator, "verify").mockResolvedValue({ isValid: true, payer: CLIENT_PUBLIC });
+    vi.spyOn(
+      facilitator as unknown as { _verify: typeof facilitator.verify },
+      "_verify",
+    ).mockImplementation(async () => mockVerifySuccess());
 
     const result = await facilitator.settle(validPayload, validRequirements);
 
@@ -497,7 +536,10 @@ describe("ExactStellarScheme - Settle with feeBumpSigner", () => {
     });
 
     const facilitator = new ExactStellarScheme([facilitatorSigner1], { feeBumpSigner });
-    vi.spyOn(facilitator, "verify").mockResolvedValue({ isValid: true, payer: CLIENT_PUBLIC });
+    vi.spyOn(
+      facilitator as unknown as { _verify: typeof facilitator.verify },
+      "_verify",
+    ).mockImplementation(async () => mockVerifySuccess());
 
     const result = await facilitator.settle(validPayload, validRequirements);
 
@@ -512,7 +554,10 @@ describe("ExactStellarScheme - Settle with feeBumpSigner", () => {
 
   it("should not use fee bump when feeBumpSigner is not set", async () => {
     const facilitator = new ExactStellarScheme([facilitatorSigner1]);
-    vi.spyOn(facilitator, "verify").mockResolvedValue({ isValid: true, payer: CLIENT_PUBLIC });
+    vi.spyOn(
+      facilitator as unknown as { _verify: typeof facilitator.verify },
+      "_verify",
+    ).mockImplementation(async () => mockVerifySuccess());
 
     const result = await facilitator.settle(validPayload, validRequirements);
 
@@ -530,7 +575,10 @@ describe("ExactStellarScheme - Settle with feeBumpSigner", () => {
     const facilitator = new ExactStellarScheme([facilitatorSigner1, facilitatorSigner2], {
       feeBumpSigner,
     });
-    vi.spyOn(facilitator, "verify").mockResolvedValue({ isValid: true, payer: CLIENT_PUBLIC });
+    vi.spyOn(
+      facilitator as unknown as { _verify: typeof facilitator.verify },
+      "_verify",
+    ).mockImplementation(async () => mockVerifySuccess());
 
     // First settle — should use signer1 for inner tx
     await facilitator.settle(validPayload, validRequirements);

--- a/typescript/packages/mechanisms/stellar/test/unit/facilitator-verify.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/facilitator-verify.test.ts
@@ -309,7 +309,7 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
     it("should reject transactions with fees exceeding the maximum", async () => {
       const lowMaxFeeFacilitator = new ExactStellarScheme(facilitatorSigners, {
         areFeesSponsored: true,
-        maxTransactionFeeStroops: 1000, // 1000 stroops max
+        maxTransactionFeeStroops: 150,
       });
 
       vi.mocked(stellarUtils.getRpcClient).mockReturnValue(mockServer as rpc.Server);
@@ -317,47 +317,12 @@ describe("ExactStellarScheme#Verify (randomly using 1-2 facilitator signers)", (
 
       const result = await lowMaxFeeFacilitator.verify(validPayload, validRequirements);
       expect(result).toEqual(
-        invalidVerifyResponse("invalid_exact_stellar_payload_fee_exceeds_maximum"),
+        invalidVerifyResponse(
+          "invalid_exact_stellar_payload_fee_exceeds_maximum",
+          CLIENT_PUBLIC,
+          "simulation-derived fee 200 stroops exceeds ceiling 150 stroops",
+        ),
       );
-    });
-
-    it("should reject transactions with fees below simulation minimum", async () => {
-      const expectedAssetHashForFeeTest = new Address(ASSET).toScAddress().contractId();
-      const mockTransferEventForFeeTest = createMockContractEvent({
-        from: CLIENT_PUBLIC,
-        to: TRANSACTION_RECIPIENT,
-        amount: BigInt("10000"),
-        contractId: expectedAssetHashForFeeTest,
-      });
-
-      const originalSimulate = vi.mocked(stellarUtils.getRpcClient).getMockImplementation();
-      const mockServerWithHighMinFee = {
-        ...mockServer,
-        simulateTransaction: vi.fn().mockResolvedValue({
-          id: "test",
-          latestLedger: 123,
-          events: [mockTransferEventForFeeTest],
-          _parsed: true,
-          transactionData: new SorobanDataBuilder(),
-          minResourceFee: "999999999",
-          cost: { cpuInsns: "0", memBytes: "0" },
-          results: [],
-        } as Api.SimulateTransactionSuccessResponse),
-      };
-
-      vi.mocked(stellarUtils.getRpcClient).mockReturnValue(
-        mockServerWithHighMinFee as unknown as rpc.Server,
-      );
-      vi.mocked(stellarUtils.getNetworkPassphrase).mockReturnValue(StellarNetworks.TESTNET);
-
-      try {
-        const result = await facilitator.verify(validPayload, validRequirements);
-        expect(result).toEqual(
-          invalidVerifyResponse("invalid_exact_stellar_payload_fee_below_minimum", CLIENT_PUBLIC),
-        );
-      } finally {
-        vi.mocked(stellarUtils.getRpcClient).mockImplementation(originalSimulate!);
-      }
     });
 
     describe("mismatching networks", () => {


### PR DESCRIPTION
## Description

Derive Stellar exact settlement fees from settle-time simulation instead of the client bid. On SDK v16, TransactionBuilder.build() sets tx.fee = fee + sorobanData.resourceFee(), but the facilitator passed the client’s total transaction.fee (already inclusion + resource) as fee while also attaching the client’s sorobanData, so the resource fee was added twice. 

The fix rebuilds with BASE_FEE as inclusion-only and fresh sorobanData from simulation (tx.fee = BASE_FEE + minResourceFee). Verify drops the client-fee check, enforces a simulation-derived ceiling via maxTransactionFeeStroops, and settle reuses the same simulation.

Closes https://github.com/x402-foundation/x402/issues/2764

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 