### PR TITLE
fix(legacy): verify Transfer event in exact EIP-3009 settle receipts

### DIFF
--- a/typescript/packages/legacy/x402/src/schemes/exact/evm/facilitator.test.ts
+++ b/typescript/packages/legacy/x402/src/schemes/exact/evm/facilitator.test.ts
@@ -1,8 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Address, Chain, parseSignature, Transport } from "viem";
+import {
+  Address,
+  Chain,
+  encodeAbiParameters,
+  getAddress,
+  keccak256,
+  padHex,
+  parseSignature,
+  toBytes,
+  Transport,
+} from "viem";
 import { PaymentPayload, PaymentRequirements, ExactEvmPayload } from "../../../types/verify";
 import { verify, settle } from "./facilitator";
 import type { SignerWallet } from "../../../types/shared/evm";
+
+const TRANSFER_TOPIC = keccak256(toBytes("Transfer(address,address,uint256)"));
 
 vi.mock("../../../shared", () => ({
   getNetworkId: vi.fn().mockReturnValue(84532),
@@ -298,6 +310,96 @@ describe("facilitator - smart wallet deployment check", () => {
           args: expect.arrayContaining([28, mockR, mockS]),
         }),
       );
+    });
+  });
+
+  describe("settle - Transfer event verification", () => {
+    const TOKEN = getAddress("0x036CbD53842c5426634e7929541eC2318f3dCF7e");
+    const RECEIVER = getAddress("0x1234567890123456789012345678901234567890");
+    const PAYER = getAddress("0xabcdef1234567890123456789012345678901234");
+    const AMOUNT = 1000000n;
+    const MOCK_TX = padHex("0xabc", { size: 32 });
+
+    function makeTransferLog(opts: {
+      address: Address;
+      from: Address;
+      to: Address;
+      value: bigint;
+    }) {
+      return {
+        address: opts.address,
+        topics: [
+          TRANSFER_TOPIC,
+          padHex(opts.from, { size: 32 }),
+          padHex(opts.to, { size: 32 }),
+        ] as [`0x${string}`, `0x${string}`, `0x${string}`],
+        data: encodeAbiParameters([{ type: "uint256" }], [opts.value]),
+        blockHash: padHex("0x1", { size: 32 }),
+        blockNumber: 1n,
+        transactionHash: MOCK_TX,
+        transactionIndex: 0,
+        logIndex: 0,
+        removed: false,
+      };
+    }
+
+    function walletWithReceipt(logs: ReturnType<typeof makeTransferLog>[]) {
+      return {
+        getCode: vi.fn().mockResolvedValue("0x"),
+        verifyTypedData: vi.fn().mockResolvedValue(true),
+        writeContract: vi.fn().mockResolvedValue(MOCK_TX),
+        waitForTransactionReceipt: vi.fn().mockResolvedValue({
+          status: "success",
+          logs,
+          transactionHash: MOCK_TX,
+        }),
+        chain: { id: 84532 },
+        account: { address: RECEIVER as Address },
+      } as unknown as SignerWallet<Chain, Transport>;
+    }
+
+    it("rejects fee-on-transfer underpay when Transfer value is short", async () => {
+      const wallet = walletWithReceipt([
+        makeTransferLog({
+          address: TOKEN,
+          from: PAYER,
+          to: RECEIVER,
+          value: AMOUNT - 100n,
+        }),
+      ]);
+      const payload = createMockPayload({ signatureLength: 130, from: PAYER });
+
+      const result = await settle(wallet, payload, mockPaymentRequirements);
+
+      expect(result.success).toBe(false);
+      expect(result.errorReason).toBe("invalid_exact_evm_transfer_event_mismatch");
+    });
+
+    it("rejects successful receipts with empty logs (no Transfer)", async () => {
+      const wallet = walletWithReceipt([]);
+      const payload = createMockPayload({ signatureLength: 130, from: PAYER });
+
+      const result = await settle(wallet, payload, mockPaymentRequirements);
+
+      expect(result.success).toBe(false);
+      expect(result.errorReason).toBe("invalid_exact_evm_transfer_event_mismatch");
+    });
+
+    it("accepts settle when Transfer matches authorized amount", async () => {
+      const wallet = walletWithReceipt([
+        makeTransferLog({
+          address: TOKEN,
+          from: PAYER,
+          to: RECEIVER,
+          value: AMOUNT,
+        }),
+      ]);
+      const payload = createMockPayload({ signatureLength: 130, from: PAYER });
+
+      const result = await settle(wallet, payload, mockPaymentRequirements);
+
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe(MOCK_TX);
     });
   });
 });

