### PR TITLE
feat(ts): payment flow handlers

### DIFF
--- a/specs/schemes/exact/scheme_exact.md
+++ b/specs/schemes/exact/scheme_exact.md
@@ -11,7 +11,11 @@ amount of funds they need to be transferred.
 - Purchasing digital credits
 - An LLM paying to use a tool
 
-## Appendix
+## Payment Flow
+
+By default, `exact` uses the `authorize` payment flow (verify → resource → settle): the payment is verified before the resource executes and settled afterward. See [Payment Flow Models](../../x402-specification-v2.md) (section 6.1) in the core specification.
+
+Some networks and use cases require settlement to become final **before** the resource executes — for example networks without a pull-settlement primitive, or servers that need payment finality before performing irreversible or expensive work. Such variants use the `upfront` flow (settle → resource) and MUST declare `extra.paymentFlow: "upfront"` in `PaymentRequirements`, so clients recognize that payment is final before the resource executes. Per-network specifications declare which flows they support.
 
 ## Critical Validation Requirements
 

--- a/specs/schemes/exact/scheme_exact.md
+++ b/specs/schemes/exact/scheme_exact.md
@@ -13,9 +13,8 @@ amount of funds they need to be transferred.
 
 ## Payment Flow
 
-By default, `exact` uses the `authorize` payment flow (verify → resource → settle): the payment is verified before the resource executes and settled afterward. See [Payment Flow Models](../../x402-specification-v2.md) (section 6.1) in the core specification.
+By default, `exact` uses the `authorization` payment flow (verify → resource → settle): the payment is verified before the resource executes and settled afterward. See [Payment Flow Models](../../x402-specification-v2.md) (section 6.1) in the core specification.
 
-Some networks and use cases require settlement to become final **before** the resource executes — for example networks without a pull-settlement primitive, or servers that need payment finality before performing irreversible or expensive work. Such variants use the `upfront` flow (settle → resource) and MUST declare `extra.paymentFlow: "upfront"` in `PaymentRequirements`, so clients recognize that payment is final before the resource executes. Per-network specifications declare which flows they support.
 
 ## Critical Validation Requirements
 

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -42,7 +42,7 @@ The x402 protocol follows a standard request-response cycle with payment integra
 3. **Payment Authorization Request**: Client submits a signed payment authorization in the subsequent request
 4. **Settlement Response**: Server verifies the payment authorization and initiates blockchain settlement
 
-This cycle describes the default `authorize` payment flow, in which the payment is verified before the resource executes and settled afterward. Schemes may declare other flows that settle before execution; see section 6.1 Payment Flow Models.
+This cycle describes the default `authorization` payment flow, in which the payment is verified before the resource executes and settled afterward. Schemes may declare other flows that settle before execution; see section 6.1 Payment Flow Models.
 
 **3. Protocol Components**
 
@@ -281,13 +281,13 @@ Individual schemes and their per-network bindings — including `exact`, `upto`,
 
 Schemes differ not only in how a payment is formed and validated, but in **when** settlement occurs relative to resource execution. A mechanism (a scheme on a specific network) declares its payment flow by name. The flow determines the ordering of the facilitator's read-only `/verify` (section 7.1) and state-committing `/settle` (section 7.2) around the resource server's execution of the protected request.
 
-When a mechanism does not declare a flow, the default is `authorize`. A mechanism selecting a non-default flow MUST signal it to the client on the wire via `extra.paymentFlow`, so the client can reason about the trust model before paying — in particular, whether payment becomes final before the resource executes: if the resource handler fails, an `authorize` payment flow is never settled, whereas an `upfront` payment flow has already been committed.
+When a mechanism does not declare a flow, the default is `authorization`. A mechanism selecting a non-default flow MUST signal it to the client on the wire via `extra.paymentFlow`, so the client can reason about the trust model before paying — in particular, whether payment becomes final before the resource executes: if the resource handler fails, an `authorization` payment flow is never settled, whereas an `upfront` payment flow has already been committed.
 
 The following flows are defined:
 
 | Flow                  | Ordering                                        | Description                                                                                                                              |
 | --------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `authorize` (default) | verify → resource → settle → respond            | Read-only verify before the resource executes; funds move only after it completes successfully. |
+| `authorization` (default) | verify → resource → settle → respond        | Read-only verify before the resource executes; funds move only after it completes successfully. |
 | `upfront`             | settle → resource → respond                     | Payment is durably committed before the resource executes, giving the server finality first. Required by networks with no pull-settlement primitive. |
 | `escrow`              | settle → resource → settle → respond            | A first settle commits a deposit or ceiling, the resource executes, and a second settle records the final charge. |
 

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -127,7 +127,7 @@ Each `PaymentRequirements` object in the `accepts` array contains:
 | `asset`             | `string` | Required | Token contract address or ISO 4217 currency code for fiat     |
 | `payTo`             | `string` | Required | Recipient wallet address or role constant (e.g., "merchant")                                                              |
 | `maxTimeoutSeconds` | `number` | Required | Maximum time allowed for payment completion                                                                               |
-| `extra`             | `object` | Optional | Scheme-specific additional information                                                                                    |
+| `extra`             | `object` | Optional | Additional information. Reserved protocol keys: `assetTransferMethod`, `paymentFlow` (section 6.1); other keys are scheme-specific |
 
 The `ResourceInfo` object contains:
 
@@ -273,15 +273,17 @@ Each scheme defines:
 
 - How to construct the `payload` field within `PaymentPayload`
 - Settlement and validation procedures
-- Scheme-specific requirements in the `extra` field of `PaymentRequirements`
+- Requirements in the `extra` field of `PaymentRequirements` (reserved protocol keys in section 6.1; remaining keys are scheme-specific)
 
 Individual schemes and their per-network bindings — including `exact`, `upto`, `batch-settlement`, and `auth-capture` — are specified under [`specs/schemes/`](./schemes/).
 
-**6.1 Payment Flow Models**
+**6.1 Asset Transfer Methods and Payment Flow Models**
 
-Schemes differ not only in how a payment is formed and validated, but in **when** settlement occurs relative to resource execution. A mechanism (a scheme on a specific network) declares its payment flow by name. The flow determines the ordering of the facilitator's read-only `/verify` (section 7.1) and state-committing `/settle` (section 7.2) around the resource server's execution of the protected request.
+An `assetTransferMethod` identifies **how** value is authorized or moved for a mechanism (a scheme on a specific network) — for example `eip3009` vs `permit2` on EVM `exact`, or `sequence` vs `ticketSequence` on XRPL `exact`. Allowed `assetTransferMethod` string values are mechanism-defined. `extra.assetTransferMethod` and `extra.paymentFlow` are protocol-reserved keys in `PaymentRequirements.extra`: clients and servers MUST interpret them as defined here rather than as opaque scheme-private fields.
 
-When a mechanism does not declare a flow, the default is `authorization`. A mechanism selecting a non-default flow MUST signal it to the client on the wire via `extra.paymentFlow`, so the client can reason about the trust model before paying — in particular, whether payment becomes final before the resource executes: if the resource handler fails, an `authorization` payment flow is never settled, whereas an `upfront` payment flow has already been committed.
+Schemes differ not only in how a payment is formed and validated, but in **when** settlement occurs relative to resource execution. A mechanism declares supported payment flows **per `assetTransferMethod`**, each with a default flow, plus a scheme-level default `assetTransferMethod` used when `extra.assetTransferMethod` is omitted. The resolved flow determines the ordering of the facilitator's read-only `/verify` (section 7.1) and state-committing `/settle` (section 7.2) around the resource server's execution of the protected request.
+
+Omitting `extra.assetTransferMethod` or `extra.paymentFlow` means the mechanism default when resolving. When the resolved payment flow is not `authorization`, `PaymentRequired` `accepts[].extra.paymentFlow` MUST be present so clients can reason about pre-handler fund commitment without scheme-specific knowledge (for example, distinguishing an SVM upto `escrow` default from an EVM upto `authorization` default). `authorization` MAY be omitted or explicit. Resource servers MUST reject unsupported `assetTransferMethod` / payment flow combinations.
 
 The following flows are defined:
 

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -42,6 +42,8 @@ The x402 protocol follows a standard request-response cycle with payment integra
 3. **Payment Authorization Request**: Client submits a signed payment authorization in the subsequent request
 4. **Settlement Response**: Server verifies the payment authorization and initiates blockchain settlement
 
+This cycle describes the default `authorize` payment flow, in which the payment is verified before the resource executes and settled afterward. Schemes may declare other flows that settle before execution; see section 6.1 Payment Flow Models.
+
 **3. Protocol Components**
 
 The x402 protocol involves three primary components:
@@ -273,53 +275,23 @@ Each scheme defines:
 - Settlement and validation procedures
 - Scheme-specific requirements in the `extra` field of `PaymentRequirements`
 
-**6.1 Exact Scheme (EVM overview)**
+Individual schemes and their per-network bindings — including `exact`, `upto`, `batch-settlement`, and `auth-capture` — are specified under [`specs/schemes/`](./schemes/).
 
-The "exact" scheme uses EIP-3009 (Transfer with Authorization) to enable secure, gasless transfers of specific amounts of ERC-20 tokens.
+**6.1 Payment Flow Models**
 
-**6.1.1 EIP-3009 Authorization**
+Schemes differ not only in how a payment is formed and validated, but in **when** settlement occurs relative to resource execution. A mechanism (a scheme on a specific network) declares its payment flow by name. The flow determines the ordering of the facilitator's read-only `/verify` (section 7.1) and state-committing `/settle` (section 7.2) around the resource server's execution of the protected request.
 
-The authorization follows the EIP-3009 standard for `transferWithAuthorization`:
+When a mechanism does not declare a flow, the default is `authorize`. A mechanism selecting a non-default flow MUST signal it to the client on the wire via `extra.paymentFlow`, so the client can reason about the trust model before paying — in particular, whether payment becomes final before the resource executes: if the resource handler fails, an `authorize` payment flow is never settled, whereas an `upfront` payment flow has already been committed.
 
-```javascript
-const authorizationTypes = {
-  TransferWithAuthorization: [
-    { name: "from", type: "address" },
-    { name: "to", type: "address" },
-    { name: "value", type: "uint256" },
-    { name: "validAfter", type: "uint256" },
-    { name: "validBefore", type: "uint256" },
-    { name: "nonce", type: "bytes32" },
-  ],
-};
-```
+The following flows are defined:
 
-**6.1.2 Verification Steps**
+| Flow                  | Ordering                                        | Description                                                                                                                              |
+| --------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `authorize` (default) | verify → resource → settle → respond            | Read-only verify before the resource executes; funds move only after it completes successfully. |
+| `upfront`             | settle → resource → respond                     | Payment is durably committed before the resource executes, giving the server finality first. Required by networks with no pull-settlement primitive. |
+| `escrow`              | settle → resource → settle → respond            | A first settle commits a deposit or ceiling, the resource executes, and a second settle records the final charge. |
 
-The facilitator performs the following verification steps:
-
-1. **Signature Validation**: Verify the EIP-712 signature is valid and properly signed by the payer
-2. **Balance Verification**: Confirm the payer has sufficient token balance for the transfer
-3. **Amount Validation**: Ensure the payment amount exactly matches the required amount
-4. **Time Window Check**: Verify the authorization is within its valid time range
-5. **Parameter Matching**: Confirm authorization parameters match the original payment requirements
-6. **Transaction Simulation**: Simulate the `transferWithAuthorization` transaction to ensure it would succeed
-
-**6.1.3 Settlement**
-
-Settlement is performed by calling the `transferWithAuthorization` function on the ERC-20 contract with the signature and authorization parameters provided in the payment payload.
-
-**6.2 Exact Scheme (SVM overview)**
-
-For Solana (SVM), the `exact` scheme is implemented using `TransferChecked` for SPL tokens. Critical verification requirements include:
-
-- Enforcing a strict instruction layout (Compute Unit Limit, Compute Unit Price, TransferChecked)
-- Ensuring the facilitator fee payer does not appear in any instruction accounts and is not the transfer `authority` or `source`
-- Bounding compute unit price to mitigate gas abuse
-- Verifying the destination ATA matches the `payTo`/`asset` PDA and account existence rules
-- Requiring the transfer `amount` to exactly equal the `amount` specified in PaymentRequirements
-
-Full SVM details are specified in `specs/schemes/exact/scheme_exact_svm.md`.
+Invariant: at least one check — a verify before the resource or a settle before the resource — MUST run before the resource executes. The resource never executes with nothing checked.
 
 **7. Facilitator Interface**
 
@@ -327,7 +299,7 @@ The facilitator provides HTTP REST APIs for payment verification and settlement.
 
 **7.1 POST /verify**
 
-Verifies a payment authorization without executing the transaction on the blockchain.
+Verifies a payment authorization without executing the transaction on the blockchain. `/verify` is **read-only**: it validates payment state but MUST NOT commit payment state or write onchain state.
 
 **Request (Exact Scheme):**
 
@@ -415,11 +387,13 @@ Example with actual data:
 
 **7.2 POST /settle**
 
-Executes a verified payment by broadcasting the transaction to the blockchain.
+Durably commits payment state, typically by broadcasting a transaction to the blockchain. A settle need not be the final charge: it MAY establish an escrow, record a charge, or transfer funds, depending on the scheme and payment flow (see section 6.1 Payment Flow Models).
 
 **Request:** Same structure as `/verify` endpoint (contains `paymentPayload` and `paymentRequirements`).
 
 > **Note**: While the request structure is identical, some payment schemes may assign different semantics to fields at settlement time versus verification time. For example, in the `upto` scheme, the `amount` field in `paymentRequirements` represents the maximum authorized amount at verification time, but the actual amount to settle at settlement time. See individual scheme specifications for details.
+
+> **Note**: `/settle` MAY be invoked more than once for a single payment (for example, the `escrow` flow settles a deposit before the resource executes and the final charge after). A scheme defining multiple settles MUST specify how the facilitator distinguishes them from payload content.
 
 **Successful Response:**
 

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -279,19 +279,19 @@ Individual schemes and their per-network bindings — including `exact`, `upto`,
 
 **6.1 Asset Transfer Methods and Payment Flow Models**
 
-An `assetTransferMethod` identifies **how** value is authorized or moved for a mechanism (a scheme on a specific network) — for example `eip3009` vs `permit2` on EVM `exact`, or `sequence` vs `ticketSequence` on XRPL `exact`. Allowed `assetTransferMethod` string values are mechanism-defined. `extra.assetTransferMethod` and `extra.paymentFlow` are protocol-reserved keys in `PaymentRequirements.extra`: clients and servers MUST interpret them as defined here rather than as opaque scheme-private fields.
+An `assetTransferMethod` identifies **how** value is authorized or moved for a mechanism (a scheme on a specific network) — for example `eip3009` vs `permit2` on EVM `exact`, or `sequence` vs `ticketSequence` on XRPL `exact`. Allowed `assetTransferMethod` string values are mechanism-defined; this protocol reserves the key name, not a global ATM vocabulary. Mechanisms MAY reuse the same ATM string across networks when semantics align. `extra.assetTransferMethod` and `extra.paymentFlow` are protocol-reserved keys in `PaymentRequirements.extra`: clients and servers MUST interpret them as defined here rather than as opaque scheme-private fields.
 
-Schemes differ not only in how a payment is formed and validated, but in **when** settlement occurs relative to resource execution. A mechanism declares supported payment flows **per `assetTransferMethod`**, each with a default flow, plus a scheme-level default `assetTransferMethod` used when `extra.assetTransferMethod` is omitted. The resolved flow determines the ordering of the facilitator's read-only `/verify` (section 7.1) and state-committing `/settle` (section 7.2) around the resource server's execution of the protected request.
+Schemes differ not only in how a payment is formed and validated, but in **when** settlement occurs relative to resource execution. A mechanism declares supported payment flows **per `assetTransferMethod`**, each with a default flow, plus a scheme-level default `assetTransferMethod` used when `extra.assetTransferMethod` is omitted. The resolved flow determines which of the facilitator's read-only `/verify` (section 7.1) and state-committing `/settle` (section 7.2) run, and in what order, around the resource server's execution of the protected request. A flow's ordering MAY omit `/verify` (see `upfront` and `escrow` below).
 
-Omitting `extra.assetTransferMethod` or `extra.paymentFlow` means the mechanism default when resolving. When the resolved payment flow is not `authorization`, `PaymentRequired` `accepts[].extra.paymentFlow` MUST be present so clients can reason about pre-handler fund commitment without scheme-specific knowledge (for example, distinguishing an SVM upto `escrow` default from an EVM upto `authorization` default). `authorization` MAY be omitted or explicit. Resource servers MUST reject unsupported `assetTransferMethod` / payment flow combinations.
+Omitting `extra.assetTransferMethod` or `extra.paymentFlow` means the mechanism default when resolving. When the resolved payment flow is not `authorization`, `PaymentRequired` `accepts[].extra.paymentFlow` MUST be present so clients can reason about pre-handler fund commitment without scheme-specific knowledge (for example, distinguishing an SVM upto `escrow` default from an EVM upto `authorization` default). `authorization` MAY be omitted or explicit. Resource servers MUST reject unsupported `assetTransferMethod` / payment flow combinations. Clients MUST NOT construct a payment for a `paymentFlow` they do not recognize, and SHOULD skip such `accepts[]` entries when selecting. When a resource offers both `authorization` (post-handler settlement) and a pre-handler-settlement flow (`upfront` or `escrow`) for the same request, clients SHOULD prefer `authorization`.
 
 The following flows are defined:
 
 | Flow                  | Ordering                                        | Description                                                                                                                              |
 | --------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `authorization` (default) | verify → resource → settle → respond        | Read-only verify before the resource executes; funds move only after it completes successfully. |
-| `upfront`             | settle → resource → respond                     | Payment is durably committed before the resource executes, giving the server finality first. Required by networks with no pull-settlement primitive. |
-| `escrow`              | settle → resource → settle → respond            | A first settle commits a deposit or ceiling, the resource executes, and a second settle records the final charge. |
+| `upfront`             | settle → resource → respond                     | Payment is durably committed before the resource executes, giving the server finality first. Facilitator `/verify` is not part of this ordering; validity is established by settle. Required by networks with no pull-settlement primitive. |
+| `escrow`              | settle → resource → settle → respond            | A first settle commits a deposit or ceiling, the resource executes, and a second settle records the final charge. Facilitator `/verify` is not part of this ordering; the first settle is the pre-resource check. |
 
 Invariant: at least one check — a verify or settle before the resource — MUST run before the resource executes. The resource never executes with nothing checked.
 
@@ -301,7 +301,7 @@ The facilitator provides HTTP REST APIs for payment verification and settlement.
 
 **7.1 POST /verify**
 
-Verifies a payment authorization without executing the transaction on the blockchain. `/verify` is **read-only**: it validates payment state but MUST NOT commit payment state or write onchain state.
+Verifies a payment authorization without executing the transaction on the blockchain. `/verify` is **read-only**: it validates payment state but MUST NOT commit payment state or write onchain state. Resource servers invoke `/verify` only when the resolved payment flow's ordering includes it (section 6.1); `upfront` and `escrow` omit it.
 
 **Request (Exact Scheme):**
 
@@ -389,7 +389,7 @@ Example with actual data:
 
 **7.2 POST /settle**
 
-Durably commits payment state, typically by updating a network ledger (for example, broadcasting a transaction). A settle need not be the final charge: it MAY establish an escrow, record a charge, or transfer funds, depending on the scheme and payment flow (see section 6.1 Payment Flow Models).
+Durably commits payment state for the request — establishing finality from the resource server's perspective — typically by updating a network ledger (for example, broadcasting a transaction). Commitment need not be an onchain write: for client-prepaid methods, settle MAY bind a payment proof to the request (for example, consuming a challenge or marking a transaction as used) after read-only observation of ledger or backend state. A settle need not be the final charge: it MAY establish an escrow, record a charge, or transfer funds, depending on the scheme and payment flow (see section 6.1 Payment Flow Models).
 
 **Request:** Same structure as `/verify` endpoint (contains `paymentPayload` and `paymentRequirements`).
 

--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -291,7 +291,7 @@ The following flows are defined:
 | `upfront`             | settle → resource → respond                     | Payment is durably committed before the resource executes, giving the server finality first. Required by networks with no pull-settlement primitive. |
 | `escrow`              | settle → resource → settle → respond            | A first settle commits a deposit or ceiling, the resource executes, and a second settle records the final charge. |
 
-Invariant: at least one check — a verify before the resource or a settle before the resource — MUST run before the resource executes. The resource never executes with nothing checked.
+Invariant: at least one check — a verify or settle before the resource — MUST run before the resource executes. The resource never executes with nothing checked.
 
 **7. Facilitator Interface**
 
@@ -387,13 +387,13 @@ Example with actual data:
 
 **7.2 POST /settle**
 
-Durably commits payment state, typically by broadcasting a transaction to the blockchain. A settle need not be the final charge: it MAY establish an escrow, record a charge, or transfer funds, depending on the scheme and payment flow (see section 6.1 Payment Flow Models).
+Durably commits payment state, typically by updating a network ledger (for example, broadcasting a transaction). A settle need not be the final charge: it MAY establish an escrow, record a charge, or transfer funds, depending on the scheme and payment flow (see section 6.1 Payment Flow Models).
 
 **Request:** Same structure as `/verify` endpoint (contains `paymentPayload` and `paymentRequirements`).
 
 > **Note**: While the request structure is identical, some payment schemes may assign different semantics to fields at settlement time versus verification time. For example, in the `upto` scheme, the `amount` field in `paymentRequirements` represents the maximum authorized amount at verification time, but the actual amount to settle at settlement time. See individual scheme specifications for details.
 
-> **Note**: `/settle` MAY be invoked more than once for a single payment (for example, the `escrow` flow settles a deposit before the resource executes and the final charge after). A scheme defining multiple settles MUST specify how the facilitator distinguishes them from payload content.
+> **Note**: `/settle` MAY be invoked more than once for a single payment (for example, the `escrow` flow settles a deposit before the resource executes and the final charge after). A scheme defining multiple settles MUST specify how the facilitator distinguishes them from payload content. Because the client typically signs a single payload, that distinction is usually server-led (for example, a scheme-specific `step` field), though a facilitator MAY instead infer the step from network-ledger state.
 
 **Successful Response:**
 

--- a/typescript/.changeset/fail-fast-payment-flow-sanitize-500s.md
+++ b/typescript/.changeset/fail-fast-payment-flow-sanitize-500s.md
@@ -1,0 +1,10 @@
+---
+"@x402/core": minor
+"@x402/express": minor
+"@x402/hono": minor
+"@x402/fastify": minor
+"@x402/next": minor
+"@x402/mcp": minor
+---
+
+Validate unsupported `paymentFlow` / `assetTransferMethod` at HTTP server construction and MCP `createPaymentWrapper` when the scheme is registered, and return a generic internal error from HTTP adapters and MCP wrappers for unexpected failures instead of leaking internal error details to clients.

--- a/typescript/.changeset/scheme-declared-payment-flows.md
+++ b/typescript/.changeset/scheme-declared-payment-flows.md
@@ -1,0 +1,12 @@
+---
+"@x402/core": minor
+"@x402/express": minor
+"@x402/hono": minor
+"@x402/fastify": minor
+"@x402/next": minor
+"@x402/mcp": minor
+---
+
+Add scheme-declared payment flows (`authorize`, `upfront`, `escrow`, `validate`) so core can verify and settle before and/or after the resource handler. Existing schemes keep the default `authorize` flow (verify → work → settle) with no behavior change.
+
+`SettleContext.phase` identifies which settle invocation is running. Multi-settle flows (`escrow`) fire settle lifecycle hooks once per settle — side-effecting `beforeSettle` / `afterSettle` / enrichment hooks should branch on `phase` when used with those flows.

--- a/typescript/.changeset/scheme-declared-payment-flows.md
+++ b/typescript/.changeset/scheme-declared-payment-flows.md
@@ -7,6 +7,6 @@
 "@x402/mcp": minor
 ---
 
-Add scheme-declared payment flows (`authorize`, `upfront`, `escrow`, `validate`) so core can verify and settle before and/or after the resource handler. Existing schemes keep the default `authorize` flow (verify → work → settle) with no behavior change.
+Add scheme-declared payment flows (`authorization`, `upfront`, `escrow`, `validation`) so core can verify and settle before and/or after the resource handler. Existing schemes keep the default `authorization` flow (verify → work → settle) with no behavior change.
 
 `SettleContext.phase` identifies which settle invocation is running. Multi-settle flows (`escrow`) fire settle lifecycle hooks once per settle — side-effecting `beforeSettle` / `afterSettle` / enrichment hooks should branch on `phase` when used with those flows.

--- a/typescript/.changeset/scheme-declared-payment-flows.md
+++ b/typescript/.changeset/scheme-declared-payment-flows.md
@@ -7,6 +7,6 @@
 "@x402/mcp": minor
 ---
 
-Add scheme-declared payment flows (`authorization`, `upfront`, `escrow`, `validation`) so core can verify and settle before and/or after the resource handler. Existing schemes keep the default `authorization` flow (verify → work → settle) with no behavior change.
+Add scheme-declared payment flows (`authorization`, `upfront`, `escrow`) so core can verify and settle before and/or after the resource handler. Existing schemes keep the default `authorization` flow (verify → work → settle) with no behavior change.
 
 `SettleContext.phase` identifies which settle invocation is running. Multi-settle flows (`escrow`) fire settle lifecycle hooks once per settle — side-effecting `beforeSettle` / `afterSettle` / enrichment hooks should branch on `phase` when used with those flows.

--- a/typescript/.changeset/scheme-declared-payment-flows.md
+++ b/typescript/.changeset/scheme-declared-payment-flows.md
@@ -1,5 +1,16 @@
 ---
 "@x402/core": minor
+"@x402/evm": minor
+"@x402/svm": minor
+"@x402/avm": minor
+"@x402/xrpl": minor
+"@x402/tvm": minor
+"@x402/stellar": minor
+"@x402/near": minor
+"@x402/keeta": minor
+"@x402/hedera": minor
+"@x402/concordium": minor
+"@x402/aptos": minor
 "@x402/express": minor
 "@x402/hono": minor
 "@x402/fastify": minor
@@ -7,6 +18,4 @@
 "@x402/mcp": minor
 ---
 
-Add scheme-declared payment flows (`authorization`, `upfront`, `escrow`) so core can verify and settle before and/or after the resource handler. Existing schemes keep the default `authorization` flow (verify → work → settle) with no behavior change.
-
-`SettleContext.phase` identifies which settle invocation is running. Multi-settle flows (`escrow`) fire settle lifecycle hooks once per settle — side-effecting `beforeSettle` / `afterSettle` / enrichment hooks should branch on `phase` when used with those flows.
+Require ATM-keyed `paymentFlows` (and `defaultAssetTransferMethod`) on every `SchemeNetworkServer`. Core resolves ATM/flow from the table, rejects unsupported combinations, and always signals non-`authorization` `paymentFlow` on the 402 wire. All schemes currently declare `authorization` only.

--- a/typescript/packages/core/src/client/x402Client.ts
+++ b/typescript/packages/core/src/client/x402Client.ts
@@ -612,8 +612,10 @@ export class x402Client {
    *
    * Selection process:
    * 1. Filter by registered schemes (network + scheme support)
-   * 2. Apply all registered policies in order
-   * 3. Use selector to choose final requirement
+   * 2. Drop accepts with unrecognized `extra.paymentFlow`
+   * 3. Apply all registered policies in order
+   * 4. Prefer authorization (omit or explicit) over upfront/escrow when both remain
+   * 5. Use selector to choose final requirement
    *
    * @param x402Version - The x402 protocol version
    * @param paymentRequirements - Array of available payment requirements
@@ -645,8 +647,24 @@ export class x402Client {
       })}`);
     }
 
-    // Step 2: Apply all policies in order
-    let filteredRequirements = supportedPaymentRequirements;
+    // Step 2: Drop unrecognized paymentFlow values
+    const recognizedFlowRequirements = supportedPaymentRequirements.filter(requirement => {
+      const flow = requirement.extra?.paymentFlow;
+      return (
+        flow == null ||
+        flow === "authorization" ||
+        flow === "upfront" ||
+        flow === "escrow"
+      );
+    });
+    if (recognizedFlowRequirements.length === 0) {
+      throw new Error(
+        `No payment requirements with a recognized paymentFlow for x402 version: ${x402Version}`,
+      );
+    }
+
+    // Step 3: Apply all policies in order
+    let filteredRequirements = recognizedFlowRequirements;
     for (const policy of this.policies) {
       filteredRequirements = policy(x402Version, filteredRequirements);
 
@@ -655,7 +673,17 @@ export class x402Client {
       }
     }
 
-    // Step 3: Use selector to choose final requirement
+    // Step 4: Prefer authorization when both post- and pre-handler flows remain
+    const authorizationAccepts = filteredRequirements.filter(
+      requirement =>
+        requirement.extra?.paymentFlow == null ||
+        requirement.extra?.paymentFlow === "authorization",
+    );
+    if (authorizationAccepts.length > 0) {
+      filteredRequirements = authorizationAccepts;
+    }
+
+    // Step 5: Use selector to choose final requirement
     return this.paymentRequirementsSelector(x402Version, filteredRequirements);
   }
 

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -303,7 +303,6 @@ export type HTTPProcessResult =
   | {
       type: "payment-verified";
       cancellationDispatcher: PaymentCancellationDispatcher;
-      /** Before-handler settle result for success-path PAYMENT-RESPONSE echo (upfront). */
       beforeHandlerSettlement?: CompletedSettlement;
       paymentPayload: PaymentPayload;
       paymentRequirements: PaymentRequirements;

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -694,6 +694,7 @@ export class x402HTTPResourceServer {
         }
         beforeHandlerSettlement = {
           phase: "before-handler",
+          flow,
           result: beforeSettleResult,
           requirements: beforeSettleResult.requirements,
         };
@@ -764,7 +765,9 @@ export class x402HTTPResourceServer {
       };
     }
 
-    const flow = this.ResourceServer.getPaymentFlow(paymentPayload, requirements);
+    const flow =
+      beforeHandlerSettlement?.flow ??
+      this.ResourceServer.getPaymentFlow(paymentPayload, requirements);
     const phases = resolvePaymentFlowPhases(flow);
 
     // After-handler path for flows that do not settle again: echo before-handler settle or no-op.

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -302,13 +302,13 @@ export interface HTTPResponseInstructions {
 export type HTTPProcessResult =
   | { type: "no-payment-required" }
   | {
-      type: "payment-verified";
-      cancellationDispatcher: PaymentCancellationDispatcher;
-      beforeHandlerSettlement?: CompletedSettlement;
-      paymentPayload: PaymentPayload;
-      paymentRequirements: PaymentRequirements;
-      declaredExtensions?: Record<string, unknown>;
-    }
+    type: "payment-verified";
+    cancellationDispatcher: PaymentCancellationDispatcher;
+    beforeHandlerSettlement?: CompletedSettlement;
+    paymentPayload: PaymentPayload;
+    paymentRequirements: PaymentRequirements;
+    declaredExtensions?: Record<string, unknown>;
+  }
   | { type: "payment-error"; response: HTTPResponseInstructions };
 
 /**
@@ -344,10 +344,10 @@ export interface RouteValidationError {
   network: Network;
   /** The type of validation failure */
   reason:
-    | "missing_scheme"
-    | "missing_facilitator"
-    | "unsupported_asset_transfer_method"
-    | "unsupported_payment_flow";
+  | "missing_scheme"
+  | "missing_facilitator"
+  | "unsupported_asset_transfer_method"
+  | "unsupported_payment_flow";
   /** Human-readable error message */
   message: string;
 }
@@ -1061,7 +1061,7 @@ export class x402HTTPResourceServer {
 
   /**
    * Validates that all payment options in routes have corresponding registered schemes,
-   * supported paymentFlow / assetTransferMethod, and (optionally) facilitator support.
+   * supported paymentFlow / assetTransferMethod and facilitator support.
    *
    * @param options - Validation options
    * @param options.includeMissingScheme - When true (default), report unregistered schemes
@@ -1092,8 +1092,8 @@ export class x402HTTPResourceServer {
       ) {
         console.warn(
           `[x402] Route "${pattern}": Wildcard (*) patterns with bazaar discovery extensions ` +
-            `will auto-generate parameter names (var1, var2, ...). ` +
-            `Consider using named parameters instead (e.g. /weather/:city) for better discovery metadata.`,
+          `will auto-generate parameter names (var1, var2, ...). ` +
+          `Consider using named parameters instead (e.g. /weather/:city) for better discovery metadata.`,
         );
       }
 
@@ -1326,14 +1326,13 @@ export class x402HTTPResourceServer {
     const [verb, path] = pattern.includes(" ") ? pattern.split(/\s+/) : ["*", pattern];
 
     const regex = new RegExp(
-      `^${
-        path
-          .replace(/\\/g, "\\\\") // Escape backslashes first
-          .replace(/[$()+.?^{|}]/g, "\\$&") // Escape regex special chars
-          .replace(/\*/g, ".*?") // Wildcards
-          .replace(/\[([^\]]+)\]/g, "[^/]+") // Parameters (Next.js style [param])
-          .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "[^/]+") // Parameters (Express style :param)
-          .replace(/\//g, "\\/") // Escape slashes
+      `^${path
+        .replace(/\\/g, "\\\\") // Escape backslashes first
+        .replace(/[$()+.?^{|}]/g, "\\$&") // Escape regex special chars
+        .replace(/\*/g, ".*?") // Wildcards
+        .replace(/\[([^\]]+)\]/g, "[^/]+") // Parameters (Next.js style [param])
+        .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "[^/]+") // Parameters (Express style :param)
+        .replace(/\//g, "\\/") // Escape slashes
       }$`,
       // "s" (dotAll): without it, "." can't match LF/CR/U+2028/U+2029, so a wildcard segment containing one fails to match.
       "is",

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -302,13 +302,13 @@ export interface HTTPResponseInstructions {
 export type HTTPProcessResult =
   | { type: "no-payment-required" }
   | {
-    type: "payment-verified";
-    cancellationDispatcher: PaymentCancellationDispatcher;
-    beforeHandlerSettlement?: CompletedSettlement;
-    paymentPayload: PaymentPayload;
-    paymentRequirements: PaymentRequirements;
-    declaredExtensions?: Record<string, unknown>;
-  }
+      type: "payment-verified";
+      cancellationDispatcher: PaymentCancellationDispatcher;
+      beforeHandlerSettlement?: CompletedSettlement;
+      paymentPayload: PaymentPayload;
+      paymentRequirements: PaymentRequirements;
+      declaredExtensions?: Record<string, unknown>;
+    }
   | { type: "payment-error"; response: HTTPResponseInstructions };
 
 /**
@@ -344,10 +344,10 @@ export interface RouteValidationError {
   network: Network;
   /** The type of validation failure */
   reason:
-  | "missing_scheme"
-  | "missing_facilitator"
-  | "unsupported_asset_transfer_method"
-  | "unsupported_payment_flow";
+    | "missing_scheme"
+    | "missing_facilitator"
+    | "unsupported_asset_transfer_method"
+    | "unsupported_payment_flow";
   /** Human-readable error message */
   message: string;
 }
