### PR TITLE
fix: reject external / in bazaar discovery schema (SSRF)

### DIFF
--- a/go/.changes/unreleased/fix-bazaar-schema-ref-ssrf.yaml
+++ b/go/.changes/unreleased/fix-bazaar-schema-ref-ssrf.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: Reject bazaar discovery extension schemas containing external "$ref"/"$id" values (anything other than a same-document "#" fragment) before validation, preventing an attacker-controlled schema from triggering an outbound HTTP request or local file read (SSRF/LFI, CWE-918)
+time: 2026-08-04T00:00:00Z

--- a/go/extensions/bazaar/bazaar_test.go
+++ b/go/extensions/bazaar/bazaar_test.go
@@ -2,7 +2,12 @@ package bazaar_test
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -3159,4 +3164,148 @@ func TestExtractDiscoveredResource_ServiceMetadata(t *testing.T) {
 		assert.Equal(t, []string{"weather"}, discovered.Tags)
 		assert.Equal(t, "https://api.example.com/icon.png", discovered.IconUrl)
 	})
+}
+
+// TestValidateDiscoveryExtension_SSRF reproduces CWE-918: a client-controlled schema `$ref`/`$id`
+// must never be dereferenced. gojsonschema's default loader resolves any unregistered `$ref` via
+// an outbound HTTP request or a filesystem read during schema compilation, before the instance is
+// ever checked. Since `schema` arrives in the client's payment payload, this is a real SSRF /
+// local file disclosure vector.
+func TestValidateDiscoveryExtension_SSRF(t *testing.T) {
+	t.Run("rejects a $ref over http without dereferencing it", func(t *testing.T) {
+		var hits int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"type": "object"}`))
+		}))
+		defer server.Close()
+
+		extension := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.QueryInput{Type: "http", Method: bazaar.MethodGET},
+			},
+			Schema: bazaar.JSONSchema{"$ref": server.URL + "/attacker-schema.json"},
+		}
+
+		result := bazaar.ValidateDiscoveryExtension(extension)
+
+		assert.Equal(t, int32(0), atomic.LoadInt32(&hits),
+			"an attacker-controlled $ref must never cause an outbound HTTP request (CWE-918 SSRF)")
+		assert.False(t, result.Valid, "schema with an external $ref must be rejected")
+	})
+
+	t.Run("rejects a $ref via file:// URI without reading the file", func(t *testing.T) {
+		dir := t.TempDir()
+		secretPath := filepath.Join(dir, "attacker-schema.json")
+		require.NoError(t, os.WriteFile(secretPath, []byte(`{"type": "object"}`), 0o600))
+
+		extension := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.QueryInput{Type: "http", Method: bazaar.MethodGET},
+			},
+			Schema: bazaar.JSONSchema{"$ref": "file://" + secretPath},
+		}
+
+		result := bazaar.ValidateDiscoveryExtension(extension)
+
+		assert.False(t, result.Valid, "schema with a file:// $ref must be rejected")
+	})
+
+	t.Run("rejects a $ref nested inside schema properties", func(t *testing.T) {
+		var hits int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"type": "object"}`))
+		}))
+		defer server.Close()
+
+		extension := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.QueryInput{Type: "http", Method: bazaar.MethodGET},
+			},
+			Schema: bazaar.JSONSchema{
+				"properties": map[string]interface{}{
+					"input": map[string]interface{}{"$ref": server.URL + "/attacker-schema.json"},
+				},
+			},
+		}
+
+		result := bazaar.ValidateDiscoveryExtension(extension)
+
+		assert.Equal(t, int32(0), atomic.LoadInt32(&hits), "nested $ref must not be dereferenced")
+		assert.False(t, result.Valid)
+	})
+
+	t.Run("rejects an external $id", func(t *testing.T) {
+		extension := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.QueryInput{Type: "http", Method: bazaar.MethodGET},
+			},
+			Schema: bazaar.JSONSchema{"$id": "https://evil.example.com/schema.json", "type": "object"},
+		}
+
+		result := bazaar.ValidateDiscoveryExtension(extension)
+
+		assert.False(t, result.Valid, "schema with an external $id must be rejected")
+	})
+
+	t.Run("still validates schemas with only local fragment refs", func(t *testing.T) {
+		extension := bazaar.DiscoveryExtension{
+			Info: bazaar.DiscoveryInfo{
+				Input: bazaar.QueryInput{Type: "http", Method: bazaar.MethodGET},
+			},
+			Schema: bazaar.JSONSchema{
+				"$ref": "#/definitions/root",
+				"definitions": map[string]interface{}{
+					"root": map[string]interface{}{"type": "object"},
+				},
+			},
+		}
+
+		result := bazaar.ValidateDiscoveryExtension(extension)
+
+		assert.True(t, result.Valid, "local fragment $ref should still validate: %v", result.Errors)
+	})
+}
+
+// TestExtractDiscoveredResourceFromPaymentPayload_SSRF matches the real attack path: a client's
+// paymentPayload with a malicious extensions.bazaar.schema, processed via
+// ExtractDiscoveredResourceFromPaymentPayload(validate=true) the way a facilitator's
+// OnAfterVerify hook does.
+func TestExtractDiscoveredResourceFromPaymentPayload_SSRF(t *testing.T) {
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"type": "object"}`))
+	}))
+	defer server.Close()
+
+	extension := bazaar.DiscoveryExtension{
+		Info: bazaar.DiscoveryInfo{
+			Input: bazaar.QueryInput{Type: "http", Method: bazaar.MethodGET},
+		},
+		Schema: bazaar.JSONSchema{"$ref": server.URL + "/attacker-schema.json"},
+	}
+
+	payload := x402.PaymentPayload{
+		X402Version: 2,
+		Accepted:    x402.PaymentRequirements{Scheme: "exact", Network: "eip155:84532"},
+		Payload:     map[string]interface{}{},
+		Resource:    &x402.ResourceInfo{URL: "http://api.example.com/weather"},
+		Extensions:  map[string]interface{}{bazaar.BAZAAR.Key(): extension},
+	}
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	discovered, err := bazaar.ExtractDiscoveredResourceFromPaymentPayload(payloadBytes, nil, true)
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&hits),
+		"an attacker-controlled $ref in extensions.bazaar.schema must never cause the facilitator "+
+			"to make an outbound HTTP request (CWE-918 SSRF)")
+	assert.Error(t, err,
+		"a schema containing an external $ref should fail validation, not silently succeed")
+	assert.Nil(t, discovered)
 }

--- a/go/extensions/bazaar/facilitator.go
+++ b/go/extensions/bazaar/facilitator.go
@@ -23,6 +23,38 @@ type ValidationResult struct {
 	Errors []string
 }
 
+// hasExternalSchemaReference recursively scans a decoded JSON Schema document for "$ref"/"$id"
+// values that are not same-document fragments (i.e. do not start with "#").
+//
+// gojsonschema's default loader resolves any other form -- absolute http(s):// URLs, file://
+// URIs, or relative paths -- via an outbound HTTP request or filesystem read during schema
+// compilation, before the instance is ever validated. Since schema is client-controlled (it
+// arrives in the payment payload), any such value is treated as unsafe (CWE-918 SSRF / local
+// file disclosure).
+func hasExternalSchemaReference(node any) bool {
+	switch v := node.(type) {
+	case map[string]any:
+		for key, value := range v {
+			if key == "$ref" || key == "$id" {
+				str, ok := value.(string)
+				if !ok || !strings.HasPrefix(str, "#") {
+					return true
+				}
+			}
+			if hasExternalSchemaReference(value) {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if hasExternalSchemaReference(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ValidateDiscoveryExtension validates a discovery extension's info against its schema
 //
 // Args:
@@ -42,6 +74,19 @@ type ValidationResult struct {
 //	    fmt.Println("Validation errors:", result.Errors)
 //	}
 func ValidateDiscoveryExtension(extension types.DiscoveryExtension) ValidationResult {
+	// The schema is attacker-controlled (it arrives in the client's payment payload).
+	// gojsonschema's default loader resolves "$ref"/"$id" values via an outbound HTTP
+	// request or filesystem read during compilation, before the instance is ever checked
+	// (CWE-918 SSRF / local file read). Only same-document fragment references (e.g.
+	// "#/definitions/foo") are safe, since they resolve against the in-memory document
+	// instead of fetching anything.
+	if hasExternalSchemaReference(map[string]any(extension.Schema)) {
+		return ValidationResult{
+			Valid:  false,
+			Errors: []string{"schema must not contain external $ref/$id references"},
+		}
+	}
+
 	// Convert schema to JSON
 	schemaJSON, err := json.Marshal(extension.Schema)
 	if err != nil {

--- a/python/x402/changelog.d/fix-bazaar-schema-ref-ssrf.bugfix.md
+++ b/python/x402/changelog.d/fix-bazaar-schema-ref-ssrf.bugfix.md
@@ -1,0 +1,1 @@
+Reject bazaar discovery extension schemas containing external "$ref"/"$id" values (anything other than a same-document "#" fragment) before validation, preventing an attacker-controlled schema from triggering an outbound HTTP request or local file read (SSRF/LFI, CWE-918)

--- a/python/x402/extensions/bazaar/facilitator.py
+++ b/python/x402/extensions/bazaar/facilitator.py
@@ -319,6 +319,30 @@ class ValidationResult:
     errors: list[str] = field(default_factory=list)
 
 
+def _has_external_schema_reference(node: Any) -> bool:
+    """Recursively scan a decoded JSON Schema document for "$ref"/"$id" values that are
+    not same-document fragments (i.e. do not start with "#").
+
+    ``jsonschema``'s default resolver dereferences any other form -- absolute http(s)://
+    URLs, file:// URIs, or relative paths -- via an outbound HTTP request or filesystem
+    read during schema compilation, before the instance is ever validated. Since schema
+    is client-controlled (it arrives in the payment payload), any such value is treated
+    as unsafe (CWE-918 SSRF / local file disclosure).
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key in ("$ref", "$id"):
+                if not isinstance(value, str) or not value.startswith("#"):
+                    return True
+            if _has_external_schema_reference(value):
+                return True
+    elif isinstance(node, list):
+        for item in node:
+            if _has_external_schema_reference(item):
+                return True
+    return False
+
+
 @dataclass
 class DiscoveredResource:
     """A discovered x402 resource with its metadata."""
@@ -375,6 +399,18 @@ def validate_discovery_extension(extension: DiscoveryExtension) -> ValidationRes
         else:
             schema = extension.schema_ if hasattr(extension, "schema_") else {}
             info = extension.info
+
+        # The schema is attacker-controlled (it arrives in the client's payment payload).
+        # jsonschema's default resolver dereferences "$ref"/"$id" values via an outbound
+        # HTTP request or filesystem read during compilation, before the instance is ever
+        # checked (CWE-918 SSRF / local file read). Only same-document fragment references
+        # (e.g. "#/definitions/foo") are safe, since they resolve against the in-memory
+        # document instead of fetching anything.
+        if _has_external_schema_reference(schema):
+            return ValidationResult(
+                valid=False,
+                errors=["schema must not contain external $ref/$id references"],
+            )
 
         # Convert info to dict if it's a Pydantic model
         if hasattr(info, "model_dump"):

--- a/python/x402/tests/unit/extensions/bazaar/test_facilitator.py
+++ b/python/x402/tests/unit/extensions/bazaar/test_facilitator.py
@@ -1034,8 +1034,7 @@ class TestValidateDiscoveryExtensionSSRF:
                 "the facilitator to make an outbound HTTP request (CWE-918 SSRF)"
             )
             assert discovered is None, (
-                "a schema containing an external $ref should fail validation, not silently "
-                "succeed"
+                "a schema containing an external $ref should fail validation, not silently succeed"
             )
         finally:
             server.shutdown()

--- a/python/x402/tests/unit/extensions/bazaar/test_facilitator.py
+++ b/python/x402/tests/unit/extensions/bazaar/test_facilitator.py
@@ -1,5 +1,8 @@
 """Tests for Bazaar facilitator functions."""
 
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
 from x402.extensions.bazaar import (
     BAZAAR,
     BodyDiscoveryInfo,
@@ -11,6 +14,7 @@ from x402.extensions.bazaar import (
     validate_discovery_extension,
 )
 from x402.extensions.bazaar.facilitator import (
+    _has_external_schema_reference,
     _is_valid_icon_url,
     _is_valid_route_template,
     _is_valid_service_name,
@@ -896,3 +900,171 @@ class TestExtractDiscoveryInfoV1Extensions:
         assert discovered.extensions is not None
         assert "outputSchema" not in discovered.extensions
         assert discovered.extensions[BAZAAR.key]["info"] == discovered.discovery_info
+
+
+class _CountingHandler(BaseHTTPRequestHandler):
+    """Records a hit and serves a trivial JSON Schema document."""
+
+    hits = 0
+
+    def do_GET(self) -> None:  # noqa: N802
+        type(self).hits += 1
+        body = b'{"type": "object"}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass
+
+
+class TestValidateDiscoveryExtensionSSRF:
+    """Regression tests for CWE-918: a client-controlled schema $ref/$id must never be
+    dereferenced. jsonschema's default resolver dereferences any non-fragment $ref via an
+    outbound HTTP request or filesystem read during schema compilation, before the instance
+    is ever checked. Since ``schema`` arrives in the client's payment payload, this is a real
+    SSRF / local file disclosure vector.
+    """
+
+    def _serve(self) -> tuple[HTTPServer, str]:
+        _CountingHandler.hits = 0
+        server = HTTPServer(("127.0.0.1", 0), _CountingHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return server, f"http://127.0.0.1:{server.server_port}"
+
+    def test_rejects_ref_over_http_without_dereferencing_it(self) -> None:
+        server, base_url = self._serve()
+        try:
+            extension = {
+                "info": {"input": {"type": "http", "method": "GET"}},
+                "schema": {"$ref": f"{base_url}/attacker-schema.json"},
+            }
+
+            result = validate_discovery_extension(extension)
+
+            assert _CountingHandler.hits == 0, (
+                "an attacker-controlled $ref must never cause an outbound HTTP request "
+                "(CWE-918 SSRF)"
+            )
+            assert result.valid is False
+        finally:
+            server.shutdown()
+
+    def test_rejects_ref_via_file_uri_without_reading_the_file(self, tmp_path) -> None:
+        secret_path = tmp_path / "attacker-schema.json"
+        secret_path.write_text('{"type": "object"}')
+
+        extension = {
+            "info": {"input": {"type": "http", "method": "GET"}},
+            "schema": {"$ref": f"file://{secret_path}"},
+        }
+
+        result = validate_discovery_extension(extension)
+
+        assert result.valid is False
+
+    def test_rejects_ref_nested_inside_schema_properties(self) -> None:
+        server, base_url = self._serve()
+        try:
+            extension = {
+                "info": {"input": {"type": "http", "method": "GET"}},
+                "schema": {
+                    "properties": {
+                        "input": {"$ref": f"{base_url}/attacker-schema.json"},
+                    },
+                },
+            }
+
+            result = validate_discovery_extension(extension)
+
+            assert _CountingHandler.hits == 0, "nested $ref must not be dereferenced"
+            assert result.valid is False
+        finally:
+            server.shutdown()
+
+    def test_rejects_external_id(self) -> None:
+        extension = {
+            "info": {"input": {"type": "http", "method": "GET"}},
+            "schema": {"$id": "https://evil.example.com/schema.json", "type": "object"},
+        }
+
+        result = validate_discovery_extension(extension)
+
+        assert result.valid is False
+
+    def test_still_validates_schemas_with_only_local_fragment_refs(self) -> None:
+        extension = {
+            "info": {"input": {"type": "http", "method": "GET"}},
+            "schema": {
+                "$ref": "#/definitions/root",
+                "definitions": {"root": {"type": "object"}},
+            },
+        }
+
+        result = validate_discovery_extension(extension)
+
+        assert result.valid is True, result.errors
+
+    def test_extract_discovery_info_rejects_external_ref_end_to_end(self) -> None:
+        """Matches the real attack path: a client's paymentPayload with a malicious
+        extensions.bazaar.schema, processed via extract_discovery_info(validate=True) the
+        way a facilitator's verify hook does.
+        """
+        server, base_url = self._serve()
+        try:
+            ext_dict = {
+                "info": {"input": {"type": "http", "method": "GET"}},
+                "schema": {"$ref": f"{base_url}/attacker-schema.json"},
+            }
+            payload = {
+                "x402Version": 2,
+                "resource": {"url": "http://api.example.com/weather"},
+                "extensions": {BAZAAR.key: ext_dict},
+                "accepted": {},
+            }
+            requirements = {"scheme": "exact", "network": "eip155:84532"}
+
+            discovered = extract_discovery_info(payload, requirements)
+
+            assert _CountingHandler.hits == 0, (
+                "an attacker-controlled $ref in extensions.bazaar.schema must never cause "
+                "the facilitator to make an outbound HTTP request (CWE-918 SSRF)"
+            )
+            assert discovered is None, (
+                "a schema containing an external $ref should fail validation, not silently "
+                "succeed"
+            )
+        finally:
+            server.shutdown()
+
+
+class TestHasExternalSchemaReference:
+    """Direct unit tests for the _has_external_schema_reference helper."""
+
+    def test_returns_false_for_empty_schema(self) -> None:
+        assert _has_external_schema_reference({}) is False
+
+    def test_returns_false_for_fragment_ref(self) -> None:
+        assert _has_external_schema_reference({"$ref": "#/definitions/foo"}) is False
+
+    def test_returns_true_for_http_ref(self) -> None:
+        assert _has_external_schema_reference({"$ref": "http://evil.com/x.json"}) is True
+
+    def test_returns_true_for_https_ref(self) -> None:
+        assert _has_external_schema_reference({"$ref": "https://evil.com/x.json"}) is True
+
+    def test_returns_true_for_file_ref(self) -> None:
+        assert _has_external_schema_reference({"$ref": "file:///etc/passwd"}) is True
+
+    def test_returns_true_for_relative_ref(self) -> None:
+        assert _has_external_schema_reference({"$ref": "../../etc/passwd"}) is True
+
+    def test_returns_true_for_external_id(self) -> None:
+        assert _has_external_schema_reference({"$id": "https://evil.com/x.json"}) is True
+
+    def test_returns_true_for_nested_ref_in_list(self) -> None:
+        schema = {"allOf": [{"type": "object"}, {"$ref": "http://evil.com/x.json"}]}
+        assert _has_external_schema_reference(schema) is True

--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -318,8 +318,9 @@ The `schema` field contains a JSON Schema (Draft 2020-12) that validates the str
 - Must validate that `input.type` equals `"http"` (for HTTP endpoints) or `"mcp"` (for MCP tools)
 - For HTTP endpoints: Must validate the appropriate `method` enum based on operation type
 - For MCP tools: Must require `toolName` and `inputSchema` fields
+- `$ref` and `$id` values must be same-document JSON Pointer fragments (starting with `#`); external references (`http(s)://`, `file://`, or any other absolute/relative URI) are not allowed
 
