### PR TITLE
docs: add ArisPay Facilitator to the facilitators table

### DIFF
--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -19,6 +19,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 
 | Name | Description |
 | ---- | ----------- | 
+| [ArisPay Facilitator](https://facilitator.arispay.app) | Free, public x402 facilitator for Base with USDC and EURC settlement; no API key required |
 | [Built on Stellar](https://developers.stellar.org/docs/build/apps/x402/built-on-stellar) | Free, public x402 facilitator for Stellar |
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
 | [Corbits](https://corbits.dev) | Production-grade multi-network, multi-token facilitator supporting EVM and Solana |


### PR DESCRIPTION
## Description

Adds ArisPay Facilitator to the production facilitators table in `docs/dev-tools/facilitators.md` (one row, alphabetically placed).

- **URL:** https://facilitator.arispay.app — live on Base mainnet since April 2026
- **Access:** open `/verify` and `/settle`, no API key or signup required, no facilitator fee
- **Settlement:** EIP-3009 `transferWithAuthorization` with replay protection; USDC **and EURC** on Base (on-chain euro-stablecoin settlement)
- **Discovery:** `GET /supported` (standard kinds response + per-kind asset/fee metadata) and `GET /facilitator` (networks, validated assets, relayer signers)

This is a resubmission of #2934 / #2980, which were closed for unsigned commits — this branch carries a single signed (Verified) commit, per the signing requirement. Apologies for the churn on the earlier submissions.

## Tests

Docs-only change — one row added to an existing markdown table, matching the surrounding format; no code touched. Verified the rendered table and that the row's links resolve (`https://facilitator.arispay.app`, `/supported`, `/facilitator`).

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)