### PR TITLE
fix(python): verify Transfer event after exact/eip3009 settle

### DIFF
--- a/python/x402/changelog.d/verify-transfer-event-eip3009-settle.bugfix.md
+++ b/python/x402/changelog.d/verify-transfer-event-eip3009-settle.bugfix.md
@@ -1,0 +1,1 @@
+Verify the expected ERC-20 Transfer event in exact EIP-3009 settle receipts when logs are available, matching the Go SDK check from #2727 and the open TypeScript fix in #2385.

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -341,6 +341,7 @@ ERR_TOKEN_NAME_MISMATCH = "invalid_exact_evm_token_name_mismatch"
 ERR_TOKEN_VERSION_MISMATCH = "invalid_exact_evm_token_version_mismatch"
 ERR_EIP3009_NOT_SUPPORTED = "invalid_exact_evm_eip3009_not_supported"
 ERR_TRANSACTION_SIMULATION_FAILED = "invalid_exact_evm_transaction_simulation_failed"
+ERR_TRANSFER_EVENT_MISMATCH = "invalid_exact_evm_transfer_event_mismatch"
 
 # Permit2-specific error codes
 ERR_PERMIT2_INVALID_SPENDER = "invalid_permit2_spender"

--- a/python/x402/mechanisms/evm/exact/eip3009_utils.py
+++ b/python/x402/mechanisms/evm/exact/eip3009_utils.py
@@ -28,8 +28,13 @@ from ..erc6492 import has_deployment_info, parse_erc6492_signature
 from ..multicall import MulticallCall, encode_contract_call, multicall
 from ..signer import FacilitatorEvmSigner
 from ..types import ERC6492SignatureData, ExactEIP3009Authorization
-from ..utils import bytes_to_hex, hex_to_bytes
+from ..utils import bytes_to_hex, hex_to_bytes, normalize_address
 from ..verify import verify_typed_data_strict
+
+# keccak256("Transfer(address,address,uint256)")
+ERC20_TRANSFER_EVENT_TOPIC = (
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+)
 
 
 @dataclass
