### PR TITLE
feat(specs): xrplFeeSponsoring extension — facilitator-sponsored fees via XLS-68

### DIFF
--- a/specs/extensions/xrpl_fee_sponsoring.md
+++ b/specs/extensions/xrpl_fee_sponsoring.md
@@ -1,0 +1,153 @@
+# Extension: `xrplFeeSponsoring`
+
+## Summary
+
+The `xrplFeeSponsoring` extension enables facilitator-sponsored network fees
+for the [`scheme_exact_xrpl.md`](../schemes/exact/scheme_exact_xrpl.md) scheme
+using XLS-68 (`Sponsor` amendment): the payer signs a `Payment` carrying
+`Sponsor` and `SponsorFlags` fields, and the facilitator — not the payer —
+pays the XRPL transaction fee.
+
+When this extension is active, `extra.areFeesSponsored` is `true` and the
+base scheme's statement that fee sponsorship "would require a different
+payment model" is satisfied: XLS-68 is that payment model.
+
+The extension only applies on networks where the `Sponsor` amendment is
+enabled (currently Devnet; not Mainnet).
+
+## Prerequisites
+
+- `Sponsor` amendment (`BE1F90581635DBCEBFC4678C4B54FEDDC1A17B50FD02CFE765A4132A342126AC`)
+  enabled on the target network. The facilitator MUST verify this against the
+  `Amendments` ledger object, not static configuration.
+- Two operating modes:
+  - `"cosigned"` — the facilitator co-signs each transaction
+    (`SponsorSignature`). No ledger setup required.
+  - `"prefunded"` — a `Sponsorship` ledger object (sponsor = facilitator's
+    account, sponsee = payer) authorizes fee payment with no per-transaction
+    facilitator signature. Bounded by the object's `FeeAmount` pool and
+    per-transaction `MaxFee`.
+
+## `PaymentRequired`
+
+A facilitator advertises support by including the `xrplFeeSponsoring` key in
+the `extensions` object of the `402 Payment Required` response.
+
+```json
+{
+  "x402Version": 2,
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "xrpl:2",
+      "asset": "524C555344000000000000000000000000000000",
+      "payTo": "rN7n3473SaZBCG4dFL83w7a1RXtXtbk2D9",
+      "amount": "2.5",
+      "maxTimeoutSeconds": 600,
+      "extra": {
+        "areFeesSponsored": true,
+        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+      }
+    }
+  ],
+  "extensions": {
+    "xrplFeeSponsoring": {
+      "info": {
+        "description": "The facilitator sponsors XRPL network fees via XLS-68.",
+        "version": "1",
+        "sponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+        "mode": "cosigned",
+        "maxFee": "1000"
+      }
+    }
+  }
+}
+```
+
+| Field           | Type   | Required | Description                                        |
+| --------------- | ------ | -------- | -------------------------------------------------- |
+| `info.sponsor`  | string | Yes      | Classic address that pays the fee                  |
+| `info.mode`     | string | Yes      | `"cosigned"` or `"prefunded"`                      |
+| `info.maxFee`   | string | Yes      | Maximum sponsored `Fee` in drops, per transaction  |
+
+## `PaymentPayload`
+
+The client builds the full transaction — including `Sponsor = info.sponsor`,
+`SponsorFlags = 1` (`spfSponsorFee`), its own `SigningPubKey`, `Fee <=
+info.maxFee`, and sequencing per the base scheme — signs it, and sends the
+blob as in the base scheme.
+
+- `"prefunded"`: the signed blob is complete and submittable as-is.
+- `"cosigned"`: the facilitator computes `SponsorSignature` over the same
+  signing payload during settlement and inserts it before submission.
+  `SponsorSignature` is a non-signing field, so adding it does not invalidate
+  the payer's signature — and the facilitator cannot alter any other field
+  without invalidating it.
+
+## Verification Logic
+
+All base-scheme verification rules apply, with these deltas:
+
+- `extra.areFeesSponsored` MUST be `true` (envelope check §1 inverted).
+- `tx_json.Sponsor` MUST equal `info.sponsor`.
+- `tx_json.SponsorFlags` MUST equal `1` (`spfSponsorFee`). A facilitator MUST
+  reject `spfSponsorReserve` unless it has an explicit reserve-sponsorship
+  policy: reserve sponsorship locks the sponsor's XRP per created object.
+- `tx_json.Fee` MUST be `<= info.maxFee` (tightens safety check §9's "Fee
+  above facilitator policy").
+- `"prefunded"` mode: the `Sponsorship` ledger object for
+  `(info.sponsor, tx_json.Account)` MUST exist with `FeeAmount >= tx_json.Fee`;
+  `tx_json.SponsorSignature` MUST be absent.
+- `"cosigned"` mode: `tx_json.SponsorSignature` MUST be absent at `/verify`
+  (the facilitator adds it); the facilitator MUST co-sign only transactions
+  that passed every verification rule — the sponsor signature is an
+  endorsement of exactly these payment terms.
+- The `Sponsor` amendment MUST be enabled on the target network.
+- Simulation (§11) MUST account for the fee being charged to the sponsor:
+  the payer needs no XRP balance for the fee.
+
+## Settlement Logic
+
+Base-scheme settlement applies unchanged, plus:
+
+- A rejection of `terNO_PERMISSION` for a `"prefunded"` payment whose
+  `Sponsorship` object does not yet exist is **pending, not dead**: `ter`
+  results are retriable, and the transaction applies automatically once the
+  sponsorship is funded. A facilitator MUST NOT create or fund a
+  `Sponsorship` object while such a transaction may still be live (its
+  `LastLedgerSequence` has not passed) unless it intends that payment to
+  settle.
+- The settlement response SHOULD include `feeSponsored: true` and the sponsor
+  address, so clients can attribute network costs.
+
+## Security Considerations
+
+- **Mutual binding.** Sponsor and payer sign the identical
+  `STX\0`-prefixed signing payload (XLS-68; rippled `STTx::checkSingleSign`).
+  Neither party can alter amount, destination, fee, or sequence after the
+  other signs; sponsor signatures cannot be replayed on other transactions
+  because `Account` and `Sequence` are signed.
+- **Fee drain is the abuse model.** Per-transaction exposure is bounded by
+  `info.maxFee` (and on-ledger by `Sponsorship.MaxFee` in prefunded mode);
+  total prefunded exposure is bounded by `FeeAmount`. Cosigned mode is
+  bounded by facilitator policy. Facilitators SHOULD rate-limit sponsorship
+  per payer account.
+- **Account-creation sponsorship is out of scope** for this extension.
+  `tfSponsorCreatedAccount` onboarding (1 XRP reserve per account) is
+  unbounded sponsor cost and MUST be gated separately if offered.
+
+## Reference Implementation
+
+End-to-end Devnet proof (all modes; negative controls including
+tamper-after-sign, sponsor-signature replay, and MaxFee fee-drain rejection),
+with a validated-run evidence file:
+https://github.com/whawk46/xls68-x402-fee-sponsoring
+
+## Implementation-vs-draft note (for the XLS-68 author)
+
+Observed on Devnet (rippled `3.3.0-rc5`), diverging from the XLS-68 draft
+text: `SponsorshipSet` is transaction type 91 and accepts additive
+`FeeAmountDelta` rather than absolute `FeeAmount`/`ReserveCount` (which are
+rejected by the transaction template); creating a budget-less `Sponsorship`
+fails with `tecNO_PERMISSION`. Implementers should code against
+`server_definitions` of the target network, not the draft field tables.

--- a/specs/extensions/xrpl_fee_sponsoring.md
+++ b/specs/extensions/xrpl_fee_sponsoring.md
@@ -27,6 +27,13 @@ enabled (currently Devnet; not Mainnet).
     account, sponsee = payer) authorizes fee payment with no per-transaction
     facilitator signature. Bounded by the object's `FeeAmount` pool and
     per-transaction `MaxFee`.
