### PR TITLE
feat(svm): make facilitator transaction limits operator-configurable

### DIFF
--- a/typescript/.changeset/svm-configurable-facilitator-limits.md
+++ b/typescript/.changeset/svm-configurable-facilitator-limits.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": minor
+---
+
+Add operator-configurable transaction limits to `ExactSvmSchemeOptions` for the static verification path: `maxPriorityFeeMicroLamports` (was hardcoded to `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS`), `maxComputeUnits` (previously unbounded), and `maxRequiredSignatures` (previously unchecked). The facilitator pays the transaction fee, so these bound the fee a payer can make it pay. All three default to existing behavior.

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -220,7 +220,7 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     // A limit that cannot be compared against is worse than no limit, so reject
     // it here rather than at verify time.
     assertLimit("maxPriorityFeeMicroLamports", this.options?.maxPriorityFeeMicroLamports, 0);
-    assertLimit("maxComputeUnits", this.options?.maxComputeUnits, 0);
+    assertLimit("maxComputeUnits", this.options?.maxComputeUnits, 1);
     // A ceiling below 1 would reject every transaction: the fee payer alone
     // always requires one signature.
     assertLimit("maxRequiredSignatures", this.options?.maxRequiredSignatures, 1);

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -134,6 +134,34 @@ export type ExactSvmSchemeOptions = {
    * Default: Squads Multisig v4, Squads Smart Account, Swig, SPL Governance, Metaplex Core
    */
   smartWalletAllowedPrograms?: string[];
+
+  /**
+   * Maximum compute unit price in microlamports accepted on the static path.
+   * The facilitator is the fee payer, so the payer chooses a priority fee the
+   * facilitator pays. Operators serving low-value payments will want this far
+   * below the default.
+   *
+   * Default: MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS (5,000,000)
+   */
+  maxPriorityFeeMicroLamports?: number;
+
+  /**
+   * Maximum compute unit limit accepted on the static path. An SPL transfer
+   * with a memo uses ~20k CU, so a low ceiling still leaves ample headroom for
+   * wallet-injected instructions.
+   *
+   * Default: unset (no limit, preserving existing behavior)
+   */
+  maxComputeUnits?: number;
+
+  /**
+   * Maximum number of required signatures. Every signature adds 5,000 lamports
+   * of base fee, paid by the facilitator. A typical x402 payment needs two
+   * (payer + fee payer).
+   *
+   * Default: unset (no limit, preserving existing behavior)
+   */
+  maxRequiredSignatures?: number;
 };
 
 /**
@@ -447,6 +475,28 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
         },
         verificationPath: null,
       };
+    }
+
+    // Signature count is a transaction-level property, so it is checked before
+    // path dispatch: it bounds the base fee the facilitator pays regardless of
+    // which verification strategy accepts the transaction, and it must not be
+    // recoverable via the Path 2 fallthrough.
+    const maxRequiredSignatures = this.options?.maxRequiredSignatures;
+    if (maxRequiredSignatures !== undefined) {
+      const compiledForSignerCheck = getCompiledTransactionMessageDecoder().decode(
+        transaction.messageBytes,
+      );
+      const numRequiredSignatures = compiledForSignerCheck.header.numSignerAccounts;
+      if (numRequiredSignatures > maxRequiredSignatures) {
+        return {
+          response: {
+            isValid: false,
+            invalidReason: "invalid_exact_svm_payload_excessive_signers",
+            payer: "",
+          },
+          verificationPath: null,
+        };
+      }
     }
 
     // ─── Path 1: Static validation (standard wallets) ───────────────────
@@ -785,8 +835,18 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     }
 
     try {
-      parseSetComputeUnitLimitInstruction(instruction as never);
-    } catch {
+      const parsedInstruction = parseSetComputeUnitLimitInstruction(instruction as never);
+
+      const maxComputeUnits = this.options?.maxComputeUnits;
+      if (maxComputeUnits !== undefined && parsedInstruction.data.units > maxComputeUnits) {
+        throw new Error(
+          "invalid_exact_svm_payload_transaction_instructions_compute_limit_instruction_too_high",
+        );
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("too_high")) {
+        throw error;
+      }
       throw new Error(
         "invalid_exact_svm_payload_transaction_instructions_compute_limit_instruction",
       );
@@ -819,8 +879,10 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     try {
       const parsedInstruction = parseSetComputeUnitPriceInstruction(instruction as never);
 
-      // Check if price exceeds maximum (5 lamports per compute unit)
-      if (parsedInstruction.data.microLamports > BigInt(MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS)) {
+      // Check if price exceeds the operator-configured maximum (default 5 lamports per compute unit)
+      const maxPriorityFee =
+        this.options?.maxPriorityFeeMicroLamports ?? MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS;
+      if (parsedInstruction.data.microLamports > BigInt(maxPriorityFee)) {
         throw new Error(
           "invalid_exact_svm_payload_transaction_instructions_compute_price_instruction_too_high",
         );

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -165,6 +165,26 @@ export type ExactSvmSchemeOptions = {
 };
 
 /**
+ * Rejects a limit that cannot function as a limit. `NaN` and `Infinity` are the
+ * dangerous cases: they arrive easily from `parseInt(process.env.X)` on an unset
+ * variable, and each option degrades differently and silently — a `NaN` compute
+ * unit or signature ceiling makes every comparison false (no limit at all),
+ * while a `NaN` priority fee makes `BigInt()` throw and rejects every payment
+ * under a misleading reason code. Failing at construction turns all of those
+ * into one loud error.
+ *
+ * @param name - Option name, used in the error message
+ * @param value - Configured value, or undefined when the option is unset
+ * @param min - Smallest meaningful value for this option
+ */
+function assertLimit(name: string, value: number | undefined, min: number): void {
+  if (value === undefined) return;
+  if (!Number.isSafeInteger(value) || value < min) {
+    throw new Error(`${name} must be a safe integer >= ${min}, received ${value}`);
+  }
+}
+
+/**
  * SVM facilitator implementation for the Exact payment scheme.
  *
  * Dual-path verification:
@@ -196,6 +216,14 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     private readonly options?: ExactSvmSchemeOptions,
   ) {
     this.settlementCache = settlementCache ?? new SettlementCache();
+
+    // A limit that cannot be compared against is worse than no limit, so reject
+    // it here rather than at verify time.
+    assertLimit("maxPriorityFeeMicroLamports", this.options?.maxPriorityFeeMicroLamports, 0);
+    assertLimit("maxComputeUnits", this.options?.maxComputeUnits, 0);
+    // A ceiling below 1 would reject every transaction: the fee payer alone
+    // always requires one signature.
+    assertLimit("maxRequiredSignatures", this.options?.maxRequiredSignatures, 1);
 
     if (this.options?.enableSmartWalletVerification) {
       // fetchAddressLookupTables is required too: assertFeePayerIsolated can't

--- a/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
@@ -345,6 +345,38 @@ describe("ExactSvmScheme", () => {
       const facilitator = new ExactSvmScheme(mockSigner);
       expect(() => callLimit(facilitator, limitInstruction(1_400_000))).not.toThrow();
     });
+
+    // NaN/Infinity reach these options easily via parseInt on an unset env var,
+    // and each degrades differently: a NaN compute-unit or signature ceiling
+    // makes every comparison false (no limit), while a NaN priority fee makes
+    // BigInt() throw and rejects every payment under a misleading reason code.
+    it.each([
+      ["maxPriorityFeeMicroLamports", NaN],
+      ["maxPriorityFeeMicroLamports", Infinity],
+      ["maxPriorityFeeMicroLamports", 1.5],
+      ["maxPriorityFeeMicroLamports", -1],
+      ["maxComputeUnits", NaN],
+      ["maxComputeUnits", Infinity],
+      ["maxComputeUnits", -1],
+      ["maxRequiredSignatures", NaN],
+      ["maxRequiredSignatures", Infinity],
+      ["maxRequiredSignatures", 0],
+    ])("should reject %s = %p at construction", (option, value) => {
+      expect(
+        () => new ExactSvmScheme(mockSigner, undefined, { [option]: value as number }),
+      ).toThrow(option);
+    });
+
+    it("should accept the boundary values of each limit", () => {
+      expect(
+        () =>
+          new ExactSvmScheme(mockSigner, undefined, {
+            maxPriorityFeeMicroLamports: 0,
+            maxComputeUnits: 0,
+            maxRequiredSignatures: 1,
+          }),
+      ).not.toThrow();
+    });
   });
 
   describe("settle", () => {

--- a/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
@@ -358,10 +358,11 @@ describe("ExactSvmScheme", () => {
       ["maxComputeUnits", NaN],
       ["maxComputeUnits", Infinity],
       ["maxComputeUnits", -1],
+      ["maxComputeUnits", 0],
       ["maxRequiredSignatures", NaN],
       ["maxRequiredSignatures", Infinity],
       ["maxRequiredSignatures", 0],
-    ])("should reject %s = %p at construction", (option, value) => {
+    ])("should reject %s = %s at construction", (option, value) => {
       expect(
         () => new ExactSvmScheme(mockSigner, undefined, { [option]: value as number }),
       ).toThrow(option);
@@ -372,7 +373,7 @@ describe("ExactSvmScheme", () => {
         () =>
           new ExactSvmScheme(mockSigner, undefined, {
             maxPriorityFeeMicroLamports: 0,
-            maxComputeUnits: 0,
+            maxComputeUnits: 1,
             maxRequiredSignatures: 1,
           }),
       ).not.toThrow();

--- a/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/facilitator.test.ts
@@ -22,6 +22,15 @@ function makeComputePriceData(microLamports: bigint): Uint8Array {
   return new Uint8Array(buf);
 }
 
+// Encodes a SetComputeUnitLimit instruction: discriminator(2) + units as u32 LE
+function makeComputeLimitData(units: number): Uint8Array {
+  const buf = new ArrayBuffer(5);
+  const view = new DataView(buf);
+  view.setUint8(0, 2);
+  view.setUint32(1, units, true);
+  return new Uint8Array(buf);
+}
+
 describe("ExactSvmScheme", () => {
   let mockSigner: FacilitatorSvmSigner;
 
@@ -286,6 +295,55 @@ describe("ExactSvmScheme", () => {
           facilitator as unknown as { verifyComputePriceInstruction: (i: unknown) => void }
         ).verifyComputePriceInstruction(instruction),
       ).not.toThrow();
+    });
+  });
+
+  describe("operator-configurable limits", () => {
+    const priceInstruction = (microLamports: bigint) => ({
+      programAddress: COMPUTE_BUDGET_PROGRAM_ADDRESS,
+      data: makeComputePriceData(microLamports),
+    });
+    const limitInstruction = (units: number) => ({
+      programAddress: COMPUTE_BUDGET_PROGRAM_ADDRESS,
+      data: makeComputeLimitData(units),
+    });
+    const callPrice = (f: ExactSvmScheme, i: unknown) =>
+      (
+        f as unknown as { verifyComputePriceInstruction: (i: unknown) => void }
+      ).verifyComputePriceInstruction(i);
+    const callLimit = (f: ExactSvmScheme, i: unknown) =>
+      (
+        f as unknown as { verifyComputeLimitInstruction: (i: unknown) => void }
+      ).verifyComputeLimitInstruction(i);
+
+    it("should enforce a lowered maxPriorityFeeMicroLamports", () => {
+      const facilitator = new ExactSvmScheme(mockSigner, undefined, {
+        maxPriorityFeeMicroLamports: 5,
+      });
+      expect(() => callPrice(facilitator, priceInstruction(6n))).toThrow(
+        "invalid_exact_svm_payload_transaction_instructions_compute_price_instruction_too_high",
+      );
+      expect(() => callPrice(facilitator, priceInstruction(5n))).not.toThrow();
+    });
+
+    it("should keep the default price cap when maxPriorityFeeMicroLamports is unset", () => {
+      const facilitator = new ExactSvmScheme(mockSigner);
+      expect(() =>
+        callPrice(facilitator, priceInstruction(BigInt(MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS))),
+      ).not.toThrow();
+    });
+
+    it("should enforce maxComputeUnits when configured", () => {
+      const facilitator = new ExactSvmScheme(mockSigner, undefined, { maxComputeUnits: 60_000 });
+      expect(() => callLimit(facilitator, limitInstruction(60_001))).toThrow(
+        "invalid_exact_svm_payload_transaction_instructions_compute_limit_instruction_too_high",
+      );
+      expect(() => callLimit(facilitator, limitInstruction(60_000))).not.toThrow();
+    });
+
+    it("should not cap compute units when maxComputeUnits is unset", () => {
+      const facilitator = new ExactSvmScheme(mockSigner);
+      expect(() => callLimit(facilitator, limitInstruction(1_400_000))).not.toThrow();
     });
   });
 

--- a/typescript/packages/mechanisms/svm/test/unit/requiredSignatures.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/requiredSignatures.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  appendTransactionMessageInstruction,
+  compileTransactionMessage,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getBase64EncodedWireTransaction,
+  getCompiledTransactionMessageEncoder,
+  pipe,
+  setTransactionMessageFeePayer,
+  setTransactionMessageLifetimeUsingBlockhash,
+  type Address,
+  type Blockhash,
+  type IInstruction,
+} from "@solana/kit";
+import { ExactSvmScheme } from "../../src/exact/facilitator/scheme";
+import { SOLANA_DEVNET_CAIP2, USDC_DEVNET_ADDRESS } from "../../src/constants";
+import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
+
+const COMPUTE_BUDGET_PROGRAM = "ComputeBudget111111111111111111111111111111" as Address;
+
+const FAKE_BLOCKHASH = {
+  blockhash: "5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF" as Blockhash,
+  lastValidBlockHeight: 1000n,
+};
+
+/**
+ * Builds a wire transaction whose compiled header requires `extraSigners + 1`
+ * signatures (the fee payer plus one writable signer per extra account).
+ *
+ * @param feePayer - Fee payer address, always the first required signer
+ * @param extraSigners - Additional writable-signer accounts to reference
+ * @returns Base64 wire transaction
+ */
+async function buildTransactionWithSigners(
+  feePayer: Address,
+  extraSigners: Address[],
+): Promise<string> {
+  const instruction: IInstruction = {
+    programAddress: COMPUTE_BUDGET_PROGRAM,
+    accounts: extraSigners.map(address => ({ address, role: 3 as never })),
+    data: new Uint8Array([2, 160, 134, 1, 0]),
+  };
+
+  const msg = pipe(
+    createTransactionMessage({ version: 0 }),
+    m => setTransactionMessageFeePayer(feePayer, m),
+    m => setTransactionMessageLifetimeUsingBlockhash(FAKE_BLOCKHASH, m),
+    m => appendTransactionMessageInstruction(instruction, m),
+  );
+
+  const messageBytes = getCompiledTransactionMessageEncoder().encode(
+    compileTransactionMessage(msg),
+  );
+  const signatures = Object.fromEntries(
+    [feePayer, ...extraSigners].map(a => [a, new Uint8Array(64)]),
+  );
+
+  return getBase64EncodedWireTransaction({ messageBytes, signatures } as never);
+}
+
+describe("ExactSvmScheme maxRequiredSignatures", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /**
+   * @param feePayer - Facilitator fee payer the mock signer manages
+   * @returns Minimal facilitator signer mock
+   */
+  function mockSigner(feePayer: Address) {
+    return {
+      getAddresses: vi.fn().mockReturnValue([feePayer]),
+      signTransaction: vi.fn(),
+      simulateTransaction: vi.fn(),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+    };
+  }
+
+  /**
+   * @param feePayer - Fee payer advertised in requirements.extra
+   * @returns Payment requirements targeting devnet USDC
+   */
+  function requirementsFor(feePayer: Address): PaymentRequirements {
+    return {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: "PayToAddress11111111111111111111111111",
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer },
+    } as PaymentRequirements;
+  }
+
+  it("rejects a transaction requiring more signatures than configured", async () => {
+    const feePayer = await generateKeyPairSigner();
+    const [a, b] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+    const transaction = await buildTransactionWithSigners(feePayer.address, [a.address, b.address]);
+
+    const scheme = new ExactSvmScheme(mockSigner(feePayer.address) as never, undefined, {
+      maxRequiredSignatures: 2,
+    });
+
+    const requirements = requirementsFor(feePayer.address);
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        accepted: requirements,
+        payload: { transaction },
+      } as unknown as PaymentPayload,
+      requirements,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_exact_svm_payload_excessive_signers");
+  });
+
+  it("does not apply a signature limit when the option is unset", async () => {
+    const feePayer = await generateKeyPairSigner();
+    const [a, b] = await Promise.all([generateKeyPairSigner(), generateKeyPairSigner()]);
+    const transaction = await buildTransactionWithSigners(feePayer.address, [a.address, b.address]);
+
+    const scheme = new ExactSvmScheme(mockSigner(feePayer.address) as never);
+
+    const requirements = requirementsFor(feePayer.address);
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        accepted: requirements,
+        payload: { transaction },
+      } as unknown as PaymentPayload,
+      requirements,
+    );
+
+    // Still invalid (the payload is not a real transfer), but it must fail on
+    // instruction layout rather than the signature count.
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).not.toBe("invalid_exact_svm_payload_excessive_signers");
+  });
+});


