### PR TITLE
docs(core): document PaymentPayloadResult's intentional partial shape

### DIFF
--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -38,6 +38,14 @@ export type MoneyParser = (amount: number, network: Network) => Promise<AssetAmo
  * Contains the x402 version, scheme-specific payload data, and optional extension data.
  * Schemes may return extensions (e.g., EIP-2612 gas sponsoring) that get merged
  * with server-declared extensions in the final PaymentPayload.
+ *
+ * This type intentionally omits `accepted` (the `PaymentRequirements` the payload
+ * satisfies). The scheme already received `paymentRequirements` as an argument, so
+ * `x402Client.createPaymentPayload()` merges it back in (as `accepted`) after calling
+ * the scheme, producing the full `PaymentPayload`. Code that calls a scheme's
+ * `createPaymentPayload()` directly instead of going through `x402Client` must add
+ * `accepted: paymentRequirements` itself before treating the result as a `PaymentPayload`
+ * (e.g. before passing it to a facilitator's `verify()`/`settle()`).
  */
 export type PaymentPayloadResult = Pick<PaymentPayload, "x402Version" | "payload"> & {
   extensions?: Record<string, unknown>;
@@ -63,6 +71,17 @@ export interface SchemeNetworkClient {
   readonly scheme: string;
   readonly schemeHooks?: SchemeClientHooks;
 
+  /**
+   * Builds the scheme-specific portion of a payment payload for the given requirements.
+   *
+   * Returns a {@link PaymentPayloadResult}, not a full `PaymentPayload` — it does not
+   * include `accepted`. Prefer calling `x402Client.createPaymentPayload()` instead of
+   * invoking a scheme's `createPaymentPayload()` directly; the client orchestrator
+   * merges `accepted: paymentRequirements` into the result for you. If you do call this
+   * method directly (e.g. to test a facilitator or scheme in isolation), you are
+   * responsible for adding `accepted: paymentRequirements` yourself before using the
+   * result as a `PaymentPayload`.
+   */
   createPaymentPayload(
     x402Version: number,
     paymentRequirements: PaymentRequirements,

--- a/typescript/packages/core/src/types/mechanisms.ts
+++ b/typescript/packages/core/src/types/mechanisms.ts
@@ -40,12 +40,15 @@ export type MoneyParser = (amount: number, network: Network) => Promise<AssetAmo
  * with server-declared extensions in the final PaymentPayload.
  *
  * This type intentionally omits `accepted` (the `PaymentRequirements` the payload
- * satisfies). The scheme already received `paymentRequirements` as an argument, so
- * `x402Client.createPaymentPayload()` merges it back in (as `accepted`) after calling
- * the scheme, producing the full `PaymentPayload`. Code that calls a scheme's
- * `createPaymentPayload()` directly instead of going through `x402Client` must add
- * `accepted: paymentRequirements` itself before treating the result as a `PaymentPayload`
- * (e.g. before passing it to a facilitator's `verify()`/`settle()`).
+ * satisfies) and `resource` (the `ResourceInfo` from `PaymentRequired`). The scheme
+ * already received `paymentRequirements` as an argument, so for x402 v2,
+ * `x402Client.createPaymentPayload()` fills both back in (`accepted` and `resource`)
+ * after calling the scheme, producing the full `PaymentPayload`. v1 payloads are
+ * passed through unchanged and carry no `accepted` or `resource`. Code that calls a
+ * scheme's `createPaymentPayload()` directly instead of going through `x402Client`
+ * must add `accepted: paymentRequirements` (and `resource`, for v2) itself before
+ * treating the result as a `PaymentPayload` (e.g. before passing it to a
+ * facilitator's `verify()`/`settle()`).
  */
 export type PaymentPayloadResult = Pick<PaymentPayload, "x402Version" | "payload"> & {
   extensions?: Record<string, unknown>;


### PR DESCRIPTION
## Description

`PaymentPayloadResult` (and `SchemeNetworkClient.createPaymentPayload()`) return only the core payload fields — `x402Version`, `payload`, and optional `extensions` — never `accepted`. This is intentional: the caller already holds `paymentRequirements`, and `x402Client.createPaymentPayload()` merges it back in as `accepted` to produce a full `PaymentPayload`. That behavior wasn't documented anywhere, so anyone calling a scheme's `createPaymentPayload()` directly (e.g. to test a facilitator or scheme in isolation) had no indication why the result is missing `accepted` when passed to `facilitator.verify()`/`.settle()`.

This is a documentation-only change to `typescript/packages/core/src/types/mechanisms.ts`:

- `PaymentPayloadResult`'s JSDoc now explains `accepted` is intentionally omitted, and why.
- `SchemeNetworkClient.createPaymentPayload()` now has a JSDoc comment pointing direct callers to `x402Client.createPaymentPayload()`, and stating that direct callers must add `accepted: paymentRequirements` themselves.

No runtime behavior changes. Fix lands once at the `@x402/core` type level, so all mechanism packages (`@x402/evm`, `@x402/stellar`, `@x402/svm`, etc.) inherit it automatically.

Closes #2763

## Tests

- `pnpm exec eslint src/types/mechanisms.ts` — clean
- `pnpm exec tsc --noEmit` — no new errors
- `pnpm exec prettier --check src/types/mechanisms.ts` — passes

No behavior changed, so no new tests were needed.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

---

**AI disclosure:** drafted with an AI coding assistant. Every claim in the new doc comment was checked by hand against the real client merge logic, including the v1-passthrough and `resource`-omission edge cases a first pass missed.