### PR TITLE
fix(python): preserve MCP settlement metadata

### DIFF
--- a/python/x402/changelog.d/3149.bugfix.md
+++ b/python/x402/changelog.d/3149.bugfix.md
@@ -1,0 +1,1 @@
+Preserve MCP settlement metadata returned by the Python MCP SDK client.

--- a/python/x402/mcp/tests/test_utils.py
+++ b/python/x402/mcp/tests/test_utils.py
@@ -2,10 +2,13 @@
 
 import json
 
+import mcp.types as mt
+
 from x402.mcp.types import MCPToolResult
 from x402.mcp.utils import (
     attach_payment_to_meta,
     build_tool_resource_info,
+    convert_mcp_result,
     create_tool_resource_url,
     extract_payment_from_meta,
     extract_payment_required_from_result,
@@ -357,6 +360,24 @@ def test_attach_payment_response_to_meta_existing_meta():
 
     assert updated.meta["other_key"] == "other_value"
     assert "x402/payment-response" in updated.meta
+
+
+def test_convert_mcp_result_reads_model_meta():
+    """The MCP SDK exposes ``meta``; ``_meta`` is only its wire alias."""
+    response = {
+        "success": True,
+        "transaction": "0xtxhash123",
+        "network": "eip155:84532",
+    }
+    raw = mt.CallToolResult(
+        content=[mt.TextContent(type="text", text="success")],
+        isError=False,
+        _meta={"x402/payment-response": response},
+    )
+
+    converted = convert_mcp_result(raw)
+
+    assert converted.meta["x402/payment-response"] == response
 
 
 def test_attach_payment_response_to_meta_does_not_mutate_original():

--- a/python/x402/mcp/utils.py
+++ b/python/x402/mcp/utils.py
@@ -351,8 +351,11 @@ def convert_mcp_result(mcp_result: Any) -> "MCPToolResult":
     if is_error is None:
         is_error = getattr(mcp_result, "is_error", False)
 
-    # Extract meta
-    
+    # Pydantic MCP models expose ``meta``; ``_meta`` is the wire alias.  Keep
+    # the alias fallback for clients that return plain protocol objects.
+    meta = getattr(mcp_result, "meta", None)
+    if meta is None:
+        meta = getattr(mcp_result, "_meta", {})
     if not isinstance(meta, dict):
         meta = {}
 

--- a/python/x402/mcp/utils.py
+++ b/python/x402/mcp/utils.py
@@ -352,7 +352,7 @@ def convert_mcp_result(mcp_result: Any) -> "MCPToolResult":
         is_error = getattr(mcp_result, "is_error", False)
 
     # Extract meta
-    meta = getattr(mcp_result, "_meta", {})
+    
     if not isinstance(meta, dict):
         meta = {}
 


### PR DESCRIPTION
## Description

Fixes #3149.

The Python MCP SDK exposes the wire key _meta as the model field meta. The x402 client wrapper only read the wire alias, so successful paid tool calls lost x402/payment-response.

This prefers meta, retains _meta compatibility for plain protocol clients, and covers the real MCP SDK model.

## Tests

- PYTHONPATH=. python -m pytest -q x402/mcp/tests/test_utils.py — 22 passed
- git diff --check

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes

AI disclosure: the patch and regression test were prepared with Codex and reviewed against the MCP SDK model and a real x402MCPClient payment retry.