### PR DESCRIPTION
## Problem

On SVM the facilitator is the fee payer, so the *payer* chooses a priority fee that the *facilitator* pays. The static verification path currently:

- caps the compute unit price at a hardcoded `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS` (5,000,000 µLamports = 5 lamports/CU),
- does not cap the compute unit **limit** at all,
- never checks the required-signature count, though each signature costs the fee payer 5,000 lamports of base fee.

At the current ceiling one transaction can direct `1,400,000 CU × 5 lamports/CU = 7,000,000 lamports` — **0.007 SOL of priority fee, ~1,400× the base fee** — for a payment that may be worth a fraction of a cent. An operator serving sub-cent payments has no way to lower that today short of patching the package.

Notably, Path 2 already exposes exactly these knobs (`smartWalletMaxComputeUnits`, `smartWalletMaxPriorityFeeMicroLamports`). This brings the static path to parity.

## Change

Three new optional fields on `ExactSvmSchemeOptions`:

| option | default | today |
|---|---|---|
| `maxPriorityFeeMicroLamports` | `MAX_COMPUTE_UNIT_PRICE_MICROLAMPORTS` | hardcoded |
| `maxComputeUnits` | unset — no limit | no limit |
| `maxRequiredSignatures` | unset — no limit | unchecked |

**All three default to existing behavior**, so this is opt-in and no current deployment changes. Configured limits must be safe integers; priority fee accepts zero, while compute-unit and required-signature limits must be at least one so they cannot become deny-all settings.

The signature check runs *before* path dispatch rather than inside `verifyStaticPath`: it bounds the base fee regardless of which path ends up accepting the transaction, and it must not be recoverable through the Path 2 fallthrough (it is a semantic rejection, not a layout one).

New reason code `invalid_exact_svm_payload_transaction_instructions_compute_limit_instruction_too_high` mirrors the existing `..._compute_price_instruction_too_high`.

## Tests

`pnpm --filter @x402/svm test` → 221 passed. `pnpm --filter @x402/svm lint:check`, `pnpm --filter @x402/svm build`, and `pnpm --filter @x402/svm format:check` also pass.

Each option is tested at the boundary in both directions, plus a test that the default is unchanged when the option is unset.

## Context

Found while migrating a production facilitator off a vendored fork onto upstream `@x402/*` 2.21.0. The fork had carried exactly these three limits as hardcoded patches for months; upstreaming them as options removes our reason to patch and gives the same control to any operator who pays the fees.

## AI disclosure

Written with AI assistance (Claude).
