### PR TITLE
fix(permit2): verify Transfer event in settle receipts (exact + upto)

### DIFF
--- a/typescript/.changeset/permit2-settle-transfer-event.md
+++ b/typescript/.changeset/permit2-settle-transfer-event.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Verify the ERC-20 Transfer event in Permit2 settle receipts (exact and upto) instead of trusting receipt status alone, so underpaying or non-conforming tokens are rejected at settlement

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -36,6 +36,7 @@ import {
   checkPermit2Prerequisites,
   validateEip2612PermitForPayment,
   buildExactPermit2SettleArgs,
+  buildExpectedPermit2Transfer,
   splitEip2612Signature,
   waitAndReturnSettleResponse,
   mapSettleError,
@@ -438,7 +439,13 @@ async function settlePermit2WithEIP2612(
       dataSuffix,
     });
 
-    return waitAndReturnSettleResponse(signer, tx, payload, payer);
+    return waitAndReturnSettleResponse(
+      signer,
+      tx,
+      payload,
+      payer,
+      buildExpectedPermit2Transfer(permit2Payload),
+    );
   } catch (error) {
     return mapSettleError(error, payload, payer);
   }
@@ -482,7 +489,13 @@ async function settlePermit2WithERC20Approval(
     ]);
 
     const settleTxHash = txHashes[txHashes.length - 1];
-    return waitAndReturnSettleResponse(extensionSigner, settleTxHash, payload, payer);
+    return waitAndReturnSettleResponse(
+      extensionSigner,
+      settleTxHash,
+      payload,
+      payer,
+      buildExpectedPermit2Transfer(permit2Payload),
+    );
   } catch (error) {
     return mapSettleError(error, payload, payer);
   }
@@ -515,7 +528,13 @@ async function settlePermit2Direct(
       dataSuffix,
     });
 
-    return waitAndReturnSettleResponse(signer, tx, payload, payer);
+    return waitAndReturnSettleResponse(
+      signer,
+      tx,
+      payload,
+      payer,
+      buildExpectedPermit2Transfer(permit2Payload),
+    );
   } catch (error) {
     return mapSettleError(error, payload, payer);
   }

--- a/typescript/packages/mechanisms/evm/src/shared/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/permit2.ts
@@ -39,7 +39,9 @@ import {
   ErrEip2612SpenderNotPermit2,
   ErrEip2612DeadlineExpired,
   ErrErc20ApprovalTxFailed,
+  ErrTransferEventMismatch,
 } from "../exact/facilitator/errors";
+import { verifyEip3009TransferEvent } from "../exact/facilitator/eip3009-utils";
 import { ClientEvmSigner, FacilitatorEvmSigner } from "../signer";
 import { ExactPermit2Payload, Permit2Authorization, UptoPermit2Payload } from "../types";
 import { validateErc20ApprovalForPayment } from "./erc20approval";
@@ -160,10 +162,20 @@ export async function verifyPermit2Allowance(
 /**
  * Waits for a transaction receipt and returns the appropriate SettleResponse.
  *
+ * Receipt status alone only proves the proxy call did not revert: a
+ * fee-on-transfer or otherwise non-conforming token can underpay (or pay
+ * nothing) without reverting. A successful receipt must therefore contain the
+ * expected ERC-20 Transfer event, mirroring the EIP-3009 settle path.
+ *
  * @param signer - Signer with waitForTransactionReceipt capability
  * @param tx - The transaction hash to wait for
  * @param payload - The payment payload (for network info)
  * @param payer - The payer address
+ * @param expectedTransfer - The Transfer fields a successful receipt must contain
+ * @param expectedTransfer.token - The token contract that must have emitted the Transfer
+ * @param expectedTransfer.from - Expected `from` of the Transfer event
+ * @param expectedTransfer.to - Expected `to` of the Transfer event
+ * @param expectedTransfer.value - Expected `value` of the Transfer event
  * @returns Promise resolving to a settlement response indicating success or failure
  */
 export async function waitAndReturnSettleResponse(
@@ -171,6 +183,12 @@ export async function waitAndReturnSettleResponse(
   tx: `0x${string}`,
   payload: PaymentPayload,
   payer: `0x${string}`,
+  expectedTransfer: {
+    token: `0x${string}`;
+    from: `0x${string}`;
+    to: `0x${string}`;
+    value: bigint;
+  },
 ): Promise<SettleResponse> {
   const receipt = await signer.waitForTransactionReceipt({ hash: tx });
 
@@ -178,6 +196,23 @@ export async function waitAndReturnSettleResponse(
     return {
       success: false,
       errorReason: ErrInvalidTransactionState,
+      transaction: tx,
+      network: payload.accepted.network,
+      payer,
+    };
+  }
+
+  if (
+    receipt.logs != null &&
+    !verifyEip3009TransferEvent(receipt.logs, expectedTransfer.token, {
+      from: expectedTransfer.from,
+      to: expectedTransfer.to,
+      value: expectedTransfer.value,
+    })
+  ) {
+    return {
+      success: false,
+      errorReason: ErrTransferEventMismatch,
       transaction: tx,
       network: payload.accepted.network,
       payer,
@@ -515,6 +550,29 @@ export async function checkPermit2Prerequisites(
   }
 
   return { isValid: true, invalidReason: undefined, payer };
+}
+
+/**
+ * Derives the ERC-20 Transfer event fields a Permit2 settle receipt must contain.
+ * The proxy pulls funds through Permit2 directly to the witness recipient, so a
+ * conforming token emits Transfer(payer, witness.to, settled amount) from the
+ * permitted token contract.
+ *
+ * @param permit2Payload - The Permit2 payload containing the authorization
+ * @param value - The settled amount. Defaults to the full permitted amount (exact
+ *   scheme); the upto scheme passes its actual settlement amount, which may be lower.
+ * @returns The expected Transfer fields for receipt verification
+ */
+export function buildExpectedPermit2Transfer(
+  permit2Payload: Permit2PayloadBase,
+  value: bigint = BigInt(permit2Payload.permit2Authorization.permitted.amount),
+): { token: `0x${string}`; from: `0x${string}`; to: `0x${string}`; value: bigint } {
+  return {
+    token: getAddress(permit2Payload.permit2Authorization.permitted.token),
+    from: getAddress(permit2Payload.permit2Authorization.from),
+    to: getAddress(permit2Payload.permit2Authorization.witness.to),
+    value,
+  };
 }
 
 /**

--- a/typescript/packages/mechanisms/evm/src/upto/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/facilitator/permit2.ts
@@ -36,6 +36,7 @@ import { validateErc20ApprovalForPayment } from "../../shared/erc20approval";
 import { verifyTypedDataSignature } from "../../shared/verifySignature";
 import {
   buildUptoPermit2SettleArgs,
+  buildExpectedPermit2Transfer,
   waitAndReturnSettleResponse,
   mapSettleError,
   splitEip2612Signature,
@@ -501,7 +502,13 @@ async function settleUptoWithEIP2612(
       dataSuffix,
     });
 
-    const response = await waitAndReturnSettleResponse(signer, tx, payload, payer);
+    const response = await waitAndReturnSettleResponse(
+      signer,
+      tx,
+      payload,
+      payer,
+      buildExpectedPermit2Transfer(permit2Payload, settlementAmount),
+    );
     return { ...response, amount: settlementAmount.toString() };
   } catch (error) {
     return mapSettleError(error, payload, payer);
@@ -556,6 +563,7 @@ async function settleUptoWithERC20Approval(
       settleTxHash,
       payload,
       payer,
+      buildExpectedPermit2Transfer(permit2Payload, settlementAmount),
     );
     return { ...response, amount: settlementAmount.toString() };
   } catch (error) {
@@ -592,7 +600,13 @@ async function settleUptoDirect(
       dataSuffix,
     });
 
-    const response = await waitAndReturnSettleResponse(signer, tx, payload, payer);
+    const response = await waitAndReturnSettleResponse(
+      signer,
+      tx,
+      payload,
+      payer,
+      buildExpectedPermit2Transfer(permit2Payload, settlementAmount),
+    );
     return { ...response, amount: settlementAmount.toString() };
   } catch (error) {
     return mapSettleError(error, payload, payer);

--- a/typescript/packages/mechanisms/evm/test/unit/exact/permit2-settle-transfer-event.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/permit2-settle-transfer-event.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Regression tests: the Permit2 exact settle path must verify the ERC-20
+ * Transfer event in the settlement receipt, not just receipt.status.
+ *
+ * The proxy's settle() does not revert when a non-conforming token underpays
+ * (fee-on-transfer) or moves nothing at all, so status alone cannot prove the
+ * recipient was paid in full. This mirrors the EIP-3009 settle path, which
+ * rejects the same receipts via verifyEip3009TransferEvent.
+ */
+import { describe, it, expect } from "vitest";
+import { encodeAbiParameters, keccak256, padHex, toBytes, toHex, getAddress } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import type { TransactionReceipt } from "viem";
+import { settlePermit2 } from "../../../src/exact/facilitator/permit2";
+import {
+  ErrInvalidTransactionState,
+  ErrTransferEventMismatch,
+} from "../../../src/exact/facilitator/errors";
+import {
+  PERMIT2_ADDRESS,
+  permit2WitnessTypes,
+  x402ExactPermit2ProxyAddress,
+} from "../../../src/constants";
+import type { ExactPermit2Payload } from "../../../src/types";
+import type { FacilitatorEvmSigner } from "../../../src/signer";
+import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+
+const TRANSFER_TOPIC = keccak256(toBytes("Transfer(address,address,uint256)"));
+const MOCK_TX = padHex("0xabc", { size: 32 });
+
+// Real keypair so the EIP-712 signature is genuinely valid (ecrecover path).
+const payerAccount = privateKeyToAccount(
+  "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+);
+const PAYER = payerAccount.address;
+const RECEIVER = getAddress("0x2222222222222222222222222222222222222222");
+const TOKEN = getAddress("0xE7C3D8C9a439feDe00D2600032D5dB0Be71C3c29");
+const NETWORK = "eip155:8453" as const;
+const AMOUNT = "1000";
+
+function makeTransferLog(opts: {
+  address: `0x${string}`;
+  from: `0x${string}`;
+  to: `0x${string}`;
+  value: bigint;
+}) {
+  return {
+    address: opts.address,
+    topics: [TRANSFER_TOPIC, padHex(opts.from, { size: 32 }), padHex(opts.to, { size: 32 })] as [
+      `0x${string}`,
+      `0x${string}`,
+      `0x${string}`,
+    ],
+    data: encodeAbiParameters([{ type: "uint256" }], [opts.value]),
+    blockHash: padHex("0x1", { size: 32 }),
+    blockNumber: 1n,
+    transactionHash: MOCK_TX,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  };
+}
+
+function makeReceipt(
+  logs: ReturnType<typeof makeTransferLog>[],
+  status: "success" | "reverted" = "success",
+): TransactionReceipt {
+  return {
+    status,
+    logs,
+    blockHash: padHex("0x1", { size: 32 }),
+    blockNumber: 1n,
+    transactionHash: MOCK_TX,
+    transactionIndex: 0,
+    cumulativeGasUsed: 0n,
+    gasUsed: 0n,
+    contractAddress: null,
+    from: PAYER,
+    to: x402ExactPermit2ProxyAddress,
+    logsBloom: toHex(new Uint8Array(256)),
+    type: "eip1559",
+    effectiveGasPrice: 0n,
+  } as unknown as TransactionReceipt;
+}
+
+async function makeSignedPayload(): Promise<ExactPermit2Payload> {
+  const now = Math.floor(Date.now() / 1000);
+  const authorization = {
+    from: PAYER,
+    permitted: { token: TOKEN, amount: AMOUNT },
+    spender: x402ExactPermit2ProxyAddress as `0x${string}`,
+    nonce: "123456789",
+    deadline: String(now + 3600),
+    witness: { to: RECEIVER, validAfter: "0" },
+  };
+
+  const signature = await payerAccount.signTypedData({
+    domain: { name: "Permit2", chainId: 8453, verifyingContract: PERMIT2_ADDRESS },
+    types: permit2WitnessTypes,
+    primaryType: "PermitWitnessTransferFrom",
+    message: {
+      permitted: { token: TOKEN, amount: BigInt(AMOUNT) },
+      spender: x402ExactPermit2ProxyAddress,
+      nonce: BigInt(authorization.nonce),
+      deadline: BigInt(authorization.deadline),
+      witness: { to: RECEIVER, validAfter: 0n },
+    },
+  });
+
+  return { signature, permit2Authorization: authorization };
+}
+
+function makeMockSigner(receipt: TransactionReceipt): FacilitatorEvmSigner {
+  return {
+    getCode: async ({ address }: { address: string }) =>
+      getAddress(address) === TOKEN ? "0x6080604052" : "0x",
+    writeContract: async () => MOCK_TX,
+    waitForTransactionReceipt: async () => receipt,
+    getAddresses: () => [],
+    readContract: async () => {
+      throw new Error("unexpected readContract in settle test (simulation disabled)");
+    },
+  } as unknown as FacilitatorEvmSigner;
+}
+
+function makeRequirements(): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: NETWORK,
+    asset: TOKEN,
+    amount: AMOUNT,
+    payTo: RECEIVER,
+    maxTimeoutSeconds: 3600,
+    extra: {},
+  } as unknown as PaymentRequirements;
+}
+
+function makePaymentPayload(requirements: PaymentRequirements): PaymentPayload {
+  return {
+    x402Version: 2,
+    accepted: requirements,
+    payload: undefined,
+  } as unknown as PaymentPayload;
+}
+
+async function settleWithReceipt(receipt: TransactionReceipt) {
+  const permit2Payload = await makeSignedPayload();
+  const requirements = makeRequirements();
+  const payload = makePaymentPayload(requirements);
+  payload.payload = permit2Payload as unknown as Record<string, unknown>;
+  return settlePermit2(makeMockSigner(receipt), payload, requirements, permit2Payload);
+}
+
+describe("settlePermit2 Transfer event verification", () => {
+  it("rejects a receipt whose Transfer delivers less than the permitted amount (fee-on-transfer)", async () => {
+    const receipt = makeReceipt([
+      makeTransferLog({ address: TOKEN, from: PAYER, to: RECEIVER, value: 900n }),
+    ]);
+
+    const result = await settleWithReceipt(receipt);
+
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(ErrTransferEventMismatch);
+    expect(result.transaction).toBe(MOCK_TX);
+  });
+
+  it("rejects a receipt with no Transfer event at all (silent no-op token)", async () => {
+    const result = await settleWithReceipt(makeReceipt([]));
+
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(ErrTransferEventMismatch);
+    expect(result.transaction).toBe(MOCK_TX);
+  });
+
+  it("rejects a receipt whose only Transfer moves the full amount to a different recipient", async () => {
+    const receipt = makeReceipt([
+      makeTransferLog({
+        address: TOKEN,
+        from: PAYER,
+        to: getAddress("0x3333333333333333333333333333333333333333"),
+        value: 1000n,
+      }),
+    ]);
+
+    const result = await settleWithReceipt(receipt);
+
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(ErrTransferEventMismatch);
+  });
+
+  it("accepts a receipt with the full-payment Transfer event", async () => {
+    const receipt = makeReceipt([
+      makeTransferLog({ address: TOKEN, from: PAYER, to: RECEIVER, value: 1000n }),
+    ]);
+
+    const result = await settleWithReceipt(receipt);
+
+    expect(result.success).toBe(true);
+    expect(result.transaction).toBe(MOCK_TX);
+    expect(result.payer).toBe(PAYER);
+  });
+
+  it("still reports invalid_transaction_state for a reverted receipt", async () => {
+    const result = await settleWithReceipt(makeReceipt([], "reverted"));
+
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(ErrInvalidTransactionState);
+  });
+});


### PR DESCRIPTION
## Description

A payer using a fee-charging (fee-on-transfer) or otherwise non-conforming token can underpay while the facilitator reports full success: every Permit2 settle path (exact and upto) trusted `receipt.status` alone, and the proxy's `settle()` does not revert when the token delivers less than the required amount.

**What changes:** `waitAndReturnSettleResponse` now takes the expected Transfer fields `{ token, from, to, value }` and requires a matching ERC-20 `Transfer` event in the receipt before reporting success, reusing the existing `verifyEip3009TransferEvent` helper and the same `invalid_exact_evm_transfer_event_mismatch` error reason. All six Permit2 settle branches are covered (exact: direct, EIP-2612 gas-sponsored, ERC-20-approval gas-sponsored; upto: the same three). Exact paths expect the full permitted amount; upto paths expect the actual settlement amount, which may be lower.

**Why:** receipt status proves only that the proxy call did not revert. With a fee-on-transfer token, the payer signs a Permit2 authorization for the full amount, the token delivers less to the recipient, the transaction still succeeds, and the merchant releases the resource underpaid. The proxy performs no balance-delta check, so the receipt is the only place to catch this.

**How:** this mirrors the structure of #2385, which added the identical check to the EIP-3009 settle path: same verifier, same error reason, same semantics (when logs are present, a matching Transfer is required). The expected Transfer is derived from the signed authorization (`from` = payer, `to` = witness recipient, `value` = settled amount, emitted by the permitted token).

**Scope and follow-ups:** the same status-only pattern exists in the Go SDK, the Python SDK, and the legacy v1 facilitator path. This PR is intentionally limited to the TypeScript exact and upto Permit2 paths (highest usage, direct analog of #2385) to stay reviewable; happy to follow up with the remaining SDKs if maintainers want.

Spotted during a security review of the facilitator settle paths. This PR was prepared with AI assistance (Cursor agent); every test assertion was validated by running the suite below, not generated blind.

## Tests

`vitest run` in `typescript/packages/mechanisms/evm`: 33 test files, 831 tests, all passing.

New regression test `test/unit/exact/permit2-settle-transfer-event.test.ts` (5 tests) drives `settlePermit2` with a real EIP-712 signature against mocked receipts:

- underpaying Transfer (900 of 1000 delivered): rejected with `invalid_exact_evm_transfer_event_mismatch`
- empty logs (token moved nothing): rejected with the same reason
- full amount transferred to a different recipient: rejected
- valid full-payment Transfer: succeeds
- reverted receipt: still reported as `invalid_transaction_state`

Pre-fix, the first three cases returned `success: true` (3 of 5 tests fail on 8bef6f7); post-fix all 5 pass.

`prettier --check` and `eslint` pass on all touched files.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
