### PR TITLE
docs(MCP guide): add a live x402 endpoint as a no-local-server alternative

### DIFF
--- a/docs/guides/mcp-server-with-x402.md
+++ b/docs/guides/mcp-server-with-x402.md
@@ -77,6 +77,15 @@ cd servers/express
 pnpm dev
 ```
 
+Alternatively, skip running a local server and point the client at any live x402 API. For example, [scrape402](https://x402.shizu.me) is a community-operated x402 service on Base mainnet whose `/trending` endpoint takes no parameters, so it works with this demo as-is:
+
+```json
+"RESOURCE_SERVER_URL": "https://x402.shizu.me",
+"ENDPOINT_PATH": "/trending"
+```
+
+Note this settles real USDC on Base mainnet (about $0.002 per call), so use a mainnet-funded wallet — and as with any third-party endpoint, it is operated independently, not by the x402 project.
+
 #### 4. Restart Claude Desktop
 
 Restart Claude Desktop to load the new MCP server, then ask Claude to use the `get-data-from-resource-server` tool.


### PR DESCRIPTION
The MCP guide currently requires cloning the repo and running the sample express server before anything works end-to-end. This adds a two-line alternative after step 3: point `RESOURCE_SERVER_URL` at a live x402 API and skip local server setup entirely, so a first-time reader can see a paid MCP call succeed in one step.

The example used is scrape402 (https://x402.shizu.me), an x402 service on Base mainnet — its `/trending` endpoint takes no parameters, so it works with the demo client's bare GET unchanged. The note states plainly that it settles real USDC (~$0.002/call) and is operated independently of the x402 project.

Disclosure: I operate scrape402. Happy to swap the example for any other no-parameter live endpoint the maintainers prefer — the point of the change is that one exists in the guide, not which one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
