### PR TITLE
Fix go deposit balance double-count

### DIFF
--- a/go/.changes/unreleased/fixed-20260716-140229.yaml
+++ b/go/.changes/unreleased/fixed-20260716-140229.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Fix batch-settlement SettleDeposit double-counting channel balance after a confirmed deposit by anchoring the optimistic balance to a pre-submit ReadChannelState and adding depositAmount once.
+time: 2026-07-16T14:02:29.783307+02:00

--- a/go/mechanisms/evm/batch-settlement/facilitator/deposit.go
+++ b/go/mechanisms/evm/batch-settlement/facilitator/deposit.go
@@ -371,6 +371,28 @@ func SettleDeposit(
 		}
 	}
 
+	// Read pre-submit onchain state. Used as the baseline for the optimistic
+	// post-deposit fallback (priorBalance + depositAmount). Reading after the
+	// receipt would already include the deposit when the RPC is current, and
+	// adding depositAmount again would double-count.
+	priorState, _ := ReadChannelState(ctx, signer, payload.Voucher.ChannelId)
+	priorBalance := big.NewInt(0)
+	priorTotalClaimed := big.NewInt(0)
+	priorWithdrawRequestedAt := 0
+	priorRefundNonce := big.NewInt(0)
+	if priorState != nil {
+		if priorState.Balance != nil {
+			priorBalance = priorState.Balance
+		}
+		if priorState.TotalClaimed != nil {
+			priorTotalClaimed = priorState.TotalClaimed
+		}
+		priorWithdrawRequestedAt = priorState.WithdrawRequestedAt
+		if priorState.RefundNonce != nil {
+			priorRefundNonce = priorState.RefundNonce
+		}
+	}
+
 	// Branch on extension settlement strategy:
 	//   erc20Approval → broadcast pre-signed approve() then deposit() via the
 	//                   facilitator extension signer's SendTransactions.
@@ -429,27 +451,11 @@ func SettleDeposit(
 	}
 
 	// Optimistic post-deposit extra (fallback if RPC hasn't caught up to
-	// the just-confirmed tx). The settle response intentionally omits
-	// `chargedCumulativeAmount` — that field is added by the resource
-	// server's `enrichSettlementResponse` hook, and emitting
-	// it from the facilitator violates the additive-enrichment policy.
-	priorState, _ := ReadChannelState(ctx, signer, payload.Voucher.ChannelId)
-	priorBalance := big.NewInt(0)
-	priorTotalClaimed := big.NewInt(0)
-	priorWithdrawRequestedAt := 0
-	priorRefundNonce := big.NewInt(0)
-	if priorState != nil {
-		if priorState.Balance != nil {
-			priorBalance = priorState.Balance
-		}
-		if priorState.TotalClaimed != nil {
-			priorTotalClaimed = priorState.TotalClaimed
-		}
-		priorWithdrawRequestedAt = priorState.WithdrawRequestedAt
-		if priorState.RefundNonce != nil {
-			priorRefundNonce = priorState.RefundNonce
-		}
-	}
+	// the just-confirmed tx). Anchored to the pre-submit read above so we
+	// add depositAmount exactly once. The settle response intentionally
+	// omits `chargedCumulativeAmount` — that field is added by the resource
+	// server's `enrichSettlementResponse` hook, and emitting it from the
+	// facilitator violates the additive-enrichment policy.
 	optimisticBalance := new(big.Int).Add(priorBalance, depositAmount)
 	optimisticState := &batchsettlement.ChannelState{
 		Balance:             optimisticBalance,

--- a/go/mechanisms/evm/batch-settlement/facilitator/exec_test.go
+++ b/go/mechanisms/evm/batch-settlement/facilitator/exec_test.go
@@ -315,6 +315,83 @@ func TestSettleDeposit_MissingAuthorization(t *testing.T) {
 	}
 }
 
