### PR TITLE
fix(core): isolate facilitator lifecycle hook errors

### DIFF
--- a/typescript/.changeset/isolate-facilitator-hook-errors.md
+++ b/typescript/.changeset/isolate-facilitator-hook-errors.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Isolate x402Facilitator lifecycle hook errors: a throwing beforeVerify/afterVerify/beforeSettle/afterSettle/onVerifyFailure/onSettleFailure hook is logged and skipped instead of altering the verify/settle outcome. Previously a throwing afterSettle hook fired onSettleFailure hooks and rejected settle() after settlement had already executed onchain. Mirrors the resource server's hook handling.

--- a/typescript/packages/core/src/facilitator/x402Facilitator.ts
+++ b/typescript/packages/core/src/facilitator/x402Facilitator.ts
@@ -291,12 +291,16 @@ export class x402Facilitator {
 
     // Execute beforeVerify hooks
     for (const hook of this.beforeVerifyHooks) {
-      const result = await hook(context);
-      if (result && "abort" in result && result.abort) {
-        return {
-          isValid: false,
-          invalidReason: result.reason,
-        };
+      try {
+        const result = await hook(context);
+        if (result && "abort" in result && result.abort) {
+          return {
+            isValid: false,
+            invalidReason: result.reason,
+          };
+        }
+      } catch (error) {
+        this.warnFacilitatorHookFailure("beforeVerify", error);
       }
     }
 
@@ -349,17 +353,25 @@ export class x402Facilitator {
 
         // Execute onVerifyFailure hooks
         for (const hook of this.onVerifyFailureHooks) {
-          const result = await hook(failureContext);
-          if (result && "recovered" in result && result.recovered) {
-            // If recovered, execute afterVerify hooks with recovered result
-            const recoveredContext: FacilitatorVerifyResultContext = {
-              ...context,
-              result: result.result,
-            };
-            for (const hook of this.afterVerifyHooks) {
-              await hook(recoveredContext);
+          try {
+            const result = await hook(failureContext);
+            if (result && "recovered" in result && result.recovered) {
+              // If recovered, execute afterVerify hooks with recovered result
+              const recoveredContext: FacilitatorVerifyResultContext = {
+                ...context,
+                result: result.result,
+              };
+              for (const afterHook of this.afterVerifyHooks) {
+                try {
+                  await afterHook(recoveredContext);
+                } catch (error) {
+                  this.warnFacilitatorHookFailure("afterVerify", error);
+                }
+              }
+              return result.result;
             }
-            return result.result;
+          } catch (error) {
+            this.warnFacilitatorHookFailure("onVerifyFailure", error);
           }
         }
 
@@ -373,7 +385,11 @@ export class x402Facilitator {
       };
 
       for (const hook of this.afterVerifyHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (error) {
+          this.warnFacilitatorHookFailure("afterVerify", error);
+        }
       }
 
       return verifyResult;
@@ -385,9 +401,13 @@ export class x402Facilitator {
 
       // Execute onVerifyFailure hooks
       for (const hook of this.onVerifyFailureHooks) {
-        const result = await hook(failureContext);
-        if (result && "recovered" in result && result.recovered) {
-          return result.result;
+        try {
+          const result = await hook(failureContext);
+          if (result && "recovered" in result && result.recovered) {
+            return result.result;
+          }
+        } catch (hookError) {
+          this.warnFacilitatorHookFailure("onVerifyFailure", hookError);
         }
       }
 
@@ -411,9 +431,17 @@ export class x402Facilitator {
       requirements: paymentRequirements,
     };
 
-    // Execute beforeSettle hooks
+    // Execute beforeSettle hooks. The hook call and the abort check are
+    // separated so a hook failure is isolated without swallowing the
+    // intentional abort throw.
     for (const hook of this.beforeSettleHooks) {
-      const result = await hook(context);
+      let result: Awaited<ReturnType<FacilitatorBeforeSettleHook>>;
+      try {
+        result = await hook(context);
+      } catch (error) {
+        this.warnFacilitatorHookFailure("beforeSettle", error);
+        continue;
+      }
       if (result && "abort" in result && result.abort) {
         throw new Error(`Settlement aborted: ${result.reason}`);
       }
@@ -463,8 +491,15 @@ export class x402Facilitator {
         result: settleResult,
       };
 
+      // Isolate afterSettle hook failures: settlement has already executed
+      // onchain, so a throwing observer must not convert a successful settle
+      // into an error response (or trigger onSettleFailure hooks).
       for (const hook of this.afterSettleHooks) {
-        await hook(resultContext);
+        try {
+          await hook(resultContext);
+        } catch (error) {
+          this.warnFacilitatorHookFailure("afterSettle", error);
+        }
       }
 
       return settleResult;
@@ -476,14 +511,31 @@ export class x402Facilitator {
 
       // Execute onSettleFailure hooks
       for (const hook of this.onSettleFailureHooks) {
-        const result = await hook(failureContext);
-        if (result && "recovered" in result && result.recovered) {
-          return result.result;
+        try {
+          const result = await hook(failureContext);
+          if (result && "recovered" in result && result.recovered) {
+            return result.result;
+          }
+        } catch (hookError) {
+          this.warnFacilitatorHookFailure("onSettleFailure", hookError);
         }
       }
 
       throw error;
     }
+  }
+
+  /**
+   * Logs a warning when a registered lifecycle hook throws. Hook failures are
+   * isolated so an observer cannot alter the outcome of verification or
+   * settlement, mirroring the resource server's hook handling.
+   *
+   * @param phase - Lifecycle phase whose hook threw
+   * @param error - Thrown value or rejection reason
+   */
+  private warnFacilitatorHookFailure(phase: string, error: unknown): void {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.warn(`[x402] Facilitator ${phase} hook threw: ${detail}`);
   }
 
   /**

--- a/typescript/packages/core/test/unit/facilitator/x402Facilitator.hooks.test.ts
+++ b/typescript/packages/core/test/unit/facilitator/x402Facilitator.hooks.test.ts
@@ -331,4 +331,130 @@ describe("x402Facilitator - Lifecycle Hooks", () => {
       expect(result).toBe(facilitator);
     });
   });
+
+  describe("hook error isolation", () => {
+    it("resolves settle() with the settle result when an afterSettle hook throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      let failureHookCalled = false;
+      facilitator.onAfterSettle(async () => {
+        throw new Error("observer crashed");
+      });
+      facilitator.onSettleFailure(async () => {
+        failureHookCalled = true;
+      });
+
+      const result = await facilitator.settle(buildPaymentPayload(), buildPaymentRequirements());
+
+      // Settlement already executed onchain: the caller must still receive it.
+      expect(result.success).toBe(true);
+      expect(result.transaction).toBe("0xMockTx");
+      // A throwing observer is not a settlement failure.
+      expect(failureHookCalled).toBe(false);
+    });
+
+    it("resolves verify() with the verify result when an afterVerify hook throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      let failureHookCalled = false;
+      facilitator.onAfterVerify(async () => {
+        throw new Error("observer crashed");
+      });
+      facilitator.onVerifyFailure(async () => {
+        failureHookCalled = true;
+      });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.isValid).toBe(true);
+      expect(failureHookCalled).toBe(false);
+    });
+
+    it("continues verification when a beforeVerify hook throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      const executionOrder: number[] = [];
+      facilitator
+        .onBeforeVerify(async () => {
+          executionOrder.push(1);
+          throw new Error("hook crashed");
+        })
+        .onBeforeVerify(async () => {
+          executionOrder.push(2);
+        });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result.isValid).toBe(true);
+      expect(executionOrder).toEqual([1, 2]);
+    });
+
+    it("continues settlement when a beforeSettle hook throws, still honoring a later abort", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register("eip155:8453", new MockSchemeFacilitator());
+
+      facilitator
+        .onBeforeSettle(async () => {
+          throw new Error("hook crashed");
+        })
+        .onBeforeSettle(async () => {
+          return { abort: true, reason: "blocked" };
+        });
+
+      await expect(
+        facilitator.settle(buildPaymentPayload(), buildPaymentRequirements()),
+      ).rejects.toThrow("Settlement aborted: blocked");
+    });
+
+    it("lets a later onVerifyFailure hook recover when an earlier one throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register(
+        "eip155:8453",
+        new MockSchemeFacilitator(async () => ({ isValid: false, invalidReason: "bad payment" })),
+      );
+
+      const recovered: VerifyResponse = { isValid: true, payer: "0xRecovered" };
+      facilitator
+        .onVerifyFailure(async () => {
+          throw new Error("first failure hook crashed");
+        })
+        .onVerifyFailure(async () => {
+          return { recovered: true, result: recovered };
+        });
+
+      const result = await facilitator.verify(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result).toEqual(recovered);
+    });
+
+    it("lets a later onSettleFailure hook recover when an earlier one throws", async () => {
+      const facilitator = new x402Facilitator();
+      facilitator.register(
+        "eip155:8453",
+        new MockSchemeFacilitator(undefined, async () => {
+          throw new Error("settlement rpc error");
+        }),
+      );
+
+      const recovered: SettleResponse = {
+        success: true,
+        transaction: "0xRecoveredTx",
+        network: "eip155:8453",
+      };
+      facilitator
+        .onSettleFailure(async () => {
+          throw new Error("first failure hook crashed");
+        })
+        .onSettleFailure(async () => {
+          return { recovered: true, result: recovered };
+        });
+
+      const result = await facilitator.settle(buildPaymentPayload(), buildPaymentRequirements());
+
+      expect(result).toEqual(recovered);
+    });
+  });
 });


### PR DESCRIPTION
Closes #1826

## Description

A throwing lifecycle hook can change the outcome of `verify()`/`settle()` on `x402Facilitator`. The worst case is `afterSettle`: settlement has already executed onchain, but a throwing hook falls into the `settle()` catch (`x402Facilitator.ts:466`), fires the `onSettleFailure` hooks, and rethrows — so the caller sees an error for a payment that actually moved money. The `beforeVerify`/`beforeSettle` loops are likewise unprotected, and a throwing `onVerifyFailure`/`onSettleFailure` hook prevents later hooks in the same loop from recovering.

The resource server side of #1826 was addressed during the payment-flow refactor (`x402ResourceServer` wraps each hook loop and warns via `warnResourceServerHookFailure`). This completes the facilitator half, which was left behind. Supersedes the stalled #1841.

## Fix

Wrap all six facilitator hook loops so a throwing hook is logged via a new `warnFacilitatorHookFailure` helper and skipped, mirroring the resource server's pattern. `beforeSettle` separates the hook call from the abort check so the isolation does not swallow the intentional `Settlement aborted` throw.

## Tests

Six cases added to `x402Facilitator.hooks.test.ts`, each confirmed to fail before the fix and pass after:

- `settle()` still resolves with the settle result when an `afterSettle` hook throws, and `onSettleFailure` hooks do not fire
- `verify()` still resolves when an `afterVerify` hook throws
- a throwing `beforeVerify`/`beforeSettle` hook does not stop later hooks, and a later `beforeSettle` abort is still honored
- a later `onVerifyFailure`/`onSettleFailure` hook can still recover when an earlier one throws

`pnpm format && pnpm lint && pnpm build && pnpm test` clean (625 core tests).

Disclosure: drafted with AI assistance (Claude Code); human-reviewed.