### PR TITLE
fix(bazaar): use raw resource URL as canonical for opaque-origin schemes

### DIFF
--- a/typescript/.changeset/bazaar-opaque-origin-canonical-url.md
+++ b/typescript/.changeset/bazaar-opaque-origin-canonical-url.md
@@ -1,0 +1,5 @@
+---
+'@x402/extensions': patch
+---
+
+Fix `extractDiscoveryInfo` building a broken canonical URL (`"null/..."`) for resource URLs on schemes without a WHATWG-defined origin, such as `mcp://tool/{toolName}`. Canonicalization is now skipped for any opaque-origin scheme, not just `mcp://`, and the raw resource URL is used as canonical instead.

--- a/typescript/.changeset/bazaar-opaque-origin-canonical-url.md
+++ b/typescript/.changeset/bazaar-opaque-origin-canonical-url.md
@@ -2,4 +2,4 @@
 '@x402/extensions': patch
 ---
 
-Fix `extractDiscoveryInfo` building a broken canonical URL (`"null/..."`) for resource URLs on schemes without a WHATWG-defined origin, such as `mcp://tool/{toolName}`. Canonicalization is now skipped for any opaque-origin scheme, not just `mcp://`, and the raw resource URL is used as canonical instead.
+Fix `extractDiscoveryInfo` building a broken canonical URL (`"null/..."`) for resource URLs on schemes without a WHATWG-defined origin, such as `mcp://tool/{toolName}`. The canonical is now reconstructed from `protocol` + `host` + `pathname` for any opaque-origin scheme, not just `mcp://`, which strips the query string and fragment the same way the special-scheme path already does, instead of falling back to the raw resource URL unstripped.

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -573,12 +573,23 @@ export function extractDiscoveryInfo(
     return null;
   }
 
-  // Strip query params (?) and hash sections (#) for discovery cataloging
+  // Strip query params (?) and hash sections (#) for discovery cataloging.
+  // Canonicalization (origin + path) is only meaningful for a WHATWG
+  // "special scheme" (http, https, ws, wss, ftp, file) — those are the only
+  // schemes the URL spec defines a real origin for. Any other scheme (e.g.
+  // mcp://) parses to an opaque origin, which URL.prototype.origin
+  // serializes as the literal string "null", not a per-scheme special case
+  // to detect and list here: skip canonicalization entirely and use the
+  // raw resource URL as-is, so this holds for every current and future
+  // non-special scheme, not just the ones enumerated by name.
   const url = new URL(resourceUrl);
   // If a routeTemplate is present (dynamic route), use it as the canonical path
-  const canonicalUrl = routeTemplate
-    ? `${url.origin}${routeTemplate}`
-    : `${url.origin}${url.pathname}`;
+  const canonicalUrl =
+    url.origin === "null"
+      ? resourceUrl
+      : routeTemplate
+        ? `${url.origin}${routeTemplate}`
+        : `${url.origin}${url.pathname}`;
 
   // Extract description and mimeType from resource info (v2) or requirements (v1)
   let description: string | undefined;

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -574,19 +574,24 @@ export function extractDiscoveryInfo(
   }
 
   // Strip query params (?) and hash sections (#) for discovery cataloging.
-  // Canonicalization (origin + path) is only meaningful for a WHATWG
-  // "special scheme" (http, https, ws, wss, ftp, file) — those are the only
-  // schemes the URL spec defines a real origin for. Any other scheme (e.g.
-  // mcp://) parses to an opaque origin, which URL.prototype.origin
-  // serializes as the literal string "null", not a per-scheme special case
-  // to detect and list here: skip canonicalization entirely and use the
-  // raw resource URL as-is, so this holds for every current and future
-  // non-special scheme, not just the ones enumerated by name.
+  // `url.origin` is only meaningful for a WHATWG "special scheme" (http,
+  // https, ws, wss, ftp, file) — those are the only schemes the URL spec
+  // defines a real origin for. Any other scheme (e.g. mcp://) parses to an
+  // opaque origin, which URL.prototype.origin serializes as the literal
+  // string "null". That's not a reason to skip stripping too: `protocol`,
+  // `host`, and `pathname` all populate correctly for an opaque-origin URL
+  // (only `origin` collapses), so reconstructing from those three still
+  // strips the query/fragment this function exists to strip, without
+  // reintroducing a per-scheme allowlist. A producer declaring
+  // `mcp://tool/x?session=abc` would otherwise carry that query into the
+  // canonical, recreating the per-variant catalog duplication the
+  // stripping exists to prevent. See
+  // https://github.com/x402-foundation/x402/pull/3138#issuecomment-5273664506.
   const url = new URL(resourceUrl);
   // If a routeTemplate is present (dynamic route), use it as the canonical path
   const canonicalUrl =
     url.origin === "null"
