### PR TITLE
fix(evm): auto-wrap any eth_account BaseAccount, not just LocalAccount

### DIFF
--- a/python/x402/changelog.d/2884.bugfix.md
+++ b/python/x402/changelog.d/2884.bugfix.md
@@ -1,0 +1,1 @@
+Fixed auto-wrapping of custom signers extending eth_account's BaseAccount (not just LocalAccount) for x402 payment signing

--- a/python/x402/mechanisms/evm/batch_settlement/client/scheme.py
+++ b/python/x402/mechanisms/evm/batch_settlement/client/scheme.py
@@ -46,11 +46,11 @@ from .voucher import sign_voucher
 
 
 def _wrap_if_local_account(signer: Any) -> ClientEvmSigner:
-    """Auto-wrap an `eth_account` LocalAccount in `EthAccountSigner`."""
+    """Auto-wrap an eth_account-compatible signer (any `BaseAccount`) in `EthAccountSigner`."""
     try:
-        from eth_account.signers.local import LocalAccount
+        from eth_account.signers.base import BaseAccount
 
-        if isinstance(signer, LocalAccount):
+        if isinstance(signer, BaseAccount):
             from ....evm.signers import EthAccountSigner
 
             return EthAccountSigner(signer)

--- a/python/x402/mechanisms/evm/exact/client.py
+++ b/python/x402/mechanisms/evm/exact/client.py
@@ -24,11 +24,11 @@ from .permit2_utils import create_permit2_payload
 
 
 def _wrap_if_local_account(signer: Any) -> ClientEvmSigner:
-    """Auto-wrap eth_account LocalAccount in EthAccountSigner if needed."""
+    """Auto-wrap an eth_account-compatible signer (any BaseAccount) in EthAccountSigner."""
     try:
-        from eth_account.signers.local import LocalAccount
+        from eth_account.signers.base import BaseAccount
 
-        if isinstance(signer, LocalAccount):
+        if isinstance(signer, BaseAccount):
             from ..signers import EthAccountSigner
 
             return EthAccountSigner(signer)

