### PR TITLE
feat(evm): add Celo mainnet (42220) and Celo Sepolia (11142220) default stablecoin

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -126,6 +126,8 @@ When you use `"$0.01"` syntax, x402 needs to know which stablecoin to use. The f
 | XDC Network | `eip155:50` | `0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1` | USDC | 6 | EIP-3009 |
 | XDC Apothem Testnet | `eip155:51` | `0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4` | USDC | 6 | EIP-3009 |
 | Igra | `eip155:38833` | `0xA5b8BF902b2844dA17d4506cc827F7F1681735E7` | USDC | 6 | Permit2 |
+| Celo | `eip155:42220` | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | USDC | 6 | EIP-3009 |
+| Celo Sepolia | `eip155:11142220` | `0x01C5C0122039549AD1493B8220cABEdD739BC44E` | USDC | 6 | EIP-3009 |
 
 
 

--- a/docs/dev-tools/facilitators.md
+++ b/docs/dev-tools/facilitators.md
@@ -21,6 +21,7 @@ If you are evaluating a mainnet EVM route, decide on your production facilitator
 | ---- | ----------- | 
 | [Built on Stellar](https://developers.stellar.org/docs/build/apps/x402/built-on-stellar) | Free, public x402 facilitator for Stellar |
 | [CDP Facilitator](https://docs.cdp.coinbase.com/x402/docs/quickstart-sellers) | Coinbase-hosted facilitator with KYT/OFAC checks on every transaction |
+| [Celo Facilitator](https://docs.celo.org/build-on-celo/build-with-ai/x402) | Gasless x402 facilitator for Celo Mainnet, accepting USDC and USD₮ via EIP-3009 |
 | [Corbits](https://corbits.dev) | Production-grade multi-network, multi-token facilitator supporting EVM and Solana |
 | [Dexter](https://dexter.cash/facilitator) | Free public x402 facilitator across Solana and EVM chains with no fees and no account required |
 | [HPP Facilitator](https://docs.hpp.io/x402/facilitator) | Gasless, public x402 facilitator for HPP Mainnet and Sepolia |

--- a/go/.changes/unreleased/add-celo-default-stablecoin.yaml
+++ b/go/.changes/unreleased/add-celo-default-stablecoin.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add Celo mainnet (chain ID 42220) and Celo Sepolia (chain ID 11142220) support with USDC as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -89,6 +89,8 @@ var (
 	ChainIDXDC           = big.NewInt(50)
 	ChainIDXDCApothem    = big.NewInt(51)
 	ChainIDIgra          = big.NewInt(38833)
+	ChainIDCelo          = big.NewInt(42220)
+	ChainIDCeloSepolia   = big.NewInt(11142220)
 
 	// Network configurations
 	// See DEFAULT_ASSET.md for guidelines on adding new chains
@@ -301,6 +303,26 @@ var (
 				Version:             "1",
 				Decimals:            DefaultDecimals,
 				AssetTransferMethod: AssetTransferMethodPermit2,
+			},
+		},
+		// Celo Mainnet
+		"eip155:42220": {
+			ChainID: ChainIDCelo,
+			DefaultAsset: AssetInfo{
+				Address:  "0xcebA9300f2b948710d2653dD7B07f33A8B32118C", // USDC on Celo
+				Name:     "USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
+			},
+		},
+		// Celo Sepolia (Testnet)
+		"eip155:11142220": {
+			ChainID: ChainIDCeloSepolia,
+			DefaultAsset: AssetInfo{
+				Address:  "0x01C5C0122039549AD1493B8220cABEdD739BC44E", // USDC on Celo Sepolia
+				Name:     "USDC",
+				Version:  "2",
+				Decimals: DefaultDecimals,
 			},
 		},
 	}

--- a/go/mechanisms/evm/v1/network.go
+++ b/go/mechanisms/evm/v1/network.go
@@ -29,6 +29,7 @@ var NetworkChainIDs = map[string]*big.Int{
 	"monad":              big.NewInt(143),
 	"stable":             big.NewInt(988),
 	"stable-testnet":     big.NewInt(2201),
+	"celo":               big.NewInt(42220),
 }
 
 // NetworkConfigs maps v1 legacy network names to their full configuration.
@@ -93,6 +94,15 @@ var NetworkConfigs = map[string]evm.NetworkConfig{
 		DefaultAsset: evm.AssetInfo{
 			Address:  "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
 			Name:     "USD Coin",
+			Version:  "2",
+			Decimals: evm.DefaultDecimals,
+		},
+	},
+	"celo": {
+		ChainID: big.NewInt(42220),
+		DefaultAsset: evm.AssetInfo{
+			Address:  "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+			Name:     "USDC",
 			Version:  "2",
 			Decimals: evm.DefaultDecimals,
 		},

--- a/python/x402/changelog.d/add-celo-default-stablecoin.feature.md
+++ b/python/x402/changelog.d/add-celo-default-stablecoin.feature.md
@@ -1,0 +1,1 @@
+Add Celo mainnet (chain ID 42220) and Celo Sepolia (chain ID 11142220) support with USDC as the default stablecoin

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -606,6 +606,26 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "asset_transfer_method": "permit2",
         },
     },
+    # Celo Mainnet
+    "eip155:42220": {
+        "chain_id": 42220,
+        "default_asset": {
+            "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
+    # Celo Sepolia (Testnet)
+    "eip155:11142220": {
+        "chain_id": 11142220,
+        "default_asset": {
+            "address": "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
+            "name": "USDC",
+            "version": "2",
+            "decimals": 6,
+        },
+    },
 }
 
 # V1 legacy constants are in x402.mechanisms.evm.v1.constants

--- a/python/x402/mechanisms/evm/v1/constants.py
+++ b/python/x402/mechanisms/evm/v1/constants.py
@@ -52,6 +52,12 @@ V1_DEFAULT_ASSETS: dict[str, AssetInfo] = {
         "version": "1",
         "decimals": 6,
     },
+    "celo": {
+        "address": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+        "name": "USDC",
+        "version": "2",
+        "decimals": 6,
+    },
 }
 
 
@@ -76,6 +82,7 @@ V1_NETWORKS = [
     "monad",
     "stable",
     "stable-testnet",
+    "celo",
 ]
 
 # V1 network name to chain ID mapping
@@ -100,4 +107,5 @@ V1_NETWORK_CHAIN_IDS: dict[str, int] = {
     "monad": 143,
     "stable": 988,
     "stable-testnet": 2201,
+    "celo": 42220,
 }

--- a/typescript/.changeset/add-celo-default-stablecoin.md
+++ b/typescript/.changeset/add-celo-default-stablecoin.md
@@ -1,0 +1,6 @@
+---
+"@x402/evm": minor
+"@x402/paywall": patch
+---
+
+Add Celo mainnet (chain ID 42220) and Celo Sepolia (chain ID 11142220) support with USDC as the default stablecoin

--- a/typescript/packages/http/paywall/src/faucetUrls.ts
+++ b/typescript/packages/http/paywall/src/faucetUrls.ts
@@ -12,6 +12,7 @@ export const FAUCET_URLS: Record<string, string> = {
   "eip155:31611": "https://faucet.test.mezo.org/", // Mezo Testnet
   "eip155:2201": "https://faucet.stable.xyz/faucet", // Stable Testnet
   "eip155:72344": "https://testnet.radiustech.xyz/wallet", // Radius Testnet
+  "eip155:11142220": "https://faucet.circle.com/", // Celo Sepolia
   // SVM testnets
   "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": "https://faucet.circle.com/",
   // AVM testnets

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -166,6 +166,18 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     decimals: 6,
     assetTransferMethod: "permit2",
   }, // Igra mainnet USDC (no EIP-3009, no EIP-2612)
+  "eip155:42220": {
+    address: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
+    name: "USDC",
+    version: "2",
+    decimals: 6,
+  }, // Celo mainnet USDC (EIP-3009 supported)
+  "eip155:11142220": {
+    address: "0x01C5C0122039549AD1493B8220cABEdD739BC44E",
+    name: "USDC",
+    version: "2",
+    decimals: 6,
+  }, // Celo Sepolia testnet USDC (EIP-3009 supported)
 };
 
 /**

--- a/typescript/packages/mechanisms/evm/src/v1/index.ts
+++ b/typescript/packages/mechanisms/evm/src/v1/index.ts
@@ -22,6 +22,7 @@ export const EVM_NETWORK_CHAIN_ID_MAP = {
   monad: 143,
   stable: 988,
   "stable-testnet": 2201,
+  celo: 42220,
 } as const;
 
 export type EvmNetworkV1 = keyof typeof EVM_NETWORK_CHAIN_ID_MAP;


### PR DESCRIPTION
## Summary

Celo has no entry in the default-asset registries, so a resource server on Celo cannot write `price: "$0.01"` — dollar-string pricing resolves through the per-chain default-stablecoin map and currently falls back to an explicit `TokenAmount` with `amountInAtomicUnits`.

This is a registry-only change. No new logic, no new files outside changelog fragments. `Network` is already an open-ended CAIP-2 string and EVM schemes register on the wildcard `eip155:*`, so nothing gated Celo other than the missing map entries.

| Chain | CAIP-2 | Token | Address | EIP-712 name / version | Dec | Transfer |
|---|---|---|---|---|---|---|
| Celo Mainnet | `eip155:42220` | USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | `USDC` / `2` | 6 | EIP-3009 |
| Celo Sepolia | `eip155:11142220` | USDC | `0x01C5C0122039549AD1493B8220cABEdD739BC44E` | `USDC` / `2` | 6 | EIP-3009 |

Also adds the v1 legacy network name `"celo"`. The production Celo facilitator advertises `{"x402Version": 1, "scheme": "exact", "network": "celo"}` in its `/supported` response, and no SDK could resolve it — `getEvmChainIdV1("celo")` threw `Unsupported v1 network: celo`. Mainnet only; the v1 name space has no Celo testnet name.

## Asset selection rationale

Per `DEFAULT_ASSETS.md` §4:

- **USDC over USDT.** Both are EIP-3009-capable 6-decimal tokens on Celo, but USDT's `version()` reverts on-chain, so its EIP-712 version cannot be read the way this table's contract assumes ("read `name()` and `version()` off the token"). USDT (`0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e`) remains fully usable via an explicit `TokenAmount`.
- **cUSD / USDm is not viable.** `0x765DE816845861e75A25fCA122bb6898B8B1282a` is Mento `StableTokenV2`: 18 decimals, EIP-2612 only, `authorizationState` reverts. It would force the Permit2 path.
- **Alfajores is excluded** — its RPC is unreachable and Circle no longer lists a USDC there. Celo Sepolia is the live testnet.
- **Celo Sepolia is included** even though the facilitator serves mainnet only. Registry entries are facilitator-independent; the entry is what makes self-hosted and self-facilitated testnet setups work.

## On-chain verification

Queried live via `forno.celo.org` / `forno.celo-sepolia.celo-testnet.org`. Each EIP-712 domain separator was recomputed from the **committed** name/version/chainId/address and byte-matched against the contract's own `DOMAIN_SEPARATOR()` — the check that catches a wrong `version`, which would otherwise silently break every signature at settle time:

```
42220     computed == onchain == 0xb2ce31d2838445fa765a491f550e7c78ac7280ab0f3bc9d6063a86df9c3fb578
11142220  computed == onchain == 0x23f491197bb8c5ea4fe8dd4c2293b600f073553f9814015e7a5eb57724df9578
```

`authorizationState(address,bytes32)` returns cleanly on both (EIP-3009 present). `decimals()` is 6 on both, so `evm/gen/decimals.ts` needs no regeneration and the `NETWORK_DECIMALS` ↔ `DEFAULT_STABLECOINS` drift test stays green.

## Verification

- **Cross-SDK parity** — the three Celo entries were parsed back out of the TypeScript, Go, and Python registries and asserted identical on address, EIP-712 name, version, decimals, and transfer method. Identical on both networks.
- **Dollar-string pricing** — `price: "$0.01"` on `eip155:42220` resolves to `10000` atomic units of `0xcebA9300…` with `extra: { name: "USDC", version: "2" }`; same for `eip155:11142220`. Before this change that path threw `No default asset configured for network eip155:42220`.
- **v1 resolution** — `getEvmChainIdV1("celo") === 42220`; Go `evmv1.NetworkChainIDs["celo"]` and `GetAssetInfo("celo", "")` both resolve; Python `V1_NETWORK_CHAIN_IDS["celo"] == 42220` and `"celo" in V1_NETWORKS`. Go's `Networks` ↔ `NetworkChainIDs` parity assertion holds (22 == 22).
- **Facilitator cross-check** — `curl https://api.x402.celo.org/supported` returns exactly the networks registered here (`eip155:42220` v2, `celo` v1).
- **Tests** — `pnpm test` 55/55 tasks pass; `pnpm format:check` 27/27 pass; `go build ./...` and `go test ./...` pass, `gofmt -l go/` clean; `pytest` 1659 passed / 52 skipped, with 3 pre-existing failures unrelated to this change (missing `solana` optional dep and an `mcp` SDK `structuredContent` → `structured_content` rename).

## A note on the paywall faucet link

`faucetUrls.ts` gets a one-line Celo Sepolia entry pointing at Circle's faucet (verified HTTP 200; two existing entries already point there). **The generated paywall bundles are deliberately not regenerated in this PR.**

Reason: I ran `build:paywall` on a pristine `main` with no source changes at all, and it produced a ~1–2 KB delta in each of the nine checked-in bundles. So the committed bundles are already out of sync with what the current build emits in my environment. Regenerating here would sweep that pre-existing drift into this PR and make the diff unreviewable. Precedent: #2931 also changed `faucetUrls.ts` without regenerating.

Happy to add the regeneration if you'd prefer it in this PR — flagging it because it looks like something worth fixing separately.