### PR TITLE
fix(go): return invalid payload for malformed payment signature

### DIFF
--- a/go/.changes/unreleased/fixed-20260720-131534.yaml
+++ b/go/.changes/unreleased/fixed-20260720-131534.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Return a spec-compatible invalid_payload error for malformed PAYMENT-SIGNATURE headers in the Go HTTP server
+time: 2026-07-20T13:15:34.715303+09:00

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -527,7 +527,7 @@ func (s *x402HTTPResourceServer) ProcessHTTPRequest(ctx context.Context, reqCtx 
 	if err != nil {
 		return HTTPProcessResult{
 			Type:     ResultPaymentError,
-			Response: &HTTPResponseInstructions{Status: 400, Body: map[string]string{"error": "Invalid payment"}},
+			Response: &HTTPResponseInstructions{Status: 400, Body: map[string]string{"error": "invalid_payload"}},
 		}
 	}
 

--- a/go/http/server_test.go
+++ b/go/http/server_test.go
@@ -190,6 +190,97 @@ func TestProcessHTTPRequestPaymentRequired(t *testing.T) {
 	}
 }
 
+func TestProcessHTTPRequestMalformedPaymentSignature(t *testing.T) {
+	ctx := context.Background()
+
+	routes := RoutesConfig{
+		"GET /api": {
+			Accepts: PaymentOptions{
+				{
+					Scheme:  "exact",
+					PayTo:   "0xtest",
+					Price:   "$1.00",
+					Network: "eip155:1",
+				},
+			},
+		},
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+	mockClient := &mockFacilitatorClient{
+		supported: func(ctx context.Context) (x402.SupportedResponse, error) {
+			return x402.SupportedResponse{
+				Kinds: []x402.SupportedKind{
+					{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+				},
+				Extensions: []string{},
+				Signers:    make(map[string][]string),
+			}, nil
+		},
+	}
+
+	server := Newx402HTTPResourceServer(
+		routes,
+		x402.WithFacilitatorClient(mockClient),
+		x402.WithSchemeServer("eip155:1", mockServer),
+	)
+	_ = server.Initialize(ctx)
+
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{
+			name:   "non-base64 header",
+			header: "garbage-value",
+		},
+		{
+			name:   "base64 invalid JSON",
+			header: base64.StdEncoding.EncodeToString([]byte("not-json")),
+		},
+		{
+			name:   "unsupported x402 version",
+			header: base64.StdEncoding.EncodeToString(mustMarshal(t, map[string]interface{}{"x402Version": 1})),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter := &mockHTTPAdapter{
+				method: "GET",
+				path:   "/api",
+				url:    "http://example.com/api",
+				headers: map[string]string{
+					"PAYMENT-SIGNATURE": tt.header,
+				},
+			}
+
+			result := server.ProcessHTTPRequest(ctx, HTTPRequestContext{
+				Adapter: adapter,
+				Path:    "/api",
+				Method:  "GET",
+			}, nil)
+
+			if result.Type != ResultPaymentError {
+				t.Fatalf("expected ResultPaymentError, got %s", result.Type)
+			}
+			if result.Response == nil {
+				t.Fatal("expected response instructions")
+			}
+			if result.Response.Status != 400 {
+				t.Fatalf("expected status 400, got %d", result.Response.Status)
+			}
+			body, ok := result.Response.Body.(map[string]string)
+			if !ok {
+				t.Fatalf("expected string map body, got %T", result.Response.Body)
+			}
+			if body["error"] != "invalid_payload" {
+				t.Fatalf("expected invalid_payload error, got %q", body["error"])
+			}
+		})
+	}
+}
+
 func TestProcessHTTPRequestServiceMetadataOnResource(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description

Align the Go HTTP resource server with the malformed `PAYMENT-SIGNATURE` behavior from #2397 and TypeScript PR #2843.

`extractPaymentV2` already returned an error for malformed payment headers, but `ProcessHTTPRequest` mapped every extraction failure to the generic body `{ "error": "Invalid payment" }` at `go/http/server.go:526-530`. 

This change returns the spec-compatible `{ "error": "invalid_payload" }` while preserving the existing `400` status and early return before facilitator verification.

Regression coverage includes:

- non-base64 `PAYMENT-SIGNATURE`
- base64-encoded invalid JSON
- unsupported `x402Version: 1`

The version case preserves the existing Go v2-only extraction behavior and verifies the updated error body. Requests without `PAYMENT-SIGNATURE` continue through the existing `402 Payment Required` path.

- Related to #2397.
- Go parity for #2843.

## Tests

- `GOCACHE=/tmp/go-build-cache go test ./http -run TestProcessHTTPRequestMalformedPaymentSignature`
- `GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache make verify`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] I added a changelog fragment for the user-facing change