### PR TITLE
fix(evm): verify Transfer event after permit2 settle (exact + upto)

### DIFF
--- a/typescript/packages/mechanisms/evm/src/constants.ts
+++ b/typescript/packages/mechanisms/evm/src/constants.ts
@@ -15,6 +15,24 @@ export const authorizationTypes = {
  * Must match the exact format expected by the Permit2 contract.
  * Note: Types must be in ALPHABETICAL order after the primary type (TokenPermissions < Witness).
  */
+/**
+ * Minimal ERC-20 Transfer event ABI, used to verify settlement receipts actually
+ * transferred the expected asset/amount to the expected recipient (receipt status
+ * alone only proves the transaction did not revert).
+ */
+export const erc20TransferEventAbi = [
+  {
+    type: "event",
+    name: "Transfer",
+    anonymous: false,
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+] as const;
+
 export const permit2WitnessTypes = {
   PermitWitnessTransferFrom: [
     { name: "permitted", type: "TokenPermissions" },

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -438,7 +438,13 @@ async function settlePermit2WithEIP2612(
       dataSuffix,
     });
 
-    return waitAndReturnSettleResponse(signer, tx, payload, payer);
+    return waitAndReturnSettleResponse(
+      signer,
+      tx,
+      payload,
+      payer,
+      exactExpectedTransfer(permit2Payload),
+    );
   } catch (error) {
     return mapSettleError(error, payload, payer);
   }
@@ -482,7 +488,13 @@ async function settlePermit2WithERC20Approval(
     ]);
 
     const settleTxHash = txHashes[txHashes.length - 1];
-    return waitAndReturnSettleResponse(extensionSigner, settleTxHash, payload, payer);
+    return waitAndReturnSettleResponse(
+      extensionSigner,
+      settleTxHash,
+      payload,
+      payer,
+      exactExpectedTransfer(permit2Payload),
+    );
   } catch (error) {
     return mapSettleError(error, payload, payer);
   }
@@ -515,8 +527,36 @@ async function settlePermit2Direct(
       dataSuffix,
     });
 
-    return waitAndReturnSettleResponse(signer, tx, payload, payer);
+    return waitAndReturnSettleResponse(
+      signer,
+      tx,
+      payload,
+      payer,
+      exactExpectedTransfer(permit2Payload),
+    );
   } catch (error) {
     return mapSettleError(error, payload, payer);
   }
+}
+
+/**
+ * Derives the Transfer event an exact Permit2 settlement must emit: the full
+ * permitted amount from the payer to the witness recipient.
+ *
+ * @param permit2Payload - The exact Permit2 payload with the authorization
+ * @returns The expected Transfer event fields for receipt verification
+ */
+function exactExpectedTransfer(permit2Payload: ExactPermit2Payload): {
+  asset: `0x${string}`;
+  from: `0x${string}`;
+  to: `0x${string}`;
+  value: bigint;
+} {
+  const auth = permit2Payload.permit2Authorization;
+  return {
+    asset: auth.permitted.token,
+    from: auth.from,
+    to: auth.witness.to,
+    value: BigInt(auth.permitted.amount),
+  };
 }

--- a/typescript/packages/mechanisms/evm/src/shared/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/permit2.ts
@@ -15,8 +15,21 @@ import {
   type Erc20ApprovalGasSponsoringFacilitatorExtension,
   type Erc20ApprovalGasSponsoringSigner,
 } from "../exact/extensions";