-Facilitators **must** validate `info` against `schema` before cataloging.
+Facilitators **must** validate `info` against `schema` before cataloging. Facilitators **must not** resolve external `$ref`/`$id` values (e.g. by fetching a URL or reading a file) when validating an untrusted `schema`; a `schema` containing one must be rejected outright, since resolving it would let an attacker-supplied payload trigger server-side requests or local file reads (SSRF/LFI, CWE-918).
 
 ### MCP Schema Example
 

--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -320,7 +320,7 @@ The `schema` field contains a JSON Schema (Draft 2020-12) that validates the str
 - For MCP tools: Must require `toolName` and `inputSchema` fields
 - `$ref` and `$id` values must be same-document JSON Pointer fragments (starting with `#`); external references (`http(s)://`, `file://`, or any other absolute/relative URI) are not allowed
 
-Facilitators **must** validate `info` against `schema` before cataloging. Facilitators **must not** resolve external `$ref`/`$id` values (e.g. by fetching a URL or reading a file) when validating an untrusted `schema`; a `schema` containing one must be rejected outright, since resolving it would let an attacker-supplied payload trigger server-side requests or local file reads (SSRF/LFI, CWE-918).
+Facilitators **must** validate `info` against `schema` before cataloging. Facilitators **must not** resolve external `$ref`/`$id` values (e.g. by fetching a URL or reading a file) when validating an untrusted `schema`.
 
 ### MCP Schema Example
 

