### PR TITLE
fix(go): verify Transfer event after permit2 settle (exact + upto)

### DIFF
--- a/go/mechanisms/evm/exact/facilitator/permit2.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/extensions/eip2612gassponsor"
 	"github.com/x402-foundation/x402/go/v2/extensions/erc20approvalgassponsor"
@@ -370,6 +371,28 @@ func SettlePermit2(
 
 	if receipt.Status != evm.TxStatusSuccess {
 		return nil, x402.NewSettleError(ErrTransactionFailed, payer, network, txHash, "")
+	}
+
+	// Receipt status only proves the tx did not revert. When logs are present,
+	// require the expected ERC-20 Transfer event so a deflationary/misbehaving
+	// token cannot yield success while the payee received less (or nothing)
+	// (same post-settle check the eip3009 path performs).
+	if receipt.Logs != nil {
+		settleValue, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Permitted.Amount, 10)
+		if !ok {
+			return nil, x402.NewSettleError(ErrTransferEventMismatch, payer, network, txHash, "invalid permitted amount")
+		}
+		transferMatched, err := verifyEIP3009TransferEvent(receipt.Logs, common.HexToAddress(permit2Payload.Permit2Authorization.Permitted.Token), expectedTransferEvent{
+			From:  common.HexToAddress(permit2Payload.Permit2Authorization.From),
+			To:    common.HexToAddress(permit2Payload.Permit2Authorization.Witness.To),
+			Value: settleValue,
+		})
+		if err != nil {
+			return nil, x402.NewSettleError(ErrTransferEventMismatch, payer, network, txHash, err.Error())
+		}
+		if !transferMatched {
+			return nil, x402.NewSettleError(ErrTransferEventMismatch, payer, network, txHash, "")
+		}
 	}
 
 	return &x402.SettleResponse{

--- a/go/mechanisms/evm/upto/facilitator/errors.go
+++ b/go/mechanisms/evm/upto/facilitator/errors.go
@@ -15,6 +15,7 @@ const (
 	ErrUptoFailedToGetNetworkConfig = "invalid_upto_evm_failed_to_get_network_config"
 	ErrUptoFailedToGetReceipt       = "invalid_upto_evm_failed_to_get_receipt"
 	ErrUptoTransactionFailed        = "invalid_upto_evm_transaction_failed"
+	ErrUptoTransferEventMismatch    = "invalid_upto_evm_transfer_event_mismatch"
 
 	// Shared Permit2 error constants — canonical values live in evm.ErrPermit2*
 	ErrPermit2InvalidSpender      = evm.ErrPermit2InvalidSpender

--- a/go/mechanisms/evm/upto/facilitator/permit2.go
+++ b/go/mechanisms/evm/upto/facilitator/permit2.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	goethtypes "github.com/ethereum/go-ethereum/core/types"
 	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/extensions/eip2612gassponsor"
 	"github.com/x402-foundation/x402/go/v2/extensions/erc20approvalgassponsor"
@@ -371,6 +374,25 @@ func SettleUptoPermit2(
 		return nil, x402.NewSettleError(ErrUptoTransactionFailed, payer, network, txHash, "")
 	}
 
+	// Receipt status only proves the tx did not revert. When logs are present,
+	// require the expected ERC-20 Transfer event (payer -> witness.to of the
+	// actual settlement amount) so a deflationary/misbehaving token cannot
+	// yield success while the payee received less (or nothing) (same
+	// post-settle check the eip3009 and exact permit2 paths perform).
+	if receipt.Logs != nil {
+		transferMatched, err := verifyUptoTransferEvent(receipt.Logs, common.HexToAddress(permit2Payload.Permit2Authorization.Permitted.Token), expectedUptoTransferEvent{
+			From:  common.HexToAddress(permit2Payload.Permit2Authorization.From),
+			To:    common.HexToAddress(permit2Payload.Permit2Authorization.Witness.To),
+			Value: settlementAmount,
+		})
+		if err != nil {
+			return nil, x402.NewSettleError(ErrUptoTransferEventMismatch, payer, network, txHash, err.Error())
+		}
+		if !transferMatched {
+			return nil, x402.NewSettleError(ErrUptoTransferEventMismatch, payer, network, txHash, "")
+		}
+	}
+
 	return &x402.SettleResponse{
 		Success:     true,
 		Transaction: txHash,
@@ -378,6 +400,54 @@ func SettleUptoPermit2(
 		Payer:       verifyResp.Payer,
 		Amount:      settlementAmount.String(),
 	}, nil
+}
+
+type expectedUptoTransferEvent struct {
+	From  common.Address
+	To    common.Address
+	Value *big.Int
+}
+
+// verifyUptoTransferEvent checks for a matching ERC-20 Transfer event in receipt logs.
+func verifyUptoTransferEvent(
+	logs []*goethtypes.Log,
+	tokenAddress common.Address,
+	expected expectedUptoTransferEvent,
+) (bool, error) {
+	contractABI, err := abi.JSON(strings.NewReader(string(evm.ERC20TransferEventABI)))
+	if err != nil {
+		return false, fmt.Errorf("parse transfer event ABI: %w", err)
+	}
+
+	transferEvent := contractABI.Events["Transfer"]
+	for _, receiptLog := range logs {
+		if receiptLog == nil ||
+			receiptLog.Address != tokenAddress ||
+			len(receiptLog.Topics) != 3 ||
+			receiptLog.Topics[0] != transferEvent.ID {
+			continue
+		}
+
+		values, err := contractABI.Unpack("Transfer", receiptLog.Data)
+		if err != nil {
+			continue
+		}
+		if len(values) != 1 {
+			continue
+		}
+		value, ok := values[0].(*big.Int)
+		if !ok {
+			continue
+		}
+
+		from := common.BytesToAddress(receiptLog.Topics[1].Bytes())
+		to := common.BytesToAddress(receiptLog.Topics[2].Bytes())
+		if from == expected.From && to == expected.To && value.Cmp(expected.Value) == 0 {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func verifyUptoPermit2Signature(

--- a/go/mechanisms/evm/upto/facilitator/permit2_transfer_event_test.go
+++ b/go/mechanisms/evm/upto/facilitator/permit2_transfer_event_test.go
@@ -1,0 +1,96 @@
+package facilitator
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	goethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var uptoTransferEventTopic = crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))
+
+func makeUptoTransferLog(token common.Address, from common.Address, to common.Address, value *big.Int) *goethtypes.Log {
+	return &goethtypes.Log{
+		Address: token,
+		Topics: []common.Hash{
+			uptoTransferEventTopic,
+			common.BytesToHash(common.LeftPadBytes(from.Bytes(), 32)),
+			common.BytesToHash(common.LeftPadBytes(to.Bytes(), 32)),
+		},
+		Data: common.LeftPadBytes(value.Bytes(), 32),
+	}
+}
+
+func TestVerifyUptoTransferEvent(t *testing.T) {
+	token := common.HexToAddress("0xE7C3D8C9a439feDe00D2600032D5dB0Be71C3c29")
+	otherToken := common.HexToAddress("0x0000000000000000000000000000000000000bad")
+	payer := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	receiver := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	attacker := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	settlement := big.NewInt(600)
+
+	tests := []struct {
+		name string
+		logs []*goethtypes.Log
+		want bool
+	}{
+		{
+			name: "matches canonical Transfer event of the settlement amount",
+			logs: []*goethtypes.Log{
+				makeUptoTransferLog(token, payer, receiver, settlement),
+			},
+			want: true,
+		},
+		{
+			name: "rejects deflationary amount below settlement",
+			logs: []*goethtypes.Log{
+				makeUptoTransferLog(token, payer, receiver, big.NewInt(599)),
+			},
+			want: false,
+		},
+		{
+			name: "rejects permitted-max amount instead of settlement amount",
+			logs: []*goethtypes.Log{
+				makeUptoTransferLog(token, payer, receiver, big.NewInt(1000)),
+			},
+			want: false,
+		},
+		{
+			name: "rejects funds sent to a different recipient",
+			logs: []*goethtypes.Log{
+				makeUptoTransferLog(token, payer, attacker, settlement),
+			},
+			want: false,
+		},
+		{
+			name: "ignores Transfer events from a different token contract",
+			logs: []*goethtypes.Log{
+				makeUptoTransferLog(otherToken, payer, receiver, settlement),
+			},
+			want: false,
+		},
+		{
+			name: "no logs at all does not match",
+			logs: []*goethtypes.Log{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := verifyUptoTransferEvent(tt.logs, token, expectedUptoTransferEvent{
+				From:  payer,
+				To:    receiver,
+				Value: settlement,
+			})
+			if err != nil {
+				t.Fatalf("verifyUptoTransferEvent returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("verifyUptoTransferEvent = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Same parity gap as the typescript SDK (#3057): both Go permit2 settle paths checked only `receipt.Status`, so a deflationary or misbehaving ERC-20 could yield a successful `SettleResponse` while the payee received less (or nothing). The eip3009 path already performs this check via `verifyEIP3009TransferEvent`.

- **exact**: reuse `verifyEIP3009TransferEvent` with expected `from=authorization.from`, `to=witness.to`, `value=permitted.amount`, failing with `ErrTransferEventMismatch` when logs are present but no matching Transfer exists (same logs-present guard as eip3009)
- **upto**: add `verifyUptoTransferEvent` checking the actual `settlementAmount` (not the permitted max) plus a new `ErrUptoTransferEventMismatch`, mirroring the scheme's existing duplicate-constant style

## Test plan

- [x] 6 new table tests for the upto verifier (canonical, deflationary, permitted-max-instead-of-settlement, wrong recipient, wrong token, empty logs)
- [x] `go build ./...` clean; `go test -count=1 ./mechanisms/evm/...` all ok

Same class as the previously merged #3032 (python) and sibling TS PR #3057.

Made with Cursor

Made with [Cursor](https://cursor.com)