+// TestSettleDeposit_PostReceiptBalanceNotDoubled pins that SettleDeposit anchors
+// optimistic balance to the pre-submit channel read. When the post-receipt RPC
+// already reflects deposit=100 (balance=100), the settle extra must report 100
+// — not 200 from adding depositAmount again on top of the post-deposit read.
+func TestSettleDeposit_PostReceiptBalanceNotDoubled(t *testing.T) {
+	cfg := validConfig()
+	channelId, err := batchsettlement.ComputeChannelId(cfg, testNetwork)
+	if err != nil {
+		t.Fatalf("compute channel id: %v", err)
+	}
+
+	var tryAggregateCalls int
+	var writeSeen bool
+	signer := &fakeFacilitatorSigner{
+		addresses: []string{"0xfacilitator"},
+		writeContract: func(functionName string, _ ...interface{}) (string, error) {
+			if functionName != "deposit" {
+				t.Fatalf("unexpected write: %s", functionName)
+			}
+			if tryAggregateCalls < 1 {
+				t.Fatal("expected pre-submit ReadChannelState before WriteContract")
+			}
+			writeSeen = true
+			return "0x" + strings.Repeat("ab", 32), nil
+		},
+		waitForReceipt: func(txHash string) (*evm.TransactionReceipt, error) {
+			return &evm.TransactionReceipt{Status: evm.TxStatusSuccess, TxHash: txHash}, nil
+		},
+		readContract: func(functionName string, _ ...interface{}) (interface{}, error) {
+			if functionName != evm.FunctionTryAggregate {
+				return nil, errors.New("unexpected rpc")
+			}
+			tryAggregateCalls++
+			if !writeSeen {
+				// Pre-submit: channel empty.
+				return multicallChannelStateResult(t, big.NewInt(0), big.NewInt(0), 0, big.NewInt(0)), nil
+			}
+			// Post-receipt: RPC already includes the mined deposit.
+			return multicallChannelStateResult(t, big.NewInt(100), big.NewInt(0), 0, big.NewInt(0)), nil
+		},
+	}
+
+	payload := &batchsettlement.BatchSettlementDepositPayload{
+		Type:          "deposit",
+		ChannelConfig: cfg,
+		Voucher: batchsettlement.BatchSettlementVoucherFields{
+			ChannelId:          channelId,
+			MaxClaimableAmount: "100",
+			Signature:          "0x" + strings.Repeat("22", 65),
+		},
+		Deposit: batchsettlement.BatchSettlementDepositData{
+			Amount: "100",
+			Authorization: batchsettlement.BatchSettlementDepositAuthorization{
+				Erc3009Authorization: goodErc3009Auth(),
+			},
+		},
+	}
+
+	resp, err := SettleDeposit(context.Background(), signer, payload, reqsFor(testNetwork), nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SettleDeposit: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success, got %+v", resp)
+	}
+	cs, ok := resp.Extra["channelState"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("missing channelState in extra: %+v", resp.Extra)
+	}
+	if got, _ := cs["balance"].(string); got != "100" {
+		t.Fatalf("channelState.balance = %q, want \"100\" (not doubled)", got)
+	}
+	if tryAggregateCalls < 2 {
+		t.Fatalf("tryAggregateCalls = %d, want at least pre-submit + post-receipt", tryAggregateCalls)
+	}
+}
+
 // ----- VerifyDeposit pre-RPC paths -----
 
 func TestVerifyDeposit_BadAmount(t *testing.T) {

--- a/go/mechanisms/evm/batch-settlement/server/hooks_test.go
+++ b/go/mechanisms/evm/batch-settlement/server/hooks_test.go
@@ -2,11 +2,17 @@ package server
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
+
 	x402 "github.com/x402-foundation/x402/go/v2"
 	batchsettlement "github.com/x402-foundation/x402/go/v2/mechanisms/evm/batch-settlement"
+	bsclient "github.com/x402-foundation/x402/go/v2/mechanisms/evm/batch-settlement/client"
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm/batch-settlement/facilitator"
+	evmsigners "github.com/x402-foundation/x402/go/v2/signers/evm"
 	"github.com/x402-foundation/x402/go/v2/types"
 )
 
@@ -23,15 +29,17 @@ type stubRequirements struct {
 	network string
 	asset   string
 	amount  string
+	payTo   string
+	extra   map[string]interface{}
 }
 
 func (s stubRequirements) GetScheme() string                { return s.scheme }
 func (s stubRequirements) GetNetwork() string               { return s.network }
 func (s stubRequirements) GetAsset() string                 { return s.asset }
 func (s stubRequirements) GetAmount() string                { return s.amount }
