### PR TITLE
feat(mech/hedera): verify payee net credit from consensus record at settle

### DIFF
--- a/typescript/packages/mechanisms/hedera/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/hedera/src/exact/facilitator/scheme.ts
@@ -255,6 +255,30 @@ export class ExactHederaScheme implements SchemeNetworkFacilitator {
         requirements.network,
       );
 
+      // Consensus success only proves the transfer executed. When the signer
+      // returns the record's effective balance changes, confirm the payee's
+      // net credit equals the required amount — HTS tokens with custom fees
+      // (fractional fees are deducted from the receiver; fixed fees with
+      // net-of-transfers likewise) can otherwise settle SUCCESS while the
+      // payee received less than required.
+      if (settled.transfers != null) {
+        const assetLegs = isHbarAsset(requirements.asset)
+          ? settled.transfers.hbarTransfers
+          : (settled.transfers.tokenTransfers[requirements.asset] ?? []);
+        const netToPayTo = assetLegs
+          .filter(entry => hederaAccountIdsEqual(entry.accountId, requirements.payTo))
+          .reduce((sum, entry) => sum + BigInt(entry.amount), 0n);
+        if (netToPayTo !== BigInt(requirements.amount)) {
+          return {
+            success: false,
+            network: requirements.network,
+            payer: valid.payer || feePayer,
+            transaction: settled.transactionId,
+            errorReason: "settlement_transfer_amount_mismatch",
+          };
+        }
+      }
+
       return {
         success: true,
         network: requirements.network,

--- a/typescript/packages/mechanisms/hedera/src/signer.ts
+++ b/typescript/packages/mechanisms/hedera/src/signer.ts
@@ -3,6 +3,7 @@ import type { PaymentRequirements } from "@x402/core/types";
 // `parseMirrorKey` below relies on the SDK's internal `Key._fromProtobufKey`,
 // so re-check its availability whenever either dependency is bumped.
 import { proto } from "@hiero-ledger/proto";
+import type { HederaTransferEntry } from "./types";
 import {
   AccountId,
   Client,
@@ -14,6 +15,7 @@ import {
   TokenId,
   Transaction,
   TransactionId,
+  TransactionRecord,
   TransferTransaction,
 } from "@hiero-ledger/sdk";
 import { HEDERA_MAINNET_CAIP2, HEDERA_TESTNET_CAIP2 } from "./constants";
@@ -59,6 +61,11 @@ export type FacilitatorHederaSigner = {
   /**
    * Add fee payer signature and submit the transaction to Hedera.
    *
+   * Implementations SHOULD include `transfers` in the result: the effective
+   * balance changes from the consensus record (i.e. after HTS custom fees are
+   * assessed), which the scheme uses to confirm the payee actually received
+   * the full amount. Custom signers that omit it skip that check.
+   *
    * Must resolve only when the transaction has reached consensus with a
    * SUCCESS receipt; any non-SUCCESS status (e.g. `TOKEN_NOT_ASSOCIATED_TO_ACCOUNT`,
    * `INSUFFICIENT_ACCOUNT_BALANCE`, `INVALID_SIGNATURE`) must throw. The scheme
@@ -76,7 +83,13 @@ export type FacilitatorHederaSigner = {
     transactionBase64: string,
     feePayer: string,
     network: string,
-  ): Promise<{ transactionId: string }>;
+  ): Promise<{
+    transactionId: string;
+    transfers?: {
+      hbarTransfers: HederaTransferEntry[];
+      tokenTransfers: Record<string, HederaTransferEntry[]>;
+    };
+  }>;
 
   /**
    * Verify that the inferred payer actually signed the frozen transaction body.
@@ -250,11 +263,52 @@ export function createHederaSignAndSubmitTransaction(
     try {
       const response = await signed.execute(client);
       await response.getReceipt(client);
-      return { transactionId: response.transactionId.toString() };
+
+      // Receipt status only proves the tx reached consensus. Fetch the record
+      // so the scheme can verify the payee's net credit after HTS custom fees
+      // (fractional fees are deducted from the receiver, fixed fees with
+      // net-of-transfers likewise) — a custom-fee token can otherwise settle
+      // SUCCESS while the payee received less than the required amount.
+      const record = await response.getRecord(client);
+      const transfers = flattenRecordTransfers(record);
+
+      return { transactionId: response.transactionId.toString(), transfers };
     } finally {
       client.close();
     }
   };
+}
+
+/**
+ * Flattens a consensus record's effective balance changes into the
+ * HederaTransferEntry shape the scheme verifies against. The record's
+ * transfer lists already include assessed custom-fee legs, so the payee's
+ * net entry reflects what was actually received.
+ *
+ * @param record - Consensus record of the settled transaction
+ * @returns Effective HBAR and per-token transfer lists
+ */
+function flattenRecordTransfers(record: TransactionRecord): {
+  hbarTransfers: HederaTransferEntry[];
+  tokenTransfers: Record<string, HederaTransferEntry[]>;
+} {
+  const hbarTransfers: HederaTransferEntry[] = (record.transfers ?? []).map(entry => ({
+    accountId: entry.accountId.toString(),
+    amount: entry.amount.toTinybars().toString(),
+  }));
+
+  const tokenTransfers: Record<string, HederaTransferEntry[]> = {};
+  if (record.tokenTransfers) {
+    for (const [tokenId, accountMap] of record.tokenTransfers) {
+      const entries: HederaTransferEntry[] = [];
+      for (const [accountId, amount] of accountMap) {
+        entries.push({ accountId: accountId.toString(), amount: amount.toString() });
+      }
+      tokenTransfers[tokenId.toString()] = entries;
+    }
+  }
+
+  return { hbarTransfers, tokenTransfers };
 }
 
 /**

--- a/typescript/packages/mechanisms/hedera/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/unit/facilitator.test.ts
@@ -527,6 +527,112 @@ describe("ExactHedera facilitator scheme", () => {
     expect(settled.errorMessage).toContain("submit failed");
   });
 
+  describe("post-settle record verification", () => {
+    async function settleWithTransfers(transfers: {
+      hbarTransfers: { accountId: string; amount: string }[];
+      tokenTransfers: Record<string, { accountId: string; amount: string }[]>;
+    }) {
+      const signer = createSigner();
+      signer.signAndSubmitTransaction = vi.fn(async () => ({
+        transactionId: "0.0.5001@1700000001.000000000",
+        transfers,
+      }));
+      const scheme = new ExactHederaScheme(signer);
+      const payload: PaymentPayload = {
+        ...basePayload,
+        payload: {
+          transaction: await createTransferTransactionBase64({
+            feePayer: "0.0.5001",
+            payer: "0.0.9001",
+            payTo: "0.0.7001",
+            asset: "0.0.6001",
+            amount: "1000",
+          }),
+        },
+      };
+      return scheme.settle(payload, baseRequirements);
+    }
+
+    it("succeeds when the record credits the payee the full amount", async () => {
+      const settled = await settleWithTransfers({
+        hbarTransfers: [],
+        tokenTransfers: {
+          "0.0.6001": [
+            { accountId: "0.0.9001", amount: "-1000" },
+            { accountId: "0.0.7001", amount: "1000" },
+          ],
+        },
+      });
+      expect(settled.success).toBe(true);
+    });
+
+    it("fails when a custom fee leaves the payee underpaid", async () => {
+      const settled = await settleWithTransfers({
+        hbarTransfers: [],
+        tokenTransfers: {
+          "0.0.6001": [
+            { accountId: "0.0.9001", amount: "-1000" },
+            { accountId: "0.0.7001", amount: "950" },
+            { accountId: "0.0.4242", amount: "50" },
+          ],
+        },
+      });
+      expect(settled.success).toBe(false);
+      expect(settled.errorReason).toBe("settlement_transfer_amount_mismatch");
+      expect(settled.transaction).toBe("0.0.5001@1700000001.000000000");
+    });
+
+    it("fails when the record credits a different account", async () => {
+      const settled = await settleWithTransfers({
+        hbarTransfers: [],
+        tokenTransfers: {
+          "0.0.6001": [
+            { accountId: "0.0.9001", amount: "-1000" },
+            { accountId: "0.0.8888", amount: "1000" },
+          ],
+        },
+      });
+      expect(settled.success).toBe(false);
+      expect(settled.errorReason).toBe("settlement_transfer_amount_mismatch");
+    });
+
+    it("ignores fee legs denominated in a different token", async () => {
+      const settled = await settleWithTransfers({
+        hbarTransfers: [],
+        tokenTransfers: {
+          "0.0.6001": [
+            { accountId: "0.0.9001", amount: "-1000" },
+            { accountId: "0.0.7001", amount: "1000" },
+          ],
+          "0.0.7777": [
+            { accountId: "0.0.9001", amount: "-5" },
+            { accountId: "0.0.4242", amount: "5" },
+          ],
+        },
+      });
+      expect(settled.success).toBe(true);
+    });
+
+    it("succeeds without the check when the signer returns no record transfers", async () => {
+      const signer = createSigner();
+      const scheme = new ExactHederaScheme(signer);
+      const payload: PaymentPayload = {
+        ...basePayload,
+        payload: {
+          transaction: await createTransferTransactionBase64({
+            feePayer: "0.0.5001",
+            payer: "0.0.9001",
+            payTo: "0.0.7001",
+            asset: "0.0.6001",
+            amount: "1000",
+          }),
+        },
+      };
+      const settled = await scheme.settle(payload, baseRequirements);
+      expect(settled.success).toBe(true);
+    });
+  });
+
   it("returns managed signer addresses via getSigners", () => {
     const signer = createSigner();
     const scheme = new ExactHederaScheme(signer);

--- a/typescript/packages/mechanisms/hedera/test/unit/signer.test.ts
+++ b/typescript/packages/mechanisms/hedera/test/unit/signer.test.ts
@@ -207,9 +207,14 @@ describe("createHederaSignAndSubmitTransaction", () => {
     const builtClient = { close: closeSpy } as unknown as Client;
     const expectedId = "0.0.5001@1700000002.000000000";
     const getReceipt = vi.fn().mockResolvedValue({ status: "SUCCESS" });
+    const getRecord = vi.fn().mockResolvedValue({
+      transfers: [],
+      tokenTransfers: new Map(),
+    });
     vi.spyOn(TransferTransaction.prototype, "execute").mockResolvedValue({
       transactionId: { toString: () => expectedId },
       getReceipt,
+      getRecord,
     } as never);
 
     const submit = createHederaSignAndSubmitTransaction(() => builtClient, feePayerKey);
@@ -219,8 +224,12 @@ describe("createHederaSignAndSubmitTransaction", () => {
       "hedera:testnet",
     );
 
-    expect(result).toEqual({ transactionId: expectedId });
+    expect(result).toEqual({
+      transactionId: expectedId,
+      transfers: { hbarTransfers: [], tokenTransfers: {} },
+    });
     expect(getReceipt).toHaveBeenCalledWith(builtClient);
+    expect(getRecord).toHaveBeenCalledWith(builtClient);
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

The Hedera facilitator verified the **declared** transfer legs in the transaction body and treated receipt `SUCCESS` as full settlement, but never checked the **effective** balance changes. HTS tokens with custom fees settle `SUCCESS` while the payee receives less than the required amount:

- **Fractional custom fees** are deducted from the token receiver.
- **Fixed custom fees with net-of-transfers** are likewise deducted from what the receiver is credited.

So a resource server charging 1000 units of a custom-fee token gets underpaid (e.g. 950 + 50 to the fee collector) while `/settle` reports `success: true`. This is the same under-delivery class the eip3009 `Transfer` event check covers on EVM (and #3057–3059 extend to Permit2); Hedera has no events, but its consensus **record** already contains the effective transfers including assessed custom-fee legs.

## Fix

- `createHederaSignAndSubmitTransaction` now fetches the consensus record and returns the effective `hbarTransfers` / `tokenTransfers` alongside the transaction id (optional field — custom signers that omit it skip the check, documented on the interface).
- `settle()` confirms the payee's **net credit for the required asset** equals `requirements.amount` when transfers are present, failing with `settlement_transfer_amount_mismatch` (and the settled tx id, for traceability) otherwise.
- Fee legs denominated in a **different** token are ignored: fixed fees charged to the payer in another token don't reduce the payee's asset credit, so they must not false-fail.

## Test plan

- [x] 5 new settle tests: full credit → success; custom-fee underpayment → `settlement_transfer_amount_mismatch` with tx id; credit to a different account → mismatch; other-token fee legs → still success; signer without record support → success (guard preserved)
- [x] Default signer test updated to assert the record is fetched and flattened
- [x] `pnpm vitest run` 107/107, `pnpm run build`, `pnpm run format`, `pnpm run lint` all green

Made with Cursor

Made with [Cursor](https://cursor.com)