### PR TITLE
fix: propagate verification message to SettleResponse.errorMessage

### DIFF
--- a/typescript/.changeset/settle-error-message-propagation.md
+++ b/typescript/.changeset/settle-error-message-propagation.md
@@ -1,0 +1,10 @@
+---
+"@x402/aptos": patch
+"@x402/concordium": patch
+"@x402/evm": patch
+"@x402/keeta": patch
+"@x402/stellar": patch
+"@x402/svm": patch
+---
+
+Propagate `invalidMessage` from the settle-time re-verification into `SettleResponse.errorMessage`, matching the behavior already present in the avm, hedera, tvm, and xrpl mechanisms. Settle failures previously returned only `errorReason`, so the diagnostic detail (e.g. the underlying Solana simulation error) was dropped even though `/verify` returned it.

--- a/typescript/.changeset/settle-error-message-propagation.md
+++ b/typescript/.changeset/settle-error-message-propagation.md
@@ -3,6 +3,7 @@
 "@x402/concordium": patch
 "@x402/evm": patch
 "@x402/keeta": patch
+"@x402/near": patch
 "@x402/stellar": patch
 "@x402/svm": patch
 ---

--- a/typescript/packages/mechanisms/aptos/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/aptos/src/exact/facilitator/scheme.ts
@@ -366,6 +366,7 @@ export class ExactAptosScheme implements SchemeNetworkFacilitator {
         network: payload.accepted.network,
         transaction: "",
         errorReason: valid.invalidReason ?? "verification_failed",
+        errorMessage: valid.invalidMessage,
         payer: valid.payer || "",
       };
     }

--- a/typescript/packages/mechanisms/concordium/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/concordium/src/exact/facilitator/scheme.ts
@@ -302,6 +302,7 @@ export class ExactConcordiumScheme implements SchemeNetworkFacilitator {
         network,
         transaction: "",
         errorReason: valid.invalidReason ?? "verification_failed",
+        errorMessage: valid.invalidMessage,
         payer: valid.payer || payer,
       };
     }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -285,6 +285,7 @@ export async function settleEIP3009(
       network: payload.accepted.network,
       transaction: "",
       errorReason: valid.invalidReason ?? Errors.ErrInvalidScheme,
+      errorMessage: valid.invalidMessage,
       payer,
     };
   }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/permit2.ts
@@ -345,6 +345,7 @@ export async function settlePermit2(
       network: payload.accepted.network,
       transaction: "",
       errorReason: valid.invalidReason ?? Errors.ErrInvalidScheme,
+      errorMessage: valid.invalidMessage,
       payer,
     };
   }

--- a/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
@@ -135,6 +135,7 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
         network: payloadV1.network,
         transaction: "",
         errorReason: valid.invalidReason ?? Errors.ErrInvalidScheme,
+        errorMessage: valid.invalidMessage,
         payer: exactEvmPayload.authorization.from,
       };
     }

--- a/typescript/packages/mechanisms/evm/src/upto/facilitator/permit2.ts
+++ b/typescript/packages/mechanisms/evm/src/upto/facilitator/permit2.ts
@@ -378,6 +378,7 @@ export async function settleUptoPermit2(
       network: payload.accepted.network,
       transaction: "",
       errorReason: valid.invalidReason ?? "invalid_scheme",
+      errorMessage: valid.invalidMessage,
       payer,
     };
   }

--- a/typescript/packages/mechanisms/evm/test/unit/v1/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/v1/facilitator.test.ts
@@ -389,5 +389,50 @@ describe("ExactEvmSchemeV1", () => {
       expect(result.success).toBe(false);
       expect(result.errorReason).toBe(Errors.ErrInvalidSignature);
     });
