### PR TITLE
docs: add CryptoAPIs Facilitator to the production facilitators table

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -22,6 +22,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | [Built on Stellar](https://developers.stellar.org/docs/build/apps/x402/built-on-stellar) | Free, public x402 facilitator for Stellar |
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
 | [Corbits](https://corbits.dev) | Production-grade multi-network, multi-token facilitator supporting EVM and Solana |
+| [CryptoAPIs Facilitator](https://cryptoapis.io/products/x402) | Non-custodial facilitator for USDC on Base and Solana, mainnet and testnet, with AML screening on every payment |
 | [Dexter](https://dexter.cash/facilitator) | Free public x402 facilitator across Solana and EVM chains with no fees and no account required |
 | [HPP Facilitator](https://docs.hpp.io/x402/facilitator) | Gasless, public x402 facilitator for HPP Mainnet and Sepolia |
 | [Meridian](https://mrdn.finance) | Multi-chain facilitator with developer-first features |


### PR DESCRIPTION
## Description

Adds the CryptoAPIs Facilitator to the production facilitators table in `docs/dev-tools/facilitators.md`, in alphabetical position between Corbits and Dexter.

**About the facilitator:** a non-custodial production facilitator for `exact`-scheme USDC payments on Base (mainnet + Sepolia) and Solana (mainnet + devnet), x402 v2, with the `payment-identifier` extension. Payers sign EIP-3009/Permit2 authorizations (EVM) or their own transfer (SVM) locally with their own keys — the facilitator holds no payer keys and exposes no signing endpoint. Its own wallets pay gas and submit settlement. Every `/verify` and `/settle` additionally runs AML screening on payer and merchant, fail-closed: a screening error rejects the payment rather than passing it through.

Docs: <https://developers.cryptoapis.io/v-2.2024-12-12-175/RESTapis/x402/x402-merchant-facilitator>

## Tests

Docs-only change (one table row); no code paths touched, so no test suite applies.

Capability advertisement is verifiable without a credential — `/supported` and `/discovery/resources` are intentionally anonymous so clients, crawlers and ecosystem directories can read them:

```bash
curl https://ai.cryptoapis.io/x402/merchant/supported
```

```json
{
  "kinds": [
    { "x402Version": 2, "scheme": "exact", "network": "eip155:8453" },
    { "x402Version": 2, "scheme": "exact", "network": "eip155:84532" },
    { "x402Version": 2, "scheme": "exact", "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" },
    { "x402Version": 2, "scheme": "exact", "network": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1" }
  ],
  "extensions": ["payment-identifier"],
  "signers": {
    "eip155:*": ["0xc970b0648bbCA7BAa264A56A0afD05A64Df44cd3"],
    "solana:*": ["9BDfKHXNvY3pTW8JBDo9UNEv3u2QQx4gF6NkoZfeCKHG"]
  }
}
```

The spec §8 Discovery API is also served, and currently returns an empty catalogue — merchant onboarding is in progress:

```bash
curl https://ai.cryptoapis.io/x402/merchant/discovery/resources
```

`/verify` and `/settle` require a CryptoAPIs API key, so they are not anonymously curl-able by design.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
