### PR TITLE
fix(fetch): preserve Request body during recovery

### DIFF
--- a/typescript/.changeset/fix-fetch-recovery-request.md
+++ b/typescript/.changeset/fix-fetch-recovery-request.md
@@ -1,0 +1,5 @@
+---
+"@x402/fetch": patch
+---
+
+Preserved Request bodies when a payment hook triggers a recovery retry.

--- a/typescript/packages/http/fetch/src/index.test.ts
+++ b/typescript/packages/http/fetch/src/index.test.ts
@@ -408,6 +408,41 @@ describe("wrapFetchWithPayment()", () => {
     expect(retryBody).toBe(bodyContent);
   });
 
+  it("should preserve a Request body during payment recovery", async () => {
+    const { x402HTTPClient: MockX402HTTPClient } = await import("@x402/core/client");
+    (
+      MockX402HTTPClient.prototype.processPaymentResult as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ recovered: true });
+
+    const bodyContent = JSON.stringify({ test: "recovery" });
+    const observedBodies: string[] = [];
+    const successResponse = createResponse(200, { data: "success" });
+
+    mockFetch.mockImplementation(async (request: Request) => {
+      observedBodies.push(await request.text());
+      if (observedBodies.length < 3) {
+        return createResponse(402, validPaymentRequired);
+      }
+      return successResponse;
+    });
+
+    const input = new Request("https://api.example.com", {
+      method: "POST",
+      body: bodyContent,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const result = await wrappedFetch(input);
+
+    expect(result).toBe(successResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(observedBodies).toEqual([bodyContent, bodyContent, bodyContent]);
+    expect(mockClient.createPaymentPayload).toHaveBeenCalledTimes(2);
+
+    const recoveryRequest = mockFetch.mock.calls[2][0] as Request;
+    expect(recoveryRequest.headers.get("PAYMENT-SIGNATURE")).toBe("encoded-payment-header");
+  });
+
   it("should preserve headers from Request object input", async () => {
     const successResponse = createResponse(200, { data: "success" });
 

--- a/typescript/packages/http/fetch/src/index.ts
+++ b/typescript/packages/http/fetch/src/index.ts
@@ -119,7 +119,7 @@ export function wrapFetchWithPayment(
     );
 
     // Retry the request with payment
-    const secondResponse = await fetch(clonedRequest);
+    const secondResponse = await fetch(clonedRequest.clone());
 
     // Fire payment response hooks and handle recovery
     const result = await httpClient.processPaymentResult(
@@ -132,7 +132,7 @@ export function wrapFetchWithPayment(
       // Hook fixed state — retry with fresh payload (bounded to one recovery)
       const freshPayload = await client.createPaymentPayload(paymentRequired);
       const retryHeaders = httpClient.encodePaymentSignatureHeader(freshPayload);
-      const retryRequest = new Request(input, init);
+      const retryRequest = clonedRequest;
       for (const [k, v] of Object.entries(retryHeaders)) {
         retryRequest.headers.set(k, v);
       }


### PR DESCRIPTION
## Summary

- retain the normalized cloned `Request` for one payment-hook recovery
- preserve POST bodies and headers when the caller supplies a `Request` object
- add a regression test covering the initial request, paid retry, and recovery retry
- add the required patch changeset

## Root cause

Constructing the first normalized `Request` can mark a caller-provided `Request` body as used. The recovery path rebuilt from that consumed input, causing body-bearing requests to throw before the retry.

## Agent impact

AI agents frequently purchase APIs through stateful POST requests. Losing the task payload during payment recovery breaks autonomous execution and forces human intervention. Preserving the body makes x402 more robust as payment infrastructure at the AI-agent frontier.

## Validation

- dependency-aware build for `@x402/core` and `@x402/fetch`
- `@x402/fetch`: 21 tests passed
- lint check
- format check

## AI assistance

Codex assisted with implementation and test preparation. I reviewed the diff, Fetch `Request` body semantics, and validation results before submission.