### PR TITLE
docs: add Agent Guild x402 payment policy

### DIFF
--- a/docs/dev-tools/third-party-extensions.md
+++ b/docs/dev-tools/third-party-extensions.md
@@ -5,6 +5,7 @@ description: "Packages built by ecosystem partners that extend x402 beyond the c
 
 | Name | Description | Languages | Links |
 | ---- | ----------- | --------- | ----- |
+| [Agent Guild](https://agent-guild-5d5r.onrender.com/for-agents) | Fail-closed wallet-risk policy for x402 clients that issues signed, exact-payment allow or block credentials before payment signing | TypeScript | [GitHub](https://github.com/AgentTanuki/agent-guild/blob/main/sdk/integrations/x402_payment_policy.mjs) · [Hosted adapter](https://agent-guild-5d5r.onrender.com/sdk/integrations/x402_payment_policy.mjs) |
 | [World AgentKit](https://docs.world.org/agents/agent-kit/integrate) | Verify human-backed agents | TypeScript | [GitHub](https://github.com/worldcoin/agentkit) · [npm](https://www.npmjs.com/package/@worldcoin/agentkit) |
 | [OMATrust](https://www.omatrust.org/x402) | Key authorizations for Signed Offers and Receipts | TypeScript | [GitHub](https://github.com/oma3dao/omatrust-sdk) · [npm](https://www.npmjs.com/package/@oma3/omatrust) |
 | [PEAC Protocol](https://x402.peacprotocol.org) | Verifiable receipts for x402 payments | TypeScript | [GitHub](https://github.com/peacprotocol/peac) · [npm](https://www.npmjs.com/package/@peac/adapter-x402) |


### PR DESCRIPTION
## Description

Adds Agent Guild to the neutral third-party extensions catalog. The linked TypeScript hook runs before payment creation, fails closed, and returns locally verified AGPD-1 allow/block credentials bound to the exact payee, network, asset, atomic amount, and resource. Both source and the hosted single-file adapter are live.

## Tests

- Verified the hosted adapter returns HTTP 200 on GET and exports `createAgentGuildX402PaymentPolicy`.
- Verified the source link resolves to the same adapter on Agent Guild `main`.
- Verified the rendered Markdown table and `git diff --check`.
- Docs-only change; no SDK test or changelog fragment required.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass (docs-only; live links and rendered table verified)
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

AI disclosure: Codex assisted with the one-row documentation contribution and live-link verification; the exact diff, current contribution rules, hosted export, and verified GitHub commit were manually inspected before review.