### PR TITLE
docs(bazaar): document description size limits and explicit rejection reasons (fixes #2993)

### DIFF
--- a/docs/extensions/bazaar.mdx
+++ b/docs/extensions/bazaar.mdx
@@ -903,8 +903,8 @@ Common protocol-level mistakes include:
    - a relative `resource.url` — use an absolute URL
    - malformed `accepts` entries (e.g. `asset` as an object instead of a string,
      or a missing atomic-units `amount`)
-   - service metadata violating the validation rules above — invalid fields are
-     soft-dropped individually
+   - `description` or field lengths exceeding facilitator size limits (keep descriptions under 1,000 characters to ensure indexing across facilitators)
+   - service metadata violating validation rules — check `rejectedReason` in the `EXTENSION-RESPONSES` header for exact rejection causes
 
 3. **Treating the absence of `EXTENSION-RESPONSES` as failure.** Facilitators
    **may** return this header; its absence carries no signal. When present,

--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -321,6 +321,12 @@ The `schema` field contains a JSON Schema (Draft 2020-12) that validates the str
 
 Facilitators **must** validate `info` against `schema` before cataloging.
 
+### Field Size Limits & Rejection Reasons
+
+To ensure indexing reliability across facilitators and prevent catalog bloat:
+- **`description` Field Length:** Resource and tool descriptions SHOULD NOT exceed 1,000 characters. Facilitators MAY reject declarations exceeding this limit.
+- **Explicit Rejection Signals:** When cataloging is rejected due to size limit or schema validation failure, facilitators MUST set `bazaar.status` to `"rejected"` in the `EXTENSION-RESPONSES` header and provide a descriptive `bazaar.rejectedReason` (e.g., `"description exceeds maximum allowed length of 1000 characters"` or `"info failed schema validation"`).
+
 ### MCP Schema Example
 
 ```json


### PR DESCRIPTION
Fixes #2993.

## Summary

This PR addresses issue #2993 by explicitly documenting field size limits and rejection response requirements for the Bazaar discovery extension:

1. **Specification Update ()**:
   - Documents the recommended 1,000-character upper bound for resource and tool  metadata to prevent indexing failures and catalog bloat across facilitators.
   - Specifies that when cataloging fails due to size limits or schema validation, facilitators must return  with a descriptive  (e.g. ).

2. **Documentation & Troubleshooting Update ()**:
   - Adds description length limits to the common protocol-level mistakes list in the *Troubleshooting catalog visibility* section.
   - Clarifies checking  in the  header to diagnose quiet cataloging failures.

---
*Submitted autonomously by Echolonius (Antigravity CLI).*
