### PR TITLE
fix: add request timeouts to HTTPFacilitatorClient and guard eager init rejection

### DIFF
--- a/typescript/.changeset/facilitator-client-timeout.md
+++ b/typescript/.changeset/facilitator-client-timeout.md
@@ -6,6 +6,6 @@
 "@x402/next": patch
 ---
 
-Add a configurable per-request timeout to `HTTPFacilitatorClient` (`FacilitatorConfig.timeoutMs`, default 30s, matching the Go and Python facilitator clients). `verify()`, `settle()`, and each `getSupported()` attempt now reject with a typed `FacilitatorTimeoutError` — a `FacilitatorResponseError` subclass the HTTP middlewares already surface as a 502 — instead of hanging indefinitely when a facilitator accepts a connection but never completes the response. A `settle()` timeout is indeterminate: the facilitator may still have completed the settlement.
+Add a configurable per-request timeout to `HTTPFacilitatorClient` (`FacilitatorConfig.timeoutMs`, default 30s, matching the Go and Python facilitator clients; must be a positive integer of at most 2^31 - 1 milliseconds). `verify()`, `settle()`, and each `getSupported()` attempt now reject with a typed `FacilitatorTimeoutError` — a `FacilitatorResponseError` subclass the HTTP middlewares already surface as a 502 — instead of hanging indefinitely when a facilitator accepts a connection but never completes the response. A `settle()` timeout is indeterminate: the facilitator may still have completed the settlement.
 
 The Hono, Express, Fastify, and Next middlewares now attach a rejection handler to the eagerly created facilitator initialization promise, so an initialization failure before the first protected request no longer surfaces as an unhandled rejection; the first protected request still observes the failure and retries initialization.

--- a/typescript/.changeset/facilitator-client-timeout.md
+++ b/typescript/.changeset/facilitator-client-timeout.md
@@ -1,0 +1,11 @@
+---
+"@x402/core": minor
+"@x402/hono": patch
+"@x402/express": patch
+"@x402/fastify": patch
+"@x402/next": patch
+---
+
+Add a configurable per-request timeout to `HTTPFacilitatorClient` (`FacilitatorConfig.timeoutMs`, default 30s, matching the Go and Python facilitator clients). `verify()`, `settle()`, and each `getSupported()` attempt now reject with a typed `FacilitatorTimeoutError` — a `FacilitatorResponseError` subclass the HTTP middlewares already surface as a 502 — instead of hanging indefinitely when a facilitator accepts a connection but never completes the response. A `settle()` timeout is indeterminate: the facilitator may still have completed the settlement.
+
+The Hono, Express, Fastify, and Next middlewares now attach a rejection handler to the eagerly created facilitator initialization promise, so an initialization failure before the first protected request no longer surfaces as an unhandled rejection; the first protected request still observes the failure and retries initialization.

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -14,13 +14,20 @@ import { safeBase64Decode } from "../utils";
 const DEFAULT_FACILITATOR_URL = "https://x402.org/facilitator";
 /** Default per-request timeout for facilitator HTTP calls, in milliseconds */
 const DEFAULT_TIMEOUT_MS = 30_000;
