### PR TITLE
docs: add ArisPay to the production facilitators table

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -19,6 +19,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 
 | Name | Description |
 | ---- | ----------- | 
+| [ArisPay Facilitator](https://facilitator.arispay.app) | Free, public x402 facilitator for Base mainnet with USDC and EURC settlement. No API key required |
 | [Built on Stellar](https://developers.stellar.org/docs/build/apps/x402/built-on-stellar) | Free, public x402 facilitator for Stellar |
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
 | [Corbits](https://corbits.dev) | Production-grade multi-network, multi-token facilitator supporting EVM and Solana |


### PR DESCRIPTION
Adds one row to the production facilitators table in `docs/dev-tools/facilitators.md` for the ArisPay Facilitator.

- **URL:** https://facilitator.arispay.app — live on Base mainnet (eip155:8453) since April 2026
- **Open `/verify` and `/settle`**, no API key, no signup; supports the exact scheme (x402 v1 and v2)
- **No facilitator fee.** Settlement is EIP-3009 `transferWithAuthorization`, replay-protected on the nonce
- **Assets:** USDC and EURC on Base — on-chain euro-stablecoin settlement, which no current row in the table offers
- Machine-readable discovery: [`GET /supported`](https://facilitator.arispay.app/supported) (kinds + fee policy), [`GET /facilitator`](https://facilitator.arispay.app/facilitator) (networks, verified asset registry, signers), [`GET /status`](https://facilitator.arispay.app/status)

Docs-only change; no code paths affected. Every claim above is verifiable against the live endpoints linked. Row is placed alphabetically; description follows the existing table style.

Disclosure: this PR was prepared with AI assistance (Claude Code) and reviewed by the submitter.