-import { getAddress, encodeFunctionData, parseErc6492Signature } from "viem";
-import { PERMIT2_ADDRESS, eip3009ABI, erc20AllowanceAbi, permit2WitnessTypes } from "../constants";
+import {
+  getAddress,
+  encodeFunctionData,
+  parseErc6492Signature,
+  parseEventLogs,
+  isAddressEqual,
+  type Log,
+} from "viem";
+import {
+  PERMIT2_ADDRESS,
+  eip3009ABI,
+  erc20AllowanceAbi,
+  erc20TransferEventAbi,
+  permit2WitnessTypes,
+} from "../constants";
 import { multicall, ContractCall } from "../multicall";
 import { createPermit2Nonce, getEvmChainId } from "../utils";
 import {
@@ -33,6 +46,7 @@ import {
   ErrPermit2ProxyNotDeployed,
   ErrInvalidTransactionState,
   ErrTransactionFailed,
+  ErrTransferEventMismatch,
   ErrInvalidEip2612ExtensionFormat,
   ErrEip2612FromMismatch,
   ErrEip2612AssetMismatch,
@@ -164,6 +178,11 @@ export async function verifyPermit2Allowance(
  * @param tx - The transaction hash to wait for
  * @param payload - The payment payload (for network info)
  * @param payer - The payer address
+ * @param expected - The Transfer event the settlement must emit
+ * @param expected.asset - Expected asset contract that must emit the event
+ * @param expected.from - Expected sender of the Transfer event
+ * @param expected.to - Expected recipient of the Transfer event
+ * @param expected.value - Expected value of the Transfer event
  * @returns Promise resolving to a settlement response indicating success or failure
  */
 export async function waitAndReturnSettleResponse(
@@ -171,6 +190,7 @@ export async function waitAndReturnSettleResponse(
   tx: `0x${string}`,
   payload: PaymentPayload,
   payer: `0x${string}`,
+  expected: { asset: `0x${string}`; from: `0x${string}`; to: `0x${string}`; value: bigint },
 ): Promise<SettleResponse> {
   const receipt = await signer.waitForTransactionReceipt({ hash: tx });
 
@@ -184,12 +204,62 @@ export async function waitAndReturnSettleResponse(
     };
   }
 
+  // Receipt status only proves the tx did not revert. When logs are present,
+  // require the expected ERC-20 Transfer event so a deflationary/misbehaving
+  // token cannot yield success:true without the full amount reaching `to`
+  // (same post-settle check the eip3009 path performs).
+  if (
+    receipt.logs != null &&
+    !verifyPermit2TransferEvent(receipt.logs, getAddress(expected.asset), {
+      from: getAddress(expected.from),
+      to: getAddress(expected.to),
+      value: expected.value,
+    })
+  ) {
+    return {
+      success: false,
+      errorReason: ErrTransferEventMismatch,
+      transaction: tx,
+      network: payload.accepted.network,
+      payer,
+    };
+  }
+
   return {
     success: true,
     transaction: tx,
     network: payload.accepted.network,
     payer,
   };
+}
+
+/**
+ * Verifies that a settlement receipt contains the expected ERC-20 Transfer event.
+ *
+ * @param logs - Receipt logs to search
+ * @param erc20Address - Expected asset contract that must have emitted the event
+ * @param expected - Expected `from`, `to`, and `value` of the Transfer event
+ * @param expected.from - Expected sender of the Transfer event
+ * @param expected.to - Expected recipient of the Transfer event
+ * @param expected.value - Expected value of the Transfer event
+ * @returns true when a matching Transfer log is present, false otherwise
+ */
+function verifyPermit2TransferEvent(
+  logs: readonly Log[],
+  erc20Address: `0x${string}`,
+  expected: { from: `0x${string}`; to: `0x${string}`; value: bigint },
+): boolean {
+  const transferLogs = parseEventLogs({
+    abi: erc20TransferEventAbi,
+    eventName: "Transfer",
+    logs: logs.filter(log => isAddressEqual(log.address, erc20Address)),
+  });
+  return transferLogs.some(
+    log =>
+      isAddressEqual(log.args.from, expected.from) &&
+      isAddressEqual(log.args.to, expected.to) &&
+      log.args.value === expected.value,
+  );
 }
 
 /**

--- a/typescript/packages/mechanisms/evm/src/upto/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/facilitator/permit2.ts
@@ -501,7 +501,13 @@ async function settleUptoWithEIP2612(
       dataSuffix,
     });
 
-    const response = await waitAndReturnSettleResponse(signer, tx, payload, payer);
+    const response = await waitAndReturnSettleResponse(
+      signer,
+      tx,
+      payload,
+      payer,
+      uptoExpectedTransfer(permit2Payload, settlementAmount),
+    );
     return { ...response, amount: settlementAmount.toString() };
   } catch (error) {
     return mapSettleError(error, payload, payer);
@@ -556,6 +562,7 @@ async function settleUptoWithERC20Approval(
       settleTxHash,
       payload,
       payer,
+      uptoExpectedTransfer(permit2Payload, settlementAmount),
     );
     return { ...response, amount: settlementAmount.toString() };
   } catch (error) {
@@ -592,9 +599,41 @@ async function settleUptoDirect(
       dataSuffix,
     });
 
-    const response = await waitAndReturnSettleResponse(signer, tx, payload, payer);
+    const response = await waitAndReturnSettleResponse(
+      signer,
+      tx,
+      payload,
+      payer,
+      uptoExpectedTransfer(permit2Payload, settlementAmount),
+    );
     return { ...response, amount: settlementAmount.toString() };
   } catch (error) {
     return mapSettleError(error, payload, payer);
   }
+}
+
+/**
+ * Derives the Transfer event an upto Permit2 settlement must emit: the actual
+ * settlement amount (not the permitted max) from the payer to the witness recipient.
+ *
+ * @param permit2Payload - The upto Permit2 payload with the authorization
+ * @param settlementAmount - The amount actually settled on-chain
+ * @returns The expected Transfer event fields for receipt verification
+ */
+function uptoExpectedTransfer(
+  permit2Payload: UptoPermit2Payload,
+  settlementAmount: bigint,
+): {
+  asset: `0x${string}`;
+  from: `0x${string}`;
+  to: `0x${string}`;
+  value: bigint;
+} {
+  const auth = permit2Payload.permit2Authorization;
+  return {
+    asset: auth.permitted.token,
+    from: auth.from,
+    to: auth.witness.to,
+    value: settlementAmount,
+  };
 }

--- a/typescript/packages/mechanisms/evm/test/unit/shared/permit2-settle-event.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/shared/permit2-settle-event.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { encodeAbiParameters, keccak256, padHex, toBytes, toHex } from "viem";
+import type { TransactionReceipt } from "viem";
+import { PaymentPayload } from "@x402/core/types";
+import { waitAndReturnSettleResponse } from "../../../src/shared/permit2";
+import {
+  ErrInvalidTransactionState,
+  ErrTransferEventMismatch,
+} from "../../../src/exact/facilitator/errors";
+
+const TRANSFER_TOPIC = keccak256(toBytes("Transfer(address,address,uint256)"));
+
+function makeTransferLog(opts: {
+  address: `0x${string}`;
+  from: `0x${string}`;
+  to: `0x${string}`;
+  value: bigint;
+}) {
+  return {
+    address: opts.address,
+    topics: [TRANSFER_TOPIC, padHex(opts.from, { size: 32 }), padHex(opts.to, { size: 32 })] as [
+      `0x${string}`,
+      `0x${string}`,
+      `0x${string}`,
+    ],
+    data: encodeAbiParameters([{ type: "uint256" }], [opts.value]),
+    blockHash: padHex("0x1", { size: 32 }),
+    blockNumber: 1n,
+    transactionHash: padHex("0x2", { size: 32 }),
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  };
+}
+
+function makeReceipt(
+  status: "success" | "reverted",
+  logs: ReturnType<typeof makeTransferLog>[],
+): TransactionReceipt {
+  return {
+    status,
+    logs,
+    blockHash: padHex("0x1", { size: 32 }),
+    blockNumber: 1n,
+    transactionHash: padHex("0x2", { size: 32 }),
+    transactionIndex: 0,
+    cumulativeGasUsed: 0n,
+    gasUsed: 0n,
+    contractAddress: null,
+    from: "0x0000000000000000000000000000000000000000",
+    to: "0x0000000000000000000000000000000000000000",
+    logsBloom: toHex(new Uint8Array(256)),
+    type: "eip1559",
+    effectiveGasPrice: 0n,
+  } as unknown as TransactionReceipt;
+}
+
+const TOKEN: `0x${string}` = "0xE7C3D8C9a439feDe00D2600032D5dB0Be71C3c29";
+const PAYER: `0x${string}` = "0x1111111111111111111111111111111111111111";
+const RECEIVER: `0x${string}` = "0x2222222222222222222222222222222222222222";
+const ATTACKER: `0x${string}` = "0x3333333333333333333333333333333333333333";
+const TX: `0x${string}` = padHex("0xabc", { size: 32 });
+
+const PAYLOAD = {
+  accepted: { network: "eip155:8453" },
+} as unknown as PaymentPayload;
+
+const EXPECTED = { asset: TOKEN, from: PAYER, to: RECEIVER, value: 1000n };
+
+function signerWith(receipt: TransactionReceipt) {
+  return { waitForTransactionReceipt: async () => receipt };
+}
+
+describe("waitAndReturnSettleResponse transfer-event verification", () => {
+  it("returns success when the receipt contains the expected Transfer event", async () => {
+    const receipt = makeReceipt("success", [
+      makeTransferLog({ address: TOKEN, from: PAYER, to: RECEIVER, value: 1000n }),
+    ]);
+    const res = await waitAndReturnSettleResponse(
+      signerWith(receipt),
+      TX,
+      PAYLOAD,
+      PAYER,
+      EXPECTED,
+    );
+    expect(res.success).toBe(true);
+    expect(res.transaction).toBe(TX);
+  });
+
+  it("fails with ErrTransferEventMismatch when no Transfer event is emitted", async () => {
+    const receipt = makeReceipt("success", []);
+    const res = await waitAndReturnSettleResponse(
+      signerWith(receipt),
+      TX,
+      PAYLOAD,
+      PAYER,
+      EXPECTED,
+    );
+    expect(res.success).toBe(false);
+    expect(res.errorReason).toBe(ErrTransferEventMismatch);
+  });
+
+  it("fails when the token moved less than the expected value (deflationary token)", async () => {
+    const receipt = makeReceipt("success", [
+      makeTransferLog({ address: TOKEN, from: PAYER, to: RECEIVER, value: 999n }),
+    ]);
+    const res = await waitAndReturnSettleResponse(
+      signerWith(receipt),
+      TX,
+      PAYLOAD,
+      PAYER,
+      EXPECTED,
+    );
+    expect(res.success).toBe(false);
+    expect(res.errorReason).toBe(ErrTransferEventMismatch);
+  });
+
+  it("fails when funds went to a different recipient", async () => {
+    const receipt = makeReceipt("success", [
+      makeTransferLog({ address: TOKEN, from: PAYER, to: ATTACKER, value: 1000n }),
+    ]);
+    const res = await waitAndReturnSettleResponse(
+      signerWith(receipt),
+      TX,
+      PAYLOAD,
+      PAYER,
+      EXPECTED,
+    );
+    expect(res.success).toBe(false);
+    expect(res.errorReason).toBe(ErrTransferEventMismatch);
+  });
+
+  it("ignores Transfer events emitted by a different token contract", async () => {
+    const receipt = makeReceipt("success", [
+      makeTransferLog({ address: ATTACKER, from: PAYER, to: RECEIVER, value: 1000n }),
+    ]);
+    const res = await waitAndReturnSettleResponse(
+      signerWith(receipt),
+      TX,
+      PAYLOAD,
+      PAYER,
+      EXPECTED,
+    );
+    expect(res.success).toBe(false);
+    expect(res.errorReason).toBe(ErrTransferEventMismatch);
+  });
+
+  it("still reports reverted receipts as ErrInvalidTransactionState", async () => {
+    const receipt = makeReceipt("reverted", []);
+    const res = await waitAndReturnSettleResponse(
+      signerWith(receipt),
+      TX,
+      PAYLOAD,
+      PAYER,
+      EXPECTED,
+    );
+    expect(res.success).toBe(false);
+    expect(res.errorReason).toBe(ErrInvalidTransactionState);
+  });
+});


### PR DESCRIPTION
## Summary

Receipt status only proves the settle transaction did not revert. A deflationary, rebasing, or otherwise misbehaving ERC-20 could still yield `success: true` while the payee received less (or nothing) — the facilitator would report payment settled when it was not.

The `eip3009` settle path already guards this via `verifyEip3009TransferEvent`. All six permit2 settle branches (exact: direct, EIP-2612 gas-sponsored, ERC-20-approval gas-sponsored; upto: same three) share `waitAndReturnSettleResponse`, which only checked `receipt.status`. This PR closes that parity gap:

- Extend `waitAndReturnSettleResponse` with an `expected { asset, from, to, value }` parameter; when logs are present, require a matching `Transfer` log or return `ErrTransferEventMismatch` (same error constant and logs-present guard as the eip3009 path)
- exact branches expect the full `permitted.amount` from payer to `witness.to`; upto branches expect the actual `settlementAmount`
- Export a minimal `erc20TransferEventAbi` from `constants`

## Test plan

- [x] 6 new unit tests: canonical match, missing event, deflationary amount, wrong recipient, wrong emitter token, reverted receipt
- [x] 832/832 tests pass (826 existing + 6 new); `pnpm run build` clean

Same class as the previously merged #3032 (python exact/eip3009 settle event verification).

Made with Cursor

Made with [Cursor](https://cursor.com)