### PR TITLE
fix(svm): validate smart wallet limits

### DIFF
--- a/typescript/.changeset/svm-validate-smart-wallet-limits.md
+++ b/typescript/.changeset/svm-validate-smart-wallet-limits.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": patch
+---
+
+Reject invalid smart-wallet compute-unit and priority-fee limits when smart-wallet verification is enabled or its exported verification helpers are called, preventing non-finite or fractional configuration values from silently disabling fee protections or causing misleading payment failures. Export `assertSmartWalletLimits` and `SmartWalletLimits` for pre-validation. Dormant limits remain ignored while smart-wallet verification is disabled.

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -37,7 +37,11 @@ import {
   getTokenPayerFromTransaction,
   transactionMessageHash,
 } from "../../utils";
-import { verifySmartWalletTransaction, verifyPostSettlement } from "./smartWalletVerification";
+import {
+  assertSmartWalletLimits,
+  verifySmartWalletTransaction,
+  verifyPostSettlement,
+} from "./smartWalletVerification";
 
 /**
  * Default allowed smart wallet program addresses.
@@ -112,6 +116,7 @@ export type ExactSvmSchemeOptions = {
    * Maximum compute units allowed for smart wallet transactions.
    * Smart wallet programs need more CU for CPI overhead.
    * Only applies when enableSmartWalletVerification is true.
+   * Invalid configured values throw when smart wallet verification is enabled.
    *
    * Default: 400,000
    */
