### PR TITLE
fix(go): make dollar settlement override conversion exact

### DIFF
--- a/go/.changes/unreleased/fixed-20260727-161020.yaml
+++ b/go/.changes/unreleased/fixed-20260727-161020.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Made dollar settlement override conversion exact for large decimal values.
+time: 2026-07-27T16:10:20+09:00

--- a/go/server.go
+++ b/go/server.go
@@ -45,16 +45,24 @@ func ResolveSettlementOverrideAmount(rawAmount string, requirements types.Paymen
 	}
 
 	if m := dollarRegex.FindStringSubmatch(rawAmount); m != nil {
-		dollarFloat, ok := new(big.Float).SetPrec(256).SetString(m[1])
+		parts := strings.SplitN(m[1], ".", 2)
+		fractionalPart := ""
+		if len(parts) == 2 {
+			fractionalPart = parts[1]
+		}
+		switch {
+		case decimals <= 0:
+			fractionalPart = ""
+		case len(fractionalPart) > decimals:
+			fractionalPart = fractionalPart[:decimals]
+		default:
+			fractionalPart += strings.Repeat("0", decimals-len(fractionalPart))
+		}
+		atomicAmount, ok := new(big.Int).SetString(parts[0]+fractionalPart, 10)
 		if !ok {
 			return "", fmt.Errorf("invalid dollar amount: %s", rawAmount)
 		}
-		multiplier := new(big.Float).SetPrec(256).SetInt(
-			new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil),
-		)
-		atomicFloat := new(big.Float).SetPrec(256).Mul(dollarFloat, multiplier)
-		atomicInt, _ := atomicFloat.Int(nil) // truncates toward zero (floor for positive values)
-		return atomicInt.String(), nil
+		return atomicAmount.String(), nil
 	}
 
 	return rawAmount, nil

--- a/go/server_test.go
+++ b/go/server_test.go
@@ -810,9 +810,25 @@ func TestResolveSettlementOverrideAmount(t *testing.T) {
 			input    string
 			expected string
 		}{
+			{"$1", "1000000"},
+			{"$1.0", "1000000"},
 			{"$1.00", "1000000"},
+			{"$1.000000", "1000000"},
 			{"$0.05", "50000"},
 			{"$0.001", "1000"},
+			{"$0.000001", "1"},
+			{"$0.0000004", "0"},
+			{"$0.0000005", "0"},
+			{"$0.0000009", "0"},
+			{"$0.0000010", "1"},
+			{"$1.0000004", "1000000"},
+			{"$1.0000005", "1000000"},
+			{"$1.0000009", "1000000"},
+			{"$123456789.123456", "123456789123456"},
+			{
+				"$12345678901234567890123456789012345678901234567890123456789012345678901234567890.123456",
+				"12345678901234567890123456789012345678901234567890123456789012345678901234567890123456",
+			},
 			{"$0", "0"},
 		}
 		for _, tt := range tests {
@@ -826,14 +842,30 @@ func TestResolveSettlementOverrideAmount(t *testing.T) {
 		}
 	})
 
-	t.Run("dollar price with 8 decimals", func(t *testing.T) {
-		reqs := types.PaymentRequirements{Amount: "2000"}
-		result, err := ResolveSettlementOverrideAmount("$0.05", reqs, 8)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+	t.Run("dollar prices with varying decimals", func(t *testing.T) {
+		tests := []struct {
+			input    string
+			decimals int
+			expected string
+		}{
+			{"$1.9", 0, "1"},
+			{"$0.05", 8, "5000000"},
+			{"$1.000000000000000001", 18, "1000000000000000001"},
 		}
-		if result != "5000000" {
-			t.Errorf("expected 5000000 (8 decimals), got %s", result)
+		for _, tt := range tests {
+			result, err := ResolveSettlementOverrideAmount(tt.input, baseReqs, tt.decimals)
+			if err != nil {
+				t.Errorf("ResolveSettlementOverrideAmount(%q, decimals=%d) error: %v", tt.input, tt.decimals, err)
+			}
+			if result != tt.expected {
+				t.Errorf(
+					"ResolveSettlementOverrideAmount(%q, decimals=%d) = %q, want %q",
+					tt.input,
+					tt.decimals,
+					result,
+					tt.expected,
+				)
+			}
 		}
 	})
 


### PR DESCRIPTION
## Description

Fix the Go dollar settlement override conversion so it does not lose precision for large decimal values.

The root cause was in `ResolveSettlementOverrideAmount` in `go/server.go`: dollar amounts were parsed with a fixed 256-bit `big.Float`, multiplied by `10^decimals`, and then truncated. 

Decimal values exceeding that precision could be rounded before truncation and produce an incorrect atomic-unit amount.

This change parses the validated decimal string directly and constructs the atomic-unit value using decimal digits and `big.Int`. It supports arbitrarily long valid dollar inputs without binary floating-point conversion.

The current Go behavior for fractional digits beyond the asset precision is intentionally preserved: positive values are truncated toward zero. The cross-SDK rounding policy remains under discussion in #2963, so this PR should remain Draft until maintainers confirm the canonical behavior.

Related to #2963.

## Tests

Added coverage for:

- exact representable dollar values
- 6-decimal precision boundaries
- 0, 8, and 18 asset decimals
- a decimal value exceeding 256-bit floating-point precision
- preservation of existing truncation behavior

The long-precision regression test failed against the parent implementation and passes with this change.

Validation:

- `make fmt`
- `make lint`
- `make build`
- `make test`
- `git diff --check`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commit is signed
- [x] I added a Go changelog fragment