### PR TITLE
fix(ts/py): path normalization

### DIFF
--- a/examples/typescript/facilitator/advanced/all_networks.ts
+++ b/examples/typescript/facilitator/advanced/all_networks.ts
@@ -138,7 +138,7 @@ if (
 // Network configuration (alphabetic order)
 const AVM_NETWORK = "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe"; // Algorand Testnet
 const APTOS_NETWORK = (process.env.APTOS_NETWORK || "aptos:2") as Network; // Aptos Testnet
-const CCD_NETWORK = "ccd:4221332d34e1694168c2a0c0b3fd0f27"; // Concordium Testnet
+const CCD_NETWORK = CONCORDIUM_TESTNET_CAIP2; // Concordium Testnet
 const EVM_NETWORK = "eip155:84532"; // Base Sepolia
 const HEDERA_NETWORK = "hedera:testnet"; // Hedera Testnet
 const KEETA_NETWORK = KEETA_TESTNET_CAIP2; // Keeta Testnet

--- a/python/x402/changelog.d/+path-normalization-bypass.bugfix.md
+++ b/python/x402/changelog.d/+path-normalization-bypass.bugfix.md
@@ -1,0 +1,1 @@
+Fixed payment-gate route matching on the escaped request path so percent-encoded separators and trailing-slash wildcard prefixes cannot bypass verification. Middleware now passes the raw WSGI/ASGI path for route matching, `_normalize_path` decodes one segment at a time while re-escaping decoded separators, and trailing `/*` patterns also match their bare prefix.

--- a/python/x402/http/middleware/fastapi.py
+++ b/python/x402/http/middleware/fastapi.py
@@ -238,9 +238,12 @@ def payment_middleware(
 
         # Create adapter and context
         adapter = FastAPIAdapter(request)
+        # Routers dispatch on the escaped path, so route matching must use the
+        # raw request path rather than the decoded URL path.
+        raw_path = request.scope["raw_path"].decode("ascii").split("?")[0]
         context = HTTPRequestContext(
             adapter=adapter,
-            path=request.url.path,
+            path=raw_path,
             method=request.method,
             payment_header=(
                 adapter.get_header("payment-signature") or adapter.get_header("x-payment")

--- a/python/x402/http/middleware/flask.py
+++ b/python/x402/http/middleware/flask.py
@@ -52,6 +52,15 @@ from ._bazaar_utils import (
 
 logger = logging.getLogger(__name__)
 
+
+def _route_matching_path(environ: dict[str, Any]) -> str:
+    """Return the escaped request path used for route matching."""
+    raw = environ.get("RAW_URI") or environ.get("REQUEST_URI")
+    if raw:
+        return str(raw).split("?")[0]
+    return str(environ.get("PATH_INFO", "/"))
+
+
 # ============================================================================
 # Flask Adapter
 # ============================================================================
@@ -331,7 +340,7 @@ class PaymentMiddleware:
             adapter = FlaskAdapter(request)
             context = HTTPRequestContext(
                 adapter=adapter,
-                path=request.path,
+                path=_route_matching_path(environ),
                 method=request.method,
                 payment_header=(
                     adapter.get_header("payment-signature") or adapter.get_header("x-payment")

--- a/python/x402/http/x402_http_server_base.py
+++ b/python/x402/http/x402_http_server_base.py
@@ -11,7 +11,6 @@ import logging
 import re
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any, Literal, Protocol
-from urllib.parse import unquote
 
 from ..schemas import (
     PaymentPayload,
@@ -74,6 +73,25 @@ def with_private_cache_control(value: str | None) -> str:
         return value
 
     return f"{value}, private"
+
+
+def _path_unescape(segment: str) -> str | None:
+    """Decode one path segment; return None if any escape is malformed."""
+    out: list[str] = []
+    i = 0
+    while i < len(segment):
+        if segment[i] != "%":
+            out.append(segment[i])
+            i += 1
+            continue
+        if i + 2 >= len(segment):
+            return None
+        hex_digits = segment[i + 1 : i + 3]
+        if not re.fullmatch(r"[0-9A-Fa-f]{2}", hex_digits):
+            return None
+        out.append(chr(int(hex_digits, 16)))
+        i += 3
+    return "".join(out)
 
 
 # ============================================================================
@@ -968,11 +986,20 @@ class x402HTTPServerBase:
             verb = "*"
             path = pattern
 
+        # A trailing "/*" must also match the bare prefix. _normalize_path strips
+        # the trailing slash, so a request for "/api/premium/" arrives as
+        # "/api/premium", which a literal "/.*?" suffix would not match even
+        # though routers dispatch it to the protected handler.
+        trailing_wildcard = path.endswith("/*")
+        path_for_regex = path[:-2] if trailing_wildcard else path
+
         # Convert to regex
-        regex_pattern = "^" + re.escape(path)
+        regex_pattern = "^" + re.escape(path_for_regex)
         regex_pattern = regex_pattern.replace(r"\*", ".*?")  # Wildcards
         regex_pattern = re.sub(r"\\\[([^\]]+)\\\]", r"[^/]+", regex_pattern)  # [param]
         regex_pattern = re.sub(r":([a-zA-Z_]\w*)", r"[^/]+", regex_pattern)  # :param
+        if trailing_wildcard:
+            regex_pattern += r"(?:/.*?)?"
         regex_pattern += "$"
 
         # re.DOTALL: without it, "." (from a "*" wildcard) does not match a line
@@ -982,17 +1009,29 @@ class x402HTTPServerBase:
 
     @staticmethod
     def _normalize_path(path: str) -> str:
-        """Normalize path for matching."""
-        # Remove query string and fragment
+        """Normalize path for matching.
+
+        The input is expected to be the *escaped* request path, which is the
+        same view HTTP routers use to split a request into segments.
+        Percent-escapes are decoded one segment at a time and any separator they
+        yield is re-escaped, so a decoded byte can never create a segment
+        boundary that the router did not see.
+        """
         path = path.split("?")[0].split("#")[0]
 
-        # Decode URL encoding
-        try:
-            path = unquote(path)
-        except Exception:
-            pass
+        segments = path.split("/")
+        normalized_segments: list[str] = []
+        for segment in segments:
+            decoded = _path_unescape(segment)
+            if decoded is None:
+                # Malformed escape sequence: match on the raw segment rather than
+                # silently widening it.
+                normalized_segments.append(segment)
+                continue
+            decoded = decoded.replace("/", "%2F").replace("\\", "%5C")
+            normalized_segments.append(decoded)
+        path = "/".join(normalized_segments)
 
-        # Normalize slashes
         path = re.sub(r"/+", "/", path)
         path = path.rstrip("/")
 

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -31,6 +31,13 @@ from x402.http.types import (
 from x402.schemas import PaymentPayload, PaymentRequirements
 from x402.schemas.hooks import PaymentCancellationDispatcher, VerifiedPaymentCancelOptions
 
+from ....mocks import (
+    CashFacilitatorClient,
+    CashSchemeNetworkFacilitator,
+    CashSchemeNetworkServer,
+)
+from x402 import x402Facilitator, x402ResourceServer
+
 # =============================================================================
 # Helpers
 # =============================================================================
@@ -921,3 +928,64 @@ class TestPaymentMiddlewareASGI:
 
         assert hasattr(middleware, "_middleware")
         assert callable(middleware._middleware)
+
+
+class TestEncodedPathBypass:
+    @staticmethod
+    def _bypass_routes() -> dict[str, RouteConfig]:
+        option = PaymentOption(
+            scheme="cash",
+            pay_to="Alice",
+            price="$0.01",
+            network="x402:cash",
+        )
+        return {
+            "GET /api/report/:id": RouteConfig(accepts=option),
+            "GET /api/premium/*": RouteConfig(accepts=option),
+        }
+
+    @staticmethod
+    def _cash_server() -> x402ResourceServer:
+        facilitator = x402Facilitator().register(
+            ["x402:cash"],
+            CashSchemeNetworkFacilitator(),
+        )
+        server = x402ResourceServer(CashFacilitatorClient(facilitator))
+        server.register("x402:cash", CashSchemeNetworkServer())
+        server.initialize()
+        return server
+
+    @pytest.fixture()
+    def client(self):
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def x402_middleware(request: Request, call_next):
+            return await payment_middleware(
+                self._bypass_routes(),
+                self._cash_server(),
+                sync_facilitator_on_start=False,
+            )(request, call_next)
+
+        @app.api_route("/{path:path}", methods=["GET"])
+        async def catch_all(path: str) -> dict[str, str]:
+            return {"status": "ok"}
+
+        return TestClient(app)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/report/baseline",
+            "/api/report/a%2Fb",
+            "/api/report/a%252Fb",
+            "/api/report/a%5Cb",
+            "/api/premium/",
+            "/api/premium",
+        ],
+    )
+    def test_protected_paths_return_402(self, client, path: str) -> None:
+        assert client.get(path).status_code == 402
+
+    def test_unrelated_path_is_not_gated(self, client) -> None:
+        assert client.get("/health").status_code == 200

--- a/python/x402/tests/unit/http/middleware/test_fastapi.py
+++ b/python/x402/tests/unit/http/middleware/test_fastapi.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 from starlette.datastructures import Headers, QueryParams
 
+from x402 import x402Facilitator, x402ResourceServer
 from x402.http.facilitator_client_base import FacilitatorResponseError
 from x402.http.middleware.fastapi import (
     FastAPIAdapter,
@@ -36,7 +37,6 @@ from ....mocks import (
     CashSchemeNetworkFacilitator,
     CashSchemeNetworkServer,
 )
-from x402 import x402Facilitator, x402ResourceServer
 
 # =============================================================================
 # Helpers
@@ -79,6 +79,7 @@ def make_mock_fastapi_request(
     mock_request.url.path = path
     mock_request.url.__str__ = lambda self: f"https://example.com{path}"
     mock_request.state = MagicMock()
+    mock_request.scope = {"raw_path": path.encode("ascii")}
     return mock_request
 
 

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -15,6 +15,7 @@ pytest.importorskip("flask")
 from flask import Flask, redirect
 from werkzeug.datastructures import Headers, ImmutableMultiDict
 
+from x402 import x402FacilitatorSync, x402ResourceServerSync
 from x402.http.facilitator_client_base import FacilitatorResponseError
 from x402.http.middleware.flask import (
     FlaskAdapter,
@@ -38,7 +39,6 @@ from ....mocks import (
     CashSchemeNetworkFacilitator,
     CashSchemeNetworkServer,
 )
-from x402 import x402FacilitatorSync, x402ResourceServerSync
 
 # =============================================================================
 # Helpers

--- a/python/x402/tests/unit/http/middleware/test_flask.py
+++ b/python/x402/tests/unit/http/middleware/test_flask.py
@@ -33,6 +33,13 @@ from x402.http.types import (
 from x402.schemas import PaymentPayload, PaymentRequirements
 from x402.schemas.hooks import PaymentCancellationDispatcher, VerifiedPaymentCancelOptions
 
+from ....mocks import (
+    CashFacilitatorClientSync,
+    CashSchemeNetworkFacilitator,
+    CashSchemeNetworkServer,
+)
+from x402 import x402FacilitatorSync, x402ResourceServerSync
+
 # =============================================================================
 # Helpers
 # =============================================================================
@@ -1035,3 +1042,63 @@ def test_payment_middleware_from_config_builds_with_sync_server():
     )
 
     assert middleware is not None
+
+
+class TestEncodedPathBypass:
+    @staticmethod
+    def _bypass_routes() -> dict[str, RouteConfig]:
+        option = PaymentOption(
+            scheme="cash",
+            pay_to="Alice",
+            price="$0.01",
+            network="x402:cash",
+        )
+        return {
+            "GET /api/report/:id": RouteConfig(accepts=option),
+            "GET /api/premium/*": RouteConfig(accepts=option),
+        }
+
+    @staticmethod
+    def _cash_server() -> x402ResourceServerSync:
+        facilitator = x402FacilitatorSync().register(
+            ["x402:cash"],
+            CashSchemeNetworkFacilitator(),
+        )
+        server = x402ResourceServerSync(CashFacilitatorClientSync(facilitator))
+        server.register("x402:cash", CashSchemeNetworkServer())
+        server.initialize()
+        return server
+
+    @pytest.fixture()
+    def client(self):
+        app = Flask(__name__)
+        payment_middleware(
+            app,
+            self._bypass_routes(),
+            self._cash_server(),
+            sync_facilitator_on_start=False,
+        )
+
+        @app.route("/", defaults={"path": ""})
+        @app.route("/<path:path>")
+        def catch_all(path: str) -> tuple[str, int]:
+            return "ok", 200
+
+        return app.test_client()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/api/report/baseline",
+            "/api/report/a%2Fb",
+            "/api/report/a%252Fb",
+            "/api/report/a%5Cb",
+            "/api/premium/",
+            "/api/premium",
+        ],
+    )
+    def test_protected_paths_return_402(self, client, path: str) -> None:
+        assert client.get(path).status_code == 402
+
+    def test_unrelated_path_is_not_gated(self, client) -> None:
+        assert client.get("/health").status_code == 200

--- a/python/x402/tests/unit/http/test_route_matching.py
+++ b/python/x402/tests/unit/http/test_route_matching.py
@@ -1,7 +1,7 @@
 """Route matching tests for the shared HTTP server base.
 
-Regression coverage for wildcard (`*`) route patterns and a payment-gate
-bypass via a line feed, which a naive `.` wildcard cannot cross.
+Regression coverage for wildcard (`*`) route patterns, path normalization
+bypasses (CWE-436), and a payment-gate bypass via a line feed.
 """
 
 from __future__ import annotations
@@ -58,3 +58,74 @@ class TestWildcardLineFeedBypass:
     )
     def test_line_feed_in_wildcard_tail_still_requires_payment(self, path: str) -> None:
         assert self._server().requires_payment(_context(path)) is True
+
+
+class TestNormalizePath:
+    @pytest.mark.parametrize(
+        ("input_path", "expected"),
+        [
+            ("/api", "/api"),
+            ("/api/", "/api"),
+            ("/api//users", "/api/users"),
+            ("/api?query=1", "/api"),
+            ("/api#fragment", "/api"),
+            ("/api%20space", "/api space"),
+            ("", "/"),
+            ("/api/users/x%2Fy", "/api/users/x%2Fy"),
+            ("/api/users/x%2fy", "/api/users/x%2Fy"),
+            ("/api/users/x%5Cy", "/api/users/x%5Cy"),
+            ("/api/users/x%252Fy", "/api/users/x%2Fy"),
+            ("/api/users/x%zzy", "/api/users/x%zzy"),
+        ],
+    )
+    def test_normalize_path(self, input_path: str, expected: str) -> None:
+        assert x402HTTPServerBase._normalize_path(input_path) == expected
+
+
+class TestRouteMatchingPathNormalizationBypass:
+    @pytest.mark.parametrize(
+        ("pattern", "escaped_path", "should_match"),
+        [
+            ("GET /api/users/:id", "/api/users/1", True),
+            ("GET /api/users/:id", "/api/users/x%2Fy", True),
+            ("GET /api/users/:id", "/api/users/x%2fy", True),
+            ("GET /api/users/:id", "/api/users/x%252Fy", True),
+            ("GET /api/users/:id", "/api/users/x%5Cy", True),
+            ("GET /api/users/:id", "/api/users/x%25y", True),
+            ("GET /api/users/[id]", "/api/users/x%2Fy", True),
+            ("GET /api/users/:id", "/api/users/x/y", False),
+            ("GET /api/premium/*", "/api/premium/abc", True),
+            ("GET /api/premium/*", "/api/premium/", True),
+            ("GET /api/premium/*", "/api/premium", True),
+            ("GET /api/premium/*", "/api/premium/a/b/c", True),
+            ("GET /api/premium/*", "/api/premiumx", False),
+            ("GET /api/premium/*", "/api/other", False),
+            ("GET /api/compute", "/api/compute", True),
+            ("GET /api/compute", "/api/compute/", True),
+            ("GET /api/compute", "/api/computex", False),
+        ],
+        ids=[
+            "param-baseline",
+            "param-encoded-slash",
+            "param-lowercase-encoded-slash",
+            "param-double-encoded-slash",
+            "param-encoded-backslash",
+            "param-encoded-percent",
+            "bracket-param-encoded-slash",
+            "param-real-extra-segment",
+            "wildcard-baseline",
+            "wildcard-trailing-slash",
+            "wildcard-bare-prefix",
+            "wildcard-deep-path",
+            "wildcard-sibling-prefix",
+            "wildcard-unrelated",
+            "static-baseline",
+            "static-trailing-slash",
+            "static-unrelated",
+        ],
+    )
+    def test_route_regex_matches_normalized_path(
+        self, pattern: str, escaped_path: str, should_match: bool
+    ) -> None:
+        server = x402HTTPServerBase(MagicMock(), {pattern: RouteConfig(accepts=[])})
+        assert server.requires_payment(_context(escaped_path)) is should_match

--- a/typescript/.changeset/trailing-wildcard-route-matching.md
+++ b/typescript/.changeset/trailing-wildcard-route-matching.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Fixed trailing wildcard route matching when `normalizePath` strips a trailing slash, so bare prefix paths like `/api/premium` and `/api/premium/` still require payment under a `/*` route pattern.

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1155,16 +1155,27 @@ export class x402HTTPResourceServer {
   private parseRoutePattern(pattern: string): { verb: string; regex: RegExp; path: string } {
     const [verb, path] = pattern.includes(" ") ? pattern.split(/\s+/) : ["*", pattern];
 
+    // A trailing "/*" must also match the bare prefix. normalizePath strips the
+    // trailing slash, so a request for "/api/premium/" arrives as "/api/premium",
+    // which a literal "/.*?" suffix would not match even though routers dispatch
+    // it to the protected handler.
+    const trailingWildcard = path.endsWith("/*");
+    const pathForRegex = trailingWildcard ? path.slice(0, -2) : path;
+
+    let regexBody = pathForRegex
+      .replace(/\\/g, "\\\\") // Escape backslashes first
+      .replace(/[$()+.?^{|}]/g, "\\$&") // Escape regex special chars
+      .replace(/\*/g, ".*?") // Wildcards
+      .replace(/\[([^\]]+)\]/g, "[^/]+") // Parameters (Next.js style [param])
+      .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "[^/]+") // Parameters (Express style :param)
+      .replace(/\//g, "\\/"); // Escape slashes
+
+    if (trailingWildcard) {
+      regexBody += "(?:/.*?)?";
+    }
+
     const regex = new RegExp(
-      `^${
-        path
-          .replace(/\\/g, "\\\\") // Escape backslashes first
-          .replace(/[$()+.?^{|}]/g, "\\$&") // Escape regex special chars
-          .replace(/\*/g, ".*?") // Wildcards
-          .replace(/\[([^\]]+)\]/g, "[^/]+") // Parameters (Next.js style [param])
-          .replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, "[^/]+") // Parameters (Express style :param)
-          .replace(/\//g, "\\/") // Escape slashes
-      }$`,
+      `^${regexBody}$`,
       // "s" (dotAll): without it, "." can't match LF/CR/U+2028/U+2029, so a wildcard segment containing one fails to match.
       "is",
     );

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -745,6 +745,62 @@ describe("x402HTTPResourceServer", () => {
       });
     });
 
+    describe("trailing wildcard prefix", () => {
+      const routes = {
+        "GET /api/premium/*": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00" as Price,
+            network: "eip155:8453" as Network,
+          },
+        },
+      };
+
+      it.each([
+        ["/api/premium/abc", true],
+        ["/api/premium/", true],
+        ["/api/premium", true],
+        ["/api/premium/a/b/c", true],
+        ["/api/premiumx", false],
+        ["/api/other", false],
+      ])("requiresPayment(%s) === %s", (path, expected) => {
+        const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path,
+          method: "GET",
+        };
+
+        expect(httpServer.requiresPayment(context)).toBe(expected);
+      });
+
+      it("should require payment when :id contains double-encoded %252F", async () => {
+        const paramRoutes = {
+          "/api/report/:id": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(ResourceServer, paramRoutes);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path: "/api/report/a%252Fb",
+          method: "GET",
+        };
+
+        expect(httpServer.requiresPayment(context)).toBe(true);
+      });
+    });
+
     describe("percent-encoded line terminators (CAT f2e83cec)", () => {
       // Without dotAll, "." (from a "*" wildcard) can't match a decoded LineTerminator.
       it.each([

--- a/typescript/packages/http/express/src/encodedPathBypass.test.ts
+++ b/typescript/packages/http/express/src/encodedPathBypass.test.ts
@@ -85,3 +85,56 @@ describe("express end-to-end: encoded path separator", () => {
     expect(await statusFor(port, "/health")).toBe(200);
   });
 });
+
+describe("express end-to-end: trailing wildcard route prefix", () => {
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    const app = express();
+    const resourceServer = new x402ResourceServer();
+    app.use(
+      paymentMiddleware(
+        {
+          "/api/premium/*": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00",
+              network: "eip155:84532",
+            },
+          },
+        },
+        resourceServer,
+        undefined,
+        undefined,
+        false,
+      ),
+    );
+    app.use((_req, res) => res.status(200).send("ok"));
+
+    server = app.listen(0);
+    await new Promise<void>(resolve => server.once("listening", () => resolve()));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  });
+
+  it("returns 402 for a baseline wildcard sub-path", async () => {
+    expect(await statusFor(port, "/api/premium/report")).toBe(402);
+  });
+
+  it("returns 402 for the bare wildcard prefix with a trailing slash", async () => {
+    expect(await statusFor(port, "/api/premium/")).toBe(402);
+  });
+
+  it("returns 402 for the bare wildcard prefix without a trailing slash", async () => {
+    expect(await statusFor(port, "/api/premium")).toBe(402);
+  });
+
+  it("returns 200 (middleware skipped) for an unrelated path", async () => {
+    expect(await statusFor(port, "/health")).toBe(200);
+  });
+});


### PR DESCRIPTION
## Description

Ts/Py sdks need some some of the path normalization patches done for the go sdk in https://github.com/x402-foundation/x402/pull/3044

- Ts: Fix in parseRoutePattern: patterns ending in /* now compile an optional (?:/.*?)? suffix so /api/premium and /api/premium/ match after normalizePath strips the trailing slash.
- Py: full #3044 port


## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 