### PR TITLE
fix(mech/svm): verify effective delivery (balance delta) for all settlements

### DIFF
--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -279,20 +279,23 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       };
     }
 
-    // Settlements verified through Path 2 (smart wallet) require post-settlement
-    // verification to defend against TOCTOU. _verify reports the path directly,
-    // so we no longer re-decode the transaction to infer it.
-    const isSmartWalletSettlement = verificationPath === "smartWallet";
+    // Post-settlement delivery verification runs for every settlement when the
+    // signer supports it: for smart wallets it defends against TOCTOU, and for
+    // all payments it confirms the payee's balance actually increased by the
+    // required amount — a Token-2022 mint with a transfer-fee extension skims
+    // at execution, so the declared TransferChecked amount can match while the
+    // payee receives less.
 
-    // For smart wallet settlements: record destination ATA balance before sending.
-    // Used as fallback verification if getTransaction has indexing lag.
+    // Record destination ATA balance before sending.
+    // Used as primary delivery verification; inner-instruction inspection is
+    // the fallback when no pre-balance is available.
     // Try both SPL Token and Token-2022 programs — the payment may use either.
     let balanceBefore: bigint | null = null;
     let balanceBeforeTokenProgram:
       | typeof TOKEN_PROGRAM_ADDRESS
       | typeof TOKEN_2022_PROGRAM_ADDRESS
       | null = null;
