### PR TITLE
Fix silent auth drop when createAuthHeaders returns a flat object

### DIFF
--- a/typescript/.changeset/facilitator-auth-headers-shape.md
+++ b/typescript/.changeset/facilitator-auth-headers-shape.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Throw a clear error when the `HTTPFacilitatorClient` `createAuthHeaders` callback returns a flat headers object instead of one keyed by facilitator path (`verify`/`settle`/`supported`). Previously this silently dropped authentication on every request. Also documented the expected shape on the `createAuthHeaders` option.

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -14,10 +14,27 @@ const DEFAULT_FACILITATOR_URL = "https://x402.org/facilitator";
 
 export interface FacilitatorConfig {
   url?: string;
+  /**
+   * Returns authentication headers for the facilitator, keyed by request path.
+   *
+   * The returned object must be keyed by path (`verify`, `settle`, `supported`,
+   * and optionally `bazaar`), each mapping to a headers object — NOT a flat
+   * headers object. Paths may be omitted (no auth is sent for them), but
+   * returning a flat object such as `{ Authorization: "Bearer ..." }` will
+   * throw, since it would otherwise silently drop auth on every request.
+   *
+   * @example
+   * ```ts
+   * createAuthHeaders: async () => {
+   *   const headers = { Authorization: `Bearer ${token}` };
+   *   return { verify: headers, settle: headers, supported: headers };
+   * }
+   * ```
+   */
   createAuthHeaders?: () => Promise<{
-    verify: Record<string, string>;
-    settle: Record<string, string>;
-    supported: Record<string, string>;
+    verify?: Record<string, string>;
+    settle?: Record<string, string>;
+    supported?: Record<string, string>;
     bazaar?: Record<string, string>;
   }>;
 }
@@ -444,17 +461,39 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
   async createAuthHeaders(path: string): Promise<{
     headers: Record<string, string>;
   }> {
-    if (this._createAuthHeaders) {
-      const authHeaders = (await this._createAuthHeaders()) as Record<
-        string,
-        Record<string, string>
-      >;
-      return {
-        headers: authHeaders[path] ?? {},
-      };
+    if (!this._createAuthHeaders) {
+      return { headers: {} };
     }
+
+    const authHeaders = (await this._createAuthHeaders()) as Record<string, unknown>;
+
+    // `createAuthHeaders` must return an object keyed by facilitator path
+    // (`verify` | `settle` | `supported` | `bazaar`), whose values are header
+    // objects.
+    // A common mistake is returning a flat headers object (e.g.
+    // `{ Authorization: "Bearer ..." }`), which would otherwise index to
+    // `undefined` here and silently drop auth on every request. Detect that
+    // shape and fail loudly instead. See
+    // https://github.com/x402-foundation/x402/issues/2762
+    const isHeaderObject = (value: unknown): value is Record<string, string> =>
+      typeof value === "object" && value !== null && !Array.isArray(value);
+    const hasPathKey = ["verify", "settle", "supported", "bazaar"].some(key =>
+      isHeaderObject(authHeaders[key]),
+    );
+    const looksFlat =
+      !hasPathKey && Object.values(authHeaders).some(value => !isHeaderObject(value));
+    if (looksFlat) {
+      throw new Error(
+        "createAuthHeaders must return an object keyed by facilitator path, e.g. " +
+          '{ verify: { Authorization: "..." }, settle: { ... }, supported: { ... } }, ' +
+          "but received a flat headers object. See " +
+          "https://github.com/x402-foundation/x402/issues/2762",
+      );
+    }
+
+    const headersForPath = authHeaders[path];
     return {
-      headers: {},
+      headers: isHeaderObject(headersForPath) ? headersForPath : {},
     };
   }
 

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -264,6 +264,99 @@ describe("HTTPFacilitatorClient", () => {
       );
     });
   });
