### PR TITLE
docs: fix cloudfront-lambda-edge clone URL (coinbase → x402-foundation)

### DIFF
--- a/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CONSOLE.md
+++ b/examples/typescript/servers/cloudfront-lambda-edge/GETTING-STARTED-CONSOLE.md
@@ -38,7 +38,7 @@ This step packages the x402 logic into a single zip file ready for AWS deploymen
 **1a. Clone the repository**
 
 ```bash
-git clone https://github.com/coinbase/x402.git
+git clone https://github.com/x402-foundation/x402.git
 cd x402/examples/typescript/servers/cloudfront-lambda-edge/lambda
 ```
 


### PR DESCRIPTION
Small follow-up to #2944 (which just merged). The console guide's clone command still points at the old repo location:

```
git clone https://github.com/coinbase/x402.git
```

The repo has moved to `x402-foundation/x402`, so this updates it to:

```
git clone https://github.com/x402-foundation/x402.git
```

One-line doc fix; the `cd x402/...` path is unchanged since the cloned directory is still `x402`. This was staged during #2944 but landed on the branch a few seconds after the merge, so it needs its own PR.