@@ -120,6 +125,7 @@ export type ExactSvmSchemeOptions = {
   /**
    * Maximum priority fee in microlamports for smart wallet transactions.
    * Only applies when enableSmartWalletVerification is true.
+   * Invalid configured values throw when smart wallet verification is enabled.
    *
    * Default: 50,000
    */
@@ -170,6 +176,11 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
     this.settlementCache = settlementCache ?? new SettlementCache();
 
     if (this.options?.enableSmartWalletVerification) {
+      assertSmartWalletLimits({
+        maxComputeUnits: this.options.smartWalletMaxComputeUnits,
+        maxPriorityFeeMicroLamports: this.options.smartWalletMaxPriorityFeeMicroLamports,
+      });
+
       // fetchAddressLookupTables is required too: assertFeePayerIsolated can't
       // inspect ALT-resolved accounts without it, so an ALT-using wallet would
       // otherwise fail at verify time rather than at construction.

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/smartWalletVerification.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/smartWalletVerification.ts
@@ -34,6 +34,35 @@ const TOKEN_PROGRAMS = new Set([
   TOKEN_2022_PROGRAM_ADDRESS.toString(),
 ]);
 
+export type SmartWalletLimits = {
+  maxComputeUnits?: number;
+  maxPriorityFeeMicroLamports?: number;
+};
+
+/**
+ * Rejects smart-wallet limits that cannot be compared safely.
+ *
+ * @param limits - Optional operator-provided compute budget caps
+ */
+export function assertSmartWalletLimits(limits?: SmartWalletLimits): void {
+  assertLimit("smartWalletMaxComputeUnits", limits?.maxComputeUnits, 1);
+  assertLimit("smartWalletMaxPriorityFeeMicroLamports", limits?.maxPriorityFeeMicroLamports, 0);
+}
+
+/**
+ * Rejects a configured limit outside its meaningful integer range.
+ *
+ * @param name - Option name, used in the error message
+ * @param value - Configured value, or undefined when the option is unset
+ * @param min - Smallest meaningful value for this option
+ */
+function assertLimit(name: string, value: number | undefined, min: number): void {
+  if (value === undefined) return;
+  if (!Number.isSafeInteger(value) || value < min) {
+    throw new Error(`${name} must be a safe integer >= ${min}, received ${value}`);
+  }
+}
+
 export type TransferCheckedInfo = {
   programId: string;
   amount: bigint;
@@ -125,8 +154,10 @@ export async function assertFeePayerIsolated(
  */
 export function validateComputeBudgetLimits(
   transaction: Transaction,
-  limits?: { maxComputeUnits?: number; maxPriorityFeeMicroLamports?: number },
+  limits?: SmartWalletLimits,
 ): void {
+  assertSmartWalletLimits(limits);
+
   const maxCU = limits?.maxComputeUnits ?? DEFAULT_SMART_WALLET_MAX_COMPUTE_UNITS;
   const maxPriorityFee =
     limits?.maxPriorityFeeMicroLamports ?? DEFAULT_SMART_WALLET_MAX_PRIORITY_FEE_MICROLAMPORTS;
@@ -257,10 +288,8 @@ export function extractTransfersFromInnerInstructions(
  * Operator-configurable options for smart wallet verification.
  * Passed through from the ExactSvmScheme constructor.
  */
-export type SmartWalletOptions = {
+export type SmartWalletOptions = SmartWalletLimits & {
   enabled: boolean;
-  maxComputeUnits?: number;
-  maxPriorityFeeMicroLamports?: number;
 };
 
 /**
@@ -288,6 +317,10 @@ export async function verifySmartWalletTransaction(
   signerAddresses: readonly string[],
   options?: SmartWalletOptions,
 ): Promise<VerifyResponse> {
+  // Configuration errors must propagate to the operator rather than being
+  // reported to the payer as a transaction verification failure.
+  assertSmartWalletLimits(options);
+
   const transaction = decodeTransactionFromPayload({ transaction: transactionBase64 });
 
   // 1. Fee payer must not appear in any instruction's accounts.

--- a/typescript/packages/mechanisms/svm/src/index.ts
+++ b/typescript/packages/mechanisms/svm/src/index.ts
@@ -11,12 +11,14 @@ export type { ExactSvmSchemeOptions } from "./exact/facilitator/scheme";
 // Export smart wallet verification helpers
 export {
   assertFeePayerIsolated,
+  assertSmartWalletLimits,
   validateComputeBudgetLimits,
   extractTransfersFromInnerInstructions,
   verifySmartWalletTransaction,
   verifyPostSettlement,
 } from "./exact/facilitator/smartWalletVerification";
 export type {
+  SmartWalletLimits,
   SmartWalletOptions,
   TransferCheckedInfo,
 } from "./exact/facilitator/smartWalletVerification";

--- a/typescript/packages/mechanisms/svm/test/unit/index.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   ExactSvmScheme,
+  assertSmartWalletLimits,
   validateSvmAddress,
   normalizeNetwork,
   getUsdcAddress,
@@ -18,6 +19,7 @@ describe("@x402/svm", () => {
     expect(ExactSvmScheme).toBeDefined();
     expect(ExactSvmScheme).toBeDefined();
     expect(ExactSvmScheme).toBeDefined();
+    expect(assertSmartWalletLimits).toBeDefined();
   });
 
   describe("validateSvmAddress", () => {

--- a/typescript/packages/mechanisms/svm/test/unit/smartWalletVerification.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/smartWalletVerification.test.ts
@@ -3,6 +3,7 @@ import {
   assertFeePayerIsolated,
   validateComputeBudgetLimits,
   extractTransfersFromInnerInstructions,
+  verifySmartWalletTransaction,
 } from "../../src/exact/facilitator/smartWalletVerification";
 import {
   appendTransactionMessageInstruction,
@@ -121,6 +122,23 @@ function buildSetComputeUnitPrice(microLamports: bigint): Uint8Array {
 }
 
 describe("validateComputeBudgetLimits", () => {
+  it.each([
+    ["maxComputeUnits", NaN, "smartWalletMaxComputeUnits"],
+    ["maxComputeUnits", Infinity, "smartWalletMaxComputeUnits"],
+    ["maxComputeUnits", 1.5, "smartWalletMaxComputeUnits"],
+    ["maxComputeUnits", 0, "smartWalletMaxComputeUnits"],
+    ["maxPriorityFeeMicroLamports", NaN, "smartWalletMaxPriorityFeeMicroLamports"],
+    ["maxPriorityFeeMicroLamports", Infinity, "smartWalletMaxPriorityFeeMicroLamports"],
+    ["maxPriorityFeeMicroLamports", 1.5, "smartWalletMaxPriorityFeeMicroLamports"],
+    ["maxPriorityFeeMicroLamports", -1, "smartWalletMaxPriorityFeeMicroLamports"],
+  ])("rejects %s = %s for direct callers", (option, value, expectedError) => {
+    // The empty transaction proves limit validation runs before message decoding;
+    // otherwise this would fail with an unrelated decoder error.
+    expect(() => validateComputeBudgetLimits({} as never, { [option]: value } as never)).toThrow(
+      expectedError,
+    );
+  });
+
   it("passes when CU and priority fee are within defaults", async () => {
     const feePayer = await generateKeyPairSigner();
 
@@ -229,6 +247,20 @@ describe("validateComputeBudgetLimits", () => {
     expect(() => validateComputeBudgetLimits(tx as never)).toThrow(
       "smart_wallet_malformed_compute_budget",
     );
+  });
+});
+
+describe("verifySmartWalletTransaction configuration", () => {
+  it.each([
+    ["maxComputeUnits", NaN, "smartWalletMaxComputeUnits"],
+    ["maxPriorityFeeMicroLamports", NaN, "smartWalletMaxPriorityFeeMicroLamports"],
+  ])("propagates %s configuration errors", async (option, value, expectedError) => {
+    await expect(
+      verifySmartWalletTransaction("invalid transaction", {} as never, {} as never, "", [], {
+        enabled: true,
+        [option]: value,
+      } as never),
+    ).rejects.toThrow(expectedError);
   });
 });
 
@@ -730,6 +762,82 @@ describe("verifyPostSettlement", () => {
 });
 
 describe("ExactSvmScheme constructor enforcement", () => {
+  it.each([
+    ["smartWalletMaxComputeUnits", NaN],
+    ["smartWalletMaxComputeUnits", Infinity],
+    ["smartWalletMaxComputeUnits", 1.5],
+    ["smartWalletMaxComputeUnits", 0],
+    ["smartWalletMaxPriorityFeeMicroLamports", NaN],
+    ["smartWalletMaxPriorityFeeMicroLamports", Infinity],
+    ["smartWalletMaxPriorityFeeMicroLamports", 1.5],
+    ["smartWalletMaxPriorityFeeMicroLamports", -1],
+  ])("throws when %s is %s", async (option, value) => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+    const completeSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      simulateTransactionWithInnerInstructions: async () => ({ innerInstructions: null }),
+      getConfirmedTransactionInnerInstructions: async () => null,
+      getTokenAccountBalance: async () => null,
+      fetchAddressLookupTables: async () => ({}),
+    };
+
+    expect(
+      () =>
+        new ExactSvmScheme(completeSigner as never, undefined, {
+          enableSmartWalletVerification: true,
+          [option]: value as number,
+        }),
+    ).toThrow(option);
+  });
+
+  it("accepts the minimum smart wallet limits", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+    const completeSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+      simulateTransactionWithInnerInstructions: async () => ({ innerInstructions: null }),
+      getConfirmedTransactionInnerInstructions: async () => null,
+      getTokenAccountBalance: async () => null,
+      fetchAddressLookupTables: async () => ({}),
+    };
+
+    expect(
+      () =>
+        new ExactSvmScheme(completeSigner as never, undefined, {
+          enableSmartWalletVerification: true,
+          smartWalletMaxComputeUnits: 1,
+          smartWalletMaxPriorityFeeMicroLamports: 0,
+        }),
+    ).not.toThrow();
+  });
+
+  it("ignores dormant smart wallet limits when verification is disabled", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+    const minimalSigner = {
+      getAddresses: () => [],
+      signTransaction: async () => "",
+      simulateTransaction: async () => {},
+      sendTransaction: async () => "",
+      confirmTransaction: async () => {},
+    };
+
+    expect(
+      () =>
+        new ExactSvmScheme(minimalSigner as never, undefined, {
+          enableSmartWalletVerification: false,
+          smartWalletMaxComputeUnits: NaN,
+          smartWalletMaxPriorityFeeMicroLamports: NaN,
+        }),
+    ).not.toThrow();
+  });
+
   it("throws when signer missing required methods for smart wallet verification", async () => {
     const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
 


### PR DESCRIPTION
## Summary

- centralize smart-wallet limit validation in `smartWalletVerification.ts`
- validate `ExactSvmScheme` configuration when smart-wallet verification is enabled
- validate direct callers of `validateComputeBudgetLimits` and propagate configuration errors from `verifySmartWalletTransaction`
- export `assertSmartWalletLimits` and `SmartWalletLimits` for operator pre-validation
- reject non-finite, fractional, and negative limits; require at least 1 compute unit while retaining a valid zero priority-fee ceiling
- ignore dormant smart-wallet limits while the feature is disabled, matching the option contract
- add a patch changeset for `@x402/svm`

## Root cause

The smart-wallet fee limits accepted any JavaScript `number`. Environment-derived values such as `NaN` or `Infinity` could therefore reach runtime comparisons. A non-finite compute-unit ceiling makes `units > maxCU` false and silently removes the configured cap, while a non-finite priority-fee ceiling can fail later under a misleading verification error.

## Relationship to #3120

This PR does not duplicate #3120's `assertLimit` helper or constructor anchor. Smart-wallet validation lives with the exported smart-wallet verification path, and a local merge-tree check against the current #3120 head is clean. The PR remains independently based on `main` and can merge in either order.

## Impact

Facilitators fail loudly during startup when active smart-wallet fee protections are misconfigured. Direct users of the exported verification helpers receive configuration errors rather than payer-facing verification failures, and operators can pre-validate with the newly exported helper. Configurations for a disabled feature remain dormant and do not prevent startup.

## Validation

- `pnpm --filter @x402/svm test` — 223 passed
- `pnpm --filter @x402/svm lint:check`
- `pnpm --filter @x402/core build`, then `pnpm --filter @x402/svm build`
- Prettier check on all changed files
- `git diff --check`
- clean `git merge-tree --write-tree pr-3120 HEAD`