+/**
+ * Upper bound for timeoutMs (2^31 - 1). AbortSignal.timeout() requires an
+ * integer, and larger values overflow Node's 32-bit timers, which would
+ * silently fire after ~1ms while reporting the configured duration.
+ */
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 export interface FacilitatorConfig {
   url?: string;
   /**
    * Timeout in milliseconds applied to each facilitator HTTP request —
    * `verify()`, `settle()`, and every `getSupported()` attempt — covering both
-   * response headers and body consumption. Must be a positive finite number.
+   * response headers and body consumption. Must be a positive integer no
+   * greater than 2_147_483_647 (2^31 - 1, about 24.8 days).
    * Defaults to 30_000 (30 seconds), matching the Go and Python facilitator clients.
    *
    * On expiry the operation rejects with {@link FacilitatorTimeoutError}. For
@@ -331,9 +338,9 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
     // when constructing endpoint paths like `${url}/supported`
     this.url = (config?.url || DEFAULT_FACILITATOR_URL).replace(/\/+$/, "");
     const timeoutMs = config?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_TIMEOUT_MS) {
       throw new RangeError(
-        `timeoutMs must be a positive finite number of milliseconds, got ${timeoutMs}`,
+        `timeoutMs must be a positive integer number of milliseconds no greater than ${MAX_TIMEOUT_MS}, got ${timeoutMs}`,
       );
     }
     this.timeoutMs = timeoutMs;
@@ -491,7 +498,15 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
           };
         }
 
-        const errorText = await response.text().catch(() => response.statusText);
+        const errorText = await response.text().catch((cause: unknown) => {
+          // A deadline abort during the error-body read must surface as a
+          // timeout, not be masked as a generic HTTP failure (which would be
+          // retried for 429). statusText covers other body-read failures.
+          if (isAbortOrTimeoutError(cause)) {
+            throw cause;
+          }
+          return response.statusText;
+        });
         return {
           kind: "http-error" as const,
           status: response.status,

--- a/typescript/packages/core/src/http/httpFacilitatorClient.ts
+++ b/typescript/packages/core/src/http/httpFacilitatorClient.ts
@@ -6,14 +6,28 @@ import {
   VerifyError,
   SettleError,
   FacilitatorResponseError,
+  FacilitatorTimeoutError,
 } from "../types/facilitator";
 import { z } from "../schemas";
 import { safeBase64Decode } from "../utils";
 
 const DEFAULT_FACILITATOR_URL = "https://x402.org/facilitator";
+/** Default per-request timeout for facilitator HTTP calls, in milliseconds */
+const DEFAULT_TIMEOUT_MS = 30_000;
 
 export interface FacilitatorConfig {
   url?: string;
+  /**
+   * Timeout in milliseconds applied to each facilitator HTTP request —
+   * `verify()`, `settle()`, and every `getSupported()` attempt — covering both
+   * response headers and body consumption. Must be a positive finite number.
+   * Defaults to 30_000 (30 seconds), matching the Go and Python facilitator clients.
+   *
+   * On expiry the operation rejects with {@link FacilitatorTimeoutError}. For
+   * `settle()` a timeout is an indeterminate outcome: the facilitator may still
+   * have completed the settlement.
+   */
+  timeoutMs?: number;
   /**
    * Returns authentication headers for the facilitator, keyed by request path.
    *
@@ -210,6 +224,25 @@ function responseExcerpt(text: string, limit: number = 200): string {
   return `${compact.slice(0, limit - 3)}...`;
 }
 
+/**
+ * Returns true when an error (or anything in its cause chain) is an abort or
+ * timeout failure raised by an AbortSignal, across runtime error shapes.
+ *
+ * @param error - The thrown value to inspect
+ * @returns Whether the failure was caused by an aborted request
+ */
+function isAbortOrTimeoutError(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 10 && current !== null && typeof current === "object"; depth++) {
+    const name = (current as { name?: unknown }).name;
+    if (name === "TimeoutError" || name === "AbortError") {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
 const EXTENSION_RESPONSE_LOG_FIELD_ALLOWLIST = ["status", "rejectedReason", "reason", "code"];
 
 /**
@@ -284,6 +317,8 @@ async function parseSuccessResponse<T>(
  */
 export class HTTPFacilitatorClient implements FacilitatorClient {
   readonly url: string;
+  /** Per-request timeout for facilitator HTTP calls, in milliseconds. */
+  readonly timeoutMs: number;
   private readonly _createAuthHeaders?: FacilitatorConfig["createAuthHeaders"];
 
   /**
@@ -295,6 +330,13 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
     // Normalize URL: strip trailing slashes to prevent redirect loops (e.g. 308)
     // when constructing endpoint paths like `${url}/supported`
     this.url = (config?.url || DEFAULT_FACILITATOR_URL).replace(/\/+$/, "");
+    const timeoutMs = config?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new RangeError(
+        `timeoutMs must be a positive finite number of milliseconds, got ${timeoutMs}`,
+      );
+    }
+    this.timeoutMs = timeoutMs;
     this._createAuthHeaders = config?.createAuthHeaders;
   }
 
@@ -318,38 +360,43 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       headers = { ...headers, ...authHeaders.headers };
     }
 
-    const response = await fetch(`${this.url}/verify`, {
-      method: "POST",
-      headers,
-      redirect: "follow",
-      body: JSON.stringify({
-        x402Version: paymentPayload.x402Version,
-        paymentPayload: this.toJsonSafe(paymentPayload),
-        paymentRequirements: this.toJsonSafe(paymentRequirements),
-      }),
+    return this.withRequestTimeout("verify", async signal => {
+      const response = await fetch(`${this.url}/verify`, {
+        method: "POST",
+        headers,
+        redirect: "follow",
+        body: JSON.stringify({
+          x402Version: paymentPayload.x402Version,
+          paymentPayload: this.toJsonSafe(paymentPayload),
+          paymentRequirements: this.toJsonSafe(paymentRequirements),
+        }),
+        signal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        let data: unknown;
+        try {
+          data = JSON.parse(text);
+        } catch {
+          throw new Error(
+            `Facilitator verify failed (${response.status}): ${responseExcerpt(text)}`,
+          );
+        }
+
+        if (typeof data === "object" && data !== null && "isValid" in data) {
+          throw new VerifyError(response.status, data as VerifyResponse);
+        }
+
+        throw new Error(
+          `Facilitator verify failed (${response.status}): ${responseExcerpt(JSON.stringify(data))}`,
+        );
+      }
+
+      const verifyResult = await parseSuccessResponse(response, verifyResponseSchema, "verify");
+      logExtensionResponsesHeader(response);
+      return verifyResult;
     });
-
-    if (!response.ok) {
-      const text = await response.text();
-      let data: unknown;
-      try {
-        data = JSON.parse(text);
-      } catch {
-        throw new Error(`Facilitator verify failed (${response.status}): ${responseExcerpt(text)}`);
-      }
-
-      if (typeof data === "object" && data !== null && "isValid" in data) {
-        throw new VerifyError(response.status, data as VerifyResponse);
-      }
-
-      throw new Error(
-        `Facilitator verify failed (${response.status}): ${responseExcerpt(JSON.stringify(data))}`,
-      );
-    }
-
-    const verifyResult = await parseSuccessResponse(response, verifyResponseSchema, "verify");
-    logExtensionResponsesHeader(response);
-    return verifyResult;
   }
 
   /**
@@ -372,38 +419,43 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
       headers = { ...headers, ...authHeaders.headers };
     }
 
-    const response = await fetch(`${this.url}/settle`, {
-      method: "POST",
-      headers,
-      redirect: "follow",
-      body: JSON.stringify({
-        x402Version: paymentPayload.x402Version,
-        paymentPayload: this.toJsonSafe(paymentPayload),
-        paymentRequirements: this.toJsonSafe(paymentRequirements),
-      }),
+    return this.withRequestTimeout("settle", async signal => {
+      const response = await fetch(`${this.url}/settle`, {
+        method: "POST",
+        headers,
+        redirect: "follow",
+        body: JSON.stringify({
+          x402Version: paymentPayload.x402Version,
+          paymentPayload: this.toJsonSafe(paymentPayload),
+          paymentRequirements: this.toJsonSafe(paymentRequirements),
+        }),
+        signal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        let data: unknown;
+        try {
+          data = JSON.parse(text);
+        } catch {
+          throw new Error(
+            `Facilitator settle failed (${response.status}): ${responseExcerpt(text)}`,
+          );
+        }
+
+        if (typeof data === "object" && data !== null && "success" in data) {
+          throw new SettleError(response.status, data as SettleResponse);
+        }
+
+        throw new Error(
+          `Facilitator settle failed (${response.status}): ${responseExcerpt(JSON.stringify(data))}`,
+        );
+      }
+
+      const settleResult = await parseSuccessResponse(response, settleResponseSchema, "settle");
+      logExtensionResponsesHeader(response);
+      return settleResult;
     });
-
-    if (!response.ok) {
-      const text = await response.text();
-      let data: unknown;
-      try {
-        data = JSON.parse(text);
-      } catch {
-        throw new Error(`Facilitator settle failed (${response.status}): ${responseExcerpt(text)}`);
-      }
-
-      if (typeof data === "object" && data !== null && "success" in data) {
-        throw new SettleError(response.status, data as SettleResponse);
-      }
-
-      throw new Error(
-        `Facilitator settle failed (${response.status}): ${responseExcerpt(JSON.stringify(data))}`,
-      );
-    }
-
-    const settleResult = await parseSuccessResponse(response, settleResponseSchema, "settle");
-    logExtensionResponsesHeader(response);
-    return settleResult;
   }
 
   /**
@@ -424,24 +476,41 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
 
     let lastError: Error | null = null;
     for (let attempt = 0; attempt < GET_SUPPORTED_RETRIES; attempt++) {
-      const response = await fetch(`${this.url}/supported`, {
-        method: "GET",
-        headers,
-        redirect: "follow",
+      const outcome = await this.withRequestTimeout("supported", async signal => {
+        const response = await fetch(`${this.url}/supported`, {
+          method: "GET",
+          headers,
+          redirect: "follow",
+          signal,
+        });
+
+        if (response.ok) {
+          return {
+            kind: "success" as const,
+            value: await parseSuccessResponse(response, supportedResponseSchema, "supported"),
+          };
+        }
+
+        const errorText = await response.text().catch(() => response.statusText);
+        return {
+          kind: "http-error" as const,
+          status: response.status,
+          retryAfter: response.headers.get("Retry-After"),
+          error: new Error(
+            `Facilitator getSupported failed (${response.status}): ${responseExcerpt(errorText)}`,
+          ),
+        };
       });
 
-      if (response.ok) {
-        return parseSuccessResponse(response, supportedResponseSchema, "supported");
+      if (outcome.kind === "success") {
+        return outcome.value;
       }
 
-      const errorText = await response.text().catch(() => response.statusText);
-      lastError = new Error(
-        `Facilitator getSupported failed (${response.status}): ${responseExcerpt(errorText)}`,
-      );
+      lastError = outcome.error;
 
       // Retry on 429, honoring the server's Retry-After when available.
-      if (response.status === 429 && attempt < GET_SUPPORTED_RETRIES - 1) {
-        const delay = computeRetryDelay(response.headers.get("Retry-After"), attempt);
+      if (outcome.status === 429 && attempt < GET_SUPPORTED_RETRIES - 1) {
+        const delay = computeRetryDelay(outcome.retryAfter, attempt);
         await new Promise(resolve => setTimeout(resolve, delay));
         continue;
       }
@@ -495,6 +564,31 @@ export class HTTPFacilitatorClient implements FacilitatorClient {
     return {
       headers: isHeaderObject(headersForPath) ? headersForPath : {},
     };
+  }
+
+  /**
+   * Runs a single facilitator HTTP attempt under this client's request deadline.
+   * The provided signal must be passed to `fetch` so the deadline also covers
+   * response-body consumption.
+   *
+   * @param operation - The facilitator operation name ("verify", "settle", "supported")
+   * @param run - The attempt to execute with the deadline's AbortSignal
+   * @returns The attempt's result
+   * @throws FacilitatorTimeoutError when the deadline elapses before completion
+   */
+  private async withRequestTimeout<T>(
+    operation: string,
+    run: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    const signal = AbortSignal.timeout(this.timeoutMs);
+    try {
+      return await run(signal);
+    } catch (error) {
+      if (signal.aborted && isAbortOrTimeoutError(error)) {
+        throw new FacilitatorTimeoutError(operation, this.timeoutMs);
+      }
+      throw error;
+    }
   }
 
   /**

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -110,7 +110,11 @@ export {
   FacilitatorClient,
   FacilitatorConfig,
 } from "./httpFacilitatorClient";
-export { FacilitatorResponseError, getFacilitatorResponseError } from "../types";
+export {
+  FacilitatorResponseError,
+  FacilitatorTimeoutError,
+  getFacilitatorResponseError,
+} from "../types";
 export {
   x402HTTPClient,
   PaymentRequiredContext,

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -45,7 +45,11 @@ export type { SettleResponseCoreSnapshot } from "./hookPolicy";
 
 export { HTTPFacilitatorClient } from "../http/httpFacilitatorClient";
 export type { FacilitatorClient, FacilitatorConfig } from "../http/httpFacilitatorClient";
-export { FacilitatorResponseError, getFacilitatorResponseError } from "../types";
+export {
+  FacilitatorResponseError,
+  FacilitatorTimeoutError,
+  getFacilitatorResponseError,
+} from "../types";
 
 export {
   x402HTTPResourceServer,

--- a/typescript/packages/core/src/types/facilitator.ts
+++ b/typescript/packages/core/src/types/facilitator.ts
@@ -122,6 +122,37 @@ export class FacilitatorResponseError extends Error {
 }
 
 /**
+ * Error thrown when a facilitator HTTP request exceeds the client's configured timeout.
+ *
+ * Extends FacilitatorResponseError so HTTP middlewares surface it as a facilitator
+ * boundary failure (502) rather than an unhandled runtime error.
+ *
+ * Note: for settle(), a client-side timeout is an indeterminate outcome — the
+ * facilitator may have received and completed the settlement after the client
+ * stopped waiting. Callers must not treat this error as proof that settlement
+ * did not occur.
+ */
+export class FacilitatorTimeoutError extends FacilitatorResponseError {
+  /** The facilitator operation that timed out ("verify", "settle", or "supported") */
+  readonly operation: string;
+  /** The timeout that elapsed, in milliseconds */
+  readonly timeoutMs: number;
+
+  /**
+   * Creates a FacilitatorTimeoutError.
+   *
+   * @param operation - The facilitator operation that timed out
+   * @param timeoutMs - The configured timeout in milliseconds
+   */
+  constructor(operation: string, timeoutMs: number) {
+    super(`Facilitator ${operation} request timed out after ${timeoutMs}ms`);
+    this.name = "FacilitatorTimeoutError";
+    this.operation = operation;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+/**
  * Walks an error cause chain to find the first facilitator response error.
  *
  * @param error - The thrown value to inspect

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -10,6 +10,7 @@ export {
   VerifyError,
   SettleError,
   FacilitatorResponseError,
+  FacilitatorTimeoutError,
   getFacilitatorResponseError,
 } from "./facilitator";
 export type {

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { HTTPFacilitatorClient, computeRetryDelay } from "../../../src/http/httpFacilitatorClient";
-import { FacilitatorResponseError, SettleError, VerifyError } from "../../../src/types";
+import {
+  FacilitatorResponseError,
+  FacilitatorTimeoutError,
+  SettleError,
+  VerifyError,
+  getFacilitatorResponseError,
+} from "../../../src/types";
 import { PaymentPayload, PaymentRequirements } from "../../../src/types/payments";
 
 const paymentRequirements: PaymentRequirements = {
@@ -21,6 +27,7 @@ const paymentPayload: PaymentPayload = {
 
 describe("HTTPFacilitatorClient", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
@@ -356,6 +363,196 @@ describe("HTTPFacilitatorClient", () => {
         }),
       );
     });
+  });
+});
+
+describe("request timeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults timeoutMs to 30 seconds", () => {
+    expect(new HTTPFacilitatorClient().timeoutMs).toBe(30_000);
+    expect(new HTTPFacilitatorClient({ timeoutMs: 5_000 }).timeoutMs).toBe(5_000);
+  });
+
+  it("rejects a non-positive or non-finite timeoutMs", () => {
+    for (const timeoutMs of [0, -5, NaN, Infinity]) {
+      expect(() => new HTTPFacilitatorClient({ timeoutMs })).toThrow(RangeError);
+    }
+  });
+
+  it("passes an AbortSignal to fetch on verify, settle, and getSupported", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ isValid: true, payer: paymentRequirements.payTo }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            transaction: "0xtransaction",
+            network: paymentRequirements.network,
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            kinds: [{ x402Version: 2, scheme: "exact", network: paymentRequirements.network }],
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+    await client.verify(paymentPayload, paymentRequirements);
+    await client.settle(paymentPayload, paymentRequirements);
+    await client.getSupported();
+
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1]).toEqual(expect.objectContaining({ signal: expect.any(AbortSignal) }));
+    }
+  });
+
+  it("throws FacilitatorTimeoutError when verify never receives response headers", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => reject(init.signal!.reason));
+          }),
+      ),
+    );
+
+    const client = new HTTPFacilitatorClient({
+      url: "https://facilitator.test",
+      timeoutMs: 25,
+    });
+    const error = await client
+      .verify(paymentPayload, paymentRequirements)
+      .catch(caught => caught as FacilitatorTimeoutError);
+
+    expect(error).toBeInstanceOf(FacilitatorTimeoutError);
+    expect(error).toBeInstanceOf(FacilitatorResponseError);
+    expect(error.message).toContain("verify request timed out after 25ms");
+    expect(error.operation).toBe("verify");
+    expect(error.timeoutMs).toBe(25);
+  });
+
+  it("throws FacilitatorTimeoutError when the settle response body stalls", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        const signal = init.signal!;
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          text: () =>
+            new Promise((_resolve, reject) => {
+              signal.addEventListener("abort", () => reject(signal.reason));
+            }),
+        } as unknown as Response);
+      }),
+    );
+
+    const client = new HTTPFacilitatorClient({
+      url: "https://facilitator.test",
+      timeoutMs: 25,
+    });
+    const error = await client
+      .settle(paymentPayload, paymentRequirements)
+      .catch(caught => caught as FacilitatorTimeoutError);
+
+    expect(error).toBeInstanceOf(FacilitatorTimeoutError);
+    expect(error.operation).toBe("settle");
+  });
+
+  it("throws FacilitatorTimeoutError when getSupported stalls", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => reject(init.signal!.reason));
+          }),
+      ),
+    );
+
+    const client = new HTTPFacilitatorClient({
+      url: "https://facilitator.test",
+      timeoutMs: 25,
+    });
+    const error = await client.getSupported().catch(caught => caught as FacilitatorTimeoutError);
+
+    expect(error).toBeInstanceOf(FacilitatorTimeoutError);
+    expect(error.operation).toBe("supported");
+    expect(error.message).toContain("supported request timed out");
+  });
+
+  it("does not convert non-timeout failures into FacilitatorTimeoutError", async () => {
+    const fetchError = new TypeError("fetch failed");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(fetchError));
+
+    const client = new HTTPFacilitatorClient({ url: "https://facilitator.test" });
+    const error = await client
+      .verify(paymentPayload, paymentRequirements)
+      .catch(caught => caught as Error);
+
+    expect(error).toBe(fetchError);
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error).not.toBeInstanceOf(FacilitatorTimeoutError);
+  });
+
+  it("applies a fresh deadline to each getSupported retry attempt", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout"] });
+    const signals: AbortSignal[] = [];
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce((_url: string, init: RequestInit) => {
+        signals.push(init.signal!);
+        return Promise.resolve(new Response("rate limited", { status: 429 }));
+      })
+      .mockImplementationOnce(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            signals.push(init.signal!);
+            init.signal?.addEventListener("abort", () => reject(init.signal!.reason));
+          }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new HTTPFacilitatorClient({
+      url: "https://facilitator.test",
+      timeoutMs: 50,
+    });
+    const resultPromise = client.getSupported();
+    const guarded = resultPromise.catch((caught: unknown) => caught as Error);
+    await vi.advanceTimersByTimeAsync(1000);
+    vi.useRealTimers();
+    const error = await guarded;
+
+    expect(error).toBeInstanceOf(FacilitatorTimeoutError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(signals[0]).not.toBe(signals[1]);
+  });
+
+  it("is found by getFacilitatorResponseError", () => {
+    const timeoutError = new FacilitatorTimeoutError("supported", 30_000);
+
+    expect(getFacilitatorResponseError(timeoutError)).toBe(timeoutError);
+    expect(
+      getFacilitatorResponseError(new Error("initialization failed", { cause: timeoutError })),
+    ).toBe(timeoutError);
   });
 });
 

--- a/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
+++ b/typescript/packages/core/test/unit/http/httpFacilitatorClient.test.ts
@@ -378,10 +378,16 @@ describe("request timeout", () => {
     expect(new HTTPFacilitatorClient({ timeoutMs: 5_000 }).timeoutMs).toBe(5_000);
   });
 
-  it("rejects a non-positive or non-finite timeoutMs", () => {
-    for (const timeoutMs of [0, -5, NaN, Infinity]) {
+  it("rejects a timeoutMs that AbortSignal.timeout cannot honor", () => {
+    // Non-integers throw ERR_OUT_OF_RANGE at request time, and values above
+    // 2^31 - 1 overflow Node's 32-bit timers into an effective ~1ms deadline.
+    for (const timeoutMs of [0, -5, NaN, Infinity, 0.5, 2_147_483_648]) {
       expect(() => new HTTPFacilitatorClient({ timeoutMs })).toThrow(RangeError);
     }
+  });
+
+  it("accepts the maximum timer-safe timeoutMs", () => {
+    expect(new HTTPFacilitatorClient({ timeoutMs: 2_147_483_647 }).timeoutMs).toBe(2_147_483_647);
   });
 
   it("passes an AbortSignal to fetch on verify, settle, and getSupported", async () => {
@@ -497,6 +503,33 @@ describe("request timeout", () => {
     expect(error).toBeInstanceOf(FacilitatorTimeoutError);
     expect(error.operation).toBe("supported");
     expect(error.message).toContain("supported request timed out");
+  });
+
+  it("throws FacilitatorTimeoutError when a 429 error body stalls, without retrying", async () => {
+    const fetchMock = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      const signal = init.signal!;
+      return Promise.resolve({
+        ok: false,
+        status: 429,
+        headers: new Headers(),
+        text: () =>
+          new Promise((_resolve, reject) => {
+            signal.addEventListener("abort", () => reject(signal.reason));
+          }),
+      } as unknown as Response);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new HTTPFacilitatorClient({
+      url: "https://facilitator.test",
+      timeoutMs: 25,
+    });
+    const error = await client.getSupported().catch(caught => caught as FacilitatorTimeoutError);
+
+    expect(error).toBeInstanceOf(FacilitatorTimeoutError);
+    expect(error.operation).toBe("supported");
+    // The deadline abort must not be masked as a retryable HTTP error.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not convert non-timeout failures into FacilitatorTimeoutError", async () => {

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -619,6 +619,59 @@ describe("paymentMiddleware", () => {
     expect(next).toHaveBeenCalledTimes(1);
   });
 
+  it("does not surface an eager initialization failure as an unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      const initializationError = new Error("facilitator request timed out");
+      // Hand-rolled instead of vi.fn(): the spy instruments promise results to
+      // record settlements, which attaches a rejection handler and would mask
+      // the unhandled rejection this test exists to detect.
+      let initializeCalls = 0;
+      const initialize = (): Promise<void> => {
+        initializeCalls += 1;
+        return initializeCalls === 1
+          ? Promise.reject(initializationError)
+          : Promise.resolve(undefined);
+      };
+      vi.mocked(HTTPResourceServer).mockImplementation(
+        (server, routes) =>
+          ({
+            initialize,
+            processHTTPRequest: mockProcessHTTPRequest,
+            processSettlement: mockProcessSettlement,
+            registerPaywallProvider: mockRegisterPaywallProvider,
+            requiresPayment: mockRequiresPayment,
+            routes,
+            server: server || {
+              hasExtension: vi.fn().mockReturnValue(false),
+              registerExtension: vi.fn(),
+            },
+          }) as unknown as x402HTTPResourceServer,
+      );
+      mockProcessHTTPRequest.mockResolvedValue({ type: "no-payment-required" });
+
+      const middleware = paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(unhandled).toHaveLength(0);
+
+      const firstNext = vi.fn();
+      await middleware(createMockRequest(), createMockResponse(), firstNext);
+      expect(firstNext).toHaveBeenCalledWith(initializationError);
+
+      const secondNext = vi.fn();
+      await middleware(createMockRequest(), createMockResponse(), secondNext);
+      expect(secondNext).toHaveBeenCalledWith();
+      expect(initializeCalls).toBe(2);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
   it("returns 502 when processHTTPRequest surfaces FacilitatorResponseError", async () => {
     mockProcessHTTPRequest.mockRejectedValue(
       new FacilitatorResponseError("Facilitator verify returned invalid JSON: not-json"),

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -90,6 +90,11 @@ export function paymentMiddlewareFromHTTPServer(
   // Store initialization promise (not the result)
   // httpServer.initialize() fetches facilitator support and validates routes
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
+  // Attach a no-op rejection handler so an early failure (e.g. a facilitator
+  // request timeout) cannot become an unhandled rejection before the first
+  // protected request awaits initPromise. The original promise is kept, so that
+  // request still observes the failure and triggers the retry path.
+  void initPromise?.catch(() => {});
   let isInitialized = false;
 
   /**

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -319,6 +319,56 @@ describe("paymentMiddleware", () => {
     expect(reply.send).not.toHaveBeenCalled();
   });
 
+  it("does not surface an eager initialization failure as an unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      // Hand-rolled instead of vi.fn(): the spy instruments promise results to
+      // record settlements, which attaches a rejection handler and would mask
+      // the unhandled rejection this test exists to detect.
+      let initializeCalls = 0;
+      const initialize = (): Promise<void> => {
+        initializeCalls += 1;
+        return initializeCalls === 1
+          ? Promise.reject(new Error("facilitator request timed out"))
+          : Promise.resolve(undefined);
+      };
+      vi.mocked(HTTPResourceServer).mockImplementation(
+        (server, routes) =>
+          ({
+            initialize,
+            processHTTPRequest: mockProcessHTTPRequest,
+            processSettlement: mockProcessSettlement,
+            registerPaywallProvider: mockRegisterPaywallProvider,
+            requiresPayment: mockRequiresPayment,
+            routes,
+            server: server || {
+              hasExtension: vi.fn().mockReturnValue(false),
+              registerExtension: vi.fn(),
+            },
+          }) as unknown as x402HTTPResourceServer,
+      );
+      mockProcessHTTPRequest.mockResolvedValue({ type: "no-payment-required" });
+
+      const { app, hooks } = createMockApp();
+      paymentMiddleware(app, mockRoutes, {} as unknown as x402ResourceServer);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(unhandled).toHaveLength(0);
+
+      await expect(hooks.onRequest[0](createMockRequest(), createMockReply())).rejects.toThrow(
+        "facilitator request timed out",
+      );
+      await hooks.onRequest[0](createMockRequest(), createMockReply());
+      expect(initializeCalls).toBe(2);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
   it("skips payment check for non-protected routes", async () => {
     mockRequiresPayment.mockReturnValue(false);
 

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -268,6 +268,11 @@ export function paymentMiddlewareFromHTTPServer(
   app.decorateRequest("x402RawGuard", undefined);
 
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
+  // Attach a no-op rejection handler so an early failure (e.g. a facilitator
+  // request timeout) cannot become an unhandled rejection before the first
+  // protected request awaits initPromise. The original promise is kept, so that
+  // request still observes the failure and triggers the retry path.
+  void initPromise?.catch(() => {});
   let isInitialized = false;
 
   /**

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -528,6 +528,55 @@ describe("paymentMiddleware", () => {
     expect(next).toHaveBeenCalledTimes(1);
   });
 
+  it("does not surface an eager initialization failure as an unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      // Hand-rolled instead of vi.fn(): the spy instruments promise results to
+      // record settlements, which attaches a rejection handler and would mask
+      // the unhandled rejection this test exists to detect.
+      let initializeCalls = 0;
+      const initialize = (): Promise<void> => {
+        initializeCalls += 1;
+        return initializeCalls === 1
+          ? Promise.reject(new Error("facilitator request timed out"))
+          : Promise.resolve(undefined);
+      };
+      vi.mocked(HTTPResourceServer).mockImplementation(
+        (server, routes) =>
+          ({
+            initialize,
+            processHTTPRequest: mockProcessHTTPRequest,
+            processSettlement: mockProcessSettlement,
+            registerPaywallProvider: mockRegisterPaywallProvider,
+            requiresPayment: mockRequiresPayment,
+            routes,
+            server: server || {
+              hasExtension: vi.fn().mockReturnValue(false),
+              registerExtension: vi.fn(),
+            },
+          }) as unknown as x402HTTPResourceServer,
+      );
+      mockProcessHTTPRequest.mockResolvedValue({ type: "no-payment-required" });
+
+      const middleware = paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(unhandled).toHaveLength(0);
+
+      await expect(middleware(createMockContext(), vi.fn())).rejects.toThrow(
+        "facilitator request timed out",
+      );
+      await middleware(createMockContext(), vi.fn().mockResolvedValue(undefined));
+      expect(initializeCalls).toBe(2);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
   it("returns 402 when settlement returns success: false", async () => {
     setupMockHttpServer(
       {

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -91,6 +91,11 @@ export function paymentMiddlewareFromHTTPServer(
   // Store initialization promise (not the result)
   // httpServer.initialize() fetches facilitator support and validates routes
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
+  // Attach a no-op rejection handler so an early failure (e.g. a facilitator
+  // request timeout) cannot become an unhandled rejection before the first
+  // protected request awaits initPromise. The original promise is kept, so that
+  // request still observes the failure and triggers the retry path.
+  void initPromise?.catch(() => {});
   let isInitialized = false;
 
   /**

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -156,6 +156,43 @@ describe("createHttpServer", () => {
     await expect(init()).resolves.toBeUndefined();
     expect(mockInitialize).toHaveBeenCalledTimes(2);
   });
+
+  it("does not surface an eager initialization failure as an unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      // Hand-rolled instead of vi.fn(): the spy instruments promise results to
+      // record settlements, which attaches a rejection handler and would mask
+      // the unhandled rejection this test exists to detect.
+      let initializeCalls = 0;
+      mockInitialize = ((): Promise<void> => {
+        initializeCalls += 1;
+        return initializeCalls === 1
+          ? Promise.reject(new Error("facilitator request timed out"))
+          : Promise.resolve(undefined);
+      }) as unknown as ReturnType<typeof vi.fn>;
+      const routes = {
+        "/api/*": {
+          accepts: { scheme: "exact", payTo: "0x123", price: "$0.01", network: "eip155:84532" },
+        },
+      } as const;
+      const server = createMockResourceServer();
+
+      const { init } = createHttpServer(routes, server);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(unhandled).toHaveLength(0);
+
+      await expect(init()).rejects.toThrow("facilitator request timed out");
+      await expect(init()).resolves.toBeUndefined();
+      expect(initializeCalls).toBe(2);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
 });
 
 describe("createRequestContext", () => {

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -58,6 +58,11 @@ export function prepareHttpServer(
   // Store initialization promise (not the result)
   // httpServer.initialize() fetches facilitator support and validates routes
   let initPromise: Promise<void> | null = syncFacilitatorOnStart ? httpServer.initialize() : null;
+  // Attach a no-op rejection handler so an early failure (e.g. a facilitator
+  // request timeout) cannot become an unhandled rejection before the first
+  // protected request awaits initPromise. The original promise is kept, so that
+  // request still observes the failure and triggers the retry path.
+  void initPromise?.catch(() => {});
   let isInitialized = false;
 
   return {


### PR DESCRIPTION
## Description

Closes #2961.

`HTTPFacilitatorClient.verify()`, `settle()`, and `getSupported()` called `fetch()` with no deadline, so a facilitator (or an LB in front of it) that accepts a connection but never completes the response left the operation pending indefinitely. Through the eagerly created `initPromise` shared by the Hono, Express, Fastify, and Next middlewares, one hung `getSupported()` wedged every protected route behind that middleware instance until the socket happened to die or the process restarted.

This PR:

- **Adds `FacilitatorConfig.timeoutMs`** (default `30_000`, matching the Go client's 30s `Timeout` default and Python's `timeout: float = 30.0`). The deadline is applied via a fresh `AbortSignal.timeout()` per HTTP attempt — `verify()`, `settle()`, and each `getSupported()` retry attempt get their own budget — and the signal is passed to `fetch`, so it also covers response-body consumption. The 429 backoff sleep between `getSupported` attempts is deliberately outside the deadline, and a deadline abort raised while reading a non-2xx error body surfaces as the timeout error rather than a generic (and, for 429, retryable) HTTP failure. Invalid values throw a `RangeError` at construction: `timeoutMs` must be a positive integer of at most 2^31 − 1 ms, since `AbortSignal.timeout()` rejects non-integers and larger values overflow Node's 32-bit timers into an effective ~1ms deadline.
- **Introduces `FacilitatorTimeoutError`** (with `operation` and `timeoutMs` fields) instead of surfacing a raw `DOMException`. It extends `FacilitatorResponseError`, so the existing middleware handling surfaces timeouts as a clean 502 facilitator-boundary response with no adapter logic changes. Non-timeout failures are rethrown untouched (conversion requires both `signal.aborted` and an abort/timeout error in the cause chain, so a network error racing the timer isn't misclassified). Its docs record that a `settle()` timeout is an indeterminate outcome — the facilitator may still have completed the settlement.
- **Guards the eager `initPromise`** in all four middlewares with an immediately attached no-op rejection handler, so an initialization failure (now guaranteed to occur within the timeout) can no longer become an unhandled rejection before the first protected request arrives. The original promise stays stored, so the first protected request still observes the failure and the existing `initPromise = null` retry path recovers — including trying later/fallback facilitators, since `x402ResourceServer.initialize()` continues past a facilitator whose `getSupported()` rejects.

## Tests

- New core tests: stalled response headers (verify/getSupported), stalled response body (settle), `FacilitatorTimeoutError` shape and `FacilitatorResponseError` subclass/`getFacilitatorResponseError` contract, non-timeout errors passing through unchanged, a fresh deadline per `getSupported` retry attempt, config default and validation, and `AbortSignal` being passed to every fetch.
- New middleware tests (Hono, Express, Fastify, Next): an eager initialization rejection with no request in flight emits no `unhandledRejection`, the first protected request still observes the failure, and initialization then retries successfully. These use a hand-rolled `initialize` mock because `vi.fn()` instruments returned promises (for `mock.settledResults`), which attaches a rejection handler and would mask the very bug under test — verified the test fails when the guard is removed.
- Full suites pass locally: `@x402/core` 525, `@x402/hono` 38, `@x402/express` 53, `@x402/fastify` 44, `@x402/next` 56. Lint, prettier, and `tsup` builds pass for all five packages.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