+
+    it("should surface the verification message in errorMessage", async () => {
+      const facilitator = new ExactEvmSchemeV1(mockSigner);
+      vi.spyOn(
+        facilitator as unknown as { _verify: () => Promise<unknown> },
+        "_verify",
+      ).mockResolvedValue({
+        isValid: false,
+        invalidReason: Errors.ErrInvalidSignature,
+        invalidMessage: "signature does not match authorization.from",
+        payer: "0x1234567890123456789012345678901234567890",
+      });
+
+      const result = await facilitator.settle(
+        {
+          x402Version: 1,
+          scheme: "exact",
+          network: "base-sepolia",
+          payload: {
+            signature: "0xinvalid",
+            authorization: {
+              from: "0x1234567890123456789012345678901234567890",
+              to: "0x9876543210987654321098765432109876543210",
+              value: "100000",
+              validAfter: "0",
+              validBefore: "99999999999",
+              nonce: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            },
+          },
+        } as never,
+        {
+          scheme: "exact",
+          network: "base-sepolia",
+          asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+          maxAmountRequired: "100000",
+          payTo: "0x9876543210987654321098765432109876543210",
+          maxTimeoutSeconds: 3600,
+          extra: { name: "USDC", version: "2" },
+        } as never,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.errorReason).toBe(Errors.ErrInvalidSignature);
+      expect(result.errorMessage).toBe("signature does not match authorization.from");
+    });
   });
 });

--- a/typescript/packages/mechanisms/keeta/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/keeta/src/exact/facilitator/scheme.ts
@@ -189,6 +189,7 @@ export class ExactKeetaScheme implements SchemeNetworkFacilitator {
         network: payload.accepted.network,
         transaction: "",
         errorReason: valid.invalidReason ?? "verification_failed",
+        errorMessage: valid.invalidMessage,
         payer: valid.payer || "",
       };
     }

--- a/typescript/packages/mechanisms/near/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/near/src/exact/facilitator/scheme.ts
@@ -349,6 +349,7 @@ export class ExactNearScheme implements SchemeNetworkFacilitator {
         verified.invalidReason || "verification_failed",
         requirements.network,
         verified.payer,
+        verified.invalidMessage,
       );
     }
 
@@ -442,12 +443,19 @@ export class ExactNearScheme implements SchemeNetworkFacilitator {
    * @param reason - Error reason code.
    * @param network - Network identifier.
    * @param payer - Payer account, when independently verified.
+   * @param message - Human-readable detail behind the reason code, when available.
    * @returns Settle response.
    */
-  private settleFailure(reason: string, network: Network, payer?: string): SettleResponse {
+  private settleFailure(
+    reason: string,
+    network: Network,
+    payer?: string,
+    message?: string,
+  ): SettleResponse {
     return {
       success: false,
       errorReason: reason,
+      errorMessage: message,
       transaction: "",
       network,
       payer,

--- a/typescript/packages/mechanisms/near/test/unit/near.facilitator.test.ts
+++ b/typescript/packages/mechanisms/near/test/unit/near.facilitator.test.ts
@@ -1,6 +1,6 @@
 import { actionCreators } from "@near-js/transactions";
 import type { PaymentRequirements } from "@x402/core/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ExactNearScheme } from "../../src/exact/facilitator/scheme";
 import { SettlementCache } from "../../src/settlement-cache";
 import { settlementCacheKey } from "../../src/utils";
@@ -359,6 +359,22 @@ describe("near facilitator settle", () => {
     );
     expect(result.success).toBe(false);
     expect(submitted).toBe(false);
+  });
+
+  it("surfaces the verification message in errorMessage", async () => {
+    const { scheme, requirements, payload } = await validSetup();
+    vi.spyOn(scheme, "verify").mockResolvedValue({
+      isValid: false,
+      invalidReason: "unexpected_verify_error",
+      invalidMessage: "rpc timeout while fetching access key",
+      payer: "alice.testnet",
+    });
+
+    const result = await scheme.settle(payload, requirements);
+
+    expect(result.success).toBe(false);
+    expect(result.errorReason).toBe("unexpected_verify_error");
+    expect(result.errorMessage).toBe("rpc timeout while fetching access key");
   });
 
   it("rejects duplicate in-flight settlements (spec §10)", async () => {

--- a/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
@@ -213,6 +213,7 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
           network: payload.accepted.network,
           transaction: "",
           errorReason: verifyResult.invalidReason ?? "verification_failed",
+          errorMessage: verifyResult.invalidMessage,
           payer: verifyResult.payer,
         };
       }

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -258,6 +258,7 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
         network: payload.accepted.network,
         transaction: "",
         errorReason: valid.invalidReason ?? "verification_failed",
+        errorMessage: valid.invalidMessage,
         payer: valid.payer || "",
       };
     }

--- a/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
@@ -385,6 +385,7 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
         network: payloadV1.network,
         transaction: "",
         errorReason: valid.invalidReason ?? "verification_failed",
+        errorMessage: valid.invalidMessage,
         payer: valid.payer || "",
       };
     }

