### PR TITLE
fix(go): prevent settlement override percent overflow

### DIFF
--- a/go/.changes/unreleased/fixed-20260727-140953.yaml
+++ b/go/.changes/unreleased/fixed-20260727-140953.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Prevented overflow when resolving large percentage settlement overrides.
+time: 2026-07-27T14:09:53.922115+09:00

--- a/go/server.go
+++ b/go/server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,13 +27,19 @@ var (
 func ResolveSettlementOverrideAmount(rawAmount string, requirements types.PaymentRequirements, decimals int) (string, error) {
 	if m := percentRegex.FindStringSubmatch(rawAmount); m != nil {
 		parts := strings.SplitN(m[1], ".", 2)
-		intPart, _ := strconv.ParseInt(parts[0], 10, 64)
-		decPart := int64(0)
+		integerPart, ok := new(big.Int).SetString(parts[0], 10)
+		if !ok {
+			return "", fmt.Errorf("invalid percent amount: %s", rawAmount)
+		}
+		fractionalPart := new(big.Int)
 		if len(parts) == 2 {
 			padded := (parts[1] + "00")[:2]
-			decPart, _ = strconv.ParseInt(padded, 10, 64)
+			if _, ok := fractionalPart.SetString(padded, 10); !ok {
+				return "", fmt.Errorf("invalid percent amount: %s", rawAmount)
+			}
 		}
-		scaledPercent := big.NewInt(intPart*100 + decPart)
+		scaledPercent := new(big.Int).Mul(integerPart, big.NewInt(100))
+		scaledPercent.Add(scaledPercent, fractionalPart)
 		base, ok := new(big.Int).SetString(requirements.Amount, 10)
 		if !ok {
 			return "", fmt.Errorf("invalid requirements amount: %s", requirements.Amount)

--- a/go/server_test.go
+++ b/go/server_test.go
@@ -787,11 +787,18 @@ func TestResolveSettlementOverrideAmount(t *testing.T) {
 			expected string
 		}{
 			{"50%", "2000", "1000"},
+			{"12.5%", "2000", "250"},
+			{"12.50%", "2000", "250"},
 			{"100%", "2000", "2000"},
 			{"0%", "2000", "0"},
 			{"25%", "2000", "500"},
 			{"33.33%", "3000", "999"},
 			{"10.5%", "1000", "105"},
+			{"50%", "3", "1"},
+			{"999999999999999999999%", "1000000", "9999999999999999999990000"},
+			{"92233720368547758.08%", "1000000", "922337203685477580800"},
+			{"184467440737095516.16%", "1000000", "1844674407370955161600"},
+			{"50%", "18446744073709551616", "9223372036854775808"},
 		}
 		for _, tt := range tests {
 			reqs := types.PaymentRequirements{Amount: tt.amount}
@@ -802,6 +809,14 @@ func TestResolveSettlementOverrideAmount(t *testing.T) {
 			if result != tt.expected {
 				t.Errorf("ResolveSettlementOverrideAmount(%q, amount=%s) = %q, want %q", tt.input, tt.amount, result, tt.expected)
 			}
+		}
+	})
+
+	t.Run("percent format with invalid requirements amount", func(t *testing.T) {
+		reqs := types.PaymentRequirements{Amount: "not-a-number"}
+		_, err := ResolveSettlementOverrideAmount("50%", reqs, 6)
+		if err == nil {
+			t.Fatal("expected invalid requirements amount error")
 		}
 	})
 


### PR DESCRIPTION
## Description

Prevent overflow when resolving large percentage settlement overrides in Go.

The root cause was in `ResolveSettlementOverrideAmount` (`go/server.go:30`): the percentage integer part was parsed into an `int64` while parse errors were ignored, and the value was multiplied by 100 using `int64` arithmetic. 
Large percentage values could therefore overflow and produce a negative or zero settlement amount.

A Go changelog fragment is included.

## Tests

- `go test ./...`
- `go vet ./...`
- `gofmt -d server.go server_test.go`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] I added a changelog fragment for the user-facing change