### PR TITLE
feat(py): server-provided recent blockhash in the exact 402 challenge

### DIFF
--- a/go/mechanisms/svm/exact/client/duplicate_tx_test.go
+++ b/go/mechanisms/svm/exact/client/duplicate_tx_test.go
@@ -279,36 +279,46 @@ func TestRecentBlockhashResolution(t *testing.T) {
 		assert.Equal(t, int32(1), atomic.LoadInt32(&blockhashCalls))
 	})
 
-	t.Run("rejects malformed recentBlockhash", func(t *testing.T) {
-		var blockhashCalls int32
-		var accountInfoCalls int32
-		server := httptest.NewServer(mockSolanaRPCHandlerWithCounts(t, func() string {
-			return fixedBlockhashAlt
-		}, &blockhashCalls, &accountInfoCalls))
-		defer server.Close()
+	for name, provided := range map[string]interface{}{
+		"empty":      "",
+		"non-string": 12345,
+		"malformed":  "not-a-blockhash",
+	} {
+		t.Run("falls back to RPC when recentBlockhash is "+name, func(t *testing.T) {
+			var blockhashCalls int32
+			var accountInfoCalls int32
+			server := httptest.NewServer(mockSolanaRPCHandlerWithCounts(t, func() string {
+				return fixedBlockhashAlt
+			}, &blockhashCalls, &accountInfoCalls))
+			defer server.Close()
 
-		signer := &mockClientSigner{keypair: solana.NewWallet().PrivateKey}
-		client := NewExactSvmScheme(signer, &svm.ClientConfig{RPCURL: server.URL})
+			signer := &mockClientSigner{keypair: solana.NewWallet().PrivateKey}
+			client := NewExactSvmScheme(signer, &svm.ClientConfig{RPCURL: server.URL})
 
-		requirements := types.PaymentRequirements{
-			Scheme:            "exact",
-			Network:           "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
-			Asset:             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
-			Amount:            "100000",
-			PayTo:             solana.NewWallet().PublicKey().String(),
-			MaxTimeoutSeconds: 3600,
-			Extra: map[string]interface{}{
-				"feePayer":        solana.NewWallet().PublicKey().String(),
-				"recentBlockhash": "not-a-blockhash",
-			},
-		}
+			requirements := types.PaymentRequirements{
+				Scheme:            "exact",
+				Network:           "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+				Asset:             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+				Amount:            "100000",
+				PayTo:             solana.NewWallet().PublicKey().String(),
+				MaxTimeoutSeconds: 3600,
+				Extra: map[string]interface{}{
+					"feePayer":        solana.NewWallet().PublicKey().String(),
+					"recentBlockhash": provided,
+				},
+			}
 
-		_, err := client.CreatePaymentPayload(context.Background(), requirements)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), ErrInvalidRecentBlockhash)
-		assert.Equal(t, int32(0), atomic.LoadInt32(&blockhashCalls))
-		assert.Equal(t, int32(1), atomic.LoadInt32(&accountInfoCalls))
-	})
+			payload, err := client.CreatePaymentPayload(context.Background(), requirements)
+			require.NoError(t, err)
+
+			decoded, err := svm.DecodeTransaction(payload.Payload["transaction"].(string))
+			require.NoError(t, err)
+
+			assert.Equal(t, solana.MustHashFromBase58(fixedBlockhashAlt), decoded.Message.RecentBlockhash)
+			assert.Equal(t, int32(1), atomic.LoadInt32(&blockhashCalls))
+			assert.Equal(t, int32(1), atomic.LoadInt32(&accountInfoCalls))
+		})
+	}
 }
 
 func TestFixedBlockhashProducesDistinctTransactions(t *testing.T) {

--- a/go/mechanisms/svm/exact/client/errors.go
+++ b/go/mechanisms/svm/exact/client/errors.go
@@ -14,7 +14,6 @@ const (
 	ErrInvalidFeePayerAddress       = "invalid_exact_solana_client_invalid_fee_payer_address"
 	ErrFailedToDecodeMintData       = "invalid_exact_solana_client_failed_to_decode_mint_data"
 	ErrFailedToGetLatestBlockhash   = "invalid_exact_solana_client_failed_to_get_latest_blockhash"
-	ErrInvalidRecentBlockhash       = "invalid_exact_solana_client_invalid_recent_blockhash"
 	ErrFailedToBuildComputeLimitIx  = "invalid_exact_solana_client_failed_to_build_compute_limit_instruction"
 	ErrFailedToBuildComputePriceIx  = "invalid_exact_solana_client_failed_to_build_compute_price_instruction"
 	ErrFailedToBuildTransferIx      = "invalid_exact_solana_client_failed_to_build_transfer_instruction"

--- a/go/mechanisms/svm/exact/client/scheme.go
+++ b/go/mechanisms/svm/exact/client/scheme.go
@@ -228,10 +228,9 @@ func (c *ExactSvmScheme) resolveRecentBlockhash(
 ) (solana.Hash, error) {
 	if blockhash, ok := requirements.Extra["recentBlockhash"].(string); ok && blockhash != "" {
 		recentBlockhash, err := solana.HashFromBase58(blockhash)
-		if err != nil {
-			return solana.Hash{}, fmt.Errorf(ErrInvalidRecentBlockhash+": %w", err)
+		if err == nil {
+			return recentBlockhash, nil
 		}
-		return recentBlockhash, nil
 	}
 
 	latestBlockhash, err := rpcClient.GetLatestBlockhash(ctx, rpc.CommitmentFinalized)

--- a/python/x402/changelog.d/2937.feature.md
+++ b/python/x402/changelog.d/2937.feature.md
@@ -1,0 +1,1 @@
+Add SVM server blockhash hints and client fallback behavior.

--- a/python/x402/mechanisms/svm/README.md
+++ b/python/x402/mechanisms/svm/README.md
@@ -42,8 +42,15 @@ from x402 import x402ResourceServer
 from x402.mechanisms.svm.exact import ExactSvmServerScheme
 
 server = x402ResourceServer(facilitator_client)
-server.register("solana:*", ExactSvmServerScheme())
+server.register(
+    "solana:*",
+    ExactSvmServerScheme(rpc_url="https://api.mainnet-beta.solana.com"),
+)
 ```
+
+The optional server RPC URL adds `recentBlockhash` and `lastValidBlockHeight`
+transaction-construction hints to payment requirements. If it is omitted or the
+lookup fails, clients fetch a fresh blockhash from their configured network RPC.
 
 ### Facilitator
 

--- a/python/x402/mechanisms/svm/exact/client.py
+++ b/python/x402/mechanisms/svm/exact/client.py
@@ -30,7 +30,7 @@ from ..constants import (
 from ..mint_cache import MintMetadataCache, get_cached_mint_metadata
 from ..signer import ClientSvmSigner
 from ..types import ExactSvmPayload
-from ..utils import derive_ata, normalize_network
+from ..utils import derive_ata, normalize_network, resolve_blockhash
 
 
 class ExactSvmScheme:
@@ -174,9 +174,7 @@ class ExactSvmScheme:
             data=memo_data,
         )
 
-        # Get latest blockhash
-        blockhash_resp = client.get_latest_blockhash()
-        blockhash = blockhash_resp.value.blockhash
+        blockhash = resolve_blockhash(client, extra.get("recentBlockhash"))
 
         # Build message
         message = MessageV0.try_compile(

--- a/python/x402/mechanisms/svm/exact/register.py
+++ b/python/x402/mechanisms/svm/exact/register.py
@@ -73,6 +73,7 @@ def register_exact_svm_client(
 def register_exact_svm_server(
     server: ServerT,
     networks: str | list[str] | None = None,
+    rpc_url: str | None = None,
 ) -> ServerT:
     """Register SVM exact payment schemes to x402ResourceServer.
 
@@ -81,13 +82,14 @@ def register_exact_svm_server(
     Args:
         server: x402ResourceServer instance.
         networks: Optional specific network(s) (default: wildcard).
+        rpc_url: Optional RPC URL used to add blockhash construction hints.
 
     Returns:
         Server for chaining.
     """
     from .server import ExactSvmScheme as ExactSvmServerScheme
 
-    scheme = ExactSvmServerScheme()
+    scheme = ExactSvmServerScheme(rpc_url)
 
     if networks:
         if isinstance(networks, str):

--- a/python/x402/mechanisms/svm/exact/server.py
+++ b/python/x402/mechanisms/svm/exact/server.py
@@ -1,10 +1,16 @@
 """SVM server implementation for the Exact payment scheme (V2)."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from ....schemas import AssetAmount, Network, PaymentRequirements, Price, SupportedKind
 from ..constants import DEFAULT_DECIMALS, SCHEME_EXACT
 from ..utils import get_network_config, get_usdc_address, parse_money_to_decimal
+
+if TYPE_CHECKING:
+    from solana.rpc.api import Client as SolanaClient
 
 # Type alias for money parser (sync)
 MoneyParser = Callable[[float, str], AssetAmount | None]
@@ -24,11 +30,24 @@ class ExactSvmScheme:
 
     scheme = SCHEME_EXACT
 
-    def __init__(self):
-        """Create ExactSvmScheme."""
-        self._money_parsers: list[MoneyParser] = []
+    def __init__(self, rpc_url: str | None = None):
+        """Create ExactSvmScheme.
 
-    def register_money_parser(self, parser: MoneyParser) -> "ExactSvmScheme":
+        Args:
+            rpc_url: Optional RPC URL used to add blockhash construction hints.
+        """
+        self._money_parsers: list[MoneyParser] = []
+        self._rpc_client: SolanaClient | None = None
+        if rpc_url:
+            try:
+                from solana.rpc.api import Client as SolanaClient
+            except ImportError as e:
+                raise ImportError(
+                    "SVM mechanism requires solana packages. Install with: pip install x402[svm]"
+                ) from e
+            self._rpc_client = SolanaClient(rpc_url)
+
+    def register_money_parser(self, parser: MoneyParser) -> ExactSvmScheme:
         """Register custom money parser in the parser chain.
 
         Multiple parsers can be registered - tried in registration order.
@@ -125,6 +144,15 @@ class ExactSvmScheme:
         extra = supported_kind.extra or {}
         if "feePayer" in extra:
             requirements.extra["feePayer"] = extra["feePayer"]
+
+        if self._rpc_client:
+            try:
+                blockhash = self._rpc_client.get_latest_blockhash().value
+                requirements.extra["recentBlockhash"] = str(blockhash.blockhash)
+                requirements.extra["lastValidBlockHeight"] = str(blockhash.last_valid_block_height)
+            except Exception:
+                requirements.extra.pop("recentBlockhash", None)
+                requirements.extra.pop("lastValidBlockHeight", None)
 
         return requirements
 

--- a/python/x402/mechanisms/svm/utils.py
+++ b/python/x402/mechanisms/svm/utils.py
@@ -4,8 +4,10 @@ import base64
 import hashlib
 import re
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 try:
+    from solders.hash import Hash, ParseHashError
     from solders.pubkey import Pubkey
     from solders.transaction import VersionedTransaction
 except ImportError as e:
@@ -29,6 +31,20 @@ from .constants import (
     NetworkConfig,
 )
 from .types import ExactSvmPayload, TransactionInfo
+
+if TYPE_CHECKING:
+    from solana.rpc.api import Client as SolanaClient
+
+
+def resolve_blockhash(client: "SolanaClient", recent_blockhash: object = None) -> Hash:
+    """Use a valid supplied blockhash, falling back to the latest blockhash from RPC."""
+    if isinstance(recent_blockhash, str) and recent_blockhash:
+        try:
+            return Hash.from_string(recent_blockhash)
+        except ParseHashError:
+            pass
+
+    return client.get_latest_blockhash().value.blockhash
 
 
 def normalize_network(network: str) -> str:

--- a/python/x402/tests/unit/mechanisms/svm/test_client.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_client.py
@@ -1,10 +1,13 @@
 """Tests for ExactSvmScheme client."""
 
+import base64
 from unittest.mock import MagicMock, patch
 
+import pytest
 from solders.hash import Hash
 from solders.keypair import Keypair
 from solders.pubkey import Pubkey
+from solders.transaction import VersionedTransaction
 
 from x402.mechanisms.svm import SOLANA_DEVNET_CAIP2, TOKEN_PROGRAM_ADDRESS, USDC_DEVNET_ADDRESS
 from x402.mechanisms.svm.exact import ExactSvmClientScheme
@@ -41,6 +44,41 @@ class TestExactSvmSchemeConstructor:
 
 class TestCreatePaymentPayload:
     """Test create_payment_payload method."""
+
+    @staticmethod
+    def _requirements(extra: dict[str, object]) -> PaymentRequirements:
+        fee_payer = Keypair.from_seed(bytes([2] * 32))
+        pay_to = Keypair.from_seed(bytes([3] * 32))
+        return PaymentRequirements(
+            scheme="exact",
+            network=SOLANA_DEVNET_CAIP2,
+            asset=USDC_DEVNET_ADDRESS,
+            amount="100000",
+            pay_to=str(pay_to.pubkey()),
+            max_timeout_seconds=3600,
+            extra={"feePayer": str(fee_payer.pubkey()), **extra},
+        )
+
+    @staticmethod
+    def _mock_rpc_client() -> MagicMock:
+        mock_client = MagicMock()
+        mock_blockhash_response = MagicMock()
+        mock_blockhash_response.value.blockhash = Hash.from_string(FIXED_BLOCKHASH_ALT)
+        mock_client.get_latest_blockhash.return_value = mock_blockhash_response
+
+        mock_account_info = MagicMock()
+        mock_account_info.value = MagicMock()
+        mock_account_info.value.owner = Pubkey.from_string(TOKEN_PROGRAM_ADDRESS)
+        mock_account_info.value.data = bytes(44) + bytes([6]) + bytes(37)
+        mock_client.get_account_info.return_value = mock_account_info
+        return mock_client
+
+    @staticmethod
+    def _payload_blockhash(payload: dict[str, object]) -> str:
+        transaction = payload["transaction"]
+        assert isinstance(transaction, str)
+        tx = VersionedTransaction.from_bytes(base64.b64decode(transaction))
+        return str(tx.message.recent_blockhash)
 
     def test_should_have_create_payment_payload_method(self):
         """Should have create_payment_payload method."""
@@ -94,6 +132,36 @@ class TestCreatePaymentPayload:
         assert client.create_payment_payload is not None
         assert requirements.extra is not None
         assert requirements.extra.get("feePayer") is None
+
+    def test_uses_valid_supplied_blockhash_without_blockhash_rpc(self):
+        """A valid challenge blockhash should be used without fetching another."""
+        client = ExactSvmClientScheme(KeypairSigner(Keypair.from_seed(bytes([1] * 32))))
+        rpc_client = self._mock_rpc_client()
+        requirements = self._requirements({"recentBlockhash": FIXED_BLOCKHASH})
+
+        with patch.object(client, "_get_client", return_value=rpc_client):
+            payload = client.create_payment_payload(requirements)
+
+        assert self._payload_blockhash(payload) == FIXED_BLOCKHASH
+        rpc_client.get_latest_blockhash.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "recent_blockhash",
+        [None, "", "not-a-blockhash", 123],
+        ids=["absent", "empty", "malformed", "wrong-type"],
+    )
+    def test_falls_back_to_rpc_for_unusable_supplied_blockhash(self, recent_blockhash: object):
+        """Missing or invalid challenge hints should fall back to RPC."""
+        client = ExactSvmClientScheme(KeypairSigner(Keypair.from_seed(bytes([1] * 32))))
+        rpc_client = self._mock_rpc_client()
+        extra = {} if recent_blockhash is None else {"recentBlockhash": recent_blockhash}
+        requirements = self._requirements(extra)
+
+        with patch.object(client, "_get_client", return_value=rpc_client):
+            payload = client.create_payment_payload(requirements)
+
+        assert self._payload_blockhash(payload) == FIXED_BLOCKHASH_ALT
+        rpc_client.get_latest_blockhash.assert_called_once_with()
 
 
 class TestMintMetadataCache:

--- a/python/x402/tests/unit/mechanisms/svm/test_server.py
+++ b/python/x402/tests/unit/mechanisms/svm/test_server.py
@@ -1,6 +1,9 @@
 """Tests for ExactSvmScheme server."""
 
+from unittest.mock import MagicMock
+
 import pytest
+from solders.hash import Hash
 
 from x402.mechanisms.svm import (
     SOLANA_DEVNET_CAIP2,
@@ -135,6 +138,27 @@ class TestParsePrice:
 class TestEnhancePaymentRequirements:
     """Test enhancePaymentRequirements method."""
 
+    @staticmethod
+    def _requirements(extra: dict[str, object] | None = None) -> PaymentRequirements:
+        return PaymentRequirements(
+            scheme="exact",
+            network=SOLANA_DEVNET_CAIP2,
+            asset=USDC_DEVNET_ADDRESS,
+            amount="100000",
+            pay_to="PayToAddress11111111111111111111111111",
+            max_timeout_seconds=3600,
+            extra=extra or {},
+        )
+
+    @staticmethod
+    def _supported_kind() -> SupportedKind:
+        return SupportedKind(
+            x402_version=2,
+            scheme="exact",
+            network=SOLANA_DEVNET_CAIP2,
+            extra={"feePayer": "FeePayer1111111111111111111111111111"},
+        )
+
     def test_should_add_fee_payer_to_payment_requirements(self):
         """Should add feePayer to payment requirements."""
         server = ExactSvmServerScheme()
@@ -188,6 +212,64 @@ class TestEnhancePaymentRequirements:
         assert result.extra is not None
         assert result.extra.get("custom") == "value"
         assert result.extra.get("feePayer") == "FeePayer1111111111111111111111111111"
+
+    def test_configured_rpc_adds_blockhash_hints_and_preserves_extras(self):
+        """Configured servers should enrich requirements with construction hints."""
+        server = ExactSvmServerScheme(rpc_url="https://example.invalid")
+        rpc_response = MagicMock()
+        rpc_response.value.blockhash = Hash.from_string(
+            "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF"
+        )
+        rpc_response.value.last_valid_block_height = 123456
+        server._rpc_client = MagicMock()
+        server._rpc_client.get_latest_blockhash.return_value = rpc_response
+
+        result = server.enhance_payment_requirements(
+            self._requirements({"custom": "value"}), self._supported_kind(), []
+        )
+
+        assert result.extra == {
+            "custom": "value",
+            "feePayer": "FeePayer1111111111111111111111111111",
+            "recentBlockhash": "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF",
+            "lastValidBlockHeight": "123456",
+        }
+
+    def test_without_rpc_configuration_omits_blockhash_hints(self):
+        """Unconfigured servers should leave blockhash lookup to clients."""
+        server = ExactSvmServerScheme()
+
+        result = server.enhance_payment_requirements(
+            self._requirements({"custom": "value"}), self._supported_kind(), []
+        )
+
+        assert result.extra == {
+            "custom": "value",
+            "feePayer": "FeePayer1111111111111111111111111111",
+        }
+
+    def test_rpc_failure_omits_blockhash_hints_and_preserves_extras(self):
+        """RPC failures should not prevent the server from returning requirements."""
+        server = ExactSvmServerScheme(rpc_url="https://example.invalid")
+        server._rpc_client = MagicMock()
+        server._rpc_client.get_latest_blockhash.side_effect = RuntimeError("RPC unavailable")
+
+        result = server.enhance_payment_requirements(
+            self._requirements(
+                {
+                    "custom": "value",
+                    "recentBlockhash": "stale",
+                    "lastValidBlockHeight": "1",
+                }
+            ),
+            self._supported_kind(),
+            [],
+        )
+
+        assert result.extra == {
+            "custom": "value",
+            "feePayer": "FeePayer1111111111111111111111111111",
+        }
 
 
 class TestRegisterMoneyParser:

--- a/specs/schemes/exact/scheme_exact_svm.md
+++ b/specs/schemes/exact/scheme_exact_svm.md
@@ -32,7 +32,7 @@ The protocol flow for `exact` on Solana is client-driven.
 
 1. Client makes a request to a Resource Server.
 2. Resource Server responds with a payment required signal containing `PaymentRequired`. The `extra` field contains a `feePayer`, identifying the sponsor, and MAY contain a `recentBlockhash` for the Client to build against.
-3. Client creates a transaction that effects a payment of an asset to the merchant for a specified amount. If `extra.recentBlockhash` is present the Client uses it as the transaction lifetime; otherwise the Client fetches a recent blockhash itself.
+3. Client creates a transaction that effects a payment of an asset to the merchant for a specified amount. If a valid `extra.recentBlockhash` is present the Client uses it as the transaction lifetime; otherwise the Client fetches a recent blockhash itself.
 4. Client signs the transaction, producing a partially signed transaction (the sponsor's `feePayer` signature is still missing).
 5. Client serializes the partially signed transaction as Base64.
 6. Client sends a request to the Resource Server, submitting the transaction via `PaymentPayload` alongside the `PaymentRequirements`.
@@ -71,8 +71,10 @@ In addition to the standard x402 `PaymentRequirements` fields, the `exact` schem
 - `payTo`: The merchant's public key.
 - `extra.feePayer`: The sponsor's public key. This MAY equal `payTo` (merchant-sponsored fees) or be a distinct third party.
 - `extra.memo` (optional): A seller-defined UTF-8 string to include in the transaction's Memo instruction. When present, the client MUST use this value as the Memo instruction data instead of a random nonce. Maximum 256 bytes. This enables sellers to attach payment references (e.g., invoice IDs) to on-chain transactions for reconciliation without requiring unique deposit addresses.
-- `extra.recentBlockhash` (optional): A recent blockhash for the Client to use as the transaction's lifetime, supplied by the Resource Server. When present, the Client SHOULD use it instead of fetching its own via `getLatestBlockhash`, saving an RPC round-trip and pinning the transaction to a blockhash the settling RPC has observed. When absent, the Client MUST fetch a recent blockhash itself. A Resource Server SHOULD only set this when it has an RPC endpoint whose view of recent blockhashes matches the settling Sponsor's; a stale or fork-divergent blockhash will cause the transaction to expire or fail to land.
-- `extra.lastValidBlockHeight` (optional): The last block height at which `extra.recentBlockhash` is valid, as a decimal string. Provided alongside `recentBlockhash` so the Client and Sponsor can bound the transaction's validity window. Ignored when `recentBlockhash` is absent.
+- `extra.recentBlockhash` (optional): A recent blockhash for the Client to use as the transaction's lifetime, supplied by the Resource Server. When present and valid, the Client SHOULD use it instead of fetching its own via `getLatestBlockhash`, saving an RPC round-trip and pinning the transaction to a blockhash the settling RPC has observed. When absent or malformed, the Client MUST fetch a recent blockhash itself. A Resource Server SHOULD only set this when it has an RPC endpoint whose view of recent blockhashes matches the settling Sponsor's; a stale or fork-divergent blockhash will cause the transaction to expire or fail to land.
+- `extra.lastValidBlockHeight` (optional): The last block height at which `extra.recentBlockhash` is valid, as a decimal string. This informational hint is not serialized into the transaction and MAY be ignored by the Client or Sponsor. It is ignored when `recentBlockhash` is absent.
+
+These optional fields are transaction-construction hints. They do not bind the submitted transaction to the hinted blockhash, and the facilitator's verification does not compare the transaction blockhash with `extra.recentBlockhash`.
 
 ## PaymentPayload `payload` Field
 

--- a/typescript/.changeset/svm-blockhash-fallback.md
+++ b/typescript/.changeset/svm-blockhash-fallback.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": patch
+---
+
+Added support for resource servers to include recent blockhash hints in SVM exact payment requirements. Clients use valid hints without a blockhash RPC call and fetch their own blockhash when a hint is absent or malformed.

--- a/typescript/packages/mechanisms/svm/src/utils.ts
+++ b/typescript/packages/mechanisms/svm/src/utils.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  getBase58Encoder,
   getBase64Encoder,
   getTransactionDecoder,
   getCompiledTransactionMessageDecoder,
@@ -174,7 +175,7 @@ export function createRpcClient(
  * Prefers a server-provided blockhash carried in the 402 challenge
  * (`extra.recentBlockhash` + `extra.lastValidBlockHeight`) so the client needn't
  * make its own RPC round-trip. Falls back to fetching one from `rpc` when the
- * challenge omits it.
+ * challenge omits it or contains a malformed value.
  *
  * @param rpc - RPC client used for the fallback fetch
  * @param requirements - The payment requirements (challenge) being paid
@@ -185,10 +186,28 @@ export async function resolveBlockhash(
   requirements: PaymentRequirements,
 ): Promise<{ blockhash: Blockhash; lastValidBlockHeight: bigint }> {
   const provided = requirements.extra?.recentBlockhash;
-  if (typeof provided === "string") {
-    const lastValid = requirements.extra?.lastValidBlockHeight as string | number | undefined;
-    return { blockhash: provided as Blockhash, lastValidBlockHeight: BigInt(lastValid ?? 0) };
+  if (typeof provided === "string" && provided !== "") {
+    try {
+      if (getBase58Encoder().encode(provided).length === 32) {
+        const lastValid = requirements.extra?.lastValidBlockHeight;
+        let lastValidBlockHeight = 0n;
+        if (typeof lastValid === "string" && /^\d+$/.test(lastValid)) {
+          lastValidBlockHeight = BigInt(lastValid);
+        } else if (
+          typeof lastValid === "number" &&
+          Number.isSafeInteger(lastValid) &&
+          lastValid >= 0
+        ) {
+          lastValidBlockHeight = BigInt(lastValid);
+        }
+
+        return { blockhash: provided as Blockhash, lastValidBlockHeight };
+      }
+    } catch {
+      // Invalid optional hints are ignored; fetch a usable blockhash below.
+    }
   }
+
   const { value } = await rpc.getLatestBlockhash().send();
   return value;
 }

--- a/typescript/packages/mechanisms/svm/test/unit/client.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/client.test.ts
@@ -3,6 +3,36 @@ import { ExactSvmScheme } from "../../src/exact";
 import type { ClientSvmSigner } from "../../src/signer";
 import type { PaymentRequirements } from "@x402/core/types";
 import { USDC_DEVNET_ADDRESS, SOLANA_DEVNET_CAIP2 } from "../../src/constants";
+import { resolveBlockhash } from "../../src/utils";
+
+const PROVIDED_BLOCKHASH = "EZ3rST5dvHmbanh75jc4PuLfV96vp9fEYBVeNk4FfM1k";
+const FALLBACK_BLOCKHASH = "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF";
+
+function createBlockhashRpc() {
+  const send = vi.fn().mockResolvedValue({
+    value: {
+      blockhash: FALLBACK_BLOCKHASH,
+      lastValidBlockHeight: 67890n,
+    },
+  });
+  const rpc = {
+    getLatestBlockhash: () => ({ send }),
+  };
+
+  return { rpc, send };
+}
+
+function requirementsWithRecentBlockhash(
+  recentBlockhash?: string | number,
+  lastValidBlockHeight?: string | number,
+) {
+  return {
+    extra: {
+      ...(recentBlockhash === undefined ? {} : { recentBlockhash }),
+      ...(lastValidBlockHeight === undefined ? {} : { lastValidBlockHeight }),
+    },
+  };
+}
 
 describe("ExactSvmScheme", () => {
   let mockSigner: ClientSvmSigner;
@@ -99,5 +129,59 @@ describe("ExactSvmScheme", () => {
       }
       expect(client.scheme).toBe("exact");
     });
+  });
+});
+
+describe("resolveBlockhash", () => {
+  it("uses a valid server-provided blockhash without an RPC call", async () => {
+    const { rpc, send } = createBlockhashRpc();
+
+    const result = await resolveBlockhash(
+      rpc as never,
+      requirementsWithRecentBlockhash(PROVIDED_BLOCKHASH, "12345") as never,
+    );
+
+    expect(result).toEqual({
+      blockhash: PROVIDED_BLOCKHASH,
+      lastValidBlockHeight: 12345n,
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("uses a valid blockhash when lastValidBlockHeight is absent or malformed", async () => {
+    const { rpc, send } = createBlockhashRpc();
+
+    const missingHeight = await resolveBlockhash(
+      rpc as never,
+      requirementsWithRecentBlockhash(PROVIDED_BLOCKHASH) as never,
+    );
+    const malformedHeight = await resolveBlockhash(
+      rpc as never,
+      requirementsWithRecentBlockhash(PROVIDED_BLOCKHASH, "not-a-height") as never,
+    );
+
+    expect(missingHeight.lastValidBlockHeight).toBe(0n);
+    expect(malformedHeight.lastValidBlockHeight).toBe(0n);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["empty", ""],
+    ["non-string", 12345],
+    ["malformed", "not-a-blockhash"],
+  ])("falls back to RPC when recentBlockhash is %s", async (_name, recentBlockhash) => {
+    const { rpc, send } = createBlockhashRpc();
+
+    const result = await resolveBlockhash(
+      rpc as never,
+      requirementsWithRecentBlockhash(recentBlockhash) as never,
+    );
+
+    expect(result).toEqual({
+      blockhash: FALLBACK_BLOCKHASH,
+      lastValidBlockHeight: 67890n,
+    });
+    expect(send).toHaveBeenCalledOnce();
   });
 });

--- a/typescript/packages/mechanisms/svm/test/unit/server.blockhash.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/server.blockhash.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+const { getLatestBlockhashSend } = vi.hoisted(() => ({
+  getLatestBlockhashSend: vi.fn(),
+}));
 
 // Stub the RPC so enhancePaymentRequirements resolves a deterministic blockhash
 // without a network round-trip. Only createRpcClient is overridden; the rest of
@@ -9,12 +13,7 @@ vi.mock("../../src/utils", async () => {
     ...actual,
     createRpcClient: () => ({
       getLatestBlockhash: () => ({
-        send: async () => ({
-          value: {
-            blockhash: "EZ3rST5dvHmbanh75jc4PuLfV96vp9fEYBVeNk4FfM1k",
-            lastValidBlockHeight: 12345n,
-          },
-        }),
+        send: getLatestBlockhashSend,
       }),
     }),
   };
@@ -24,6 +23,16 @@ import { ExactSvmScheme } from "../../src/exact/server/scheme";
 import { SOLANA_DEVNET_CAIP2 } from "../../src/constants";
 
 describe("ExactSvmScheme — recent blockhash in the 402 challenge", () => {
+  beforeEach(() => {
+    getLatestBlockhashSend.mockReset();
+    getLatestBlockhashSend.mockResolvedValue({
+      value: {
+        blockhash: "EZ3rST5dvHmbanh75jc4PuLfV96vp9fEYBVeNk4FfM1k",
+        lastValidBlockHeight: 12345n,
+      },
+    });
+  });
+
   const base = {
     scheme: "exact",
     network: SOLANA_DEVNET_CAIP2,
@@ -52,6 +61,17 @@ describe("ExactSvmScheme — recent blockhash in the 402 challenge", () => {
   it("omits the blockhash when no rpcUrl is configured", async () => {
     const scheme = new ExactSvmScheme();
     const req = await scheme.enhancePaymentRequirements(base as never, supportedKind as never, []);
+    expect(req.extra?.recentBlockhash).toBeUndefined();
+    expect(req.extra?.lastValidBlockHeight).toBeUndefined();
+    expect(req.extra?.feePayer).toBe("FeePay3r1111111111111111111111111111111111");
+  });
+
+  it("omits the blockhash when the configured RPC fails", async () => {
+    getLatestBlockhashSend.mockRejectedValueOnce(new Error("RPC unavailable"));
+    const scheme = new ExactSvmScheme({ rpcUrl: "https://rpc.example" });
+
+    const req = await scheme.enhancePaymentRequirements(base as never, supportedKind as never, []);
+
     expect(req.extra?.recentBlockhash).toBeUndefined();
     expect(req.extra?.lastValidBlockHeight).toBeUndefined();
     expect(req.extra?.feePayer).toBe("FeePay3r1111111111111111111111111111111111");


### PR DESCRIPTION
## Description

- Aligns ts https://github.com/x402-foundation/x402/pull/2693 and go https://github.com/x402-foundation/x402/pull/2731 implementation of server-provided recent blockhash
- Adds equivalent py implementation

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 