### PR TITLE
Add Mazza Group AI APIs to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ go get github.com/x402-foundation/x402/go/v2
 
 Curated third-party SDKs, extensions, and facilitators are listed in the [Developer Tools docs](https://docs.x402.org/dev-tools/overview). For broader discovery of x402 services and integrations, see community-maintained directories such as [x402scan.com](https://x402scan.com), [Agentic.Market](https://agentic.market), [Pay.sh](https://pay.sh), [app.ampersend.ai/discover](https://app.ampersend.ai/discover), and [x402-list.com](https://x402-list.com).
 
+**Featured services built on x402:**
+
+- **[Mazza Group AI APIs](https://mazzagrp.com)** — 21 AI API endpoints (RAG, SQL generation, negotiation training, web agent, simulation, etc.) that accept USDC on Base via x402. Includes MCP server wrapper, Python SDK, and llms.txt for agent discovery. Prices range from $0.20 to $5.00 per call.
+
 **Roadmap:** see [ROADMAP.md](https://github.com/x402-foundation/x402/blob/main/ROADMAP.md)
 
 **Documentation:** see [`docs/`](./docs/) for the published documentation source (Mintlify). Payment **schemes** include **`exact`**, **`upto`**, and **`batch-settlement`**; specifications live under [`specs/schemes/`](./specs/schemes/).


### PR DESCRIPTION
## What

Added Mazza Group (mazzagrp.com) to the Ecosystem section of the README. Mazza Group offers 21 AI API endpoints that accept USDC on Base via the x402 protocol — including RAG, SQL generation, negotiation training, web agent, simulation, and more. Prices range from $0.20 to $5.00 per call.

## Why

The Ecosystem section currently only lists community directories (x402scan, agentic.market, etc.) but doesn't feature any actual services built on x402. Adding real-world examples helps showcase the protocol's capabilities and helps agents discover payable services.

## Details

- 21 API endpoints at mazzagrp.com/api/* 
- All return HTTP 402 with x402 v2 payment requirements
- Bazaar extension enabled for agentic.market discovery
- Python SDK: github.com/itsmeadamdamroma/mazzagrp-python
- llms.txt and agents.md published for agent discovery
- Facilitator: x402.org/facilitator (testnet)

Live endpoint example:
```bash
curl -X POST https://mazzagrp.com/api/recall -H 'Content-Type: application/json' -d '{"prompt":"test"}'
# Returns 402 with accepts[] payment requirements
```