@@ -292,6 +297,84 @@ def diagnose_eip3009_simulation_failure(
             pass
 
     return ERR_TRANSACTION_SIMULATION_FAILED
+
+
+def _log_field(log: object, key: str) -> object:
+    if isinstance(log, dict):
+        return log.get(key)
+    return getattr(log, key, None)
+
+
+def _as_hex(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return "0x" + value.hex()
+    text = str(value)
+    return text if text.startswith("0x") else "0x" + text
+
+
+def _topic_to_address(topic: object) -> str:
+    hex_topic = _as_hex(topic).lower().removeprefix("0x")
+    if len(hex_topic) < 40:
+        raise ValueError(f"invalid address topic: {topic!r}")
+    return normalize_address("0x" + hex_topic[-40:])
+
+
+def verify_eip3009_transfer_event(
+    logs: list[object] | None,
+    token_address: str,
+    *,
+    from_address: str,
+    to: str,
+    value: int,
+) -> bool:
+    """Return True when receipt logs contain the expected ERC-20 Transfer.
+
+    Mirrors Go ``verifyEIP3009TransferEvent`` / TS ``verifyEip3009TransferEvent``.
+    """
+    if not logs:
+        return False
+
+    expected_token = normalize_address(token_address)
+    expected_from = normalize_address(from_address)
+    expected_to = normalize_address(to)
+    expected_value = int(value)
+    expected_topic = ERC20_TRANSFER_EVENT_TOPIC.lower()
+
+    for log in logs:
+        try:
+            log_address = normalize_address(str(_log_field(log, "address")))
+        except Exception:
+            continue
+        if log_address != expected_token:
+            continue
+
+        topics = _log_field(log, "topics") or []
+        if len(topics) != 3:
+            continue
+        if _as_hex(topics[0]).lower() != expected_topic:
+            continue
+
+        data = _as_hex(_log_field(log, "data"))
+        data_hex = data.lower().removeprefix("0x")
+        if len(data_hex) < 64:
+            continue
+        try:
+            log_value = int(data_hex[-64:], 16)
+            log_from = _topic_to_address(topics[1])
+            log_to = _topic_to_address(topics[2])
+        except Exception:
+            continue
+
+        if (
+            log_from == expected_from
+            and log_to == expected_to
+            and log_value == expected_value
+        ):
+            return True
+
+    return False
 
 
 def parse_eip3009_transfer_error(error: Exception) -> str:

--- a/python/x402/mechanisms/evm/exact/eip3009_utils.py
+++ b/python/x402/mechanisms/evm/exact/eip3009_utils.py
@@ -32,9 +32,7 @@ from ..utils import bytes_to_hex, hex_to_bytes, normalize_address
 from ..verify import verify_typed_data_strict
 
 # keccak256("Transfer(address,address,uint256)")
-ERC20_TRANSFER_EVENT_TOPIC = (
-    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
-)
+ERC20_TRANSFER_EVENT_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 
 
 @dataclass
@@ -367,11 +365,7 @@ def verify_eip3009_transfer_event(
         except Exception:
             continue
 
-        if (
-            log_from == expected_from
-            and log_to == expected_to
-            and log_value == expected_value
-        ):
+        if log_from == expected_from and log_to == expected_to and log_value == expected_value:
             return True
 
     return False

--- a/python/x402/mechanisms/evm/exact/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/facilitator.py
@@ -25,6 +25,7 @@ from ..constants import (
     ERR_SMART_WALLET_DEPLOYMENT_FAILED,
     ERR_TRANSACTION_FAILED,
     ERR_TRANSACTION_SIMULATION_FAILED,
+    ERR_TRANSFER_EVENT_MISMATCH,
     ERR_UNDEPLOYED_SMART_WALLET,
     ERR_UNSUPPORTED_SCHEME,
     ERR_VALID_AFTER_FUTURE,
@@ -41,6 +42,7 @@ from ..exact.eip3009_utils import (
     parse_eip3009_authorization,
     parse_eip3009_transfer_error,
     simulate_eip3009_transfer_result,
+    verify_eip3009_transfer_event,
 )
 from ..exact.permit2_utils import settle_permit2, verify_permit2
 from ..signer import FacilitatorEvmSigner
@@ -442,6 +444,23 @@ class ExactEvmScheme:
                 return SettleResponse(
                     success=False,
                     error_reason=ERR_TRANSACTION_FAILED,
+                    transaction=tx_hash,
+                    network=network,
+                    payer=payer,
+                )
+
+            # Receipt status only proves the tx did not revert. Mirror Go #2727 /
+            # TS #2385: require the expected ERC-20 Transfer when logs are present.
+            if receipt.logs is not None and not verify_eip3009_transfer_event(
+                receipt.logs,
+                token_address,
+                from_address=parsed_authorization.from_address,
+                to=parsed_authorization.to,
+                value=parsed_authorization.value,
+            ):
+                return SettleResponse(
+                    success=False,
+                    error_reason=ERR_TRANSFER_EVENT_MISMATCH,
                     transaction=tx_hash,
                     network=network,
                     payer=payer,

--- a/python/x402/mechanisms/evm/exact/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/facilitator.py
@@ -449,8 +449,7 @@ class ExactEvmScheme:
                     payer=payer,
                 )
 
-            # Receipt status only proves the tx did not revert. Mirror Go #2727 /
-            # TS #2385: require the expected ERC-20 Transfer when logs are present.
+            # Receipt status only proves the tx did not revert.
             if receipt.logs is not None and not verify_eip3009_transfer_event(
                 receipt.logs,
                 token_address,

--- a/python/x402/mechanisms/evm/exact/v1/facilitator.py
+++ b/python/x402/mechanisms/evm/exact/v1/facilitator.py
@@ -18,6 +18,7 @@ from ...constants import (
     ERR_RECIPIENT_MISMATCH,
     ERR_SMART_WALLET_DEPLOYMENT_FAILED,
     ERR_TRANSACTION_FAILED,
+    ERR_TRANSFER_EVENT_MISMATCH,
     ERR_UNDEPLOYED_SMART_WALLET,
     ERR_UNSUPPORTED_SCHEME,
     ERR_VALID_AFTER_FUTURE,
@@ -37,6 +38,7 @@ from ..eip3009_utils import (
     parse_eip3009_authorization,
     parse_eip3009_transfer_error,
     simulate_eip3009_transfer,
+    verify_eip3009_transfer_event,
 )
 
 
@@ -385,6 +387,21 @@ class ExactEvmSchemeV1:
                 return SettleResponse(
                     success=False,
                     error_reason=ERR_TRANSACTION_FAILED,
+                    transaction=tx_hash,
+                    network=network,
+                    payer=payer,
+                )
+
+            if receipt.logs is not None and not verify_eip3009_transfer_event(
+                receipt.logs,
+                token_address,
+                from_address=parsed_authorization.from_address,
+                to=parsed_authorization.to,
+                value=parsed_authorization.value,
+            ):
+                return SettleResponse(
+                    success=False,
+                    error_reason=ERR_TRANSFER_EVENT_MISMATCH,
                     transaction=tx_hash,
                     network=network,
                     payer=payer,

--- a/python/x402/mechanisms/evm/signers.py
+++ b/python/x402/mechanisms/evm/signers.py
@@ -560,6 +560,7 @@ class FacilitatorWeb3Signer:
             status=TX_STATUS_SUCCESS if receipt["status"] == 1 else 0,
             block_number=receipt["blockNumber"],
             tx_hash=tx_hash,
+            logs=list(receipt.get("logs") or []),
         )
 
     def get_balance(self, address: str, token_address: str) -> int:

--- a/python/x402/mechanisms/evm/types.py
+++ b/python/x402/mechanisms/evm/types.py
@@ -306,9 +306,6 @@ class TransactionReceipt:
     status: int
     block_number: int
     tx_hash: str
-    # When present (including empty list), exact EIP-3009 settle verifies a matching
-    # ERC-20 Transfer log. None preserves backward-compatible mock/signers that omit logs
-    # (mirrors Go's `if receipt.Logs != nil` gate).
     logs: list[Any] | None = None
 
 

--- a/python/x402/mechanisms/evm/types.py
+++ b/python/x402/mechanisms/evm/types.py
@@ -306,6 +306,10 @@ class TransactionReceipt:
     status: int
     block_number: int
     tx_hash: str
+    # When present (including empty list), exact EIP-3009 settle verifies a matching
+    # ERC-20 Transfer log. None preserves backward-compatible mock/signers that omit logs
+    # (mirrors Go's `if receipt.Logs != nil` gate).
+    logs: list[Any] | None = None
 
 
 @dataclass

--- a/python/x402/tests/unit/mechanisms/evm/test_eip3009_transfer_event.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_eip3009_transfer_event.py
@@ -38,11 +38,7 @@ def make_transfer_log(
 
 
 def test_matches_canonical_transfer_event():
-    logs = [
-        make_transfer_log(
-            address=TOKEN, from_address=PAYER, to=RECEIVER, value=1000
-        )
-    ]
+    logs = [make_transfer_log(address=TOKEN, from_address=PAYER, to=RECEIVER, value=1000)]
     assert verify_eip3009_transfer_event(
         logs,
         TOKEN,
@@ -54,12 +50,8 @@ def test_matches_canonical_transfer_event():
 
 def test_matches_when_unrelated_logs_present():
     logs = [
-        make_transfer_log(
-            address=OTHER_TOKEN, from_address=ATTACKER, to=RECEIVER, value=999
-        ),
-        make_transfer_log(
-            address=TOKEN, from_address=PAYER, to=RECEIVER, value=1000
-        ),
+        make_transfer_log(address=OTHER_TOKEN, from_address=ATTACKER, to=RECEIVER, value=999),
+        make_transfer_log(address=TOKEN, from_address=PAYER, to=RECEIVER, value=1000),
     ]
     assert verify_eip3009_transfer_event(
         logs,
@@ -71,53 +63,35 @@ def test_matches_when_unrelated_logs_present():
 
 
 def test_rejects_wrong_value():
-    logs = [
-        make_transfer_log(
-            address=TOKEN, from_address=PAYER, to=RECEIVER, value=1
-        )
-    ]
+    logs = [make_transfer_log(address=TOKEN, from_address=PAYER, to=RECEIVER, value=1)]
     assert not verify_eip3009_transfer_event(
         logs, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
     )
 
 
 def test_rejects_wrong_recipient():
-    logs = [
-        make_transfer_log(
-            address=TOKEN, from_address=PAYER, to=ATTACKER, value=1000
-        )
-    ]
+    logs = [make_transfer_log(address=TOKEN, from_address=PAYER, to=ATTACKER, value=1000)]
     assert not verify_eip3009_transfer_event(
         logs, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
     )
 
 
 def test_rejects_wrong_sender():
-    logs = [
-        make_transfer_log(
-            address=TOKEN, from_address=ATTACKER, to=RECEIVER, value=1000
-        )
-    ]
+    logs = [make_transfer_log(address=TOKEN, from_address=ATTACKER, to=RECEIVER, value=1000)]
     assert not verify_eip3009_transfer_event(
         logs, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
     )
 
 
 def test_rejects_wrong_token():
-    logs = [
-        make_transfer_log(
-            address=OTHER_TOKEN, from_address=PAYER, to=RECEIVER, value=1000
-        )
-    ]
+    logs = [make_transfer_log(address=OTHER_TOKEN, from_address=PAYER, to=RECEIVER, value=1000)]
     assert not verify_eip3009_transfer_event(
         logs, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
     )
 
 
 def test_rejects_empty_or_missing_logs():
-    assert not verify_eip3009_transfer_event(
-        [], TOKEN, from_address=PAYER, to=RECEIVER, value=1000
-    )
+    assert not verify_eip3009_transfer_event([], TOKEN, from_address=PAYER, to=RECEIVER, value=1000)
     assert not verify_eip3009_transfer_event(
         None, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
     )

--- a/python/x402/tests/unit/mechanisms/evm/test_eip3009_transfer_event.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_eip3009_transfer_event.py
@@ -1,0 +1,123 @@
+"""Unit tests for exact EIP-3009 post-settle Transfer event verification."""
+
+from __future__ import annotations
+
+from x402.mechanisms.evm.exact.eip3009_utils import (
+    ERC20_TRANSFER_EVENT_TOPIC,
+    verify_eip3009_transfer_event,
+)
+from x402.mechanisms.evm.utils import normalize_address
+
+TOKEN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+OTHER_TOKEN = "0x0000000000000000000000000000000000000001"
+PAYER = "0x1234567890123456789012345678901234567890"
+RECEIVER = "0x0987654321098765432109876543210987654321"
+ATTACKER = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+def _addr_topic(address: str) -> str:
+    return "0x" + "0" * 24 + address.lower().removeprefix("0x")
+
+
+def make_transfer_log(
+    *,
+    address: str,
+    from_address: str,
+    to: str,
+    value: int,
+) -> dict:
+    return {
+        "address": address,
+        "topics": [
+            ERC20_TRANSFER_EVENT_TOPIC,
+            _addr_topic(from_address),
+            _addr_topic(to),
+        ],
+        "data": "0x" + f"{value:064x}",
+    }
+
+
+def test_matches_canonical_transfer_event():
+    logs = [
+        make_transfer_log(
+            address=TOKEN, from_address=PAYER, to=RECEIVER, value=1000
+        )
+    ]
+    assert verify_eip3009_transfer_event(
+        logs,
+        TOKEN,
+        from_address=PAYER,
+        to=RECEIVER,
+        value=1000,
+    )
+
+
+def test_matches_when_unrelated_logs_present():
+    logs = [
+        make_transfer_log(
+            address=OTHER_TOKEN, from_address=ATTACKER, to=RECEIVER, value=999
+        ),
+        make_transfer_log(
+            address=TOKEN, from_address=PAYER, to=RECEIVER, value=1000
+        ),
+    ]
+    assert verify_eip3009_transfer_event(
+        logs,
+        normalize_address(TOKEN),
+        from_address=PAYER,
+        to=RECEIVER,
+        value=1000,
+    )
+
+
+def test_rejects_wrong_value():
+    logs = [
+        make_transfer_log(
+            address=TOKEN, from_address=PAYER, to=RECEIVER, value=1
+        )
+    ]
+    assert not verify_eip3009_transfer_event(
+        logs, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
+    )
+
+
+def test_rejects_wrong_recipient():
+    logs = [
+        make_transfer_log(
+            address=TOKEN, from_address=PAYER, to=ATTACKER, value=1000
+        )
+    ]
+    assert not verify_eip3009_transfer_event(
+        logs, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
+    )
+
+
+def test_rejects_wrong_sender():
+    logs = [
+        make_transfer_log(
+            address=TOKEN, from_address=ATTACKER, to=RECEIVER, value=1000
+        )
+    ]
+    assert not verify_eip3009_transfer_event(
+        logs, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
+    )
+
+
+def test_rejects_wrong_token():
+    logs = [
+        make_transfer_log(
+            address=OTHER_TOKEN, from_address=PAYER, to=RECEIVER, value=1000
+        )
+    ]
+    assert not verify_eip3009_transfer_event(
+        logs, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
+    )
+
+
+def test_rejects_empty_or_missing_logs():
+    assert not verify_eip3009_transfer_event(
+        [], TOKEN, from_address=PAYER, to=RECEIVER, value=1000
+    )
+    assert not verify_eip3009_transfer_event(
+        None, TOKEN, from_address=PAYER, to=RECEIVER, value=1000
+    )


### PR DESCRIPTION
## Description

`settle` for exact EIP-3009 in the Python SDK currently treats a successful transaction receipt status as proof that the expected ERC-20 transfer occurred. Receipt status only shows the transaction did not revert; it does not prove that the token emitted `Transfer(from, to, value)` for the authorization.

This ports the defensive post-settle check already landed in Go (#2727) and proposed for TypeScript (#2385):

- Add optional `logs` on `TransactionReceipt` and populate them from the web3 signer
- Add `verify_eip3009_transfer_event(...)` (topic + from/to/value match)
- When `receipt.logs is not None`, require a matching Transfer or return `invalid_exact_evm_transfer_event_mismatch`
- Apply in exact V2 and V1 facilitators
- Unit tests mirror the Go/TS cases

`logs is None` keeps backward compatibility with mocks/signers that omit logs (same idea as Go's `if receipt.Logs != nil` gate). The default web3 signer now always supplies a list.

## Related

- Python parity with #2727 / companion to open TS #2385
- Payment-integrity hardening; no new exploit details beyond those PRs

## AI disclosure

Majority of this PR was drafted with AI assistance and reviewed against Go #2727 / TS #2385 behavior and existing Python settle tests.

## Test plan

- [x] `pytest tests/unit/mechanisms/evm/test_eip3009_transfer_event.py`
- [x] `pytest tests/unit/mechanisms/evm/test_facilitator.py`
- [ ] CI on this PR