-func (s stubRequirements) GetPayTo() string                 { return "" }
+func (s stubRequirements) GetPayTo() string                 { return s.payTo }
 func (s stubRequirements) GetMaxTimeoutSeconds() int        { return 60 }
-func (s stubRequirements) GetExtra() map[string]interface{} { return nil }
+func (s stubRequirements) GetExtra() map[string]interface{} { return s.extra }
 
 func batchedReqs() stubRequirements {
 	return stubRequirements{scheme: batchsettlement.SchemeBatched, network: "eip155:8453", amount: "10"}
@@ -197,6 +205,81 @@ func TestBeforeVerifyHook_FreshCumulativePasses(t *testing.T) {
 	})
 	if err != nil || res != nil {
 		t.Fatalf("expected pass-through, got %v / %v", res, err)
+	}
+}
+
+// TestBeforeVerifyHook_LocalVerifyRejectsOverEscrow pins that a voucher whose
+// cumulative maxClaimable exceeds the cached (real) escrow balance is not
+// locally approved. With an inflated cached balance (e.g. SettleDeposit
+// double-count), the same voucher would incorrectly pass the local fast path.
+func TestBeforeVerifyHook_LocalVerifyRejectsOverEscrow(t *testing.T) {
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	voucherSigner, err := evmsigners.NewClientSignerFromPrivateKey(hex.EncodeToString(crypto.FromECDSA(priv)))
+	if err != nil {
+		t.Fatalf("client signer: %v", err)
+	}
+	payerAuthorizer := voucherSigner.Address()
+
+	cfg := testConfig()
+	cfg.PayerAuthorizer = payerAuthorizer
+	channelId, err := batchsettlement.ComputeChannelId(cfg, "eip155:8453")
+	if err != nil {
+		t.Fatalf("compute channel id: %v", err)
+	}
+
+	// charged=100, reqAmount=10 → expected maxClaimable=110 > Balance=100.
+	const maxClaimable = "110"
+	voucher, err := bsclient.SignVoucher(context.Background(), voucherSigner, channelId, maxClaimable, "eip155:8453")
+	if err != nil {
+		t.Fatalf("sign voucher: %v", err)
+	}
+
+	s := NewBatchSettlementEvmScheme(cfg.Receiver, nil)
+	sess := sampleSession(channelId, "100")
+	sess.ChannelConfig = cfg
+	sess.Balance = "100"
+	sess.TotalClaimed = "0"
+	sess.OnchainSyncedAt = time.Now().UnixMilli()
+	_ = s.UpdateSession(channelId, sess)
+
+	reqs := stubRequirements{
+		scheme:  batchsettlement.SchemeBatched,
+		network: "eip155:8453",
+		asset:   cfg.Token,
+		amount:  "10",
+		payTo:   cfg.Receiver,
+		extra: map[string]interface{}{
+			"receiverAuthorizer": cfg.ReceiverAuthorizer,
+		},
+	}
+	payload := map[string]interface{}{
+		"type":          "voucher",
+		"channelConfig": batchsettlement.ChannelConfigToMap(cfg),
+		"voucher": map[string]interface{}{
+			"channelId":          channelId,
+			"maxClaimableAmount": maxClaimable,
+			"signature":          voucher.Signature,
+		},
+	}
+
+	res, err := s.BeforeVerifyHook()(x402.VerifyContext{
+		Payload:      &stubPayload{data: payload},
+		Requirements: reqs,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if res == nil || !res.Skip || res.SkipVerifyResult == nil {
+		t.Fatalf("expected local verify skip result, got %+v", res)
+	}
+	if res.SkipVerifyResult.IsValid {
+		t.Fatal("expected local verify to reject over-escrow voucher")
+	}
+	if res.SkipVerifyResult.InvalidReason != facilitator.ErrMaxClaimableExceedsBal {
+		t.Fatalf("InvalidReason = %q, want %q", res.SkipVerifyResult.InvalidReason, facilitator.ErrMaxClaimableExceedsBal)
 	}
 }
 


### PR DESCRIPTION
## Description

Go batch-settlement `SettleDeposit` waits for the receipt, then calls ReadChannelState and computes `optimisticBalance = priorBalance + depositAmount`. Result depends on RPC freshness and might be double counting deposit. 

TS /Py correctly fetch raw pre-deposit chBalance and add depositAmount once settled

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 