### PR TITLE
spec(auth-capture): add Security Considerations section

### DIFF
--- a/specs/schemes/auth-capture/scheme_auth_capture.md
+++ b/specs/schemes/auth-capture/scheme_auth_capture.md
@@ -75,6 +75,18 @@ Two absolute-timestamp deadlines govern the payment lifecycle (network-specific 
 | Refundable | No                 | Yes (both paths)                                                      |
 | Fee system | None               | Configurable (min/max bounds, client-signed)                          |
 
+## Security Considerations
+
+1. **Capture margin before `captureDeadline`**: In the two-phase path, reclaim becomes available to the client the moment `captureDeadline` passes, so a capture initiated near the deadline races both the client's reclaim and its own transaction latency — a capture that lands after the deadline reverts and the escrow returns to the client even though the resource was already delivered. CaptureAuthorizers should treat `captureDeadline − margin` as the effective deadline, with the margin sized to cover capture-transaction latency, any batching cadence, and clock skew. This matters most for the periodic-capture use case, where the final capture naturally drifts toward the end of the window.
+
+2. **CaptureAuthorizer liveness is settlement liveness**: Funds reach the receiver only if the captureAuthorizer acts inside the capture window. If it is unavailable for the remainder of the window, the client reclaims and the receiver bears the loss for resources already delivered; in the single-shot path the same outage instead blocks refunds, shifting the risk to the client. `captureDeadline` should be sized with authorizer downtime in mind, and receivers should capture promptly after delivery rather than deferring to the end of the window.
+
+3. **CaptureAuthorizer compromise and settlement finality**: The captureAuthorizer can void before capture and refund after it, until `refundDeadline`. A compromised authorizer — or one colluding with a payer — can therefore return already-settled funds to the client after the resource was delivered. Receivers should treat `refundDeadline`, not capture, as the moment of settlement finality and price that exposure window accordingly; using a contract (arbiter, multisig) rather than an EOA as the captureAuthorizer reduces single-key risk. Fee parameters are a second lever: with `feeRecipient` unset, a compromised authorizer may direct up to `maxFeeBps` of every capture to an address of its choice, so clients should keep `maxFeeBps` tight and pin `feeRecipient` where the fee model allows.
+
+4. **Delivery before on-chain authorization re-opens the serve/settle race**: Escrow protects the receiver against the payer invalidating funds after delivery — but only once `authorize()` (or `charge()`) is confirmed on-chain. A server that delivers the resource on successful verification alone (signature check + simulation) is exposed to the same race as `exact`'s verify-then-settle flow: balances or allowances can move between simulation and settlement so that collection fails after the resource is gone. Servers wanting escrow-grade safety should deliver only after settlement confirmation.
+
+5. **Operation-level idempotency**: The payment nonce is consumed on-chain, so a duplicate authorization is rejected — but capture, void, and refund are separately triggered operations, and their transport-level retries are not covered by that nonce. Facilitator APIs exposing these operations should define an idempotency key per operation and replay the original outcome for repeats, rather than surfacing a revert that tempts callers into blind retries. This matters most for partial-capture billing, where several captures legitimately share one authorization.
+
 ## Appendix
 
 Network-specific implementation details (contracts, signature formats, verification logic) are in per-network documents: `scheme_auth_capture_evm.md` (EVM).


### PR DESCRIPTION
## What

Adds a `Security Considerations` section to `specs/schemes/auth-capture/scheme_auth_capture.md`. Spec text only, no code changes.

## Why

`specs/CONTRIBUTING.md` asks scheme specs to document security considerations (replay prevention, authorization scope, settlement atomicity). `exact`, `upto` and `batch-settlement` each have such a section; `auth-capture` currently documents Core Properties (fund safety, replay prevention, expiry enforcement) but has no analysis of the operational races or the captureAuthorizer trust model.

## Contents

Five considerations, kept at the network-agnostic level (they apply to both settlement paths):

1. **Capture margin before `captureDeadline`** — reclaim becomes available the moment the deadline passes, so late captures race the client's reclaim and their own tx latency; effective deadline should be `captureDeadline − margin`. Same deadline-race class as the batch-settlement acceptance margin discussed in #2901.
2. **CaptureAuthorizer liveness is settlement liveness** — authorizer downtime inside the window means client reclaim (two-phase) or blocked refunds (single-shot).
3. **Compromise and settlement finality** — void/refund powers mean `refundDeadline`, not capture, is finality for the receiver; plus the `maxFeeBps`/unset-`feeRecipient` fee-diversion lever.
4. **Serve/settle race** — escrow protection only starts at on-chain confirmation; delivering on verification alone re-opens the `exact`-style race.
5. **Operation-level idempotency** — the on-chain nonce covers authorization, not transport-level retries of capture/void/refund.

## Background

Distilled from review findings in the Stipendex project, where we shipped and hardened a deferred-settlement rail with the same authorize-deliver-settle shape. Drafted with AI assistance and reviewed per the AI contribution policy in CONTRIBUTING.md.

Commit is SSH-signed (Verified).
