### PR TITLE
fix(go): propagate batch settlement storage errors

### DIFF
--- a/go/.changes/unreleased/fixed-20260722-095249.yaml
+++ b/go/.changes/unreleased/fixed-20260722-095249.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Propagated client storage errors during batch settlement and refunds.
+time: 2026-07-22T09:52:49.309703+09:00

--- a/go/mechanisms/evm/batch-settlement/client/refund.go
+++ b/go/mechanisms/evm/batch-settlement/client/refund.go
@@ -110,7 +110,10 @@ func UpdateSessionAfterRefund(storage ClientChannelStorage, channelKey string, s
 		return storage.Delete(channelKey)
 	}
 
-	prev, _ := storage.Get(channelKey)
+	prev, err := storage.Get(channelKey)
+	if err != nil {
+		return fmt.Errorf("get channel session: %w", err)
+	}
 	next := &BatchSettlementClientContext{}
 	if prev != nil {
 		*next = *prev
@@ -262,7 +265,9 @@ func executeRefund(
 		if settle != nil && settle.Extra != nil {
 			if cs, ok := settle.Extra["channelState"].(map[string]interface{}); ok {
 				if channelId, ok := cs["channelId"].(string); ok && channelId != "" {
-					_ = UpdateSessionAfterRefund(scheme.Storage(), channelId, settle.Extra)
+					if err := UpdateSessionAfterRefund(scheme.Storage(), channelId, settle.Extra); err != nil {
+						return settle, fmt.Errorf("refund: update channel session: %w", err)
+					}
 				}
 			}
 		}
@@ -293,7 +298,10 @@ func buildRefundVoucherPayload(
 	}
 
 	storage := scheme.Storage()
-	session, _ := storage.Get(channelId)
+	session, err := storage.Get(channelId)
+	if err != nil {
+		return nil, fmt.Errorf("refund: get channel session: %w", err)
+	}
 	if session == nil {
 		// Try recovery if the signer supports onchain reads.
 		if _, ok := scheme.Signer().(evm.ClientEvmSignerWithReadContract); ok {

--- a/go/mechanisms/evm/batch-settlement/client/refund_test.go
+++ b/go/mechanisms/evm/batch-settlement/client/refund_test.go
@@ -201,6 +201,25 @@ func TestUpdateSessionAfterRefund_NoPriorSessionPartial(t *testing.T) {
 	}
 }
 
+func TestUpdateSessionAfterRefund_GetError(t *testing.T) {
+	storageErr := errors.New("storage unavailable")
+	storage := &failingClientChannelStorage{
+		storage: NewInMemoryClientChannelStorage(),
+		getErr:  storageErr,
+	}
+	err := UpdateSessionAfterRefund(storage, testChannelID, map[string]interface{}{
+		"channelState": map[string]interface{}{
+			"balance": "500",
+		},
+	})
+	if !errors.Is(err, storageErr) {
+		t.Fatalf("expected storage error, got %v", err)
+	}
+	if storage.setCalls != 0 {
+		t.Fatalf("Set called %d time(s) after Get failure", storage.setCalls)
+	}
+}
+
 // ---------- probeRefundRequirements (HTTP) ----------
 
 func TestProbeRefundRequirements_Non402(t *testing.T) {
@@ -288,7 +307,7 @@ func TestProbeRefundRequirements_BadHeader(t *testing.T) {
 // ---------- buildRefundVoucherPayload via stub RefundContext ----------
 
 type fakeRefundContext struct {
-	storage       *InMemoryClientChannelStorage
+	storage       ClientChannelStorage
 	signer        *mockSigner
 	voucherSigner *mockSigner
 	config        batchsettlement.ChannelConfig
@@ -342,6 +361,23 @@ func TestBuildRefundVoucherPayload_NoSession(t *testing.T) {
 	_, err := buildRefundVoucherPayload(context.Background(), fctx, types.PaymentRequirements{Network: "eip155:8453"}, "")
 	if err == nil || !strings.Contains(err.Error(), "existing channel session") {
 		t.Fatalf("expected missing-session error, got %v", err)
+	}
+}
+
+func TestBuildRefundVoucherPayload_GetError(t *testing.T) {
+	storageErr := errors.New("storage unavailable")
+	fctx := &fakeRefundContext{
+		storage: &failingClientChannelStorage{
+			storage: NewInMemoryClientChannelStorage(),
+			getErr:  storageErr,
+		},
+		signer: &mockSigner{address: "0x1"},
+		config: defaultConfig(),
+	}
+
+	_, err := buildRefundVoucherPayload(context.Background(), fctx, types.PaymentRequirements{Network: "eip155:8453"}, "")
+	if !errors.Is(err, storageErr) {
+		t.Fatalf("expected storage error, got %v", err)
 	}
 }
 
@@ -669,5 +705,66 @@ func TestExecuteRefund_402MissingHeadersErrors(t *testing.T) {
 		"", http.DefaultClient)
 	if err == nil || !strings.Contains(err.Error(), "missing PAYMENT-REQUIRED") {
 		t.Fatalf("got %v", err)
+	}
+}
+
+func TestExecuteRefund_SessionUpdateErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		balance   string
+		configure func(*failingClientChannelStorage, error)
+	}{
+		{
+			name:    "partial refund set",
+			balance: "500",
+			configure: func(storage *failingClientChannelStorage, err error) {
+				storage.setErr = err
+			},
+		},
+		{
+			name:    "full refund delete",
+			balance: "0",
+			configure: func(storage *failingClientChannelStorage, err error) {
+				storage.deleteErr = err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			storageErr := errors.New("storage unavailable")
+			fctx := fakeRefundContextWithSession("100")
+			storage := &failingClientChannelStorage{storage: fctx.storage}
+			tc.configure(storage, storageErr)
+			fctx.storage = storage
+
+			settle := x402.SettleResponse{
+				Success: true,
+				Extra: map[string]interface{}{
+					"channelState": map[string]interface{}{
+						"channelId": testChannelID,
+						"balance":   tc.balance,
+					},
+				},
+			}
+			settleBytes, err := json.Marshal(settle)
+			if err != nil {
+				t.Fatalf("marshal settle response: %v", err)
+			}
+			settleHeader := base64.StdEncoding.EncodeToString(settleBytes)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("PAYMENT-RESPONSE", settleHeader)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			got, err := executeRefund(context.Background(), fctx, srv.URL,
+				types.PaymentRequirements{Scheme: batchsettlement.SchemeBatched, Network: "eip155:8453"},
+				"", http.DefaultClient)
+			if !errors.Is(err, storageErr) {
+				t.Fatalf("expected storage error, got %v", err)
+			}
+			if got == nil || !got.Success {
+				t.Fatalf("expected settle response with storage error, got %+v", got)
+			}
+		})
 	}
 }

--- a/go/mechanisms/evm/batch-settlement/client/scheme.go
+++ b/go/mechanisms/evm/batch-settlement/client/scheme.go
@@ -374,7 +374,10 @@ func (c *BatchSettlementEvmScheme) ProcessSettleResponse(settle map[string]inter
 		return err
 	}
 
-	prev, _ := c.storage.Get(channelId)
+	prev, err := c.storage.Get(channelId)
+	if err != nil {
+		return fmt.Errorf("get channel session: %w", err)
+	}
 	next := &BatchSettlementClientContext{}
 	if prev != nil {
 		*next = *prev

--- a/go/mechanisms/evm/batch-settlement/client/scheme_test.go
+++ b/go/mechanisms/evm/batch-settlement/client/scheme_test.go
@@ -334,6 +334,28 @@ func TestProcessSettleResponse_StoresSession(t *testing.T) {
 	}
 }
 
+func TestProcessSettleResponse_GetError(t *testing.T) {
+	storageErr := errors.New("storage unavailable")
+	storage := &failingClientChannelStorage{
+		storage: NewInMemoryClientChannelStorage(),
+		getErr:  storageErr,
+	}
+	scheme := NewBatchSettlementEvmScheme(&mockSigner{address: "0x1"}, &BatchSettlementEvmSchemeOptions{Storage: storage})
+
+	err := scheme.ProcessSettleResponse(map[string]interface{}{
+		"channelState": map[string]interface{}{
+			"channelId": testChannelID,
+			"balance":   "1000",
+		},
+	})
+	if !errors.Is(err, storageErr) {
+		t.Fatalf("expected storage error, got %v", err)
+	}
+	if storage.setCalls != 0 {
+		t.Fatalf("Set called %d time(s) after Get failure", storage.setCalls)
+	}
+}
+
 // ProcessSettleResponse is a pure-merge updater.
 // It does NOT delete sessions on zero balance — that responsibility belongs to
 // UpdateSessionAfterRefund, called explicitly at the refund call site.

--- a/go/mechanisms/evm/batch-settlement/client/storage_test.go
+++ b/go/mechanisms/evm/batch-settlement/client/storage_test.go
@@ -20,6 +20,36 @@ func sampleCtx() *BatchSettlementClientContext {
 	}
 }
 
+type failingClientChannelStorage struct {
+	storage   ClientChannelStorage
+	getErr    error
+	setErr    error
+	deleteErr error
+	setCalls  int
+}
+
+func (s *failingClientChannelStorage) Get(channelId string) (*BatchSettlementClientContext, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	return s.storage.Get(channelId)
+}
+
+func (s *failingClientChannelStorage) Set(channelId string, ctx *BatchSettlementClientContext) error {
+	s.setCalls++
+	if s.setErr != nil {
+		return s.setErr
+	}
+	return s.storage.Set(channelId, ctx)
+}
+
+func (s *failingClientChannelStorage) Delete(channelId string) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	return s.storage.Delete(channelId)
+}
+
 func TestInMemoryClientChannelStorage_GetMissing(t *testing.T) {
 	s := NewInMemoryClientChannelStorage()
 	got, err := s.Get(missingChannelID)


### PR DESCRIPTION
## Description

The Go batch-settlement client ignored storage errors while merging settlement state, reconciling refunds, and building refund vouchers. 

After #2863 made file-backed storage surface real read and write failures, these paths could treat storage failures as missing sessions or report a successful refund despite failed local reconciliation.

This change:

- propagates `Get` failures from `ProcessSettleResponse` (`scheme.go:377`), `UpdateSessionAfterRefund` (`refund.go:113`), and refund voucher creation (`refund.go:301`)
- propagates `Set` and `Delete` failures after a successful remote refund (`refund.go:268`)
- preserves the decoded settle response alongside reconciliation errors because the remote refund has already completed
- adds regression coverage using storage implementations that fail `Get`, `Set`, or `Delete`

Follow-up to #2863.

AI assistance was used for implementation and tests; the final diff was reviewed and independently cross-verified.

## Tests

- `make verify`
- `make build`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes