### PR TITLE
fix py sdk formatting

### DIFF
--- a/python/x402/README.md
+++ b/python/x402/README.md
@@ -217,16 +217,20 @@ client.register_policy(max_amount(1_000_000))  # 1 USDC max
 ```python
 from x402 import AbortResult, RecoveredPayloadResult
 
+
 def before_payment(ctx):
     print(f"Creating payment for: {ctx.selected_requirements.network}")
     # Return AbortResult(reason="...") to cancel
 
+
 def after_payment(ctx):
     print(f"Payment created: {ctx.payment_payload}")
+
 
 def on_failure(ctx):
     print(f"Payment failed: {ctx.error}")
     # Return RecoveredPayloadResult(payload=...) to recover
+
 
 client.on_before_payment_creation(before_payment)
 client.on_after_payment_creation(after_payment)

--- a/python/x402/extensions/README.md
+++ b/python/x402/extensions/README.md
@@ -193,7 +193,12 @@ server.register_extension(create_siwx_resource_server_extension(storage=storage)
 
 routes = {
     "GET /weather": {
-        "accepts": {"scheme": "exact", "price": "$0.001", "network": "eip155:84532", "payTo": "0x..."},
+        "accepts": {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:84532",
+            "payTo": "0x...",
+        },
         "extensions": declare_siwx_extension(),
     },
     "GET /profile": {

--- a/python/x402/extensions/builder_code/README.md
+++ b/python/x402/extensions/builder_code/README.md
@@ -47,9 +47,7 @@ Register the facilitator extension to encode the ERC-8021 suffix at settlement. 
 ```python
 from x402.extensions.builder_code import BuilderCodeFacilitatorExtension
 
-facilitator.register_extension(
-    BuilderCodeFacilitatorExtension(builder_code="bc_my_facilitator")
-)
+facilitator.register_extension(BuilderCodeFacilitatorExtension(builder_code="bc_my_facilitator"))
 ```
 
 At settlement the extension reads `a` and `s` from the client payment payload, adds its configured `w`, CBOR-encodes the present fields, and returns the hex suffix for the settlement mechanism to append to calldata. It returns `None` when no attribution is present.

--- a/python/x402/http/README.md
+++ b/python/x402/http/README.md
@@ -22,9 +22,7 @@ Communicates with remote x402 facilitator services.
 ```python
 from x402.http import HTTPFacilitatorClient, FacilitatorConfig
 
-facilitator = HTTPFacilitatorClient(
-    FacilitatorConfig(url="https://x402.org/facilitator")
-)
+facilitator = HTTPFacilitatorClient(FacilitatorConfig(url="https://x402.org/facilitator"))
 
 # Get supported payment kinds
 supported = await facilitator.get_supported()
@@ -52,6 +50,7 @@ result = facilitator.verify(payload, requirements)
 ```python
 from x402.http import FacilitatorConfig, AuthHeaders
 
+
 class MyAuth:
     async def get_auth_headers(self) -> AuthHeaders:
         return AuthHeaders(
@@ -59,6 +58,7 @@ class MyAuth:
             settle={"Authorization": "Bearer ..."},
             supported={},
         )
+
 
 config = FacilitatorConfig(
     url="https://custom-facilitator.com",
@@ -91,12 +91,12 @@ payload = decode_payment_signature_header(header_value)
 
 ```python
 from x402.http import (
-    PAYMENT_SIGNATURE_HEADER,    # "PAYMENT-SIGNATURE"
-    PAYMENT_REQUIRED_HEADER,     # "PAYMENT-REQUIRED"
-    PAYMENT_RESPONSE_HEADER,     # "PAYMENT-RESPONSE"
-    X_PAYMENT_HEADER,            # "X-PAYMENT" (V1)
-    X_PAYMENT_RESPONSE_HEADER,   # "X-PAYMENT-RESPONSE" (V1)
-    HTTP_STATUS_PAYMENT_REQUIRED, # 402
+    PAYMENT_SIGNATURE_HEADER,  # "PAYMENT-SIGNATURE"
+    PAYMENT_REQUIRED_HEADER,  # "PAYMENT-REQUIRED"
+    PAYMENT_RESPONSE_HEADER,  # "PAYMENT-RESPONSE"
+    X_PAYMENT_HEADER,  # "X-PAYMENT" (V1)
+    X_PAYMENT_RESPONSE_HEADER,  # "X-PAYMENT-RESPONSE" (V1)
+    HTTP_STATUS_PAYMENT_REQUIRED,  # 402
     DEFAULT_FACILITATOR_URL,
 )
 ```
@@ -133,6 +133,7 @@ def get_price(context):
     if context.path.endswith("/premium"):
         return "$0.10"
     return "$0.01"
+
 
 routes = {
     "GET /api/*": RouteConfig(

--- a/python/x402/http/clients/README.md
+++ b/python/x402/http/clients/README.md
@@ -19,9 +19,7 @@ import httpx
 client = x402Client()
 client.register("eip155:*", ExactEvmScheme(signer=signer))
 
-async with httpx.AsyncClient(
-    transport=x402_httpx_transport(client)
-) as http:
+async with httpx.AsyncClient(transport=x402_httpx_transport(client)) as http:
     response = await http.get("https://api.example.com/paid")
 ```
 

--- a/python/x402/http/middleware/README.md
+++ b/python/x402/http/middleware/README.md
@@ -37,6 +37,7 @@ routes = {
     },
 }
 
+
 # Add middleware
 @app.middleware("http")
 async def x402_middleware(request, call_next):
@@ -103,6 +104,7 @@ routes = {
 # Add middleware
 PaymentMiddleware(app, routes, server)
 
+
 @app.route("/api/weather")
 def weather():
     payload = g.payment_payload
@@ -154,9 +156,11 @@ Browser requests to protected routes show an HTML paywall. API requests receive 
 ```python
 from x402.http import PaywallProvider
 
+
 class MyPaywall(PaywallProvider):
     def generate_html(self, payment_required, config):
         return "<html>Custom paywall...</html>"
+
 
 PaymentMiddleware(app, routes, server, paywall_provider=MyPaywall())
 ```

--- a/python/x402/mechanisms/evm/README.md
+++ b/python/x402/mechanisms/evm/README.md
@@ -114,12 +114,12 @@ The Exact scheme uses signed authorizations:
 
 ```python
 {
-    "from": "0x...",      # Payer address
-    "to": "0x...",        # Recipient (payTo)
-    "value": 1000000,     # Amount in token units
-    "validAfter": 0,      # Unix timestamp
-    "validBefore": ...,   # Expiration timestamp
-    "nonce": "0x...",     # Random nonce
+    "from": "0x...",  # Payer address
+    "to": "0x...",  # Recipient (payTo)
+    "value": 1000000,  # Amount in token units
+    "validAfter": 0,  # Unix timestamp
+    "validBefore": ...,  # Expiration timestamp
+    "nonce": "0x...",  # Random nonce
 }
 ```
 


### PR DESCRIPTION
## Description

Fixes python sdk formatting accounting for recent ruff 0.16.0 release

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 