-      ? resourceUrl
+      ? `${url.protocol}//${url.host}${url.pathname}`
       : routeTemplate
         ? `${url.origin}${routeTemplate}`
         : `${url.origin}${url.pathname}`;

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -1714,6 +1714,42 @@ describe("Bazaar Discovery Extension", () => {
       expect(discovered!.resourceUrl).toBe("test-scheme://tool/financial_analysis");
       expect(discovered!.resourceUrl).not.toContain("null");
     });
+
+    it("should strip query params from an opaque-origin resource URL", () => {
+      // The gap whawk46 flagged on #3138: the opaque-origin branch above
+      // used the raw resourceUrl verbatim, so a query string survived into
+      // the canonical instead of being stripped like every special-scheme
+      // canonical already strips it. `mcp://tool/x?session=abc` recreates
+      // the per-variant catalog duplication the stripping exists to
+      // prevent unless it's stripped here too.
+      const declared = declareDiscoveryExtension({
+        toolName: "financial_analysis",
+        description: "Analyze financial data",
+        inputSchema: {
+          type: "object",
+          properties: { ticker: { type: "string" } },
+        },
+      });
+
+      const paymentPayload = {
+        x402Version: 2,
+        scheme: "exact",
+        network: "eip155:8453" as unknown,
+        payload: {},
+        accepted: {} as unknown,
+        resource: { url: "mcp://tool/financial_analysis?session=abc" },
+        extensions: {
+          [BAZAAR.key]: declared.bazaar,
+        },
+      };
+
+      const discovered = extractDiscoveryInfo(paymentPayload, {} as unknown);
+
+      expect(discovered).not.toBeNull();
+      expect(discovered!.resourceUrl).toBe("mcp://tool/financial_analysis");
+      expect(discovered!.resourceUrl).not.toContain("session");
+      expect(discovered!.resourceUrl).not.toContain("?");
+    });
   });
 
   describe("validateAndExtract - MCP", () => {

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -1646,6 +1646,76 @@ describe("Bazaar Discovery Extension", () => {
     });
   });
 
