### PR TITLE
fix(python): match wildcard routes containing a line feed

### DIFF
--- a/python/x402/changelog.d/+wildcard-line-feed-bypass.bugfix.md
+++ b/python/x402/changelog.d/+wildcard-line-feed-bypass.bugfix.md
@@ -1,0 +1,1 @@
+Fixed wildcard (`*`) route matching in the HTTP server when the wildcard tail contains a decoded line feed. Wildcard route regexes now compile with `re.DOTALL`, preventing protected routes from being missed before payment verification and settlement.

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -975,7 +975,10 @@ class x402HTTPServerBase:
         regex_pattern = re.sub(r":([a-zA-Z_]\w*)", r"[^/]+", regex_pattern)  # :param
         regex_pattern += "$"
 
-        return verb, path, re.compile(regex_pattern, re.IGNORECASE)
+        # re.DOTALL: without it, "." (from a "*" wildcard) does not match a line
+        # feed, so a request path whose wildcard tail contains a decoded LF fails
+        # to match its own route, skipping payment verification and settlement.
+        return verb, path, re.compile(regex_pattern, re.IGNORECASE | re.DOTALL)
 
     @staticmethod
     def _normalize_path(path: str) -> str:

--- a/python/x402/tests/unit/http/test_route_matching.py
+++ b/python/x402/tests/unit/http/test_route_matching.py
@@ -1,0 +1,60 @@
+"""Route matching tests for the shared HTTP server base.
+
+Regression coverage for wildcard (`*`) route patterns and a payment-gate
+bypass via a line feed, which a naive `.` wildcard cannot cross.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from x402.http.types import HTTPRequestContext, RouteConfig
+from x402.http.x402_http_server_base import x402HTTPServerBase
+
+
+def _context(path: str, method: str = "GET") -> HTTPRequestContext:
+    """Build a request context that carries an explicit path and method.
+
+    The adapter is only consulted when ``method`` is empty, so a bare
+    MagicMock is sufficient for route-matching tests.
+    """
+    return HTTPRequestContext(adapter=MagicMock(), path=path, method=method)
+
+
+class TestWildcardLineFeedBypass:
+    """A wildcard segment must match a line feed like any other character.
+
+    The compiled route regex expands ``*`` to ``.*?``. Without the ``re.DOTALL``
+    flag, ``.`` does not match ``\\n``, so a request path whose wildcard tail
+    contains a (decoded) line feed fails to match its own protected route. When
+    the route misses, ``requires_payment`` returns ``False`` and the middleware
+    serves the protected resource with no payment verification or settlement.
+    """
+
+    def _server(self) -> x402HTTPServerBase:
+        return x402HTTPServerBase(
+            MagicMock(),
+            {"GET /api/premium/*": RouteConfig(accepts=[])},
+        )
+
+    def test_plain_wildcard_path_requires_payment(self) -> None:
+        # Baseline: an ordinary sub-path of the wildcard route is protected.
+        assert self._server().requires_payment(_context("/api/premium/report")) is True
+
+    def test_unrelated_path_does_not_require_payment(self) -> None:
+        # Guard against a fix that makes every path match.
+        assert self._server().requires_payment(_context("/public/report")) is False
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/premium/re\nport",  # decoded LF mid-segment (what an ASGI server delivers)
+            "/api/premium/re%0Aport",  # percent-encoded LF, decoded by _normalize_path
+            "/api/premium/a\n/b",  # LF before a later segment boundary
+        ],
+        ids=["decoded-lf", "encoded-lf", "lf-before-segment"],
+    )
+    def test_line_feed_in_wildcard_tail_still_requires_payment(self, path: str) -> None:
+        assert self._server().requires_payment(_context(path)) is True


### PR DESCRIPTION
## Description

The Python HTTP server compiles each route pattern to a regex where `*` becomes `.*?`. That regex is compiled with `re.IGNORECASE` but **not** `re.DOTALL`, so `.` does not match a line feed (`\n`).

A wildcard route such as `GET /api/premium/*` therefore fails to match a request path whose wildcard tail contains a decoded line feed. When the route misses, `_get_route_config()` returns `None`, `requires_payment()` returns `False`, and `_process_request_core()` returns `RESULT_NO_PAYMENT_REQUIRED` — the protected resource is served with no payment verification and no settlement.

This is the Python counterpart of the TypeScript fix in #3036 (which added the `s`/dotAll flag). The Python surface is narrower than the TS one: Python's `$` matches before a trailing `\n`, and Python's `.` only excludes `\n` (it already matches CR, U+2028, U+2029), so only a **line feed inside the wildcard tail** triggers the miss. The fix and its rationale are identical.

Fix: compile the route regex with `re.DOTALL` so a wildcard segment matches any character, including a line feed.

## Tests

`uv run pytest` from `python/x402/` — full suite **1855 passed, 65 skipped**. New file `tests/unit/http/test_route_matching.py` adds regression coverage that fails before the change and passes after:
- baseline: an ordinary sub-path of a wildcard route requires payment;
- guard: an unrelated path does **not** require payment (so the fix doesn't make everything match);
- decoded LF, percent-encoded LF, and LF-before-a-later-segment in the wildcard tail all still require payment.

`uvx ruff check` and `uvx ruff format --check` both clean.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [ ] My commits are signed (will re-sign before merge per the template)
- [x] I added a changelog fragment for user-facing changes
