### PR TITLE
fix(evm): correct Monad USDC v1 EIP-712 domain name to "USDC"

### DIFF
--- a/go/.changes/unreleased/fixed-20260814-062853.yaml
+++ b/go/.changes/unreleased/fixed-20260814-062853.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Correct Monad USDC EIP-712 domain name to "USDC" in the v1 legacy network table; v1-signed transferWithAuthorization payloads previously failed on-chain signature recovery
+time: 2026-08-14T06:28:53.000000+00:00

--- a/go/mechanisms/evm/v1/network.go
+++ b/go/mechanisms/evm/v1/network.go
@@ -67,7 +67,7 @@ var NetworkConfigs = map[string]evm.NetworkConfig{
 		ChainID: big.NewInt(143),
 		DefaultAsset: evm.AssetInfo{
 			Address:  "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
-			Name:     "USD Coin",
+			Name:     "USDC",
 			Version:  "2",
 			Decimals: evm.DefaultDecimals,
 		},

--- a/python/x402/changelog.d/+monad-v1-usdc-domain-name.bugfix.md
+++ b/python/x402/changelog.d/+monad-v1-usdc-domain-name.bugfix.md
@@ -1,0 +1,1 @@
+Corrected Monad USDC's EIP-712 domain name to `"USDC"` in the v1 legacy default-asset table; v1 `transferWithAuthorization` signatures on Monad previously failed on-chain signature recovery.

--- a/python/x402/mechanisms/evm/v1/constants.py
+++ b/python/x402/mechanisms/evm/v1/constants.py
@@ -42,7 +42,7 @@ V1_DEFAULT_ASSETS: dict[str, AssetInfo] = {
     },
     "monad": {
         "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
-        "name": "USD Coin",
+        "name": "USDC",
         "version": "2",
         "decimals": 6,
     },


### PR DESCRIPTION
## Description

Closes #3152. #3105 corrected the Monad (`eip155:143`) USDC EIP-712 domain name in the v2 default-asset tables; the legacy v1 tables in Go and Python still say `"USD Coin"`. The v1 exact client builds its EIP-3009 signing domain from these tables, so v1 payments on Monad fail on-chain signature recovery. TypeScript needs no change; its v1 path resolves through the shared table #3105 fixed.

Most of this PR was produced with an AI coding agent (Claude Code); I reviewed the change and the on-chain verification.

## Tests

Constant-only change, verified on-chain (evidence in #3152): the deployed contract reports `name() == "USDC"` and its `DOMAIN_SEPARATOR` reproduces only with that name. No unit tests added, matching the review guidance on #3105; existing v1 tests pin chain IDs, not domain names.

Run locally: `go test ./...` (32 packages, all pass), `make lint` (golangci-lint v2.7.2, 0 issues), `gofmt` and `go vet` clean; `uv run pytest` (1898 passed, 65 skipped), `uvx ruff format --check` and `uvx ruff check` clean.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)