### PR TITLE
feat(stellar): add typed simulation errors

### DIFF
--- a/typescript/.changeset/stellar-simulation-errors.md
+++ b/typescript/.changeset/stellar-simulation-errors.md
@@ -1,0 +1,5 @@
+---
+"@x402/stellar": minor
+---
+
+Mapped common Stellar simulation failures to exported typed errors with account and asset context.

--- a/typescript/packages/mechanisms/stellar/src/errors.ts
+++ b/typescript/packages/mechanisms/stellar/src/errors.ts
@@ -1,0 +1,63 @@
+/**
+ * Error thrown when a Stellar transaction simulation fails.
+ */
+export class SimulationFailedError extends Error {
+  readonly cause: string;
+
+  /**
+   * Creates a simulation failure error.
+   *
+   * @param cause - Raw error message returned by Stellar RPC
+   */
+  constructor(cause: string) {
+    super(`Stellar simulation failed${cause ? ` with error message: ${cause}` : ""}`);
+    this.name = "SimulationFailedError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * Error thrown when a Stellar account lacks a trustline for an asset.
+ */
+export class TrustlineMissingError extends SimulationFailedError {
+  readonly account: string;
+  readonly asset: string;
+
+  /**
+   * Creates a missing trustline error.
+   *
+   * @param account - Account missing the trustline
+   * @param asset - Asset contract address
+   * @param cause - Raw error message returned by Stellar RPC
+   */
+  constructor(account: string, asset: string, cause: string) {
+    super(cause);
+    this.name = "TrustlineMissingError";
+    this.message = `Stellar trustline is missing for account ${account} and asset ${asset}${cause ? `: ${cause}` : ""}`;
+    this.account = account;
+    this.asset = asset;
+  }
+}
+
+/**
+ * Error thrown when a Stellar account has insufficient balance for an asset.
+ */
+export class InsufficientBalanceError extends SimulationFailedError {
+  readonly account: string;
+  readonly asset: string;
+
+  /**
+   * Creates an insufficient balance error.
+   *
+   * @param account - Account with insufficient balance
+   * @param asset - Asset contract address
+   * @param cause - Raw error message returned by Stellar RPC
+   */
+  constructor(account: string, asset: string, cause: string) {
+    super(cause);
+    this.name = "InsufficientBalanceError";
+    this.message = `Stellar account ${account} has insufficient balance for asset ${asset}${cause ? `: ${cause}` : ""}`;
+    this.account = account;
+    this.asset = asset;
+  }
+}

--- a/typescript/packages/mechanisms/stellar/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/client/scheme.ts
@@ -79,7 +79,12 @@ export class ExactStellarScheme implements SchemeNetworkClient {
       rpcUrl,
       parseResultXdr: result => result,
     });
-    handleSimulationResult(tx.simulation);
+    const simulationContext = {
+      payer: sourcePublicKey,
+      payee: payTo,
+      asset,
+    };
+    handleSimulationResult(tx.simulation, simulationContext);
 
     let missingSigners = tx.needsNonInvokerSigningBy();
     if (!missingSigners.includes(sourcePublicKey) || missingSigners.length > 1) {
@@ -94,7 +99,7 @@ export class ExactStellarScheme implements SchemeNetworkClient {
     });
 
     await tx.simulate();
-    handleSimulationResult(tx.simulation);
+    handleSimulationResult(tx.simulation, simulationContext);
 
     missingSigners = tx.needsNonInvokerSigningBy();
     if (missingSigners.length > 0) {

--- a/typescript/packages/mechanisms/stellar/src/index.ts
+++ b/typescript/packages/mechanisms/stellar/src/index.ts
@@ -19,6 +19,9 @@ export * from "./constants";
 // Signers
 export * from "./signer";
 
+// Errors
+export * from "./errors";
+
 // Utilities
 export * from "./utils";
 export * from "./shared";

--- a/typescript/packages/mechanisms/stellar/src/shared.ts
+++ b/typescript/packages/mechanisms/stellar/src/shared.ts
@@ -1,13 +1,88 @@
-import { Transaction, Address, Operation, xdr } from "@stellar/stellar-sdk";
+import { Transaction, Address, humanizeEvents, Operation, xdr } from "@stellar/stellar-sdk";
 import { Api, assembleTransaction } from "@stellar/stellar-sdk/rpc";
+import { InsufficientBalanceError, SimulationFailedError, TrustlineMissingError } from "./errors";
+
+const TRUSTLINE_MISSING_MESSAGE = "trustline entry is missing for account";
+const INSUFFICIENT_BALANCE_MESSAGE = "resulting balance is not within the allowed range";
+
+/**
+ * Account and asset context for a Stellar transfer simulation.
+ */
+export type SimulationErrorContext = {
+  /** Account sending the payment. */
+  payer: string;
+  /** Account receiving the payment. */
+  payee: string;
+  /** Asset contract address. */
+  asset: string;
+};
+
+/**
+ * Finds the arguments embedded in a matching diagnostic error event.
+ *
+ * @param simulation - Failed simulation response
+ * @param message - Error message to match
+ * @returns The diagnostic event arguments, if available
+ */
+function getDiagnosticErrorArgs(
+  simulation: Api.SimulateTransactionErrorResponse,
+  message: string,
+): unknown[] | undefined {
+  const events = simulation.events ?? [];
+  for (let index = events.length - 1; index >= 0; index--) {
+    try {
+      const [event] = humanizeEvents([events[index]]);
+      if (event.type !== "diagnostic" || event.topics[0] !== "error") {
+        continue;
+      }
+
+      const args = event.data;
+      if (Array.isArray(args) && typeof args[0] === "string" && args[0].includes(message)) {
+        return args;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolves the payer whose balance fell below its allowed range.
+ *
+ * @param args - Balance error diagnostic arguments
+ * @param context - Payer and payee transfer context
+ * @returns The payer account for an insufficient balance failure
+ */
+function getInsufficientBalanceAccount(
+  args: unknown[] | undefined,
+  context: SimulationErrorContext,
+): string | undefined {
+  const [minBalance, resultingBalance] = args?.slice(1) ?? [];
+
+  if (
+    typeof minBalance === "bigint" &&
+    typeof resultingBalance === "bigint" &&
+    resultingBalance < minBalance
+  ) {
+    return context.payer;
+  }
+
+  return undefined;
+}
 
 /**
  * Handles the simulation result of a Stellar transaction.
  *
  * @param simulation - The simulation result to handle
+ * @param context - Payer, payee, and asset context for typed errors
  * @throws An error if the simulation result is of type "RESTORE" or "ERROR"
  */
-export function handleSimulationResult(simulation?: Api.SimulateTransactionResponse) {
+export function handleSimulationResult(
+  simulation?: Api.SimulateTransactionResponse,
+  context?: SimulationErrorContext,
+) {
   if (!simulation) {
     throw new Error("Simulation result is undefined");
   }
@@ -19,9 +94,26 @@ export function handleSimulationResult(simulation?: Api.SimulateTransactionRespo
   }
 
   if (Api.isSimulationError(simulation)) {
-    const msg = `Stellar simulation failed${simulation.error ? ` with error message: ${simulation.error}` : ""}`;
+    const rawError = simulation.error ?? "";
 
-    throw new Error(msg);
+    if (context) {
+      const diagnosticArgs = getDiagnosticErrorArgs(simulation, TRUSTLINE_MISSING_MESSAGE);
+      const trustlineAccount = diagnosticArgs?.[1];
+      if (
+        typeof trustlineAccount === "string" &&
+        (trustlineAccount === context.payer || trustlineAccount === context.payee)
+      ) {
+        throw new TrustlineMissingError(trustlineAccount, context.asset, rawError);
+      }
+
+      const balanceArgs = getDiagnosticErrorArgs(simulation, INSUFFICIENT_BALANCE_MESSAGE);
+      const account = getInsufficientBalanceAccount(balanceArgs, context);
+      if (account) {
+        throw new InsufficientBalanceError(account, context.asset, rawError);
+      }
+    }
+
+    throw new SimulationFailedError(rawError);
   }
 }
 

--- a/typescript/packages/mechanisms/stellar/test/integrations/exact-stellar.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/integrations/exact-stellar.test.ts
@@ -18,7 +18,12 @@ import {
 } from "@x402/core/types";
 import { convertToTokenAmount } from "@x402/core/utils";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { createEd25519Signer, Ed25519Signer, STELLAR_TESTNET_CAIP2 } from "../../src";
+import {
+  createEd25519Signer,
+  Ed25519Signer,
+  InsufficientBalanceError,
+  STELLAR_TESTNET_CAIP2,
+} from "../../src";
 import { ExactStellarScheme as ExactStellarClient } from "../../src/exact/client";
 import { ExactStellarScheme as ExactStellarFacilitator } from "../../src/exact/facilitator";
 import { ExactStellarScheme as ExactStellarServer } from "../../src/exact/server";
@@ -158,17 +163,22 @@ function buildStellarPaymentRequirements(
 }
 
 /**
- * Helper to check if an error is due to insufficient balance
+ * Checks whether an error represents an insufficient Stellar balance.
+ *
+ * @param error - Error to inspect
+ * @returns Whether the error indicates insufficient balance
  */
 function isInsufficientBalanceError(error: unknown): boolean {
-  if (error instanceof Error) {
-    return (
-      error.message.includes("resulting balance is not within the allowed range") ||
-      error.message.includes("insufficient balance") ||
-      error.message.includes("Error(Contract, #10)")
-    );
+  if (error instanceof InsufficientBalanceError) {
+    return true;
   }
-  return false;
+
+  return (
+    error instanceof Error &&
+    (error.message.includes("resulting balance is not within the allowed range") ||
+      error.message.includes("insufficient balance") ||
+      error.message.includes("Error(Contract, #10)"))
+  );
 }
 
 describe.skipIf(missingEnvVars)("Stellar Integration Tests", () => {

--- a/typescript/packages/mechanisms/stellar/test/unit/shared.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/shared.test.ts
@@ -1,4 +1,6 @@
+import { Buffer } from "buffer";
 import {
+  nativeToScVal,
   SorobanDataBuilder,
   xdr,
   Networks as StellarNetworks,
@@ -8,6 +10,11 @@ import { AssembledTransaction } from "@stellar/stellar-sdk/contract";
 import { Api } from "@stellar/stellar-sdk/rpc";
 import { beforeEach, describe, it, expect, vi } from "vitest";
 import { STELLAR_TESTNET_CAIP2 } from "../../src/constants";
+import {
+  InsufficientBalanceError,
+  SimulationFailedError,
+  TrustlineMissingError,
+} from "../../src/errors";
 import { ExactStellarScheme } from "../../src/exact/client/scheme";
 import { gatherAuthEntrySignatureStatus, handleSimulationResult } from "../../src/shared";
 import { createEd25519Signer } from "../../src/signer";
@@ -25,6 +32,55 @@ vi.mock("../../src/utils", async () => {
 
 describe("Stellar Shared Utilities", () => {
   describe("handleSimulationResult", () => {
+    const context = {
+      payer: "GBBO4ZDDZTSM2IUKQYBAST3CFHNPFXECGEFTGWTA2WELR2BIWDK57UVE",
+      payee: "GCHEI4PQEFJOA27MNZRPQNLGURS6KASW76X5UZCUZIXCOJLKXYCXOR2W",
+      asset: "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
+    };
+    const BALANCE_ERROR_CODE = 10;
+    const BALANCE_RANGE_MESSAGE = "resulting balance is not within the allowed range";
+    const TRUSTLINE_MISSING_ERROR_CODE = 13;
+    const TRUSTLINE_MISSING_MESSAGE = "trustline entry is missing for account";
+
+    const captureError = (callback: () => void): Error => {
+      try {
+        callback();
+      } catch (error) {
+        if (error instanceof Error) {
+          return error;
+        }
+        throw error;
+      }
+      throw new Error("Expected callback to throw");
+    };
+
+    const createDiagnosticErrorEvent = (
+      errorCode: number,
+      args: xdr.ScVal[],
+    ): xdr.DiagnosticEvent => {
+      const eventV0 = new xdr.ContractEventV0({
+        topics: [
+          nativeToScVal("error", { type: "symbol" }),
+          xdr.ScVal.scvError(xdr.ScError.sceContract(errorCode)),
+        ],
+        data: xdr.ScVal.scvVec(args),
+      });
+      const body = xdr.ContractEventBody.fromXDR(
+        Buffer.concat([Buffer.from([0, 0, 0, 0]), xdr.ContractEventV0.toXDR(eventV0)]),
+      );
+      const event = new xdr.ContractEvent({
+        ext: xdr.ExtensionPoint.fromXDR(Buffer.from([0, 0, 0, 0])),
+        contractId: null,
+        type: xdr.ContractEventType.diagnostic(),
+        body,
+      });
+
+      return new xdr.DiagnosticEvent({
+        inSuccessfulContractCall: false,
+        event,
+      });
+    };
+
     it("should throw error when simulation is undefined", () => {
       expect(() => handleSimulationResult(undefined)).toThrow("Simulation result is undefined");
     });
@@ -52,30 +108,154 @@ describe("Stellar Shared Utilities", () => {
       );
     });
 
-    it("should throw error when simulation has type ERROR", () => {
+    it("should throw a typed generic error for an unmapped simulation failure", () => {
+      const rawError = "Transaction simulation failed: insufficient balance";
       const mockErrorSimulation: Api.SimulateTransactionResponse = {
         id: "test-id",
         latestLedger: 12345,
+        events: [],
         _parsed: true,
-        error: "Transaction simulation failed: insufficient balance",
+        error: rawError,
       } as Api.SimulateTransactionErrorResponse;
 
-      expect(() => handleSimulationResult(mockErrorSimulation)).toThrow(
-        /Stellar simulation failed with error message: Transaction simulation failed: insufficient balance/,
-      );
+      const error = captureError(() => handleSimulationResult(mockErrorSimulation, context));
+
+      expect(error).toBeInstanceOf(SimulationFailedError);
+      expect(error).toMatchObject({ cause: rawError });
+    });
+
+    it("should keep a known failure generic when diagnostics do not identify an account", () => {
+      const rawError = `HostError: ${TRUSTLINE_MISSING_MESSAGE}`;
+      const mockErrorSimulation = {
+        id: "test-id",
+        latestLedger: 12345,
+        events: [],
+        _parsed: true,
+        error: rawError,
+      } as Api.SimulateTransactionErrorResponse;
+
+      const error = captureError(() => handleSimulationResult(mockErrorSimulation, context));
+
+      expect(error).toBeInstanceOf(SimulationFailedError);
+      expect(error).not.toBeInstanceOf(TrustlineMissingError);
+      expect(error).toMatchObject({ cause: rawError });
+    });
+
+    it.each([
+      ["payer", context.payer],
+      ["payee", context.payee],
+    ])("should use the missing trustline %s from diagnostic events", (_, account) => {
+      const rawError = `HostError: ${TRUSTLINE_MISSING_MESSAGE}`;
+      const mockErrorSimulation = {
+        id: "test-id",
+        latestLedger: 12345,
+        events: [
+          createDiagnosticErrorEvent(TRUSTLINE_MISSING_ERROR_CODE, [
+            nativeToScVal(TRUSTLINE_MISSING_MESSAGE),
+            nativeToScVal(account, { type: "address" }),
+          ]),
+        ],
+        _parsed: true,
+        error: rawError,
+      } as Api.SimulateTransactionErrorResponse;
+
+      const error = captureError(() => handleSimulationResult(mockErrorSimulation, context));
+
+      expect(error).toBeInstanceOf(TrustlineMissingError);
+      expect(error).toMatchObject({
+        account,
+        asset: context.asset,
+        cause: rawError,
+      });
+    });
+
+    it("should keep a foreign trustline diagnostic generic", () => {
+      const rawError = `HostError: ${TRUSTLINE_MISSING_MESSAGE}`;
+      const foreignAccount = "GAHPYWLK6YRN7CVYZOO4H3VDRZ7PVF5UJGLZCSPAEIKJE2XSWF5LAGER";
+      const mockErrorSimulation = {
+        id: "test-id",
+        latestLedger: 12345,
+        events: [
+          createDiagnosticErrorEvent(TRUSTLINE_MISSING_ERROR_CODE, [
+            nativeToScVal(TRUSTLINE_MISSING_MESSAGE),
+            nativeToScVal(foreignAccount, { type: "address" }),
+          ]),
+        ],
+        _parsed: true,
+        error: rawError,
+      } as Api.SimulateTransactionErrorResponse;
+
+      const error = captureError(() => handleSimulationResult(mockErrorSimulation, context));
+
+      expect(error).toBeInstanceOf(SimulationFailedError);
+      expect(error).not.toBeInstanceOf(TrustlineMissingError);
+      expect(error).toMatchObject({ cause: rawError });
+    });
+
+    it("should keep an over-limit recipient balance generic", () => {
+      const rawError = `HostError: ${BALANCE_RANGE_MESSAGE}`;
+      const mockErrorSimulation = {
+        id: "test-id",
+        latestLedger: 12345,
+        events: [
+          createDiagnosticErrorEvent(BALANCE_ERROR_CODE, [
+            nativeToScVal(BALANCE_RANGE_MESSAGE),
+            xdr.ScVal.scvI64(xdr.Int64.fromString("0")),
+            xdr.ScVal.scvI64(xdr.Int64.fromString("101")),
+            xdr.ScVal.scvI64(xdr.Int64.fromString("100")),
+          ]),
+        ],
+        _parsed: true,
+        error: rawError,
+      } as Api.SimulateTransactionErrorResponse;
+
+      const error = captureError(() => handleSimulationResult(mockErrorSimulation, context));
+
+      expect(error).toBeInstanceOf(SimulationFailedError);
+      expect(error).not.toBeInstanceOf(InsufficientBalanceError);
+      expect(error).toMatchObject({ cause: rawError });
+    });
+
+    it("should map an insufficient balance to the payer and asset", () => {
+      const rawError = "Error(Contract, #10)";
+      const mockErrorSimulation = {
+        id: "test-id",
+        latestLedger: 12345,
+        events: [
+          createDiagnosticErrorEvent(BALANCE_ERROR_CODE, [
+            nativeToScVal(BALANCE_RANGE_MESSAGE),
+            xdr.ScVal.scvI64(xdr.Int64.fromString("100")),
+            xdr.ScVal.scvI64(xdr.Int64.fromString("99")),
+            xdr.ScVal.scvI64(xdr.Int64.fromString("1000")),
+          ]),
+        ],
+        _parsed: true,
+        error: rawError,
+      } as Api.SimulateTransactionErrorResponse;
+
+      const error = captureError(() => handleSimulationResult(mockErrorSimulation, context));
+
+      expect(error).toBeInstanceOf(InsufficientBalanceError);
+      expect(error).toMatchObject({
+        account: context.payer,
+        asset: context.asset,
+        cause: rawError,
+      });
     });
 
     it("should handle simulation with empty error message", () => {
       const mockErrorSimulation: Api.SimulateTransactionResponse = {
         id: "test-id",
         latestLedger: 12345,
+        events: [],
         _parsed: true,
         error: "",
       } as Api.SimulateTransactionErrorResponse;
 
-      expect(() => handleSimulationResult(mockErrorSimulation)).toThrow(
-        /Stellar simulation failed/,
-      );
+      const error = captureError(() => handleSimulationResult(mockErrorSimulation, context));
+
+      expect(error).toBeInstanceOf(SimulationFailedError);
+      expect(error).toMatchObject({ cause: "" });
     });
 
     it("should not throw error when simulation is successful", () => {


### PR DESCRIPTION
## Summary

- add public `SimulationFailedError`, `TrustlineMissingError`, and `InsufficientBalanceError` classes
- decode Soroban diagnostic events so trustline failures carry the exact payer/payee account and asset
- map a proven lower-bound balance failure to the payer while keeping ambiguous, malformed, foreign-account, and recipient-overflow failures generic
- preserve the raw Stellar RPC error as `cause` and retain the integration test's legacy string fallbacks

## Why

Stellar payment clients currently have to match raw simulation strings to offer actionable recovery guidance. Those strings alone do not safely identify which transfer participant failed. This change reads the structured diagnostic arguments and emits a specific public error only when the account or balance direction can be proven; otherwise it falls back to `SimulationFailedError`.

The mapping was checked against Stellar's asset-contract diagnostics in [`rs-soroban-env@358d8ba`](https://github.com/stellar/rs-soroban-env/tree/358d8bafde7332ad176165b8f9da0bd979e33cd9/soroban-env-host/src/builtin_contracts/stellar_asset_contract).

## Validation

- `@x402/stellar`: 168/168 tests passed
- ESM, CJS, and declaration builds passed
- ESLint and Prettier checks passed
- runtime smoke check confirmed all three classes are exported from `@x402/stellar`
- `git diff --check` passed

## AI assistance

Significant AI assistance was used to research the Stellar diagnostic semantics and draft parts of the implementation and tests. I personally reviewed every changed line, verified the behavior against the official Stellar source above, and reran the package validation listed here.

Closes #2761

