### PR TITLE
docs(examples): add a recipient-screening client example

### DIFF
--- a/examples/typescript/clients/advanced/README.md
+++ b/examples/typescript/clients/advanced/README.md
@@ -1,6 +1,6 @@
 # Advanced x402 Client Examples
 
-Advanced patterns for x402 TypeScript clients demonstrating builder pattern registration, payment lifecycle hooks, network preferences, and spend controls.
+Advanced patterns for x402 TypeScript clients demonstrating builder pattern registration, payment lifecycle hooks, network preferences, spend controls, and recipient screening (`onBeforePaymentCreation` → abort on a bad `payTo`).
 
 ```typescript
 import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
@@ -125,6 +125,7 @@ Each example demonstrates a specific advanced pattern:
 | `hooks` | `pnpm dev:hooks` | Payment lifecycle hooks |
 | `preferred-network` | `pnpm dev:preferred-network` | Client-side network preferences |
 | `spend-controls` | `pnpm dev:spend-controls` | Default `$1` USD cap, `allowedAssets`, and per-asset caps |
+| `screen-recipient` | `pnpm dev:screen-recipient` | Screen the recipient (`payTo`) before paying; abort a bad address |
 
 ## Testing the Examples
 

--- a/examples/typescript/clients/advanced/index.ts
+++ b/examples/typescript/clients/advanced/index.ts
@@ -3,6 +3,7 @@ import { runHooksExample } from "./hooks";
 import { runPreferredNetworkExample } from "./preferred-network";
 import { runBuilderPatternExample } from "./builder-pattern";
 import { runSpendControlsExample } from "./spend-controls";
+import { runScreenRecipientExample } from "./screen-recipient";
 
 config();
 
@@ -22,6 +23,7 @@ const url = `${baseURL}${endpointPath}`;
  * - hooks: Payment lifecycle hooks for custom logic at different stages
  * - preferred-network: Client-side payment network preferences
  * - spend-controls: Default $1 USD cap, allowedAssets, and per-asset caps
+ * - screen-recipient: Screen the recipient (payTo) in a before-payment hook and abort a bad address
  *
  * To run this example, you need to set the following environment variables:
  * - EVM_PRIVATE_KEY: The private key of the EVM signer
@@ -33,6 +35,7 @@ const url = `${baseURL}${endpointPath}`;
  *   pnpm start hooks
  *   pnpm start preferred-network
  *   pnpm start spend-controls
+ *   pnpm start screen-recipient
  */
 async function main(): Promise<void> {
   const pattern = process.argv[2] || "builder-pattern";
@@ -71,12 +74,14 @@ async function main(): Promise<void> {
 
     case "spend-controls":
       await runSpendControlsExample(evmPrivateKey, url);
+    case "screen-recipient":
+      await runScreenRecipientExample(evmPrivateKey, url);
       break;
 
     default:
       console.error(`Unknown pattern: ${pattern}`);
       console.error(
-        "Available patterns: all-networks, builder-pattern, hooks, preferred-network, spend-controls",
+        "Available patterns: all-networks, builder-pattern, hooks, preferred-network, spend-controls, screen-recipient",
       );
       process.exit(1);
   }

--- a/examples/typescript/clients/advanced/package.json
+++ b/examples/typescript/clients/advanced/package.json
@@ -10,6 +10,7 @@
     "dev:hooks": "tsx index.ts hooks",
     "dev:preferred-network": "tsx index.ts preferred-network",
     "dev:spend-controls": "tsx index.ts spend-controls",
+    "dev:screen-recipient": "tsx index.ts screen-recipient",
     "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
     "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
     "lint": "eslint . --ext .ts --fix",

--- a/examples/typescript/clients/advanced/screen-recipient.ts
+++ b/examples/typescript/clients/advanced/screen-recipient.ts
@@ -1,0 +1,61 @@
+import { privateKeyToAccount } from "viem/accounts";
+import { x402Client, wrapFetchWithPayment } from "@x402/fetch";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+
+/**
+ * Stand-in for a real recipient screen — replace with a sanctions /
+ * address-reputation API that returns allow/block for an address (e.g.
+ * `anchor-x402-safe-pay`, or your own). The hook shape is provider-agnostic.
+ *
+ * @param payTo - The recipient address the payment would be sent to.
+ * @returns Whether the payment to this recipient is allowed, and why not if blocked.
+ */
+async function screenRecipient(payTo: string): Promise<{ allow: boolean; reason?: string }> {
+  const DENY = new Set<string>([
+    // Illustrative only — populate from your screening provider (OFAC SDN, etc.).
+    "0x8589427373d6d84e98730d7795d8f6f8731fda16", // Tornado Cash (OFAC SDN)
+  ]);
+  return DENY.has(payTo.toLowerCase())
+    ? { allow: false, reason: "recipient failed sanctions/reputation screen" }
+    : { allow: true };
+}
+
+/**
+ * Screen Recipient Example
+ *
+ * Screen the payment recipient before paying. `onBeforePaymentCreation` runs
+ * with the selected requirements — including `payTo`, the address you're about
+ * to send funds to — and can abort. Checking the recipient here is the canonical
+ * real-world use of that abort: an autonomous payer shouldn't send funds to a
+ * sanctioned or known-malicious address without a human in the loop.
+ *
+ * @param evmPrivateKey - The EVM private key for signing
+ * @param url - The URL to make the request to
+ */
+export async function runScreenRecipientExample(
+  evmPrivateKey: `0x${string}`,
+  url: string,
+): Promise<void> {
+  console.log("🛡️  Creating client that screens the recipient before paying...\n");
+
+  const client = new x402Client()
+    .register("eip155:*", new ExactEvmScheme(privateKeyToAccount(evmPrivateKey)))
+    .onBeforePaymentCreation(async context => {
+      const { payTo } = context.selectedRequirements;
+      const verdict = await screenRecipient(payTo);
+      if (!verdict.allow) {
+        console.log(`⛔ [BeforePaymentCreation] blocking payment to ${payTo}: ${verdict.reason}`);
+        return { abort: true, reason: verdict.reason };
+      }
+      console.log(`✅ [BeforePaymentCreation] recipient ${payTo} cleared`);
+    });
+
+  const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+  console.log(`🌐 Making request to: ${url}\n`);
+  const response = await fetchWithPayment(url, { method: "GET" });
+  const body = await response.json();
+
+  console.log("✅ Request completed\n");
+  console.log("Response body:", body);
+}


### PR DESCRIPTION
Adds a small, provider-agnostic example to `examples/typescript/clients/advanced` showing the canonical real-world use of `onBeforePaymentCreation`'s abort: **screen the payment recipient (`payTo`) before paying, and abort a bad address.**

The existing `hooks.ts` demonstrates the lifecycle hooks and notes you *can* abort; this shows the most common reason to — an autonomous payer shouldn't send funds to a sanctioned / known-malicious address without a human in the loop.

- New `screen-recipient.ts` mirroring the `hooks.ts` style; `onBeforePaymentCreation` reads `context.selectedRequirements.payTo`, calls a `screenRecipient(payTo)` check, and returns `{ abort, reason }` on a block.
- `screenRecipient` is a **stub** (inline deny-set) — the comment points at swapping in any sanctions/address-reputation API; the hook shape stays provider-agnostic.
- Wired into `index.ts` dispatch (`pnpm start screen-recipient`) + a README line.

Docs/example-only; no SDK behavior change, so no changelog fragment. Commit is signed.