+  describe("extractDiscoveryInfo - opaque-origin resource schemes", () => {
+    // mcp:// is not a WHATWG "special scheme" (only http/https/ws/wss/ftp/file
+    // are), so it parses to an opaque origin, and URL.prototype.origin
+    // serializes an opaque origin as the literal string "null" — see
+    // https://github.com/x402-foundation/x402/issues/3121. The fix is
+    // scheme-agnostic (detect the opaque-origin sentinel, not a scheme
+    // allowlist), so this pins the general rule with two independent
+    // schemes, not just mcp://, to catch the next undocumented scheme
+    // before it regresses the same way.
+    it("should use the raw resource URL as canonical for mcp:// (opaque origin)", () => {
+      const declared = declareDiscoveryExtension({
+        toolName: "financial_analysis",
+        description: "Analyze financial data",
+        inputSchema: {
+          type: "object",
+          properties: { ticker: { type: "string" } },
+        },
+      });
+
+      const paymentPayload = {
+        x402Version: 2,
+        scheme: "exact",
+        network: "eip155:8453" as unknown,
+        payload: {},
+        accepted: {} as unknown,
+        resource: { url: "mcp://tool/financial_analysis" },
+        extensions: {
+          [BAZAAR.key]: declared.bazaar,
+        },
+      };
+
+      const discovered = extractDiscoveryInfo(paymentPayload, {} as unknown);
+
+      expect(discovered).not.toBeNull();
+      expect(discovered!.resourceUrl).toBe("mcp://tool/financial_analysis");
+      expect(discovered!.resourceUrl).not.toContain("null");
+    });
+
+    it("should use the raw resource URL as canonical for an arbitrary non-special scheme (opaque origin)", () => {
+      // Not mcp:// — a made-up scheme this package has never heard of, to
+      // prove the fix doesn't special-case mcp specifically.
+      const declared = declareDiscoveryExtension({
+        toolName: "financial_analysis",
+        description: "Analyze financial data",
+        inputSchema: {
+          type: "object",
+          properties: { ticker: { type: "string" } },
+        },
+      });
+
+      const paymentPayload = {
+        x402Version: 2,
+        scheme: "exact",
+        network: "eip155:8453" as unknown,
+        payload: {},
+        accepted: {} as unknown,
+        resource: { url: "test-scheme://tool/financial_analysis" },
+        extensions: {
+          [BAZAAR.key]: declared.bazaar,
+        },
+      };
+
+      const discovered = extractDiscoveryInfo(paymentPayload, {} as unknown);
+
+      expect(discovered).not.toBeNull();
+      expect(discovered!.resourceUrl).toBe("test-scheme://tool/financial_analysis");
+      expect(discovered!.resourceUrl).not.toContain("null");
+    });
+  });
+
   describe("validateAndExtract - MCP", () => {
     it("should validate and extract MCP discovery info", () => {
       const declared = declareDiscoveryExtension({


### PR DESCRIPTION
Closes #3121.

## What

`extractDiscoveryInfo`'s canonical-URL computation (`packages/extensions/src/bazaar/facilitator.ts`) always ran `new URL(resourceUrl)` and built the canonical URL from `url.origin`. `mcp:` is not a WHATWG "special scheme" (only `http`/`https`/`ws`/`wss`/`ftp`/`file` are), so an `mcp://tool/{toolName}` resource URL parses to an opaque origin, and `URL.prototype.origin` serializes that as the literal string `"null"` — producing `"null/financial_analysis"` instead of the documented `"mcp://tool/financial_analysis"`.

## The fix

Scheme-agnostic, per [@whawk46's comment](https://github.com/x402-foundation/x402/issues/3121#issuecomment-5249065267) on the issue: compute the origin, and when it comes back as the opaque-origin sentinel (`origin === "null"`), skip canonicalization entirely and use the raw resource URL string as canonical. No `mcp://`-specific branch, no scheme allowlist to maintain going forward — this covers every current and future non-special scheme, which is the actual shape of the bug, not "mcp specifically."

## Tests

Two regression tests, shaped the way @whawk46 asked for in the issue thread: one for `mcp://`, and a second for an unrelated, made-up non-special scheme (`test-scheme://`), so the test pins the general rule ("opaque origins are never serialized into canonical URLs") rather than "mcp is special-cased." Confirmed both fail on the pre-fix code (2 failed, 136 passed) and pass with the fix (138 passed) before opening this PR.

`pnpm --filter @x402/extensions build` and `pnpm --filter @x402/extensions test` (full package, 522 tests) both pass.

## Credit

@whawk46 suggested this exact fix shape (detect the opaque-origin sentinel instead of a scheme allowlist) and the regression-test framing (a second, unrelated scheme, not just re-testing `mcp://`) in a comment on #3121. Both are implemented here as proposed, not just "per feedback" — the fix and the tests are whawk46's design, this PR is the implementation of it.

## AI disclosure

Drafted with AI assistance, reviewed and verified by hand. The fix and both regression tests were run against a real `pnpm build`/`pnpm test`, not asserted — confirmed failing without the fix, passing with it, before this PR was opened. Flagging per CONTRIBUTING.md so reviewers can calibrate.

## Checklist

- [x] I have formatted and linted my changes
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] Changelog fragment added (`typescript/.changeset/bazaar-opaque-origin-canonical-url.md`, `@x402/extensions` patch) — this is a user-facing bug fix, not docs-only
