### PR TITLE
fix(python): verify Transfer event in Permit2 settle receipts (exact + upto)

### DIFF
--- a/python/x402/CHANGELOG.md
+++ b/python/x402/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## [Unreleased]
+
+### Fixed
+
+- Verify the expected ERC-20 Transfer event in exact and upto Permit2 settle receipts when logs are available, matching the EIP-3009 settle check and the TypeScript/Go Permit2 fixes (#2385 / #3080 / #3084).
+
 ## [2.18.0] - 2026-08-04
 
 ### Fixed

--- a/python/x402/mechanisms/evm/exact/permit2_utils.py
+++ b/python/x402/mechanisms/evm/exact/permit2_utils.py
@@ -37,6 +37,7 @@ from ..constants import (  # noqa: E402
     ERR_PERMIT2_RECIPIENT_MISMATCH,
     ERR_PERMIT2_TOKEN_MISMATCH,
     ERR_TRANSACTION_FAILED,
+    ERR_TRANSFER_EVENT_MISMATCH,
     ERR_UNSUPPORTED_SCHEME,
     PERMIT2_ADDRESS,
     PERMIT2_WITNESS_TYPES,
@@ -63,6 +64,32 @@ from ..utils import (  # noqa: E402
     normalize_address,
 )
 from ..verify import verify_typed_data_strict  # noqa: E402
+from .eip3009_utils import verify_eip3009_transfer_event  # noqa: E402
+
+
+def _permit2_settle_transfer_matches(
+    receipt: Any,
+    *,
+    token: str,
+    from_address: str,
+    to: str,
+    value: int,
+) -> bool:
+    """Return True when the settle receipt's Transfer check passes.
+
+    Receipt status alone only proves the proxy call did not revert. When logs
+    are present (including an empty list), require a matching ERC-20 Transfer,
+    matching EIP-3009 settle semantics (#2385 / #2727 / TS #3080).
+    """
+    if getattr(receipt, "logs", None) is None:
+        return True
+    return verify_eip3009_transfer_event(
+        receipt.logs,
+        token,
+        from_address=from_address,
+        to=to,
+        value=value,
+    )
 
 
 def create_permit2_payload(
@@ -527,6 +554,22 @@ def _settle_permit2_direct(
                 payer=payer,
             )
 
+        auth = permit2_payload.permit2_authorization
+        if not _permit2_settle_transfer_matches(
+            receipt,
+            token=auth.permitted.token,
+            from_address=auth.from_address,
+            to=auth.witness.to,
+            value=int(auth.permitted.amount),
+        ):
+            return SettleResponse(
+                success=False,
+                error_reason=ERR_TRANSFER_EVENT_MISMATCH,
+                transaction=tx_hash,
+                network=network,
+                payer=payer,
+            )
+
         return SettleResponse(
             success=True,
             transaction=tx_hash,
@@ -594,6 +637,22 @@ def _settle_permit2_with_eip2612(
                 payer=payer,
             )
 
+        auth = permit2_payload.permit2_authorization
+        if not _permit2_settle_transfer_matches(
+            receipt,
+            token=auth.permitted.token,
+            from_address=auth.from_address,
+            to=auth.witness.to,
+            value=int(auth.permitted.amount),
+        ):
+            return SettleResponse(
+                success=False,
+                error_reason=ERR_TRANSFER_EVENT_MISMATCH,
+                transaction=tx_hash,
+                network=network,
+                payer=payer,
+            )
+
         return SettleResponse(
             success=True,
             transaction=tx_hash,
@@ -642,6 +701,22 @@ def _settle_permit2_with_erc20_approval(
             return SettleResponse(
                 success=False,
                 error_reason=ERR_TRANSACTION_FAILED,
+                transaction=settle_tx_hash,
+                network=network,
+                payer=payer,
+            )
+
+        auth = permit2_payload.permit2_authorization
+        if not _permit2_settle_transfer_matches(
+            receipt,
+            token=auth.permitted.token,
+            from_address=auth.from_address,
+            to=auth.witness.to,
+            value=int(auth.permitted.amount),
+        ):
+            return SettleResponse(
+                success=False,
+                error_reason=ERR_TRANSFER_EVENT_MISMATCH,
                 transaction=settle_tx_hash,
                 network=network,
                 payer=payer,

--- a/python/x402/mechanisms/evm/upto/permit2_utils.py
+++ b/python/x402/mechanisms/evm/upto/permit2_utils.py
@@ -36,6 +36,7 @@ from ..constants import (  # noqa: E402
     ERR_PERMIT2_NOT_YET_VALID,
     ERR_PERMIT2_RECIPIENT_MISMATCH,
     ERR_PERMIT2_TOKEN_MISMATCH,
+    ERR_TRANSFER_EVENT_MISMATCH,
     ERR_UPTO_AMOUNT_EXCEEDS_PERMITTED,
     ERR_UPTO_FACILITATOR_MISMATCH,
     ERR_UPTO_FAILED_TO_GET_NETWORK_CONFIG,
@@ -55,8 +56,9 @@ from ..constants import (  # noqa: E402
 from ..data_suffix import resolve_data_suffix  # noqa: E402
 from ..erc6492 import parse_erc6492_signature  # noqa: E402
 
-# Reuse exact's allowance verification and settle error mapping
+# Reuse exact's allowance verification, Transfer-event check, and settle error mapping
 from ..exact.permit2_utils import (  # noqa: E402
+    _permit2_settle_transfer_matches,
     _verify_permit2_allowance,
 )
 from ..signer import FacilitatorEvmSigner  # noqa: E402
@@ -651,6 +653,22 @@ def _settle_upto_direct(
                 payer=payer,
             )
 
+        auth = permit2_payload.permit2_authorization
+        if not _permit2_settle_transfer_matches(
+            receipt,
+            token=auth.permitted.token,
+            from_address=auth.from_address,
+            to=auth.witness.to,
+            value=settlement_amount,
+        ):
+            return SettleResponse(
+                success=False,
+                error_reason=ERR_TRANSFER_EVENT_MISMATCH,
+                transaction=tx_hash,
+                network=network,
+                payer=payer,
+            )
+
         return SettleResponse(
             success=True,
             transaction=tx_hash,
@@ -721,6 +739,22 @@ def _settle_upto_with_eip2612(
                 payer=payer,
             )
 
+        auth = permit2_payload.permit2_authorization
+        if not _permit2_settle_transfer_matches(
+            receipt,
+            token=auth.permitted.token,
+            from_address=auth.from_address,
+            to=auth.witness.to,
+            value=settlement_amount,
+        ):
+            return SettleResponse(
+                success=False,
+                error_reason=ERR_TRANSFER_EVENT_MISMATCH,
+                transaction=tx_hash,
+                network=network,
+                payer=payer,
+            )
+
         return SettleResponse(
             success=True,
             transaction=tx_hash,
@@ -771,6 +805,22 @@ def _settle_upto_with_erc20_approval(
             return SettleResponse(
                 success=False,
                 error_reason=ERR_UPTO_TRANSACTION_FAILED,
+                transaction=settle_tx_hash,
+                network=network,
+                payer=payer,
+            )
+
+        auth = permit2_payload.permit2_authorization
+        if not _permit2_settle_transfer_matches(
+            receipt,
+            token=auth.permitted.token,
+            from_address=auth.from_address,
+            to=auth.witness.to,
+            value=settlement_amount,
+        ):
+            return SettleResponse(
+                success=False,
+                error_reason=ERR_TRANSFER_EVENT_MISMATCH,
                 transaction=settle_tx_hash,
                 network=network,
                 payer=payer,

--- a/python/x402/tests/unit/mechanisms/evm/test_permit2_settle_transfer_event.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_permit2_settle_transfer_event.py
@@ -1,0 +1,170 @@
+"""Regression: exact Permit2 settle must verify ERC-20 Transfer, not only status.
+
+Receipt status alone is not enough: fee-on-transfer / non-conforming tokens can
+underpay without reverting the proxy call. Mirrors EIP-3009 settle (#2385) and
+TS #3080 / Go #3084.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from x402.mechanisms.evm.constants import (
+    ERR_TRANSACTION_FAILED,
+    ERR_TRANSFER_EVENT_MISMATCH,
+    X402_EXACT_PERMIT2_PROXY_ADDRESS,
+)
+from x402.mechanisms.evm.exact.eip3009_utils import ERC20_TRANSFER_EVENT_TOPIC
+from x402.mechanisms.evm.exact.permit2_utils import _settle_permit2_direct
+from x402.mechanisms.evm.types import (
+    ExactPermit2Authorization,
+    ExactPermit2Payload,
+    ExactPermit2TokenPermissions,
+    ExactPermit2Witness,
+    TransactionReceipt,
+)
+from x402.schemas import PaymentPayload, PaymentRequirements, ResourceInfo
+
+NETWORK = "eip155:84532"
+TOKEN = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+PAYER = "0x1234567890123456789012345678901234567890"
+RECEIVER = "0x0987654321098765432109876543210987654321"
+AMOUNT = "1000"
+TX_HASH = "0x" + "ab" * 32
+
+
+def _addr_topic(address: str) -> str:
+    return "0x" + "0" * 24 + address.lower().removeprefix("0x")
+
+
+def make_transfer_log(
+    *,
+    address: str,
+    from_address: str,
+    to: str,
+    value: int,
+) -> dict:
+    return {
+        "address": address,
+        "topics": [
+            ERC20_TRANSFER_EVENT_TOPIC,
+            _addr_topic(from_address),
+            _addr_topic(to),
+        ],
+        "data": "0x" + f"{value:064x}",
+    }
+
+
+def make_permit2_payload() -> ExactPermit2Payload:
+    now = int(time.time())
+    return ExactPermit2Payload(
+        permit2_authorization=ExactPermit2Authorization(
+            from_address=PAYER,
+            permitted=ExactPermit2TokenPermissions(token=TOKEN, amount=AMOUNT),
+            spender=X402_EXACT_PERMIT2_PROXY_ADDRESS,
+            nonce="12345678901234567890",
+            deadline=str(now + 3600),
+            witness=ExactPermit2Witness(
+                to=RECEIVER,
+                valid_after=str(now - 600),
+            ),
+        ),
+        signature="0x" + "aa" * 65,
+    )
+
+
+def make_payment_payload(permit2_payload: ExactPermit2Payload) -> PaymentPayload:
+    return PaymentPayload(
+        x402_version=2,
+        resource=ResourceInfo(
+            url="http://example.com/protected-permit2",
+            description="Test resource",
+            mime_type="application/json",
+        ),
+        accepted=PaymentRequirements(
+            scheme="exact",
+            network=NETWORK,
+            asset=TOKEN,
+            amount=AMOUNT,
+            pay_to=RECEIVER,
+            max_timeout_seconds=3600,
+            extra={"assetTransferMethod": "permit2"},
+        ),
+        payload=permit2_payload.to_dict(),
+    )
+
+
+class _SettleMockSigner:
+    def __init__(self, *, status: int = 1, logs: list[Any] | None = None):
+        self._status = status
+        self._logs = logs
+        self.write_calls: list[tuple] = []
+
+    def write_contract(self, *args: Any, **kwargs: Any) -> str:
+        self.write_calls.append((args, kwargs))
+        return TX_HASH
+
+    def wait_for_transaction_receipt(self, tx_hash: str) -> TransactionReceipt:
+        return TransactionReceipt(
+            status=self._status,
+            block_number=1,
+            tx_hash=tx_hash,
+            logs=self._logs,
+        )
+
+
+def test_settle_rejects_underpaying_transfer_event():
+    permit2_payload = make_permit2_payload()
+    signer = _SettleMockSigner(
+        logs=[make_transfer_log(address=TOKEN, from_address=PAYER, to=RECEIVER, value=900)]
+    )
+    result = _settle_permit2_direct(signer, make_payment_payload(permit2_payload), permit2_payload)
+    assert result.success is False
+    assert result.error_reason == ERR_TRANSFER_EVENT_MISMATCH
+    assert result.transaction == TX_HASH
+
+
+def test_settle_rejects_empty_logs():
+    permit2_payload = make_permit2_payload()
+    signer = _SettleMockSigner(logs=[])
+    result = _settle_permit2_direct(signer, make_payment_payload(permit2_payload), permit2_payload)
+    assert result.success is False
+    assert result.error_reason == ERR_TRANSFER_EVENT_MISMATCH
+
+
+def test_settle_rejects_wrong_recipient():
+    permit2_payload = make_permit2_payload()
+    attacker = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    signer = _SettleMockSigner(
+        logs=[make_transfer_log(address=TOKEN, from_address=PAYER, to=attacker, value=1000)]
+    )
+    result = _settle_permit2_direct(signer, make_payment_payload(permit2_payload), permit2_payload)
+    assert result.success is False
+    assert result.error_reason == ERR_TRANSFER_EVENT_MISMATCH
+
+
+def test_settle_accepts_matching_transfer_event():
+    permit2_payload = make_permit2_payload()
+    signer = _SettleMockSigner(
+        logs=[make_transfer_log(address=TOKEN, from_address=PAYER, to=RECEIVER, value=1000)]
+    )
+    result = _settle_permit2_direct(signer, make_payment_payload(permit2_payload), permit2_payload)
+    assert result.success is True
+    assert result.transaction == TX_HASH
+
+
+def test_settle_still_fails_on_reverted_receipt():
+    permit2_payload = make_permit2_payload()
+    signer = _SettleMockSigner(status=0, logs=[])
+    result = _settle_permit2_direct(signer, make_payment_payload(permit2_payload), permit2_payload)
+    assert result.success is False
+    assert result.error_reason == ERR_TRANSACTION_FAILED
+
+
+def test_settle_skips_transfer_check_when_logs_absent():
+    """Preserve prior semantics when the RPC omits logs entirely (logs is None)."""
+    permit2_payload = make_permit2_payload()
+    signer = _SettleMockSigner(logs=None)
+    result = _settle_permit2_direct(signer, make_payment_payload(permit2_payload), permit2_payload)
+    assert result.success is True

--- a/python/x402/tests/unit/mechanisms/evm/test_upto_permit2_settle_transfer_event.py
+++ b/python/x402/tests/unit/mechanisms/evm/test_upto_permit2_settle_transfer_event.py
@@ -1,0 +1,160 @@
+"""Regression: upto Permit2 settle must verify ERC-20 Transfer for settlement amount."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from x402.mechanisms.evm.constants import (
+    ERR_TRANSFER_EVENT_MISMATCH,
+    X402_UPTO_PERMIT2_PROXY_ADDRESS,
+)
+from x402.mechanisms.evm.exact.eip3009_utils import ERC20_TRANSFER_EVENT_TOPIC
+from x402.mechanisms.evm.types import (
+    ExactPermit2TokenPermissions,
+    TransactionReceipt,
+    UptoPermit2Authorization,
+    UptoPermit2Payload,
+    UptoPermit2Witness,
+)
+from x402.mechanisms.evm.upto.permit2_utils import _settle_upto_direct
+from x402.schemas import PaymentPayload, PaymentRequirements, ResourceInfo
+
+NETWORK = "eip155:84532"
+TOKEN = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+PAYER = "0x1234567890123456789012345678901234567890"
+RECEIVER = "0x0987654321098765432109876543210987654321"
+FACILITATOR = "0x1111111111111111111111111111111111111111"
+PERMITTED = "1000"
+SETTLEMENT = 800
+TX_HASH = "0x" + "cd" * 32
+
+
+def _addr_topic(address: str) -> str:
+    return "0x" + "0" * 24 + address.lower().removeprefix("0x")
+
+
+def make_transfer_log(
+    *,
+    address: str,
+    from_address: str,
+    to: str,
+    value: int,
+) -> dict:
+    return {
+        "address": address,
+        "topics": [
+            ERC20_TRANSFER_EVENT_TOPIC,
+            _addr_topic(from_address),
+            _addr_topic(to),
+        ],
+        "data": "0x" + f"{value:064x}",
+    }
+
+
+def make_upto_payload() -> UptoPermit2Payload:
+    now = int(time.time())
+    return UptoPermit2Payload(
+        permit2_authorization=UptoPermit2Authorization(
+            from_address=PAYER,
+            permitted=ExactPermit2TokenPermissions(token=TOKEN, amount=PERMITTED),
+            spender=X402_UPTO_PERMIT2_PROXY_ADDRESS,
+            nonce="12345678901234567890",
+            deadline=str(now + 3600),
+            witness=UptoPermit2Witness(
+                to=RECEIVER,
+                facilitator=FACILITATOR,
+                valid_after=str(now - 600),
+            ),
+        ),
+        signature="0x" + "bb" * 65,
+    )
+
+
+def make_payment_payload(permit2_payload: UptoPermit2Payload) -> PaymentPayload:
+    return PaymentPayload(
+        x402_version=2,
+        resource=ResourceInfo(
+            url="http://example.com/protected-upto",
+            description="Test resource",
+            mime_type="application/json",
+        ),
+        accepted=PaymentRequirements(
+            scheme="upto",
+            network=NETWORK,
+            asset=TOKEN,
+            amount=str(SETTLEMENT),
+            pay_to=RECEIVER,
+            max_timeout_seconds=3600,
+            extra={"assetTransferMethod": "permit2", "facilitatorAddress": FACILITATOR},
+        ),
+        payload=permit2_payload.to_dict(),
+    )
+
+
+class _SettleMockSigner:
+    def __init__(self, *, status: int = 1, logs: list[Any] | None = None):
+        self._status = status
+        self._logs = logs
+
+    def write_contract(self, *args: Any, **kwargs: Any) -> str:
+        return TX_HASH
+
+    def wait_for_transaction_receipt(self, tx_hash: str) -> TransactionReceipt:
+        return TransactionReceipt(
+            status=self._status,
+            block_number=1,
+            tx_hash=tx_hash,
+            logs=self._logs,
+        )
+
+
+def test_upto_settle_rejects_underpaying_transfer_event():
+    permit2_payload = make_upto_payload()
+    signer = _SettleMockSigner(
+        logs=[make_transfer_log(address=TOKEN, from_address=PAYER, to=RECEIVER, value=700)]
+    )
+    result = _settle_upto_direct(
+        signer, make_payment_payload(permit2_payload), permit2_payload, SETTLEMENT
+    )
+    assert result.success is False
+    assert result.error_reason == ERR_TRANSFER_EVENT_MISMATCH
+    assert result.transaction == TX_HASH
+
+
+def test_upto_settle_rejects_empty_logs():
+    permit2_payload = make_upto_payload()
+    signer = _SettleMockSigner(logs=[])
+    result = _settle_upto_direct(
+        signer, make_payment_payload(permit2_payload), permit2_payload, SETTLEMENT
+    )
+    assert result.success is False
+    assert result.error_reason == ERR_TRANSFER_EVENT_MISMATCH
+
+
+def test_upto_settle_rejects_full_permitted_when_settlement_is_lower():
+    """Upto must bind Transfer value to settlement amount, not permitted max."""
+    permit2_payload = make_upto_payload()
+    signer = _SettleMockSigner(
+        logs=[
+            make_transfer_log(address=TOKEN, from_address=PAYER, to=RECEIVER, value=int(PERMITTED))
+        ]
+    )
+    result = _settle_upto_direct(
+        signer, make_payment_payload(permit2_payload), permit2_payload, SETTLEMENT
+    )
+    assert result.success is False
+    assert result.error_reason == ERR_TRANSFER_EVENT_MISMATCH
+
+
+def test_upto_settle_accepts_matching_settlement_transfer():
+    permit2_payload = make_upto_payload()
+    signer = _SettleMockSigner(
+        logs=[make_transfer_log(address=TOKEN, from_address=PAYER, to=RECEIVER, value=SETTLEMENT)]
+    )
+    result = _settle_upto_direct(
+        signer, make_payment_payload(permit2_payload), permit2_payload, SETTLEMENT
+    )
+    assert result.success is True
+    assert result.transaction == TX_HASH
+    assert result.amount == str(SETTLEMENT)


### PR DESCRIPTION
## Description

Python Permit2 settle (exact and upto) still trusted `receipt.status` alone, so a fee-on-transfer or otherwise non-conforming token could underpay while the facilitator reported full success. This PR requires a matching ERC-20 `Transfer` event in the settle receipt when logs are present, the same class of fix as TypeScript #3080, Go #3084, and the EIP-3009 path (#2385).

**What changes:** after a successful receipt status, all six Python Permit2 settle branches (exact: direct / EIP-2612 / ERC-20-approval; upto: the same three) require a matching `Transfer` when logs are present, reusing `verify_eip3009_transfer_event`. Exact expects the full permitted amount; upto expects the actual settlement amount. Same logs-present guard semantics as EIP-3009 settle (`logs is None` skips; empty list rejects).

**Why:** receipt status proves only that the proxy call did not revert. The Permit2 proxy performs no balance-delta check, so underpayment is invisible without inspecting Transfer logs. Merchants using arbitrary ERC-20s via Permit2 can deliver resources underpaid.

**Lineage:** sibling of merged #2385 (EIP-3009 Transfer verification) and open TypeScript #3080 / Go #3084 (Permit2 Transfer verification). This PR rebases the earlier Python attempt onto current main, drops the Cursor co-author trailer, uses the shared exact helper (no separate upto error string), and adds settle-path regressions that bind upto to the settlement amount.

**Signing note:** this commit is unsigned in git metadata. x402 requires signed commits for merge. Please amend with your GitHub-registered signing key:

```bash
cd /tmp/x402-second-pass
git checkout fix/python-permit2-settle-transfer-event
git commit --amend --no-edit -S
git push --force-with-lease fork HEAD:fix/python-permit2-settle-transfer-event
```

(Same human amend path as #3080 / #3084.)

Spotted during a security review of the facilitator settle paths (F-201). Prepared with AI assistance (Cursor agent); every test assertion was validated by running the suite below.

## Tests

```bash
cd python
pytest x402/tests/unit/mechanisms/evm/test_permit2_settle_transfer_event.py \
       x402/tests/unit/mechanisms/evm/test_upto_permit2_settle_transfer_event.py \
       x402/tests/unit/mechanisms/evm/test_permit2.py::TestSettlePermit2 -q
```

14 passed (10 new regressions + 4 existing settle tests).

New settle-path regressions:

- exact: underpaying Transfer (900 of 1000) rejected; empty logs rejected; wrong recipient rejected; matching Transfer succeeds; reverted receipt still `invalid_transaction_state`; `logs is None` keeps prior skip semantics
- upto: underpaying Transfer rejected; empty logs rejected; full permitted amount rejected when settlement is lower; matching settlement Transfer succeeds

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- unsigned here; human amend `-S` before merge
- [x] I added a changelog fragment for user-facing changes (`python/x402/CHANGELOG.md` Unreleased)