### PR TITLE
fix(next): let withX402 take an explicit route pattern

### DIFF
--- a/typescript/.changeset/next-withx402-route-pattern.md
+++ b/typescript/.changeset/next-withx402-route-pattern.md
@@ -2,4 +2,4 @@
 "@x402/next": minor
 ---
 
-`withX402` now accepts a `RoutesConfig`, so the route's path pattern can be given explicitly (e.g. `{ "/api/users/[id]": config }`) instead of always registering a wildcard route. This fixes bazaar discovery for Next.js resources: the hardcoded `*` pattern produced an auto-generated `routeTemplate` (`:var1`) that fails discovery validation, so resources were never indexed. Passing a bare route config remains supported and unchanged.
+`withX402` now accepts a `RoutesConfig`, so the route's path pattern can be given explicitly (e.g. `{ "/api/users/[id]": config }`) instead of always registering a wildcard route. This fixes bazaar discovery for Next.js resources: the hardcoded `*` pattern produced an auto-generated `routeTemplate` (`:var1`) that fails discovery validation, so resources were never indexed. Passing a bare route config remains supported and unchanged. When a pattern-keyed config matches no request path, the handler runs without payment and a warning is logged once per wrapper.

--- a/typescript/.changeset/next-withx402-route-pattern.md
+++ b/typescript/.changeset/next-withx402-route-pattern.md
@@ -1,0 +1,5 @@
+---
+"@x402/next": minor
+---
+
+`withX402` now accepts a `RoutesConfig`, so the route's path pattern can be given explicitly (e.g. `{ "/api/users/[id]": config }`) instead of always registering a wildcard route. This fixes bazaar discovery for Next.js resources: the hardcoded `*` pattern produced an auto-generated `routeTemplate` (`:var1`) that fails discovery validation, so resources were never indexed. Passing a bare route config remains supported and unchanged.

