### PR TITLE
fix(extensions): stop misattributing bazaar ajv compile failures on Workers

### DIFF
--- a/typescript/.changeset/hono-bazaar-ajv-workers.md
+++ b/typescript/.changeset/hono-bazaar-ajv-workers.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": patch
+---
+
+Fix bazaar extension schema validation logging a misleading per-route "invalid bazaar extension" warning (plus an Ajv compile error) on JS runtimes that forbid dynamic code generation, such as Cloudflare Workers. `validateDiscoveryExtension` now reports this as `unavailable` rather than `valid: false`, and `validateBazaarRouteExtensions` (used by `@x402/hono`, `@x402/express`, `@x402/fastify`, and `@x402/next`) emits a single one-time notice and skips further schema checks instead of repeating the error for every gated route.

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -288,6 +288,26 @@ export function sanitizeResourceServiceMetadata(
 export interface ValidationResult {
   valid: boolean;
   errors?: string[];
+  /**
+   * True when validation could not run because the current JS runtime forbids
+   * dynamic code generation (e.g. Cloudflare Workers), rather than because the
+   * schema itself is invalid. Callers should not treat this the same as an
+   * actually-invalid extension.
+   */
+  unavailable?: boolean;
+}
+
+/**
+ * Detects Ajv's "code generation from strings disallowed" failure, which occurs
+ * when `ajv.compile()` runs in a JS runtime that forbids `new Function()` (e.g.
+ * Cloudflare Workers). This is an environment limitation, not a schema problem.
+ *
+ * @param error - The error thrown by `ajv.compile()`
+ * @returns True if the error indicates dynamic code generation is unavailable
+ */
+function isCodeGenerationDisallowedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /code generation from strings disallowed|unsafe-eval/i.test(message);
 }
 
 /**
@@ -372,6 +392,15 @@ export function validateDiscoveryExtension(extension: DiscoveryExtension): Valid
 
     return { valid: false, errors };
   } catch (error) {
+    if (isCodeGenerationDisallowedError(error)) {
+      return {
+        valid: false,
+        unavailable: true,
+        errors: [
+          "Schema validation is unavailable in this runtime (dynamic code generation is disallowed)",
+        ],
+      };
+    }
     return {
       valid: false,
       errors: [

--- a/typescript/packages/extensions/src/bazaar/startupValidation.ts
+++ b/typescript/packages/extensions/src/bazaar/startupValidation.ts
@@ -14,6 +14,13 @@ export { checkIfBazaarNeeded } from "@x402/core/server";
 const HTTP_VERB_RE = /^(GET|POST|PUT|PATCH|DELETE|HEAD)\b/i;
 
 /**
+ * Tracks whether we've already warned, for this process, that bazaar schema
+ * validation is unavailable (e.g. because dynamic code generation is disallowed
+ * on Cloudflare Workers). Prevents emitting the same notice once per route.
+ */
+let warnedSchemaValidationUnavailable = false;
+
+/**
  * Inject a synthetic method into a pre-enrichment extension so the schema's
  * required:["method"] check doesn't produce a false-positive warning at startup.
  * Priority: (1) route pattern verb (e.g. "GET /api"), (2) body vs query inference.
@@ -71,6 +78,21 @@ export function validateBazaarRouteExtensions(routes: RoutesConfig): void {
       const schemaResult = validateDiscoveryExtension(
         extForSchema as unknown as DiscoveryExtension,
       );
+      if (schemaResult.unavailable) {
+        // The runtime forbids dynamic code generation (e.g. Cloudflare Workers), so
+        // schema validation cannot run for any route here. This is an environment
+        // limitation, not a sign the schemas are invalid, so warn once and stop
+        // trying rather than repeating the same per-route noise.
+        if (!warnedSchemaValidationUnavailable) {
+          console.warn(
+            "x402: Bazaar extension schema validation is unavailable in this runtime " +
+              "(dynamic code generation is disallowed); skipping schema checks. " +
+              "Extensions are not affected and will still be served as declared.",
+          );
+          warnedSchemaValidationUnavailable = true;
+        }
+        return;
+      }
       if (!schemaResult.valid) {
         console.warn(
           `x402: Route "${pattern}" has an invalid bazaar extension: ${schemaResult.errors?.join(", ")}`,

--- a/typescript/packages/extensions/src/bazaar/startupValidation.ts
+++ b/typescript/packages/extensions/src/bazaar/startupValidation.ts
@@ -91,7 +91,7 @@ export function validateBazaarRouteExtensions(routes: RoutesConfig): void {
           );
           warnedSchemaValidationUnavailable = true;
         }
-        return;
+        continue;
       }
       if (!schemaResult.valid) {
         console.warn(

--- a/typescript/packages/extensions/test/bazaarSchemaValidationUnavailable.test.ts
+++ b/typescript/packages/extensions/test/bazaarSchemaValidationUnavailable.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Simulates Cloudflare Workers (`workerd`), which forbids `new Function()` and
+// therefore makes Ajv's `compile()` throw instead of returning a validator.
+// See https://github.com/x402-foundation/x402/issues/3029
+vi.mock("ajv/dist/2020.js", () => {
+  return {
+    default: class MockAjv {
+      /** Mimics Ajv throwing when `new Function()` is disallowed. */
+      compile() {
+        throw new Error("Code generation from strings disallowed for this context");
+      }
+    },
+  };
+});
+
+describe("bazaar schema validation on runtimes without dynamic code generation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("validateDiscoveryExtension reports `unavailable` instead of `valid: false` for schema reasons", async () => {
+    const { validateDiscoveryExtension } = await import("../src/bazaar/facilitator");
+
+    const result = validateDiscoveryExtension({
+      info: { input: { type: "http", method: "GET" } },
+      schema: { type: "object" },
+    } as never);
+
+    expect(result.valid).toBe(false);
+    expect(result.unavailable).toBe(true);
+  });
+
+  it("validateBazaarRouteExtensions warns once for the whole call, not once per route", async () => {
+    const { validateBazaarRouteExtensions } = await import("../src/bazaar/startupValidation");
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const routeExtension = {
+      info: { input: { type: "http", method: "GET" } },
+      schema: { type: "object" },
+    };
+    const routes = {
+      "GET /a": {
+        accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+        extensions: { bazaar: routeExtension },
+      },
+      "GET /b": {
+        accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+        extensions: { bazaar: routeExtension },
+      },
+      "GET /c": {
+        accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+        extensions: { bazaar: routeExtension },
+      },
+    };
+
+    validateBazaarRouteExtensions(routes);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toContain("unavailable in this runtime");
+    spy.mockRestore();
+  });
+});

--- a/typescript/packages/extensions/test/bazaarSchemaValidationUnavailable.test.ts
+++ b/typescript/packages/extensions/test/bazaarSchemaValidationUnavailable.test.ts
@@ -60,4 +60,35 @@ describe("bazaar schema validation on runtimes without dynamic code generation",
     expect(spy.mock.calls[0][0]).toContain("unavailable in this runtime");
     spy.mockRestore();
   });
+
+  it("still runs non-schema checks on routes after the first schema-unavailable warning", async () => {
+    const { validateBazaarRouteExtensions } = await import("../src/bazaar/startupValidation");
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const validExtension = {
+      info: { input: { type: "http", method: "GET" } },
+      schema: { type: "object" },
+    };
+    const routes = {
+      "GET /a": {
+        accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+        extensions: { bazaar: validExtension },
+      },
+      "GET /b": {
+        accepts: [{ scheme: "exact", payTo: "0x1", price: "$0.01", network: "eip155:1" as const }],
+        // Malformed: missing "schema" field entirely, so this should hit the
+        // "declares a bazaar extension but it is malformed" branch, which is
+        // pure JS and unaffected by the ajv-unavailable condition on /a.
+        extensions: { bazaar: { info: { input: { type: "http", method: "GET" } } } },
+      },
+    };
+
+    validateBazaarRouteExtensions(routes);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.mock.calls[0][0]).toContain("unavailable in this runtime");
+    expect(spy.mock.calls[1][0]).toContain('Route "GET /b"');
+    expect(spy.mock.calls[1][0]).toContain("malformed");
+    spy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Description

Fixes #3029.

On Cloudflare Workers (`workerd`), `new Function()` is disallowed, so `ajv.compile()` throws when `validateBazaarRouteExtensions()` runs eagerly at route-config time (this eager call site is shared by `@x402/hono`, `@x402/express`, `@x402/fastify`, and `@x402/next`). The failure was caught and reported per-route as "invalid bazaar extension", which misattributes an environment limitation as a schema authoring bug and floods logs (~1 warn/error pair per gated route per isolate).

This PR:

- Adds a check in `validateDiscoveryExtension` (`@x402/extensions`) to detect Ajv's "code generation from strings disallowed" failure and report it as `unavailable: true` in the `ValidationResult`, distinct from an actually-invalid schema.
- Updates `validateBazaarRouteExtensions` to emit a single one-time notice for the whole process when this happens, and skip further schema validation for remaining routes, instead of repeating the misleading warn/error pair per route.
- Extensions are unaffected — they still ship exactly as declared; only the startup-time schema *check* is skipped when it can't run.

This corresponds to option 1 + 3 from the issue's suggested fixes (guard the AJV path and distinguish "validator could not run" from "schema is invalid", emitted once per process).

## Tests

- Added `typescript/packages/extensions/test/bazaarSchemaValidationUnavailable.test.ts`, which mocks `ajv/dist/2020.js` to throw the same error `workerd` produces, and verifies:
  - `validateDiscoveryExtension` returns `unavailable: true` (not just `valid: false`) for this case.
  - `validateBazaarRouteExtensions` warns exactly once across a config with multiple gated routes carrying the extension, instead of once per route.
- Ran `pnpm vitest run` in `typescript/packages/extensions` — all pre-existing tests pass (138 tests incl. the 2 new ones); one unrelated pre-existing failure in `test/integrations/builder-code.test.ts` reproduces identically on `main` without this change.
- `pnpm run build` succeeds.
- `pnpm exec eslint` clean on changed/added files.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes (`typescript/.changeset/hono-bazaar-ajv-workers.md`, `@x402/extensions` patch)

---

**AI disclosure:** drafted with an AI coding assistant. Reviewed by me by actually running the extensions test suite (138 tests, including the 2 new ones) rather than relying on generated assertions alone.