### PR TITLE
examples(python): demonstrate service metadata in the bazaar server example

### DIFF
--- a/examples/python/servers/bazaar/README.md
+++ b/examples/python/servers/bazaar/README.md
@@ -40,6 +40,8 @@ async def get_weather(city: str) -> dict:
 
 Note that the x402 route key uses `:city` (Express convention) while the FastAPI handler uses `{city}` (FastAPI convention). The x402 middleware handles the `:city` matching; FastAPI handles the `{city}` extraction for your handler.
 
+**Service metadata** -- `RouteConfig` also accepts `service_name`, `tags`, and `icon_url`. They are emitted on the top-level `resource` block of the 402 response, and catalogs use them to render a named, tagged service page instead of a raw-domain listing. Keep the metadata identical across routes (catalogs group routes into one service by name), and mind the indexer caps -- `service_name` <= 32 printable-ASCII chars, <= 5 tags of <= 32 chars each, absolute http(s) icon URL -- values that exceed them are silently dropped field-by-field.
+
 ## Prerequisites
 
 - Python 3.10+

--- a/examples/python/servers/bazaar/main.py
+++ b/examples/python/servers/bazaar/main.py
@@ -46,6 +46,12 @@ routes = {
         accepts=payment_options,
         mime_type="application/json",
         description="Weather data for a city",
+        # Service metadata rides on the top-level `resource` block so catalogs
+        # can render a named, tagged listing instead of the raw domain.
+        # Indexers soft-drop violations: service_name <= 32 printable-ASCII
+        # chars, <= 5 tags of <= 32 chars each, absolute http(s) icon URL.
+        service_name="Weather API",
+        tags=["weather", "api"],
         extensions=declare_discovery_extension(
             path_params_schema={
                 "properties": {"city": {"type": "string", "description": "City name slug"}},
@@ -63,6 +69,10 @@ routes = {
         accepts=payment_options,
         mime_type="application/json",
         description="Weather data for a city in a specific country",
+        # Keep service metadata identical across routes — catalogs group
+        # routes into one service page by name.
+        service_name="Weather API",
+        tags=["weather", "api"],
         extensions=declare_discovery_extension(
             path_params_schema={
                 "properties": {


### PR DESCRIPTION
## Summary

The TypeScript advanced bazaar example demonstrates `serviceName` / `tags` on the route config, but the Python bazaar example doesn't — even though the Python SDK's `RouteConfig` fully supports `service_name` / `tags` / `icon_url`. In practice this metadata is the difference between a catalog listing that shows up as a bare domain and a named, tagged service page, and it's easy to miss since values that violate the indexer caps are soft-dropped silently (per the validation rules in `specs/extensions/bazaar.md`).

- add `service_name="Weather API"` / `tags=["weather", "api"]` to both routes in `examples/python/servers/bazaar/main.py`, mirroring the TS example
- README: short section on service metadata, the keep-it-identical-across-routes grouping behavior, and the ≤32-char / ≤5-tags / absolute-URL caps

Verified the end-to-end effect on a production FastAPI x402 service this week (settle carrying the declaration + `resource.serviceName` → enriched catalog listing); details in x402-foundation/x402#2112.

Refs #2112