### PR TITLE
Fix: Algorand CAIP-2 network IDs

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -10,7 +10,7 @@ x402 uses [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) standard network iden
 - **EVM networks**: `eip155:<chainId>` — any EVM chain is supported (e.g., `eip155:8453` for Base)
 - **Solana**: `solana:<genesisHash>` (first 32 bytes of the genesis block hash)
 - **TON (TVM)**: `tvm:<workchain>` (e.g., `tvm:-239` for mainnet, `tvm:-3` for testnet)
-- **Algorand**: `algorand:<genesisHash>` (base64-encoded genesis hash)
+- **Algorand**: `algorand:<reference>` — URL-safe base64 of the genesis hash, first 32 characters ([Algorand CAIP-2 profile](https://namespaces.chainagnostic.org/algorand/caip2))
 - **Stellar**: `stellar:<network>` (`pubnet` or `testnet`)
 - **Aptos**: `aptos:<chainId>` (e.g., `aptos:1` for mainnet)
 - **Hedera**: `hedera:<network>` (`mainnet` or `testnet`)
@@ -147,8 +147,8 @@ When you use `"$0.01"` syntax, x402 needs to know which stablecoin to use. The f
 
 | Chain | CAIP-2 | ASA ID | Decimals |
 |-------|--------|--------|----------|
-| Algorand Mainnet | `algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=` | `31566704` (USDC) | 6 |
-| Algorand Testnet | `algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=` | `10458941` (USDC) | 6 |
+| Algorand Mainnet | `algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k` | `31566704` (USDC) | 6 |
+| Algorand Testnet | `algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe` | `10458941` (USDC) | 6 |
 
 ### Stellar
 

--- a/docs/getting-started/quickstart-for-sellers.mdx
+++ b/docs/getting-started/quickstart-for-sellers.mdx
@@ -136,7 +136,7 @@ Integrate the payment middleware into your application. You will need to provide
               {
                 scheme: "exact",
                 price: "$0.001",
-                network: "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=", // Algorand Testnet
+                network: "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe", // Algorand Testnet
                 payTo: avmAddress,
               },
             ],
@@ -147,7 +147,7 @@ Integrate the payment middleware into your application. You will need to provide
         new x402ResourceServer(facilitatorClient)
           .register("eip155:84532", new ExactEvmScheme())
           .register("solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", new ExactSvmScheme())
-          .register("algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=", new ExactAvmScheme()),
+          .register("algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe", new ExactAvmScheme()),
       ),
     );
 

--- a/e2e/facilitators/typescript/index.ts
+++ b/e2e/facilitators/typescript/index.ts
@@ -110,7 +110,7 @@ const SVM_NETWORK =
 const APTOS_NETWORK = process.env.APTOS_NETWORK || "aptos:2";
 const AVM_NETWORK =
   process.env.AVM_NETWORK ||
-  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe";
 const HEDERA_NETWORK = process.env.HEDERA_NETWORK || "hedera:testnet";
 const KEETA_NETWORK = process.env.KEETA_NETWORK || KEETA_TESTNET_CAIP2;
 const STELLAR_NETWORK = process.env.STELLAR_NETWORK || "stellar:testnet";

