### PR TITLE
fix(core): fail closed when no scheme server is registered in buildPaymentRequirements (fixes #2760)

### DIFF
--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -685,12 +685,10 @@ export class x402ResourceServer {
     );
 
     if (!SchemeNetworkServer) {
-      // Fallback to placeholder implementation if no server registered
-      // TODO: Remove this fallback once implementations are registered
-      console.warn(
-        `No server implementation registered for scheme: ${scheme}, network: ${resourceConfig.network}`,
+      throw new Error(
+        `No server implementation registered for scheme: ${scheme}, network: ${resourceConfig.network}. ` +
+          `Register a scheme server before building payment requirements.`,
       );
-      return requirements;
     }
 
     // Find the matching supported kind from facilitator

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -504,18 +504,20 @@ describe("x402ResourceServer", () => {
       expect(requirements[0].maxTimeoutSeconds).toBe(600);
     });
 
-    it("should return empty array if no scheme registered for network", async () => {
+    it("should throw if no scheme registered for network", async () => {
       const server = new x402ResourceServer();
 
-      const requirements = await server.buildPaymentRequirements({
-        scheme: "test-scheme",
-        payTo: "recipient",
-        price: 1.0,
-        network: "test:network" as Network,
-      });
-
-      // Current implementation returns empty array and logs warning
-      expect(requirements).toEqual([]);
+      await expect(
+        async () =>
+          await server.buildPaymentRequirements({
+            scheme: "test-scheme",
+            payTo: "recipient",
+            price: 1.0,
+            network: "test:network" as Network,
+          }),
+      ).rejects.toThrow(
+        "No server implementation registered for scheme: test-scheme, network: test:network",
+      );
     });
 
     it("should throw if facilitator doesn't support scheme/network", async () => {


### PR DESCRIPTION
## Problem

`x402ResourceServer.buildPaymentRequirements()` fails silently when no scheme server is registered for the requested scheme and network. In `typescript/packages/core/src/server/x402ResourceServer.ts`, the `!SchemeNetworkServer` branch logged a `console.warn` and returned the (still empty) `requirements` array instead of throwing. The code's own comment flagged it: `// TODO: Remove this fallback once implementations are registered`.

As #2760 notes, callers already wrap this in a `try/catch` that expects a throw:

```ts
try { requirements = await resourceServer.buildPaymentRequirements(resourceConfig); }
catch { return PRICE_COMPUTE_FAILED; }
```

Because nothing throws, that catch never fires, and the caller proceeds to build a client-facing `402` with `accepts: []`: "payment required" with zero payment options and no indication anything is broken server-side (the `console.warn` is server-side only).

## Fix

Throw when no matching scheme server is registered, mirroring the adjacent `!supportedKind` guard a few lines below. This fails closed and gives consumers the real signal their error-handling path already expects.

Fixes #2760.

## Acceptance criteria
- [x] `buildPaymentRequirements()` throws when no matching scheme is registered, instead of silently resolving to an empty array
- [x] Consumers relying on a thrown exception get a real signal instead of building a client-facing `accepts: []` response
