### PR TITLE
fix(mcp): withhold tool result when settlement resolves success:false

### DIFF
--- a/typescript/packages/mcp/src/server/paymentWrapper.ts
+++ b/typescript/packages/mcp/src/server/paymentWrapper.ts
@@ -425,6 +425,20 @@ async function settlePaymentResult(
       transportContext,
     );
 
+    // settlePayment resolves (does not throw) on facilitator-side failures:
+    // e.g. a double-spend race where the nonce was consumed between verify
+    // and settle. Returning the tool result here would serve paid content
+    // for free, so mirror the HTTP resource server and withhold it.
+    if (!settleResult.success) {
+      return createSettlementFailedResult(
+        resourceServer,
+        toolName,
+        config,
+        settleResult.errorMessage || settleResult.errorReason || "Settlement failed",
+        transportContext,
+      );
+    }
+
     if (config.hooks?.onAfterSettlement) {
       const settlementContext: SettlementContext = {
         ...hookContext,

--- a/typescript/packages/mcp/test/unit/server.test.ts
+++ b/typescript/packages/mcp/test/unit/server.test.ts
@@ -160,6 +160,42 @@ describe("createPaymentWrapper", () => {
       expect(result._meta?.[MCP_PAYMENT_RESPONSE_META_KEY]).toEqual(mockSettleResponse);
     });
 
+    it("should withhold tool result when settlement resolves with success: false", async () => {
+      mockResourceServer.settlePayment.mockResolvedValue({
+        success: false,
+        errorReason: "invalid_exact_evm_payload_authorization_nonce_already_used",
+        transaction: "",
+        network: "eip155:84532",
+      } as SettleResponse);
+
+      const onAfterSettlement = vi.fn();
+      const paid = createPaymentWrapper(
+        mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],
+        {
+          accepts: [mockPaymentRequirements],
+          hooks: { onAfterSettlement },
+        },
+      );
+
+      const handler = vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "paid content" }],
+      });
+
+      const wrappedHandler = paid(handler);
+      const result = await wrappedHandler(
+        { test: "arg" },
+        { _meta: { "x402/payment": mockPaymentPayload } },
+      );
+
+      // Double-spend race: verify passed, another call consumed the nonce,
+      // settle resolves success:false. The paid content must NOT be served.
+      expect(handler).toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).not.toContain("paid content");
+      expect(result._meta?.[MCP_PAYMENT_RESPONSE_META_KEY]).toBeUndefined();
+      expect(onAfterSettlement).not.toHaveBeenCalled();
+    });
+
     it("should settle payment after successful execution", async () => {
       const paid = createPaymentWrapper(
         mockResourceServer as unknown as Parameters<typeof createPaymentWrapper>[0],


### PR DESCRIPTION
## Summary

`createPaymentWrapper`'s `settlePaymentResult` only treated a *thrown* error as settlement failure. `settlePayment` resolves (does not throw) on facilitator-side failures, so a `SettleResponse` with `success: false` fell through: `onAfterSettlement` fired and the paid tool result was returned with settlement metadata attached — **served for free**.

Concrete instance: the double-spend race. Two parallel calls present the same eip3009 authorization; both verify, both execute the tool, the first settles and consumes the nonce; the second's settle resolves `{ success: false, errorReason: nonce_already_used }` — and previously still received the paid content.

The HTTP resource server already checks `!settleResponse.success` and builds a failure response (`x402HTTPResourceServer`). This mirrors that check in the MCP wrapper: on `success: false` it returns the settlement-failure 402 result instead of the tool result (content withheld).

## Test plan

- [x] New unit test: handler executed, result `isError`, no paid content in body, no settlement metadata attached, `onAfterSettlement` not fired
- [x] 100/100 mcp tests pass (99 existing + 1 new); lint + format + build clean

Same repo-hygiene family as #3057/#3058/#3059 (settle-failure semantics parity across surfaces).

Made with Cursor

Made with [Cursor](https://cursor.com)