### PR TITLE
docs: add XRPL to buyer quickstart, network lists, and facilitators

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -20,7 +20,7 @@ x402 uses [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) standard network iden
 
 ## Token Support
 
-x402 supports tokens on EVM, Solana, TON, Algorand (AVM), Stellar, Aptos, Hedera, Keeta, and Concordium networks:
+x402 supports tokens on EVM, Solana, TON, Algorand (AVM), Stellar, Aptos, Hedera, Keeta, Concordium, and XRPL networks:
 
 | Ecosystem | Supported Tokens | Transfer Method |
 |-----------|------------------|-----------------|
@@ -33,6 +33,7 @@ x402 supports tokens on EVM, Solana, TON, Algorand (AVM), Stellar, Aptos, Hedera
 | **Hedera** | HBAR or any HTS fungible token | Hedera Transfer Transaction |
 | **Keeta** | Any Keeta token | `SEND` operation |
 | **Concordium** | CCD or any PLT token (e.g., EURR) | Sponsored V1 transfer |
+| **XRPL** | XRP or any issued currency (e.g., RLUSD) | Payer-signed `Payment` transaction |
 
 Facilitators support **networks**, not specific tokens — any compatible token works on any facilitator that supports that network.
 

--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -321,7 +321,7 @@ Video Guide: [Adding EVM Chains to x402](https://x.com/jaycoolh/status/192085155
 
 Key takeaways:
 
-* **Any EVM chain** is supported via `eip155:<chainId>` — plus Solana, TON (TVM), Algorand (AVM), Stellar, Aptos, Hedera, Keeta, and Concordium
+* **Any EVM chain** is supported via `eip155:<chainId>` — plus Solana, TON (TVM), Algorand (AVM), Stellar, Aptos, Hedera, Keeta, Concordium, and XRPL
 * [Default assets](#default-assets-for-dollar-string-pricing) are a convenience for `"$0.01"` dollar-string pricing; explicit `TokenAmount` works on any chain
 * Any ERC-20 token works on any EVM facilitator (via EIP-3009 or Permit2)
 * CAIP-2 identifiers provide unambiguous cross-chain support

--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -16,6 +16,7 @@ x402 uses [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) standard network iden
 - **Hedera**: `hedera:<network>` (`mainnet` or `testnet`)
 - **Keeta**: `keeta:<networkId>` (e.g., `keeta:21378` for mainnet)
 - **Concordium**: `ccd:<genesisHash>` (e.g., `ccd:9dd9ca4d19e9393877d2c44b70f89acb` for mainnet)
+- **XRPL**: `xrpl:<networkId>` (e.g., `xrpl:0` for mainnet, `xrpl:1` for testnet)
 
 ## Token Support
 

--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -29,5 +29,6 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
 | [Solvador](https://solvador.com) | Multi-network facilitator with broad mainnet coverage across EVM plus Solana and NEAR, supporting multiple schemes and extensions |
+| [T54 XRPL Facilitator](https://xrpl-x402.t54.ai) | x402 facilitator for the XRP Ledger, covering mainnet and testnet with XRP and RLUSD support |
 
 For testnet development, the [x402.org facilitator](/core-concepts/network-and-token-support#x402org-facilitator) requires no setup. It is not intended for mainnet routes; use a production facilitator, a self-hosted facilitator, or [self-facilitation](https://github.com/x402-foundation/x402/tree/main/examples/typescript/servers/self-facilitation) for production networks.

--- a/docs/getting-started/quickstart-for-buyers.mdx
+++ b/docs/getting-started/quickstart-for-buyers.mdx
@@ -53,6 +53,9 @@ There are pre-configured [examples available in the x402 repo](https://github.co
 
     # For NEAR support, also add:
     npm install @x402/near
+
+    # For XRPL support, also add:
+    npm install @x402/xrpl
     ```
   </Tab>
   <Tab title="Go">
@@ -254,6 +257,17 @@ const nearSigner = createClientNearSigner({
   accountId: "alice.testnet",
   secretKey: process.env.NEAR_SECRET_KEY!, // ed25519:... full-access key
 });
+```
+
+#### XRPL
+
+Use `@x402/xrpl` to instantiate a signer:
+
+```typescript
+import { Wallet } from "xrpl";
+import { createXrplWalletSigner } from "@x402/xrpl";
+
+const xrplSigner = createXrplWalletSigner(Wallet.fromSeed(process.env.XRPL_SEED!));
 ```
 
 ### 3. Make Paid Requests Automatically
@@ -585,6 +599,14 @@ You can register multiple payment schemes to handle different networks:
       secretKey: process.env.NEAR_SECRET_KEY!, // ed25519:... full-access key
     });
     client.register("near:*", new ExactNearScheme(nearSigner));
+
+    // For XRPL support, also add:
+    import { Wallet } from "xrpl";
+    import { createXrplWalletSigner } from "@x402/xrpl";
+    import { ExactXrplScheme } from "@x402/xrpl/exact/client";
+
+    const xrplSigner = createXrplWalletSigner(Wallet.fromSeed(process.env.XRPL_SEED!));
+    client.register("xrpl:*", new ExactXrplScheme(xrplSigner));
     ```
   </Tab>
   <Tab title="Go">
@@ -717,7 +739,7 @@ try {
 
 ### Summary
 
-* Install x402 client packages (`@x402/fetch` or `@x402/axios`) and mechanism packages (`@x402/evm`, `@x402/svm`, `@x402/tvm`, `@x402/aptos`, `@x402/keeta`, `@x402/near`)
+* Install x402 client packages (`@x402/fetch` or `@x402/axios`) and mechanism packages (`@x402/evm`, `@x402/svm`, `@x402/tvm`, `@x402/aptos`, `@x402/keeta`, `@x402/near`, `@x402/xrpl`)
 * Create a wallet signer
 * Create an `x402Client` and register payment schemes (`exact` for fixed-price, `upto` for usage-based billing, `batch-settlement` for batched EVM micropayments when the server advertises it)
 * Use the provided wrapper/interceptor to make paid API requests

--- a/docs/schemes/overview.mdx
+++ b/docs/schemes/overview.mdx
@@ -3,7 +3,7 @@ title: "Payment Schemes"
 description: "Choose between exact, upto, and batch-settlement payment schemes in x402."
 ---
 
-Payment schemes define the payment semantics for a resource: `exact` is for fixed-price requests where the buyer authorizes the advertised amount, `upto` is for single-request usage-based billing where the buyer authorizes a maximum and the seller charges actual usage, and `batch-settlement` is for high-volume or repeated micropayments where per-request authorizations are accumulated against a reusable channel. Network implementations define how those semantics are encoded for EVM, SVM, TVM (TON), AVM, Stellar, Aptos, Hedera, Keeta, Concordium, and NEAR; see [SDK Features](/sdk-features) for current SDK support.
+Payment schemes define the payment semantics for a resource: `exact` is for fixed-price requests where the buyer authorizes the advertised amount, `upto` is for single-request usage-based billing where the buyer authorizes a maximum and the seller charges actual usage, and `batch-settlement` is for high-volume or repeated micropayments where per-request authorizations are accumulated against a reusable channel. Network implementations define how those semantics are encoded for EVM, SVM, TVM (TON), AVM, Stellar, Aptos, Hedera, Keeta, Concordium, NEAR, and XRPL; see [SDK Features](/sdk-features) for current SDK support.
 
 ### Schemes in a 402 Response
 


### PR DESCRIPTION
## Description

Documentation follow-up for the XRPL `exact` scheme TypeScript reference implementation (#2801), complementing the Mintlify docs update in #2854.

#2854 covers `docs/schemes/exact.mdx` (XRPL Setup section) and the `docs/sdk-features.md` tables. This PR adds the remaining pages, mirroring how NEAR was documented in #2771 after its implementation (#2663) merged. The two PRs touch disjoint files, so they can land in either order.

### Changes

- **`docs/getting-started/quickstart-for-buyers.mdx`** — the four per-chain touchpoints every other network has: the `npm install @x402/xrpl` install line, an `#### XRPL` signer section (`createXrplWalletSigner`), the multi-scheme registration example (`client.register("xrpl:*", new ExactXrplScheme(xrplSigner))`), and the summary package list.
- **`docs/schemes/overview.mdx`** — add XRPL to the network implementations sentence.
- **`docs/core-concepts/network-and-token-support.mdx`** — add the `xrpl:<networkId>` CAIP-2 identifier (`xrpl:0` mainnet, `xrpl:1` testnet) to the Network Identifiers list, matching the merged spec's NetworkID rules; add an XRPL row to the Token Support table (XRP or any issued currency, e.g. RLUSD, via a payer-signed `Payment` transaction); bring the page's Summary list in line.
- **`docs/dev-tools/facilitators.md`** — list the T54 XRPL Facilitator. This restores a listing that existed on the website ecosystem page (added in #2190) until the site was deprecated in #2794. Both endpoints are live and advertise v2 support via `GET /supported`:
  - `https://xrpl-facilitator-mainnet.t54.ai/supported` → `{"kinds":[{"x402Version":2,"scheme":"exact","network":"xrpl:0"}],"extensions":["x402Secure"],"signers":{"xrpl:*":[]}}`
  - `https://xrpl-facilitator-testnet.t54.ai/supported` → `{"kinds":[{"x402Version":2,"scheme":"exact","network":"xrpl:1"}],"extensions":[],"signers":{"xrpl:*":[]}}`

### Intentionally not included

- `quickstart-for-sellers.mdx` keeps its EVM/SVM/AVM-only scope (no other non-core chain is documented there); its "Update the Facilitator URL" section already points sellers to `/dev-tools/facilitators`.
- No default-asset table entries: XRPL uses explicit `AssetAmount` pricing (no dollar-string default asset), consistent with #2801.


### Related follow-ups

- **x402.org testnet facilitator registration** — done separately in #2857, which registers `xrpl:1` behind an explicit `FACILITATOR_XRPL_ENABLED=true` opt-in, per [the follow-up suggestion on #2801](https://github.com/x402-foundation/x402/pull/2801#issuecomment-4934160050).
- **npm availability** — `@x402/xrpl` publishes with the next changesets release (the changeset from #2801 is already on `main`); until then the quickstart's `npm install @x402/xrpl` line refers to a not-yet-published package. Same sequencing as NEAR: the docs PR #2771 merged on 2026-07-03, and `@x402/near` was first published on 2026-07-06.
