### PR TITLE
fix(ts/py): add cache control, no-store for 402, private for 200

### DIFF
--- a/python/x402/changelog.d/2990.bugfix.md
+++ b/python/x402/changelog.d/2990.bugfix.md
@@ -1,0 +1,1 @@
+Set Cache-Control on x402 HTTP payment responses: `no-store` on 402/412 PAYMENT-REQUIRED and settlement failures, and merge `private` on 200 PAYMENT-RESPONSE success so shared caches cannot store user-specific settlement metadata.

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -31,6 +31,7 @@ from ..types import (
     RoutesConfig,
 )
 from ..x402_http_server import PaywallProvider, x402HTTPResourceServer
+from ..x402_http_server_base import PAYMENT_REQUIRED_CACHE_CONTROL, with_private_cache_control
 
 if TYPE_CHECKING:
     from ...server import x402ResourceServer
@@ -367,6 +368,7 @@ def payment_middleware(
                 # Add settlement headers
                 headers = dict(response.headers)
                 headers.update(settle_result.headers)
+                headers["Cache-Control"] = with_private_cache_control(headers.get("Cache-Control"))
 
                 return Response(
                     content=body,
@@ -398,7 +400,11 @@ def payment_middleware(
                 return JSONResponse(
                     content={},
                     status_code=402,
-                    headers={"Content-Type": "application/json", **settle_headers},
+                    headers={
+                        "Content-Type": "application/json",
+                        "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
+                        **settle_headers,
+                    },
                 )
 
         # Fallthrough - should not happen

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -30,6 +30,7 @@ from ..types import (
     RoutesConfig,
 )
 from ..x402_http_server import PaywallProvider, x402HTTPResourceServerSync
+from ..x402_http_server_base import PAYMENT_REQUIRED_CACHE_CONTROL, with_private_cache_control
 
 if TYPE_CHECKING:
     from ...server import x402ResourceServerSync
@@ -447,6 +448,31 @@ class PaymentMiddleware:
                             # Add settlement headers
                             for key, value in settle_result.headers.items():
                                 response_wrapper.add_header(key, value)
+                            existing_cache_control = next(
+                                (
+                                    value
+                                    for key, value in response_wrapper.headers
+                                    if key.lower() == "cache-control"
+                                ),
+                                None,
+                            )
+                            private_cache_control = with_private_cache_control(
+                                existing_cache_control
+                            )
+                            cache_control_updated = False
+                            for index, (key, _) in enumerate(response_wrapper.headers):
+                                if key.lower() == "cache-control":
+                                    response_wrapper.headers[index] = (
+                                        key,
+                                        private_cache_control,
+                                    )
+                                    cache_control_updated = True
+                                    break
+                            if not cache_control_updated:
+                                response_wrapper.add_header(
+                                    "Cache-Control",
+                                    private_cache_control,
+                                )
                         else:
                             # Settlement failed - use response from process_settlement
                             # (includes PAYMENT-RESPONSE header and empty body by default)
@@ -495,7 +521,11 @@ class PaymentMiddleware:
                         )
                         start_response(
                             "402 Payment Required",
-                            [("Content-Type", "application/json"), *settle_headers.items()],
+                            [
+                                ("Content-Type", "application/json"),
+                                ("Cache-Control", PAYMENT_REQUIRED_CACHE_CONTROL),
+                                *settle_headers.items(),
+                            ],
                         )
                         return [json.dumps({}).encode("utf-8")]
 

--- a/python/x402/http/x402_http_server.py
+++ b/python/x402/http/x402_http_server.py
@@ -26,6 +26,7 @@ from .types import (
     RoutesConfig,
 )
 from .x402_http_server_base import (
+    PAYMENT_REQUIRED_CACHE_CONTROL,
     PaywallProvider,
     x402HTTPServerBase,
 )
@@ -309,6 +310,7 @@ class x402HTTPResourceServer(x402HTTPServerBase):
             headers={
                 "Content-Type": content_type,
                 **settlement_headers,
+                "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
             },
             body=body,
             is_html=content_type.startswith("text/html"),

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -61,6 +61,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("x402")
 
+PAYMENT_REQUIRED_CACHE_CONTROL = "no-store"
+
+
+def with_private_cache_control(value: str | None) -> str:
+    """Append the ``private`` directive to an existing Cache-Control header value."""
+    if not value:
+        return "private"
+
+    directives = [directive.strip().lower() for directive in value.split(",")]
+    if "private" in directives:
+        return value
+
+    return f"{value}, private"
+
 
 # ============================================================================
 # Paywall Provider Protocol
@@ -674,6 +688,7 @@ class x402HTTPServerBase:
                 headers={
                     "Content-Type": content_type,
                     **settle_result.headers,
+                    "Cache-Control": with_private_cache_control(None),
                 },
                 body=body,
                 is_html="text/html" in content_type,
@@ -817,6 +832,7 @@ class x402HTTPServerBase:
                 headers={
                     "Content-Type": "text/html",
                     PAYMENT_REQUIRED_HEADER: encode_payment_required_header(payment_required),
+                    "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
                 },
                 body=html_content,
                 is_html=True,
@@ -835,6 +851,7 @@ class x402HTTPServerBase:
             headers={
                 "Content-Type": content_type,
                 PAYMENT_REQUIRED_HEADER: encode_payment_required_header(payment_required),
+                "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
             },
             body=body,
         )
@@ -877,6 +894,7 @@ class x402HTTPServerBase:
             headers={
                 "Content-Type": content_type,
                 **settlement_headers,
+                "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
             },
             body=body,
             is_html=content_type.startswith("text/html"),

--- a/python/x402/tests/integrations/test_http_integration.py
+++ b/python/x402/tests/integrations/test_http_integration.py
@@ -226,6 +226,7 @@ class TestHTTPIntegration:
         assert result.response is not None
         assert result.response.status == 402
         assert "PAYMENT-REQUIRED" in result.response.headers
+        assert result.response.headers["Cache-Control"] == "no-store"
         assert result.response.is_html is False
         assert result.response.body == {}
 
@@ -278,6 +279,7 @@ class TestHTTPIntegration:
             )
         assert settlement.success is True
         assert "PAYMENT-RESPONSE" in settlement.headers
