### PR TITLE
fix(go): propagate payment response hook errors

### DIFF
--- a/go/.changes/unreleased/fixed-20260731-220657.yaml
+++ b/go/.changes/unreleased/fixed-20260731-220657.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Propagate payment response hook errors after corrective retries and close response bodies on hook failure.
+time: 2026-07-31T22:06:57.340821-04:00

--- a/go/http/client.go
+++ b/go/http/client.go
@@ -275,6 +275,7 @@ func (t *PaymentRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	// retry once more with a freshly built payload (mirrors @x402/fetch recovery).
 	recovered, err := t.dispatchPaymentResponseHooks(ctx, build, newResp)
 	if err != nil {
+		newResp.Body.Close()
 		return nil, err
 	}
 	if !recovered || newResp.StatusCode != http.StatusPaymentRequired {
@@ -311,7 +312,8 @@ func (t *PaymentRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	correctiveBuild.paymentPayload = freshPayload
 	correctiveBuild.payloadBytes = freshBytes
 	if _, err := t.dispatchPaymentResponseHooks(ctx, &correctiveBuild, correctiveResp); err != nil {
-		return correctiveResp, nil
+		correctiveResp.Body.Close()
+		return nil, err
 	}
 	return correctiveResp, nil
 }

--- a/go/http/client_test.go
+++ b/go/http/client_test.go
@@ -975,6 +975,7 @@ type hookSchemeClient struct {
 	settleCalls      int
 	correctiveCalls  int
 	signalRecover    bool
+	settleErr        error
 	createPayloadCnt int
 }
 
@@ -991,6 +992,9 @@ func (m *hookSchemeClient) CreatePaymentPayload(ctx context.Context, requirement
 func (m *hookSchemeClient) OnPaymentResponse(ctx context.Context, prCtx x402.PaymentResponseContext) (x402.PaymentResponseResult, error) {
 	if prCtx.SettleResponse != nil {
 		m.settleCalls++
+		if m.settleErr != nil {
+			return x402.PaymentResponseResult{}, m.settleErr
+		}
 		return x402.PaymentResponseResult{}, nil
 	}
 	if prCtx.PaymentRequired != nil {
@@ -1067,6 +1071,85 @@ func TestPaymentRoundTripper_DispatchesOnPaymentResponseOnSuccess(t *testing.T) 
 	}
 	if scheme.correctiveCalls != 0 {
 		t.Fatalf("did not expect corrective dispatch, got %d", scheme.correctiveCalls)
+	}
+}
+
+func TestPaymentRoundTripper_PropagatesPaymentResponseHookErrors(t *testing.T) {
+	accepts := []types.PaymentRequirements{{
+		Scheme:  "test-scheme",
+		Network: "eip155:1",
+		Asset:   "USDC",
+		Amount:  "100",
+		PayTo:   "0xrecipient",
+	}}
+
+	for _, tt := range []struct {
+		name       string
+		corrective bool
+	}{
+		{name: "first paid response"},
+		{name: "corrective response", corrective: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			hookErr := errors.New("payment response hook failed")
+			scheme := &hookSchemeClient{
+				scheme:        "test-scheme",
+				signalRecover: tt.corrective,
+				settleErr:     hookErr,
+			}
+			x402Client := x402.Newx402Client()
+			x402Client.Register("eip155:1", scheme)
+
+			responseBody := &oneShotBody{reader: strings.NewReader("response")}
+			attempt := 0
+			transport := roundTripFunc(func(*http.Request) (*http.Response, error) {
+				attempt++
+				if attempt == 1 || tt.corrective && attempt == 2 {
+					return stringResponse(http.StatusPaymentRequired, map[string]string{
+						"PAYMENT-REQUIRED": paymentRequiredHeader(t, accepts),
+					}, "")
+				}
+
+				resp := &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       responseBody,
+				}
+				resp.Header.Set("PAYMENT-RESPONSE", paymentResponseHeader(t, x402.SettleResponse{
+					Success:     true,
+					Transaction: "0xtx",
+					Network:     "eip155:1",
+				}))
+				return resp, nil
+			})
+			rt := &PaymentRoundTripper{
+				Transport:  transport,
+				x402Client: Newx402HTTPClient(x402Client),
+				retryCount: &sync.Map{},
+			}
+			req, err := http.NewRequest(http.MethodGet, "https://api.example.com/resource", nil)
+			if err != nil {
+				t.Fatalf("NewRequest() error = %v", err)
+			}
+
+			resp, err := rt.RoundTrip(req)
+			if !errors.Is(err, hookErr) {
+				if resp != nil && resp.Body != nil {
+					resp.Body.Close()
+				}
+				t.Fatalf("RoundTrip() error = %v, want %v", err, hookErr)
+			}
+			if resp != nil {
+				resp.Body.Close()
+				t.Fatalf("RoundTrip() response = %v, want nil", resp)
+			}
+			if !responseBody.closed {
+				t.Fatal("response body was not closed")
+			}
+			if responseBody.closeCalls != 1 {
+				t.Fatalf("response body close calls = %d, want 1", responseBody.closeCalls)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

Closes #2913.

Propagates payment-response hook errors from both the initial paid response and the corrective retry. On either failure, the response body is closed and `RoundTrip` returns `(nil, err)` instead of exposing a response whose reconciliation failed.

The existing recovery API and one-retry behavior remain unchanged.

## Tests

- Added regression coverage for hook failures on the first paid response and corrective response.
- Verified the affected response body is closed exactly once and the original hook error is returned.
- `cd go && make verify`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes
