### PR TITLE
feat(xrpl): add cross-currency exact payments

### DIFF
--- a/docs/schemes/exact.mdx
+++ b/docs/schemes/exact.mdx
@@ -289,7 +289,9 @@ const client = new x402Client().register("xrpl:*", xrplScheme);
 The client and facilitator reject partial payments, `DeliverMin`, invalid path
 policy, and same-asset or non-positive caps. The facilitator simulates the
 signed transaction and accepts settlement only when validated metadata reports
-the exact required `delivered_amount`.
+the required `delivered_amount`. XRP drops must match exactly; issued-currency
+metadata uses XRPL's 15-significant-digit precision tolerance for ledger
+rounding. Issued-currency `SendMax` caps may use XRPL scientific notation.
 
 **Facilitator**
 

--- a/docs/schemes/exact.mdx
+++ b/docs/schemes/exact.mdx
@@ -238,6 +238,24 @@ const resourceServer = new x402ResourceServer(facilitatorClient)
 }
 ```
 
+To accept an exact destination amount from a different payer-selected source
+asset, opt in with `extra.crossCurrency: true`:
+
+```typescript
+{
+  scheme: "exact",
+  price: { amount: "1000000", asset: "XRP" },
+  network: "xrpl:1",
+  payTo: "rYourXrplAddress",
+  extra: { crossCurrency: true },
+}
+```
+
+The server advertises this requirement only when the selected facilitator
+reports cross-currency support. `Amount` remains the exact destination target;
+the client must set a payer-approved `SendMax` source-asset cap after a current
+path and quote preflight.
+
 **Client**
 
 ```typescript
@@ -252,6 +270,26 @@ const signer = createXrplWalletSigner(wallet);
 const client = new x402Client()
   .register("xrpl:*", new ExactXrplScheme(signer));
 ```
+
+Cross-currency payments require a transaction preparer so the payer controls
+the source asset, cap, and optional explicit paths:
+
+```typescript
+const xrplScheme = new ExactXrplScheme(signer, {
+  preparePaymentTransaction: async transaction =>
+    xrplClient.autofill({
+      ...transaction,
+      SendMax: "25000000",
+    }),
+});
+
+const client = new x402Client().register("xrpl:*", xrplScheme);
+```
+
+The client and facilitator reject partial payments, `DeliverMin`, invalid path
+policy, and same-asset or non-positive caps. The facilitator simulates the
+signed transaction and accepts settlement only when validated metadata reports
+the exact required `delivered_amount`.
 
 **Facilitator**
 

--- a/docs/sdk-features.md
+++ b/docs/sdk-features.md
@@ -59,6 +59,12 @@ This page tracks which features are implemented in each SDK (TypeScript, Go, Pyt
 | batch-settlement | evm | `eip3009` | ✅ | ✅ | ✅ |
 | batch-settlement | evm | `permit2` | ✅ | ✅ | ✅ |
 
+### XRPL Optional Capabilities
+
+| Capability | TypeScript | Go | Python |
+|------------|------------|-----|--------|
+| Cross-currency exact payments | ✅ | ❌ | ❌ |
+
 ## Extensions
 
 | Extension | TypeScript | Go | Python |

--- a/typescript/.changeset/xrpl-cross-currency-exact.md
+++ b/typescript/.changeset/xrpl-cross-currency-exact.md
@@ -2,4 +2,4 @@
 "@x402/xrpl": minor
 ---
 
-Add opt-in exact cross-currency XRPL payments with payer-approved `SendMax` caps and Paths, capability negotiation, mandatory simulation, exact delivery metadata verification, and positive and negative interoperability tests.
+Add opt-in exact cross-currency XRPL payments with payer-approved `SendMax` caps and Paths, scientific-notation support, capability negotiation, mandatory simulation metadata checks, XRPL-precision delivery verification, and positive and negative interoperability tests.

--- a/typescript/.changeset/xrpl-cross-currency-exact.md
+++ b/typescript/.changeset/xrpl-cross-currency-exact.md
@@ -1,0 +1,5 @@
+---
+"@x402/xrpl": minor
+---
+
+Add opt-in exact cross-currency XRPL payments with payer-approved `SendMax` caps and Paths, capability negotiation, mandatory simulation, exact delivery metadata verification, and positive and negative interoperability tests.

--- a/typescript/packages/mechanisms/xrpl/README.md
+++ b/typescript/packages/mechanisms/xrpl/README.md
@@ -50,6 +50,33 @@ The payer signs a complete XRPL `Payment` transaction and pays the XRPL transact
 
 There is no `extra.decimals` field: XRPL issued-currency amounts are ledger decimal values, so the requirement `amount` is used verbatim as the signed `value`. XRPL exact payments use explicit `AssetAmount` pricing; dollar-string default asset mapping is not included for XRPL.
 
+## Cross-Currency Exact Payments
+
+Set `extra.crossCurrency: true` in the resource configuration to let the payer deliver the exact target amount from a different source asset. The signed transaction keeps `Amount`/`DeliverMax` equal to the required destination amount; `SendMax` is the payer's absolute source-asset cap, including transfer fees, exchange rates, and approved slippage.
+
+The server enables this only when the facilitator advertises `features.crossCurrency: true`. The client requires `preparePaymentTransaction` for cross-currency requirements so the application must perform current path/quote preflight and explicitly apply its approved `SendMax` and optional `Paths` before signing:
+
+```typescript
+import type { Payment } from "xrpl";
+import { ExactXrplScheme } from "@x402/xrpl/exact/client";
+
+const approvedSendMax: Payment["SendMax"] = "25000000";
+const approvedPaths: Payment["Paths"] = undefined;
+
+const xrplScheme = new ExactXrplScheme(signer, {
+  preparePaymentTransaction: async transaction =>
+    xrplClient.autofill({
+      ...transaction,
+      SendMax: approvedSendMax,
+      ...(approvedPaths ? { Paths: approvedPaths } : {}),
+    }),
+});
+```
+
+The callback must preserve the destination and exact target amount. Omitted `Paths` uses XRPL's default path; explicit paths must be non-empty. `tfNoRippleDirect` is valid only with explicit paths. The client and facilitator reject `tfPartialPayment`, `DeliverMin`, same-asset or non-positive source caps, and malformed path policy.
+
+The facilitator simulates the exact signed transaction during verification and settlement re-verification. Settlement succeeds only for validated `tesSUCCESS` metadata whose `delivered_amount` exactly matches the required destination amount and issue. Quote or simulation success is not a guarantee because ledger liquidity can change before validation.
+
 ## Asset Transfer Methods
 
 `extra.assetTransferMethod` selects how the signed transaction is sequenced:
@@ -104,7 +131,7 @@ The default client uses `xrpl.Client` to autofill ledger-derived fields before s
 - `LastLedgerSequence`
 - `NetworkID` for custom XRPL networks
 
-Use `wsUrlByNetwork` or `clientFactory` to customize the XRPL connection, and `feeDrops` only when the client should use an explicit fee instead of the network autofill value. If a wallet or application prepares transactions externally, pass `preparePaymentTransaction`; the returned transaction must satisfy the selected asset transfer method, and include `Fee`, `LastLedgerSequence`, and the correct custom-network `NetworkID` when applicable.
+Use `wsUrlByNetwork` or `clientFactory` to customize the XRPL connection, and `feeDrops` only when the client should use an explicit fee instead of the network autofill value. If a wallet or application prepares transactions externally, pass `preparePaymentTransaction`; the returned transaction must satisfy the selected asset transfer method, and include `Fee`, `LastLedgerSequence`, and the correct custom-network `NetworkID` when applicable. Cross-currency requirements always require this callback to apply a payer-approved source cap and path policy.
 
 For `"ticketSequence"` payments, `ticketCreateCount` controls automatic ticket creation when the
 account has no available tickets. It defaults to `1`; set it to `0` to require pre-provisioned
@@ -136,7 +163,7 @@ Use explicit asset pricing:
 }
 ```
 
-The server scheme adds `extra.areFeesSponsored: false` to the advertised requirements. Invoice binding is enforced when the resource configuration provides `extra.invoiceId`; requirements are rebuilt for every request, so the scheme never injects per-request values.
+The server scheme adds `extra.areFeesSponsored: false` to the advertised requirements. Invoice binding is enforced when the resource configuration provides `extra.invoiceId`; cross-currency behavior is enabled only when it provides `extra.crossCurrency: true` and the facilitator advertises support. Requirements are rebuilt for every request, so the scheme never injects per-request values.
 
 ### Facilitator
 
@@ -147,7 +174,7 @@ import { ExactXrplScheme } from "@x402/xrpl/exact/facilitator";
 const facilitator = new x402Facilitator().register("xrpl:*", new ExactXrplScheme());
 ```
 
-Verification enforces the spec's checks: envelope consistency, offline signature validation, signer-to-account authorization (the embedded `SigningPubKey` must be the account's master key pair, unless disabled, or its configured regular key), destination and amount matching, NetworkID binding, per-method sequencing (current account `Sequence`, or ticket availability), `LastLedgerSequence` expiry policy, invoice binding via `InvoiceID`, fee caps, safety rejections (`Delegate`, `Memos`, `Paths`, `DeliverMin`, partial payments, multisigned blobs), and an XRPL simulation. Settlement re-runs verification, submits the signed blob, and succeeds only on a validated `tesSUCCESS` result.
+Verification enforces the spec's checks: envelope consistency, offline signature validation, signer-to-account authorization (the embedded `SigningPubKey` must be the account's master key pair, unless disabled, or its configured regular key), destination and amount matching, NetworkID binding, per-method sequencing (current account `Sequence`, or ticket availability), `LastLedgerSequence` expiry policy, invoice binding via `InvoiceID`, fee caps, safety rejections (`Delegate`, `Memos`, unnegotiated `Paths`, `DeliverMin`, partial payments, multisigned blobs), and an XRPL simulation. For opt-in cross-currency payments it additionally validates the signed source cap and path policy. Settlement re-runs verification, submits the signed blob, and succeeds only on validated `tesSUCCESS`; cross-currency settlement also requires exact `delivered_amount` metadata.
 
 ## Duplicate Settlement Protection
 

--- a/typescript/packages/mechanisms/xrpl/README.md
+++ b/typescript/packages/mechanisms/xrpl/README.md
@@ -75,7 +75,9 @@ const xrplScheme = new ExactXrplScheme(signer, {
 
 The callback must preserve the destination and exact target amount. Omitted `Paths` uses XRPL's default path; explicit paths must be non-empty. `tfNoRippleDirect` is valid only with explicit paths. The client and facilitator reject `tfPartialPayment`, `DeliverMin`, same-asset or non-positive source caps, and malformed path policy.
 
-The facilitator simulates the exact signed transaction during verification and settlement re-verification. Settlement succeeds only for validated `tesSUCCESS` metadata whose `delivered_amount` exactly matches the required destination amount and issue. Quote or simulation success is not a guarantee because ledger liquidity can change before validation.
+The facilitator simulates the exact signed transaction during verification and settlement re-verification, including its `delivered_amount` metadata. Settlement succeeds only for validated `tesSUCCESS` metadata with the required destination asset and issue. XRP drops must match exactly; issued-currency values use XRPL's 15-significant-digit precision tolerance because ledger metadata can differ from `Amount` by one least-significant precision unit. Quote or simulation success is not a guarantee because ledger liquidity can change before validation.
+
+Issued-currency `SendMax.value` accepts XRPL decimal strings in plain or `e`/`E` scientific notation and is parsed without binary floating point.
 
 ## Asset Transfer Methods
 
@@ -174,7 +176,7 @@ import { ExactXrplScheme } from "@x402/xrpl/exact/facilitator";
 const facilitator = new x402Facilitator().register("xrpl:*", new ExactXrplScheme());
 ```
 
