### PR TITLE
fix: match payment-gated routes on the escaped request path

### DIFF
--- a/go/.changes/unreleased/fixed-20260804-142718.yaml
+++ b/go/.changes/unreleased/fixed-20260804-142718.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: 'Match payment-gated routes on the escaped request path so percent-encoded separators cannot bypass the payment gate: the Echo, Gin, and net/http middlewares now pass URL.EscapedPath() instead of the decoded URL.Path, normalizePath decodes one segment at a time (re-escaping any decoded / or \) instead of decoding the whole path twice, and a trailing /* route pattern now also matches its bare prefix'
+time: 2026-08-04T14:27:18.169799-04:00

--- a/go/http/echo/middleware.go
+++ b/go/http/echo/middleware.go
@@ -296,8 +296,11 @@ func createMiddlewareHandler(server *x402http.HTTPServer, config *MiddlewareConf
 			adapter := NewEchoAdapter(c)
 			reqCtx := x402http.HTTPRequestContext{
 				Adapter: adapter,
-				Path:    c.Request().URL.Path,
-				Method:  c.Request().Method,
+				// EscapedPath, not Path: routers dispatch on the escaped path, so
+				// matching on the decoded one lets "%2F" split a segment here but
+				// not in the router, bypassing the payment gate.
+				Path:   c.Request().URL.EscapedPath(),
+				Method: c.Request().Method,
 			}
 
 			// Check if route requires payment before waiting for initialization

--- a/go/http/echo/middleware_test.go
+++ b/go/http/echo/middleware_test.go
@@ -1473,3 +1473,78 @@ func TestValidateBazaarExtensions_MalformedExtension(t *testing.T) {
 		t.Errorf("Expected 'malformed' in warning output, got: %q", output)
 	}
 }
+
+// TestPaymentMiddleware_EncodedPathDoesNotBypassPaymentGate guards against a
+// path-equivalence bypass (CWE-436): Echo's router dispatches on the escaped
+// path, so a request carrying "%2F" in a ":param" segment reaches the protected
+// handler. If the middleware matched routes on the decoded URL.Path instead,
+// the encoded slash would split the segment, the route regex would miss, and
+// the paid handler would run with no payment verification or settlement.
+func TestPaymentMiddleware_EncodedPathDoesNotBypassPaymentGate(t *testing.T) {
+	bypassPaths := []string{
+		"/api/users/1",       // baseline: plainly protected
+		"/api/users/x%2Fy",   // encoded slash splits the :id segment
+		"/api/users/x%2fy",   // lowercase encoding
+		"/api/users/x%252Fy", // double encoding survives a second decode pass
+		"/api/users/x%5Cy",   // encoded backslash
+		"/api/premium/",      // wildcard route with a bare trailing slash
+		"/api/premium/a%2Fb", // wildcard route with an encoded slash
+	}
+
+	routes := x402http.RoutesConfig{
+		"GET /api/users/:id": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{Scheme: "exact", PayTo: "0xtest", Price: "$1.00", Network: "eip155:1"},
+			},
+		},
+		"GET /api/premium/*": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{Scheme: "exact", PayTo: "0xtest", Price: "$1.00", Network: "eip155:1"},
+			},
+		},
+	}
+
+	for _, path := range bypassPaths {
+		t.Run(path, func(t *testing.T) {
+			mockClient := &mockFacilitatorClient{
+				supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+					return x402.SupportedResponse{
+						Kinds: []x402.SupportedKind{
+							{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+						},
+						Extensions: []string{},
+						Signers:    make(map[string][]string),
+					}, nil
+				},
+			}
+
+			e := createTestEcho()
+			e.Use(PaymentMiddlewareFromConfig(routes,
+				WithFacilitatorClient(mockClient),
+				WithScheme("eip155:1", &mockSchemeServer{scheme: "exact"}),
+				WithSyncFacilitatorOnStart(true),
+				WithTimeout(5*time.Second),
+			))
+
+			handlerRan := false
+			paidHandler := func(c echo.Context) error {
+				handlerRan = true
+				return c.JSON(http.StatusOK, map[string]interface{}{"data": "protected"})
+			}
+			e.GET("/api/users/:id", paidHandler)
+			e.GET("/api/premium/*", paidHandler)
+
+			req := httptest.NewRequest("GET", path, nil)
+			req.Header.Set("Accept", "application/json")
+			w := httptest.NewRecorder()
+			e.ServeHTTP(w, req)
+
+			if handlerRan {
+				t.Errorf("payment bypassed: paid handler ran for %s (status %d)", path, w.Code)
+			}
+			if w.Code != http.StatusPaymentRequired {
+				t.Errorf("Expected status 402 for %s, got %d", path, w.Code)
+			}
+		})
+	}
+}

