### PR TITLE
docs: add raxol_payments to third-party SDKs

### DIFF
--- a/docs/dev-tools/third-party-sdks.md
+++ b/docs/dev-tools/third-party-sdks.md
@@ -6,5 +6,6 @@ description: "Community-maintained x402 SDKs."
 | Name | Description | Languages | Links |
 | ---- | ----------- | --------- | ----- |
 | [Mogami](https://mogami.gitbook.io/mogami) | Java x402 stack | Java | [GitHub](https://github.com/mogami-tech/) |
+| [raxol_payments](https://github.com/DROOdotFOO/raxol/tree/master/packages/raxol_payments) | x402 client for Elixir/OTP agents, with ledger-enforced spend limits | Elixir | [GitHub](https://github.com/DROOdotFOO/raxol/tree/master/packages/raxol_payments) · [Hex](https://hex.pm/packages/raxol_payments) |
 | [x402-rs](https://github.com/x402-rs/x402-rs/blob/main/README.md) | Rust toolkit for x402 | Rust | [GitHub](https://github.com/x402-rs/x402-rs) |
 | [x402-rails](https://github.com/quiknode-labs/x402-rails/blob/main/README.md) | x402 for Rails applications by Quicknode | Ruby | [GitHub](https://github.com/quiknode-labs/x402-rails) |


### PR DESCRIPTION
Adds `raxol_payments` to the third-party SDKs table. There is no Elixir entry today.

It is an x402 client for Elixir/OTP agents: EIP-712/ERC-3009 signing, a Req middleware that handles a 402 response transparently, and spend limits enforced against a ledger rather than checked advisorily — an agent cannot exceed its per-request, per-session, or lifetime cap because the reservation happens before the signature.

MIT, on Hex, docs on HexDocs.

Placed alphabetically after Mogami.

Disclosure per CONTRIBUTING.md's AI-assisted contributions section: the table row and this description were drafted by an AI agent and reviewed before submission. The claims above are about code I maintain, not generated code — no x402 signing or protocol logic was written for this PR.