+- Codec support for the XLS-68 fields in the client's signing stack — the
+  practical blocker at the time of writing: `xrpl.js` has not shipped the
+  `Sponsor`/`SponsorFlags`/`SponsorSignature` field definitions, and
+  `xrpl-py` carries them on `main` only (absent from the latest release,
+  checked against v5.0.0). Implementations SHOULD load definitions from the
+  target network's `server_definitions` rather than a library snapshot (see
+  the implementation-vs-draft note below).
 
 ## `PaymentRequired`
 
@@ -84,11 +91,54 @@ blob as in the base scheme.
   the payer's signature — and the facilitator cannot alter any other field
   without invalidating it.
 
+The client MUST echo the extension key in `PaymentPayload.extensions`. The
+echo — not the mere presence of sponsorship fields in the decoded blob — is
+what activates this extension's verification deltas for a given payload, so
+a payload carrying sponsorship fields without the echo fails the base
+scheme's §9 check deterministically instead of being inferred into the
+extension path.
+
+```json
+{
+  "x402Version": 2,
+  "resource": { "url": "https://api.example.com/data" },
+  "payload": { "signedTxBlob": "..." },
+  "extensions": { "xrplFeeSponsoring": {} }
+}
+```
+
+### Example `tx_json` (payer-built, before signing)
+
+```json
+{
+  "TransactionType": "Payment",
+  "Account": "rPayer111111111111111111111111111",
+  "Destination": "rN7n3473SaZBCG4dFL83w7a1RXtXtbk2D9",
+  "Amount": {
+    "currency": "524C555344000000000000000000000000000000",
+    "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+    "value": "2.5"
+  },
+  "Fee": "12",
+  "Sequence": 12345678,
+  "LastLedgerSequence": 99999999,
+  "SigningPubKey": "ED...",
+  "Sponsor": "rSponsor1VktvzBz8JF2oJC6qaww6RZ7Lw",
+  "SponsorFlags": 1
+}
+```
+
+The same `tx_json` serves both modes: in `"prefunded"` the signed blob is
+submitted exactly as received; in `"cosigned"` the facilitator inserts
+`SponsorSignature` before submission (never any other field).
+
 ## Verification Logic
 
 All base-scheme verification rules apply, with these deltas:
 