@@ -1092,8 +1092,8 @@ export class x402HTTPResourceServer {
       ) {
         console.warn(
           `[x402] Route "${pattern}": Wildcard (*) patterns with bazaar discovery extensions ` +
-          `will auto-generate parameter names (var1, var2, ...). ` +
-          `Consider using named parameters instead (e.g. /weather/:city) for better discovery metadata.`,
+            `will auto-generate parameter names (var1, var2, ...). ` +
+            `Consider using named parameters instead (e.g. /weather/:city) for better discovery metadata.`,
         );
       }
 
@@ -1326,13 +1326,14 @@ export class x402HTTPResourceServer {
     const [verb, path] = pattern.includes(" ") ? pattern.split(/\s+/) : ["*", pattern];
 
     const regex = new RegExp(
-      `^${path
-        .replace(/\\/g, "\\\\") // Escape backslashes first
-        .replace(/[$()+.?^{|}]/g, "\\$&") // Escape regex special chars
-        .replace(/\*/g, ".*?") // Wildcards
-        .replace(/\[([^\]]+)\]/g, "[^/]+") // Parameters (Next.js style [param])
-        .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "[^/]+") // Parameters (Express style :param)
-        .replace(/\//g, "\\/") // Escape slashes
+      `^${
+        path
+          .replace(/\\/g, "\\\\") // Escape backslashes first
+          .replace(/[$()+.?^{|}]/g, "\\$&") // Escape regex special chars
+          .replace(/\*/g, ".*?") // Wildcards
+          .replace(/\[([^\]]+)\]/g, "[^/]+") // Parameters (Next.js style [param])
+          .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "[^/]+") // Parameters (Express style :param)
+          .replace(/\//g, "\\/") // Escape slashes
       }$`,
       // "s" (dotAll): without it, "." can't match LF/CR/U+2028/U+2029, so a wildcard segment containing one fails to match.
       "is",

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -3,6 +3,9 @@ import {
   SettlementOverrides,
   SkipHandlerDirective,
   PaymentCancellationDispatcher,
+  CompletedSettlement,
+  SettlePhase,
+  resolvePaymentFlowPhases,
 } from "../server";
 import {
   decodePaymentSignatureHeader,
@@ -300,6 +303,8 @@ export type HTTPProcessResult =
   | {
       type: "payment-verified";
       cancellationDispatcher: PaymentCancellationDispatcher;
+      /** Before-handler settle result for success-path PAYMENT-RESPONSE echo (upfront). */
+      beforeHandlerSettlement?: CompletedSettlement;
       paymentPayload: PaymentPayload;
       paymentRequirements: PaymentRequirements;
       declaredExtensions?: Record<string, unknown>;
@@ -399,6 +404,7 @@ export class x402HTTPResourceServer {
   private routesConfig: RoutesConfig;
   private paywallProvider?: PaywallProvider;
   private protectedRequestHooks: ProtectedRequestHook[] = [];
+  private warnedMissingBeforeHandlerSettlement = false;
 
   /**
    * Creates a new x402HTTPResourceServer instance.
@@ -594,7 +600,7 @@ export class x402HTTPResourceServer {
       };
     }
 
-    // Verify payment
+    // Match requirements, resolve flow, then verify/settle per flow phases
     try {
       const matchingRequirements = this.ResourceServer.findMatchingRequirements(
         paymentRequired.accepts,
@@ -634,37 +640,64 @@ export class x402HTTPResourceServer {
         };
       }
 
-      const verifyResult = await this.ResourceServer.verifyPayment(
-        paymentPayload,
-        matchingRequirements,
-        extensions,
-        transportContext,
-      );
+      const flow = this.ResourceServer.getPaymentFlow(paymentPayload, matchingRequirements);
+      const phases = resolvePaymentFlowPhases(flow);
 
-      if (!verifyResult.isValid) {
-        const errorResponse = await this.ResourceServer.createPaymentRequiredResponse(
-          requirements,
-          resourceInfo,
-          verifyResult.invalidReason,
-          extensions,
-          transportContext,
-          paymentPayload,
-        );
-        return {
-          type: "payment-error",
-          response: this.createHTTPResponse(errorResponse, false, paywallConfig),
-        };
-      }
-
-      // Bypass the resource handler
-      if (verifyResult.skipHandler) {
-        return await this.processSkipHandlerSettlement(
+      if (phases.verifyBeforeHandler) {
+        const verifyResult = await this.ResourceServer.verifyPayment(
           paymentPayload,
           matchingRequirements,
           extensions,
           transportContext,
-          verifyResult.skipHandler,
         );
+
+        if (!verifyResult.isValid) {
+          const errorResponse = await this.ResourceServer.createPaymentRequiredResponse(
+            requirements,
+            resourceInfo,
+            verifyResult.invalidReason,
+            extensions,
+            transportContext,
+            paymentPayload,
+          );
+          return {
+            type: "payment-error",
+            response: this.createHTTPResponse(errorResponse, false, paywallConfig),
+          };
+        }
+
+        // Bypass the resource handler
+        if (verifyResult.skipHandler) {
+          return await this.processSkipHandlerSettlement(
+            paymentPayload,
+            matchingRequirements,
+            extensions,
+            transportContext,
+            verifyResult.skipHandler,
+          );
+        }
+      }
+
+      let beforeHandlerSettlement: CompletedSettlement | undefined;
+
+      if (phases.settleBeforeHandler) {
+        const beforeSettleResult = await this.processSettlement(
+          paymentPayload,
+          matchingRequirements,
+          extensions,
+          transportContext,
+          undefined,
+          undefined,
+          "before-handler",
+        );
+        if (!beforeSettleResult.success) {
+          return { type: "payment-error", response: beforeSettleResult.response };
+        }
+        beforeHandlerSettlement = {
+          phase: "before-handler",
+          result: beforeSettleResult,
+          requirements: beforeSettleResult.requirements,
+        };
       }
 
       const cancellationDispatcher = this.ResourceServer.createPaymentCancellationDispatcher(
@@ -672,12 +705,13 @@ export class x402HTTPResourceServer {
         matchingRequirements,
         extensions,
         transportContext,
+        beforeHandlerSettlement ? ["before-handler"] : [],
       );
 
-      // Payment is valid, return data needed for settlement
       return {
         type: "payment-verified",
         cancellationDispatcher,
+        beforeHandlerSettlement,
         paymentPayload,
         paymentRequirements: matchingRequirements,
         declaredExtensions: extensions,
@@ -708,6 +742,8 @@ export class x402HTTPResourceServer {
    * @param declaredExtensions - Optional declared extensions (for per-key enrichment)
    * @param transportContext - Optional HTTP transport context
    * @param settlementOverrides - Optional settlement overrides (e.g., partial settlement amount)
+   * @param beforeHandlerSettlement - Before-handler settle from processHTTPRequest (for PAYMENT-RESPONSE echo)
+   * @param phase - Explicit settle phase; omit to derive from the payment flow
    * @returns ProcessSettleResultResponse - SettleResponse with headers if success or errorReason if failure
    */
   async processSettlement(
@@ -716,6 +752,8 @@ export class x402HTTPResourceServer {
     declaredExtensions?: Record<string, unknown>,
     transportContext?: HTTPTransportContext,
     settlementOverrides?: SettlementOverrides,
+    beforeHandlerSettlement?: CompletedSettlement,
+    phase?: SettlePhase,
   ): Promise<ProcessSettleResultResponse> {
     if (transportContext?.request && !transportContext.request.method) {
       transportContext = {
@@ -726,6 +764,39 @@ export class x402HTTPResourceServer {
         },
       };
     }
+
+    const flow = this.ResourceServer.getPaymentFlow(paymentPayload, requirements);
+    const phases = resolvePaymentFlowPhases(flow);
+
+    // After-handler path for flows that do not settle again: echo before-handler settle or no-op.
+    if (phase !== "before-handler" && !phases.settleAfterHandler) {
+      if (beforeHandlerSettlement) {
+        return {
+          ...beforeHandlerSettlement.result,
+          success: true,
+          headers: this.createSettlementHeaders(beforeHandlerSettlement.result),
+          requirements: beforeHandlerSettlement.requirements,
+        };
+      }
+      if (phases.settleBeforeHandler && !beforeHandlerSettlement) {
+        if (!this.warnedMissingBeforeHandlerSettlement) {
+          this.warnedMissingBeforeHandlerSettlement = true;
+          console.warn(
+            `[x402] Payment flow "${flow}" settles before the handler, but processSettlement was called without beforeHandlerSettlement from processHTTPRequest. Skipping after-handler settle. Pass that settle result to echo the before-handler PAYMENT-RESPONSE.`,
+          );
+        }
+      }
+      return {
+        success: true,
+        transaction: "",
+        network: requirements.network as Network,
+        headers: {},
+        requirements,
+      };
+    }
+
+    const resolvedPhase: SettlePhase = phase ?? "after-handler";
+
     try {
       // Resolve overrides: explicit param takes precedence, fall back to response header
       let resolvedOverrides = settlementOverrides;
@@ -749,6 +820,7 @@ export class x402HTTPResourceServer {
         declaredExtensions,
         transportContext,
         resolvedOverrides,
+        resolvedPhase,
       );
 
       if (!settleResponse.success) {
@@ -850,6 +922,9 @@ export class x402HTTPResourceServer {
       requirements,
       declaredExtensions,
       transportContext,
+      undefined,
+      undefined,
+      "after-handler",
     );
 
     if (!settleResult.success) {

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -692,11 +692,13 @@ export class x402HTTPResourceServer {
         if (!beforeSettleResult.success) {
           return { type: "payment-error", response: beforeSettleResult.response };
         }
+        // Store SettleResponse only — omit SDK-only headers/requirements from the wire payload.
+        const { headers: _headers, requirements, ...settleResult } = beforeSettleResult;
         beforeHandlerSettlement = {
           phase: "before-handler",
           flow,
-          result: beforeSettleResult,
-          requirements: beforeSettleResult.requirements,
+          result: settleResult,
+          requirements,
         };
       }
 
@@ -1221,6 +1223,26 @@ export class x402HTTPResourceServer {
   private createSettlementHeaders(settleResponse: SettleResponse): Record<string, string> {
     const encoded = encodePaymentResponseHeader(settleResponse);
     return { "PAYMENT-RESPONSE": encoded };
+  }
+
+  /**
+   * Headers for echoing a completed before-handler settle onto a response.
+   * Merges `private` into Cache-Control so shared caches do not store settlement metadata.
+   *
+   * Used when the resource handler fails after payment was already committed (e.g. `upfront`).
+   *
+   * @param settlement - Completed before-handler settle
+   * @param existingCacheControl - Existing Cache-Control value, if any
+   * @returns PAYMENT-RESPONSE and Cache-Control headers
+   */
+  createCompletedSettlementHeaders(
+    settlement: CompletedSettlement,
+    existingCacheControl?: string | null,
+  ): Record<string, string> {
+    return {
+      ...this.createSettlementHeaders(settlement.result),
+      "Cache-Control": withPrivateCacheControl(existingCacheControl ?? null),
+    };
   }
 
   /**

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -690,12 +690,15 @@ export class x402HTTPResourceServer {
         if (!beforeSettleResult.success) {
           return { type: "payment-error", response: beforeSettleResult.response };
         }
-        // Store SettleResponse only — omit SDK-only headers/requirements from the wire payload.
-        const { headers: _headers, requirements, ...settleResult } = beforeSettleResult;
+        // Store SettleResponse only — omit SDK-only headers from CompletedSettlement.
+        const { result, requirements } = (({ headers: _, requirements, ...result }) => ({
+          result,
+          requirements,
+        }))(beforeSettleResult);
         beforeHandlerSettlement = {
           phase: "before-handler",
           flow,
-          result: settleResult,
+          result,
           requirements,
         };
       }
@@ -895,6 +898,26 @@ export class x402HTTPResourceServer {
   requiresPayment(context: HTTPRequestContext): boolean {
     const method = context.method || context.adapter.getMethod();
     return this.getRouteConfig(context.path, method) !== undefined;
+  }
+
+  /**
+   * Headers for echoing a completed before-handler settle onto a response.
+   * Merges `private` into Cache-Control so shared caches do not store settlement metadata.
+   *
+   * Used when the resource handler fails after payment was already committed (e.g. `upfront`).
+   *
+   * @param settlement - Completed before-handler settle
+   * @param existingCacheControl - Existing Cache-Control value, if any
+   * @returns PAYMENT-RESPONSE and Cache-Control headers
+   */
+  createCompletedSettlementHeaders(
+    settlement: CompletedSettlement,
+    existingCacheControl?: string | null,
+  ): Record<string, string> {
+    return {
+      ...this.createSettlementHeaders(settlement.result),
+      "Cache-Control": withPrivateCacheControl(existingCacheControl ?? null),
+    };
   }
 
   /**
@@ -1221,26 +1244,6 @@ export class x402HTTPResourceServer {
   private createSettlementHeaders(settleResponse: SettleResponse): Record<string, string> {
     const encoded = encodePaymentResponseHeader(settleResponse);
     return { "PAYMENT-RESPONSE": encoded };
-  }
-
-  /**
-   * Headers for echoing a completed before-handler settle onto a response.
-   * Merges `private` into Cache-Control so shared caches do not store settlement metadata.
-   *
-   * Used when the resource handler fails after payment was already committed (e.g. `upfront`).
-   *
-   * @param settlement - Completed before-handler settle
-   * @param existingCacheControl - Existing Cache-Control value, if any
-   * @returns PAYMENT-RESPONSE and Cache-Control headers
-   */
-  createCompletedSettlementHeaders(
-    settlement: CompletedSettlement,
-    existingCacheControl?: string | null,
-  ): Record<string, string> {
-    return {
-      ...this.createSettlementHeaders(settlement.result),
-      "Cache-Control": withPrivateCacheControl(existingCacheControl ?? null),
-    };
   }
 
   /**

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -642,39 +642,37 @@ export class x402HTTPResourceServer {
       const flow = this.ResourceServer.getPaymentFlow(paymentPayload, matchingRequirements);
       const phases = resolvePaymentFlowPhases(flow);
 
-      if (phases.verifyBeforeHandler) {
-        const verifyResult = await this.ResourceServer.verifyPayment(
+      const verifyResult = await this.ResourceServer.verifyPayment(
+        paymentPayload,
+        matchingRequirements,
+        extensions,
+        transportContext,
+      );
+
+      if (!verifyResult.isValid) {
+        const errorResponse = await this.ResourceServer.createPaymentRequiredResponse(
+          requirements,
+          resourceInfo,
+          verifyResult.invalidReason,
+          extensions,
+          transportContext,
+          paymentPayload,
+        );
+        return {
+          type: "payment-error",
+          response: this.createHTTPResponse(errorResponse, false, paywallConfig),
+        };
+      }
+
+      // Bypass the resource handler
+      if (verifyResult.skipHandler) {
+        return await this.processSkipHandlerSettlement(
           paymentPayload,
           matchingRequirements,
           extensions,
           transportContext,
+          verifyResult.skipHandler,
         );
-
-        if (!verifyResult.isValid) {
-          const errorResponse = await this.ResourceServer.createPaymentRequiredResponse(
-            requirements,
-            resourceInfo,
-            verifyResult.invalidReason,
-            extensions,
-            transportContext,
-            paymentPayload,
-          );
-          return {
-            type: "payment-error",
-            response: this.createHTTPResponse(errorResponse, false, paywallConfig),
-          };
-        }
-
-        // Bypass the resource handler
-        if (verifyResult.skipHandler) {
-          return await this.processSkipHandlerSettlement(
-            paymentPayload,
-            matchingRequirements,
-            extensions,
-            transportContext,
-            verifyResult.skipHandler,
-          );
-        }
       }
 
       let beforeHandlerSettlement: CompletedSettlement | undefined;

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -5,6 +5,7 @@ import {
   PaymentCancellationDispatcher,
   CompletedSettlement,
   SettlePhase,
+  resolvePaymentFlow,
   resolvePaymentFlowPhases,
 } from "../server";
 import {
@@ -342,7 +343,11 @@ export interface RouteValidationError {
   /** The network that failed validation */
   network: Network;
   /** The type of validation failure */
-  reason: "missing_scheme" | "missing_facilitator";
+  reason:
+    | "missing_scheme"
+    | "missing_facilitator"
+    | "unsupported_asset_transfer_method"
+    | "unsupported_payment_flow";
   /** Human-readable error message */
   message: string;
 }
@@ -410,6 +415,8 @@ export class x402HTTPResourceServer {
    *
    * @param ResourceServer - The core x402ResourceServer instance to use
    * @param routes - Route configuration for payment-protected endpoints
+   * @throws RouteConfigurationError if a registered scheme does not support the
+   *         declared paymentFlow / assetTransferMethod
    */
   constructor(ResourceServer: x402ResourceServer, routes: RoutesConfig) {
     this.ResourceServer = ResourceServer;
@@ -429,6 +436,14 @@ export class x402HTTPResourceServer {
         config,
         pattern: parsed.path,
       });
+    }
+
+    const paymentFlowErrors = this.validateRouteConfiguration({
+      includeMissingScheme: false,
+      includeFacilitator: false,
+    });
+    if (paymentFlowErrors.length > 0) {
+      throw new RouteConfigurationError(paymentFlowErrors);
     }
   }
 
@@ -1045,12 +1060,19 @@ export class x402HTTPResourceServer {
   }
 
   /**
-   * Validates that all payment options in routes have corresponding registered schemes
-   * and facilitator support.
+   * Validates that all payment options in routes have corresponding registered schemes,
+   * supported paymentFlow / assetTransferMethod, and (optionally) facilitator support.
    *
+   * @param options - Validation options
+   * @param options.includeMissingScheme - When true (default), report unregistered schemes
+   * @param options.includeFacilitator - When true (default), also check facilitator kinds
    * @returns Array of validation errors (empty if all routes are valid)
    */
-  private validateRouteConfiguration(): RouteValidationError[] {
+  private validateRouteConfiguration(
+    options: { includeMissingScheme?: boolean; includeFacilitator?: boolean } = {},
+  ): RouteValidationError[] {
+    const includeMissingScheme = options.includeMissingScheme !== false;
+    const includeFacilitator = options.includeFacilitator !== false;
     const errors: RouteValidationError[] = [];
 
     // Normalize routes to array of [pattern, config] pairs
@@ -1079,19 +1101,67 @@ export class x402HTTPResourceServer {
 
       for (const option of paymentOptions) {
         // Check 1: Is scheme registered?
-        if (!this.ResourceServer.hasRegisteredScheme(option.network, option.scheme)) {
+        const schemeServer = this.ResourceServer.getRegisteredScheme(option.network, option.scheme);
+        if (!schemeServer) {
+          if (includeMissingScheme) {
+            errors.push({
+              routePattern: pattern,
+              scheme: option.scheme,
+              network: option.network,
+              reason: "missing_scheme",
+              message: `Route "${pattern}": No scheme implementation registered for "${option.scheme}" on network "${option.network}"`,
+            });
+          }
+          // Skip further checks if scheme isn't registered
+          continue;
+        }
+
+        // Check 2: Does the scheme support the declared ATM / paymentFlow?
+        const atm =
+          typeof option.extra?.assetTransferMethod === "string"
+            ? option.extra.assetTransferMethod
+            : schemeServer.defaultAssetTransferMethod;
+        if (!schemeServer.paymentFlows[atm]) {
           errors.push({
             routePattern: pattern,
             scheme: option.scheme,
             network: option.network,
-            reason: "missing_scheme",
-            message: `Route "${pattern}": No scheme implementation registered for "${option.scheme}" on network "${option.network}"`,
+            reason: "unsupported_asset_transfer_method",
+            message:
+              `Route "${pattern}": [x402] Scheme "${schemeServer.scheme}" does not support ` +
+              `assetTransferMethod "${atm}". Supported: ${Object.keys(schemeServer.paymentFlows).join(", ")}.`,
           });
-          // Skip facilitator check if scheme isn't registered
           continue;
         }
 
-        // Check 2: Does facilitator support this scheme/network combination?
+        try {
+          resolvePaymentFlow(schemeServer, {
+            scheme: option.scheme,
+            network: option.network,
+            asset: "",
+            amount: "0",
+            payTo: "",
+            maxTimeoutSeconds: 0,
+            extra: option.extra ?? {},
+          });
+        } catch (error) {
+          errors.push({
+            routePattern: pattern,
+            scheme: option.scheme,
+            network: option.network,
+            reason: "unsupported_payment_flow",
+            message:
+              error instanceof Error
+                ? `Route "${pattern}": ${error.message}`
+                : `Route "${pattern}": Unsupported paymentFlow`,
+          });
+        }
+
+        if (!includeFacilitator) {
+          continue;
+        }
+
+        // Check 3: Does facilitator support this scheme/network combination?
         const supportedKind = this.ResourceServer.getSupportedKind(
           x402Version,
           option.network,

--- a/typescript/packages/core/src/server/hookPolicy.ts
+++ b/typescript/packages/core/src/server/hookPolicy.ts
@@ -2,6 +2,9 @@ import type { SettleResponse } from "../types/facilitator";
 import type { PaymentRequirements } from "../types/payments";
 import { deepEqual } from "../utils";
 
+/** Protocol-reserved `extra` keys; enrichment must not add or change them. */
+const RESERVED_PAYMENT_FLOW_EXTRA_KEYS = ["paymentFlow", "assetTransferMethod"] as const;
+
 /**
  * True when a string field is treated as unset and may be filled by `enrichPaymentRequiredResponse`.
  *
@@ -32,7 +35,9 @@ export function snapshotPaymentRequirementsList(
  * **`payTo`**, **`amount`**, and **`asset`** may change only when the baseline value is vacant
  * (whitespace-only string). **`scheme`**, **`network`**, and **`maxTimeoutSeconds`** are never
  * writable by extensions. **`extra`** may gain new keys; values for keys present in the baseline
- * must be unchanged (deep-equal).
+ * must be unchanged (deep-equal). **`extra.paymentFlow`** and **`extra.assetTransferMethod`**
+ * are protocol-reserved: their presence and values must match the baseline (enrichment must
+ * not add or rewrite them).
  *
  * @param baseline - Snapshot taken before any enrich hooks for this response
  * @param current - Live `accepts` entries after an extension enrich step
@@ -87,11 +92,24 @@ export function assertAcceptsAllowlistedAfterExtensionEnrich(
         );
       }
     }
+
+    for (const key of RESERVED_PAYMENT_FLOW_EXTRA_KEYS) {
+      const inBaseline = Object.prototype.hasOwnProperty.call(b.extra, key);
+      const inCurrent = Object.prototype.hasOwnProperty.call(c.extra, key);
+      if (inBaseline !== inCurrent) {
+        throw new Error(
+          `[x402] extension "${extensionKey}" violated accepts mutation policy: extra["${key}"] is protocol-reserved and immutable during enrichment (index ${i})`,
+        );
+      }
+    }
   }
 }
 
 /**
  * Ensures scheme 402 enrichment only adds `extra` keys to matching accepts.
+ * **`extra.paymentFlow`** and **`extra.assetTransferMethod`** are protocol-reserved on every
+ * accept: their presence and values must match the baseline (enrichment must not add or
+ * rewrite them).
  *
  * @param baseline - Snapshot before the scheme enrich step
  * @param current - Live `accepts` entries after scheme enrichment
@@ -148,6 +166,16 @@ export function assertAcceptsAdditiveExtraAfterSchemeEnrich(
       throw new Error(
         `[x402] scheme "${scheme}" violated accepts mutation policy: only matching accepts may receive new extra fields (index ${i})`,
       );
+    }
+
+    for (const key of RESERVED_PAYMENT_FLOW_EXTRA_KEYS) {
+      const inBaseline = Object.prototype.hasOwnProperty.call(b.extra, key);
+      const inCurrent = Object.prototype.hasOwnProperty.call(c.extra, key);
+      if (inBaseline !== inCurrent) {
+        throw new Error(
+          `[x402] scheme "${scheme}" violated accepts mutation policy: extra["${key}"] is protocol-reserved and immutable during enrichment (index ${i})`,
+        );
+      }
     }
   }
 }

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -8,10 +8,12 @@ export type {
   SettleContext,
   SettleResultContext,
   SettleFailureContext,
+  SettlePhase,
   VerifiedPaymentCanceledContext,
   VerifiedPaymentCancellationReason,
   VerifiedPaymentCancelOptions,
   PaymentCancellationDispatcher,
+  CompletedSettlement,
   SettlementOverrides,
   ExtensionValidationResult,
   SkipHandlerDirective,
@@ -24,11 +26,14 @@ export type {
   OnSettleFailureHook,
   OnVerifiedPaymentCanceledHook,
 } from "./x402ResourceServer";
+export { DEFAULT_PAYMENT_FLOW, PAYMENT_FLOWS, resolvePaymentFlowPhases } from "./paymentFlow";
 export type {
   SchemeEnrichPaymentRequiredResponseHook,
   SchemePaymentRequiredContext,
   SchemeEnrichSettlementPayloadHook,
   SchemeEnrichSettlementResponseHook,
+  PaymentFlowName,
+  PaymentFlowPhases,
 } from "../types/mechanisms";
 
 export {

--- a/typescript/packages/core/src/server/index.ts
+++ b/typescript/packages/core/src/server/index.ts
@@ -26,7 +26,13 @@ export type {
   OnSettleFailureHook,
   OnVerifiedPaymentCanceledHook,
 } from "./x402ResourceServer";
-export { DEFAULT_PAYMENT_FLOW, PAYMENT_FLOWS, resolvePaymentFlowPhases } from "./paymentFlow";
+export {
+  SDK_DEFAULT_ASSET_TRANSFER_METHOD,
+  PAYMENT_FLOWS,
+  resolvePaymentFlow,
+  applyPaymentFlowWireExtra,
+  resolvePaymentFlowPhases,
+} from "./paymentFlow";
 export type {
   SchemeEnrichPaymentRequiredResponseHook,
   SchemePaymentRequiredContext,
@@ -34,6 +40,7 @@ export type {
   SchemeEnrichSettlementResponseHook,
   PaymentFlowName,
   PaymentFlowPhases,
+  PaymentFlowConfig,
 } from "../types/mechanisms";
 
 export {

--- a/typescript/packages/core/src/server/paymentFlow.ts
+++ b/typescript/packages/core/src/server/paymentFlow.ts
@@ -4,7 +4,7 @@ import type { PaymentFlowName, PaymentFlowPhases } from "../types/mechanisms";
  * Default flow when a scheme omits {@link SchemeNetworkServer.getPaymentFlow}.
  * Matches today's verify → work → settle orchestration for all existing schemes.
  */
-export const DEFAULT_PAYMENT_FLOW: PaymentFlowName = "authorize";
+export const DEFAULT_PAYMENT_FLOW: PaymentFlowName = "authorization";
 
 /**
  * Closed set of payment-flow phase tables.
@@ -14,7 +14,7 @@ export const DEFAULT_PAYMENT_FLOW: PaymentFlowName = "authorize";
  * {@link SettleContext.phase} when used with those flows.
  */
 export const PAYMENT_FLOWS: Record<PaymentFlowName, PaymentFlowPhases> = {
-  authorize: {
+  authorization: {
     verifyBeforeHandler: true,
     settleBeforeHandler: false,
     settleAfterHandler: true,
@@ -29,7 +29,7 @@ export const PAYMENT_FLOWS: Record<PaymentFlowName, PaymentFlowPhases> = {
     settleBeforeHandler: true,
     settleAfterHandler: true,
   },
-  validate: {
+  validation: {
     verifyBeforeHandler: true,
     settleBeforeHandler: false,
     settleAfterHandler: false,

--- a/typescript/packages/core/src/server/paymentFlow.ts
+++ b/typescript/packages/core/src/server/paymentFlow.ts
@@ -1,0 +1,47 @@
+import type { PaymentFlowName, PaymentFlowPhases } from "../types/mechanisms";
+
+/**
+ * Default flow when a scheme omits {@link SchemeNetworkServer.getPaymentFlow}.
+ * Matches today's verify → work → settle orchestration for all existing schemes.
+ */
+export const DEFAULT_PAYMENT_FLOW: PaymentFlowName = "authorize";
+
+/**
+ * Closed set of payment-flow phase tables.
+ *
+ * Multi-settle flows (`escrow`) invoke settle lifecycle hooks once per settle.
+ * Authors of side-effecting `beforeSettle` / `afterSettle` hooks should branch on
+ * {@link SettleContext.phase} when used with those flows.
+ */
+export const PAYMENT_FLOWS: Record<PaymentFlowName, PaymentFlowPhases> = {
+  authorize: {
+    verifyBeforeHandler: true,
+    settleBeforeHandler: false,
+    settleAfterHandler: true,
+  },
+  upfront: {
+    verifyBeforeHandler: false,
+    settleBeforeHandler: true,
+    settleAfterHandler: false,
+  },
+  escrow: {
+    verifyBeforeHandler: false,
+    settleBeforeHandler: true,
+    settleAfterHandler: true,
+  },
+  validate: {
+    verifyBeforeHandler: true,
+    settleBeforeHandler: false,
+    settleAfterHandler: false,
+  },
+};
+
+/**
+ * Resolve the phase table for a payment flow name.
+ *
+ * @param flow - Declared or default payment flow name
+ * @returns Phase flags for verify/settle orchestration
+ */
+export function resolvePaymentFlowPhases(flow: PaymentFlowName): PaymentFlowPhases {
+  return PAYMENT_FLOWS[flow];
+}

--- a/typescript/packages/core/src/server/paymentFlow.ts
+++ b/typescript/packages/core/src/server/paymentFlow.ts
@@ -29,11 +29,6 @@ export const PAYMENT_FLOWS: Record<PaymentFlowName, PaymentFlowPhases> = {
     settleBeforeHandler: true,
     settleAfterHandler: true,
   },
-  validation: {
-    verifyBeforeHandler: true,
-    settleBeforeHandler: false,
-    settleAfterHandler: false,
-  },
 };
 
 /**
@@ -41,7 +36,14 @@ export const PAYMENT_FLOWS: Record<PaymentFlowName, PaymentFlowPhases> = {
  *
  * @param flow - Declared or default payment flow name
  * @returns Phase flags for verify/settle orchestration
+ * @throws Error when `flow` is not one of the defined payment flows
  */
 export function resolvePaymentFlowPhases(flow: PaymentFlowName): PaymentFlowPhases {
-  return PAYMENT_FLOWS[flow];
+  const phases: PaymentFlowPhases | undefined = PAYMENT_FLOWS[flow];
+  if (!phases) {
+    throw new Error(
+      `[x402] Unknown payment flow "${flow}". getPaymentFlow must return one of: ${Object.keys(PAYMENT_FLOWS).join(", ")}.`,
+    );
+  }
+  return phases;
 }

--- a/typescript/packages/core/src/server/paymentFlow.ts
+++ b/typescript/packages/core/src/server/paymentFlow.ts
@@ -1,10 +1,12 @@
-import type { PaymentFlowName, PaymentFlowPhases } from "../types/mechanisms";
+import type { PaymentFlowName, PaymentFlowPhases, SchemeNetworkServer } from "../types/mechanisms";
+import type { PaymentRequirements } from "../types/payments";
+import type { DeepReadonly } from "../types/readonly";
 
 /**
- * Default flow when a scheme omits {@link SchemeNetworkServer.getPaymentFlow}.
- * Matches today's verify → work → settle orchestration for all existing schemes.
+ * SDK-only ATM key for schemes with no on-wire assetTransferMethod.
+ * Never emit `assetTransferMethod: "default"` on the 402 wire.
  */
-export const DEFAULT_PAYMENT_FLOW: PaymentFlowName = "authorization";
+export const SDK_DEFAULT_ASSET_TRANSFER_METHOD = "default";
 
 /**
  * Closed set of payment-flow phase tables.
@@ -32,6 +34,81 @@ export const PAYMENT_FLOWS: Record<PaymentFlowName, PaymentFlowPhases> = {
 };
 
 /**
+ * Resolve assetTransferMethod and paymentFlow from a scheme table and requirements.
+ *
+ * Omit ATM → `scheme.defaultAssetTransferMethod`. Omit paymentFlow → that ATM's table default.
+ * Unsupported ATM or flow throws.
+ *
+ * @param scheme - Scheme declaring default ATM and per-ATM paymentFlows
+ * @param requirements - Payment requirements (possibly omitting ATM / paymentFlow)
+ * @returns Resolved ATM and payment flow
+ */
+export function resolvePaymentFlow(
+  scheme: Pick<SchemeNetworkServer, "defaultAssetTransferMethod" | "paymentFlows" | "scheme">,
+  requirements: DeepReadonly<PaymentRequirements>,
+): { assetTransferMethod: string; paymentFlow: PaymentFlowName } {
+  const atm =
+    typeof requirements.extra?.assetTransferMethod === "string"
+      ? requirements.extra.assetTransferMethod
+      : scheme.defaultAssetTransferMethod;
+
+  const config = scheme.paymentFlows[atm];
+  if (!config) {
+    throw new Error(
+      `[x402] Scheme "${scheme.scheme}" does not support assetTransferMethod "${atm}". ` +
+        `Supported: ${Object.keys(scheme.paymentFlows).join(", ")}.`,
+    );
+  }
+  if (!config.supported.includes(config.default)) {
+    throw new Error(
+      `[x402] Scheme "${scheme.scheme}" paymentFlows["${atm}"].default is not in supported.`,
+    );
+  }
+
+  const requested = requirements.extra?.paymentFlow;
+  const flow: PaymentFlowName =
+    requested === undefined || requested === null ? config.default : (requested as PaymentFlowName);
+
+  if (!config.supported.includes(flow)) {
+    throw new Error(
+      `[x402] Scheme "${scheme.scheme}" assetTransferMethod "${atm}" does not support paymentFlow "${String(requested)}". ` +
+        `Supported: ${config.supported.join(", ")} (default: ${config.default}).`,
+    );
+  }
+
+  return { assetTransferMethod: atm, paymentFlow: flow };
+}
+
+/**
+ * Apply resolved payment-flow rules to 402 `extra`:
+ * - Strip the SDK ATM sentinel `"default"` (never on the wire).
+ * - When resolved flow is not `authorization`, set `extra.paymentFlow` so clients
+ *   can distinguish trust models without scheme-specific knowledge.
+ *
+ * @param extra - Current requirements extra
+ * @param resolved - Result of {@link resolvePaymentFlow}
+ * @param resolved.assetTransferMethod - Resolved asset transfer method
+ * @param resolved.paymentFlow - Resolved payment flow name
+ * @returns New extra object with wire rules applied
+ */
+export function applyPaymentFlowWireExtra(
+  extra: Record<string, unknown>,
+  resolved: { assetTransferMethod: string; paymentFlow: PaymentFlowName },
+): Record<string, unknown> {
+  const next = { ...extra };
+  if (
+    resolved.assetTransferMethod === SDK_DEFAULT_ASSET_TRANSFER_METHOD ||
+    next.assetTransferMethod === SDK_DEFAULT_ASSET_TRANSFER_METHOD
+  ) {
+    delete next.assetTransferMethod;
+  }
+  if (resolved.paymentFlow !== "authorization") {
+    next.paymentFlow = resolved.paymentFlow;
+  }
+  return next;
+}
+
+/**
  * Resolve the phase table for a payment flow name.
  *
  * @param flow - Declared or default payment flow name
@@ -42,7 +119,7 @@ export function resolvePaymentFlowPhases(flow: PaymentFlowName): PaymentFlowPhas
   const phases: PaymentFlowPhases | undefined = PAYMENT_FLOWS[flow];
   if (!phases) {
     throw new Error(
-      `[x402] Unknown payment flow "${flow}". getPaymentFlow must return one of: ${Object.keys(PAYMENT_FLOWS).join(", ")}.`,
+      `[x402] Unknown payment flow "${flow}". Expected one of: ${Object.keys(PAYMENT_FLOWS).join(", ")}.`,
     );
   }
   return phases;

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -155,6 +155,7 @@ export interface VerifiedPaymentCancelOptions {
 
 export interface CompletedSettlement {
   phase: SettlePhase;
+  flow: PaymentFlowName;
   result: SettleResponse;
   requirements: PaymentRequirements;
 }

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -11,7 +11,11 @@ import {
   PaymentRequired,
   ResourceInfo,
 } from "../types/payments";
-import { SchemeNetworkServer, SchemePaymentRequiredContext } from "../types/mechanisms";
+import {
+  PaymentFlowName,
+  SchemeNetworkServer,
+  SchemePaymentRequiredContext,
+} from "../types/mechanisms";
 import { Price, Network, ResourceServerExtension, ResourceServerExtensionHooks } from "../types";
 import type { DeepReadonly } from "../types/readonly";
 import {
@@ -31,8 +35,23 @@ import {
   snapshotPaymentRequirementsList,
   snapshotSettleResponseCore,
 } from "./hookPolicy";
+import { DEFAULT_PAYMENT_FLOW } from "./paymentFlow";
 import { FacilitatorClient, HTTPFacilitatorClient } from "../http/httpFacilitatorClient";
 import { x402Version } from "..";
+
+/**
+ * Which settle invocation is running for a payment.
+ *
+ * - `before-handler` — settle before the resource handler (e.g. escrow deposit)
+ * - `after-handler` — settle after the resource handler (authorize charge, escrow charge)
+ * - `cancel` — refund/close settle from verified-payment cancellation
+ *
+ * Settle lifecycle hooks (`beforeSettle`, `afterSettle`, `onSettleFailure`,
+ * `enrichSettlementPayload`, `enrichSettlementResponse`) fire once per settle.
+ * Multi-settle flows (`escrow`) therefore invoke them more than once; branch on
+ * this field when a hook has side effects that must not double-run.
+ */
+export type SettlePhase = "before-handler" | "after-handler" | "cancel";
 
 /**
  * Configuration for a protected resource
@@ -104,6 +123,7 @@ export interface SettleContext {
   paymentPayload: DeepReadonly<PaymentPayload>;
   requirements: DeepReadonly<PaymentRequirements>;
   declaredExtensions: DeepReadonly<Record<string, unknown>>;
+  phase: SettlePhase;
   transportContext?: unknown;
 }
 
@@ -124,6 +144,7 @@ export interface VerifiedPaymentCanceledContext extends SettleContext {
   reason: VerifiedPaymentCancellationReason;
   error?: unknown;
   responseStatus?: number;
+  readonly settledPhases: readonly SettlePhase[];
 }
 
 export interface VerifiedPaymentCancelOptions {
@@ -132,6 +153,18 @@ export interface VerifiedPaymentCancelOptions {
   responseStatus?: number;
 }
 
+export interface CompletedSettlement {
+  phase: SettlePhase;
+  result: SettleResponse;
+  requirements: PaymentRequirements;
+}
+
+/**
+ * Failure-path cancel hook for a payment that already passed pre-handler gates.
+ * Created by {@link x402ResourceServer.createPaymentCancellationDispatcher}.
+ * Success-path settle results are not stored here — callers pass
+ * `beforeHandlerSettlement` into settlement separately when echoing PAYMENT-RESPONSE.
+ */
 export interface PaymentCancellationDispatcher {
   cancel(options: VerifiedPaymentCancelOptions): Promise<void>;
 }
@@ -1035,21 +1068,44 @@ export class x402ResourceServer {
   }
 
   /**
-   * Create cancellation controls for a verified payment attempt.
+   * Resolve the payment flow name for a payload/requirements pair.
+   * Returns {@link DEFAULT_PAYMENT_FLOW} when the scheme omits `getPaymentFlow`.
+   *
+   * @param payload - Client payment payload
+   * @param requirements - Matched payment requirements
+   * @returns Declared or default payment flow name
+   */
+  getPaymentFlow(
+    payload: DeepReadonly<PaymentPayload>,
+    requirements: DeepReadonly<PaymentRequirements>,
+  ): PaymentFlowName {
+    const scheme = findByNetworkAndScheme(
+      this.registeredServerSchemes,
+      requirements.scheme,
+      requirements.network as Network,
+    );
+    return scheme?.getPaymentFlow?.(payload, requirements) ?? DEFAULT_PAYMENT_FLOW;
+  }
+
+  /**
+   * Create a failure-path cancel hook for a payment that passed pre-handler gates.
    *
    * @param paymentPayload - Signed payment payload from the client
    * @param requirements - Requirements matched to the payload
    * @param declaredExtensions - Optional per-extension declarations for the request
    * @param transportContext - Optional transport-specific context
-   * @returns Cancellation controls for the verified payment attempt
+   * @param settledPhases - Settle phases already completed before the handler (for settleOnCancel)
+   * @returns Dispatcher with cancel only
    */
   createPaymentCancellationDispatcher(
     paymentPayload: PaymentPayload,
     requirements: PaymentRequirements,
     declaredExtensions?: Record<string, unknown>,
     transportContext?: unknown,
+    settledPhases: readonly SettlePhase[] = [],
   ): PaymentCancellationDispatcher {
     const resolvedDeclaredExtensions = declaredExtensions ?? {};
+    const resolvedSettledPhases = settledPhases;
     let cancelPromise: Promise<void> | undefined;
 
     return {
@@ -1061,6 +1117,7 @@ export class x402ResourceServer {
             resolvedDeclaredExtensions,
             options,
             transportContext,
+            resolvedSettledPhases,
           );
         }
         return cancelPromise;
@@ -1076,6 +1133,7 @@ export class x402ResourceServer {
    * @param declaredExtensions - Optional declared extensions (for per-key enrichment)
    * @param transportContext - Optional transport-specific context (e.g., HTTP request/response, MCP tool context)
    * @param settlementOverrides - Optional overrides for settlement parameters (e.g., partial settlement amount)
+   * @param phase - Which settle invocation this is (defaults to `after-handler`)
    * @returns Settlement response
    */
   async settlePayment(
@@ -1084,6 +1142,7 @@ export class x402ResourceServer {
     declaredExtensions?: Record<string, unknown>,
     transportContext?: unknown,
     settlementOverrides?: SettlementOverrides,
+    phase: SettlePhase = "after-handler",
   ): Promise<SettleResponse> {
     const resolvedDeclaredExtensions = declaredExtensions ?? {};
     const extensionKeysInUse = Object.keys(resolvedDeclaredExtensions);
@@ -1108,6 +1167,7 @@ export class x402ResourceServer {
       paymentPayload,
       requirements: effectiveRequirements,
       declaredExtensions: resolvedDeclaredExtensions,
+      phase,
       transportContext,
     };
     const matchedScheme = {
@@ -1171,19 +1231,26 @@ export class x402ResourceServer {
         matchedScheme.scheme,
         matchedScheme.network,
       );
+      // Settle-local payload copy so a second settle can enrich the same keys
+      // without mutating the caller's object (assertAdditivePayloadEnrichment
+      // still runs against the original client payload).
+      let settlePayload: PaymentPayload = paymentPayload;
       const payloadEnrichmentHook = scheme?.enrichSettlementPayload;
       if (payloadEnrichmentHook) {
         const label = `scheme "${matchedScheme.scheme}" enrichSettlementPayload`;
         const enrichment = await payloadEnrichmentHook(context);
         if (enrichment !== undefined) {
           assertAdditivePayloadEnrichment(paymentPayload.payload, enrichment, label);
-          paymentPayload.payload = { ...paymentPayload.payload, ...enrichment };
+          settlePayload = {
+            ...paymentPayload,
+            payload: { ...paymentPayload.payload, ...enrichment },
+          };
         }
       }
 
       // Find the facilitator that supports this payment type
       const facilitatorClient = this.getFacilitatorClient(
-        paymentPayload.x402Version,
+        settlePayload.x402Version,
         effectiveRequirements.network,
         effectiveRequirements.scheme,
       );
@@ -1196,7 +1263,7 @@ export class x402ResourceServer {
 
         for (const client of this.facilitatorClients) {
           try {
-            settleResult = await client.settle(paymentPayload, effectiveRequirements);
+            settleResult = await client.settle(settlePayload, effectiveRequirements);
             break;
           } catch (error) {
             lastError = error as Error;
@@ -1207,13 +1274,13 @@ export class x402ResourceServer {
           throw (
             lastError ||
             new Error(
-              `No facilitator supports ${effectiveRequirements.scheme} on ${effectiveRequirements.network} for v${paymentPayload.x402Version}`,
+              `No facilitator supports ${effectiveRequirements.scheme} on ${effectiveRequirements.network} for v${settlePayload.x402Version}`,
             )
           );
         }
       } else {
         // Use the specific facilitator that supports this payment
-        settleResult = await facilitatorClient.settle(paymentPayload, effectiveRequirements);
+        settleResult = await facilitatorClient.settle(settlePayload, effectiveRequirements);
       }
 
       // Execute afterSettle hooks
@@ -1459,6 +1526,7 @@ export class x402ResourceServer {
             context.declaredExtensions,
             { reason: "after_verify_aborted" },
             context.transportContext,
+            [],
           );
           return {
             isValid: false,
@@ -1542,6 +1610,7 @@ export class x402ResourceServer {
    * @param declaredExtensions - Optional per-extension declarations for the request
    * @param options - Cancellation reason and optional diagnostics
    * @param fallbackTransportContext - Optional transport-specific context
+   * @param settledPhases - Settle phases that already completed for this payment
    */
   private async dispatchVerifiedPaymentCanceled(
     paymentPayload: DeepReadonly<PaymentPayload>,
@@ -1549,6 +1618,7 @@ export class x402ResourceServer {
     declaredExtensions: DeepReadonly<Record<string, unknown>>,
     options: VerifiedPaymentCancelOptions,
     fallbackTransportContext?: unknown,
+    settledPhases: readonly SettlePhase[] = [],
   ): Promise<void> {
     const extensionKeysInUse = Object.keys(declaredExtensions);
     const matchedScheme = {
@@ -1559,10 +1629,12 @@ export class x402ResourceServer {
       paymentPayload,
       requirements,
       declaredExtensions,
+      phase: "cancel",
       transportContext: fallbackTransportContext,
       reason: options.reason,
       error: options.error,
       responseStatus: options.responseStatus,
+      settledPhases,
     };
 
     for (const { label, hook } of this.getLabeledHooks(

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -35,7 +35,7 @@ import {
   snapshotPaymentRequirementsList,
   snapshotSettleResponseCore,
 } from "./hookPolicy";
-import { DEFAULT_PAYMENT_FLOW } from "./paymentFlow";
+import { DEFAULT_PAYMENT_FLOW, resolvePaymentFlowPhases } from "./paymentFlow";
 import { FacilitatorClient, HTTPFacilitatorClient } from "../http/httpFacilitatorClient";
 import { x402Version } from "..";
 
@@ -947,6 +947,12 @@ export class x402ResourceServer {
   /**
    * Verifies a payment against requirements, running manual and in-use extension hooks.
    *
+   * Resource-server `beforeVerify` hooks always run. Facilitator `/verify` runs only when
+   * the scheme's payment flow has `verifyBeforeHandler` (the `authorization` flow). For
+   * `upfront` / `escrow`, payment validity is established by settle; `afterVerify` /
+   * `onVerifyFailure` still run when a `VerifyResponse` exists (facilitator result or a
+   * beforeVerify skip).
+   *
    * @param paymentPayload - Signed payment payload from the client
    * @param requirements - Requirements matched to the payload
    * @param declaredExtensions - Optional per-extension declarations for the request
@@ -999,6 +1005,13 @@ export class x402ResourceServer {
       } catch (error) {
         this.warnResourceServerHookFailure("beforeVerify", label, error);
       }
+    }
+
+    const { verifyBeforeHandler } = resolvePaymentFlowPhases(
+      this.getPaymentFlow(paymentPayload, requirements),
+    );
+    if (!verifyBeforeHandler) {
+      return { isValid: true };
     }
 
     try {

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -35,7 +35,11 @@ import {
   snapshotPaymentRequirementsList,
   snapshotSettleResponseCore,
 } from "./hookPolicy";
-import { DEFAULT_PAYMENT_FLOW, resolvePaymentFlowPhases } from "./paymentFlow";
+import {
+  applyPaymentFlowWireExtra,
+  resolvePaymentFlow,
+  resolvePaymentFlowPhases,
+} from "./paymentFlow";
 import { FacilitatorClient, HTTPFacilitatorClient } from "../http/httpFacilitatorClient";
 import { x402Version } from "..";
 
@@ -392,6 +396,17 @@ export class x402ResourceServer {
    */
   hasRegisteredScheme(network: Network, scheme: string): boolean {
     return !!findByNetworkAndScheme(this.registeredServerSchemes, scheme, network);
+  }
+
+  /**
+   * Get the registered scheme implementation for a network and scheme name.
+   *
+   * @param network - The network identifier
+   * @param scheme - The payment scheme name
+   * @returns The registered scheme, or undefined if none is registered
+   */
+  getRegisteredScheme(network: Network, scheme: string): SchemeNetworkServer | undefined {
+    return findByNetworkAndScheme(this.registeredServerSchemes, scheme, network);
   }
 
   /**
@@ -788,6 +803,9 @@ export class x402ResourceServer {
       facilitatorExtensions,
     );
 
+    const resolved = resolvePaymentFlow(SchemeNetworkServer, requirement);
+    requirement.extra = applyPaymentFlowWireExtra(requirement.extra ?? {}, resolved);
+
     requirements.push(requirement);
     return requirements;
   }
@@ -1082,15 +1100,15 @@ export class x402ResourceServer {
   }
 
   /**
-   * Resolve the payment flow name for a payload/requirements pair.
-   * Returns {@link DEFAULT_PAYMENT_FLOW} when the scheme omits `getPaymentFlow`.
+   * Resolve the payment flow name for a payload/requirements pair from the
+   * scheme's ATM-keyed {@link SchemeNetworkServer.paymentFlows} table.
    *
-   * @param payload - Client payment payload
+   * @param _payload - Client payment payload (unused; flow is requirements-driven)
    * @param requirements - Matched payment requirements
-   * @returns Declared or default payment flow name
+   * @returns Resolved payment flow name
    */
   getPaymentFlow(
-    payload: DeepReadonly<PaymentPayload>,
+    _payload: DeepReadonly<PaymentPayload>,
     requirements: DeepReadonly<PaymentRequirements>,
   ): PaymentFlowName {
     const scheme = findByNetworkAndScheme(
@@ -1098,7 +1116,12 @@ export class x402ResourceServer {
       requirements.scheme,
       requirements.network as Network,
     );
-    return scheme?.getPaymentFlow?.(payload, requirements) ?? DEFAULT_PAYMENT_FLOW;
+    if (!scheme) {
+      throw new Error(
+        `[x402] No server implementation registered for scheme: ${requirements.scheme}, network: ${requirements.network}`,
+      );
+    }
+    return resolvePaymentFlow(scheme, requirements).paymentFlow;
   }
 
   /**

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -43,7 +43,7 @@ import { x402Version } from "..";
  * Which settle invocation is running for a payment.
  *
  * - `before-handler` — settle before the resource handler (e.g. escrow deposit)
- * - `after-handler` — settle after the resource handler (authorize charge, escrow charge)
+ * - `after-handler` — settle after the resource handler (authorization charge, escrow charge)
  * - `cancel` — refund/close settle from verified-payment cancellation
  *
  * Settle lifecycle hooks (`beforeSettle`, `afterSettle`, `onSettleFailure`,

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -81,6 +81,8 @@ export interface ResourceConfig {
  * (see {@link assertAcceptsAllowlistedAfterExtensionEnrich}): `scheme`, `network`, and
  * `maxTimeoutSeconds` are immutable; `payTo`, `amount`, and `asset` may change only when the
  * baseline value was vacant; `extra` may add keys but must not change or remove baseline keys.
+ * `extra.paymentFlow` and `extra.assetTransferMethod` are protocol-reserved and immutable
+ * during enrichment (enrichment must not add or rewrite them).
  */
 export interface PaymentRequiredContext {
   requirements: PaymentRequirements[];

--- a/typescript/packages/core/src/types/extensions.ts
+++ b/typescript/packages/core/src/types/extensions.ts
@@ -89,7 +89,8 @@ export interface ResourceServerExtension {
    * Return value merges into `extensions[key]`. In-place edits to `accepts` are allowlisted only
    * (see server `assertAcceptsAllowlistedAfterExtensionEnrich`): vacant `payTo` / `amount` / `asset`
    * may be filled; locked values and `scheme` / `network` / `maxTimeoutSeconds` / baseline `extra`
-   * entries are immutable.
+   * entries are immutable. `extra.paymentFlow` and `extra.assetTransferMethod` are
+   * protocol-reserved and must not be added or changed during enrichment.
    */
   enrichPaymentRequiredResponse?: (
     declaration: unknown,

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -31,6 +31,8 @@ export type {
   FacilitatorContext,
   SchemePaymentRequiredContext,
   SchemeEnrichPaymentRequiredResponseHook,
+  PaymentFlowName,
+  PaymentFlowPhases,
 } from "./mechanisms";
 export type { PaymentRequirementsV1, PaymentRequiredV1, PaymentPayloadV1 } from "./v1";
 export type {

--- a/typescript/packages/core/src/types/index.ts
+++ b/typescript/packages/core/src/types/index.ts
@@ -33,6 +33,7 @@ export type {
   SchemeEnrichPaymentRequiredResponseHook,
   PaymentFlowName,
   PaymentFlowPhases,
+  PaymentFlowConfig,
 } from "./mechanisms";
 export type { PaymentRequirementsV1, PaymentRequiredV1, PaymentPayloadV1 } from "./v1";
 export type {

--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -202,25 +202,32 @@ export interface PaymentFlowPhases {
   settleAfterHandler: boolean;
 }
 
+/**
+ * Supported payment flows for one assetTransferMethod, plus the default when
+ * `extra.paymentFlow` is omitted.
+ */
+export interface PaymentFlowConfig {
+  readonly supported: readonly PaymentFlowName[];
+  /** Must be a member of {@link PaymentFlowConfig.supported}. */
+  readonly default: PaymentFlowName;
+}
+
 export interface SchemeNetworkServer {
   readonly scheme: string;
+  /**
+   * ATM used when `requirements.extra.assetTransferMethod` is absent.
+   * Use `"default"` only as SDK plumbing when the scheme has no on-wire ATM.
+   */
+  readonly defaultAssetTransferMethod: string;
+  /**
+   * Payment flows supported per assetTransferMethod.
+   * Every ATM the scheme accepts must appear here.
+   */
+  readonly paymentFlows: Readonly<Record<string, PaymentFlowConfig>>;
   readonly schemeHooks?: SchemeServerHooks;
   enrichPaymentRequiredResponse?: SchemeEnrichPaymentRequiredResponseHook;
   enrichSettlementPayload?: SchemeEnrichSettlementPayloadHook;
   enrichSettlementResponse?: SchemeEnrichSettlementResponseHook;
-
-  /**
-   * Optional: declare which payment flow this scheme uses for a given payload.
-   * Omit for the default `authorization` flow (verify → work → settle).
-   *
-   * @param payload - Client payment payload
-   * @param requirements - Matched payment requirements
-   * @returns Flow name from the closed {@link PaymentFlowName} set
-   */
-  getPaymentFlow?(
-    payload: DeepReadonly<PaymentPayload>,
-    requirements: DeepReadonly<PaymentRequirements>,
-  ): PaymentFlowName;
 
   /**
    * Convert a user-friendly price to the scheme's specific amount and asset format

--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -184,12 +184,43 @@ export type SchemeEnrichPaymentRequiredResponseHook = (
   ctx: SchemePaymentRequiredContext,
 ) => Promise<PaymentRequirements[] | void>;
 
+/**
+ * Named payment flow declared by a scheme. Controls whether core verifies and/or
+ * settles before the resource handler, and whether it settles after.
+ *
+ * Multi-settle flows (`escrow`) fire settle lifecycle hooks once per settle.
+ * Side-effecting hooks should branch on {@link SettleContext.phase}.
+ */
+export type PaymentFlowName = "authorize" | "upfront" | "escrow" | "validate";
+
+/**
+ * Phase flags for a {@link PaymentFlowName}.
+ */
+export interface PaymentFlowPhases {
+  verifyBeforeHandler: boolean;
+  settleBeforeHandler: boolean;
+  settleAfterHandler: boolean;
+}
+
 export interface SchemeNetworkServer {
   readonly scheme: string;
   readonly schemeHooks?: SchemeServerHooks;
   enrichPaymentRequiredResponse?: SchemeEnrichPaymentRequiredResponseHook;
   enrichSettlementPayload?: SchemeEnrichSettlementPayloadHook;
   enrichSettlementResponse?: SchemeEnrichSettlementResponseHook;
+
+  /**
+   * Optional: declare which payment flow this scheme uses for a given payload.
+   * Omit for the default `authorize` flow (verify → work → settle).
+   *
+   * @param payload - Client payment payload
+   * @param requirements - Matched payment requirements
+   * @returns Flow name from the closed {@link PaymentFlowName} set
+   */
+  getPaymentFlow?(
+    payload: DeepReadonly<PaymentPayload>,
+    requirements: DeepReadonly<PaymentRequirements>,
+  ): PaymentFlowName;
 
   /**
    * Convert a user-friendly price to the scheme's specific amount and asset format

--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -191,7 +191,7 @@ export type SchemeEnrichPaymentRequiredResponseHook = (
  * Multi-settle flows (`escrow`) fire settle lifecycle hooks once per settle.
  * Side-effecting hooks should branch on {@link SettleContext.phase}.
  */
-export type PaymentFlowName = "authorization" | "upfront" | "escrow" | "validation";
+export type PaymentFlowName = "authorization" | "upfront" | "escrow";
 
 /**
  * Phase flags for a {@link PaymentFlowName}.

--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -191,7 +191,7 @@ export type SchemeEnrichPaymentRequiredResponseHook = (
  * Multi-settle flows (`escrow`) fire settle lifecycle hooks once per settle.
  * Side-effecting hooks should branch on {@link SettleContext.phase}.
  */
-export type PaymentFlowName = "authorize" | "upfront" | "escrow" | "validate";
+export type PaymentFlowName = "authorization" | "upfront" | "escrow" | "validation";
 
 /**
  * Phase flags for a {@link PaymentFlowName}.
@@ -211,7 +211,7 @@ export interface SchemeNetworkServer {
 
   /**
    * Optional: declare which payment flow this scheme uses for a given payload.
-   * Omit for the default `authorize` flow (verify → work → settle).
+   * Omit for the default `authorization` flow (verify → work → settle).
    *
    * @param payload - Client payment payload
    * @param requirements - Matched payment requirements

--- a/typescript/packages/core/test/integrations/paymentFlows.test.ts
+++ b/typescript/packages/core/test/integrations/paymentFlows.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { x402Client, x402HTTPClient } from "../../src/client";
+import { x402Facilitator } from "../../src/facilitator";
+import {
+  FacilitatorClient,
+  HTTPAdapter,
+  SettlePhase,
+  x402HTTPResourceServer,
+  x402ResourceServer,
+} from "../../src/server";
+import {
+  CashFacilitatorClient,
+  CashSchemeNetworkClient,
+  CashSchemeNetworkFacilitator,
+  MockAuthorizeSchemeNetworkServer,
+  MockEscrowSchemeNetworkServer,
+  MockUpfrontSchemeNetworkServer,
+} from "../mocks";
+import {
+  Network,
+  PaymentPayload,
+  PaymentRequirements,
+  SchemeNetworkServer,
+  SettleResponse,
+  SupportedResponse,
+  VerifyResponse,
+} from "../../src/types";
+import { decodePaymentResponseHeader } from "../../src/http";
+
+/**
+ * Wraps a facilitator client to count verify/settle calls for payment-flow assertions.
+ */
+class CountingFacilitatorClient implements FacilitatorClient {
+  verifyCalls = 0;
+  settleCalls = 0;
+
+  /**
+   * @param inner - Underlying facilitator client
+   */
+  constructor(private readonly inner: FacilitatorClient) {}
+
+  /**
+   * @returns Supported kinds from the inner client
+   */
+  getSupported(): Promise<SupportedResponse> {
+    return this.inner.getSupported();
+  }
+
+  /**
+   * @param payload - Payment payload
+   * @param requirements - Payment requirements
+   * @returns Verify response from the inner client
+   */
+  verify(payload: PaymentPayload, requirements: PaymentRequirements): Promise<VerifyResponse> {
+    this.verifyCalls++;
+    return this.inner.verify(payload, requirements);
+  }
+
+  /**
+   * @param payload - Payment payload
+   * @param requirements - Payment requirements
+   * @returns Settle response from the inner client
+   */
+  settle(payload: PaymentPayload, requirements: PaymentRequirements): Promise<SettleResponse> {
+    this.settleCalls++;
+    return this.inner.settle(payload, requirements);
+  }
+}
+
+describe("Payment flow integration (MockAuthorize / MockUpfront / MockEscrow)", () => {
+  const routes = {
+    "/api/protected": {
+      accepts: {
+        scheme: "cash",
+        payTo: "merchant@example.com",
+        price: "$0.10",
+        network: "x402:cash" as Network,
+      },
+      description: "Access to protected API",
+      mimeType: "application/json",
+    },
+  };
+
+  let client: x402HTTPClient;
+  let httpServer: x402HTTPResourceServer;
+  let resourceServer: x402ResourceServer;
+  let facilitatorClient: CountingFacilitatorClient;
+  let paymentSignatureHeader: string;
+
+  /**
+   * @param schemeServer - Cash server variant declaring a payment flow
+   */
+  async function setup(schemeServer: SchemeNetworkServer) {
+    const facilitator = new x402Facilitator().register(
+      "x402:cash",
+      new CashSchemeNetworkFacilitator(),
+    );
+    facilitatorClient = new CountingFacilitatorClient(new CashFacilitatorClient(facilitator));
+
+    const paymentClient = new x402Client().register(
+      "x402:cash",
+      new CashSchemeNetworkClient("John"),
+    );
+    client = new x402HTTPClient(paymentClient);
+
+    resourceServer = new x402ResourceServer(facilitatorClient);
+    resourceServer.register("x402:cash", schemeServer);
+    await resourceServer.initialize();
+
+    httpServer = new x402HTTPResourceServer(resourceServer, routes);
+
+    // Obtain a signed PAYMENT-SIGNATURE for the protected route
+    const unpaidAdapter: HTTPAdapter = {
+      getHeader: () => undefined,
+      getMethod: () => "GET",
+      getPath: () => "/api/protected",
+      getUrl: () => "https://example.com/api/protected",
+      getAcceptHeader: () => "application/json",
+      getUserAgent: () => "TestClient/1.0",
+    };
+    const unpaid = await httpServer.processHTTPRequest({
+      adapter: unpaidAdapter,
+      path: "/api/protected",
+      method: "GET",
+    });
+    expect(unpaid.type).toBe("payment-error");
+    if (unpaid.type !== "payment-error") return;
+
+    const paymentRequired = client.getPaymentRequiredResponse(
+      name => unpaid.response.headers[name],
+      unpaid.response.body,
+    );
+    const paymentPayload = await client.createPaymentPayload(paymentRequired);
+    const headers = await client.encodePaymentSignatureHeader(paymentPayload);
+    paymentSignatureHeader = headers["PAYMENT-SIGNATURE"];
+
+    facilitatorClient.verifyCalls = 0;
+    facilitatorClient.settleCalls = 0;
+  }
+
+  /**
+   * @returns Adapter that presents the pre-built PAYMENT-SIGNATURE
+   */
+  function paidAdapter(): HTTPAdapter {
+    return {
+      getHeader: (name: string) =>
+        name.toUpperCase() === "PAYMENT-SIGNATURE" ? paymentSignatureHeader : undefined,
+      getMethod: () => "GET",
+      getPath: () => "/api/protected",
+      getUrl: () => "https://example.com/api/protected",
+      getAcceptHeader: () => "application/json",
+      getUserAgent: () => "TestClient/1.0",
+    };
+  }
+
+  describe("MockAuthorize", () => {
+    beforeEach(async () => {
+      await setup(new MockAuthorizeSchemeNetworkServer());
+    });
+
+    it("verifies before handler and settles after", async () => {
+      const result = await httpServer.processHTTPRequest({
+        adapter: paidAdapter(),
+        path: "/api/protected",
+        method: "GET",
+      });
+      expect(result.type).toBe("payment-verified");
+      if (result.type !== "payment-verified") return;
+
+      expect(result.beforeHandlerSettlement).toBeUndefined();
+      expect(facilitatorClient.verifyCalls).toBe(1);
+      expect(facilitatorClient.settleCalls).toBe(0);
+
+      const settle = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+        result.declaredExtensions,
+        undefined,
+        undefined,
+        result.beforeHandlerSettlement,
+      );
+      expect(settle.success).toBe(true);
+      expect(facilitatorClient.verifyCalls).toBe(1);
+      expect(facilitatorClient.settleCalls).toBe(1);
+      if (settle.success) {
+        expect(settle.headers["PAYMENT-RESPONSE"]).toBeDefined();
+      }
+    });
+  });
+
+  describe("MockUpfront", () => {
+    beforeEach(async () => {
+      await setup(new MockUpfrontSchemeNetworkServer());
+    });
+
+    it("settles before handler and echoes receipt without a second settle", async () => {
+      const result = await httpServer.processHTTPRequest({
+        adapter: paidAdapter(),
+        path: "/api/protected",
+        method: "GET",
+      });
+      expect(result.type).toBe("payment-verified");
+      if (result.type !== "payment-verified") return;
+
+      expect(result.beforeHandlerSettlement?.phase).toBe("before-handler");
+      expect(result.beforeHandlerSettlement?.flow).toBe("upfront");
+      expect(facilitatorClient.verifyCalls).toBe(0);
+      expect(facilitatorClient.settleCalls).toBe(1);
+
+      const settle = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+        result.declaredExtensions,
+        undefined,
+        undefined,
+        result.beforeHandlerSettlement,
+      );
+      expect(settle.success).toBe(true);
+      // Echo path — no second facilitator settle
+      expect(facilitatorClient.settleCalls).toBe(1);
+      if (settle.success) {
+        expect(settle.headers["PAYMENT-RESPONSE"]).toBeDefined();
+        expect(settle.transaction).toBe(result.beforeHandlerSettlement!.result.transaction);
+      }
+    });
+  });
+
+  describe("MockEscrow", () => {
+    beforeEach(async () => {
+      await setup(new MockEscrowSchemeNetworkServer());
+    });
+
+    it("settles before and after handler", async () => {
+      const result = await httpServer.processHTTPRequest({
+        adapter: paidAdapter(),
+        path: "/api/protected",
+        method: "GET",
+      });
+      expect(result.type).toBe("payment-verified");
+      if (result.type !== "payment-verified") return;
+
+      expect(result.beforeHandlerSettlement?.phase).toBe("before-handler");
+      expect(result.beforeHandlerSettlement?.flow).toBe("escrow");
+      expect(facilitatorClient.verifyCalls).toBe(0);
+      expect(facilitatorClient.settleCalls).toBe(1);
+
+      const settle = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+        result.declaredExtensions,
+        undefined,
+        undefined,
+        result.beforeHandlerSettlement,
+      );
+      expect(settle.success).toBe(true);
+      expect(facilitatorClient.settleCalls).toBe(2);
+      if (settle.success) {
+        expect(settle.headers["PAYMENT-RESPONSE"]).toBeDefined();
+      }
+    });
+
+    it("cancels after deposit with settledPhases and deposit receipt", async () => {
+      let settledPhases: readonly SettlePhase[] | undefined;
+      resourceServer.onVerifiedPaymentCanceled(async ctx => {
+        settledPhases = ctx.settledPhases;
+        expect(ctx.phase).toBe("cancel");
+        expect(ctx.reason).toBe("handler_failed");
+      });
+
+      const result = await httpServer.processHTTPRequest({
+        adapter: paidAdapter(),
+        path: "/api/protected",
+        method: "GET",
+      });
+      expect(result.type).toBe("payment-verified");
+      if (result.type !== "payment-verified") return;
+
+      expect(result.beforeHandlerSettlement?.phase).toBe("before-handler");
+      expect(facilitatorClient.settleCalls).toBe(1);
+
+      await result.cancellationDispatcher.cancel({
+        reason: "handler_failed",
+        responseStatus: 500,
+      });
+      expect(settledPhases).toEqual(["before-handler"]);
+      // Cancel does not invoke a second facilitator settle
+      expect(facilitatorClient.settleCalls).toBe(1);
+
+      const receiptHeaders = httpServer.createCompletedSettlementHeaders(
+        result.beforeHandlerSettlement!,
+      );
+      expect(decodePaymentResponseHeader(receiptHeaders["PAYMENT-RESPONSE"])).toEqual(
+        expect.objectContaining({
+          success: true,
+          transaction: result.beforeHandlerSettlement!.result.transaction,
+        }),
+      );
+    });
+  });
+});

--- a/typescript/packages/core/test/mocks/cash/index.ts
+++ b/typescript/packages/core/test/mocks/cash/index.ts
@@ -6,14 +6,13 @@ import {
   VerifyResponse,
 } from "../../../../src/types/facilitator";
 import {
-  PaymentFlowName,
+  PaymentFlowConfig,
   SchemeNetworkClient,
   SchemeNetworkFacilitator,
   SchemeNetworkServer,
 } from "../../../../src/types/mechanisms";
 import { PaymentPayload, PaymentRequirements } from "../../../../src/types/payments";
 import { Price, AssetAmount, Network } from "../../../../src/types";
-import type { DeepReadonly } from "../../../../src/types/readonly";
 
 /**
  *
@@ -164,6 +163,10 @@ export function buildCashPaymentRequirements(
  */
 export class CashSchemeNetworkServer implements SchemeNetworkServer {
   readonly scheme = "cash";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows: Readonly<Record<string, PaymentFlowConfig>> = {
+    default: { supported: ["authorization"], default: "authorization" },
+  };
 
   /**
    * Parses a price into asset amount format.
@@ -243,40 +246,16 @@ export class CashSchemeNetworkServer implements SchemeNetworkServer {
  * Cash server that declares the default `authorization` payment flow.
  * Used by integration tests to prove verify → work → settle wiring.
  */
-export class MockAuthorizeSchemeNetworkServer extends CashSchemeNetworkServer {
-  /**
-   * @param _payload - Unused; flow is fixed for this mock
-   * @param _requirements - Unused; flow is fixed for this mock
-   * @returns `authorization`
-   */
-  getPaymentFlow(
-    _payload: DeepReadonly<PaymentPayload>,
-    _requirements: DeepReadonly<PaymentRequirements>,
-  ): PaymentFlowName {
-    void _payload;
-    void _requirements;
-    return "authorization";
-  }
-}
+export class MockAuthorizeSchemeNetworkServer extends CashSchemeNetworkServer {}
 
 /**
  * Cash server that declares the `upfront` payment flow.
  * Used by integration tests to prove settle → work wiring without a real prepaid scheme.
  */
 export class MockUpfrontSchemeNetworkServer extends CashSchemeNetworkServer {
-  /**
-   * @param _payload - Unused; flow is fixed for this mock
-   * @param _requirements - Unused; flow is fixed for this mock
-   * @returns `upfront`
-   */
-  getPaymentFlow(
-    _payload: DeepReadonly<PaymentPayload>,
-    _requirements: DeepReadonly<PaymentRequirements>,
-  ): PaymentFlowName {
-    void _payload;
-    void _requirements;
-    return "upfront";
-  }
+  override readonly paymentFlows = {
+    default: { supported: ["upfront"], default: "upfront" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
 }
 
 /**
@@ -284,19 +263,9 @@ export class MockUpfrontSchemeNetworkServer extends CashSchemeNetworkServer {
  * Used by integration tests to prove settle → work → settle wiring without a real escrow scheme.
  */
 export class MockEscrowSchemeNetworkServer extends CashSchemeNetworkServer {
-  /**
-   * @param _payload - Unused; flow is fixed for this mock
-   * @param _requirements - Unused; flow is fixed for this mock
-   * @returns `escrow`
-   */
-  getPaymentFlow(
-    _payload: DeepReadonly<PaymentPayload>,
-    _requirements: DeepReadonly<PaymentRequirements>,
-  ): PaymentFlowName {
-    void _payload;
-    void _requirements;
-    return "escrow";
-  }
+  override readonly paymentFlows = {
+    default: { supported: ["escrow"], default: "escrow" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
 }
 
 /**

--- a/typescript/packages/core/test/mocks/cash/index.ts
+++ b/typescript/packages/core/test/mocks/cash/index.ts
@@ -6,12 +6,14 @@ import {
   VerifyResponse,
 } from "../../../../src/types/facilitator";
 import {
+  PaymentFlowName,
   SchemeNetworkClient,
   SchemeNetworkFacilitator,
   SchemeNetworkServer,
 } from "../../../../src/types/mechanisms";
 import { PaymentPayload, PaymentRequirements } from "../../../../src/types/payments";
 import { Price, AssetAmount, Network } from "../../../../src/types";
+import type { DeepReadonly } from "../../../../src/types/readonly";
 
 /**
  *
@@ -234,6 +236,66 @@ export class CashSchemeNetworkServer implements SchemeNetworkServer {
     void supportedKind;
     void facilitatorExtensions;
     return paymentRequirements;
+  }
+}
+
+/**
+ * Cash server that declares the default `authorization` payment flow.
+ * Used by integration tests to prove verify → work → settle wiring.
+ */
+export class MockAuthorizeSchemeNetworkServer extends CashSchemeNetworkServer {
+  /**
+   * @param _payload - Unused; flow is fixed for this mock
+   * @param _requirements - Unused; flow is fixed for this mock
+   * @returns `authorization`
+   */
+  getPaymentFlow(
+    _payload: DeepReadonly<PaymentPayload>,
+    _requirements: DeepReadonly<PaymentRequirements>,
+  ): PaymentFlowName {
+    void _payload;
+    void _requirements;
+    return "authorization";
+  }
+}
+
+/**
+ * Cash server that declares the `upfront` payment flow.
+ * Used by integration tests to prove settle → work wiring without a real prepaid scheme.
+ */
+export class MockUpfrontSchemeNetworkServer extends CashSchemeNetworkServer {
+  /**
+   * @param _payload - Unused; flow is fixed for this mock
+   * @param _requirements - Unused; flow is fixed for this mock
+   * @returns `upfront`
+   */
+  getPaymentFlow(
+    _payload: DeepReadonly<PaymentPayload>,
+    _requirements: DeepReadonly<PaymentRequirements>,
+  ): PaymentFlowName {
+    void _payload;
+    void _requirements;
+    return "upfront";
+  }
+}
+
+/**
+ * Cash server that declares the `escrow` payment flow.
+ * Used by integration tests to prove settle → work → settle wiring without a real escrow scheme.
+ */
+export class MockEscrowSchemeNetworkServer extends CashSchemeNetworkServer {
+  /**
+   * @param _payload - Unused; flow is fixed for this mock
+   * @param _requirements - Unused; flow is fixed for this mock
+   * @returns `escrow`
+   */
+  getPaymentFlow(
+    _payload: DeepReadonly<PaymentPayload>,
+    _requirements: DeepReadonly<PaymentRequirements>,
+  ): PaymentFlowName {
+    void _payload;
+    void _requirements;
+    return "escrow";
   }
 }
 

--- a/typescript/packages/core/test/mocks/generic/MockSchemeServer.ts
+++ b/typescript/packages/core/test/mocks/generic/MockSchemeServer.ts
@@ -1,4 +1,8 @@
-import { SchemeNetworkServer, SchemeServerHooks } from "../../../src/types/mechanisms";
+import {
+  PaymentFlowConfig,
+  SchemeNetworkServer,
+  SchemeServerHooks,
+} from "../../../src/types/mechanisms";
 import { AssetAmount, Network, Price } from "../../../src/types";
 import { PaymentRequirements } from "../../../src/types/payments";
 import type { SupportedKind } from "../../../src/types/facilitator";
@@ -8,6 +12,10 @@ import type { SupportedKind } from "../../../src/types/facilitator";
  */
 export class MockSchemeNetworkServer implements SchemeNetworkServer {
   public readonly scheme: string;
+  public readonly defaultAssetTransferMethod = "default";
+  public readonly paymentFlows: Readonly<Record<string, PaymentFlowConfig>> = {
+    default: { supported: ["authorization"], default: "authorization" },
+  };
   public readonly schemeHooks?: SchemeServerHooks;
   private parsePriceResult: AssetAmount | Error;
   private enhanceResult: PaymentRequirements | Error | null = null;

--- a/typescript/packages/core/test/mocks/index.ts
+++ b/typescript/packages/core/test/mocks/index.ts
@@ -18,4 +18,7 @@ export {
   CashSchemeNetworkClient,
   CashSchemeNetworkFacilitator,
   CashSchemeNetworkServer,
+  MockAuthorizeSchemeNetworkServer,
+  MockEscrowSchemeNetworkServer,
+  MockUpfrontSchemeNetworkServer,
 } from "./cash";

--- a/typescript/packages/core/test/unit/client/x402Client.test.ts
+++ b/typescript/packages/core/test/unit/client/x402Client.test.ts
@@ -877,6 +877,159 @@ describe("x402Client", () => {
         expect(mockClient.createPaymentPayloadCalls[0].requirements.amount).toBe("100000");
       });
     });
+
+    describe("Payment flow selection", () => {
+      it("should drop accepts with unrecognized paymentFlow", async () => {
+        const client = new x402Client();
+        const mockClient = new MockSchemeNetworkClient("exact");
+        client.register("eip155:8453" as Network, mockClient);
+
+        const knownReq = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+          amount: "100",
+        });
+        const unknownReq = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+          amount: "200",
+          extra: { paymentFlow: "future-flow" },
+        });
+
+        const paymentRequired = buildPaymentRequired({
+          accepts: [unknownReq, knownReq],
+        });
+
+        await client.createPaymentPayload(paymentRequired);
+
+        expect(mockClient.createPaymentPayloadCalls[0].requirements).toEqual(knownReq);
+      });
+
+      it("should throw when every accept has unrecognized paymentFlow", async () => {
+        const client = new x402Client();
+        const mockClient = new MockSchemeNetworkClient("exact");
+        client.register("eip155:8453" as Network, mockClient);
+
+        const paymentRequired = buildPaymentRequired({
+          accepts: [
+            buildPaymentRequirements({
+              scheme: "exact",
+              network: "eip155:8453" as Network,
+              extra: { paymentFlow: "future-flow" },
+            }),
+          ],
+        });
+
+        await expect(client.createPaymentPayload(paymentRequired)).rejects.toThrow(
+          "No payment requirements with a recognized paymentFlow",
+        );
+      });
+
+      it("should prefer authorization over upfront when both are offered", async () => {
+        const client = new x402Client();
+        const mockClient = new MockSchemeNetworkClient("exact");
+        client.register("eip155:8453" as Network, mockClient);
+
+        const upfrontReq = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+          amount: "100",
+          extra: { paymentFlow: "upfront" },
+        });
+        const authReq = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+          amount: "200",
+        });
+
+        const paymentRequired = buildPaymentRequired({
+          accepts: [upfrontReq, authReq],
+        });
+
+        await client.createPaymentPayload(paymentRequired);
+
+        expect(mockClient.createPaymentPayloadCalls[0].requirements).toEqual(authReq);
+      });
+
+      it("should prefer explicit authorization over escrow when both are offered", async () => {
+        const client = new x402Client();
+        const mockClient = new MockSchemeNetworkClient("exact");
+        client.register("eip155:8453" as Network, mockClient);
+
+        const escrowReq = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+          amount: "100",
+          extra: { paymentFlow: "escrow" },
+        });
+        const authReq = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+          amount: "200",
+          extra: { paymentFlow: "authorization" },
+        });
+
+        const paymentRequired = buildPaymentRequired({
+          accepts: [escrowReq, authReq],
+        });
+
+        await client.createPaymentPayload(paymentRequired);
+
+        expect(mockClient.createPaymentPayloadCalls[0].requirements).toEqual(authReq);
+      });
+
+      it("should still select upfront when it is the only remaining accept", async () => {
+        const client = new x402Client();
+        const mockClient = new MockSchemeNetworkClient("exact");
+        client.register("eip155:8453" as Network, mockClient);
+
+        const upfrontReq = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+          amount: "100",
+          extra: { paymentFlow: "upfront" },
+        });
+
+        const paymentRequired = buildPaymentRequired({
+          accepts: [upfrontReq],
+        });
+
+        await client.createPaymentPayload(paymentRequired);
+
+        expect(mockClient.createPaymentPayloadCalls[0].requirements).toEqual(upfrontReq);
+      });
+
+      it("should let custom policies override authorization preference", async () => {
+        const client = new x402Client();
+        const mockClient = new MockSchemeNetworkClient("exact");
+        client.register("eip155:8453" as Network, mockClient);
+
+        const upfrontReq = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+          amount: "100",
+          extra: { paymentFlow: "upfront" },
+        });
+        const authReq = buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+          amount: "200",
+        });
+
+        const upfrontOnlyPolicy: PaymentPolicy = (_version, reqs) =>
+          reqs.filter(r => r.extra?.paymentFlow === "upfront");
+
+        client.registerPolicy(upfrontOnlyPolicy);
+
+        const paymentRequired = buildPaymentRequired({
+          accepts: [authReq, upfrontReq],
+        });
+
+        await client.createPaymentPayload(paymentRequired);
+
+        expect(mockClient.createPaymentPayloadCalls[0].requirements).toEqual(upfrontReq);
+      });
+    });
   });
 
   describe("Extension Hooks", () => {

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceServer.initialize.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceServer.initialize.test.ts
@@ -88,6 +88,59 @@ describe("x402HTTPResourceServer.initialize", () => {
 
       await expect(httpServer.initialize()).resolves.not.toThrow();
     });
+
+    it("should throw RouteConfigurationError at construction for unsupported paymentFlow", () => {
+      const routes: RoutesConfig = {
+        "GET /api/data": {
+          accepts: {
+            scheme: testScheme,
+            payTo: "0x123",
+            price: "$0.01",
+            network: testNetwork,
+            extra: { paymentFlow: "escrow" },
+          },
+          description: "Test endpoint",
+        },
+      };
+
+      try {
+        new x402HTTPResourceServer(server, routes);
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(RouteConfigurationError);
+        const configError = error as RouteConfigurationError;
+        expect(configError.errors).toHaveLength(1);
+        expect(configError.errors[0].reason).toBe("unsupported_payment_flow");
+        expect(configError.errors[0].routePattern).toBe("GET /api/data");
+        expect(configError.errors[0].message).toContain("does not support paymentFlow");
+      }
+    });
+
+    it("should throw RouteConfigurationError at construction for unsupported assetTransferMethod", () => {
+      const routes: RoutesConfig = {
+        "GET /api/data": {
+          accepts: {
+            scheme: testScheme,
+            payTo: "0x123",
+            price: "$0.01",
+            network: testNetwork,
+            extra: { assetTransferMethod: "not-a-real-atm" },
+          },
+          description: "Test endpoint",
+        },
+      };
+
+      try {
+        new x402HTTPResourceServer(server, routes);
+        expect.fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(RouteConfigurationError);
+        const configError = error as RouteConfigurationError;
+        expect(configError.errors).toHaveLength(1);
+        expect(configError.errors[0].reason).toBe("unsupported_asset_transfer_method");
+        expect(configError.errors[0].message).toContain("does not support assetTransferMethod");
+      }
+    });
   });
 
   describe("with missing scheme registration", () => {

--- a/typescript/packages/core/test/unit/server/hookPolicy.test.ts
+++ b/typescript/packages/core/test/unit/server/hookPolicy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   assertAcceptsAllowlistedAfterExtensionEnrich,
+  assertAcceptsAdditiveExtraAfterSchemeEnrich,
   assertAdditivePayloadEnrichment,
   assertAdditiveSettlementExtra,
   assertSettleResponseCoreUnchanged,
@@ -101,6 +102,76 @@ describe("hookPolicy", () => {
       expect(() => assertAcceptsAllowlistedAfterExtensionEnrich(baseline, current, "ext")).toThrow(
         /extra\["nested"\]/,
       );
+    });
+
+    describe.each([
+      ["paymentFlow", "upfront"],
+      ["assetTransferMethod", "permit2"],
+    ] as const)("protocol-reserved extra.${0}", (key, injectedValue) => {
+      it("rejects injection when baseline omitted the key", () => {
+        const baseline = snapshotPaymentRequirementsList([
+          buildPaymentRequirements({ extra: { schemeField: "x" } }),
+        ]);
+        const current = snapshotPaymentRequirementsList(baseline);
+        current[0].extra = { ...current[0].extra, [key]: injectedValue };
+        expect(() =>
+          assertAcceptsAllowlistedAfterExtensionEnrich(baseline, current, "ext"),
+        ).toThrow(new RegExp(`extra\\["${key}"\\].*protocol-reserved`));
+      });
+
+      it("rejects changing the key when baseline set it", () => {
+        const baseline = snapshotPaymentRequirementsList([
+          buildPaymentRequirements({
+            extra: { [key]: key === "paymentFlow" ? "authorization" : "eip3009" },
+          }),
+        ]);
+        const current = snapshotPaymentRequirementsList(baseline);
+        current[0].extra = { ...current[0].extra, [key]: injectedValue };
+        expect(() =>
+          assertAcceptsAllowlistedAfterExtensionEnrich(baseline, current, "ext"),
+        ).toThrow(new RegExp(`extra\\["${key}"\\]`));
+      });
+    });
+  });
+
+  describe("assertAcceptsAdditiveExtraAfterSchemeEnrich", () => {
+    describe.each([
+      ["paymentFlow", "upfront"],
+      ["assetTransferMethod", "permit2"],
+    ] as const)("protocol-reserved extra.${0}", (key, injectedValue) => {
+      it("rejects injection on a matching accept when baseline omitted the key", () => {
+        const baseline = snapshotPaymentRequirementsList([
+          buildPaymentRequirements({ extra: { name: "USDC" } }),
+        ]);
+        const current = snapshotPaymentRequirementsList(baseline);
+        current[0].extra = { ...current[0].extra, [key]: injectedValue };
+        expect(() =>
+          assertAcceptsAdditiveExtraAfterSchemeEnrich(
+            baseline,
+            current,
+            baseline[0].scheme,
+            baseline[0].network,
+          ),
+        ).toThrow(new RegExp(`extra\\["${key}"\\].*protocol-reserved`));
+      });
+
+      it("rejects changing the key when baseline set it", () => {
+        const baseline = snapshotPaymentRequirementsList([
+          buildPaymentRequirements({
+            extra: { [key]: key === "paymentFlow" ? "escrow" : "eip3009" },
+          }),
+        ]);
+        const current = snapshotPaymentRequirementsList(baseline);
+        current[0].extra = { ...current[0].extra, [key]: injectedValue };
+        expect(() =>
+          assertAcceptsAdditiveExtraAfterSchemeEnrich(
+            baseline,
+            current,
+            baseline[0].scheme,
+            baseline[0].network,
+          ),
+        ).toThrow(new RegExp(`extra\\["${key}"\\]`));
+      });
     });
   });
 

--- a/typescript/packages/core/test/unit/server/paymentFlow.test.ts
+++ b/typescript/packages/core/test/unit/server/paymentFlow.test.ts
@@ -101,16 +101,16 @@ describe("payment flows", () => {
   });
 
   describe("vocabulary", () => {
-    it("defaults to authorize", () => {
-      expect(DEFAULT_PAYMENT_FLOW).toBe("authorize");
-      expect(PAYMENT_FLOWS.authorize).toEqual({
+    it("defaults to authorization", () => {
+      expect(DEFAULT_PAYMENT_FLOW).toBe("authorization");
+      expect(PAYMENT_FLOWS.authorization).toEqual({
         verifyBeforeHandler: true,
         settleBeforeHandler: false,
         settleAfterHandler: true,
       });
     });
 
-    it("getPaymentFlow returns authorize when scheme omits the hook", async () => {
+    it("getPaymentFlow returns authorization when scheme omits the hook", async () => {
       const mockClient = new MockFacilitatorClient(
         buildSupportedResponse({
           kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
@@ -125,7 +125,7 @@ describe("payment flows", () => {
           buildPaymentPayload(),
           buildPaymentRequirements({ scheme: "exact", network: "eip155:8453" as Network }),
         ),
-      ).toBe("authorize");
+      ).toBe("authorization");
     });
   });
 
@@ -321,8 +321,8 @@ describe("payment flows", () => {
       });
     }
 
-    it("authorize: verifies before handler and settles after with phase after-handler", async () => {
-      const httpServer = await setup("authorize");
+    it("authorization: verifies before handler and settles after with phase after-handler", async () => {
+      const httpServer = await setup("authorization");
       const phases: SettlePhase[] = [];
       ResourceServer.onBeforeSettle(async ctx => {
         phases.push(ctx.phase);
@@ -406,8 +406,8 @@ describe("payment flows", () => {
       expect(phases).toEqual(["before-handler", "after-handler"]);
     });
 
-    it("validate: verifies before handler and returns success with no PAYMENT-RESPONSE", async () => {
-      const httpServer = await setup("validate");
+    it("validation: verifies before handler and returns success with no PAYMENT-RESPONSE", async () => {
+      const httpServer = await setup("validation");
       const phases: SettlePhase[] = [];
       ResourceServer.onBeforeSettle(async ctx => {
         phases.push(ctx.phase);

--- a/typescript/packages/core/test/unit/server/paymentFlow.test.ts
+++ b/typescript/packages/core/test/unit/server/paymentFlow.test.ts
@@ -406,35 +406,6 @@ describe("payment flows", () => {
       expect(phases).toEqual(["before-handler", "after-handler"]);
     });
 
-    it("validation: verifies before handler and returns success with no PAYMENT-RESPONSE", async () => {
-      const httpServer = await setup("validation");
-      const phases: SettlePhase[] = [];
-      ResourceServer.onBeforeSettle(async ctx => {
-        phases.push(ctx.phase);
-      });
-
-      const result = await verifiedRequest(httpServer);
-      expect(result.type).toBe("payment-verified");
-      expect(mockFacilitator.verifyCalls).toHaveLength(1);
-      expect(mockFacilitator.settleCalls).toHaveLength(0);
-
-      if (result.type !== "payment-verified") return;
-      const settle = await httpServer.processSettlement(
-        result.paymentPayload,
-        result.paymentRequirements,
-        result.declaredExtensions,
-        undefined,
-        undefined,
-        result.beforeHandlerSettlement,
-      );
-      expect(settle.success).toBe(true);
-      if (settle.success) {
-        expect(settle.headers).toEqual({});
-      }
-      expect(mockFacilitator.settleCalls).toHaveLength(0);
-      expect(phases).toEqual([]);
-    });
-
     it("warns once when settleBeforeHandler flow is settled without beforeHandlerSettlement", async () => {
       const httpServer = await setup("upfront");
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);

--- a/typescript/packages/core/test/unit/server/paymentFlow.test.ts
+++ b/typescript/packages/core/test/unit/server/paymentFlow.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../../mocks";
 import { Network, PaymentFlowName } from "../../../src/types";
 import type { HTTPAdapter } from "../../../src/http/x402HTTPResourceServer";
-import { encodePaymentSignatureHeader } from "../../../src/http";
+import { decodePaymentResponseHeader, encodePaymentSignatureHeader } from "../../../src/http";
 
 /**
  *
@@ -362,6 +362,24 @@ describe("payment flows", () => {
 
       if (result.type !== "payment-verified") return;
       expect(result.beforeHandlerSettlement?.phase).toBe("before-handler");
+      // Wire payload must be SettleResponse only (no SDK-only headers/requirements)
+      expect(result.beforeHandlerSettlement?.result).toEqual(
+        expect.objectContaining({ success: true, transaction: "0xtx" }),
+      );
+      expect(result.beforeHandlerSettlement?.result).not.toHaveProperty("headers");
+      expect(result.beforeHandlerSettlement?.result).not.toHaveProperty("requirements");
+
+      const failureReceiptHeaders = httpServer.createCompletedSettlementHeaders(
+        result.beforeHandlerSettlement!,
+      );
+      expect(failureReceiptHeaders["Cache-Control"]).toBe("private");
+      expect(decodePaymentResponseHeader(failureReceiptHeaders["PAYMENT-RESPONSE"])).toEqual(
+        expect.objectContaining({ success: true, transaction: "0xtx" }),
+      );
+      expect(
+        decodePaymentResponseHeader(failureReceiptHeaders["PAYMENT-RESPONSE"]),
+      ).not.toHaveProperty("headers");
+
       const settle = await httpServer.processSettlement(
         result.paymentPayload,
         result.paymentRequirements,

--- a/typescript/packages/core/test/unit/server/paymentFlow.test.ts
+++ b/typescript/packages/core/test/unit/server/paymentFlow.test.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  x402ResourceServer,
+  SettleContext,
+  SettlePhase,
+  PAYMENT_FLOWS,
+  DEFAULT_PAYMENT_FLOW,
+} from "../../../src/server";
+import { x402HTTPResourceServer } from "../../../src/http/x402HTTPResourceServer";
+import {
+  MockFacilitatorClient,
+  MockSchemeNetworkServer,
+  buildSupportedResponse,
+  buildVerifyResponse,
+  buildSettleResponse,
+  buildPaymentPayload,
+  buildPaymentRequirements,
+} from "../../mocks";
+import { Network, PaymentFlowName } from "../../../src/types";
+import type { HTTPAdapter } from "../../../src/http/x402HTTPResourceServer";
+import { encodePaymentSignatureHeader } from "../../../src/http";
+
+/**
+ *
+ */
+class MockHTTPAdapter implements HTTPAdapter {
+  private headers: Record<string, string> = {};
+
+  /**
+   *
+   * @param headers
+   */
+  constructor(headers: Record<string, string> = {}) {
+    this.headers = headers;
+  }
+
+  /**
+   *
+   * @param name
+   */
+  getHeader(name: string): string | undefined {
+    return this.headers[name.toLowerCase()];
+  }
+
+  /**
+   *
+   */
+  getMethod(): string {
+    return "GET";
+  }
+
+  /**
+   *
+   */
+  getPath(): string {
+    return "/api/test";
+  }
+
+  /**
+   *
+   */
+  getUrl(): string {
+    return "https://example.com/api/test";
+  }
+
+  /**
+   *
+   */
+  getAcceptHeader(): string {
+    return "application/json";
+  }
+
+  /**
+   *
+   */
+  getUserAgent(): string {
+    return "TestClient/1.0";
+  }
+}
+
+/**
+ *
+ * @param flow
+ */
+function schemeWithFlow(flow: PaymentFlowName): MockSchemeNetworkServer {
+  return Object.assign(
+    new MockSchemeNetworkServer("exact", {
+      amount: "1000000",
+      asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      extra: {},
+    }),
+    {
+      getPaymentFlow: () => flow,
+    },
+  );
+}
+
+describe("payment flows", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("vocabulary", () => {
+    it("defaults to authorize", () => {
+      expect(DEFAULT_PAYMENT_FLOW).toBe("authorize");
+      expect(PAYMENT_FLOWS.authorize).toEqual({
+        verifyBeforeHandler: true,
+        settleBeforeHandler: false,
+        settleAfterHandler: true,
+      });
+    });
+
+    it("getPaymentFlow returns authorize when scheme omits the hook", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+      );
+      const server = new x402ResourceServer(mockClient);
+      server.register("eip155:8453" as Network, new MockSchemeNetworkServer("exact"));
+      await server.initialize();
+
+      expect(
+        server.getPaymentFlow(
+          buildPaymentPayload(),
+          buildPaymentRequirements({ scheme: "exact", network: "eip155:8453" as Network }),
+        ),
+      ).toBe("authorize");
+    });
+  });
+
+  describe("settlePayment phase", () => {
+    it("passes phase on SettleContext to beforeSettle hooks", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+        undefined,
+        buildSettleResponse({ success: true }),
+      );
+      const server = new x402ResourceServer(mockClient);
+      server.register("eip155:8453" as Network, new MockSchemeNetworkServer("exact"));
+      await server.initialize();
+
+      const phases: SettlePhase[] = [];
+      server.onBeforeSettle(async (ctx: SettleContext) => {
+        phases.push(ctx.phase);
+      });
+
+      await server.settlePayment(
+        buildPaymentPayload({
+          accepted: buildPaymentRequirements({
+            scheme: "exact",
+            network: "eip155:8453" as Network,
+          }),
+        }),
+        buildPaymentRequirements({ scheme: "exact", network: "eip155:8453" as Network }),
+        undefined,
+        undefined,
+        undefined,
+        "before-handler",
+      );
+
+      expect(phases).toEqual(["before-handler"]);
+    });
+
+    it("allows the same enrichment keys on a second settle via settle-local payload copy", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+        undefined,
+        buildSettleResponse({ success: true }),
+      );
+      const server = new x402ResourceServer(mockClient);
+      let enrichCalls = 0;
+      server.register(
+        "eip155:8453" as Network,
+        Object.assign(new MockSchemeNetworkServer("exact"), {
+          enrichSettlementPayload: async (ctx: SettleContext) => {
+            enrichCalls += 1;
+            return { settlePhase: ctx.phase === "before-handler" ? "deposit" : "charge" };
+          },
+        }),
+      );
+      await server.initialize();
+
+      const payload = buildPaymentPayload({
+        accepted: buildPaymentRequirements({
+          scheme: "exact",
+          network: "eip155:8453" as Network,
+        }),
+        payload: { signature: "sig" },
+      });
+      const requirements = buildPaymentRequirements({
+        scheme: "exact",
+        network: "eip155:8453" as Network,
+      });
+
+      await server.settlePayment(
+        payload,
+        requirements,
+        undefined,
+        undefined,
+        undefined,
+        "before-handler",
+      );
+      await server.settlePayment(
+        payload,
+        requirements,
+        undefined,
+        undefined,
+        undefined,
+        "after-handler",
+      );
+
+      expect(enrichCalls).toBe(2);
+      expect(mockClient.settleCalls).toHaveLength(2);
+      expect(mockClient.settleCalls[0].payload.payload).toEqual({
+        signature: "sig",
+        settlePhase: "deposit",
+      });
+      expect(mockClient.settleCalls[1].payload.payload).toEqual({
+        signature: "sig",
+        settlePhase: "charge",
+      });
+      expect(payload.payload).toEqual({ signature: "sig" });
+    });
+  });
+
+  describe("cancellation dispatcher settledPhases", () => {
+    it("exposes completed settle phases on cancel", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+        undefined,
+        buildSettleResponse({ success: true, transaction: "0xdeposit" }),
+      );
+      const server = new x402ResourceServer(mockClient);
+      server.register("eip155:8453" as Network, schemeWithFlow("escrow"));
+      await server.initialize();
+
+      const requirements = buildPaymentRequirements({
+        scheme: "exact",
+        network: "eip155:8453" as Network,
+      });
+      const payload = buildPaymentPayload({ accepted: requirements });
+      const handle = server.createPaymentCancellationDispatcher(
+        payload,
+        requirements,
+        undefined,
+        undefined,
+        ["before-handler"],
+      );
+
+      let settledPhases: readonly SettlePhase[] | undefined;
+      server.onVerifiedPaymentCanceled(async ctx => {
+        settledPhases = ctx.settledPhases;
+        expect(ctx.phase).toBe("cancel");
+      });
+
+      await handle.cancel({ reason: "handler_failed", responseStatus: 500 });
+      expect(settledPhases).toEqual(["before-handler"]);
+    });
+  });
+
+  describe("HTTP orchestration", () => {
+    let ResourceServer: x402ResourceServer;
+    let mockFacilitator: MockFacilitatorClient;
+
+    /**
+     *
+     * @param flow
+     */
+    async function setup(flow: PaymentFlowName) {
+      mockFacilitator = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+        buildVerifyResponse({ isValid: true }),
+        buildSettleResponse({ success: true, transaction: "0xtx" }),
+      );
+      ResourceServer = new x402ResourceServer(mockFacilitator);
+      ResourceServer.register("eip155:8453" as Network, schemeWithFlow(flow));
+      await ResourceServer.initialize();
+      return new x402HTTPResourceServer(ResourceServer, {
+        "/api/test": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00",
+            network: "eip155:8453" as Network,
+          },
+        },
+      });
+    }
+
+    /**
+     *
+     * @param httpServer
+     */
+    async function verifiedRequest(httpServer: x402HTTPResourceServer) {
+      const requirements = buildPaymentRequirements({
+        scheme: "exact",
+        network: "eip155:8453" as Network,
+        payTo: "0xabc",
+        amount: "1000000",
+        asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      });
+      const payload = buildPaymentPayload({
+        accepted: requirements,
+      });
+      const adapter = new MockHTTPAdapter({
+        "payment-signature": encodePaymentSignatureHeader(payload),
+      });
+      return httpServer.processHTTPRequest({
+        adapter,
+        path: "/api/test",
+        method: "GET",
+      });
+    }
+
+    it("authorize: verifies before handler and settles after with phase after-handler", async () => {
+      const httpServer = await setup("authorize");
+      const phases: SettlePhase[] = [];
+      ResourceServer.onBeforeSettle(async ctx => {
+        phases.push(ctx.phase);
+      });
+
+      const result = await verifiedRequest(httpServer);
+      expect(result.type).toBe("payment-verified");
+      expect(mockFacilitator.verifyCalls).toHaveLength(1);
+      expect(mockFacilitator.settleCalls).toHaveLength(0);
+
+      if (result.type !== "payment-verified") return;
+      const settle = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+        result.declaredExtensions,
+        undefined,
+        undefined,
+        result.beforeHandlerSettlement,
+      );
+      expect(settle.success).toBe(true);
+      expect(mockFacilitator.settleCalls).toHaveLength(1);
+      expect(phases).toEqual(["after-handler"]);
+    });
+
+    it("upfront: settles before handler and echoes after without a second settle", async () => {
+      const httpServer = await setup("upfront");
+      const phases: SettlePhase[] = [];
+      ResourceServer.onBeforeSettle(async ctx => {
+        phases.push(ctx.phase);
+      });
+
+      const result = await verifiedRequest(httpServer);
+      expect(result.type).toBe("payment-verified");
+      expect(mockFacilitator.verifyCalls).toHaveLength(0);
+      expect(mockFacilitator.settleCalls).toHaveLength(1);
+      expect(phases).toEqual(["before-handler"]);
+
+      if (result.type !== "payment-verified") return;
+      expect(result.beforeHandlerSettlement?.phase).toBe("before-handler");
+      const settle = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+        result.declaredExtensions,
+        undefined,
+        undefined,
+        result.beforeHandlerSettlement,
+      );
+      expect(settle.success).toBe(true);
+      if (settle.success) {
+        expect(settle.headers["PAYMENT-RESPONSE"]).toBeDefined();
+        expect(settle.transaction).toBe("0xtx");
+      }
+      expect(mockFacilitator.settleCalls).toHaveLength(1);
+      expect(phases).toEqual(["before-handler"]);
+    });
+
+    it("escrow: settles before and after handler with distinct phases", async () => {
+      const httpServer = await setup("escrow");
+      const phases: SettlePhase[] = [];
+      ResourceServer.onBeforeSettle(async ctx => {
+        phases.push(ctx.phase);
+      });
+
+      const result = await verifiedRequest(httpServer);
+      expect(result.type).toBe("payment-verified");
+      expect(mockFacilitator.verifyCalls).toHaveLength(0);
+      expect(mockFacilitator.settleCalls).toHaveLength(1);
+
+      if (result.type !== "payment-verified") return;
+      expect(result.beforeHandlerSettlement?.phase).toBe("before-handler");
+      const settle = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+        result.declaredExtensions,
+        undefined,
+        undefined,
+        result.beforeHandlerSettlement,
+      );
+      expect(settle.success).toBe(true);
+      expect(mockFacilitator.settleCalls).toHaveLength(2);
+      expect(phases).toEqual(["before-handler", "after-handler"]);
+    });
+
+    it("validate: verifies before handler and returns success with no PAYMENT-RESPONSE", async () => {
+      const httpServer = await setup("validate");
+      const phases: SettlePhase[] = [];
+      ResourceServer.onBeforeSettle(async ctx => {
+        phases.push(ctx.phase);
+      });
+
+      const result = await verifiedRequest(httpServer);
+      expect(result.type).toBe("payment-verified");
+      expect(mockFacilitator.verifyCalls).toHaveLength(1);
+      expect(mockFacilitator.settleCalls).toHaveLength(0);
+
+      if (result.type !== "payment-verified") return;
+      const settle = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+        result.declaredExtensions,
+        undefined,
+        undefined,
+        result.beforeHandlerSettlement,
+      );
+      expect(settle.success).toBe(true);
+      if (settle.success) {
+        expect(settle.headers).toEqual({});
+      }
+      expect(mockFacilitator.settleCalls).toHaveLength(0);
+      expect(phases).toEqual([]);
+    });
+
+    it("warns once when settleBeforeHandler flow is settled without beforeHandlerSettlement", async () => {
+      const httpServer = await setup("upfront");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      const result = await verifiedRequest(httpServer);
+      expect(result.type).toBe("payment-verified");
+      if (result.type !== "payment-verified") return;
+
+      // Drop beforeHandlerSettlement: adapters that have not been updated yet.
+      const settle1 = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+      );
+      const settle2 = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+      );
+
+      expect(settle1.success).toBe(true);
+      expect(settle2.success).toBe(true);
+      if (settle1.success) {
+        expect(settle1.headers).toEqual({});
+      }
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("without beforeHandlerSettlement");
+    });
+  });
+});

--- a/typescript/packages/core/test/unit/server/paymentFlow.test.ts
+++ b/typescript/packages/core/test/unit/server/paymentFlow.test.ts
@@ -4,7 +4,9 @@ import {
   SettleContext,
   SettlePhase,
   PAYMENT_FLOWS,
-  DEFAULT_PAYMENT_FLOW,
+  SDK_DEFAULT_ASSET_TRANSFER_METHOD,
+  applyPaymentFlowWireExtra,
+  resolvePaymentFlow,
 } from "../../../src/server";
 import { x402HTTPResourceServer } from "../../../src/http/x402HTTPResourceServer";
 import {
@@ -90,19 +92,112 @@ function schemeWithFlow(flow: PaymentFlowName): MockSchemeNetworkServer {
       extra: {},
     }),
     {
-      getPaymentFlow: () => flow,
+      paymentFlows: {
+        default: { supported: [flow], default: flow },
+      },
     },
   );
 }
+
+const exactEvmLikeScheme = {
+  scheme: "exact",
+  defaultAssetTransferMethod: "eip3009",
+  paymentFlows: {
+    eip3009: {
+      supported: ["authorization", "upfront"] as const,
+      default: "authorization" as const,
+    },
+    permit2: {
+      supported: ["authorization", "upfront"] as const,
+      default: "authorization" as const,
+    },
+  },
+};
 
 describe("payment flows", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
+  describe("resolvePaymentFlow", () => {
+    it("omits ATM and paymentFlow to scheme defaults", () => {
+      expect(
+        resolvePaymentFlow(exactEvmLikeScheme, buildPaymentRequirements({ extra: {} })),
+      ).toEqual({ assetTransferMethod: "eip3009", paymentFlow: "authorization" });
+    });
+
+    it("resolves explicit defaults the same as omitted", () => {
+      expect(
+        resolvePaymentFlow(
+          exactEvmLikeScheme,
+          buildPaymentRequirements({
+            extra: { assetTransferMethod: "eip3009", paymentFlow: "authorization" },
+          }),
+        ),
+      ).toEqual({ assetTransferMethod: "eip3009", paymentFlow: "authorization" });
+    });
+
+    it("resolves upfront and permit2 ATM", () => {
+      expect(
+        resolvePaymentFlow(
+          exactEvmLikeScheme,
+          buildPaymentRequirements({
+            extra: { assetTransferMethod: "permit2", paymentFlow: "upfront" },
+          }),
+        ),
+      ).toEqual({ assetTransferMethod: "permit2", paymentFlow: "upfront" });
+    });
+
+    it("throws on unknown ATM", () => {
+      expect(() =>
+        resolvePaymentFlow(
+          exactEvmLikeScheme,
+          buildPaymentRequirements({ extra: { assetTransferMethod: "unknown" } }),
+        ),
+      ).toThrow(/does not support assetTransferMethod "unknown"/);
+    });
+
+    it("throws on unsupported flow", () => {
+      expect(() =>
+        resolvePaymentFlow(
+          exactEvmLikeScheme,
+          buildPaymentRequirements({ extra: { paymentFlow: "escrow" } }),
+        ),
+      ).toThrow(/does not support paymentFlow "escrow"/);
+    });
+  });
+
+  describe("applyPaymentFlowWireExtra", () => {
+    it("leaves authorization alone", () => {
+      expect(
+        applyPaymentFlowWireExtra(
+          { name: "USDC" },
+          { assetTransferMethod: "eip3009", paymentFlow: "authorization" },
+        ),
+      ).toEqual({ name: "USDC" });
+    });
+
+    it("forces non-authorization paymentFlow onto extra", () => {
+      expect(
+        applyPaymentFlowWireExtra({}, { assetTransferMethod: "eip3009", paymentFlow: "upfront" }),
+      ).toEqual({ paymentFlow: "upfront" });
+      expect(
+        applyPaymentFlowWireExtra({}, { assetTransferMethod: "default", paymentFlow: "escrow" }),
+      ).toEqual({ paymentFlow: "escrow" });
+    });
+
+    it("strips SDK ATM sentinel", () => {
+      expect(
+        applyPaymentFlowWireExtra(
+          { assetTransferMethod: SDK_DEFAULT_ASSET_TRANSFER_METHOD, name: "USDC" },
+          { assetTransferMethod: SDK_DEFAULT_ASSET_TRANSFER_METHOD, paymentFlow: "authorization" },
+        ),
+      ).toEqual({ name: "USDC" });
+    });
+  });
+
   describe("vocabulary", () => {
-    it("defaults to authorization", () => {
-      expect(DEFAULT_PAYMENT_FLOW).toBe("authorization");
+    it("authorization phase table", () => {
       expect(PAYMENT_FLOWS.authorization).toEqual({
         verifyBeforeHandler: true,
         settleBeforeHandler: false,
@@ -110,7 +205,7 @@ describe("payment flows", () => {
       });
     });
 
-    it("getPaymentFlow returns authorization when scheme omits the hook", async () => {
+    it("getPaymentFlow returns table default when requirements omit paymentFlow", async () => {
       const mockClient = new MockFacilitatorClient(
         buildSupportedResponse({
           kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
@@ -126,6 +221,54 @@ describe("payment flows", () => {
           buildPaymentRequirements({ scheme: "exact", network: "eip155:8453" as Network }),
         ),
       ).toBe("authorization");
+    });
+
+    it("buildPaymentRequirements rejects unsupported escrow for ExactEvm-like table", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+      );
+      const server = new x402ResourceServer(mockClient);
+      server.register(
+        "eip155:8453" as Network,
+        Object.assign(new MockSchemeNetworkServer("exact"), {
+          defaultAssetTransferMethod: "eip3009",
+          paymentFlows: exactEvmLikeScheme.paymentFlows,
+        }),
+      );
+      await server.initialize();
+
+      await expect(
+        server.buildPaymentRequirements({
+          scheme: "exact",
+          payTo: "0xabc",
+          price: "$1.00",
+          network: "eip155:8453" as Network,
+          extra: { paymentFlow: "escrow" },
+        }),
+      ).rejects.toThrow(/does not support paymentFlow "escrow"/);
+    });
+
+    it("buildPaymentRequirements emits paymentFlow for escrow-default mock", async () => {
+      const mockClient = new MockFacilitatorClient(
+        buildSupportedResponse({
+          kinds: [{ x402Version: 2, scheme: "exact", network: "eip155:8453" as Network }],
+        }),
+      );
+      const server = new x402ResourceServer(mockClient);
+      server.register("eip155:8453" as Network, schemeWithFlow("escrow"));
+      await server.initialize();
+
+      const [requirement] = await server.buildPaymentRequirements({
+        scheme: "exact",
+        payTo: "0xabc",
+        price: "$1.00",
+        network: "eip155:8453" as Network,
+      });
+
+      expect(requirement.extra?.paymentFlow).toBe("escrow");
+      expect(requirement.extra).not.toHaveProperty("assetTransferMethod");
     });
   });
 
@@ -299,14 +442,16 @@ describe("payment flows", () => {
     /**
      *
      * @param httpServer
+     * @param flow - Payment flow used when building accepted requirements to match the 402 wire
      */
-    async function verifiedRequest(httpServer: x402HTTPResourceServer) {
+    async function verifiedRequest(httpServer: x402HTTPResourceServer, flow: PaymentFlowName) {
       const requirements = buildPaymentRequirements({
         scheme: "exact",
         network: "eip155:8453" as Network,
         payTo: "0xabc",
         amount: "1000000",
         asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+        extra: flow === "authorization" ? {} : { paymentFlow: flow },
       });
       const payload = buildPaymentPayload({
         accepted: requirements,
@@ -328,7 +473,7 @@ describe("payment flows", () => {
         phases.push(ctx.phase);
       });
 
-      const result = await verifiedRequest(httpServer);
+      const result = await verifiedRequest(httpServer, "authorization");
       expect(result.type).toBe("payment-verified");
       expect(mockFacilitator.verifyCalls).toHaveLength(1);
       expect(mockFacilitator.settleCalls).toHaveLength(0);
@@ -362,7 +507,7 @@ describe("payment flows", () => {
         phases.push(ctx.phase);
       });
 
-      const result = await verifiedRequest(httpServer);
+      const result = await verifiedRequest(httpServer, "upfront");
       expect(result.type).toBe("payment-verified");
       expect(beforeVerifyRan).toBe(true);
       expect(afterVerifyRan).toBe(false);
@@ -413,7 +558,7 @@ describe("payment flows", () => {
         return { abort: true, reason: "extension_gate" };
       });
 
-      const result = await verifiedRequest(httpServer);
+      const result = await verifiedRequest(httpServer, "upfront");
       expect(result.type).toBe("payment-error");
       expect(mockFacilitator.verifyCalls).toHaveLength(0);
       expect(mockFacilitator.settleCalls).toHaveLength(0);
@@ -430,7 +575,7 @@ describe("payment flows", () => {
         phases.push(ctx.phase);
       });
 
-      const result = await verifiedRequest(httpServer);
+      const result = await verifiedRequest(httpServer, "escrow");
       expect(result.type).toBe("payment-verified");
       expect(beforeVerifyRan).toBe(true);
       expect(mockFacilitator.verifyCalls).toHaveLength(0);
@@ -463,7 +608,7 @@ describe("payment flows", () => {
           }),
         );
 
-        const result = await verifiedRequest(httpServer);
+        const result = await verifiedRequest(httpServer, flow);
         expect(result.type).toBe("payment-error");
         expect(mockFacilitator.verifyCalls).toHaveLength(0);
         expect(mockFacilitator.settleCalls).toHaveLength(1);
@@ -485,7 +630,7 @@ describe("payment flows", () => {
         expect(ctx.reason).toBe("handler_failed");
       });
 
-      const result = await verifiedRequest(httpServer);
+      const result = await verifiedRequest(httpServer, "escrow");
       expect(result.type).toBe("payment-verified");
       if (result.type !== "payment-verified") return;
 
@@ -514,7 +659,7 @@ describe("payment flows", () => {
       const httpServer = await setup("upfront");
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
-      const result = await verifiedRequest(httpServer);
+      const result = await verifiedRequest(httpServer, "upfront");
       expect(result.type).toBe("payment-verified");
       if (result.type !== "payment-verified") return;
 

--- a/typescript/packages/core/test/unit/server/paymentFlow.test.ts
+++ b/typescript/packages/core/test/unit/server/paymentFlow.test.ts
@@ -451,6 +451,65 @@ describe("payment flows", () => {
       expect(phases).toEqual(["before-handler", "after-handler"]);
     });
 
+    it.each(["upfront", "escrow"] as const)(
+      "%s: before-handler settle failure returns payment-error",
+      async flow => {
+        const httpServer = await setup(flow);
+        mockFacilitator.setSettleResponse(
+          buildSettleResponse({
+            success: false,
+            errorReason: "insufficient_funds",
+            transaction: "",
+          }),
+        );
+
+        const result = await verifiedRequest(httpServer);
+        expect(result.type).toBe("payment-error");
+        expect(mockFacilitator.verifyCalls).toHaveLength(0);
+        expect(mockFacilitator.settleCalls).toHaveLength(1);
+        if (result.type !== "payment-error") return;
+        expect(result.response.status).toBe(402);
+      },
+    );
+
+    it("escrow: cancel after before-handler settle exposes settledPhases and deposit receipt", async () => {
+      const httpServer = await setup("escrow");
+      mockFacilitator.setSettleResponse(
+        buildSettleResponse({ success: true, transaction: "0xdeposit" }),
+      );
+
+      let settledPhases: readonly SettlePhase[] | undefined;
+      ResourceServer.onVerifiedPaymentCanceled(async ctx => {
+        settledPhases = ctx.settledPhases;
+        expect(ctx.phase).toBe("cancel");
+        expect(ctx.reason).toBe("handler_failed");
+      });
+
+      const result = await verifiedRequest(httpServer);
+      expect(result.type).toBe("payment-verified");
+      if (result.type !== "payment-verified") return;
+
+      expect(result.beforeHandlerSettlement?.phase).toBe("before-handler");
+      expect(result.beforeHandlerSettlement?.result.transaction).toBe("0xdeposit");
+      expect(mockFacilitator.settleCalls).toHaveLength(1);
+
+      await result.cancellationDispatcher.cancel({
+        reason: "handler_failed",
+        responseStatus: 500,
+      });
+      expect(settledPhases).toEqual(["before-handler"]);
+
+      // No after-handler settle on cancel
+      expect(mockFacilitator.settleCalls).toHaveLength(1);
+
+      const receiptHeaders = httpServer.createCompletedSettlementHeaders(
+        result.beforeHandlerSettlement!,
+      );
+      expect(decodePaymentResponseHeader(receiptHeaders["PAYMENT-RESPONSE"])).toEqual(
+        expect.objectContaining({ success: true, transaction: "0xdeposit" }),
+      );
+    });
+
     it("warns once when settleBeforeHandler flow is settled without beforeHandlerSettlement", async () => {
       const httpServer = await setup("upfront");
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);

--- a/typescript/packages/core/test/unit/server/paymentFlow.test.ts
+++ b/typescript/packages/core/test/unit/server/paymentFlow.test.ts
@@ -347,15 +347,25 @@ describe("payment flows", () => {
       expect(phases).toEqual(["after-handler"]);
     });
 
-    it("upfront: settles before handler and echoes after without a second settle", async () => {
+    it("upfront: runs beforeVerify hooks, skips facilitator /verify, settles before handler", async () => {
       const httpServer = await setup("upfront");
       const phases: SettlePhase[] = [];
+      let beforeVerifyRan = false;
+      let afterVerifyRan = false;
+      ResourceServer.onBeforeVerify(async () => {
+        beforeVerifyRan = true;
+      });
+      ResourceServer.onAfterVerify(async () => {
+        afterVerifyRan = true;
+      });
       ResourceServer.onBeforeSettle(async ctx => {
         phases.push(ctx.phase);
       });
 
       const result = await verifiedRequest(httpServer);
       expect(result.type).toBe("payment-verified");
+      expect(beforeVerifyRan).toBe(true);
+      expect(afterVerifyRan).toBe(false);
       expect(mockFacilitator.verifyCalls).toHaveLength(0);
       expect(mockFacilitator.settleCalls).toHaveLength(1);
       expect(phases).toEqual(["before-handler"]);
@@ -397,15 +407,32 @@ describe("payment flows", () => {
       expect(phases).toEqual(["before-handler"]);
     });
 
+    it("upfront: beforeVerify abort returns payment-error and never settles", async () => {
+      const httpServer = await setup("upfront");
+      ResourceServer.onBeforeVerify(async () => {
+        return { abort: true, reason: "extension_gate" };
+      });
+
+      const result = await verifiedRequest(httpServer);
+      expect(result.type).toBe("payment-error");
+      expect(mockFacilitator.verifyCalls).toHaveLength(0);
+      expect(mockFacilitator.settleCalls).toHaveLength(0);
+    });
+
     it("escrow: settles before and after handler with distinct phases", async () => {
       const httpServer = await setup("escrow");
       const phases: SettlePhase[] = [];
+      let beforeVerifyRan = false;
+      ResourceServer.onBeforeVerify(async () => {
+        beforeVerifyRan = true;
+      });
       ResourceServer.onBeforeSettle(async ctx => {
         phases.push(ctx.phase);
       });
 
       const result = await verifiedRequest(httpServer);
       expect(result.type).toBe("payment-verified");
+      expect(beforeVerifyRan).toBe(true);
       expect(mockFacilitator.verifyCalls).toHaveLength(0);
       expect(mockFacilitator.settleCalls).toHaveLength(1);
 

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -713,6 +713,92 @@ describe("x402ResourceServer", () => {
 
         warnSpy.mockRestore();
       });
+
+      it("runs beforeVerify but skips facilitator /verify for upfront flow", async () => {
+        let beforeVerifyRan = false;
+        let afterVerifyRan = false;
+
+        server.register(
+          "test:network" as Network,
+          Object.assign(new MockSchemeNetworkServer("test-scheme"), {
+            getPaymentFlow: () => "upfront" as const,
+          }),
+        );
+        await server.initialize();
+
+        server
+          .onBeforeVerify(async () => {
+            beforeVerifyRan = true;
+          })
+          .onAfterVerify(async () => {
+            afterVerifyRan = true;
+          });
+
+        const result = await server.verifyPayment(
+          buildPaymentPayload(),
+          buildPaymentRequirements(),
+        );
+
+        expect(beforeVerifyRan).toBe(true);
+        expect(afterVerifyRan).toBe(false);
+        expect(mockClient.verifyCalls.length).toBe(0);
+        expect(result).toEqual({ isValid: true });
+      });
+
+      it("aborts without facilitator /verify for upfront flow", async () => {
+        server.register(
+          "test:network" as Network,
+          Object.assign(new MockSchemeNetworkServer("test-scheme"), {
+            getPaymentFlow: () => "upfront" as const,
+          }),
+        );
+        await server.initialize();
+
+        server.onBeforeVerify(async () => {
+          return { abort: true, reason: "gated" };
+        });
+
+        const result = await server.verifyPayment(
+          buildPaymentPayload(),
+          buildPaymentRequirements(),
+        );
+
+        expect(result).toMatchObject({ isValid: false, invalidReason: "gated" });
+        expect(mockClient.verifyCalls.length).toBe(0);
+      });
+
+      it("runs afterVerify on beforeVerify skip for upfront flow", async () => {
+        const executionOrder: string[] = [];
+
+        server.register(
+          "test:network" as Network,
+          Object.assign(new MockSchemeNetworkServer("test-scheme"), {
+            getPaymentFlow: () => "upfront" as const,
+          }),
+        );
+        await server.initialize();
+
+        server
+          .onBeforeVerify(async () => {
+            executionOrder.push("before");
+            return {
+              skip: true,
+              result: buildVerifyResponse({ isValid: true, payer: "0xlocal" }),
+            };
+          })
+          .onAfterVerify(async () => {
+            executionOrder.push("after");
+          });
+
+        const result = await server.verifyPayment(
+          buildPaymentPayload(),
+          buildPaymentRequirements(),
+        );
+
+        expect(mockClient.verifyCalls.length).toBe(0);
+        expect(executionOrder).toEqual(["before", "after"]);
+        expect(result).toMatchObject({ isValid: true, payer: "0xlocal" });
+      });
     });
 
     describe("onAfterVerify", () => {

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -554,6 +554,7 @@ describe("x402ResourceServer", () => {
         buildSettleResponse({ success: true }),
       );
       server = new x402ResourceServer(mockClient);
+      server.register("test:network" as Network, new MockSchemeNetworkServer("test-scheme"));
     });
 
     describe("onBeforeVerify", () => {
@@ -721,7 +722,9 @@ describe("x402ResourceServer", () => {
         server.register(
           "test:network" as Network,
           Object.assign(new MockSchemeNetworkServer("test-scheme"), {
-            getPaymentFlow: () => "upfront" as const,
+            paymentFlows: {
+              default: { supported: ["upfront"], default: "upfront" },
+            },
           }),
         );
         await server.initialize();
@@ -749,7 +752,9 @@ describe("x402ResourceServer", () => {
         server.register(
           "test:network" as Network,
           Object.assign(new MockSchemeNetworkServer("test-scheme"), {
-            getPaymentFlow: () => "upfront" as const,
+            paymentFlows: {
+              default: { supported: ["upfront"], default: "upfront" },
+            },
           }),
         );
         await server.initialize();
@@ -773,7 +778,9 @@ describe("x402ResourceServer", () => {
         server.register(
           "test:network" as Network,
           Object.assign(new MockSchemeNetworkServer("test-scheme"), {
-            getPaymentFlow: () => "upfront" as const,
+            paymentFlows: {
+              default: { supported: ["upfront"], default: "upfront" },
+            },
           }),
         );
         await server.initialize();
@@ -1311,6 +1318,7 @@ describe("x402ResourceServer", () => {
       );
 
       const server = new x402ResourceServer(mockClient);
+      server.register("eip155:8453" as Network, new MockSchemeNetworkServer("exact"));
 
       const payload = buildPaymentPayload();
       const requirements = buildPaymentRequirements({
@@ -1332,6 +1340,7 @@ describe("x402ResourceServer", () => {
       );
 
       const server = new x402ResourceServer(mockClient);
+      server.register("eip155:8453" as Network, new MockSchemeNetworkServer("exact"));
 
       await expect(
         async () =>
@@ -2548,12 +2557,21 @@ describe("x402ResourceServer", () => {
   });
 
   describe("registerExtension lifecycle hooks", () => {
+    /**
+     * @param mockClient - Facilitator client for the server under test
+     */
+    function serverWithScheme(mockClient: MockFacilitatorClient): x402ResourceServer {
+      const server = new x402ResourceServer(mockClient);
+      server.register("test:network" as Network, new MockSchemeNetworkServer("test-scheme"));
+      return server;
+    }
+
     it("runs extension onBeforeVerify only when extension key is in declaredExtensions", async () => {
       const mockClient = new MockFacilitatorClient(
         buildSupportedResponse(),
         buildVerifyResponse({ isValid: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       let extCalls = 0;
       server.registerExtension({
         key: "extA",
@@ -2576,7 +2594,7 @@ describe("x402ResourceServer", () => {
         buildSupportedResponse(),
         buildVerifyResponse({ isValid: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       let extCalls = 0;
       server.registerExtension({
         key: "extB",
@@ -2604,7 +2622,7 @@ describe("x402ResourceServer", () => {
         buildSupportedResponse(),
         buildVerifyResponse({ isValid: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       const order: string[] = [];
       server.onBeforeVerify(async () => {
         order.push("manual");
@@ -2627,7 +2645,7 @@ describe("x402ResourceServer", () => {
         buildSupportedResponse(),
         buildVerifyResponse({ isValid: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       let callsA = 0;
       let callsB = 0;
       server.registerExtension({
@@ -2657,7 +2675,7 @@ describe("x402ResourceServer", () => {
         buildSupportedResponse(),
         buildVerifyResponse({ isValid: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       let afterCalls = 0;
       server.registerExtension({
         key: "afterExt",
@@ -2682,7 +2700,7 @@ describe("x402ResourceServer", () => {
         buildSupportedResponse(),
         buildVerifyResponse({ isValid: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       mockClient.setVerifyResponse(new Error("verify boom"));
       let failCalls = 0;
       server.registerExtension({
@@ -2711,7 +2729,7 @@ describe("x402ResourceServer", () => {
         buildVerifyResponse({ isValid: true }),
         buildSettleResponse({ success: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       let beforeCalls = 0;
       let afterCalls = 0;
       server.registerExtension({
@@ -2743,7 +2761,7 @@ describe("x402ResourceServer", () => {
         buildVerifyResponse({ isValid: true }),
         buildSettleResponse({ success: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       mockClient.setSettleResponse(new Error("settle boom"));
       let failCalls = 0;
       server.registerExtension({
@@ -2773,7 +2791,7 @@ describe("x402ResourceServer", () => {
         buildSupportedResponse(),
         buildVerifyResponse({ isValid: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       mockClient.setVerifyResponse(new Error("verify boom"));
       let manualCalls = 0;
       server.onVerifyFailure(async () => {
@@ -2799,7 +2817,7 @@ describe("x402ResourceServer", () => {
         buildSupportedResponse(),
         buildVerifyResponse({ isValid: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       let calls = 0;
       server.registerExtension({
         key: "reReg",
@@ -2822,7 +2840,7 @@ describe("x402ResourceServer", () => {
         buildSupportedResponse(),
         buildVerifyResponse({ isValid: true }),
       );
-      const server = new x402ResourceServer(mockClient);
+      const server = serverWithScheme(mockClient);
       let calls = 0;
       server.registerExtension({
         key: "noHooks",

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -1578,16 +1578,16 @@ describe("x402ResourceServer", () => {
         }),
       );
 
-      await server.settlePayment(
-        buildPaymentPayload({ payload: { clientField: "client" } }),
-        buildPaymentRequirements(),
-      );
+      const payload = buildPaymentPayload({ payload: { clientField: "client" } });
+      await server.settlePayment(payload, buildPaymentRequirements());
 
       expect(order).toEqual(["payload"]);
       expect(mockClient.settleCalls[0].payload.payload).toEqual({
         clientField: "client",
         serverField: "server",
       });
+      // Enrichment must not mutate the caller's payload (multi-settle safety).
+      expect(payload.payload).toEqual({ clientField: "client" });
     });
 
     it("rejects payload enrichment that overwrites client payload fields", async () => {

--- a/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
+++ b/typescript/packages/core/test/unit/server/x402ResourceServer.test.ts
@@ -2554,6 +2554,31 @@ describe("x402ResourceServer", () => {
         ),
       ).rejects.toThrow(/payTo.*vacant/);
     });
+
+    it("rejects extension enrichment that injects paymentFlow into an authorization requirement", async () => {
+      const server = new x402ResourceServer();
+      server.registerExtension({
+        key: "flowAttack",
+        enrichPaymentRequiredResponse: async (_d, ctx) => {
+          ctx.paymentRequiredResponse.accepts[0]!.extra.paymentFlow = "upfront";
+          return {};
+        },
+      });
+      const requirements = [
+        buildPaymentRequirements({
+          extra: { name: "USDC" },
+        }),
+      ];
+
+      await expect(
+        server.createPaymentRequiredResponse(
+          requirements,
+          { url: "https://example.com", description: "", mimeType: "" },
+          undefined,
+          { flowAttack: {} },
+        ),
+      ).rejects.toThrow(/extra\["paymentFlow"\].*protocol-reserved/);
+    });
   });
 
   describe("registerExtension lifecycle hooks", () => {

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -395,6 +395,8 @@ describe("paymentMiddleware", () => {
         }),
         responseBody: expect.any(Buffer),
       }),
+      undefined,
+      undefined,
     );
     expect(res.setHeader).toHaveBeenCalledWith("PAYMENT-RESPONSE", "settled");
   });

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -37,6 +37,7 @@ const mockPaymentRequirements = {
 // --- Mock setup ---
 let mockProcessHTTPRequest: ReturnType<typeof vi.fn>;
 let mockProcessSettlement: ReturnType<typeof vi.fn>;
+let mockCreateCompletedSettlementHeaders: ReturnType<typeof vi.fn>;
 let mockRegisterPaywallProvider: ReturnType<typeof vi.fn>;
 let mockRequiresPayment: ReturnType<typeof vi.fn>;
 
@@ -94,6 +95,7 @@ vi.mock("@x402/core/server", async importOriginal => {
       initialize: vi.fn().mockResolvedValue(undefined),
       processHTTPRequest: mockProcessHTTPRequest,
       processSettlement: mockProcessSettlement,
+      createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
       registerPaywallProvider: mockRegisterPaywallProvider,
       requiresPayment: mockRequiresPayment,
       routes: routes,
@@ -231,6 +233,10 @@ describe("paymentMiddleware", () => {
     vi.clearAllMocks();
     mockProcessHTTPRequest = vi.fn();
     mockProcessSettlement = vi.fn();
+    mockCreateCompletedSettlementHeaders = vi.fn((_settlement, existingCacheControl) => ({
+      "PAYMENT-RESPONSE": "before-handler-receipt",
+      "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+    }));
     mockRegisterPaywallProvider = vi.fn();
     mockRequiresPayment = vi.fn().mockReturnValue(true);
 
@@ -240,6 +246,7 @@ describe("paymentMiddleware", () => {
         ({
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes: routes,
@@ -462,6 +469,7 @@ describe("paymentMiddleware", () => {
 
     expect(next).toHaveBeenCalled();
     expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(mockCreateCompletedSettlementHeaders).not.toHaveBeenCalled();
     expect(res.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
     expect(res._headers["Settlement-Overrides"]).toBeUndefined();
     const cancellationDispatcher = (await mockProcessHTTPRequest.mock.results[0].value)
@@ -472,6 +480,52 @@ describe("paymentMiddleware", () => {
         responseStatus: 500,
       }),
     );
+  });
+
+  it("echoes before-handler PAYMENT-RESPONSE when handler returns >= 400", async () => {
+    const beforeHandlerSettlement = {
+      phase: "before-handler" as const,
+      flow: "upfront" as const,
+      result: {
+        success: true,
+        transaction: "0xdeposit",
+        network: "eip155:84532" as const,
+      },
+      requirements: mockPaymentRequirements,
+    };
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+        beforeHandlerSettlement,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest();
+    const res = createMockResponse();
+    const next = vi.fn(() => {
+      res.statusCode = 500;
+      res.end();
+    });
+
+    await middleware(req, res, next);
+
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(mockCreateCompletedSettlementHeaders).toHaveBeenCalledWith(
+      beforeHandlerSettlement,
+      null,
+    );
+    expect(res.setHeader).toHaveBeenCalledWith("PAYMENT-RESPONSE", "before-handler-receipt");
+    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "private");
   });
 
   it("cancels payment when handler throws", async () => {
@@ -558,6 +612,7 @@ describe("paymentMiddleware", () => {
           initialize,
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes,
@@ -600,6 +655,7 @@ describe("paymentMiddleware", () => {
           initialize,
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes,
@@ -649,6 +705,7 @@ describe("paymentMiddleware", () => {
             initialize,
             processHTTPRequest: mockProcessHTTPRequest,
             processSettlement: mockProcessSettlement,
+            createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
             registerPaywallProvider: mockRegisterPaywallProvider,
             requiresPayment: mockRequiresPayment,
             routes,
@@ -824,6 +881,7 @@ describe("paymentMiddlewareFromConfig", () => {
           initialize: vi.fn().mockResolvedValue(undefined),
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes: routes,
@@ -896,6 +954,7 @@ describe("ExpressAdapter", () => {
         ({
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes: routes,

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -722,9 +722,12 @@ describe("paymentMiddleware", () => {
       await new Promise(resolve => setTimeout(resolve, 0));
       expect(unhandled).toHaveLength(0);
 
+      const firstRes = createMockResponse();
       const firstNext = vi.fn();
-      await middleware(createMockRequest(), createMockResponse(), firstNext);
-      expect(firstNext).toHaveBeenCalledWith(initializationError);
+      await middleware(createMockRequest(), firstRes, firstNext);
+      expect(firstRes.status).toHaveBeenCalledWith(500);
+      expect(firstRes.json).toHaveBeenCalledWith({ error: "Internal Server Error" });
+      expect(firstNext).not.toHaveBeenCalled();
 
       const secondNext = vi.fn();
       await middleware(createMockRequest(), createMockResponse(), secondNext);
@@ -758,6 +761,32 @@ describe("paymentMiddleware", () => {
       error: "Facilitator verify returned invalid JSON: not-json",
     });
     expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns a generic 500 when processHTTPRequest throws an unexpected error", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockProcessHTTPRequest.mockRejectedValue(
+      new Error('[x402] Scheme "exact" does not support paymentFlow "escrow"'),
+    );
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const req = createMockRequest();
+    const res = createMockResponse();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal Server Error" });
+    expect(next).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 
   it("returns 502 when settlement surfaces FacilitatorResponseError", async () => {

--- a/typescript/packages/http/express/src/index.test.ts
+++ b/typescript/packages/http/express/src/index.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import http from "node:http";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import type { Request, Response } from "express";
 import type {
+  CompletedSettlement,
   HTTPProcessResult,
   x402HTTPResourceServer,
   PaywallProvider,
@@ -530,12 +535,23 @@ describe("paymentMiddleware", () => {
 
   it("cancels payment when handler throws", async () => {
     const cancellationDispatcher = createMockPaymentCancellationDispatcher();
+    const beforeHandlerSettlement = {
+      phase: "before-handler" as const,
+      flow: "upfront" as const,
+      result: {
+        success: true,
+        transaction: "0xdeposit",
+        network: "eip155:84532" as const,
+      },
+      requirements: mockPaymentRequirements,
+    };
     setupMockHttpServer(
       {
         type: "payment-verified",
         paymentPayload: mockPaymentPayload,
         paymentRequirements: mockPaymentRequirements,
         cancellationDispatcher,
+        beforeHandlerSettlement,
       },
       { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
     );
@@ -564,6 +580,12 @@ describe("paymentMiddleware", () => {
       error: handlerError,
     });
     expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(mockCreateCompletedSettlementHeaders).toHaveBeenCalledWith(
+      beforeHandlerSettlement,
+      null,
+    );
+    expect(res.setHeader).toHaveBeenCalledWith("PAYMENT-RESPONSE", "before-handler-receipt");
+    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "private");
     expect(next).toHaveBeenCalledWith(handlerError);
   });
 
@@ -1116,5 +1138,167 @@ describe("ExpressAdapter", () => {
       }),
       undefined,
     );
+  });
+});
+
+/**
+ * Real Express app probes: whether the middleware's `handler_threw` catch or its
+ * `statusCode >= 400` branch runs is decided by Express's error routing.
+ */
+describe("before-handler receipt survives a failing handler", () => {
+  const RECEIPT_HEADER = "payment-response";
+  const BEFORE_HANDLER_RECEIPT = "before-handler-receipt";
+  const AFTER_HANDLER_RECEIPT = "after-handler-receipt";
+
+  const upfrontSettlement: CompletedSettlement = {
+    phase: "before-handler",
+    flow: "upfront",
+    result: { success: true, transaction: "0xdeposit", network: "eip155:84532" },
+    requirements: mockPaymentRequirements,
+  };
+
+  let beforeHandlerSettlement: CompletedSettlement | undefined;
+  let cancel: ReturnType<typeof vi.fn>;
+  let server: Server;
+  let port: number;
+
+  /**
+   * Issues a real HTTP GET against the test server.
+   *
+   * @param path - Request path.
+   * @returns Client-visible status and headers.
+   */
+  async function probe(
+    path: string,
+  ): Promise<{ status: number; headers: http.IncomingHttpHeaders }> {
+    return new Promise((resolve, reject) => {
+      const request = http.get({ host: "127.0.0.1", port, path }, response => {
+        response.resume();
+        response.on("end", () =>
+          resolve({ status: response.statusCode ?? 0, headers: response.headers }),
+        );
+      });
+      request.on("error", reject);
+    });
+  }
+
+  beforeEach(async () => {
+    beforeHandlerSettlement = upfrontSettlement;
+    cancel = vi.fn().mockResolvedValue(undefined);
+    mockProcessSettlement = vi.fn().mockResolvedValue({
+      success: true,
+      headers: { "PAYMENT-RESPONSE": AFTER_HANDLER_RECEIPT },
+    });
+    mockCreateCompletedSettlementHeaders = vi.fn(
+      (_settlement: CompletedSettlement, existingCacheControl?: string | null) => ({
+        "PAYMENT-RESPONSE": BEFORE_HANDLER_RECEIPT,
+        "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+      }),
+    );
+    mockProcessHTTPRequest = vi.fn(async () => ({
+      type: "payment-verified" as const,
+      cancellationDispatcher: { cancel },
+      beforeHandlerSettlement,
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+    }));
+    mockRegisterPaywallProvider = vi.fn();
+    mockRequiresPayment = vi.fn().mockReturnValue(true);
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (serverArg, routes) =>
+        ({
+          initialize: vi.fn().mockResolvedValue(undefined),
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes,
+          server: serverArg || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+
+    const app = express();
+    app.use(
+      paymentMiddleware(
+        mockRoutes,
+        {} as unknown as x402ResourceServer,
+        undefined,
+        undefined,
+        false,
+      ),
+    );
+    app.get("/api/throw-sync", () => {
+      throw new Error("handler exploded");
+    });
+    app.get("/api/throw-async", async (_req, _res, next) => {
+      await Promise.resolve();
+      next(new Error("handler exploded asynchronously"));
+    });
+    app.get("/api/status-503", (_req, res) => {
+      res.status(503).json({ error: "upstream unavailable" });
+    });
+    app.get("/api/ok", (_req, res) => {
+      res.status(200).json({ data: "protected" });
+    });
+
+    server = app.listen(0);
+    await new Promise<void>(resolve => server.once("listening", () => resolve()));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  });
+
+  it("echoes the receipt when the handler throws synchronously", async () => {
+    const result = await probe("/api/throw-sync");
+
+    expect(result.status).toBe(500);
+    expect(result.headers[RECEIPT_HEADER]).toBe(BEFORE_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledWith({ reason: "handler_failed", responseStatus: 500 });
+  });
+
+  it("echoes the receipt when the handler fails asynchronously", async () => {
+    const result = await probe("/api/throw-async");
+
+    expect(result.status).toBe(500);
+    expect(result.headers[RECEIPT_HEADER]).toBe(BEFORE_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledWith({ reason: "handler_failed", responseStatus: 500 });
+  });
+
+  it("echoes the receipt when the handler returns a 5xx", async () => {
+    const result = await probe("/api/status-503");
+
+    expect(result.status).toBe(503);
+    expect(result.headers[RECEIPT_HEADER]).toBe(BEFORE_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledWith({ reason: "handler_failed", responseStatus: 503 });
+  });
+
+  it("settles after the handler when it succeeds", async () => {
+    const result = await probe("/api/ok");
+
+    expect(result.status).toBe(200);
+    expect(result.headers[RECEIPT_HEADER]).toBe(AFTER_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds no receipt for a flow that has not settled before the handler", async () => {
+    beforeHandlerSettlement = undefined;
+
+    const result = await probe("/api/throw-sync");
+
+    expect(result.status).toBe(500);
+    expect(result.headers[RECEIPT_HEADER]).toBeUndefined();
+    expect(mockCreateCompletedSettlementHeaders).not.toHaveBeenCalled();
   });
 });

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -207,8 +207,13 @@ export function paymentMiddlewareFromHTTPServer(
 
       case "payment-verified":
         // Payment is valid, need to wrap response for settlement
-        const { cancellationDispatcher, paymentPayload, paymentRequirements, declaredExtensions } =
-          result;
+        const {
+          cancellationDispatcher,
+          beforeHandlerSettlement,
+          paymentPayload,
+          paymentRequirements,
+          declaredExtensions,
+        } = result;
 
         // Intercept and buffer all core methods that can commit response to client
         const originalWriteHead = res.writeHead.bind(res);
@@ -329,6 +334,8 @@ export function paymentMiddlewareFromHTTPServer(
             paymentRequirements,
             declaredExtensions,
             { request: context, responseBody, responseHeaders },
+            undefined,
+            beforeHandlerSettlement,
           );
 
           // If settlement fails, return an error and do not send the buffered response

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -298,6 +298,21 @@ export function paymentMiddlewareFromHTTPServer(
             reason: "handler_threw",
             error,
           });
+          // Echo before-handler receipt so the payer still gets the tx hash
+          if (beforeHandlerSettlement) {
+            const existingCacheControl =
+              res.getHeader("Cache-Control") != null
+                ? String(res.getHeader("Cache-Control"))
+                : null;
+            Object.entries(
+              httpServer.createCompletedSettlementHeaders(
+                beforeHandlerSettlement,
+                existingCacheControl,
+              ),
+            ).forEach(([key, value]) => {
+              res.setHeader(key, value);
+            });
+          }
           bufferedCalls = [];
           restoreResponseMethods();
           return next(error);

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -54,6 +54,17 @@ function sendFacilitatorError(res: Response, error: FacilitatorResponseError): v
 }
 
 /**
+ * Logs an unexpected error and sends a generic 500 without leaking internals.
+ *
+ * @param res - The Express response to write to
+ * @param error - The unexpected error
+ */
+function sendInternalError(res: Response, error: unknown): void {
+  console.error(error);
+  res.status(500).json({ error: "Internal Server Error" });
+}
+
+/**
  * Express payment middleware for x402 protocol (direct HTTP server instance).
  *
  * Use this when you need to configure HTTP-level hooks.
@@ -163,7 +174,8 @@ export function paymentMiddlewareFromHTTPServer(
           sendFacilitatorError(res, facilitatorError);
           return;
         }
-        return next(error);
+        sendInternalError(res, error);
+        return;
       }
     }
 
@@ -182,7 +194,8 @@ export function paymentMiddlewareFromHTTPServer(
         sendFacilitatorError(res, error);
         return;
       }
-      return next(error);
+      sendInternalError(res, error);
+      return;
     }
 
     // Handle the different result types

--- a/typescript/packages/http/express/src/index.ts
+++ b/typescript/packages/http/express/src/index.ts
@@ -300,6 +300,21 @@ export function paymentMiddlewareFromHTTPServer(
             responseStatus: res.statusCode,
           });
           res.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
+          // Echo before-handler receipt (e.g. upfront) so the payer still gets the tx hash
+          if (beforeHandlerSettlement) {
+            const existingCacheControl =
+              res.getHeader("Cache-Control") != null
+                ? String(res.getHeader("Cache-Control"))
+                : null;
+            Object.entries(
+              httpServer.createCompletedSettlementHeaders(
+                beforeHandlerSettlement,
+                existingCacheControl,
+              ),
+            ).forEach(([key, value]) => {
+              res.setHeader(key, value);
+            });
+          }
           restoreResponseMethods();
           // Replay all buffered calls in order
           for (const [method, args] of bufferedCalls) {

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -36,6 +36,7 @@ const mockPaymentRequirements = {
 // --- Mock setup ---
 let mockProcessHTTPRequest: ReturnType<typeof vi.fn>;
 let mockProcessSettlement: ReturnType<typeof vi.fn>;
+let mockCreateCompletedSettlementHeaders: ReturnType<typeof vi.fn>;
 let mockRegisterPaywallProvider: ReturnType<typeof vi.fn>;
 let mockRequiresPayment: ReturnType<typeof vi.fn>;
 
@@ -93,6 +94,7 @@ vi.mock("@x402/core/server", async importOriginal => {
       initialize: vi.fn().mockResolvedValue(undefined),
       processHTTPRequest: mockProcessHTTPRequest,
       processSettlement: mockProcessSettlement,
+      createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
       registerPaywallProvider: mockRegisterPaywallProvider,
       requiresPayment: mockRequiresPayment,
       routes: routes,
@@ -267,6 +269,10 @@ describe("paymentMiddleware", () => {
     vi.clearAllMocks();
     mockProcessHTTPRequest = vi.fn();
     mockProcessSettlement = vi.fn();
+    mockCreateCompletedSettlementHeaders = vi.fn((_settlement, existingCacheControl) => ({
+      "PAYMENT-RESPONSE": "before-handler-receipt",
+      "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+    }));
     mockRegisterPaywallProvider = vi.fn();
     mockRequiresPayment = vi.fn().mockReturnValue(true);
 
@@ -276,6 +282,7 @@ describe("paymentMiddleware", () => {
           initialize: vi.fn().mockResolvedValue(undefined),
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes: routes,
@@ -346,6 +353,7 @@ describe("paymentMiddleware", () => {
             initialize,
             processHTTPRequest: mockProcessHTTPRequest,
             processSettlement: mockProcessSettlement,
+            createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
             registerPaywallProvider: mockRegisterPaywallProvider,
             requiresPayment: mockRequiresPayment,
             routes,
@@ -645,6 +653,7 @@ describe("paymentMiddleware", () => {
     const result = await hooks.onSend[0](request, reply, payload);
 
     expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(mockCreateCompletedSettlementHeaders).not.toHaveBeenCalled();
     expect(reply.removeHeader).toHaveBeenCalledWith("Settlement-Overrides");
     expect(reply._headers["Settlement-Overrides"]).toBeUndefined();
     expect(request.x402Context?.cancellationDispatcher.cancel).toHaveBeenCalledWith(
@@ -653,6 +662,56 @@ describe("paymentMiddleware", () => {
         responseStatus: 500,
       }),
     );
+    expect(result).toBe(payload);
+  });
+
+  it("echoes before-handler PAYMENT-RESPONSE when handler returns >= 400", async () => {
+    const beforeHandlerSettlement = {
+      phase: "before-handler" as const,
+      flow: "upfront" as const,
+      result: {
+        success: true,
+        transaction: "0xdeposit",
+        network: "eip155:84532" as const,
+      },
+      requirements: mockPaymentRequirements,
+    };
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+        beforeHandlerSettlement,
+      },
+      { success: true, headers: {} },
+    );
+
+    const { app, hooks } = createMockApp();
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    const request = createMockRequest();
+    const reply = createMockReply();
+
+    await hooks.onRequest[0](request, reply);
+
+    reply.statusCode = 500;
+    const payload = JSON.stringify({ error: "Server error" });
+    const result = await hooks.onSend[0](request, reply, payload);
+
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(mockCreateCompletedSettlementHeaders).toHaveBeenCalledWith(
+      beforeHandlerSettlement,
+      null,
+    );
+    expect(reply.header).toHaveBeenCalledWith("PAYMENT-RESPONSE", "before-handler-receipt");
+    expect(reply.header).toHaveBeenCalledWith("Cache-Control", "private");
     expect(result).toBe(payload);
   });
 
@@ -791,6 +850,7 @@ describe("paymentMiddlewareFromConfig", () => {
           initialize: vi.fn().mockResolvedValue(undefined),
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes: routes,
@@ -859,6 +919,7 @@ describe("FastifyAdapter integration", () => {
           initialize: vi.fn().mockResolvedValue(undefined),
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes: routes,

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -371,9 +371,12 @@ describe("paymentMiddleware", () => {
       await new Promise(resolve => setTimeout(resolve, 0));
       expect(unhandled).toHaveLength(0);
 
-      await expect(hooks.onRequest[0](createMockRequest(), createMockReply())).rejects.toThrow(
-        "facilitator request timed out",
-      );
+      const firstReply = createMockReply();
+      await hooks.onRequest[0](createMockRequest(), firstReply);
+      expect(firstReply.status).toHaveBeenCalledWith(500);
+      expect(firstReply.send).toHaveBeenCalledWith({ error: "Internal Server Error" });
+      expect(mockProcessHTTPRequest).not.toHaveBeenCalled();
+
       await hooks.onRequest[0](createMockRequest(), createMockReply());
       expect(initializeCalls).toBe(2);
     } finally {

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
 import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
 import type {
+  CompletedSettlement,
   HTTPProcessResult,
   x402HTTPResourceServer,
   PaywallProvider,
@@ -1085,5 +1087,131 @@ describe("FastifyAdapter integration", () => {
       }),
       undefined,
     );
+  });
+});
+
+/**
+ * Real Fastify inject probes: the receipt depends on onSend running after onError
+ * for a thrown handler, which only the real lifecycle can show.
+ */
+describe("before-handler receipt survives a failing handler", () => {
+  const RECEIPT_HEADER = "payment-response";
+  const BEFORE_HANDLER_RECEIPT = "before-handler-receipt";
+  const AFTER_HANDLER_RECEIPT = "after-handler-receipt";
+
+  const upfrontSettlement: CompletedSettlement = {
+    phase: "before-handler",
+    flow: "upfront",
+    result: { success: true, transaction: "0xdeposit", network: "eip155:84532" },
+    requirements: mockPaymentRequirements,
+  };
+
+  let beforeHandlerSettlement: CompletedSettlement | undefined;
+  let cancel: ReturnType<typeof vi.fn>;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    beforeHandlerSettlement = upfrontSettlement;
+    cancel = vi.fn().mockResolvedValue(undefined);
+    mockProcessSettlement = vi.fn().mockResolvedValue({
+      success: true,
+      headers: { "PAYMENT-RESPONSE": AFTER_HANDLER_RECEIPT },
+    });
+    mockCreateCompletedSettlementHeaders = vi.fn(
+      (_settlement: CompletedSettlement, existingCacheControl?: string | null) => ({
+        "PAYMENT-RESPONSE": BEFORE_HANDLER_RECEIPT,
+        "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+      }),
+    );
+    mockProcessHTTPRequest = vi.fn(async () => ({
+      type: "payment-verified" as const,
+      cancellationDispatcher: { cancel },
+      beforeHandlerSettlement,
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+    }));
+    mockRegisterPaywallProvider = vi.fn();
+    mockRequiresPayment = vi.fn().mockReturnValue(true);
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize: vi.fn().mockResolvedValue(undefined),
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+
+    app = Fastify({ logger: false });
+    paymentMiddleware(
+      app,
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    app.get("/api/throw", async () => {
+      throw new Error("handler exploded");
+    });
+    app.get("/api/status-503", async (_request, reply) => {
+      reply.status(503);
+      return { error: "upstream unavailable" };
+    });
+    app.get("/api/ok", async () => ({ data: "protected" }));
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("echoes the receipt when the handler throws", async () => {
+    const response = await app.inject({ method: "GET", url: "/api/throw" });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.headers[RECEIPT_HEADER]).toBe(BEFORE_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenNthCalledWith(1, {
+      reason: "handler_threw",
+      error: expect.any(Error),
+    });
+  });
+
+  it("echoes the receipt when the handler returns a 5xx", async () => {
+    const response = await app.inject({ method: "GET", url: "/api/status-503" });
+
+    expect(response.statusCode).toBe(503);
+    expect(response.headers[RECEIPT_HEADER]).toBe(BEFORE_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledWith({ reason: "handler_failed", responseStatus: 503 });
+  });
+
+  it("settles after the handler when it succeeds", async () => {
+    const response = await app.inject({ method: "GET", url: "/api/ok" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers[RECEIPT_HEADER]).toBe(AFTER_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).toHaveBeenCalledTimes(1);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it("adds no receipt for a flow that has not settled before the handler", async () => {
+    beforeHandlerSettlement = undefined;
+
+    const response = await app.inject({ method: "GET", url: "/api/throw" });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.headers[RECEIPT_HEADER]).toBeUndefined();
+    expect(mockCreateCompletedSettlementHeaders).not.toHaveBeenCalled();
   });
 });

--- a/typescript/packages/http/fastify/src/index.test.ts
+++ b/typescript/packages/http/fastify/src/index.test.ts
@@ -521,6 +521,8 @@ describe("paymentMiddleware", () => {
         }),
         responseBody: expect.any(Buffer),
       }),
+      undefined,
+      undefined,
     );
     expect(reply.header).toHaveBeenCalledWith("PAYMENT-RESPONSE", "settled");
     expect(result).toBe(payload);

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -436,6 +436,21 @@ export function paymentMiddlewareFromHTTPServer(
         responseStatus: reply.statusCode,
       });
       reply.removeHeader(SETTLEMENT_OVERRIDES_HEADER);
+      // Echo before-handler receipt (e.g. upfront) so the payer still gets the tx hash
+      if (x402Context.beforeHandlerSettlement) {
+        const existingCacheControl =
+          reply.getHeader("Cache-Control") != null
+            ? String(reply.getHeader("Cache-Control"))
+            : null;
+        for (const [key, value] of Object.entries(
+          httpServer.createCompletedSettlementHeaders(
+            x402Context.beforeHandlerSettlement,
+            existingCacheControl,
+          ),
+        )) {
+          reply.header(key, value);
+        }
+      }
       return effectivePayload;
     }
 

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -13,6 +13,7 @@ import {
   SettlementOverrides,
   checkIfBazaarNeeded,
   PaymentCancellationDispatcher,
+  CompletedSettlement,
   withPrivateCacheControl,
 } from "@x402/core/server";
 import {
@@ -37,6 +38,7 @@ export function setSettlementOverrides(reply: FastifyReply, overrides: Settlemen
 
 interface X402PaymentContext {
   cancellationDispatcher: PaymentCancellationDispatcher;
+  beforeHandlerSettlement?: CompletedSettlement;
   paymentPayload: PaymentPayload;
   paymentRequirements: PaymentRequirements;
   declaredExtensions?: Record<string, unknown>;
@@ -378,6 +380,7 @@ export function paymentMiddlewareFromHTTPServer(
       case "payment-verified": {
         request.x402Context = {
           cancellationDispatcher: result.cancellationDispatcher,
+          beforeHandlerSettlement: result.beforeHandlerSettlement,
           paymentPayload: result.paymentPayload,
           paymentRequirements: result.paymentRequirements,
           declaredExtensions: result.declaredExtensions,
@@ -451,6 +454,8 @@ export function paymentMiddlewareFromHTTPServer(
         x402Context.paymentRequirements,
         x402Context.declaredExtensions,
         { request: x402Context.requestContext, responseBody, responseHeaders },
+        undefined,
+        x402Context.beforeHandlerSettlement,
       );
 
       if (!settleResult.success) {

--- a/typescript/packages/http/fastify/src/index.ts
+++ b/typescript/packages/http/fastify/src/index.ts
@@ -218,6 +218,17 @@ function sendFacilitatorError(reply: FastifyReply, error: FacilitatorResponseErr
 }
 
 /**
+ * Logs an unexpected error and sends a generic 500 without leaking internals.
+ *
+ * @param reply - The Fastify reply to write to
+ * @param error - The unexpected error
+ */
+function sendInternalError(reply: FastifyReply, error: unknown): void {
+  console.error(error);
+  reply.status(500).send({ error: "Internal Server Error" });
+}
+
+/**
  * Configuration for registering a payment scheme with a specific network.
  */
 export interface SchemeRegistration {
@@ -342,7 +353,7 @@ export function paymentMiddlewareFromHTTPServer(
         if (facilitatorError) {
           return sendFacilitatorError(reply, facilitatorError);
         }
-        throw error;
+        return sendInternalError(reply, error);
       }
     }
 
@@ -358,7 +369,7 @@ export function paymentMiddlewareFromHTTPServer(
       if (error instanceof FacilitatorResponseError) {
         return sendFacilitatorError(reply, error);
       }
-      throw error;
+      return sendInternalError(reply, error);
     }
 
     switch (result.type) {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 import type { Context } from "hono";
 import type {
+  CompletedSettlement,
   HTTPProcessResult,
   x402HTTPResourceServer,
   PaywallProvider,
@@ -935,5 +938,149 @@ describe("HonoAdapter", () => {
       }),
       undefined,
     );
+  });
+});
+
+/**
+ * Real Hono app.fetch probes: whether the middleware's `handler_threw` catch or
+ * its `status >= 400` branch runs is decided by Hono's `compose`.
+ */
+describe("before-handler receipt survives a failing handler", () => {
+  const RECEIPT_HEADER = "PAYMENT-RESPONSE";
+  const BEFORE_HANDLER_RECEIPT = "before-handler-receipt";
+  const AFTER_HANDLER_RECEIPT = "after-handler-receipt";
+
+  const upfrontSettlement: CompletedSettlement = {
+    phase: "before-handler",
+    flow: "upfront",
+    result: { success: true, transaction: "0xdeposit", network: "eip155:84532" },
+    requirements: mockPaymentRequirements,
+  };
+
+  let beforeHandlerSettlement: CompletedSettlement | undefined;
+  let cancel: ReturnType<typeof vi.fn>;
+  let app: Hono;
+
+  beforeEach(() => {
+    beforeHandlerSettlement = upfrontSettlement;
+    cancel = vi.fn().mockResolvedValue(undefined);
+    mockProcessSettlement = vi.fn().mockResolvedValue({
+      success: true,
+      headers: { "PAYMENT-RESPONSE": AFTER_HANDLER_RECEIPT },
+    });
+    mockCreateCompletedSettlementHeaders = vi.fn(
+      (_settlement: CompletedSettlement, existingCacheControl?: string | null) => ({
+        "PAYMENT-RESPONSE": BEFORE_HANDLER_RECEIPT,
+        "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+      }),
+    );
+    mockProcessHTTPRequest = vi.fn(async () => ({
+      type: "payment-verified" as const,
+      cancellationDispatcher: { cancel },
+      beforeHandlerSettlement,
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+    }));
+    mockRegisterPaywallProvider = vi.fn();
+    mockRequiresPayment = vi.fn().mockReturnValue(true);
+
+    vi.mocked(HTTPResourceServer).mockImplementation(
+      (server, routes) =>
+        ({
+          initialize: vi.fn().mockResolvedValue(undefined),
+          processHTTPRequest: mockProcessHTTPRequest,
+          processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
+          registerPaywallProvider: mockRegisterPaywallProvider,
+          requiresPayment: mockRequiresPayment,
+          routes,
+          server: server || {
+            hasExtension: vi.fn().mockReturnValue(false),
+            registerExtension: vi.fn(),
+          },
+        }) as unknown as x402HTTPResourceServer,
+    );
+
+    app = new Hono();
+    app.use(
+      "*",
+      paymentMiddleware(
+        mockRoutes,
+        {} as unknown as x402ResourceServer,
+        undefined,
+        undefined,
+        false,
+      ),
+    );
+    app.get("/api/throw-error", () => {
+      throw new Error("handler exploded");
+    });
+    app.get("/api/throw-http-exception", () => {
+      throw new HTTPException(503, { message: "upstream unavailable" });
+    });
+    app.get("/api/throw-non-error", () => {
+      throw "handler exploded";
+    });
+    app.get("/api/status-503", c => c.json({ error: "upstream unavailable" }, 503));
+    app.get("/api/ok", c => c.json({ data: "protected" }));
+  });
+
+  it("echoes the receipt when the handler throws an Error", async () => {
+    const response = await app.fetch(new Request("http://localhost/api/throw-error"));
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get(RECEIPT_HEADER)).toBe(BEFORE_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledWith({ reason: "handler_failed", responseStatus: 500 });
+  });
+
+  it("echoes the receipt when the handler throws an HTTPException", async () => {
+    const response = await app.fetch(new Request("http://localhost/api/throw-http-exception"));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get(RECEIPT_HEADER)).toBe(BEFORE_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel).toHaveBeenCalledWith({ reason: "handler_failed", responseStatus: 503 });
+  });
+
+  it("echoes the receipt when the handler returns a 5xx", async () => {
+    const response = await app.fetch(new Request("http://localhost/api/status-503"));
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get(RECEIPT_HEADER)).toBe(BEFORE_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledWith({ reason: "handler_failed", responseStatus: 503 });
+  });
+
+  it("settles after the handler when it succeeds", async () => {
+    const response = await app.fetch(new Request("http://localhost/api/ok"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get(RECEIPT_HEADER)).toBe(AFTER_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds no receipt for a flow that has not settled before the handler", async () => {
+    beforeHandlerSettlement = undefined;
+
+    const response = await app.fetch(new Request("http://localhost/api/throw-error"));
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get(RECEIPT_HEADER)).toBeNull();
+    expect(mockCreateCompletedSettlementHeaders).not.toHaveBeenCalled();
+  });
+
+  it("echoes the receipt when the handler throws a non-Error", async () => {
+    const response = await app.fetch(new Request("http://localhost/api/throw-non-error"));
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get(RECEIPT_HEADER)).toBe(BEFORE_HANDLER_RECEIPT);
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledWith({
+      reason: "handler_threw",
+      error: "handler exploded",
+    });
   });
 });

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -384,6 +384,8 @@ describe("paymentMiddleware", () => {
         }),
         responseBody: expect.any(Buffer),
       }),
+      undefined,
+      undefined,
     );
     expect(responseHeaders.get("PAYMENT-RESPONSE")).toBe("settled");
   });

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -627,9 +627,14 @@ describe("paymentMiddleware", () => {
       await new Promise(resolve => setTimeout(resolve, 0));
       expect(unhandled).toHaveLength(0);
 
-      await expect(middleware(createMockContext(), vi.fn())).rejects.toThrow(
-        "facilitator request timed out",
-      );
+      const firstResult = await middleware(createMockContext(), vi.fn());
+      expect(firstResult).toBeInstanceOf(Response);
+      expect((firstResult as Response).status).toBe(500);
+      await expect((firstResult as Response).json()).resolves.toEqual({
+        error: "Internal Server Error",
+      });
+      expect(mockProcessHTTPRequest).not.toHaveBeenCalled();
+
       await middleware(createMockContext(), vi.fn().mockResolvedValue(undefined));
       expect(initializeCalls).toBe(2);
     } finally {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -37,6 +37,7 @@ const mockPaymentRequirements = {
 // --- Mock setup ---
 let mockProcessHTTPRequest: ReturnType<typeof vi.fn>;
 let mockProcessSettlement: ReturnType<typeof vi.fn>;
+let mockCreateCompletedSettlementHeaders: ReturnType<typeof vi.fn>;
 let mockRegisterPaywallProvider: ReturnType<typeof vi.fn>;
 let mockRequiresPayment: ReturnType<typeof vi.fn>;
 
@@ -94,6 +95,7 @@ vi.mock("@x402/core/server", async importOriginal => {
       initialize: vi.fn().mockResolvedValue(undefined),
       processHTTPRequest: mockProcessHTTPRequest,
       processSettlement: mockProcessSettlement,
+      createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
       registerPaywallProvider: mockRegisterPaywallProvider,
       requiresPayment: mockRequiresPayment,
       routes: routes,
@@ -218,6 +220,10 @@ describe("paymentMiddleware", () => {
     vi.clearAllMocks();
     mockProcessHTTPRequest = vi.fn();
     mockProcessSettlement = vi.fn();
+    mockCreateCompletedSettlementHeaders = vi.fn((_settlement, existingCacheControl) => ({
+      "PAYMENT-RESPONSE": "before-handler-receipt",
+      "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+    }));
     mockRegisterPaywallProvider = vi.fn();
     mockRequiresPayment = vi.fn().mockReturnValue(true);
 
@@ -227,6 +233,7 @@ describe("paymentMiddleware", () => {
         ({
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes: routes,
@@ -458,7 +465,52 @@ describe("paymentMiddleware", () => {
 
     expect(next).toHaveBeenCalled();
     expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(mockCreateCompletedSettlementHeaders).not.toHaveBeenCalled();
     expect(context.res?.headers.has("Settlement-Overrides")).toBe(false);
+  });
+
+  it("echoes before-handler PAYMENT-RESPONSE when handler returns >= 400", async () => {
+    const beforeHandlerSettlement = {
+      phase: "before-handler" as const,
+      flow: "upfront" as const,
+      result: {
+        success: true,
+        transaction: "0xdeposit",
+        network: "eip155:84532" as const,
+      },
+      requirements: mockPaymentRequirements,
+    };
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+        beforeHandlerSettlement,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const context = createMockContext();
+    const next = vi.fn().mockImplementation(async () => {
+      context.res = new Response("Error", { status: 500 });
+    });
+
+    await middleware(context, next);
+
+    expect(mockProcessSettlement).not.toHaveBeenCalled();
+    expect(mockCreateCompletedSettlementHeaders).toHaveBeenCalledWith(
+      beforeHandlerSettlement,
+      null,
+    );
+    expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("before-handler-receipt");
+    expect(context.res?.headers.get("Cache-Control")).toBe("private");
   });
 
   it("returns 402 when settlement throws error", async () => {
@@ -512,6 +564,7 @@ describe("paymentMiddleware", () => {
           initialize,
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes,
@@ -557,6 +610,7 @@ describe("paymentMiddleware", () => {
             initialize,
             processHTTPRequest: mockProcessHTTPRequest,
             processSettlement: mockProcessSettlement,
+            createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
             registerPaywallProvider: mockRegisterPaywallProvider,
             requiresPayment: mockRequiresPayment,
             routes,
@@ -676,6 +730,7 @@ describe("paymentMiddlewareFromConfig", () => {
           initialize: vi.fn().mockResolvedValue(undefined),
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes: routes,
@@ -747,6 +802,7 @@ describe("HonoAdapter", () => {
         ({
           processHTTPRequest: mockProcessHTTPRequest,
           processSettlement: mockProcessSettlement,
+          createCompletedSettlementHeaders: mockCreateCompletedSettlementHeaders,
           registerPaywallProvider: mockRegisterPaywallProvider,
           requiresPayment: mockRequiresPayment,
           routes: routes,

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -232,7 +232,22 @@ export function paymentMiddlewareFromHTTPServer(
             reason: "handler_threw",
             error,
           });
-          throw error;
+          // Echo before-handler receipt so the payer still gets the tx hash.
+          // Only reachable for non-Error throws; compose diverts Error/HTTPException to >= 400.
+          if (!beforeHandlerSettlement) {
+            throw error;
+          }
+          const res = internalErrorResponse(c, error);
+          Object.entries(
+            httpServer.createCompletedSettlementHeaders(
+              beforeHandlerSettlement,
+              res.headers.get("Cache-Control"),
+            ),
+          ).forEach(([key, value]) => {
+            res.headers.set(key, value);
+          });
+          c.res = res;
+          return;
         }
 
         // Get the current response

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -233,6 +233,17 @@ export function paymentMiddlewareFromHTTPServer(
             responseStatus: res.status,
           });
           res.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
+          // Echo before-handler receipt (e.g. upfront) so the payer still gets the tx hash
+          if (beforeHandlerSettlement) {
+            Object.entries(
+              httpServer.createCompletedSettlementHeaders(
+                beforeHandlerSettlement,
+                res.headers.get("Cache-Control"),
+              ),
+            ).forEach(([key, value]) => {
+              res.headers.set(key, value);
+            });
+          }
           return;
         }
 

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -55,6 +55,18 @@ function facilitatorErrorResponse(c: Context, error: FacilitatorResponseError): 
 }
 
 /**
+ * Logs an unexpected error and builds a generic 500 without leaking internals.
+ *
+ * @param c - The current Hono context
+ * @param error - The unexpected error
+ * @returns A JSON 500 response
+ */
+function internalErrorResponse(c: Context, error: unknown): Response {
+  console.error(error);
+  return c.json({ error: "Internal Server Error" }, 500);
+}
+
+/**
  * Hono payment middleware for x402 protocol (direct HTTP server instance).
  *
  * Use this when you need to configure HTTP-level hooks.
@@ -163,7 +175,7 @@ export function paymentMiddlewareFromHTTPServer(
         if (facilitatorError) {
           return facilitatorErrorResponse(c, facilitatorError);
         }
-        throw error;
+        return internalErrorResponse(c, error);
       }
     }
 
@@ -181,7 +193,7 @@ export function paymentMiddlewareFromHTTPServer(
       if (error instanceof FacilitatorResponseError) {
         return facilitatorErrorResponse(c, error);
       }
-      throw error;
+      return internalErrorResponse(c, error);
     }
 
     // Handle the different result types

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -204,8 +204,13 @@ export function paymentMiddlewareFromHTTPServer(
 
       case "payment-verified":
         // Payment is valid, need to wrap response for settlement
-        const { cancellationDispatcher, paymentPayload, paymentRequirements, declaredExtensions } =
-          result;
+        const {
+          cancellationDispatcher,
+          beforeHandlerSettlement,
+          paymentPayload,
+          paymentRequirements,
+          declaredExtensions,
+        } = result;
 
         // Proceed to the next middleware or route handler
         try {
@@ -248,6 +253,8 @@ export function paymentMiddlewareFromHTTPServer(
             paymentRequirements,
             declaredExtensions,
             { request: context, responseBody, responseHeaders },
+            undefined,
+            beforeHandlerSettlement,
           );
 
           if (!settleResult.success) {

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -290,6 +290,8 @@ describe("paymentProxy", () => {
         }),
         responseBody: expect.any(Buffer),
       }),
+      undefined,
+      undefined,
     );
   });
 

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
-import type { HTTPProcessResult, PaywallProvider, FacilitatorClient } from "@x402/core/server";
+import type {
+  CompletedSettlement,
+  HTTPProcessResult,
+  PaywallProvider,
+  FacilitatorClient,
+} from "@x402/core/server";
 import { x402ResourceServer, x402HTTPResourceServer } from "@x402/core/server";
 import type { PaymentPayload, PaymentRequirements, SchemeNetworkServer } from "@x402/core/types";
 import { paymentProxy, paymentProxyFromConfig, withX402, type SchemeRegistration } from "./index";
@@ -20,6 +25,12 @@ vi.mock("./utils", async () => {
 const mockFunctions = {
   processHTTPRequest: vi.fn(),
   processSettlement: vi.fn(),
+  createCompletedSettlementHeaders: vi.fn(
+    (_settlement: unknown, existingCacheControl?: string | null) => ({
+      "PAYMENT-RESPONSE": "before-handler-receipt",
+      "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+    }),
+  ),
   requiresPayment: vi.fn().mockReturnValue(true),
 };
 
@@ -61,6 +72,8 @@ vi.mock("@x402/core/server", async importOriginal => {
       registerPaywallProvider: vi.fn(),
       processHTTPRequest: (...args: unknown[]) => mockFunctions.processHTTPRequest(...args),
       processSettlement: (...args: unknown[]) => mockFunctions.processSettlement(...args),
+      createCompletedSettlementHeaders: (...args: unknown[]) =>
+        mockFunctions.createCompletedSettlementHeaders(...args),
       requiresPayment: (...args: unknown[]) => mockFunctions.requiresPayment(...args),
       routes: routes || {},
       server: server || {
@@ -197,6 +210,8 @@ function setupMockCreateHttpServer(mockServer: x402HTTPResourceServer): void {
   // This allows the mock constructor to use the configured mocks
   mockFunctions.processHTTPRequest = mockServer.processHTTPRequest as ReturnType<typeof vi.fn>;
   mockFunctions.processSettlement = mockServer.processSettlement as ReturnType<typeof vi.fn>;
+  mockFunctions.createCompletedSettlementHeaders =
+    mockServer.createCompletedSettlementHeaders as ReturnType<typeof vi.fn>;
   mockFunctions.requiresPayment = mockServer.requiresPayment as ReturnType<typeof vi.fn>;
 
   // Also set up createHttpServer mock for backward compatibility
@@ -212,6 +227,12 @@ describe("paymentProxy", () => {
     // Reset shared mock functions
     mockFunctions.processHTTPRequest = vi.fn();
     mockFunctions.processSettlement = vi.fn();
+    mockFunctions.createCompletedSettlementHeaders = vi.fn(
+      (_settlement: unknown, existingCacheControl?: string | null) => ({
+        "PAYMENT-RESPONSE": "before-handler-receipt",
+        "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+      }),
+    );
     mockFunctions.requiresPayment = vi.fn().mockReturnValue(true);
   });
 
@@ -455,6 +476,98 @@ describe("withX402", () => {
         responseStatus: 400,
       }),
     );
+  });
+
+  it("echoes before-handler PAYMENT-RESPONSE when handler throws", async () => {
+    const beforeHandlerSettlement: CompletedSettlement = {
+      phase: "before-handler",
+      flow: "upfront",
+      result: { success: true, transaction: "0xdeposit", network: "eip155:84532" },
+      requirements: mockPaymentRequirements,
+    };
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const mockServer = createMockHttpServer({
+      type: "payment-verified",
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+      beforeHandlerSettlement,
+      cancellationDispatcher: { cancel } as PaymentVerifiedResult["cancellationDispatcher"],
+    });
+    setupMockCreateHttpServer(mockServer);
+    const handler = vi.fn().mockRejectedValue(new Error("handler exploded"));
+
+    const wrappedHandler = withX402(
+      handler,
+      mockRouteConfig,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const response = await wrappedHandler(createMockRequest());
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("PAYMENT-RESPONSE")).toBe("before-handler-receipt");
+    expect(mockServer.processSettlement).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledWith({ reason: "handler_threw", error: expect.any(Error) });
+  });
+
+  it("echoes before-handler PAYMENT-RESPONSE when handler returns 5xx", async () => {
+    const beforeHandlerSettlement: CompletedSettlement = {
+      phase: "before-handler",
+      flow: "upfront",
+      result: { success: true, transaction: "0xdeposit", network: "eip155:84532" },
+      requirements: mockPaymentRequirements,
+    };
+    const mockServer = createMockHttpServer({
+      type: "payment-verified",
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+      beforeHandlerSettlement,
+    });
+    setupMockCreateHttpServer(mockServer);
+    const handler = vi
+      .fn()
+      .mockResolvedValue(NextResponse.json({ error: "upstream" }, { status: 503 }));
+
+    const wrappedHandler = withX402(
+      handler,
+      mockRouteConfig,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const response = await wrappedHandler(createMockRequest());
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("PAYMENT-RESPONSE")).toBe("before-handler-receipt");
+    expect(mockServer.processSettlement).not.toHaveBeenCalled();
+  });
+
+  it("rethrows when handler throws and nothing settled before the handler", async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const mockServer = createMockHttpServer({
+      type: "payment-verified",
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+      cancellationDispatcher: { cancel } as PaymentVerifiedResult["cancellationDispatcher"],
+    });
+    setupMockCreateHttpServer(mockServer);
+    const handler = vi.fn().mockRejectedValue(new Error("handler exploded"));
+
+    const wrappedHandler = withX402(
+      handler,
+      mockRouteConfig,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+
+    await expect(wrappedHandler(createMockRequest())).rejects.toThrow("handler exploded");
+    expect(mockServer.createCompletedSettlementHeaders).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledWith({ reason: "handler_threw", error: expect.any(Error) });
   });
 
   it("returns 402 when settlement throws error, not the handler response", async () => {

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -148,6 +148,10 @@ function createMockHttpServer(
   return {
     processHTTPRequest: vi.fn().mockResolvedValue(normalizedResult),
     processSettlement: vi.fn().mockResolvedValue(settlementResult),
+    createCompletedSettlementHeaders: vi.fn((_settlement, existingCacheControl) => ({
+      "PAYMENT-RESPONSE": "before-handler-receipt",
+      "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+    })),
     registerPaywallProvider: vi.fn(),
     initialize: vi.fn().mockResolvedValue(undefined),
     requiresPayment: vi.fn().mockReturnValue(true),

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -156,6 +156,7 @@ export function paymentProxyFromHTTPServer(
           result.declaredExtensions,
           result.cancellationDispatcher,
           context,
+          result.beforeHandlerSettlement,
         );
       }
     }
@@ -348,6 +349,7 @@ export function withX402FromHTTPServer<T = unknown>(
           result.declaredExtensions,
           result.cancellationDispatcher,
           context,
+          result.beforeHandlerSettlement,
         ) as Promise<NextResponse<T>>;
       }
     }

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -356,7 +356,20 @@ export function withX402FromHTTPServer<T = unknown>(
             reason: "handler_threw",
             error,
           });
-          throw error;
+          // Echo before-handler receipt so the payer still gets the tx hash
+          if (!result.beforeHandlerSettlement) {
+            throw error;
+          }
+          const response = createInternalErrorResponse(error);
+          Object.entries(
+            httpServer.createCompletedSettlementHeaders(
+              result.beforeHandlerSettlement,
+              response.headers.get("Cache-Control"),
+            ),
+          ).forEach(([key, value]) => {
+            response.headers.set(key, value);
+          });
+          return response as NextResponse<T>;
         }
         return handleSettlement(
           httpServer,

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -19,6 +19,7 @@ import {
   handlePaymentError,
   handleSettlement,
   createFacilitatorErrorResponse,
+  createInternalErrorResponse,
   getFacilitatorResponseError,
 } from "./utils";
 
@@ -115,7 +116,7 @@ export function paymentProxyFromHTTPServer(
       if (facilitatorError) {
         return createFacilitatorErrorResponse(facilitatorError);
       }
-      throw error;
+      return createInternalErrorResponse(error);
     }
 
     // Await bazaar extension loading if needed
@@ -132,7 +133,7 @@ export function paymentProxyFromHTTPServer(
       if (error instanceof FacilitatorResponseError) {
         return createFacilitatorErrorResponse(error);
       }
-      throw error;
+      return createInternalErrorResponse(error);
     }
 
     // Handle the different result types
@@ -307,7 +308,15 @@ export function withX402FromHTTPServer<T = unknown>(
 
   return async (request: NextRequest): Promise<NextResponse<T>> => {
     // Only initialize when processing a protected route
-    await init();
+    try {
+      await init();
+    } catch (error) {
+      const facilitatorError = getFacilitatorResponseError(error);
+      if (facilitatorError) {
+        return createFacilitatorErrorResponse(facilitatorError) as NextResponse<T>;
+      }
+      return createInternalErrorResponse(error) as NextResponse<T>;
+    }
 
     // Await bazaar extension loading if needed
     if (bazaarPromise) {
@@ -318,7 +327,15 @@ export function withX402FromHTTPServer<T = unknown>(
     const context = createRequestContext(request);
 
     // Process payment requirement check
-    const result = await httpServer.processHTTPRequest(context, paywallConfig);
+    let result: Awaited<ReturnType<x402HTTPResourceServer["processHTTPRequest"]>>;
+    try {
+      result = await httpServer.processHTTPRequest(context, paywallConfig);
+    } catch (error) {
+      if (error instanceof FacilitatorResponseError) {
+        return createFacilitatorErrorResponse(error) as NextResponse<T>;
+      }
+      return createInternalErrorResponse(error) as NextResponse<T>;
+    }
 
     // Handle the different result types
     switch (result.type) {

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -372,6 +372,8 @@ describe("handleSettlement", () => {
         responseBody: expect.any(Buffer),
         responseHeaders: expect.any(Object),
       }),
+      undefined,
+      undefined,
     );
   });
 
@@ -420,6 +422,8 @@ describe("handleSettlement", () => {
           "settlement-overrides": JSON.stringify({ amount: "32%" }),
         }),
       }),
+      undefined,
+      undefined,
     );
   });
 

--- a/typescript/packages/http/next/src/utils.test.ts
+++ b/typescript/packages/http/next/src/utils.test.ts
@@ -304,6 +304,10 @@ describe("handleSettlement", () => {
       processSettlement: vi
         .fn()
         .mockResolvedValue({ success: true, headers: { "PAYMENT-RESPONSE": "settled" } }),
+      createCompletedSettlementHeaders: vi.fn((_settlement, existingCacheControl) => ({
+        "PAYMENT-RESPONSE": "before-handler-receipt",
+        "Cache-Control": existingCacheControl ? `${existingCacheControl}, private` : "private",
+      })),
     } as unknown as x402HTTPResourceServer;
   });
 
@@ -322,6 +326,7 @@ describe("handleSettlement", () => {
 
     expect(result.status).toBe(500);
     expect(mockHttpServer.processSettlement).not.toHaveBeenCalled();
+    expect(mockHttpServer.createCompletedSettlementHeaders).not.toHaveBeenCalled();
     expect(mockPaymentCancellationDispatcher.cancel).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: "handler_failed",
@@ -345,6 +350,40 @@ describe("handleSettlement", () => {
 
     expect(result.status).toBe(400);
     expect(mockHttpServer.processSettlement).not.toHaveBeenCalled();
+  });
+
+  it("echoes before-handler PAYMENT-RESPONSE when status >= 400", async () => {
+    const beforeHandlerSettlement = {
+      phase: "before-handler" as const,
+      flow: "upfront" as const,
+      result: {
+        success: true,
+        transaction: "0xdeposit",
+        network: "eip155:84532" as const,
+      },
+      requirements: mockRequirements,
+    };
+    const response = new NextResponse("Error", { status: 500 });
+
+    const result = await handleSettlement(
+      mockHttpServer,
+      response,
+      mockPaymentPayload,
+      mockRequirements,
+      mockDeclaredExtensions,
+      mockPaymentCancellationDispatcher,
+      mockHttpContext,
+      beforeHandlerSettlement,
+    );
+
+    expect(result.status).toBe(500);
+    expect(mockHttpServer.processSettlement).not.toHaveBeenCalled();
+    expect(mockHttpServer.createCompletedSettlementHeaders).toHaveBeenCalledWith(
+      beforeHandlerSettlement,
+      null,
+    );
+    expect(result.headers.get("PAYMENT-RESPONSE")).toBe("before-handler-receipt");
+    expect(result.headers.get("Cache-Control")).toBe("private");
   });
 
   it("adds settlement headers on successful settlement", async () => {

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -9,6 +9,7 @@ import {
   FacilitatorResponseError,
   getFacilitatorResponseError as getCoreFacilitatorResponseError,
   PaymentCancellationDispatcher,
+  CompletedSettlement,
   SETTLEMENT_OVERRIDES_HEADER,
   withPrivateCacheControl,
 } from "@x402/core/server";
@@ -160,8 +161,9 @@ export function handlePaymentError(response: HTTPResponseInstructions): NextResp
  * @param paymentPayload - The payment payload from the client
  * @param paymentRequirements - The payment requirements for the route
  * @param declaredExtensions - Optional declared extensions (for per-key enrichment)
- * @param cancellationDispatcher - Cancels verified payments that should not settle
+ * @param cancellationDispatcher - Cancels payments that should not settle after the handler
  * @param httpContext - HTTP request context for extensions
+ * @param beforeHandlerSettlement - Optional before-handler settle for PAYMENT-RESPONSE echo
  * @returns The response with settlement headers or an error response if settlement fails
  */
 export async function handleSettlement(
@@ -172,6 +174,7 @@ export async function handleSettlement(
   declaredExtensions: Record<string, unknown> | undefined,
   cancellationDispatcher: PaymentCancellationDispatcher,
   httpContext: HTTPRequestContext,
+  beforeHandlerSettlement?: CompletedSettlement,
 ): Promise<NextResponse> {
   // If the response from the protected route is >= 400, do not settle payment
   if (response.status >= 400) {
@@ -197,6 +200,8 @@ export async function handleSettlement(
       paymentRequirements,
       declaredExtensions,
       { request: httpContext, responseBody, responseHeaders },
+      undefined,
+      beforeHandlerSettlement,
     );
 
     if (!result.success) {

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -40,6 +40,20 @@ export function createFacilitatorErrorResponse(error: FacilitatorResponseError):
 }
 
 /**
+ * Logs an unexpected error and builds a generic 500 without leaking internals.
+ *
+ * @param error - The unexpected error
+ * @returns A JSON 500 response
+ */
+export function createInternalErrorResponse(error: unknown): NextResponse {
+  console.error(error);
+  return new NextResponse(JSON.stringify({ error: "Internal Server Error" }), {
+    status: 500,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
  * Prepares an existing x402HTTPResourceServer with initialization logic
  *
  * @param httpServer - Pre-configured x402HTTPResourceServer instance

--- a/typescript/packages/http/next/src/utils.ts
+++ b/typescript/packages/http/next/src/utils.ts
@@ -183,6 +183,17 @@ export async function handleSettlement(
       responseStatus: response.status,
     });
     response.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
+    // Echo before-handler receipt (e.g. upfront) so the payer still gets the tx hash
+    if (beforeHandlerSettlement) {
+      Object.entries(
+        httpServer.createCompletedSettlementHeaders(
+          beforeHandlerSettlement,
+          response.headers.get("Cache-Control"),
+        ),
+      ).forEach(([key, value]) => {
+        response.headers.set(key, value);
+      });
+    }
     return response;
   }
 

--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -435,7 +435,15 @@ async function processPaidToolCall<TArgs extends Record<string, unknown>>(
       reason: "handler_threw",
       error: error instanceof Error ? error : new Error(String(error)),
     });
-    throw error;
+    // Echo before-handler receipt so the payer still gets the tx hash
+    if (!beforeHandlerSettlement) {
+      throw error;
+    }
+    return {
+      content: [{ type: "text", text: "Internal Server Error" }],
+      isError: true,
+      _meta: { [MCP_PAYMENT_RESPONSE_META_KEY]: beforeHandlerSettlement.result },
+    };
   }
   transportContext.result = result;
 

--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -400,7 +400,17 @@ export function createPaymentWrapper(
       // If the tool handler returned an error, don't proceed to settlement
       if (result.isError) {
         await cancellationDispatcher.cancel({ reason: "handler_failed" });
-        return result;
+        // Echo before-handler receipt (e.g. upfront) so the payer still gets the tx hash
+        if (!beforeHandlerSettlement) {
+          return result;
+        }
+        return {
+          ...result,
+          _meta: {
+            ...(result._meta as Record<string, unknown> | undefined),
+            [MCP_PAYMENT_RESPONSE_META_KEY]: beforeHandlerSettlement.result,
+          },
+        };
       }
 
       return settlePaymentResult(

--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -336,6 +336,7 @@ export function createPaymentWrapper(
           }
           beforeHandlerSettlement = {
             phase: "before-handler",
+            flow,
             result: beforeSettle,
             requirements: paymentRequirements,
           };
@@ -469,7 +470,9 @@ async function settlePaymentResult(
   beforeHandlerSettlement?: CompletedSettlement,
 ): Promise<WrappedToolResult> {
   try {
-    const flow = resourceServer.getPaymentFlow(paymentPayload, paymentRequirements);
+    const flow =
+      beforeHandlerSettlement?.flow ??
+      resourceServer.getPaymentFlow(paymentPayload, paymentRequirements);
     const phases = resolvePaymentFlowPhases(flow);
 
     if (!phases.settleAfterHandler) {

--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -6,7 +6,11 @@
  */
 
 import type { PaymentPayload, PaymentRequirements, ResourceInfo } from "@x402/core/types";
-import { x402ResourceServer } from "@x402/core/server";
+import {
+  CompletedSettlement,
+  resolvePaymentFlowPhases,
+  x402ResourceServer,
+} from "@x402/core/server";
 
 import type {
   MCPToolContext,
@@ -264,23 +268,8 @@ export function createPaymentWrapper(
       }
 
       const extMap = config.extensions ?? {};
-      const verifyResult = await resourceServer.verifyPayment(
-        paymentPayload,
-        paymentRequirements,
-        extMap,
-        transportContext,
-      );
-
-      if (!verifyResult.isValid) {
-        return createPaymentRequiredResult(
-          resourceServer,
-          toolName,
-          config,
-          verifyResult.invalidReason || "Payment verification failed",
-          transportContext,
-          paymentPayload,
-        );
-      }
+      const flow = resourceServer.getPaymentFlow(paymentPayload, paymentRequirements);
+      const phases = resolvePaymentFlowPhases(flow);
 
       // Build hook context
       const hookContext: ServerHookContext = {
@@ -289,26 +278,85 @@ export function createPaymentWrapper(
         paymentRequirements,
         paymentPayload,
       };
+
+      if (phases.verifyBeforeHandler) {
+        const verifyResult = await resourceServer.verifyPayment(
+          paymentPayload,
+          paymentRequirements,
+          extMap,
+          transportContext,
+        );
+
+        if (!verifyResult.isValid) {
+          return createPaymentRequiredResult(
+            resourceServer,
+            toolName,
+            config,
+            verifyResult.invalidReason || "Payment verification failed",
+            transportContext,
+            paymentPayload,
+          );
+        }
+
+        if (verifyResult.skipHandler) {
+          return settlePaymentResult(
+            resourceServer,
+            toolName,
+            config,
+            hookContext,
+            paymentPayload,
+            paymentRequirements,
+            extMap,
+            transportContext,
+            createSkipHandlerResult(verifyResult.skipHandler.body),
+          );
+        }
+      }
+
+      let beforeHandlerSettlement: CompletedSettlement | undefined;
+
+      if (phases.settleBeforeHandler) {
+        try {
+          const beforeSettle = await resourceServer.settlePayment(
+            paymentPayload,
+            paymentRequirements,
+            extMap,
+            transportContext,
+            undefined,
+            "before-handler",
+          );
+          if (!beforeSettle.success) {
+            return createSettlementFailedResult(
+              resourceServer,
+              toolName,
+              config,
+              beforeSettle.errorReason || beforeSettle.errorMessage || "Settlement failed",
+              transportContext,
+            );
+          }
+          beforeHandlerSettlement = {
+            phase: "before-handler",
+            result: beforeSettle,
+            requirements: paymentRequirements,
+          };
+        } catch (settleError) {
+          return createSettlementFailedResult(
+            resourceServer,
+            toolName,
+            config,
+            settleError instanceof Error ? settleError.message : "Settlement failed",
+            transportContext,
+          );
+        }
+      }
+
       const cancellationDispatcher = resourceServer.createPaymentCancellationDispatcher(
         paymentPayload,
         paymentRequirements,
         extMap,
         transportContext,
+        beforeHandlerSettlement ? ["before-handler"] : [],
       );
-
-      if (verifyResult.skipHandler) {
-        return settlePaymentResult(
-          resourceServer,
-          toolName,
-          config,
-          hookContext,
-          paymentPayload,
-          paymentRequirements,
-          extMap,
-          transportContext,
-          createSkipHandlerResult(verifyResult.skipHandler.body),
-        );
-      }
 
       // Run onBeforeExecution hook if present
       if (config.hooks?.onBeforeExecution) {
@@ -364,6 +412,7 @@ export function createPaymentWrapper(
         extMap,
         transportContext,
         result,
+        beforeHandlerSettlement,
       );
     };
   };
@@ -404,6 +453,7 @@ function createSkipHandlerResult(body: unknown): WrappedToolResult {
  * @param extMap - Extension map forwarded to the settlement call.
  * @param transportContext - MCP payment transport context for this invocation.
  * @param result - Successful tool result to merge settlement metadata into.
+ * @param beforeHandlerSettlement - Optional before-handler settle for PAYMENT-RESPONSE echo.
  * @returns Tool result including `_meta` with settlement details, or a settlement-failure error result.
  */
 async function settlePaymentResult(
@@ -416,13 +466,47 @@ async function settlePaymentResult(
   extMap: Record<string, unknown>,
   transportContext: MCPPaymentTransportContext,
   result: WrappedToolResult | ToolResult,
+  beforeHandlerSettlement?: CompletedSettlement,
 ): Promise<WrappedToolResult> {
   try {
+    const flow = resourceServer.getPaymentFlow(paymentPayload, paymentRequirements);
+    const phases = resolvePaymentFlowPhases(flow);
+
+    if (!phases.settleAfterHandler) {
+      const settleResult = beforeHandlerSettlement?.result;
+      if (!settleResult) {
+        return {
+          ...result,
+          _meta: {
+            ...(result._meta as Record<string, unknown> | undefined),
+          },
+        };
+      }
+
+      if (config.hooks?.onAfterSettlement) {
+        const settlementContext: SettlementContext = {
+          ...hookContext,
+          settlement: settleResult,
+        };
+        await config.hooks.onAfterSettlement(settlementContext);
+      }
+
+      return {
+        ...result,
+        _meta: {
+          ...(result._meta as Record<string, unknown> | undefined),
+          [MCP_PAYMENT_RESPONSE_META_KEY]: settleResult,
+        },
+      };
+    }
+
     const settleResult = await resourceServer.settlePayment(
       paymentPayload,
       paymentRequirements,
       extMap,
       transportContext,
+      undefined,
+      "after-handler",
     );
 
     if (config.hooks?.onAfterSettlement) {

--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -279,38 +279,36 @@ export function createPaymentWrapper(
         paymentPayload,
       };
 
-      if (phases.verifyBeforeHandler) {
-        const verifyResult = await resourceServer.verifyPayment(
+      const verifyResult = await resourceServer.verifyPayment(
+        paymentPayload,
+        paymentRequirements,
+        extMap,
+        transportContext,
+      );
+
+      if (!verifyResult.isValid) {
+        return createPaymentRequiredResult(
+          resourceServer,
+          toolName,
+          config,
+          verifyResult.invalidReason || "Payment verification failed",
+          transportContext,
+          paymentPayload,
+        );
+      }
+
+      if (verifyResult.skipHandler) {
+        return settlePaymentResult(
+          resourceServer,
+          toolName,
+          config,
+          hookContext,
           paymentPayload,
           paymentRequirements,
           extMap,
           transportContext,
+          createSkipHandlerResult(verifyResult.skipHandler.body),
         );
-
-        if (!verifyResult.isValid) {
-          return createPaymentRequiredResult(
-            resourceServer,
-            toolName,
-            config,
-            verifyResult.invalidReason || "Payment verification failed",
-            transportContext,
-            paymentPayload,
-          );
-        }
-
-        if (verifyResult.skipHandler) {
-          return settlePaymentResult(
-            resourceServer,
-            toolName,
-            config,
-            hookContext,
-            paymentPayload,
-            paymentRequirements,
-            extMap,
-            transportContext,
-            createSkipHandlerResult(verifyResult.skipHandler.body),
-          );
-        }
       }
 
       let beforeHandlerSettlement: CompletedSettlement | undefined;

--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -5,9 +5,10 @@
  * Use createPaymentWrapper to wrap tool handlers with payment verification and settlement.
  */
 
-import type { PaymentPayload, PaymentRequirements, ResourceInfo } from "@x402/core/types";
+import type { Network, PaymentPayload, PaymentRequirements, ResourceInfo } from "@x402/core/types";
 import {
   CompletedSettlement,
+  resolvePaymentFlow,
   resolvePaymentFlowPhases,
   x402ResourceServer,
 } from "@x402/core/server";
@@ -189,242 +190,294 @@ export function createPaymentWrapper(
     throw new Error("PaymentWrapperConfig.accepts must have at least one payment requirement");
   }
 
+  for (const requirement of config.accepts) {
+    const schemeServer = resourceServer.getRegisteredScheme(
+      requirement.network as Network,
+      requirement.scheme,
+    );
+    if (!schemeServer) {
+      throw new Error(
+        `[x402] No scheme implementation registered for "${requirement.scheme}" on network "${requirement.network}"`,
+      );
+    }
+    resolvePaymentFlow(schemeServer, requirement);
+  }
+
   // Return wrapper function that takes only the handler
   return <TArgs extends Record<string, unknown>>(
     handler: PaymentWrappedHandler<TArgs>,
   ): MCPToolCallback<TArgs> => {
     return async (args: TArgs, extra: unknown): Promise<WrappedToolResult> => {
-      // Extract _meta from extra if it's an object
-      const _meta = (extra as { _meta?: Record<string, unknown> })?._meta;
-      // Derive toolName from resource URL if available, otherwise use placeholder
-      const toolName = config.resource?.url?.replace("mcp://tool/", "") || "paid_tool";
-
-      const context: MCPToolContext = {
-        toolName,
-        arguments: args,
-        meta: _meta,
-      };
-      const transportContext: MCPPaymentTransportContext = {
-        toolName,
-        arguments: args,
-        meta: _meta,
-      };
-
-      // Extract payment from _meta if present
-      const paymentPayload = extractPaymentFromMeta({
-        name: toolName,
-        arguments: args,
-        _meta,
-      });
-
-      // If no payment provided, return 402 error
-      if (!paymentPayload) {
-        return createPaymentRequiredResult(
-          resourceServer,
-          toolName,
-          config,
-          "Payment required to access this tool",
-          transportContext,
-        );
-      }
-
-      const resourceInfoForMatch = buildToolResourceInfo(toolName, config);
-      // Match on post-enrichment accepts (same as HTTP): extensions may change payTo etc.
-      const paymentRequiredForMatch = await resourceServer.createPaymentRequiredResponse(
-        config.accepts,
-        resourceInfoForMatch,
-        undefined,
-        config.extensions,
-        transportContext,
-      );
-      const paymentRequirements = resourceServer.findMatchingRequirements(
-        paymentRequiredForMatch.accepts,
-        paymentPayload,
-      );
-
-      if (!paymentRequirements) {
-        return createPaymentRequiredResult(
-          resourceServer,
-          toolName,
-          config,
-          "No matching payment requirements found",
-          transportContext,
-        );
-      }
-
-      const extensionResult = resourceServer.validateExtensions(
-        paymentRequiredForMatch,
-        paymentPayload,
-      );
-      if (!extensionResult.valid) {
-        return createPaymentRequiredResult(
-          resourceServer,
-          toolName,
-          config,
-          extensionResult.invalidReason,
-          transportContext,
-          paymentPayload,
-        );
-      }
-
-      const extMap = config.extensions ?? {};
-      const flow = resourceServer.getPaymentFlow(paymentPayload, paymentRequirements);
-      const phases = resolvePaymentFlowPhases(flow);
-
-      // Build hook context
-      const hookContext: ServerHookContext = {
-        toolName,
-        arguments: args,
-        paymentRequirements,
-        paymentPayload,
-      };
-
-      const verifyResult = await resourceServer.verifyPayment(
-        paymentPayload,
-        paymentRequirements,
-        extMap,
-        transportContext,
-      );
-
-      if (!verifyResult.isValid) {
-        return createPaymentRequiredResult(
-          resourceServer,
-          toolName,
-          config,
-          verifyResult.invalidReason || "Payment verification failed",
-          transportContext,
-          paymentPayload,
-        );
-      }
-
-      if (verifyResult.skipHandler) {
-        return settlePaymentResult(
-          resourceServer,
-          toolName,
-          config,
-          hookContext,
-          paymentPayload,
-          paymentRequirements,
-          extMap,
-          transportContext,
-          createSkipHandlerResult(verifyResult.skipHandler.body),
-        );
-      }
-
-      let beforeHandlerSettlement: CompletedSettlement | undefined;
-
-      if (phases.settleBeforeHandler) {
-        try {
-          const beforeSettle = await resourceServer.settlePayment(
-            paymentPayload,
-            paymentRequirements,
-            extMap,
-            transportContext,
-            undefined,
-            "before-handler",
-          );
-          if (!beforeSettle.success) {
-            return createSettlementFailedResult(
-              resourceServer,
-              toolName,
-              config,
-              beforeSettle.errorReason || beforeSettle.errorMessage || "Settlement failed",
-              transportContext,
-            );
-          }
-          beforeHandlerSettlement = {
-            phase: "before-handler",
-            flow,
-            result: beforeSettle,
-            requirements: paymentRequirements,
-          };
-        } catch (settleError) {
-          return createSettlementFailedResult(
-            resourceServer,
-            toolName,
-            config,
-            settleError instanceof Error ? settleError.message : "Settlement failed",
-            transportContext,
-          );
-        }
-      }
-
-      const cancellationDispatcher = resourceServer.createPaymentCancellationDispatcher(
-        paymentPayload,
-        paymentRequirements,
-        extMap,
-        transportContext,
-        beforeHandlerSettlement ? ["before-handler"] : [],
-      );
-
-      // Run onBeforeExecution hook if present
-      if (config.hooks?.onBeforeExecution) {
-        const hookResult = await config.hooks.onBeforeExecution(hookContext);
-        if (hookResult === false) {
-          return createPaymentRequiredResult(
-            resourceServer,
-            toolName,
-            config,
-            "Execution blocked by hook",
-            transportContext,
-          );
-        }
-      }
-
-      // Execute the tool handler
-      let result: ToolResult;
+      let handlerThrew = false;
       try {
-        result = await handler(args, context);
-      } catch (error) {
-        await cancellationDispatcher.cancel({
-          reason: "handler_threw",
-          error: error instanceof Error ? error : new Error(String(error)),
+        return await processPaidToolCall(resourceServer, config, handler, args, extra, () => {
+          handlerThrew = true;
         });
-        throw error;
-      }
-      transportContext.result = result;
-
-      // Build after execution context
-      const afterExecContext: AfterExecutionContext = {
-        ...hookContext,
-        result,
-      };
-
-      // Run onAfterExecution hook if present
-      if (config.hooks?.onAfterExecution) {
-        await config.hooks.onAfterExecution(afterExecContext);
-      }
-
-      // If the tool handler returned an error, don't proceed to settlement
-      if (result.isError) {
-        await cancellationDispatcher.cancel({ reason: "handler_failed" });
-        // Echo before-handler receipt (e.g. upfront) so the payer still gets the tx hash
-        if (!beforeHandlerSettlement) {
-          return result;
+      } catch (error) {
+        if (handlerThrew) {
+          throw error;
         }
+        console.error(error);
         return {
-          ...result,
-          _meta: {
-            ...(result._meta as Record<string, unknown> | undefined),
-            [MCP_PAYMENT_RESPONSE_META_KEY]: beforeHandlerSettlement.result,
-          },
+          content: [{ type: "text", text: "Internal Server Error" }],
+          isError: true,
         };
       }
+    };
+  };
+}
 
-      return settlePaymentResult(
+/**
+ * Runs verify / settle / handler for a single paid MCP tool call.
+ *
+ * @param resourceServer - Resource server used for payment processing
+ * @param config - Payment wrapper configuration
+ * @param handler - Underlying tool handler
+ * @param args - Tool arguments
+ * @param extra - MCP extra/context (may include _meta payment)
+ * @param markHandlerThrew - Called when the tool handler throws so the outer
+ *   catch can rethrow without sanitizing
+ * @returns Wrapped MCP tool result
+ */
+async function processPaidToolCall<TArgs extends Record<string, unknown>>(
+  resourceServer: x402ResourceServer,
+  config: PaymentWrapperConfig,
+  handler: PaymentWrappedHandler<TArgs>,
+  args: TArgs,
+  extra: unknown,
+  markHandlerThrew: () => void,
+): Promise<WrappedToolResult> {
+  // Extract _meta from extra if it's an object
+  const _meta = (extra as { _meta?: Record<string, unknown> })?._meta;
+  // Derive toolName from resource URL if available, otherwise use placeholder
+  const toolName = config.resource?.url?.replace("mcp://tool/", "") || "paid_tool";
+
+  const context: MCPToolContext = {
+    toolName,
+    arguments: args,
+    meta: _meta,
+  };
+  const transportContext: MCPPaymentTransportContext = {
+    toolName,
+    arguments: args,
+    meta: _meta,
+  };
+
+  // Extract payment from _meta if present
+  const paymentPayload = extractPaymentFromMeta({
+    name: toolName,
+    arguments: args,
+    _meta,
+  });
+
+  // If no payment provided, return 402 error
+  if (!paymentPayload) {
+    return createPaymentRequiredResult(
+      resourceServer,
+      toolName,
+      config,
+      "Payment required to access this tool",
+      transportContext,
+    );
+  }
+
+  const resourceInfoForMatch = buildToolResourceInfo(toolName, config);
+  // Match on post-enrichment accepts (same as HTTP): extensions may change payTo etc.
+  const paymentRequiredForMatch = await resourceServer.createPaymentRequiredResponse(
+    config.accepts,
+    resourceInfoForMatch,
+    undefined,
+    config.extensions,
+    transportContext,
+  );
+  const paymentRequirements = resourceServer.findMatchingRequirements(
+    paymentRequiredForMatch.accepts,
+    paymentPayload,
+  );
+
+  if (!paymentRequirements) {
+    return createPaymentRequiredResult(
+      resourceServer,
+      toolName,
+      config,
+      "No matching payment requirements found",
+      transportContext,
+    );
+  }
+
+  const extensionResult = resourceServer.validateExtensions(
+    paymentRequiredForMatch,
+    paymentPayload,
+  );
+  if (!extensionResult.valid) {
+    return createPaymentRequiredResult(
+      resourceServer,
+      toolName,
+      config,
+      extensionResult.invalidReason,
+      transportContext,
+      paymentPayload,
+    );
+  }
+
+  const extMap = config.extensions ?? {};
+  const flow = resourceServer.getPaymentFlow(paymentPayload, paymentRequirements);
+  const phases = resolvePaymentFlowPhases(flow);
+
+  // Build hook context
+  const hookContext: ServerHookContext = {
+    toolName,
+    arguments: args,
+    paymentRequirements,
+    paymentPayload,
+  };
+
+  const verifyResult = await resourceServer.verifyPayment(
+    paymentPayload,
+    paymentRequirements,
+    extMap,
+    transportContext,
+  );
+
+  if (!verifyResult.isValid) {
+    return createPaymentRequiredResult(
+      resourceServer,
+      toolName,
+      config,
+      verifyResult.invalidReason || "Payment verification failed",
+      transportContext,
+      paymentPayload,
+    );
+  }
+
+  if (verifyResult.skipHandler) {
+    return settlePaymentResult(
+      resourceServer,
+      toolName,
+      config,
+      hookContext,
+      paymentPayload,
+      paymentRequirements,
+      extMap,
+      transportContext,
+      createSkipHandlerResult(verifyResult.skipHandler.body),
+    );
+  }
+
+  let beforeHandlerSettlement: CompletedSettlement | undefined;
+
+  if (phases.settleBeforeHandler) {
+    try {
+      const beforeSettle = await resourceServer.settlePayment(
+        paymentPayload,
+        paymentRequirements,
+        extMap,
+        transportContext,
+        undefined,
+        "before-handler",
+      );
+      if (!beforeSettle.success) {
+        return createSettlementFailedResult(
+          resourceServer,
+          toolName,
+          config,
+          beforeSettle.errorReason || beforeSettle.errorMessage || "Settlement failed",
+          transportContext,
+        );
+      }
+      beforeHandlerSettlement = {
+        phase: "before-handler",
+        flow,
+        result: beforeSettle,
+        requirements: paymentRequirements,
+      };
+    } catch (settleError) {
+      console.error(settleError);
+      return createSettlementFailedResult(
         resourceServer,
         toolName,
         config,
-        hookContext,
-        paymentPayload,
-        paymentRequirements,
-        extMap,
+        "Settlement failed",
         transportContext,
-        result,
-        beforeHandlerSettlement,
       );
-    };
+    }
+  }
+
+  const cancellationDispatcher = resourceServer.createPaymentCancellationDispatcher(
+    paymentPayload,
+    paymentRequirements,
+    extMap,
+    transportContext,
+    beforeHandlerSettlement ? ["before-handler"] : [],
+  );
+
+  // Run onBeforeExecution hook if present
+  if (config.hooks?.onBeforeExecution) {
+    const hookResult = await config.hooks.onBeforeExecution(hookContext);
+    if (hookResult === false) {
+      return createPaymentRequiredResult(
+        resourceServer,
+        toolName,
+        config,
+        "Execution blocked by hook",
+        transportContext,
+      );
+    }
+  }
+
+  // Execute the tool handler
+  let result: ToolResult;
+  try {
+    result = await handler(args, context);
+  } catch (error) {
+    markHandlerThrew();
+    await cancellationDispatcher.cancel({
+      reason: "handler_threw",
+      error: error instanceof Error ? error : new Error(String(error)),
+    });
+    throw error;
+  }
+  transportContext.result = result;
+
+  // Build after execution context
+  const afterExecContext: AfterExecutionContext = {
+    ...hookContext,
+    result,
   };
+
+  // Run onAfterExecution hook if present
+  if (config.hooks?.onAfterExecution) {
+    await config.hooks.onAfterExecution(afterExecContext);
+  }
+
+  // If the tool handler returned an error, don't proceed to settlement
+  if (result.isError) {
+    await cancellationDispatcher.cancel({ reason: "handler_failed" });
+    // Echo before-handler receipt (e.g. upfront) so the payer still gets the tx hash
+    if (!beforeHandlerSettlement) {
+      return result;
+    }
+    return {
+      ...result,
+      _meta: {
+        ...(result._meta as Record<string, unknown> | undefined),
+        [MCP_PAYMENT_RESPONSE_META_KEY]: beforeHandlerSettlement.result,
+      },
+    };
+  }
+
+  return settlePaymentResult(
+    resourceServer,
+    toolName,
+    config,
+    hookContext,
+    paymentPayload,
+    paymentRequirements,
+    extMap,
+    transportContext,
+    result,
+    beforeHandlerSettlement,
+  );
 }
 
 /**
@@ -536,11 +589,12 @@ async function settlePaymentResult(
       },
     };
   } catch (settleError) {
+    console.error(settleError);
     return createSettlementFailedResult(
       resourceServer,
       toolName,
       config,
-      settleError instanceof Error ? settleError.message : "Settlement failed",
+      "Settlement failed",
       transportContext,
     );
   }

--- a/typescript/packages/mcp/test/unit/server.test.ts
+++ b/typescript/packages/mcp/test/unit/server.test.ts
@@ -555,6 +555,37 @@ describe("createPaymentWrapper", () => {
       expect(mockResourceServer.settlePayment).not.toHaveBeenCalled();
     });
 
+    it("should echo before-handler settlement when tool handler throws under upfront", async () => {
+      mockResourceServer.getPaymentFlow.mockReturnValue("upfront");
+      mockResourceServer.settlePayment.mockResolvedValue(mockSettleResponse);
+
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+        },
+      );
+      const error = new Error("handler failed");
+      const handler = vi.fn().mockRejectedValue(error);
+      const wrappedHandler = paid(handler);
+
+      const result = await wrappedHandler(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "Internal Server Error" }]);
+      expect(result._meta?.[MCP_PAYMENT_RESPONSE_META_KEY]).toEqual(mockSettleResponse);
+      expect(mockResourceServer.settlePayment).toHaveBeenCalledTimes(1);
+      const dispatcher = mockResourceServer.createPaymentCancellationDispatcher.mock.results[0]
+        .value as { cancel: ReturnType<typeof vi.fn> };
+      expect(dispatcher.cancel).toHaveBeenCalledWith({
+        reason: "handler_threw",
+        error,
+      });
+    });
+
     it("should settle skipHandler responses without executing the tool", async () => {
       mockResourceServer.verifyPayment.mockResolvedValueOnce({
         isValid: true,

--- a/typescript/packages/mcp/test/unit/server.test.ts
+++ b/typescript/packages/mcp/test/unit/server.test.ts
@@ -18,12 +18,24 @@ import type {
 interface MockResourceServer {
   findMatchingRequirements: ReturnType<typeof vi.fn>;
   validateExtensions: ReturnType<typeof vi.fn>;
+  getRegisteredScheme: ReturnType<typeof vi.fn>;
   getPaymentFlow: ReturnType<typeof vi.fn>;
   verifyPayment: ReturnType<typeof vi.fn>;
   settlePayment: ReturnType<typeof vi.fn>;
   createPaymentRequiredResponse: ReturnType<typeof vi.fn>;
   createPaymentCancellationDispatcher: ReturnType<typeof vi.fn>;
 }
+
+const mockSchemeServer = {
+  scheme: "exact",
+  defaultAssetTransferMethod: "default",
+  paymentFlows: {
+    default: {
+      supported: ["authorization", "upfront", "escrow"] as const,
+      default: "authorization" as const,
+    },
+  },
+};
 
 // ============================================================================
 // Test Fixtures
@@ -90,6 +102,7 @@ function createMockResourceServer(): MockResourceServer {
   return {
     findMatchingRequirements: vi.fn().mockReturnValue(mockPaymentRequirements),
     validateExtensions: vi.fn().mockReturnValue({ valid: true }),
+    getRegisteredScheme: vi.fn().mockReturnValue(mockSchemeServer),
     getPaymentFlow: vi.fn().mockReturnValue("authorization"),
     verifyPayment: vi.fn().mockResolvedValue(mockVerifyResponse),
     settlePayment: vi.fn().mockResolvedValue(mockSettleResponse),
@@ -394,7 +407,7 @@ describe("createPaymentWrapper", () => {
       expect(mockResourceServer.createPaymentRequiredResponse).toHaveBeenCalledWith(
         [mockPaymentRequirements],
         expect.any(Object),
-        "Payment settlement failed: facilitator unavailable",
+        "Payment settlement failed: Settlement failed",
         undefined,
         expect.any(Object),
         undefined,
@@ -671,6 +684,34 @@ describe("createPaymentWrapper", () => {
           {} as Parameters<typeof createPaymentWrapper>[1],
         ),
       ).toThrow("PaymentWrapperConfig.accepts must have at least one payment requirement");
+    });
+
+    it("should throw at creation for unsupported paymentFlow", () => {
+      expect(() =>
+        createPaymentWrapper(
+          mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+          {
+            accepts: [
+              {
+                ...mockPaymentRequirements,
+                extra: { paymentFlow: "not-a-real-flow" },
+              },
+            ],
+          },
+        ),
+      ).toThrow(/does not support paymentFlow/);
+    });
+
+    it("should throw at creation when scheme is not registered", () => {
+      mockResourceServer.getRegisteredScheme.mockReturnValueOnce(undefined);
+      expect(() =>
+        createPaymentWrapper(
+          mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+          {
+            accepts: [mockPaymentRequirements],
+          },
+        ),
+      ).toThrow(/No scheme implementation registered/);
     });
   });
 
@@ -967,6 +1008,34 @@ describe("createPaymentWrapper", () => {
       expect(handler).toHaveBeenCalled(); // Handler executed
       expect(result.isError).toBe(true); // But error returned due to settlement failure
       expect(result.structuredContent).toBeDefined();
+    });
+  });
+
+  describe("unexpected errors", () => {
+    it("returns a generic Internal Server Error without leaking internals", async () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockResourceServer.getPaymentFlow.mockImplementationOnce(() => {
+        throw new Error('[x402] Scheme "exact" does not support paymentFlow "escrow"');
+      });
+
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+        },
+      );
+
+      const handler = vi.fn();
+      const result = await paid(handler)(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([{ type: "text", text: "Internal Server Error" }]);
+      expect(JSON.stringify(result)).not.toContain("does not support paymentFlow");
+      expect(consoleError).toHaveBeenCalled();
+      consoleError.mockRestore();
     });
   });
 });

--- a/typescript/packages/mcp/test/unit/server.test.ts
+++ b/typescript/packages/mcp/test/unit/server.test.ts
@@ -18,6 +18,7 @@ import type {
 interface MockResourceServer {
   findMatchingRequirements: ReturnType<typeof vi.fn>;
   validateExtensions: ReturnType<typeof vi.fn>;
+  getPaymentFlow: ReturnType<typeof vi.fn>;
   verifyPayment: ReturnType<typeof vi.fn>;
   settlePayment: ReturnType<typeof vi.fn>;
   createPaymentRequiredResponse: ReturnType<typeof vi.fn>;
@@ -89,10 +90,13 @@ function createMockResourceServer(): MockResourceServer {
   return {
     findMatchingRequirements: vi.fn().mockReturnValue(mockPaymentRequirements),
     validateExtensions: vi.fn().mockReturnValue({ valid: true }),
+    getPaymentFlow: vi.fn().mockReturnValue("authorize"),
     verifyPayment: vi.fn().mockResolvedValue(mockVerifyResponse),
     settlePayment: vi.fn().mockResolvedValue(mockSettleResponse),
     createPaymentRequiredResponse: vi.fn().mockResolvedValue(mockPaymentRequired),
-    createPaymentCancellationDispatcher: vi.fn().mockReturnValue({ cancel }),
+    createPaymentCancellationDispatcher: vi.fn().mockReturnValue({
+      cancel,
+    }),
   };
 }
 
@@ -183,6 +187,8 @@ describe("createPaymentWrapper", () => {
           toolName: "paid_tool",
           arguments: { test: "arg" },
         }),
+        undefined,
+        "after-handler",
       );
     });
 
@@ -356,6 +362,7 @@ describe("createPaymentWrapper", () => {
         mockPaymentRequirements,
         {},
         expectedContext,
+        [],
       );
       expect(mockResourceServer.settlePayment).toHaveBeenCalledWith(
         mockPaymentPayload,
@@ -367,6 +374,8 @@ describe("createPaymentWrapper", () => {
             content: [{ type: "text", text: "success" }],
           }),
         }),
+        undefined,
+        "after-handler",
       );
     });
 

--- a/typescript/packages/mcp/test/unit/server.test.ts
+++ b/typescript/packages/mcp/test/unit/server.test.ts
@@ -90,7 +90,7 @@ function createMockResourceServer(): MockResourceServer {
   return {
     findMatchingRequirements: vi.fn().mockReturnValue(mockPaymentRequirements),
     validateExtensions: vi.fn().mockReturnValue({ valid: true }),
-    getPaymentFlow: vi.fn().mockReturnValue("authorize"),
+    getPaymentFlow: vi.fn().mockReturnValue("authorization"),
     verifyPayment: vi.fn().mockResolvedValue(mockVerifyResponse),
     settlePayment: vi.fn().mockResolvedValue(mockSettleResponse),
     createPaymentRequiredResponse: vi.fn().mockResolvedValue(mockPaymentRequired),

--- a/typescript/packages/mcp/test/unit/server.test.ts
+++ b/typescript/packages/mcp/test/unit/server.test.ts
@@ -308,6 +308,211 @@ describe("createPaymentWrapper", () => {
       );
       expect(result._meta?.traceId).toBe("trace_err");
       expect(result._meta?.[MCP_PAYMENT_RESPONSE_META_KEY]).toEqual(mockSettleResponse);
+      expect(mockResourceServer.createPaymentCancellationDispatcher).toHaveBeenCalledWith(
+        mockPaymentPayload,
+        mockPaymentRequirements,
+        expect.anything(),
+        expect.anything(),
+        ["before-handler"],
+      );
+      const dispatcher = mockResourceServer.createPaymentCancellationDispatcher.mock.results[0]
+        .value as { cancel: ReturnType<typeof vi.fn> };
+      expect(dispatcher.cancel).toHaveBeenCalledWith({ reason: "handler_failed" });
+    });
+
+    it("should return 402 when before-handler settlement fails under upfront", async () => {
+      mockResourceServer.getPaymentFlow.mockReturnValue("upfront");
+      mockResourceServer.settlePayment.mockResolvedValue({
+        success: false,
+        errorReason: "insufficient_funds",
+        transaction: "",
+        network: "eip155:84532",
+      });
+
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+        },
+      );
+
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "success" }],
+      });
+
+      const wrappedHandler = paid(handler);
+      const result = await wrappedHandler(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(mockResourceServer.settlePayment).toHaveBeenCalledTimes(1);
+      expect(mockResourceServer.settlePayment).toHaveBeenCalledWith(
+        mockPaymentPayload,
+        mockPaymentRequirements,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        "before-handler",
+      );
+      expect(mockResourceServer.createPaymentRequiredResponse).toHaveBeenCalledWith(
+        [mockPaymentRequirements],
+        expect.any(Object),
+        "Payment settlement failed: insufficient_funds",
+        undefined,
+        expect.any(Object),
+        undefined,
+      );
+      expect(mockResourceServer.createPaymentCancellationDispatcher).not.toHaveBeenCalled();
+    });
+
+    it("should return 402 when before-handler settlement throws under upfront", async () => {
+      mockResourceServer.getPaymentFlow.mockReturnValue("upfront");
+      mockResourceServer.settlePayment.mockRejectedValue(new Error("facilitator unavailable"));
+
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+        },
+      );
+
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "success" }],
+      });
+
+      const wrappedHandler = paid(handler);
+      const result = await wrappedHandler(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(mockResourceServer.createPaymentRequiredResponse).toHaveBeenCalledWith(
+        [mockPaymentRequirements],
+        expect.any(Object),
+        "Payment settlement failed: facilitator unavailable",
+        undefined,
+        expect.any(Object),
+        undefined,
+      );
+      expect(mockResourceServer.createPaymentCancellationDispatcher).not.toHaveBeenCalled();
+    });
+
+    it("should settle before and after handler under escrow", async () => {
+      mockResourceServer.getPaymentFlow.mockReturnValue("escrow");
+      mockResourceServer.settlePayment
+        .mockResolvedValueOnce({
+          ...mockSettleResponse,
+          transaction: "0xdeposit",
+        })
+        .mockResolvedValueOnce({
+          ...mockSettleResponse,
+          transaction: "0xcharge",
+        });
+
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+        },
+      );
+
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "success" }],
+      });
+
+      const wrappedHandler = paid(handler);
+      const result = await wrappedHandler(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      expect(handler).toHaveBeenCalled();
+      expect(mockResourceServer.verifyPayment).toHaveBeenCalled();
+      expect(mockResourceServer.settlePayment).toHaveBeenCalledTimes(2);
+      expect(mockResourceServer.settlePayment).toHaveBeenNthCalledWith(
+        1,
+        mockPaymentPayload,
+        mockPaymentRequirements,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        "before-handler",
+      );
+      expect(mockResourceServer.settlePayment).toHaveBeenNthCalledWith(
+        2,
+        mockPaymentPayload,
+        mockPaymentRequirements,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        "after-handler",
+      );
+      expect(result._meta?.[MCP_PAYMENT_RESPONSE_META_KEY]).toEqual({
+        ...mockSettleResponse,
+        transaction: "0xcharge",
+      });
+      expect(mockResourceServer.createPaymentCancellationDispatcher).toHaveBeenCalledWith(
+        mockPaymentPayload,
+        mockPaymentRequirements,
+        expect.anything(),
+        expect.anything(),
+        ["before-handler"],
+      );
+    });
+
+    it("should cancel with before-handler settledPhases and echo receipt when escrow tool errors", async () => {
+      mockResourceServer.getPaymentFlow.mockReturnValue("escrow");
+      mockResourceServer.settlePayment.mockResolvedValue({
+        ...mockSettleResponse,
+        transaction: "0xdeposit",
+      });
+
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+        },
+      );
+
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "error" }],
+        isError: true,
+        _meta: { traceId: "trace_escrow_err" },
+      });
+
+      const wrappedHandler = paid(handler);
+      const result = await wrappedHandler(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      expect(result.isError).toBe(true);
+      expect(mockResourceServer.settlePayment).toHaveBeenCalledTimes(1);
+      expect(mockResourceServer.settlePayment).toHaveBeenCalledWith(
+        mockPaymentPayload,
+        mockPaymentRequirements,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        "before-handler",
+      );
+      expect(result._meta?.traceId).toBe("trace_escrow_err");
+      expect(result._meta?.[MCP_PAYMENT_RESPONSE_META_KEY]).toEqual({
+        ...mockSettleResponse,
+        transaction: "0xdeposit",
+      });
+      expect(mockResourceServer.createPaymentCancellationDispatcher).toHaveBeenCalledWith(
+        mockPaymentPayload,
+        mockPaymentRequirements,
+        expect.anything(),
+        expect.anything(),
+        ["before-handler"],
+      );
       const dispatcher = mockResourceServer.createPaymentCancellationDispatcher.mock.results[0]
         .value as { cancel: ReturnType<typeof vi.fn> };
       expect(dispatcher.cancel).toHaveBeenCalledWith({ reason: "handler_failed" });

--- a/typescript/packages/mcp/test/unit/server.test.ts
+++ b/typescript/packages/mcp/test/unit/server.test.ts
@@ -266,6 +266,48 @@ describe("createPaymentWrapper", () => {
 
       expect(result.isError).toBe(true);
       expect(mockResourceServer.settlePayment).not.toHaveBeenCalled();
+      expect(result._meta?.[MCP_PAYMENT_RESPONSE_META_KEY]).toBeUndefined();
+      const dispatcher = mockResourceServer.createPaymentCancellationDispatcher.mock.results[0]
+        .value as { cancel: ReturnType<typeof vi.fn> };
+      expect(dispatcher.cancel).toHaveBeenCalledWith({ reason: "handler_failed" });
+    });
+
+    it("should echo before-handler settlement when tool returns error under upfront", async () => {
+      mockResourceServer.getPaymentFlow.mockReturnValue("upfront");
+      // verify is skipped for upfront; settle runs before handler
+      mockResourceServer.settlePayment.mockResolvedValue(mockSettleResponse);
+
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+        },
+      );
+
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "error" }],
+        isError: true,
+        _meta: { traceId: "trace_err" },
+      });
+
+      const wrappedHandler = paid(handler);
+      const result = await wrappedHandler(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      expect(result.isError).toBe(true);
+      expect(mockResourceServer.settlePayment).toHaveBeenCalledTimes(1);
+      expect(mockResourceServer.settlePayment).toHaveBeenCalledWith(
+        mockPaymentPayload,
+        mockPaymentRequirements,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        "before-handler",
+      );
+      expect(result._meta?.traceId).toBe("trace_err");
+      expect(result._meta?.[MCP_PAYMENT_RESPONSE_META_KEY]).toEqual(mockSettleResponse);
       const dispatcher = mockResourceServer.createPaymentCancellationDispatcher.mock.results[0]
         .value as { cancel: ReturnType<typeof vi.fn> };
       expect(dispatcher.cancel).toHaveBeenCalledWith({ reason: "handler_failed" });

--- a/typescript/packages/mechanisms/aptos/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/aptos/src/exact/server/scheme.ts
@@ -3,6 +3,7 @@ import type {
   Money,
   MoneyParser,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -15,6 +16,10 @@ import { APTOS_ADDRESS_REGEX, USDC_MAINNET_FA, USDC_TESTNET_FA } from "../../con
  */
 export class ExactAptosScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows = {
+    default: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
 
   /**

--- a/typescript/packages/mechanisms/avm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/avm/src/exact/server/scheme.ts
@@ -7,6 +7,7 @@
 import type {
   AssetAmount,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -23,6 +24,10 @@ import { normalizeAlgorandNetwork } from "../../utils";
  */
 export class ExactAvmScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows = {
+    default: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
 
   /**

--- a/typescript/packages/mechanisms/concordium/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/concordium/src/exact/server/scheme.ts
@@ -90,8 +90,8 @@ export class ExactConcordiumScheme implements SchemeNetworkServer {
     // No parser matched — throw, no silent CCD fallback
     throw new Error(
       `Cannot resolve price "${String(price)}" to a Concordium asset. ` +
-      `Register a money parser via registerMoneyParser() to map prices ` +
-      `to a specific token (e.g., EURR, USDR).`,
+        `Register a money parser via registerMoneyParser() to map prices ` +
+        `to a specific token (e.g., EURR, USDR).`,
     );
   }
 

--- a/typescript/packages/mechanisms/concordium/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/concordium/src/exact/server/scheme.ts
@@ -1,6 +1,7 @@
 import type {
   AssetAmount,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -21,6 +22,10 @@ import { parseMoneyString } from "@x402/core/utils";
  */
 export class ExactConcordiumScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows = {
+    default: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
 
   /** Custom money parser chain — tried in registration order */
   private moneyParsers: MoneyParser[] = [];
@@ -85,8 +90,8 @@ export class ExactConcordiumScheme implements SchemeNetworkServer {
     // No parser matched — throw, no silent CCD fallback
     throw new Error(
       `Cannot resolve price "${String(price)}" to a Concordium asset. ` +
-        `Register a money parser via registerMoneyParser() to map prices ` +
-        `to a specific token (e.g., EURR, USDR).`,
+      `Register a money parser via registerMoneyParser() to map prices ` +
+      `to a specific token (e.g., EURR, USDR).`,
     );
   }
 

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/server/scheme.ts
@@ -1,6 +1,7 @@
 import {
   AssetAmount,
   Network,
+  PaymentFlowConfig,
   PaymentPayload,
   PaymentRequirements,
   Price,
@@ -16,7 +17,7 @@ import type { FacilitatorClient } from "@x402/core/server";
 import { getAddress } from "viem";
 import { BatchSettlementChannelManager } from "./channelManager";
 import { getDefaultAsset } from "../../shared/defaultAssets";
-import type { AuthorizerSigner } from "../types";
+import type { AuthorizerSigner, BatchSettlementAssetTransferMethod } from "../types";
 import { BATCH_SETTLEMENT_SCHEME, MIN_WITHDRAW_DELAY } from "../constants";
 import { InMemoryChannelStorage, ChannelStorage, type Channel } from "./storage";
 import {
@@ -54,6 +55,11 @@ export interface BatchSettlementRequestContext {
  */
 export class BatchSettlementEvmScheme implements SchemeNetworkServer {
   readonly scheme = BATCH_SETTLEMENT_SCHEME;
+  readonly defaultAssetTransferMethod: BatchSettlementAssetTransferMethod = "eip3009";
+  readonly paymentFlows = {
+    eip3009: { supported: ["authorization"], default: "authorization" },
+    permit2: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<BatchSettlementAssetTransferMethod, PaymentFlowConfig>;
   readonly schemeHooks: SchemeServerHooks;
 
   private readonly requestContexts = new WeakMap<

--- a/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/server/scheme.ts
@@ -1,6 +1,7 @@
 import {
   AssetAmount,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -8,12 +9,18 @@ import {
 } from "@x402/core/types";
 import { convertToTokenAmount, numberToDecimalString, parseMoneyString } from "@x402/core/utils";
 import { getDefaultAsset, type ExactDefaultAssetInfo } from "../../shared/defaultAssets";
+import type { AssetTransferMethod } from "../../types";
 
 /**
  * EVM server implementation for the Exact payment scheme.
  */
 export class ExactEvmScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod: AssetTransferMethod = "eip3009";
+  readonly paymentFlows = {
+    eip3009: { supported: ["authorization"], default: "authorization" },
+    permit2: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<AssetTransferMethod, PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
 
   /**

--- a/typescript/packages/mechanisms/evm/src/upto/server/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/server/scheme.ts
@@ -1,6 +1,7 @@
 import {
   AssetAmount,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -9,6 +10,7 @@ import {
 import { convertToTokenAmount, numberToDecimalString, parseMoneyString } from "@x402/core/utils";
 import { getAddress } from "viem";
 import { getDefaultAsset } from "../../shared/defaultAssets";
+import type { AssetTransferMethod } from "../../types";
 
 /**
  * EVM server implementation for the Upto payment scheme.
@@ -16,6 +18,10 @@ import { getDefaultAsset } from "../../shared/defaultAssets";
  */
 export class UptoEvmScheme implements SchemeNetworkServer {
   readonly scheme = "upto";
+  readonly defaultAssetTransferMethod: AssetTransferMethod = "permit2";
+  readonly paymentFlows = {
+    permit2: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<"permit2", PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
 
   /**

--- a/typescript/packages/mechanisms/hedera/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/hedera/src/exact/server/scheme.ts
@@ -3,6 +3,7 @@ import type {
   Money,
   MoneyParser,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -37,6 +38,10 @@ export type HederaServerConfig = {
  */
 export class ExactHederaScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows = {
+    default: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
 
   /**
@@ -44,7 +49,7 @@ export class ExactHederaScheme implements SchemeNetworkServer {
    *
    * @param config - Optional server config
    */
-  constructor(private readonly config: HederaServerConfig = {}) {}
+  constructor(private readonly config: HederaServerConfig = {}) { }
 
   /**
    * Register a custom money parser in order.

--- a/typescript/packages/mechanisms/hedera/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/hedera/src/exact/server/scheme.ts
@@ -49,7 +49,7 @@ export class ExactHederaScheme implements SchemeNetworkServer {
    *
    * @param config - Optional server config
    */
-  constructor(private readonly config: HederaServerConfig = {}) { }
+  constructor(private readonly config: HederaServerConfig = {}) {}
 
   /**
    * Register a custom money parser in order.

--- a/typescript/packages/mechanisms/keeta/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/keeta/src/exact/server/scheme.ts
@@ -2,6 +2,7 @@ import type {
   AssetAmount,
   MoneyParser,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -14,6 +15,10 @@ import { getUsdcAddress, validateTokenAsset } from "../../utils";
  */
 export class ExactKeetaScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows = {
+    default: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
   private usdcAddressCache: Map<Network, string> = new Map();
 

--- a/typescript/packages/mechanisms/near/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/near/src/exact/server/scheme.ts
@@ -2,6 +2,7 @@ import type {
   AssetAmount,
   MoneyParser,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -25,6 +26,10 @@ type SupportedKindLike = {
  */
 export class ExactNearScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows = {
+    default: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
   private readonly moneyParsers: MoneyParser[] = [];
 
   /**

--- a/typescript/packages/mechanisms/stellar/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/server/scheme.ts
@@ -4,6 +4,7 @@ import { getUsdcAddress } from "../../utils";
 import type {
   AssetAmount,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -15,6 +16,10 @@ import type {
  */
 export class ExactStellarScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows = {
+    default: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
 
   /**

--- a/typescript/packages/mechanisms/svm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/server/scheme.ts
@@ -42,7 +42,7 @@ export class ExactSvmScheme implements SchemeNetworkServer {
    * @param options - Optional server configuration (e.g. an `rpcUrl` to embed a
    *   recent blockhash in the challenge).
    */
-  constructor(private readonly options: ExactSvmServerOptions = {}) { }
+  constructor(private readonly options: ExactSvmServerOptions = {}) {}
 
   /**
    * Register a custom money parser in the parser chain.

--- a/typescript/packages/mechanisms/svm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/server/scheme.ts
@@ -1,6 +1,7 @@
 import type {
   AssetAmount,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -29,6 +30,10 @@ export interface ExactSvmServerOptions {
  */
 export class ExactSvmScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows = {
+    default: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
 
   /**
@@ -37,7 +42,7 @@ export class ExactSvmScheme implements SchemeNetworkServer {
    * @param options - Optional server configuration (e.g. an `rpcUrl` to embed a
    *   recent blockhash in the challenge).
    */
-  constructor(private readonly options: ExactSvmServerOptions = {}) {}
+  constructor(private readonly options: ExactSvmServerOptions = {}) { }
 
   /**
    * Register a custom money parser in the parser chain.

--- a/typescript/packages/mechanisms/tvm/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/tvm/src/exact/server/scheme.ts
@@ -1,6 +1,7 @@
 import {
   AssetAmount,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
@@ -15,6 +16,10 @@ import { getDefaultAsset, makeZeroBitCellBoc, normalizeTonAddress } from "../../
  */
 export class ExactTvmScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod = "default";
+  readonly paymentFlows = {
+    default: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<string, PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
 
   /**

--- a/typescript/packages/mechanisms/xrpl/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/xrpl/src/exact/server/scheme.ts
@@ -3,12 +3,14 @@ import type {
   Money,
   MoneyParser,
   Network,
+  PaymentFlowConfig,
   PaymentRequirements,
   Price,
   SchemeNetworkServer,
   SupportedKind,
 } from "@x402/core/types";
 import { parseMoneyString } from "@x402/core/utils";
+import type { XrplAssetTransferMethod } from "../../types";
 import {
   isDecimalString,
   isIntegerString,
@@ -22,6 +24,11 @@ import {
  */
 export class ExactXrplScheme implements SchemeNetworkServer {
   readonly scheme = "exact";
+  readonly defaultAssetTransferMethod: XrplAssetTransferMethod = "sequence";
+  readonly paymentFlows = {
+    sequence: { supported: ["authorization"], default: "authorization" },
+    ticketSequence: { supported: ["authorization"], default: "authorization" },
+  } as const satisfies Record<XrplAssetTransferMethod, PaymentFlowConfig>;
   private moneyParsers: MoneyParser[] = [];
 
   /**


### PR DESCRIPTION
## Description

x402 currently hardcodes a single verify → work → settle path, which works well for authorization-style payments but blocks escrow models like svm upto and prepaid models like upfront. This PR lets each mechanism declare which payment flow it needs, so core can order verify and settle around the resource handler without baking one trust model into the middleware.

Payment flow handlers are the named orderings of verify / settle relative to resource execution. Mechanisms opt in via a declared flow (signaled on the wire with extra.paymentFlow when not the default); clients and facilitators stay the same, while servers gain a first-class way to settle before work, settle twice around work, or skip settle entirely when payment was already committed.

verify should remain **read-only**: it may validate payment state but must not commit funds or write onchain state. Escrowing a ceiling (or opening a channel) is a durable commitment, so it belongs on the settle path; the settle itself is the check, and a later settle records the final charge.

**Payment flows:**
- `authorize (default)`: verify → work → settle → respond. Used by today’s exact flows and EVM upto
- `escrow`: settle → work → settle → respond. Used by SVM upto (deposit, then charge) and EVM auth-capture (authorize, then capture)
- `upfront`:  settle → work → respond. Used by upcoming exact with assetTransferMethod=transaction-proof, and BTC Lightning-style prepaid flows

Multiple payment flows can live under one scheme, eg exact can cover simultaneously:

Facilitator-settled flows:
```
{
 "extra": {
  "assetTransferMethod": "eip3009",
  "paymentFlow": "authorize"
 }
}
```
and 
```
{
 "extra": {
  "assetTransferMethod": "eip3009",
  "paymentFlow": "upfront"
 }
}
```
as well as client settled flows:
```
{
 "extra": {
  "assetTransferMethod": "tranasction-proof",
  "paymentFlow": "upfront"
 }
}
```

References:
- upfront PR: https://github.com/x402-foundation/x402/pull/2520 

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 