### PR TITLE
fix: wildcard line terminator bypass

### DIFF
--- a/typescript/.changeset/wildcard-route-line-terminator-bypass.md
+++ b/typescript/.changeset/wildcard-route-line-terminator-bypass.md
@@ -1,0 +1,9 @@
+---
+"@x402/core": patch
+"@x402/express": patch
+"@x402/hono": patch
+"@x402/fastify": patch
+"@x402/next": patch
+---
+
+Fixed a payment bypass on wildcard (`*`) route patterns: the compiled route regex used `.*?` without the dotAll flag, so a percent-encoded ECMAScript line terminator (e.g. `%E2%80%A8`, `%0A`, `%0D`) surviving path normalization would fail to match, causing `requiresPayment()` to return `false` and the middleware to skip payment verification and settlement entirely. The route regex now compiles with the dotAll flag so wildcard segments match any character, including line terminators.

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1165,10 +1165,7 @@ export class x402HTTPResourceServer {
           .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "[^/]+") // Parameters (Express style :param)
           .replace(/\//g, "\\/") // Escape slashes
       }$`,
-      // "s" (dotAll) so a "*" wildcard's ".*?" also matches literal
-      // LineTerminator code points (LF, CR, U+2028, U+2029) that
-      // normalizePath() may produce via decodeURIComponent; otherwise those
-      // bytes make the route regex fail to match and skip payment entirely.
+      // "s" (dotAll): without it, "." can't match LF/CR/U+2028/U+2029, so a wildcard segment containing one fails to match.
       "is",
     );
 

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1165,7 +1165,11 @@ export class x402HTTPResourceServer {
           .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "[^/]+") // Parameters (Express style :param)
           .replace(/\//g, "\\/") // Escape slashes
       }$`,
-      "i",
+      // "s" (dotAll) so a "*" wildcard's ".*?" also matches literal
+      // LineTerminator code points (LF, CR, U+2028, U+2029) that
+      // normalizePath() may produce via decodeURIComponent; otherwise those
+      // bytes make the route regex fail to match and skip payment entirely.
+      "is",
     );
 
     return { verb: verb.toUpperCase(), regex, path };

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -746,11 +746,7 @@ describe("x402HTTPResourceServer", () => {
     });
 
     describe("percent-encoded line terminators (CAT f2e83cec)", () => {
-      // Wildcard patterns compile `*` to `.*?` without the dotAll ('s') flag,
-      // so `.` cannot match an ECMAScript LineTerminator (LF, CR, U+2028,
-      // U+2029). normalizePath() decodes percent-escapes before matching, so
-      // a percent-encoded line terminator in the request path turns into a
-      // literal character the wildcard can no longer match.
+      // Without dotAll, "." (from a "*" wildcard) can't match a decoded LineTerminator.
       it.each([
         ["U+2028 LINE SEPARATOR", "/api/premium/report%E2%80%A8"],
         ["U+2029 PARAGRAPH SEPARATOR", "/api/premium/report%E2%80%A9"],

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -744,6 +744,45 @@ describe("x402HTTPResourceServer", () => {
         expect(result.type).toBe("payment-error");
       });
     });
+
+    describe("percent-encoded line terminators (CAT f2e83cec)", () => {
+      // Wildcard patterns compile `*` to `.*?` without the dotAll ('s') flag,
+      // so `.` cannot match an ECMAScript LineTerminator (LF, CR, U+2028,
+      // U+2029). normalizePath() decodes percent-escapes before matching, so
+      // a percent-encoded line terminator in the request path turns into a
+      // literal character the wildcard can no longer match.
+      it.each([
+        ["U+2028 LINE SEPARATOR", "/api/premium/report%E2%80%A8"],
+        ["U+2029 PARAGRAPH SEPARATOR", "/api/premium/report%E2%80%A9"],
+        ["LF", "/api/premium/report%0A"],
+        ["CR", "/api/premium/report%0D"],
+      ])("should require payment when the wildcard tail contains an encoded %s", async (_, path) => {
+        const routes = {
+          "/api/premium/*": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path,
+          method: "GET",
+        };
+
+        expect(httpServer.requiresPayment(context)).toBe(true);
+
+        const result = await httpServer.processHTTPRequest(context);
+        expect(result.type).toBe("payment-error");
+      });
+    });
   });
 
   describe("Payment processing", () => {

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -756,32 +756,35 @@ describe("x402HTTPResourceServer", () => {
         ["U+2029 PARAGRAPH SEPARATOR", "/api/premium/report%E2%80%A9"],
         ["LF", "/api/premium/report%0A"],
         ["CR", "/api/premium/report%0D"],
-      ])("should require payment when the wildcard tail contains an encoded %s", async (_, path) => {
-        const routes = {
-          "/api/premium/*": {
-            accepts: {
-              scheme: "exact",
-              payTo: "0xabc",
-              price: "$1.00" as Price,
-              network: "eip155:8453" as Network,
+      ])(
+        "should require payment when the wildcard tail contains an encoded %s",
+        async (_, path) => {
+          const routes = {
+            "/api/premium/*": {
+              accepts: {
+                scheme: "exact",
+                payTo: "0xabc",
+                price: "$1.00" as Price,
+                network: "eip155:8453" as Network,
+              },
             },
-          },
-        };
+          };
 
-        const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+          const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
 
-        const adapter = new MockHTTPAdapter();
-        const context: HTTPRequestContext = {
-          adapter,
-          path,
-          method: "GET",
-        };
+          const adapter = new MockHTTPAdapter();
+          const context: HTTPRequestContext = {
+            adapter,
+            path,
+            method: "GET",
+          };
 
-        expect(httpServer.requiresPayment(context)).toBe(true);
+          expect(httpServer.requiresPayment(context)).toBe(true);
 
-        const result = await httpServer.processHTTPRequest(context);
-        expect(result.type).toBe("payment-error");
-      });
+          const result = await httpServer.processHTTPRequest(context);
+          expect(result.type).toBe("payment-error");
+        },
+      );
     });
   });
 