+        assert "Cache-Control" not in settlement.headers
 
     def test_no_payment_required_for_unprotected_route(
         self,
@@ -746,6 +748,7 @@ class TestSettlementFailureWithContext:
         assert response.status == 402
         assert response.body == {}
         assert "PAYMENT-RESPONSE" in response.headers
+        assert response.headers["Cache-Control"] == "no-store"
 
 
 class TestColonParamRouteMatching:

--- a/python/x402/tests/unit/core/test_settlement_overrides.py
+++ b/python/x402/tests/unit/core/test_settlement_overrides.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
-from x402.http.x402_http_server_base import x402HTTPServerBase
-from x402.schemas import PaymentRequirements
+from unittest.mock import MagicMock
+
+from x402.http.types import RouteConfig
+from x402.http.x402_http_server_base import (
+    PAYMENT_REQUIRED_CACHE_CONTROL,
+    with_private_cache_control,
+    x402HTTPServerBase,
+)
+from x402.schemas import PaymentRequired, PaymentRequirements, ResourceInfo
 
 
 def _requirements(amount: str = "2000") -> PaymentRequirements:
@@ -109,3 +116,32 @@ class TestHttpSettlementOverrides:
             {"amount": "7%"},
         )
         assert effective.amount == "700"
+
+
+class TestCacheControl:
+    def test_payment_required_cache_control_constant(self):
+        assert PAYMENT_REQUIRED_CACHE_CONTROL == "no-store"
+
+    def test_with_private_cache_control_without_existing_header(self):
+        assert with_private_cache_control(None) == "private"
+        assert with_private_cache_control("") == "private"
+
+    def test_with_private_cache_control_appends_private(self):
+        assert with_private_cache_control("max-age=60") == "max-age=60, private"
+
+    def test_with_private_cache_control_is_idempotent(self):
+        assert with_private_cache_control("max-age=60, private") == "max-age=60, private"
+
+    def test_create_http_response_sets_no_store(self):
+        http_server = x402HTTPServerBase(MagicMock(), {"*": RouteConfig(accepts=[])})
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[],
+            resource=ResourceInfo(url="https://example.com", description="", mime_type=""),
+        )
+        response = http_server._create_http_response(
+            payment_required,
+            is_web_browser=False,
+        )
+        assert response.headers["Cache-Control"] == "no-store"
+        assert "PAYMENT-REQUIRED" in response.headers

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -389,6 +389,66 @@ class TestFastAPIMiddlewareIntegration:
                 assert response.status_code == 200
                 assert response.json() == {"data": "Protected content"}
                 assert "PAYMENT-RESPONSE" in response.headers
