### PR TITLE
specs/bazaar: metadata handling must not block payment

### DIFF
--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -428,6 +428,18 @@ When a facilitator receives a `PaymentPayload` containing the `bazaar` extension
 
 How a facilitator stores, indexes, and exposes discovered resources is an implementation detail. Facilitators may choose to catalog resources in a database, expose them via a discovery API, or process them in any manner they see fit.
 
+Discovery metadata **MUST NOT** affect payment verification or settlement.
+Cataloging and payment are independent: a field that fails a validation rule, a
+field that has no rule (such as `description`), and a `bazaar` block rejected in
+full are all cataloging outcomes, and the payment is verified and settled on its
+own terms regardless. Facilitators **MUST NOT** return a payment error for a
+metadata problem.
+
+The reason is that the seller cannot tell the difference. A verify-side
+rejection, an invalid signature, and an unfunded payer all surface as the same
+fast `402`, so a resource refused over its metadata looks to its operator like an
+outage with no cause — and to a buyer like a broken endpoint.
+
 ### Optional Discovery Endpoints
 
 Facilitators that implement Bazaar discovery may expose discovery APIs to let clients browse and search cataloged resources.
@@ -506,6 +518,12 @@ EXTENSION-RESPONSES: eyJiYXphYXIiOnsic3RhdHVzIjoicmVqZWN0ZWQiLCJyZWplY3RlZFJlYXN
 *(base64 of `{"bazaar":{"status":"rejected","rejectedReason":"info failed schema validation"}}`)*
 
 Clients that understand the `bazaar` extension SHOULD read the `bazaar` key of this header to confirm cataloging succeeded and surface any rejection reason for debugging.
+
+A facilitator that rejects discovery info **SHOULD** emit this header with
+`status: "rejected"` and a `rejectedReason`. Without it, rejection is silent:
+the resource never appears in the catalog and its operator has no signal to act
+on. This is the only place in the flow where a cataloging failure can be
+reported, because per the rule above it must not be reported as a payment error.
 
 ---
 


### PR DESCRIPTION
Closes the gap that #2993 has been circling: the spec says what to do with bad discovery metadata, but never says what happens to the **payment** when metadata is unacceptable.

Today those two things are entangled in at least one facilitator. A resource of mine is indexed, healthy, and refused at verify — a `402` in ~1.2s, before the handler runs, no settlement. That is byte-identical to a bad signature and to an unfunded payer, so from the seller's side it is an outage with no cause. Five of my endpoints sat unpayable for over a month on this before I worked out what changed.

The measurement behind it, on one resource inside two hours today:

| `resource.description` | paid attempts | result |
|---|---|---|
| 469 chars | 1 | settled |
| 494 chars | 1 | settled |
| 582 chars — original text | 2 | `402`, no settlement |
| 582 chars — **different text, same 582 chars / 584 bytes** | 3 | `402`, no settlement |

Same endpoint, handler, price, `payTo` and deploy; only the description string moved. The control rules out the obvious confound: the same buyer wallet settled a different endpoint of mine in the same minute, holding 1.73 USDC against a $0.05 price.

Note the last row — a completely different string of exactly the same length fails identically, so on this resource the trigger tracks length rather than content.

## What this PR changes

Two additions, no behaviour redefined that wasn't already implied:

1. **Facilitator Behavior** — cataloging and payment are independent. A field that fails a validation rule, a field with no rule (`description` has none), and a `bazaar` block rejected in full are all cataloging outcomes; the payment is verified and settled on its own terms. Facilitators MUST NOT return a payment error for a metadata problem.

2. **Verify and Settlement Response Header** — a facilitator that rejects discovery info SHOULD emit `EXTENSION-RESPONSES` with `status: "rejected"` and a `rejectedReason`. Once a metadata failure may not be reported as a payment error, this header is the only place left to report it.

The first is already the spec's own logic — the soft-drop rules exist precisely so that hostile metadata degrades the catalog entry rather than the transaction — it just is not stated for the payment. The second only moves an existing `MAY` to `SHOULD` for the rejection case, using the mechanism the spec already defines.

## What this PR deliberately does not do

It does not add a length rule for `description`, and it should not: @Nikolife2016 measured the full public index and found, in code points, 74 resources carrying 508 or more, 73 of which took paid calls in the last 30 days — with a high-water mark of 723 code points and 102 distinct payers. (An earlier revision of this body quoted 90 resources at 517+ characters; that count was taken in UTF-16 units and was corrected in #2993. The conclusion and the direction are unchanged.) Whatever produces the behaviour above, a global cap is not it, and writing one into the spec would codify a bug.

I have since pinned my own threshold and posted it in #2993: the count is **Unicode code points**, with the cutoff between 499 and 508. A probe carrying 20 non-BMP emoji settled at 498 code points while measuring 518 UTF-16 units and 558 bytes — values already refused in earlier rows — so a rule on UTF-16 units would have to refuse 519 and accept 518, and a rule on bytes would have to refuse 511 and accept 558. It is also not the specific text: two unrelated 582-code-point strings fail identically.

That number stays out of this diff, but the unit is worth a line here for anyone writing a checker: `length` in TypeScript, `len()` in Python and `len()` in Go give three different answers for a description containing an emoji, and only Python's matches. The spec already names that divergence as the reason `serviceName` is bounded to ASCII; `description` has no rule at all.




