### PR TITLE
fix: add Cache-Control no-store to 402 responses across all SDKs

### DIFF
--- a/go/http/server.go
+++ b/go/http/server.go
@@ -958,6 +958,7 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 			Headers: map[string]string{
 				"Content-Type":     "text/html",
 				"PAYMENT-REQUIRED": encodedHeader,
+				"Cache-Control":   "no-store",
 			},
 			Body:   html,
 			IsHTML: true,
@@ -978,6 +979,7 @@ func (s *x402HTTPResourceServer) createHTTPResponseV2(paymentRequired types.Paym
 		Headers: map[string]string{
 			"Content-Type":     contentType,
 			"PAYMENT-REQUIRED": encodedHeader,
+			"Cache-Control":   "no-store",
 		},
 		Body: body,
 	}, nil

--- a/python/legacy/src/x402/flask/middleware.py
+++ b/python/legacy/src/x402/flask/middleware.py
@@ -221,7 +221,10 @@ class PaymentMiddleware:
                         ] or get_paywall_html(
                             error, payment_requirements, config["paywall_config"]
                         )
-                        headers = [("Content-Type", "text/html; charset=utf-8")]
+                        headers = [
+                            ("Content-Type", "text/html; charset=utf-8"),
+                            ("Cache-Control", "no-store"),
+                        ]
 
                         start_response(status, headers)
                         return [html_content.encode("utf-8")]
@@ -235,6 +238,7 @@ class PaymentMiddleware:
                         headers = [
                             ("Content-Type", "application/json"),
                             ("Content-Length", str(len(json.dumps(response_data)))),
+                            ("Cache-Control", "no-store"),
                         ]
 
                         start_response(status, headers)

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -824,7 +824,9 @@ class x402HTTPServerBase:
 
         # API response
         content_type = "application/json"
-        body: Any = {}
+        body = payment_required.model_dump(
+            by_alias=True, exclude_none=True, mode="json"
+        )
 
         if unpaid_response:
             content_type = unpaid_response.content_type

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1073,6 +1073,7 @@ export class x402HTTPResourceServer {
         status,
         headers: {
           "Content-Type": "text/html",
+          "Cache-Control": "no-store",
           ...response.headers,
         },
         body: html,
@@ -1088,6 +1089,7 @@ export class x402HTTPResourceServer {
       status,
       headers: {
         "Content-Type": contentType,
+        "Cache-Control": "no-store",
         ...response.headers,
       },
       body,


### PR DESCRIPTION
Fixes #2955

Adds Cache-Control: no-store to all 402 Payment Required responses in Go, Python (Flask), and TypeScript SDKs. Without this header, CDN/reverse proxy caches may store 402 responses containing PAYMENT-REQUIRED headers, causing incorrect behavior for paid clients and information exposure through shared caches.