+                assert response.headers["Cache-Control"] == "private"
+
+    def test_settlement_success_merges_private_into_existing_cache_control(self):
+        """Successful settlement appends private without clobbering handler directives."""
+        app = FastAPI()
+
+        @app.get("/api/protected")
+        def protected_route():
+            return JSONResponse(
+                content={"data": "Protected content"},
+                headers={"Cache-Control": "max-age=60"},
+            )
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.fastapi.x402HTTPResourceServer") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request = AsyncMock(
+                return_value=HTTPProcessResult(
+                    type="payment-verified",
+                    payment_payload=payment_payload,
+                    payment_requirements=payment_requirements,
+                )
+            )
+            mock_http_server_instance.process_settlement = AsyncMock(
+                return_value=ProcessSettleResult(
+                    success=True,
+                    headers={"PAYMENT-RESPONSE": "settlement_encoded"},
+                )
+            )
+            mock_http_server.return_value = mock_http_server_instance
+
+            @app.middleware("http")
+            async def x402_middleware(request: Request, call_next):
+                return await payment_middleware(
+                    routes, mock_server, sync_facilitator_on_start=False
+                )(request, call_next)
+
+            with TestClient(app) as client:
+                response = client.get(
+                    "/api/protected",
+                    headers={"PAYMENT-SIGNATURE": "valid_payment"},
+                )
+                assert response.status_code == 200
+                assert response.headers["Cache-Control"] == "max-age=60, private"
+                assert "PAYMENT-RESPONSE" in response.headers
 
     def test_settlement_failure_returns_402(self):
         """Test that settlement failure returns 402 with empty body and PAYMENT-RESPONSE header."""

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -635,6 +635,58 @@ class TestFlaskMiddlewareIntegration:
                 assert response.status_code == 200
                 assert b"Protected content" in response.data
                 assert "PAYMENT-RESPONSE" in response.headers
+                assert response.headers["Cache-Control"] == "private"
+
+    def test_verified_payment_merges_private_into_existing_cache_control(self):
+        """Successful settlement appends private without clobbering handler directives."""
+        app = Flask(__name__)
+
+        @app.route("/api/protected")
+        def protected_route():
+            response = app.response_class("Protected content")
+            response.headers["Cache-Control"] = "max-age=300"
+            return response
+
+        mock_server = MagicMock()
+        routes = {
+            "GET /api/protected": RouteConfig(
+                accepts=PaymentOption(
+                    scheme="exact",
+                    pay_to="0x1234567890123456789012345678901234567890",
+                    price="$0.01",
+                    network="eip155:8453",
+                ),
+            )
+        }
+
+        payment_payload = make_v2_payload()
+        payment_requirements = make_payment_requirements()
+
+        with patch("x402.http.middleware.flask.x402HTTPResourceServerSync") as mock_http_server:
+            mock_http_server_instance = MagicMock()
+            mock_http_server_instance.requires_payment.return_value = True
+            mock_http_server_instance.process_http_request.return_value = HTTPProcessResult(
+                type="payment-verified",
+                payment_payload=payment_payload,
+                payment_requirements=payment_requirements,
+            )
+            mock_http_server_instance.process_settlement.return_value = ProcessSettleResult(
+                success=True,
+                headers={"PAYMENT-RESPONSE": "settlement_encoded"},
+            )
+            mock_http_server.return_value = mock_http_server_instance
+
+            PaymentMiddleware(app, routes, mock_server, sync_facilitator_on_start=False)
+
+            with app.test_client() as client:
+                response = client.get(
+                    "/api/protected",
+                    headers={"PAYMENT-SIGNATURE": "valid_payment"},
+                )
+                assert response.status_code == 200
+                assert b"Protected content" in response.data
+                assert response.headers["Cache-Control"] == "max-age=300, private"
+                assert "PAYMENT-RESPONSE" in response.headers
 
     def test_verified_payment_settles_on_redirect(self):
         """Test that verified payment settles on 3xx redirect responses."""

--- a/typescript/.changeset/http-402-cache-control.md
+++ b/typescript/.changeset/http-402-cache-control.md
@@ -1,0 +1,9 @@
+---
+"@x402/core": patch
+"@x402/next": patch
+"@x402/express": patch
+"@x402/hono": patch
+"@x402/fastify": patch
+---
+
+Set Cache-Control on x402 HTTP payment responses: `no-store` on 402/412 PAYMENT-REQUIRED and settlement failures, and merge `private` on 200 PAYMENT-RESPONSE success so shared caches cannot store user-specific settlement metadata.

--- a/typescript/packages/core/src/http/index.ts
+++ b/typescript/packages/core/src/http/index.ts
@@ -77,7 +77,6 @@ export function decodePaymentResponseHeader(paymentResponseHeader: string): Sett
   return JSON.parse(safeBase64Decode(paymentResponseHeader)) as SettleResponse;
 }
 
