### PR TITLE
fix(batch-settlement): fail closed when settle emits no Settled amount

### DIFF
--- a/go/.changes/unreleased/fixed-3092-settled-event.yaml
+++ b/go/.changes/unreleased/fixed-3092-settled-event.yaml
@@ -1,0 +1,2 @@
+kind: fixed
+body: Fail closed when a batch-settlement settle receipt does not advance receivers.totalSettled (possible no-op early return).

--- a/go/mechanisms/evm/batch-settlement/facilitator/errors.go
+++ b/go/mechanisms/evm/batch-settlement/facilitator/errors.go
@@ -116,7 +116,8 @@ const (
 	ErrAuthorizerNotConfigured   = "invalid_batch_settlement_evm_authorizer_not_configured"
 
 	// Settle action errors
-	ErrUnknownSettleAction = "invalid_batch_settlement_evm_unknown_settle_action"
-	ErrNothingToSettle     = "invalid_batch_settlement_evm_nothing_to_settle"
-	ErrRefundNoBalance     = batchsettlement.ErrRefundNoBalance
+	ErrUnknownSettleAction  = "invalid_batch_settlement_evm_unknown_settle_action"
+	ErrNothingToSettle      = "invalid_batch_settlement_evm_nothing_to_settle"
+	ErrSettledEventMismatch = "invalid_batch_settlement_evm_settled_event_mismatch"
+	ErrRefundNoBalance      = batchsettlement.ErrRefundNoBalance
 )

--- a/go/mechanisms/evm/batch-settlement/facilitator/errors_test.go
+++ b/go/mechanisms/evm/batch-settlement/facilitator/errors_test.go
@@ -84,6 +84,7 @@ func TestExportedErrorReasonsAreStable(t *testing.T) {
 		"ErrAuthorizerAddressMismatch": ErrAuthorizerAddressMismatch,
 		"ErrUnknownSettleAction":       ErrUnknownSettleAction,
 		"ErrNothingToSettle":           ErrNothingToSettle,
+		"ErrSettledEventMismatch":      ErrSettledEventMismatch,
 		"ErrRefundNoBalance":           ErrRefundNoBalance,
 
 		// Permit2 deposit authorization errors
@@ -234,7 +235,7 @@ func TestNoLegacyBatchSettlementEvmPrefix(t *testing.T) {
 		ErrDepositSimulationFailed, ErrClaimSimulationFailed,
 		ErrSettleSimulationFailed, ErrRefundSimulationFailed,
 		ErrAuthorizerAddressMismatch, ErrUnknownSettleAction, ErrNothingToSettle,
-		ErrRefundNoBalance,
+		ErrSettledEventMismatch, ErrRefundNoBalance,
 		ErrPermit2AuthorizationRequired, ErrPermit2InvalidSpender,
 		ErrPermit2AmountMismatch, ErrPermit2DeadlineExpired,
 		ErrPermit2InvalidSignature, ErrPermit2AllowanceRequired,

--- a/go/mechanisms/evm/batch-settlement/facilitator/exec_test.go
+++ b/go/mechanisms/evm/batch-settlement/facilitator/exec_test.go
@@ -410,6 +410,75 @@ func TestExecuteSettle_InvalidBroadcastHashIsTerminal(t *testing.T) {
 	}
 }
 
+func TestExecuteSettle_NoTotalSettledAdvanceFailsClosed(t *testing.T) {
+	txHash := "0x" + strings.Repeat("ab", 32)
+	signer := &fakeFacilitatorSigner{
+		addresses: []string{"0xfacilitator"},
+		readContract: func(functionName string, _ ...interface{}) (interface{}, error) {
+			if functionName == "receivers" {
+				return []interface{}{big.NewInt(2500), big.NewInt(0)}, nil
+			}
+			return nil, nil
+		},
+		writeContract: func(functionName string, _ ...interface{}) (string, error) {
+			return txHash, nil
+		},
+		waitForReceipt: func(got string) (*evm.TransactionReceipt, error) {
+			return &evm.TransactionReceipt{Status: evm.TxStatusSuccess, TxHash: got}, nil
+		},
+	}
+	payload := &batchsettlement.BatchSettlementSettlePayload{
+		Type:     "settle",
+		Receiver: "0x3333333333333333333333333333333333333333",
+		Token:    "0x5555555555555555555555555555555555555555",
+	}
+
+	resp, err := ExecuteSettle(context.Background(), signer, payload, reqsFor(testNetwork), nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp.Success || resp.ErrorReason != ErrSettledEventMismatch {
+		t.Fatalf("got %+v", resp)
+	}
+}
+
+func TestExecuteSettle_TotalSettledAdvanceReportsAmount(t *testing.T) {
+	txHash := "0x" + strings.Repeat("ab", 32)
+	reads := 0
+	signer := &fakeFacilitatorSigner{
+		addresses: []string{"0xfacilitator"},
+		readContract: func(functionName string, _ ...interface{}) (interface{}, error) {
+			if functionName != "receivers" {
+				return nil, nil
+			}
+			reads++
+			if reads == 1 {
+				return []interface{}{big.NewInt(2500), big.NewInt(0)}, nil
+			}
+			return []interface{}{big.NewInt(2500), big.NewInt(2500)}, nil
+		},
+		writeContract: func(functionName string, _ ...interface{}) (string, error) {
+			return txHash, nil
+		},
+		waitForReceipt: func(got string) (*evm.TransactionReceipt, error) {
+			return &evm.TransactionReceipt{Status: evm.TxStatusSuccess, TxHash: got}, nil
+		},
+	}
+	payload := &batchsettlement.BatchSettlementSettlePayload{
+		Type:     "settle",
+		Receiver: "0x3333333333333333333333333333333333333333",
+		Token:    "0x5555555555555555555555555555555555555555",
+	}
+
+	resp, err := ExecuteSettle(context.Background(), signer, payload, reqsFor(testNetwork), nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !resp.Success || resp.Amount != "2500" {
+		t.Fatalf("got %+v", resp)
+	}
+}
+
 // ----- SettleDeposit -----
 
 func TestSettleDeposit_BadAmount(t *testing.T) {

--- a/go/mechanisms/evm/batch-settlement/facilitator/settle.go
+++ b/go/mechanisms/evm/batch-settlement/facilitator/settle.go
@@ -82,10 +82,32 @@ func ExecuteSettle(
 		return nil, err
 	}
 
+	// Settled event. Re-read receivers and require totalSettled advanced.
+	_, postSettled, postErr := readReceiverSettlementTotals(ctx, signer, receiver, token)
+	if postErr != nil {
+		return &x402.SettleResponse{ //nolint:nilerr // RPC read failure -> error encoded in response
+			Success:      false,
+			ErrorReason:  ErrRpcReadFailed,
+			ErrorMessage: postErr.Error(),
+			Transaction:  txHash,
+			Network:      network,
+		}, nil
+	}
+	if postSettled.Cmp(totalSettled) <= 0 {
+		return &x402.SettleResponse{ //nolint:nilerr // no-op settle -> error encoded in response
+			Success:      false,
+			ErrorReason:  ErrSettledEventMismatch,
+			ErrorMessage: "settle receipt did not advance totalSettled (possible no-op early return)",
+			Transaction:  txHash,
+			Network:      network,
+		}, nil
+	}
+
 	return &x402.SettleResponse{
 		Success:     true,
 		Transaction: txHash,
 		Network:     network,
+		Amount:      new(big.Int).Sub(postSettled, totalSettled).String(),
 	}, nil
 }
 

--- a/python/x402/changelog.d/3092.bugfix.md
+++ b/python/x402/changelog.d/3092.bugfix.md
@@ -1,0 +1,1 @@
+Fail closed when a batch-settlement `settle` receipt has no positive `Settled` amount, and expose `FacilitatorWeb3Signer.web3` so receipt-log decode reaches the SDK signer.

--- a/python/x402/mechanisms/evm/batch_settlement/errors.py
+++ b/python/x402/mechanisms/evm/batch_settlement/errors.py
@@ -46,6 +46,7 @@ ERR_SETTLE_PAYLOAD = "invalid_batch_settlement_evm_settle_payload"
 ERR_SETTLE_SIMULATION_FAILED = "invalid_batch_settlement_evm_settle_simulation_failed"
 ERR_SETTLE_TRANSACTION_FAILED = "invalid_batch_settlement_evm_settle_transaction_failed"
 ERR_NOTHING_TO_SETTLE = "invalid_batch_settlement_evm_nothing_to_settle"
+ERR_SETTLED_EVENT_MISMATCH = "invalid_batch_settlement_evm_settled_event_mismatch"
 ERR_UNKNOWN_SETTLE_ACTION = "invalid_batch_settlement_evm_unknown_settle_action"
 
 ERR_REFUND_PAYLOAD = "invalid_batch_settlement_evm_refund_payload"

--- a/python/x402/mechanisms/evm/batch_settlement/facilitator/settle.py
+++ b/python/x402/mechanisms/evm/batch_settlement/facilitator/settle.py
@@ -20,6 +20,7 @@ from ..errors import (
     ERR_RPC_READ_FAILED,
     ERR_SETTLE_SIMULATION_FAILED,
     ERR_SETTLE_TRANSACTION_FAILED,
+    ERR_SETTLED_EVENT_MISMATCH,
 )
 from ..types import SettlePayload
 
@@ -97,12 +98,39 @@ def execute_settle(
         network,
         None,
         failed_reason=ERR_SETTLE_TRANSACTION_FAILED,
-        on_success=lambda receipt: SettleResponse(
-            success=True,
+        on_success=lambda receipt: _settle_response_from_receipt(
+            signer, receipt, tx, network, contract_addr, receiver, token
+        ),
+    )
+
+
+def _settle_response_from_receipt(
+    signer: FacilitatorEvmSigner,
+    receipt,
+    tx: str,
+    network: str,
+    contract_addr: str,
+    receiver: str,
+    token: str,
+) -> SettleResponse:
+    """Fail closed when the receipt has no positive Settled amount."""
+    amount = _parse_settled_amount(signer, receipt, contract_addr, receiver, token)
+    if not amount or amount == "0":
+        return SettleResponse(
+            success=False,
+            error_reason=ERR_SETTLED_EVENT_MISMATCH,
+            error_message=(
+                "settle receipt missing Settled event with positive amount "
+                "(possible no-op early return)"
+            ),
             transaction=tx,
             network=network,
-            amount=_parse_settled_amount(signer, receipt, contract_addr, receiver, token),
-        ),
+        )
+    return SettleResponse(
+        success=True,
+        transaction=tx,
+        network=network,
+        amount=amount,
     )
 
 
@@ -119,18 +147,22 @@ def _parse_settled_amount(
     receiver: str,
     token: str,
 ) -> str:
-    """Best-effort Settled event extraction.
+    """Extract Settled amount from receipt logs.
 
-    Falls back to "" when logs cannot be decoded — the on-chain transaction
-    has already succeeded by the time we get here, so a missing amount is
-    informational only.
+    Empty or "0" means the caller must fail closed. Looks up web3 on the signer
+    as `web3`, `w3`, or `_w3` so FacilitatorWeb3Signer and protocol-compatible
+    custom signers all decode.
     """
     logs = getattr(receipt, "logs", None)
     if not logs:
         return ""
 
     try:
-        web3 = getattr(signer, "web3", None) or getattr(signer, "w3", None)
+        web3 = (
+            getattr(signer, "web3", None)
+            or getattr(signer, "w3", None)
+            or getattr(signer, "_w3", None)
+        )
         if web3 is None:
             return ""
         contract = web3.eth.contract(address=contract_addr, abi=BATCH_SETTLEMENT_ABI)

--- a/python/x402/mechanisms/evm/signers.py
+++ b/python/x402/mechanisms/evm/signers.py
@@ -307,6 +307,11 @@ class FacilitatorWeb3Signer:
         """The signer's Ethereum address (checksummed)."""
         return self._account.address
 
+    @property
+    def web3(self):
+        """web3.py instance used for RPC and receipt-log decoding."""
+        return self._w3
+
     def get_addresses(self) -> list[str]:
         """Get all addresses this facilitator can use.
 

--- a/python/x402/tests/unit/mechanisms/evm/batch_settlement/facilitator/test_scheme.py
+++ b/python/x402/tests/unit/mechanisms/evm/batch_settlement/facilitator/test_scheme.py
@@ -16,6 +16,7 @@ try:
         ERR_INVALID_SCHEME,
         ERR_NETWORK_MISMATCH,
         ERR_SETTLE_TRANSACTION_FAILED,
+        ERR_SETTLED_EVENT_MISMATCH,
     )
     from x402.mechanisms.evm.batch_settlement.facilitator import refund as refund_mod
     from x402.mechanisms.evm.batch_settlement.facilitator.claim import (
@@ -508,6 +509,32 @@ class TestSettleReceiptWait:
 
         assert out.success is False
         assert out.error_reason == ERR_SETTLEMENT_PENDING
+        assert out.transaction == _SUCCESSFUL_TX_HASH
+
+    def test_noop_receipt_without_settled_event_fails_closed(self):
+        payload = SettlePayload(
+            receiver="0x3333333333333333333333333333333333333333",
+            token="0x5555555555555555555555555555555555555555",
+        )
+
+        class _EmptyLogsSigner:
+            def read_contract(self, *args, **kwargs):
+                return (1000, 0)
+
+            def write_contract(self, *args, **kwargs):
+                return _SUCCESSFUL_TX_HASH
+
+            def wait_for_transaction_receipt(self, tx):
+                return _FakeReceipt()
+
+        out = execute_settle(
+            _EmptyLogsSigner(),  # type: ignore[arg-type]
+            payload,
+            _requirements(),
+        )
+
+        assert out.success is False
+        assert out.error_reason == ERR_SETTLED_EVENT_MISMATCH
         assert out.transaction == _SUCCESSFUL_TX_HASH
 
 

--- a/python/x402/tests/unit/mechanisms/evm/batch_settlement/facilitator/test_settle_event.py
+++ b/python/x402/tests/unit/mechanisms/evm/batch_settlement/facilitator/test_settle_event.py
@@ -1,0 +1,56 @@
+"""Settled-event decode must work with the exported FacilitatorWeb3Signer."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    from eth_abi import encode
+    from eth_utils import event_abi_to_log_topic, to_checksum_address
+    from hexbytes import HexBytes
+
+    from x402.mechanisms.evm.batch_settlement.abi import BATCH_SETTLEMENT_ABI
+    from x402.mechanisms.evm.batch_settlement.constants import BATCH_SETTLEMENT_ADDRESS
+    from x402.mechanisms.evm.batch_settlement.facilitator.settle import _parse_settled_amount
+    from x402.mechanisms.evm.signers import FacilitatorWeb3Signer
+except ImportError:
+    pytest.skip("batch_settlement requires evm extras", allow_module_level=True)
+
+
+_ANVIL_KEY = "0x" + "11" * 32
+
+
+def _addr_topic(addr: str) -> HexBytes:
+    return HexBytes("0x" + addr[2:].lower().rjust(64, "0"))
+
+
+def test_parse_settled_amount_with_facilitator_web3_signer():
+    signer = FacilitatorWeb3Signer(private_key=_ANVIL_KEY, rpc_url="http://127.0.0.1:9")
+    assert signer.web3 is signer._w3
+
+    contract_addr = to_checksum_address(BATCH_SETTLEMENT_ADDRESS)
+    receiver = to_checksum_address("0x" + "33" * 20)
+    token = to_checksum_address("0x" + "55" * 20)
+    amount = 999
+
+    settled_abi = next(item for item in BATCH_SETTLEMENT_ABI if item.get("name") == "Settled")
+    log = {
+        "address": contract_addr,
+        "topics": [
+            HexBytes(event_abi_to_log_topic(settled_abi)),
+            _addr_topic(receiver),
+            _addr_topic(token),
+            _addr_topic(signer.address),
+        ],
+        "data": "0x" + encode(["uint128"], [amount]).hex(),
+        "logIndex": 0,
+        "transactionIndex": 0,
+        "transactionHash": HexBytes("0x" + "ab" * 32),
+        "blockHash": HexBytes("0x" + "cd" * 32),
+        "blockNumber": 1,
+    }
+
+    class _Receipt:
+        logs = [log]
+
+    assert _parse_settled_amount(signer, _Receipt(), contract_addr, receiver, token) == "999"

--- a/typescript/.changeset/batch-settle-fail-closed.md
+++ b/typescript/.changeset/batch-settle-fail-closed.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Fail closed when a batch-settlement settle receipt has no positive Settled amount (possible no-op early return).

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/errors.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/errors.ts
@@ -46,6 +46,7 @@ export const ErrSmartWalletDeploymentFailed =
 export const ErrClaimSimulationFailed = "invalid_batch_settlement_evm_claim_simulation_failed";
 export const ErrSettleSimulationFailed = "invalid_batch_settlement_evm_settle_simulation_failed";
 export const ErrNothingToSettle = "invalid_batch_settlement_evm_nothing_to_settle";
+export const ErrSettledEventMismatch = "invalid_batch_settlement_evm_settled_event_mismatch";
 export const ErrRefundPayload = "invalid_batch_settlement_evm_refund_payload";
 export const ErrRefundSimulationFailed = "invalid_batch_settlement_evm_refund_simulation_failed";
 export const ErrRpcReadFailed = "invalid_batch_settlement_evm_rpc_read_failed";

--- a/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/settle.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/facilitator/settle.ts
@@ -108,20 +108,36 @@ export async function executeSettle(
     return await waitAndReturnSettleResponse(signer, tx, network, undefined, {
       failedStatusReason: Errors.ErrSettleTransactionFailed,
       onSuccess: receipt => {
-        let amount = "";
-        if (receipt.logs) {
-          const logs = parseEventLogs({
-            abi: batchSettlementABI,
-            eventName: "Settled",
-            logs: receipt.logs.filter(log => isAddressEqual(log.address, contractAddr)),
-          });
-          const settledLog = logs.find(
-            log =>
-              isAddressEqual(log.args.receiver, receiver) && isAddressEqual(log.args.token, token),
-          );
-          amount = settledLog?.args.amount.toString() ?? "0";
+        const logs = receipt.logs
+          ? parseEventLogs({
+              abi: batchSettlementABI,
+              eventName: "Settled",
+              logs: receipt.logs.filter(log => isAddressEqual(log.address, contractAddr)),
+            })
+          : [];
+        const settledLog = logs.find(
+          log =>
+            isAddressEqual(log.args.receiver, receiver) &&
+            isAddressEqual(log.args.token, token) &&
+            log.args.amount !== undefined &&
+            log.args.amount > 0n,
+        );
+        if (!settledLog || settledLog.args.amount === undefined) {
+          return {
+            success: false,
+            errorReason: Errors.ErrSettledEventMismatch,
+            errorMessage:
+              "settle receipt missing Settled event with positive amount (possible no-op early return)",
+            transaction: tx,
+            network,
+          };
         }
-        return { success: true, transaction: tx, network, amount };
+        return {
+          success: true,
+          transaction: tx,
+          network,
+          amount: settledLog.args.amount.toString(),
+        };
       },
     });
   } catch (e) {

--- a/typescript/packages/mechanisms/evm/test/unit/batch-settlement/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/batch-settlement/facilitator.test.ts
@@ -1190,7 +1190,7 @@ describe("BatchSettlementEvmScheme (Facilitator) — settle routing", () => {
     expect(settleCall?.[0].gas).toBeGreaterThan(0n);
   });
 
-  it("returns zero amount for no-op settle receipts without a Settled event", async () => {
+  it("fails closed for no-op settle receipts without a Settled event", async () => {
     const signer = buildSigner({
       waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success", logs: [] }),
     });
@@ -1204,8 +1204,8 @@ describe("BatchSettlementEvmScheme (Facilitator) — settle routing", () => {
       envelopeSettle(sp as unknown as Record<string, unknown>),
       makeRequirements(),
     );
-    expect(result.success).toBe(true);
-    expect(result.amount).toBe("0");
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(Errors.ErrSettledEventMismatch);
   });
 
   it("returns ErrNothingToSettle without submitting when receiver has no pending settlement", async () => {
@@ -1232,7 +1232,7 @@ describe("BatchSettlementEvmScheme (Facilitator) — settle routing", () => {
     expect(signer.writeContract).not.toHaveBeenCalled();
   });
 
-  it("returns empty amount when settle receipt logs are unavailable", async () => {
+  it("fails closed when settle receipt logs are unavailable", async () => {
     const signer = buildSigner();
     const scheme = new BatchSettlementEvmScheme(signer, authorizer);
     const sp: BatchSettlementSettlePayload = {
@@ -1244,8 +1244,8 @@ describe("BatchSettlementEvmScheme (Facilitator) — settle routing", () => {
       envelopeSettle(sp as unknown as Record<string, unknown>),
       makeRequirements(),
     );
-    expect(result.success).toBe(true);
-    expect(result.amount).toBe("");
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe(Errors.ErrSettledEventMismatch);
   });
 
   it("returns settlement_pending when the settle receipt wait fails", async () => {


### PR DESCRIPTION
## Summary
- On-chain `settle` early-returns with receipt status success and **no** `Settled` event when a concurrent settle already drained pending funds (`amount == 0`).
- Facilitators previously returned `success: true` with `amount` `"0"` / `""` (TS/Python) or success with no amount (Go), which can unlock merchant fulfillment after a no-op.
- Require a positive matching `Settled` event (TypeScript + Python) or an advanced `receivers.totalSettled` (Go). New error: `invalid_batch_settlement_evm_settled_event_mismatch`.

Same class as the open Permit2 / EIP-3009 Transfer-event settle checks.

## Test plan
- [x] `pnpm exec vitest run test/unit/batch-settlement/facilitator.test.ts` in `@x402/evm` (48 passed), including fail-closed cases for empty logs / missing Settled
- [x] `go test ./mechanisms/evm/batch-settlement/facilitator/ -run ExecuteSettle` (includes `FailsClosedWhenTotalSettledUnchanged`)


Made with [Cursor](https://cursor.com)