### PR TITLE
fix(evm): classify reverted verify simulations in Go and TypeScript (Python parity)

### DIFF
--- a/go/.changes/unreleased/fixed-20260808-225239.yaml
+++ b/go/.changes/unreleased/fixed-20260808-225239.yaml
@@ -1,0 +1,3 @@
+kind: fixed
+body: 'Bring the Go exact/EVM verify path to parity with Python: when the EIP-3009 transfer simulation fails, classify an on-chain revert through parseEIP3009TransferError (guarded by evm.IsContractRevert) before falling back to the diagnostic probe, instead of returning invalid_exact_evm_transaction_simulation_failed for every simulation failure. That code reports a payload that is valid but whose simulation could not run, so a caller may retry it; a revert is terminal and the same payload is rejected on every attempt. The diagnostic probe now runs only when the node answered, so a transport failure no longer triggers four more reads down the same dead path.'
+time: 2026-08-08T22:52:39.000000+09:00

--- a/go/mechanisms/evm/exact/facilitator/eip3009.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009.go
@@ -122,27 +122,46 @@ func (f *ExactEvmScheme) verifyEIP3009(
 	}
 
 	if simulate {
-		simulationSucceeded, err := SimulateEIP3009Transfer(
+		simulationSucceeded, simErr := SimulateEIP3009Transfer(
 			ctx,
 			f.signer,
 			tokenAddress,
 			parsedAuthorization,
 			classification.SigData,
 		)
-		if err != nil {
-			return nil, x402.NewVerifyError(ErrEip3009SimulationFailed, evmPayload.Authorization.From, err.Error())
-		}
-		if !simulationSucceeded {
-			reason := DiagnoseEIP3009SimulationFailure(
-				ctx,
-				f.signer,
-				tokenAddress,
-				evmPayload.Authorization,
-				requiredValue,
-				tokenName,
-				tokenVersion,
-			)
-			return nil, x402.NewVerifyError(reason, evmPayload.Authorization.From, "")
+		if simErr != nil || !simulationSucceeded {
+			// Prefer the concrete on-chain revert reason the simulation surfaced (e.g.
+			// insufficient balance / used nonce) over the opaque generic code. Fall back
+			// to a diagnostic probe only when the revert could not be classified.
+			// ErrEip3009SimulationFailed reports that the payload was valid but the
+			// simulation could not run, so a caller may retry it; a revert is terminal and
+			// must not share that code. Mirrors the Python facilitator.
+			reason := ErrEip3009SimulationFailed
+			reverted := evm.IsContractRevert(simErr)
+			if reverted {
+				if mapped := parseEIP3009TransferError(simErr); mapped != ErrFailedToExecuteTransfer {
+					reason = mapped
+				}
+			}
+			// Probe only when the node answered: either the call reverted, or the simulation
+			// reported failure without an error at all. Probing after a transport failure
+			// sends four more reads down the same dead path.
+			if reason == ErrEip3009SimulationFailed && (reverted || simErr == nil) {
+				reason = DiagnoseEIP3009SimulationFailure(
+					ctx,
+					f.signer,
+					tokenAddress,
+					evmPayload.Authorization,
+					requiredValue,
+					tokenName,
+					tokenVersion,
+				)
+			}
+			message := ""
+			if simErr != nil {
+				message = simErr.Error()
+			}
+			return nil, x402.NewVerifyError(reason, evmPayload.Authorization.From, message)
 		}
 	}
 

--- a/go/mechanisms/evm/exact/facilitator/eip3009_verify_simulation_reason_test.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_verify_simulation_reason_test.go
@@ -1,0 +1,165 @@
+package facilitator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	x402 "github.com/x402-foundation/x402/go/v2"
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+// contractPayerMockSigner models a deployed ERC-1271 payer whose off-chain signature check
+// succeeds, so verify reaches the transfer simulation. simulateErr is what the simulated
+// transferWithAuthorization returns: either an on-chain revert (terminal) or a transport
+// failure (retryable). diagnosticCalls counts the diagnostic probe's multicall.
+type contractPayerMockSigner struct {
+	simulateErr     error
+	diagnosticCalls int
+}
+
+func (m *contractPayerMockSigner) GetAddresses() []string { return []string{"0xFac11"} }
+
+func (m *contractPayerMockSigner) ReadContract(ctx context.Context, address string, abi []byte, functionName string, args ...interface{}) (interface{}, error) {
+	switch functionName {
+	case "isValidSignature":
+		// The payer's own validator accepts the signature: this is a valid ERC-1271 payer.
+		return [4]byte{0x16, 0x26, 0xba, 0x7e}, nil
+	case evm.FunctionTransferWithAuthorization:
+		return nil, m.simulateErr
+	case evm.FunctionTryAggregate:
+		m.diagnosticCalls++
+		return nil, m.simulateErr
+	}
+	return nil, nil
+}
+
+func (m *contractPayerMockSigner) VerifyTypedData(ctx context.Context, address string, domain evm.TypedDataDomain, types map[string][]evm.TypedDataField, primaryType string, message map[string]interface{}, signature []byte) (bool, error) {
+	return false, nil
+}
+
+func (m *contractPayerMockSigner) WriteContract(ctx context.Context, address string, abi []byte, functionName string, dataSuffix []byte, args ...interface{}) (string, error) {
+	return "0x" + strings.Repeat("ab", 32), nil
+}
+
+func (m *contractPayerMockSigner) SendTransaction(ctx context.Context, to string, data []byte) (string, error) {
+	return "0x" + strings.Repeat("cd", 32), nil
+}
+
+func (m *contractPayerMockSigner) WaitForTransactionReceipt(ctx context.Context, txHash string) (*evm.TransactionReceipt, error) {
+	return &evm.TransactionReceipt{Status: evm.TxStatusSuccess, TxHash: txHash}, nil
+}
+
+func (m *contractPayerMockSigner) GetBalance(ctx context.Context, address string, tokenAddress string) (*big.Int, error) {
+	return big.NewInt(1_000_000_000), nil
+}
+
+func (m *contractPayerMockSigner) GetChainID(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(84532), nil
+}
+
+func (m *contractPayerMockSigner) GetCode(ctx context.Context, address string) ([]byte, error) {
+	// Both the payer and the asset are deployed contracts.
+	return []byte{0x60, 0x60}, nil
+}
+
+// contractPayerPayload builds a payment from a deployed smart-account payer. The signature is
+// deliberately not 65 bytes so it is classified as a smart-wallet signature and verified via
+// ERC-1271 rather than ecrecover.
+func contractPayerPayload(t *testing.T) (types.PaymentPayload, types.PaymentRequirements) {
+	t.Helper()
+	const (
+		payer = "0x4906Ae16bBCb3b366F82F7E4a612bd764B4B315D"
+		payTo = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0"
+		token = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+	)
+	p := &evm.ExactEIP3009Payload{
+		Signature: "0x" + strings.Repeat("77", 96),
+		Authorization: evm.ExactEIP3009Authorization{
+			From:        payer,
+			To:          payTo,
+			Value:       "1000000",
+			ValidAfter:  "0",
+			ValidBefore: fmt.Sprintf("%d", time.Now().Unix()+3600),
+			Nonce:       "0x" + strings.Repeat("22", 32),
+		},
+	}
+	requirements := types.PaymentRequirements{
+		Scheme:  "exact",
+		Network: "eip155:84532",
+		Amount:  "1000000",
+		Asset:   token,
+		PayTo:   payTo,
+		Extra:   map[string]interface{}{"name": "USDC", "version": "2"},
+	}
+	return types.PaymentPayload{X402Version: 2, Payload: p.ToMap(), Accepted: requirements}, requirements
+}
+
+// verifyReasonFor runs verify with the given simulation error and returns the reported reason
+// along with the signer, so callers can assert on whether the diagnostic probe ran.
+func verifyReasonFor(t *testing.T, simulateErr error) (string, *contractPayerMockSigner) {
+	t.Helper()
+	payload, requirements := contractPayerPayload(t)
+	signer := &contractPayerMockSigner{simulateErr: simulateErr}
+	scheme := NewExactEvmScheme(signer, &ExactEvmSchemeConfig{})
+
+	_, err := scheme.Verify(context.Background(), payload, requirements, nil)
+	if err == nil {
+		t.Fatalf("expected verify to fail, got success")
+	}
+	ve := &x402.VerifyError{}
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *x402.VerifyError, got %T: %v", err, err)
+	}
+	return ve.InvalidReason, signer
+}
+
+// A token whose transferWithAuthorization verifies with ecrecover only rejects every contract
+// payer: no retry, no funding and no configuration change makes this payment succeed. The
+// on-chain revert reason says so, and settle already maps that reason to ErrInvalidSignature
+// through parseEIP3009TransferError. Verify must report the same terminal reason.
+func TestVerifyEIP3009_RevertedSimulationReportsTheRevertsOwnReason(t *testing.T) {
+	reason, _ := verifyReasonFor(t, errors.New("execution reverted: EIP3009: invalid signature"))
+
+	if reason == ErrEip3009SimulationFailed {
+		t.Fatalf("terminal on-chain rejection reported as %q, the code #2062 introduced for "+
+			"payloads that are valid but whose simulation could not run; callers cannot tell it "+
+			"apart from a transport failure and will retry a payment that can never succeed",
+			reason)
+	}
+	if reason != ErrInvalidSignature {
+		t.Fatalf("expected %q, got %q", ErrInvalidSignature, reason)
+	}
+}
+
+// A transport failure says nothing about the payload, so the retryable code stays correct — and
+// the diagnostic probe must not run, since it would send four more reads down the same dead path.
+func TestVerifyEIP3009_TransportFailureKeepsRetryableReasonWithoutProbing(t *testing.T) {
+	reason, signer := verifyReasonFor(t, errors.New("dial tcp 10.0.0.1:8545: connect: connection refused"))
+
+	if reason != ErrEip3009SimulationFailed {
+		t.Fatalf("expected %q for a transport failure, got %q", ErrEip3009SimulationFailed, reason)
+	}
+	if signer.diagnosticCalls != 0 {
+		t.Fatalf("diagnostic probe ran %d time(s) after a transport failure; the node is "+
+			"already unreachable, so the probe cannot answer either", signer.diagnosticCalls)
+	}
+}
+
+// A revert whose reason no parser recognises still deserves the probe: the node answered, so the
+// diagnostic reads can run and may identify a used nonce or an insufficient balance.
+func TestVerifyEIP3009_UnrecognisedRevertStillProbes(t *testing.T) {
+	reason, signer := verifyReasonFor(t, errors.New("execution reverted: Pausable: paused"))
+
+	if signer.diagnosticCalls == 0 {
+		t.Fatalf("diagnostic probe did not run for a revert the parser could not classify")
+	}
+	if reason != ErrEip3009SimulationFailed {
+		t.Fatalf("expected the probe to fall through to %q, got %q", ErrEip3009SimulationFailed, reason)
+	}
+}

--- a/typescript/.changeset/classify-reverted-verify-simulation.md
+++ b/typescript/.changeset/classify-reverted-verify-simulation.md
@@ -1,0 +1,5 @@
+---
+"@x402/evm": patch
+---
+
+Bring the TypeScript exact/EVM verify path to parity with Python: when the EIP-3009 transfer simulation fails, classify an on-chain revert through `parseEip3009TransferError` (guarded by `isContractRevert`) before falling back to the diagnostic probe, instead of letting every simulation failure resolve to `invalid_exact_evm_transaction_simulation_failed`. That code reports a payload that is valid but whose simulation could not run, so a caller may retry it; a revert is terminal and the same payload is rejected on every attempt. Failures that are not recognised reverts keep the existing diagnostic behaviour.

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -12,6 +12,7 @@ import { getEvmChainId } from "../../utils";
 import { ExactEIP3009Payload } from "../../types";
 import * as Errors from "./errors";
 import { resolveDataSuffix } from "../../shared/extensions";
+import { isContractRevert } from "../../shared/revert";
 import { verifyTypedDataSignature, classifyErc6492Payer } from "../../shared/verifySignature";
 import {
   diagnoseEip3009SimulationFailure,
@@ -228,17 +229,31 @@ export async function verifyEIP3009(
       eip6492Deployment,
     );
     if (!ok) {
-      const diagnosis = await diagnoseEip3009SimulationFailure(
-        signer,
-        erc20Address,
-        eip3009Payload,
-        requirements,
-        requirements.amount,
-      );
+      // Prefer the concrete on-chain revert reason the simulation surfaced (e.g. insufficient
+      // balance / used nonce) over the opaque generic code. Fall back to the diagnostic probe
+      // only when the revert could not be classified. ErrEip3009SimulationFailed reports that
+      // the payload was valid but the simulation could not run, so a caller may retry it; a
+      // revert is terminal and must not share that code. Mirrors the Python facilitator.
+      let revertReason: string | undefined;
+      if (isContractRevert(simError)) {
+        const mapped = parseEip3009TransferError(simError);
+        if (mapped !== Errors.ErrTransactionFailed) {
+          revertReason = mapped;
+        }
+      }
+      const response: VerifyResponse = revertReason
+        ? { isValid: false, invalidReason: revertReason, payer }
+        : await diagnoseEip3009SimulationFailure(
+            signer,
+            erc20Address,
+            eip3009Payload,
+            requirements,
+            requirements.amount,
+          );
       // Carry the raw revert text so the concrete reason survives the mapping to a code.
       const rawMessage =
         simError instanceof Error ? simError.message : simError ? String(simError) : undefined;
-      return rawMessage ? { ...diagnosis, invalidMessage: rawMessage } : diagnosis;
+      return rawMessage ? { ...response, invalidMessage: rawMessage } : response;
     }
   }
 

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -234,22 +234,31 @@ export async function verifyEIP3009(
       // only when the revert could not be classified. ErrEip3009SimulationFailed reports that
       // the payload was valid but the simulation could not run, so a caller may retry it; a
       // revert is terminal and must not share that code. Mirrors the Python facilitator.
+      const reverted = isContractRevert(simError);
       let revertReason: string | undefined;
-      if (isContractRevert(simError)) {
+      if (reverted) {
         const mapped = parseEip3009TransferError(simError);
         if (mapped !== Errors.ErrTransactionFailed) {
           revertReason = mapped;
         }
       }
-      const response: VerifyResponse = revertReason
-        ? { isValid: false, invalidReason: revertReason, payer }
-        : await diagnoseEip3009SimulationFailure(
-            signer,
-            erc20Address,
-            eip3009Payload,
-            requirements,
-            requirements.amount,
-          );
+      let response: VerifyResponse;
+      if (revertReason) {
+        response = { isValid: false, invalidReason: revertReason, payer };
+      } else if (reverted || !simError) {
+        // Probe only when the node answered: either the call reverted, or the simulation
+        // reported failure without an error at all. Probing after a transport failure sends
+        // four more reads down the same dead path.
+        response = await diagnoseEip3009SimulationFailure(
+          signer,
+          erc20Address,
+          eip3009Payload,
+          requirements,
+          requirements.amount,
+        );
+      } else {
+        response = { isValid: false, invalidReason: Errors.ErrEip3009SimulationFailed, payer };
+      }
       // Carry the raw revert text so the concrete reason survives the mapping to a code.
       const rawMessage =
         simError instanceof Error ? simError.message : simError ? String(simError) : undefined;

--- a/typescript/packages/mechanisms/evm/test/unit/exact/verify-simulation-reason.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/verify-simulation-reason.test.ts
@@ -15,6 +15,12 @@ const requirements: PaymentRequirements = {
   extra: { name: "USDC", version: "2" },
 };
 
+interface VerifyOutcome {
+  reason: string | undefined;
+  /** How many times the diagnostic probe's multicall ran. */
+  diagnosticCalls: number;
+}
+
 describe("verify: EIP-3009 simulation failure reason", () => {
   let client: ClientExactEvmScheme;
   let mockClientSigner: ClientEvmSigner;
@@ -30,18 +36,19 @@ describe("verify: EIP-3009 simulation failure reason", () => {
 
   /**
    * Runs verify against a deployed ERC-1271 payer whose off-chain signature check passes, so
-   * verify reaches the transfer simulation, and returns the reason it reports.
+   * verify reaches the transfer simulation.
    *
    * @param simulationError - what the simulated transferWithAuthorization throws
-   * @returns the invalidReason verify reports
+   * @returns the reason verify reports and how many times the diagnostic probe ran
    */
-  async function verifyReasonFor(simulationError: Error): Promise<string | undefined> {
+  async function verifyOutcomeFor(simulationError: Error): Promise<VerifyOutcome> {
+    let diagnosticCalls = 0;
     const signer: FacilitatorEvmSigner = {
       getAddresses: vi.fn().mockReturnValue(["0x742D35CC6634c0532925A3b844BC9E7595F0BEb0"]),
       readContract: vi.fn().mockImplementation(async (args: { functionName?: string }) => {
         // The payer's own validator accepts the signature: this is a valid ERC-1271 payer.
         if (args?.functionName === "isValidSignature") return "0x1626ba7e";
-        // Both the simulated transfer and the diagnostic multicall fail the same way.
+        if (args?.functionName === "tryAggregate") diagnosticCalls++;
         throw simulationError;
       }),
       verifyTypedData: vi.fn().mockResolvedValue(true),
@@ -61,7 +68,7 @@ describe("verify: EIP-3009 simulation failure reason", () => {
 
     const response = await facilitator.verify(fullPayload, requirements);
     expect(response.isValid).toBe(false);
-    return response.invalidReason;
+    return { reason: response.invalidReason, diagnosticCalls };
   }
 
   // A token whose transferWithAuthorization verifies with ecrecover only rejects every contract
@@ -69,7 +76,7 @@ describe("verify: EIP-3009 simulation failure reason", () => {
   // on-chain revert reason says so, and settle already maps that reason to ErrInvalidSignature
   // through parseEip3009TransferError. Verify must report the same terminal reason.
   it("reports a reverted simulation with the revert's own reason, not the retryable code", async () => {
-    const reason = await verifyReasonFor(
+    const { reason } = await verifyOutcomeFor(
       new Error("execution reverted: EIP3009: invalid signature"),
     );
 
@@ -77,13 +84,25 @@ describe("verify: EIP-3009 simulation failure reason", () => {
     expect(reason).toBe(Errors.ErrInvalidSignature);
   });
 
-  // The transient case must keep ErrEip3009SimulationFailed: the payload is fine and the
-  // simulation simply could not run, so retrying is the correct client behaviour.
-  it("keeps the retryable code when the simulation could not run", async () => {
-    const reason = await verifyReasonFor(
+  // A transport failure says nothing about the payload, so the retryable code stays correct — and
+  // the probe must not run, since it would send four more reads down the same dead path.
+  it("keeps the retryable code after a transport failure without probing", async () => {
+    const { reason, diagnosticCalls } = await verifyOutcomeFor(
       new Error("dial tcp 10.0.0.1:8545: connect: connection refused"),
     );
 
+    expect(reason).toBe(Errors.ErrEip3009SimulationFailed);
+    expect(diagnosticCalls).toBe(0);
+  });
+
+  // A revert whose reason no parser recognises still deserves the probe: the node answered, so
+  // the diagnostic reads can run and may identify a used nonce or an insufficient balance.
+  it("still probes when the revert reason is not recognised", async () => {
+    const { reason, diagnosticCalls } = await verifyOutcomeFor(
+      new Error("execution reverted: Pausable: paused"),
+    );
+
+    expect(diagnosticCalls).toBeGreaterThan(0);
     expect(reason).toBe(Errors.ErrEip3009SimulationFailed);
   });
 });

--- a/typescript/packages/mechanisms/evm/test/unit/exact/verify-simulation-reason.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/verify-simulation-reason.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ExactEvmScheme } from "../../../src/exact/facilitator/scheme";
+import { ExactEvmScheme as ClientExactEvmScheme } from "../../../src/exact/client/scheme";
+import type { ClientEvmSigner, FacilitatorEvmSigner } from "../../../src/signer";
+import { PaymentRequirements, PaymentPayload } from "@x402/core/types";
+import * as Errors from "../../../src/exact/facilitator/errors";
+
+const requirements: PaymentRequirements = {
+  scheme: "exact",
+  network: "eip155:84532",
+  amount: "1000000",
+  asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  payTo: "0x742D35CC6634c0532925A3b844BC9E7595F0BEb0",
+  maxTimeoutSeconds: 300,
+  extra: { name: "USDC", version: "2" },
+};
+
+describe("verify: EIP-3009 simulation failure reason", () => {
+  let client: ClientExactEvmScheme;
+  let mockClientSigner: ClientEvmSigner;
+
+  beforeEach(() => {
+    mockClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+      readContract: vi.fn().mockResolvedValue(BigInt(0)),
+    };
+    client = new ClientExactEvmScheme(mockClientSigner);
+  });
+
+  /**
+   * Runs verify against a deployed ERC-1271 payer whose off-chain signature check passes, so
+   * verify reaches the transfer simulation, and returns the reason it reports.
+   *
+   * @param simulationError - what the simulated transferWithAuthorization throws
+   * @returns the invalidReason verify reports
+   */
+  async function verifyReasonFor(simulationError: Error): Promise<string | undefined> {
+    const signer: FacilitatorEvmSigner = {
+      getAddresses: vi.fn().mockReturnValue(["0x742D35CC6634c0532925A3b844BC9E7595F0BEb0"]),
+      readContract: vi.fn().mockImplementation(async (args: { functionName?: string }) => {
+        // The payer's own validator accepts the signature: this is a valid ERC-1271 payer.
+        if (args?.functionName === "isValidSignature") return "0x1626ba7e";
+        // Both the simulated transfer and the diagnostic multicall fail the same way.
+        throw simulationError;
+      }),
+      verifyTypedData: vi.fn().mockResolvedValue(true),
+      writeContract: vi.fn().mockResolvedValue("0xtxhash"),
+      sendTransaction: vi.fn().mockResolvedValue("0xtxhash"),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success" }),
+      getCode: vi.fn().mockResolvedValue("0x6080604052"),
+    };
+    const facilitator = new ExactEvmScheme(signer);
+
+    const paymentPayload = await client.createPaymentPayload(2, requirements);
+    const fullPayload: PaymentPayload = {
+      ...paymentPayload,
+      accepted: requirements,
+      resource: { url: "test", description: "", mimeType: "" },
+    };
+
+    const response = await facilitator.verify(fullPayload, requirements);
+    expect(response.isValid).toBe(false);
+    return response.invalidReason;
+  }
+
+  // A token whose transferWithAuthorization verifies with ecrecover only rejects every contract
+  // payer: no retry, no funding and no configuration change makes this payment succeed. The
+  // on-chain revert reason says so, and settle already maps that reason to ErrInvalidSignature
+  // through parseEip3009TransferError. Verify must report the same terminal reason.
+  it("reports a reverted simulation with the revert's own reason, not the retryable code", async () => {
+    const reason = await verifyReasonFor(
+      new Error("execution reverted: EIP3009: invalid signature"),
+    );
+
+    expect(reason).not.toBe(Errors.ErrEip3009SimulationFailed);
+    expect(reason).toBe(Errors.ErrInvalidSignature);
+  });
+
+  // The transient case must keep ErrEip3009SimulationFailed: the payload is fine and the
+  // simulation simply could not run, so retrying is the correct client behaviour.
+  it("keeps the retryable code when the simulation could not run", async () => {
+    const reason = await verifyReasonFor(
+      new Error("dial tcp 10.0.0.1:8545: connect: connection refused"),
+    );
+
+    expect(reason).toBe(Errors.ErrEip3009SimulationFailed);
+  });
+});


### PR DESCRIPTION
## Summary

`ErrEip3009SimulationFailed` carries two incompatible meanings in the EVM `exact` verify path.

#2062 introduced it for a payload that is valid but whose simulation *could not run* — a caller may retry. It is also what verify returns when the simulation *did* run and reverted, which is terminal: the same payload is rejected on every attempt. Callers cannot tell the two apart, so a client that retries on the documented meaning retries a payment that can never succeed.

`settleEIP3009` already maps revert reasons to specific codes through `parseEIP3009TransferError`, and the Python facilitator already applies that classifier in verify. #2658 shipped the revert heuristic to all three SDKs (`evm.IsContractRevert`, `isContractRevert`, `is_contract_revert`) but wired it into the verify path only in Python. This brings Go and TypeScript to that behaviour.

## Changes

Go and TypeScript, on a failed transfer simulation:

1. If the failure is a recognised on-chain revert, report the revert's own code (`parseEIP3009TransferError` / `parseEip3009TransferError`, guarded by the revert heuristic).
2. Otherwise fall back to the existing diagnostic probe.
3. Transport failures keep `ErrEip3009SimulationFailed`.

**One deliberate deviation from Python:** the diagnostic probe now runs only when the node answered — a revert, or a failure the simulation reported without an error. Python probes unconditionally, which after a transport failure sends four more reads down the same unreachable path. Python could adopt the same guard as a follow-up. In TypeScript this also narrows one existing case: a transient failure that previously reached the probe now returns the retryable code without probing.

## Reproduction

Any EIP-3009 token whose `transferWithAuthorization` verifies with `ecrecover` only rejects every contract payer, regardless of configuration. The `exact` scheme supports arbitrary EIP-3009 assets, and such a token is in production use today: JPYC on Polygon (`0xe7c3d8c9a439fede00d2600032d5db0be71c3c29`), whose implementation contains no `isValidSignature`, `SignatureChecker` or ERC-1271 reference.

Against a mainnet fork, with a minimal ERC-1271 stub as the payer, funded, nonce unused, name matching:

```
isValidSignature(hash, sig)      -> 0x1626ba7e     # off-chain check accepts the payer
balanceOf(payer)                 -> 1000e18        # no ErrInsufficientBalance
name()                           -> "JPY Coin"     # no ErrEip3009TokenNameMismatch
authorizationState(payer, nonce) -> false          # no ErrNonceAlreadyUsed
transferWithAuthorization(...)   -> revert: EIP3009: invalid signature
```

Every diagnostic probe passes and only the simulation fails, so before this change verify reported the retryable code and nothing else.

To reproduce with foundry alone, no funds and no API keys: fork Polygon, deploy the 16-byte stub `0x631626ba7e60e01b60005260206000f3` (returns the ERC-1271 magic value for any input) as the payer, set its balance with `anvil_setStorageAt` on `cast index address <stub> 516`, then `cast call` the four probes and the transfer above.

The default assets are not affected: probing all nine reachable mainnet EIP-3009 entries in `DEFAULT_STABLECOINS` (USDC on Base/Polygon/Arbitrum/Celo/Monad, USDT0 on Flare/Stable, Bridged USDC on XDC/HPP) with the same stub shows all of them code-route. The exposure is in the arbitrary-asset path.

## Observed, not changed

Pre-existing differences found while working on this. Each would also change settle's classification, so they are out of scope here:

- Go's `parseEIP3009TransferError` matches case-sensitively; the TypeScript and Python parsers do not.
- TypeScript's patterns are broader than Go's and Python's (`insufficient.*balance`, `valid before`).
- The default code for an unrecognised transfer error differs on the wire: Go `invalid_exact_evm_failed_to_execute_transfer`, TypeScript `invalid_exact_evm_transaction_failed`.

## Test plan

Three cases per SDK, each covering a distinct branch:

- a classified revert reports the revert's code, not the retryable one;
- a transport failure keeps the retryable code and does not probe;
- an unrecognised revert still probes.

Each was confirmed to fail with the fix reverted. `go test ./...` passes with `go vet` clean; `vitest run` passes 829 tests in `@x402/evm` with `lint:check` clean. The Python facilitator is unchanged.

---

*Disclosure per CONTRIBUTING: written with significant AI assistance under human direction and review. The defect was located by reading the merged Python implementation and #2062/#2658 rather than from memory, the reproduction was run against a Polygon mainnet fork, and each test was confirmed to fail with the fix reverted.*
