### PR TITLE
docs(spec): add informative discovery troubleshooting section to bazaar extension

### DIFF
--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -514,6 +514,49 @@ Clients are expected to echo the `bazaar` extension from `PaymentRequired` into 
 
 ---
 
+## Troubleshooting Discovery (Informative)
+
+A resource server that settles payments successfully can still fail to appear in a
+facilitator's catalog. In practice these are the most common causes, in the order
+worth checking (see x402-foundation/x402#2112 for field reports):
+
+1. **The settled payload did not carry the extension.** Cataloging happens when the
+   facilitator processes a `PaymentPayload` containing the `bazaar` extension (see
+   [Client Behavior](#client-behavior)). Declaring the extension on `402` responses
+   that are never paid catalogs nothing, and settlements whose payloads omit the
+   extension catalog nothing either — a resource is cataloged by a settlement
+   *carrying* the declaration. Declaration alone and settlement alone are each
+   insufficient.
+
+2. **The `PaymentRequired` body is not spec-conformant.** Facilitators validate the
+   declaration (and the surrounding payment body) before cataloging, and a
+   non-conforming resource may be dropped from cataloging even though verification
+   and settlement succeed. Mistakes frequently reported by integrators:
+   - missing `info.input.type` / `info.output.type` discriminators (see
+     [Input Type Discriminator](#input-type-discriminator))
+   - a relative `resource.url` — it must be an absolute URL
+   - malformed `accepts` entries, e.g. `asset` as a rich object instead of the
+     token address string, or a missing atomic-units `amount`
+   - service metadata violating the rules in
+     [Service Metadata on `resource`](#service-metadata-on-resource) — those
+     fields are soft-dropped individually, so a too-long `serviceName` disappears
+     silently rather than failing the request
+
+3. **Treating the absence of `EXTENSION-RESPONSES` as failure.** The header is
+   optional (**MAY**): facilitators can catalog a resource without ever emitting
+   it. Its absence carries no signal. When the header *is* present,
+   `bazaar.status` and `rejectedReason` are the authoritative outcome.
+
+4. **Not allowing for asynchronous cataloging.** A `"processing"` status means the
+   declaration was accepted but indexing happens later; allow for indexing delay
+   before concluding failure.
+
+Where a facilitator exposes the optional discovery endpoints,
+`GET /discovery/resources?payTo=<address>` is the quickest way to confirm what has
+actually been cataloged for a given payee.
+
+---
+
 ## Dynamic Routes and `routeTemplate`
 
 HTTP endpoints can use parameterized route patterns (e.g. `/users/[userId]`). When a route has


### PR DESCRIPTION
## Summary

Adds an **informative** "Troubleshooting Discovery" section to `specs/extensions/bazaar.md`, between *Client Behavior* and *Dynamic Routes*. No normative changes.

#2112 has accumulated months of independent reports of the same integration failure — services that verify and settle correctly but never appear in a catalog — and the causes have now been isolated empirically by multiple teams (controlled A/B by @Marysbrain, independently reproduced by us at chain-analyzer.com, EOA/CDP-wallet gating ruled out by @ederaildo). This PR captures those findings where integrators will actually look for them:

1. cataloging requires a settlement **carrying** the declaration — declaration alone and settlement alone are each insufficient (this is implied by *Client Behavior* today, but stated nowhere from the seller's debugging perspective)
2. non-conformant `PaymentRequired` bodies can be silently dropped from cataloging even though verify/settle succeed, with the concrete mistakes repeatedly reported in the wild (missing `info.input.type`/`output.type`, relative `resource.url`, malformed `accepts`, soft-dropped service metadata)
3. `EXTENSION-RESPONSES` is **MAY** — its absence carries no signal and should not be read as failure (the original title of #2112)
4. `"processing"` means asynchronous cataloging; allow for delay

## Why in the spec

Each of these is a protocol-level property (client echo requirement, validation rules, optional header semantics), not a facilitator implementation detail — but today they are only discoverable by reading a 30-comment issue thread. A short informative section saves the next integrator that archaeology.

Refs #2112