--- a/typescript/.changeset/fix-bazaar-schema-ref-ssrf.md
+++ b/typescript/.changeset/fix-bazaar-schema-ref-ssrf.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": patch
+---
+
+Reject bazaar discovery extension schemas containing external "$ref"/"$id" values (anything other than a same-document "#" fragment) before validation, preventing an attacker-controlled schema from triggering an outbound HTTP request or local file read (SSRF/LFI, CWE-918)

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -300,6 +300,9 @@ export interface ValidationResult {
  * since schema is client-controlled (it arrives in the payment payload) and any external
  * $ref/$id is a CWE-918 SSRF / local file disclosure pattern other JSON Schema tooling
  * (including future Ajv options like `loadSchema`) can act on.
+ *
+ * @param node - The (sub)tree of a decoded JSON Schema document to scan
+ * @returns True if any non-fragment "$ref"/"$id" value is found
  */
 function hasExternalSchemaReference(node: unknown): boolean {
   if (Array.isArray(node)) {

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -291,6 +291,36 @@ export interface ValidationResult {
 }
 
 /**
+ * Recursively scans a decoded JSON Schema document for "$ref"/"$id" values that are not
+ * same-document fragments (i.e. do not start with "#").
+ *
+ * Ajv's default `compile` throws rather than dereferencing an unregistered absolute/relative
+ * `$ref`, so this SDK does not fetch or read anything by default. This guard exists for
+ * defense-in-depth and to give a consistent, explicit rejection message across all x402 SDKs,
+ * since schema is client-controlled (it arrives in the payment payload) and any external
+ * $ref/$id is a CWE-918 SSRF / local file disclosure pattern other JSON Schema tooling
+ * (including future Ajv options like `loadSchema`) can act on.
+ */
+function hasExternalSchemaReference(node: unknown): boolean {
+  if (Array.isArray(node)) {
+    return node.some(item => hasExternalSchemaReference(item));
+  }
+  if (node && typeof node === "object") {
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (key === "$ref" || key === "$id") {
+        if (typeof value !== "string" || !value.startsWith("#")) {
+          return true;
+        }
+      }
+      if (hasExternalSchemaReference(value)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Validates a discovery extension's info against its schema
  *
  * @param extension - The discovery extension containing info and schema
@@ -310,6 +340,16 @@ export interface ValidationResult {
  */
 export function validateDiscoveryExtension(extension: DiscoveryExtension): ValidationResult {
   try {
+    // The schema is attacker-controlled (it arrives in the client's payment payload). Only
+    // same-document fragment references (e.g. "#/definitions/foo") are safe, since they
+    // resolve against the in-memory document instead of fetching or reading anything.
+    if (hasExternalSchemaReference(extension.schema)) {
+      return {
+        valid: false,
+        errors: ["schema must not contain external $ref/$id references"],
+      };
+    }
+
     const ajv = new Ajv({ strict: false, allErrors: true });
     const validate = ajv.compile(extension.schema);
 

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -2575,4 +2575,126 @@ describe("Bazaar Discovery Extension", () => {
       spy.mockRestore();
     });
   });
+
+  describe("SSRF via external $ref/$id in schema (CWE-918)", () => {
+    // The schema is attacker-controlled (it arrives in the client's payment payload). Some
+    // JSON Schema validators dereference "$ref"/"$id" values via an outbound HTTP request or
+    // filesystem read during schema compilation, before the instance is ever checked. Ajv's
+    // default `compile` already throws rather than fetching an unregistered external `$ref`,
+    // but validateDiscoveryExtension explicitly rejects these up front for a consistent error
+    // message across SDKs and as defense-in-depth.
+    async function withHitCountingServer(
+      run: (baseUrl: string, getHits: () => number) => void | Promise<void>,
+    ): Promise<void> {
+      const http = await import("node:http");
+      let hits = 0;
+      const server = http.createServer((_req, res) => {
+        hits += 1;
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ type: "object" }));
+      });
+      await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+      try {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        await run(`http://127.0.0.1:${port}`, () => hits);
+      } finally {
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    }
+
+    it("rejects a $ref over http without dereferencing it", async () => {
+      await withHitCountingServer((baseUrl, getHits) => {
+        const extension = {
+          info: { input: { type: "http", method: "GET" } },
+          schema: { $ref: `${baseUrl}/attacker-schema.json` },
+        } as unknown as DiscoveryExtension;
+
+        const result = validateDiscoveryExtension(extension);
+
+        expect(getHits()).toBe(0);
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    it("rejects a $ref via file:// URI without reading the file", () => {
+      const extension = {
+        info: { input: { type: "http", method: "GET" } },
+        schema: { $ref: "file:///etc/passwd" },
+      } as unknown as DiscoveryExtension;
+
+      const result = validateDiscoveryExtension(extension);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects a $ref nested inside schema properties", async () => {
+      await withHitCountingServer((baseUrl, getHits) => {
+        const extension = {
+          info: { input: { type: "http", method: "GET" } },
+          schema: {
+            properties: {
+              input: { $ref: `${baseUrl}/attacker-schema.json` },
+            },
+          },
+        } as unknown as DiscoveryExtension;
+
+        const result = validateDiscoveryExtension(extension);
+
+        expect(getHits()).toBe(0);
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    it("rejects an external $id", () => {
+      const extension = {
+        info: { input: { type: "http", method: "GET" } },
+        schema: { $id: "https://evil.example.com/schema.json", type: "object" },
+      } as unknown as DiscoveryExtension;
+
+      const result = validateDiscoveryExtension(extension);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it("still validates schemas with only local fragment refs", () => {
+      const extension = {
+        info: { input: { type: "http", method: "GET" } },
+        schema: {
+          $ref: "#/definitions/root",
+          definitions: { root: { type: "object" } },
+        },
+      } as unknown as DiscoveryExtension;
+
+      const result = validateDiscoveryExtension(extension);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects an external $ref end-to-end via extractDiscoveryInfo without dereferencing it", async () => {
+      await withHitCountingServer((baseUrl, getHits) => {
+        const extension = {
+          info: { input: { type: "http", method: "GET" } },
+          schema: { $ref: `${baseUrl}/attacker-schema.json` },
+        };
+
+        const paymentPayload = {
+          x402Version: 2,
+          scheme: "exact",
+          network: "eip155:84532" as unknown,
+          payload: {},
+          accepted: {} as unknown,
+          resource: { url: "http://api.example.com/weather" },
+          extensions: {
+            [BAZAAR.key]: extension,
+          },
+        };
+
+        const discovered = extractDiscoveryInfo(paymentPayload, {} as unknown);
+
+        expect(getHits()).toBe(0);
+        expect(discovered).toBeNull();
+      });
+    });
+  });
 });

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -2583,6 +2583,13 @@ describe("Bazaar Discovery Extension", () => {
     // default `compile` already throws rather than fetching an unregistered external `$ref`,
     // but validateDiscoveryExtension explicitly rejects these up front for a consistent error
     // message across SDKs and as defense-in-depth.
+    /**
+     * Starts a local HTTP server that counts requests it receives, runs the given callback
+     * against it, and tears it down afterwards.
+     *
+     * @param run - Callback invoked with the server's base URL and a hit-count getter
+     * @returns A promise that resolves once the callback has run and the server has shut down
+     */
     async function withHitCountingServer(
       run: (baseUrl: string, getHits: () => number) => void | Promise<void>,
     ): Promise<void> {


### PR DESCRIPTION
  ## Description

  Fixes an SSRF / local-file-read vulnerability in the Bazaar discovery extension's schema validation,
  present in all three SDKs.

  `paymentPayload.extensions.bazaar.schema` is a client-controlled JSON Schema document that gets passed into
  each language's JSON Schema validator during `validateDiscoveryExtension`/`validate_discovery_extension`. In Go
  and Python, the default schema loader/resolver dereferences any `$ref`/`$id` value that isn't a same-document
  fragment — meaning an attacker could embed a `$ref` pointing at `http://169.254.169.254/...` (cloud metadata),
  an internal service, or a `file://` path, and the facilitator would fetch/read it before ever validating the
  actual `info` payload.

  - **Go** (`go/extensions/bazaar/facilitator.go`): `gojsonschema`'s default loader resolves external
  `$ref`/`$id` via `http.Get`/`os.Open`.
  - **Python** (`python/x402/extensions/bazaar/facilitator.py`): `jsonschema`'s default registry resolves
  external `$ref`/`$id` via `urllib.request.urlopen` (both `http(s)://` and `file://`).
  - **TypeScript** (`typescript/packages/extensions/src/bazaar/facilitator.ts`): Ajv's synchronous `compile()`
  already throws on unresolved external `$ref` by default, but silently accepted a standalone external `$id` with
  no fetch and no rejection.

  **Fix:** each language now recursively scans the schema for `$ref`/`$id` values before compiling/validating it,
  and rejects the schema outright unless every such value is a same-document JSON Pointer fragment (starts with
  `#`). Same-document refs (`#/definitions/foo`) continue to work normally.

  The rule is now documented in `specs/extensions/bazaar.md` so all current and future SDKs implement the same
  behavior consistently.

  ## Tests

  Added targeted regression tests per language, each proving (via a local HTTP server / temp file with a hit
  counter) that no outbound request or file read occurs and the schema is rejected:

  - **Go** (`go/extensions/bazaar/bazaar_test.go`): `TestValidateDiscoveryExtension_SSRF` (5 subtests: `$ref`
  over HTTP, `$ref` via `file://`, `$ref` nested in `properties`, external `$id`, local-fragment-only schema
  still validates) + `TestExtractDiscoveredResourceFromPaymentPayload_SSRF` (end-to-end via a full
  `PaymentPayload`).
  - **Python** (`python/x402/tests/unit/extensions/bazaar/test_facilitator.py`):
  `TestValidateDiscoveryExtensionSSRF` (6 tests, same shape as Go, using a real `HTTPServer`) +
  `TestHasExternalSchemaReference` (8 direct unit tests of the helper).
  - **TypeScript** (`typescript/packages/extensions/test/bazaar.test.ts`): new `describe("SSRF via external
  $ref/$id in schema", ...)` block, 6 tests using a local `node:http` server.

  For each language, I confirmed the tests are meaningful by temporarily reverting just the guard invocation
  (keeping the helper defined) and re-running:
  - Go: caught a real bug this way — the guard call compiled but was a complete no-op due to a type-switch
  identity mismatch (`extension.Schema` is the named type `types.JSONSchema`, which never matches a `case
  map[string]any:`). Fixed with an explicit conversion at the call site.
  - Python: confirmed a real outbound HTTP hit occurs without the fix (and `jsonschema` itself emits a
  deprecation warning calling out this exact behavior as a security concern).
  - TypeScript: confirmed 5 of 6 tests already pass without the fix (Ajv fails closed on `$ref` by default) —
  isolating the guard's real value to the external-`$id` case.

  ## Checklist

  - [x] I have formatted and linted my code
  - [x] All new and existing tests pass
  - [x] My commits are signed (required for merge)
  - [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
 