--- a/typescript/packages/legacy/x402/src/schemes/exact/evm/facilitator.test.ts
+++ b/typescript/packages/legacy/x402/src/schemes/exact/evm/facilitator.test.ts
@@ -320,12 +320,12 @@ describe("facilitator - smart wallet deployment check", () => {
     const AMOUNT = 1000000n;
     const MOCK_TX = padHex("0xabc", { size: 32 });
 
-    function makeTransferLog(opts: {
+    const makeTransferLog = (opts: {
       address: Address;
       from: Address;
       to: Address;
       value: bigint;
-    }) {
+    }) => {
       return {
         address: opts.address,
         topics: [
@@ -341,9 +341,9 @@ describe("facilitator - smart wallet deployment check", () => {
         logIndex: 0,
         removed: false,
       };
-    }
+    };
 
-    function walletWithReceipt(logs: ReturnType<typeof makeTransferLog>[]) {
+    const walletWithReceipt = (logs: ReturnType<typeof makeTransferLog>[]) => {
       return {
         getCode: vi.fn().mockResolvedValue("0x"),
         verifyTypedData: vi.fn().mockResolvedValue(true),
@@ -356,7 +356,7 @@ describe("facilitator - smart wallet deployment check", () => {
         chain: { id: 84532 },
         account: { address: RECEIVER as Address },
       } as unknown as SignerWallet<Chain, Transport>;
-    }
+    };
 
     it("rejects fee-on-transfer underpay when Transfer value is short", async () => {
       const wallet = walletWithReceipt([

--- a/typescript/packages/legacy/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/legacy/x402/src/schemes/exact/evm/facilitator.ts
@@ -47,6 +47,14 @@ const erc20TransferEventAbi = [
  * Receipt status alone does not prove the payee received the authorized amount
  * (fee-on-transfer / non-conforming tokens). Mirrors the v2 EIP-3009 settle
  * guard (`verifyEip3009TransferEvent`) that landed after #2385 / #3032.
+ *
+ * @param logs - Receipt logs to search for a matching Transfer
+ * @param erc20Address - The ERC-20 token contract that should have emitted the Transfer
+ * @param expected - The expected Transfer arguments from the authorization
+ * @param expected.from - Expected `from` of the Transfer event
+ * @param expected.to - Expected `to` of the Transfer event
+ * @param expected.value - Expected `value` of the Transfer event
+ * @returns true when a matching Transfer log is present, false otherwise
  */
 export function verifyExactEvmTransferEvent(
   logs: readonly Log[],

--- a/typescript/packages/legacy/x402/src/schemes/exact/evm/facilitator.ts
+++ b/typescript/packages/legacy/x402/src/schemes/exact/evm/facilitator.ts
@@ -4,9 +4,12 @@ import {
   Chain,
   getAddress,
   Hex,
+  isAddressEqual,
   parseErc6492Signature,
+  parseEventLogs,
   parseSignature,
   Transport,
+  type Log,
 } from "viem";
 import { getNetworkId } from "../../../shared";
 import { getVersion, getERC20Balance } from "../../../shared/evm";
@@ -25,6 +28,43 @@ import {
   ExactEvmPayload,
 } from "../../../types/verify";
 import { SCHEME } from "../../exact";
+
+const erc20TransferEventAbi = [
+  {
+    type: "event",
+    name: "Transfer",
+    anonymous: false,
+    inputs: [
+      { name: "from", type: "address", indexed: true },
+      { name: "to", type: "address", indexed: true },
+      { name: "value", type: "uint256", indexed: false },
+    ],
+  },
+] as const;
+
+/**
+ * Require a matching ERC-20 Transfer event in the settle receipt.
+ * Receipt status alone does not prove the payee received the authorized amount
+ * (fee-on-transfer / non-conforming tokens). Mirrors the v2 EIP-3009 settle
+ * guard (`verifyEip3009TransferEvent`) that landed after #2385 / #3032.
+ */
+export function verifyExactEvmTransferEvent(
+  logs: readonly Log[],
+  erc20Address: Address,
+  expected: { from: Address; to: Address; value: bigint },
+): boolean {
+  const transferLogs = parseEventLogs({
+    abi: erc20TransferEventAbi,
+    eventName: "Transfer",
+    logs: logs.filter(log => isAddressEqual(log.address, erc20Address)),
+  });
+  return transferLogs.some(
+    log =>
+      isAddressEqual(log.args.from, expected.from) &&
+      isAddressEqual(log.args.to, expected.to) &&
+      log.args.value === expected.value,
+  );
+}
 
 /**
  * Verifies a payment payload against the required payment details
@@ -323,6 +363,25 @@ export async function settle<transport extends Transport, chain extends Chain>(
     return {
       success: false,
       errorReason: "invalid_transaction_state", //`Transaction failed`,
+      transaction: tx,
+      network: paymentPayload.network,
+      payer: payload.authorization.from,
+    };
+  }
+
+  // Receipt status only proves the tx did not revert. When logs are present,
+  // require the expected ERC-20 Transfer (parity with v2 EIP-3009 settle).
+  if (
+    receipt.logs != null &&
+    !verifyExactEvmTransferEvent(receipt.logs, getAddress(paymentRequirements.asset), {
+      from: getAddress(payload.authorization.from),
+      to: getAddress(payload.authorization.to),
+      value: BigInt(payload.authorization.value),
+    })
+  ) {
+    return {
+      success: false,
+      errorReason: "invalid_exact_evm_transfer_event_mismatch",
       transaction: tx,
       network: paymentPayload.network,
       payer: payload.authorization.from,


### PR DESCRIPTION
## Description

The legacy `x402` package (`typescript/packages/legacy/x402`) still settles exact EIP-3009 payments by checking `receipt.status` alone. A fee-on-transfer or otherwise non-conforming token can underpay (or move nothing) while the facilitator reports `success: true`. The v2 EIP-3009 path already rejects that class via `verifyEip3009TransferEvent` (upstream #2385 / #3032 lineage). Open Permit2 PRs (#3080 / #3084 / #3059) close the same gap on Permit2 rails; this PR backports the guard to the still-published legacy package.

**Change:** after a successful receipt, when `receipt.logs` is present, require a matching ERC-20 `Transfer(from, to, value)` for the authorized amount. Failure reason: `invalid_exact_evm_transfer_event_mismatch`.

## Test plan

- [x] `vitest run src/schemes/exact/evm/facilitator.test.ts` (16/16): existing smart-wallet + EOA cases green; new cases cover underpay, empty logs, and matching Transfer
- [ ] CI on this PR


Made with [Cursor](https://cursor.com)