### PR TITLE
fix(mcp): plumb spend policies through createx402MCPClient factory

### DIFF
--- a/typescript/.changeset/mcp-factory-spend-policies.md
+++ b/typescript/.changeset/mcp-factory-spend-policies.md
@@ -1,0 +1,5 @@
+---
+"@x402/mcp": patch
+---
+
+Plumb policies and paymentRequirementsSelector through createx402MCPClient so the documented factory can bound agent spend.

--- a/typescript/packages/mcp/src/client/x402MCPClient.ts
+++ b/typescript/packages/mcp/src/client/x402MCPClient.ts
@@ -996,7 +996,7 @@ export function wrapMCPClientWithPaymentFromConfig(
  *   schemes: [
  *     { network: "eip155:84532", client: new ExactEvmScheme(account) },
  *   ],
- *   // Bound spend — without policies the factory used to drop all spend controls
+ *   // Optional spend policies
  *   policies: [
  *     (_v, reqs) => reqs.filter(r => BigInt(r.amount ?? "0") < 1_000_000n),
  *   ],
@@ -1028,8 +1028,7 @@ export function createx402MCPClient(config: x402MCPClientConfig): x402MCPClient 
     config.mcpClientOptions,
   );
 
-  // Build payment client via fromConfig so policies / selector are not silently dropped.
-  // (Previously this used `new x402Client()` + register-only, which could not bound spend.)
+  // Apply schemes (and optional policies/selector) via fromConfig.
   const paymentClient = x402Client.fromConfig({
     schemes: config.schemes,
     policies: config.policies,

--- a/typescript/packages/mcp/src/client/x402MCPClient.ts
+++ b/typescript/packages/mcp/src/client/x402MCPClient.ts
@@ -7,7 +7,11 @@ import type {
 } from "@x402/core/types";
 import { parsePaymentRequired } from "@x402/core/schemas";
 import { x402Client } from "@x402/core/client";
-import type { x402ClientConfig } from "@x402/core/client";
+import type {
+  PaymentPolicy,
+  SelectPaymentRequirements,
+  x402ClientConfig,
+} from "@x402/core/client";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 
 import type {
@@ -858,6 +862,25 @@ export interface x402MCPClientConfig {
   }>;
 
   /**
+   * Optional spend / selection policies (same as x402Client.fromConfig).
+   * Use these to cap amount, filter assets/networks, etc.
+   *
+   * @example
+   * ```typescript
+   * policies: [
+   *   (_version, reqs) => reqs.filter(r => BigInt(r.amount) < 1_000_000n),
+   * ],
+   * ```
+   */
+  policies?: PaymentPolicy[];
+
+  /**
+   * Custom selector for which accept entry to pay.
+   * Default (via x402Client) is server-ordered accepts[0] — prefer an explicit selector in production.
+   */
+  paymentRequirementsSelector?: SelectPaymentRequirements;
+
+  /**
    * Whether to automatically retry tool calls with payment on 402 errors.
    *
    * @default true
@@ -973,6 +996,10 @@ export function wrapMCPClientWithPaymentFromConfig(
  *   schemes: [
  *     { network: "eip155:84532", client: new ExactEvmScheme(account) },
  *   ],
+ *   // Bound spend — without policies the factory used to drop all spend controls
+ *   policies: [
+ *     (_v, reqs) => reqs.filter(r => BigInt(r.amount ?? "0") < 1_000_000n),
+ *   ],
  *   autoPayment: true,
  *   onPaymentRequested: async ({ paymentRequired }) => {
  *     console.log(`Payment required: ${paymentRequired.accepts[0].amount}`);
@@ -1001,17 +1028,13 @@ export function createx402MCPClient(config: x402MCPClientConfig): x402MCPClient 
     config.mcpClientOptions,
   );
 
-  // Create x402 payment client
-  const paymentClient = new x402Client();
-
-  // Register schemes
-  for (const scheme of config.schemes) {
-    if (scheme.x402Version === 1) {
-      paymentClient.registerV1(scheme.network, scheme.client);
-    } else {
-      paymentClient.register(scheme.network, scheme.client);
-    }
-  }
+  // Build payment client via fromConfig so policies / selector are not silently dropped.
+  // (Previously this used `new x402Client()` + register-only, which could not bound spend.)
+  const paymentClient = x402Client.fromConfig({
+    schemes: config.schemes,
+    policies: config.policies,
+    paymentRequirementsSelector: config.paymentRequirementsSelector,
+  });
 
   // Create x402MCPClient with options
   return new x402MCPClient(mcpClient, paymentClient, {


### PR DESCRIPTION
## Description

`createx402MCPClient` is documented as the simplest way to get started, but it previously did `new x402Client()` and registered schemes only — dropping `policies` and `paymentRequirementsSelector`. Those are the only mechanisms that bound agent spend before `accepts[0]` selection / auto-pay.

This change:

- Adds optional `policies` and `paymentRequirementsSelector` to `x402MCPClientConfig`
- Builds the payment client via `x402Client.fromConfig` (same path as `wrapMCPClientWithPaymentFromConfig`)
- Documents a max-amount policy example on the factory

Defaults are unchanged for callers who omit the new fields; production agents should set an explicit policy.

## AI disclosure

Drafted with AI assistance.

## Test plan

- [ ] Factory without policies behaves as before (schemes register, autoPayment works)
- [ ] Factory with a max-amount policy filters expensive accepts
- [ ] CI on this PR
