### PR TITLE
fix(go): verify Transfer event in Permit2 settle receipts (exact + upto)

### DIFF
--- a/go/CHANGELOG.md
+++ b/go/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Fixed
+- Verify matching ERC-20 Transfer logs in Go Permit2 settle receipts (exact and upto) instead of trusting receipt status alone, so fee-on-transfer / non-conforming tokens cannot underpay while settle reports success (parity with EIP-3009 #2727 and TypeScript #3080)
+
 ## v2.21.0 - 2026-08-04
 ### Added
 - Add Celo mainnet (chain ID 42220) and Celo Sepolia (chain ID 11142220) support with USDC as the default stablecoin ([#3025](https://github.com/x402-foundation/x402/pull/3025)) - Thanks [@GigaHierz](https://github.com/GigaHierz) and [@claude](https://github.com/claude)!

--- a/go/mechanisms/evm/exact/facilitator/eip3009.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009.go
@@ -239,7 +239,7 @@ func (f *ExactEvmScheme) settleEIP3009(
 	}
 
 	if receipt.Logs != nil {
-		transferMatched, err := verifyEIP3009TransferEvent(receipt.Logs, common.HexToAddress(tokenAddress), expectedTransferEvent{
+		transferMatched, err := VerifyEIP3009TransferEvent(receipt.Logs, common.HexToAddress(tokenAddress), ExpectedTransferEvent{
 			From:  parsedAuthorization.From,
 			To:    parsedAuthorization.To,
 			Value: parsedAuthorization.Value,

--- a/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_helpers.go
@@ -31,17 +31,18 @@ type EIP3009SignatureClassification struct {
 	SigData       *evm.ERC6492SignatureData
 }
 
-type expectedTransferEvent struct {
+// ExpectedTransferEvent is the ERC-20 Transfer that a successful settle receipt must contain.
+type ExpectedTransferEvent struct {
 	From  common.Address
 	To    common.Address
 	Value *big.Int
 }
 
-// verifyEIP3009TransferEvent checks for a matching ERC-20 Transfer event in receipt logs.
-func verifyEIP3009TransferEvent(
+// VerifyEIP3009TransferEvent checks for a matching ERC-20 Transfer event in receipt logs.
+func VerifyEIP3009TransferEvent(
 	logs []*goethtypes.Log,
 	tokenAddress common.Address,
-	expected expectedTransferEvent,
+	expected ExpectedTransferEvent,
 ) (bool, error) {
 	contractABI, err := abi.JSON(strings.NewReader(string(evm.ERC20TransferEventABI)))
 	if err != nil {

--- a/go/mechanisms/evm/exact/facilitator/eip3009_transfer_event_test.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_transfer_event_test.go
@@ -90,7 +90,7 @@ func TestVerifyEIP3009TransferEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := verifyEIP3009TransferEvent(tt.logs, token, expectedTransferEvent{
+			got, err := VerifyEIP3009TransferEvent(tt.logs, token, ExpectedTransferEvent{
 				From:  payer,
 				To:    receiver,
 				Value: value,

--- a/go/mechanisms/evm/exact/facilitator/permit2.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/extensions/eip2612gassponsor"
 	"github.com/x402-foundation/x402/go/v2/extensions/erc20approvalgassponsor"
@@ -370,6 +372,31 @@ func SettlePermit2(
 
 	if receipt.Status != evm.TxStatusSuccess {
 		return nil, x402.NewSettleError(ErrTransactionFailed, payer, network, txHash, "")
+	}
+
+	// Receipt status alone is not enough: fee-on-transfer / non-conforming tokens can
+	// underpay without reverting the proxy call. Require a matching ERC-20 Transfer
+	// when logs are present (same semantics as EIP-3009 settle / #2385 / #2727).
+	if receipt.Logs != nil {
+		transferValue, ok := new(big.Int).SetString(permit2Payload.Permit2Authorization.Permitted.Amount, 10)
+		if !ok {
+			return nil, x402.NewSettleError(ErrInvalidPayload, payer, network, txHash, "invalid permitted amount")
+		}
+		transferMatched, matchErr := VerifyEIP3009TransferEvent(
+			receipt.Logs,
+			common.HexToAddress(evm.NormalizeAddress(permit2Payload.Permit2Authorization.Permitted.Token)),
+			ExpectedTransferEvent{
+				From:  common.HexToAddress(permit2Payload.Permit2Authorization.From),
+				To:    common.HexToAddress(permit2Payload.Permit2Authorization.Witness.To),
+				Value: transferValue,
+			},
+		)
+		if matchErr != nil {
+			return nil, x402.NewSettleError(ErrTransferEventMismatch, payer, network, txHash, matchErr.Error())
+		}
+		if !transferMatched {
+			return nil, x402.NewSettleError(ErrTransferEventMismatch, payer, network, txHash, "")
+		}
 	}
 
 	return &x402.SettleResponse{

--- a/go/mechanisms/evm/exact/facilitator/permit2_settle_transfer_event_test.go
+++ b/go/mechanisms/evm/exact/facilitator/permit2_settle_transfer_event_test.go
@@ -1,0 +1,204 @@
+package facilitator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	goethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	x402 "github.com/x402-foundation/x402/go/v2"
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+const (
+	permit2TestPayer   = "0xa0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0"
+	permit2TestPayTo   = "0xb1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"
+	permit2TestToken   = "0x036cbd53842c5426634e7929541ec2318f3dcf7e"
+	permit2TestNetwork = "eip155:84532"
+	permit2TestAmount  = "1000"
+	permit2DummySig    = "0x" +
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" +
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" +
+		"1b"
+)
+
+// permit2SettleMockSigner is a minimal FacilitatorEvmSigner for Permit2 settle transfer-event tests.
+// The payer is treated as a deployed contract so a dummy signature falls through to settle when
+// simulation is disabled (same pattern as the upto Permit2 settle suite).
+type permit2SettleMockSigner struct {
+	receipt *evm.TransactionReceipt
+	txHash  string
+}
+
+func (m *permit2SettleMockSigner) GetAddresses() []string {
+	return []string{"0xf1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1f1"}
+}
+
+func (m *permit2SettleMockSigner) ReadContract(ctx context.Context, address string, abi []byte, functionName string, args ...interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *permit2SettleMockSigner) VerifyTypedData(ctx context.Context, address string, domain evm.TypedDataDomain, types map[string][]evm.TypedDataField, primaryType string, message map[string]interface{}, signature []byte) (bool, error) {
+	return false, nil
+}
+
+func (m *permit2SettleMockSigner) WriteContract(ctx context.Context, address string, abi []byte, functionName string, dataSuffix []byte, args ...interface{}) (string, error) {
+	if m.txHash != "" {
+		return m.txHash, nil
+	}
+	return "0x" + strings.Repeat("ab", 32), nil
+}
+
+func (m *permit2SettleMockSigner) SendTransaction(ctx context.Context, to string, data []byte) (string, error) {
+	return m.WriteContract(ctx, to, nil, "", nil)
+}
+
+func (m *permit2SettleMockSigner) WaitForTransactionReceipt(ctx context.Context, txHash string) (*evm.TransactionReceipt, error) {
+	if m.receipt != nil {
+		return m.receipt, nil
+	}
+	return &evm.TransactionReceipt{Status: evm.TxStatusSuccess, TxHash: txHash}, nil
+}
+
+func (m *permit2SettleMockSigner) GetBalance(ctx context.Context, address string, tokenAddress string) (*big.Int, error) {
+	return big.NewInt(999_000_000), nil
+}
+
+func (m *permit2SettleMockSigner) GetChainID(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(84532), nil
+}
+
+func (m *permit2SettleMockSigner) GetCode(ctx context.Context, address string) ([]byte, error) {
+	normalized := strings.ToLower(address)
+	if normalized == strings.ToLower(permit2TestToken) || normalized == strings.ToLower(permit2TestPayer) {
+		return []byte{0x60, 0x60}, nil
+	}
+	return []byte{}, nil
+}
+
+func buildExactPermit2SettleFixture() (types.PaymentPayload, types.PaymentRequirements, *evm.ExactPermit2Payload) {
+	now := time.Now().Unix()
+	permit2Payload := &evm.ExactPermit2Payload{
+		Signature: permit2DummySig,
+		Permit2Authorization: evm.Permit2Authorization{
+			From: permit2TestPayer,
+			Permitted: evm.Permit2TokenPermissions{
+				Token:  permit2TestToken,
+				Amount: permit2TestAmount,
+			},
+			Spender:  evm.X402ExactPermit2ProxyAddress,
+			Nonce:    "12345",
+			Deadline: fmt.Sprintf("%d", now+300),
+			Witness: evm.Permit2Witness{
+				To:         permit2TestPayTo,
+				ValidAfter: fmt.Sprintf("%d", now-600),
+			},
+		},
+	}
+	requirements := types.PaymentRequirements{
+		Scheme:  evm.SchemeExact,
+		Network: permit2TestNetwork,
+		Asset:   permit2TestToken,
+		Amount:  permit2TestAmount,
+		PayTo:   permit2TestPayTo,
+	}
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted:    requirements,
+		Payload:     permit2Payload.ToMap(),
+	}
+	return payload, requirements, permit2Payload
+}
+
+func TestSettlePermit2_RejectsUnderpayingTransferEvent(t *testing.T) {
+	payload, requirements, permit2Payload := buildExactPermit2SettleFixture()
+	txHash := "0x" + strings.Repeat("ab", 32)
+	token := common.HexToAddress(permit2TestToken)
+	payer := common.HexToAddress(permit2TestPayer)
+	payTo := common.HexToAddress(permit2TestPayTo)
+
+	signer := &permit2SettleMockSigner{
+		txHash: txHash,
+		receipt: &evm.TransactionReceipt{
+			Status: evm.TxStatusSuccess,
+			TxHash: txHash,
+			Logs: []*goethtypes.Log{
+				makeTransferLog(token, payer, payTo, big.NewInt(900)),
+			},
+		},
+	}
+
+	_, err := SettlePermit2(context.Background(), signer, payload, requirements, permit2Payload, nil, &Permit2FacilitatorConfig{SimulateInSettle: false})
+	assertPermit2SettleTransferMismatch(t, err, txHash)
+}
+
+func TestSettlePermit2_RejectsEmptyLogs(t *testing.T) {
+	payload, requirements, permit2Payload := buildExactPermit2SettleFixture()
+	txHash := "0x" + strings.Repeat("cd", 32)
+
+	signer := &permit2SettleMockSigner{
+		txHash: txHash,
+		receipt: &evm.TransactionReceipt{
+			Status: evm.TxStatusSuccess,
+			TxHash: txHash,
+			Logs:   []*goethtypes.Log{},
+		},
+	}
+
+	_, err := SettlePermit2(context.Background(), signer, payload, requirements, permit2Payload, nil, &Permit2FacilitatorConfig{SimulateInSettle: false})
+	assertPermit2SettleTransferMismatch(t, err, txHash)
+}
+
+func TestSettlePermit2_AcceptsMatchingTransferEvent(t *testing.T) {
+	payload, requirements, permit2Payload := buildExactPermit2SettleFixture()
+	txHash := "0x" + strings.Repeat("ef", 32)
+	token := common.HexToAddress(permit2TestToken)
+	payer := common.HexToAddress(permit2TestPayer)
+	payTo := common.HexToAddress(permit2TestPayTo)
+
+	signer := &permit2SettleMockSigner{
+		txHash: txHash,
+		receipt: &evm.TransactionReceipt{
+			Status: evm.TxStatusSuccess,
+			TxHash: txHash,
+			Logs: []*goethtypes.Log{
+				makeTransferLog(token, payer, payTo, big.NewInt(1000)),
+			},
+		},
+	}
+
+	resp, err := SettlePermit2(context.Background(), signer, payload, requirements, permit2Payload, nil, &Permit2FacilitatorConfig{SimulateInSettle: false})
+	if err != nil {
+		t.Fatalf("expected settle success, got error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected resp.Success = true, got %+v", resp)
+	}
+	if resp.Transaction != txHash {
+		t.Fatalf("expected transaction %q, got %q", txHash, resp.Transaction)
+	}
+}
+
+func assertPermit2SettleTransferMismatch(t *testing.T, err error, txHash string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected transfer event mismatch error, got nil")
+	}
+	se := &x402.SettleError{}
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *x402.SettleError, got %T: %v", err, err)
+	}
+	if se.ErrorReason != ErrTransferEventMismatch {
+		t.Fatalf("expected reason %q, got %q", ErrTransferEventMismatch, se.ErrorReason)
+	}
+	if se.Transaction != txHash {
+		t.Fatalf("expected transaction %q, got %q", txHash, se.Transaction)
+	}
+}

--- a/go/mechanisms/evm/upto/facilitator/errors.go
+++ b/go/mechanisms/evm/upto/facilitator/errors.go
@@ -15,6 +15,8 @@ const (
 	ErrUptoFailedToGetNetworkConfig = "invalid_upto_evm_failed_to_get_network_config"
 	ErrUptoFailedToGetReceipt       = "invalid_upto_evm_failed_to_get_receipt"
 	ErrUptoTransactionFailed        = "invalid_upto_evm_transaction_failed"
+	// Same reason string as exact EIP-3009/Permit2 settle (TS #3080 / Go #2727 lineage).
+	ErrTransferEventMismatch = "invalid_exact_evm_transfer_event_mismatch"
 
 	// Shared Permit2 error constants — canonical values live in evm.ErrPermit2*
 	ErrPermit2InvalidSpender      = evm.ErrPermit2InvalidSpender

--- a/go/mechanisms/evm/upto/facilitator/permit2.go
+++ b/go/mechanisms/evm/upto/facilitator/permit2.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/extensions/eip2612gassponsor"
 	"github.com/x402-foundation/x402/go/v2/extensions/erc20approvalgassponsor"
@@ -369,6 +371,28 @@ func SettleUptoPermit2(
 
 	if receipt.Status != evm.TxStatusSuccess {
 		return nil, x402.NewSettleError(ErrUptoTransactionFailed, payer, network, txHash, "")
+	}
+
+	// Receipt status alone is not enough: fee-on-transfer / non-conforming tokens can
+	// underpay without reverting the proxy call. Require a matching ERC-20 Transfer
+	// for the actual settlement amount when logs are present (parity with exact Permit2
+	// and EIP-3009 settle / #2385 / #2727 / TS #3080).
+	if receipt.Logs != nil {
+		transferMatched, matchErr := exactfacilitator.VerifyEIP3009TransferEvent(
+			receipt.Logs,
+			common.HexToAddress(evm.NormalizeAddress(permit2Payload.Permit2Authorization.Permitted.Token)),
+			exactfacilitator.ExpectedTransferEvent{
+				From:  common.HexToAddress(permit2Payload.Permit2Authorization.From),
+				To:    common.HexToAddress(permit2Payload.Permit2Authorization.Witness.To),
+				Value: settlementAmount,
+			},
+		)
+		if matchErr != nil {
+			return nil, x402.NewSettleError(ErrTransferEventMismatch, payer, network, txHash, matchErr.Error())
+		}
+		if !transferMatched {
+			return nil, x402.NewSettleError(ErrTransferEventMismatch, payer, network, txHash, "")
+		}
 	}
 
 	return &x402.SettleResponse{

--- a/go/mechanisms/evm/upto/facilitator/permit2_settle_transfer_event_test.go
+++ b/go/mechanisms/evm/upto/facilitator/permit2_settle_transfer_event_test.go
@@ -1,0 +1,167 @@
+package facilitator
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	goethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+)
+
+var uptoTransferEventTopic = crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))
+
+func makeUptoTransferLog(token common.Address, from common.Address, to common.Address, value *big.Int) *goethtypes.Log {
+	return &goethtypes.Log{
+		Address: token,
+		Topics: []common.Hash{
+			uptoTransferEventTopic,
+			common.BytesToHash(common.LeftPadBytes(from.Bytes(), 32)),
+			common.BytesToHash(common.LeftPadBytes(to.Bytes(), 32)),
+		},
+		Data: common.LeftPadBytes(value.Bytes(), 32),
+	}
+}
+
+func TestSettleUptoPermit2_RejectsUnderpayingTransferEvent(t *testing.T) {
+	txHash := "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	token := common.HexToAddress(testTokenAddr)
+	payer := common.HexToAddress(testPayerAddr)
+	payTo := common.HexToAddress(testPayToAddr)
+
+	signer := newMockSigner()
+	signer.writeContractTx = txHash
+	signer.receiptResult = &evm.TransactionReceipt{
+		Status: evm.TxStatusSuccess,
+		TxHash: txHash,
+		Logs: []*goethtypes.Log{
+			makeUptoTransferLog(token, payer, payTo, big.NewInt(900)),
+		},
+	}
+
+	_, err := SettleUptoPermit2(
+		context.Background(),
+		signer,
+		buildValidPayload(testFacilitatorAddr),
+		buildValidRequirements(),
+		buildValidUptoPayload(testFacilitatorAddr),
+		nil,
+		false,
+	)
+	assertSettleError(t, err, ErrTransferEventMismatch)
+}
+
+func TestSettleUptoPermit2_RejectsEmptyLogs(t *testing.T) {
+	txHash := "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	signer := newMockSigner()
+	signer.writeContractTx = txHash
+	signer.receiptResult = &evm.TransactionReceipt{
+		Status: evm.TxStatusSuccess,
+		TxHash: txHash,
+		Logs:   []*goethtypes.Log{},
+	}
+
+	_, err := SettleUptoPermit2(
+		context.Background(),
+		signer,
+		buildValidPayload(testFacilitatorAddr),
+		buildValidRequirements(),
+		buildValidUptoPayload(testFacilitatorAddr),
+		nil,
+		false,
+	)
+	assertSettleError(t, err, ErrTransferEventMismatch)
+}
+
+func TestSettleUptoPermit2_AcceptsMatchingTransferEvent(t *testing.T) {
+	txHash := "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	token := common.HexToAddress(testTokenAddr)
+	payer := common.HexToAddress(testPayerAddr)
+	payTo := common.HexToAddress(testPayToAddr)
+
+	signer := newMockSigner()
+	signer.writeContractTx = txHash
+	signer.receiptResult = &evm.TransactionReceipt{
+		Status: evm.TxStatusSuccess,
+		TxHash: txHash,
+		Logs: []*goethtypes.Log{
+			makeUptoTransferLog(token, payer, payTo, big.NewInt(1000)),
+		},
+	}
+
+	resp, err := SettleUptoPermit2(
+		context.Background(),
+		signer,
+		buildValidPayload(testFacilitatorAddr),
+		buildValidRequirements(),
+		buildValidUptoPayload(testFacilitatorAddr),
+		nil,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected settle success, got error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success, got %+v", resp)
+	}
+	if resp.Transaction != txHash {
+		t.Fatalf("expected transaction %q, got %q", txHash, resp.Transaction)
+	}
+	if resp.Amount != testAmount {
+		t.Fatalf("expected Amount=%q, got %q", testAmount, resp.Amount)
+	}
+}
+
+func TestSettleUptoPermit2_PartialAmount_RequiresSettlementTransfer(t *testing.T) {
+	txHash := "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	token := common.HexToAddress(testTokenAddr)
+	payer := common.HexToAddress(testPayerAddr)
+	payTo := common.HexToAddress(testPayToAddr)
+
+	req := buildValidRequirements()
+	req.Amount = "500"
+
+	signer := newMockSigner()
+	signer.writeContractTx = txHash
+	// Full permitted amount in the log must not satisfy a partial settlement.
+	signer.receiptResult = &evm.TransactionReceipt{
+		Status: evm.TxStatusSuccess,
+		TxHash: txHash,
+		Logs: []*goethtypes.Log{
+			makeUptoTransferLog(token, payer, payTo, big.NewInt(1000)),
+		},
+	}
+
+	_, err := SettleUptoPermit2(
+		context.Background(),
+		signer,
+		buildValidPayload(testFacilitatorAddr),
+		req,
+		buildValidUptoPayload(testFacilitatorAddr),
+		nil,
+		false,
+	)
+	assertSettleError(t, err, ErrTransferEventMismatch)
+
+	signer.receiptResult.Logs = []*goethtypes.Log{
+		makeUptoTransferLog(token, payer, payTo, big.NewInt(500)),
+	}
+	resp, err := SettleUptoPermit2(
+		context.Background(),
+		signer,
+		buildValidPayload(testFacilitatorAddr),
+		req,
+		buildValidUptoPayload(testFacilitatorAddr),
+		nil,
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected settle success for matching partial transfer, got error: %v", err)
+	}
+	if resp.Amount != "500" {
+		t.Fatalf("expected Amount='500', got %q", resp.Amount)
+	}
+}


### PR DESCRIPTION
Go Permit2 settle (exact and upto) still trusted `receipt.status` alone, so a fee-on-transfer or otherwise non-conforming token could underpay while the facilitator reported full success. This PR requires a matching ERC-20 `Transfer` event in the settle receipt, the same class of fix as TypeScript #3080 and the EIP-3009 path (#2385 / Go #2727).

**What changes:** after a successful receipt status, both Go Permit2 settle paths require a matching `Transfer` when logs are present, reusing `VerifyEIP3009TransferEvent` (exported from the exact facilitator package). Exact expects the full permitted amount; upto expects the actual settlement amount. Same logs-present guard semantics as EIP-3009 settle.

**Why:** receipt status proves only that the proxy call did not revert. The Permit2 proxy performs no balance-delta check, so underpayment is invisible without inspecting Transfer logs.

**Lineage:** same bug class as merged #2385 / #2727 (EIP-3009 Transfer verification) and open TypeScript #3080 (Permit2 Transfer verification). Earlier Go attempt #3058 covered the same gap but predates current main, duplicated the verifier in upto, and only unit-tested the helper. This PR rebases onto current main, reuses the exact verifier, adds settle-path regression tests, and drops the Cursor co-author trailer.

**Signing note:** this commit carries an SSH signature (`id_ed25519_codered_signing`). If GitHub's `check-verified-commits` still fails because that key is not registered as a signing key on the account, please amend with your GPG/SSH signing key:

```bash
cd /tmp/x402-second-pass
git checkout fix/go-permit2-settle-transfer-event-v2
git commit --amend --no-edit -S
git push --force-with-lease origin HEAD:fix/go-permit2-settle-transfer-event-v2
```

(Same human amend path as #3080.)

Spotted during a security review of the facilitator settle paths (F-201). Prepared with AI assistance (Cursor agent); every test assertion was validated by running the suite below.

## Tests

```bash
cd go
go test ./mechanisms/evm/exact/facilitator/ ./mechanisms/evm/upto/facilitator/ -count=1
```

New settle-path regressions:

- exact: underpaying Transfer (900 of 1000) rejected; empty logs rejected; matching Transfer succeeds
- upto: underpaying Transfer rejected; empty logs rejected; matching Transfer succeeds; partial settlement binds to settlement amount (not permitted max)

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- SSH-signed here; amend with a GitHub-registered signing key if the verified-commits check fails
- [x] I added a changelog fragment for user-facing changes (`go/CHANGELOG.md` Unreleased)


Made with [Cursor](https://cursor.com)