### PR TITLE
feat: add Solana support to cloudfront-lambda-edge example

### DIFF
--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -2930,11 +2930,14 @@ importers:
   servers/cloudfront-lambda-edge/lambda:
     dependencies:
       '@x402/core':
-        specifier: ^2.11.0
-        version: 2.11.0
+        specifier: ^2.19.0
+        version: 2.19.0
       '@x402/evm':
-        specifier: ^2.11.0
-        version: 2.11.0(typescript@5.9.3)
+        specifier: ^2.19.0
+        version: 2.19.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/svm':
+        specifier: ^2.19.0
+        version: 2.19.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
     devDependencies:
       '@types/aws-lambda':
         specifier: ^8.10.159
@@ -7061,11 +7064,16 @@ packages:
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
 
-  '@x402/core@2.11.0':
-    resolution: {integrity: sha512-aqTfZc/BULrlWnd3I0lsqRQaH4gjJd8CsPcL16XqK2Lx5c6QDm+zCljgUVS1yj9BGJoZeQWTzI5hE+SVFkqMTw==}
+  '@x402/core@2.19.0':
+    resolution: {integrity: sha512-IPQIHzIrwvbri1339QWHvwtiTTDbGsrF5Yff0LZfufmVXNdOSYbjY8oz6vZg7+4W13f7/k81NUMAFoDOU4gswQ==}
 
-  '@x402/evm@2.11.0':
-    resolution: {integrity: sha512-F8uU1txDZA+wc/sEnmaHAyYvoTi/w39r7K3a44MmQHSxECDTEuB3A0FwbxOxUPLN1eyCxTAFKEiqlGe3bwybKA==}
+  '@x402/evm@2.19.0':
+    resolution: {integrity: sha512-ycbYCjJmLC1I7tRQslAwB73FhJAVMPzsojYunWuR5hk+jKUwgC6djch1ZrKFC1f9lJi7IOiezZtRHj6TWyCCrg==}
+
+  '@x402/svm@2.19.0':
+    resolution: {integrity: sha512-ZceHsvidxNCe/vX9N8D5GMJ29iZMp2IsimzBPTNw48ylGNEzVSBIEtTYrhcrUTebwSlDWdutM5J25AIGp05oZQ==}
+    peerDependencies:
+      '@solana/kit': '>=5.1.0'
 
   '@xrplf/isomorphic@1.0.2':
     resolution: {integrity: sha512-ncZUdMXr6VlSXtdoiDi0jTH+gBrgGxwVeEidhoegII3PmyErbQsyj6e+j7acmR4LW/lvBkPkzb9QzRfJH0n3rA==}
@@ -13863,6 +13871,10 @@ snapshots:
     dependencies:
       '@solana/kit': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
+  '@solana-program/compute-budget@0.11.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+
   '@solana-program/compute-budget@0.8.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
@@ -13885,6 +13897,11 @@ snapshots:
       '@solana/kit': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@solana/sysvars': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)
 
+  '@solana-program/token-2022@0.6.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/sysvars': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+
   '@solana-program/token@0.5.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(utf-8-validate@5.0.10)
@@ -13900,6 +13917,10 @@ snapshots:
   '@solana-program/token@0.9.0(@solana/kit@5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
     dependencies:
       '@solana/kit': 5.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.2)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+
+  '@solana-program/token@0.9.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
   '@solana/accounts@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -19086,19 +19107,29 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
-  '@x402/core@2.11.0':
+  '@x402/core@2.19.0':
     dependencies:
       zod: 3.25.76
 
-  '@x402/evm@2.11.0(typescript@5.9.3)':
+  '@x402/evm@2.19.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@x402/core': 2.11.0
-      viem: 2.48.11(typescript@5.9.3)(zod@3.25.76)
+      '@x402/core': 2.19.0
+      viem: 2.48.11(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
+
+  '@x402/svm@2.19.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))':
+    dependencies:
+      '@solana-program/compute-budget': 0.11.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana-program/token': 0.9.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana-program/token-2022': 0.6.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))
+      '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402/core': 2.19.0
+    transitivePeerDependencies:
+      - '@solana/sysvars'
 
   '@xrplf/isomorphic@1.0.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
@@ -19503,7 +19534,7 @@ snapshots:
 
   borsh@0.7.0:
     dependencies:
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
@@ -21493,7 +21524,7 @@ snapshots:
     dependencies:
       ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