-- `extra.areFeesSponsored` MUST be `true` (envelope check §1 inverted).
+- `extra.areFeesSponsored` MUST be `true`, and the payload MUST carry the
+  `xrplFeeSponsoring` key in `PaymentPayload.extensions` (envelope check §1
+  inverted; the echo is the activation signal).
 - `tx_json.Sponsor` MUST equal `info.sponsor`.
 - `tx_json.SponsorFlags` MUST equal `1` (`spfSponsorFee`). A facilitator MUST
   reject `spfSponsorReserve` unless it has an explicit reserve-sponsorship
@@ -96,8 +146,15 @@ All base-scheme verification rules apply, with these deltas:
 - `tx_json.Fee` MUST be `<= info.maxFee` (tightens safety check §9's "Fee
   above facilitator policy").
 - `"prefunded"` mode: the `Sponsorship` ledger object for
-  `(info.sponsor, tx_json.Account)` MUST exist with `FeeAmount >= tx_json.Fee`;
-  `tx_json.SponsorSignature` MUST be absent.
+  `(info.sponsor, tx_json.Account)` MUST exist with remaining fee budget
+  `>= tx_json.Fee`, its object-level `MaxFee` (when present) MUST be
+  `>= tx_json.Fee`, and its `lsfSponsorshipRequireSignForFee` flag MUST be
+  unset — a sponsorship requiring per-transaction signatures sinks an
+  unsigned submit even with sufficient budget. `tx_json.SponsorSignature`
+  MUST be absent. No shipped client library knows the `Sponsorship` entry
+  type at the time of writing; fetch it directly via `ledger_entry` using
+  the Sponsorship keylet for `(sponsor, sponsee)` against the target
+  network.
 - `"cosigned"` mode: `tx_json.SponsorSignature` MUST be absent at `/verify`
   (the facilitator adds it); the facilitator MUST co-sign only transactions
   that passed every verification rule — the sponsor signature is an
@@ -117,6 +174,23 @@ Base-scheme settlement applies unchanged, plus:
   `Sponsorship` object while such a transaction may still be live (its
   `LastLedgerSequence` has not passed) unless it intends that payment to
   settle.
+- **Transaction hash under cosigning.** `SponsorSignature` does not
+  participate in signing, but the txid is computed over the full
+  serialization — so cosigning changes the transaction hash after the
+  client last sees its transaction. Three rules keep all parties
+  consistent:
+  - The duplicate-settlement cache key (base scheme) is computed over the
+    blob **as received**; it stays stable across retries of the same client
+    submission but, under cosigning, is not the on-ledger txid.
+  - The facilitator MUST poll for and report the **final** txid — the hash
+    of the cosigned blob as submitted — in `SettlementResponse.transaction`.
+  - A cosigned-mode client MUST NOT predict its own transaction hash; it
+    MUST take the txid from the settlement response. For client-side
+    reconciliation independent of hash, the payer-scoped pair
+    `(Account, Sequence or TicketSequence)` identifies the payment in both
+    modes (e.g. via `account_tx`).
+  In `"prefunded"` mode the received blob is submitted unchanged and the
+  two hashes coincide, as in the base scheme.
 - The settlement response SHOULD include `feeSponsored: true` and the sponsor
   address, so clients can attribute network costs.
 

--- a/specs/schemes/exact/scheme_exact_xrpl.md
+++ b/specs/schemes/exact/scheme_exact_xrpl.md
@@ -401,11 +401,28 @@ The facilitator MUST reject if `invoiceId` is present and `InvoiceID` is missing
 
 ### 9. Safety Checks (MUST)
 
-The facilitator MUST reject transactions with:
+**Field acceptance is an allowlist, not a denylist.** The facilitator MUST hold
+the decoded `Payment` to an explicit set of permitted fields and reject any
+transaction carrying a field outside it, unless an active extension admits that
+field deliberately.
+
+This is normative because the alternative fails open. A denylist of named
+fields silently widens what a facilitator accepts every time the XRPL adds a
+field, and the field names in any such list are not stable: XLS-68 renamed
+`FeeAmount` to `FeeAmountDelta` between the published draft and the Devnet
+`3.3.0-rc5` implementation, so a list written from the draft would already be
+wrong. Deriving the permitted set from rippled's own field template for the
+transaction type keeps the check correct without maintenance.
+
+The fields below are therefore **informative examples** of what an allowlist
+excludes for this scheme, not the mechanism itself:
 
 - `Fee` above facilitator policy.
 - `Delegate` present.
-- `Sponsor`, `SponsorFlags`, or `SponsorSignature` present, unless a fee-sponsoring extension is active.
+- Sponsorship fields — at the time of writing `Sponsor`, `SponsorFlags`,
+  `SponsorSignature`, and on `SponsorshipSet` the budget fields — unless a
+  fee-sponsoring extension is active. Named for the reader's benefit; the
+  allowlist, not this list, is what rejects them.
 - `Memos` present.
 - `SendMax` present for XRP.
 - `Paths` present.
@@ -532,3 +549,4 @@ Implementations MAY include additional fields when defined by the SDK or facilit
 - [XRPL Currency Formats](https://xrpl.org/docs/references/protocol/data-types/currency-formats)
 - [CAIP-2 Specification](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-2.md)
 - [x402 Protocol Specification](https://github.com/coinbase/x402/blob/main/specs/x402-specification-v2.md)
+

--- a/specs/schemes/exact/scheme_exact_xrpl.md
+++ b/specs/schemes/exact/scheme_exact_xrpl.md
@@ -419,10 +419,13 @@ excludes for this scheme, not the mechanism itself:
 
 - `Fee` above facilitator policy.
 - `Delegate` present.
-- Sponsorship fields — at the time of writing `Sponsor`, `SponsorFlags`,
-  `SponsorSignature`, and on `SponsorshipSet` the budget fields — unless a
-  fee-sponsoring extension is active. Named for the reader's benefit; the
-  allowlist, not this list, is what rejects them.
+- Sponsorship fields — at the time of writing `Sponsor`, `SponsorFlags`, and
+  `SponsorSignature` — unless a fee-sponsoring extension is active. Named for
+  the reader's benefit; the allowlist, not this list, is what rejects them.
+  (A `SponsorshipSet` and its budget fields never reach this check in the
+  base scheme: §3 already refuses any `TransactionType` other than
+  `Payment`. They belong to the fee-sponsoring extension's territory and are
+  specified there.)
 - `Memos` present.
 - `SendMax` present for XRP.
 - `Paths` present.

--- a/specs/schemes/exact/scheme_exact_xrpl.md
+++ b/specs/schemes/exact/scheme_exact_xrpl.md
@@ -16,9 +16,9 @@ This scheme facilitates payments of a specific amount of XRP or an issued curren
 | **Settlement**            | The facilitator submits the signed transaction to XRPL                       |
 | **Fee payer**             | The payer pays the XRPL transaction fee embedded in the signed transaction   |
 
-XRPL charges the transaction fee to the transaction `Account`. This exact scheme therefore does not support facilitator-sponsored network fees for the signed `Payment` transaction. Supporting fee sponsorship would require a different payment model, not only a facilitator implementation change.
+XRPL charges the transaction fee to the transaction `Account`. This exact scheme therefore does not support facilitator-sponsored network fees for the signed `Payment` transaction. Supporting fee sponsorship would require a different payment model, not only a facilitator implementation change. The [`xrplFeeSponsoring`](../../extensions/xrpl_fee_sponsoring.md) extension defines that payment model via the XLS-68 `Sponsor` amendment, on networks where that amendment is enabled.
 
-`PaymentRequirements.extra.areFeesSponsored` MUST be present and MUST be `false`.
+`PaymentRequirements.extra.areFeesSponsored` MUST be present and MUST be `false`, unless a fee-sponsoring extension (e.g. [`xrplFeeSponsoring`](../../extensions/xrpl_fee_sponsoring.md)) is active, in which case that extension's rules apply.
 
 ## Asset Transfer Methods
 
@@ -150,7 +150,7 @@ The resource server advertises payment requirements in the `accepts` array.
 | `payTo`                  | string  | Yes      | XRPL classic address receiving the payment       |
 | `amount`                 | string  | Yes      | XRP drops string or IOU issued-currency value    |
 | `maxTimeoutSeconds`      | integer | Yes      | Maximum validity window for payment attempt      |
-| `extra.areFeesSponsored` | boolean | Yes      | Must be `false` for XRPL exact payments          |
+| `extra.areFeesSponsored` | boolean | Yes      | `false` unless a fee-sponsoring extension is active |
 | `extra.assetTransferMethod` | string | No     | `"sequence"` (default) or `"ticketSequence"`     |
 | `extra.invoiceId`        | string  | No       | Unique invoice identifier for binding            |
 | `extra.destinationTag`   | integer | No       | DestinationTag for hosted accounts               |
@@ -158,7 +158,7 @@ The resource server advertises payment requirements in the `accepts` array.
 
 `extra.destinationTag` applies to both native XRP and IOU payments. It is used when the receiver is a hosted account or otherwise requires a destination tag for attribution.
 
-`extra.areFeesSponsored` is always `false` because this scheme uses payer-signed XRPL `Payment` transactions whose fee is paid by the payer account.
+`extra.areFeesSponsored` is `false` in the base scheme because payer-signed XRPL `Payment` transactions carry a fee paid by the payer account. A fee-sponsoring extension changes this; see [`xrplFeeSponsoring`](../../extensions/xrpl_fee_sponsoring.md).
 
 `extra.assetTransferMethod` selects how the signed transaction is sequenced. See [Asset Transfer Methods](#asset-transfer-methods) for negotiation rules and tradeoffs.
 
@@ -273,7 +273,7 @@ The facilitator MUST reject if:
 - `paymentPayload.accepted.network` is unsupported
 - `paymentPayload.accepted` does not match `paymentRequirements` on `scheme`, `network`, `asset`, `payTo`, `amount`, or `maxTimeoutSeconds`
 - Required `extra` keys are missing or mismatched:
-  - `areFeesSponsored=false`
+  - `areFeesSponsored=false` (`true` only under an active fee-sponsoring extension, per that extension's rules)
   - `assetTransferMethod` when present in `paymentRequirements.extra` (the payload MUST NOT select a different method; when the requirement omits it, `accepted.extra.assetTransferMethod` MAY declare the selected method, see section 7)
   - `issuer` for IOU payments
   - `invoiceId` when invoice binding is required
@@ -405,6 +405,7 @@ The facilitator MUST reject transactions with:
 
 - `Fee` above facilitator policy.
 - `Delegate` present.
+- `Sponsor`, `SponsorFlags`, or `SponsorSignature` present, unless a fee-sponsoring extension is active.
 - `Memos` present.
 - `SendMax` present for XRP.
 - `Paths` present.
@@ -448,6 +449,8 @@ The payer pays the XRPL transaction fee because:
 - `Fee` is embedded in the signed transaction.
 - XRPL charges fees to the transaction's `Account` field.
 - `Delegate` is not supported by this scheme.
+
+Under an active fee-sponsoring extension the sponsor pays the fee instead; see [`xrplFeeSponsoring`](../../extensions/xrpl_fee_sponsoring.md).
 
 ### Settlement Timeout
 

--- a/specs/schemes/exact/scheme_exact_xrpl.md
+++ b/specs/schemes/exact/scheme_exact_xrpl.md
@@ -411,17 +411,27 @@ fields silently widens what a facilitator accepts every time the XRPL adds a
 field, and the field names in any such list are not stable: XLS-68 renamed
 `FeeAmount` to `FeeAmountDelta` between the published draft and the Devnet
 `3.3.0-rc5` implementation, so a list written from the draft would already be
-wrong. Deriving the permitted set from rippled's own field template for the
-transaction type keeps the check correct without maintenance.
+wrong. The permitted set MUST therefore be a pinned, explicit snapshot chosen
+by the implementation and reviewed when an amendment activates. Deriving the
+set mechanically from rippled's field template is NOT a substitute: the
+template includes the common fields (`Memos`, `Delegate`, and — once the
+amendment is active — the sponsorship fields), so a derived set admits much
+of what this section exists to exclude. A derived set MAY be used to *detect*
+newly added fields and raise an alarm; it MUST NOT be used to admit them —
+derive to detect, pin to admit.
 
-The fields below are therefore **informative examples** of what an allowlist
-excludes for this scheme, not the mechanism itself:
+The allowlist is the mechanism. In addition to it, the facilitator MUST
+reject a transaction with any of the following, each with its own reason
+code. These checks bind values and combinations that field presence alone
+cannot express, and implementations legitimately keep several of these
+fields (e.g. `Memos`, `Delegate`) inside their permitted decode set
+precisely so each rejection can carry its own reason rather than a generic
+field-not-permitted error:
 
 - `Fee` above facilitator policy.
 - `Delegate` present.
 - Sponsorship fields — at the time of writing `Sponsor`, `SponsorFlags`, and
-  `SponsorSignature` — unless a fee-sponsoring extension is active. Named for
-  the reader's benefit; the allowlist, not this list, is what rejects them.
+  `SponsorSignature` — unless a fee-sponsoring extension is active.
   (A `SponsorshipSet` and its budget fields never reach this check in the
   base scheme: §3 already refuses any `TransactionType` other than
   `Payment`. They belong to the fee-sponsoring extension's territory and are
@@ -488,7 +498,7 @@ Unlike a probabilistic confirmation race, this behavior is deterministic on XRPL
 
 Facilitators MUST deduplicate in-flight settlements across every process that serves `/settle`, keyed on the transaction hash. Before submitting a verified transaction:
 
-1. After verification succeeds, derive the cache key from the signed transaction blob: the canonical XRPL transaction hash (as returned by, e.g., `hashSignedTx`).
+1. After verification succeeds, derive the cache key from the signed transaction blob **as received from the client**: the canonical XRPL transaction hash (as returned by, e.g., `hashSignedTx`). Under an extension that adds fields before submission — e.g. cosigned fee sponsoring — this key remains stable per client submission but is not necessarily the on-ledger txid; such an extension defines which hash `SettlementResponse.transaction` reports.
 2. If the key is already present, reject the settlement with a `"duplicate_settlement"` error.
 3. If the key is not present, record it and proceed with submission.
 4. Retain the key until its transaction can no longer land — that is, until its `LastLedgerSequence` has passed (bounded by `maxTimeoutSeconds`; see [§7. Expiry and Account Sequencing](#7-expiry-and-account-sequencing)). A shorter window reopens the race: while the transaction is still landable, a re-submission passes re-verification because the consumed sequence number — or ticket — is not yet consumed, so the entry MUST outlive that window rather than a fixed interval. (Solana's fixed ~60-90s blockhash lifetime lets its cache use a constant TTL; XRPL's expiry is policy-derived, so the retention window is too.)


### PR DESCRIPTION
Implements the proposal in #3047: facilitator-sponsored network fees for the XRPL `exact` scheme via the XLS-68 `Sponsor` amendment (Devnet-enabled; amendment status must be verified per network).

## What's in this PR

- **`specs/extensions/xrpl_fee_sponsoring.md`** (new) — follows the `eip2612_gas_sponsoring` pattern: advertisement via the `extensions` object, `cosigned` and `prefunded` modes, verification deltas to the base scheme's MUST list, fee-drain bounds (`maxFee` per tx, `Sponsorship.FeeAmount` pool), and a settlement rule for XRPL's `ter`-retry semantics (a sponsored tx rejected for missing sponsorship is *pending, not dead* — it applies when the sponsorship is funded).
- **`specs/schemes/exact/scheme_exact_xrpl.md`** (7 surgical edits) — `areFeesSponsored` and the safety-check rejections of sponsor fields now read "unless a fee-sponsoring extension is active". No behavior change for implementations not using the extension.

## Reference implementation

https://github.com/whawk46/xls68-x402-fee-sponsoring — end-to-end Devnet proof with validated-run evidence: zero-XRP payer onboarded, sponsored TrustSet, IOU payment with the facilitator paying exactly the fee, both modes, and negative controls (tamper-after-sign, sponsor-signature replay, `MaxFee` fee-drain — all rejected). Includes an implementer note where Devnet (rippled 3.3.0-rc5) diverges from the XLS-0068 draft text (`FeeAmountDelta`, tx type 91).

## Review

@aristotle-satoshi — this touches your scheme; the base-scheme edits are deliberately minimal and I'll happily restructure (or split the PR) per your preference.

No changeset: spec-only.

---

*Disclosure per CONTRIBUTING: built with significant AI assistance (Claude), under significant human monitoring, direction, and correction. Field names and behavior claims verified against live Devnet (`server_definitions`, `Amendments` ledger object) and rippled source rather than generated from memory.*