-    if (isSmartWalletSettlement && typeof this.signer.getTokenAccountBalance === "function") {
+    if (typeof this.signer.getTokenAccountBalance === "function") {
       for (const tokenProgram of [TOKEN_PROGRAM_ADDRESS, TOKEN_2022_PROGRAM_ADDRESS]) {
         try {
           const [destinationAta] = await findAssociatedTokenPda({
@@ -335,9 +338,17 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       // Wait for confirmation
       await this.signer.confirmTransaction(signature, requirements.network);
 
-      // Post-settlement verification for smart wallet transactions.
-      // Confirms the TransferChecked actually executed on-chain (TOCTOU defense).
-      if (isSmartWalletSettlement) {
+      // Post-settlement verification for every settlement the signer can
+      // support. Smart-wallet settlements keep fail-closed TOCTOU semantics
+      // (inner-instruction inspection); static-path settlements get the
+      // balance-delta delivery check (transfer-fee skim), where "unverified"
+      // (e.g. fresh ATA with no pre-balance) preserves legacy fail-open
+      // behavior — only hard evidence of under-delivery fails the settlement.
+      if (
+        typeof this.signer.getTokenAccountBalance === "function" ||
+        typeof this.signer.getConfirmedTransactionInnerInstructions === "function"
+      ) {
+        const isSmartWalletSettlement = verificationPath === "smartWallet";
         const signerAddresses = this.signer.getAddresses().map(a => a.toString());
         const postVerify = await verifyPostSettlement(
           this.signer,
@@ -347,9 +358,13 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
           signerAddresses,
           balanceBefore,
           balanceBeforeTokenProgram?.toString() ?? null,
+          { inspectInnerInstructions: isSmartWalletSettlement },
         );
 
-        if (!postVerify.verified) {
+        if (
+          !postVerify.verified &&
+          (isSmartWalletSettlement || postVerify.method !== "unverified")
+        ) {
           return {
             success: false,
             errorReason: "post_settlement_transfer_not_confirmed",

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/smartWalletVerification.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/smartWalletVerification.ts
@@ -465,22 +465,35 @@ export async function verifySmartWalletTransaction(
 }
 
 /**
- * Post-settlement verification for smart wallet transactions.
+ * Post-settlement verification.
  *
- * After a transaction confirms on-chain, verifies the TransferChecked actually
- * executed by inspecting the confirmed transaction's inner instructions.
- * Falls back to balance-delta checking if the RPC's transaction index has lag.
+ * Two independent evidence sources:
  *
- * This closes the TOCTOU gap where a malicious program could pass simulation
- * but skip the transfer during on-chain execution.
+ * - Inner instructions (smart-wallet settlements): confirms a TransferChecked
+ *   CPI to the expected destination ATA actually executed, closing the TOCTOU
+ *   gap where a malicious program passes simulation but skips the transfer
+ *   on-chain. Only meaningful for smart-wallet (CPI) settlements — a standard
+ *   wallet's transfer is a top-level instruction and never appears in inner
+ *   instructions, so callers pass `inspectInnerInstructions: false` there.
+ * - Balance delta (all settlements): confirms the destination ATA balance
+ *   actually increased by the required amount. This is the only check that
+ *   catches effective under-delivery — a Token-2022 mint with a transfer-fee
+ *   extension skims at execution, so the declared TransferChecked amount can
+ *   match while the payee receives less.
+ *
+ * When both sources are available, BOTH must pass: the inner-instruction
+ * amount is the declared one, so a skim can only be caught by the delta.
  *
  * @param signer - Facilitator signer with optional getConfirmedTransactionInnerInstructions
  * @param signature - Confirmed transaction signature
  * @param network - CAIP-2 network identifier
  * @param requirements - Payment requirements (asset, payTo, amount)
  * @param signerAddresses - Facilitator signer addresses
- * @param balanceBefore - Destination ATA balance before settlement (for fallback)
+ * @param balanceBefore - Destination ATA balance before settlement (for delivery check)
  * @param balanceBeforeTokenProgram - Which token program the balanceBefore was captured from (SPL Token or Token-2022)
+ * @param options - Verification options
+ * @param options.inspectInnerInstructions - Whether to inspect the confirmed
+ *   transaction's inner instructions (smart-wallet settlements only)
  * @returns Whether the transfer was verified on-chain
  */
 export async function verifyPostSettlement(
@@ -491,13 +504,17 @@ export async function verifyPostSettlement(
   signerAddresses: string[],
   balanceBefore: bigint | null,
   balanceBeforeTokenProgram?: string | null,
+  options?: { inspectInnerInstructions?: boolean },
 ): Promise<{ verified: boolean; method: "innerInstructions" | "balanceDelta" | "unverified" }> {
   const requiredAmount = BigInt(requirements.amount);
 
-  // Primary path: fetch confirmed transaction and inspect inner instructions.
+  // Smart-wallet path: fetch confirmed transaction and inspect inner instructions.
   // Retry with backoff to handle RPC indexing lag (transaction confirmed but
   // not yet indexed). Same polling pattern as confirmTransaction in the SVM signer.
-  if (typeof signer.getConfirmedTransactionInnerInstructions === "function") {
+  if (
+    options?.inspectInnerInstructions !== false &&
+    typeof signer.getConfirmedTransactionInnerInstructions === "function"
+  ) {
     let confirmed: SvmInnerInstructionsResult | null = null;
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
@@ -543,6 +560,22 @@ export async function verifyPostSettlement(
         );
 
         if (matching.length >= 1) {
+          // The declared transfer executed. When a pre-balance is available,
+          // also confirm effective delivery — inner instructions carry the
+          // declared amount, so only the delta catches a transfer-fee skim.
+          if (balanceBefore !== null) {
+            const delta = await checkDeliveryBalanceDelta(
+              signer,
+              network,
+              requirements,
+              requiredAmount,
+              balanceBefore,
+              balanceBeforeTokenProgram,
+            );
+            if (delta === "bad") {
+              return { verified: false, method: "balanceDelta" };
+            }
+          }
           return { verified: true, method: "innerInstructions" };
         }
 
@@ -555,51 +588,23 @@ export async function verifyPostSettlement(
     }
   }
 
-  // Fallback: balance-delta check.
+  // Balance-delta delivery check.
   // If we recorded balanceBefore and the signer supports getTokenAccountBalance,
   // check whether the destination ATA balance increased by at least the required amount.
   // Try both SPL Token and Token-2022 programs — the payment may use either.
   if (balanceBefore !== null && typeof signer.getTokenAccountBalance === "function") {
-    // If we know which token program was used for balanceBefore, check that one first.
-    // Otherwise try both (SPL Token first, then Token-2022).
-    const tokenProgramsToCheck = balanceBeforeTokenProgram
-      ? [
-          balanceBeforeTokenProgram as Address,
-          ...(balanceBeforeTokenProgram === TOKEN_PROGRAM_ADDRESS.toString()
-            ? [TOKEN_2022_PROGRAM_ADDRESS as unknown as Address]
-            : [TOKEN_PROGRAM_ADDRESS as unknown as Address]),
-        ]
-      : [
-          TOKEN_PROGRAM_ADDRESS as unknown as Address,
-          TOKEN_2022_PROGRAM_ADDRESS as unknown as Address,
-        ];
-
-    let anyBalanceChecked = false;
-    for (const tokenProgram of tokenProgramsToCheck) {
-      try {
-        const [destinationAta] = await findAssociatedTokenPda({
-          mint: requirements.asset as Address,
-          owner: requirements.payTo as Address,
-          tokenProgram,
-        });
-
-        const balanceAfter = await signer.getTokenAccountBalance(
-          destinationAta.toString(),
-          network,
-        );
-
-        if (balanceAfter !== null) {
-          anyBalanceChecked = true;
-          if (balanceAfter - balanceBefore >= requiredAmount) {
-            return { verified: true, method: "balanceDelta" };
-          }
-        }
-      } catch {
-        // ATA doesn't exist or balance check failed for this token program. Try next.
-      }
+    const delta = await checkDeliveryBalanceDelta(
+      signer,
+      network,
+      requirements,
+      requiredAmount,
+      balanceBefore,
+      balanceBeforeTokenProgram,
+    );
+    if (delta === "ok") {
+      return { verified: true, method: "balanceDelta" };
     }
-
-    if (anyBalanceChecked) {
+    if (delta === "bad") {
       // We got balance data but it didn't show sufficient increase.
       return { verified: false, method: "balanceDelta" };
     }
@@ -609,4 +614,67 @@ export async function verifyPostSettlement(
   // Neither verification method available or both failed.
   // Return unverified — caller decides policy.
   return { verified: false, method: "unverified" };
+}
+
+/**
+ * Checks whether the destination ATA balance increased by at least the
+ * required amount. This reflects EFFECTIVE delivery: Token-2022 transfer-fee
+ * extensions and any other execution-time skim reduce the credited amount,
+ * so a short delta proves under-delivery even when every declared amount
+ * matched.
+ *
+ * @param signer - Facilitator signer with getTokenAccountBalance
+ * @param network - CAIP-2 network identifier
+ * @param requirements - Payment requirements (asset, payTo)
+ * @param requiredAmount - Minimum expected balance increase
+ * @param balanceBefore - Destination ATA balance captured pre-settlement
+ * @param balanceBeforeTokenProgram - Token program balanceBefore came from
+ * @returns "ok" (delta sufficient), "bad" (delta proven short), or
+ *   "unavailable" (no balance data could be read)
+ */
+async function checkDeliveryBalanceDelta(
+  signer: FacilitatorSvmSigner,
+  network: string,
+  requirements: PaymentRequirements,
+  requiredAmount: bigint,
+  balanceBefore: bigint,
+  balanceBeforeTokenProgram?: string | null,
+): Promise<"ok" | "bad" | "unavailable"> {
+  // If we know which token program was used for balanceBefore, check that one first.
+  // Otherwise try both (SPL Token first, then Token-2022).
+  const tokenProgramsToCheck = balanceBeforeTokenProgram
+    ? [
+        balanceBeforeTokenProgram as Address,
+        ...(balanceBeforeTokenProgram === TOKEN_PROGRAM_ADDRESS.toString()
+          ? [TOKEN_2022_PROGRAM_ADDRESS as unknown as Address]
+          : [TOKEN_PROGRAM_ADDRESS as unknown as Address]),
+      ]
+    : [
+        TOKEN_PROGRAM_ADDRESS as unknown as Address,
+        TOKEN_2022_PROGRAM_ADDRESS as unknown as Address,
+      ];
+
+  let anyBalanceChecked = false;
+  for (const tokenProgram of tokenProgramsToCheck) {
+    try {
+      const [destinationAta] = await findAssociatedTokenPda({
+        mint: requirements.asset as Address,
+        owner: requirements.payTo as Address,
+        tokenProgram,
+      });
+
+      const balanceAfter = await signer.getTokenAccountBalance!(destinationAta.toString(), network);
+
+      if (balanceAfter !== null) {
+        anyBalanceChecked = true;
+        if (balanceAfter - balanceBefore >= requiredAmount) {
+          return "ok";
+        }
+      }
+    } catch {
+      // ATA doesn't exist or balance check failed for this token program. Try next.
+    }
+  }
+
+  return anyBalanceChecked ? "bad" : "unavailable";
 }

--- a/typescript/packages/mechanisms/svm/test/unit/smartWalletVerification.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/smartWalletVerification.test.ts
@@ -727,6 +727,160 @@ describe("verifyPostSettlement", () => {
     // Should succeed on the first ATA check (Token-2022, the hinted program)
     expect(callCount).toBe(1);
   });
+
+  it("catches a transfer-fee skim when inner instructions pass but the delta is short", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+    const { findAssociatedTokenPda } = await import("@solana-program/token-2022");
+    const { TOKEN_PROGRAM_ADDRESS } = await import("@solana-program/token");
+
+    // Derive the real destination ATA so the inner-instruction match succeeds;
+    // the skim is then only catchable via the balance delta.
+    const [realDestAta] = await findAssociatedTokenPda({
+      mint: USDC_MINT as never,
+      owner: PAY_TO as never,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS as never,
+    });
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      // Declared TransferChecked matches requirements — but a Token-2022
+      // transfer fee skimmed at execution, so the payee only received half.
+      getConfirmedTransactionInnerInstructions: async () => ({
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [
+              {
+                programId: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                parsed: {
+                  type: "transferChecked",
+                  info: {
+                    mint: USDC_MINT,
+                    destination: realDestAta.toString(),
+                    authority: AUTHORITY,
+                    tokenAmount: { amount: "10000" },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      }),
+      getTokenAccountBalance: async () => BigInt(15000), // before 10000 → delta 5000 < 10000
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      BigInt(10000),
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.method).toBe("balanceDelta");
+  });
+
+  it("skips inner-instruction inspection when inspectInnerInstructions is false (static path)", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    let innerCalled = false;
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getConfirmedTransactionInnerInstructions: async () => {
+        innerCalled = true;
+        return null;
+      },
+      getTokenAccountBalance: async () => BigInt(20000), // delta 10000 == required
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      BigInt(10000),
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      { inspectInnerInstructions: false },
+    );
+
+    expect(result.verified).toBe(true);
+    expect(result.method).toBe("balanceDelta");
+    expect(innerCalled).toBe(false);
+  });
+
+  it("fails a static-path settle when the delta proves under-delivery", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getTokenAccountBalance: async () => BigInt(19500), // before 10000 → delta 9500 < 10000
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      BigInt(10000),
+      null,
+      { inspectInnerInstructions: false },
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.method).toBe("balanceDelta");
+  });
+
+  it("returns unverified on the static path when no pre-balance is available", async () => {
+    const { verifyPostSettlement } = await import(
+      "../../src/exact/facilitator/smartWalletVerification"
+    );
+
+    const mockSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      getTokenAccountBalance: async () => BigInt(20000),
+    };
+
+    const result = await verifyPostSettlement(
+      mockSigner as never,
+      "fakeSig123",
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      mockRequirements as never,
+      [],
+      null,
+      null,
+      { inspectInnerInstructions: false },
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.method).toBe("unverified");
+  });
 });
 
 describe("ExactSvmScheme constructor enforcement", () => {


### PR DESCRIPTION
## Summary

The SVM facilitator ran post-settlement verification only for **smart-wallet** settlements, and even there the inner-instruction check compares the **declared** `TransferChecked` amount. A Token-2022 mint with a **transfer-fee extension** skims at execution: the declared amount matches verify, the transaction confirms, and `settle` reports `success: true` while the payee received less.

This is the same under-delivery class as the EVM `Transfer`-event check (eip3009, extended to Permit2 in #3057–#3059) and the Hedera consensus-record check (#3061); SVM's base path simply had no equivalent.

## Fix

- **Balance-delta delivery verification now runs for every settlement** when the signer supports `getTokenAccountBalance` — the destination ATA balance must increase by `requirements.amount`. This catches any execution-time skim (transfer fees, hooks) for standard-wallet payments, not just smart wallets.
- **Smart-wallet settlements** keep their fail-closed TOCTOU semantics (inner-instruction inspection) and now *additionally* require the delta when a pre-balance is available — inner instructions carry declared amounts, so only the delta catches a skim.
- **Static-path settlements** use the delta only (their transfers are top-level instructions, never CPI inners, so inner inspection would false-fail) and stay **fail-open on "unverified"** — e.g. first payment to a fresh ATA with no pre-balance. Legacy signers and previously-correct settlements are unaffected; only hard evidence of under-delivery fails the settlement.

## Test plan

- [x] Skim test: inner instructions pass with the real derived ATA while the delta is short → rejected via `balanceDelta`
- [x] Static path: `inspectInnerInstructions: false` never touches `getTransaction`; delta OK → verified; delta short → rejected; no pre-balance → `unverified` (fail-open)
- [x] 207/207 unit tests, build, format, lint green

Made with Cursor

Made with [Cursor](https://cursor.com)