@@ -24210,7 +24241,7 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.2)(zod@3.22.4)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.14.20(typescript@5.9.2)(zod@3.22.4)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
@@ -24227,7 +24258,7 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.2)(zod@3.25.76)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.14.20(typescript@5.9.2)(zod@3.25.76)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
@@ -24244,7 +24275,7 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.22.4)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.14.20(typescript@5.9.3)(zod@3.22.4)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
@@ -24261,7 +24292,7 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.14.20(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
@@ -24278,25 +24309,8 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@4.1.13)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       ox: 0.14.20(typescript@5.9.3)(zod@4.1.13)
-      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
-  viem@2.48.11(typescript@5.9.3)(zod@3.25.76):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.14.20(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3

--- a/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CDK.md
+++ b/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CDK.md
@@ -21,7 +21,7 @@ This guide deploys the same architecture as the [Console guide](./GETTING-STARTE
   aws sts get-caller-identity  # verify it works
   ```
 - **Node.js 20+** and **pnpm** — verify with `node --version` and `pnpm --version`
-- **Ethereum wallet address on Base Sepolia** — install [MetaMask](https://metamask.io) and copy your `0x...` address. Base Sepolia is a testnet — no real money required.
+- **Wallet addresses on Base Sepolia and Solana Devnet** — use an Ethereum wallet such as [MetaMask](https://metamask.io) and a Solana wallet. Both networks are testnets — no real money required.
 
 ---
 
@@ -37,11 +37,16 @@ cd examples/typescript/servers/cloudfront-lambda-edge/lambda
 
 **1b. Configure your wallet address**
 
-Open `src/config.ts` and replace the placeholder:
+Open `src/config.ts` and replace both payment-address placeholders:
 
 ```typescript
-export const PAY_TO = '0xYourActualAddressHere';
+export const EVM_PAY_TO = '0xYourActualEvmAddressHere';
+export const SVM_PAY_TO = 'YourActualSolanaAddressHere';
 ```
+
+Leave `FACILITATOR_URL`, `EVM_NETWORK`, and `SVM_NETWORK` as-is — the default facilitator supports Base Sepolia and Solana Devnet.
+
+> The Solana `payTo` address must already have a USDC token account (an address gets one the first time it ever receives that token); send it any amount of USDC once before going live.
 
 **1c. Install and build**
 
@@ -133,14 +138,33 @@ Expected response:
 HTTP/2 402
 
 {
-  "x402Version": 1,
+  "x402Version": 2,
   "error": "Payment required",
-  "accepts": [{
-    "scheme": "exact",
-    "network": "eip155:84532",
-    "payTo": "0xYourAddress...",
-    "price": "$0.001"
-  }]
+  "resource": {
+    "url": "https://[YOUR_DOMAIN]/api/test",
+    "description": "API access",
+    "mimeType": ""
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:84532",
+      "amount": "1000",
+      "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "payTo": "0xYourEvmAddress...",
+      "maxTimeoutSeconds": 300,
+      "extra": { "name": "USDC", "version": "2" }
+    },
+    {
+      "scheme": "exact",
+      "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+      "amount": "1000",
+      "asset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+      "payTo": "YourSolanaAddress...",
+      "maxTimeoutSeconds": 300,
+      "extra": { "feePayer": "..." }
+    }
+  ]
 }
 ```
 
@@ -156,6 +180,8 @@ The path `/get` is not in your `ROUTES` config, so it passes through to httpbin 
 
 **Test 3 — Full payment flow**
 
+Get test USDC for Base Sepolia or Solana Devnet from the [Circle faucet](https://faucet.circle.com). The default facilitator supports both testnets, so no facilitator change is needed.
+
 Use the [`fetch` client example](../../../../clients/fetch/) to make a paid request:
 
 ```bash
@@ -166,6 +192,7 @@ cp .env-local .env
 Edit `.env`:
 ```
 EVM_PRIVATE_KEY=0xYourBaseSepoliaPrivateKey
+SVM_PRIVATE_KEY=YourSolanaDevnetPrivateKey
 RESOURCE_SERVER_URL=https://[YOUR_DOMAIN]
 ENDPOINT_PATH=/api/test
 ```
@@ -177,7 +204,7 @@ pnpm install && pnpm start
 
 The client automatically detects the `402`, constructs and signs the payment, attaches it as a `PAYMENT-SIGNATURE` header, and retries — returning the 200 response from httpbin.
 
-> **Never use a mainnet private key here.** Use a throwaway Base Sepolia wallet with test funds only.
+> **Never use mainnet private keys here.** Use throwaway Base Sepolia and Solana Devnet wallets with test funds only.
 
 ---
 
@@ -234,10 +261,14 @@ Then `npx cdk deploy` to update. Your origin needs no changes — that's the poi
 Update `src/config.ts` in the lambda directory:
 
 ```typescript
-export const NETWORK = 'eip155:8453'; // Base mainnet
+export const EVM_NETWORK = 'eip155:8453'; // Base mainnet
+export const EVM_PAY_TO = '0xYourEvmMainnetWalletAddress';
+export const SVM_NETWORK = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'; // Solana mainnet
+export const SVM_PAY_TO = 'YourSolanaMainnetWalletAddress';
 export const FACILITATOR_URL = 'https://your-mainnet-facilitator-url';
-export const PAY_TO = '0xYourMainnetWalletAddress';
 ```
+
+Mainnet requires a facilitator that supports your networks. The CDP facilitator supports Base and Solana mainnet and requires CDP API keys; pass its authenticated `facilitatorConfig` through the middleware as described in the [README](./README.md#running-on-mainnet). The [PayAI facilitator](https://facilitator.payai.network) supports both mainnets with no API keys. See the [full facilitator list](../../../../docs/dev-tools/facilitators.md).
 
 Rebuild and redeploy:
 
@@ -245,8 +276,6 @@ Rebuild and redeploy:
 cd ../lambda && pnpm build
 cd ../cdk && npx cdk deploy
 ```
-
-Browse available mainnet facilitators at the [x402 ecosystem](https://www.x402.org/ecosystem?filter=facilitators).
 
 ---
 

--- a/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CDK.md
+++ b/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CDK.md
@@ -21,7 +21,7 @@ This guide deploys the same architecture as the [Console guide](./GETTING-STARTE
   aws sts get-caller-identity  # verify it works
   ```
 - **Node.js 20+** and **pnpm** — verify with `node --version` and `pnpm --version`
-- **Wallet addresses on Base Sepolia and Solana Devnet** — use an Ethereum wallet such as [MetaMask](https://metamask.io) and a Solana wallet. Both networks are testnets — no real money required.
+- **Wallet addresses on Base Sepolia and Solana Devnet** — use an Ethereum wallet such as [MetaMask](https://metamask.io) and a Solana wallet such as [Phantom](https://phantom.com) or [Solflare](https://solflare.com). Both networks are testnets — no real money required.
 
 ---
 
@@ -268,7 +268,7 @@ export const SVM_PAY_TO = 'YourSolanaMainnetWalletAddress';
 export const FACILITATOR_URL = 'https://your-mainnet-facilitator-url';
 ```
 
-Mainnet requires a facilitator that supports your networks. The CDP facilitator supports Base and Solana mainnet and requires CDP API keys; pass its authenticated `facilitatorConfig` through the middleware as described in the [README](./README.md#running-on-mainnet). The [PayAI facilitator](https://facilitator.payai.network) supports both mainnets with no API keys. See the [full facilitator list](../../../../docs/dev-tools/facilitators.md).
+Mainnet requires a facilitator that supports your networks, and each may have different authentication requirements. If yours requires auth, pass its `facilitatorConfig` through the middleware as described in the [README](./README.md#running-on-mainnet). Browse available facilitators at the [x402 Ecosystem — Facilitators](https://www.x402.org/ecosystem?filter=facilitators).
 
 Rebuild and redeploy:
 

--- a/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CONSOLE.md
+++ b/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CONSOLE.md
@@ -27,7 +27,7 @@ The "verify then settle" pattern ensures clients are never charged for failed re
 
 - **AWS account** ([aws.amazon.com](https://aws.amazon.com)) — free tier is sufficient
 - **Node.js 20+** and **pnpm** — verify with `node --version` and `pnpm --version`
-- **Wallet addresses on Base Sepolia and Solana Devnet** — use an Ethereum wallet such as [MetaMask](https://metamask.io) and a Solana wallet. Both networks are testnets — no real money required.
+- **Wallet addresses on Base Sepolia and Solana Devnet** — use an Ethereum wallet such as [MetaMask](https://metamask.io) and a Solana wallet such as [Phantom](https://phantom.com) or [Solflare](https://solflare.com). Both networks are testnets — no real money required.
 
 ---
 
@@ -391,7 +391,7 @@ export const SVM_NETWORK = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'; // Solana 
 export const SVM_PAY_TO = 'YourSolanaMainnetWalletAddress';
 ```
 
-Mainnet requires a facilitator that supports your networks. The CDP facilitator supports Base and Solana mainnet and requires CDP API keys; pass its authenticated `facilitatorConfig` through the middleware as described in the [README](./README.md#running-on-mainnet). The [PayAI facilitator](https://facilitator.payai.network) supports both mainnets with no API keys. See the [full facilitator list](../../../../docs/dev-tools/facilitators.md).
+Mainnet requires a facilitator that supports your networks, and each may have different authentication requirements. If yours requires auth, pass its `facilitatorConfig` through the middleware as described in the [README](./README.md#running-on-mainnet). Browse available facilitators at the [x402 Ecosystem — Facilitators](https://www.x402.org/ecosystem?filter=facilitators).
 
 Rebuild, upload the new bundle to both functions, and publish and associate new Lambda versions.
 

--- a/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CONSOLE.md
+++ b/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CONSOLE.md
@@ -27,7 +27,7 @@ The "verify then settle" pattern ensures clients are never charged for failed re
 
 - **AWS account** ([aws.amazon.com](https://aws.amazon.com)) — free tier is sufficient
 - **Node.js 20+** and **pnpm** — verify with `node --version` and `pnpm --version`
-- **Ethereum wallet address on Base Sepolia** — the quickest option is [MetaMask](https://metamask.io); copy your `0x...` address. Base Sepolia is a testnet — no real money required.
+- **Wallet addresses on Base Sepolia and Solana Devnet** — use an Ethereum wallet such as [MetaMask](https://metamask.io) and a Solana wallet. Both networks are testnets — no real money required.
 
 ---
 
@@ -44,13 +44,16 @@ cd x402/examples/typescript/servers/cloudfront-lambda-edge/lambda
 
 **1b. Configure your wallet address**
 
-Open `src/config.ts` and replace the placeholder with your wallet address:
+Open `src/config.ts` and replace both payment-address placeholders:
 
 ```typescript
-export const PAY_TO = '0xYourActualAddressHere';
+export const EVM_PAY_TO = '0xYourActualEvmAddressHere';
+export const SVM_PAY_TO = 'YourActualSolanaAddressHere';
 ```
 
-Leave `FACILITATOR_URL` and `NETWORK` as-is — they point to the public testnet facilitator on Base Sepolia.
+Leave `FACILITATOR_URL`, `EVM_NETWORK`, and `SVM_NETWORK` as-is — the default facilitator supports Base Sepolia and Solana Devnet.
+
+> The Solana `payTo` address must already have a USDC token account (an address gets one the first time it ever receives that token); send it any amount of USDC once before going live.
 
 **1c. Install dependencies and build**
 
@@ -307,14 +310,33 @@ Expected response:
 HTTP/2 402
 
 {
-  "x402Version": 1,
+  "x402Version": 2,
   "error": "Payment required",
-  "accepts": [{
-    "scheme": "exact",
-    "network": "eip155:84532",
-    "payTo": "0xYourAddress...",
-    "price": "$0.001"
-  }]
+  "resource": {
+    "url": "https://[YOUR_DOMAIN]/api/test",
+    "description": "API access",
+    "mimeType": ""
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:84532",
+      "amount": "1000",
+      "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+      "payTo": "0xYourEvmAddress...",
+      "maxTimeoutSeconds": 300,
+      "extra": { "name": "USDC", "version": "2" }
+    },
+    {
+      "scheme": "exact",
+      "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+      "amount": "1000",
+      "asset": "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
+      "payTo": "YourSolanaAddress...",
+      "maxTimeoutSeconds": 300,
+      "extra": { "feePayer": "..." }
+    }
+  ]
 }
 ```
 
@@ -330,6 +352,8 @@ The path `/get` is not in your `ROUTES` config, so it passes through to httpbin 
 
 **Test 3 — Full payment flow**
 
+Get test USDC for Base Sepolia or Solana Devnet from the [Circle faucet](https://faucet.circle.com). The default facilitator supports both testnets, so no facilitator change is needed.
+
 Use the [`fetch` client example](../../../../clients/fetch/) from this repo to make a paid request:
 
 ```bash
@@ -340,6 +364,7 @@ cp .env-local .env
 Edit `.env`:
 ```
 EVM_PRIVATE_KEY=0xYourBaseSepoliaPrivateKey
+SVM_PRIVATE_KEY=YourSolanaDevnetPrivateKey
 RESOURCE_SERVER_URL=https://[YOUR_DOMAIN].cloudfront.net
 ENDPOINT_PATH=/api/test
 ```
@@ -351,7 +376,24 @@ pnpm install && pnpm start
 
 The client will automatically detect the `402`, construct and sign the payment, attach it as a `PAYMENT-SIGNATURE` header, and retry — returning the 200 response from httpbin.
 
-> **Never use a mainnet private key here.** Use a throwaway Base Sepolia wallet with test funds only.
+> **Never use mainnet private keys here.** Use throwaway Base Sepolia and Solana Devnet wallets with test funds only.
+
+---
+
+## Going to Mainnet
+
+Update both networks and payment addresses in `src/config.ts`:
+
+```typescript
+export const EVM_NETWORK = 'eip155:8453'; // Base mainnet
+export const EVM_PAY_TO = '0xYourEvmMainnetWalletAddress';
+export const SVM_NETWORK = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'; // Solana mainnet
+export const SVM_PAY_TO = 'YourSolanaMainnetWalletAddress';
+```
+
+Mainnet requires a facilitator that supports your networks. The CDP facilitator supports Base and Solana mainnet and requires CDP API keys; pass its authenticated `facilitatorConfig` through the middleware as described in the [README](./README.md#running-on-mainnet). The [PayAI facilitator](https://facilitator.payai.network) supports both mainnets with no API keys. See the [full facilitator list](../../../../docs/dev-tools/facilitators.md).
+
+Rebuild, upload the new bundle to both functions, and publish and associate new Lambda versions.
 
 ---
 
@@ -382,4 +424,4 @@ CloudFront's free tier covers 1TB data transfer and 10M requests/month, so works
 - **Use your own origin** — replace `httpbin.org` with any HTTP server (AWS, GCP, Azure, on-prem, SaaS)
 - **Adjust pricing and routes** — edit `src/config.ts`, rebuild, re-upload the zip, and publish a new version
 - **Add WAF bot protection** — charge only bot/scraper traffic while keeping humans free (see [Advanced Patterns](./README.md#advanced-patterns))
-- **Go to mainnet** — update `NETWORK` to `eip155:8453` and `FACILITATOR_URL` to a mainnet facilitator from the [x402 ecosystem](https://www.x402.org/ecosystem?filter=facilitators)
+- **Go to mainnet** — follow [Going to Mainnet](#going-to-mainnet) to update both networks, addresses, and facilitator

--- a/examples/typescript/servers/cloudfront-lambda-edge/README.md
+++ b/examples/typescript/servers/cloudfront-lambda-edge/README.md
@@ -18,6 +18,7 @@ flowchart LR
 - **Works with any origin** — APIs, static sites, cached or non-cached content
 - **Any cloud or on-prem** — AWS, GCP, Azure, third-party services, or your own infrastructure
 - **Drop-in monetization** — add payments to existing endpoints in minutes
+- **Multi-chain** — accept payments on Base and Solana from the same routes
 - **Edge performance** — payment verification at CloudFront's global edge locations
 - **Fair billing** — customers only charged when the request succeeds
 
@@ -86,9 +87,15 @@ Edit `config.ts`:
 
 ```typescript
 export const FACILITATOR_URL = 'https://x402.org/facilitator';
-export const PAY_TO = '0xYourPaymentAddressHere';  // Your wallet address
-export const NETWORK = 'eip155:84532';              // Base Sepolia (testnet)
+export const EVM_NETWORK = 'eip155:84532'; // Base Sepolia testnet
+export const EVM_PAY_TO = '0xYourEvmPaymentAddressHere';
+export const SVM_NETWORK = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1'; // Solana Devnet
+export const SVM_PAY_TO = 'YourSolanaPaymentAddressHere';
 ```
+
+The default facilitator supports both testnets, so no facilitator change is needed for testing. Get test USDC for either network from the [Circle faucet](https://faucet.circle.com).
+
+> The Solana `payTo` address must already have a USDC token account (an address gets one the first time it ever receives that token); send it any amount of USDC once before going live.
 
 ### 3. Configure Routes
 
@@ -97,12 +104,20 @@ Define which routes require payment:
 ```typescript
 export const ROUTES: RoutesConfig = {
   '/api/*': {
-    accepts: {
-      scheme: 'exact',
-      network: NETWORK,
-      payTo: PAY_TO,
-      price: '$0.001',
-    },
+    accepts: [
+      {
+        scheme: 'exact',
+        network: EVM_NETWORK,
+        payTo: EVM_PAY_TO,
+        price: '$0.001',
+      },
+      {
+        scheme: 'exact',
+        network: SVM_NETWORK,
+        payTo: SVM_PAY_TO,
+        price: '$0.001',
+      },
+    ],
     description: 'API access',
   },
 };
@@ -136,14 +151,16 @@ import { originRequestHandler, originResponseHandler } from './index';
 
 ## Running on Mainnet
 
-To accept real payments, you need a mainnet facilitator. Each facilitator may have different authentication requirements. Browse available facilitators at the [x402 Ecosystem — Facilitators](https://www.x402.org/ecosystem?filter=facilitators).
+To accept real payments, you need a facilitator that supports your mainnet networks. The CDP facilitator supports Base and Solana mainnet and requires CDP API keys. The [PayAI facilitator](https://facilitator.payai.network) also supports both mainnets and requires no API keys. See the [full facilitator list](../../../../docs/dev-tools/facilitators.md).
 
-Update `config.ts` with your chosen facilitator, a mainnet network, and your wallet address:
+Update `config.ts` with your chosen facilitator, both mainnet networks, and your wallet addresses:
 
 ```typescript
 export const FACILITATOR_URL = 'https://your-facilitator-url';
-export const NETWORK = 'eip155:8453'; // Base mainnet
-export const PAY_TO = '0xYourMainnetWalletAddress';
+export const EVM_NETWORK = 'eip155:8453'; // Base mainnet
+export const EVM_PAY_TO = '0xYourEvmMainnetWalletAddress';
+export const SVM_NETWORK = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'; // Solana mainnet
+export const SVM_PAY_TO = 'YourSolanaMainnetWalletAddress';
 ```
 
 If your facilitator requires authentication, you can pass a `facilitatorConfig` object (with `url` and `createAuthHeaders`) via the middleware config. Update `config.ts`:
@@ -160,7 +177,6 @@ Then pass it in `origin-request.ts` and `origin-response.ts`:
 ```typescript
 const x402 = createX402Middleware({
   facilitatorUrl: FACILITATOR_URL,
-  network: NETWORK,
   routes: ROUTES,
   facilitatorConfig: FACILITATOR_CONFIG, // overrides facilitatorUrl when provided
 });
@@ -199,10 +215,17 @@ import { createX402Middleware, MiddlewareResultType } from './lib';
 // Create middleware with config
 const x402 = createX402Middleware({
   facilitatorUrl: 'https://x402.org/facilitator',
-  network: 'eip155:84532',
   routes: {
     '/api/*': {
-      accepts: { scheme: 'exact', network: 'eip155:84532', payTo: '0x...', price: '$0.01' },
+      accepts: [
+        { scheme: 'exact', network: 'eip155:84532', payTo: '0x...', price: '$0.01' },
+        {
+          scheme: 'exact',
+          network: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+          payTo: '...',
+          price: '$0.01',
+        },
+      ],
       description: 'API access',
     },
   },

--- a/examples/typescript/servers/cloudfront-lambda-edge/README.md
+++ b/examples/typescript/servers/cloudfront-lambda-edge/README.md
@@ -151,7 +151,7 @@ import { originRequestHandler, originResponseHandler } from './index';
 
 ## Running on Mainnet
 
-To accept real payments, you need a facilitator that supports your mainnet networks. The CDP facilitator supports Base and Solana mainnet and requires CDP API keys. The [PayAI facilitator](https://facilitator.payai.network) also supports both mainnets and requires no API keys. See the [full facilitator list](../../../../docs/dev-tools/facilitators.md).
+To accept real payments, you need a mainnet facilitator that supports your networks. Each facilitator may have different authentication requirements. Browse available facilitators at the [x402 Ecosystem — Facilitators](https://www.x402.org/ecosystem?filter=facilitators).
 
 Update `config.ts` with your chosen facilitator, both mainnet networks, and your wallet addresses:
 

--- a/examples/typescript/servers/cloudfront-lambda-edge/lambda/package.json
+++ b/examples/typescript/servers/cloudfront-lambda-edge/lambda/package.json
@@ -13,8 +13,9 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@x402/core": "^2.11.0",
-    "@x402/evm": "^2.11.0"
+    "@x402/core": "^2.19.0",
+    "@x402/evm": "^2.19.0",
+    "@x402/svm": "^2.19.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.159",

--- a/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/config.ts
+++ b/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/config.ts
@@ -9,36 +9,63 @@ import type { RoutesConfig } from '@x402/core/server';
 
 // Payment configuration
 export const FACILITATOR_URL = 'https://x402.org/facilitator';
-export const PAY_TO = '0xYourPaymentAddressHere';
-export const NETWORK = 'eip155:84532'; // Base Sepolia testnet
+export const EVM_NETWORK = 'eip155:84532'; // Base Sepolia testnet
+export const EVM_PAY_TO = '0xYourEvmPaymentAddressHere';
+export const SVM_NETWORK = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1'; // Solana Devnet
+export const SVM_PAY_TO = 'YourSolanaPaymentAddressHere';
 
 // Route configuration
+// Each route offers both networks, and the client picks one.
 export const ROUTES: RoutesConfig = {
   '/api/*': {
-    accepts: {
-      scheme: 'exact',
-      network: NETWORK,
-      payTo: PAY_TO,
-      price: '$0.001',
-    },
+    accepts: [
+      {
+        scheme: 'exact',
+        network: EVM_NETWORK,
+        payTo: EVM_PAY_TO,
+        price: '$0.001',
+      },
+      {
+        scheme: 'exact',
+        network: SVM_NETWORK,
+        payTo: SVM_PAY_TO,
+        price: '$0.001',
+      },
+    ],
     description: 'API access',
   },
   '/api/premium/**': {
-    accepts: {
-      scheme: 'exact',
-      network: NETWORK,
-      payTo: PAY_TO,
-      price: '$0.01',
-    },
+    accepts: [
+      {
+        scheme: 'exact',
+        network: EVM_NETWORK,
+        payTo: EVM_PAY_TO,
+        price: '$0.01',
+      },
+      {
+        scheme: 'exact',
+        network: SVM_NETWORK,
+        payTo: SVM_PAY_TO,
+        price: '$0.01',
+      },
+    ],
     description: 'Premium API access',
   },
   '/content/**': {
-    accepts: {
-      scheme: 'exact',
-      network: NETWORK,
-      payTo: PAY_TO,
-      price: '$0.005',
-    },
+    accepts: [
+      {
+        scheme: 'exact',
+        network: EVM_NETWORK,
+        payTo: EVM_PAY_TO,
+        price: '$0.005',
+      },
+      {
+        scheme: 'exact',
+        network: SVM_NETWORK,
+        payTo: SVM_PAY_TO,
+        price: '$0.005',
+      },
+    ],
     description: 'Premium content',
   },
 };

--- a/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/lib/middleware.ts
+++ b/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/lib/middleware.ts
@@ -64,10 +64,17 @@ const PENDING_SETTLEMENT_HEADER = 'x-x402-pending-settlement';
  * 
  * const x402 = createX402Middleware({
  *   facilitatorUrl: 'https://x402.org/facilitator',
- *   network: 'eip155:84532',
  *   routes: {
  *     '/api/*': {
- *       accepts: { scheme: 'exact', network: 'eip155:84532', payTo: '0x...', price: '$0.01' }
+ *       accepts: [
+ *         { scheme: 'exact', network: 'eip155:84532', payTo: '0x...', price: '$0.01' },
+ *         {
+ *           scheme: 'exact',
+ *           network: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+ *           payTo: '...',
+ *           price: '$0.01',
+ *         },
+ *       ]
  *     }
  *   }
  * });

--- a/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/lib/server.ts
+++ b/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/lib/server.ts
@@ -1,6 +1,7 @@
 import type { RoutesConfig, FacilitatorConfig } from '@x402/core/server';
 import { x402ResourceServer, x402HTTPResourceServer, HTTPFacilitatorClient } from '@x402/core/server';
 import { ExactEvmScheme } from '@x402/evm/exact/server';
+import { ExactSvmScheme } from '@x402/svm/exact/server';
 
 /**
  * Configuration for creating an x402 server
@@ -8,8 +9,6 @@ import { ExactEvmScheme } from '@x402/evm/exact/server';
 export interface X402ServerConfig {
   /** Facilitator URL (e.g., 'https://x402.org/facilitator') */
   facilitatorUrl: string;
-  /** Network ID (e.g., 'eip155:84532' for Base Sepolia) */
-  network: string;
   /** Route configuration defining which paths require payment */
   routes: RoutesConfig;
   /** Optional facilitator config with auth headers (for facilitators that require authentication) */
@@ -24,14 +23,12 @@ export interface X402ServerConfig {
  * // Testnet (no auth)
  * const server = await createX402Server({
  *   facilitatorUrl: 'https://x402.org/facilitator',
- *   network: 'eip155:84532',
- *   routes: { ... },
+ *   routes: { ... }, // Networks offered per route come from the routes' accepts entries
  * });
  * 
  * // Mainnet with auth (pass a facilitator config from your facilitator package)
  * const server = await createX402Server({
  *   facilitatorUrl: 'https://your-facilitator-url',
- *   network: 'eip155:8453',
  *   routes: { ... },
  *   facilitatorConfig: createFacilitatorConfig('api-key-id', 'api-key-secret'),
  * });
@@ -42,7 +39,8 @@ export async function createX402Server(config: X402ServerConfig): Promise<x402HT
     config.facilitatorConfig ?? { url: config.facilitatorUrl },
   );
   const resourceServer = new x402ResourceServer(facilitator)
-    .register(config.network as `${string}:${string}`, new ExactEvmScheme());
+    .register('eip155:*', new ExactEvmScheme())
+    .register('solana:*', new ExactSvmScheme());
 
   const httpServer = new x402HTTPResourceServer(resourceServer, config.routes);
   await httpServer.initialize();

--- a/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/origin-request.ts
+++ b/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/origin-request.ts
@@ -7,11 +7,10 @@
 
 import type { CloudFrontRequestEvent, CloudFrontRequestResult } from 'aws-lambda';
 import { createX402Middleware, MiddlewareResultType, type LambdaEdgeResponse } from './lib';
-import { FACILITATOR_URL, NETWORK, ROUTES } from './config';
+import { FACILITATOR_URL, ROUTES } from './config';
 
 const x402 = createX402Middleware({
   facilitatorUrl: FACILITATOR_URL,
-  network: NETWORK,
   routes: ROUTES,
 });
 

--- a/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/origin-response.ts
+++ b/examples/typescript/servers/cloudfront-lambda-edge/lambda/src/origin-response.ts
@@ -7,11 +7,10 @@
 
 import type { CloudFrontResponseEvent, CloudFrontResponseResult } from 'aws-lambda';
 import { createX402Middleware, MiddlewareResultType, type LambdaEdgeResponse } from './lib';
-import { FACILITATOR_URL, NETWORK, ROUTES } from './config';
+import { FACILITATOR_URL, ROUTES } from './config';
 
 const x402 = createX402Middleware({
   facilitatorUrl: FACILITATOR_URL,
-  network: NETWORK,
   routes: ROUTES,
 });
 


### PR DESCRIPTION
## What

Adds Solana support to the CloudFront + Lambda@Edge example alongside the existing Base support. Each route's `accepts` now offers both an `eip155:84532` (Base Sepolia) and a `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` (Solana Devnet) payment option, and the client picks one — following the pattern of `examples/typescript/servers/express`.

- `lambda/src/lib/server.ts` registers schemes per namespace (`eip155:*` → `ExactEvmScheme`, `solana:*` → `ExactSvmScheme`), so the concrete networks come entirely from the routes config; the single-network `network` field is gone from the middleware config.
- `lambda/src/config.ts` gains `EVM_*`/`SVM_*` constants and dual-entry `accepts` arrays per route.
- `@x402/*` deps bumped `^2.11.0` → `^2.19.0` (+ `@x402/svm`). Bundle stays small (237 KB) since `ExactSvmScheme` needs no RPC on the server side — the facilitator does the chain work, which suits Lambda@Edge's no-env-var, latency-sensitive constraints.
- Docs: both getting-started guides + README updated for dual-network setup (wallets — with example EVM and Solana wallets — Circle faucet for both testnets, mainnet network IDs); the mainnet section keeps the example's existing neutral facilitator guidance (links the [x402 Ecosystem facilitators list](https://www.x402.org/ecosystem?filter=facilitators); no facilitator is singled out), and notes the Solana payTo needs an existing USDC token account.
- Doc fixes in passing, scoped to the sections this PR already touches: the sample 402 body now matches the real v2 wire shape (was `x402Version: 1` with `price` fields), and the Test 3 client snippet now sets both `EVM_PRIVATE_KEY` and `SVM_PRIVATE_KEY` (the fetch client exits if either is missing).

No changes to `cdk/` (it has no network config) or to the handlers beyond dropping the removed config field.

## Why

The default `x402.org` facilitator, the v2 SDK, and the ecosystem around this example (including AWS's native CloudFront/WAF x402 monetization) are all dual-chain now; this example was the remaining Base-only piece.

## How it was tested

`tsc --noEmit` and the esbuild bundle are green. Full payment flows were exercised end-to-end against the **live x402.org facilitator** with **real on-chain settlement**, driving the built handlers with CloudFront-shaped `origin-request`/`origin-response` events via a local Lambda@Edge event harness (a real CloudFront distribution was not part of this run; the CDK stack is unchanged):

1. **Unpaid request → 402** with both networks offered (Solana entry includes the facilitator's `feePayer` from the live `/supported` data).
2. **Paid via Solana Devnet USDC** → verify → forward → settle → HTTP 200 with `x-payment-response`; settlement on-chain: [`aQRrXdZRkgBeZAiiYvpvjx5BFMQxbP9wM7Hu1NtA137zARCtxAYPx37Snf3KjNjLj84y1ciN5WoGotu36QFyoZB`](https://explorer.solana.com/tx/aQRrXdZRkgBeZAiiYvpvjx5BFMQxbP9wM7Hu1NtA137zARCtxAYPx37Snf3KjNjLj84y1ciN5WoGotu36QFyoZB?cluster=devnet) — payTo received exactly 0.005 USDC (the `/content/**` price).
3. **Paid via Base Sepolia USDC** (regression check on the wildcard EVM registration) → HTTP 200; settlement on-chain: [`0x5db0a99862d31bce69d1beed44dbc3a8b45666ef5e8c2c7fb22c8f666da3fdb2`](https://sepolia.basescan.org/tx/0x5db0a99862d31bce69d1beed44dbc3a8b45666ef5e8c2c7fb22c8f666da3fdb2) — payTo received exactly 0.005 USDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