-Verification enforces the spec's checks: envelope consistency, offline signature validation, signer-to-account authorization (the embedded `SigningPubKey` must be the account's master key pair, unless disabled, or its configured regular key), destination and amount matching, NetworkID binding, per-method sequencing (current account `Sequence`, or ticket availability), `LastLedgerSequence` expiry policy, invoice binding via `InvoiceID`, fee caps, safety rejections (`Delegate`, `Memos`, unnegotiated `Paths`, `DeliverMin`, partial payments, multisigned blobs), and an XRPL simulation. For opt-in cross-currency payments it additionally validates the signed source cap and path policy. Settlement re-runs verification, submits the signed blob, and succeeds only on validated `tesSUCCESS`; cross-currency settlement also requires exact `delivered_amount` metadata.
+Verification enforces the spec's checks: envelope consistency, offline signature validation, signer-to-account authorization (the embedded `SigningPubKey` must be the account's master key pair, unless disabled, or its configured regular key), destination and amount matching, NetworkID binding, per-method sequencing (current account `Sequence`, or ticket availability), `LastLedgerSequence` expiry policy, invoice binding via `InvoiceID`, fee caps, safety rejections (`Delegate`, `Memos`, unnegotiated `Paths`, `DeliverMin`, partial payments, multisigned blobs), and an XRPL simulation. For opt-in cross-currency payments it additionally validates the signed source cap, path policy, and simulated delivery metadata. Settlement re-runs verification, submits the signed blob, and succeeds only on validated `tesSUCCESS`; cross-currency settlement also requires XRPL-precision-equivalent `delivered_amount` metadata.
 
 ## Duplicate Settlement Protection
 

--- a/typescript/packages/mechanisms/xrpl/src/constants.ts
+++ b/typescript/packages/mechanisms/xrpl/src/constants.ts
@@ -54,6 +54,11 @@ export const DEFAULT_LEDGER_TOLERANCE = 2;
 export const TF_PARTIAL_PAYMENT = 0x00020000;
 
 /**
+ * XRPL Payment tfNoRippleDirect flag.
+ */
+export const TF_NO_RIPPLE_DIRECT = 0x00010000;
+
+/**
  * XRPL AccountRoot lsfDisableMaster flag: the account's master key pair is disabled.
  */
 export const LSF_DISABLE_MASTER = 0x00100000;

--- a/typescript/packages/mechanisms/xrpl/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/client/scheme.ts
@@ -9,9 +9,10 @@ import {
   isDecimalString,
   isIntegerString,
   isIssuedCurrencyAmount,
-  isNonEmptyXrplPathSet,
   isRecord,
+  isSameXrplCurrency,
   isValidDestinationTag,
+  isValidXrplPathSet,
   isXrplAssetTransferMethod,
   isXrplNetwork,
   parseXrplNetworkId,
@@ -312,7 +313,7 @@ export class ExactXrplScheme implements SchemeNetworkClient {
       }
     } else if (
       !isIssuedCurrencyAmount(destinationAmount) ||
-      destinationAmount.currency !== requirements.asset ||
+      !isSameXrplCurrency(destinationAmount.currency, requirements.asset) ||
       destinationAmount.issuer !== requirements.extra?.issuer ||
       compareDecimalStrings(destinationAmount.value, requirements.amount) !== 0
     ) {
@@ -339,8 +340,8 @@ export class ExactXrplScheme implements SchemeNetworkClient {
       if (noRippleDirect) {
         throw new Error("tfNoRippleDirect requires explicit Paths");
       }
-    } else if (!isNonEmptyXrplPathSet(transaction.Paths)) {
-      throw new Error("cross-currency Paths must contain at least one non-empty path");
+    } else if (!isValidXrplPathSet(transaction.Paths)) {
+      throw new Error("cross-currency Paths must contain 1-6 paths with 1-8 steps each");
     }
   }
 

--- a/typescript/packages/mechanisms/xrpl/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/client/scheme.ts
@@ -1,16 +1,22 @@
 import {
+  compareDecimalStrings,
   createTickets,
   createXrplClient,
   getMaxLastLedgerSequence,
   getXrplTicketSequences,
   invoiceIdToInvoiceIdField,
+  isDifferentXrplSourceAsset,
   isDecimalString,
   isIntegerString,
+  isIssuedCurrencyAmount,
+  isNonEmptyXrplPathSet,
+  isRecord,
   isValidDestinationTag,
   isXrplAssetTransferMethod,
   isXrplNetwork,
   parseXrplNetworkId,
 } from "../../utils";
+import { TF_NO_RIPPLE_DIRECT, TF_PARTIAL_PAYMENT } from "../../constants";
 import type { ClientXrplSigner, XrplAssetTransferMethod, XrplClientOptions } from "../../types";
 import type {
   Network,
@@ -95,6 +101,7 @@ export class ExactXrplScheme implements SchemeNetworkClient {
       );
     }
     const isXrp = requirements.asset === "XRP";
