### PR TITLE
fix(go): bound HTTP response body reads

### DIFF
--- a/go/.changes/unreleased/fixed-20260728-101028.yaml
+++ b/go/.changes/unreleased/fixed-20260728-101028.yaml
@@ -1,0 +1,4 @@
+kind: fixed
+body: Bounded buffered HTTP response bodies in Go payment, facilitator, and Bazaar
+  clients (1 MiB for control-plane responses, 4 MiB for Bazaar discovery).
+time: 2026-07-28T10:10:28+09:00

--- a/go/extensions/bazaar/facilitator_client.go
+++ b/go/extensions/bazaar/facilitator_client.go
@@ -214,7 +214,7 @@ func (c *BazaarFacilitatorClient) ListDiscoveryResources(
 	defer resp.Body.Close()
 
 	// Read response body
-	body, err := io.ReadAll(resp.Body)
+	body, err := readLimitedBody(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -275,7 +275,7 @@ func (c *BazaarFacilitatorClient) SearchDiscoveryResources(
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readLimitedBody(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -367,4 +367,22 @@ func (c *BazaarFacilitatorClient) buildSearchURL(params *SearchDiscoveryResource
 
 	u.RawQuery = q.Encode()
 	return u.String(), nil
+}
+
+// maxDiscoveryResponseBytes bounds discovery responses. Catalog pages carry
+// resource extensions and MCP JSON schemas, so they need more room than
+// control-plane JSON.
+const maxDiscoveryResponseBytes int64 = 4 << 20
+
+// readLimitedBody reads at most maxDiscoveryResponseBytes from r. A larger body
+// returns x402http.ErrResponseBodyTooLarge without buffering the rest.
+func readLimitedBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxDiscoveryResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxDiscoveryResponseBytes {
+		return nil, fmt.Errorf("%w: limit %d bytes", x402http.ErrResponseBodyTooLarge, maxDiscoveryResponseBytes)
+	}
+	return body, nil
 }

--- a/go/extensions/bazaar/facilitator_client_test.go
+++ b/go/extensions/bazaar/facilitator_client_test.go
@@ -3,6 +3,8 @@ package bazaar
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -696,6 +698,58 @@ func TestSearchDiscoveryResources_ErrorResponse(t *testing.T) {
 	}
 }
 
+func TestDiscoveryClientsRejectOversizedResponses(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		call       func(*BazaarFacilitatorClient) error
+	}{
+		{
+			name:       "list success",
+			statusCode: http.StatusOK,
+			call: func(client *BazaarFacilitatorClient) error {
+				_, err := client.ListDiscoveryResources(context.Background(), nil)
+				return err
+			},
+		},
+		{
+			name:       "search error",
+			statusCode: http.StatusInternalServerError,
+			call: func(client *BazaarFacilitatorClient) error {
+				_, err := client.SearchDiscoveryResources(
+					context.Background(),
+					&SearchDiscoveryResourcesParams{Query: "test"},
+				)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := &trackingBody{Reader: io.LimitReader(zeroReader{}, maxDiscoveryResponseBytes+1)}
+			client := WithBazaar(x402http.NewHTTPFacilitatorClient(&x402http.FacilitatorConfig{
+				URL: "https://facilitator.example.com",
+				HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tt.statusCode,
+						Header:     make(http.Header),
+						Body:       body,
+					}, nil
+				})},
+			}))
+
+			err := tt.call(client)
+			if !errors.Is(err, x402http.ErrResponseBodyTooLarge) {
+				t.Fatalf("call() error = %v, want ErrResponseBodyTooLarge", err)
+			}
+			if !body.closed {
+				t.Fatal("response body was not closed")
+			}
+		})
+	}
+}
+
 func TestSearchDiscoveryResources_WithAuthHeaders(t *testing.T) {
 	ctx := context.Background()
 
@@ -732,4 +786,27 @@ func TestSearchDiscoveryResources_WithAuthHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingBody struct {
+	io.Reader
+	closed bool
+}
+
+func (b *trackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
 }

--- a/go/http/client.go
+++ b/go/http/client.go
@@ -223,7 +223,7 @@ func (t *PaymentRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	}
 
 	// Read response body for V1 support
-	body, err := io.ReadAll(resp.Body)
+	body, err := readLimitedBody(resp.Body)
 	resp.Body.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
@@ -387,7 +387,7 @@ func (t *PaymentRoundTripper) tryPaymentRequiredHooks(
 		}
 
 		authHeaders := responseHeaders(authResp)
-		authBody, err := io.ReadAll(authResp.Body)
+		authBody, err := readLimitedBody(authResp.Body)
 		authResp.Body.Close()
 		if err != nil {
 			return nil, headers, body, false, fmt.Errorf("failed to read auth retry body: %w", err)

--- a/go/http/client_test.go
+++ b/go/http/client_test.go
@@ -84,6 +84,144 @@ func TestPaymentRoundTripper_OnPaymentRequiredHeaderRetry(t *testing.T) {
 	}
 }
 
+func TestReadLimitedBody(t *testing.T) {
+	t.Run("short body", func(t *testing.T) {
+		body, err := readLimitedBody(strings.NewReader("response"))
+		if err != nil {
+			t.Fatalf("readLimitedBody() error = %v", err)
+		}
+		if string(body) != "response" {
+			t.Fatalf("readLimitedBody() body = %q, want response", body)
+		}
+	})
+
+	t.Run("exact limit", func(t *testing.T) {
+		body, err := readLimitedBody(io.LimitReader(testZeroReader{}, maxControlPlaneResponseBytes))
+		if err != nil {
+			t.Fatalf("readLimitedBody() error = %v", err)
+		}
+		if int64(len(body)) != maxControlPlaneResponseBytes {
+			t.Fatalf("readLimitedBody() length = %d, want %d", len(body), maxControlPlaneResponseBytes)
+		}
+	})
+
+	t.Run("over limit", func(t *testing.T) {
+		body, err := readLimitedBody(io.LimitReader(testZeroReader{}, maxControlPlaneResponseBytes+1))
+		if body != nil {
+			t.Fatalf("readLimitedBody() body length = %d, want nil", len(body))
+		}
+		if !errors.Is(err, ErrResponseBodyTooLarge) {
+			t.Fatalf("readLimitedBody() error = %v, want ErrResponseBodyTooLarge", err)
+		}
+	})
+
+	t.Run("reader error", func(t *testing.T) {
+		readErr := errors.New("read failed")
+		body, err := readLimitedBody(errorReader{err: readErr})
+		if body != nil {
+			t.Fatalf("readLimitedBody() body length = %d, want nil", len(body))
+		}
+		if !errors.Is(err, readErr) {
+			t.Fatalf("readLimitedBody() error = %v, want %v", err, readErr)
+		}
+	})
+}
+
+type errorReader struct {
+	err error
+}
+
+func (r errorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestPaymentRoundTripper_RejectsOversizedInitial402(t *testing.T) {
+	body := &oneShotBody{reader: io.LimitReader(testZeroReader{}, maxControlPlaneResponseBytes+1)}
+	rt := &PaymentRoundTripper{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusPaymentRequired,
+				Header:     make(http.Header),
+				Body:       body,
+			}, nil
+		}),
+		retryCount: &sync.Map{},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/data", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		resp.Body.Close()
+		t.Fatalf("RoundTrip() response = %v, want nil", resp)
+	}
+	if !errors.Is(err, ErrResponseBodyTooLarge) {
+		t.Fatalf("RoundTrip() error = %v, want ErrResponseBodyTooLarge", err)
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
+	}
+}
+
+func TestPaymentRoundTripper_RejectsOversizedAuthRetry402(t *testing.T) {
+	required := types.PaymentRequired{
+		X402Version: 2,
+		Extensions: map[string]interface{}{
+			"sign-in-with-x": map[string]interface{}{"info": map[string]interface{}{"nonce": "abc"}},
+		},
+		Accepts: []types.PaymentRequirements{
+			{Scheme: "exact", Network: "eip155:1"},
+		},
+	}
+	encodedRequired, err := encodePaymentRequiredHeader(required)
+	if err != nil {
+		t.Fatalf("encodePaymentRequiredHeader() error = %v", err)
+	}
+
+	authBody := &oneShotBody{reader: io.LimitReader(testZeroReader{}, maxControlPlaneResponseBytes+1)}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("SIGN-IN-WITH-X") == "" {
+			return stringResponse(http.StatusPaymentRequired, map[string]string{
+				"PAYMENT-REQUIRED": encodedRequired,
+			}, "")
+		}
+		return &http.Response{
+			StatusCode: http.StatusPaymentRequired,
+			Header:     make(http.Header),
+			Body:       authBody,
+		}, nil
+	})
+	client := Newx402HTTPClient(x402.Newx402Client()).
+		OnPaymentRequired(func(context.Context, types.PaymentRequired, string) (*PaymentRequiredHookResult, error) {
+			return &PaymentRequiredHookResult{
+				Headers: map[string]string{"SIGN-IN-WITH-X": "signed"},
+			}, nil
+		})
+	rt := &PaymentRoundTripper{
+		Transport:  transport,
+		x402Client: client,
+		retryCount: &sync.Map{},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.example.com/profile", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		resp.Body.Close()
+		t.Fatalf("RoundTrip() response = %v, want nil", resp)
+	}
+	if !errors.Is(err, ErrResponseBodyTooLarge) {
+		t.Fatalf("RoundTrip() error = %v, want ErrResponseBodyTooLarge", err)
+	}
+	if !authBody.closed {
+		t.Fatal("auth retry response body was not closed")
+	}
+}
+
 func TestPaymentRoundTripper_OnPaymentRequiredHookSkippedWithoutHeaders(t *testing.T) {
 	required := types.PaymentRequired{
 		X402Version: 2,
@@ -366,6 +504,13 @@ type oneShotBody struct {
 	reader     io.Reader
 	closed     bool
 	closeCalls int
+}
+
+type testZeroReader struct{}
+
+func (testZeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
 }
 
 type failingBody struct {

--- a/go/http/facilitator_client.go
+++ b/go/http/facilitator_client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -370,7 +369,7 @@ func (c *HTTPFacilitatorClient) GetSupported(ctx context.Context) (x402.Supporte
 		}
 
 		// Read response body
-		responseBody, err := io.ReadAll(resp.Body)
+		responseBody, err := readLimitedBody(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			return x402.SupportedResponse{}, fmt.Errorf("failed to read response body: %w", err)
@@ -456,7 +455,7 @@ func (c *HTTPFacilitatorClient) verifyHTTP(ctx context.Context, version int, pay
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := readLimitedBody(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -530,7 +529,7 @@ func (c *HTTPFacilitatorClient) settleHTTP(ctx context.Context, version int, pay
 	}
 	defer resp.Body.Close()
 
-	responseBody, err := io.ReadAll(resp.Body)
+	responseBody, err := readLimitedBody(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/go/http/facilitator_client_test.go
+++ b/go/http/facilitator_client_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -623,6 +624,89 @@ func TestHTTPFacilitatorClientGetSupportedInvalidResponse(t *testing.T) {
 	}
 	if !strings.Contains(responseErr.Error(), "facilitator getSupported returned invalid data") {
 		t.Errorf("Expected invalid data message, got %q", responseErr.Error())
+	}
+}
+
+func TestHTTPFacilitatorClientRejectsOversizedResponses(t *testing.T) {
+	requirements := x402.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:1",
+		Asset:   "USDC",
+		Amount:  "1000000",
+		PayTo:   "0xrecipient",
+	}
+	payload := x402.PaymentPayload{
+		X402Version: 2,
+		Accepted:    requirements,
+		Payload:     map[string]interface{}{},
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal(payload) error = %v", err)
+	}
+	requirementsBytes, err := json.Marshal(requirements)
+	if err != nil {
+		t.Fatalf("json.Marshal(requirements) error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		statusCode int
+		call       func(*HTTPFacilitatorClient) error
+	}{
+		{
+			name:       "supported 429",
+			statusCode: http.StatusTooManyRequests,
+			call: func(client *HTTPFacilitatorClient) error {
+				_, err := client.GetSupported(context.Background())
+				return err
+			},
+		},
+		{
+			name:       "verify success",
+			statusCode: http.StatusOK,
+			call: func(client *HTTPFacilitatorClient) error {
+				_, err := client.Verify(context.Background(), payloadBytes, requirementsBytes)
+				return err
+			},
+		},
+		{
+			name:       "settle error",
+			statusCode: http.StatusInternalServerError,
+			call: func(client *HTTPFacilitatorClient) error {
+				_, err := client.Settle(context.Background(), payloadBytes, requirementsBytes)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var attempts atomic.Int32
+			body := &oneShotBody{reader: io.LimitReader(testZeroReader{}, maxControlPlaneResponseBytes+1)}
+			client := NewHTTPFacilitatorClient(&FacilitatorConfig{
+				URL: "https://facilitator.example.com",
+				HTTPClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					attempts.Add(1)
+					return &http.Response{
+						StatusCode: tt.statusCode,
+						Header:     make(http.Header),
+						Body:       body,
+					}, nil
+				})},
+			})
+
+			err := tt.call(client)
+			if !errors.Is(err, ErrResponseBodyTooLarge) {
+				t.Fatalf("call() error = %v, want ErrResponseBodyTooLarge", err)
+			}
+			if !body.closed {
+				t.Fatal("response body was not closed")
+			}
+			if attempts.Load() != 1 {
+				t.Fatalf("attempts = %d, want 1", attempts.Load())
+			}
+		})
 	}
 }
 

--- a/go/http/http.go
+++ b/go/http/http.go
@@ -4,6 +4,8 @@ package http
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -64,4 +66,30 @@ func Post(ctx context.Context, url string, body io.Reader, x402Client *x402HTTPC
 // Do performs an HTTP request with automatic payment handling
 func Do(ctx context.Context, req *http.Request, x402Client *x402HTTPClient) (*http.Response, error) {
 	return x402Client.DoWithPayment(ctx, req)
+}
+
+// ============================================================================
+// Response body limits
+// ============================================================================
+
+// ErrResponseBodyTooLarge indicates that an HTTP response body exceeded the
+// buffering limit applied by x402 clients.
+var ErrResponseBodyTooLarge = errors.New("http response body too large")
+
+// maxControlPlaneResponseBytes bounds the payment-required and facilitator
+// responses buffered by this package. Control-plane JSON is small, so a tight
+// limit is enough.
+const maxControlPlaneResponseBytes int64 = 1 << 20
+
+// readLimitedBody reads at most maxControlPlaneResponseBytes from r. A larger
+// body returns ErrResponseBodyTooLarge without buffering the rest.
+func readLimitedBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxControlPlaneResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxControlPlaneResponseBytes {
+		return nil, fmt.Errorf("%w: limit %d bytes", ErrResponseBodyTooLarge, maxControlPlaneResponseBytes)
+	}
+	return body, nil
 }


### PR DESCRIPTION
## Summary

- limit buffered HTTP response bodies to 4 MiB across Go payment, facilitator, and Bazaar clients
- return `ErrResponseBodyTooLarge` so callers can identify oversized responses with `errors.Is`
- preserve existing parsing, typed errors, error messages, and body-closing behavior
- add boundary and regression coverage for all affected response paths

## Root cause

The response boundaries in `go/http/client.go:227`, `go/http/facilitator_client.go:365`, and `go/extensions/bazaar/facilitator_client.go:217` used `io.ReadAll` directly. 
A facilitator or resource server could therefore cause the SDK to buffer an arbitrarily large response before validating its status or decoding the expected JSON.

## Implementation

A shared internal helper reads at most 4 MiB plus one byte. Responses exactly at the limit are accepted, while larger responses return an exported sentinel error.

The 4 MiB limit leaves compatibility room for Bazaar resources containing larger extension payloads or MCP JSON schemas while still placing a firm bound on memory usage. The helper and limit remain internal; only the sentinel error is public.

Oversized bodies are closed without draining the remaining untrusted data.

## Testing

- `make fmt`
- `make lint`
- `make build`
- `make test`

Tests cover exact-limit responses, one-byte-over responses, reader errors, all seven affected call paths, body closure, and oversized `429` responses without retrying.

Fixes #2920