+
+  describe("createAuthHeaders", () => {
+    it("returns the path-scoped headers for a correctly keyed callback", async () => {
+      const client = new HTTPFacilitatorClient({
+        url: "https://facilitator.test",
+        createAuthHeaders: async () => ({
+          verify: { Authorization: "Bearer verify" },
+          settle: { Authorization: "Bearer settle" },
+          supported: { Authorization: "Bearer supported" },
+        }),
+      });
+
+      expect(await client.createAuthHeaders("verify")).toEqual({
+        headers: { Authorization: "Bearer verify" },
+      });
+      expect(await client.createAuthHeaders("settle")).toEqual({
+        headers: { Authorization: "Bearer settle" },
+      });
+    });
+
+    it("returns empty headers for a path the callback intentionally omits", async () => {
+      const client = new HTTPFacilitatorClient({
+        url: "https://facilitator.test",
+        createAuthHeaders: async () => ({ verify: { Authorization: "Bearer verify" } }),
+      });
+
+      expect(await client.createAuthHeaders("settle")).toEqual({ headers: {} });
+    });
+
+    it("returns empty headers when the callback returns an empty object", async () => {
+      const client = new HTTPFacilitatorClient({
+        url: "https://facilitator.test",
+        createAuthHeaders: async () => ({}),
+      });
+
+      expect(await client.createAuthHeaders("verify")).toEqual({ headers: {} });
+    });
+
+    it("throws when the callback returns a flat headers object", async () => {
+      const client = new HTTPFacilitatorClient({
+        url: "https://facilitator.test",
+        // Intentionally wrong shape: a flat headers object instead of one keyed by path.
+        createAuthHeaders: async () => ({ Authorization: "Bearer token" }) as never,
+      });
+
+      const error = await client.createAuthHeaders("verify").catch(caught => caught as Error);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain("must return an object keyed by facilitator path");
+    });
+
+    it("throws when a flat object has non-string header values", async () => {
+      const client = new HTTPFacilitatorClient({
+        url: "https://facilitator.test",
+        createAuthHeaders: async () => ({ Authorization: 123 }) as never,
+      });
+
+      const error = await client.createAuthHeaders("verify").catch(caught => caught as Error);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toContain("must return an object keyed by facilitator path");
+    });
+
+    it("returns empty headers when no callback is configured", async () => {
+      const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+      expect(await client.createAuthHeaders("verify")).toEqual({ headers: {} });
+    });
+
+    it("sends the path-scoped auth headers on the outgoing verify request", async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ isValid: true, payer: paymentRequirements.payTo }), {
+          status: 200,
+        }),
+      );
+      vi.stubGlobal("fetch", mockFetch);
+
+      const client = new HTTPFacilitatorClient({
+        url: "https://facilitator.test",
+        createAuthHeaders: async () => ({
+          verify: { Authorization: "Bearer verify" },
+          settle: { Authorization: "Bearer settle" },
+          supported: { Authorization: "Bearer supported" },
+        }),
+      });
+
+      await client.verify(paymentPayload, paymentRequirements).catch(() => undefined);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://facilitator.test/verify",
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer verify" }),
+        }),
+      );
+    });
+  });
 });
 
 describe("computeRetryDelay", () => {


### PR DESCRIPTION
Fixes #2762.

### Problem

`HTTPFacilitatorClient`'s `createAuthHeaders` callback must return an object keyed by facilitator path (`verify` / `settle` / `supported`), each mapping to a headers object. The internal `createAuthHeaders(path)` does `authHeaders[path] ?? {}`.

Returning the obvious **flat** shape — e.g. `createAuthHeaders: () => ({ Authorization: "Bearer ..." })` — indexes to `undefined`, so auth is **silently dropped on every request** and the facilitator returns a `401` with no indication of why. (The type already declares the path-keyed shape, so TypeScript users are guided, but JS callers and anyone casting hit a silent failure.)

### Fix

- **Fail loudly**: `createAuthHeaders(path)` now detects a flat headers object (no path keys, string values) and throws a descriptive error instead of silently dropping auth. Correct path-keyed usage — and intentionally omitting a path — is unchanged.
- **Document the expected shape**: added JSDoc with an example to the `createAuthHeaders` option.

### Tests

Added cases to `httpFacilitatorClient.test.ts`: correct path-keyed callback returns the right headers, an omitted path returns `{}`, a flat object throws a clear error, and no callback returns `{}`. All 26 tests pass; `prettier`, `eslint`, and the package build are clean.