+    const isCrossCurrency = requirements.extra?.crossCurrency === true;
     let amount: Payment["Amount"] = requirements.amount;
     let sendMax: Payment["SendMax"];
     if (!isXrp) {
@@ -103,11 +110,13 @@ export class ExactXrplScheme implements SchemeNetworkClient {
         issuer: String(requirements.extra?.issuer),
         value: requirements.amount,
       };
-      sendMax = {
-        currency: requirements.asset,
-        issuer: String(requirements.extra?.issuer),
-        value: requirements.amount,
-      };
+      if (!isCrossCurrency) {
+        sendMax = {
+          currency: requirements.asset,
+          issuer: String(requirements.extra?.issuer),
+          value: requirements.amount,
+        };
+      }
     }
     const transaction: Payment = {
       TransactionType: "Payment",
@@ -180,11 +189,16 @@ export class ExactXrplScheme implements SchemeNetworkClient {
     requirements: PaymentRequirements,
     method: XrplAssetTransferMethod,
   ): Promise<Payment> {
+    if (requirements.extra?.crossCurrency === true && !this.options.preparePaymentTransaction) {
+      throw new Error(
+        "XRPL cross-currency payments require preparePaymentTransaction to apply a payer-approved SendMax and optional Paths",
+      );
+    }
     const preparedPayment = this.options.preparePaymentTransaction
       ? await this.options.preparePaymentTransaction(transaction, requirements)
       : await this.autofillPaymentTransaction(transaction, requirements);
 
-    this.validatePreparedPaymentTransaction(preparedPayment, requirements.network, method);
+    this.validatePreparedPaymentTransaction(preparedPayment, requirements, method);
     return preparedPayment;
   }
 
@@ -223,12 +237,12 @@ export class ExactXrplScheme implements SchemeNetworkClient {
    * Ensures the transaction can be submitted after signing.
    *
    * @param transaction - Prepared XRPL payment transaction
-   * @param network - XRPL network id
+   * @param requirements - Payment requirements encoded by the transaction
    * @param method - Selected asset transfer method
    */
   private validatePreparedPaymentTransaction(
     transaction: Payment,
-    network: Network,
+    requirements: PaymentRequirements,
     method: XrplAssetTransferMethod,
   ): void {
     if (transaction.TransactionType !== "Payment") {
@@ -255,7 +269,7 @@ export class ExactXrplScheme implements SchemeNetworkClient {
     if (typeof transaction.LastLedgerSequence !== "number") {
       throw new Error("preparePaymentTransaction must set LastLedgerSequence");
     }
-    const networkId = parseXrplNetworkId(network);
+    const networkId = parseXrplNetworkId(requirements.network);
     if (networkId <= 1024 && transaction.NetworkID !== undefined) {
       throw new Error(
         "preparePaymentTransaction must not set NetworkID for standard XRPL networks",
@@ -265,6 +279,68 @@ export class ExactXrplScheme implements SchemeNetworkClient {
       if (transaction.NetworkID !== networkId) {
         throw new Error("preparePaymentTransaction must set NetworkID for custom XRPL networks");
       }
+    }
+    if (requirements.extra?.crossCurrency === true) {
+      this.validateCrossCurrencyPayment(transaction, requirements);
+    }
+  }
+
+  /**
+   * Ensures a custom preparer preserves the exact target and applies a safe source cap.
+   *
+   * @param transaction - Prepared cross-currency payment
+   * @param requirements - Exact destination requirements
+   */
+  private validateCrossCurrencyPayment(
+    transaction: Payment,
+    requirements: PaymentRequirements,
+  ): void {
+    if (transaction.Destination !== requirements.payTo) {
+      throw new Error("preparePaymentTransaction must preserve the payment Destination");
+    }
+    if (transaction.Amount !== undefined && transaction.DeliverMax !== undefined) {
+      throw new Error("cross-currency payments must set either Amount or DeliverMax, not both");
+    }
+    const destinationAmount = transaction.DeliverMax ?? transaction.Amount;
+    if (requirements.asset === "XRP") {
+      if (
+        typeof destinationAmount !== "string" ||
+        !isIntegerString(destinationAmount) ||
+        BigInt(destinationAmount) !== BigInt(requirements.amount)
+      ) {
+        throw new Error("preparePaymentTransaction must preserve the exact XRP destination amount");
+      }
+    } else if (
+      !isIssuedCurrencyAmount(destinationAmount) ||
+      destinationAmount.currency !== requirements.asset ||
+      destinationAmount.issuer !== requirements.extra?.issuer ||
+      compareDecimalStrings(destinationAmount.value, requirements.amount) !== 0
+    ) {
+      throw new Error("preparePaymentTransaction must preserve the exact IOU destination amount");
+    }
+
+    if (!isDifferentXrplSourceAsset(transaction.SendMax, destinationAmount)) {
+      throw new Error(
+        "preparePaymentTransaction must set a positive SendMax in a different source asset",
+      );
+    }
+    if (transaction.DeliverMin !== undefined) {
+      throw new Error("cross-currency payments must not set DeliverMin");
+    }
+    if (hasPaymentFlag(transaction.Flags, TF_PARTIAL_PAYMENT, "tfPartialPayment")) {
+      throw new Error("cross-currency payments must not enable tfPartialPayment");
+    }
+    const noRippleDirect = hasPaymentFlag(
+      transaction.Flags,
+      TF_NO_RIPPLE_DIRECT,
+      "tfNoRippleDirect",
+    );
+    if (transaction.Paths === undefined) {
+      if (noRippleDirect) {
+        throw new Error("tfNoRippleDirect requires explicit Paths");
+      }
+    } else if (!isNonEmptyXrplPathSet(transaction.Paths)) {
+      throw new Error("cross-currency Paths must contain at least one non-empty path");
     }
   }
 
@@ -290,6 +366,10 @@ export class ExactXrplScheme implements SchemeNetworkClient {
         throw new Error("XRPL exact payments require a non-empty extra.invoiceId when provided");
       }
     }
+    const crossCurrency = requirements.extra?.crossCurrency;
+    if (crossCurrency !== undefined && crossCurrency !== true) {
+      throw new Error("XRPL exact payments require extra.crossCurrency to be true when provided");
+    }
     if (requirements.asset === "XRP") {
       if (!isIntegerString(requirements.amount)) {
         throw new Error("XRPL native payments require amount as an integer drops string");
@@ -305,6 +385,23 @@ export class ExactXrplScheme implements SchemeNetworkClient {
       );
     }
   }
+}
+
+/**
+ * Checks a numeric or object-form XRPL Payment flag.
+ *
+ * @param flags - Payment Flags field
+ * @param bit - Numeric flag bit
+ * @param name - Object-form flag name
+ * @returns Whether the flag is enabled
+ */
+function hasPaymentFlag(
+  flags: Payment["Flags"],
+  bit: number,
+  name: "tfNoRippleDirect" | "tfPartialPayment",
+): boolean {
+  if (typeof flags === "number") return (flags & bit) !== 0;
+  return isRecord(flags) && flags[name] === true;
 }
 
 /**

--- a/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
@@ -19,9 +19,11 @@ import {
   invoiceIdToInvoiceIdField,
   isDifferentXrplSourceAsset,
   isIssuedCurrencyAmount,
-  isNonEmptyXrplPathSet,
   isRecord,
+  isSameXrplCurrency,
+  isSameXrplIssue,
   isValidDestinationTag,
+  isValidXrplPathSet,
   isXrplNetwork,
   isXrplTicketAvailable,
   parseXrplNetworkId,
@@ -461,7 +463,7 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     if (!isIssuedCurrencyAmount(destinationAmount)) {
       return "invalid_exact_xrpl_payload_iou_amount";
     }
-    if (destinationAmount.currency !== requirements.asset) {
+    if (!isSameXrplCurrency(destinationAmount.currency, requirements.asset)) {
       return "invalid_exact_xrpl_payload_iou_currency_mismatch";
     }
     if (destinationAmount.issuer !== requirements.extra?.issuer) {
@@ -476,10 +478,7 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     if (!isIssuedCurrencyAmount(transaction.SendMax)) {
       return "invalid_exact_xrpl_payload_sendmax_required";
     }
-    if (
-      transaction.SendMax.currency !== destinationAmount.currency ||
-      transaction.SendMax.issuer !== destinationAmount.issuer
-    ) {
+    if (!isSameXrplIssue(transaction.SendMax, destinationAmount)) {
       return "invalid_exact_xrpl_payload_sendmax_iou_mismatch";
     }
     if (compareDecimalStrings(transaction.SendMax.value, destinationAmount.value) < 0) {
@@ -525,7 +524,7 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
       }
       return undefined;
     }
-    if (!isNonEmptyXrplPathSet(transaction.Paths)) {
+    if (!isValidXrplPathSet(transaction.Paths)) {
       return "invalid_exact_xrpl_payload_paths_malformed";
     }
     return undefined;
@@ -551,7 +550,7 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     }
     return (
       isIssuedCurrencyAmount(deliveredAmount) &&
-      deliveredAmount.currency === requirements.asset &&
+      isSameXrplCurrency(deliveredAmount.currency, requirements.asset) &&
       deliveredAmount.issuer === requirements.extra?.issuer &&
       areXrplTokenAmountsEquivalent(deliveredAmount.value, requirements.amount)
     );

--- a/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
@@ -2,6 +2,7 @@ import {
   CANONICAL_SIGNING_PUB_KEY_PATTERN,
   DEFAULT_MAX_FEE_DROPS,
   SETTLEMENT_TTL_MS,
+  TF_NO_RIPPLE_DIRECT,
   TF_PARTIAL_PAYMENT,
   XRPL_CAIP_FAMILY,
 } from "../../constants";
@@ -15,7 +16,9 @@ import {
   getXrplAccountAuthorization,
   getXrplAccountSequence,
   invoiceIdToInvoiceIdField,
+  isDifferentXrplSourceAsset,
   isIssuedCurrencyAmount,
+  isNonEmptyXrplPathSet,
   isRecord,
   isValidDestinationTag,
   isXrplNetwork,
@@ -65,7 +68,10 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
    * @returns Extra metadata advertising that fees are never sponsored
    */
   getExtra(_network: Network): Record<string, unknown> | undefined {
-    return { areFeesSponsored: false };
+    return {
+      areFeesSponsored: false,
+      features: { crossCurrency: true },
+    };
   }
 
   /**
@@ -234,6 +240,18 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
           errorReason: `transaction_failed: ${result.resultCode}`,
         };
       }
+      if (
+        requirements.extra?.crossCurrency === true &&
+        !this.isExactDeliveredAmount(result.deliveredAmount, requirements)
+      ) {
+        return {
+          success: false,
+          transaction: result.hash || transactionHash,
+          network: payload.accepted.network,
+          payer: verification.payer ?? "",
+          errorReason: "transaction_failed: delivered_amount_mismatch",
+        };
+      }
 
       return {
         success: true,
@@ -298,6 +316,17 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     }
     if (payload.accepted.extra?.destinationTag !== requirements.extra?.destinationTag) {
       return "invalid_exact_xrpl_destination_tag_mismatch";
+    }
+    const requiredCrossCurrency = requirements.extra?.crossCurrency;
+    const acceptedCrossCurrency = payload.accepted.extra?.crossCurrency;
+    if (
+      (requiredCrossCurrency !== undefined && requiredCrossCurrency !== true) ||
+      (acceptedCrossCurrency !== undefined && acceptedCrossCurrency !== true)
+    ) {
+      return "invalid_exact_xrpl_cross_currency_malformed";
+    }
+    if (acceptedCrossCurrency !== requiredCrossCurrency) {
+      return "invalid_exact_xrpl_cross_currency_mismatch";
     }
     if (requirements.asset !== "XRP") {
       try {
@@ -398,6 +427,9 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     if (BigInt(destinationAmount) !== BigInt(requirements.amount)) {
       return "invalid_exact_xrpl_payload_amount_mismatch";
     }
+    if (requirements.extra?.crossCurrency === true) {
+      return this.verifyCrossCurrencyControls(transaction, destinationAmount);
+    }
     if (transaction.SendMax !== undefined) {
       return "invalid_exact_xrpl_payload_sendmax_not_allowed";
     }
@@ -437,6 +469,9 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     if (compareDecimalStrings(destinationAmount.value, requirements.amount) !== 0) {
       return "invalid_exact_xrpl_payload_iou_value_mismatch";
     }
+    if (requirements.extra?.crossCurrency === true) {
+      return this.verifyCrossCurrencyControls(transaction, destinationAmount);
+    }
     if (!isIssuedCurrencyAmount(transaction.SendMax)) {
       return "invalid_exact_xrpl_payload_sendmax_required";
     }
@@ -459,6 +494,66 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
       return "invalid_exact_xrpl_payload_partial_payment_not_allowed";
     }
     return undefined;
+  }
+
+  /**
+   * Verifies cross-currency source-cap, partial-payment, and path invariants.
+   *
+   * @param transaction - Decoded XRPL payment transaction
+   * @param destinationAmount - Exact destination amount
+   * @returns Invalid reason, if validation fails
+   */
+  private verifyCrossCurrencyControls(
+    transaction: Payment,
+    destinationAmount: Payment["Amount"],
+  ): string | undefined {
+    if (!isDifferentXrplSourceAsset(transaction.SendMax, destinationAmount)) {
+      return "invalid_exact_xrpl_payload_cross_currency_sendmax";
+    }
+    if (transaction.DeliverMin !== undefined) {
+      return "invalid_exact_xrpl_payload_delivermin_not_allowed";
+    }
+    if (hasPartialPaymentFlag(transaction.Flags)) {
+      return "invalid_exact_xrpl_payload_partial_payment_not_allowed";
+    }
+
+    const noRippleDirect = hasNoRippleDirectFlag(transaction.Flags);
+    if (transaction.Paths === undefined) {
+      if (noRippleDirect) {
+        return "invalid_exact_xrpl_payload_default_path_disabled_without_paths";
+      }
+      return undefined;
+    }
+    if (!isNonEmptyXrplPathSet(transaction.Paths)) {
+      return "invalid_exact_xrpl_payload_paths_malformed";
+    }
+    return undefined;
+  }
+
+  /**
+   * Checks validated metadata against the exact negotiated destination amount.
+   *
+   * @param deliveredAmount - Metadata delivered_amount value
+   * @param requirements - Exact destination requirements
+   * @returns Whether the delivered amount and issue are exact
+   */
+  private isExactDeliveredAmount(
+    deliveredAmount: Payment["Amount"] | "unavailable" | undefined,
+    requirements: PaymentRequirements,
+  ): boolean {
+    if (requirements.asset === "XRP") {
+      return (
+        typeof deliveredAmount === "string" &&
+        /^\d+$/.test(deliveredAmount) &&
+        BigInt(deliveredAmount) === BigInt(requirements.amount)
+      );
+    }
+    return (
+      isIssuedCurrencyAmount(deliveredAmount) &&
+      deliveredAmount.currency === requirements.asset &&
+      deliveredAmount.issuer === requirements.extra?.issuer &&
+      compareDecimalStrings(deliveredAmount.value, requirements.amount) === 0
+    );
   }
 
   /**
@@ -710,6 +805,19 @@ function hasPartialPaymentFlag(flags: Payment["Flags"]): boolean {
     return (flags & TF_PARTIAL_PAYMENT) !== 0;
   }
   return isRecord(flags) && flags.tfPartialPayment === true;
+}
+
+/**
+ * Checks whether XRPL Payment flags disable the default path.
+ *
+ * @param flags - XRPL payment flags
+ * @returns Whether tfNoRippleDirect is enabled
+ */
+function hasNoRippleDirectFlag(flags: Payment["Flags"]): boolean {
+  if (typeof flags === "number") {
+    return (flags & TF_NO_RIPPLE_DIRECT) !== 0;
+  }
+  return isRecord(flags) && flags.tfNoRippleDirect === true;
 }
 
 /**

--- a/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
@@ -7,6 +7,7 @@ import {
   XRPL_CAIP_FAMILY,
 } from "../../constants";
 import {
+  areXrplTokenAmountsEquivalent,
   compareDecimalStrings,
   decodeSignedTransactionBlob,
   getCurrentLedgerIndex,
@@ -552,7 +553,7 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
       isIssuedCurrencyAmount(deliveredAmount) &&
       deliveredAmount.currency === requirements.asset &&
       deliveredAmount.issuer === requirements.extra?.issuer &&
-      compareDecimalStrings(deliveredAmount.value, requirements.amount) === 0
+      areXrplTokenAmountsEquivalent(deliveredAmount.value, requirements.amount)
     );
   }
 
@@ -759,6 +760,12 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     );
     if (result.engineResult !== "tesSUCCESS") {
       return `invalid_exact_xrpl_payload_simulation_failed: ${result.engineResult}`;
+    }
+    if (
+      requirements.extra?.crossCurrency === true &&
+      !this.isExactDeliveredAmount(result.deliveredAmount, requirements)
+    ) {
+      return "invalid_exact_xrpl_payload_simulation_delivered_amount_mismatch";
     }
     return undefined;
   }

--- a/typescript/packages/mechanisms/xrpl/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/server/scheme.ts
@@ -12,6 +12,7 @@ import { parseMoneyString } from "@x402/core/utils";
 import {
   isDecimalString,
   isIntegerString,
+  isRecord,
   isValidDestinationTag,
   isXrplAssetTransferMethod,
   requireClassicAddress,
@@ -85,7 +86,6 @@ export class ExactXrplScheme implements SchemeNetworkServer {
     supportedKind: SupportedKind,
     extensionKeys: string[],
   ): Promise<PaymentRequirements> {
-    void supportedKind;
     void extensionKeys;
 
     const assetTransferMethod = paymentRequirements.extra?.assetTransferMethod;
@@ -101,6 +101,14 @@ export class ExactXrplScheme implements SchemeNetworkServer {
       throw new Error(
         "XRPL exact payments require extra.destinationTag to be a 32-bit unsigned integer",
       );
+    }
+    const crossCurrency = paymentRequirements.extra?.crossCurrency;
+    if (crossCurrency !== undefined && crossCurrency !== true) {
+      throw new Error("XRPL exact payments require extra.crossCurrency to be true when provided");
+    }
+    const features = supportedKind.extra?.features;
+    if (crossCurrency === true && (!isRecord(features) || features.crossCurrency !== true)) {
+      throw new Error("XRPL facilitator does not advertise cross-currency support");
     }
 
     return Promise.resolve({

--- a/typescript/packages/mechanisms/xrpl/src/types.ts
+++ b/typescript/packages/mechanisms/xrpl/src/types.ts
@@ -49,6 +49,11 @@ export type XrplPaymentRequirementsExtra = {
    */
   destinationTag?: number;
   /**
+   * Enables a payer-selected source asset and signed SendMax cap.
+   * The only valid present value is true.
+   */
+  crossCurrency?: true;
+  /**
    * Required IOU issuer address for issued-currency payments.
    */
   issuer?: string;
@@ -95,6 +100,8 @@ export type XrplClientOptions = {
   ticketCreateCount?: number;
   /**
    * Optional function to prepare/autofill the transaction before signing.
+   * Required for crossCurrency payments, where it must apply a payer-approved
+   * SendMax and optional Paths from current quote preflight.
    */
   preparePaymentTransaction?: (
     transaction: Payment,
@@ -126,6 +133,10 @@ export type XrplSettlementResult = {
    * XRPL transaction result code.
    */
   resultCode: string;
+  /**
+   * Amount actually delivered according to validated transaction metadata.
+   */
+  deliveredAmount?: Payment["Amount"] | "unavailable";
 };
 
 /**

--- a/typescript/packages/mechanisms/xrpl/src/types.ts
+++ b/typescript/packages/mechanisms/xrpl/src/types.ts
@@ -151,6 +151,10 @@ export type XrplSimulationResult = {
    * Human-readable engine result message.
    */
   engineResultMessage?: string;
+  /**
+   * Amount the simulated transaction would deliver according to metadata.
+   */
+  deliveredAmount?: Payment["Amount"] | "unavailable";
 };
 
 /**

--- a/typescript/packages/mechanisms/xrpl/src/utils.ts
+++ b/typescript/packages/mechanisms/xrpl/src/utils.ts
@@ -342,6 +342,60 @@ export function isPositiveXrplAmount(amount: unknown): amount is NonNullable<Pay
   );
 }
 
+const STANDARD_CURRENCY_HEX_PATTERN = /^0{24}([A-F0-9]{6})0{10}$/;
+const STANDARD_CURRENCY_CODE_PATTERN = /^[A-Z0-9a-z?!@#$%^&*(){}[\]|]{3}$/;
+type XrplIssue = { currency: string; issuer: string };
+
+/**
+ * Returns the canonical identity for an XRPL currency code.
+ *
+ * XRPL serializes a standard three-character code as 12 zero bytes, the
+ * three code bytes, and 5 zero bytes. All other 160-bit values remain custom
+ * currencies and must not be shortened based on printable bytes alone.
+ *
+ * @param currency - Three-character or 160-bit XRPL currency code
+ * @returns Canonical currency identity
+ */
+function canonicalizeXrplCurrency(currency: string): string {
+  const match = STANDARD_CURRENCY_HEX_PATTERN.exec(currency);
+  if (!match) return currency;
+
+  const codeBytes = match[1]!;
+  const code = String.fromCharCode(
+    Number.parseInt(codeBytes.slice(0, 2), 16),
+    Number.parseInt(codeBytes.slice(2, 4), 16),
+    Number.parseInt(codeBytes.slice(4, 6), 16),
+  );
+  if (code === "XRP" || !STANDARD_CURRENCY_CODE_PATTERN.test(code)) return currency;
+  return code;
+}
+
+/**
+ * Compares XRPL currencies using their canonical protocol identity.
+ *
+ * @param left - First currency code
+ * @param right - Second currency code
+ * @returns Whether both values identify the same XRPL currency
+ */
+export function isSameXrplCurrency(left: string, right: string): boolean {
+  return canonicalizeXrplCurrency(left) === canonicalizeXrplCurrency(right);
+}
+
+/**
+ * Compares XRPL issued-currency issues using canonical currency and exact issuer identity.
+ *
+ * @param left - First issued-currency issue
+ * @param left.currency - First issue currency code
+ * @param left.issuer - First issue issuer address
+ * @param right - Second issued-currency issue
+ * @param right.currency - Second issue currency code
+ * @param right.issuer - Second issue issuer address
+ * @returns Whether both values identify the same XRPL issue
+ */
+export function isSameXrplIssue(left: XrplIssue, right: XrplIssue): boolean {
+  return left.issuer === right.issuer && isSameXrplCurrency(left.currency, right.currency);
+}
+
 /**
  * Checks that a positive source cap uses a different asset or issue from the destination.
  *
@@ -360,23 +414,21 @@ export function isDifferentXrplSourceAsset(
   if (!isIssuedCurrencyAmount(destinationAmount)) return false;
   if (typeof sourceAmount === "string") return true;
   if (!isIssuedCurrencyAmount(sourceAmount)) return false;
-  return (
-    sourceAmount.currency !== destinationAmount.currency ||
-    sourceAmount.issuer !== destinationAmount.issuer
-  );
+  return !isSameXrplIssue(sourceAmount, destinationAmount);
 }
 
 /**
- * Checks that an explicit XRPL path set contains at least one non-empty path.
+ * Checks that an explicit XRPL path set satisfies the protocol path bounds.
  *
  * @param paths - Signed Payment Paths field
- * @returns Whether the path set is non-empty and usable
+ * @returns Whether there are 1-6 paths with 1-8 steps in every path
  */
-export function isNonEmptyXrplPathSet(paths: Payment["Paths"]): boolean {
+export function isValidXrplPathSet(paths: Payment["Paths"]): boolean {
   return (
     Array.isArray(paths) &&
-    paths.length > 0 &&
-    paths.some(path => Array.isArray(path) && path.length > 0)
+    paths.length >= 1 &&
+    paths.length <= 6 &&
+    paths.every(path => Array.isArray(path) && path.length >= 1 && path.length <= 8)
   );
 }
 

--- a/typescript/packages/mechanisms/xrpl/src/utils.ts
+++ b/typescript/packages/mechanisms/xrpl/src/utils.ts
@@ -274,24 +274,55 @@ export function isIssuedCurrencyAmount(amount: unknown): amount is {
  * @returns -1, 0, or 1
  */
 export function compareDecimalStrings(left: string, right: string): number {
-  const normalizedLeft = normalizeDecimalString(left);
-  const normalizedRight = normalizeDecimalString(right);
+  const parsedLeft = parseUnsignedDecimal(left);
+  const parsedRight = parseUnsignedDecimal(right);
+  return compareParsedDecimals(parsedLeft, parsedRight);
+}
 
-  if (normalizedLeft.whole.length !== normalizedRight.whole.length) {
-    return normalizedLeft.whole.length > normalizedRight.whole.length ? 1 : -1;
+/**
+ * Checks issued-currency metadata equality within one XRPL precision unit.
+ *
+ * XRPL issued currencies use 15 decimal digits of precision and successful
+ * non-partial payments can report a delivered amount one least-significant
+ * precision unit away from the requested amount because of ledger rounding.
+ *
+ * @param delivered - Metadata delivered amount value
+ * @param required - Negotiated destination value
+ * @returns Whether the values are XRPL-precision equivalent
+ */
+export function areXrplTokenAmountsEquivalent(delivered: string, required: string): boolean {
+  if (!isValidXrplTokenValue(delivered, true) || !isValidXrplTokenValue(required, true)) {
+    return false;
   }
-  if (normalizedLeft.whole !== normalizedRight.whole) {
-    return normalizedLeft.whole > normalizedRight.whole ? 1 : -1;
+  let parsedDelivered: ParsedDecimal;
+  let parsedRequired: ParsedDecimal;
+  try {
+    parsedDelivered = parseUnsignedDecimal(delivered);
+    parsedRequired = parseUnsignedDecimal(required);
+  } catch {
+    return false;
   }
+  if (compareParsedDecimals(parsedDelivered, parsedRequired) === 0) return true;
+  if (parsedRequired.coefficient === 0n || parsedDelivered.coefficient === 0n) return false;
 
-  const maxFractionLength = Math.max(
-    normalizedLeft.fraction.length,
-    normalizedRight.fraction.length,
+  const requiredMagnitude =
+    parsedRequired.coefficient.toString().length - 1 + parsedRequired.exponent;
+  const toleranceExponent = requiredMagnitude - 14;
+  const commonExponent = Math.min(
+    parsedDelivered.exponent,
+    parsedRequired.exponent,
+    toleranceExponent,
   );
-  const leftFraction = normalizedLeft.fraction.padEnd(maxFractionLength, "0");
-  const rightFraction = normalizedRight.fraction.padEnd(maxFractionLength, "0");
-  if (leftFraction === rightFraction) return 0;
-  return leftFraction > rightFraction ? 1 : -1;
+  const deliveredInteger =
+    parsedDelivered.coefficient * powerOfTen(parsedDelivered.exponent - commonExponent);
+  const requiredInteger =
+    parsedRequired.coefficient * powerOfTen(parsedRequired.exponent - commonExponent);
+  const difference =
+    deliveredInteger >= requiredInteger
+      ? deliveredInteger - requiredInteger
+      : requiredInteger - deliveredInteger;
+  const tolerance = powerOfTen(toleranceExponent - commonExponent);
+  return difference <= tolerance;
 }
 
 /**
@@ -307,8 +338,7 @@ export function isPositiveXrplAmount(amount: unknown): amount is NonNullable<Pay
   return (
     isIssuedCurrencyAmount(amount) &&
     isValidClassicAddress(amount.issuer) &&
-    isDecimalString(amount.value) &&
-    compareDecimalStrings(amount.value, "0") > 0
+    isValidXrplTokenValue(amount.value, false)
   );
 }
 
@@ -670,9 +700,14 @@ export async function simulateSignedTransaction(
   try {
     await client.connect();
     const response = await client.simulate(unsignedTransaction as SubmittableTransaction);
+    const deliveredAmount =
+      typeof response.result.meta === "object" && response.result.meta !== null
+        ? response.result.meta.delivered_amount
+        : undefined;
     return {
       engineResult: response.result.engine_result,
       engineResultMessage: response.result.engine_result_message,
+      deliveredAmount,
     };
   } finally {
     await client.disconnect();
@@ -703,17 +738,93 @@ function extractCreatedTicketSequences(meta: TransactionMetadata): number[] {
 }
 
 /**
- * Normalizes a decimal string for exact decimal comparison.
+ * Parsed arbitrary-precision decimal representation.
+ *
+ * The represented value is `coefficient * 10^exponent`.
+ */
+type ParsedDecimal = {
+  coefficient: bigint;
+  exponent: number;
+};
+
+/**
+ * Parses a non-negative decimal or scientific-notation value without using
+ * binary floating point.
  *
  * @param value - Decimal string
- * @returns Normalized decimal parts
+ * @returns Integer coefficient and base-10 exponent
  */
-function normalizeDecimalString(value: string): { whole: string; fraction: string } {
-  if (!isDecimalString(value)) {
-    throw new Error(`Invalid decimal string: ${value}`);
+function parseUnsignedDecimal(value: string): ParsedDecimal {
+  const match = /^(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/.exec(value);
+  if (!match) throw new Error(`Invalid decimal string: ${value}`);
+  const explicitExponent = Number(match[3] ?? "0");
+  if (!Number.isSafeInteger(explicitExponent) || Math.abs(explicitExponent) > 1_000) {
+    throw new Error(`Invalid decimal exponent: ${value}`);
   }
-  const [rawWhole, rawFraction = ""] = value.split(".");
-  const whole = rawWhole.replace(/^0+(?=\d)/, "") || "0";
-  const fraction = rawFraction.replace(/0+$/, "");
-  return { whole, fraction };
+  const fraction = match[2] ?? "";
+  const rawDigits = `${match[1]}${fraction}`.replace(/^0+/, "");
+  if (rawDigits === "") return { coefficient: 0n, exponent: 0 };
+
+  let coefficientDigits = rawDigits;
+  let exponent = explicitExponent - fraction.length;
+  while (coefficientDigits.endsWith("0")) {
+    coefficientDigits = coefficientDigits.slice(0, -1);
+    exponent += 1;
+  }
+  return { coefficient: BigInt(coefficientDigits), exponent };
+}
+
+/**
+ * Validates the XRPL issued-currency numeric range and precision.
+ *
+ * @param value - Issued-currency value
+ * @param allowZero - Whether zero is valid
+ * @returns Whether the value can be represented by XRPL issued currency
+ */
+function isValidXrplTokenValue(value: string, allowZero: boolean): boolean {
+  try {
+    const parsed = parseUnsignedDecimal(value);
+    if (parsed.coefficient === 0n) return allowZero;
+    const coefficientDigits = parsed.coefficient.toString().length;
+    const magnitude = coefficientDigits - 1 + parsed.exponent;
+    return coefficientDigits <= 16 && magnitude >= -81 && magnitude <= 95;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compares parsed non-negative decimal values.
+ *
+ * @param left - Left parsed decimal
+ * @param right - Right parsed decimal
+ * @returns -1, 0, or 1
+ */
+function compareParsedDecimals(left: ParsedDecimal, right: ParsedDecimal): number {
+  if (left.coefficient === 0n || right.coefficient === 0n) {
+    if (left.coefficient === right.coefficient) return 0;
+    return left.coefficient === 0n ? -1 : 1;
+  }
+  const leftMagnitude = left.coefficient.toString().length + left.exponent;
+  const rightMagnitude = right.coefficient.toString().length + right.exponent;
+  if (leftMagnitude !== rightMagnitude) return leftMagnitude > rightMagnitude ? 1 : -1;
+
+  const commonExponent = Math.min(left.exponent, right.exponent);
+  const leftInteger = left.coefficient * powerOfTen(left.exponent - commonExponent);
+  const rightInteger = right.coefficient * powerOfTen(right.exponent - commonExponent);
+  if (leftInteger === rightInteger) return 0;
+  return leftInteger > rightInteger ? 1 : -1;
+}
+
+/**
+ * Computes a bounded non-negative power of ten as bigint.
+ *
+ * @param exponent - Non-negative exponent
+ * @returns 10 raised to exponent
+ */
+function powerOfTen(exponent: number): bigint {
+  if (!Number.isInteger(exponent) || exponent < 0 || exponent > 2_000) {
+    throw new Error(`Invalid decimal scaling exponent: ${exponent}`);
+  }
+  return 10n ** BigInt(exponent);
 }

--- a/typescript/packages/mechanisms/xrpl/src/utils.ts
+++ b/typescript/packages/mechanisms/xrpl/src/utils.ts
@@ -4,6 +4,7 @@ import {
   decode,
   hashes,
   isValidClassicAddress,
+  type Payment,
   type SubmittableTransaction,
   type TicketCreate,
   type Transaction,
@@ -294,6 +295,62 @@ export function compareDecimalStrings(left: string, right: string): number {
 }
 
 /**
+ * Checks whether an XRPL amount is positive and valid for a cross-currency source cap.
+ *
+ * @param amount - Source amount to validate
+ * @returns Whether the amount is positive XRP or an issued-currency amount
+ */
+export function isPositiveXrplAmount(amount: unknown): amount is NonNullable<Payment["SendMax"]> {
+  if (typeof amount === "string") {
+    return /^\d+$/.test(amount) && BigInt(amount) > 0n;
+  }
+  return (
+    isIssuedCurrencyAmount(amount) &&
+    isValidClassicAddress(amount.issuer) &&
+    isDecimalString(amount.value) &&
+    compareDecimalStrings(amount.value, "0") > 0
+  );
+}
+
+/**
+ * Checks that a positive source cap uses a different asset or issue from the destination.
+ *
+ * @param sourceAmount - Signed SendMax source cap
+ * @param destinationAmount - Exact destination Amount or DeliverMax
+ * @returns Whether the payment exchanges a different source asset or issue
+ */
+export function isDifferentXrplSourceAsset(
+  sourceAmount: unknown,
+  destinationAmount: unknown,
+): boolean {
+  if (!isPositiveXrplAmount(sourceAmount)) return false;
+  if (typeof destinationAmount === "string") {
+    return isIssuedCurrencyAmount(sourceAmount);
+  }
+  if (!isIssuedCurrencyAmount(destinationAmount)) return false;
+  if (typeof sourceAmount === "string") return true;
+  if (!isIssuedCurrencyAmount(sourceAmount)) return false;
+  return (
+    sourceAmount.currency !== destinationAmount.currency ||
+    sourceAmount.issuer !== destinationAmount.issuer
+  );
+}
+
+/**
+ * Checks that an explicit XRPL path set contains at least one non-empty path.
+ *
+ * @param paths - Signed Payment Paths field
+ * @returns Whether the path set is non-empty and usable
+ */
+export function isNonEmptyXrplPathSet(paths: Payment["Paths"]): boolean {
+  return (
+    Array.isArray(paths) &&
+    paths.length > 0 &&
+    paths.some(path => Array.isArray(path) && path.length > 0)
+  );
+}
+
+/**
  * Computes the transaction hash for a signed blob.
  *
  * @param signedTxBlob - Hex-encoded signed transaction blob
@@ -562,10 +619,15 @@ export async function submitSignedTransaction(
       typeof response.result.meta === "object" && response.result.meta !== null
         ? response.result.meta.TransactionResult
         : "unknown";
+    const deliveredAmount =
+      typeof response.result.meta === "object" && response.result.meta !== null
+        ? response.result.meta.delivered_amount
+        : undefined;
     return {
       hash: response.result.hash ?? getSignedTransactionHash(signedTxBlob),
       validated: response.result.validated === true,
       resultCode,
+      deliveredAmount,
     };
   } finally {
     await client.disconnect();

--- a/typescript/packages/mechanisms/xrpl/src/utils.ts
+++ b/typescript/packages/mechanisms/xrpl/src/utils.ts
@@ -343,7 +343,7 @@ export function isPositiveXrplAmount(amount: unknown): amount is NonNullable<Pay
 }
 
 const STANDARD_CURRENCY_HEX_PATTERN = /^0{24}([A-F0-9]{6})0{10}$/;
-const STANDARD_CURRENCY_CODE_PATTERN = /^[A-Z0-9a-z?!@#$%^&*(){}[\]|]{3}$/;
+const STANDARD_CURRENCY_CODE_PATTERN = /^[A-Z0-9a-z?!@#$%^&*<>(){}[\]|]{3}$/;
 type XrplIssue = { currency: string; issuer: string };
 
 /**

--- a/typescript/packages/mechanisms/xrpl/test/integrations/exact-xrpl.test.ts
+++ b/typescript/packages/mechanisms/xrpl/test/integrations/exact-xrpl.test.ts
@@ -85,7 +85,10 @@ describe("ExactXrplScheme settlement", () => {
       getAccountSequence: async () => 1,
       getAccountAuthorization: async () => ({ isMasterKeyDisabled: false }),
       submitSignedTransaction,
-      simulateSignedTransaction: async () => ({ engineResult: "tesSUCCESS" }),
+      simulateSignedTransaction: async () => ({
+        engineResult: "tesSUCCESS",
+        deliveredAmount: { currency: "USD", issuer, value: "10.50" },
+      }),
     });
     const server = new ExactXrplServerScheme();
     const enhancedRequirements = await server.enhancePaymentRequirements(

--- a/typescript/packages/mechanisms/xrpl/test/integrations/exact-xrpl.test.ts
+++ b/typescript/packages/mechanisms/xrpl/test/integrations/exact-xrpl.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 import { Wallet } from "xrpl";
-import { ExactXrplScheme } from "../../src/exact/facilitator/scheme";
-import { invoiceIdToInvoiceIdField } from "../../src";
+import { ExactXrplScheme as ExactXrplClientScheme } from "../../src/exact/client/scheme";
+import { ExactXrplScheme as ExactXrplFacilitatorScheme } from "../../src/exact/facilitator/scheme";
+import { ExactXrplScheme as ExactXrplServerScheme } from "../../src/exact/server/scheme";
+import { createXrplWalletSigner, invoiceIdToInvoiceIdField } from "../../src";
 import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
 import type { Payment } from "xrpl";
 
 const payerWallet = Wallet.fromSeed("sEdTM1uX8pu2do5XvTnutH6HsouMaM2");
 const invoiceId = "INV-2026-XRPL-SETTLE";
+const issuer = "rL4JcsJfvkYYAqNhjZ7Gvkh14eF7GXRh3q";
 
 const requirements: PaymentRequirements = {
   scheme: "exact",
@@ -16,6 +19,13 @@ const requirements: PaymentRequirements = {
   payTo: "rGsd42GGEq1tJBPQ3Aoj9iyePZbxiX5Nrv",
   maxTimeoutSeconds: 60,
   extra: { areFeesSponsored: false, invoiceId },
+};
+
+const crossCurrencyRequirements: PaymentRequirements = {
+  ...requirements,
+  asset: "USD",
+  amount: "10.5",
+  extra: { ...requirements.extra, issuer, crossCurrency: true },
 };
 
 function payload(): PaymentPayload {
@@ -44,7 +54,7 @@ describe("ExactXrplScheme settlement", () => {
       validated: true,
       resultCode: "tesSUCCESS",
     });
-    const facilitator = new ExactXrplScheme({
+    const facilitator = new ExactXrplFacilitatorScheme({
       getCurrentLedgerIndex: async () => 990,
       getAccountSequence: async () => 1,
       getAccountAuthorization: async () => ({ isMasterKeyDisabled: false }),
@@ -63,8 +73,59 @@ describe("ExactXrplScheme settlement", () => {
     expect(submitSignedTransaction).toHaveBeenCalledOnce();
   });
 
+  it("settles an exact cross-currency payment with matching delivery metadata", async () => {
+    const submitSignedTransaction = vi.fn().mockResolvedValue({
+      hash: "D".repeat(64),
+      validated: true,
+      resultCode: "tesSUCCESS",
+      deliveredAmount: { currency: "USD", issuer, value: "10.50" },
+    });
+    const facilitator = new ExactXrplFacilitatorScheme({
+      getCurrentLedgerIndex: async () => 990,
+      getAccountSequence: async () => 1,
+      getAccountAuthorization: async () => ({ isMasterKeyDisabled: false }),
+      submitSignedTransaction,
+      simulateSignedTransaction: async () => ({ engineResult: "tesSUCCESS" }),
+    });
+    const server = new ExactXrplServerScheme();
+    const enhancedRequirements = await server.enhancePaymentRequirements(
+      crossCurrencyRequirements,
+      {
+        x402Version: 2,
+        scheme: "exact",
+        network: "xrpl:1",
+        extra: facilitator.getExtra("xrpl:1"),
+      },
+      [],
+    );
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...transaction,
+        SendMax: "25000000",
+        Fee: "12",
+        Sequence: 1,
+        LastLedgerSequence: 1_000,
+      }),
+    });
+    const generated = await client.createPaymentPayload(2, enhancedRequirements);
+    const generatedPayload: PaymentPayload = {
+      x402Version: generated.x402Version,
+      accepted: enhancedRequirements,
+      payload: generated.payload,
+    };
+
+    const result = await facilitator.settle(generatedPayload, enhancedRequirements);
+
+    expect(result).toMatchObject({
+      success: true,
+      transaction: "D".repeat(64),
+      payer: payerWallet.classicAddress,
+    });
+    expect(submitSignedTransaction).toHaveBeenCalledOnce();
+  });
+
   it("fails settlement for a validated non-success result", async () => {
-    const facilitator = new ExactXrplScheme({
+    const facilitator = new ExactXrplFacilitatorScheme({
       getCurrentLedgerIndex: async () => 990,
       getAccountSequence: async () => 1,
       getAccountAuthorization: async () => ({ isMasterKeyDisabled: false }),

--- a/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
+++ b/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
@@ -17,7 +17,8 @@ import {
   getXrplTicketSequences,
   invoiceIdToInvoiceIdField,
   isDifferentXrplSourceAsset,
-  isNonEmptyXrplPathSet,
+  isSameXrplCurrency,
+  isValidXrplPathSet,
   resolveAssetTransferMethod,
   simulateSignedTransaction,
   submitSignedTransaction,
@@ -31,6 +32,8 @@ const payTo = "rGsd42GGEq1tJBPQ3Aoj9iyePZbxiX5Nrv";
 const issuer = "rL4JcsJfvkYYAqNhjZ7Gvkh14eF7GXRh3q";
 const invoiceId = "INV-2026-XRPL-001";
 const sourceIssuer = otherWallet.classicAddress;
+const standardUsdHex = "0000000000000000000000005553440000000000";
+const customUsdPrefixHex = "5553440000000000000000000000000000000000";
 
 const baseXrpRequirements: PaymentRequirements = {
   scheme: "exact",
@@ -71,6 +74,11 @@ const crossCurrencyIouRequirements: PaymentRequirements = {
     ...baseIouRequirements.extra,
     crossCurrency: true,
   },
+};
+
+const standardHexCrossCurrencyIouRequirements: PaymentRequirements = {
+  ...crossCurrencyIouRequirements,
+  asset: standardUsdHex,
 };
 
 const crossCurrencyXrpRequirements: PaymentRequirements = {
@@ -204,6 +212,21 @@ describe("XRPL exact utilities", () => {
     expect(
       isDifferentXrplSourceAsset({ currency: "USD", issuer, value: "20" }, destinationIou),
     ).toBe(false);
+    expect(
+      isDifferentXrplSourceAsset({ currency: standardUsdHex, issuer, value: "20" }, destinationIou),
+    ).toBe(false);
+    expect(
+      isDifferentXrplSourceAsset(
+        { currency: standardUsdHex, issuer: sourceIssuer, value: "20" },
+        destinationIou,
+      ),
+    ).toBe(true);
+    expect(
+      isDifferentXrplSourceAsset(
+        { currency: customUsdPrefixHex, issuer, value: "20" },
+        destinationIou,
+      ),
+    ).toBe(true);
     expect(isDifferentXrplSourceAsset("0", destinationIou)).toBe(false);
     expect(
       isDifferentXrplSourceAsset(
@@ -219,10 +242,24 @@ describe("XRPL exact utilities", () => {
     ).toBe(false);
   });
 
-  it("recognizes only non-empty explicit path sets", () => {
-    expect(isNonEmptyXrplPathSet([[{ account: issuer }]])).toBe(true);
-    expect(isNonEmptyXrplPathSet([])).toBe(false);
-    expect(isNonEmptyXrplPathSet([[]])).toBe(false);
+  it("compares only exact standard-layout currency hex as a three-character code", () => {
+    expect(isSameXrplCurrency("USD", standardUsdHex)).toBe(true);
+    expect(isSameXrplCurrency(standardUsdHex, "USD")).toBe(true);
+    expect(isSameXrplCurrency("USD", customUsdPrefixHex)).toBe(false);
+    expect(isSameXrplCurrency("XRP", "0000000000000000000000005852500000000000")).toBe(false);
+  });
+
+  it("enforces explicit PathSet protocol bounds", () => {
+    const step = { account: issuer };
+
+    expect(isValidXrplPathSet([[step]])).toBe(true);
+    expect(isValidXrplPathSet(Array.from({ length: 6 }, () => [step]))).toBe(true);
+    expect(isValidXrplPathSet([Array.from({ length: 8 }, () => step)])).toBe(true);
+    expect(isValidXrplPathSet([])).toBe(false);
+    expect(isValidXrplPathSet([[]])).toBe(false);
+    expect(isValidXrplPathSet([[step], []])).toBe(false);
+    expect(isValidXrplPathSet(Array.from({ length: 7 }, () => [step]))).toBe(false);
+    expect(isValidXrplPathSet([Array.from({ length: 9 }, () => step)])).toBe(false);
   });
 
   it("defaults the asset transfer method to sequence", () => {
@@ -806,6 +843,21 @@ describe("ExactXrplScheme client", () => {
     expect(decoded.DeliverMin).toBeUndefined();
   });
 
+  it("accepts the standard-layout hex form of the destination currency", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...(await preparePaymentForTest(transaction)),
+        SendMax: "25000000",
+      }),
+    });
+
+    const result = await client.createPaymentPayload(2, standardHexCrossCurrencyIouRequirements);
+    const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
+
+    expect(decoded.Amount).toEqual({ currency: "USD", issuer, value: "10.5" });
+    expect(decoded.SendMax).toBe("25000000");
+  });
+
   it("creates a cross-currency XRP destination payment with explicit paths", async () => {
     const sourceAmount = { currency: "USD", issuer: sourceIssuer, value: "20" };
     const paths: NonNullable<Payment["Paths"]> = [[{ account: issuer }]];
@@ -839,6 +891,20 @@ describe("ExactXrplScheme client", () => {
     const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
 
     expect(decoded.SendMax).toEqual({ currency: "EUR", issuer: sourceIssuer, value: "0.00001" });
+  });
+
+  it("preserves a custom 160-bit source currency that begins with USD bytes", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...(await preparePaymentForTest(transaction)),
+        SendMax: { currency: customUsdPrefixHex, issuer, value: "20" },
+      }),
+    });
+
+    const result = await client.createPaymentPayload(2, crossCurrencyIouRequirements);
+    const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
+
+    expect(decoded.SendMax).toEqual({ currency: customUsdPrefixHex, issuer, value: "20" });
   });
 
   it("requires explicit quote preparation before signing cross-currency payments", async () => {
@@ -877,6 +943,11 @@ describe("ExactXrplScheme client", () => {
       payment => ({ ...payment, SendMax: { currency: "USD", issuer, value: "20" } }),
       "different source asset",
     ],
+    [
+      "same-issue standard-layout hex SendMax",
+      payment => ({ ...payment, SendMax: { currency: standardUsdHex, issuer, value: "20" } }),
+      "different source asset",
+    ],
     ["zero SendMax", payment => ({ ...payment, SendMax: "0" }), "positive SendMax"],
     [
       "DeliverMin",
@@ -896,7 +967,34 @@ describe("ExactXrplScheme client", () => {
     [
       "empty Paths",
       payment => ({ ...payment, SendMax: "25000000", Paths: [] }),
-      "at least one non-empty path",
+      "1-6 paths with 1-8 steps each",
+    ],
+    [
+      "empty sibling Path",
+      payment => ({
+        ...payment,
+        SendMax: "25000000",
+        Paths: [[{ account: sourceIssuer }], []],
+      }),
+      "1-6 paths with 1-8 steps each",
+    ],
+    [
+      "seven Paths",
+      payment => ({
+        ...payment,
+        SendMax: "25000000",
+        Paths: Array.from({ length: 7 }, () => [{ account: sourceIssuer }]),
+      }),
+      "1-6 paths with 1-8 steps each",
+    ],
+    [
+      "nine Path steps",
+      payment => ({
+        ...payment,
+        SendMax: "25000000",
+        Paths: [Array.from({ length: 9 }, () => ({ account: sourceIssuer }))],
+      }),
+      "1-6 paths with 1-8 steps each",
     ],
     [
       "changed destination amount",
@@ -1194,12 +1292,35 @@ describe("ExactXrplScheme facilitator verify", () => {
     });
   });
 
+  it("accepts canonical standard-layout hex destination requirements", async () => {
+    const result = await facilitator.verify(
+      buildPayload(standardHexCrossCurrencyIouRequirements, { SendMax: "25000000" }),
+      standardHexCrossCurrencyIouRequirements,
+    );
+
+    expect(result).toMatchObject({
+      isValid: true,
+      payer: payerWallet.classicAddress,
+    });
+  });
+
   it("accepts an exact XRP destination with an issued-currency source cap", async () => {
     const result = await facilitator.verify(
       buildPayload(crossCurrencyXrpRequirements, {
         SendMax: { currency: "USD", issuer: sourceIssuer, value: "20" },
       }),
       crossCurrencyXrpRequirements,
+    );
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it("accepts a custom 160-bit source issue that begins with USD bytes", async () => {
+    const result = await facilitator.verify(
+      buildPayload(crossCurrencyIouRequirements, {
+        SendMax: { currency: customUsdPrefixHex, issuer, value: "20" },
+      }),
+      crossCurrencyIouRequirements,
     );
 
     expect(result.isValid).toBe(true);
@@ -1257,6 +1378,11 @@ describe("ExactXrplScheme facilitator verify", () => {
       { SendMax: { currency: "USD", issuer, value: "20" } },
       "cross_currency_sendmax",
     ],
+    [
+      "same-issue standard-layout hex SendMax",
+      { SendMax: { currency: standardUsdHex, issuer, value: "20" } },
+      "cross_currency_sendmax",
+    ],
     ["zero SendMax", { SendMax: "0" }, "cross_currency_sendmax"],
     [
       "partial payment",
@@ -1272,6 +1398,22 @@ describe("ExactXrplScheme facilitator verify", () => {
       "tfNoRippleDirect without Paths",
       { SendMax: "25000000", Flags: TF_NO_RIPPLE_DIRECT },
       "default_path_disabled_without_paths",
+    ],
+    [
+      "seven Paths",
+      {
+        SendMax: "25000000",
+        Paths: Array.from({ length: 7 }, () => [{ account: sourceIssuer }]),
+      },
+      "paths_malformed",
+    ],
+    [
+      "nine Path steps",
+      {
+        SendMax: "25000000",
+        Paths: [Array.from({ length: 9 }, () => ({ account: sourceIssuer }))],
+      },
+      "paths_malformed",
     ],
   ])("rejects cross-currency payment with %s", async (_name, overrides, expectedReason) => {
     const result = await facilitator.verify(

--- a/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
+++ b/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
@@ -34,6 +34,8 @@ const invoiceId = "INV-2026-XRPL-001";
 const sourceIssuer = otherWallet.classicAddress;
 const standardUsdHex = "0000000000000000000000005553440000000000";
 const customUsdPrefixHex = "5553440000000000000000000000000000000000";
+const angleBracketCurrency = "A>B";
+const angleBracketCurrencyHex = "000000000000000000000000413E420000000000";
 
 const baseXrpRequirements: PaymentRequirements = {
   scheme: "exact",
@@ -79,6 +81,11 @@ const crossCurrencyIouRequirements: PaymentRequirements = {
 const standardHexCrossCurrencyIouRequirements: PaymentRequirements = {
   ...crossCurrencyIouRequirements,
   asset: standardUsdHex,
+};
+
+const angleBracketCrossCurrencyIouRequirements: PaymentRequirements = {
+  ...crossCurrencyIouRequirements,
+  asset: angleBracketCurrency,
 };
 
 const crossCurrencyXrpRequirements: PaymentRequirements = {
@@ -245,6 +252,7 @@ describe("XRPL exact utilities", () => {
   it("compares only exact standard-layout currency hex as a three-character code", () => {
     expect(isSameXrplCurrency("USD", standardUsdHex)).toBe(true);
     expect(isSameXrplCurrency(standardUsdHex, "USD")).toBe(true);
+    expect(isSameXrplCurrency(angleBracketCurrency, angleBracketCurrencyHex)).toBe(true);
     expect(isSameXrplCurrency("USD", customUsdPrefixHex)).toBe(false);
     expect(isSameXrplCurrency("XRP", "0000000000000000000000005852500000000000")).toBe(false);
   });
@@ -858,6 +866,21 @@ describe("ExactXrplScheme client", () => {
     expect(decoded.SendMax).toBe("25000000");
   });
 
+  it("accepts an angle-bracket currency whose wire form decodes as standard-layout hex", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...(await preparePaymentForTest(transaction)),
+        SendMax: "25000000",
+      }),
+    });
+
+    const result = await client.createPaymentPayload(2, angleBracketCrossCurrencyIouRequirements);
+    const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
+
+    expect(decoded.Amount).toEqual({ currency: angleBracketCurrencyHex, issuer, value: "10.5" });
+    expect(decoded.SendMax).toBe("25000000");
+  });
+
   it("creates a cross-currency XRP destination payment with explicit paths", async () => {
     const sourceAmount = { currency: "USD", issuer: sourceIssuer, value: "20" };
     const paths: NonNullable<Payment["Paths"]> = [[{ account: issuer }]];
@@ -1296,6 +1319,18 @@ describe("ExactXrplScheme facilitator verify", () => {
     const result = await facilitator.verify(
       buildPayload(standardHexCrossCurrencyIouRequirements, { SendMax: "25000000" }),
       standardHexCrossCurrencyIouRequirements,
+    );
+
+    expect(result).toMatchObject({
+      isValid: true,
+      payer: payerWallet.classicAddress,
+    });
+  });
+
+  it("accepts an angle-bracket requirement matching its standard-layout wire hex", async () => {
+    const result = await facilitator.verify(
+      buildPayload(angleBracketCrossCurrencyIouRequirements, { SendMax: "25000000" }),
+      angleBracketCrossCurrencyIouRequirements,
     );
 
     expect(result).toMatchObject({

--- a/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
+++ b/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
@@ -11,6 +11,7 @@ import {
   TF_NO_RIPPLE_DIRECT,
   TF_PARTIAL_PAYMENT,
   XRPL_TESTNET,
+  areXrplTokenAmountsEquivalent,
   compareDecimalStrings,
   createTickets,
   getXrplTicketSequences,
@@ -156,7 +157,13 @@ function createFacilitator(
       getAccountAuthorization: async () => ({ isMasterKeyDisabled: false }),
       isTicketAvailable: async () => true,
       maxFeeDrops: DEFAULT_MAX_FEE_DROPS,
-      simulateSignedTransaction: async () => ({ engineResult: "tesSUCCESS" }),
+      simulateSignedTransaction: async signedTxBlob => {
+        const transaction = decode(signedTxBlob) as Payment;
+        return {
+          engineResult: "tesSUCCESS",
+          deliveredAmount: transaction.DeliverMax ?? transaction.Amount,
+        };
+      },
       ...overrides,
     },
     settlementCache,
@@ -172,6 +179,16 @@ describe("XRPL exact utilities", () => {
     expect(compareDecimalStrings("10.5", "10.50")).toBe(0);
     expect(compareDecimalStrings("10.5", "10.49")).toBe(1);
     expect(compareDecimalStrings("0.000001", "0.00001")).toBe(-1);
+    expect(compareDecimalStrings("1.23e11", "123000000000")).toBe(0);
+    expect(compareDecimalStrings("1E-5", "0.000009")).toBe(1);
+  });
+
+  it("compares delivered token amounts using XRPL precision", () => {
+    expect(areXrplTokenAmountsEquivalent("10.5", "10.50")).toBe(true);
+    expect(areXrplTokenAmountsEquivalent("10.49999999999999", "10.5")).toBe(true);
+    expect(areXrplTokenAmountsEquivalent("10.499999999", "10.5")).toBe(false);
+    expect(areXrplTokenAmountsEquivalent("1.23e11", "123000000000")).toBe(true);
+    expect(areXrplTokenAmountsEquivalent("1e1000", "10.5")).toBe(false);
   });
 
   it("recognizes positive cross-currency source caps", () => {
@@ -188,6 +205,18 @@ describe("XRPL exact utilities", () => {
       isDifferentXrplSourceAsset({ currency: "USD", issuer, value: "20" }, destinationIou),
     ).toBe(false);
     expect(isDifferentXrplSourceAsset("0", destinationIou)).toBe(false);
+    expect(
+      isDifferentXrplSourceAsset(
+        { currency: "EUR", issuer: sourceIssuer, value: "1e-5" },
+        destinationIou,
+      ),
+    ).toBe(true);
+    expect(
+      isDifferentXrplSourceAsset(
+        { currency: "EUR", issuer: sourceIssuer, value: "1E96" },
+        destinationIou,
+      ),
+    ).toBe(false);
   });
 
   it("recognizes only non-empty explicit path sets", () => {
@@ -245,6 +274,12 @@ describe("XRPL exact utilities", () => {
       result: {
         engine_result: "tesSUCCESS",
         engine_result_message: "The transaction was applied.",
+        meta: {
+          TransactionIndex: 0,
+          TransactionResult: "tesSUCCESS",
+          AffectedNodes: [],
+          delivered_amount: "1000000",
+        },
       },
     }));
     const fakeClient = {
@@ -270,6 +305,7 @@ describe("XRPL exact utilities", () => {
     expect(result).toEqual({
       engineResult: "tesSUCCESS",
       engineResultMessage: "The transaction was applied.",
+      deliveredAmount: "1000000",
     });
   });
 
@@ -789,6 +825,20 @@ describe("ExactXrplScheme client", () => {
     expect(decoded.SendMax).toEqual(sourceAmount);
     expect(decoded.Paths).toEqual(paths);
     expect(Number(decoded.Flags) & TF_NO_RIPPLE_DIRECT).toBe(TF_NO_RIPPLE_DIRECT);
+  });
+
+  it("accepts a scientific-notation issued-currency source cap", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...(await preparePaymentForTest(transaction)),
+        SendMax: { currency: "EUR", issuer: sourceIssuer, value: "1e-5" },
+      }),
+    });
+
+    const result = await client.createPaymentPayload(2, crossCurrencyIouRequirements);
+    const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
+
+    expect(decoded.SendMax).toEqual({ currency: "EUR", issuer: sourceIssuer, value: "0.00001" });
   });
 
   it("requires explicit quote preparation before signing cross-currency payments", async () => {
@@ -1597,6 +1647,23 @@ describe("ExactXrplScheme facilitator verify", () => {
     expect(result.invalidReason).toContain("simulation_failed: tecPATH_DRY");
   });
 
+  it("fails cross-currency verification when simulation metadata under-delivers", async () => {
+    const simulator = createFacilitator({
+      simulateSignedTransaction: async () => ({
+        engineResult: "tesSUCCESS",
+        deliveredAmount: { currency: "USD", issuer, value: "10.49" },
+      }),
+    });
+
+    const result = await simulator.verify(
+      buildPayload(crossCurrencyIouRequirements, { SendMax: "25000000" }),
+      crossCurrencyIouRequirements,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toContain("simulation_delivered_amount_mismatch");
+  });
+
   it("rejects a non-Payment transaction", async () => {
     const blob = buildBlobFromTransaction({
       TransactionType: "AccountSet",
@@ -1983,13 +2050,13 @@ describe("ExactXrplScheme facilitator settle", () => {
     expect(submitSignedTransaction).toHaveBeenCalledOnce();
   });
 
-  it("settles cross-currency only when delivered_amount is exact", async () => {
+  it("settles cross-currency when delivered_amount is XRPL-precision equivalent", async () => {
     const settleFacilitator = createFacilitator({
       submitSignedTransaction: async () => ({
         hash: settledHash,
         validated: true,
         resultCode: "tesSUCCESS",
-        deliveredAmount: { currency: "USD", issuer, value: "10.50" },
+        deliveredAmount: { currency: "USD", issuer, value: "10.49999999999999" },
       }),
     });
 

--- a/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
+++ b/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
@@ -8,13 +8,18 @@ import {
   DEFAULT_MAX_FEE_DROPS,
   SETTLEMENT_TTL_MS,
   SettlementCache,
+  TF_NO_RIPPLE_DIRECT,
+  TF_PARTIAL_PAYMENT,
   XRPL_TESTNET,
   compareDecimalStrings,
   createTickets,
   getXrplTicketSequences,
   invoiceIdToInvoiceIdField,
+  isDifferentXrplSourceAsset,
+  isNonEmptyXrplPathSet,
   resolveAssetTransferMethod,
   simulateSignedTransaction,
+  submitSignedTransaction,
 } from "../../src";
 import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
 import type { Client, Payment, Transaction } from "xrpl";
@@ -24,6 +29,7 @@ const otherWallet = Wallet.fromSeed("sEd7t79mzn2dwy3vvpvRmaaLbLhvme6");
 const payTo = "rGsd42GGEq1tJBPQ3Aoj9iyePZbxiX5Nrv";
 const issuer = "rL4JcsJfvkYYAqNhjZ7Gvkh14eF7GXRh3q";
 const invoiceId = "INV-2026-XRPL-001";
+const sourceIssuer = otherWallet.classicAddress;
 
 const baseXrpRequirements: PaymentRequirements = {
   scheme: "exact",
@@ -55,6 +61,22 @@ const ticketXrpRequirements: PaymentRequirements = {
   extra: {
     ...baseXrpRequirements.extra,
     assetTransferMethod: "ticketSequence",
+  },
+};
+
+const crossCurrencyIouRequirements: PaymentRequirements = {
+  ...baseIouRequirements,
+  extra: {
+    ...baseIouRequirements.extra,
+    crossCurrency: true,
+  },
+};
+
+const crossCurrencyXrpRequirements: PaymentRequirements = {
+  ...baseXrpRequirements,
+  extra: {
+    ...baseXrpRequirements.extra,
+    crossCurrency: true,
   },
 };
 
@@ -152,6 +174,28 @@ describe("XRPL exact utilities", () => {
     expect(compareDecimalStrings("0.000001", "0.00001")).toBe(-1);
   });
 
+  it("recognizes positive cross-currency source caps", () => {
+    const destinationIou = { currency: "USD", issuer, value: "10.5" };
+
+    expect(isDifferentXrplSourceAsset("25000000", destinationIou)).toBe(true);
+    expect(
+      isDifferentXrplSourceAsset(
+        { currency: "EUR", issuer: sourceIssuer, value: "20" },
+        destinationIou,
+      ),
+    ).toBe(true);
+    expect(
+      isDifferentXrplSourceAsset({ currency: "USD", issuer, value: "20" }, destinationIou),
+    ).toBe(false);
+    expect(isDifferentXrplSourceAsset("0", destinationIou)).toBe(false);
+  });
+
+  it("recognizes only non-empty explicit path sets", () => {
+    expect(isNonEmptyXrplPathSet([[{ account: issuer }]])).toBe(true);
+    expect(isNonEmptyXrplPathSet([])).toBe(false);
+    expect(isNonEmptyXrplPathSet([[]])).toBe(false);
+  });
+
   it("defaults the asset transfer method to sequence", () => {
     const payload = buildPayload(baseXrpRequirements);
 
@@ -227,6 +271,34 @@ describe("XRPL exact utilities", () => {
       engineResult: "tesSUCCESS",
       engineResultMessage: "The transaction was applied.",
     });
+  });
+
+  it("extracts delivered_amount from validated submission metadata", async () => {
+    const deliveredAmount = { currency: "USD", issuer, value: "10.5" };
+    const fakeClient = {
+      connect: vi.fn(async () => undefined),
+      disconnect: vi.fn(async () => undefined),
+      submitAndWait: vi.fn(async () => ({
+        result: {
+          hash: "D".repeat(64),
+          validated: true,
+          meta: {
+            TransactionIndex: 0,
+            TransactionResult: "tesSUCCESS",
+            AffectedNodes: [],
+            delivered_amount: deliveredAmount,
+          },
+        },
+      })),
+    } as unknown as Client;
+
+    const result = await submitSignedTransaction(
+      String(buildPayload(baseXrpRequirements).payload.signedTxBlob),
+      XRPL_TESTNET,
+      { clientFactory: () => fakeClient },
+    );
+
+    expect(result.deliveredAmount).toEqual(deliveredAmount);
   });
 
   it("lists available ticket sequences across paginated ledger objects", async () => {
@@ -582,6 +654,55 @@ describe("ExactXrplScheme server", () => {
       ),
     ).toThrow("destinationTag");
   });
+
+  it("preserves cross-currency opt-in when the facilitator supports it", async () => {
+    const server = new ExactXrplServerScheme();
+
+    const result = await server.enhancePaymentRequirements(
+      crossCurrencyIouRequirements,
+      {
+        x402Version: 2,
+        scheme: "exact",
+        network: XRPL_TESTNET,
+        extra: { features: { crossCurrency: true } },
+      },
+      [],
+    );
+
+    expect(result.extra?.crossCurrency).toBe(true);
+  });
+
+  it("rejects cross-currency requirements with an incompatible facilitator", () => {
+    const server = new ExactXrplServerScheme();
+
+    expect(() =>
+      server.enhancePaymentRequirements(
+        crossCurrencyIouRequirements,
+        { x402Version: 2, scheme: "exact", network: XRPL_TESTNET },
+        [],
+      ),
+    ).toThrow("does not advertise cross-currency");
+  });
+
+  it("rejects false cross-currency negotiation", () => {
+    const server = new ExactXrplServerScheme();
+
+    expect(() =>
+      server.enhancePaymentRequirements(
+        {
+          ...baseXrpRequirements,
+          extra: { ...baseXrpRequirements.extra, crossCurrency: false },
+        },
+        {
+          x402Version: 2,
+          scheme: "exact",
+          network: XRPL_TESTNET,
+          extra: { features: { crossCurrency: true } },
+        },
+        [],
+      ),
+    ).toThrow("crossCurrency to be true");
+  });
 });
 
 describe("ExactXrplScheme client", () => {
@@ -630,6 +751,117 @@ describe("ExactXrplScheme client", () => {
     expect(decoded.Sequence).toBe(1);
     expect(decoded.Fee).toBe(DEFAULT_MAX_FEE_DROPS);
     expect(decoded.LastLedgerSequence).toBe(994);
+  });
+
+  it("creates a cross-currency IOU destination payment with an XRP source cap", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...(await preparePaymentForTest(transaction)),
+        SendMax: "25000000",
+      }),
+    });
+
+    const result = await client.createPaymentPayload(2, crossCurrencyIouRequirements);
+    const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
+
+    expect(decoded.Amount).toEqual({ currency: "USD", issuer, value: "10.5" });
+    expect(decoded.SendMax).toBe("25000000");
+    expect(decoded.Paths).toBeUndefined();
+    expect(decoded.DeliverMin).toBeUndefined();
+  });
+
+  it("creates a cross-currency XRP destination payment with explicit paths", async () => {
+    const sourceAmount = { currency: "USD", issuer: sourceIssuer, value: "20" };
+    const paths: NonNullable<Payment["Paths"]> = [[{ account: issuer }]];
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...(await preparePaymentForTest(transaction)),
+        SendMax: sourceAmount,
+        Paths: paths,
+        Flags: TF_NO_RIPPLE_DIRECT,
+      }),
+    });
+
+    const result = await client.createPaymentPayload(2, crossCurrencyXrpRequirements);
+    const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
+
+    expect(decoded.Amount).toBe(baseXrpRequirements.amount);
+    expect(decoded.SendMax).toEqual(sourceAmount);
+    expect(decoded.Paths).toEqual(paths);
+    expect(Number(decoded.Flags) & TF_NO_RIPPLE_DIRECT).toBe(TF_NO_RIPPLE_DIRECT);
+  });
+
+  it("requires explicit quote preparation before signing cross-currency payments", async () => {
+    const sign = vi.fn(createXrplWalletSigner(payerWallet).sign);
+    const client = new ExactXrplClientScheme({
+      classicAddress: payerWallet.classicAddress,
+      sign,
+    });
+
+    await expect(client.createPaymentPayload(2, crossCurrencyIouRequirements)).rejects.toThrow(
+      "require preparePaymentTransaction",
+    );
+    expect(sign).not.toHaveBeenCalled();
+  });
+
+  it("rejects false cross-currency negotiation before signing", async () => {
+    const sign = vi.fn(createXrplWalletSigner(payerWallet).sign);
+    const client = new ExactXrplClientScheme({
+      classicAddress: payerWallet.classicAddress,
+      sign,
+    });
+
+    await expect(
+      client.createPaymentPayload(2, {
+        ...baseXrpRequirements,
+        extra: { ...baseXrpRequirements.extra, crossCurrency: false },
+      }),
+    ).rejects.toThrow("crossCurrency to be true");
+    expect(sign).not.toHaveBeenCalled();
+  });
+
+  it.each<Array<[string, (payment: Payment) => Payment, string]>>([
+    ["missing SendMax", payment => ({ ...payment, SendMax: undefined }), "positive SendMax"],
+    [
+      "same-issue SendMax",
+      payment => ({ ...payment, SendMax: { currency: "USD", issuer, value: "20" } }),
+      "different source asset",
+    ],
+    ["zero SendMax", payment => ({ ...payment, SendMax: "0" }), "positive SendMax"],
+    [
+      "DeliverMin",
+      payment => ({ ...payment, SendMax: "25000000", DeliverMin: "1" }),
+      "must not set DeliverMin",
+    ],
+    [
+      "partial payment",
+      payment => ({ ...payment, SendMax: "25000000", Flags: TF_PARTIAL_PAYMENT }),
+      "must not enable tfPartialPayment",
+    ],
+    [
+      "tfNoRippleDirect without Paths",
+      payment => ({ ...payment, SendMax: "25000000", Flags: TF_NO_RIPPLE_DIRECT }),
+      "requires explicit Paths",
+    ],
+    [
+      "empty Paths",
+      payment => ({ ...payment, SendMax: "25000000", Paths: [] }),
+      "at least one non-empty path",
+    ],
+    [
+      "changed destination amount",
+      payment => ({ ...payment, Amount: { currency: "USD", issuer, value: "9" }, SendMax: "25" }),
+      "preserve the exact IOU destination amount",
+    ],
+  ])("rejects a cross-currency preparer with %s", async (_name, mutate, expectedMessage) => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction =>
+        mutate(await preparePaymentForTest(transaction)),
+    });
+
+    await expect(client.createPaymentPayload(2, crossCurrencyIouRequirements)).rejects.toThrow(
+      expectedMessage,
+    );
   });
 
   it("creates a ticketSequence payment when the requirements pin the method", async () => {
@@ -900,8 +1132,105 @@ describe("ExactXrplScheme facilitator verify", () => {
     });
   });
 
-  it("advertises unsponsored fees in supported metadata", () => {
-    expect(facilitator.getExtra(XRPL_TESTNET)).toEqual({ areFeesSponsored: false });
+  it("accepts an exact IOU destination with an XRP source cap", async () => {
+    const result = await facilitator.verify(
+      buildPayload(crossCurrencyIouRequirements, { SendMax: "25000000" }),
+      crossCurrencyIouRequirements,
+    );
+
+    expect(result).toMatchObject({
+      isValid: true,
+      payer: payerWallet.classicAddress,
+    });
+  });
+
+  it("accepts an exact XRP destination with an issued-currency source cap", async () => {
+    const result = await facilitator.verify(
+      buildPayload(crossCurrencyXrpRequirements, {
+        SendMax: { currency: "USD", issuer: sourceIssuer, value: "20" },
+      }),
+      crossCurrencyXrpRequirements,
+    );
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it("accepts explicit paths with tfNoRippleDirect", async () => {
+    const result = await facilitator.verify(
+      buildPayload(crossCurrencyIouRequirements, {
+        SendMax: "25000000",
+        Paths: [[{ account: sourceIssuer }]],
+        Flags: TF_NO_RIPPLE_DIRECT,
+      }),
+      crossCurrencyIouRequirements,
+    );
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it("advertises unsponsored fees and cross-currency support", () => {
+    expect(facilitator.getExtra(XRPL_TESTNET)).toEqual({
+      areFeesSponsored: false,
+      features: { crossCurrency: true },
+    });
+  });
+
+  it("rejects malformed or mismatched cross-currency envelope negotiation", async () => {
+    const basePayload = buildPayload(baseIouRequirements);
+    const malformedRequirements = {
+      ...baseIouRequirements,
+      extra: { ...baseIouRequirements.extra, crossCurrency: false },
+    };
+    const malformed = await facilitator.verify(
+      { ...basePayload, accepted: malformedRequirements },
+      malformedRequirements,
+    );
+    const mismatched = await facilitator.verify(
+      {
+        ...basePayload,
+        accepted: {
+          ...basePayload.accepted,
+          extra: { ...basePayload.accepted.extra, crossCurrency: true },
+        },
+      },
+      baseIouRequirements,
+    );
+
+    expect(malformed.invalidReason).toBe("invalid_exact_xrpl_cross_currency_malformed");
+    expect(mismatched.invalidReason).toBe("invalid_exact_xrpl_cross_currency_mismatch");
+  });
+
+  it.each<Array<[string, Partial<Payment>, string]>>([
+    ["missing SendMax", { SendMax: undefined }, "cross_currency_sendmax"],
+    [
+      "same-issue SendMax",
+      { SendMax: { currency: "USD", issuer, value: "20" } },
+      "cross_currency_sendmax",
+    ],
+    ["zero SendMax", { SendMax: "0" }, "cross_currency_sendmax"],
+    [
+      "partial payment",
+      { SendMax: "25000000", Flags: TF_PARTIAL_PAYMENT },
+      "partial_payment_not_allowed",
+    ],
+    [
+      "DeliverMin",
+      { SendMax: "25000000", DeliverMin: "1", Flags: TF_PARTIAL_PAYMENT },
+      "delivermin_not_allowed",
+    ],
+    [
+      "tfNoRippleDirect without Paths",
+      { SendMax: "25000000", Flags: TF_NO_RIPPLE_DIRECT },
+      "default_path_disabled_without_paths",
+    ],
+  ])("rejects cross-currency payment with %s", async (_name, overrides, expectedReason) => {
+    const result = await facilitator.verify(
+      buildPayload(crossCurrencyIouRequirements, overrides),
+      crossCurrencyIouRequirements,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toContain(expectedReason);
   });
 
   it("returns a stable reason and separate message for malformed payloads", async () => {
@@ -1252,6 +1581,20 @@ describe("ExactXrplScheme facilitator verify", () => {
 
     expect(result.isValid).toBe(false);
     expect(result.invalidReason).toContain("simulation_failed");
+  });
+
+  it("fails cross-currency verification closed when route simulation fails", async () => {
+    const simulator = createFacilitator({
+      simulateSignedTransaction: async () => ({ engineResult: "tecPATH_DRY" }),
+    });
+
+    const result = await simulator.verify(
+      buildPayload(crossCurrencyIouRequirements, { SendMax: "25000000" }),
+      crossCurrencyIouRequirements,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toContain("simulation_failed: tecPATH_DRY");
   });
 
   it("rejects a non-Payment transaction", async () => {
@@ -1638,6 +1981,48 @@ describe("ExactXrplScheme facilitator settle", () => {
       payer: payerWallet.classicAddress,
     });
     expect(submitSignedTransaction).toHaveBeenCalledOnce();
+  });
+
+  it("settles cross-currency only when delivered_amount is exact", async () => {
+    const settleFacilitator = createFacilitator({
+      submitSignedTransaction: async () => ({
+        hash: settledHash,
+        validated: true,
+        resultCode: "tesSUCCESS",
+        deliveredAmount: { currency: "USD", issuer, value: "10.50" },
+      }),
+    });
+
+    const result = await settleFacilitator.settle(
+      buildPayload(crossCurrencyIouRequirements, { SendMax: "25000000" }),
+      crossCurrencyIouRequirements,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each<Array<[string, Payment["Amount"] | "unavailable" | undefined]>>([
+    ["missing metadata", undefined],
+    ["unavailable metadata", "unavailable"],
+    ["wrong value", { currency: "USD", issuer, value: "10.49" }],
+    ["wrong issue", { currency: "USD", issuer: sourceIssuer, value: "10.5" }],
+  ])("rejects cross-currency settlement with %s", async (_name, deliveredAmount) => {
+    const settleFacilitator = createFacilitator({
+      submitSignedTransaction: async () => ({
+        hash: settledHash,
+        validated: true,
+        resultCode: "tesSUCCESS",
+        deliveredAmount,
+      }),
+    });
+
+    const result = await settleFacilitator.settle(
+      buildPayload(crossCurrencyIouRequirements, { SendMax: "25000000" }),
+      crossCurrencyIouRequirements,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe("transaction_failed: delivered_amount_mismatch");
   });
 
   it("does not submit when re-verification fails", async () => {


### PR DESCRIPTION
## Description

Implements the official TypeScript reference implementation for #2865.

This PR depends on the XRPL amendment in #2872 and must not merge before that specification is accepted. The implementation diff is code, docs, tests, and a changeset only; it does not modify the specification.

- negotiates `extra.crossCurrency: true` through supported capabilities
- preserves exact destination `Amount` while requiring a payer-approved source-asset `SendMax` cap
- accepts XRPL scientific-notation IOU caps with arbitrary-precision validation
- canonicalizes only valid three-character currencies and their exact XRPL standard 160-bit layout for issue comparison, including `USD` and `A>B`, while preserving custom 160-bit currency identity
- enforces default/explicit path policy; explicit `Paths` require 1–6 paths and 1–8 steps in every path with no empty sibling
- rejects invalid paths client-side before signing and facilitator-side before mandatory simulation
- rejects partial payment and `DeliverMin`
- requires simulation `delivered_amount` and validated settlement metadata
- applies an XRPL 15-significant-digit precision bound to IOU metadata, avoiding post-payment false failures
- integrates client, resource-server scheme, facilitator verification/settlement, SDK parity docs, examples, tests, and changeset

AI assistance was used to draft code, tests, and documentation. The contributor reviewed the resulting diff and test evidence.

## Independent review

Two independent reviewers inspected the final specification, implementation, and combined interoperability diffs. Canonical issue identity, angle-bracket standard currencies, custom 160-bit preservation, the 1–6 × 1–8 PathSet bounds, client/facilitator validation order, mandatory simulation, and test adequacy were explicitly re-checked. Reviewer 1's two spec wording P2s were fixed in #2872 and both reviewers confirmed the fixes; no actionable P0/P1/P2 remains.

Both reviewers explicitly retained `toleranceExponent = magnitude - 14`: XRPL documents 15-significant-digit ledger token arithmetic, yielding one ULP of `10^(magnitude-14)`; no rippled/protocol evidence showed a different precision model for `delivered_amount`.

A signed compatibility branch at [`test/xrpl-amendments-combined`](https://github.com/aristotle-satoshi/x402/tree/test/xrpl-amendments-combined) retains both attribution and cross-currency suites and includes combined SourceTag/Memo/InvoiceID/SendMax/default-path/explicit-path coverage.

## Tests

- `cd typescript && pnpm format && pnpm lint && pnpm build && pnpm test` — 28/28 format, 28/28 lint, 28/28 build, 55/55 test tasks
- `cd typescript/packages/mechanisms/xrpl && pnpm format && pnpm lint && pnpm build && pnpm test` — 173/173 tests
- `cd typescript/packages/mechanisms/xrpl && pnpm test:integration` — 3 passed; 1 credential-gated live test skipped
- combined branch `b35b2d7a9feb54d5cd300a3cb167f50092902b0d` — 326/326 unit tests; 5 integration tests passed; 1 credential-gated live test skipped
- `cd typescript && pnpm changeset status` — valid
- `git diff --check` — clean
- current head: `c98218ffee0fb0897510ed42d9aa28d3ad121dda`
- 4/4 branch commits have good signatures: `37ee5183`, `7934a6ff`, `e38f4c3d`, `c98218ff`
- current head: 16/16 repository GitHub Actions checks passed
- Vercel preview status remains failed because the fork author lacks Coinbase Vercel deployment authorization; no deploy is part of this PR

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes