### PR TITLE
@x402/sui: exact scheme for Sui (effects-only verification)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/typescript/.changeset/sui-exact-mechanism.md
+++ b/typescript/.changeset/sui-exact-mechanism.md
@@ -1,0 +1,5 @@
+---
+"@x402/sui": minor
+---
+
+Add `@x402/sui`: the exact payment scheme for Sui — client, server, and facilitator, with effects-only verification and optional gas sponsorship.

--- a/typescript/packages/mechanisms/sui/.prettierignore
+++ b/typescript/packages/mechanisms/sui/.prettierignore
@@ -1,0 +1,3 @@
+# build output
+dist/
+node_modules/

--- a/typescript/packages/mechanisms/sui/.prettierrc
+++ b/typescript/packages/mechanisms/sui/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "avoid",
+  "printWidth": 100,
+  "proseWrap": "never"
+}

--- a/typescript/packages/mechanisms/sui/README.md
+++ b/typescript/packages/mechanisms/sui/README.md
@@ -1,0 +1,113 @@
+# `@x402/sui` [![npm version](https://img.shields.io/npm/v/%40x402%2Fsui.svg)](https://www.npmjs.com/package/@x402/sui)
+
+Sui implementation of the x402 `exact` payment scheme.
+
+## Installation
+
+```bash
+npm install @x402/sui
+# or
+pnpm add @x402/sui
+```
+
+## Usage
+
+The package exports the `exact` scheme for all three x402 roles under `@x402/sui/exact/{client,server,facilitator}`. Each is registered on the matching core object for the `sui:*` network family.
+
+### Client
+
+```typescript
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { x402Client } from "@x402/core/client";
+import { ExactSuiScheme } from "@x402/sui/exact/client";
+
+// Any Sui signer works — Ed25519, Secp256k1, or a wallet-backed signer.
+const keypair = Ed25519Keypair.generate();
+const client = new x402Client().register("sui:*", new ExactSuiScheme(keypair));
+
+// On a 402 response, `client` builds and signs the payment transaction from the
+// returned PaymentRequirements — sourcing the asset and arranging gas per the
+// requirements — then retries the request with the signed PaymentPayload.
+```
+
+### Server
+
+```typescript
+import { x402ResourceServer } from "@x402/core/server";
+import { ExactSuiScheme } from "@x402/sui/exact/server";
+
+const server = new x402ResourceServer({
+  facilitatorUrl: "https://facilitator.example",
+}).register("sui:*", new ExactSuiScheme());
+
+// Price resources in USDC — "$0.01" or an explicit { amount, asset }. The scheme
+// converts the price to atomic units in the PaymentRequirements it builds.
+```
+
+### Facilitator
+
+```typescript
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { x402Facilitator } from "@x402/core/facilitator";
+import { ExactSuiScheme } from "@x402/sui/exact/facilitator";
+
+// No key is needed for self-paid or gasless payments. All options are optional:
+//   clients             per-network Sui client overrides (any core-API client);
+//                       networks without one fall back to the public fullnode
+//   executeTransaction  a custom executor settlement is delegated to (e.g. a gas
+//                       sponsor); absent, the facilitator broadcasts directly
+//   feePayer            a sponsor address to advertise as `extra.feePayer`
+//   settlementGuard     a dedup guard (default: in-process, digest-keyed)
+const facilitator = new x402Facilitator().register(
+  "sui:*",
+  new ExactSuiScheme({
+    clients: {
+      "sui:mainnet": new SuiGrpcClient({ network: "mainnet", baseUrl: "https://my-node:443" }),
+    },
+  }),
+);
+```
+
+#### Gas sponsorship
+
+Advertise a `feePayer` (which clients set as the gas owner) and supply an `executeTransaction` that co-signs the gas. The executor is a plain function that submits the signed bytes and returns the result; a gas sponsor is one example:
+
+```typescript
+import type { SuiExecutor } from "@x402/sui";
+
+// e.g. wrap the mysten-incubation sponsor SDK's createSponsor(...).
+const executeTransaction: SuiExecutor = ({ transaction, signatures }) =>
+  sponsor.signAndExecuteTransaction({ transaction, userSignature: signatures });
+
+new ExactSuiScheme({ feePayer: sponsorAddress, executeTransaction });
+```
+
+#### Cross-instance dedup
+
+A horizontally-scaled facilitator should supply a shared `settlementGuard` so a payment can't be served twice across instances. It is keyed on the tx digest (with the declared nonce when present):
+
+```typescript
+import type { SettlementGuard } from "@x402/sui";
+
+const settlementGuard: SettlementGuard = {
+  // Atomic reserve, e.g. Redis SET NX; true when the digest was already present.
+  async isDuplicate({ digest }) {
+    return (await redis.set(`settle:${digest}`, "1", { NX: true, EX: 600 })) === null;
+  },
+};
+```
+
+## Features
+
+- **Effects-only verification**: the facilitator checks that `payTo` is credited exactly `amount` from the transaction's `balanceChanges`, not how the transaction is built — so payments may be sourced from an Address Balance, coins, swaps, or withdrawals.
+- **Gas sponsorship**: optional, advertised as `extra.feePayer`; settlement is delegated to a custom `executeTransaction` (e.g. a gas sponsor that co-signs under its own policy).
+- **Network support**: Mainnet (`sui:mainnet`), Testnet (`sui:testnet`), and Devnet (`sui:devnet`).
+
+## Testnet Resources
+
+- **Test SUI**: https://faucet.sui.io/
+- **Test USDC**: https://faucet.circle.com/
+
+## License
+
+Apache-2.0

--- a/typescript/packages/mechanisms/sui/eslint.config.js
+++ b/typescript/packages/mechanisms/sui/eslint.config.js
@@ -1,0 +1,92 @@
+import js from "@eslint/js";
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import prettier from "eslint-plugin-prettier";
+import jsdoc from "eslint-plugin-jsdoc";
+import importPlugin from "eslint-plugin-import";
+
+export default [
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: ["**/*.test.ts", "test/**/*"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+      globals: {
+        process: "readonly",
+        __dirname: "readonly",
+        module: "readonly",
+        require: "readonly",
+        Buffer: "readonly",
+        exports: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        console: "readonly",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+      jsdoc: jsdoc,
+      import: importPlugin,
+    },
+    rules: {
+      ...ts.configs.recommended.rules,
+      "import/first": "error",
+      "prettier/prettier": "error",
+      "@typescript-eslint/member-ordering": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
+      "jsdoc/tag-lines": ["error", "any", { startLines: 1 }],
+      "jsdoc/check-alignment": "error",
+      "jsdoc/no-undefined-types": "off",
+      "jsdoc/check-param-names": "error",
+      "jsdoc/check-tag-names": "error",
+      "jsdoc/check-types": "error",
+      "jsdoc/implements-on-classes": "error",
+      "jsdoc/require-description": "error",
+      "jsdoc/require-jsdoc": [
+        "error",
+        {
+          require: {
+            FunctionDeclaration: true,
+            MethodDefinition: true,
+            ClassDeclaration: true,
+            ArrowFunctionExpression: false,
+            FunctionExpression: false,
+          },
+        },
+      ],
+      "jsdoc/require-param": "error",
+      "jsdoc/require-param-description": "error",
+      "jsdoc/require-param-type": "off",
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      "jsdoc/require-returns-type": "off",
+      "jsdoc/require-hyphen-before-param-description": ["error", "always"],
+    },
+  },
+  {
+    files: ["**/*.test.ts", "test/**/*"],
+    languageOptions: {
+      parser: tsParser,
+      sourceType: "module",
+      ecmaVersion: 2020,
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+      prettier: prettier,
+    },
+    rules: {
+      "prettier/prettier": "error",
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/member-ordering": "off",
+    },
+  },
+];

--- a/typescript/packages/mechanisms/sui/package.json
+++ b/typescript/packages/mechanisms/sui/package.json
@@ -1,0 +1,92 @@
+{
+  "name": "@x402/sui",
+  "version": "0.1.0",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "watch": "tsc --watch",
+    "format": "prettier -c .prettierrc --write \"**/*.{ts,js,cjs,json,md}\"",
+    "format:check": "prettier -c .prettierrc --check \"**/*.{ts,js,cjs,json,md}\"",
+    "lint": "eslint . --ext .ts --fix",
+    "lint:check": "eslint . --ext .ts"
+  },
+  "keywords": [
+    "x402",
+    "payment",
+    "protocol",
+    "sui"
+  ],
+  "license": "Apache-2.0",
+  "repository": "https://github.com/x402-foundation/x402",
+  "description": "x402 Payment Protocol Sui Implementation",
+  "devDependencies": {
+    "@eslint/js": "^9.24.0",
+    "@types/node": "^22.13.4",
+    "@typescript-eslint/eslint-plugin": "^8.29.1",
+    "@typescript-eslint/parser": "^8.29.1",
+    "eslint": "^9.24.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsdoc": "^50.6.9",
+    "eslint-plugin-prettier": "^5.2.6",
+    "prettier": "3.5.2",
+    "tsup": "^8.4.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3",
+    "vite": "^6.2.6",
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.0.5"
+  },
+  "dependencies": {
+    "@x402/core": "workspace:~",
+    "@mysten/sui": "2.23.1"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
+    "./exact/client": {
+      "import": {
+        "types": "./dist/esm/exact/client/index.d.mts",
+        "default": "./dist/esm/exact/client/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/exact/client/index.d.ts",
+        "default": "./dist/cjs/exact/client/index.js"
+      }
+    },
+    "./exact/server": {
+      "import": {
+        "types": "./dist/esm/exact/server/index.d.mts",
+        "default": "./dist/esm/exact/server/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/exact/server/index.d.ts",
+        "default": "./dist/cjs/exact/server/index.js"
+      }
+    },
+    "./exact/facilitator": {
+      "import": {
+        "types": "./dist/esm/exact/facilitator/index.d.mts",
+        "default": "./dist/esm/exact/facilitator/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/exact/facilitator/index.d.ts",
+        "default": "./dist/cjs/exact/facilitator/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/typescript/packages/mechanisms/sui/src/constants.ts
+++ b/typescript/packages/mechanisms/sui/src/constants.ts
@@ -1,0 +1,67 @@
+import type { Network } from "@x402/core/types";
+
+/**
+ * CAIP-2 network identifier for Sui Mainnet.
+ */
+export const SUI_MAINNET_CAIP2 = "sui:mainnet";
+
+/**
+ * CAIP-2 network identifier for Sui Testnet.
+ */
+export const SUI_TESTNET_CAIP2 = "sui:testnet";
+
+/**
+ * CAIP-2 network identifier for Sui Devnet.
+ */
+export const SUI_DEVNET_CAIP2 = "sui:devnet";
+
+/**
+ * Native Circle USDC on Sui mainnet (CCTP).
+ */
+export const USDC_MAINNET =
+  "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC";
+
+/**
+ * Circle native USDC on Sui testnet.
+ */
+export const USDC_TESTNET =
+  "0xa1ec7fc00a6f40db9693ad1415d0c193ad3906494428cf252621037bd7117e29::usdc::USDC";
+
+/**
+ * USDC decimal places.
+ */
+export const USDC_DECIMALS = 6;
+
+/**
+ * Default fullnode URLs, keyed by CAIP-2 network id.
+ */
+export const SUI_FULLNODE_URLS: Record<string, string> = {
+  [SUI_MAINNET_CAIP2]: "https://fullnode.mainnet.sui.io:443",
+  [SUI_TESTNET_CAIP2]: "https://fullnode.testnet.sui.io:443",
+  [SUI_DEVNET_CAIP2]: "https://fullnode.devnet.sui.io:443",
+};
+
+/**
+ * Recommended maximum byte length of the optional server nonce (`extra.nonce`)
+ * for gasless eligibility: a gasless transaction may carry one unused `Pure`
+ * input of at most 32 bytes. A recommendation, not a facilitator-enforced cap.
+ */
+export const NONCE_GASLESS_PURE_BYTES = 32;
+
+/**
+ * Get the default USDC coin type for a network. Devnet has no canonical USDC:
+ * prices there must be passed as an explicit AssetAmount.
+ *
+ * @param network - CAIP-2 network identifier
+ * @returns USDC coin type string
+ */
+export function getUsdcCoinType(network: Network): string {
+  switch (network) {
+    case SUI_MAINNET_CAIP2:
+      return USDC_MAINNET;
+    case SUI_TESTNET_CAIP2:
+      return USDC_TESTNET;
+    default:
+      throw new Error(`No default USDC coin type configured for network: ${network}`);
+  }
+}

--- a/typescript/packages/mechanisms/sui/src/exact/client/index.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/client/index.ts
@@ -1,0 +1,1 @@
+export { ExactSuiScheme } from "./scheme";

--- a/typescript/packages/mechanisms/sui/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/client/scheme.ts
@@ -1,0 +1,108 @@
+import type { Signer } from "@mysten/sui/cryptography";
+import { Transaction } from "@mysten/sui/transactions";
+import { isValidSuiAddress, normalizeStructTag, toBase64 } from "@mysten/sui/utils";
+import type {
+  PaymentPayloadResult,
+  PaymentRequirements,
+  SchemeNetworkClient,
+} from "@x402/core/types";
+import type { ExactSuiPayload, SuiClientOptions } from "../../types";
+import { createSuiClientResolver, parseBase64Bytes, type SuiClientResolver } from "../../utils";
+
+/**
+ * Sui client implementation for the Exact payment scheme. Builds and signs (but
+ * does not execute) a transaction whose effects transfer `amount` to `payTo`,
+ * sourced via the SDK's `tx.balance()` input. When the requirements announce a
+ * `feePayer` it sets the sponsor as gas owner; when they declare a server
+ * `nonce` its bytes ride as a `Pure` input.
+ */
+export class ExactSuiScheme implements SchemeNetworkClient {
+  readonly scheme = "exact";
+
+  private readonly getClient: SuiClientResolver;
+
+  /**
+   * Creates a new ExactSuiScheme client instance.
+   *
+   * @param signer - Any Sui signer (Ed25519Keypair, Secp256k1Keypair, wallet-backed, ...)
+   * @param options - Optional per-network Sui client overrides
+   */
+  constructor(
+    private readonly signer: Signer,
+    options?: SuiClientOptions,
+  ) {
+    this.getClient = createSuiClientResolver(options?.clients);
+  }
+
+  /**
+   * Creates a payment payload by building and signing the payment transaction.
+   *
+   * @param x402Version - The x402 protocol version
+   * @param paymentRequirements - The payment requirements (amount, asset, payTo, network, extra)
+   * @returns Promise resolving to a signed payment payload
+   */
+  async createPaymentPayload(
+    x402Version: number,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<PaymentPayloadResult> {
+    const { amount, asset, payTo, network } = paymentRequirements;
+    if (!asset) {
+      throw new Error("Asset is required");
+    }
+    if (!payTo || !isValidSuiAddress(payTo)) {
+      throw new Error(`Invalid pay-to address: ${payTo}`);
+    }
+    if (!amount || !/^[0-9]+$/.test(amount) || BigInt(amount) <= 0n) {
+      throw new Error(`Amount must be a positive atomic-unit integer: ${amount}`);
+    }
+    const coinType = normalizeStructTag(asset);
+
+    // Decode the declared server nonce (Base64) so it can ride as an unused Pure
+    // input below. A nonce beyond 32 bytes stays valid but may forfeit gasless
+    // eligibility (see NONCE_GASLESS_PURE_BYTES).
+    const declaredNonce = paymentRequirements.extra?.nonce;
+    let nonceBytes: Uint8Array | undefined;
+    if (declaredNonce !== undefined) {
+      const parsed = parseBase64Bytes(declaredNonce);
+      if (!parsed) {
+        throw new Error(`Invalid payment nonce in requirements: ${String(declaredNonce)}`);
+      }
+      nonceBytes = parsed;
+    }
+
+    const tx = new Transaction();
+    tx.setSender(this.signer.toSuiAddress());
+    tx.moveCall({
+      target: "0x2::balance::send_funds",
+      typeArguments: [coinType],
+      arguments: [tx.balance({ type: coinType, balance: BigInt(amount) }), tx.pure.address(payTo)],
+    });
+    // Passed as raw bytes (no BCS length prefix) so the decoded `Pure.bytes` is
+    // exactly the nonce.
+    if (nonceBytes) {
+      tx.pure(nonceBytes);
+    }
+
+    // When the requirements announce a sponsor, set it as gas owner with empty
+    // gas payment (Address Balance gas); the sponsor co-signs at settlement.
+    const feePayer = paymentRequirements.extra?.feePayer;
+    if (typeof feePayer === "string") {
+      tx.setGasOwner(feePayer);
+      tx.setGasPayment([]);
+    }
+
+    const client = this.getClient(network);
+    const bytes = await tx.build({ client });
+    const { signature } = await this.signer.signTransaction(bytes);
+
+    const payload: ExactSuiPayload = {
+      transaction: toBase64(bytes),
+      signature,
+    };
+
+    return {
+      x402Version,
+      payload,
+    };
+  }
+}

--- a/typescript/packages/mechanisms/sui/src/exact/facilitator/index.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/facilitator/index.ts
@@ -1,0 +1,1 @@
+export { ExactSuiScheme } from "./scheme";

--- a/typescript/packages/mechanisms/sui/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/facilitator/scheme.ts
@@ -1,0 +1,515 @@
+import type { ClientWithCoreApi, SuiClientTypes } from "@mysten/sui/client";
+import { Transaction } from "@mysten/sui/transactions";
+import { fromBase64 } from "@mysten/sui/utils";
+import { verifyTransactionSignature } from "@mysten/sui/verify";
+import type {
+  Network,
+  PaymentPayload,
+  PaymentRequirements,
+  SchemeNetworkFacilitator,
+  SettleResponse,
+  VerifyResponse,
+} from "@x402/core/types";
+import { SettlementCache } from "../../settlement-cache";
+import type {
+  ExactSuiPayload,
+  FacilitatorSuiOptions,
+  SettlementGuard,
+  SettlementKey,
+  SuiExecutor,
+  SuiExecutorResult,
+} from "../../types";
+import {
+  createSuiClientResolver,
+  matchExactPayment,
+  normalizeSignatures,
+  parseBase64Bytes,
+  transactionCarriesNonce,
+  type SuiClientResolver,
+} from "../../utils";
+
+/**
+ * A payment that passed the offline checks. verify then runs the network checks
+ * and simulates; settle executes.
+ */
+type ValidatedPayment =
+  | {
+      ok: true;
+      sender: string;
+      transactionBytes: Uint8Array;
+      data: ReturnType<Transaction["getData"]>;
+    }
+  | { ok: false; reason: string; message?: string; payer: string };
+
+/**
+ * Sui facilitator implementation for the Exact payment scheme. Verification is
+ * effects-only: it checks that `payTo` is credited exactly `amount`, not how the
+ * transaction is built. A custom executor, when configured, handles settlement
+ * (e.g. a gas sponsor that co-signs under its own policy).
+ */
+export class ExactSuiScheme implements SchemeNetworkFacilitator {
+  readonly scheme = "exact";
+  readonly caipFamily = "sui:*";
+
+  private readonly getClient: SuiClientResolver;
+  private readonly executeTransaction?: SuiExecutor;
+  private readonly feePayer?: string;
+  private readonly guard: SettlementGuard;
+
+  /**
+   * Creates a new ExactSuiScheme facilitator instance.
+   *
+   * @param options - Optional client overrides, executor, fee-payer, and guard
+   */
+  constructor(options?: FacilitatorSuiOptions) {
+    this.getClient = createSuiClientResolver(options?.clients);
+    this.executeTransaction = options?.executeTransaction;
+    this.feePayer = options?.feePayer;
+    this.guard = options?.settlementGuard ?? new SettlementCache();
+  }
+
+  /**
+   * Advertise the fee-payer address when one is configured; its presence in
+   * `extra.feePayer` signals that sponsorship is offered.
+   *
+   * @param _ - The network identifier (unused)
+   * @returns `{ feePayer }` when a fee-payer is set, otherwise undefined
+   */
+  getExtra(_: Network): Record<string, unknown> | undefined {
+    void _;
+    return this.feePayer ? { feePayer: this.feePayer } : undefined;
+  }
+
+  /**
+   * The facilitator's signing addresses: the fee-payer address when configured,
+   * otherwise none (a self-paid/gasless broadcast needs no facilitator key).
+   *
+   * @param _ - The network identifier (unused)
+   * @returns The fee-payer address array, or empty
+   */
+  getSigners(_: string): string[] {
+    void _;
+    return this.feePayer ? [this.feePayer] : [];
+  }
+
+  /**
+   * Verify a payment: offline checks, then not-already-executed, simulation, and
+   * effects-only recipient verification.
+   *
+   * @param payload - The payment payload to verify
+   * @param requirements - The payment requirements
+   * @returns Promise resolving to verification response
+   */
+  async verify(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<VerifyResponse> {
+    try {
+      const validated = await this.validate(payload, requirements);
+      if (!validated.ok) {
+        return {
+          isValid: false,
+          invalidReason: validated.reason,
+          invalidMessage: validated.message,
+          payer: validated.payer,
+        };
+      }
+      const { transactionBytes, sender } = validated;
+      const client = this.getClient(requirements.network);
+
+      // Not-already-executed replay guard (simulation is not a replay guard for
+      // Address-Balance-sourced transactions — they have no object inputs).
+      const digest = await Transaction.from(transactionBytes).getDigest();
+      if (await this.isExecuted(client, digest)) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_transaction_state",
+          invalidMessage: `transaction ${digest} already executed`,
+          payer: sender,
+        };
+      }
+
+      const simulation = await client.core.simulateTransaction({
+        transaction: transactionBytes,
+        include: { balanceChanges: true },
+      });
+      if (simulation.$kind === "FailedTransaction") {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_sui_payload_simulation_failed",
+          invalidMessage: simulation.FailedTransaction.status.error?.message,
+          payer: sender,
+        };
+      }
+
+      const problem = this.matchRecipients(simulation.Transaction.balanceChanges, requirements);
+      if (problem) {
+        return {
+          isValid: false,
+          invalidReason: "invalid_exact_sui_payload_transfer_mismatch",
+          invalidMessage: problem,
+          payer: sender,
+        };
+      }
+
+      return { isValid: true, invalidReason: undefined, payer: sender };
+    } catch (error) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_sui_payload_verification_error",
+        invalidMessage: error instanceof Error ? error.message : String(error),
+        payer: "",
+      };
+    }
+  }
+
+  /**
+   * Settle a payment: dedup, re-run the offline checks, then execute (or
+   * delegate to the sponsor) and gate success on the executed effects.
+   *
+   * @param payload - The payment payload to settle
+   * @param requirements - The payment requirements
+   * @returns Promise resolving to settlement response
+   */
+  async settle(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    const network = payload.accepted.network;
+    const suiPayload = payload.payload as ExactSuiPayload;
+
+    // Guard against double-serving before validating or executing, keyed on the
+    // transaction digest (with the declared nonce, when present, for a shared
+    // guard's reconciliation). Re-executing a settled transaction is harmless on
+    // Sui; this stops the server serving the same payment twice. A malformed
+    // payload yields no key and is rejected by validate() below. Cross-instance
+    // exactly-once needs a shared SettlementGuard.
+    const settlementKey = await this.settlementKey(suiPayload, requirements);
+    if (settlementKey && (await this.guard.isDuplicate(settlementKey))) {
+      return {
+        success: false,
+        network,
+        transaction: "",
+        errorReason: "duplicate_settlement",
+        payer: "",
+      };
+    }
+
+    try {
+      const validated = await this.validate(payload, requirements);
+      if (!validated.ok) {
+        return {
+          success: false,
+          network,
+          transaction: "",
+          errorReason: validated.reason,
+          errorMessage: validated.message,
+          payer: validated.payer,
+        };
+      }
+      const { transactionBytes, sender } = validated;
+
+      const executed = await this.execute(suiPayload, transactionBytes, requirements);
+      if ("failure" in executed) return executed.failure;
+      const { transaction } = executed;
+
+      if (!transaction.status.success) {
+        return {
+          success: false,
+          errorReason: "transaction_failed",
+          errorMessage: transaction.status.error?.message,
+          transaction: transaction.digest,
+          network,
+          payer: sender,
+        };
+      }
+      const problem = this.matchRecipients(transaction.balanceChanges, requirements);
+      if (problem) {
+        return {
+          success: false,
+          errorReason: "settlement_effects_mismatch",
+          errorMessage: problem,
+          transaction: transaction.digest,
+          network,
+          payer: sender,
+        };
+      }
+      return { success: true, transaction: transaction.digest, network, payer: sender };
+    } catch (error) {
+      return {
+        success: false,
+        errorReason: "transaction_failed",
+        errorMessage: error instanceof Error ? error.message : String(error),
+        transaction: "",
+        network,
+        payer: "",
+      };
+    }
+  }
+
+  /**
+   * The offline checks shared by verify and settle: envelope, signature binding
+   * the sender, and the optional declared server nonce.
+   *
+   * @param payload - The payment payload
+   * @param requirements - The payment requirements
+   * @returns The decoded bytes/data/client/sender, or a typed rejection
+   */
+  private async validate(
+    payload: PaymentPayload,
+    requirements: PaymentRequirements,
+  ): Promise<ValidatedPayment> {
+    if (payload.x402Version !== 2) {
+      return { ok: false, reason: "invalid_x402_version", payer: "" };
+    }
+    if (payload.accepted.scheme !== "exact" || requirements.scheme !== "exact") {
+      return { ok: false, reason: "unsupported_scheme", payer: "" };
+    }
+    if (payload.accepted.network !== requirements.network) {
+      return { ok: false, reason: "network_mismatch", payer: "" };
+    }
+
+    let client: ClientWithCoreApi;
+    try {
+      client = this.getClient(requirements.network);
+    } catch {
+      return { ok: false, reason: "invalid_network", payer: "" };
+    }
+
+    const suiPayload = payload.payload as ExactSuiPayload;
+    const signatures = normalizeSignatures(suiPayload?.signature);
+    if (typeof suiPayload?.transaction !== "string" || !signatures) {
+      return { ok: false, reason: "invalid_payload", payer: "" };
+    }
+
+    let transactionBytes: Uint8Array;
+    let data: ReturnType<Transaction["getData"]>;
+    try {
+      transactionBytes = fromBase64(suiPayload.transaction);
+      data = Transaction.from(transactionBytes).getData();
+    } catch (error) {
+      return {
+        ok: false,
+        reason: "invalid_exact_sui_payload_transaction_could_not_be_decoded",
+        message: error instanceof Error ? error.message : String(error),
+        payer: "",
+      };
+    }
+
+    const sender = data.sender;
+    if (!sender) {
+      return { ok: false, reason: "invalid_exact_sui_payload_missing_sender", payer: "" };
+    }
+
+    // A transaction may require more than one signer (e.g. a sponsor distinct
+    // from the sender). Verify only that the sender is covered by one of the
+    // signatures; other required signers are enforced at execution, not here.
+    let senderBound = false;
+    let lastError: unknown;
+    for (const signature of signatures) {
+      try {
+        await verifyTransactionSignature(transactionBytes, signature, { client, address: sender });
+        senderBound = true;
+        break;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    if (!senderBound) {
+      return {
+        ok: false,
+        reason: "invalid_exact_sui_payload_invalid_signature",
+        message: lastError instanceof Error ? lastError.message : String(lastError),
+        payer: sender,
+      };
+    }
+
+    const nonceProblem = this.checkNonce(data, requirements);
+    if (nonceProblem) {
+      return {
+        ok: false,
+        reason: nonceProblem.reason,
+        message: nonceProblem.message,
+        payer: sender,
+      };
+    }
+
+    return { ok: true, sender, transactionBytes, data };
+  }
+
+  /**
+   * When `requirements.extra.nonce` is declared, require the transaction to carry
+   * its Base64-decoded bytes as a `Pure` input. No size cap; a malformed
+   * (non-Base64) value is rejected.
+   *
+   * @param data - The decoded transaction data
+   * @param requirements - The payment requirements
+   * @returns A rejection, or null when the nonce is satisfied (or not declared)
+   */
+  private checkNonce(
+    data: ReturnType<Transaction["getData"]>,
+    requirements: PaymentRequirements,
+  ): { reason: string; message: string } | null {
+    const declaredNonce = requirements.extra?.nonce;
+    if (declaredNonce === undefined) return null;
+
+    if (!parseBase64Bytes(declaredNonce)) {
+      return {
+        reason: "invalid_exact_sui_payload_missing_nonce",
+        message: "requirements.extra.nonce is not valid Base64",
+      };
+    }
+    if (!transactionCarriesNonce(data, declaredNonce as string)) {
+      return {
+        reason: "invalid_exact_sui_payload_missing_nonce",
+        message: "transaction does not carry the declared nonce",
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Submit the payment and wait for finality, then return the finalized
+   * transaction with its balance changes. Submission is delegated to the custom
+   * `executeTransaction` when configured (a gas sponsor, for example, co-signs the
+   * gas under its own policy or declines); otherwise the signed bytes are
+   * broadcast directly via the network client. Balance changes are read from the
+   * finalized transaction, not the submission. Sui execution is idempotent, so a
+   * retry returns the same effects.
+   *
+   * @param suiPayload - The signed payload
+   * @param transactionBytes - The decoded transaction bytes
+   * @param requirements - The payment requirements
+   * @returns The finalized transaction, or a settlement failure
+   */
+  private async execute(
+    suiPayload: ExactSuiPayload,
+    transactionBytes: Uint8Array,
+    requirements: PaymentRequirements,
+  ): Promise<
+    | { transaction: SuiClientTypes.Transaction<{ balanceChanges: true }> }
+    | { failure: SettleResponse }
+  > {
+    const network = requirements.network;
+    const signatures = normalizeSignatures(suiPayload.signature) ?? [];
+    const client = this.getClient(network);
+
+    const submitted: SuiExecutorResult = this.executeTransaction
+      ? await this.executeTransaction({ transaction: transactionBytes, signatures })
+      : await client.core.executeTransaction({ transaction: transactionBytes, signatures });
+
+    if (submitted.$kind === "Rejected") {
+      // Wire code stays `sponsor_rejected` (the spec's name for a policy rejection
+      // during sponsored settlement) even though the executor is generic.
+      return {
+        failure: {
+          success: false,
+          errorReason: "sponsor_rejected",
+          errorMessage:
+            submitted.reason ??
+            submitted.issues
+              ?.map(i => i.message)
+              .filter(Boolean)
+              .join("; "),
+          transaction: "",
+          network,
+          payer: "",
+        },
+      };
+    }
+    if (submitted.$kind === "FailedTransaction") {
+      return {
+        failure: {
+          success: false,
+          errorReason: "transaction_failed",
+          errorMessage: submitted.FailedTransaction.status.error?.message,
+          transaction: submitted.FailedTransaction.digest,
+          network,
+          payer: "",
+        },
+      };
+    }
+
+    // Wait for finality and read the balance changes from the finalized tx.
+    const finalized = await client.core.waitForTransaction({
+      digest: submitted.Transaction.digest,
+      include: { balanceChanges: true },
+    });
+    if (finalized.$kind === "FailedTransaction") {
+      return {
+        failure: {
+          success: false,
+          errorReason: "transaction_failed",
+          errorMessage: finalized.FailedTransaction.status.error?.message,
+          transaction: finalized.FailedTransaction.digest,
+          network,
+          payer: "",
+        },
+      };
+    }
+    return { transaction: finalized.Transaction };
+  }
+
+  /**
+   * Effects-only recipient verification against the single declared recipient:
+   * `payTo` must net exactly `amount` in the asset.
+   *
+   * @param balanceChanges - The simulated or executed balance changes
+   * @param requirements - The payment requirements
+   * @returns A problem string, or null when the effects match
+   */
+  private matchRecipients(
+    balanceChanges: readonly SuiClientTypes.BalanceChange[],
+    requirements: PaymentRequirements,
+  ): string | null {
+    return matchExactPayment(
+      balanceChanges,
+      requirements.asset,
+      requirements.payTo,
+      requirements.amount,
+    );
+  }
+
+  /**
+   * The settlement identity for the dedup guard: the transaction digest, plus the
+   * declared server nonce when present. Returns undefined for a malformed payload
+   * (no dedup possible — validate() rejects it).
+   *
+   * @param suiPayload - The Sui payload (for the transaction bytes)
+   * @param requirements - The payment requirements (for the declared nonce)
+   * @returns The settlement key, or undefined when the payload is malformed
+   */
+  private async settlementKey(
+    suiPayload: ExactSuiPayload,
+    requirements: PaymentRequirements,
+  ): Promise<SettlementKey | undefined> {
+    if (typeof suiPayload?.transaction !== "string") return undefined;
+    let digest: string;
+    try {
+      digest = await Transaction.from(fromBase64(suiPayload.transaction)).getDigest();
+    } catch {
+      return undefined;
+    }
+    const nonce = requirements.extra?.nonce;
+    return typeof nonce === "string" ? { digest, nonce } : { digest };
+  }
+
+  /**
+   * Whether a transaction digest is already committed on-chain.
+   *
+   * @param client - The Sui client
+   * @param digest - The transaction digest
+   * @returns True when committed, false when not found
+   */
+  private async isExecuted(client: ClientWithCoreApi, digest: string): Promise<boolean> {
+    try {
+      await client.core.getTransaction({ digest });
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/not found|NOT_FOUND/i.test(message)) return false;
+      throw error;
+    }
+  }
+}

--- a/typescript/packages/mechanisms/sui/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/facilitator/scheme.ts
@@ -507,8 +507,7 @@ export class ExactSuiScheme implements SchemeNetworkFacilitator {
       await client.core.getTransaction({ digest });
       return true;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (/not found|NOT_FOUND/i.test(message)) return false;
+      if (error instanceof Error && "code" in error && error.code === "NOT_FOUND") return false;
       throw error;
     }
   }

--- a/typescript/packages/mechanisms/sui/src/exact/index.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/index.ts
@@ -1,0 +1,1 @@
+export { ExactSuiScheme } from "./client/scheme";

--- a/typescript/packages/mechanisms/sui/src/exact/server/index.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/server/index.ts
@@ -1,0 +1,1 @@
+export { ExactSuiScheme } from "./scheme";

--- a/typescript/packages/mechanisms/sui/src/exact/server/scheme.ts
+++ b/typescript/packages/mechanisms/sui/src/exact/server/scheme.ts
@@ -1,0 +1,173 @@
+import { normalizeStructTag } from "@mysten/sui/utils";
+import type {
+  AssetAmount,
+  Money,
+  MoneyParser,
+  Network,
+  PaymentRequirements,
+  Price,
+  SchemeNetworkServer,
+  SupportedKind,
+} from "@x402/core/types";
+import { parseMoneyString } from "@x402/core/utils";
+import { getUsdcCoinType, USDC_DECIMALS, USDC_MAINNET, USDC_TESTNET } from "../../constants";
+
+/**
+ * Sui server implementation for the Exact payment scheme. Parses prices into
+ * atomic USDC amounts and passes any operator-set `extra.nonce` through
+ * untouched (auto-generating one would break requirement matching).
+ */
+export class ExactSuiScheme implements SchemeNetworkServer {
+  readonly scheme = "exact";
+  private moneyParsers: MoneyParser[] = [];
+
+  /**
+   * Register a custom money parser in the parser chain. Parsers run in
+   * registration order; returning null falls through to the next. The default
+   * USDC conversion is the final fallback.
+   *
+   * @param parser - Custom function to convert an amount to an AssetAmount (or null to skip)
+   * @returns The scheme instance for chaining
+   */
+  registerMoneyParser(parser: MoneyParser): ExactSuiScheme {
+    this.moneyParsers.push(parser);
+    return this;
+  }
+
+  /**
+   * Parse a price into an asset amount. An AssetAmount passes through
+   * (validated as a coin type); Money is parsed to a decimal, offered to
+   * custom parsers, then converted to USDC on the network.
+   *
+   * @param price - The price to parse
+   * @param network - The CAIP-2 network identifier
+   * @returns Promise resolving to the parsed asset amount
+   */
+  async parsePrice(price: Price, network: Network): Promise<AssetAmount> {
+    if (typeof price === "object" && price !== null && "amount" in price) {
+      if (!price.asset) {
+        throw new Error(`Asset must be specified for AssetAmount on network ${network}`);
+      }
+      normalizeStructTag(price.asset); // throws on a malformed coin type
+      this.assertPositiveAmount(price.amount);
+      return { amount: price.amount, asset: price.asset, extra: price.extra || {} };
+    }
+
+    const amount = this.parseMoneyToDecimal(price as Money);
+
+    for (const parser of this.moneyParsers) {
+      const result = await parser(amount, network);
+      if (result !== null) {
+        return result;
+      }
+    }
+
+    return this.defaultMoneyConversion(amount, network);
+  }
+
+  /**
+   * Return the decimal precision of an asset. Only USDC is known; other assets
+   * must be priced with an explicit AssetAmount in atomic units.
+   *
+   * @param asset - The asset coin type
+   * @param network - The CAIP-2 network identifier (unused)
+   * @returns Number of decimal places
+   */
+  getAssetDecimals(asset: string, network: Network): number {
+    void network;
+    const normalized = normalizeStructTag(asset);
+    if (
+      normalized === normalizeStructTag(USDC_MAINNET) ||
+      normalized === normalizeStructTag(USDC_TESTNET)
+    ) {
+      return USDC_DECIMALS;
+    }
+    throw new Error(
+      `Unknown decimals for asset ${asset}; price it with an explicit AssetAmount in atomic units`,
+    );
+  }
+
+  /**
+   * Build payment requirements: merge the facilitator's advertised extras
+   * (e.g. `feePayer`) and reject a non-positive amount.
+   *
+   * @param paymentRequirements - The base payment requirements
+   * @param supportedKind - The supported kind from the facilitator's /supported endpoint
+   * @param facilitatorExtensions - Extension keys supported by the facilitator
+   * @returns Enhanced payment requirements
+   */
+  enhancePaymentRequirements(
+    paymentRequirements: PaymentRequirements,
+    supportedKind: SupportedKind,
+    facilitatorExtensions: string[],
+  ): Promise<PaymentRequirements> {
+    void facilitatorExtensions;
+
+    const extra: Record<string, unknown> = {
+      ...paymentRequirements.extra,
+      ...supportedKind.extra,
+    };
+
+    if (BigInt(paymentRequirements.amount) <= 0n) {
+      return Promise.reject(
+        new Error(
+          `invalid_payment_requirements: amount must be positive, got ${paymentRequirements.amount}`,
+        ),
+      );
+    }
+
+    return Promise.resolve({ ...paymentRequirements, extra });
+  }
+
+  /**
+   * Parse Money to a decimal number.
+   *
+   * @param money - The money value to parse
+   * @returns Decimal number
+   */
+  private parseMoneyToDecimal(money: string | number): number {
+    if (typeof money === "number") {
+      return money;
+    }
+
+    return parseMoneyString(money);
+  }
+
+  /**
+   * Default money conversion — to atomic USDC on the network.
+   *
+   * @param amount - The decimal amount
+   * @param network - The CAIP-2 network identifier
+   * @returns The parsed asset amount in USDC
+   */
+  private defaultMoneyConversion(amount: number, network: Network): AssetAmount {
+    const tokenAmount = this.convertToTokenAmount(amount.toString(), USDC_DECIMALS);
+    this.assertPositiveAmount(tokenAmount);
+    return { amount: tokenAmount, asset: getUsdcCoinType(network), extra: {} };
+  }
+
+  /**
+   * Throw when an atomic-unit amount is not a positive integer.
+   *
+   * @param amount - The atomic-unit amount string
+   */
+  private assertPositiveAmount(amount: string): void {
+    if (!/^[0-9]+$/.test(amount) || BigInt(amount) <= 0n) {
+      throw new Error(`Amount must be a positive atomic-unit integer: ${amount}`);
+    }
+  }
+
+  /**
+   * Convert a decimal amount string to atomic units.
+   *
+   * @param amount - The decimal amount
+   * @param decimals - Number of decimals for the token
+   * @returns The amount in atomic units as a string
+   */
+  private convertToTokenAmount(amount: string, decimals: number): string {
+    const parts = amount.split(".");
+    const wholePart = parts[0] || "0";
+    const fractionalPart = (parts[1] || "").padEnd(decimals, "0").slice(0, decimals);
+    return BigInt(wholePart + fractionalPart).toString();
+  }
+}

--- a/typescript/packages/mechanisms/sui/src/index.ts
+++ b/typescript/packages/mechanisms/sui/src/index.ts
@@ -1,0 +1,14 @@
+// Exact scheme exports
+export * from "./exact";
+
+// Types
+export * from "./types";
+
+// Constants
+export * from "./constants";
+
+// Utils
+export * from "./utils";
+
+// Settlement dedup
+export * from "./settlement-cache";

--- a/typescript/packages/mechanisms/sui/src/settlement-cache.ts
+++ b/typescript/packages/mechanisms/sui/src/settlement-cache.ts
@@ -1,0 +1,48 @@
+import type { SettlementGuard, SettlementKey } from "./types";
+
+/**
+ * Default TTL for settlement dedup entries (ms). Sized to exceed a typical
+ * freshness window so a payment cannot be settled twice within its own validity.
+ */
+export const SETTLEMENT_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * In-process settlement dedup keyed on the transaction digest. Prevents one
+ * facilitator process from settling the same payment twice — the check-plus-insert
+ * is synchronous, so it runs before the first `await` in settle. Not
+ * cross-instance: a scaled facilitator supplies a shared `SettlementGuard`.
+ */
+export class SettlementCache implements SettlementGuard {
+  private readonly entries = new Map<string, number>();
+
+  /**
+   * Create a settlement cache.
+   *
+   * @param ttlMs - Entry lifetime in milliseconds
+   */
+  constructor(private readonly ttlMs: number = SETTLEMENT_TTL_MS) {}
+
+  /**
+   * Returns `true` if the settlement's digest is already pending (a duplicate),
+   * or `false` after recording it as newly pending.
+   *
+   * @param payment - The settlement identity; keyed on `digest`
+   * @returns Whether the digest was already present
+   */
+  isDuplicate(payment: SettlementKey): boolean {
+    this.prune();
+    if (this.entries.has(payment.digest)) return true;
+    this.entries.set(payment.digest, Date.now());
+    return false;
+  }
+
+  /**
+   * Remove entries older than the TTL.
+   */
+  private prune(): void {
+    const cutoff = Date.now() - this.ttlMs;
+    for (const [key, timestamp] of this.entries) {
+      if (timestamp < cutoff) this.entries.delete(key);
+    }
+  }
+}

--- a/typescript/packages/mechanisms/sui/src/types.ts
+++ b/typescript/packages/mechanisms/sui/src/types.ts
@@ -1,0 +1,102 @@
+import type { ClientWithCoreApi, SuiClientTypes } from "@mysten/sui/client";
+
+/**
+ * Exact Sui payload: a fully signed, ready-to-broadcast transaction.
+ */
+export type ExactSuiPayload = {
+  /**
+   * Base64-encoded BCS transaction bytes.
+   */
+  transaction: string;
+  /**
+   * Base64-encoded serialized signature(s) over the transaction bytes. A single
+   * string is the sole sender signature; an array carries multiple required
+   * signers (e.g. a sponsored transaction whose sponsor is a distinct signer).
+   */
+  signature: string | string[];
+};
+
+/**
+ * The result of a {@link SuiExecutor}: the submitted transaction, an on-chain
+ * failure, or a policy rejection. Balance changes need not be included — the
+ * facilitator reads them from `waitForTransaction`.
+ */
+export type SuiExecutorResult =
+  | { $kind: "Transaction"; Transaction: SuiClientTypes.Transaction }
+  | { $kind: "FailedTransaction"; FailedTransaction: SuiClientTypes.Transaction }
+  | { $kind: "Rejected"; reason?: string; issues?: ReadonlyArray<{ message?: string }> };
+
+/**
+ * A pluggable executor settlement is delegated to. It receives the signed bytes
+ * and the user signatures, submits (or delegates submission — a gas sponsor, for
+ * example, co-signs under its own policy), and returns the submitted transaction,
+ * an on-chain failure, or a rejection. When no executor is configured, the
+ * facilitator broadcasts directly via the network client. The facilitator then
+ * waits for finality and reads balance changes from the finalized transaction.
+ */
+export type SuiExecutor = (input: {
+  transaction: Uint8Array;
+  signatures: string[];
+}) => Promise<SuiExecutorResult>;
+
+/**
+ * The identity of a settlement for deduplication: the transaction digest, plus
+ * the declared server nonce when present (which a shared guard MAY use for
+ * invoice or challenge reconciliation).
+ */
+export type SettlementKey = {
+  digest: string;
+  nonce?: string;
+};
+
+/**
+ * A dedup guard consulted at the top of settle. The default in-process
+ * implementation covers a single process; a scaled facilitator SHOULD supply a
+ * shared implementation (e.g. Redis) for cross-instance serving.
+ */
+export interface SettlementGuard {
+  /**
+   * Atomically record the settlement as in-progress. Returns `true` when it was
+   * already present (a duplicate the caller MUST reject), `false` otherwise. May
+   * be async so a shared store (e.g. Redis) can back it.
+   *
+   * @param payment - The settlement identity (digest, and nonce when declared)
+   * @returns Whether it was already present
+   */
+  isDuplicate(payment: SettlementKey): boolean | Promise<boolean>;
+}
+
+/**
+ * Options shared by the client and facilitator schemes: per-network Sui client
+ * overrides. Any client implementing the core API works (gRPC, GraphQL, ...);
+ * networks without an override fall back to a gRPC client for the default
+ * public fullnode.
+ */
+export type SuiClientOptions = {
+  /**
+   * Sui clients keyed by CAIP-2 network id (e.g. "sui:mainnet").
+   */
+  clients?: Record<string, ClientWithCoreApi>;
+};
+
+/**
+ * Facilitator options: client overrides, an optional custom executor and
+ * advertised fee-payer address, and a settlement dedup guard.
+ */
+export type FacilitatorSuiOptions = SuiClientOptions & {
+  /**
+   * Optional executor settlement is delegated to (e.g. a gas sponsor). When
+   * absent, the facilitator broadcasts directly via the network client.
+   */
+  executeTransaction?: SuiExecutor;
+  /**
+   * Optional gas-sponsor address advertised as `extra.feePayer`, so clients build
+   * sponsored transactions with it as the gas owner. Independent of
+   * `executeTransaction`.
+   */
+  feePayer?: string;
+  /**
+   * Settlement dedup guard. Defaults to an in-process, digest-keyed cache.
+   */
+  settlementGuard?: SettlementGuard;
+};

--- a/typescript/packages/mechanisms/sui/src/utils.ts
+++ b/typescript/packages/mechanisms/sui/src/utils.ts
@@ -1,0 +1,169 @@
+import type { ClientWithCoreApi, SuiClientTypes } from "@mysten/sui/client";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import type { Transaction } from "@mysten/sui/transactions";
+import { fromBase64, normalizeStructTag, normalizeSuiAddress, toBase64 } from "@mysten/sui/utils";
+import type { Network } from "@x402/core/types";
+import {
+  SUI_DEVNET_CAIP2,
+  SUI_FULLNODE_URLS,
+  SUI_MAINNET_CAIP2,
+  SUI_TESTNET_CAIP2,
+} from "./constants";
+
+/**
+ * Map a CAIP-2 Sui network id to the SDK's network name.
+ *
+ * @param network - CAIP-2 network identifier (e.g. "sui:testnet")
+ * @returns The SDK network name ("mainnet" | "testnet" | "devnet")
+ */
+export function getSuiNetworkName(network: Network): SuiClientTypes.Network {
+  switch (network) {
+    case SUI_MAINNET_CAIP2:
+      return "mainnet";
+    case SUI_TESTNET_CAIP2:
+      return "testnet";
+    case SUI_DEVNET_CAIP2:
+      return "devnet";
+    default:
+      throw new Error(`Unsupported Sui network: ${network}`);
+  }
+}
+
+/**
+ * Normalize an ExactSuiPayload `signature` into a non-empty array of signature
+ * strings. Returns null when malformed (undefined, an empty array, or a
+ * non-string element).
+ *
+ * @param signature - The payload signature field (string | string[])
+ * @returns A non-empty string array, or null when malformed
+ */
+export function normalizeSignatures(signature: unknown): string[] | null {
+  const arr = typeof signature === "string" ? [signature] : signature;
+  if (!Array.isArray(arr) || arr.length === 0) return null;
+  if (!arr.every((s): s is string => typeof s === "string")) return null;
+  return arr;
+}
+
+/**
+ * Resolves a Sui client for a CAIP-2 network id.
+ */
+export type SuiClientResolver = (network: Network) => ClientWithCoreApi;
+
+/**
+ * Create a client resolver from optional per-network overrides. Networks
+ * without an override get a lazily constructed, cached gRPC client for the
+ * default public fullnode.
+ *
+ * @param clients - Optional Sui clients keyed by CAIP-2 network id
+ * @returns A resolver from CAIP-2 network id to a Sui client
+ */
+export function createSuiClientResolver(
+  clients?: Record<string, ClientWithCoreApi>,
+): SuiClientResolver {
+  const defaults = new Map<string, ClientWithCoreApi>();
+
+  return (network: Network): ClientWithCoreApi => {
+    const override = clients?.[network];
+    if (override) return override;
+
+    const cached = defaults.get(network);
+    if (cached) return cached;
+
+    const client = new SuiGrpcClient({
+      network: getSuiNetworkName(network),
+      baseUrl: SUI_FULLNODE_URLS[network],
+    });
+    defaults.set(network, client);
+    return client;
+  };
+}
+
+/**
+ * Decode a Base64 string into bytes; no size cap. Returns null for a non-string,
+ * an empty value, or one that is not valid Base64.
+ *
+ * @param value - The Base64 value
+ * @returns The decoded bytes, or null when malformed
+ */
+export function parseBase64Bytes(value: unknown): Uint8Array | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  try {
+    const bytes = fromBase64(value);
+    return bytes.length === 0 ? null : bytes;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The Base64 bytes of every `Pure` input, whether or not a command references it.
+ * An optional server nonce may ride as an unused `Pure` input.
+ *
+ * @param data - The decoded transaction data (`Transaction.getData()`)
+ * @returns The Base64 string of each Pure input
+ */
+export function pureInputsBase64(data: ReturnType<Transaction["getData"]>): string[] {
+  const out: string[] = [];
+  for (const input of data.inputs) {
+    if (input.Pure?.bytes) out.push(input.Pure.bytes);
+  }
+  return out;
+}
+
+/**
+ * Whether the transaction carries `nonceBase64` as a `Pure` input. Compares
+ * Base64 strings directly — both sides are SDK-canonical — canonicalizing the
+ * declared nonce once so a byte-equal value matches.
+ *
+ * @param data - The decoded transaction data (`Transaction.getData()`)
+ * @param nonceBase64 - The declared server nonce (Base64)
+ * @returns True when a Pure input equals the nonce
+ */
+export function transactionCarriesNonce(
+  data: ReturnType<Transaction["getData"]>,
+  nonceBase64: string,
+): boolean {
+  let canonical: string;
+  try {
+    canonical = toBase64(fromBase64(nonceBase64));
+  } catch {
+    return false;
+  }
+  return pureInputsBase64(data).includes(canonical);
+}
+
+/**
+ * The exact-payment effects check: assert `payTo`'s net balance change in the
+ * requested asset equals exactly `amount`. Recipient-credit-only — it does not
+ * constrain the payer's debit or forbid other credits.
+ *
+ * @param balanceChanges - Balance changes from a simulation or executed transaction
+ * @param asset - The required coin type
+ * @param payTo - The declared recipient
+ * @param amount - The exact atomic-unit amount the recipient must net
+ * @returns A problem description, or null when the recipient nets exactly
+ */
+export function matchExactPayment(
+  balanceChanges: readonly SuiClientTypes.BalanceChange[],
+  asset: string,
+  payTo: string,
+  amount: string,
+): string | null {
+  const coinType = normalizeStructTag(asset);
+  const recipient = normalizeSuiAddress(payTo);
+  const want = BigInt(amount);
+
+  // Sui emits at most one balance change per (coinType, address), so the
+  // recipient's credit is a single entry, not a sum.
+  const change = balanceChanges.find(
+    c =>
+      normalizeStructTag(c.coinType) === coinType && normalizeSuiAddress(c.address) === recipient,
+  );
+  const got = change ? BigInt(change.amount) : 0n;
+
+  if (got !== want) {
+    return `recipient ${payTo} credited ${got}, expected exactly ${want}`;
+  }
+
+  return null;
+}

--- a/typescript/packages/mechanisms/sui/test/unit/client.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/client.test.ts
@@ -1,0 +1,98 @@
+import { Transaction } from "@mysten/sui/transactions";
+import { normalizeSuiAddress } from "@mysten/sui/utils";
+import { describe, expect, it, vi } from "vitest";
+import { verifyTransactionSignature } from "@mysten/sui/verify";
+import { ExactSuiScheme } from "../../src/exact/client/scheme";
+import { SUI_TESTNET_CAIP2 } from "../../src/constants";
+import { pureInputsBase64, transactionCarriesNonce } from "../../src/utils";
+import type { ExactSuiPayload } from "../../src/types";
+import { fromBase64, payer, payerKeypair, testRequirements } from "./helpers";
+
+/**
+ * A mock client that resolves gas/coin-balance offline so createPaymentPayload
+ * can build without a network.
+ *
+ * @returns The mock client
+ */
+function offlineClient() {
+  return {
+    core: {
+      getBalance: vi.fn().mockResolvedValue({
+        balance: { balance: "999999999999", addressBalance: "999999999999", coinBalance: "0" },
+      }),
+      listCoins: vi.fn().mockResolvedValue({ objects: [], hasNextPage: false, cursor: null }),
+      resolveTransactionPlugin: vi
+        .fn()
+        .mockReturnValue(
+          async (
+            data: { gasData: { price: unknown; budget: unknown; payment: unknown } },
+            _o: unknown,
+            next: () => Promise<void>,
+          ) => {
+            data.gasData.price = "1000";
+            data.gasData.budget = "5000000";
+            data.gasData.payment = [];
+            await next();
+          },
+        ),
+    },
+  } as never;
+}
+
+describe("ExactSuiScheme client", () => {
+  const scheme = new ExactSuiScheme(payerKeypair, {
+    clients: { [SUI_TESTNET_CAIP2]: offlineClient() },
+  });
+
+  it("builds a signed payment bound to the sender with no embedded nonce", async () => {
+    const result = await scheme.createPaymentPayload(2, testRequirements());
+    const payload = result.payload as ExactSuiPayload;
+    const data = Transaction.from(payload.transaction).getData();
+    expect(data.sender).toBe(payer);
+
+    expect(transactionCarriesNonce(data, "q6urq6urq6s=")).toBe(false);
+
+    await expect(
+      verifyTransactionSignature(fromBase64(payload.transaction), payload.signature, {
+        address: payer,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("embeds a declared server nonce as a Pure input", async () => {
+    const nonce = "q6urq6urq6s="; // 8 bytes of 0xab, Base64
+    const result = await scheme.createPaymentPayload(2, testRequirements({ extra: { nonce } }));
+    const data = Transaction.from((result.payload as ExactSuiPayload).transaction).getData();
+    expect(pureInputsBase64(data)).toContain(nonce);
+    expect(transactionCarriesNonce(data, nonce)).toBe(true);
+  });
+
+  it("sets the announced sponsor as gas owner with empty gas payment", async () => {
+    const feePayer = `0x${"cd".repeat(32)}`;
+    const result = await scheme.createPaymentPayload(2, testRequirements({ extra: { feePayer } }));
+    const data = Transaction.from((result.payload as ExactSuiPayload).transaction).getData();
+    expect(normalizeSuiAddress(data.gasData.owner!)).toBe(normalizeSuiAddress(feePayer));
+    expect(data.gasData.payment).toEqual([]);
+  });
+
+  it("validates requirements", async () => {
+    await expect(scheme.createPaymentPayload(2, testRequirements({ asset: "" }))).rejects.toThrow(
+      "Asset is required",
+    );
+    await expect(
+      scheme.createPaymentPayload(2, testRequirements({ payTo: "0x123" })),
+    ).rejects.toThrow("Invalid pay-to address");
+    await expect(scheme.createPaymentPayload(2, testRequirements({ amount: "0" }))).rejects.toThrow(
+      "positive atomic-unit integer",
+    );
+  });
+
+  it("embeds the nonce as raw bytes (no BCS length prefix)", async () => {
+    const nonce = "q6urq6urq6s="; // 8 bytes of 0xab, Base64
+    const result = await scheme.createPaymentPayload(2, testRequirements({ extra: { nonce } }));
+    const data = Transaction.from((result.payload as ExactSuiPayload).transaction).getData();
+    // tx.pure(bytes) writes the raw bytes, so the decoded Pure input is exactly
+    // the 8-byte nonce — not a length-prefixed 9-byte BCS vector.
+    expect(pureInputsBase64(data)).toContain(nonce);
+  });
+});

--- a/typescript/packages/mechanisms/sui/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/facilitator.test.ts
@@ -231,6 +231,14 @@ describe("ExactSuiScheme facilitator", () => {
       );
     });
 
+    it("does not treat an unrelated not-found message as a missing transaction", async () => {
+      const payload = await validPayload();
+      mock.core.getTransaction.mockRejectedValue(new Error("proxy route not found"));
+      const result = await scheme.verify(payload, testRequirements());
+      expect(result.invalidReason).toBe("invalid_exact_sui_payload_verification_error");
+      expect(mock.core.simulateTransaction).not.toHaveBeenCalled();
+    });
+
     it("rejects a failed simulation", async () => {
       const payload = await signPayload(await buildTestTransaction());
       mock.core.simulateTransaction.mockResolvedValue({

--- a/typescript/packages/mechanisms/sui/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/facilitator.test.ts
@@ -1,0 +1,428 @@
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExactSuiScheme } from "../../src/exact/facilitator/scheme";
+import { SUI_MAINNET_CAIP2, SUI_TESTNET_CAIP2, USDC_TESTNET } from "../../src/constants";
+import {
+  buildTestTransaction,
+  exactBalanceChanges,
+  failureRecord,
+  mockClient,
+  payer,
+  payTo,
+  signOnly,
+  signPayload,
+  successRecord,
+  testPayload,
+  testRequirements,
+} from "./helpers";
+
+describe("ExactSuiScheme facilitator", () => {
+  let mock: ReturnType<typeof mockClient>;
+  let scheme: ExactSuiScheme;
+
+  beforeEach(() => {
+    mock = mockClient();
+    scheme = new ExactSuiScheme({ clients: { [SUI_TESTNET_CAIP2]: mock.client } });
+  });
+
+  /**
+   * A verified-clean payload whose simulation returns the exact transfer.
+   *
+   * @returns The payment payload envelope
+   */
+  async function validPayload() {
+    const payload = await signPayload(await buildTestTransaction());
+    mock.core.simulateTransaction.mockResolvedValue({
+      $kind: "Transaction",
+      Transaction: successRecord(exactBalanceChanges()),
+    });
+    return testPayload(payload);
+  }
+
+  /**
+   * Mock a settled transaction: submission acks, and waitForTransaction returns
+   * the finalized record — balance changes are read from the wait, not submission.
+   *
+   * @param record - The finalized transaction record
+   */
+  function settled(record: ReturnType<typeof successRecord>) {
+    const result = { $kind: "Transaction" as const, Transaction: record };
+    mock.core.executeTransaction.mockResolvedValue(result);
+    mock.core.waitForTransaction.mockResolvedValue(result);
+  }
+
+  describe("verify", () => {
+    it("accepts a valid payment and reports the sender as payer", async () => {
+      const result = await scheme.verify(await validPayload(), testRequirements());
+      expect(result).toEqual({ isValid: true, invalidReason: undefined, payer });
+    });
+
+    it("accepts effects-only: an unexpected command shape still verifies if effects match", async () => {
+      // buildTestTransaction uses transferObjects — a command the client never
+      // emits — proving verification does not gate on command shape.
+      const result = await scheme.verify(await validPayload(), testRequirements());
+      expect(result.isValid).toBe(true);
+    });
+
+    it("rejects a wrong x402 version", async () => {
+      const payload = { ...(await validPayload()), x402Version: 1 };
+      expect((await scheme.verify(payload, testRequirements())).invalidReason).toBe(
+        "invalid_x402_version",
+      );
+    });
+
+    it("rejects a non-exact scheme", async () => {
+      const result = await scheme.verify(
+        await validPayload(),
+        testRequirements({ scheme: "upto" }),
+      );
+      expect(result.invalidReason).toBe("unsupported_scheme");
+    });
+
+    it("rejects a network mismatch", async () => {
+      const result = await scheme.verify(
+        await validPayload(),
+        testRequirements({ network: SUI_MAINNET_CAIP2 }),
+      );
+      expect(result.invalidReason).toBe("network_mismatch");
+    });
+
+    it("rejects an unsupported network", async () => {
+      const requirements = testRequirements({ network: "sui:unknown" });
+      const payload = testPayload(await signPayload(await buildTestTransaction()), requirements);
+      expect((await scheme.verify(payload, requirements)).invalidReason).toBe("invalid_network");
+    });
+
+    it("rejects a malformed payload", async () => {
+      const payload = testPayload({ transaction: "abc", signature: undefined as never });
+      expect((await scheme.verify(payload, testRequirements())).invalidReason).toBe(
+        "invalid_payload",
+      );
+    });
+
+    it("rejects undecodable transaction bytes", async () => {
+      const payload = testPayload({ transaction: "bm90IGEgdHg=", signature: "sig" });
+      expect((await scheme.verify(payload, testRequirements())).invalidReason).toBe(
+        "invalid_exact_sui_payload_transaction_could_not_be_decoded",
+      );
+    });
+
+    it("rejects a signature that does not bind the sender", async () => {
+      const payload = await signPayload(await buildTestTransaction(), new Ed25519Keypair());
+      expect((await scheme.verify(testPayload(payload), testRequirements())).invalidReason).toBe(
+        "invalid_exact_sui_payload_invalid_signature",
+      );
+    });
+
+    it("accepts a signature ARRAY where one entry binds the sender", async () => {
+      // A multi-signer transaction (e.g. a sponsor distinct from the sender): the
+      // array carries a non-binding entry first, then the sender's signature.
+      const transaction = await buildTestTransaction();
+      const senderSig = await signOnly(transaction);
+      const otherSig = await signOnly(transaction, new Ed25519Keypair());
+      mock.core.simulateTransaction.mockResolvedValue({
+        $kind: "Transaction",
+        Transaction: successRecord(exactBalanceChanges()),
+      });
+      const payload = testPayload({ transaction, signature: [otherSig, senderSig] });
+      const result = await scheme.verify(payload, testRequirements());
+      expect(result).toEqual({ isValid: true, invalidReason: undefined, payer });
+    });
+
+    it("rejects a signature ARRAY where none binds the sender", async () => {
+      const transaction = await buildTestTransaction();
+      const otherSigA = await signOnly(transaction, new Ed25519Keypair());
+      const otherSigB = await signOnly(transaction, new Ed25519Keypair());
+      const payload = testPayload({ transaction, signature: [otherSigA, otherSigB] });
+      expect((await scheme.verify(payload, testRequirements())).invalidReason).toBe(
+        "invalid_exact_sui_payload_invalid_signature",
+      );
+    });
+
+    // 16 bytes of 0xab / 0xcd, Base64.
+    const NONCE = "q6urq6urq6urq6urq6urqw==";
+    const OTHER_NONCE = "zc3Nzc3Nzc3Nzc3Nzc3NzQ==";
+
+    it("accepts a declared nonce carried as an unused Pure input", async () => {
+      const payload = await signPayload(await buildTestTransaction({ nonce: NONCE }));
+      mock.core.simulateTransaction.mockResolvedValue({
+        $kind: "Transaction",
+        Transaction: successRecord(exactBalanceChanges()),
+      });
+      const result = await scheme.verify(
+        testPayload(payload),
+        testRequirements({ extra: { nonce: NONCE } }),
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it("accepts a declared nonce carried as a USED Pure input (referenced by a command)", async () => {
+      const payload = await signPayload(
+        await buildTestTransaction({ nonce: NONCE, nonceUsed: true }),
+      );
+      mock.core.simulateTransaction.mockResolvedValue({
+        $kind: "Transaction",
+        Transaction: successRecord(exactBalanceChanges()),
+      });
+      const result = await scheme.verify(
+        testPayload(payload),
+        testRequirements({ extra: { nonce: NONCE } }),
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it("accepts a declared nonce LONGER than 32 bytes (no size cap)", async () => {
+      // 40 bytes of 0xab, Base64 — beyond the 32-byte gasless recommendation.
+      const bigNonce = "q6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urqw==";
+      const payload = await signPayload(await buildTestTransaction({ nonce: bigNonce }));
+      mock.core.simulateTransaction.mockResolvedValue({
+        $kind: "Transaction",
+        Transaction: successRecord(exactBalanceChanges()),
+      });
+      const result = await scheme.verify(
+        testPayload(payload),
+        testRequirements({ extra: { nonce: bigNonce } }),
+      );
+      expect(result.isValid).toBe(true);
+    });
+
+    it("accepts when no nonce is declared and none is carried", async () => {
+      const payload = await signPayload(await buildTestTransaction());
+      mock.core.simulateTransaction.mockResolvedValue({
+        $kind: "Transaction",
+        Transaction: successRecord(exactBalanceChanges()),
+      });
+      const result = await scheme.verify(testPayload(payload), testRequirements());
+      expect(result.isValid).toBe(true);
+    });
+
+    it("rejects when a declared nonce is not carried", async () => {
+      const payload = await signPayload(await buildTestTransaction({ nonce: NONCE }));
+      const result = await scheme.verify(
+        testPayload(payload),
+        testRequirements({ extra: { nonce: OTHER_NONCE } }),
+      );
+      expect(result.invalidReason).toBe("invalid_exact_sui_payload_missing_nonce");
+    });
+
+    it("rejects when a declared nonce is absent from the transaction", async () => {
+      const payload = await signPayload(await buildTestTransaction());
+      const result = await scheme.verify(
+        testPayload(payload),
+        testRequirements({ extra: { nonce: OTHER_NONCE } }),
+      );
+      expect(result.invalidReason).toBe("invalid_exact_sui_payload_missing_nonce");
+    });
+
+    it("rejects a malformed (invalid Base64) declared nonce", async () => {
+      const payload = await signPayload(await buildTestTransaction());
+      const result = await scheme.verify(
+        testPayload(payload),
+        testRequirements({ extra: { nonce: "!!!not base64!!!" } }),
+      );
+      expect(result.invalidReason).toBe("invalid_exact_sui_payload_missing_nonce");
+    });
+
+    it("rejects an already-executed transaction", async () => {
+      const payload = await validPayload();
+      mock.core.getTransaction.mockResolvedValue({ $kind: "Transaction" });
+      expect((await scheme.verify(payload, testRequirements())).invalidReason).toBe(
+        "invalid_transaction_state",
+      );
+    });
+
+    it("rejects a failed simulation", async () => {
+      const payload = await signPayload(await buildTestTransaction());
+      mock.core.simulateTransaction.mockResolvedValue({
+        $kind: "FailedTransaction",
+        FailedTransaction: failureRecord("insufficient balance"),
+      });
+      expect((await scheme.verify(testPayload(payload), testRequirements())).invalidReason).toBe(
+        "invalid_exact_sui_payload_simulation_failed",
+      );
+    });
+
+    it("rejects underpayment and overpayment (exact means exact)", async () => {
+      for (const amt of ["9999", "10001"]) {
+        const payload = await signPayload(await buildTestTransaction());
+        mock.core.simulateTransaction.mockResolvedValue({
+          $kind: "Transaction",
+          Transaction: successRecord(exactBalanceChanges(amt)),
+        });
+        const result = await scheme.verify(testPayload(payload), testRequirements());
+        expect(result.invalidReason).toBe("invalid_exact_sui_payload_transfer_mismatch");
+      }
+    });
+
+    it("is composable: verifies despite an undeclared credit and a non-(-amount) payer delta", async () => {
+      // The declared recipient nets exactly its amount, but the transaction ALSO
+      // credits an undeclared address and the payer does NOT net -amount (a
+      // swap-sourced payment where the payer nets ~0). Recipient-credit-only
+      // verification accepts this.
+      const payload = await signPayload(await buildTestTransaction());
+      mock.core.simulateTransaction.mockResolvedValue({
+        $kind: "Transaction",
+        Transaction: successRecord([
+          { coinType: USDC_TESTNET, address: payer, amount: "2000" }, // net inflow, not -amount
+          { coinType: USDC_TESTNET, address: `0x${"44".repeat(32)}`, amount: "-12000" },
+          { coinType: USDC_TESTNET, address: payTo, amount: "10000" },
+          { coinType: USDC_TESTNET, address: `0x${"33".repeat(32)}`, amount: "1000" }, // undeclared
+        ]),
+      });
+      expect((await scheme.verify(testPayload(payload), testRequirements())).isValid).toBe(true);
+    });
+  });
+
+  describe("settle", () => {
+    it("fails when validation fails, without executing", async () => {
+      const payload = await signPayload(await buildTestTransaction(), new Ed25519Keypair());
+      const result = await scheme.settle(testPayload(payload), testRequirements());
+      expect(result.success).toBe(false);
+      expect(result.errorReason).toBe("invalid_exact_sui_payload_invalid_signature");
+      expect(mock.core.executeTransaction).not.toHaveBeenCalled();
+    });
+
+    it("succeeds on executed effects that contain the exact transfer", async () => {
+      const payload = await validPayload();
+      settled(successRecord(exactBalanceChanges(), "settled-digest"));
+      const result = await scheme.settle(payload, testRequirements());
+      expect(result).toMatchObject({ success: true, transaction: "settled-digest", payer });
+    });
+
+    it("passes a signature ARRAY through to executeTransaction", async () => {
+      const transaction = await buildTestTransaction();
+      const senderSig = await signOnly(transaction);
+      const otherSig = await signOnly(transaction, new Ed25519Keypair());
+      const signature = [senderSig, otherSig];
+      settled(successRecord(exactBalanceChanges(), "multi-sig-digest"));
+      const payload = testPayload({ transaction, signature });
+      const result = await scheme.settle(payload, testRequirements());
+      expect(result).toMatchObject({ success: true, transaction: "multi-sig-digest", payer });
+      expect(mock.core.executeTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ signatures: signature }),
+      );
+    });
+
+    it("does not simulate during settle", async () => {
+      const payload = await validPayload();
+      mock.core.simulateTransaction.mockClear();
+      settled(successRecord(exactBalanceChanges(), "d"));
+      await scheme.settle(payload, testRequirements());
+      expect(mock.core.simulateTransaction).not.toHaveBeenCalled();
+    });
+
+    it("fails when execution commits a failed transaction", async () => {
+      const payload = await validPayload();
+      mock.core.executeTransaction.mockResolvedValue({
+        $kind: "FailedTransaction",
+        FailedTransaction: failureRecord("abort"),
+      });
+      const result = await scheme.settle(payload, testRequirements());
+      expect(result.errorReason).toBe("transaction_failed");
+    });
+
+    it("fails when executed effects do not match the requirements", async () => {
+      const payload = await validPayload();
+      settled(successRecord(exactBalanceChanges("9999"), "short"));
+      const result = await scheme.settle(payload, testRequirements());
+      expect(result.errorReason).toBe("settlement_effects_mismatch");
+    });
+
+    it("is idempotent: re-execution yields the same success", async () => {
+      const payload = await validPayload();
+      settled(successRecord(exactBalanceChanges(), "orig"));
+      const first = await scheme.settle(payload, testRequirements());
+      // fresh scheme to avoid the dedup guard rejecting the identical replay
+      const scheme2 = new ExactSuiScheme({ clients: { [SUI_TESTNET_CAIP2]: mock.client } });
+      const second = await scheme2.settle(payload, testRequirements());
+      expect(first).toMatchObject({ success: true, transaction: "orig" });
+      expect(second).toEqual(first);
+    });
+
+    it("rejects a concurrent duplicate via the settlement guard", async () => {
+      const payload = await validPayload();
+      settled(successRecord(exactBalanceChanges(), "orig"));
+      const first = await scheme.settle(payload, testRequirements());
+      const second = await scheme.settle(payload, testRequirements());
+      expect(first.success).toBe(true);
+      expect(second.errorReason).toBe("duplicate_settlement");
+    });
+
+    it("surfaces a genuine execution error as transaction_failed", async () => {
+      const payload = await validPayload();
+      mock.core.executeTransaction.mockRejectedValue(new Error("fullnode unavailable"));
+      const result = await scheme.settle(payload, testRequirements());
+      expect(result.errorReason).toBe("transaction_failed");
+      expect(result.errorMessage).toBe("fullnode unavailable");
+    });
+  });
+
+  describe("executor", () => {
+    const feePayer = new Ed25519Keypair().toSuiAddress();
+
+    /**
+     * Build a facilitator with a mock executor and matching sponsored requirements.
+     *
+     * @param result - The executor's result
+     * @returns The scheme, the executor mock, and sponsored requirements
+     */
+    function withExecutor(result: unknown) {
+      const executeTransaction = vi.fn().mockResolvedValue(result);
+      const s = new ExactSuiScheme({
+        clients: { [SUI_TESTNET_CAIP2]: mock.client },
+        executeTransaction,
+        feePayer,
+      });
+      const requirements = testRequirements({ extra: { feePayer } });
+      return { s, executeTransaction, requirements };
+    }
+
+    it("advertises the fee-payer via getExtra / getSigners", () => {
+      const { s } = withExecutor(null);
+      expect(s.getExtra(SUI_TESTNET_CAIP2)).toEqual({ feePayer });
+      expect(s.getSigners(SUI_TESTNET_CAIP2)).toEqual([feePayer]);
+    });
+
+    it("advertises nothing without a fee-payer", () => {
+      expect(scheme.getExtra(SUI_TESTNET_CAIP2)).toBeUndefined();
+      expect(scheme.getSigners(SUI_TESTNET_CAIP2)).toEqual([]);
+    });
+
+    it("settles by delegating to the executor", async () => {
+      const { s, executeTransaction, requirements } = withExecutor({
+        $kind: "Transaction",
+        Transaction: successRecord(exactBalanceChanges(), "executor-digest"),
+      });
+      mock.core.waitForTransaction.mockResolvedValue({
+        $kind: "Transaction",
+        Transaction: successRecord(exactBalanceChanges(), "executor-digest"),
+      });
+      const payload = testPayload(await signPayload(await buildTestTransaction()), requirements);
+      const result = await s.settle(payload, requirements);
+      expect(result).toMatchObject({ success: true, transaction: "executor-digest" });
+      expect(executeTransaction).toHaveBeenCalledOnce();
+      expect(mock.core.executeTransaction).not.toHaveBeenCalled();
+    });
+
+    it("fails when the executor rejects by policy", async () => {
+      const { s, requirements } = withExecutor({
+        $kind: "Rejected",
+        reason: "package not allowed",
+      });
+      const payload = testPayload(await signPayload(await buildTestTransaction()), requirements);
+      const result = await s.settle(payload, requirements);
+      expect(result.errorReason).toBe("sponsor_rejected");
+      expect(result.errorMessage).toBe("package not allowed");
+    });
+
+    it("fails when the executor's transaction aborts on-chain", async () => {
+      const { s, requirements } = withExecutor({
+        $kind: "FailedTransaction",
+        FailedTransaction: failureRecord("abort in move call"),
+      });
+      const payload = testPayload(await signPayload(await buildTestTransaction()), requirements);
+      const result = await s.settle(payload, requirements);
+      expect(result.errorReason).toBe("transaction_failed");
+    });
+  });
+});

--- a/typescript/packages/mechanisms/sui/test/unit/helpers.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/helpers.ts
@@ -205,7 +205,11 @@ export function mockClient() {
   const core = {
     simulateTransaction: vi.fn(),
     executeTransaction: vi.fn(),
-    getTransaction: vi.fn().mockRejectedValue(new Error("Transaction not found")),
+    getTransaction: vi.fn().mockRejectedValue(
+      Object.assign(new Error("Transaction%20test-digest%20not%20found"), {
+        code: "NOT_FOUND",
+      }),
+    ),
     waitForTransaction: vi.fn().mockResolvedValue(undefined),
   };
   return { client: { core } as unknown as ClientWithCoreApi, core };

--- a/typescript/packages/mechanisms/sui/test/unit/helpers.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/helpers.ts
@@ -1,0 +1,214 @@
+import type { ClientWithCoreApi, SuiClientTypes } from "@mysten/sui/client";
+import type { Signer } from "@mysten/sui/cryptography";
+import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
+import { Transaction } from "@mysten/sui/transactions";
+import { fromBase64, toBase64 } from "@mysten/sui/utils";
+import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+import { vi } from "vitest";
+import { SUI_TESTNET_CAIP2, USDC_TESTNET } from "../../src/constants";
+import type { ExactSuiPayload } from "../../src/types";
+
+export const payerKeypair = new Ed25519Keypair();
+export const payer = payerKeypair.toSuiAddress();
+export const payTo = new Ed25519Keypair().toSuiAddress();
+
+/**
+ * Build a fully resolved transaction offline. Verification is effects-only, so a
+ * placeholder `transferObjects` stands in for the command graph. When `nonce` is
+ * given, its bytes ride as a Pure input — unused by default, or consumed by a
+ * command with `nonceUsed`.
+ *
+ * @param options - Overrides
+ * @param options.sender - Sender address (defaults to the shared payer)
+ * @param options.nonce - Optional Base64 server-nonce to embed as a Pure input
+ * @param options.nonceUsed - Reference the nonce Pure input from a command
+ * @param options.expiration - Transaction expiration (defaults to None)
+ * @returns Base64-encoded transaction bytes
+ */
+export async function buildTestTransaction(options?: {
+  sender?: string;
+  nonce?: string;
+  nonceUsed?: boolean;
+  expiration?: { $kind?: string } | { Epoch: number } | { None: true };
+}): Promise<string> {
+  const { sender = payer, nonce, nonceUsed = false, expiration = { None: true } } = options ?? {};
+
+  const tx = new Transaction();
+  tx.setSender(sender);
+  tx.transferObjects(
+    [
+      tx.objectRef({
+        objectId: `0x${"11".repeat(32)}`,
+        version: "1",
+        digest: "11111111111111111111111111111111",
+      }),
+    ],
+    tx.pure.address(payTo),
+  );
+  if (nonce) {
+    const nonceArg = tx.pure(fromBase64(nonce));
+    if (nonceUsed) {
+      // Consume the nonce Pure input from a command, as a client might when
+      // writing it to an on-chain receipt.
+      tx.moveCall({ target: `0x${"33".repeat(32)}::receipt::write`, arguments: [nonceArg] });
+    }
+  }
+
+  tx.setGasPrice(1000);
+  tx.setGasBudget(5_000_000);
+  tx.setGasPayment([
+    { objectId: `0x${"22".repeat(32)}`, version: "1", digest: "11111111111111111111111111111111" },
+  ]);
+  tx.setExpiration(expiration as never);
+
+  return toBase64(await tx.build());
+}
+
+/**
+ * Sign transaction bytes and assemble an ExactSuiPayload.
+ *
+ * @param transaction - Base64-encoded transaction bytes
+ * @param signer - The signer (defaults to the shared payer keypair)
+ * @returns The signed payload
+ */
+export async function signPayload(
+  transaction: string,
+  signer: Signer = payerKeypair,
+): Promise<ExactSuiPayload> {
+  const { signature } = await signer.signTransaction(fromBase64(transaction));
+  return { transaction, signature };
+}
+
+/**
+ * Produce a serialized signature over transaction bytes without assembling a
+ * payload. Useful for building multi-signature `signature` arrays.
+ *
+ * @param transaction - Base64-encoded transaction bytes
+ * @param signer - The signer (defaults to the shared payer keypair)
+ * @returns The base64 serialized signature
+ */
+export async function signOnly(
+  transaction: string,
+  signer: Signer = payerKeypair,
+): Promise<string> {
+  const { signature } = await signer.signTransaction(fromBase64(transaction));
+  return signature;
+}
+
+/**
+ * Payment requirements for the standard test payment.
+ *
+ * @param overrides - Field overrides
+ * @returns Payment requirements
+ */
+export function testRequirements(overrides?: Partial<PaymentRequirements>): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: SUI_TESTNET_CAIP2,
+    amount: "10000",
+    asset: USDC_TESTNET,
+    payTo,
+    maxTimeoutSeconds: 300,
+    extra: {},
+    ...overrides,
+  };
+}
+
+/**
+ * Wrap a Sui payload in the x402 payment envelope.
+ *
+ * @param payload - The scheme payload
+ * @param requirements - The accepted requirements
+ * @returns The payment payload envelope
+ */
+export function testPayload(
+  payload: ExactSuiPayload,
+  requirements: PaymentRequirements = testRequirements(),
+): PaymentPayload {
+  return {
+    x402Version: 2,
+    accepted: requirements,
+    payload: payload as unknown as Record<string, unknown>,
+  };
+}
+
+/**
+ * Balance changes for an exact single-recipient payment (payer debit + credit).
+ *
+ * @param amount - Amount credited to payTo / debited from payer
+ * @returns Balance change list
+ */
+export function exactBalanceChanges(amount = "10000"): SuiClientTypes.BalanceChange[] {
+  return [
+    { coinType: USDC_TESTNET, address: payer, amount: `-${amount}` },
+    { coinType: USDC_TESTNET, address: payTo, amount },
+  ];
+}
+
+/**
+ * A successful transaction record with the given balance changes.
+ *
+ * @param balanceChanges - The balance changes
+ * @param digest - The transaction digest
+ * @returns A Transaction record
+ */
+export function successRecord(
+  balanceChanges: SuiClientTypes.BalanceChange[],
+  digest = "test-digest",
+): SuiClientTypes.Transaction<{ balanceChanges: true }> {
+  return {
+    digest,
+    signatures: [],
+    epoch: "1",
+    status: { success: true, error: null },
+    balanceChanges,
+    effects: undefined,
+    events: undefined,
+    objectTypes: undefined,
+    transaction: undefined,
+    bcs: undefined,
+  };
+}
+
+/**
+ * A failed transaction record.
+ *
+ * @param message - The execution error message
+ * @param digest - The transaction digest
+ * @returns A failed Transaction record
+ */
+export function failureRecord(
+  message: string,
+  digest = "failed-digest",
+): SuiClientTypes.Transaction<{ balanceChanges: true }> {
+  return {
+    digest,
+    signatures: [],
+    epoch: "1",
+    status: { success: false, error: { message } },
+    balanceChanges: [],
+    effects: undefined,
+    events: undefined,
+    objectTypes: undefined,
+    transaction: undefined,
+    bcs: undefined,
+  };
+}
+
+/**
+ * A mock Sui client whose core methods are vitest mocks. `getTransaction`
+ * defaults to not-found (so the replay guard passes).
+ *
+ * @returns The mock client and its core method mocks
+ */
+export function mockClient() {
+  const core = {
+    simulateTransaction: vi.fn(),
+    executeTransaction: vi.fn(),
+    getTransaction: vi.fn().mockRejectedValue(new Error("Transaction not found")),
+    waitForTransaction: vi.fn().mockResolvedValue(undefined),
+  };
+  return { client: { core } as unknown as ClientWithCoreApi, core };
+}
+
+export { toBase64, fromBase64 };

--- a/typescript/packages/mechanisms/sui/test/unit/server.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/server.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { ExactSuiScheme } from "../../src/exact/server/scheme";
+import {
+  SUI_MAINNET_CAIP2,
+  SUI_TESTNET_CAIP2,
+  USDC_MAINNET,
+  USDC_TESTNET,
+} from "../../src/constants";
+import { testRequirements } from "./helpers";
+
+const supportedKind = { x402Version: 2, scheme: "exact", network: SUI_TESTNET_CAIP2 };
+
+describe("ExactSuiScheme server", () => {
+  const scheme = new ExactSuiScheme();
+
+  describe("parsePrice", () => {
+    it("passes through an AssetAmount and converts money to USDC", async () => {
+      await expect(
+        scheme.parsePrice({ amount: "12345", asset: USDC_TESTNET }, SUI_TESTNET_CAIP2),
+      ).resolves.toMatchObject({ amount: "12345", asset: USDC_TESTNET });
+      await expect(scheme.parsePrice("$1.50", SUI_TESTNET_CAIP2)).resolves.toMatchObject({
+        amount: "1500000",
+        asset: USDC_TESTNET,
+      });
+      await expect(scheme.parsePrice(0.1, SUI_MAINNET_CAIP2)).resolves.toMatchObject({
+        amount: "100000",
+        asset: USDC_MAINNET,
+      });
+    });
+
+    it("rejects malformed asset, devnet money, and non-positive amounts", async () => {
+      await expect(
+        scheme.parsePrice({ amount: "1", asset: "not-a-coin" }, SUI_TESTNET_CAIP2),
+      ).rejects.toThrow();
+      await expect(scheme.parsePrice("$1.00", "sui:devnet")).rejects.toThrow(
+        "No default USDC coin type",
+      );
+      await expect(
+        scheme.parsePrice({ amount: "0", asset: USDC_TESTNET }, SUI_TESTNET_CAIP2),
+      ).rejects.toThrow("positive");
+    });
+  });
+
+  describe("getAssetDecimals", () => {
+    it("knows USDC and throws otherwise", () => {
+      expect(scheme.getAssetDecimals(USDC_MAINNET, SUI_MAINNET_CAIP2)).toBe(6);
+      expect(() => scheme.getAssetDecimals("0x2::sui::SUI", SUI_MAINNET_CAIP2)).toThrow(
+        "Unknown decimals",
+      );
+    });
+  });
+
+  describe("enhancePaymentRequirements", () => {
+    it("does NOT auto-generate a nonce", async () => {
+      const enhanced = await scheme.enhancePaymentRequirements(
+        testRequirements({ extra: {} }),
+        supportedKind,
+        [],
+      );
+      expect(enhanced.extra?.nonce).toBeUndefined();
+    });
+
+    it("passes through a stable nonce and facilitator feePayer", async () => {
+      const enhanced = await scheme.enhancePaymentRequirements(
+        testRequirements({ extra: { nonce: "3q2+7w==" } }),
+        { ...supportedKind, extra: { feePayer: "0xspon" } },
+        [],
+      );
+      expect(enhanced.extra).toMatchObject({ nonce: "3q2+7w==", feePayer: "0xspon" });
+    });
+
+    it("rejects a non-positive amount", async () => {
+      await expect(
+        scheme.enhancePaymentRequirements(testRequirements({ amount: "0" }), supportedKind, []),
+      ).rejects.toThrow("invalid_payment_requirements");
+    });
+  });
+});

--- a/typescript/packages/mechanisms/sui/test/unit/utils.test.ts
+++ b/typescript/packages/mechanisms/sui/test/unit/utils.test.ts
@@ -1,0 +1,109 @@
+import { Transaction } from "@mysten/sui/transactions";
+import { fromBase64, toBase64 } from "@mysten/sui/utils";
+import { describe, expect, it } from "vitest";
+import { SUI_MAINNET_CAIP2, SUI_TESTNET_CAIP2, USDC_TESTNET } from "../../src/constants";
+import {
+  createSuiClientResolver,
+  getSuiNetworkName,
+  matchExactPayment,
+  parseBase64Bytes,
+  pureInputsBase64,
+  transactionCarriesNonce,
+} from "../../src/utils";
+import { buildTestTransaction, payer, payTo } from "./helpers";
+
+describe("getSuiNetworkName", () => {
+  it("maps CAIP-2 ids and throws on unsupported", () => {
+    expect(getSuiNetworkName(SUI_MAINNET_CAIP2)).toBe("mainnet");
+    expect(getSuiNetworkName(SUI_TESTNET_CAIP2)).toBe("testnet");
+    expect(() => getSuiNetworkName("eip155:1")).toThrow("Unsupported Sui network");
+  });
+});
+
+describe("createSuiClientResolver", () => {
+  it("returns overrides and caches defaults", () => {
+    const override = { core: {} } as never;
+    const resolve = createSuiClientResolver({ [SUI_TESTNET_CAIP2]: override });
+    expect(resolve(SUI_TESTNET_CAIP2)).toBe(override);
+    const bare = createSuiClientResolver();
+    expect(bare(SUI_MAINNET_CAIP2)).toBe(bare(SUI_MAINNET_CAIP2));
+  });
+});
+
+describe("parseBase64Bytes", () => {
+  it("decodes valid Base64 and rejects malformed / empty", () => {
+    expect(parseBase64Bytes("q6urq6urq6s=")).toEqual(new Uint8Array(8).fill(0xab));
+    expect(parseBase64Bytes(undefined)).toBeNull();
+    expect(parseBase64Bytes("")).toBeNull();
+    expect(parseBase64Bytes("!!!not base64!!!")).toBeNull();
+  });
+
+  it("accepts a nonce longer than 32 bytes (no size cap)", () => {
+    const big = toBase64(new Uint8Array(40).fill(0xab));
+    expect(parseBase64Bytes(big)).toEqual(new Uint8Array(40).fill(0xab));
+  });
+});
+
+describe("nonce Pure input", () => {
+  const NONCE = "q6urq6urq6s="; // 8 bytes of 0xab, Base64
+  const OTHER = "zc3Nzc3Nzc0="; // 8 bytes of 0xcd, Base64
+
+  it("matches a declared nonce carried as an unused Pure input", async () => {
+    const bytes = fromBase64(await buildTestTransaction({ nonce: NONCE }));
+    const data = Transaction.from(bytes).getData();
+    expect(pureInputsBase64(data)).toContain(NONCE);
+    expect(transactionCarriesNonce(data, NONCE)).toBe(true);
+  });
+
+  it("matches a declared nonce carried as a USED Pure input (referenced by a command)", async () => {
+    const bytes = fromBase64(await buildTestTransaction({ nonce: NONCE, nonceUsed: true }));
+    const data = Transaction.from(bytes).getData();
+    expect(pureInputsBase64(data)).toContain(NONCE);
+    expect(transactionCarriesNonce(data, NONCE)).toBe(true);
+  });
+
+  it("does not match a nonce the transaction does not carry", async () => {
+    const bytes = fromBase64(await buildTestTransaction({ nonce: NONCE }));
+    const data = Transaction.from(bytes).getData();
+    expect(transactionCarriesNonce(data, OTHER)).toBe(false);
+  });
+
+  it("does not carry a nonce when none is embedded", async () => {
+    const bytes = fromBase64(await buildTestTransaction());
+    const data = Transaction.from(bytes).getData();
+    expect(transactionCarriesNonce(data, NONCE)).toBe(false);
+  });
+});
+
+describe("matchExactPayment", () => {
+  const single = [
+    { coinType: USDC_TESTNET, address: payer, amount: "-10000" },
+    { coinType: USDC_TESTNET, address: payTo, amount: "10000" },
+  ];
+
+  it("accepts an exact single payment", () => {
+    expect(matchExactPayment(single, USDC_TESTNET, payTo, "10000")).toBeNull();
+  });
+
+  it("rejects under/overpayment", () => {
+    expect(matchExactPayment(single, USDC_TESTNET, payTo, "9999")).toContain("expected");
+  });
+
+  it("ignores other coin types", () => {
+    const changes = [...single, { coinType: "0x2::sui::SUI", address: payTo, amount: "5" }];
+    expect(matchExactPayment(changes, USDC_TESTNET, payTo, "10000")).toBeNull();
+  });
+
+  it("is composable: recipient-credit-only, unconstrained sourcing and extra credits", () => {
+    // The payer nets ~0 (a swap-sourced payment: an external inflow funds the
+    // outgoing transfer) AND an extra, undeclared address is also credited the
+    // asset. As long as the declared recipient nets exactly its amount, verify.
+    const changes = [
+      { coinType: USDC_TESTNET, address: payer, amount: "5000" }, // net inflow, not -amount
+      { coinType: USDC_TESTNET, address: "0xsource", amount: "-15000" },
+      { coinType: USDC_TESTNET, address: payTo, amount: "10000" },
+      { coinType: USDC_TESTNET, address: "0xother", amount: "3000" }, // undeclared credit
+    ];
+    expect(matchExactPayment(changes, USDC_TESTNET, payTo, "10000")).toBeNull();
+  });
+});

--- a/typescript/packages/mechanisms/sui/tsconfig.json
+++ b/typescript/packages/mechanisms/sui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/typescript/packages/mechanisms/sui/tsup.config.ts
+++ b/typescript/packages/mechanisms/sui/tsup.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "tsup";
+
+const baseConfig = {
+  entry: {
+    index: "src/index.ts",
+    "exact/client/index": "src/exact/client/index.ts",
+    "exact/server/index": "src/exact/server/index.ts",
+    "exact/facilitator/index": "src/exact/facilitator/index.ts",
+  },
+  dts: {
+    resolve: true,
+  },
+  sourcemap: true,
+  target: "es2020",
+};
+
+export default defineConfig([
+  {
+    ...baseConfig,
+    format: "esm",
+    outDir: "dist/esm",
+    clean: true,
+  },
+  {
+    ...baseConfig,
+    format: "cjs",
+    outDir: "dist/cjs",
+    clean: false,
+  },
+]);

--- a/typescript/packages/mechanisms/sui/vitest.config.ts
+++ b/typescript/packages/mechanisms/sui/vitest.config.ts
@@ -1,0 +1,15 @@
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig(({ mode }) => ({
+  test: {
+    env: loadEnv(mode, process.cwd(), ""),
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/test/integrations/**", // Exclude integration tests from default run
+    ],
+  },
+  plugins: [tsconfigPaths({ projects: ["."] })],
+}));

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1634,6 +1634,61 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.18.0)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
 
+  packages/mechanisms/sui:
+    dependencies:
+      '@mysten/sui':
+        specifier: 2.23.1
+        version: 2.23.1(typescript@5.9.2)
+      '@x402/core':
+        specifier: workspace:~
+        version: link:../../core
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.24.0
+        version: 9.34.0
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.19.17
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.29.1
+        version: 8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0)(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.29.1
+        version: 8.49.0(eslint@9.34.0)(typescript@5.9.2)
+      eslint:
+        specifier: ^9.24.0
+        version: 9.34.0
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.34.0)(typescript@5.9.2))(eslint@9.34.0)
+      eslint-plugin-jsdoc:
+        specifier: ^50.6.9
+        version: 50.8.0(eslint@9.34.0)
+      eslint-plugin-prettier:
+        specifier: ^5.2.6
+        version: 5.5.4(eslint@9.34.0)(prettier@3.5.2)
+      prettier:
+        specifier: 3.5.2
+        version: 3.5.2
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.0(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.2
+      vite:
+        specifier: ^6.2.6
+        version: 6.3.5(@types/node@22.19.17)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.2)(vite@6.3.5(@types/node@22.19.17)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1))
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.17)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.1)
+
   packages/mechanisms/svm:
     dependencies:
       '@solana-program/compute-budget':
@@ -1915,6 +1970,20 @@ importers:
         version: 5.9.2
 
 packages:
+
+  '@0no-co/graphql.web@1.3.3':
+    resolution: {integrity: sha512-4gFGBdyaFmQ6n9euhp5JtIGS4ZeivwDr1tCPENUxTvy5wyv532yOtFCr9zzYAJh1s6uibgC+TRXUcay+mxzCoQ==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+
+  '@0no-co/graphqlsp@1.17.3':
+    resolution: {integrity: sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0
 
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
@@ -2609,6 +2678,26 @@ packages:
     resolution: {integrity: sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==}
     engines: {node: '>=18'}
 
+  '@gql.tada/cli-utils@1.9.3':
+    resolution: {integrity: sha512-P1TiXErpJwIi73sei5fzwGA/SOeCaIHFWFR4RdZPLwqxZzQN0T6MAUivzXBgKCORL67rvYnLaaPoWeqWq/61ug==}
+    peerDependencies:
+      '@0no-co/graphqlsp': ^1.16.0
+      '@gql.tada/svelte-support': 1.0.3
+      '@gql.tada/vue-support': 1.0.3
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@gql.tada/svelte-support':
+        optional: true
+      '@gql.tada/vue-support':
+        optional: true
+
+  '@gql.tada/internal@1.2.2':
+    resolution: {integrity: sha512-4lZcElPP6MC8Ct8KN70LR2WQsHjbAsyAmTGG09VsOPhx738UFIYaL0S1XiI2pqq2tj/sDs/y3b9jvKoWGL7iuQ==}
+    peerDependencies:
+      graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   '@graphql-typed-document-node/core@3.2.0':
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
@@ -3024,6 +3113,16 @@ packages:
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
     engines: {node: '>= 18'}
 
+  '@mysten/bcs@2.1.0':
+    resolution: {integrity: sha512-rIR/cDAqDfBDxmYEZXppN/on8gmh1OW0dYi/Bk2kMBZcYMTaBaEtEX1VR6g7HicVxuMbFAIP0/SQkdH7J9Y5dQ==}
+
+  '@mysten/sui@2.23.1':
+    resolution: {integrity: sha512-9MF+MsQWQWm6TFhUfkddigT2/aMv6t4uoOiW8aft3DFYh8k+TjErSJWKIlqKZZKO+R1paXg09qM3K0ZlOMbMfQ==}
+    engines: {node: '>=22'}
+
+  '@mysten/utils@0.4.0':
+    resolution: {integrity: sha512-nHlXECBl9kE+AHF/aw5a7JVNizae8Kb71A4H18BV/sXd5/l2BaWNGWVatq05fzJo3hF78AWorDxa++1TgcBKWw==}
+
   '@near-js/crypto@2.5.1':
     resolution: {integrity: sha512-Kb+bbnUrfvuzzed9hpLRpcIlCMOaQlw/7BxlZPCq8DggVaK1m0nKR1DHQs2cV0Q0WSKSk2UrFJho1dxeKL5alg==}
     peerDependencies:
@@ -3218,6 +3317,14 @@ packages:
     resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.3.0':
+    resolution: {integrity: sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/ed25519@2.3.0':
     resolution: {integrity: sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==}
 
@@ -3253,6 +3360,10 @@ packages:
 
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -3586,6 +3697,9 @@ packages:
   '@scure/bip32@1.7.0':
     resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
 
+  '@scure/bip32@2.2.0':
+    resolution: {integrity: sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==}
+
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
 
@@ -3594,6 +3708,9 @@ packages:
 
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@scure/bip39@2.2.0':
+    resolution: {integrity: sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==}
 
   '@signinwithethereum/siwe-parser@4.1.0':
     resolution: {integrity: sha512-aS+bU5QpTQgMpC6HjQHuKJpltUrkyGUVNuhuBLARa39wF1B+m05/4bgnf2qrEcgQONfU36A2Nbn3ibmwhHkc2Q==}
@@ -5933,6 +6050,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
@@ -6753,6 +6871,12 @@ packages:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
     engines: {node: '>=10.19.0'}
 
+  gql.tada@1.11.3:
+    resolution: {integrity: sha512-5JCI4j2f0nug8ILaCQys/yjOP78QqqjVUf47OQsME63rZfemsHT3e5vcfbHsnZiG6vxyqpKUJArtXEVwSefUhw==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -6766,6 +6890,10 @@ packages:
 
   graphql@16.11.0:
     resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   gtoken@7.1.0:
@@ -9186,6 +9314,14 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   valtio@1.13.2:
     resolution: {integrity: sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==}
     engines: {node: '>=12.20.0'}
@@ -9586,6 +9722,16 @@ packages:
         optional: true
 
 snapshots:
+
+  '@0no-co/graphql.web@1.3.3(graphql@16.14.2)':
+    optionalDependencies:
+      graphql: 16.14.2
+
+  '@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.9.2)':
+    dependencies:
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.9.2)
+      graphql: 16.14.2
+      typescript: 5.9.2
 
   '@adraffy/ens-normalize@1.10.1': {}
 
@@ -10590,9 +10736,26 @@ snapshots:
   '@google-cloud/promisify@4.1.0':
     optional: true
 
+  '@gql.tada/cli-utils@1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.9.2))(graphql@16.14.2)(typescript@5.9.2)':
+    dependencies:
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.9.2)
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.9.2)
+      graphql: 16.14.2
+      typescript: 5.9.2
+
+  '@gql.tada/internal@1.2.2(graphql@16.14.2)(typescript@5.9.2)':
+    dependencies:
+      '@0no-co/graphql.web': 1.3.3(graphql@16.14.2)
+      graphql: 16.14.2
+      typescript: 5.9.2
+
   '@graphql-typed-document-node/core@3.2.0(graphql@16.11.0)':
     dependencies:
       graphql: 16.11.0
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.14.2)':
+    dependencies:
+      graphql: 16.14.2
 
   '@grpc/grpc-js@1.12.6':
     dependencies:
@@ -11162,6 +11325,37 @@ snapshots:
 
   '@msgpack/msgpack@3.1.3': {}
 
+  '@mysten/bcs@2.1.0':
+    dependencies:
+      '@mysten/utils': 0.4.0
+      '@scure/base': 2.2.0
+
+  '@mysten/sui@2.23.1(typescript@5.9.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
+      '@mysten/bcs': 2.1.0
+      '@mysten/utils': 0.4.0
+      '@noble/curves': 2.3.0
+      '@noble/hashes': 2.3.0
+      '@protobuf-ts/grpcweb-transport': 2.11.1
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      '@scure/base': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      gql.tada: 1.11.3(graphql@16.14.2)(typescript@5.9.2)
+      graphql: 16.14.2
+      poseidon-lite: 0.2.1
+      valibot: 1.4.2(typescript@5.9.2)
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - typescript
+
+  '@mysten/utils@0.4.0':
+    dependencies:
+      '@scure/base': 2.2.0
+
   '@near-js/crypto@2.5.1(@near-js/types@2.5.1)(@near-js/utils@2.5.1(@near-js/types@2.5.1))':
     dependencies:
       '@near-js/types': 2.5.1
@@ -11302,6 +11496,14 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.0.1
 
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@noble/curves@2.3.0':
+    dependencies:
+      '@noble/hashes': 2.3.0
+
   '@noble/ed25519@2.3.0': {}
 
   '@noble/ed25519@3.0.0': {}
@@ -11321,6 +11523,8 @@ snapshots:
   '@noble/hashes@2.0.1': {}
 
   '@noble/hashes@2.2.0': {}
+
+  '@noble/hashes@2.3.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -12119,6 +12323,12 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
+  '@scure/bip32@2.2.0':
+    dependencies:
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
+
   '@scure/bip39@1.3.0':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -12133,6 +12343,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
+
+  '@scure/bip39@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+      '@scure/base': 2.2.0
 
   '@signinwithethereum/siwe-parser@4.1.0':
     dependencies:
@@ -17425,6 +17640,18 @@ snapshots:
       p-cancelable: 2.1.1
       responselike: 2.0.1
 
+  gql.tada@1.11.3(graphql@16.14.2)(typescript@5.9.2):
+    dependencies:
+      '@0no-co/graphql.web': 1.3.3(graphql@16.14.2)
+      '@0no-co/graphqlsp': 1.17.3(graphql@16.14.2)(typescript@5.9.2)
+      '@gql.tada/cli-utils': 1.9.3(@0no-co/graphqlsp@1.17.3(graphql@16.14.2)(typescript@5.9.2))(graphql@16.14.2)(typescript@5.9.2)
+      '@gql.tada/internal': 1.2.2(graphql@16.14.2)(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@gql.tada/svelte-support'
+      - '@gql.tada/vue-support'
+      - graphql
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
@@ -17438,6 +17665,8 @@ snapshots:
       - encoding
 
   graphql@16.11.0: {}
+
+  graphql@16.14.2: {}
 
   gtoken@7.1.0:
     dependencies:
@@ -20255,6 +20484,10 @@ snapshots:
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
+
+  valibot@1.4.2(typescript@5.9.2):
+    optionalDependencies:
+      typescript: 5.9.2
 
   valtio@1.13.2(@types/react@19.1.12)(react@19.2.1):
     dependencies:


### PR DESCRIPTION
## Description

Adds `@x402/sui`, the Sui implementation of the `exact` scheme — client, server, and facilitator.

This is an **alternative implementation** to #2616 by @Sceat, whose PR built out the first `@x402/sui` mechanism and gasless-transfer flow; full credit for that foundation. This version pairs with the effects-only spec and differs mainly in what the facilitator checks:

- **Effects-only verification.** The facilitator answers one question — "did the declared recipient receive exactly the requested amount?" — from the transaction's balance changes. It does not inspect or constrain commands, funding source, or gas shape, so a payment may draw from an address balance, owned coins, an on-demand swap, or a contract withdrawal and still verify. Verify simulates (a preflight the resource server can call before doing work); settle executes; both check the balance changes.
- **Stateless replay + idempotent settlement.** Verify rejects an already-committed digest; a retried settle re-executes to the same effects. One simulation per request.
- **Optional Base64 `extra.nonce`** carried as a `Pure` input, matched byte-for-byte when declared.
- **Sponsorship** is a single `extra.feePayer` field; sponsored settlement is delegated to the sponsor (structural interface, satisfied by the mysten-incubation sponsor SDK), which applies its own policy. x402 performs no gas-shape validation.

**Implements the spec in #3081 — please review that first.** This is a single-commit PR based on `main`; it does not depend on the spec doc to build or test, so the two are separate PRs rather than a git stack, but #3081 is the design of record for what this implements.

## Tests

`pnpm test` from `typescript/` — 59 unit tests pass (facilitator 36, utils 12, server 6, client 5). `lint:check`, `format:check`, and `build` are green.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes (`typescript/.changeset/sui-exact-mechanism.md`)

---

*Disclosure: this implementation was written with substantial AI assistance and reviewed by me — including the signing and settlement paths — before submission, per the AI-assisted contributions guidance.*