-// Export HTTP service and types
 export {
   x402HTTPResourceServer,
   HTTPAdapter,
@@ -104,6 +103,9 @@ export {
   ProtectedRequestHook,
   HTTPResourceServerExtensionHooks,
   ResourceServerTransportExtensionHooks,
+  SETTLEMENT_OVERRIDES_HEADER,
+  PAYMENT_REQUIRED_CACHE_CONTROL,
+  withPrivateCacheControl,
 } from "./x402HTTPResourceServer";
 export {
   HTTPFacilitatorClient,

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -23,6 +23,28 @@ import { x402Version } from "..";
 
 export const SETTLEMENT_OVERRIDES_HEADER = "Settlement-Overrides";
 
+export const PAYMENT_REQUIRED_CACHE_CONTROL = "no-store";
+
+/**
+ * Appends the `private` directive to an existing Cache-Control header value.
+ * Shared caches must not store responses with user-specific settlement metadata.
+ *
+ * @param value - Existing Cache-Control header value, or null/empty if unset
+ * @returns Cache-Control value with `private` merged in
+ */
+export function withPrivateCacheControl(value: string | null): string {
+  if (!value) {
+    return "private";
+  }
+
+  const directives = value.split(",").map(directive => directive.trim().toLowerCase());
+  if (directives.includes("private")) {
+    return value;
+  }
+
+  return `${value}, private`;
+}
+
 /**
  * Framework-agnostic HTTP adapter interface
  * Implementations provide framework-specific HTTP operations
@@ -844,6 +866,7 @@ export class x402HTTPResourceServer {
         headers: {
           "Content-Type": contentType,
           ...settleResult.headers,
+          "Cache-Control": withPrivateCacheControl(null),
         },
         body,
         isHtml: contentType.includes("text/html"),
@@ -880,6 +903,7 @@ export class x402HTTPResourceServer {
       headers: {
         "Content-Type": contentType,
         ...settlementHeaders,
+        "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
       },
       body,
       isHtml: contentType.includes("text/html"),
@@ -1106,6 +1130,7 @@ export class x402HTTPResourceServer {
     return {
       headers: {
         "PAYMENT-REQUIRED": encodePaymentRequiredHeader(paymentRequired),
+        "Cache-Control": PAYMENT_REQUIRED_CACHE_CONTROL,
       },
     };
   }

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -55,6 +55,8 @@ export {
   x402HTTPResourceServer,
   RouteConfigurationError,
   SETTLEMENT_OVERRIDES_HEADER,
+  PAYMENT_REQUIRED_CACHE_CONTROL,
+  withPrivateCacheControl,
   checkIfBazaarNeeded,
 } from "../http/x402HTTPResourceServer";
 export type {

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -3,6 +3,8 @@ import {
   x402HTTPResourceServer,
   HTTPRequestContext,
   HTTPAdapter,
+  PAYMENT_REQUIRED_CACHE_CONTROL,
+  withPrivateCacheControl,
 } from "../../../src/http/x402HTTPResourceServer";
 import { x402ResourceServer } from "../../../src/server/x402ResourceServer";
 import {
@@ -772,6 +774,7 @@ describe("x402HTTPResourceServer", () => {
       if (result.type === "payment-error") {
         expect(result.response.status).toBe(402);
         expect(result.response.headers["PAYMENT-REQUIRED"]).toBeDefined();
+        expect(result.response.headers["Cache-Control"]).toBe("no-store");
       }
     });
 
@@ -872,6 +875,7 @@ describe("x402HTTPResourceServer", () => {
         // Should return 412 for permit2_allowance_required
         expect(result.response.status).toBe(412);
         expect(result.response.headers["PAYMENT-REQUIRED"]).toBeDefined();
+        expect(result.response.headers["Cache-Control"]).toBe("no-store");
       }
     });
 
@@ -996,6 +1000,7 @@ describe("x402HTTPResourceServer", () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.headers["PAYMENT-RESPONSE"]).toBeDefined();
+        expect(result.headers["Cache-Control"]).toBeUndefined();
       }
       expect(mockFacilitator.settleCalls.length).toBe(1);
     });
@@ -1035,6 +1040,7 @@ describe("x402HTTPResourceServer", () => {
         expect(result.errorReason).toBe("Insufficient funds");
         expect(result.headers).toBeDefined();
         expect(result.headers["PAYMENT-RESPONSE"]).toBeDefined();
+        expect(result.response.headers["Cache-Control"]).toBe("no-store");
       }
     });
 
@@ -1371,6 +1377,7 @@ describe("x402HTTPResourceServer", () => {
       if (result.type === "payment-error") {
         expect(result.response.status).toBe(200);
         expect(result.response.headers["PAYMENT-RESPONSE"]).toBeDefined();
+        expect(result.response.headers["Cache-Control"]).toBe("private");
         expect(result.response.body).toEqual({ message: "Refund acknowledged" });
       }
     });
@@ -1405,6 +1412,30 @@ describe("x402HTTPResourceServer", () => {
       if (result.type === "payment-error") {
         expect(result.response.isHtml).toBeFalsy();
       }
+    });
+  });
+
+  describe("withPrivateCacheControl", () => {
+    it("exports no-store for payment-required responses", () => {
+      expect(PAYMENT_REQUIRED_CACHE_CONTROL).toBe("no-store");
+    });
+
+    it("returns private when no existing header is set", () => {
+      expect(withPrivateCacheControl(null)).toBe("private");
+      expect(withPrivateCacheControl("")).toBe("private");
+    });
+
+    it("appends private to existing directives", () => {
+      expect(withPrivateCacheControl("max-age=60")).toBe("max-age=60, private");
+    });
+
+    it("is idempotent when private is already present", () => {
+      expect(withPrivateCacheControl("max-age=60, private")).toBe("max-age=60, private");
+      expect(withPrivateCacheControl("private")).toBe("private");
+    });
+
+    it("detects private case-insensitively", () => {
+      expect(withPrivateCacheControl("max-age=60, Private")).toBe("max-age=60, Private");
     });
   });
 });

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -58,49 +58,53 @@ function createMockPaymentCancellationDispatcher(): PaymentVerifiedResult["cance
   } as unknown as PaymentVerifiedResult["cancellationDispatcher"];
 }
 
-vi.mock("@x402/core/server", () => ({
-  SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
-  FacilitatorResponseError: class FacilitatorResponseError extends Error {
-    /**
-     * Creates a mock facilitator response error.
-     *
-     * @param message - Error message.
-     */
-    constructor(message: string) {
-      super(message);
-      this.name = "FacilitatorResponseError";
-    }
-  },
-  getFacilitatorResponseError: (error: unknown) => {
-    let current = error;
-    while (current instanceof Error) {
-      if (current.name === "FacilitatorResponseError") {
-        return current;
+vi.mock("@x402/core/server", async importOriginal => {
+  const actual = await importOriginal<typeof import("@x402/core/server")>();
+  return {
+    ...actual,
+    SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
+    FacilitatorResponseError: class FacilitatorResponseError extends Error {
+      /**
+       * Creates a mock facilitator response error.
+       *
+       * @param message - Error message.
+       */
+      constructor(message: string) {
+        super(message);
+        this.name = "FacilitatorResponseError";
       }
-      current = (current as Error & { cause?: unknown }).cause;
-    }
-    return null;
-  },
-  x402ResourceServer: vi.fn().mockImplementation(() => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    registerExtension: vi.fn(),
-    register: vi.fn(),
-    hasExtension: vi.fn().mockReturnValue(false),
-  })),
-  x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    processHTTPRequest: mockProcessHTTPRequest,
-    processSettlement: mockProcessSettlement,
-    registerPaywallProvider: mockRegisterPaywallProvider,
-    requiresPayment: mockRequiresPayment,
-    routes: routes,
-    server: server || {
-      hasExtension: vi.fn().mockReturnValue(false),
-      registerExtension: vi.fn(),
     },
-  })),
-  checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
-}));
+    getFacilitatorResponseError: (error: unknown) => {
+      let current = error;
+      while (current instanceof Error) {
+        if (current.name === "FacilitatorResponseError") {
+          return current;
+        }
+        current = (current as Error & { cause?: unknown }).cause;
+      }
+      return null;
+    },
+    x402ResourceServer: vi.fn().mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      registerExtension: vi.fn(),
+      register: vi.fn(),
+      hasExtension: vi.fn().mockReturnValue(false),
+    })),
+    x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      processHTTPRequest: mockProcessHTTPRequest,
+      processSettlement: mockProcessSettlement,
+      registerPaywallProvider: mockRegisterPaywallProvider,
+      requiresPayment: mockRequiresPayment,
+      routes: routes,
+      server: server || {
+        hasExtension: vi.fn().mockReturnValue(false),
+        registerExtension: vi.fn(),
+      },
+    })),
+    checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
+  };
+});
 
 // --- Mock Factories ---
 /**

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -11,6 +11,7 @@ import {
   SETTLEMENT_OVERRIDES_HEADER,
   SettlementOverrides,
   checkIfBazaarNeeded,
+  withPrivateCacheControl,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { NextFunction, Request, Response } from "express";
@@ -349,6 +350,14 @@ export function paymentMiddlewareFromHTTPServer(
           Object.entries(settleResult.headers).forEach(([key, value]) => {
             res.setHeader(key, value);
           });
+          res.setHeader(
+            "Cache-Control",
+            withPrivateCacheControl(
+              res.getHeader("Cache-Control") != null
+                ? String(res.getHeader("Cache-Control"))
+                : null,
+            ),
+          );
         } catch (error) {
           if (error instanceof FacilitatorResponseError) {
             bufferedCalls = [];

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -57,49 +57,53 @@ function createMockPaymentCancellationDispatcher(): PaymentVerifiedResult["cance
   } as unknown as PaymentVerifiedResult["cancellationDispatcher"];
 }
 
-vi.mock("@x402/core/server", () => ({
-  SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
-  FacilitatorResponseError: class FacilitatorResponseError extends Error {
-    /**
-     * Mock error class matching @x402/core/server FacilitatorResponseError.
-     *
-     * @param message - Error message passed to the superclass.
-     */
-    constructor(message: string) {
-      super(message);
-      this.name = "FacilitatorResponseError";
-    }
-  },
-  getFacilitatorResponseError: (error: unknown) => {
-    let current = error;
-    while (current instanceof Error) {
-      if (current.name === "FacilitatorResponseError") {
-        return current;
+vi.mock("@x402/core/server", async importOriginal => {
+  const actual = await importOriginal<typeof import("@x402/core/server")>();
+  return {
+    ...actual,
+    SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
+    FacilitatorResponseError: class FacilitatorResponseError extends Error {
+      /**
+       * Mock error class matching @x402/core/server FacilitatorResponseError.
+       *
+       * @param message - Error message passed to the superclass.
+       */
+      constructor(message: string) {
+        super(message);
+        this.name = "FacilitatorResponseError";
       }
-      current = (current as Error & { cause?: unknown }).cause;
-    }
-    return null;
-  },
-  x402ResourceServer: vi.fn().mockImplementation(() => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    registerExtension: vi.fn(),
-    register: vi.fn(),
-    hasExtension: vi.fn().mockReturnValue(false),
-  })),
-  x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    processHTTPRequest: mockProcessHTTPRequest,
-    processSettlement: mockProcessSettlement,
-    registerPaywallProvider: mockRegisterPaywallProvider,
-    requiresPayment: mockRequiresPayment,
-    routes: routes,
-    server: server || {
-      hasExtension: vi.fn().mockReturnValue(false),
-      registerExtension: vi.fn(),
     },
-  })),
-  checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
-}));
+    getFacilitatorResponseError: (error: unknown) => {
+      let current = error;
+      while (current instanceof Error) {
+        if (current.name === "FacilitatorResponseError") {
+          return current;
+        }
+        current = (current as Error & { cause?: unknown }).cause;
+      }
+      return null;
+    },
+    x402ResourceServer: vi.fn().mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      registerExtension: vi.fn(),
+      register: vi.fn(),
+      hasExtension: vi.fn().mockReturnValue(false),
+    })),
+    x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      processHTTPRequest: mockProcessHTTPRequest,
+      processSettlement: mockProcessSettlement,
+      registerPaywallProvider: mockRegisterPaywallProvider,
+      requiresPayment: mockRequiresPayment,
+      routes: routes,
+      server: server || {
+        hasExtension: vi.fn().mockReturnValue(false),
+        registerExtension: vi.fn(),
+      },
+    })),
+    checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
+  };
+});
 
 // --- Hook Capture ---
 type HookHandler = (...args: unknown[]) => Promise<unknown>;

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -13,6 +13,7 @@ import {
   SettlementOverrides,
   checkIfBazaarNeeded,
   PaymentCancellationDispatcher,
+  withPrivateCacheControl,
 } from "@x402/core/server";
 import {
   SchemeNetworkServer,
@@ -469,6 +470,14 @@ export function paymentMiddlewareFromHTTPServer(
       for (const [key, value] of Object.entries(settleResult.headers)) {
         reply.header(key, value);
       }
+      reply.header(
+        "Cache-Control",
+        withPrivateCacheControl(
+          reply.getHeader("Cache-Control") != null
+            ? String(reply.getHeader("Cache-Control"))
+            : null,
+        ),
+      );
       reply.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
       return effectivePayload;
     } catch (error) {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -58,49 +58,53 @@ function createMockPaymentCancellationDispatcher(): PaymentVerifiedResult["cance
   } as unknown as PaymentVerifiedResult["cancellationDispatcher"];
 }
 
-vi.mock("@x402/core/server", () => ({
-  SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
-  FacilitatorResponseError: class FacilitatorResponseError extends Error {
-    /**
-     * Creates a mock facilitator response error.
-     *
-     * @param message - Error message.
-     */
-    constructor(message: string) {
-      super(message);
-      this.name = "FacilitatorResponseError";
-    }
-  },
-  getFacilitatorResponseError: (error: unknown) => {
-    let current = error;
-    while (current instanceof Error) {
-      if (current.name === "FacilitatorResponseError") {
-        return current;
+vi.mock("@x402/core/server", async importOriginal => {
+  const actual = await importOriginal<typeof import("@x402/core/server")>();
+  return {
+    ...actual,
+    SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
+    FacilitatorResponseError: class FacilitatorResponseError extends Error {
+      /**
+       * Creates a mock facilitator response error.
+       *
+       * @param message - Error message.
+       */
+      constructor(message: string) {
+        super(message);
+        this.name = "FacilitatorResponseError";
       }
-      current = (current as Error & { cause?: unknown }).cause;
-    }
-    return null;
-  },
-  x402ResourceServer: vi.fn().mockImplementation(() => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    registerExtension: vi.fn(),
-    register: vi.fn(),
-    hasExtension: vi.fn().mockReturnValue(false),
-  })),
-  x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    processHTTPRequest: mockProcessHTTPRequest,
-    processSettlement: mockProcessSettlement,
-    registerPaywallProvider: mockRegisterPaywallProvider,
-    requiresPayment: mockRequiresPayment,
-    routes: routes,
-    server: server || {
-      hasExtension: vi.fn().mockReturnValue(false),
-      registerExtension: vi.fn(),
     },
-  })),
-  checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
-}));
+    getFacilitatorResponseError: (error: unknown) => {
+      let current = error;
+      while (current instanceof Error) {
+        if (current.name === "FacilitatorResponseError") {
+          return current;
+        }
+        current = (current as Error & { cause?: unknown }).cause;
+      }
+      return null;
+    },
+    x402ResourceServer: vi.fn().mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      registerExtension: vi.fn(),
+      register: vi.fn(),
+      hasExtension: vi.fn().mockReturnValue(false),
+    })),
+    x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      processHTTPRequest: mockProcessHTTPRequest,
+      processSettlement: mockProcessSettlement,
+      registerPaywallProvider: mockRegisterPaywallProvider,
+      requiresPayment: mockRequiresPayment,
+      routes: routes,
+      server: server || {
+        hasExtension: vi.fn().mockReturnValue(false),
+        registerExtension: vi.fn(),
+      },
+    })),
+    checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
+  };
+});
 
 // --- Mock Factories ---
 /**

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -11,6 +11,7 @@ import {
   SETTLEMENT_OVERRIDES_HEADER,
   SettlementOverrides,
   checkIfBazaarNeeded,
+  withPrivateCacheControl,
 } from "@x402/core/server";
 import { SchemeNetworkServer, Network } from "@x402/core/types";
 import { Context, MiddlewareHandler } from "hono";
@@ -264,6 +265,10 @@ export function paymentMiddlewareFromHTTPServer(
             Object.entries(settleResult.headers).forEach(([key, value]) => {
               res.headers.set(key, value);
             });
+            res.headers.set(
+              "Cache-Control",
+              withPrivateCacheControl(res.headers.get("Cache-Control")),
+            );
             res.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
           }
         } catch (error) {

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -24,49 +24,53 @@ const mockFunctions = {
 };
 
 // Mock @x402/core/server
-vi.mock("@x402/core/server", () => ({
-  FacilitatorResponseError: class FacilitatorResponseError extends Error {
-    /**
-     * Creates a mock facilitator response error.
-     *
-     * @param message - Error message.
-     */
-    constructor(message: string) {
-      super(message);
-      this.name = "FacilitatorResponseError";
-    }
-  },
-  getFacilitatorResponseError: (error: unknown) => {
-    let current = error;
-    while (current instanceof Error) {
-      if (current.name === "FacilitatorResponseError") {
-        return current;
+vi.mock("@x402/core/server", async importOriginal => {
+  const actual = await importOriginal<typeof import("@x402/core/server")>();
+  return {
+    ...actual,
+    FacilitatorResponseError: class FacilitatorResponseError extends Error {
+      /**
+       * Creates a mock facilitator response error.
+       *
+       * @param message - Error message.
+       */
+      constructor(message: string) {
+        super(message);
+        this.name = "FacilitatorResponseError";
       }
-      current = (current as Error & { cause?: unknown }).cause;
-    }
-    return null;
-  },
-  SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
-  x402ResourceServer: vi.fn().mockImplementation(() => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    registerExtension: vi.fn(),
-    register: vi.fn(),
-    hasExtension: vi.fn().mockReturnValue(false),
-  })),
-  x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
-    initialize: vi.fn().mockResolvedValue(undefined),
-    registerPaywallProvider: vi.fn(),
-    processHTTPRequest: (...args: unknown[]) => mockFunctions.processHTTPRequest(...args),
-    processSettlement: (...args: unknown[]) => mockFunctions.processSettlement(...args),
-    requiresPayment: (...args: unknown[]) => mockFunctions.requiresPayment(...args),
-    routes: routes || {},
-    server: server || {
-      hasExtension: vi.fn().mockReturnValue(false),
-      registerExtension: vi.fn(),
     },
-  })),
-  checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
-}));
+    getFacilitatorResponseError: (error: unknown) => {
+      let current = error;
+      while (current instanceof Error) {
+        if (current.name === "FacilitatorResponseError") {
+          return current;
+        }
+        current = (current as Error & { cause?: unknown }).cause;
+      }
+      return null;
+    },
+    SETTLEMENT_OVERRIDES_HEADER: "Settlement-Overrides",
+    x402ResourceServer: vi.fn().mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      registerExtension: vi.fn(),
+      register: vi.fn(),
+      hasExtension: vi.fn().mockReturnValue(false),
+    })),
+    x402HTTPResourceServer: vi.fn().mockImplementation((server, routes) => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      registerPaywallProvider: vi.fn(),
+      processHTTPRequest: (...args: unknown[]) => mockFunctions.processHTTPRequest(...args),
+      processSettlement: (...args: unknown[]) => mockFunctions.processSettlement(...args),
+      requiresPayment: (...args: unknown[]) => mockFunctions.requiresPayment(...args),
+      routes: routes || {},
+      server: server || {
+        hasExtension: vi.fn().mockReturnValue(false),
+        registerExtension: vi.fn(),
+      },
+    })),
+    checkIfBazaarNeeded: vi.fn().mockReturnValue(false),
+  };
+});
 
 // --- Test Fixtures ---
 const mockRoutes = {

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -17,7 +17,8 @@ import {
 let mockInitialize: ReturnType<typeof vi.fn>;
 
 // Mock @x402/core/server
-vi.mock("@x402/core/server", () => {
+vi.mock("@x402/core/server", async importOriginal => {
+  const actual = await importOriginal<typeof import("@x402/core/server")>();
   const MockHTTPResourceServer = vi.fn().mockImplementation(() => ({
     initialize: mockInitialize,
     registerPaywallProvider: vi.fn(),
@@ -25,6 +26,7 @@ vi.mock("@x402/core/server", () => {
     requiresPayment: vi.fn().mockReturnValue(true),
   }));
   return {
+    ...actual,
     FacilitatorResponseError: class FacilitatorResponseError extends Error {
       /**
        * Creates a mock facilitator response error.
@@ -360,6 +362,7 @@ describe("handleSettlement", () => {
 
     expect(result.status).toBe(200);
     expect(result.headers.get("PAYMENT-RESPONSE")).toBe("settled");
+    expect(result.headers.get("Cache-Control")).toBe("private");
     expect(mockHttpServer.processSettlement).toHaveBeenCalledWith(
       mockPaymentPayload,
       mockRequirements,
@@ -370,6 +373,25 @@ describe("handleSettlement", () => {
         responseHeaders: expect.any(Object),
       }),
     );
+  });
+
+  it("merges private into existing Cache-Control on successful settlement", async () => {
+    const response = new NextResponse("OK", {
+      status: 200,
+      headers: { "Cache-Control": "max-age=60" },
+    });
+
+    const result = await handleSettlement(
+      mockHttpServer,
+      response,
+      mockPaymentPayload,
+      mockRequirements,
+      mockDeclaredExtensions,
+      mockPaymentCancellationDispatcher,
+      mockHttpContext,
+    );
+
+    expect(result.headers.get("Cache-Control")).toBe("max-age=60, private");
   });
 
   it("forwards response headers to processSettlement for settlement overrides", async () => {

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -10,6 +10,7 @@ import {
   getFacilitatorResponseError as getCoreFacilitatorResponseError,
   PaymentCancellationDispatcher,
   SETTLEMENT_OVERRIDES_HEADER,
+  withPrivateCacheControl,
 } from "@x402/core/server";
 import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
 import { NextAdapter } from "./adapter";
@@ -212,6 +213,10 @@ export async function handleSettlement(
     Object.entries(result.headers).forEach(([key, value]) => {
       response.headers.set(key, value);
     });
+    response.headers.set(
+      "Cache-Control",
+      withPrivateCacheControl(response.headers.get("Cache-Control")),
+    );
 
     // Strip internal settlement override header before sending to client.
     response.headers.delete(SETTLEMENT_OVERRIDES_HEADER);


### PR DESCRIPTION
## Description

x402 HTTP responses carry payment protocol data in PAYMENT-REQUIRED (402/412) and PAYMENT-RESPONSE (200 success, 402 settlement failure) headers. Without explicit cache directives, shared caches (CDN, reverse proxy) can store and replay those responses, exposing stale payment requirements or user-specific settlement metadata to the wrong client.

This patch sets Cache-Control: no-store on responses where the entire payload is ephemeral payment state: unpaid 402/412 with PAYMENT-REQUIRED, and 402 settlement failures with PAYMENT-RESPONSE. On successful 200 responses with PAYMENT-RESPONSE, the SDK merges private into any existing handler Cache-Control (e.g. max-age=60 → max-age=60, private) so shared caches are blocked while private/browser caching policy is preserved. Handlers that need zero caching on success can still set no-store themselves 

Follow up of go patch in https://github.com/x402-foundation/x402/pull/2956, for ts/py sdks

Closes https://github.com/x402-foundation/x402/issues/2955


## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 