--- a/typescript/packages/http/next/README.md
+++ b/typescript/packages/http/next/README.md
@@ -60,17 +60,26 @@ const handler = async (_: NextRequest) => {
 export const GET = withX402(
   handler,
   {
-    accepts: {
-      scheme: "exact",
-      price: "$0.01",
-      network: "eip155:84532",
-      payTo: "0xYourAddress",
+    "/api/your-endpoint": {
+      accepts: {
+        scheme: "exact",
+        price: "$0.01",
+        network: "eip155:84532",
+        payTo: "0xYourAddress",
+      },
+      description: "Access to API endpoint",
     },
-    description: "Access to API endpoint",
   },
   server, // your configured x402ResourceServer
 );
 ```
+
+Keying the configuration by the route's path pattern (dynamic segments like
+`/api/users/[id]` are supported) is preferred over passing a bare route config.
+A bare config still works and matches any path, but it registers as a wildcard
+(`*`) route — with bazaar discovery extensions that produces an auto-generated
+`routeTemplate` (`:var1`) that discovery services reject, so the resource is
+never indexed.
 
 ## Configuration
 
@@ -103,7 +112,7 @@ The `withX402` function wraps API route handlers. This is the recommended approa
 ```typescript
 withX402(
   routeHandler: (request: NextRequest) => Promise<NextResponse>,
-  routeConfig: RouteConfig,
+  routes: RoutesConfig,
   server: x402ResourceServer,
   paywallConfig?: PaywallConfig,
   paywall?: PaywallProvider,
@@ -114,7 +123,7 @@ withX402(
 #### Parameters
 
 1. **`routeHandler`** (required): Your API route handler function
-2. **`routeConfig`** (required): Payment configuration for this specific route
+2. **`routes`** (required): Payment configuration for this route — a map keyed by the route's path pattern (preferred, e.g. `{ "/api/users/[id]": config }`), or a bare route config that matches any path
 3. **`server`** (required): Pre-configured x402ResourceServer instance
 4. **`paywallConfig`** (optional): Configuration for the built-in paywall UI
 5. **`paywall`** (optional): Custom paywall provider

--- a/typescript/packages/http/next/README.md
+++ b/typescript/packages/http/next/README.md
@@ -81,6 +81,11 @@ A bare config still works and matches any path, but it registers as a wildcard
 `routeTemplate` (`:var1`) that discovery services reject, so the resource is
 never indexed.
 
+The pattern must match the request path exactly as served (including any
+`basePath`, no trailing slash). If it does not match — a typo, a missing
+dynamic segment — the handler runs **without** payment protection; `withX402`
+logs a warning when this happens.
+
 ## Configuration
 
 ### paymentProxy

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -503,6 +503,32 @@ describe("withX402", () => {
     expect(body).toEqual({});
     expect(response.headers.get("PAYMENT-RESPONSE")).toBe("settlement-failed-encoded");
   });
+
+  it("passes a pattern-keyed routes config to x402HTTPResourceServer unchanged", async () => {
+    const mockServer = createMockHttpServer({ type: "no-payment-required" });
+    setupMockCreateHttpServer(mockServer);
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ data: "protected" }));
+    const routes = { "/api/users/[id]": mockRouteConfig };
+
+    const wrappedHandler = withX402(handler, routes, {} as unknown as x402ResourceServer);
+    const response = await wrappedHandler(createMockRequest());
+
+    expect(vi.mocked(x402HTTPResourceServer)).toHaveBeenCalledWith(expect.anything(), routes);
+    expect(response.status).toBe(200);
+  });
+
+  it("passes a bare route config through for core's default wildcard handling", () => {
+    const mockServer = createMockHttpServer({ type: "no-payment-required" });
+    setupMockCreateHttpServer(mockServer);
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ data: "protected" }));
+
+    withX402(handler, mockRouteConfig, {} as unknown as x402ResourceServer);
+
+    expect(vi.mocked(x402HTTPResourceServer)).toHaveBeenCalledWith(
+      expect.anything(),
+      mockRouteConfig,
+    );
+  });
 });
 
 describe("paymentProxyFromConfig", () => {

--- a/typescript/packages/http/next/src/index.test.ts
+++ b/typescript/packages/http/next/src/index.test.ts
@@ -529,6 +529,41 @@ describe("withX402", () => {
       mockRouteConfig,
     );
   });
+
+  it("warns once when a pattern-keyed routes config matches no request", async () => {
+    const mockServer = createMockHttpServer({ type: "no-payment-required" });
+    vi.mocked(mockServer.requiresPayment).mockReturnValue(false);
+    setupMockCreateHttpServer(mockServer);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ data: "protected" }));
+
+    const wrappedHandler = withX402(
+      handler,
+      { "/api/users/[id]": mockRouteConfig },
+      {} as unknown as x402ResourceServer,
+    );
+    await wrappedHandler(createMockRequest());
+    await wrappedHandler(createMockRequest());
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('"/api/users/[id]"');
+    expect(handler).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn for a bare route config when no route matches", async () => {
+    const mockServer = createMockHttpServer({ type: "no-payment-required" });
+    vi.mocked(mockServer.requiresPayment).mockReturnValue(false);
+    setupMockCreateHttpServer(mockServer);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ data: "protected" }));
+
+    const wrappedHandler = withX402(handler, mockRouteConfig, {} as unknown as x402ResourceServer);
+    await wrappedHandler(createMockRequest());
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });
 
 describe("paymentProxyFromConfig", () => {

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -265,7 +265,7 @@ export function paymentProxyFromConfig(
  * const resourceServer = new x402ResourceServer(facilitatorClient)
  *   .register(NETWORK, new ExactEvmScheme());
  *
- * const httpServer = new x402HTTPResourceServer(resourceServer, { "*": routeConfig })
+ * const httpServer = new x402HTTPResourceServer(resourceServer, { "/api/protected": routeConfig })
  *   .onProtectedRequest(requestHook);
  *
  * const handler = async (request: NextRequest) => {
@@ -303,6 +303,8 @@ export function withX402FromHTTPServer<T = unknown>(
       });
   }
 
+  let warnedNoMatch = false;
+
   return async (request: NextRequest): Promise<NextResponse<T>> => {
     // Only initialize when processing a protected route
     await init();
@@ -321,6 +323,23 @@ export function withX402FromHTTPServer<T = unknown>(
     // Handle the different result types
     switch (result.type) {
       case "no-payment-required":
+        // This wrapper protects a single handler, so with pattern-keyed routes every
+        // request should match one; a miss means the pattern is wrong and the handler
+        // is being served without payment.
+        if (
+          !warnedNoMatch &&
+          !("accepts" in httpServer.routes) &&
+          !httpServer.requiresPayment(context)
+        ) {
+          warnedNoMatch = true;
+          const patterns = Object.keys(httpServer.routes)
+            .map(pattern => `"${pattern}"`)
+            .join(", ");
+          console.warn(
+            `[x402] Request path "${context.path}" did not match any configured route pattern (${patterns}); ` +
+              `the handler ran without payment. Check the route patterns passed to withX402.`,
+          );
+        }
         // No payment needed, proceed directly to the route handler
         return routeHandler(request);
 
@@ -366,6 +385,8 @@ export function withX402FromHTTPServer<T = unknown>(
  * route's path pattern (e.g. `{ "/api/users/[id]": config }`). Prefer the keyed form
  * when using bazaar discovery extensions: a bare config registers as a wildcard, which
  * produces an auto-generated `routeTemplate` (`:var1`) that discovery services reject.
+ * The pattern must match the request path exactly as served (including any `basePath`);
+ * if it does not match, the handler runs without payment and a warning is logged.
  * @param server - Pre-configured x402ResourceServer instance
  * @param paywallConfig - Optional configuration for the built-in paywall UI
  * @param paywall - Optional custom paywall provider (overrides default)

--- a/typescript/packages/http/next/src/index.ts
+++ b/typescript/packages/http/next/src/index.ts
@@ -4,7 +4,6 @@ import {
   x402ResourceServer,
   x402HTTPResourceServer,
   RoutesConfig,
-  RouteConfig,
   FacilitatorClient,
   FacilitatorResponseError,
   checkIfBazaarNeeded,
@@ -362,7 +361,11 @@ export function withX402FromHTTPServer<T = unknown>(
  * response (status < 400). This provides more precise control over when payments are settled.
  *
  * @param routeHandler - The API route handler function to wrap
- * @param routeConfig - Payment configuration for this specific route
+ * @param routes - Payment configuration for this route: either a bare route config
+ * (matches any path, like the previous behavior) or a single-entry map keyed by the
+ * route's path pattern (e.g. `{ "/api/users/[id]": config }`). Prefer the keyed form
+ * when using bazaar discovery extensions: a bare config registers as a wildcard, which
+ * produces an auto-generated `routeTemplate` (`:var1`) that discovery services reject.
  * @param server - Pre-configured x402ResourceServer instance
  * @param paywallConfig - Optional configuration for the built-in paywall UI
  * @param paywall - Optional custom paywall provider (overrides default)
@@ -384,13 +387,15 @@ export function withX402FromHTTPServer<T = unknown>(
  * export const GET = withX402(
  *   handler,
  *   {
- *     accepts: {
- *       scheme: "exact",
- *       payTo: "0x123...",
- *       price: "$0.01",
- *       network: "eip155:84532",
+ *     "/api/protected": {
+ *       accepts: {
+ *         scheme: "exact",
+ *         payTo: "0x123...",
+ *         price: "$0.01",
+ *         network: "eip155:84532",
+ *       },
+ *       description: "Access to protected API",
  *     },
- *     description: "Access to protected API",
  *   },
  *   server,
  * );
@@ -398,13 +403,12 @@ export function withX402FromHTTPServer<T = unknown>(
  */
 export function withX402<T = unknown>(
   routeHandler: (request: NextRequest) => Promise<NextResponse<T>>,
-  routeConfig: RouteConfig,
+  routes: RoutesConfig,
   server: x402ResourceServer,
   paywallConfig?: PaywallConfig,
   paywall?: PaywallProvider,
   syncFacilitatorOnStart: boolean = true,
 ): (request: NextRequest) => Promise<NextResponse<T>> {
-  const routes = { "*": routeConfig };
   // Create the x402 HTTP server instance with the resource server
   const httpServer = new x402HTTPResourceServer(server, routes);
 
@@ -429,6 +433,7 @@ export type {
   PaywallProvider,
   PaywallConfig,
   RouteConfig,
+  RoutesConfig,
   SettlementOverrides,
 } from "@x402/core/server";
 


### PR DESCRIPTION
## Description

`withX402()` always registered its route as the wildcard `"*"`. With bazaar discovery extensions, that wildcard becomes an auto-generated `routeTemplate` (`":var1"`), which fails discovery validation's required `matches_resource` check — so Next.js resources using `withX402()` were never indexed, no matter how many payments settled.

This widens `withX402`'s second parameter from `RouteConfig` to `RoutesConfig`, so the route's real path can be given explicitly (e.g. `{ "/api/users/[id]": config }`) — the same convention `paymentProxy`, express, hono, and fastify already use. A bare `RouteConfig` still works unchanged: `@x402/core` applies its own `"*"` default for that shape, so existing callers are unaffected.

Closes #3019

## Tests

- Two new tests in `typescript/packages/http/next/src/index.test.ts` pin the routes shape reaching `x402HTTPResourceServer`: a pattern-keyed map passes through unchanged (failed before this fix), and a bare config passes through untouched.
- `pnpm test` from `/typescript`: full suite green.
- `pnpm lint:check` and `pnpm format:check` pass.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes
