### PR TITLE
docs: add Agent Guild x402 payment policy

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -5,6 +5,7 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 
 | Name | Description | Languages | Links |
 | ---- | ----------- | --------- | ----- |
+| [Agent Guild](https://agent-guild-5d5r.onrender.com/for-agents) | Fail-closed wallet-risk policy for x402 clients that issues signed, exact-payment allow or block credentials before payment signing | TypeScript | [GitHub](https://github.com/AgentTanuki/agent-guild/blob/main/sdk/integrations/x402_payment_policy.mjs) · [Hosted adapter](https://agent-guild-5d5r.onrender.com/sdk/integrations/x402_payment_policy.mjs) |
 | [World AgentKit](https://docs.world.org/agents/agent-kit/integrate) | Verify human-backed agents | TypeScript | [GitHub](https://github.com/worldcoin/agentkit) · [npm](https://www.npmjs.com/package/@worldcoin/agentkit) |
 | [OMATrust](https://www.omatrust.org/x402) | Key authorizations for Signed Offers and Receipts | TypeScript | [GitHub](https://github.com/oma3dao/omatrust-sdk) · [npm](https://www.npmjs.com/package/@oma3/omatrust) |
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |


### PR DESCRIPTION
## Description

Adds Agent Guild to the curated third-party extensions catalog with links to its live x402 pre-signature policy hook and hosted adapter.

The hook registers with the official `onBeforePaymentCreation` lifecycle, buys and locally verifies a short-lived signed decision bound to the selected scheme, network, asset, amount, payee, and resource, and fails closed before payment signing unless the credential says `allow`.

## Tests

- `git diff --check`
- Verified the hosted adapter returns HTTP 200
- Confirmed the contribution commit is signed and verified by GitHub

## Checklist

- [x] I have formatted and linted the documentation change
- [x] My commit is signed
- [x] Changelog fragment skipped because this is docs-only
