### PR TITLE
docs(specs): correct v2 §8 discovery fields to match the wire format

### DIFF
--- a/specs/x402-specification-v2.md
+++ b/specs/x402-specification-v2.md
@@ -530,7 +530,7 @@ List discoverable x402 resources from the Bazaar.
     {
       "resource": "https://api.example.com/premium-data",
       "type": "http",
-      "x402Version": 1,
+      "x402Version": 2,
       "accepts": [
         {
           "scheme": "exact",
@@ -545,11 +545,7 @@ List discoverable x402 resources from the Bazaar.
           }
         }
       ],
-      "lastUpdated": 1703123456,
-      "metadata": {
-        "category": "finance",
-        "provider": "Example Corp"
-      }
+      "lastUpdated": "2025-08-09T01:07:04.005Z"
     }
   ],
   "pagination": {
@@ -573,7 +569,7 @@ Search semantics and response shape are defined in the Bazaar extension specific
 | `type`        | `string` | Required | Resource type (currently "http" for HTTP endpoints)             |
 | `x402Version` | `number` | Required | Protocol version supported by the resource                      |
 | `accepts`     | `array`  | Required | Array of PaymentRequirements objects specifying payment methods |
-| `lastUpdated` | `number` | Required | Unix timestamp of when the resource was last updated            |
+| `lastUpdated` | `string` | Required | ISO 8601 timestamp of when the resource was last updated        |
 | `extensions`  | `object` | Optional | Additional extension payloads associated with this discovered resource |
 
 **8.4 Bazaar Concept**


### PR DESCRIPTION
## Description

§8 Discovery still describes the v1 response. #2094 synced part of the 8.3 table to the SDKs (`metadata` row → `extensions`) but left the rest as it was copied from `x402-specification-v1.md`.

| # | Where | Currently | Change |
|---|---|---|---|
| 1 | 8.3 table + 8.1 example | `lastUpdated` is a `number` (Unix timestamp) | `string`, ISO 8601 |
| 2 | 8.1 example | carries a `metadata` object | remove — 8.3 replaced that row with `extensions` |
| 3 | 8.1 example | item declares `x402Version: 1`, but its `accepts` uses the v2 `amount` field and a CAIP-2 network | `2` |

One table row and three lines of the example. Spec-only.

### Evidence

- All six reference facilitators under `e2e/facilitators/*` and `examples/*/facilitator/advanced/*` write `lastUpdated` as ISO 8601 (`toISOString()` / `RFC3339` / `isoformat()`). None emits a Unix timestamp; none branches on item version.
- All three SDK clients declare it a string (`facilitatorClient.ts:108`, `facilitator_client.go:82`, `facilitator_client.py:90`). Producers and consumers therefore agree with each other and only the document sits outside that agreement, which is why nothing fails in practice. Fed the 8.1 example the way `facilitator_client.go:228` reads a response, Go *would* fail: `cannot unmarshal number into Go struct field DiscoveryResource.items.lastUpdated of type string`. TypeScript and Python would accept it silently and carry a value whose runtime type contradicts the declaration.
- Reference facilitator's live catalog, 2,000 of 14,500 entries sampled: `lastUpdated` a string 2000/2000, `metadata` 0/2000, and 0 items combining `x402Version: 1` with `accepts.amount`. The 12 v1-versioned items all carry an ISO `lastUpdated` and use `maxAmountRequired` — so "it's a v1 item, v1 shapes are correct for it" does not explain any of the three defects.

Nothing is broken today; the cost falls on the next person who implements §8.3 as written — and on #2776, which would turn the spec into executable conformance vectors.

For `lastUpdated` this ratifies shipped behavior rather than correcting a typo — please redirect me if the Foundation intends the spec to lead here.

### Out of scope

- `description` / `mimeType` / `serviceName` / `tags` / `iconUrl` are modelled on the discovery item by all three SDKs, but the spec defines them on `ResourceInfo` (`:132-139`), the `resource` **object** of a 402 response, while a discovery item's `resource` is a plain string (`:572`). Nothing describes lifting them across. That is a normative addition rather than a correction — separate issue to follow.
- `x402-specification-v1.md` is unchanged, and 8.1's `offset` parameter is correct as written.

## Tests

Docs-only. The 8.1 example parses with `json.loads` and its field set matches the 8.3 table. The Go and Python round-trips above were run against the SDK type declarations, with a real catalog page as control.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] I added a changelog fragment for user-facing changes — n/a, docs-only per `CONTRIBUTING.md`; `specs/` is outside the release tooling

---

Drafted with Claude Code; claims verified against the cited files, this repo's Go and Python clients, and the live catalog before submission.
