### PR TITLE
feat(evm): add Flare mainnet (14) default stablecoin

### DIFF
--- a/docs/core-concepts/network-and-token-support.mdx
+++ b/docs/core-concepts/network-and-token-support.mdx
@@ -126,6 +126,7 @@ When you use `"$0.01"` syntax, x402 needs to know which stablecoin to use. The f
 | XDC Network | `eip155:50` | `0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1` | USDC | 6 | EIP-3009 |
 | XDC Apothem Testnet | `eip155:51` | `0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4` | USDC | 6 | EIP-3009 |
 | Igra | `eip155:38833` | `0xA5b8BF902b2844dA17d4506cc827F7F1681735E7` | USDC | 6 | Permit2 |
+| Flare | `eip155:14` | `0xe7cd86e13AC4309349F30B3435a9d337750fC82D` | USD₮0 | 6 | EIP-3009 |
 | Celo | `eip155:42220` | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | USDC | 6 | EIP-3009 |
 | Celo Sepolia | `eip155:11142220` | `0x01C5C0122039549AD1493B8220cABEdD739BC44E` | USDC | 6 | EIP-3009 |
 

--- a/go/.changes/unreleased/add-flare-default-stablecoin.yaml
+++ b/go/.changes/unreleased/add-flare-default-stablecoin.yaml
@@ -1,0 +1,2 @@
+kind: added
+body: Add Flare mainnet (chain ID 14) support with USD₮0 as the default stablecoin

--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -89,6 +89,7 @@ var (
 	ChainIDXDC           = big.NewInt(50)
 	ChainIDXDCApothem    = big.NewInt(51)
 	ChainIDIgra          = big.NewInt(38833)
+	ChainIDFlare         = big.NewInt(14)
 	ChainIDCelo          = big.NewInt(42220)
 	ChainIDCeloSepolia   = big.NewInt(11142220)
 
@@ -306,6 +307,16 @@ var (
 			},
 		},
 		// Celo Mainnet
+		// Flare (Mainnet)
+		"eip155:14": {
+			ChainID: ChainIDFlare,
+			DefaultAsset: AssetInfo{
+				Address:  "0xe7cd86e13AC4309349F30B3435a9d337750fC82D", // USD₮0 on Flare
+				Name:     "USD₮0",
+				Version:  "1",
+				Decimals: DefaultDecimals,
+			},
+		},
 		"eip155:42220": {
 			ChainID: ChainIDCelo,
 			DefaultAsset: AssetInfo{

--- a/go/mechanisms/evm/v1/network.go
+++ b/go/mechanisms/evm/v1/network.go
@@ -30,6 +30,7 @@ var NetworkChainIDs = map[string]*big.Int{
 	"stable":             big.NewInt(988),
 	"stable-testnet":     big.NewInt(2201),
 	"celo":               big.NewInt(42220),
+	"flare":              big.NewInt(14),
 }
 
 // NetworkConfigs maps v1 legacy network names to their full configuration.
@@ -95,6 +96,15 @@ var NetworkConfigs = map[string]evm.NetworkConfig{
 			Address:  "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
 			Name:     "USD Coin",
 			Version:  "2",
+			Decimals: evm.DefaultDecimals,
+		},
+	},
+	"flare": {
+		ChainID: big.NewInt(14),
+		DefaultAsset: evm.AssetInfo{
+			Address:  "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+			Name:     "USD₮0",
+			Version:  "1",
 			Decimals: evm.DefaultDecimals,
 		},
 	},

--- a/python/x402/changelog.d/add-flare-default-stablecoin.feature.md
+++ b/python/x402/changelog.d/add-flare-default-stablecoin.feature.md
@@ -1,0 +1,1 @@
+Add Flare mainnet (chain ID 14) support with USD₮0 as the default stablecoin

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -606,6 +606,16 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
             "asset_transfer_method": "permit2",
         },
     },
+    # Flare Mainnet
+    "eip155:14": {
+        "chain_id": 14,
+        "default_asset": {
+            "address": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+            "name": "USD₮0",
+            "version": "1",
+            "decimals": 6,
+        },
+    },
     # Celo Mainnet
     "eip155:42220": {
         "chain_id": 42220,

--- a/python/x402/mechanisms/evm/v1/constants.py
+++ b/python/x402/mechanisms/evm/v1/constants.py
@@ -4,6 +4,12 @@ from ..constants import AssetInfo
 
 # Default assets keyed by v1 legacy network name.
 V1_DEFAULT_ASSETS: dict[str, AssetInfo] = {
+    "flare": {
+        "address": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+        "name": "USD₮0",
+        "version": "1",
+        "decimals": 6,
+    },
     "ethereum": {
         "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         "name": "USD Coin",
@@ -108,4 +114,5 @@ V1_NETWORK_CHAIN_IDS: dict[str, int] = {
     "stable": 988,
     "stable-testnet": 2201,
     "celo": 42220,
+    "flare": 14,
 }

--- a/typescript/.changeset/add-flare-default-stablecoin.md
+++ b/typescript/.changeset/add-flare-default-stablecoin.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": minor
+---
+
+Add Flare mainnet (chain ID 14) support with USD₮0 as the default stablecoin

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -166,6 +166,12 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
     decimals: 6,
     assetTransferMethod: "permit2",
   }, // Igra mainnet USDC (no EIP-3009, no EIP-2612)
+  "eip155:14": {
+    address: "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+    name: "USD\u20AE0",
+    version: "1",
+    decimals: 6,
+  }, // Flare mainnet USD₮0 (EIP-3009 supported)
   "eip155:42220": {
     address: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C",
     name: "USDC",

--- a/typescript/packages/mechanisms/evm/src/v1/index.ts
+++ b/typescript/packages/mechanisms/evm/src/v1/index.ts
@@ -23,6 +23,7 @@ export const EVM_NETWORK_CHAIN_ID_MAP = {
   stable: 988,
   "stable-testnet": 2201,
   celo: 42220,
+  flare: 14,
 } as const;
 
 export type EvmNetworkV1 = keyof typeof EVM_NETWORK_CHAIN_ID_MAP;


### PR DESCRIPTION
Adds Flare mainnet (`eip155:14`) to the EVM default-asset registry across TypeScript, Go and Python, plus the v1 legacy network maps and the support-table docs. Follows `DEFAULT_ASSETS.md`; no paywall regeneration needed (6 decimals).

**Asset:** USD₮0 `0xe7cd86e13AC4309349F30B3435a9d337750fC82D` — EIP-712 name `USD₮0`, version `1`, 6 decimals, EIP-3009.

### Why this asset

Flare has not endorsed a stablecoin for x402, so per the selection policy I used ecosystem alignment as the tiebreaker:

| token | address | supply on Flare | EIP-3009 |
|---|---|---|---|
| **USD₮0** | `0xe7cd86e13AC4309349F30B3435a9d337750fC82D` | **~23.1M** | ✅ |
| USDC.e | `0xFbDa5F676cB37624f28265A144A48B0d6e87d3b6` | ~3.25M | ✅ |

USDC.e is a fully verified alternative (EIP-712 name `Bridged USDC (Stargate)`, version `2`, 6 decimals, EIP-3009 confirmed) — happy to switch on request, it's one line per SDK. If the Flare team would rather make the call themselves, please treat this as a starting point rather than a claim.

### Verification

The policy asks for correct EIP-712 domain parameters, so both facts were checked against the deployed contract rather than read from a docs page:

- **EIP-3009 is present.** `transferWithAuthorization` called with a junk signature reverts `TetherToken: invalid signature` — the function exists and validates. (USDC.e answers `FiatTokenV2: invalid signature`.) A missing function reverts differently, which is what distinguishes "supported" from "absent". `authorizationState(address,bytes32)` also returns cleanly.
- **The domain is correct.** I recomputed `hashDomain({name, version: "1", chainId: 14, verifyingContract})` from the values **as written in each of the three SDK files** and compared against the token's on-chain `DOMAIN_SEPARATOR`:

```
on-chain: 0x4c53d754dcb2f406ecf83695856d8c10b13296a318d9a481043412bf253d43ae
TypeScript  name="USD₮0" → MATCH
Go          name="USD₮0" → MATCH
Python      name="USD₮0" → MATCH
```

One note worth flagging for implementers: this token's EIP-712 name contains **₮ (U+20AE)**. That is a legitimate name and a genuine interop probe — an implementation that mishandles non-ASCII in the domain name produces a different digest and every signature fails. The TypeScript entry encodes it as a `₮` escape, verified above to decode to the same 5-character string in all three SDKs.

### Disclosure

We operate an x402 facilitator on Flare and issue our own EIP-3009 token on Coston2 testnet. This PR deliberately proposes **mainnet only**, with a third-party asset we do not control — a testnet default naming our own token would be self-dealing dressed as a registry entry. Happy to add a Coston2 entry separately if maintainers want one, with the conflict stated up front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

*Disclosure per CONTRIBUTING (added retroactively once we noticed the AI-assisted-contributions policy): this PR was built with significant AI assistance (Claude), under significant human monitoring, direction, and correction. Spec claims and reference-implementation behavior were verified against live networks and running code rather than generated from memory. Happy to answer any provenance questions.*