### PR TITLE
Fix: SVM SIWx small-order Ed25519 verification

### DIFF
--- a/go/.changes/unreleased/fixed-20260723-115300.yaml
+++ b/go/.changes/unreleased/fixed-20260723-115300.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Rejected small-order Ed25519 public keys in SIWx Solana signature verification.
+time: 2026-07-23T11:53:00.000000+02:00

--- a/go/extensions/signinwithx/signinwithx_test.go
+++ b/go/extensions/signinwithx/signinwithx_test.go
@@ -411,6 +411,29 @@ func TestVerifySolanaSignature(t *testing.T) {
 	}
 }
 
+func TestVerifySolanaSignatureRejectsSmallOrderPublicKey(t *testing.T) {
+	publicKey := bytesRepeat(ed25519.PublicKeySize, 0)
+	publicKey[0] = 1
+	signature := bytesRepeat(ed25519.SignatureSize, 0)
+	signature[0] = 1
+
+	if VerifySolanaSignature("arbitrary message", signature, publicKey) {
+		t.Fatal("VerifySolanaSignature() valid for small-order public key forgery")
+	}
+
+	payload := testSolanaPayload()
+	payload.Address = EncodeBase58(publicKey)
+	payload.Signature = EncodeBase58(signature)
+
+	result := VerifySignature(payload)
+	if result.IsValid {
+		t.Fatal("VerifySignature() valid for small-order public key forgery")
+	}
+	if result.InvalidReason != ErrInvalidSIWxSignature {
+		t.Fatalf("InvalidReason = %q, want %q", result.InvalidReason, ErrInvalidSIWxSignature)
+	}
+}
+
 func TestVerifySolanaSignatureRejectsInvalidBase58(t *testing.T) {
 	payload := testSolanaPayload()
 	payload.Signature = "0OIl"

--- a/go/extensions/signinwithx/solana.go
+++ b/go/extensions/signinwithx/solana.go
@@ -3,6 +3,7 @@ package signinwithx
 import (
 	"crypto/ed25519"
 
+	"filippo.io/edwards25519"
 	"github.com/mr-tron/base58"
 )
 
@@ -18,5 +19,16 @@ func EncodeBase58(bytes []byte) string {
 
 // VerifySolanaSignature verifies an Ed25519 SIWS signature.
 func VerifySolanaSignature(message string, signature []byte, publicKey []byte) bool {
+	// Reject small-order public keys. Classic Ed25519 verify accepts
+	// identity-point forgeries of the form (R=identity, S=0) for any message.
+	var point edwards25519.Point
+	if _, err := point.SetBytes(publicKey); err != nil {
+		return false
+	}
+	var cofactored edwards25519.Point
+	if cofactored.MultByCofactor(&point).Equal(edwards25519.NewIdentityPoint()) == 1 {
+		return false
+	}
+
 	return ed25519.Verify(publicKey, []byte(message), signature)
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -18,6 +18,7 @@ require (
 require github.com/google/uuid v1.6.0
 
 require (
+	filippo.io/edwards25519 v1.0.0-rc.1
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/mr-tron/base58 v1.2.0
 	github.com/signinwithethereum/siwe-go v1.0.0
@@ -25,7 +26,6 @@ require (
 )
 
 require (
-	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect

--- a/python/x402/tests/unit/extensions/sign_in_with_x/test_sign_in_with_x.py
+++ b/python/x402/tests/unit/extensions/sign_in_with_x/test_sign_in_with_x.py
@@ -38,6 +38,7 @@ from x402.extensions.sign_in_with_x import (
     parse_siwx_header,
     validate_siwx_message,
     verify_siwx_signature,
+    verify_solana_signature,
 )
 from x402.http.types import HTTPRequestContext, PaymentOption, RouteConfig
 from x402.schemas import (
@@ -393,6 +394,27 @@ class TestSolana:
         result = await verify_siwx_signature(payload)
         assert result.is_valid
         assert result.payer == address
+
+    def test_rejects_small_order_public_key_forgery(self):
+        public_key = b"\x01" + bytes(31)
+        signature = b"\x01" + bytes(63)
+
+        assert verify_solana_signature("arbitrary message", signature, public_key) is False
+
+    @pytest.mark.asyncio
+    async def test_siwx_rejects_small_order_public_key_forgery(self):
+        public_key = b"\x01" + bytes(31)
+        signature = b"\x01" + bytes(63)
+        payload = _valid_payload(
+            chainId=SOLANA_MAINNET,
+            type="ed25519",
+            address=encode_base58(public_key),
+            signature=encode_base58(signature),
+        )
+
+        result = await verify_siwx_signature(payload)
+        assert result.is_valid is False
+        assert result.invalid_reason == "invalid_siwx_signature"
 
     @pytest.mark.asyncio
     async def test_keypair_signer_sign_verify(self):

--- a/typescript/.changeset/siwx-reject-small-order-ed25519.md
+++ b/typescript/.changeset/siwx-reject-small-order-ed25519.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": patch
+---
+
+Rejected small-order Ed25519 public keys in SIWx Solana signature verification.

--- a/typescript/packages/extensions/src/sign-in-with-x/solana.ts
+++ b/typescript/packages/extensions/src/sign-in-with-x/solana.ts
@@ -5,6 +5,7 @@
  * for Solana wallets.
  */
 
+import { ed25519 } from "@noble/curves/ed25519";
 import { base58 } from "@scure/base";
 import nacl from "tweetnacl";
 import type { CompleteSIWxInfo } from "./client";
@@ -122,6 +123,17 @@ export function verifySolanaSignature(
   signature: Uint8Array,
   publicKey: Uint8Array,
 ): boolean {
+  // Reject small-order public keys. Classic Ed25519 verify (tweetnacl) accepts
+  // identity-point forgeries of the form (R=identity, S=0) for any message.
+  try {
+    const point = ed25519.ExtendedPoint.fromHex(publicKey);
+    if (point.isSmallOrder()) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+
   const messageBytes = new TextEncoder().encode(message);
   return nacl.sign.detached.verify(messageBytes, signature, publicKey);
 }

--- a/typescript/packages/extensions/test/sign-in-with-x.test.ts
+++ b/typescript/packages/extensions/test/sign-in-with-x.test.ts
@@ -39,6 +39,7 @@ import {
 } from "../src/sign-in-with-x/index";
 import { safeBase64Encode } from "@x402/core/utils";
 import { x402ResourceServer } from "@x402/core/server";
+import { ED25519_TORSION_SUBGROUP } from "@noble/curves/ed25519.js";
 import { privateKeyToAccount, generatePrivateKey } from "viem/accounts";
 import nacl from "tweetnacl";
 import { randomBytes } from "crypto";
@@ -794,6 +795,14 @@ describe("Sign-In-With-X Extension", () => {
       const valid = verifySolanaSignature(message, signature, keypair2.publicKey);
       expect(valid).toBe(false);
     });
+
+    it.each(ED25519_TORSION_SUBGROUP)("should reject small-order public key %s", publicKeyHex => {
+      const publicKey = Uint8Array.from(Buffer.from(publicKeyHex, "hex"));
+      const signature = new Uint8Array(64);
+      signature[0] = 1;
+
+      expect(verifySolanaSignature("arbitrary message", signature, publicKey)).toBe(false);
+    });
   });
 
   describe("verifySIWxSignature - chain routing", () => {
@@ -852,6 +861,28 @@ describe("Sign-In-With-X Extension", () => {
       const result = await verifySIWxSignature(payload);
       expect(result.isValid).toBe(true);
       expect(result.payer).toBe(address);
+    });
+
+    it("should reject a small-order Solana public key forgery", async () => {
+      const publicKey = new Uint8Array(32);
+      publicKey[0] = 1;
+      const signature = new Uint8Array(64);
+      signature[0] = 1;
+      const payload = {
+        domain: "api.example.com",
+        uri: "https://api.example.com/data",
+        version: "1",
+        chainId: SOLANA_MAINNET,
+        type: "ed25519" as const,
+        nonce: "test123",
+        issuedAt: new Date().toISOString(),
+        address: encodeBase58(publicKey),
+        signature: encodeBase58(signature),
+      };
+
+      const result = await verifySIWxSignature(payload);
+      expect(result.isValid).toBe(false);
+      expect(result.invalidReason).toBe("invalid_siwx_signature");
     });
 
     it("should reject invalid Solana signature length", async () => {


### PR DESCRIPTION
## Description

Hardens SVM SIWx signature verification by rejecting small-order Ed25519 public keys before signature validation. Applies consistent checks across the TypeScript and Go implementations, while Python’s existing verifier already provides the expected behavior.

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 