### PR TITLE
fix(http): JSON 402 response body should mirror the PAYMENT-REQUIRED header, not default to {}

### DIFF
--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -822,9 +822,13 @@ class x402HTTPServerBase:
                 is_html=True,
             )
 
-        # API response
+        # API response. Default the body to the same payload the
+        # PAYMENT-REQUIRED header carries so body-reading clients see the
+        # full challenge rather than an empty object.
         content_type = "application/json"
-        body: Any = {}
+        body: Any = payment_required.model_dump(
+            by_alias=True, exclude_none=True, mode="json"
+        )
 
         if unpaid_response:
             content_type = unpaid_response.content_type

--- a/python/x402/tests/unit/http/test_x402_http_server_base.py
+++ b/python/x402/tests/unit/http/test_x402_http_server_base.py
@@ -1,0 +1,107 @@
+"""Tests for x402HTTPServerBase._create_http_response.
+
+Regression coverage for the JSON (non-browser) 402 response: the body must
+carry the same challenge as the PAYMENT-REQUIRED header, not an empty object.
+Body-reading clients (i.e. clients that parse the response body rather than
+the header) otherwise fail closed on `{}`.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock
+
+from x402.http.constants import PAYMENT_REQUIRED_HEADER
+from x402.http.types import PaymentOption, RouteConfig
+from x402.http.x402_http_server_base import x402HTTPServerBase
+from x402.schemas import PaymentRequired, PaymentRequirements, ResourceInfo
+
+
+def _make_payment_required() -> PaymentRequired:
+    return PaymentRequired(
+        x402_version=2,
+        accepts=[
+            PaymentRequirements(
+                scheme="exact",
+                network="eip155:84532",
+                asset="0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+                amount="1000000",
+                pay_to="0x209693Bc6afc0C5328bA36FaF04C514EF312287C",
+                max_timeout_seconds=60,
+            )
+        ],
+        resource=ResourceInfo(url="https://example.com/api/data"),
+        error="Payment required",
+    )
+
+
+def _make_server_base() -> x402HTTPServerBase:
+    route_config = RouteConfig(
+        accepts=PaymentOption(
+            scheme="exact",
+            pay_to="0x209693Bc6afc0C5328bA36FaF04C514EF312287C",
+            price="$1.00",
+            network="eip155:84532",
+        )
+    )
+    return x402HTTPServerBase(server=MagicMock(), routes=route_config)
+
+
+def _decode_header_payload(header_value: str) -> dict:
+    return json.loads(base64.b64decode(header_value.encode("utf-8")).decode("utf-8"))
+
+
+def test_json_402_body_mirrors_header_payload() -> None:
+    """Non-browser 402 response body must deep-equal the decoded header payload."""
+    server_base = _make_server_base()
+    payment_required = _make_payment_required()
+
+    response = server_base._create_http_response(
+        payment_required,
+        is_web_browser=False,
+    )
+
+    assert response.status == 402
+    assert response.headers["Content-Type"] == "application/json"
+
+    header_payload = _decode_header_payload(response.headers[PAYMENT_REQUIRED_HEADER])
+
+    assert response.body != {}
+    assert response.body == header_payload
+    assert response.body["accepts"], "challenge body must include payment requirements"
+
+
+def test_json_402_body_uses_same_serialization_flags_as_header() -> None:
+    """Body must be produced with by_alias=True, exclude_none=True, mode='json'."""
+    server_base = _make_server_base()
+    payment_required = _make_payment_required()
+
+    response = server_base._create_http_response(
+        payment_required,
+        is_web_browser=False,
+    )
+
+    expected_body = payment_required.model_dump(
+        by_alias=True, exclude_none=True, mode="json"
+    )
+    assert response.body == expected_body
+
+
+def test_route_level_unpaid_response_override_still_wins() -> None:
+    """An explicit unpaid_response argument still overrides the default body."""
+    from x402.http.types import HTTPResponseBody
+
+    server_base = _make_server_base()
+    payment_required = _make_payment_required()
+
+    override = HTTPResponseBody(
+        content_type="application/json", body={"custom": "challenge"}
+    )
+    response = server_base._create_http_response(
+        payment_required,
+        is_web_browser=False,
+        unpaid_response=override,
+    )
+
+    assert response.body == {"custom": "challenge"}


### PR DESCRIPTION
`x402HTTPServerBase._create_http_response()` builds the `PAYMENT-REQUIRED`
header from the `PaymentRequired` model (`model_dump_json(by_alias=True,
exclude_none=True)`, via `encode_payment_required_header`), but the
non-browser JSON response body defaults to `{}` — an empty challenge.

Impact: any client that reads the payment challenge from the response body
instead of decoding the header (e.g. clients that do not special-case the
`PAYMENT-REQUIRED` header) receives an empty object and fails closed with
no challenge to act on, even though a spec-compliant challenge is present
in the header the whole time.

Fix: default the body to
`payment_required.model_dump(by_alias=True, exclude_none=True, mode="json")`
— the same field set, aliasing, and null-exclusion the header uses;
`mode="json"` preserves the same type coercion as `model_dump_json`. This
only changes the *default* — an explicit route-level `unpaid_response`
(`unpaid_response_body` hook) is unaffected and still overrides the body,
same as before.

Adds a unit test asserting the JSON 402 body deep-equals the decoded
header payload (and is non-empty), a serialization-flag-parity test, and
a test confirming the route-level override still wins.

(Found via a public endpoint checker exercising the JSON 402 path against
a live x402 resource server.)
