### PR TITLE
fix: escape backslashes in normalizePath

### DIFF
--- a/typescript/.changeset/backslash-path-normalization-bypass.md
+++ b/typescript/.changeset/backslash-path-normalization-bypass.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Fixed a paywall bypass where a backslash in a `:param`/`[param]` segment let an unauthenticated request reach a protected handler. `normalizePath` rewrote `\` to `/` after decoding, so the middleware saw more segments than the framework router did, missed the route, and fell through to the handler with nothing settled. Percent-escapes are now decoded one segment at a time and any separator they yield is re-escaped, matching the Go and Python SDKs. Reachable on Express via a raw `\` and on Hono via `%5C`.

--- a/typescript/packages/core/src/http/x402HTTPResourceServer.ts
+++ b/typescript/packages/core/src/http/x402HTTPResourceServer.ts
@@ -1362,27 +1362,27 @@ export class x402HTTPResourceServer {
   private normalizePath(path: string): string {
     const pathWithoutQuery = path.split(/[?#]/)[0];
 
-    // Decode percent-escapes per segment, preserving encoded path separators
-    // (%2F, %5C) as their literal escaped form. Otherwise an attacker could
-    // hide a "/" inside a single segment (e.g. /api/report/a%2Fb), bypassing
-    // a :param route whose regex compiles to [^/]+ while the framework still
-    // dispatches the request as a single-segment match.
-    const parts = pathWithoutQuery.split(/(%2[fF]|%5[cC])/);
-    const decoded = parts
-      .map((part, i) => {
-        if (i % 2 === 1) return part;
+    // Decode percent-escapes per segment and re-escape any separator the decode
+    // yields, so a decoded byte can never create a segment boundary the router
+    // did not see. "\" is escaped rather than folded into "/" because routers
+    // treat it as an ordinary in-segment character; folding it would split the
+    // path into more segments than the router saw and fail open on a :param
+    // route whose regex compiles to [^/]+.
+    const normalized = pathWithoutQuery
+      .split("/")
+      .map(segment => {
+        let decoded: string;
         try {
-          return decodeURIComponent(part);
+          decoded = decodeURIComponent(segment);
         } catch {
-          return part;
+          // Malformed escape: match the raw segment rather than widening it.
+          return segment;
         }
+        return decoded.replace(/\//g, "%2F").replace(/\\/g, "%5C");
       })
-      .join("");
+      .join("/");
 
-    return decoded
-      .replace(/\\/g, "/")
-      .replace(/\/+/g, "/")
-      .replace(/(.+?)\/+$/, "$1");
+    return normalized.replace(/\/+/g, "/").replace(/(.+?)\/+$/, "$1");
   }
 
   /**

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceService.test.ts
@@ -718,6 +718,39 @@ describe("x402HTTPResourceServer", () => {
         },
       );
 
+      // Express hands over the escaped path, Hono an already-decoded one, so a
+      // backslash can arrive raw or as %5C. Neither may be folded into a "/".
+      it.each([
+        ["raw backslash", "/api/report/a\\b"],
+        ["raw backslash, multiple", "/api/report/a\\b\\c"],
+        ["raw backslash after a decoded escape", "/api/report/a%41\\b"],
+      ])("should require payment when a :param segment contains a %s", async (_, path) => {
+        const routes = {
+          "/api/report/:id": {
+            accepts: {
+              scheme: "exact",
+              payTo: "0xabc",
+              price: "$1.00" as Price,
+              network: "eip155:8453" as Network,
+            },
+          },
+        };
+
+        const httpServer = new x402HTTPResourceServer(ResourceServer, routes);
+
+        const adapter = new MockHTTPAdapter();
+        const context: HTTPRequestContext = {
+          adapter,
+          path,
+          method: "GET",
+        };
+
+        expect(httpServer.requiresPayment(context)).toBe(true);
+
+        const result = await httpServer.processHTTPRequest(context);
+        expect(result.type).toBe("payment-error");
+      });
+
       it("should still decode non-separator percent-escapes for non-ASCII route patterns", async () => {
         const routes = {
           "/api/categoría/:id": {

--- a/typescript/packages/http/express/src/encodedPathBypass.test.ts
+++ b/typescript/packages/http/express/src/encodedPathBypass.test.ts
@@ -81,6 +81,12 @@ describe("express end-to-end: encoded path separator", () => {
     expect(await statusFor(port, "/api/report/a%5Cb")).toBe(402);
   });
 
+  // path-to-regexp still dispatches /api/report/a\b to the :id handler, so
+  // folding that "\" into a "/" in the middleware would fail open.
+  it("returns 402 even when the :id segment contains a raw backslash", async () => {
+    expect(await statusFor(port, "/api/report/a\\b")).toBe(402);
+  });
+
   it("returns 200 (middleware skipped) for an unrelated path", async () => {
     expect(await statusFor(port, "/health")).toBe(200);
   });

--- a/typescript/packages/http/hono/src/encodedPathBypass.test.ts
+++ b/typescript/packages/http/hono/src/encodedPathBypass.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { x402ResourceServer } from "@x402/core/server";
+import { paymentMiddleware } from "./index";
+
+/**
+ * Hono's `c.req.path` comes from `getPath()`, which runs `decodeURI()` before
+ * the router matches, so an encoded backslash reaches the middleware as a raw
+ * `\` while the router still dispatches `/api/report/a%5Cb` to `:id`.
+ *
+ * `app.request()` drives the full fetch handler without a real socket.
+ *
+ * @returns A Hono app with a paid `:id` route and a catch-all, so a skipped
+ * paywall is observable as the paid body rather than a framework 404.
+ */
+function buildApp() {
+  const app = new Hono();
+  const resourceServer = new x402ResourceServer();
+  app.use(
+    "*",
+    paymentMiddleware(
+      {
+        "/api/report/:id": {
+          accepts: {
+            scheme: "exact",
+            payTo: "0xabc",
+            price: "$1.00",
+            network: "eip155:84532",
+          },
+        },
+      },
+      resourceServer,
+      undefined,
+      undefined,
+      // syncFacilitatorOnStart=false so the test does not call a real facilitator
+      false,
+    ),
+  );
+  app.get("/api/report/:id", c => c.text("PAID_CONTENT", 200));
+  app.all("*", c => c.text("unrouted", 404));
+  return app;
+}
+
+describe("hono end-to-end: encoded path separator in a :param segment", () => {
+  it("returns 402 for a baseline single-segment :id", async () => {
+    const res = await buildApp().request("/api/report/baseline");
+    expect(res.status).toBe(402);
+  });
+
+  it.each([
+    ["encoded slash %2F", "/api/report/a%2Fb"],
+    ["encoded slash %2f (lowercase)", "/api/report/a%2fb"],
+    ["encoded backslash %5C", "/api/report/a%5Cb"],
+    ["encoded backslash %5c (lowercase)", "/api/report/a%5cb"],
+  ])("returns 402, not the paid body, for %s", async (_, path) => {
+    const res = await buildApp().request(path);
+
+    expect(res.status).toBe(402);
+    expect(await res.text()).not.toContain("PAID_CONTENT");
+  });
+
+  // Guards the test above from going vacuous: if Hono ever starts 404ing on
+  // %5C, the 402 assertion would pass for the wrong reason.
+  it("confirms Hono's router does dispatch an encoded backslash to the :id route", async () => {
+    const app = new Hono();
+    app.get("/api/report/:id", c => c.text("routed", 200));
+    app.all("*", c => c.text("unrouted", 404));
+
+    const res = await app.request("/api/report/a%5Cb");
+
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
### Description

normalizePath rewrote every \ to / after percent-decoding. Route patterns compile :param/[param] to [^/]+, so a backslash inside a parameter segment split the middleware's view of the path into more segments than the framework router saw. The compiled regex missed, getRouteConfig returned undefined, and the request was treated as unprotected — the framework then dispatched it to the paid handler anyway. The protected resource is served with no verify and no settle.

Reachable two ways, because adapters differ in how much they decode before handing the path over:


Adapter │        Request        │                           Before                            │

Express │ `GET /api/report/a\b`   │ 200, paid handler ran (raw `\;` req.path is the escaped path) │

Hono    │ `GET /api/report/a%5Cb` │ 200, paid handler ran (c.req.path is already decodeURI'd)   │


Both are `GET /api/report/:id` routes that the framework router dispatches to the paid handler.

#2372 closed the `%2F/%5C` token case by treating those two escapes as opaque, but left the `\ → /` rewrite in place, so a backslash arriving in any other form — raw, or produced by a decode the adapter already performed — still reached it.

### Changes

normalizePath now splits on / first, decodes percent-escapes one segment at a time, and re-escapes any separator the decode yields (/ → %2F, \ → %5C). A decoded byte can never create a segment boundary the router did not see. Backslash is escaped rather than folded, because routers treat it as an ordinary in-segment character. Malformed escapes fall back to the raw segment rather than widening it.

This matches what the Go (#3044) and Python (#3073) SDKs already do; neither was affected.

### Tests

- packages/core/test/unit/http/x402HTTPResourceService.test.ts — unit coverage for raw backslashes in :param and [param] segments.
- packages/http/hono/src/encodedPathBypass.test.ts (new) — end-to-end over the real Hono fetch pipeline: %2F, %2f, %5C, %5c. Includes a guard test
asserting Hono's router really does dispatch %5C to the :id route, so the 402 assertions can't pass vacuously via a framework 404.
- packages/http/express/src/encodedPathBypass.test.ts — added the raw-backslash case to the existing end-to-end suite.

Verified against the parent commit: 3 core unit tests, 2 Hono e2e tests, and 1 Express e2e test fail without the normalizePath change and pass with it.

pnpm test from /typescript.