### PR TITLE
fix(evm): correct Monad USDC EIP-712 domain name to "USDC" (#3102)

### DIFF
--- a/go/mechanisms/evm/constants.go
+++ b/go/mechanisms/evm/constants.go
@@ -142,7 +142,7 @@ var (
 			ChainID: ChainIDMonad,
 			DefaultAsset: AssetInfo{
 				Address:  "0x754704Bc059F8C67012fEd69BC8A327a5aafb603", // USDC on Monad
-				Name:     "USD Coin",
+				Name:     "USDC",
 				Version:  "2",
 				Decimals: DefaultDecimals,
 			},

--- a/python/x402/mechanisms/evm/constants.py
+++ b/python/x402/mechanisms/evm/constants.py
@@ -435,7 +435,7 @@ NETWORK_CONFIGS: dict[str, NetworkConfig] = {
         "chain_id": 143,
         "default_asset": {
             "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
-            "name": "USD Coin",
+            "name": "USDC",
             "version": "2",
             "decimals": 6,
         },

--- a/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
+++ b/typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts
@@ -63,7 +63,7 @@ export const DEFAULT_STABLECOINS: Record<string, ExactDefaultAssetInfo> = {
   }, // MegaETH mainnet MegaUSD (no EIP-3009, supports EIP-2612)
   "eip155:143": {
     address: "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
-    name: "USD Coin",
+    name: "USDC",
     version: "2",
     decimals: 6,
   }, // Monad mainnet USDC


### PR DESCRIPTION
## Summary

Fixes #3102. The Monad (`eip155:143`) USDC entry declares its EIP-712 domain `name` as `"USD Coin"` in all three SDKs, but the deployed token reports `name() == "USDC"`. Because a FiatToken-style domain separator is derived from `name()`, the SDK-computed `DOMAIN_SEPARATOR` never matches the token's, so `transferWithAuthorization` signatures produced by the SDK fail signature recovery on chain and the transfer reverts.

## Verification (on-chain)

For `0x754704Bc059F8C67012fEd69BC8A327a5aafb603` on Monad:
- `name()` returns `"USDC"`.
- On-chain `DOMAIN_SEPARATOR()` is `0xfe22123edc0dd4aeb912eb7948c5f0e531592c2053b3067612f427db342c93c6`.
- Recomputing `EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)` with `version="2"`, `chainId=143` and that address:
  - `name="USDC"` reproduces the on-chain separator exactly.
  - `name="USD Coin"` does not.

## Fix

Change the domain `name` from `"USD Coin"` to `"USDC"` for that one Monad USDC entry, in:
- `go/mechanisms/evm/constants.go`
- `python/x402/mechanisms/evm/constants.py`
- `typescript/packages/mechanisms/evm/src/shared/defaultAssets.ts`

No other token or chain is touched.

## Tests

Adds a regression test in each SDK that recomputes the EIP-712 domain separator from the constant and asserts it equals the on-chain value (and that `"USD Coin"` does not). These run fully offline (Go `crypto.Keccak256`, Python eth-hash keccak, TS viem `keccak256`), so the only trust anchor is the on-chain value above.

## Validation

Green at pinned toolchains: Go `go test ./mechanisms/evm/`; Python `pytest` (evm mechanism, 673 passed); TypeScript `vitest` (829 passed). Reverting the constant fails the new test.
