### PR TITLE
fix(mcp): re-approve before signing corrective 402 recovery payment

### DIFF
--- a/typescript/.changeset/mcp-reapprove-corrective-402.md
+++ b/typescript/.changeset/mcp-reapprove-corrective-402.md
@@ -1,0 +1,5 @@
+---
+"@x402/mcp": patch
+---
+
+Re-run onPaymentRequired / onPaymentRequested gates before signing a corrective-402 recovery payment.

--- a/typescript/packages/mcp/src/client/x402MCPClient.ts
+++ b/typescript/packages/mcp/src/client/x402MCPClient.ts
@@ -633,8 +633,43 @@ export class x402MCPClient {
 
     // A paid attempt can return a corrective 402. Scheme hooks recover local
     // state from it, then we retry once with a fresh payload from that response.
+    // Corrective terms (amount/asset/payTo) are server-controlled — re-run the
+    // same approval / abort gates used for the first payment before signing again.
     if (recoveryResult?.recovered && paymentRequired) {
-      const freshPayload = await this._paymentClient.createPaymentPayload(paymentRequired);
+      const correctiveRequiredContext: PaymentRequiredContext = {
+        toolName: name,
+        arguments: args,
+        paymentRequired,
+      };
+      let correctivePayload: PaymentPayload | undefined;
+      for (const hook of this.paymentRequiredHooks) {
+        const hookResult = await hook(correctiveRequiredContext);
+        if (hookResult?.abort) {
+          throw new Error("Payment aborted by hook");
+        }
+        if (hookResult?.payment) {
+          correctivePayload = hookResult.payment;
+          break;
+        }
+      }
+      if (!correctivePayload) {
+        const correctiveRequestedContext: PaymentRequestedContext = {
+          toolName: name,
+          arguments: args,
+          paymentRequired,
+        };
+        const correctiveApproved =
+          await this.options.onPaymentRequested(correctiveRequestedContext);
+        if (!correctiveApproved) {
+          throw new Error("Payment request denied");
+        }
+        for (const hook of this.beforePaymentHooks) {
+          await hook(correctiveRequestedContext);
+        }
+        correctivePayload = await this._paymentClient.createPaymentPayload(paymentRequired);
+      }
+
+      const freshPayload = correctivePayload;
       const retryCallParams = {
         name,
         arguments: args,


### PR DESCRIPTION
## Description

In `callToolWithPayment`, after a paid tool call, recovery from a corrective 402 (`handlePaymentResponse` → `{ recovered: true }`) previously called `createPaymentPayload(paymentRequired)` and retried **without** re-running:

- `paymentRequiredHooks` (including `{ abort: true }`)
- `onPaymentRequested` (human / policy approval)
- `beforePaymentHooks`

Those gates run only once in `callTool()` for the first payment. Because the corrective `PaymentRequired` is server-controlled, a malicious or compromised MCP server could escalate amount / asset / payTo on the second signature.

This change re-runs the same approval/abort path before signing the recovery payment (still a single retry).

## AI disclosure

Drafted with AI assistance; reviewed against the MCP payment client control flow.

## Test plan

- [ ] Corrective 402 with unchanged terms still recovers when `onPaymentRequested` returns true
- [ ] Corrective 402 is denied when `onPaymentRequested` returns false
- [ ] `paymentRequiredHooks` `{ abort: true }` stops the recovery payment
- [ ] CI on this PR
