### PR TITLE
fix(ts): require TransferChecked discriminator in svm exact

### DIFF
--- a/typescript/.changeset/calm-chefs-dream.md
+++ b/typescript/.changeset/calm-chefs-dream.md
@@ -1,0 +1,5 @@
+---
+'@x402/svm': patch
+---
+
+Added validation guard for TransferChecked

--- a/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/facilitator/scheme.ts
@@ -54,6 +54,8 @@ const DEFAULT_SMART_WALLET_ALLOWED_PROGRAMS = [
   LIGHTHOUSE_PROGRAM_ADDRESS, // Phantom's wallet-protection assertions (see #2097)
 ];
 
+const IX_TOKEN_TRANSFER_CHECKED = 12;
+
 /**
  * Which verification path produced a successful result.
  * Returned by the internal _verify so settle() knows whether post-settlement
@@ -678,6 +680,16 @@ export class ExactSvmScheme implements SchemeNetworkFacilitator {
       programAddress !== TOKEN_PROGRAM_ADDRESS.toString() &&
       programAddress !== TOKEN_2022_PROGRAM_ADDRESS.toString()
     ) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_svm_payload_no_transfer_instruction",
+        payer,
+      };
+    }
+
+    // parseTransferCheckedInstruction does not assert discriminator 12.
+    const ixData = transferIx.data;
+    if (!ixData || ixData.length < 10 || ixData[0] !== IX_TOKEN_TRANSFER_CHECKED) {
       return {
         isValid: false,
         invalidReason: "invalid_exact_svm_payload_no_transfer_instruction",

--- a/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/exact/v1/facilitator/scheme.ts
@@ -39,6 +39,8 @@ import {
   transactionMessageHash,
 } from "../../../utils";
 
+const IX_TOKEN_TRANSFER_CHECKED = 12;
+
 /**
  * SVM facilitator implementation for the Exact payment scheme (V1).
  */
@@ -201,6 +203,16 @@ export class ExactSvmSchemeV1 implements SchemeNetworkFacilitator {
       programAddress !== TOKEN_PROGRAM_ADDRESS.toString() &&
       programAddress !== TOKEN_2022_PROGRAM_ADDRESS.toString()
     ) {
+      return {
+        isValid: false,
+        invalidReason: "invalid_exact_svm_payload_no_transfer_instruction",
+        payer,
+      };
+    }
+
+    // parseTransferCheckedInstruction does not assert discriminator 12.
+    const ixData = transferIx.data;
+    if (!ixData || ixData.length < 10 || ixData[0] !== IX_TOKEN_TRANSFER_CHECKED) {
       return {
         isValid: false,
         invalidReason: "invalid_exact_svm_payload_no_transfer_instruction",

--- a/typescript/packages/mechanisms/svm/test/unit/smartWalletFallback.test.ts
+++ b/typescript/packages/mechanisms/svm/test/unit/smartWalletFallback.test.ts
@@ -128,10 +128,11 @@ async function buildStaticTransferPayload(args: {
   destination: Address;
   authority: Address;
   amount: bigint;
+  discriminator?: number;
   trailing?: IInstruction[];
 }) {
   const data = new Uint8Array(10);
-  data[0] = 12; // TransferChecked discriminator
+  data[0] = args.discriminator ?? 12;
   new DataView(data.buffer).setBigUint64(1, args.amount, true);
   data[9] = 6; // decimals
 
@@ -881,6 +882,67 @@ describe("ExactSvmScheme smart wallet fallback path", () => {
 
     expect(result.isValid).toBe(false);
     expect(result.invalidReason).toBe("invalid_exact_svm_payload_memo_count");
+  });
+
+  it("verify rejects ApproveChecked (discriminator 13) as a TransferChecked lookalike", async () => {
+    const { ExactSvmScheme } = await import("../../src/exact/facilitator/scheme");
+
+    const feePayer = await generateKeyPairSigner();
+    const payTo = await generateKeyPairSigner();
+    const payer = await generateKeyPairSigner();
+    const source = await generateKeyPairSigner();
+
+    const expectedAta = payTo.address;
+    mockAtaMap[payTo.address] = expectedAta;
+
+    const txBase64 = await buildStaticTransferPayload({
+      feePayer: feePayer.address,
+      source: source.address,
+      mint: USDC_DEVNET_ADDRESS as Address,
+      destination: expectedAta,
+      authority: payer.address,
+      amount: 100000n,
+      discriminator: 13, // ApproveChecked
+    });
+
+    const mockSigner = {
+      getAddresses: vi.fn().mockReturnValue([feePayer.address]),
+      signTransaction: vi.fn().mockResolvedValue(txBase64),
+      simulateTransaction: vi.fn().mockResolvedValue(undefined),
+      sendTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getConfirmedTransactionInnerInstructions: vi.fn().mockResolvedValue(null),
+      getTokenAccountBalance: vi.fn().mockResolvedValue(null),
+      fetchAddressLookupTables: vi.fn().mockResolvedValue({}),
+      simulateTransactionWithInnerInstructions: vi
+        .fn()
+        .mockResolvedValue({ innerInstructions: [] }),
+    };
+
+    const scheme = new ExactSvmScheme(mockSigner as never);
+
+    const accepted = {
+      scheme: "exact",
+      network: SOLANA_DEVNET_CAIP2,
+      asset: USDC_DEVNET_ADDRESS,
+      amount: "100000",
+      payTo: payTo.address,
+      maxTimeoutSeconds: 3600,
+      extra: { feePayer: feePayer.address },
+    };
+
+    const result = await scheme.verify(
+      {
+        x402Version: 2,
+        resource: { url: "http://test.com", description: "test", mimeType: "application/json" },
+        accepted,
+        payload: { transaction: txBase64 },
+      } as never,
+      accepted as never,
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.invalidReason).toBe("invalid_exact_svm_payload_no_transfer_instruction");
   });
 
   it("verify does NOT fall through to Path 2 on a semantic (amount mismatch) failure", async () => {


### PR DESCRIPTION
## Description

TS SVM exact static path validated the token program at instruction index 2 but not the instruction discriminator. 
This adds an explicit data[0] === 12 guard, matching Python/Go and the smart-wallet path

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 