### PR TITLE
feat(xrpl): add facilitator attribution

### DIFF
--- a/docs/schemes/exact.mdx
+++ b/docs/schemes/exact.mdx
@@ -238,6 +238,29 @@ const resourceServer = new x402ResourceServer(facilitatorClient)
 }
 ```
 
+To require facilitator attribution, the resource server selects a `sourceTag`
+and may add a 32-byte `facilitatorProof` commitment:
+
+```typescript
+{
+  scheme: "exact",
+  price: { amount: "1000000", asset: "XRP" },
+  network: "xrpl:1",
+  payTo: "rYourXrplAddress",
+  extra: {
+    sourceTag: 804681468,
+    facilitatorProof:
+      "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+  },
+}
+```
+
+The server advertises these fields only when the selected facilitator reports
+the matching capabilities. The client then signs the negotiated `SourceTag`
+and, when a proof is present, its canonical typed Memo. The facilitator never
+inserts a fallback tag. Invoice binding remains independent and uses
+`extra.invoiceId` plus the signed `InvoiceID` field.
+
 **Client**
 
 ```typescript

--- a/docs/schemes/exact.mdx
+++ b/docs/schemes/exact.mdx
@@ -261,6 +261,12 @@ and, when a proof is present, its canonical typed Memo. The facilitator never
 inserts a fallback tag. Invoice binding remains independent and uses
 `extra.invoiceId` plus the signed `InvoiceID` field.
 
+The tag and Memo identify the facilitator expected by the resource server; they
+do not authenticate the network peer that broadcasts the payer-signed blob.
+When attribution is omitted, a custom transaction preparer may preserve an
+independent payer-signed `SourceTag`, but it has no facilitator-attribution
+meaning.
+
 **Client**
 
 ```typescript

--- a/docs/sdk-features.md
+++ b/docs/sdk-features.md
@@ -59,6 +59,12 @@ This page tracks which features are implemented in each SDK (TypeScript, Go, Pyt
 | batch-settlement | evm | `eip3009` | ✅ | ✅ | ✅ |
 | batch-settlement | evm | `permit2` | ✅ | ✅ | ✅ |
 
+### XRPL Optional Capabilities
+
+| Capability | TypeScript | Go | Python |
+|------------|------------|-----|--------|
+| Facilitator attribution (`sourceTag`, `facilitatorProof`) | ✅ | ❌ | ❌ |
+
 ## Extensions
 
 | Extension | TypeScript | Go | Python |

--- a/typescript/.changeset/xrpl-facilitator-attribution.md
+++ b/typescript/.changeset/xrpl-facilitator-attribution.md
@@ -1,0 +1,5 @@
+---
+"@x402/xrpl": minor
+---
+
+Add explicitly negotiated XRPL facilitator attribution using `extra.sourceTag` and an optional canonical `extra.facilitatorProof` Memo, with client, resource-server, facilitator, capability advertisement, and validation support.

--- a/typescript/packages/mechanisms/xrpl/README.md
+++ b/typescript/packages/mechanisms/xrpl/README.md
@@ -96,7 +96,9 @@ Resource servers can explicitly bind a payment to the facilitator expected to su
 }
 ```
 
-The server checks the facilitator's `/supported` metadata before advertising these fields. The official facilitator advertises `features.sourceTag` and `features.facilitatorProof`; it never supplies a fallback tag. If the fields are omitted, the client omits both `SourceTag` and `Memos`.
+The server checks the facilitator's `/supported` metadata before advertising these fields. The official facilitator advertises `features.sourceTag` and `features.facilitatorProof`; it never supplies a fallback tag. If the fields are omitted, the default client omits both `SourceTag` and `Memos`. For backward compatibility, a custom transaction preparer may preserve its own payer-signed `SourceTag`, but that value has no facilitator-attribution meaning.
+
+These fields label the facilitator expected by the resource server; they do not prove which network peer broadcast the signed blob. Do not use them alone for rewards, security decisions, or submitter accountability.
 
 Invoice binding is independent and continues to use `extra.invoiceId` plus the signed `InvoiceID` field. The facilitator-attribution Memo is never accepted as invoice binding.
 

--- a/typescript/packages/mechanisms/xrpl/README.md
+++ b/typescript/packages/mechanisms/xrpl/README.md
@@ -28,6 +28,7 @@ The payer signs a complete XRPL `Payment` transaction and pays the XRPL transact
 - `createTickets(signer, network, ticketCount)` - Creates XRPL Tickets for `ticketSequence` payments.
 - `getXrplTicketSequences(account, network)` - Lists an account's available ticket sequences.
 - `invoiceIdToInvoiceIdField(invoiceId)` - Converts an invoice id to an XRPL `InvoiceID`.
+- `buildFacilitatorAttributionMemos(sourceTag, facilitatorProof)` - Builds the canonical facilitator-attribution Memo.
 - XRPL network constants: `XRPL_MAINNET`, `XRPL_TESTNET`, `XRPL_DEVNET`.
 
 ### Subpath Exports
@@ -73,6 +74,31 @@ const ticketSequences = await createTickets(signer, "xrpl:1", 5);
 ```
 
 Each outstanding ticket locks owner reserve (currently 0.2 XRP on mainnet) until it is used or deleted, and an account can hold at most 250 outstanding tickets.
+
+## Facilitator Attribution
+
+Resource servers can explicitly bind a payment to the facilitator expected to submit it:
+
+- `extra.sourceTag` is an XRPL `uint32` selected by the resource server and copied into the signed transaction's `SourceTag`.
+- `extra.facilitatorProof` is an optional 32-byte hex commitment. It requires `sourceTag` and is encoded with that tag in one canonical typed Memo.
+
+```typescript
+{
+  scheme: "exact",
+  price: { amount: "1000000", asset: "XRP" },
+  network: "xrpl:1",
+  payTo: "r...",
+  extra: {
+    sourceTag: 804681468,
+    facilitatorProof:
+      "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+  },
+}
+```
+
+The server checks the facilitator's `/supported` metadata before advertising these fields. The official facilitator advertises `features.sourceTag` and `features.facilitatorProof`; it never supplies a fallback tag. If the fields are omitted, the client omits both `SourceTag` and `Memos`.
+
+Invoice binding is independent and continues to use `extra.invoiceId` plus the signed `InvoiceID` field. The facilitator-attribution Memo is never accepted as invoice binding.
 
 ## Testnet Setup
 
@@ -136,7 +162,7 @@ Use explicit asset pricing:
 }
 ```
 
-The server scheme adds `extra.areFeesSponsored: false` to the advertised requirements. Invoice binding is enforced when the resource configuration provides `extra.invoiceId`; requirements are rebuilt for every request, so the scheme never injects per-request values.
+The server scheme adds `extra.areFeesSponsored: false` to the advertised requirements. Invoice binding is enforced when the resource configuration provides `extra.invoiceId`; facilitator attribution is enforced only when the resource configuration provides `extra.sourceTag` and optionally `extra.facilitatorProof`. Requirements are rebuilt for every request, so the scheme never injects per-request values.
 
 ### Facilitator
 
@@ -147,7 +173,7 @@ import { ExactXrplScheme } from "@x402/xrpl/exact/facilitator";
 const facilitator = new x402Facilitator().register("xrpl:*", new ExactXrplScheme());
 ```
 
-Verification enforces the spec's checks: envelope consistency, offline signature validation, signer-to-account authorization (the embedded `SigningPubKey` must be the account's master key pair, unless disabled, or its configured regular key), destination and amount matching, NetworkID binding, per-method sequencing (current account `Sequence`, or ticket availability), `LastLedgerSequence` expiry policy, invoice binding via `InvoiceID`, fee caps, safety rejections (`Delegate`, `Memos`, `Paths`, `DeliverMin`, partial payments, multisigned blobs), and an XRPL simulation. Settlement re-runs verification, submits the signed blob, and succeeds only on a validated `tesSUCCESS` result.
+Verification enforces the spec's checks: envelope consistency, offline signature validation, signer-to-account authorization (the embedded `SigningPubKey` must be the account's master key pair, unless disabled, or its configured regular key), destination and amount matching, NetworkID binding, per-method sequencing (current account `Sequence`, or ticket availability), `LastLedgerSequence` expiry policy, invoice binding via `InvoiceID`, negotiated `SourceTag` and canonical facilitator-attribution Memo validation, fee caps, safety rejections (`Delegate`, unnegotiated `Memos`, `Paths`, `DeliverMin`, partial payments, multisigned blobs), and an XRPL simulation. Settlement re-runs verification, submits the signed blob, and succeeds only on a validated `tesSUCCESS` result.
 
 ## Duplicate Settlement Protection
 

--- a/typescript/packages/mechanisms/xrpl/src/constants.ts
+++ b/typescript/packages/mechanisms/xrpl/src/constants.ts
@@ -71,6 +71,20 @@ export const CANONICAL_SIGNING_PUB_KEY_PATTERN = /^(02|03|ED)[0-9A-F]{64}$/i;
 export const MAX_DESTINATION_TAG = 0xffffffff;
 
 /**
+ * Canonical XRPL MemoType for x402 facilitator attribution.
+ * UTF-8 `urn:x402:xrpl:facilitator`, encoded as uppercase hex.
+ */
+export const FACILITATOR_ATTRIBUTION_MEMO_TYPE =
+  "75726E3A783430323A7872706C3A666163696C697461746F72";
+
+/**
+ * Canonical XRPL MemoFormat for x402 facilitator attribution.
+ * UTF-8 `application/octet-stream`, encoded as uppercase hex.
+ */
+export const FACILITATOR_ATTRIBUTION_MEMO_FORMAT =
+  "6170706C69636174696F6E2F6F637465742D73747265616D";
+
+/**
  * Maximum number of outstanding tickets an XRPL account can hold.
  */
 export const MAX_ACCOUNT_TICKETS = 250;

--- a/typescript/packages/mechanisms/xrpl/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/client/scheme.ts
@@ -1,12 +1,16 @@
 import {
+  buildFacilitatorAttributionMemos,
   createTickets,
   createXrplClient,
+  getFacilitatorAttributionMemoError,
   getMaxLastLedgerSequence,
   getXrplTicketSequences,
   invoiceIdToInvoiceIdField,
   isDecimalString,
+  isValidFacilitatorProof,
   isIntegerString,
   isValidDestinationTag,
+  isValidSourceTag,
   isXrplAssetTransferMethod,
   isXrplNetwork,
   parseXrplNetworkId,
@@ -94,6 +98,12 @@ export class ExactXrplScheme implements SchemeNetworkClient {
         "XRPL exact payments require extra.destinationTag to be a 32-bit unsigned integer",
       );
     }
+    const sourceTag = isValidSourceTag(requirements.extra?.sourceTag)
+      ? requirements.extra.sourceTag
+      : undefined;
+    const facilitatorProof = isValidFacilitatorProof(requirements.extra?.facilitatorProof)
+      ? requirements.extra.facilitatorProof
+      : undefined;
     const isXrp = requirements.asset === "XRP";
     let amount: Payment["Amount"] = requirements.amount;
     let sendMax: Payment["SendMax"];
@@ -118,6 +128,10 @@ export class ExactXrplScheme implements SchemeNetworkClient {
       ...(this.options.feeDrops !== undefined ? { Fee: this.options.feeDrops } : {}),
       ...(lastLedgerSequence !== undefined ? { LastLedgerSequence: lastLedgerSequence } : {}),
       ...(destinationTag !== undefined ? { DestinationTag: destinationTag } : {}),
+      ...(sourceTag !== undefined ? { SourceTag: sourceTag } : {}),
+      ...(facilitatorProof !== undefined && sourceTag !== undefined
+        ? { Memos: buildFacilitatorAttributionMemos(sourceTag, facilitatorProof) }
+        : {}),
       ...(networkId > 1024 ? { NetworkID: networkId } : {}),
     };
 
@@ -184,7 +198,7 @@ export class ExactXrplScheme implements SchemeNetworkClient {
       ? await this.options.preparePaymentTransaction(transaction, requirements)
       : await this.autofillPaymentTransaction(transaction, requirements);
 
-    this.validatePreparedPaymentTransaction(preparedPayment, requirements.network, method);
+    this.validatePreparedPaymentTransaction(preparedPayment, requirements, method);
     return preparedPayment;
   }
 
@@ -223,12 +237,12 @@ export class ExactXrplScheme implements SchemeNetworkClient {
    * Ensures the transaction can be submitted after signing.
    *
    * @param transaction - Prepared XRPL payment transaction
-   * @param network - XRPL network id
+   * @param requirements - Payment requirements encoded by the transaction
    * @param method - Selected asset transfer method
    */
   private validatePreparedPaymentTransaction(
     transaction: Payment,
-    network: Network,
+    requirements: PaymentRequirements,
     method: XrplAssetTransferMethod,
   ): void {
     if (transaction.TransactionType !== "Payment") {
@@ -255,7 +269,28 @@ export class ExactXrplScheme implements SchemeNetworkClient {
     if (typeof transaction.LastLedgerSequence !== "number") {
       throw new Error("preparePaymentTransaction must set LastLedgerSequence");
     }
-    const networkId = parseXrplNetworkId(network);
+    const sourceTag = isValidSourceTag(requirements.extra?.sourceTag)
+      ? requirements.extra.sourceTag
+      : undefined;
+    if (transaction.SourceTag !== sourceTag) {
+      throw new Error("preparePaymentTransaction must preserve the negotiated SourceTag");
+    }
+    const facilitatorProof = isValidFacilitatorProof(requirements.extra?.facilitatorProof)
+      ? requirements.extra.facilitatorProof
+      : undefined;
+    if (facilitatorProof === undefined) {
+      if (transaction.Memos !== undefined) {
+        throw new Error("preparePaymentTransaction must not add unnegotiated Memos");
+      }
+    } else if (
+      sourceTag === undefined ||
+      getFacilitatorAttributionMemoError(transaction.Memos, sourceTag, facilitatorProof) !==
+        undefined
+    ) {
+      throw new Error("preparePaymentTransaction must preserve the facilitator attribution Memo");
+    }
+
+    const networkId = parseXrplNetworkId(requirements.network);
     if (networkId <= 1024 && transaction.NetworkID !== undefined) {
       throw new Error(
         "preparePaymentTransaction must not set NetworkID for standard XRPL networks",
@@ -288,6 +323,23 @@ export class ExactXrplScheme implements SchemeNetworkClient {
     if (requirements.extra?.invoiceId !== undefined) {
       if (typeof requirements.extra.invoiceId !== "string" || requirements.extra.invoiceId === "") {
         throw new Error("XRPL exact payments require a non-empty extra.invoiceId when provided");
+      }
+    }
+    const sourceTag = requirements.extra?.sourceTag;
+    if (sourceTag !== undefined && !isValidSourceTag(sourceTag)) {
+      throw new Error(
+        "XRPL exact payments require extra.sourceTag to be a 32-bit unsigned integer",
+      );
+    }
+    const facilitatorProof = requirements.extra?.facilitatorProof;
+    if (facilitatorProof !== undefined) {
+      if (!isValidFacilitatorProof(facilitatorProof)) {
+        throw new Error(
+          "XRPL exact payments require extra.facilitatorProof to be 64 hexadecimal characters",
+        );
+      }
+      if (sourceTag === undefined) {
+        throw new Error("XRPL exact payments require extra.sourceTag with facilitatorProof");
       }
     }
     if (requirements.asset === "XRP") {

--- a/typescript/packages/mechanisms/xrpl/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/client/scheme.ts
@@ -272,7 +272,7 @@ export class ExactXrplScheme implements SchemeNetworkClient {
     const sourceTag = isValidSourceTag(requirements.extra?.sourceTag)
       ? requirements.extra.sourceTag
       : undefined;
-    if (transaction.SourceTag !== sourceTag) {
+    if (sourceTag !== undefined && transaction.SourceTag !== sourceTag) {
       throw new Error("preparePaymentTransaction must preserve the negotiated SourceTag");
     }
     const facilitatorProof = isValidFacilitatorProof(requirements.extra?.facilitatorProof)

--- a/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
@@ -418,9 +418,6 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     const facilitatorProof = requirements.extra?.facilitatorProof;
 
     if (sourceTag === undefined) {
-      if (transaction.SourceTag !== undefined) {
-        return "invalid_exact_xrpl_payload_source_tag_unexpected";
-      }
       if (transaction.Memos !== undefined) {
         return "invalid_exact_xrpl_payload_memos_not_allowed";
       }

--- a/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/facilitator/scheme.ts
@@ -10,6 +10,7 @@ import {
   decodeSignedTransactionBlob,
   getCurrentLedgerIndex,
   getExactXrplPayload,
+  getFacilitatorAttributionMemoError,
   getMaxLastLedgerSequence,
   getSignedTransactionHash,
   getXrplAccountAuthorization,
@@ -18,6 +19,8 @@ import {
   isIssuedCurrencyAmount,
   isRecord,
   isValidDestinationTag,
+  isValidFacilitatorProof,
+  isValidSourceTag,
   isXrplNetwork,
   isXrplTicketAvailable,
   parseXrplNetworkId,
@@ -65,7 +68,13 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
    * @returns Extra metadata advertising that fees are never sponsored
    */
   getExtra(_network: Network): Record<string, unknown> | undefined {
-    return { areFeesSponsored: false };
+    return {
+      areFeesSponsored: false,
+      features: {
+        sourceTag: true,
+        facilitatorProof: true,
+      },
+    };
   }
 
   /**
@@ -299,6 +308,35 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     if (payload.accepted.extra?.destinationTag !== requirements.extra?.destinationTag) {
       return "invalid_exact_xrpl_destination_tag_mismatch";
     }
+    const requiredSourceTag = requirements.extra?.sourceTag;
+    const acceptedSourceTag = payload.accepted.extra?.sourceTag;
+    if (
+      (requiredSourceTag !== undefined && !isValidSourceTag(requiredSourceTag)) ||
+      (acceptedSourceTag !== undefined && !isValidSourceTag(acceptedSourceTag))
+    ) {
+      return "invalid_exact_xrpl_source_tag_malformed";
+    }
+    if (acceptedSourceTag !== requiredSourceTag) {
+      return "invalid_exact_xrpl_source_tag_mismatch";
+    }
+    const requiredFacilitatorProof = requirements.extra?.facilitatorProof;
+    const acceptedFacilitatorProof = payload.accepted.extra?.facilitatorProof;
+    if (
+      (requiredFacilitatorProof !== undefined &&
+        !isValidFacilitatorProof(requiredFacilitatorProof)) ||
+      (acceptedFacilitatorProof !== undefined && !isValidFacilitatorProof(acceptedFacilitatorProof))
+    ) {
+      return "invalid_exact_xrpl_facilitator_proof_malformed";
+    }
+    if (
+      (requiredFacilitatorProof !== undefined && requiredSourceTag === undefined) ||
+      (acceptedFacilitatorProof !== undefined && acceptedSourceTag === undefined)
+    ) {
+      return "invalid_exact_xrpl_facilitator_proof_requires_source_tag";
+    }
+    if (acceptedFacilitatorProof !== requiredFacilitatorProof) {
+      return "invalid_exact_xrpl_facilitator_proof_mismatch";
+    }
     if (requirements.asset !== "XRP") {
       try {
         requireClassicAddress(requirements.extra?.issuer, "issuer");
@@ -353,12 +391,75 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
         : this.verifyIouAmount(transaction, requirements);
     if (amountError) return amountError;
 
+    const attributionError = this.verifyFacilitatorAttribution(transaction, requirements);
+    if (attributionError) return attributionError;
+
     const invoiceError = this.verifyInvoiceBinding(transaction, requirements);
     if (invoiceError) return invoiceError;
 
     const feeError = this.verifyFee(transaction);
     if (feeError) return feeError;
 
+    return undefined;
+  }
+
+  /**
+   * Verifies negotiated SourceTag and canonical facilitator-attribution Memo fields.
+   *
+   * @param transaction - Decoded XRPL payment transaction
+   * @param requirements - Payment requirements
+   * @returns Invalid reason, if validation fails
+   */
+  private verifyFacilitatorAttribution(
+    transaction: Payment,
+    requirements: PaymentRequirements,
+  ): string | undefined {
+    const sourceTag = requirements.extra?.sourceTag;
+    const facilitatorProof = requirements.extra?.facilitatorProof;
+
+    if (sourceTag === undefined) {
+      if (transaction.SourceTag !== undefined) {
+        return "invalid_exact_xrpl_payload_source_tag_unexpected";
+      }
+      if (transaction.Memos !== undefined) {
+        return "invalid_exact_xrpl_payload_memos_not_allowed";
+      }
+      return undefined;
+    }
+    if (!isValidSourceTag(sourceTag)) {
+      return "invalid_exact_xrpl_source_tag_malformed";
+    }
+    if (transaction.SourceTag !== sourceTag) {
+      return "invalid_exact_xrpl_payload_source_tag_mismatch";
+    }
+
+    if (facilitatorProof === undefined) {
+      if (transaction.Memos !== undefined) {
+        return "invalid_exact_xrpl_payload_memos_not_allowed";
+      }
+      return undefined;
+    }
+    if (!isValidFacilitatorProof(facilitatorProof)) {
+      return "invalid_exact_xrpl_facilitator_proof_malformed";
+    }
+
+    const memoError = getFacilitatorAttributionMemoError(
+      transaction.Memos,
+      sourceTag,
+      facilitatorProof,
+    );
+    if (memoError === "missing") {
+      return "invalid_exact_xrpl_payload_attribution_memo_missing";
+    }
+    if (memoError === "cardinality") {
+      return "invalid_exact_xrpl_payload_attribution_memo_cardinality";
+    }
+    if (memoError === "malformed") {
+      return "invalid_exact_xrpl_payload_attribution_memo_malformed";
+    }
+    if (memoError === "mismatch") {
+      return "invalid_exact_xrpl_payload_attribution_memo_mismatch";
+    }
     return undefined;
   }
 
@@ -472,10 +573,6 @@ export class ExactXrplScheme implements SchemeNetworkFacilitator {
     transaction: Payment,
     requirements: PaymentRequirements,
   ): string | undefined {
-    if (transaction.Memos !== undefined) {
-      return "invalid_exact_xrpl_payload_memos_not_allowed";
-    }
-
     const invoiceId = requirements.extra?.invoiceId;
     if (invoiceId === undefined) {
       return undefined;

--- a/typescript/packages/mechanisms/xrpl/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/server/scheme.ts
@@ -12,7 +12,10 @@ import { parseMoneyString } from "@x402/core/utils";
 import {
   isDecimalString,
   isIntegerString,
+  isRecord,
   isValidDestinationTag,
+  isValidFacilitatorProof,
+  isValidSourceTag,
   isXrplAssetTransferMethod,
   requireClassicAddress,
 } from "../../utils";
@@ -85,7 +88,6 @@ export class ExactXrplScheme implements SchemeNetworkServer {
     supportedKind: SupportedKind,
     extensionKeys: string[],
   ): Promise<PaymentRequirements> {
-    void supportedKind;
     void extensionKeys;
 
     const assetTransferMethod = paymentRequirements.extra?.assetTransferMethod;
@@ -101,6 +103,34 @@ export class ExactXrplScheme implements SchemeNetworkServer {
       throw new Error(
         "XRPL exact payments require extra.destinationTag to be a 32-bit unsigned integer",
       );
+    }
+    const sourceTag = paymentRequirements.extra?.sourceTag;
+    if (sourceTag !== undefined && !isValidSourceTag(sourceTag)) {
+      throw new Error(
+        "XRPL exact payments require extra.sourceTag to be a 32-bit unsigned integer",
+      );
+    }
+    const facilitatorProof = paymentRequirements.extra?.facilitatorProof;
+    if (facilitatorProof !== undefined) {
+      if (!isValidFacilitatorProof(facilitatorProof)) {
+        throw new Error(
+          "XRPL exact payments require extra.facilitatorProof to be 64 hexadecimal characters",
+        );
+      }
+      if (sourceTag === undefined) {
+        throw new Error("XRPL exact payments require extra.sourceTag with facilitatorProof");
+      }
+    }
+
+    const features = supportedKind.extra?.features;
+    if (sourceTag !== undefined && (!isRecord(features) || features.sourceTag !== true)) {
+      throw new Error("XRPL facilitator does not advertise SourceTag attribution support");
+    }
+    if (
+      facilitatorProof !== undefined &&
+      (!isRecord(features) || features.facilitatorProof !== true)
+    ) {
+      throw new Error("XRPL facilitator does not advertise facilitatorProof support");
     }
 
     return Promise.resolve({

--- a/typescript/packages/mechanisms/xrpl/src/types.ts
+++ b/typescript/packages/mechanisms/xrpl/src/types.ts
@@ -49,6 +49,15 @@ export type XrplPaymentRequirementsExtra = {
    */
   destinationTag?: number;
   /**
+   * Optional facilitator attribution tag selected by the resource server.
+   */
+  sourceTag?: number;
+  /**
+   * Optional 32-byte facilitator proof commitment encoded as 64 hex characters.
+   * Requires sourceTag.
+   */
+  facilitatorProof?: string;
+  /**
    * Required IOU issuer address for issued-currency payments.
    */
   issuer?: string;

--- a/typescript/packages/mechanisms/xrpl/src/utils.ts
+++ b/typescript/packages/mechanisms/xrpl/src/utils.ts
@@ -4,6 +4,7 @@ import {
   decode,
   hashes,
   isValidClassicAddress,
+  type Payment,
   type SubmittableTransaction,
   type TicketCreate,
   type Transaction,
@@ -12,6 +13,8 @@ import {
 import {
   DEFAULT_LEDGER_CLOSE_SECONDS,
   DEFAULT_LEDGER_TOLERANCE,
+  FACILITATOR_ATTRIBUTION_MEMO_FORMAT,
+  FACILITATOR_ATTRIBUTION_MEMO_TYPE,
   LSF_DISABLE_MASTER,
   MAX_ACCOUNT_TICKETS,
   MAX_DESTINATION_TAG,
@@ -212,6 +215,116 @@ export function isValidDestinationTag(value: unknown): value is number {
     value >= 0 &&
     value <= MAX_DESTINATION_TAG
   );
+}
+
+/**
+ * Checks whether a value is a valid XRPL source tag.
+ *
+ * @param value - Value to inspect
+ * @returns Whether the value is a 32-bit unsigned integer
+ */
+export function isValidSourceTag(value: unknown): value is number {
+  return isValidDestinationTag(value);
+}
+
+/**
+ * Checks whether a value is a 32-byte facilitator proof commitment.
+ *
+ * @param value - Value to inspect
+ * @returns Whether the value is exactly 64 hexadecimal characters
+ */
+export function isValidFacilitatorProof(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Fa-f0-9]{64}$/.test(value);
+}
+
+/**
+ * Builds the canonical facilitator-attribution MemoData value.
+ *
+ * @param sourceTag - Negotiated facilitator source tag
+ * @param facilitatorProof - 32-byte facilitator proof commitment
+ * @returns Four-byte source tag followed by proof bytes, as uppercase hex
+ */
+export function facilitatorAttributionMemoData(
+  sourceTag: number,
+  facilitatorProof: string,
+): string {
+  if (!isValidSourceTag(sourceTag)) {
+    throw new Error("sourceTag must be a 32-bit unsigned integer");
+  }
+  if (!isValidFacilitatorProof(facilitatorProof)) {
+    throw new Error("facilitatorProof must be 64 hexadecimal characters");
+  }
+
+  return `${sourceTag.toString(16).padStart(8, "0")}${facilitatorProof}`.toUpperCase();
+}
+
+/**
+ * Builds the canonical, single XRPL Memo for facilitator attribution.
+ *
+ * @param sourceTag - Negotiated facilitator source tag
+ * @param facilitatorProof - 32-byte facilitator proof commitment
+ * @returns A one-entry XRPL Memos array
+ */
+export function buildFacilitatorAttributionMemos(
+  sourceTag: number,
+  facilitatorProof: string,
+): NonNullable<Payment["Memos"]> {
+  return [
+    {
+      Memo: {
+        MemoType: FACILITATOR_ATTRIBUTION_MEMO_TYPE,
+        MemoFormat: FACILITATOR_ATTRIBUTION_MEMO_FORMAT,
+        MemoData: facilitatorAttributionMemoData(sourceTag, facilitatorProof),
+      },
+    },
+  ];
+}
+
+/**
+ * Canonical facilitator-attribution Memo validation failures.
+ */
+export type FacilitatorAttributionMemoError = "missing" | "cardinality" | "malformed" | "mismatch";
+
+/**
+ * Validates the exact facilitator-attribution Memo encoding and cardinality.
+ *
+ * @param memos - Signed XRPL Memos field
+ * @param sourceTag - Negotiated facilitator source tag
+ * @param facilitatorProof - Negotiated facilitator proof commitment
+ * @returns Validation failure, or undefined when canonical
+ */
+export function getFacilitatorAttributionMemoError(
+  memos: Payment["Memos"],
+  sourceTag: number,
+  facilitatorProof: string,
+): FacilitatorAttributionMemoError | undefined {
+  if (memos === undefined) return "missing";
+  if (!Array.isArray(memos) || memos.length !== 1) return "cardinality";
+
+  const entry = memos[0];
+  if (!isRecord(entry) || !isRecord(entry.Memo)) return "malformed";
+
+  const memo = entry.Memo;
+  if (
+    Object.keys(memo).length !== 3 ||
+    typeof memo.MemoType !== "string" ||
+    typeof memo.MemoFormat !== "string" ||
+    typeof memo.MemoData !== "string" ||
+    !/^[A-F0-9]+$/.test(memo.MemoType) ||
+    !/^[A-F0-9]+$/.test(memo.MemoFormat) ||
+    !/^[A-F0-9]{72}$/.test(memo.MemoData)
+  ) {
+    return "malformed";
+  }
+
+  if (
+    memo.MemoType !== FACILITATOR_ATTRIBUTION_MEMO_TYPE ||
+    memo.MemoFormat !== FACILITATOR_ATTRIBUTION_MEMO_FORMAT ||
+    memo.MemoData !== facilitatorAttributionMemoData(sourceTag, facilitatorProof)
+  ) {
+    return "mismatch";
+  }
+  return undefined;
 }
 
 /**

--- a/typescript/packages/mechanisms/xrpl/test/integrations/exact-xrpl.test.ts
+++ b/typescript/packages/mechanisms/xrpl/test/integrations/exact-xrpl.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
 import { Wallet } from "xrpl";
-import { ExactXrplScheme } from "../../src/exact/facilitator/scheme";
-import { invoiceIdToInvoiceIdField } from "../../src";
+import { ExactXrplScheme as ExactXrplClientScheme } from "../../src/exact/client/scheme";
+import { ExactXrplScheme as ExactXrplFacilitatorScheme } from "../../src/exact/facilitator/scheme";
+import { ExactXrplScheme as ExactXrplServerScheme } from "../../src/exact/server/scheme";
+import {
+  buildFacilitatorAttributionMemos,
+  createXrplWalletSigner,
+  invoiceIdToInvoiceIdField,
+} from "../../src";
 import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
 import type { Payment } from "xrpl";
 
 const payerWallet = Wallet.fromSeed("sEdTM1uX8pu2do5XvTnutH6HsouMaM2");
 const invoiceId = "INV-2026-XRPL-SETTLE";
+const sourceTag = 804_681_468;
+const facilitatorProof = "ab".repeat(32);
 
 const requirements: PaymentRequirements = {
   scheme: "exact",
@@ -18,21 +26,38 @@ const requirements: PaymentRequirements = {
   extra: { areFeesSponsored: false, invoiceId },
 };
 
-function payload(): PaymentPayload {
+const attributedRequirements: PaymentRequirements = {
+  ...requirements,
+  extra: { ...requirements.extra, sourceTag, facilitatorProof },
+};
+
+function payload(paymentRequirements: PaymentRequirements = requirements): PaymentPayload {
   const tx: Payment = {
     TransactionType: "Payment",
     Account: payerWallet.classicAddress,
-    Destination: requirements.payTo,
-    Amount: requirements.amount,
+    Destination: paymentRequirements.payTo,
+    Amount: paymentRequirements.amount,
     Fee: "12",
     Sequence: 1,
     LastLedgerSequence: 1_000,
     InvoiceID: invoiceIdToInvoiceIdField(invoiceId),
+    ...(typeof paymentRequirements.extra?.sourceTag === "number"
+      ? { SourceTag: paymentRequirements.extra.sourceTag }
+      : {}),
+    ...(typeof paymentRequirements.extra?.sourceTag === "number" &&
+    typeof paymentRequirements.extra?.facilitatorProof === "string"
+      ? {
+          Memos: buildFacilitatorAttributionMemos(
+            paymentRequirements.extra.sourceTag,
+            paymentRequirements.extra.facilitatorProof,
+          ),
+        }
+      : {}),
   };
 
   return {
     x402Version: 2,
-    accepted: requirements,
+    accepted: paymentRequirements,
     payload: { signedTxBlob: payerWallet.sign(tx).tx_blob },
   };
 }
@@ -44,7 +69,7 @@ describe("ExactXrplScheme settlement", () => {
       validated: true,
       resultCode: "tesSUCCESS",
     });
-    const facilitator = new ExactXrplScheme({
+    const facilitator = new ExactXrplFacilitatorScheme({
       getCurrentLedgerIndex: async () => 990,
       getAccountSequence: async () => 1,
       getAccountAuthorization: async () => ({ isMasterKeyDisabled: false }),
@@ -63,8 +88,57 @@ describe("ExactXrplScheme settlement", () => {
     expect(submitSignedTransaction).toHaveBeenCalledOnce();
   });
 
+  it("settles a payment with negotiated facilitator attribution", async () => {
+    const submitSignedTransaction = vi.fn().mockResolvedValue({
+      hash: "D".repeat(64),
+      validated: true,
+      resultCode: "tesSUCCESS",
+    });
+    const facilitator = new ExactXrplFacilitatorScheme({
+      getCurrentLedgerIndex: async () => 990,
+      getAccountSequence: async () => 1,
+      getAccountAuthorization: async () => ({ isMasterKeyDisabled: false }),
+      submitSignedTransaction,
+      simulateSignedTransaction: async () => ({ engineResult: "tesSUCCESS" }),
+    });
+    const server = new ExactXrplServerScheme();
+    const enhancedRequirements = await server.enhancePaymentRequirements(
+      attributedRequirements,
+      {
+        x402Version: 2,
+        scheme: "exact",
+        network: "xrpl:1",
+        extra: facilitator.getExtra("xrpl:1"),
+      },
+      [],
+    );
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...transaction,
+        Fee: "12",
+        Sequence: 1,
+        LastLedgerSequence: 1_000,
+      }),
+    });
+    const generated = await client.createPaymentPayload(2, enhancedRequirements);
+    const generatedPayload: PaymentPayload = {
+      x402Version: generated.x402Version,
+      accepted: enhancedRequirements,
+      payload: generated.payload,
+    };
+
+    const result = await facilitator.settle(generatedPayload, enhancedRequirements);
+
+    expect(result).toMatchObject({
+      success: true,
+      transaction: "D".repeat(64),
+      payer: payerWallet.classicAddress,
+    });
+    expect(submitSignedTransaction).toHaveBeenCalledOnce();
+  });
+
   it("fails settlement for a validated non-success result", async () => {
-    const facilitator = new ExactXrplScheme({
+    const facilitator = new ExactXrplFacilitatorScheme({
       getCurrentLedgerIndex: async () => 990,
       getAccountSequence: async () => 1,
       getAccountAuthorization: async () => ({ isMasterKeyDisabled: false }),

--- a/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
+++ b/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
@@ -776,6 +776,21 @@ describe("ExactXrplScheme client", () => {
     );
   });
 
+  it("preserves a payer-selected SourceTag when attribution is not negotiated", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...(await preparePaymentForTest(transaction)),
+        SourceTag: sourceTag,
+      }),
+    });
+
+    const result = await client.createPaymentPayload(2, baseXrpRequirements);
+    const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
+
+    expect(decoded.SourceTag).toBe(sourceTag);
+    expect(baseXrpRequirements.extra?.sourceTag).toBeUndefined();
+  });
+
   it("rejects a preparer that changes the attribution Memo", async () => {
     const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
       preparePaymentTransaction: async transaction => ({
@@ -1161,13 +1176,13 @@ describe("ExactXrplScheme facilitator verify", () => {
     expect(result.invalidReason).toBe("invalid_exact_xrpl_source_tag_mismatch");
   });
 
-  it("rejects a transaction SourceTag that was not negotiated", async () => {
+  it("accepts a payer-signed SourceTag without giving it attribution semantics", async () => {
     const result = await facilitator.verify(
       buildPayload(baseXrpRequirements, { SourceTag: sourceTag }),
       baseXrpRequirements,
     );
 
-    expect(result.invalidReason).toBe("invalid_exact_xrpl_payload_source_tag_unexpected");
+    expect(result.isValid).toBe(true);
   });
 
   it("rejects a missing or mismatched negotiated transaction SourceTag", async () => {

--- a/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
+++ b/typescript/packages/mechanisms/xrpl/test/unit/xrpl.test.ts
@@ -6,11 +6,15 @@ import { ExactXrplScheme as ExactXrplServerScheme } from "../../src/exact/server
 import { createXrplWalletSigner } from "../../src/signer";
 import {
   DEFAULT_MAX_FEE_DROPS,
+  FACILITATOR_ATTRIBUTION_MEMO_FORMAT,
+  FACILITATOR_ATTRIBUTION_MEMO_TYPE,
   SETTLEMENT_TTL_MS,
   SettlementCache,
   XRPL_TESTNET,
   compareDecimalStrings,
+  buildFacilitatorAttributionMemos,
   createTickets,
+  facilitatorAttributionMemoData,
   getXrplTicketSequences,
   invoiceIdToInvoiceIdField,
   resolveAssetTransferMethod,
@@ -24,6 +28,8 @@ const otherWallet = Wallet.fromSeed("sEd7t79mzn2dwy3vvpvRmaaLbLhvme6");
 const payTo = "rGsd42GGEq1tJBPQ3Aoj9iyePZbxiX5Nrv";
 const issuer = "rL4JcsJfvkYYAqNhjZ7Gvkh14eF7GXRh3q";
 const invoiceId = "INV-2026-XRPL-001";
+const sourceTag = 804_681_468;
+const facilitatorProof = "0123456789abcdef".repeat(4);
 
 const baseXrpRequirements: PaymentRequirements = {
   scheme: "exact",
@@ -58,6 +64,15 @@ const ticketXrpRequirements: PaymentRequirements = {
   },
 };
 
+const attributionXrpRequirements: PaymentRequirements = {
+  ...baseXrpRequirements,
+  extra: {
+    ...baseXrpRequirements.extra,
+    sourceTag,
+    facilitatorProof,
+  },
+};
+
 function signPayment(tx: Payment): string {
   return payerWallet.sign(tx).tx_blob;
 }
@@ -71,6 +86,8 @@ function buildPayload(
     typeof requirements.extra?.invoiceId === "string"
       ? { InvoiceID: invoiceIdToInvoiceIdField(requirements.extra.invoiceId) }
       : {};
+  const requiredSourceTag = requirements.extra?.sourceTag;
+  const requiredFacilitatorProof = requirements.extra?.facilitatorProof;
   const basePayment: Payment = {
     TransactionType: "Payment",
     Account: payerWallet.classicAddress,
@@ -88,6 +105,12 @@ function buildPayload(
     ...invoice,
     ...(typeof requirements.extra?.destinationTag === "number"
       ? { DestinationTag: requirements.extra.destinationTag }
+      : {}),
+    ...(typeof requiredSourceTag === "number" ? { SourceTag: requiredSourceTag } : {}),
+    ...(typeof requiredSourceTag === "number" && typeof requiredFacilitatorProof === "string"
+      ? {
+          Memos: buildFacilitatorAttributionMemos(requiredSourceTag, requiredFacilitatorProof),
+        }
       : {}),
     ...(!isXrp
       ? {
@@ -144,6 +167,26 @@ function createFacilitator(
 describe("XRPL exact utilities", () => {
   it("encodes invoice binding values", () => {
     expect(invoiceIdToInvoiceIdField("INV-1")).toMatch(/^[A-F0-9]{64}$/);
+  });
+
+  it("encodes canonical facilitator attribution memos", () => {
+    const expectedData = "2FF676FC0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+
+    expect(facilitatorAttributionMemoData(sourceTag, facilitatorProof)).toBe(expectedData);
+    expect(buildFacilitatorAttributionMemos(sourceTag, facilitatorProof)).toEqual([
+      {
+        Memo: {
+          MemoType: FACILITATOR_ATTRIBUTION_MEMO_TYPE,
+          MemoFormat: FACILITATOR_ATTRIBUTION_MEMO_FORMAT,
+          MemoData: expectedData,
+        },
+      },
+    ]);
+  });
+
+  it("rejects malformed facilitator attribution memo inputs", () => {
+    expect(() => facilitatorAttributionMemoData(-1, facilitatorProof)).toThrow("sourceTag");
+    expect(() => facilitatorAttributionMemoData(sourceTag, "not-hex")).toThrow("facilitatorProof");
   });
 
   it("compares issued-currency decimal values exactly", () => {
@@ -582,6 +625,63 @@ describe("ExactXrplScheme server", () => {
       ),
     ).toThrow("destinationTag");
   });
+
+  it("preserves negotiated facilitator attribution when supported", async () => {
+    const server = new ExactXrplServerScheme();
+
+    const result = await server.enhancePaymentRequirements(
+      attributionXrpRequirements,
+      {
+        x402Version: 2,
+        scheme: "exact",
+        network: XRPL_TESTNET,
+        extra: {
+          features: { sourceTag: true, facilitatorProof: true },
+        },
+      },
+      [],
+    );
+
+    expect(result.extra).toMatchObject({ sourceTag, facilitatorProof });
+  });
+
+  it("rejects attribution when the facilitator does not advertise support", () => {
+    const server = new ExactXrplServerScheme();
+
+    expect(() =>
+      server.enhancePaymentRequirements(
+        attributionXrpRequirements,
+        { x402Version: 2, scheme: "exact", network: XRPL_TESTNET },
+        [],
+      ),
+    ).toThrow("does not advertise SourceTag");
+  });
+
+  it.each<Array<[string, Record<string, unknown>, string]>>([
+    ["negative SourceTag", { sourceTag: -1 }, "sourceTag"],
+    ["oversized SourceTag", { sourceTag: 0x1_0000_0000 }, "sourceTag"],
+    ["fractional SourceTag", { sourceTag: 1.5 }, "sourceTag"],
+    ["malformed proof", { sourceTag, facilitatorProof: "not-hex" }, "facilitatorProof"],
+    ["proof without SourceTag", { facilitatorProof }, "extra.sourceTag"],
+  ])("rejects %s when enhancing requirements", (_caseName, attribution, expectedMessage) => {
+    const server = new ExactXrplServerScheme();
+
+    expect(() =>
+      server.enhancePaymentRequirements(
+        {
+          ...baseXrpRequirements,
+          extra: { ...baseXrpRequirements.extra, ...attribution },
+        },
+        {
+          x402Version: 2,
+          scheme: "exact",
+          network: XRPL_TESTNET,
+          extra: { features: { sourceTag: true, facilitatorProof: true } },
+        },
+        [],
+      ),
+    ).toThrow(expectedMessage);
+  });
 });
 
 describe("ExactXrplScheme client", () => {
@@ -605,6 +705,88 @@ describe("ExactXrplScheme client", () => {
     expect(decoded.Sequence).toBe(1);
     expect(decoded.Fee).toBe(DEFAULT_MAX_FEE_DROPS);
     expect(decoded.LastLedgerSequence).toBe(994);
+    expect(decoded.SourceTag).toBeUndefined();
+    expect(decoded.Memos).toBeUndefined();
+  });
+
+  it("creates a signed payment with negotiated facilitator attribution", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      getCurrentLedgerIndex: async () => 980,
+      preparePaymentTransaction: preparePaymentForTest,
+    });
+
+    const result = await client.createPaymentPayload(2, attributionXrpRequirements);
+    const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
+
+    expect(decoded.SourceTag).toBe(sourceTag);
+    expect(decoded.Memos).toEqual(buildFacilitatorAttributionMemos(sourceTag, facilitatorProof));
+    expect(decoded.InvoiceID).toBe(invoiceIdToInvoiceIdField(invoiceId));
+  });
+
+  it("creates a SourceTag-only attribution payment without Memos", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      getCurrentLedgerIndex: async () => 980,
+      preparePaymentTransaction: preparePaymentForTest,
+    });
+    const requirements = {
+      ...baseXrpRequirements,
+      extra: { ...baseXrpRequirements.extra, sourceTag },
+    };
+
+    const result = await client.createPaymentPayload(2, requirements);
+    const decoded = decode(String(result.payload.signedTxBlob)) as Payment;
+
+    expect(decoded.SourceTag).toBe(sourceTag);
+    expect(decoded.Memos).toBeUndefined();
+  });
+
+  it.each<Array<[string, Record<string, unknown>, string]>>([
+    ["negative SourceTag", { sourceTag: -1 }, "sourceTag"],
+    ["oversized SourceTag", { sourceTag: 0x1_0000_0000 }, "sourceTag"],
+    ["malformed proof", { sourceTag, facilitatorProof: "not-hex" }, "facilitatorProof"],
+    ["proof without SourceTag", { facilitatorProof }, "extra.sourceTag"],
+  ])("rejects %s before signing", async (_caseName, attribution, expectedMessage) => {
+    const sign = vi.fn(createXrplWalletSigner(payerWallet).sign);
+    const client = new ExactXrplClientScheme(
+      { classicAddress: payerWallet.classicAddress, sign },
+      { preparePaymentTransaction: preparePaymentForTest },
+    );
+
+    await expect(
+      client.createPaymentPayload(2, {
+        ...baseXrpRequirements,
+        extra: { ...baseXrpRequirements.extra, ...attribution },
+      }),
+    ).rejects.toThrow(expectedMessage);
+    expect(sign).not.toHaveBeenCalled();
+  });
+
+  it("rejects a preparer that removes negotiated SourceTag attribution", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => {
+        const prepared = await preparePaymentForTest(transaction);
+        const withoutSourceTag = { ...prepared };
+        delete withoutSourceTag.SourceTag;
+        return withoutSourceTag;
+      },
+    });
+
+    await expect(client.createPaymentPayload(2, attributionXrpRequirements)).rejects.toThrow(
+      "preserve the negotiated SourceTag",
+    );
+  });
+
+  it("rejects a preparer that changes the attribution Memo", async () => {
+    const client = new ExactXrplClientScheme(createXrplWalletSigner(payerWallet), {
+      preparePaymentTransaction: async transaction => ({
+        ...(await preparePaymentForTest(transaction)),
+        Memos: [{ Memo: { MemoData: "00".repeat(36) } }],
+      }),
+    });
+
+    await expect(client.createPaymentPayload(2, attributionXrpRequirements)).rejects.toThrow(
+      "preserve the facilitator attribution Memo",
+    );
   });
 
   it("creates a signed IOU payment payload with SendMax and destination tag", async () => {
@@ -900,8 +1082,164 @@ describe("ExactXrplScheme facilitator verify", () => {
     });
   });
 
-  it("advertises unsponsored fees in supported metadata", () => {
-    expect(facilitator.getExtra(XRPL_TESTNET)).toEqual({ areFeesSponsored: false });
+  it("accepts negotiated SourceTag and canonical facilitator proof with InvoiceID", async () => {
+    const result = await facilitator.verify(
+      buildPayload(attributionXrpRequirements),
+      attributionXrpRequirements,
+    );
+
+    expect(result).toMatchObject({
+      isValid: true,
+      payer: payerWallet.classicAddress,
+    });
+  });
+
+  it("accepts negotiated SourceTag without a facilitator proof Memo", async () => {
+    const requirements = {
+      ...baseXrpRequirements,
+      extra: { ...baseXrpRequirements.extra, sourceTag },
+    };
+
+    const result = await facilitator.verify(buildPayload(requirements), requirements);
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it("advertises unsponsored fees and facilitator attribution capabilities", () => {
+    expect(facilitator.getExtra(XRPL_TESTNET)).toEqual({
+      areFeesSponsored: false,
+      features: { sourceTag: true, facilitatorProof: true },
+    });
+  });
+
+  it.each<Array<[string, PaymentRequirements, string]>>([
+    [
+      "malformed SourceTag",
+      {
+        ...baseXrpRequirements,
+        extra: { ...baseXrpRequirements.extra, sourceTag: "123" },
+      },
+      "source_tag_malformed",
+    ],
+    [
+      "malformed facilitator proof",
+      {
+        ...baseXrpRequirements,
+        extra: { ...baseXrpRequirements.extra, sourceTag, facilitatorProof: "not-hex" },
+      },
+      "facilitator_proof_malformed",
+    ],
+    [
+      "facilitator proof without SourceTag",
+      {
+        ...baseXrpRequirements,
+        extra: { ...baseXrpRequirements.extra, facilitatorProof },
+      },
+      "facilitator_proof_requires_source_tag",
+    ],
+  ])("rejects %s in the envelope", async (_caseName, requirements, expectedReason) => {
+    const payload = buildPayload(baseXrpRequirements);
+    const result = await facilitator.verify({ ...payload, accepted: requirements }, requirements);
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toContain(expectedReason);
+  });
+
+  it("rejects SourceTag present only in the accepted envelope", async () => {
+    const payload = buildPayload(baseXrpRequirements);
+    const result = await facilitator.verify(
+      {
+        ...payload,
+        accepted: {
+          ...payload.accepted,
+          extra: { ...payload.accepted.extra, sourceTag },
+        },
+      },
+      baseXrpRequirements,
+    );
+
+    expect(result.invalidReason).toBe("invalid_exact_xrpl_source_tag_mismatch");
+  });
+
+  it("rejects a transaction SourceTag that was not negotiated", async () => {
+    const result = await facilitator.verify(
+      buildPayload(baseXrpRequirements, { SourceTag: sourceTag }),
+      baseXrpRequirements,
+    );
+
+    expect(result.invalidReason).toBe("invalid_exact_xrpl_payload_source_tag_unexpected");
+  });
+
+  it("rejects a missing or mismatched negotiated transaction SourceTag", async () => {
+    const missing = await facilitator.verify(
+      buildPayload(attributionXrpRequirements, { SourceTag: undefined }),
+      attributionXrpRequirements,
+    );
+    const mismatched = await facilitator.verify(
+      buildPayload(attributionXrpRequirements, { SourceTag: sourceTag + 1 }),
+      attributionXrpRequirements,
+    );
+
+    expect(missing.invalidReason).toBe("invalid_exact_xrpl_payload_source_tag_mismatch");
+    expect(mismatched.invalidReason).toBe("invalid_exact_xrpl_payload_source_tag_mismatch");
+  });
+
+  it("rejects a missing facilitator attribution Memo", async () => {
+    const result = await facilitator.verify(
+      buildPayload(attributionXrpRequirements, { Memos: undefined }),
+      attributionXrpRequirements,
+    );
+
+    expect(result.invalidReason).toBe("invalid_exact_xrpl_payload_attribution_memo_missing");
+  });
+
+  it("rejects duplicated facilitator attribution Memos", async () => {
+    const [memo] = buildFacilitatorAttributionMemos(sourceTag, facilitatorProof);
+    const result = await facilitator.verify(
+      buildPayload(attributionXrpRequirements, { Memos: [memo, memo] }),
+      attributionXrpRequirements,
+    );
+
+    expect(result.invalidReason).toBe("invalid_exact_xrpl_payload_attribution_memo_cardinality");
+  });
+
+  it("rejects malformed facilitator attribution Memo fields", async () => {
+    const result = await facilitator.verify(
+      buildPayload(attributionXrpRequirements, {
+        Memos: [
+          { Memo: { MemoData: facilitatorAttributionMemoData(sourceTag, facilitatorProof) } },
+        ],
+      }),
+      attributionXrpRequirements,
+    );
+
+    expect(result.invalidReason).toBe("invalid_exact_xrpl_payload_attribution_memo_malformed");
+  });
+
+  it("rejects a facilitator attribution Memo that does not match the proof", async () => {
+    const result = await facilitator.verify(
+      buildPayload(attributionXrpRequirements, {
+        Memos: buildFacilitatorAttributionMemos(sourceTag, "ff".repeat(32)),
+      }),
+      attributionXrpRequirements,
+    );
+
+    expect(result.invalidReason).toBe("invalid_exact_xrpl_payload_attribution_memo_mismatch");
+  });
+
+  it("rejects Memos when only SourceTag was negotiated", async () => {
+    const requirements = {
+      ...baseXrpRequirements,
+      extra: { ...baseXrpRequirements.extra, sourceTag },
+    };
+    const result = await facilitator.verify(
+      buildPayload(requirements, {
+        Memos: buildFacilitatorAttributionMemos(sourceTag, facilitatorProof),
+      }),
+      requirements,
+    );
+
+    expect(result.invalidReason).toBe("invalid_exact_xrpl_payload_memos_not_allowed");
   });
 
   it("returns a stable reason and separate message for malformed payloads", async () => {


### PR DESCRIPTION
## Description

Implements the official TypeScript reference implementation for #2864.

This PR depends on the XRPL amendment in #2871 and must not merge before that specification is accepted. The implementation diff is code, docs, tests, and a changeset only; it does not modify the specification.

- negotiates resource-server-selected `sourceTag` and optional `facilitatorProof` through supported capabilities
- signs the exact `SourceTag` and canonical typed attribution Memo without facilitator fallback
- preserves independently payer-signed SourceTags when attribution is not negotiated
- keeps invoice binding exclusively on `InvoiceID`
- validates malformed, missing, duplicated, unexpected, or mismatched attribution fields fail closed
- documents that attribution labels do not authenticate the network submitter
- integrates client, resource-server scheme, facilitator verification/settlement, SDK parity docs, examples, tests, and changeset

AI assistance was used to draft code, tests, and documentation. The contributor reviewed the resulting diff and test evidence.

## Independent review

Two independent reviewers inspected all four amendment/implementation diffs. Confirmed backward-compatibility, submitter-proof semantics, parity, and combined-interop findings were fixed. A signed compatibility branch at [`test/xrpl-amendments-combined`](https://github.com/aristotle-satoshi/x402/tree/test/xrpl-amendments-combined) retains both unit suites and adds combined SourceTag/Memo/InvoiceID/SendMax/default-path/explicit-path tests.

## Tests

- `cd typescript && pnpm format && pnpm lint && pnpm build && pnpm test` — 28/28 format, 28/28 lint, 28/28 build, 55/55 test tasks
- `cd typescript/packages/mechanisms/xrpl && pnpm format:check && pnpm lint:check && pnpm build && pnpm test` — 153/153 tests
- `cd typescript/packages/mechanisms/xrpl && pnpm test:integration` — 3 passed; credential-gated live test skipped
- combined branch — 312/312 unit and 5 integration passed; one credential-gated live test skipped
- `cd typescript && pnpm changeset status` — valid
- `git diff --check` — clean
- all GitHub Actions checks passed on the current head

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes