### PR TITLE
Update NEAR x402 Facilitator for Base support

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -26,7 +26,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | [HPP Facilitator](https://docs.hpp.io/x402/facilitator) | Gasless, public x402 facilitator for HPP Mainnet and Sepolia |
 | [Meridian](https://mrdn.finance) | Multi-chain facilitator with developer-first features |
 | [Mogami Facilitator](https://facilitator.mogami.tech) | Free, developer-focused facilitator for Base with optional self-hosted Docker deployment |
-| [NEAR x402 Facilitator](https://x402.mikedotexe.com/supported) | Independent facilitator for NEAR mainnet and testnet; NEP-141 USDC settled through NEP-366 signed delegates with relayer-sponsored gas |
+| [NEAR x402 Facilitator](https://x402.mikedotexe.com/) | Independent open-source facilitator for exact Circle USDC payments on NEAR and Base, with sponsored gas and durable settlement recovery |
 | [PayAI Facilitator](https://facilitator.payai.network) | Multi-network facilitator supporting all tokens. No API keys required |
 | [Polygon Facilitator](https://docs.polygon.technology/payment-services/agentic-payments/x402/intro/) | Production-grade x402 facilitator for Polygon Mainnet and Amoy testnet |
 | [Solvador](https://solvador.com) | Multi-network facilitator with broad mainnet coverage across EVM plus Solana and NEAR, supporting multiple schemes and extensions |


### PR DESCRIPTION
## What changed

Updates the existing NEAR x402 Facilitator table row to reflect its deployed
NEAR and Base support and links the human-facing project page.

## Why

The original entry landed before the Base mainnet instance was promoted.
v0.5.1 now serves NEAR mainnet, NEAR testnet, and Base mainnet from the same
open-source durable settlement engine.

Deployment evidence:
https://github.com/fastnear/x402-near-facilitator/blob/main/docs/evidence/2026-07-26-v051-reference-deployment.md

## Scope

One existing table row only. No deprecated ecosystem-page files are restored.

## Validation

- Landing page returns successfully over HTTPS.
- Markdown diff and whitespace checks pass.
