### PR TITLE
fix(go/http): add Cache-Control: no-store to 402 responses

### DIFF
--- a/go/.changes/unreleased/fix-http-402-cache-control.yaml
+++ b/go/.changes/unreleased/fix-http-402-cache-control.yaml
@@ -1,0 +1,2 @@
+kind: fix
+body: Add Cache-Control no-store to 402 responses to prevent CDN caching of payment headers

--- a/go/.changes/unreleased/fix-http-402-cache-control.yaml
+++ b/go/.changes/unreleased/fix-http-402-cache-control.yaml
@@ -1,2 +1,2 @@
 kind: fix
-body: Add Cache-Control no-store to 402 responses to prevent CDN caching of payment headers
+body: Add Cache-Control no-store to 402/412 PAYMENT-REQUIRED responses and private (merged with handler directives) on 200 PAYMENT-RESPONSE responses to prevent shared caches from storing payment signaling headers

--- a/go/http/echo/middleware.go
+++ b/go/http/echo/middleware.go
@@ -470,6 +470,7 @@ func handlePaymentVerified(c echo.Context, next echo.HandlerFunc, server *x402ht
 	for key, value := range settleResult.Headers {
 		origWriter.Header().Set(key, value)
 	}
+	origWriter.Header().Set("Cache-Control", x402http.WithPrivateCacheControl(origWriter.Header().Get("Cache-Control")))
 
 	// Call settlement handler if configured
 	if config.SettlementHandler != nil {

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -525,6 +525,7 @@ func handlePaymentVerified(c *gin.Context, server *x402http.HTTPServer, ctx cont
 	for key, value := range settleResult.Headers {
 		c.Header(key, value)
 	}
+	c.Header("Cache-Control", x402http.WithPrivateCacheControl(c.Writer.Header().Get("Cache-Control")))
 
 	// Call settlement handler if configured
 	if config.SettlementHandler != nil {

--- a/go/http/nethttp/middleware.go
+++ b/go/http/nethttp/middleware.go
@@ -387,6 +387,7 @@ func handlePaymentVerified(w http.ResponseWriter, r *http.Request, next http.Han
 	for key, value := range settleResult.Headers {
 		w.Header().Set(key, value)
 	}
+	w.Header().Set("Cache-Control", x402http.WithPrivateCacheControl(w.Header().Get("Cache-Control")))
 
 	// Call settlement handler if configured
 	if config.SettlementHandler != nil {

--- a/go/http/nethttp/middleware_test.go
+++ b/go/http/nethttp/middleware_test.go
@@ -452,6 +452,73 @@ func TestPaymentMiddleware_SettlesAndReturnsResponseForVerifiedPayment(t *testin
 	if w.Header().Get("PAYMENT-RESPONSE") == "" {
 		t.Error("Expected PAYMENT-RESPONSE header")
 	}
+	if w.Header().Get("Cache-Control") != "private" {
+		t.Errorf("Expected Cache-Control private, got %q", w.Header().Get("Cache-Control"))
+	}
+}
+
+func TestPaymentMiddleware_SettlesWithPrivateCacheControlMergedFromHandler(t *testing.T) {
+	mockClient := &mockFacilitatorClient{
+		verifyFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.VerifyResponse, error) {
+			return &x402.VerifyResponse{IsValid: true, Payer: "0xpayer"}, nil
+		},
+		settleFunc: func(ctx context.Context, payloadBytes []byte, requirementsBytes []byte) (*x402.SettleResponse, error) {
+			return &x402.SettleResponse{
+				Success:     true,
+				Transaction: "0xtx",
+				Network:     "eip155:1",
+				Payer:       "0xpayer",
+			}, nil
+		},
+		supportedFunc: defaultSupportedFunc(),
+	}
+
+	mockServer := &mockSchemeServer{scheme: "exact"}
+
+	routes := x402http.RoutesConfig{
+		"POST /api": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{
+					Scheme:  "exact",
+					PayTo:   "0xtest",
+					Price:   "$1.00",
+					Network: "eip155:1",
+				},
+			},
+		},
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=300")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"data": "protected-data"})
+	})
+
+	middleware := PaymentMiddlewareFromConfig(routes,
+		WithFacilitatorClient(mockClient),
+		WithScheme("eip155:1", mockServer),
+		WithSyncFacilitatorOnStart(true),
+		WithTimeout(5*time.Second),
+	)
+	wrapped := middleware(handler)
+
+	req := httptest.NewRequest("POST", "/api", nil)
+	req.Header.Set("PAYMENT-SIGNATURE", createPaymentHeader("0xtest"))
+	req.Host = "example.com"
+
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d. Body: %s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("PAYMENT-RESPONSE") == "" {
+		t.Error("Expected PAYMENT-RESPONSE header")
+	}
+	if w.Header().Get("Cache-Control") != "max-age=300, private" {
+		t.Errorf("Expected Cache-Control max-age=300, private, got %q", w.Header().Get("Cache-Control"))
+	}
 }
 
 func TestPaymentMiddleware_SkipsSettlementWhenHandlerReturns400OrHigher(t *testing.T) {

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -761,6 +761,24 @@ func (s *x402HTTPResourceServer) RequiresPayment(reqCtx HTTPRequestContext) bool
 // with both http.Header methods and direct map access.
 const SettlementOverridesHeader = "Settlement-Overrides"
 
+// PaymentRequiredCacheControl is the Cache-Control directive for 402/412 responses
+// carrying PAYMENT-REQUIRED or 402 settlement-failure PAYMENT-RESPONSE.
+const PaymentRequiredCacheControl = "no-store"
+
+// WithPrivateCacheControl appends the private directive for 200 responses with
+// PAYMENT-RESPONSE without clobbering existing handler Cache-Control values.
+func WithPrivateCacheControl(value string) string {
+	if value == "" {
+		return "private"
+	}
+	for _, directive := range strings.Split(value, ",") {
+		if strings.EqualFold(strings.TrimSpace(directive), "private") {
+			return value
+		}
+	}
+	return value + ", private"
+}
+
 // MarshalSettlementOverrides serializes overrides to the JSON string suitable for
 // the SettlementOverridesHeader value. Returns an empty string on marshal failure
 // (which cannot happen for a well-formed SettlementOverrides value).
@@ -847,20 +865,28 @@ func (s *x402HTTPResourceServer) buildSettlementFailureResult(errorReason string
 			Success:     false,
 			ErrorReason: errorReason,
 			Response: &HTTPResponseInstructions{
-				Status:  402,
-				Headers: map[string]string{},
-				Body:    map[string]interface{}{},
+				Status: 402,
+				Headers: map[string]string{
+					"Cache-Control": PaymentRequiredCacheControl,
+				},
+				Body: map[string]interface{}{},
 			},
 		}
 	}
 
+	responseHeaders := make(map[string]string, len(headers)+1)
+	for k, v := range headers {
+		responseHeaders[k] = v
+	}
+	responseHeaders["Cache-Control"] = PaymentRequiredCacheControl
+
 	return &ProcessSettleResult{
 		Success:     false,
 		ErrorReason: errorReason,
-		Headers:     headers,
+		Headers:     responseHeaders,
 		Response: &HTTPResponseInstructions{
 			Status:  402,
-			Headers: headers,
+			Headers: responseHeaders,
 			Body:    map[string]interface{}{},
 		},
 	}
@@ -958,7 +984,7 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 			Headers: map[string]string{
 				"Content-Type":     "text/html",
 				"PAYMENT-REQUIRED": encodedHeader,
-                                "Cache-Control":    "no-store",
+				"Cache-Control":    PaymentRequiredCacheControl,
 			},
 			Body:   html,
 			IsHTML: true,
@@ -979,7 +1005,7 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 		Headers: map[string]string{
 			"Content-Type":     contentType,
 			"PAYMENT-REQUIRED": encodedHeader,
-                        "Cache-Control":    "no-store",
+			"Cache-Control":    PaymentRequiredCacheControl,
 		},
 		Body: body,
 	}, nil

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -958,6 +958,7 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 			Headers: map[string]string{
 				"Content-Type":     "text/html",
 				"PAYMENT-REQUIRED": encodedHeader,
+                                "Cache-Control":    "no-store",
 			},
 			Body:   html,
 			IsHTML: true,
@@ -978,6 +979,7 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 		Headers: map[string]string{
 			"Content-Type":     contentType,
 			"PAYMENT-REQUIRED": encodedHeader,
+                        "Cache-Control":    "no-store",
 		},
 		Body: body,
 	}, nil