--- a/go/http/gin/middleware.go
+++ b/go/http/gin/middleware.go
@@ -345,8 +345,11 @@ func createMiddlewareHandler(server *x402http.HTTPServer, config *MiddlewareConf
 		adapter := NewGinAdapter(c)
 		reqCtx := x402http.HTTPRequestContext{
 			Adapter: adapter,
-			Path:    c.Request.URL.Path,
-			Method:  c.Request.Method,
+			// EscapedPath, not Path: routers dispatch on the escaped path, so
+			// matching on the decoded one lets "%2F" split a segment here but
+			// not in the router, bypassing the payment gate.
+			Path:   c.Request.URL.EscapedPath(),
+			Method: c.Request.Method,
 		}
 
 		// Check if route requires payment before waiting for initialization

--- a/go/http/gin/middleware_test.go
+++ b/go/http/gin/middleware_test.go
@@ -1728,3 +1728,85 @@ func TestValidateBazaarExtensions_MalformedExtension(t *testing.T) {
 		t.Errorf("Expected 'malformed' in warning output, got: %q", output)
 	}
 }
+
+// TestPaymentMiddleware_EncodedPathDoesNotBypassPaymentGate guards against a
+// path-equivalence bypass (CWE-436): Gin's router dispatches on the escaped
+// path, so a request carrying "%2F" in a ":param" segment reaches the protected
+// handler. If the middleware matched routes on the decoded URL.Path instead,
+// the encoded slash would split the segment, the route regex would miss, and
+// the paid handler would run with no payment verification or settlement.
+func TestPaymentMiddleware_EncodedPathDoesNotBypassPaymentGate(t *testing.T) {
+	bypassPaths := []string{
+		"/api/users/1",       // baseline: plainly protected
+		"/api/users/x%2Fy",   // encoded slash splits the :id segment
+		"/api/users/x%2fy",   // lowercase encoding
+		"/api/users/x%252Fy", // double encoding survives a second decode pass
+		"/api/users/x%5Cy",   // encoded backslash
+		"/api/premium/",      // wildcard route with a bare trailing slash
+		"/api/premium/a%2Fb", // wildcard route with an encoded slash
+	}
+
+	routes := x402http.RoutesConfig{
+		"GET /api/users/:id": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{Scheme: "exact", PayTo: "0xtest", Price: "$1.00", Network: "eip155:1"},
+			},
+		},
+		"GET /api/premium/*": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{Scheme: "exact", PayTo: "0xtest", Price: "$1.00", Network: "eip155:1"},
+			},
+		},
+	}
+
+	for _, path := range bypassPaths {
+		t.Run(path, func(t *testing.T) {
+			mockClient := &mockFacilitatorClient{
+				supportedFunc: func(ctx context.Context) (x402.SupportedResponse, error) {
+					return x402.SupportedResponse{
+						Kinds: []x402.SupportedKind{
+							{X402Version: 2, Scheme: "exact", Network: "eip155:1"},
+						},
+						Extensions: []string{},
+						Signers:    make(map[string][]string),
+					}, nil
+				},
+			}
+
+			router := createTestRouter()
+			// Gin only consults URL.RawPath when UseRawPath is set; with the
+			// default (false) it routes on the decoded path and "%2F" simply
+			// 404s, so the bypass vector would never reach the handler.
+			router.UseRawPath = true
+			router.UnescapePathValues = false
+			router.Use(PaymentMiddlewareFromConfig(routes,
+				WithFacilitatorClient(mockClient),
+				WithScheme("eip155:1", &mockSchemeServer{scheme: "exact"}),
+				WithSyncFacilitatorOnStart(true),
+				WithTimeout(5*time.Second),
+			))
+
+			handlerRan := false
+			paidHandler := func(c *gin.Context) {
+				handlerRan = true
+				c.JSON(http.StatusOK, gin.H{"data": "protected"})
+			}
+			router.GET("/api/users/:id", paidHandler)
+			// Gin spells its catch-all as a named "*param", but the x402 route
+			// config above stays in x402's own "/*" pattern language.
+			router.GET("/api/premium/*rest", paidHandler)
+
+			req := httptest.NewRequest("GET", path, nil)
+			req.Header.Set("Accept", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if handlerRan {
+				t.Errorf("payment bypassed: paid handler ran for %s (status %d)", path, w.Code)
+			}
+			if w.Code != http.StatusPaymentRequired {
+				t.Errorf("Expected status 402 for %s, got %d", path, w.Code)
+			}
+		})
+	}
+}

