### PR TITLE
fix(hono): rebuild response from buffered body after successful settle

### DIFF
--- a/typescript/.changeset/hono-settle-response-body.md
+++ b/typescript/.changeset/hono-settle-response-body.md
@@ -2,4 +2,4 @@
 "@x402/hono": patch
 ---
 
-Rebuild the response from the buffered body after successful settlement, so the body sent to the client no longer depends on the state of the handler's body stream across the settlement await. Responses that cannot be reconstructed keep their original object rather than surfacing as a 402 after the payment has settled on-chain.
+Rebuild the response from the buffered body after successful settlement, so the body sent to the client no longer depends on the state of the handler's body stream across the settlement await

--- a/typescript/.changeset/hono-settle-response-body.md
+++ b/typescript/.changeset/hono-settle-response-body.md
@@ -1,0 +1,5 @@
+---
+"@x402/hono": patch
+---
+
+Rebuild the response from the buffered body after successful settlement, so the body sent to the client no longer depends on the state of the handler's body stream across the settlement await. Responses that cannot be reconstructed keep their original object rather than surfacing as a 402 after the payment has settled on-chain.

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -529,7 +529,7 @@ describe("paymentMiddleware", () => {
       ),
     );
     app.get("/api/test", () => {
-      // `new Headers(res.headers)` must not collapse these into one value.
+      // Carrying headers into the rebuilt response must not collapse these into one.
       const headers = new Headers({ "content-type": "application/json" });
       headers.append("set-cookie", "a=1; Path=/");
       headers.append("set-cookie", "b=2; Path=/");
@@ -564,7 +564,7 @@ describe("paymentMiddleware", () => {
     // A status outside 200-599 makes `new Response()` throw whatever the body is.
     // Undici cannot build one, but workerd can (a 101 upgrade carries a webSocket),
     // so the middleware has to survive receiving it. The payment is already settled
-    // on-chain at this point, so a 402 here would charge and withhold.
+    // onchain at this point, so a 402 here would charge and withhold.
     const responseHeaders = new Headers();
     responseHeaders.set("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
     const upgradeResponse = {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -462,6 +462,86 @@ describe("paymentMiddleware", () => {
     expect(res.headers.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
+  it("preserves status text and handler headers through the rebuild", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const app = new Hono();
+    app.use(
+      "/api/*",
+      paymentMiddleware(
+        mockRoutes,
+        {} as unknown as x402ResourceServer,
+        undefined,
+        undefined,
+        false,
+      ),
+    );
+    app.get(
+      "/api/test",
+      () =>
+        new Response('{"ok":true}', {
+          status: 200,
+          statusText: "Totally Fine",
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+            "content-length": "11",
+            "x-custom": "kept",
+          },
+        }),
+    );
+
+    const res = await app.request("/api/test");
+
+    expect(res.statusText).toBe("Totally Fine");
+    expect(res.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(res.headers.get("content-length")).toBe("11");
+    expect(res.headers.get("x-custom")).toBe("kept");
+    expect(res.headers.get("Cache-Control")).toContain("private");
+    expect(await res.text()).toBe('{"ok":true}');
+  });
+
+  it("keeps multiple Set-Cookie headers separate through the rebuild", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const app = new Hono();
+    app.use(
+      "/api/*",
+      paymentMiddleware(
+        mockRoutes,
+        {} as unknown as x402ResourceServer,
+        undefined,
+        undefined,
+        false,
+      ),
+    );
+    app.get("/api/test", () => {
+      // `new Headers(res.headers)` must not collapse these into one value.
+      const headers = new Headers({ "content-type": "application/json" });
+      headers.append("set-cookie", "a=1; Path=/");
+      headers.append("set-cookie", "b=2; Path=/");
+      return new Response('{"ok":true}', { status: 200, headers });
+    });
+
+    const res = await app.request("/api/test");
+
+    expect(res.headers.getSetCookie()).toEqual(["a=1; Path=/", "b=2; Path=/"]);
+    expect(res.headers.get("PAYMENT-RESPONSE")).toBe("settled");
+  });
+
   it("does not turn an unreconstructable response into a 402 after settling", async () => {
     setupMockHttpServer(
       {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -397,7 +397,115 @@ describe("paymentMiddleware", () => {
       undefined,
       undefined,
     );
-    expect(responseHeaders.get("PAYMENT-RESPONSE")).toBe("settled");
+    expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("settled");
+  });
+
+  it("sends the handler body to the client after settlement succeeds", async () => {
+    setupMockHttpServer({
+      type: "payment-verified",
+      paymentPayload: mockPaymentPayload,
+      paymentRequirements: mockPaymentRequirements,
+    });
+    // Settlement against a real facilitator takes seconds; the body buffered
+    // before it started must still reach the client once it resolves.
+    mockProcessSettlement.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 20));
+      return { success: true, headers: { "PAYMENT-RESPONSE": "settled" } };
+    });
+
+    const app = new Hono();
+    app.use(
+      "/api/*",
+      paymentMiddleware(
+        mockRoutes,
+        {} as unknown as x402ResourceServer,
+        undefined,
+        undefined,
+        false,
+      ),
+    );
+    app.get("/api/test", c => c.json({ ok: true }));
+
+    const res = await app.request("/api/test");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("PAYMENT-RESPONSE")).toBe("settled");
+    expect(await res.text()).toBe('{"ok":true}');
+  });
+
+  it("keeps a null-body status intact after settlement succeeds", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const app = new Hono();
+    app.use(
+      "/api/*",
+      paymentMiddleware(
+        mockRoutes,
+        {} as unknown as x402ResourceServer,
+        undefined,
+        undefined,
+        false,
+      ),
+    );
+    app.get("/api/test", c => c.body(null, 204));
+
+    const res = await app.request("/api/test");
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("PAYMENT-RESPONSE")).toBe("settled");
+  });
+
+  it("does not turn an unreconstructable response into a 402 after settling", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const middleware = paymentMiddleware(
+      mockRoutes,
+      {} as unknown as x402ResourceServer,
+      undefined,
+      undefined,
+      false,
+    );
+    const context = createMockContext();
+
+    // A status outside 200-599 makes `new Response()` throw whatever the body is.
+    // Undici cannot build one, but workerd can (a 101 upgrade carries a webSocket),
+    // so the middleware has to survive receiving it. The payment is already settled
+    // on-chain at this point, so a 402 here would charge and withhold.
+    const responseHeaders = new Headers();
+    responseHeaders.set("Settlement-Overrides", JSON.stringify({ amount: "32%" }));
+    const upgradeResponse = {
+      status: 101,
+      headers: responseHeaders,
+      clone: () => ({
+        arrayBuffer: async () => new ArrayBuffer(0),
+      }),
+    } as unknown as Response;
+
+    const next = vi.fn().mockImplementation(async () => {
+      context.res = upgradeResponse;
+    });
+
+    await middleware(context, next);
+
+    expect(context.json).not.toHaveBeenCalledWith({}, 402);
+    expect(context.res).toBe(upgradeResponse);
+    expect(context.res?.status).toBe(101);
+    expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("settled");
+    expect(context.res?.headers.has("Settlement-Overrides")).toBe(false);
   });
 
   it("strips settlement override header from client response", async () => {
@@ -435,8 +543,8 @@ describe("paymentMiddleware", () => {
 
     await middleware(context, next);
 
-    expect(responseHeaders.has("Settlement-Overrides")).toBe(false);
-    expect(responseHeaders.get("PAYMENT-RESPONSE")).toBe("settled");
+    expect(context.res?.headers.has("Settlement-Overrides")).toBe(false);
+    expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
   it("skips settlement when handler returns >= 400", async () => {

--- a/typescript/packages/http/hono/src/index.test.ts
+++ b/typescript/packages/http/hono/src/index.test.ts
@@ -145,6 +145,22 @@ function setupMockHttpServer(
 }
 
 /**
+ * Creates a Hono app with the payment middleware mounted on /api/*.
+ *
+ * @param handler - Handler for GET /api/test.
+ * @returns The app.
+ */
+function createPaidApp(handler: Parameters<Hono["get"]>[1]): Hono {
+  const app = new Hono();
+  app.use(
+    "/api/*",
+    paymentMiddleware(mockRoutes, {} as unknown as x402ResourceServer, undefined, undefined, false),
+  );
+  app.get("/api/test", handler);
+  return app;
+}
+
+/**
  * Creates a mock Hono Context for testing.
  *
  * @param options - Configuration options for the mock context.
@@ -400,91 +416,20 @@ describe("paymentMiddleware", () => {
     expect(context.res?.headers.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
-  it("sends the handler body to the client after settlement succeeds", async () => {
+  it("sends the handler response to the client after settlement succeeds", async () => {
     setupMockHttpServer({
       type: "payment-verified",
       paymentPayload: mockPaymentPayload,
       paymentRequirements: mockPaymentRequirements,
     });
-    // Settlement against a real facilitator takes seconds; the body buffered
+    // Settlement against a real facilitator takes seconds; what was buffered
     // before it started must still reach the client once it resolves.
     mockProcessSettlement.mockImplementation(async () => {
       await new Promise(resolve => setTimeout(resolve, 20));
       return { success: true, headers: { "PAYMENT-RESPONSE": "settled" } };
     });
 
-    const app = new Hono();
-    app.use(
-      "/api/*",
-      paymentMiddleware(
-        mockRoutes,
-        {} as unknown as x402ResourceServer,
-        undefined,
-        undefined,
-        false,
-      ),
-    );
-    app.get("/api/test", c => c.json({ ok: true }));
-
-    const res = await app.request("/api/test");
-
-    expect(res.status).toBe(200);
-    expect(res.headers.get("PAYMENT-RESPONSE")).toBe("settled");
-    expect(await res.text()).toBe('{"ok":true}');
-  });
-
-  it("keeps a null-body status intact after settlement succeeds", async () => {
-    setupMockHttpServer(
-      {
-        type: "payment-verified",
-        paymentPayload: mockPaymentPayload,
-        paymentRequirements: mockPaymentRequirements,
-      },
-      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
-    );
-
-    const app = new Hono();
-    app.use(
-      "/api/*",
-      paymentMiddleware(
-        mockRoutes,
-        {} as unknown as x402ResourceServer,
-        undefined,
-        undefined,
-        false,
-      ),
-    );
-    app.get("/api/test", c => c.body(null, 204));
-
-    const res = await app.request("/api/test");
-
-    expect(res.status).toBe(204);
-    expect(res.headers.get("PAYMENT-RESPONSE")).toBe("settled");
-  });
-
-  it("preserves status text and handler headers through the rebuild", async () => {
-    setupMockHttpServer(
-      {
-        type: "payment-verified",
-        paymentPayload: mockPaymentPayload,
-        paymentRequirements: mockPaymentRequirements,
-      },
-      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
-    );
-
-    const app = new Hono();
-    app.use(
-      "/api/*",
-      paymentMiddleware(
-        mockRoutes,
-        {} as unknown as x402ResourceServer,
-        undefined,
-        undefined,
-        false,
-      ),
-    );
-    app.get(
-      "/api/test",
+    const app = createPaidApp(
       () =>
         new Response('{"ok":true}', {
           status: 200,
@@ -499,12 +444,32 @@ describe("paymentMiddleware", () => {
 
     const res = await app.request("/api/test");
 
+    expect(res.status).toBe(200);
     expect(res.statusText).toBe("Totally Fine");
+    expect(res.headers.get("PAYMENT-RESPONSE")).toBe("settled");
     expect(res.headers.get("content-type")).toBe("application/json; charset=utf-8");
     expect(res.headers.get("content-length")).toBe("11");
     expect(res.headers.get("x-custom")).toBe("kept");
     expect(res.headers.get("Cache-Control")).toContain("private");
     expect(await res.text()).toBe('{"ok":true}');
+  });
+
+  it("keeps a null-body status intact after settlement succeeds", async () => {
+    setupMockHttpServer(
+      {
+        type: "payment-verified",
+        paymentPayload: mockPaymentPayload,
+        paymentRequirements: mockPaymentRequirements,
+      },
+      { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
+    );
+
+    const app = createPaidApp(c => c.body(null, 204));
+
+    const res = await app.request("/api/test");
+
+    expect(res.status).toBe(204);
+    expect(res.headers.get("PAYMENT-RESPONSE")).toBe("settled");
   });
 
   it("keeps multiple Set-Cookie headers separate through the rebuild", async () => {
@@ -517,18 +482,7 @@ describe("paymentMiddleware", () => {
       { success: true, headers: { "PAYMENT-RESPONSE": "settled" } },
     );
 
-    const app = new Hono();
-    app.use(
-      "/api/*",
-      paymentMiddleware(
-        mockRoutes,
-        {} as unknown as x402ResourceServer,
-        undefined,
-        undefined,
-        false,
-      ),
-    );
-    app.get("/api/test", () => {
+    const app = createPaidApp(() => {
       // Carrying headers into the rebuilt response must not collapse these into one.
       const headers = new Headers({ "content-type": "application/json" });
       headers.append("set-cookie", "a=1; Path=/");

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -315,12 +315,10 @@ export function paymentMiddlewareFromHTTPServer(
               withPrivateCacheControl(res.headers.get("Cache-Control")),
             );
             res.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
-            // Rebuild from the bytes buffered before settlement so the body sent to
-            // the client does not depend on the state of the original stream across
-            // the settlement await. A throw here would be caught as a settlement
-            // failure and return 402 after the payment settled onchain, so statuses
-            // `new Response` rejects are left alone: outside 200-599 it throws
-            // whatever the body is, and null-body statuses reject a non-null body.
+            // Rebuild from the buffered bytes so the body does not depend on the
+            // original stream's state across the settlement await. `new Response`
+            // rejects statuses outside 200-599, and any body on a null-body status;
+            // throwing here would settle the payment and then return 402.
             if (res.status >= 200 && res.status < 600) {
               res = new Response(responseBody.length > 0 ? responseBody : null, {
                 status: res.status,

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -306,15 +306,38 @@ export function paymentMiddlewareFromHTTPServer(
               headers: response.headers,
             });
           } else {
-            // Settlement succeeded - add headers to response
+            // Settlement succeeded - rebuild the response from the bytes buffered
+            // before settlement, so what reaches the client does not depend on the
+            // state of the original body stream across the settlement await.
+            const headers = new Headers(res.headers);
             Object.entries(settleResult.headers).forEach(([key, value]) => {
-              res.headers.set(key, value);
+              headers.set(key, value);
             });
-            res.headers.set(
-              "Cache-Control",
-              withPrivateCacheControl(res.headers.get("Cache-Control")),
-            );
-            res.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
+            headers.set("Cache-Control", withPrivateCacheControl(headers.get("Cache-Control")));
+            headers.delete(SETTLEMENT_OVERRIDES_HEADER);
+            try {
+              // Null-body statuses must pass null: `new Response(buf, { status: 204 })`
+              // throws.
+              res = new Response(responseBody.length > 0 ? responseBody : null, {
+                status: res.status,
+                statusText: res.statusText,
+                headers,
+              });
+            } catch {
+              // Some responses cannot be reconstructed at all - a status outside
+              // 200-599 throws whatever the body is (e.g. a 101 upgrade, which is
+              // constructible on workerd). The payment has already settled on-chain,
+              // so this must not fall through to the 402 below: keep the handler's
+              // own response and apply the settlement headers in place instead.
+              Object.entries(settleResult.headers).forEach(([key, value]) => {
+                res.headers.set(key, value);
+              });
+              res.headers.set(
+                "Cache-Control",
+                withPrivateCacheControl(res.headers.get("Cache-Control")),
+              );
+              res.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
+            }
           }
         } catch (error) {
           if (error instanceof FacilitatorResponseError) {

--- a/typescript/packages/http/hono/src/index.ts
+++ b/typescript/packages/http/hono/src/index.ts
@@ -306,37 +306,27 @@ export function paymentMiddlewareFromHTTPServer(
               headers: response.headers,
             });
           } else {
-            // Settlement succeeded - rebuild the response from the bytes buffered
-            // before settlement, so what reaches the client does not depend on the
-            // state of the original body stream across the settlement await.
-            const headers = new Headers(res.headers);
+            // Settlement succeeded - add headers to response
             Object.entries(settleResult.headers).forEach(([key, value]) => {
-              headers.set(key, value);
+              res.headers.set(key, value);
             });
-            headers.set("Cache-Control", withPrivateCacheControl(headers.get("Cache-Control")));
-            headers.delete(SETTLEMENT_OVERRIDES_HEADER);
-            try {
-              // Null-body statuses must pass null: `new Response(buf, { status: 204 })`
-              // throws.
+            res.headers.set(
+              "Cache-Control",
+              withPrivateCacheControl(res.headers.get("Cache-Control")),
+            );
+            res.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
+            // Rebuild from the bytes buffered before settlement so the body sent to
+            // the client does not depend on the state of the original stream across
+            // the settlement await. A throw here would be caught as a settlement
+            // failure and return 402 after the payment settled onchain, so statuses
+            // `new Response` rejects are left alone: outside 200-599 it throws
+            // whatever the body is, and null-body statuses reject a non-null body.
+            if (res.status >= 200 && res.status < 600) {
               res = new Response(responseBody.length > 0 ? responseBody : null, {
                 status: res.status,
                 statusText: res.statusText,
-                headers,
+                headers: res.headers,
               });
-            } catch {
-              // Some responses cannot be reconstructed at all - a status outside
-              // 200-599 throws whatever the body is (e.g. a 101 upgrade, which is
-              // constructible on workerd). The payment has already settled on-chain,
-              // so this must not fall through to the 402 below: keep the handler's
-              // own response and apply the settlement headers in place instead.
-              Object.entries(settleResult.headers).forEach(([key, value]) => {
-                res.headers.set(key, value);
-              });
-              res.headers.set(
-                "Cache-Control",
-                withPrivateCacheControl(res.headers.get("Cache-Control")),
-              );
-              res.headers.delete(SETTLEMENT_OVERRIDES_HEADER);
             }
           }
         } catch (error) {


### PR DESCRIPTION
## Description

`paymentMiddlewareFromHTTPServer` buffers the handler's body with `clone().arrayBuffer()` (`typescript/packages/http/hono/src/index.ts:235`), clears `c.res`, then awaits settlement. On failure it builds a fresh `Response` (`:259`); on success it mutated headers on the original `res` and returned that (`:264`). This makes the success path rebuild from the buffered bytes as well, so the body reaching the client no longer depends on the state of the original stream across the settlement await.

Reported in #3035.

**Please read the issue before reviewing — this is hardening, not a verified bug fix.** I could not reproduce the empty body in-process against `main` (8 configurations listed there, all return the body). To be precise about the mechanism: `clone()` tees, so reading the clone does not disturb the original — `bodyUsed` stays `false` and the original stays readable, including across an `await`. **No test in this PR fails against `main`.** I would rather say that than dress it up; happy to close if you would prefer not to touch the success path without a reproduction.

### Why a status guard rather than try/catch

Reconstruction sits inside the `try` whose `catch` means "settlement failed → 402", so a throw there would charge the caller and then withhold the resource. `new Response` rejects any status outside 200-599 whatever the body is, and the `res.status >= 400` check at `:225` lets 1xx through (a 101 upgrade is not constructible on undici, but is on workerd).

I first wrapped the rebuild in try/catch. That is a silent fallback and it duplicated the header handling across both branches, so this checks the status up front instead: statuses the constructor rejects keep the handler's own response object. Null-body statuses pass `null`, which the constructor requires.

Headers are applied in place first, exactly as before, so the diff adds a block without modifying existing lines. Streaming is unaffected — `clone().arrayBuffer()` at `:235` already drains any stream before settlement runs, so the response is de-streamed either way.

## Tests

`pnpm format && pnpm lint && pnpm build && pnpm test` from `typescript/` — all pass.

Four tests in `packages/http/hono/src/index.test.ts`. As above, none fail against `main`; what each one actually constrains:

- **does not turn an unreconstructable response into a 402 after settling** — load-bearing. Remove the status guard and it fails with `expected "spy" to not be called with arguments: [ {}, 402 ]`.
- **keeps a null-body status intact after settlement succeeds** — same, for the `null` body branch.
- **sends the handler response to the client after settlement succeeds** — drop `statusText` from the reconstruction and it fails with `expected '' to be 'Totally Fine'`. Its body assertion is characterisation only and passes against `main` too; it is there because no test asserted the response body at all. The existing settle tests use a hand-rolled fake context whose `clone()` returns `new ArrayBuffer(0)`, so an empty body passes today — this one drives a real `Hono` app, and settles after a delay, since that is what makes the assertion mean anything.
- **keeps multiple Set-Cookie headers separate through the rebuild** — carrying headers across with `forEach` + `set` collapses two cookies into one, so this is a live constraint on how they are passed.

Two existing settle tests asserted on the mock context's internal `Headers` object rather than the outgoing response, so they failed once the response is rebuilt. They now assert on `context.res` — what the client receives — matching the pattern the `success: false` test already uses.

302, 304 and HEAD take the same empty-body reconstruction path as the 204 case above and are not tested separately.

## Related

`typescript/packages/http/next/src/utils.ts` (`handleSettlement`) has the same clone-then-return-original shape on its success path. Untouched here — I have no evidence for it, and this keeps to one issue per contribution. `express` and `fastify` buffer and replay the body themselves and are structurally safe.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes

---

AI disclosure: developed with AI assistance (Claude). I reviewed the diff, ran the reproduction attempts myself, and the negative result above is why this is framed as hardening rather than a bug fix.