--- a/python/x402/mechanisms/evm/upto/client.py
+++ b/python/x402/mechanisms/evm/upto/client.py
@@ -32,11 +32,11 @@ from ..utils import (
 
 
 def _wrap_if_local_account(signer: Any) -> ClientEvmSigner:
-    """Auto-wrap eth_account LocalAccount in EthAccountSigner if needed."""
+    """Auto-wrap an eth_account-compatible signer (any BaseAccount) in EthAccountSigner."""
     try:
-        from eth_account.signers.local import LocalAccount
+        from eth_account.signers.base import BaseAccount
 
-        if isinstance(signer, LocalAccount):
+        if isinstance(signer, BaseAccount):
             from ..signers import EthAccountSigner
 
             return EthAccountSigner(signer)

--- a/python/x402/tests/unit/mechanisms/evm/test_client.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_client.py
@@ -2,6 +2,7 @@
 
 try:
     from eth_account import Account
+    from eth_account.signers.base import BaseAccount
     from eth_account.signers.local import LocalAccount
 except ImportError:
     import pytest
@@ -208,3 +209,91 @@ class TestLocalAccountAutoWrap:
         assert auth["validAfter"] == "0"
         assert int(auth["validBefore"]) >= now + 600 - 2
         assert int(auth["validBefore"]) <= now + 600 + 2
+
+
+class _CustomBaseAccountSigner(BaseAccount):
+    """A signer that satisfies `BaseAccount` without being a `LocalAccount`.
+
+    Mirrors third-party wallet-provider adapters (e.g. Coinbase AgentKit's
+    `EvmWalletSigner`) that wrap non-key-based custody backends: they extend
+    the abstract `BaseAccount` directly and implement `sign_typed_data` with
+    eth_account's keyword convention, but are never a `LocalAccount` instance.
+    """
+
+    def __init__(self):
+        self._account = Account.create()
+
+    @property
+    def address(self):
+        return self._account.address
+
+    def unsafe_sign_hash(self, message_hash):
+        return self._account.unsafe_sign_hash(message_hash)
+
+    def sign_message(self, signable_message):
+        return self._account.sign_message(signable_message)
+
+    def sign_transaction(self, transaction_dict):
+        return self._account.sign_transaction(transaction_dict)
+
+    def sign_typed_data(
+        self, domain_data=None, message_types=None, message_data=None, full_message=None
+    ):
+        return self._account.sign_typed_data(
+            domain_data=domain_data,
+            message_types=message_types,
+            message_data=message_data,
+            full_message=full_message,
+        )
+
+
+class TestBaseAccountAutoWrap:
+    """A non-`LocalAccount` `BaseAccount` signer must also be auto-wrapped.
+
+    Regression test: `_wrap_if_local_account` previously checked
+    `isinstance(signer, LocalAccount)`, which only matches raw private-key
+    accounts. Wallet-provider adapters that extend `BaseAccount` directly
+    (not `LocalAccount`) fell through unwrapped, and were then called with
+    `EthAccountSigner`'s 4-positional-argument convention
+    (`domain, types, primary_type, message`), which does not match
+    eth_account's keyword convention — causing a `KeyError` deep in
+    `eth_account.messages.encode_typed_data`.
+    """
+
+    def test_should_auto_wrap_base_account_signer(self):
+        """A custom BaseAccount (not LocalAccount) should be auto-wrapped."""
+        signer = _CustomBaseAccountSigner()
+        assert isinstance(signer, BaseAccount)
+        assert not isinstance(signer, LocalAccount)
+
+        client = ExactEvmClientScheme(signer=signer)
+
+        assert isinstance(client._signer, EthAccountSigner)
+
+    def test_custom_base_account_signer_can_sign_payload(self):
+        """End-to-end: a custom BaseAccount signer should produce a valid signed payload."""
+        signer = _CustomBaseAccountSigner()
+        network = "eip155:8453"
+
+        client = ExactEvmClientScheme(signer=signer)
+
+        requirements = PaymentRequirements(
+            scheme="exact",
+            network=network,
+            asset=get_asset_info(network, "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")["address"],
+            amount="500000",
+            pay_to="0x0987654321098765432109876543210987654321",
+            max_timeout_seconds=3600,
+            extra={
+                "name": "USD Coin",
+                "version": "2",
+            },
+        )
+
+        payload = client.create_payment_payload(requirements)
+
+        assert isinstance(payload, dict)
+        assert "authorization" in payload
+        assert "signature" in payload
+        assert payload["signature"].startswith("0x")
+        assert len(payload["signature"]) > 2  # not just "0x"


### PR DESCRIPTION
## Problem

`_wrap_if_local_account` (duplicated in the `exact`, `upto`, and
`batch_settlement` EVM client schemes) only auto-wraps a signer in
`EthAccountSigner` when it is an instance of `eth_account.signers.local.LocalAccount`:

```python
if isinstance(signer, LocalAccount):
    return EthAccountSigner(signer)
return signer
```

Third-party wallet-provider adapters that extend `eth_account`'s abstract
`BaseAccount` directly — rather than being a raw-private-key `LocalAccount` —
fall through unwrapped. Coinbase AgentKit's `EvmWalletProvider.to_signer()` is
one concrete example: it returns an `EvmWalletSigner(BaseAccount)` for any
custody backend (CDP, smart wallets, or a custom signer such as an AWS
KMS-backed one).

When such a signer reaches `ExactEvmScheme._sign_authorization`, it's called
with x402's positional `ClientEvmSigner` convention —
`sign_typed_data(domain, types, primary_type, message)` — but
`EvmWalletSigner.sign_typed_data` (and `eth_account`'s own convention) expects
keyword arguments `(domain_data, message_types, message_data, full_message)`.
`primary_type` lands in the `message_data` slot and `message` lands in
`full_message`, so the "already has a message" branch is taken with an
incomplete dict, and `eth_account.messages.encode_typed_data` raises
`KeyError: 'types'`.

Discovered while wiring an AWS KMS-backed signer (subclassing `BaseAccount`,
not `LocalAccount`) into an x402 buyer paying a real x402 v2
`GatewayWalletBatched` payment requirement.

## Fix

Broaden the `isinstance` check from `LocalAccount` to `BaseAccount`
(`LocalAccount`'s own parent class) in all three occurrences. Every
`LocalAccount` is already a `BaseAccount`, so this is a strict superset — no
behavior changes for existing raw-private-key callers, and non-`LocalAccount`
`BaseAccount` signers are now correctly wrapped instead of crashing.

## Testing

Added `TestBaseAccountAutoWrap` to `tests/unit/mechanisms/evm/test_client.py`
with a minimal `BaseAccount`-only signer (not a `LocalAccount`), mirroring
third-party wallet-provider adapters. Verified the new tests fail without the
fix (`KeyError`/`ValueError` from `eth_account.messages`) and pass with it.
Full `tests/unit` suite passes (excluding two pre-existing, unrelated Solana
package-version failures in `sign_in_with_x` tests, not touched by this
change).

Changelog fragment will follow in `python/x402/changelog.d/<this-PR>.bugfix.md`
once the PR number is known, per CONTRIBUTING.md.

## Disclosure

Most of this change (diagnosis, fix, and tests) was written with AI
assistance (Claude Code), reviewed and verified by me — including confirming
the failure/fix behavior by running the test suite before and after the
change — before opening this PR, per this repo's AI-assisted contribution
guidelines.