--- a/go/http/nethttp/middleware.go
+++ b/go/http/nethttp/middleware.go
@@ -230,8 +230,11 @@ func createMiddlewareHandler(server *x402http.HTTPServer, config *MiddlewareConf
 			adapter := NewNetHTTPAdapter(r)
 			reqCtx := x402http.HTTPRequestContext{
 				Adapter: adapter,
-				Path:    r.URL.Path,
-				Method:  r.Method,
+				// EscapedPath, not Path: routers dispatch on the escaped path, so
+				// matching on the decoded one lets "%2F" split a segment here but
+				// not in the router, bypassing the payment gate.
+				Path:   r.URL.EscapedPath(),
+				Method: r.Method,
 			}
 
 			// Check if route requires payment

--- a/go/http/nethttp/middleware_test.go
+++ b/go/http/nethttp/middleware_test.go
@@ -1526,3 +1526,79 @@ func TestValidateBazaarExtensions_MalformedExtension(t *testing.T) {
 		t.Errorf("Expected 'malformed' in warning output, got: %q", output)
 	}
 }
+
+// TestPaymentMiddleware_EncodedPathDoesNotBypassPaymentGate guards against a
+// path-equivalence bypass (CWE-436): net/http's ServeMux dispatches on the
+// escaped path, so a request carrying "%2F" in a "{id}" segment reaches the
+// protected handler. If the middleware matched routes on the decoded URL.Path
+// instead, the encoded slash would split the segment, the route regex would
+// miss, and the paid handler would run with no payment verification or
+// settlement.
+func TestPaymentMiddleware_EncodedPathDoesNotBypassPaymentGate(t *testing.T) {
+	bypassPaths := []string{
+		"/api/users/1",       // baseline: plainly protected
+		"/api/users/x%2Fy",   // encoded slash splits the :id segment
+		"/api/users/x%2fy",   // lowercase encoding
+		"/api/users/x%252Fy", // double encoding survives a second decode pass
+		"/api/users/x%5Cy",   // encoded backslash
+		"/api/premium/",      // wildcard route with a bare trailing slash
+		"/api/premium/a%2Fb", // wildcard route with an encoded slash
+	}
+
+	routes := x402http.RoutesConfig{
+		"GET /api/users/:id": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{Scheme: "exact", PayTo: "0xtest", Price: "$1.00", Network: "eip155:1"},
+			},
+		},
+		"GET /api/premium/*": x402http.RouteConfig{
+			Accepts: x402http.PaymentOptions{
+				{Scheme: "exact", PayTo: "0xtest", Price: "$1.00", Network: "eip155:1"},
+			},
+		},
+	}
+
+	for _, path := range bypassPaths {
+		t.Run(path, func(t *testing.T) {
+			mockClient := &mockFacilitatorClient{supportedFunc: defaultSupportedFunc()}
+
+			handlerRan := false
+			paidHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerRan = true
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(map[string]string{"data": "protected"})
+			})
+
+			// The nethttp middleware wraps any http.Handler, so the downstream
+			// router is ours to pick: ServeMux with Go 1.22+ patterns. Its
+			// patterns are spelled in ServeMux's language ("{id}", a trailing
+			// "/" subtree), while the x402 route config above stays in x402's
+			// own "/:id" and "/*" pattern language. Every path listed here was
+			// confirmed to dispatch to paidHandler (no 301, no 404) when the
+			// middleware is absent.
+			mux := http.NewServeMux()
+			mux.Handle("GET /api/users/{id}", paidHandler)
+			mux.Handle("GET /api/premium/", paidHandler)
+
+			middleware := PaymentMiddlewareFromConfig(routes,
+				WithFacilitatorClient(mockClient),
+				WithScheme("eip155:1", &mockSchemeServer{scheme: "exact"}),
+				WithSyncFacilitatorOnStart(true),
+				WithTimeout(5*time.Second),
+			)
+			wrapped := middleware(mux)
+
+			req := httptest.NewRequest("GET", path, nil)
+			req.Header.Set("Accept", "application/json")
+			w := httptest.NewRecorder()
+			wrapped.ServeHTTP(w, req)
+
+			if handlerRan {
+				t.Errorf("payment bypassed: paid handler ran for %s (status %d)", path, w.Code)
+			}
+			if w.Code != http.StatusPaymentRequired {
+				t.Errorf("Expected status 402 for %s, got %d", path, w.Code)
+			}
+		})
+	}
+}

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -1240,10 +1240,24 @@ func parseRoutePattern(pattern string) (string, string, *regexp.Regexp) {
 
 	// Convert pattern to regex
 	regexPattern := "^" + regexp.QuoteMeta(path)
+
+	// A trailing "/*" must also match the bare prefix. normalizePath strips the
+	// trailing slash, so a request for "/api/premium/" arrives as "/api/premium",
+	// which a literal "/.*?" suffix would not match even though routers dispatch
+	// it to the protected handler.
+	trailingWildcard := strings.HasSuffix(regexPattern, `/\*`)
+	if trailingWildcard {
+		regexPattern = strings.TrimSuffix(regexPattern, `/\*`)
+	}
+
 	regexPattern = strings.ReplaceAll(regexPattern, `\*`, `.*?`)
 	// Handle parameters: [param] (Next.js style) and :param (Express style)
 	regexPattern = paramRegex.ReplaceAllString(regexPattern, `[^/]+`)
 	regexPattern = colonParamRegex.ReplaceAllString(regexPattern, `[^/]+`)
+
+	if trailingWildcard {
+		regexPattern += `(?:/.*?)?`
+	}
 	regexPattern += "$"
 
 	regex := regexp.MustCompile(regexPattern)
@@ -1251,20 +1265,40 @@ func parseRoutePattern(pattern string) (string, string, *regexp.Regexp) {
 	return verb, path, regex
 }
 
-// normalizePath normalizes a URL path for matching
+// normalizePath normalizes a URL path for matching.
+//
+// The input is expected to be the *escaped* request path (net/url's
+// URL.EscapedPath), which is the same view HTTP routers use to split a request
+// into segments. Percent-escapes are therefore decoded one segment at a time
+// and any separator they yield is re-escaped, so a decoded byte can never
+// create a segment boundary that the router did not see.
+//
+// Decoding the whole path in one pass, as an earlier version did, let an
+// attacker smuggle "%2F" (or "%5C") into a single segment: the middleware saw
+// "/api/users/x/y" and stopped matching "GET /api/users/:id", while the router
+// still dispatched the request to the protected handler, bypassing the payment
+// gate entirely (CWE-436).
 func normalizePath(path string) string {
 	// Remove query string and fragment
 	if idx := strings.IndexAny(path, "?#"); idx >= 0 {
 		path = path[:idx]
 	}
 
-	// Decode URL encoding
-	if decoded, err := url.PathUnescape(path); err == nil {
-		path = decoded
+	// Decode percent-escapes per segment, keeping decoded separators inside the
+	// segment they came from.
+	segments := strings.Split(path, "/")
+	for i, segment := range segments {
+		decoded, err := url.PathUnescape(segment)
+		if err != nil {
+			// Malformed escape sequence: match on the raw segment rather than
+			// silently widening it.
+			continue
+		}
+		decoded = strings.ReplaceAll(decoded, `/`, `%2F`)
+		segments[i] = strings.ReplaceAll(decoded, `\`, `%5C`)
 	}
+	path = strings.Join(segments, "/")
 
-	// Normalize slashes
-	path = strings.ReplaceAll(path, `\`, `/`)
 	// Replace multiple slashes with single slash
 	path = multiSlashRegex.ReplaceAllString(path, `/`)
 	// Remove trailing slash

--- a/go/http/server_test.go
+++ b/go/http/server_test.go
@@ -986,6 +986,16 @@ func TestNormalizePath(t *testing.T) {
 		{"/api#fragment", "/api"},
 		{"/api%20space", "/api space"},
 		{"", "/"},
+
+		// Encoded separators must stay inside the segment they were sent in,
+		// otherwise they split a ":param" segment that the router keeps whole.
+		{"/api/users/x%2Fy", "/api/users/x%2Fy"},
+		{"/api/users/x%2fy", "/api/users/x%2Fy"},
+		{"/api/users/x%5Cy", "/api/users/x%5Cy"},
+		// Only one round of decoding: %252F must not collapse into a separator.
+		{"/api/users/x%252Fy", "/api/users/x%2Fy"},
+		// Malformed escapes are matched raw rather than silently widened.
+		{"/api/users/x%zzy", "/api/users/x%zzy"},
 	}
 
 	for _, tt := range tests {
@@ -993,6 +1003,53 @@ func TestNormalizePath(t *testing.T) {
 			result := normalizePath(tt.input)
 			if result != tt.expected {
 				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestRouteMatching_PathNormalizationBypass covers CWE-436 path-equivalence
+// bypasses: a request the router dispatches to a protected handler must still
+// match the route pattern that guards it. Paths here are the escaped form the
+// middleware passes in (URL.EscapedPath).
+func TestRouteMatching_PathNormalizationBypass(t *testing.T) {
+	tests := []struct {
+		name        string
+		pattern     string
+		escapedPath string
+		shouldMatch bool
+	}{
+		{"param baseline", "GET /api/users/:id", "/api/users/1", true},
+		{"param encoded slash", "GET /api/users/:id", "/api/users/x%2Fy", true},
+		{"param lowercase encoded slash", "GET /api/users/:id", "/api/users/x%2fy", true},
+		{"param double encoded slash", "GET /api/users/:id", "/api/users/x%252Fy", true},
+		{"param encoded backslash", "GET /api/users/:id", "/api/users/x%5Cy", true},
+		{"param encoded percent", "GET /api/users/:id", "/api/users/x%25y", true},
+		{"bracket param encoded slash", "GET /api/users/[id]", "/api/users/x%2Fy", true},
+		// A genuine extra segment is a different route and must not match.
+		{"param real extra segment", "GET /api/users/:id", "/api/users/x/y", false},
+
+		{"wildcard baseline", "GET /api/premium/*", "/api/premium/abc", true},
+		{"wildcard trailing slash", "GET /api/premium/*", "/api/premium/", true},
+		{"wildcard bare prefix", "GET /api/premium/*", "/api/premium", true},
+		{"wildcard deep path", "GET /api/premium/*", "/api/premium/a/b/c", true},
+		// The wildcard must not leak onto a sibling prefix.
+		{"wildcard sibling prefix", "GET /api/premium/*", "/api/premiumx", false},
+		{"wildcard unrelated", "GET /api/premium/*", "/api/other", false},
+
+		{"static baseline", "GET /api/compute", "/api/compute", true},
+		{"static trailing slash", "GET /api/compute", "/api/compute/", true},
+		{"static unrelated", "GET /api/compute", "/api/computex", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, regex := parseRoutePattern(tt.pattern)
+			normalized := normalizePath(tt.escapedPath)
+
+			if got := regex.MatchString(normalized); got != tt.shouldMatch {
+				t.Errorf("pattern %q vs path %q (normalized %q): match=%v, want %v",
+					tt.pattern, tt.escapedPath, normalized, got, tt.shouldMatch)
 			}
 		})
 	}


### PR DESCRIPTION
PR description

 ## Description

 The Go payment middleware matched routes against the percent-decoded `URL.Path`,
 while HTTP routers dispatch on the escaped path. A request that encodes a
 separator inside a path parameter — `GET /api/users/x%2Fy` against a
 `"GET /api/users/:id"` route — splits into an extra segment for the middleware
 but not for the router. The compiled pattern `^/api/users/[^/]+$` misses,
 `RequiresPayment` returns false, and the router invokes the paid handler anyway:
 the protected resource is served with no `VerifyPayment` and no
 `ProcessSettlement`.

 This is a path-equivalence bug. Four vectors were confirmed, and three
 of them live in the shared `normalizePath`/`parseRoutePattern` helpers in
 `http/server.go`, so **all three adapters (Echo, Gin, net/http) were affected**:

 | Vector | Root cause | Adapter-specific |
 | --- | --- | --- |
 | `%2F` in a `:param` | Middleware used decoded `URL.Path` | Yes |
 | `%252F` | `normalizePath` ran `url.PathUnescape` on an already-decoded path | No |
 | `%5C` | `normalizePath` rewrote every `\` to `/` | No |
 | Trailing `/` on a `/*` route | Trailing slash trimmed, but the pattern required it | No |

 Worth calling out: `%252F` and `%5C` arrive with an **empty** `URL.RawPath`, so
 they bypass purely through `normalizePath` regardless of how the router resolves
 the path. An adapter-only fix would have left those open.

 ### Changes

 - `http/echo`, `http/gin`, `http/nethttp` — pass `URL.EscapedPath()` instead of
   `URL.Path`. `reqCtx.Path` only feeds `getRouteConfig`, so this is contained to
   route matching. `Adapter.GetPath()` is intentionally left decoded: it feeds the
   bazaar extension's path-param *values* after the gate, where decoded is right.
 - `http/server.go` — `normalizePath` decodes one segment at a time and re-escapes
   any decoded `/` and `\`, so a decoded byte can never create a segment boundary
   the router didn't see. Only one decode pass now happens.
 - `http/server.go` — `parseRoutePattern` emits `(?:/.*?)?` for a trailing `/*` so
   the bare prefix matches after the trailing slash is trimmed.

 ### Behavior change

 With a `GET /api/premium/*` route config, a bare `/api/premium` now returns 402
 instead of falling through. Echo and Gin 404 that path anyway, so no
 previously-working request changes outcome — but the gate is now fail-closed.

 ## Tests

 `go test ./...` from `/go` — all 30 packages pass.

 New regression coverage:

 - `http/server_test.go` — `TestRouteMatching_PathNormalizationBypass` (18 cases)
   at the matching layer, plus new `TestNormalizePath` cases. Includes negative
   cases so the fix doesn't over-match: a genuine extra segment
   (`/api/users/x/y`) still misses `:id`, and `/api/premiumx` still misses
   `/api/premium/*`.
 - `http/{echo,gin,nethttp}/middleware_test.go` —
   `TestPaymentMiddleware_EncodedPathDoesNotBypassPaymentGate`, end-to-end through
   each adapter, asserting both that the paid handler never runs *and* that the
   response is 402.

 These were verified to **fail without the fix**: with the four source files
 reverted, all four packages fail and 15 `payment bypassed` assertions fire across
 the three adapter suites.

 Adapter-specific notes discovered while testing:

 - Gin only routes on `RawPath` when `UseRawPath = true`, so the Gin test sets it
   explicitly — otherwise the `%2F` vector 404s and the subtest would silently
   assert nothing.
 - The net/http test uses `http.ServeMux` with Go 1.22+ patterns; every listed
   path was confirmed to dispatch to the paid handler (no 301, no 404) before the
   fix.

 ## Checklist

 - [x] I have formatted and linted my code (`go fmt ./...`, `go vet ./...` clean)
 - [x] All new and existing tests pass
 - [x] My commits are signed (required for merge)
 - [x] I added a changelog fragment for user-facing changes
