### PR TITLE
docs: fix DEFAULT_ASSETS.md examples and stale file references

### DIFF
--- a/DEFAULT_ASSETS.md
+++ b/DEFAULT_ASSETS.md
@@ -52,11 +52,13 @@ Add to the `DEFAULT_STABLECOINS` map:
 <details>
 <summary><strong>Go</strong> — <code>go/mechanisms/evm/constants.go</code></summary>
 
-Add to the `NetworkConfigs` map:
+Declare the chain ID in the `ChainID*` var block, then add to the `NetworkConfigs` map:
 
 ```go
+ChainIDYourChain = big.NewInt(YOUR_CHAIN_ID)
+
 "eip155:YOUR_CHAIN_ID": {
-    ChainID: big.NewInt(YOUR_CHAIN_ID),
+    ChainID: ChainIDYourChain,
     DefaultAsset: AssetInfo{
         Address:  "0xYOUR_STABLECOIN_ADDRESS",
         Name:     "Token Name",  // EIP-712 domain name
@@ -75,17 +77,17 @@ Add to the `NetworkConfigs` map:
 Add to the `NETWORK_CONFIGS` dict:
 
 ```python
-"eip155:YOUR_CHAIN_ID": NetworkConfig(
-    chain_id=YOUR_CHAIN_ID,
-    default_asset=AssetInfo(
-        address="0xYOUR_STABLECOIN_ADDRESS",
-        name="Token Name",       # EIP-712 domain name
-        version="1",             # EIP-712 domain version
-        decimals=6,
-        # asset_transfer_method=AssetTransferMethod.PERMIT2,  # Only if token lacks EIP-3009
-        # supports_eip2612=True,                               # Only for Permit2 tokens with EIP-2612
-    ),
-),
+"eip155:YOUR_CHAIN_ID": {
+    "chain_id": YOUR_CHAIN_ID,
+    "default_asset": {
+        "address": "0xYOUR_STABLECOIN_ADDRESS",
+        "name": "Token Name",    # EIP-712 domain name
+        "version": "1",          # EIP-712 domain version
+        "decimals": 6,
+        # "asset_transfer_method": "permit2",  # Only if token lacks EIP-3009
+        # "supports_eip2612": True,            # Only for Permit2 tokens with EIP-2612
+    },
+},
 ```
 </details>
 

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -91,7 +91,7 @@ var (
 	ChainIDIgra          = big.NewInt(38833)
 
 	// Network configurations
-	// See DEFAULT_ASSET.md for guidelines on adding new chains
+	// See DEFAULT_ASSETS.md for guidelines on adding new chains
 	//
 	// Default Asset Selection Policy:
 	// - Each chain has the right to determine its own default stablecoin
@@ -100,7 +100,7 @@ var (
 	//
 	// Both EIP-3009 (transferWithAuthorization) and Permit2 asset transfer methods are supported.
 	// EIP-3009 is the default. Set AssetTransferMethod to AssetTransferMethodPermit2 for tokens
-	// that don't support EIP-3009. See DEFAULT_ASSET.md for details.
+	// that don't support EIP-3009. See DEFAULT_ASSETS.md for details.
 	NetworkConfigs = map[string]NetworkConfig{
 		// Base Mainnet
 		"eip155:8453": {

--- a/go/mechanisms/evm/types.go
+++ b/go/mechanisms/evm/types.go
@@ -306,7 +306,7 @@ type AssetInfo struct {
 }
 
 // NetworkConfig contains network-specific configuration
-// See DEFAULT_ASSET.md for guidelines on adding new chains
+// See DEFAULT_ASSETS.md for guidelines on adding new chains
 type NetworkConfig struct {
 	ChainID      *big.Int
 	DefaultAsset AssetInfo

--- a/go/mechanisms/svm/constants.go
+++ b/go/mechanisms/svm/constants.go
@@ -69,7 +69,7 @@ const (
 
 var (
 	// NetworkConfigs maps CAIP-2 identifiers to network configurations
-	// See DEFAULT_ASSET.md for guidelines on adding new networks
+	// See DEFAULT_ASSETS.md for guidelines on adding new networks
 	NetworkConfigs = map[string]NetworkConfig{
 		SolanaMainnetCAIP2: {
 			Name:   "Solana Mainnet",

--- a/go/mechanisms/svm/types.go
+++ b/go/mechanisms/svm/types.go
@@ -62,7 +62,7 @@ type AssetInfo struct {
 }
 
 // NetworkConfig contains network-specific configuration
-// See DEFAULT_ASSET.md for guidelines on adding new chains
+// See DEFAULT_ASSETS.md for guidelines on adding new chains
 type NetworkConfig struct {
 	Name         string    // Network name
 	CAIP2        string    // CAIP-2 identifier

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -37,8 +37,8 @@ export type ExactDefaultAssetInfo = DefaultAssetInfo & {
  * Default stablecoins indexed by CAIP-2 network identifier.
  *
  * Each network has the right to determine its own default stablecoin that can
- * be expressed as a USD string by calling servers. See DEFAULT_ASSET.md in
- * exact/server/ for how to add new chains.
+ * be expressed as a USD string by calling servers. See DEFAULT_ASSETS.md at the
+ * repository root for how to add new chains.
  */
 export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
   "eip155:8453": {


### PR DESCRIPTION
## Summary

Three inaccuracies in the add-a-default-asset runbook and the comments pointing at it. Comment- and markdown-only — no behaviour change.

### 1. The Python snippet doesn't match any real code

`DEFAULT_ASSETS.md` showed:

```python
"eip155:YOUR_CHAIN_ID": NetworkConfig(
    chain_id=YOUR_CHAIN_ID,
    default_asset=AssetInfo(
        ...
        # asset_transfer_method=AssetTransferMethod.PERMIT2,
```

Two problems:

- **`AssetTransferMethod` does not exist anywhere in the Python package.** `grep -rn 'AssetTransferMethod' python/ --include='*.py'` returns nothing. Uncommenting that line raises `NameError`. The real value is the literal string `"permit2"` (`python/x402/mechanisms/evm/constants.py:428, 450, 462, 532, 544, 606`).
- `NetworkConfig`/`AssetInfo` are `TypedDict`s (`constants.py:379, 392`), so the constructor form technically runs — but every one of the ~30 entries in `NETWORK_CONFIGS` is a plain dict literal with snake_case string keys. Following the doc produces an entry unlike all its neighbours.

Rewritten to mirror the real Permit2 entry at `constants.py:421-431`.

### 2. The Go snippet omits a required step

The doc used `ChainID: big.NewInt(YOUR_CHAIN_ID)`, while every real entry uses a named constant from the `ChainID*` var block (`ChainID: ChainIDBase`, `go/mechanisms/evm/constants.go:107`). The doc form compiles, but silently skips declaring the constant. Now shows both.

The TypeScript snippet was already accurate and is untouched.

### 3. Six comments name a file that doesn't exist

The file is `DEFAULT_ASSETS.md` (plural), at the repository root:

| File | |
|---|---|
| `go/mechanisms/evm/constants.go:94, :103` | `DEFAULT_ASSET.md` → `DEFAULT_ASSETS.md` |
| `go/mechanisms/evm/types.go:309` | same |
| `go/mechanisms/svm/constants.go:72` | same |
| `go/mechanisms/svm/types.go:65` | same |
| `typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts:40` | same, **plus** it placed the file in a nonexistent `exact/server/` directory |

Correct references already exist at `CONTRIBUTING.md:215`, `faucetUrls.ts:4`, and `docs/core-concepts/network-and-token-support.mdx:291`.

## For maintainers — one thing I didn't change

`go/mechanisms/svm/constants.go:72` and `go/mechanisms/svm/types.go:65` point SVM code at a document titled "Default Assets for **EVM** Chains" that contains no SVM guidance. Fixing the typo preserves the clearly-intended reference, but re-pointing or removing it looked like a judgement call rather than a typo fix. Happy to follow up either way.

## Verification

- `grep -rn 'DEFAULT_ASSET\.md'` across the repo → zero hits; the 9 remaining `DEFAULT_ASSETS.md` references are all correct.
- `gofmt -l go/` → clean; `go build ./...` → OK.
- `npx prettier --check` on the changed `.ts` file → passes.
- The new Python snippet was extracted from the markdown, `exec()`'d, and asserted key-by-key against the `AssetInfo`/`NetworkConfig` TypedDict fields at `constants.py:370-395`. The previous snippet fails this.

No changelog fragments: `CONTRIBUTING.md:152` exempts docs-only changes, and recent docs-only PRs (#2949, #2925, #2947) carried none.