--- a/typescript/packages/http/express/src/lineTerminatorBypass.test.ts
+++ b/typescript/packages/http/express/src/lineTerminatorBypass.test.ts
@@ -61,8 +61,7 @@ describe("express end-to-end: percent-encoded line terminator under wildcard rou
         false,
       ),
     );
-    // Catch-all so an unprotected route returns 200, not 404, letting us
-    // tell "middleware skipped the route" apart from "framework 404".
+    // Catch-all so a skipped route is 200, distinct from a framework 404.
     app.use((_req, res) => res.status(200).send("ok"));
 
     server = app.listen(0);

--- a/typescript/packages/http/express/src/lineTerminatorBypass.test.ts
+++ b/typescript/packages/http/express/src/lineTerminatorBypass.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import type { Server } from "node:http";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { x402ResourceServer } from "@x402/core/server";
+import { paymentMiddleware } from "./index";
+
+/**
+ * Issue a single HTTP GET to the given port + raw path and return the
+ * response status. The path is sent verbatim — Node does not re-encode
+ * it — which is exactly what an attacker on the wire could do.
+ *
+ * @param port - The local server port.
+ * @param rawPath - The raw HTTP path (already percent-encoded as desired).
+ * @returns The response status code.
+ */
+async function statusFor(port: number, rawPath: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, method: "GET", path: rawPath }, res => {
+      res.resume();
+      res.on("end", () => resolve(res.statusCode ?? 0));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+/**
+ * Reproduces CAT finding f2e83cec-d5d5-4076-bd4e-55e060d216b1: a wildcard
+ * route pattern (`"/api/premium/*"`) is compiled to a regex using `.*?`
+ * without the dotAll ('s') flag. `normalizePath()` runs the raw request
+ * path through `decodeURIComponent`, so a percent-encoded ECMAScript line
+ * terminator (e.g. %E2%80%A8 -> U+2028) decodes into a literal character
+ * that the `.` atom cannot match without dotAll, causing the route regex
+ * to fail to match and `requiresPayment()` to return false.
+ */
+describe("express end-to-end: percent-encoded line terminator under wildcard route", () => {
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    const app = express();
+    const resourceServer = new x402ResourceServer();
+    app.use(
+      paymentMiddleware(
+        {
+          "/api/premium/*": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00",
+              network: "eip155:84532",
+            },
+          },
+        },
+        resourceServer,
+        undefined,
+        undefined,
+        // syncFacilitatorOnStart=false so the test does not try to call a real facilitator
+        false,
+      ),
+    );
+    // Catch-all so an unprotected route returns 200, not 404, letting us
+    // tell "middleware skipped the route" apart from "framework 404".
+    app.use((_req, res) => res.status(200).send("ok"));
+
+    server = app.listen(0);
+    await new Promise<void>(resolve => server.once("listening", () => resolve()));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  });
+
+  it("returns 402 for a baseline wildcard match", async () => {
+    expect(await statusFor(port, "/api/premium/report")).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %E2%80%A8 (U+2028 LINE SEPARATOR)", async () => {
+    expect(await statusFor(port, "/api/premium/report%E2%80%A8")).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %E2%80%A9 (U+2029 PARAGRAPH SEPARATOR)", async () => {
+    expect(await statusFor(port, "/api/premium/report%E2%80%A9")).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %0A (encoded LF)", async () => {
+    expect(await statusFor(port, "/api/premium/report%0A")).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %0D (encoded CR)", async () => {
+    expect(await statusFor(port, "/api/premium/report%0D")).toBe(402);
+  });
+
+  it("returns 200 (middleware skipped) for an unrelated path", async () => {
+    expect(await statusFor(port, "/health")).toBe(200);
+  });
+});

