### PR TITLE
docs(examples): refresh TypeScript examples index

### DIFF
--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -14,56 +14,72 @@ pnpm build
 
 ## Example Structure
 
-The examples are organized into several categories:
+To see a full payment flow end to end, run a server from [`servers/`](./servers/) and point a client from [`clients/`](./clients/) at it.
 
 ### Clients
 
-Examples of different client implementations for interacting with X402 services:
+Clients that pay for x402-protected endpoints. See [`clients/`](./clients/).
 
-- `clients/axios/` - Axios client with x402 payment interceptor from `x402-axios`.
-- `clients/fetch/` - Client using the `x402-fetch` wrapper around the native fetch API.
-- `clients/cdp-sdk/` - Client that uses CDP Server Wallets as the signer with `x402-axios`.
-- `clients/chainlink-vrf-nft/` - Example using [Chainlink](docs.chain.link) to mint a randomized NFT (see them on [Opensea](https://testnets.opensea.io/collection/vrfnft-1)). Demonstrates verify/settle flow with `x402-axios`.
-
-### Agents
-
-- `agent/` - Anthropic agent that pays via a Go proxy using `x402-fetch`.
-- `dynamic_agent/` - Agent that discovers tools dynamically and pays per-request using x402.
-
-### Discovery
-
-- `discovery/` - Uses the facilitator to list available x402-protected resources (Bazaar).
-
-### MCP
-
-- `mcp/` - MCP server that makes paid API requests via `x402-axios` (Claude Desktop compatible).
-- `mcp-embedded-wallet/` - Electron-based MCP server with an embedded wallet that signs requests via IPC.
-
-### Facilitator
-
-- `facilitator/` - Example implementation of an x402 payment facilitator exposing `/verify` and `/settle`.
-
-### Fullstack
-
-- `fullstack/next/` - Next.js app demonstrating route protection with `x402-next` middleware.
-- `fullstack/mainnet/` - Next.js app configured for Base mainnet using the Coinbase hosted facilitator.
-- `fullstack/next-advanced/` - [WIP] Deep Next.js integration using a paywall + session cookie after verify/settle.
-- `fullstack/browser-wallet-example/` - Browser wallet template: Hono server + React client with session and one-time payments.
-- `fullstack/farcaster-miniapp/` - Farcaster Mini App template with x402-protected APIs using [MiniKit](https://www.base.org/build/mini-apps).
-- `fullstack/auth_based_pricing/` - SIWE + JWT with conditional pricing ($0.01 with JWT vs $0.10 without) using x402.
+| Directory | Description |
+| --- | --- |
+| [`fetch/`](./clients/fetch/) | `@x402/fetch` wrapper around the native Fetch API |
+| [`axios/`](./clients/axios/) | `@x402/axios` payment interceptor |
+| [`advanced/`](./clients/advanced/) | Builder-pattern registration, payment lifecycle hooks, network preferences |
+| [`custom/`](./clients/custom/) | Manual payment handling without `@x402/fetch` or `@x402/axios` |
+| [`auth-capture/`](./clients/auth-capture/) | Pays an auth-capture endpoint by signing an ERC-3009 `ReceiveWithAuthorization` |
+| [`batch-settlement/`](./clients/batch-settlement/) | Pays a sequence of requests over one payment channel using cumulative vouchers |
+| [`builder-code/`](./clients/builder-code/) | Verifies ERC-8021 builder-code attribution on the settlement transaction |
+| [`erc7702/`](./clients/erc7702/) | Paying from an ERC-7702 delegated EOA |
+| [`offer-receipt/`](./clients/offer-receipt/) | Extracts and verifies signed offers and receipts |
+| [`payment-identifier/`](./clients/payment-identifier/) | Idempotent retries via the `payment-identifier` extension |
+| [`sign-in-with-x/`](./clients/sign-in-with-x/) | Both SIWX flows: auth-only access and paid-once access |
+| [`mcp/`](./clients/mcp/) | MCP client that pays for tool calls |
+| [`mcp-chatbot/`](./clients/mcp-chatbot/) | Chatbot combining an LLM, MCP tool discovery, and x402 payments |
 
 ### Servers
 
-Examples of different server implementations:
+Servers that put a paywall in front of a resource. See [`servers/`](./servers/).
 
-- `servers/express/` - Express.js server using `x402-express` middleware.
-- `servers/hono/` - Hono server using `x402-hono` middleware.
-- `servers/advanced/` - Express server without middleware: delayed settlement, dynamic pricing, multiple requirements.
-- `servers/mainnet/` - Server example for accepting real USDC on Base mainnet using the Coinbase hosted facilitator.
+| Directory | Description |
+| --- | --- |
+| [`express/`](./servers/express/) | `@x402/express` middleware |
+| [`hono/`](./servers/hono/) | `@x402/hono` middleware |
+| [`fastify/`](./servers/fastify/) | `@x402/fastify` middleware |
+| [`advanced/`](./servers/advanced/) | Dynamic pricing, payment routing, lifecycle hooks, discoverability |
+| [`custom/`](./servers/custom/) | Manual payment handling without an x402 middleware package |
+| [`self-facilitation/`](./servers/self-facilitation/) | In-process `x402Facilitator` instead of an external facilitator URL |
+| [`upto/`](./servers/upto/) | `upto` scheme: authorize a ceiling, settle only actual usage |
+| [`batch-settlement/`](./servers/batch-settlement/) | Off-chain vouchers claimed and settled in batches by a `ChannelManager` |
+| [`bazaar/`](./servers/bazaar/) | Makes a paid API discoverable via the Bazaar extension |
+| [`builder-code/`](./servers/builder-code/) | ERC-8021 builder-code attribution on paid endpoints |
+| [`offer-receipt/`](./servers/offer-receipt/) | Signed offers (payment terms) and receipts (proof of delivery) |
+| [`payment-identifier/`](./servers/payment-identifier/) | Idempotency via the `payment-identifier` extension |
+| [`sign-in-with-x/`](./servers/sign-in-with-x/) | Auth-only routes and pay-once-then-authenticate routes |
+| [`cloudfront-lambda-edge/`](./servers/cloudfront-lambda-edge/) | Adds x402 at the CDN edge without modifying the backend |
+| [`mcp/`](./servers/mcp/) | MCP server exposing paid tools |
+
+### Fullstack
+
+| Directory | Description |
+| --- | --- |
+| [`next/`](./fullstack/next/) | Next.js route protection with `@x402/next` middleware |
+| [`miniapp/`](./fullstack/miniapp/) | Farcaster Mini App with x402-protected API routes |
+| [`next-batch-settlement-redis/`](./fullstack/next-batch-settlement-redis/) | Next.js batch-settlement with Redis-backed channel storage |
+
+### Facilitator
+
+Services that verify and settle payments on-chain.
+
+| Directory | Description |
+| --- | --- |
+| [`basic/`](./facilitator/basic/) | Minimal facilitator exposing `/verify` and `/settle` |
+| [`advanced/`](./facilitator/advanced/) | All-networks support, Bazaar discovery, gas-sponsoring extensions, hooks |
+| [`batch-settlement/`](./facilitator/batch-settlement/) | Submits batch-settlement contract calls |
+| [`builder-code/`](./facilitator/builder-code/) | Appends ERC-8021 wallet attribution at settlement |
 
 ## Running Examples
 
-Each example directory contains its own README with specific instructions for running that example. Navigate to the desired example directory and follow its instructions.
+Most example directories contain their own README with specific instructions for running that example. Navigate to the desired example directory and follow its instructions.
 
 ## Development
 

--- a/examples/typescript/clients/README.md
+++ b/examples/typescript/clients/README.md
@@ -9,7 +9,16 @@ This directory contains TypeScript client examples demonstrating how to make HTT
 | [`fetch/`](./fetch/) | Using `@x402/fetch` with the native Fetch API |
 | [`axios/`](./axios/) | Using `@x402/axios` with Axios |
 | [`advanced/`](./advanced/) | Advanced patterns: lifecycle hooks, network preferences |
-| [`custom/`](./custom/) | Manual implementation using only `@x402/core` |
+| [`custom/`](./custom/) | Manual implementation without `@x402/fetch` or `@x402/axios` |
+| [`auth-capture/`](./auth-capture/) | Pays an auth-capture endpoint by signing an ERC-3009 `ReceiveWithAuthorization` |
+| [`batch-settlement/`](./batch-settlement/) | Pays a sequence of requests over one payment channel using cumulative vouchers |
+| [`builder-code/`](./builder-code/) | Verifies ERC-8021 builder-code attribution on the settlement transaction |
+| [`erc7702/`](./erc7702/) | Paying from an ERC-7702 delegated EOA |
+| [`offer-receipt/`](./offer-receipt/) | Extracts and verifies signed offers and receipts |
+| [`payment-identifier/`](./payment-identifier/) | Idempotent retries via the `payment-identifier` extension |
+| [`sign-in-with-x/`](./sign-in-with-x/) | Both SIWX flows: auth-only access and paid-once access |
+| [`mcp/`](./mcp/) | MCP client that pays for tool calls |
+| [`mcp-chatbot/`](./mcp-chatbot/) | Chatbot combining an LLM, MCP tool discovery, and x402 payments |
 
 ## Framework Examples
 
@@ -33,7 +42,7 @@ These patterns are useful for production applications that need observability, c
 
 ## Custom Implementation
 
-The **custom** directory shows how to implement x402 payment handling manually using only `@x402/core`, without any client interceptors. Use this approach when:
+The **custom** directory shows how to implement x402 payment handling manually, without any client interceptors. Use this approach when:
 
 - You need complete control over the payment flow
 - You're integrating with an HTTP client we don't have a package for
@@ -42,6 +51,6 @@ The **custom** directory shows how to implement x402 payment handling manually u
 ## Getting Started
 
 1. Pick an example directory
-2. Follow the README in that directory
+2. Follow the README in that directory, if it has one
 3. Make sure you have a [server](../servers/) running to test against
 

--- a/examples/typescript/facilitator/README.md
+++ b/examples/typescript/facilitator/README.md
@@ -1,0 +1,18 @@
+# x402 Facilitator Examples
+
+This directory contains TypeScript facilitator examples. A facilitator verifies payment payloads and settles them on-chain, so a resource server can accept payments without holding keys or submitting transactions itself.
+
+## Directory Structure
+
+| Directory | Description |
+| --- | --- |
+| [`basic/`](./basic/) | Minimal facilitator exposing `/verify` and `/settle` |
+| [`advanced/`](./advanced/) | All-networks support, Bazaar discovery, gas-sponsoring extensions, lifecycle hooks |
+| [`batch-settlement/`](./batch-settlement/) | Submits batch-settlement contract calls |
+| [`builder-code/`](./builder-code/) | Appends ERC-8021 wallet attribution at settlement |
+
+## Getting Started
+
+1. Pick an example directory
+2. Follow the README in that directory
+3. Point a [server](../servers/)'s `FACILITATOR_URL` at it, then drive the flow with a [client](../clients/)

--- a/examples/typescript/fullstack/README.md
+++ b/examples/typescript/fullstack/README.md
@@ -1,0 +1,16 @@
+# x402 Fullstack Examples
+
+This directory contains TypeScript examples that serve x402-protected routes from a web application framework.
+
+## Directory Structure
+
+| Directory | Description |
+| --- | --- |
+| [`next/`](./next/) | Next.js route protection with `@x402/next` middleware |
+| [`miniapp/`](./miniapp/) | Farcaster Mini App with x402-protected API routes |
+| [`next-batch-settlement-redis/`](./next-batch-settlement-redis/) | Next.js batch-settlement with Redis-backed channel storage |
+
+## Getting Started
+
+1. Pick an example directory
+2. Follow the README in that directory

--- a/examples/typescript/servers/README.md
+++ b/examples/typescript/servers/README.md
@@ -7,14 +7,24 @@ This directory contains TypeScript server examples demonstrating how to protect 
 | Directory | Description |
 | --- | --- |
 | [`express/`](./express/) | Using `@x402/express` middleware |
-| [`self-facilitation/`](./self-facilitation/) | Express middleware with in-process SDK facilitator |
 | [`hono/`](./hono/) | Using `@x402/hono` middleware |
+| [`fastify/`](./fastify/) | Using `@x402/fastify` middleware |
+| [`self-facilitation/`](./self-facilitation/) | Express middleware with in-process SDK facilitator |
 | [`advanced/`](./advanced/) | Advanced patterns: hooks, dynamic pricing, custom tokens |
-| [`custom/`](./custom/) | Manual implementation using only `@x402/core` |
+| [`custom/`](./custom/) | Manual implementation without an x402 middleware package |
+| [`upto/`](./upto/) | `upto` scheme: authorize a ceiling, settle only actual usage |
+| [`batch-settlement/`](./batch-settlement/) | Off-chain vouchers claimed and settled in batches by a `ChannelManager` |
+| [`bazaar/`](./bazaar/) | Makes a paid API discoverable via the Bazaar extension |
+| [`builder-code/`](./builder-code/) | ERC-8021 builder-code attribution on paid endpoints |
+| [`offer-receipt/`](./offer-receipt/) | Signed offers (payment terms) and receipts (proof of delivery) |
+| [`payment-identifier/`](./payment-identifier/) | Idempotency via the `payment-identifier` extension |
+| [`sign-in-with-x/`](./sign-in-with-x/) | Auth-only routes and pay-once-then-authenticate routes |
+| [`cloudfront-lambda-edge/`](./cloudfront-lambda-edge/) | Adds x402 at the CDN edge without modifying the backend |
+| [`mcp/`](./mcp/) | MCP server exposing paid tools |
 
 ## Framework Examples
 
-The **express**, **self-facilitation**, and **hono** directories showcase the minimal approach to adding x402 paywalls to your API. These use our middleware packages that automatically handle:
+The **express**, **hono**, and **fastify** directories showcase the minimal approach to adding x402 paywalls to your API. These use our middleware packages that automatically handle:
 
 1. Checking for payment headers on protected routes
 2. Returning 402 with payment requirements if no payment
@@ -37,15 +47,15 @@ These patterns are useful for production applications that need custom business 
 
 ## Custom Implementation
 
-The **custom** directory shows how to implement x402 payment handling manually using only `@x402/core`, without any middleware. Use this approach when:
+The **custom** directory shows how to implement x402 payment handling manually, without a prebuilt x402 middleware package. Use this approach when:
 
 - You need complete control over the payment flow
-- You're using a web framework we don't have a package for (Koa, Fastify, etc.)
+- You're using a web framework we don't have a package for
 - You want to understand how x402 works under the hood
 
 ## Getting Started
 
 1. Pick an example directory
-2. Follow the README in that directory
+2. Follow the README in that directory, if it has one
 3. Use one of the [clients](../clients/) to test your server
 


### PR DESCRIPTION
## Description

`examples/typescript/README.md` was last updated in #345 (2025-08-18). The v2
restructure in #705 rewrote every example in that tree but left the index files
untouched.

| File | Listed | Dead links | Examples omitted |
| --- | --- | --- | --- |
| `examples/typescript/README.md` | 20 | 13 | 29 of 35 |
| `clients/README.md` | 4 | 0 | 9 of 13 |
| `servers/README.md` | 5 | 0 | 10 of 15 |
| `fullstack/`, `facilitator/` | no index | — | 7 |

All listings are rebuilt from what is on disk. Descriptions come from each
example's own README, or from its source for `clients/erc7702/` and
`servers/upto/`, which have none. New indexes added for `fullstack/` and
`facilitator/`.

Three corrections beyond the listings, called out because they touch existing
prose rather than just adding entries:

- `custom/` was described as using "only `@x402/core`"; both examples also
  import `@x402/evm` (plus `@x402/svm` and Express respectively).
- Fastify was listed as a framework without a package, but `@x402/fastify` and
  `servers/fastify/` now exist.
- "Each example directory contains its own README" is now "Most" —
  `clients/erc7702/` and `servers/upto/` have none.

## Tests

Docs-only; no code paths changed. Verified mechanically that every relative link
in the five index files resolves to an existing directory, and that every
example directory under `clients/`, `servers/`, `fullstack/`, and `facilitator/`
appears in its index — 35/35, no dead links.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

---

Drafted with Claude Code and reviewed by me before submission.
