### PR TITLE
docs: add x402-list.com to ecosystem directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ go get github.com/x402-foundation/x402/go/v2
 
 ## Ecosystem
 
-Curated third-party SDKs, extensions, and facilitators are listed in the [Developer Tools docs](https://docs.x402.org/dev-tools/overview). For broader discovery of x402 services and integrations, see community-maintained directories such as [x402scan.com](https://x402scan.com), [Agentic.Market](https://agentic.market), [Pay.sh](https://pay.sh), and [app.ampersend.ai/discover](https://app.ampersend.ai/discover).
+Curated third-party SDKs, extensions, and facilitators are listed in the [Developer Tools docs](https://docs.x402.org/dev-tools/overview). For broader discovery of x402 services and integrations, see community-maintained directories such as [x402scan.com](https://x402scan.com), [Agentic.Market](https://agentic.market), [Pay.sh](https://pay.sh), [app.ampersend.ai/discover](https://app.ampersend.ai/discover), and [x402-list.com](https://x402-list.com).
 
 **Roadmap:** see [ROADMAP.md](https://github.com/x402-foundation/x402/blob/main/ROADMAP.md)
 


### PR DESCRIPTION
## Description

Follow-up from the Slack thread in #github-discussions (thanks Kevin for the go-ahead): adds x402-list.com to the community-maintained directories in the Ecosystem section. Kept it to the single line as promised.

## Tests

Docs-only README change; verified the link resolves.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)