--- a/e2e/servers/express/index.ts
+++ b/e2e/servers/express/index.ts
@@ -35,7 +35,7 @@ dotenv.config();
 
 const PORT = process.env.PORT || "4021";
 const AVM_NETWORK = (process.env.AVM_NETWORK ||
-  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=") as `${string}:${string}`;
+  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe") as `${string}:${string}`;
 const EVM_NETWORK = (process.env.EVM_NETWORK || "eip155:84532") as `${string}:${string}`;
 const SVM_NETWORK = (process.env.SVM_NETWORK ||
   "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1") as `${string}:${string}`;

--- a/e2e/servers/fastify/index.ts
+++ b/e2e/servers/fastify/index.ts
@@ -40,7 +40,7 @@ const SVM_NETWORK = (process.env.SVM_NETWORK ||
 const APTOS_NETWORK = (process.env.APTOS_NETWORK || "aptos:2") as `${string}:${string}`;
 const HEDERA_NETWORK = (process.env.HEDERA_NETWORK || "hedera:testnet") as `${string}:${string}`;
 const AVM_NETWORK = (process.env.AVM_NETWORK ||
-  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=") as `${string}:${string}`;
+  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe") as `${string}:${string}`;
 const KEETA_NETWORK = (process.env.KEETA_NETWORK || KEETA_TESTNET_CAIP2) as `${string}:${string}`;
 const STELLAR_NETWORK = (process.env.STELLAR_NETWORK || "stellar:testnet") as `${string}:${string}`;
 const TVM_NETWORK = (process.env.TVM_NETWORK || "tvm:-3") as `${string}:${string}`;

--- a/e2e/servers/hono/index.ts
+++ b/e2e/servers/hono/index.ts
@@ -41,7 +41,7 @@ const SVM_NETWORK = (process.env.SVM_NETWORK ||
 const APTOS_NETWORK = (process.env.APTOS_NETWORK || "aptos:2") as `${string}:${string}`;
 const HEDERA_NETWORK = (process.env.HEDERA_NETWORK || "hedera:testnet") as `${string}:${string}`;
 const AVM_NETWORK = (process.env.AVM_NETWORK ||
-  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=") as `${string}:${string}`;
+  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe") as `${string}:${string}`;
 const KEETA_NETWORK = (process.env.KEETA_NETWORK || KEETA_TESTNET_CAIP2) as `${string}:${string}`;
 const STELLAR_NETWORK = (process.env.STELLAR_NETWORK || "stellar:testnet") as `${string}:${string}`;
 const TVM_NETWORK = (process.env.TVM_NETWORK || "tvm:-3") as `${string}:${string}`;

--- a/e2e/servers/next/proxy.ts
+++ b/e2e/servers/next/proxy.ts
@@ -34,7 +34,7 @@ export const EVM_NETWORK = (process.env.EVM_NETWORK || "eip155:84532") as `${str
 export const SVM_NETWORK = (process.env.SVM_NETWORK ||
   "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1") as `${string}:${string}`;
 export const AVM_NETWORK = (process.env.AVM_NETWORK ||
-  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=") as `${string}:${string}`;
+  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe") as `${string}:${string}`;
 export const APTOS_NETWORK = (process.env.APTOS_NETWORK || "aptos:2") as `${string}:${string}`;
 export const HEDERA_NETWORK = (process.env.HEDERA_NETWORK ||
   "hedera:testnet") as `${string}:${string}`;

--- a/e2e/src/networks/networks.ts
+++ b/e2e/src/networks/networks.ts
@@ -47,7 +47,7 @@ const NETWORK_SETS: Record<NetworkMode, NetworkSet> = {
     },
     avm: {
       name: 'Algorand Testnet',
-      caip2: 'algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=',
+      caip2: 'algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe',
       rpcUrl: process.env.AVM_TESTNET_RPC_URL || 'https://testnet-api.4160.nodely.dev',
     },
     ccd: {
@@ -106,7 +106,7 @@ const NETWORK_SETS: Record<NetworkMode, NetworkSet> = {
     },
     avm: {
       name: 'Algorand Mainnet',
-      caip2: 'algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=',
+      caip2: 'algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k',
       rpcUrl: process.env.AVM_RPC_URL || 'https://mainnet-api.4160.nodely.dev',
     },
     ccd: {

--- a/examples/typescript/facilitator/advanced/all_networks.ts
+++ b/examples/typescript/facilitator/advanced/all_networks.ts
@@ -136,7 +136,7 @@ if (
 }
 
 // Network configuration (alphabetic order)
-const AVM_NETWORK = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI="; // Algorand Testnet
+const AVM_NETWORK = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe"; // Algorand Testnet
 const APTOS_NETWORK = (process.env.APTOS_NETWORK || "aptos:2") as Network; // Aptos Testnet
 const CCD_NETWORK = "ccd:4221332d34e1694168c2a0c0b3fd0f27"; // Concordium Testnet
 const EVM_NETWORK = "eip155:84532"; // Base Sepolia

--- a/examples/typescript/servers/advanced/README.md
+++ b/examples/typescript/servers/advanced/README.md
@@ -67,6 +67,8 @@ cp .env-local .env
 and fill required environment variables:
 
 - `FACILITATOR_URL` - Facilitator endpoint URL
+- `AVM_ADDRESS` - Algorand address to receive payments (optional for `all-networks`)
+- `AVM_NETWORK` - Algorand network CAIP-2 (optional; defaults to canonical Algorand Testnet)
 - `APTOS_ADDRESS` - Aptos account address to receive payments (optional for `all-networks`)
 - `CCD_ADDRESS` - Concordium account address to receive payments (optional for `all-networks`)
 - `EVM_ADDRESS` - Ethereum address to receive payments
@@ -92,6 +94,16 @@ cd servers/advanced
 
 ```bash
 pnpm dev
+```
+
+### Network configuration
+
+The `network` in route `accepts` and `.register(...)` must **exactly match** a scheme/network pair from your facilitator's `/supported` response. The server checks this on startup; a mismatch fails initialization.
+
+Check what your facilitator supports before configuring networks:
+
+```bash
+curl -s "$FACILITATOR_URL/supported" | jq '.kinds[] | {scheme, network}'
 ```
 
 ### Account Setup Instructions

--- a/examples/typescript/servers/advanced/all_networks.ts
+++ b/examples/typescript/servers/advanced/all_networks.ts
@@ -14,6 +14,7 @@ import { paymentMiddleware, x402ResourceServer } from "@x402/express";
 import { APTOS_TESTNET_CAIP2 } from "@x402/aptos";
 import { ExactAptosScheme } from "@x402/aptos/exact/server";
 import { ExactAvmScheme } from "@x402/avm/exact/server";
+import { ALGORAND_TESTNET_CAIP2 } from "@x402/avm";
 import { ExactConcordiumScheme } from "@x402/concordium/exact/server";
 import { ExactEvmScheme } from "@x402/evm/exact/server";
 import { ExactHederaScheme } from "@x402/hedera/exact/server";
@@ -71,7 +72,7 @@ if (!facilitatorUrl) {
 }
 
 // Network configuration
-const AVM_NETWORK = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe" as const; // Algorand Testnet
+const AVM_NETWORK = (process.env.AVM_NETWORK || ALGORAND_TESTNET_CAIP2) as Network; // Algorand Testnet
 const APTOS_NETWORK = (process.env.APTOS_NETWORK || APTOS_TESTNET_CAIP2) as Network; // Aptos Testnet
 const CCD_NETWORK = "ccd:4221332d34e1694168c2a0c0b3fd0f27" as const; // Concordium Testnet
 const EVM_NETWORK = "eip155:84532" as const; // Base Sepolia

--- a/examples/typescript/servers/advanced/all_networks.ts
+++ b/examples/typescript/servers/advanced/all_networks.ts
@@ -71,7 +71,7 @@ if (!facilitatorUrl) {
 }
 
 // Network configuration
-const AVM_NETWORK = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=" as const; // Algorand Testnet
+const AVM_NETWORK = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe" as const; // Algorand Testnet
 const APTOS_NETWORK = (process.env.APTOS_NETWORK || APTOS_TESTNET_CAIP2) as Network; // Aptos Testnet
 const CCD_NETWORK = "ccd:4221332d34e1694168c2a0c0b3fd0f27" as const; // Concordium Testnet
 const EVM_NETWORK = "eip155:84532" as const; // Base Sepolia

--- a/specs/schemes/exact/scheme_exact_algo.md
+++ b/specs/schemes/exact/scheme_exact_algo.md
@@ -66,7 +66,7 @@ Full `paymentRequirements` Example:
 ```json
 {
   "scheme": "exact",
-  "network": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
+  "network": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k",
   "amount": "5000000",
   "payTo": "RESOURCESERVERADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALTSRPAE",
   "maxTimeoutSeconds": 60,
@@ -110,7 +110,7 @@ Example of a USDC asset transfer with an abstracted fee (i.e paid by the facilit
 {
   "x402Version": 2,
   "scheme": "exact",
-  "network": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
+  "network": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k",
   "resource": {
     "url": "https://example.net/signup",
     "description": "$5 registration payment",
@@ -118,7 +118,7 @@ Example of a USDC asset transfer with an abstracted fee (i.e paid by the facilit
   },
   "accepted": {
     "scheme": "exact",
-    "network": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
+    "network": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k",
     "amount": "5000000",
     "payTo": "RESOURCESERVERADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALTSRPAE",
     "maxTimeoutSeconds": 60,
@@ -153,7 +153,7 @@ Should the settlement fail, the transaction ID **SHOULD** be returned, but since
   "errorReason": null,
   "payer": "<payer>",
   "transaction": "NTRZR6HGMMZGYMJKUNVNLKLA427ACAVIPFNC6JHA5XNBQQHW7MWA",
-  "network": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8="
+  "network": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k"
 }
 ```
 
@@ -182,6 +182,17 @@ Steps to verify a payment for the `exact` scheme on Algorand:
 Once the group is validated by the resource server, settlement can occur by the facilitator submitting the verified transaction group to the Algorand network through the `v2/transactions` endpoint against any valid Algorand node.
 
 In Algorand there are no consensus forks and so it achieves instant finality the moment a transaction is included in a block. So as soon as the transaction is included in a block, the payment is considered settled and the facilitator can inform the resource server of the successful payment and proceed with the resource delivery.
+
+## Network Identifiers (CAIP-2)
+
+Algorand `network` values **MUST** use CAIP-2 identifiers in the `algorand` namespace. The reference is the URL-safe base64 encoding of the genesis hash, truncated to the first 32 characters. Full genesis hashes are used only in onchain transaction `gh` fields, not in CAIP-2 `network` values.
+
+| Network | CAIP-2 |
+| ------- | ------ |
+| Mainnet | `algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k` |
+| Testnet | `algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe` |
+
+See the [Algorand CAIP-2 namespace profile](https://namespaces.chainagnostic.org/algorand/caip2) for the encoding rules.
 
 ## Additional Considerations
 

--- a/typescript/.changeset/algorand-caip2-network-ids.md
+++ b/typescript/.changeset/algorand-caip2-network-ids.md
@@ -1,0 +1,5 @@
+---
+"@x402/avm": minor
+---
+
+Adopted CAIP-2-compliant Algorand network identifiers per the Algorand namespace profile. Server registration and constants emit canonical truncated IDs; client and facilitator normalize legacy full-hash IDs on input for backwards compatibility.

--- a/typescript/packages/http/paywall/src/avm/algorand/rpc.ts
+++ b/typescript/packages/http/paywall/src/avm/algorand/rpc.ts
@@ -1,6 +1,6 @@
 import { AlgorandClient } from "@algorandfoundation/algokit-utils/algorand-client";
 import type { AlgodClient } from "@algorandfoundation/algokit-utils/algod-client";
-import { ALGORAND_NETWORK_REFS } from "../../paywallUtils";
+import { ALGORAND_NETWORK_REFS, resolveAlgorandGenesisRef } from "../../paywallUtils";
 
 /**
  * Gets an AlgorandClient for the given network.
@@ -16,7 +16,7 @@ export function getAlgorandClient(network: string): AlgorandClient {
     );
   }
 
-  const ref = network.split(":")[1];
+  const ref = resolveAlgorandGenesisRef(network);
   const isTestnet = ref === ALGORAND_NETWORK_REFS.TESTNET;
 
   return isTestnet ? AlgorandClient.testNet() : AlgorandClient.mainNet();
@@ -56,5 +56,8 @@ export const USDC_ASA_IDS: Record<string, string> = {
  * @returns The USDC ASA ID or undefined if not found.
  */
 export function getUsdcAsaId(networkRef: string): string | undefined {
-  return USDC_ASA_IDS[networkRef];
+  const ref = networkRef.startsWith("algorand:")
+    ? resolveAlgorandGenesisRef(networkRef)
+    : resolveAlgorandGenesisRef(`algorand:${networkRef}`);
+  return USDC_ASA_IDS[ref];
 }

--- a/typescript/packages/http/paywall/src/avm/entry.tsx
+++ b/typescript/packages/http/paywall/src/avm/entry.tsx
@@ -4,7 +4,7 @@ import { WalletManager, WalletId, NetworkId } from "@txnlab/use-wallet";
 import { AlgorandClient } from "@algorandfoundation/algokit-utils/algorand-client";
 import { AvmPaywall } from "./AvmPaywall";
 import type {} from "../window";
-import { ALGORAND_NETWORK_REFS } from "../paywallUtils";
+import { isTestnetNetwork } from "../paywallUtils";
 
 // AVM-specific paywall entry point
 window.addEventListener("load", async () => {
@@ -23,7 +23,7 @@ window.addEventListener("load", async () => {
   }
 
   const network = paymentRequired.accepts[0].network;
-  const isTestnet = network.includes(ALGORAND_NETWORK_REFS.TESTNET);
+  const isTestnet = isTestnetNetwork(network);
 
   // Create AlgorandClient using algokit-utils built-in network defaults
   const algorandClient = isTestnet ? AlgorandClient.testNet() : AlgorandClient.mainNet();

--- a/typescript/packages/http/paywall/src/faucetUrls.ts
+++ b/typescript/packages/http/paywall/src/faucetUrls.ts
@@ -15,7 +15,7 @@ export const FAUCET_URLS: Record<string, string> = {
   // SVM testnets
   "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": "https://faucet.circle.com/",
   // AVM testnets
-  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=":
+  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe":
     "https://dispenser.testnet.aws.algodev.network/",
 };
 

--- a/typescript/packages/http/paywall/src/faucetUrls.ts
+++ b/typescript/packages/http/paywall/src/faucetUrls.ts
@@ -15,8 +15,7 @@ export const FAUCET_URLS: Record<string, string> = {
   // SVM testnets
   "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": "https://faucet.circle.com/",
   // AVM testnets
-  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe":
-    "https://dispenser.testnet.aws.algodev.network/",
+  "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe": "https://dispenser.testnet.aws.algodev.network/",
 };
 
 /**

--- a/typescript/packages/http/paywall/src/paywallUtils.ts
+++ b/typescript/packages/http/paywall/src/paywallUtils.ts
@@ -16,11 +16,37 @@ export const SOLANA_NETWORK_REFS = {
   DEVNET: "EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
 } as const;
 
-// Algorand Network References (CAIP-2 format: algorand:genesisHash)
+// Algorand Network References (full base64 genesis hash for SDK/RPC routing)
 export const ALGORAND_NETWORK_REFS = {
   MAINNET: "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
   TESTNET: "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
 } as const;
+
+/** Canonical truncated CAIP-2 references per the Algorand namespace profile. */
+const ALGORAND_CANONICAL_REFS = {
+  MAINNET: "wGHE2Pwdvd7S12BL5FaOP20EGYesN73k",
+  TESTNET: "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe",
+} as const;
+
+/**
+ * Resolves a CAIP-2 Algorand network identifier to its full genesis hash reference.
+ *
+ * @param network - CAIP-2 network identifier (canonical or legacy full-hash form)
+ * @returns Full base64 genesis hash reference
+ */
+export function resolveAlgorandGenesisRef(network: string): string {
+  const ref = network.split(":")[1];
+  if (ref === ALGORAND_NETWORK_REFS.MAINNET || ref === ALGORAND_NETWORK_REFS.TESTNET) {
+    return ref;
+  }
+  if (ref === ALGORAND_CANONICAL_REFS.MAINNET) {
+    return ALGORAND_NETWORK_REFS.MAINNET;
+  }
+  if (ref === ALGORAND_CANONICAL_REFS.TESTNET) {
+    return ALGORAND_NETWORK_REFS.TESTNET;
+  }
+  return ref;
+}
 
 /**
  * Normalizes the payment requirements into an array.
@@ -134,7 +160,7 @@ export function getNetworkDisplayName(network: string): string {
   }
 
   if (network.startsWith("algorand:")) {
-    const ref = network.split(":")[1];
+    const ref = resolveAlgorandGenesisRef(network);
     return ref === ALGORAND_NETWORK_REFS.TESTNET ? "Algorand Testnet" : "Algorand Mainnet";
   }
 
@@ -161,7 +187,7 @@ export function isTestnetNetwork(network: string): boolean {
   }
 
   if (network.startsWith("algorand:")) {
-    const ref = network.split(":")[1];
+    const ref = resolveAlgorandGenesisRef(network);
     return ref === ALGORAND_NETWORK_REFS.TESTNET;
   }
 

--- a/typescript/packages/mechanisms/avm/README.md
+++ b/typescript/packages/mechanisms/avm/README.md
@@ -45,9 +45,9 @@ const client = new x402Client()
 
 ## Supported Networks
 
-Networks are identified via CAIP-2:
-- `algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=` - Mainnet
-- `algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=` - Testnet
+Networks are identified via CAIP-2 per the [Algorand namespace profile](https://namespaces.chainagnostic.org/algorand/caip2):
+- `algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k` - Mainnet
+- `algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe` - Testnet
 - `algorand:*` - Wildcard (matches all Algorand networks)
 
 ## Signer Implementation

--- a/typescript/packages/mechanisms/avm/src/constants.ts
+++ b/typescript/packages/mechanisms/avm/src/constants.ts
@@ -1,8 +1,12 @@
 /**
  * Algorand Network Constants for x402 AVM Implementation
  *
- * CAIP-2 Network Identifiers use the format: algorand:<genesis-hash-base64>
- * Genesis hashes uniquely identify Algorand networks.
+ * CAIP-2 network identifiers use the Algorand namespace profile:
+ * algorand:<url-safe-base64-genesis-hash-first-32-chars>
+ *
+ * @see https://namespaces.chainagnostic.org/algorand/caip2
+ *
+ * Full genesis hashes (standard base64) are used for onchain transaction `gh` fields.
  */
 
 // ============================================================================
@@ -11,15 +15,13 @@
 
 /**
  * CAIP-2 network identifier for Algorand Mainnet
- * Format: algorand:<genesis-hash-base64>
  */
-export const ALGORAND_MAINNET_CAIP2 = "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=";
+export const ALGORAND_MAINNET_CAIP2 = "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k";
 
 /**
  * CAIP-2 network identifier for Algorand Testnet
- * Format: algorand:<genesis-hash-base64>
  */
-export const ALGORAND_TESTNET_CAIP2 = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=";
+export const ALGORAND_TESTNET_CAIP2 = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe";
 
 /**
  * All supported CAIP-2 network identifiers

--- a/typescript/packages/mechanisms/avm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/avm/src/exact/client/scheme.ts
@@ -21,9 +21,8 @@ import type {
 } from "@x402/core/types";
 import type { ClientAvmSigner, ClientAvmConfig } from "../../signer";
 import type { ExactAvmPayloadV2 } from "../../types";
-import { encodeTransaction } from "../../utils";
 import { USDC_CONFIG } from "../../constants";
-import { isTestnetNetwork } from "../../utils";
+import { encodeTransaction, isTestnetNetwork, normalizeAlgorandNetwork } from "../../utils";
 
 /**
  * AVM client implementation for the Exact payment scheme.
@@ -65,7 +64,8 @@ export class ExactAvmScheme implements SchemeNetworkClient {
     x402Version: number,
     paymentRequirements: PaymentRequirements,
   ): Promise<PaymentPayloadResult> {
-    const { amount, asset, payTo, network, extra } = paymentRequirements;
+    const { amount, asset, payTo, network: rawNetwork, extra } = paymentRequirements;
+    const network = normalizeAlgorandNetwork(rawNetwork);
 
     const algorandClient = this.getAlgorandClient(network);
 
@@ -178,6 +178,7 @@ export class ExactAvmScheme implements SchemeNetworkClient {
    * @returns AlgorandClient instance
    */
   private getAlgorandClient(network: string): AlgorandClient {
+    const normalizedNetwork = normalizeAlgorandNetwork(network);
     if (this.config?.algorandClient) {
       return this.config.algorandClient;
     }
@@ -190,7 +191,9 @@ export class ExactAvmScheme implements SchemeNetworkClient {
       });
     }
     // Auto-detect network
-    return isTestnetNetwork(network) ? AlgorandClient.testNet() : AlgorandClient.mainNet();
+    return isTestnetNetwork(normalizedNetwork)
+      ? AlgorandClient.testNet()
+      : AlgorandClient.mainNet();
   }
 
   /**
@@ -201,13 +204,14 @@ export class ExactAvmScheme implements SchemeNetworkClient {
    * @returns Asset ID as string
    */
   private getAssetId(asset: string, network: string): string {
+    const normalizedNetwork = normalizeAlgorandNetwork(network);
     // If asset is already a numeric string, use it directly
     if (/^\d+$/.test(asset)) {
       return asset;
     }
 
     // Try to get from USDC config
-    const usdcConfig = USDC_CONFIG[network];
+    const usdcConfig = USDC_CONFIG[normalizedNetwork];
     if (usdcConfig) {
       return usdcConfig.asaId;
     }

--- a/typescript/packages/mechanisms/avm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/avm/src/exact/facilitator/scheme.ts
@@ -25,7 +25,7 @@ import type { FacilitatorAvmSigner } from "../../signer";
 import type { ExactAvmPayloadV2 } from "../../types";
 import { isExactAvmPayload } from "../../types";
 import { MAX_TRANSACTION_GROUP_SIZE } from "@algorandfoundation/algokit-utils/common";
-import { decodeTransaction, hasSignature } from "../../utils";
+import { decodeTransaction, hasSignature, normalizeAlgorandNetwork } from "../../utils";
 import { maxReasonableGroupFee } from "../../constants";
 import * as Errors from "./errors";
 
@@ -115,8 +115,11 @@ export class ExactAvmScheme implements SchemeNetworkFacilitator {
         };
       }
 
-      // Validate network
-      if (payload.accepted.network !== requirements.network) {
+      // Validate network (accept legacy full-hash identifiers on input)
+      if (
+        normalizeAlgorandNetwork(payload.accepted.network) !==
+        normalizeAlgorandNetwork(requirements.network)
+      ) {
         return {
           isValid: false,
           invalidReason: Errors.ErrNetworkMismatch,
@@ -186,7 +189,7 @@ export class ExactAvmScheme implements SchemeNetworkFacilitator {
       // Simulate the assembled group
       const simResult = await this.simulateTransactionGroup(
         prepared.signedTxns,
-        requirements.network,
+        normalizeAlgorandNetwork(requirements.network),
       );
       if (!simResult.isValid) return simResult;
 
@@ -268,7 +271,10 @@ export class ExactAvmScheme implements SchemeNetworkFacilitator {
 
     // Submit transaction group
     try {
-      await this.signer.sendTransactions(prepared.signedTxns, requirements.network);
+      await this.signer.sendTransactions(
+        prepared.signedTxns,
+        normalizeAlgorandNetwork(requirements.network),
+      );
     } catch (error) {
       return {
         success: false,
@@ -283,7 +289,11 @@ export class ExactAvmScheme implements SchemeNetworkFacilitator {
     // Wait for on-chain confirmation
     try {
       // Wait up to 10 rounds for on-chain confirmation
-      await this.signer.waitForConfirmation(paymentTxId, requirements.network, 10);
+      await this.signer.waitForConfirmation(
+        paymentTxId,
+        normalizeAlgorandNetwork(requirements.network),
+        10,
+      );
     } catch (error) {
       return {
         success: false,

--- a/typescript/packages/mechanisms/avm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/avm/src/exact/server/scheme.ts
@@ -13,7 +13,8 @@ import type {
   MoneyParser,
 } from "@x402/core/types";
 import { convertToTokenAmount, numberToDecimalString, parseMoneyString } from "@x402/core/utils";
-import { USDC_CONFIG, USDC_DECIMALS } from "../../constants";
+import { USDC_CONFIG } from "../../constants";
+import { normalizeAlgorandNetwork } from "../../utils";
 
 /**
  * AVM server implementation for the Exact payment scheme.
@@ -113,28 +114,18 @@ export class ExactAvmScheme implements SchemeNetworkServer {
     // Mark unused parameter
     void extensionKeys;
 
-    // Get USDC config for the network
-    const usdcConfig = USDC_CONFIG[supportedKind.network];
-    const decimals = usdcConfig?.decimals ?? USDC_DECIMALS;
+    // Add feePayer from supportedKind.extra if provided
+    if (!supportedKind.extra?.feePayer) {
+      return Promise.resolve(paymentRequirements);
+    }
 
-    // Build enhanced requirements with feePayer and decimals
-    const enhanced: PaymentRequirements = {
+    return Promise.resolve({
       ...paymentRequirements,
       extra: {
         ...paymentRequirements.extra,
-        decimals,
-      },
-    };
-
-    // Add feePayer from supportedKind.extra if provided
-    if (supportedKind.extra?.feePayer) {
-      enhanced.extra = {
-        ...enhanced.extra,
         feePayer: supportedKind.extra.feePayer,
-      };
-    }
-
-    return Promise.resolve(enhanced);
+      },
+    });
   }
 
   /**
@@ -181,7 +172,7 @@ export class ExactAvmScheme implements SchemeNetworkServer {
     name: string;
     decimals: number;
   } {
-    const assetInfo = USDC_CONFIG[network];
+    const assetInfo = USDC_CONFIG[normalizeAlgorandNetwork(network)];
     if (!assetInfo) {
       throw new Error(`No default asset configured for network ${network}`);
     }

--- a/typescript/packages/mechanisms/avm/src/index.ts
+++ b/typescript/packages/mechanisms/avm/src/index.ts
@@ -83,6 +83,7 @@ export {
   getNetworkFromCaip2,
   isAlgorandNetwork,
   isTestnetNetwork,
+  normalizeAlgorandNetwork,
   getGenesisHashFromTransaction,
   validateGroupId,
   getTransactionId,

--- a/typescript/packages/mechanisms/avm/src/signer.ts
+++ b/typescript/packages/mechanisms/avm/src/signer.ts
@@ -32,7 +32,7 @@ import type {
 } from "@algorandfoundation/algokit-utils/transact";
 import { waitForConfirmation } from "@algorandfoundation/algokit-utils/transaction";
 import type { Network } from "@x402/core/types";
-import { ALGORAND_TESTNET_CAIP2 } from "./constants";
+import { isTestnetNetwork } from "./utils";
 
 /**
  * Symbol key used to attach the internal algokit-utils AddressWithSigners
@@ -287,16 +287,6 @@ export function getAlgokitSigner(signer: ClientAvmSigner): AddressWithTransactio
 }
 
 /**
- * Determines if a network identifier refers to testnet.
- *
- * @param network - The network identifier (CAIP-2 format)
- * @returns True if the network is testnet
- */
-function isTestnet(network: string): boolean {
-  return network === ALGORAND_TESTNET_CAIP2;
-}
-
-/**
  * Creates a FacilitatorAvmSigner from a Base64-encoded private key.
  *
  * This is the recommended way to create a facilitator-side AVM signer for x402 payments.
@@ -321,7 +311,7 @@ function isTestnet(network: string): boolean {
  *   mainnetUrl: "https://my-mainnet-node.example.com",
  * });
  *
- * facilitator.register("algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=", new ExactAvmScheme(signer));
+ * facilitator.register("algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe", new ExactAvmScheme(signer));
  * ```
  */
 export function toFacilitatorAvmSigner(
@@ -336,7 +326,7 @@ export function toFacilitatorAvmSigner(
 
   // Create AlgorandClient instances for each network, with optional URL overrides
   const getAlgorandClientForNetwork = (network: string) => {
-    if (isTestnet(network)) {
+    if (isTestnetNetwork(network)) {
       if (config?.testnetUrl) {
         return AlgorandClient.fromConfig({
           algodConfig: { server: config.testnetUrl, token: config.algodToken ?? "" },
@@ -356,7 +346,7 @@ export function toFacilitatorAvmSigner(
   const clientCache = new Map<string, ReturnType<typeof AlgorandClient.testNet>>();
 
   const getClient = (network: string) => {
-    const key = isTestnet(network) ? "testnet" : "mainnet";
+    const key = isTestnetNetwork(network) ? "testnet" : "mainnet";
     let client = clientCache.get(key);
     if (!client) {
       client = getAlgorandClientForNetwork(network);

--- a/typescript/packages/mechanisms/avm/src/utils.ts
+++ b/typescript/packages/mechanisms/avm/src/utils.ts
@@ -10,11 +10,40 @@ import {
   decodeSignedTransaction as decodeSignedTxn,
 } from "@algorandfoundation/algokit-utils/transact";
 import { isValidAddress } from "@algorandfoundation/algokit-utils/common";
+import type { Network } from "@x402/core/types";
 import {
+  ALGORAND_MAINNET_CAIP2,
   ALGORAND_MAINNET_GENESIS_HASH,
-  ALGORAND_TESTNET_GENESIS_HASH,
   ALGORAND_TESTNET_CAIP2,
+  ALGORAND_TESTNET_GENESIS_HASH,
 } from "./constants";
+
+/**
+ * Normalizes an Algorand network identifier to canonical CAIP-2 form.
+ * Accepts full genesis hash identifiers for backwards compatibility.
+ *
+ * @param network - Network identifier (canonical or full-hash CAIP-2 format)
+ * @returns Canonical CAIP-2 network identifier
+ */
+export function normalizeAlgorandNetwork(network: string): Network {
+  if (!network.startsWith("algorand:")) {
+    throw new Error(`Unsupported Algorand network: ${network}`);
+  }
+
+  if (network === ALGORAND_MAINNET_CAIP2 || network === ALGORAND_TESTNET_CAIP2) {
+    return network as Network;
+  }
+
+  if (network === `algorand:${ALGORAND_MAINNET_GENESIS_HASH}`) {
+    return ALGORAND_MAINNET_CAIP2;
+  }
+
+  if (network === `algorand:${ALGORAND_TESTNET_GENESIS_HASH}`) {
+    return ALGORAND_TESTNET_CAIP2;
+  }
+
+  throw new Error(`Unsupported Algorand network: ${network}`);
+}
 
 /**
  * Encodes transaction bytes to base64 string
@@ -123,13 +152,16 @@ export function getNetworkFromCaip2(caip2: string): "mainnet" | "testnet" | null
     return null;
   }
 
-  const genesisHash = caip2.slice("algorand:".length);
-
-  if (genesisHash === ALGORAND_MAINNET_GENESIS_HASH) {
-    return "mainnet";
-  }
-  if (genesisHash === ALGORAND_TESTNET_GENESIS_HASH) {
-    return "testnet";
+  try {
+    const normalized = normalizeAlgorandNetwork(caip2);
+    if (normalized === ALGORAND_MAINNET_CAIP2) {
+      return "mainnet";
+    }
+    if (normalized === ALGORAND_TESTNET_CAIP2) {
+      return "testnet";
+    }
+  } catch {
+    return null;
   }
 
   return null;
@@ -152,7 +184,15 @@ export function isAlgorandNetwork(network: string): boolean {
  * @returns True if the network is a testnet
  */
 export function isTestnetNetwork(network: string): boolean {
-  return network === ALGORAND_TESTNET_CAIP2;
+  if (!network.startsWith("algorand:")) {
+    return false;
+  }
+
+  try {
+    return normalizeAlgorandNetwork(network) === ALGORAND_TESTNET_CAIP2;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/typescript/packages/mechanisms/avm/test/integrations/exact-avm.test.ts
+++ b/typescript/packages/mechanisms/avm/test/integrations/exact-avm.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   ExactAvmScheme as ExactAvmClient,
   ALGORAND_TESTNET_CAIP2,
+  ALGORAND_TESTNET_GENESIS_HASH,
   USDC_TESTNET_ASA_ID,
   toClientAvmSigner,
   toFacilitatorAvmSigner,
@@ -206,6 +207,32 @@ describe("AVM Integration Tests", () => {
         expect(settleResponse.network).toBe(ALGORAND_TESTNET_CAIP2);
         expect(settleResponse.transaction).toBeDefined();
         expect(settleResponse.payer).toBe(clientAddress);
+      },
+    );
+
+    it(
+      "should verify and settle when paymentRequirements use legacy full-hash network ID",
+      { timeout: 30000 },
+      async () => {
+        const legacyNetwork = `algorand:${ALGORAND_TESTNET_GENESIS_HASH}` as Network;
+        const accepts = [buildAvmPaymentRequirements(SERVER_ADDRESS, "1000", legacyNetwork)];
+        const resource = {
+          url: "https://company.co",
+          description: "Company Co. resource",
+          mimeType: "application/json",
+        };
+        const paymentRequired = await server.createPaymentRequiredResponse(accepts, resource);
+        const paymentPayload = await client.createPaymentPayload(paymentRequired);
+        const accepted = server.findMatchingRequirements(accepts, paymentPayload);
+
+        expect(accepted).toBeDefined();
+
+        const verifyResponse = await server.verifyPayment(paymentPayload, accepted!);
+        expect(verifyResponse.isValid).toBe(true);
+
+        const settleResponse = await server.settlePayment(paymentPayload, accepted!);
+        expect(settleResponse.success).toBe(true);
+        expect(settleResponse.network).toBe(legacyNetwork);
       },
     );
   });

--- a/typescript/packages/mechanisms/avm/test/unit/index.test.ts
+++ b/typescript/packages/mechanisms/avm/test/unit/index.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from "vitest";
 import {
   ALGORAND_MAINNET_CAIP2,
+  ALGORAND_MAINNET_GENESIS_HASH,
   ALGORAND_TESTNET_CAIP2,
+  ALGORAND_TESTNET_GENESIS_HASH,
   USDC_MAINNET_ASA_ID,
   USDC_TESTNET_ASA_ID,
   isValidAlgorandAddress,
   isAlgorandNetwork,
   isTestnetNetwork,
+  normalizeAlgorandNetwork,
   convertToTokenAmount,
   convertFromTokenAmount,
   isExactAvmPayload,
@@ -15,13 +18,36 @@ import {
 describe("@x402/avm", () => {
   describe("constants", () => {
     it("should export correct CAIP-2 network identifiers", () => {
-      expect(ALGORAND_MAINNET_CAIP2).toBe("algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=");
-      expect(ALGORAND_TESTNET_CAIP2).toBe("algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
+      expect(ALGORAND_MAINNET_CAIP2).toBe("algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k");
+      expect(ALGORAND_TESTNET_CAIP2).toBe("algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe");
     });
 
     it("should export correct USDC ASA IDs", () => {
       expect(USDC_MAINNET_ASA_ID).toBe("31566704");
       expect(USDC_TESTNET_ASA_ID).toBe("10458941");
+    });
+  });
+
+  describe("normalizeAlgorandNetwork", () => {
+    it("should return canonical IDs unchanged", () => {
+      expect(normalizeAlgorandNetwork(ALGORAND_MAINNET_CAIP2)).toBe(ALGORAND_MAINNET_CAIP2);
+      expect(normalizeAlgorandNetwork(ALGORAND_TESTNET_CAIP2)).toBe(ALGORAND_TESTNET_CAIP2);
+    });
+
+    it("should map legacy full-hash IDs to canonical form", () => {
+      expect(normalizeAlgorandNetwork(`algorand:${ALGORAND_MAINNET_GENESIS_HASH}`)).toBe(
+        ALGORAND_MAINNET_CAIP2,
+      );
+      expect(normalizeAlgorandNetwork(`algorand:${ALGORAND_TESTNET_GENESIS_HASH}`)).toBe(
+        ALGORAND_TESTNET_CAIP2,
+      );
+    });
+
+    it("should throw for unsupported networks", () => {
+      expect(() => normalizeAlgorandNetwork("algorand:unknown")).toThrow(
+        "Unsupported Algorand network",
+      );
+      expect(() => normalizeAlgorandNetwork("eip155:1")).toThrow("Unsupported Algorand network");
     });
   });
 
@@ -55,10 +81,12 @@ describe("@x402/avm", () => {
   describe("isTestnetNetwork", () => {
     it("should return true for testnet networks", () => {
       expect(isTestnetNetwork(ALGORAND_TESTNET_CAIP2)).toBe(true);
+      expect(isTestnetNetwork(`algorand:${ALGORAND_TESTNET_GENESIS_HASH}`)).toBe(true);
     });
 
     it("should return false for mainnet networks", () => {
       expect(isTestnetNetwork(ALGORAND_MAINNET_CAIP2)).toBe(false);
+      expect(isTestnetNetwork(`algorand:${ALGORAND_MAINNET_GENESIS_HASH}`)).toBe(false);
     });
   });
 

--- a/typescript/packages/mechanisms/avm/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/avm/test/unit/signer.test.ts
@@ -114,7 +114,7 @@ describe("AVM Signer", () => {
 
       expect(signer).toBeDefined();
       // getAlgodClient should return an algod client using AlgorandClient defaults
-      const algod = signer.getAlgodClient("algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=");
+      const algod = signer.getAlgodClient("algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe");
       expect(algod).toBeDefined();
     });
 

--- a/typescript/site/app/facilitator/index.ts
+++ b/typescript/site/app/facilitator/index.ts
@@ -145,7 +145,7 @@ async function createFacilitator(): Promise<x402Facilitator> {
   if (avmPrivateKey) {
     const avmSigner = toFacilitatorAvmSigner(avmPrivateKey);
     facilitator.register(
-      "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+      "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe",
       new ExactAvmScheme(avmSigner),
     );
   }

--- a/typescript/site/proxy.ts
+++ b/typescript/site/proxy.ts
@@ -16,7 +16,7 @@ const facilitatorUrl = process.env.FACILITATOR_URL as string;
 
 const EVM_NETWORK = "eip155:84532" as const; // Base Sepolia
 const SVM_NETWORK = "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1" as const; // Solana Devnet
-const AVM_NETWORK = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=" as const; // Algorand Testnet
+const AVM_NETWORK = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe" as const; // Algorand Testnet
 
 // List of blocked countries and regions
 const BLOCKED_COUNTRIES = [


### PR DESCRIPTION
## Description

Algorand network values use the full base64 genesis hash, which is not valid [CAIP-2](https://chainagnostic.org/CAIPs/caip-2). The correct form is defined by the [Algorand CAIP-2 namespace profile](https://namespaces.chainagnostic.org/algorand/caip2): URL-safe base64 of the genesis hash, first 32 characters.

Server registration and constants emit canonical truncated IDs; client and facilitator normalize legacy full-hash IDs on input for backwards compatibility.

Closes https://github.com/x402-foundation/x402/issues/2904

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 