### PR TITLE
docs: add ArisPay Facilitator to the facilitators table

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -19,6 +19,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 
 | Name | Description |
 | ---- | ----------- | 
+| [ArisPay Facilitator](https://facilitator.arispay.app) | Free, public x402 facilitator for Base with USDC and EURC settlement; no API key required |
 | [Built on Stellar](https://developers.stellar.org/docs/build/apps/x402/built-on-stellar) | Free, public x402 facilitator for Stellar |
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
 | [Corbits](https://corbits.dev) | Production-grade multi-network, multi-token facilitator supporting EVM and Solana |


### PR DESCRIPTION
Adds one row to the facilitators table for the ArisPay Facilitator, following the single-entry precedent of earlier facilitator additions.

Everything in the row is verifiable in-band:

- Live service: https://facilitator.arispay.app (open `/verify` + `/settle`, no API key or signup)
- Networks/assets: `GET /supported` — Base mainnet (`eip155:8453`), USDC + EURC, `exact` scheme, EIP-3009; fee policy is machine-readable there (no facilitator fee)
- Discovery: `GET /facilitator` and `GET /supported`
- Observability without an account: `/status`, `/metrics`, `/trust`, `/receipts/{txHash}`, `/settlements/{nonce}`

Row is inserted in alphabetical order. Disclosure: this PR was prepared with AI assistance and reviewed by the maintainer of the facilitator.