--- a/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
@@ -330,6 +330,51 @@ describe("ExactSvmScheme", () => {
       expect(result.errorReason).toBe("unsupported_scheme");
       expect(result.network).toBe(SOLANA_DEVNET_CAIP2);
     });
+
+    it("should surface the verification message in errorMessage", async () => {
+      const facilitator = new ExactSvmScheme(mockSigner);
+      vi.spyOn(
+        facilitator as unknown as { _verify: () => Promise<unknown> },
+        "_verify",
+      ).mockResolvedValue({
+        response: {
+          isValid: false,
+          invalidReason: "transaction_simulation_failed",
+          invalidMessage: 'Simulation failed: {"InstructionError":[2,{"Custom":1}]}',
+          payer: "PayerAddress111111111111111111111111",
+        },
+        verificationPath: null,
+      });
+
+      const result = await facilitator.settle(
+        {
+          x402Version: 2,
+          accepted: {
+            scheme: "exact",
+            network: SOLANA_DEVNET_CAIP2,
+            asset: USDC_DEVNET_ADDRESS,
+            amount: "100000",
+            payTo: "PayToAddress11111111111111111111111111",
+            maxTimeoutSeconds: 3600,
+            extra: { feePayer: "FeePayer1111111111111111111111111111" },
+          },
+          payload: { transaction: "base64transaction==" },
+        } as unknown as PaymentPayload,
+        {
+          scheme: "exact",
+          network: SOLANA_DEVNET_CAIP2,
+          asset: USDC_DEVNET_ADDRESS,
+          amount: "100000",
+          payTo: "PayToAddress11111111111111111111111111",
+          maxTimeoutSeconds: 3600,
+          extra: { feePayer: "FeePayer1111111111111111111111111111" },
+        } as PaymentRequirements,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.errorReason).toBe("transaction_simulation_failed");
+      expect(result.errorMessage).toBe('Simulation failed: {"InstructionError":[2,{"Custom":1}]}');
+    });
   });
 
   describe("duplicate settlement cache", () => {


### PR DESCRIPTION
## Problem

`settle()` re-verifies before submitting. When that re-verification fails, six mechanisms return `errorReason` but drop `invalidMessage`, so the diagnostic detail is lost — even though `/verify` returns it for the same payload and `SettleResponse.errorMessage` already exists and is surfaced by `FacilitatorResponseError`.

The most visible case is SVM: `/verify` returns `transaction_simulation_failed` **with** the underlying Solana error (`{"InstructionError":[2,{"Custom":1}]}` — insufficient funds vs. missing token account vs. expired blockhash), while `/settle` returns the bare reason. Operators debugging a merchant's failed payment have to correlate settle failures against verify logs by timestamp to recover information the SDK already had in hand.

## Fix

One line per call site, propagating the message the same way four mechanisms already do.

**Already correct** (unchanged): `avm`, `hedera`, `tvm`, `xrpl`
**Fixed**: `aptos`, `concordium`, `evm` (exact eip3009 + permit2, upto permit2, exact/v1), `keeta`, `stellar`, `svm` (exact + exact/v1)

No behavior change when the underlying scheme doesn't set `invalidMessage` — the field is optional and simply stays undefined.

## Tests

Added one test each to the `svm` and `evm/v1` facilitator suites — the two differ in `_verify` return shape (`{response, verificationPath}` vs. a bare `VerifyResponse`), so both paths are worth pinning. Rather than duplicating the assertion across all ten sites, these cover the two distinct shapes.

`pnpm --filter @x402/svm test` → 204 passed
`pnpm --filter @x402/evm test` → 827 passed

## AI disclosure

Written with AI assistance (Claude). The change was found while migrating a production facilitator from a vendored fork onto upstream `@x402/*` 2.21.0, where the lost settle detail showed up as a regression in our operational logs.