--- a/go/http/server_test.go
+++ b/go/http/server_test.go
@@ -188,6 +188,9 @@ func TestProcessHTTPRequestPaymentRequired(t *testing.T) {
 	if result.Response.Headers["PAYMENT-REQUIRED"] == "" {
 		t.Error("Expected PAYMENT-REQUIRED header")
 	}
+	if result.Response.Headers["Cache-Control"] != "no-store" {
+		t.Errorf("Expected Cache-Control no-store, got %q", result.Response.Headers["Cache-Control"])
+	}
 }
 
 func TestProcessHTTPRequestMalformedPaymentSignature(t *testing.T) {
@@ -642,6 +645,9 @@ func TestProcessSettlement(t *testing.T) {
 	if result.Headers["PAYMENT-RESPONSE"] == "" {
 		t.Error("Expected PAYMENT-RESPONSE header")
 	}
+	if _, ok := result.Headers["Cache-Control"]; ok {
+		t.Errorf("Expected settlement headers to omit Cache-Control, got %q", result.Headers["Cache-Control"])
+	}
 }
 
 func TestProcessSettlement_Failure(t *testing.T) {
@@ -694,6 +700,9 @@ func TestProcessSettlement_Failure(t *testing.T) {
 	body, ok := result.Response.Body.(map[string]interface{})
 	if !ok || len(body) != 0 {
 		t.Errorf("Expected empty body {}, got %v", result.Response.Body)
+	}
+	if result.Response.Headers["Cache-Control"] != "no-store" {
+		t.Errorf("Expected Cache-Control no-store, got %q", result.Response.Headers["Cache-Control"])
 	}
 }
 
@@ -1745,4 +1754,25 @@ func (e testProtectedRequestExtension) EnrichDeclaration(declaration interface{}
 
 func (e testProtectedRequestExtension) ProtectedRequestHook() ProtectedRequestHook {
 	return e.hook
+}
+
+func TestWithPrivateCacheControl(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "empty", input: "", want: "private"},
+		{name: "append private", input: "max-age=60", want: "max-age=60, private"},
+		{name: "idempotent lowercase", input: "max-age=60, private", want: "max-age=60, private"},
+		{name: "idempotent mixed case", input: "max-age=60, Private", want: "max-age=60, Private"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := WithPrivateCacheControl(tt.input); got != tt.want {
+				t.Errorf("WithPrivateCacheControl(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes #2955

## What

Add `Cache-Control: no-store` to all 402 Payment Required responses in
the Go HTTP middleware.

## Why

Without this header, CDN or reverse proxy caches may cache 402 responses
that contain `PAYMENT-REQUIRED` headers. This causes two problems:

1. Clients who have already paid receive a stale cached 402 instead of
   the resource
2. Payment metadata in PAYMENT-REQUIRED headers may be served to
   different users by shared caches

## Changes

- `go/http/server.go`: Added `Cache-Control: no-store` to both the HTML
  (browser/paywall) and JSON (API) 402 response paths in
  `createHTTPResponseV2()`

## Notes

Python and TypeScript SDKs have the same issue separate PRs to follow.