### PR TITLE
feat(site): register XRPL testnet on the x402.org facilitator

### DIFF
--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1861,6 +1861,9 @@ importers:
       '@x402/svm':
         specifier: workspace:*
         version: link:../packages/mechanisms/svm
+      '@x402/xrpl':
+        specifier: workspace:*
+        version: link:../packages/mechanisms/xrpl
       next:
         specifier: ^16.2.6
         version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/typescript/site/README.md
+++ b/typescript/site/README.md
@@ -1,6 +1,6 @@
 # x402 Facilitator
 
-A standalone [Next.js](https://nextjs.org) service that runs the x402 testnet facilitator. It exposes the facilitator API used to verify and settle x402 payments across EVM, SVM, AVM, Aptos, Stellar, Hedera, and Keeta.
+A standalone [Next.js](https://nextjs.org) service that runs the x402 testnet facilitator. It exposes the facilitator API used to verify and settle x402 payments across EVM, SVM, AVM, Aptos, Stellar, Hedera, Keeta, and XRPL.
 
 ## Endpoints
 
@@ -27,7 +27,7 @@ pnpm install
 
 ### Configuration
 
-Configure environment variables in `.env`. EVM and SVM keys are required; other networks are registered only when their variables are present.
+Configure environment variables in `.env`. EVM and SVM keys are required; other networks are registered only when their variables are present (XRPL, which needs no key, is enabled by an explicit `FACILITATOR_XRPL_ENABLED=true` flag).
 
 ```bash
 # Required
@@ -50,6 +50,13 @@ FACILITATOR_HEDERA_PRIVATE_KEY=your_hedera_ecdsa_private_key
 FACILITATOR_KEETA_MNEMONIC=...
 # Number of signers to derive from the mnemonic for concurrent settlement (each must be funded).
 # FACILITATOR_KEETA_SIGNER_AMOUNT=2
+
+# Optional: XRPL (registers xrpl:1 testnet). No key or funds are needed: the
+# payer signs the transaction and pays its fee, and the facilitator only
+# verifies and submits the signed blob.
+# FACILITATOR_XRPL_ENABLED=true
+# Optional override for the default public testnet WebSocket endpoint.
+# FACILITATOR_XRPL_TESTNET_WS_URL=wss://s.altnet.rippletest.net:51233
 
 # Optional: builder attribution
 FACILITATOR_BUILDER_CODE=your_builder_code

--- a/typescript/site/app/facilitator/index.ts
+++ b/typescript/site/app/facilitator/index.ts
@@ -35,12 +35,14 @@ import { ExactSvmScheme } from "@x402/svm/exact/facilitator";
 import { ExactSvmSchemeV1 } from "@x402/svm/exact/v1/facilitator";
 import { toFacilitatorAvmSigner } from "@x402/avm";
 import { ExactAvmScheme } from "@x402/avm/exact/facilitator";
+import { XRPL_TESTNET } from "@x402/xrpl";
+import { ExactXrplScheme } from "@x402/xrpl/exact/facilitator";
 import { createWalletClient, http, publicActions } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { baseSepolia } from "viem/chains";
 
 /**
- * Initialize and configure the x402 facilitator with EVM, SVM, AVM, Aptos, Stellar, Hedera, and Keeta support
+ * Initialize and configure the x402 facilitator with EVM, SVM, AVM, Aptos, Stellar, Hedera, Keeta, and XRPL support
  * This is called lazily on first use to support Next.js module loading
  *
  * @returns A configured x402Facilitator instance
@@ -229,6 +231,17 @@ async function createFacilitator(): Promise<x402Facilitator> {
     facilitator.register(
       "hedera:testnet",
       new ExactHederaScheme(hederaSigner, { aliasPolicy: "reject" }),
+    );
+  }
+
+  // Optionally register XRPL if enabled. Unlike the other networks, no
+  // facilitator key or funds are needed: the payer signs the transaction and
+  // pays its fee, and the facilitator only verifies and submits the signed blob.
+  if (process.env.FACILITATOR_XRPL_ENABLED === "true") {
+    const xrplWsUrl = process.env.FACILITATOR_XRPL_TESTNET_WS_URL;
+    facilitator.register(
+      XRPL_TESTNET,
+      new ExactXrplScheme(xrplWsUrl ? { wsUrlByNetwork: { [XRPL_TESTNET]: xrplWsUrl } } : {}),
     );
   }
 

--- a/typescript/site/package.json
+++ b/typescript/site/package.json
@@ -30,6 +30,7 @@
     "@x402/paywall": "workspace:*",
     "@x402/stellar": "workspace:*",
     "@x402/svm": "workspace:*",
+    "@x402/xrpl": "workspace:*",
     "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",


### PR DESCRIPTION
## Description

Follow-up to #2801, implementing the suggestion from [this review comment](https://github.com/x402-foundation/x402/pull/2801#issuecomment-4934160050) to add XRPL as an optional network on the x402.org testnet facilitator:

> We would also be happy to include XRPL in the x402.org testnet facilitator, provided your team/Ripple could supply sufficient testnet funds.

**On the testnet-funds condition: enabling XRPL requires no facilitator-side key or funds at all.** In the XRPL `exact` scheme the payer signs the `Payment` transaction and pays its fee; the facilitator only verifies and submits the pre-signed blob. Concretely:

- `ExactXrplScheme.getSigners()` returns `[]` and `getExtra()` advertises `areFeesSponsored: false` — there is no facilitator hot wallet, no reserve, and nothing to top up.
- The e2e facilitator already registers XRPL the same way (`e2e/facilitators/typescript/index.ts`, logged as *"payer-signed; no facilitator signer"*).
- T54's production facilitators show the same shape in the wild: `https://xrpl-facilitator-testnet.t54.ai/supported` → `"signers":{"xrpl:*":[]}`.

The only funded accounts in any XRPL x402 flow are the payers' own wallets, which on testnet come from the public faucet. Should you nonetheless want funded monitoring/demo wallets, T54/Ripple is happy to provide and maintain them — but nothing in this deployment depends on it.

### Changes

Mirrors the Hedera site registration (#2589), adapted for a keyless scheme:

- **`typescript/site/app/facilitator/index.ts`** — register `xrpl:1` behind an explicit `FACILITATOR_XRPL_ENABLED=true` opt-in (a private-key gate would be artificial since no key exists). An optional `FACILITATOR_XRPL_TESTNET_WS_URL` lets the deployment point at its own node instead of the default public testnet endpoint, mirroring the e2e facilitator's `XRPL_WS_URL`.
- **`typescript/site/package.json`** + lockfile — add `@x402/xrpl` workspace dependency.
- **`typescript/site/README.md`** — document the two env vars.

No changeset: `site` is a private package (same as #2589).

## Tests

- `pnpm build` (turbo, site + all workspace deps) passes; `pnpm lint:check` and `pnpm format:check` pass in `typescript/site`.
- Ran the built server (`next start`) with `FACILITATOR_XRPL_ENABLED=true`: `GET /facilitator/supported` returns

  ```json
  { "scheme": "exact", "network": "xrpl:1", "extra": { "areFeesSponsored": false } }
  ```

  with `"signers": { "xrpl:*": [] }`.
- Ran it again without the flag: no `xrpl` entry is present (0 occurrences in the response), and the existing kinds are unchanged.
- Exercised the full networked verify path against the built server: `POST /facilitator/verify` with a signed XRPL `Payment` blob (stale `LastLedgerSequence`) returned `{"isValid":false,"invalidReason":"invalid_exact_xrpl_payload_expired","payer":"r..."}` — a result only computable by fetching the live testnet ledger index over the default WebSocket endpoint, confirming the `xrpl`/`ws` client works inside the Next.js server bundle.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip) — N/A: `site` is private/unpublished, matching #2589