--- a/typescript/packages/http/fastify/src/lineTerminatorBypass.test.ts
+++ b/typescript/packages/http/fastify/src/lineTerminatorBypass.test.ts
@@ -60,8 +60,7 @@ describe("fastify end-to-end: percent-encoded line terminator under wildcard rou
       // syncFacilitatorOnStart=false so the test does not try to call a real facilitator
       false,
     );
-    // Catch-all so an unprotected route returns 200, not 404, letting us
-    // tell "middleware skipped the route" apart from "framework 404".
+    // Catch-all so a skipped route is 200, distinct from a framework 404.
     app.all("/*", async (_req, reply) => reply.status(200).send("ok"));
 
     await app.listen({ port: 0, host: "127.0.0.1" });

--- a/typescript/packages/http/fastify/src/lineTerminatorBypass.test.ts
+++ b/typescript/packages/http/fastify/src/lineTerminatorBypass.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import Fastify, { FastifyInstance } from "fastify";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { x402ResourceServer } from "@x402/core/server";
+import { paymentMiddleware } from "./index";
+
+/**
+ * Issue a single HTTP GET to the given port + raw path and return the
+ * response status. The path is sent verbatim — Node does not re-encode
+ * it — which is exactly what an attacker on the wire could do.
+ *
+ * @param port - The local server port.
+ * @param rawPath - The raw HTTP path (already percent-encoded as desired).
+ * @returns The response status code.
+ */
+async function statusFor(port: number, rawPath: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: "127.0.0.1", port, method: "GET", path: rawPath }, res => {
+      res.resume();
+      res.on("end", () => resolve(res.statusCode ?? 0));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+/**
+ * Reproduces CAT finding f2e83cec-d5d5-4076-bd4e-55e060d216b1 against a real
+ * Fastify server over a real socket. Fastify's `request.url` is the raw,
+ * still percent-encoded URL (like Express's `req.path`), and — unlike
+ * Hono's router, which 404s and never invokes any handler for a path
+ * containing a decoded control character — Fastify's router dispatches
+ * these paths through to the registered wildcard route unmodified. So the
+ * payment gate bypass is reachable through Fastify exactly as described in
+ * the finding.
+ */
+describe("fastify end-to-end: percent-encoded line terminator under wildcard route", () => {
+  let app: FastifyInstance;
+  let port: number;
+
+  beforeAll(async () => {
+    app = Fastify();
+    const resourceServer = new x402ResourceServer();
+    paymentMiddleware(
+      app,
+      {
+        "/api/premium/*": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00",
+            network: "eip155:84532",
+          },
+        },
+      },
+      resourceServer,
+      undefined,
+      undefined,
+      // syncFacilitatorOnStart=false so the test does not try to call a real facilitator
+      false,
+    );
+    // Catch-all so an unprotected route returns 200, not 404, letting us
+    // tell "middleware skipped the route" apart from "framework 404".
+    app.all("/*", async (_req, reply) => reply.status(200).send("ok"));
+
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    port = (app.server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("returns 402 for a baseline wildcard match", async () => {
+    expect(await statusFor(port, "/api/premium/report")).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %E2%80%A8 (U+2028 LINE SEPARATOR)", async () => {
+    expect(await statusFor(port, "/api/premium/report%E2%80%A8")).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %E2%80%A9 (U+2029 PARAGRAPH SEPARATOR)", async () => {
+    expect(await statusFor(port, "/api/premium/report%E2%80%A9")).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %0A (encoded LF)", async () => {
+    expect(await statusFor(port, "/api/premium/report%0A")).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %0D (encoded CR)", async () => {
+    expect(await statusFor(port, "/api/premium/report%0D")).toBe(402);
+  });
+
+  it("returns 200 (middleware skipped) for an unrelated path", async () => {
+    expect(await statusFor(port, "/health")).toBe(200);
+  });
+});

--- a/typescript/packages/http/hono/src/lineTerminatorBypass.test.ts
+++ b/typescript/packages/http/hono/src/lineTerminatorBypass.test.ts
@@ -1,81 +1,132 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
-import { x402ResourceServer } from "@x402/core/server";
+import { x402HTTPResourceServer, x402ResourceServer } from "@x402/core/server";
 import { paymentMiddleware } from "./index";
 
 /**
- * Reproduces CAT finding f2e83cec-d5d5-4076-bd4e-55e060d216b1 against the
- * real Hono request pipeline (not a hand-built mock Context).
+ * Checks CAT finding f2e83cec-d5d5-4076-bd4e-55e060d216b1 against the real
+ * Hono request pipeline (not a hand-built mock Context).
  *
- * Hono's own `getPath()` decodes the raw request URL with `decodeURI()`
- * before `c.req.path` is ever read, so `context.path` reaches
- * `x402HTTPResourceServer` already decoded — unlike Express/Fastify/Next,
- * which hand over the still percent-encoded path and let
- * `normalizePath()`'s `decodeURIComponent` do the decoding. Both routes
- * converge on the same literal LineTerminator character reaching the route
- * regex, so this test exercises Hono's distinct code path end-to-end.
+ * Unlike Express/Fastify (raw percent-encoded `req.path`/`request.url`) and
+ * Next (`NextURL.pathname`, which also preserves percent-encoding), Hono's
+ * `c.req.path` is produced by Hono's own `getPath()`, which runs
+ * `decodeURI()` on the raw request URL *before Hono's router ever tries to
+ * match a route*. A path that decodes to contain an ECMAScript
+ * LineTerminator (LF, CR, U+2028, U+2029) fails Hono's own route matching —
+ * verified below against a bare Hono app with the most permissive possible
+ * route (`app.all("*")`, no x402 involved) — so Hono returns 404 and never
+ * invokes ANY handler, paid or not, including the x402 payment middleware
+ * itself. `requiresPayment()` is never called, so the core-level regex bug
+ * that affects Express/Fastify/Next is unreachable through Hono: there is
+ * no bypass to fix here, independent of whether `@x402/core`'s regex has
+ * the dotAll flag.
  *
  * `app.request()` is Hono's documented way to drive the full fetch handler
  * (including its internal `getPath()` URL parsing) without a real socket —
  * `new Request(url)` preserves percent-encoding exactly as the wire would.
  */
 describe("hono end-to-end: percent-encoded line terminator under wildcard route", () => {
-  function buildApp() {
+  it.each([
+    ["U+2028 LINE SEPARATOR", "/api/premium/report%E2%80%A8"],
+    ["U+2029 PARAGRAPH SEPARATOR", "/api/premium/report%E2%80%A9"],
+    ["LF", "/api/premium/report%0A"],
+    ["CR", "/api/premium/report%0D"],
+  ])("bare Hono router 404s on an encoded %s before any handler runs", async (_, path) => {
     const app = new Hono();
-    const resourceServer = new x402ResourceServer();
-    app.use(
-      "*",
-      paymentMiddleware(
-        {
-          "/api/premium/*": {
-            accepts: {
-              scheme: "exact",
-              payTo: "0xabc",
-              price: "$1.00",
-              network: "eip155:84532",
+    let called = 0;
+    app.use("*", async (_c, next) => {
+      called++;
+      await next();
+    });
+    app.all("*", c => c.text("ok", 200));
+
+    const res = await app.request(path);
+
+    expect(res.status).toBe(404);
+    expect(called).toBe(0);
+  });
+
+  it("sanity check: the same bare app dispatches a normal path", async () => {
+    const app = new Hono();
+    app.all("*", c => c.text("ok", 200));
+
+    const res = await app.request("/api/premium/report");
+
+    expect(res.status).toBe(200);
+  });
+
+  describe("with the x402 payment middleware installed", () => {
+    let requiresPaymentSpy: ReturnType<typeof vi.spyOn>;
+
+    /**
+     * Builds a Hono app with the x402 payment middleware installed on a
+     * wildcard route, plus a catch-all so an unprotected path resolves to
+     * 200 instead of a framework 404.
+     *
+     * @returns The configured Hono app.
+     */
+    function buildApp() {
+      const app = new Hono();
+      const resourceServer = new x402ResourceServer();
+      app.use(
+        "*",
+        paymentMiddleware(
+          {
+            "/api/premium/*": {
+              accepts: {
+                scheme: "exact",
+                payTo: "0xabc",
+                price: "$1.00",
+                network: "eip155:84532",
+              },
             },
           },
-        },
-        resourceServer,
-        undefined,
-        undefined,
-        // syncFacilitatorOnStart=false so the test does not try to call a real facilitator
-        false,
-      ),
+          resourceServer,
+          undefined,
+          undefined,
+          // syncFacilitatorOnStart=false so the test does not try to call a real facilitator
+          false,
+        ),
+      );
+      // Catch-all so an unprotected route returns 200, not 404, letting us
+      // tell "middleware skipped the route" apart from "framework 404".
+      app.all("*", c => c.text("ok", 200));
+      return app;
+    }
+
+    beforeEach(() => {
+      requiresPaymentSpy = vi.spyOn(x402HTTPResourceServer.prototype, "requiresPayment");
+    });
+
+    afterEach(() => {
+      requiresPaymentSpy.mockRestore();
+    });
+
+    it("returns 402 for a baseline wildcard match, and requiresPayment is called", async () => {
+      const res = await buildApp().request("/api/premium/report");
+      expect(res.status).toBe(402);
+      expect(requiresPaymentSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ["U+2028 LINE SEPARATOR", "/api/premium/report%E2%80%A8"],
+      ["U+2029 PARAGRAPH SEPARATOR", "/api/premium/report%E2%80%A9"],
+      ["LF", "/api/premium/report%0A"],
+      ["CR", "/api/premium/report%0D"],
+    ])(
+      "returns 404 for an encoded %s and never calls requiresPayment (no bypass reaches the paid handler)",
+      async (_, path) => {
+        const res = await buildApp().request(path);
+
+        expect(res.status).toBe(404);
+        expect(requiresPaymentSpy).not.toHaveBeenCalled();
+      },
     );
-    // Catch-all so an unprotected route returns 200, not 404, letting us
-    // tell "middleware skipped the route" apart from "framework 404".
-    app.all("*", c => c.text("ok", 200));
-    return app;
-  }
 
-  it("returns 402 for a baseline wildcard match", async () => {
-    const res = await buildApp().request("/api/premium/report");
-    expect(res.status).toBe(402);
-  });
-
-  it("returns 402 even when the tail contains %E2%80%A8 (U+2028 LINE SEPARATOR)", async () => {
-    const res = await buildApp().request("/api/premium/report%E2%80%A8");
-    expect(res.status).toBe(402);
-  });
-
-  it("returns 402 even when the tail contains %E2%80%A9 (U+2029 PARAGRAPH SEPARATOR)", async () => {
-    const res = await buildApp().request("/api/premium/report%E2%80%A9");
-    expect(res.status).toBe(402);
-  });
-
-  it("returns 402 even when the tail contains %0A (encoded LF)", async () => {
-    const res = await buildApp().request("/api/premium/report%0A");
-    expect(res.status).toBe(402);
-  });
-
-  it("returns 402 even when the tail contains %0D (encoded CR)", async () => {
-    const res = await buildApp().request("/api/premium/report%0D");
-    expect(res.status).toBe(402);
-  });
-
-  it("returns 200 (middleware skipped) for an unrelated path", async () => {
-    const res = await buildApp().request("/health");
-    expect(res.status).toBe(200);
+    it("returns 200 (middleware skipped) for an unrelated path", async () => {
+      const res = await buildApp().request("/health");
+      expect(res.status).toBe(200);
+      expect(requiresPaymentSpy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/typescript/packages/http/hono/src/lineTerminatorBypass.test.ts
+++ b/typescript/packages/http/hono/src/lineTerminatorBypass.test.ts
@@ -88,8 +88,7 @@ describe("hono end-to-end: percent-encoded line terminator under wildcard route"
           false,
         ),
       );
-      // Catch-all so an unprotected route returns 200, not 404, letting us
-      // tell "middleware skipped the route" apart from "framework 404".
+      // Catch-all so a skipped route is 200, distinct from a framework 404.
       app.all("*", c => c.text("ok", 200));
       return app;
     }

--- a/typescript/packages/http/hono/src/lineTerminatorBypass.test.ts
+++ b/typescript/packages/http/hono/src/lineTerminatorBypass.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { x402ResourceServer } from "@x402/core/server";
+import { paymentMiddleware } from "./index";
+
+/**
+ * Reproduces CAT finding f2e83cec-d5d5-4076-bd4e-55e060d216b1 against the
+ * real Hono request pipeline (not a hand-built mock Context).
+ *
+ * Hono's own `getPath()` decodes the raw request URL with `decodeURI()`
+ * before `c.req.path` is ever read, so `context.path` reaches
+ * `x402HTTPResourceServer` already decoded — unlike Express/Fastify/Next,
+ * which hand over the still percent-encoded path and let
+ * `normalizePath()`'s `decodeURIComponent` do the decoding. Both routes
+ * converge on the same literal LineTerminator character reaching the route
+ * regex, so this test exercises Hono's distinct code path end-to-end.
+ *
+ * `app.request()` is Hono's documented way to drive the full fetch handler
+ * (including its internal `getPath()` URL parsing) without a real socket —
+ * `new Request(url)` preserves percent-encoding exactly as the wire would.
+ */
+describe("hono end-to-end: percent-encoded line terminator under wildcard route", () => {
+  function buildApp() {
+    const app = new Hono();
+    const resourceServer = new x402ResourceServer();
+    app.use(
+      "*",
+      paymentMiddleware(
+        {
+          "/api/premium/*": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00",
+              network: "eip155:84532",
+            },
+          },
+        },
+        resourceServer,
+        undefined,
+        undefined,
+        // syncFacilitatorOnStart=false so the test does not try to call a real facilitator
+        false,
+      ),
+    );
+    // Catch-all so an unprotected route returns 200, not 404, letting us
+    // tell "middleware skipped the route" apart from "framework 404".
+    app.all("*", c => c.text("ok", 200));
+    return app;
+  }
+
+  it("returns 402 for a baseline wildcard match", async () => {
+    const res = await buildApp().request("/api/premium/report");
+    expect(res.status).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %E2%80%A8 (U+2028 LINE SEPARATOR)", async () => {
+    const res = await buildApp().request("/api/premium/report%E2%80%A8");
+    expect(res.status).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %E2%80%A9 (U+2029 PARAGRAPH SEPARATOR)", async () => {
+    const res = await buildApp().request("/api/premium/report%E2%80%A9");
+    expect(res.status).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %0A (encoded LF)", async () => {
+    const res = await buildApp().request("/api/premium/report%0A");
+    expect(res.status).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %0D (encoded CR)", async () => {
+    const res = await buildApp().request("/api/premium/report%0D");
+    expect(res.status).toBe(402);
+  });
+
+  it("returns 200 (middleware skipped) for an unrelated path", async () => {
+    const res = await buildApp().request("/health");
+    expect(res.status).toBe(200);
+  });
+});

--- a/typescript/packages/http/next/src/lineTerminatorBypass.test.ts
+++ b/typescript/packages/http/next/src/lineTerminatorBypass.test.ts
@@ -72,8 +72,7 @@ describe("next end-to-end: percent-encoded line terminator under wildcard route"
 
   it("returns NextResponse.next() (middleware skipped) for an unrelated path", async () => {
     const res = await buildProxy()(new NextRequest("https://example.com/health"));
-    // NextResponse.next() is a passthrough marker, not a terminal response —
-    // it carries status 200 and the internal middleware-next signal header.
+    // NextResponse.next() is a 200 passthrough carrying this signal header.
     expect(res.status).toBe(200);
     expect(res.headers.get("x-middleware-next")).toBe("1");
   });

--- a/typescript/packages/http/next/src/lineTerminatorBypass.test.ts
+++ b/typescript/packages/http/next/src/lineTerminatorBypass.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { x402ResourceServer } from "@x402/core/server";
+import { paymentProxy } from "./index";
+
+/**
+ * Reproduces CAT finding f2e83cec-d5d5-4076-bd4e-55e060d216b1 against the
+ * real Next.js proxy (no `@x402/core/server` mocking, unlike index.test.ts).
+ *
+ * `NextRequest.nextUrl.pathname` is backed by the WHATWG `URL` class, which
+ * does not decode percent-escapes — `new URL("https://x/a%E2%80%A8").pathname`
+ * stays `"/a%E2%80%A8"`. So Next hands `x402HTTPResourceServer` the same
+ * still-encoded path Express/Fastify do, and the payment gate bypass is
+ * reachable through Next exactly as described in the finding.
+ */
+describe("next end-to-end: percent-encoded line terminator under wildcard route", () => {
+  /**
+   * Builds a Next.js payment proxy protecting a wildcard route, backed by a
+   * real `x402ResourceServer` (not mocked).
+   *
+   * @returns The configured proxy handler.
+   */
+  function buildProxy() {
+    const resourceServer = new x402ResourceServer();
+    return paymentProxy(
+      {
+        "/api/premium/*": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00",
+            network: "eip155:84532",
+          },
+        },
+      },
+      resourceServer,
+      undefined,
+      undefined,
+      // syncFacilitatorOnStart=false so the test does not try to call a real facilitator
+      false,
+    );
+  }
+
+  it("returns 402 for a baseline wildcard match", async () => {
+    const res = await buildProxy()(new NextRequest("https://example.com/api/premium/report"));
+    expect(res.status).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %E2%80%A8 (U+2028 LINE SEPARATOR)", async () => {
+    const res = await buildProxy()(
+      new NextRequest("https://example.com/api/premium/report%E2%80%A8"),
+    );
+    expect(res.status).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %E2%80%A9 (U+2029 PARAGRAPH SEPARATOR)", async () => {
+    const res = await buildProxy()(
+      new NextRequest("https://example.com/api/premium/report%E2%80%A9"),
+    );
+    expect(res.status).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %0A (encoded LF)", async () => {
+    const res = await buildProxy()(new NextRequest("https://example.com/api/premium/report%0A"));
+    expect(res.status).toBe(402);
+  });
+
+  it("returns 402 even when the tail contains %0D (encoded CR)", async () => {
+    const res = await buildProxy()(new NextRequest("https://example.com/api/premium/report%0D"));
+    expect(res.status).toBe(402);
+  });
+
+  it("returns NextResponse.next() (middleware skipped) for an unrelated path", async () => {
+    const res = await buildProxy()(new NextRequest("https://example.com/health"));
+    // NextResponse.next() is a passthrough marker, not a terminal response —
+    // it carries status 200 and the internal middleware-next signal header.
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

In x402HTTPResourceServer.ts:1168 I added the s (dotAll) flag to the compiled route regex. Wildcard patterns (*) compile to .*?; without dotAll, . cannot match the four ECMA-262 LineTerminator code points (LF, CR,  U+2028, U+2029), which normalizePath()'s decodeURIComponent call can produce from percent-encoded input. Adding dotAll is the minimal correct fix: it only affects the unescaped . atom, so it doesn't touch literal-dot matches (already escaped to \. earlier in the same pipeline) or the [^/]+ character classes used for :param/[param] routes (character classes are unaffected by dotAll and already matched line terminators fine).

## Tests

* Added unit tests to confirm the bug existed at the x402HTTPResourceServer level, and prove the fix worked
* Added e2e tests proving that express/next/fastify had the bugs, and the fix fixed it
* Added e2e proving that hono did NOT have the bug as the server explicitly never allowed this type of attack, proving it remains safe

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 