### PR TITLE
fix: fail closed on unmatched legacy requirements

### DIFF
--- a/typescript/.changeset/fail-closed-legacy-selection.md
+++ b/typescript/.changeset/fail-closed-legacy-selection.md
@@ -1,0 +1,5 @@
+---
+"x402": patch
+---
+
+Fail closed when explicit network or scheme filters match no payment requirements.

--- a/typescript/packages/legacy/x402-fetch/src/index.test.ts
+++ b/typescript/packages/legacy/x402-fetch/src/index.test.ts
@@ -165,4 +165,30 @@ describe("fetchWithPayment()", () => {
       } as RequestInitWithRetry),
     ).rejects.toBe(paymentError);
   });
+
+  it("does not sign or retry when no payment requirement matches", async () => {
+    const selectionError = new Error(
+      "No payment requirements match the requested network and scheme",
+    );
+    const { createPaymentHeader, selectPaymentRequirements } = await import("x402/client");
+    (selectPaymentRequirements as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw selectionError;
+    });
+    mockFetch.mockResolvedValue(
+      createResponse(402, {
+        accepts: validPaymentRequirements,
+        x402Version: 1,
+      }),
+    );
+
+    await expect(
+      wrappedFetch("https://api.example.com", {
+        method: "GET",
+      } as RequestInitWithRetry),
+    ).rejects.toBe(selectionError);
+
+    expect(createPaymentHeader).not.toHaveBeenCalled();
+    expect(mockWalletClient.signMessage).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/typescript/packages/legacy/x402/src/client/selectPaymentRequirements.test.ts
+++ b/typescript/packages/legacy/x402/src/client/selectPaymentRequirements.test.ts
@@ -6,6 +6,10 @@ import { PaymentRequirements, Network } from "../types";
 import { getUsdcChainConfigForChain } from "../shared/evm";
 import { getNetworkId } from "../shared/network";
 
+const BASE_CAIP2 = "eip155:8453";
+const SOLANA_MAINNET_CAIP2 =
+  "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+
 /**
  * Test helper to create a payment requirement with the given network, asset, and overrides.
  *
@@ -144,15 +148,15 @@ describe("selectPaymentRequirements", () => {
     expect(selected.network).toBe("avalanche");
   });
 
-  it("when no broadly accepted requirement exists, returns the first requirement", () => {
+  it("fails closed when no broadly accepted requirement exists", () => {
     const reqs: PaymentRequirements[] = [
       makeRequirement("avalanche", "0x6666666666666666666666666666666666666666"),
       makeRequirement("base", "0x7777777777777777777777777777777777777777"),
     ];
 
-    const selected = selectPaymentRequirements(reqs, "solana");
-    // No matches for solana; function returns the first element in input order
-    expect(selected.network).toBe("avalanche");
+    expect(() => selectPaymentRequirements(reqs, "solana")).toThrow(
+      "No payment requirements match the requested network and scheme",
+    );
   });
 
   it("supports SVM networks by matching their USDC asset", () => {
@@ -166,4 +170,51 @@ describe("selectPaymentRequirements", () => {
     expect(selected.network).toBe("solana");
     expect(selected.asset).toBe(solanaUsdc);
   });
+
+  it.each([
+    ["Base first", [BASE_CAIP2, SOLANA_MAINNET_CAIP2]],
+    ["Solana first", [SOLANA_MAINNET_CAIP2, BASE_CAIP2]],
+  ])(
+    "selects an exact Solana CAIP-2 match with %s",
+    (_label, orderedNetworks) => {
+      const reqs = orderedNetworks.map(network =>
+        makeRequirement(
+          network as Network,
+          network === SOLANA_MAINNET_CAIP2
+            ? "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+            : "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        ),
+      );
+
+      const selected = selectPaymentRequirements(
+        reqs,
+        SOLANA_MAINNET_CAIP2 as Network,
+        "exact",
+      );
+
+      expect(selected.network).toBe(SOLANA_MAINNET_CAIP2);
+    },
+  );
+
+  it.each([
+    ["Base first", [BASE_CAIP2, SOLANA_MAINNET_CAIP2]],
+    ["Solana first", [SOLANA_MAINNET_CAIP2, BASE_CAIP2]],
+  ])(
+    "fails closed for legacy Solana aliases against CAIP-2 offers with %s",
+    (_label, orderedNetworks) => {
+      const reqs = orderedNetworks.map(network =>
+        makeRequirement(network as Network, "asset"),
+      );
+
+      expect(() =>
+        selectPaymentRequirements(
+          reqs,
+          ["solana", "solana-devnet"],
+          "exact",
+        ),
+      ).toThrow(
+        "No payment requirements match the requested network and scheme",
+      );
+    },
+  );
 });

--- a/typescript/packages/legacy/x402/src/client/selectPaymentRequirements.ts
+++ b/typescript/packages/legacy/x402/src/client/selectPaymentRequirements.ts
@@ -1,6 +1,6 @@
 import { Network, PaymentRequirements } from "../types";
 import { getUsdcChainConfigForChain } from "../shared/evm";
-import { getNetworkId } from "../shared/network";
+import { EvmNetworkToChainId, SvmNetworkToChainId } from "../types/shared";
 
 /**
  * Default selector for payment requirements.
@@ -11,6 +11,7 @@ import { getNetworkId } from "../shared/network";
  * @param network - The network to check against. If not provided, the network will not be checked.
  * @param scheme - The scheme to check against. If not provided, the scheme will not be checked.
  * @returns The payment requirement that is the most appropriate for the user.
+ * @throws Error if no requirement matches an explicitly requested network or scheme.
  */
 export function selectPaymentRequirements(paymentRequirements: PaymentRequirements[], network?: Network | Network[], scheme?: "exact"): PaymentRequirements {
   // Filter down to the scheme/network if provided
@@ -25,8 +26,14 @@ export function selectPaymentRequirements(paymentRequirements: PaymentRequiremen
 
   // Filter down to USDC requirements
   const usdcRequirements = broadlyAcceptedPaymentRequirements.filter(requirement => {
-    // If the address is a USDC address, we return it.
-    return requirement.asset === getUsdcChainConfigForChain(getNetworkId(requirement.network))?.usdcAddress;
+    const networkId =
+      EvmNetworkToChainId.get(requirement.network) ??
+      SvmNetworkToChainId.get(requirement.network);
+
+    return (
+      networkId !== undefined &&
+      requirement.asset === getUsdcChainConfigForChain(networkId)?.usdcAddress
+    );
   });
 
   // Prioritize USDC requirements if available
@@ -37,8 +44,7 @@ export function selectPaymentRequirements(paymentRequirements: PaymentRequiremen
   if (broadlyAcceptedPaymentRequirements.length > 0) {
     return broadlyAcceptedPaymentRequirements[0];
   }
-  // If no matching requirements are found, return the first requirement.
-  return paymentRequirements[0];
+  throw new Error("No payment requirements match the requested network and scheme");
 }
 
 /**
@@ -50,4 +56,3 @@ export function selectPaymentRequirements(paymentRequirements: PaymentRequiremen
  * @returns The payment requirement that is the most appropriate for the user.
  */
 export type PaymentRequirementsSelector = (paymentRequirements: PaymentRequirements[], network?: Network | Network[], scheme?: "exact") => PaymentRequirements;
-


### PR DESCRIPTION
## Description

The deprecated `x402-fetch@1.2.0` client delegates requirement selection to `x402@1.2.0`. With dual Base and Solana CAIP-2 offers, a legacy Solana network filter that matches neither offer silently falls back to the first requirement. This makes the selected rail depend on server offer order. An exact Solana CAIP-2 filter also throws while evaluating USDC preference.

This patch makes explicit no-match selection fail closed, avoids looking up unknown CAIP-2 identifiers through legacy network maps, and verifies that `x402-fetch` neither signs nor retries after selection fails.

Scope note: this prevents wrong-rail signing in the deprecated v1 packages. It does not add x402 v2 response compatibility to `x402-fetch@1.2.0`. Modern integrations should use `@x402/fetch` and `@x402/core`.

AI assistance was used to reproduce the defect, implement the focused patch, and prepare tests.

## Reproduction

With released `x402@1.2.0` and `x402-fetch@1.2.0`:

- Base first plus legacy Solana aliases selects Base by fallback.
- Solana first plus the same aliases selects Solana by fallback.
- Exact Solana CAIP-2 selection throws.
- An unrelated no-match filter selects the first requirement.

The new tests cover both offer orders, exact CAIP-2 matching, no-match failure, and the no-sign/no-retry boundary.

## Tests

- `pnpm test`: 55 of 55 workspace tasks passed
- Legacy `x402`: 274 tests passed
- Legacy `x402-fetch`: 7 tests passed
- `pnpm build`: passed
- `pnpm format:check`: 27 of 27 packages passed
- `pnpm lint:check`: 27 of 27 packages passed
- Changed-file gitleaks scan: no findings
- Dependency manifests and lockfiles: unchanged
- Workspace production audit baseline: 178 existing advisories, including 2 critical; this PR adds no dependency changes

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes