### PR TITLE
fix(go): compile route patterns with (?s) so wildcards match line feeds

### DIFF
--- a/go/.changes/unreleased/fixed-20260808-160500.yaml
+++ b/go/.changes/unreleased/fixed-20260808-160500.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: 'Compile route patterns with the (?s) flag so wildcard-derived `.*?` matches a line feed: normalizePath decodes %0A to a raw LF inside a segment, and without (?s) a wildcard route missed such a path while routers still dispatched it to the protected handler, skipping payment verification (Go counterpart of the TypeScript #3036 and Python #3055 dotAll fixes)'
+time: 2026-08-08T16:05:00.000000-07:00

--- a/go/http/server.go
+++ b/go/http/server.go
@@ -1238,8 +1238,12 @@ func parseRoutePattern(pattern string) (string, string, *regexp.Regexp) {
 		path = pattern
 	}
 
-	// Convert pattern to regex
-	regexPattern := "^" + regexp.QuoteMeta(path)
+	// Convert pattern to regex. The (?s) flag lets wildcard-derived `.*?` match
+	// a line feed: normalizePath decodes "%0A" to a raw LF inside a segment, and
+	// without (?s) a wildcard route misses such a path while routers still
+	// dispatch it to the protected handler, skipping payment verification
+	// (Go counterpart of the TypeScript dotAll fix).
+	regexPattern := "(?s)^" + regexp.QuoteMeta(path)
 
 	// A trailing "/*" must also match the bare prefix. normalizePath strips the
 	// trailing slash, so a request for "/api/premium/" arrives as "/api/premium",

--- a/go/http/server_test.go
+++ b/go/http/server_test.go
@@ -1033,6 +1033,17 @@ func TestRouteMatching_PathNormalizationBypass(t *testing.T) {
 		{"wildcard trailing slash", "GET /api/premium/*", "/api/premium/", true},
 		{"wildcard bare prefix", "GET /api/premium/*", "/api/premium", true},
 		{"wildcard deep path", "GET /api/premium/*", "/api/premium/a/b/c", true},
+		// normalizePath decodes %0A to a raw LF inside the segment. RE2's `.`
+		// does not match LF without (?s), so these missed the wildcard while
+		// routers still dispatched the handler — payment bypass (CWE-436),
+		// Go counterpart of the TypeScript/Python dotAll fixes.
+		{"wildcard encoded LF", "GET /api/premium/*", "/api/premium/a%0Ab", true},
+		{"wildcard trailing encoded LF", "GET /api/premium/*", "/api/premium/report%0A", true},
+		{"wildcard LF in deep path", "GET /api/premium/*", "/api/premium/a%0A/b", true},
+		// RE2's `.` excludes only \n; CR already matched before the (?s) fix.
+		{"wildcard encoded CR", "GET /api/premium/*", "/api/premium/a%0Db", true},
+		// Params compile to [^/]+, which matches LF regardless of (?s).
+		{"param encoded LF", "GET /api/users/:id", "/api/users/x%0Ay", true},
 		// The wildcard must not leak onto a sibling prefix.
 		{"wildcard sibling prefix", "GET /api/premium/*", "/api/premiumx", false},
 		{"wildcard unrelated", "GET /api/premium/*", "/api/other", false},


### PR DESCRIPTION
## Description

The Go HTTP server compiles each route pattern to a regex where `*` becomes `.*?`.
RE2's `.` does not match a line feed, and `normalizePath` decodes `%0A` to a raw LF
inside a segment (only `/` and `\` are re-escaped). A wildcard route such as
`GET /api/premium/*` therefore fails to match a request path whose wildcard tail
contains a decoded line feed: `getRouteConfig()` finds no route, `RequiresPayment()`
returns false, and the protected resource is served with no payment verification —
while string-based framework routing still dispatches the handler.

This is the Go counterpart of the TypeScript fix in #3036 (dotAll flag) and the
Python fix in #3055 (`re.DOTALL`). The Go surface is narrower than the TS one:
RE2's `.` excludes only `\n`, so CR and U+2028/U+2029 already matched; the bypass
is LF-only. Parameter routes compile to `[^/]+`, which matches LF regardless, so
only wildcard routes were affected.

Root cause: `parseRoutePattern` (`go/http/server.go:1246`) compiled the pattern
without the `(?s)` flag.

## Fix

Prefix `(?s)` to the compiled pattern (one line), mirroring #3036/#3055. New rows
in `TestRouteMatching_PathNormalizationBypass` cover encoded LF in a wildcard tail,
trailing position, and a deep path — each confirmed to fail before the fix and pass
after — plus rows documenting that CR and parameter routes were unaffected.

## Tests

- `go test ./http/ -run TestRouteMatching_PathNormalizationBypass` — 3 new LF rows
  fail at HEAD, pass with the fix
- `make fmt && make lint && make build && make test` — clean

Disclosure: drafted with AI assistance (Claude Code); human-reviewed.
