### PR TITLE
fix(stellar): let a contract account sign its own auth entries

### DIFF
--- a/typescript/.changeset/stellar-contract-account-signing.md
+++ b/typescript/.changeset/stellar-contract-account-signing.md
@@ -1,0 +1,5 @@
+---
+"@x402/stellar": patch
+---
+
+`ClientStellarSigner` accepts an optional `authorizeEntry`, forwarded to `signAuthEntries`. Contract (C) accounts can now sign their own auth entries; the SDK's default resolves signers through `Keypair.fromPublicKey`, which rejects a contract address. Keypair signers are unaffected.

--- a/typescript/packages/mechanisms/stellar/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/client/scheme.ts
@@ -89,6 +89,8 @@ export class ExactStellarScheme implements SchemeNetworkClient {
       address: sourcePublicKey,
       signAuthEntry: this.signer.signAuthEntry,
       expiration: maxLedger,
+      // Only when supplied, so keypair signers keep the SDK default.
+      ...(this.signer.authorizeEntry ? { authorizeEntry: this.signer.authorizeEntry } : {}),
     });
 
     await tx.simulate();

--- a/typescript/packages/mechanisms/stellar/src/signer.ts
+++ b/typescript/packages/mechanisms/stellar/src/signer.ts
@@ -2,7 +2,11 @@ import { Keypair } from "@stellar/stellar-sdk";
 import { basicNodeSigner, SignAuthEntry, SignTransaction } from "@stellar/stellar-sdk/contract";
 import { STELLAR_TESTNET_CAIP2 } from "./constants";
 import { getNetworkPassphrase } from "./utils";
+import type { authorizeEntry as AuthorizeEntryFn } from "@stellar/stellar-sdk";
 import type { Network } from "@x402/core/types";
+
+/** The SDK's `authorizeEntry`, which `signAuthEntries` accepts as an override. */
+type AuthorizeEntry = typeof AuthorizeEntryFn;
 
 /**
  * Ed25519 signer for Stellar transactions and auth entries.
@@ -38,6 +42,8 @@ export type ClientStellarSigner = {
   address: string;
   signAuthEntry: SignAuthEntry;
   signTransaction?: SignTransaction;
+  /** Override for contract (C) accounts, which the SDK's default `authorizeEntry` cannot sign for. */
+  authorizeEntry?: AuthorizeEntry;
 };
 
 /**

--- a/typescript/packages/mechanisms/stellar/test/unit/client.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/client.test.ts
@@ -259,4 +259,37 @@ describe("ExactStellarScheme", () => {
       },
     );
   });
+
+  describe("contract account signing", () => {
+    // A C-account must supply its own `authorizeEntry`; the SDK default cannot sign for it.
+    const contractAddress = "CA6DO6TXG4IAIYQ7OWS2OBSO7J66SGG6KEBKAO22H3LJ6QHLWOSCSKCQ";
+
+    it("forwards a signer's authorizeEntry to signAuthEntries", async () => {
+      const customAuthorizeEntry = vi.fn();
+      const contractSigner: ClientStellarSigner = {
+        address: contractAddress,
+        signAuthEntry: vi.fn().mockResolvedValue({ signedAuthEntry: "signed" }),
+        authorizeEntry: customAuthorizeEntry as never,
+      };
+      mockTransaction.needsNonInvokerSigningBy.mockReturnValueOnce([contractAddress]);
+      mockTransaction.needsNonInvokerSigningBy.mockReturnValueOnce([]);
+
+      await new ExactStellarScheme(contractSigner).createPaymentPayload(2, validPaymentReq);
+
+      expect(mockTransaction.signAuthEntries).toHaveBeenCalledWith(
+        expect.objectContaining({ authorizeEntry: customAuthorizeEntry }),
+      );
+    });
+
+    it("omits authorizeEntry entirely when the signer does not supply one", async () => {
+      setupSuccessfulTransaction();
+
+      await new ExactStellarScheme(mockSigner).createPaymentPayload(2, validPaymentReq);
+
+      // Absent, not undefined, so the SDK applies its own default.
+      expect(mockTransaction.signAuthEntries).toHaveBeenCalledWith(
+        expect.not.objectContaining({ authorizeEntry: expect.anything() }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Description

A contract account (`C…`) cannot produce a payment with `exact` on Stellar. `createPaymentPayload` throws `invalid version byte. expected 48, got 16` (48 is the strkey byte for `G`, 16 for `C`). The same call from a classic account succeeds.

`signAuthEntries` delegates to the SDK's default `authorizeEntry`, which resolves every signer through `Keypair.fromPublicKey(publicKey)`. That rejects a contract address, so it throws before a payload is built. `signAuthEntries` already accepts an `authorizeEntry` override, but the Stellar client never passed one, so the keypair path was taken regardless of account type.

This PR adds an optional `authorizeEntry` to `ClientStellarSigner` and forwards it only when supplied. Keypair signers are unaffected. No wire format, payload, or facilitator changes.

`ClientStellarSigner` already documents support for both `G` and `C` accounts. This makes that true.

Contract accounts cannot sign transaction envelopes at all, so auth entries are their only route to paying.

## Tests

Two unit tests added to `test/unit/client.test.ts`: one asserts the override is forwarded, one asserts the key is absent when no override is supplied so the SDK default still applies. Reverting the source change fails the first; the other 158 pass.

Verified end to end on testnet. A `__check_auth` account with an ed25519 session key and an on-chain spending policy paid through the client and settled:

- Transaction: [`f1330843315ee93e…`](https://stellar.expert/explorer/testnet/tx/f1330843315ee93e8eb760511d046d573e8f3c6fad0aed3102c4c03f40f3c4c6) (ledger 3915905) · [raw on Horizon](https://horizon-testnet.stellar.org/transactions/f1330843315ee93e8eb760511d046d573e8f3c6fad0aed3102c4c03f40f3c4c6)

- Payer: [`CD752A22JHVS7ZWD…`](https://stellar.expert/explorer/testnet/contract/CD752A22JHVS7ZWDRBFPLNMNTLVCWZAO4EZUZN7FHYA76V362MON7MHZ), a contract account. It is the transfer's `from`.

Without the change, the same code against the same account never reaches the override.

`pnpm test` from `/typescript`: 159 passing. Lint and format clean.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)