### PR TITLE
feat(go): spend controls

### DIFF
--- a/e2e/clients/go/client.go
+++ b/e2e/clients/go/client.go
@@ -75,7 +75,7 @@ func BuildPaymentClient() *PaymentClientContext {
 		log.Fatal("At least one of CLIENT_EVM_PRIVATE_KEY or CLIENT_SVM_PRIVATE_KEY is required")
 	}
 
-	x402Client := x402.Newx402Client()
+	x402Client := x402.Newx402Client().DisableSpendControls()
 	var batchedScheme *batchedclient.BatchSettlementEvmScheme
 
 	if evmPrivateKey != "" {

--- a/examples/go/clients/advanced/README.md
+++ b/examples/go/clients/advanced/README.md
@@ -38,6 +38,7 @@ Each example demonstrates a specific advanced pattern:
 | `error-recovery` | `go run . error-recovery` | Error classification and recovery |
 | `multi-network-priority` | `go run . multi-network-priority` | Network-specific signer registration |
 | `hooks` | `go run . hooks` | Payment lifecycle hooks |
+| `spend-controls` | `go run . spend-controls` | Asset allowlist and USD spend caps |
 
 ## Testing the Examples
 
@@ -123,6 +124,40 @@ client := x402.Newx402Client().
 More specific registrations always override wildcards.
 
 **Use case:** Different signers per network, mainnet/testnet separation, multi-chain applications.
+
+## Example: Spend Controls
+
+By default the client caps recognized pegged assets at `$1` and rejects everything else. Use `SetSpendControls` to raise the cap or opt into non-default tokens (custom ERC-20s).
+
+```go
+client := x402.Newx402Client().
+    SetSpendControls(x402.SpendControls{
+        MaxAmountPerPayment: "$1", // default USD cap on recognized pegged assets
+        AllowedAssets: []x402.SpendControlAsset{
+            // opt-in non-default with atomic cap
+            {Network: "eip155:*", Asset: "0xCustomToken", MaxAmountPerPayment: "2000000"},
+            // opt-in non-default uncapped
+            {Network: "eip155:*", Asset: "0xOtherToken"},
+            // override USD cap for a default asset by ticker (or on-chain id)
+            {Network: "eip155:*", Asset: "USDC", MaxAmountPerPayment: "1000000"},
+        },
+    }).
+    Register("eip155:*", evm.NewExactEvmScheme(evmSigner, nil))
+```
+
+| Control | Purpose |
+| --- | --- |
+| `DisableSpendControls()` | Disable all spend controls (any asset, no caps). Useful for UI-confirmed flows and tests. |
+| `MaxAmountPerPayment` | USD ceiling on recognized pegged assets (default `$1`). Set a higher value to raise the cap, or set `DisableMaxAmountPerPayment: true` to remove it. |
+| `AllowedAssets` | Opt-in for non-default tokens. List of `{ Network, Asset }` with optional atomic `MaxAmountPerPayment`, or set `AllowAnyAsset: true` to allow any asset. `Asset` may be an on-chain id or a default-asset symbol (e.g. `"PYUSD"`). |
+
+**Use case:**
+
+- Bound spend against a malicious 402 or unbounded custom token
+- Allow a specific custom token without disabling the USD cap on stables
+- Override the cap for one ticker (e.g. PYUSD) without raising it globally
+
+Run the example: `go run . spend-controls`
 
 ## Example: Custom Transport
 

--- a/examples/go/clients/advanced/go.mod
+++ b/examples/go/clients/advanced/go.mod
@@ -7,8 +7,8 @@ toolchain go1.24.1
 replace github.com/x402-foundation/x402/go/v2 => ../../../../go
 
 require (
-	github.com/x402-foundation/x402/go/v2 v2.14.0
 	github.com/joho/godotenv v1.5.1
+	github.com/x402-foundation/x402/go/v2 v2.14.0
 )
 
 require (
@@ -19,27 +19,28 @@ require (
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
-	github.com/consensys/gnark-crypto v0.18.0 // indirect
-	github.com/crate-crypto/go-eth-kzg v1.4.0 // indirect
-	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/consensys/gnark-crypto v0.18.1 // indirect
+	github.com/crate-crypto/go-eth-kzg v1.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
-	github.com/ethereum/c-kzg-4844/v2 v2.1.5 // indirect
-	github.com/ethereum/go-ethereum v1.16.7 // indirect
-	github.com/ethereum/go-verkle v0.2.2 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
+	github.com/ethereum/c-kzg-4844/v2 v2.1.6 // indirect
+	github.com/ethereum/go-ethereum v1.17.2 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/gagliardetto/binary v0.8.0 // indirect
 	github.com/gagliardetto/solana-go v1.14.0 // indirect
 	github.com/gagliardetto/treeout v0.1.4 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.16.0 // indirect
+	github.com/klauspost/compress v1.17.8 // indirect
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -48,17 +49,21 @@ require (
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091 // indirect
-	github.com/supranational/blst v0.3.16-0.20250831170142-f48500c1fdbe // indirect
+	github.com/supranational/blst v0.3.16 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	go.mongodb.org/mongo-driver v1.12.2 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel v1.40.0 // indirect
+	go.opentelemetry.io/otel/metric v1.40.0 // indirect
+	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
-	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/sys v0.36.0 // indirect
-	golang.org/x/term v0.34.0 // indirect
-	golang.org/x/time v0.9.0 // indirect
+	golang.org/x/crypto v0.46.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
+	golang.org/x/term v0.38.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
 )

--- a/examples/go/clients/advanced/main.go
+++ b/examples/go/clients/advanced/main.go
@@ -21,6 +21,7 @@ import (
  * - error-recovery: Advanced error handling and automatic recovery strategies
  * - multi-network-priority: Network selection with priority and fallback
  * - hooks: Payment lifecycle hooks for custom logic at different stages
+ * - spend-controls: Client-side asset allowlist and USD spend caps
  *
  * Usage:
  *   go run . all-networks
@@ -98,9 +99,15 @@ func main() {
 			os.Exit(1)
 		}
 
+	case "spend-controls":
+		if err := runSpendControlsExample(ctx, evmPrivateKey, url); err != nil {
+			fmt.Printf("❌ Error: %v\n", err)
+			os.Exit(1)
+		}
+
 	default:
 		fmt.Printf("❌ Unknown pattern: %s\n", pattern)
-		fmt.Println("Available patterns: all-networks, custom-transport, error-recovery, multi-network-priority, hooks")
+		fmt.Println("Available patterns: all-networks, custom-transport, error-recovery, multi-network-priority, hooks, spend-controls")
 		os.Exit(1)
 	}
 }

--- a/examples/go/clients/advanced/spend_controls.go
+++ b/examples/go/clients/advanced/spend_controls.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	x402 "github.com/x402-foundation/x402/go/v2"
+	x402http "github.com/x402-foundation/x402/go/v2/http"
+	exactevm "github.com/x402-foundation/x402/go/v2/mechanisms/evm/exact/client"
+	uptoevm "github.com/x402-foundation/x402/go/v2/mechanisms/evm/upto/client"
+	evmsigners "github.com/x402-foundation/x402/go/v2/signers/evm"
+)
+
+/**
+ * Spend Controls Example
+ *
+ * Demonstrates client-side spend controls: the default $1 USD cap on
+ * recognized pegged assets, opt-in AllowedAssets (atomic per-asset caps or
+ * uncapped), and ticker overrides for a default asset.
+ */
+
+func runSpendControlsExample(ctx context.Context, evmPrivateKey, url string) error {
+	fmt.Println("🛡️  Creating client with spend controls...\n")
+
+	evmSigner, err := evmsigners.NewClientSignerFromPrivateKey(evmPrivateKey)
+	if err != nil {
+		return fmt.Errorf("failed to create EVM signer: %w", err)
+	}
+
+	client := x402.Newx402Client().
+		SetSpendControls(x402.SpendControls{
+			MaxAmountPerPayment: "$1", // default USD cap on recognized pegged assets
+			AllowedAssets: []x402.SpendControlAsset{
+				// opt-in non-default with atomic cap
+				{Network: "eip155:*", Asset: "0xCustomToken", MaxAmountPerPayment: "2000000"},
+				// opt-in non-default uncapped
+				{Network: "eip155:*", Asset: "0xOtherToken"},
+				// override USD cap for a default asset by ticker (or on-chain id)
+				{Network: "eip155:*", Asset: "USDC", MaxAmountPerPayment: "1000000"},
+			},
+		}).
+		Register("eip155:*", exactevm.NewExactEvmScheme(evmSigner, nil)).
+		Register("eip155:*", uptoevm.NewUptoEvmScheme(evmSigner, nil))
+
+	httpClient := x402http.Newx402HTTPClient(client)
+	wrappedClient := x402http.WrapHTTPClientWithPayment(http.DefaultClient, httpClient)
+
+	fmt.Printf("🌐 Making request to: %s\n\n", url)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	start := time.Now()
+	resp, err := wrappedClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	printDuration(start, "Request")
+	if err := printResponse(resp, "Response with spend controls"); err != nil {
+		return err
+	}
+
+	printPaymentDetails(resp.Header)
+	fmt.Println("✅ Request completed with spend controls\n")
+
+	return nil
+}

--- a/examples/go/clients/http/README.md
+++ b/examples/go/clients/http/README.md
@@ -66,9 +66,14 @@ import (
 // Create signer
 signer, err := evmsigners.NewClientSignerFromPrivateKey(os.Getenv("EVM_PRIVATE_KEY"))
 
-// Configure client with builder pattern
+// Configure client with builder pattern.
+// Newx402Client() enables default spend controls: recognized pegged assets only, capped at $1 USD.
 client := x402.Newx402Client().
     Register("eip155:*", evm.NewExactEvmScheme(signer))
+
+// Optional: raise the cap or opt into non-default tokens
+// client.SetSpendControls(x402.SpendControls{MaxAmountPerPayment: "$5"})
+// client.DisableSpendControls() // disable all spend controls (any asset, no caps)
 
 // Wrap HTTP client with payment handling
 httpClient := x402http.WrapHTTPClientWithPayment(

--- a/examples/go/clients/mcp/README.md
+++ b/examples/go/clients/mcp/README.md
@@ -146,6 +146,23 @@ x402Mcp := mcp.NewX402MCPClient(session, paymentClient, mcp.Options{
 })
 ```
 
+When using `NewX402MCPClientFromConfig`, configure spend controls via `Options`:
+
+```go
+x402Mcp := mcp.NewX402MCPClientFromConfig(session, schemes, mcp.Options{
+    AutoPayment: mcp.BoolPtr(true),
+    SpendControls: &x402.SpendControls{
+        MaxAmountPerPayment: "$5",
+        AllowedAssets: []x402.SpendControlAsset{
+            {Network: "eip155:84532", Asset: "0xCustomToken"},
+        },
+    },
+    // DisableSpendControls: true, // equivalent to spendControls: false
+})
+```
+
+When wrapping an existing client with `NewX402MCPClient`, configure spend controls on `paymentClient` before wrapping (`SetSpendControls` / `DisableSpendControls`). `Options.SpendControls` is not applied in that path.
+
 ### Hooks
 
 ```go

--- a/examples/go/clients/mcp/README.md
+++ b/examples/go/clients/mcp/README.md
@@ -146,22 +146,25 @@ x402Mcp := mcp.NewX402MCPClient(session, paymentClient, mcp.Options{
 })
 ```
 
-Configure spend controls via `Options` for either constructor:
+Configure spend controls on the payment client, then wrap:
 
 ```go
-x402Mcp := mcp.NewX402MCPClientFromConfig(session, schemes, mcp.Options{
-    AutoPayment: mcp.BoolPtr(true),
-    SpendControls: &x402.SpendControls{
+paymentClient := x402.Newx402Client().
+    Register("eip155:84532", evmClientScheme).
+    SetSpendControls(x402.SpendControls{
         MaxAmountPerPayment: "$5",
         AllowedAssets: []x402.SpendControlAsset{
             {Network: "eip155:84532", Asset: "0xCustomToken"},
         },
-    },
-    // DisableSpendControls: true, // equivalent to spendControls: false
+    })
+    // .DisableSpendControls() // any asset, no caps
+
+x402Mcp := mcp.NewX402MCPClient(session, paymentClient, mcp.Options{
+    AutoPayment: mcp.BoolPtr(true),
 })
 ```
 
-When wrapping an existing client with `NewX402MCPClient`, `Options.SpendControls` / `DisableSpendControls` overwrite the wrapped client's controls when set. If both are unset, the payment client's existing spend controls are left as-is.
+`NewX402MCPClientFromConfig` uses the default `$1` USD cap and default-asset allowlist from `Newx402Client()`.
 
 ### Hooks
 

--- a/examples/go/clients/mcp/README.md
+++ b/examples/go/clients/mcp/README.md
@@ -146,7 +146,7 @@ x402Mcp := mcp.NewX402MCPClient(session, paymentClient, mcp.Options{
 })
 ```
 
-When using `NewX402MCPClientFromConfig`, configure spend controls via `Options`:
+Configure spend controls via `Options` for either constructor:
 
 ```go
 x402Mcp := mcp.NewX402MCPClientFromConfig(session, schemes, mcp.Options{
@@ -161,7 +161,7 @@ x402Mcp := mcp.NewX402MCPClientFromConfig(session, schemes, mcp.Options{
 })
 ```
 
-When wrapping an existing client with `NewX402MCPClient`, configure spend controls on `paymentClient` before wrapping (`SetSpendControls` / `DisableSpendControls`). `Options.SpendControls` is not applied in that path.
+When wrapping an existing client with `NewX402MCPClient`, `Options.SpendControls` / `DisableSpendControls` overwrite the wrapped client's controls when set. If both are unset, the payment client's existing spend controls are left as-is.
 
 ### Hooks
 

--- a/examples/go/servers/advanced/README.md
+++ b/examples/go/servers/advanced/README.md
@@ -226,11 +226,15 @@ Accept payments in custom tokens. Register a money parser on the scheme to suppo
 
 ```go
 evmScheme := evm.NewExactEvmScheme().RegisterMoneyParser(
-    func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+    func(amount string, network x402.Network) (*x402.AssetAmount, error) {
         // Use Wrapped XDAI on Gnosis Chain
         if string(network) == "eip155:100" {
+            tokenAmount, err := x402.ConvertToTokenAmount(amount, 18)
+            if err != nil {
+                return nil, err
+            }
             return &x402.AssetAmount{
-                Amount: fmt.Sprintf("%.0f", amount*1e18),
+                Amount: tokenAmount,
                 Asset:  "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d",
                 Extra:  map[string]interface{}{"token": "Wrapped XDAI"},
             }, nil

--- a/examples/go/servers/advanced/custom-money-definition.go
+++ b/examples/go/servers/advanced/custom-money-definition.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"math"
 	"net/http"
 	"os"
 	"time"
@@ -52,32 +51,24 @@ func main() {
 	 * Create EVM Scheme with Custom Money Parser
 	 *
 	 * This demonstrates registering a custom money parser that handles
-	 * specific network or amount conditions differently.
+	 * a specific network differently.
 	 *
 	 * For example, on Gnosis Chain (xDai) network, we could use Wrapped XDAI
 	 * instead of USDC (this is for demonstration - WXDAI isn't EIP-3009 compliant).
 	 */
-	evmScheme := evm.NewExactEvmScheme().RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+	evmScheme := evm.NewExactEvmScheme().RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
 		// Custom logic for Gnosis Chain (eip155:100)
 		if string(network) == "eip155:100" {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 18)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e18),             // Wrapped XDAI has 18 decimals
+				Amount: tokenAmount,                                  // Wrapped XDAI has 18 decimals
 				Asset:  "0xe91d153e0b41518a2ce8dd3d7944fa863463a97d", // WXDAI address on Gnosis
 				Extra: map[string]interface{}{
 					"token":   "Wrapped XDAI",
 					"network": "gnosis",
-				},
-			}, nil
-		}
-
-		// For large amounts on any network, use DAI instead of USDC
-		if amount > 100 {
-			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", math.Round(amount*1e18)), // DAI has 18 decimals
-				Asset:  "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb", // DAI on Base Sepolia
-				Extra: map[string]interface{}{
-					"token": "DAI",
-					"tier":  "large",
 				},
 			}, nil
 		}
@@ -121,7 +112,7 @@ func main() {
 	})
 
 	fmt.Printf("🚀 Custom Money Definition example running on http://localhost:%s\n", DefaultPort)
-	fmt.Printf("   Using custom money parsers for different networks and amounts\n")
+	fmt.Printf("   Using custom money parsers for different networks\n")
 
 	if err := r.Run(":" + DefaultPort); err != nil {
 		fmt.Printf("Error starting server: %v\n", err)

--- a/go/.changes/unreleased/added-20260814-093000.yaml
+++ b/go/.changes/unreleased/added-20260814-093000.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add client spend controls (default-asset allowlist and $1 USD cap) and EVM/SVM default-asset tables so USD-pegged tokens are recognized for caps and money strings.
+time: 2026-08-14T09:30:00.000000-07:00

--- a/go/.changes/unreleased/changed-20260817-204600.yaml
+++ b/go/.changes/unreleased/changed-20260817-204600.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: ParseMoney and MoneyParser now use decimal strings instead of float64; amounts too small for the asset decimals truncate to "0" instead of erroring.
+time: 2026-08-17T20:46:00.000000+02:00

--- a/go/CLIENT.md
+++ b/go/CLIENT.md
@@ -203,7 +203,7 @@ Accept selection runs in three stages: **spend controls** enforce built-in safet
 |---------|---------|
 | `DisableSpendControls()` | Disable all spend controls (any asset, no caps). Useful for UI-confirmed flows (paywall) and tests. |
 | `MaxAmountPerPayment` | USD ceiling on payments in recognized USD-pegged assets (default **`$1`**). Set a higher value to raise the cap, or `DisableMaxAmountPerPayment: true` to remove it. |
-| `AllowedAssets` | Opt-in for non-default tokens. Omit for default assets only; `AllowAnyAsset: true` to allow any asset; or a list of `{ Network, Asset }` with optional atomic `MaxAmountPerPayment` per entry. `Asset` may be an on-chain id or a default-asset symbol (e.g. `"PYUSD"`). |
+| `AllowedAssets` | Opt-in for non-default tokens. Omit for default assets only; `AllowAnyAsset: true` to allow any asset; or a list of `{ Network, Asset }` with optional atomic `MaxAmountPerPayment` per entry. Per-entry `MaxAmountPerPayment` is an integer atomic string (`"2000000"`), not `"$1"`. `Asset` may be an on-chain id or a default-asset symbol (e.g. `"PYUSD"`). |
 
 Network scoping is separate: register only the networks you intend to pay on. Unregistered networks are never selected regardless of spend controls.
 

--- a/go/CLIENT.md
+++ b/go/CLIENT.md
@@ -171,7 +171,45 @@ client.Register("eip155:*", evm.NewExactEvmScheme(defaultSigner, &evm.ExactEvmSc
 }))
 ```
 
-### 4. HTTP Integration
+### 4. Spend Controls
+
+Built-in safety rails applied before policies during accept selection. Use these for amount and asset bounds—not for network preference.
+
+`Newx402Client()` enables spend controls by default: only assets the registered scheme's `FindDefaultAsset` recognizes are allowed, with a **`$1`** USD ceiling. Opt into other tokens via `AllowedAssets`, or call `DisableSpendControls()` to disable all spend controls.
+
+```go
+client := x402.Newx402Client().
+    SetSpendControls(x402.SpendControls{
+        MaxAmountPerPayment: "$5", // USD cap on default assets; empty => "$1"
+        AllowedAssets: []x402.SpendControlAsset{
+            // opt-in non-default with atomic cap
+            {Network: "eip155:8453", Asset: "0xCustomToken", MaxAmountPerPayment: "2000000"},
+            // opt-in non-default uncapped
+            {Network: "eip155:8453", Asset: "0xOtherToken"},
+            // override USD cap for a default asset by ticker (or on-chain id)
+            {Network: "eip155:8453", Asset: "PYUSD", MaxAmountPerPayment: "500000"},
+        },
+        // AllowAnyAsset: true, // allow any asset (USD cap still applies to defaults)
+    }).
+    Register("eip155:*", evm.NewExactEvmScheme(signer, nil))
+
+// Or disable all spend controls (any asset, no caps):
+// client.DisableSpendControls()
+```
+
+Accept selection runs in three stages: **spend controls** enforce built-in safety caps, **policies** filter the remaining list, and **paymentRequirementsSelector** picks one accept (default: first remaining). Do not use policies for USD caps or asset allowlists—that is what spend controls are for.
+
+| Control | Purpose |
+|---------|---------|
+| `DisableSpendControls()` | Disable all spend controls (any asset, no caps). Useful for UI-confirmed flows (paywall) and tests. |
+| `MaxAmountPerPayment` | USD ceiling on payments in recognized USD-pegged assets (default **`$1`**). Set a higher value to raise the cap, or `DisableMaxAmountPerPayment: true` to remove it. |
+| `AllowedAssets` | Opt-in for non-default tokens. Omit for default assets only; `AllowAnyAsset: true` to allow any asset; or a list of `{ Network, Asset }` with optional atomic `MaxAmountPerPayment` per entry. `Asset` may be an on-chain id or a default-asset symbol (e.g. `"PYUSD"`). |
+
+Network scoping is separate: register only the networks you intend to pay on. Unregistered networks are never selected regardless of spend controls.
+
+See [Advanced Examples](../examples/go/clients/advanced/) for a runnable spend-controls example.
+
+### 5. HTTP Integration
 
 The HTTP layer adds automatic payment handling to standard HTTP clients.
 
@@ -335,6 +373,14 @@ func (c *X402Client) Register(network Network, scheme SchemeNetworkClient) *X402
 func (c *X402Client) OnBeforePaymentCreation(hook BeforePaymentCreationHook) *X402Client
 func (c *X402Client) OnAfterPaymentCreation(hook AfterPaymentCreationHook) *X402Client
 func (c *X402Client) OnPaymentCreationFailure(hook PaymentCreationFailureHook) *X402Client
+```
+
+**Spend Control Methods:**
+```go
+func (c *X402Client) SetSpendControls(controls SpendControls) *X402Client
+func (c *X402Client) DisableSpendControls() *X402Client
+func WithSpendControls(controls SpendControls) ClientOption
+func WithSpendControlsDisabled() ClientOption
 ```
 
 **Payment Methods:**

--- a/go/README.md
+++ b/go/README.md
@@ -277,6 +277,7 @@ Transfer an exact amount to access a resource:
 - ✅ Extensible plugin architecture
 - ✅ Production ready with comprehensive testing
 - ✅ Lifecycle hooks for customization
+- ✅ Client spend controls (default-asset allowlist and $1 USD cap)
 
 ## Package Documentation
 

--- a/go/SERVER.md
+++ b/go/SERVER.md
@@ -281,16 +281,16 @@ Use alternative tokens for payments:
 
 ```go
 evmScheme := evm.NewExactEvmScheme().RegisterMoneyParser(
-    func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-        // Use DAI for large amounts
-        if amount > 100 {
-            return &x402.AssetAmount{
-                Amount: fmt.Sprintf("%.0f", amount*1e18),
-                Asset:  "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb", // DAI
-                Extra:  map[string]interface{}{"token": "DAI"},
-            }, nil
+    func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+        tokenAmount, err := x402.ConvertToTokenAmount(amount, 18)
+        if err != nil {
+            return nil, err
         }
-        return nil, nil // Use default USDC for small amounts
+        return &x402.AssetAmount{
+            Amount: tokenAmount,
+            Asset:  "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb", // DAI
+            Extra:  map[string]interface{}{"token": "DAI"},
+        }, nil
     },
 )
 ```

--- a/go/client.go
+++ b/go/client.go
@@ -470,11 +470,17 @@ func (c *x402Client) applySpendControls(x402Version int, requirements []PaymentR
 	for _, requirement := range beforeAmountCaps {
 		assetEntry := findAssetEntry(requirement)
 		if assetEntry != nil && assetEntry.MaxAmountPerPayment != "" {
-			capN, ok := new(big.Int).SetString(assetEntry.MaxAmountPerPayment, 10)
-			if !ok {
+			if !atomicAmountPattern.MatchString(assetEntry.MaxAmountPerPayment) {
+				return nil, fmt.Errorf(
+					"spendControls.allowedAssets[].maxAmountPerPayment must be an integer atomic amount, not a dollar value; got %q",
+					assetEntry.MaxAmountPerPayment,
+				)
+			}
+			if !atomicAmountPattern.MatchString(rawAmountOf(requirement)) {
 				rejectedByAssetCap = true
 				continue
 			}
+			capN, _ := new(big.Int).SetString(assetEntry.MaxAmountPerPayment, 10)
 			if amountOf(requirement).Cmp(capN) <= 0 {
 				capped = append(capped, requirement)
 			} else {

--- a/go/client.go
+++ b/go/client.go
@@ -504,7 +504,7 @@ func (c *x402Client) applySpendControls(x402Version int, requirements []PaymentR
 			if err != nil {
 				return nil, err
 			}
-			capScaled, err := ConvertToTokenAmount(NumberToDecimalString(parsed), 18)
+			capScaled, err := ConvertToTokenAmount(parsed, 18)
 			if err != nil {
 				return nil, err
 			}
@@ -522,7 +522,7 @@ func (c *x402Client) applySpendControls(x402Version int, requirements []PaymentR
 		if err != nil {
 			return nil, err
 		}
-		maxAtomic, err := ConvertToTokenAmount(NumberToDecimalString(parsed), defaultAsset.Decimals)
+		maxAtomic, err := ConvertToTokenAmount(parsed, defaultAsset.Decimals)
 		if err != nil {
 			return nil, err
 		}

--- a/go/client.go
+++ b/go/client.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"reflect"
+	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/x402-foundation/x402/go/v2/types"
@@ -32,6 +35,9 @@ type x402Client struct {
 	afterPaymentCreationHooks     []AfterPaymentCreationHook
 	onPaymentCreationFailureHooks []OnPaymentCreationFailureHook
 	onPaymentResponseHooks        []OnPaymentResponseHook
+
+	spendControlsEnabled bool
+	spendControls        SpendControls
 }
 
 // ClientOption configures the client
@@ -51,6 +57,21 @@ func WithPolicy(policy PaymentPolicy) ClientOption {
 	}
 }
 
+// WithSpendControls sets spend controls at creation time.
+func WithSpendControls(controls SpendControls) ClientOption {
+	return func(c *x402Client) {
+		c.spendControlsEnabled = true
+		c.spendControls = controls
+	}
+}
+
+// WithSpendControlsDisabled disables spend controls at creation time.
+func WithSpendControlsDisabled() ClientOption {
+	return func(c *x402Client) {
+		c.spendControlsEnabled = false
+	}
+}
+
 // Newx402Client creates a new x402 client
 func Newx402Client(opts ...ClientOption) *x402Client {
 	c := &x402Client{
@@ -59,6 +80,7 @@ func Newx402Client(opts ...ClientOption) *x402Client {
 		requirementsSelector: DefaultPaymentSelector,
 		policies:             []PaymentPolicy{},
 		extensions:           make(map[string]ClientExtension),
+		spendControlsEnabled: true,
 	}
 
 	for _, opt := range opts {
@@ -163,6 +185,23 @@ func (c *x402Client) OnPaymentResponse(hook OnPaymentResponseHook) *x402Client {
 	return c
 }
 
+// SetSpendControls enables spend controls with the given configuration.
+func (c *x402Client) SetSpendControls(controls SpendControls) *x402Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.spendControlsEnabled = true
+	c.spendControls = controls
+	return c
+}
+
+// DisableSpendControls disables all spend controls (any asset, no caps).
+func (c *x402Client) DisableSpendControls() *x402Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.spendControlsEnabled = false
+	return c
+}
+
 // HandlePaymentResponse dispatches the OnPaymentResponse lifecycle for a paid
 // response: invokes the scheme's PaymentResponseHandler (if implemented) followed
 // by every user-registered OnPaymentResponseHook. Returns Recovered=true if any
@@ -229,8 +268,13 @@ func (c *x402Client) SelectPaymentRequirementsV1(requirements []types.PaymentReq
 	// Convert to views for selector/policies
 	views := toViews(supported)
 
+	// Apply spend controls before policies
+	filtered, err := c.applySpendControls(1, views)
+	if err != nil {
+		return types.PaymentRequirementsV1{}, err
+	}
+
 	// Apply policies
-	filtered := views
 	for _, policy := range c.policies {
 		filtered = policy(filtered)
 		if len(filtered) == 0 {
@@ -251,9 +295,10 @@ func (c *x402Client) SelectPaymentRequirementsV1(requirements []types.PaymentReq
 // Selection process:
 //  1. Filter by registered schemes (network + scheme support)
 //  2. Drop accepts with unrecognized extra.paymentFlow
-//  3. Apply all registered policies in order
-//  4. Prefer authorization (omit or explicit) over upfront/escrow when both remain
-//  5. Use selector to choose final requirement
+//  3. Apply spend controls (default-asset allowlist and USD cap)
+//  4. Apply all registered policies in order
+//  5. Prefer authorization (omit or explicit) over upfront/escrow when both remain
+//  6. Use selector to choose final requirement
 func (c *x402Client) SelectPaymentRequirements(requirements []types.PaymentRequirements) (types.PaymentRequirements, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -298,8 +343,13 @@ func (c *x402Client) SelectPaymentRequirements(requirements []types.PaymentRequi
 	// Convert to views for selector/policies
 	views := toViews(recognized)
 
-	// Step 3: Apply policies
-	filtered := views
+	// Step 3: Apply spend controls
+	filtered, err := c.applySpendControls(2, views)
+	if err != nil {
+		return types.PaymentRequirements{}, err
+	}
+
+	// Step 4: Apply policies
 	for _, policy := range c.policies {
 		filtered = policy(filtered)
 		if len(filtered) == 0 {
@@ -310,7 +360,7 @@ func (c *x402Client) SelectPaymentRequirements(requirements []types.PaymentRequi
 		}
 	}
 
-	// Step 4: Prefer authorization when both post- and pre-handler flows remain
+	// Step 5: Prefer authorization when both post- and pre-handler flows remain
 	var authorizationViews []PaymentRequirementsView
 	for _, req := range filtered {
 		extra := req.GetExtra()
@@ -326,9 +376,197 @@ func (c *x402Client) SelectPaymentRequirements(requirements []types.PaymentRequi
 		filtered = authorizationViews
 	}
 
-	// Step 5: Select final and convert back
+	// Step 6: Select final and convert back
 	selected := c.requirementsSelector(filtered)
 	return fromView[types.PaymentRequirements](selected), nil
+}
+
+var atomicAmountPattern = regexp.MustCompile(`^\d+$`)
+
+// applySpendControls filters by spend controls (default-asset allowlist → opt-in assets → caps).
+// Keeps any accept that fits so a mixed offer can still pay the affordable option.
+func (c *x402Client) applySpendControls(x402Version int, requirements []PaymentRequirementsView) ([]PaymentRequirementsView, error) {
+	if !c.spendControlsEnabled {
+		return requirements, nil
+	}
+	controls := c.spendControls
+
+	rawAmountOf := func(requirement PaymentRequirementsView) string {
+		return requirement.GetAmount()
+	}
+	amountOf := func(requirement PaymentRequirementsView) *big.Int {
+		n, ok := new(big.Int).SetString(rawAmountOf(requirement), 10)
+		if !ok {
+			return big.NewInt(0)
+		}
+		return n
+	}
+	schemeFor := func(requirement PaymentRequirementsView) any {
+		network := Network(requirement.GetNetwork())
+		scheme := requirement.GetScheme()
+		if x402Version == 1 {
+			return any(findByNetworkAndScheme(c.schemesV1, scheme, network))
+		}
+		return any(findByNetworkAndScheme(c.schemes, scheme, network))
+	}
+	defaultAssetFor := func(requirement PaymentRequirementsView) *DefaultAsset {
+		finder, ok := schemeFor(requirement).(DefaultAssetFinder)
+		if !ok {
+			return nil
+		}
+		return finder.FindDefaultAsset(requirement.GetAsset(), Network(requirement.GetNetwork()))
+	}
+	matchesAssetEntry := func(entry SpendControlAsset, requirement PaymentRequirementsView) bool {
+		if !MatchesNetwork(entry.Network, Network(requirement.GetNetwork())) {
+			return false
+		}
+		if strings.EqualFold(entry.Asset, requirement.GetAsset()) {
+			return true
+		}
+		defaultAsset := defaultAssetFor(requirement)
+		return defaultAsset != nil && strings.EqualFold(defaultAsset.Symbol, entry.Asset)
+	}
+	var assetEntries []SpendControlAsset
+	if !controls.AllowAnyAsset {
+		assetEntries = controls.AllowedAssets
+	}
+	findAssetEntry := func(requirement PaymentRequirementsView) *SpendControlAsset {
+		for i := range assetEntries {
+			if matchesAssetEntry(assetEntries[i], requirement) {
+				return &assetEntries[i]
+			}
+		}
+		return nil
+	}
+
+	filtered := requirements
+	if !controls.AllowAnyAsset {
+		filtered = filtered[:0]
+		for _, requirement := range requirements {
+			if defaultAssetFor(requirement) != nil || findAssetEntry(requirement) != nil {
+				filtered = append(filtered, requirement)
+			}
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf(
+			"all payment requirements were rejected by spendControls: only default assets " +
+				"or entries in spendControls.allowedAssets are allowed. Add an allowedAssets " +
+				"entry for non-default tokens, set allowedAssets: true, or set spendControls: false",
+		)
+	}
+
+	usdLimit := DefaultMaxAmountPerPayment
+	usdLimitDisabled := controls.DisableMaxAmountPerPayment
+	if !usdLimitDisabled && controls.MaxAmountPerPayment != "" {
+		usdLimit = controls.MaxAmountPerPayment
+	}
+
+	beforeAmountCaps := filtered
+	rejectedByAssetCap := false
+	var rejectedUsdSymbol string
+
+	capped := beforeAmountCaps[:0]
+	for _, requirement := range beforeAmountCaps {
+		assetEntry := findAssetEntry(requirement)
+		if assetEntry != nil && assetEntry.MaxAmountPerPayment != "" {
+			capN, ok := new(big.Int).SetString(assetEntry.MaxAmountPerPayment, 10)
+			if !ok {
+				rejectedByAssetCap = true
+				continue
+			}
+			if amountOf(requirement).Cmp(capN) <= 0 {
+				capped = append(capped, requirement)
+			} else {
+				rejectedByAssetCap = true
+			}
+			continue
+		}
+
+		defaultAsset := defaultAssetFor(requirement)
+		if defaultAsset == nil {
+			capped = append(capped, requirement)
+			continue
+		}
+
+		if usdLimitDisabled {
+			capped = append(capped, requirement)
+			continue
+		}
+
+		rawAmount := rawAmountOf(requirement)
+		if !atomicAmountPattern.MatchString(rawAmount) {
+			valueScaled, err := ConvertToTokenAmount(rawAmount, 18)
+			if err != nil {
+				return nil, err
+			}
+			parsed, err := ParseMoneyString(usdLimit)
+			if err != nil {
+				return nil, err
+			}
+			capScaled, err := ConvertToTokenAmount(NumberToDecimalString(parsed), 18)
+			if err != nil {
+				return nil, err
+			}
+			valueN, _ := new(big.Int).SetString(valueScaled, 10)
+			capN, _ := new(big.Int).SetString(capScaled, 10)
+			if valueN.Cmp(capN) <= 0 {
+				capped = append(capped, requirement)
+			} else {
+				rejectedUsdSymbol = defaultAsset.Symbol
+			}
+			continue
+		}
+
+		parsed, err := ParseMoneyString(usdLimit)
+		if err != nil {
+			return nil, err
+		}
+		maxAtomic, err := ConvertToTokenAmount(NumberToDecimalString(parsed), defaultAsset.Decimals)
+		if err != nil {
+			return nil, err
+		}
+		maxN, _ := new(big.Int).SetString(maxAtomic, 10)
+		if amountOf(requirement).Cmp(maxN) <= 0 {
+			capped = append(capped, requirement)
+		} else {
+			rejectedUsdSymbol = defaultAsset.Symbol
+		}
+	}
+	filtered = capped
+
+	if len(filtered) == 0 {
+		allAssetCapped := rejectedByAssetCap
+		if allAssetCapped {
+			for _, requirement := range beforeAmountCaps {
+				entry := findAssetEntry(requirement)
+				if entry == nil || entry.MaxAmountPerPayment == "" {
+					allAssetCapped = false
+					break
+				}
+			}
+		}
+		if allAssetCapped {
+			return nil, fmt.Errorf(
+				"all payment requirements were rejected by spendControls.allowedAssets maxAmountPerPayment. " +
+					"Raise the per-asset cap, or omit maxAmountPerPayment to allow uncapped " +
+					"(default assets then fall back to the top-level USD cap)",
+			)
+		}
+		symbolNote := ""
+		if rejectedUsdSymbol != "" {
+			symbolNote = ", including " + rejectedUsdSymbol
+		}
+		return nil, fmt.Errorf(
+			"all payment requirements were rejected by spendControls.maxAmountPerPayment "+
+				"(%s%s). Raise maxAmountPerPayment, set it to false to disable, "+
+				"set allowedAssets[].maxAmountPerPayment for a per-asset atomic cap, "+
+				"or set spendControls: false to disable all spend controls",
+			usdLimit, symbolNote,
+		)
+	}
+
+	return filtered, nil
 }
 
 // CreatePaymentPayloadV1 creates a V1 payment payload

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -995,6 +995,43 @@ func TestSpendControls(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("rejects a non-integer 402 amount on a per-asset atomic cap", func(t *testing.T) {
+		customAsset := "0xCustomToken"
+		client := clientWithDefaultAsset(usdc, &SpendControls{
+			AllowedAssets: []SpendControlAsset{{Asset: customAsset, Network: network, MaxAmountPerPayment: "10000"}},
+		}, false)
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(customAsset, "1.5", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "allowedAssets maxAmountPerPayment")
+	})
+
+	t.Run("keeps a sibling atomic accept when a per-asset amount is not an integer", func(t *testing.T) {
+		customAsset := "0xCustomToken"
+		client := clientWithDefaultAsset(usdc, &SpendControls{
+			AllowedAssets: []SpendControlAsset{{Asset: customAsset, Network: network, MaxAmountPerPayment: "10000"}},
+		}, false)
+		selected, err := client.SelectPaymentRequirements([]types.PaymentRequirements{
+			req(customAsset, "1.5", ""),
+			req(customAsset, "100", ""),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "100", selected.Amount)
+	})
+
+	t.Run("errors when a per-asset cap is not an integer atomic amount", func(t *testing.T) {
+		customAsset := "0xCustomToken"
+		for _, cap := range []string{"$1", "1.5"} {
+			client := clientWithDefaultAsset(usdc, &SpendControls{
+				AllowedAssets: []SpendControlAsset{{Asset: customAsset, Network: network, MaxAmountPerPayment: cap}},
+			}, false)
+			_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(customAsset, "100", "")})
+			require.Error(t, err, "cap %q", cap)
+			require.Contains(t, err.Error(), "maxAmountPerPayment")
+			require.Contains(t, err.Error(), "integer atomic")
+			require.NotContains(t, err.Error(), "Raise the per-asset cap")
+		}
+	})
+
 	t.Run("overrides the USD cap for default assets by id or symbol", func(t *testing.T) {
 		byID := clientWithDefaultAsset(usdc, &SpendControls{
 			AllowedAssets: []SpendControlAsset{{Asset: usdc.Asset, Network: network, MaxAmountPerPayment: "500000"}},

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,11 +13,23 @@ import (
 
 // Mock V1 client for testing
 type mockSchemeNetworkClientV1 struct {
-	scheme string
+	scheme             string
+	findDefaultAsset   func(asset string, network Network) *DefaultAsset
+	noFindDefaultAsset bool
 }
 
 func (m *mockSchemeNetworkClientV1) Scheme() string {
 	return m.scheme
+}
+
+func (m *mockSchemeNetworkClientV1) FindDefaultAsset(asset string, network Network) *DefaultAsset {
+	if m.noFindDefaultAsset {
+		return nil
+	}
+	if m.findDefaultAsset != nil {
+		return m.findDefaultAsset(asset, network)
+	}
+	return &DefaultAsset{Asset: asset, Decimals: 6, Symbol: "MOCK"}
 }
 
 func (m *mockSchemeNetworkClientV1) CreatePaymentPayload(ctx context.Context, requirements types.PaymentRequirementsV1) (types.PaymentPayloadV1, error) {
@@ -33,11 +46,23 @@ func (m *mockSchemeNetworkClientV1) CreatePaymentPayload(ctx context.Context, re
 
 // Mock V2 client for testing
 type mockSchemeNetworkClientV2 struct {
-	scheme string
+	scheme             string
+	findDefaultAsset   func(asset string, network Network) *DefaultAsset
+	noFindDefaultAsset bool
 }
 
 func (m *mockSchemeNetworkClientV2) Scheme() string {
 	return m.scheme
+}
+
+func (m *mockSchemeNetworkClientV2) FindDefaultAsset(asset string, network Network) *DefaultAsset {
+	if m.noFindDefaultAsset {
+		return nil
+	}
+	if m.findDefaultAsset != nil {
+		return m.findDefaultAsset(asset, network)
+	}
+	return &DefaultAsset{Asset: asset, Decimals: 6, Symbol: "MOCK"}
 }
 
 func (m *mockSchemeNetworkClientV2) CreatePaymentPayload(ctx context.Context, requirements types.PaymentRequirements) (types.PaymentPayload, error) {
@@ -222,7 +247,7 @@ func TestClientSelectPaymentRequirementsWithCustomSelector(t *testing.T) {
 		return highest
 	}
 
-	client := Newx402Client(WithPaymentSelector(customSelector))
+	client := Newx402Client(WithPaymentSelector(customSelector)).DisableSpendControls()
 	mockClient := &mockSchemeNetworkClientV2{scheme: "exact"}
 	client.Register("eip155:1", mockClient)
 
@@ -785,5 +810,306 @@ func TestMergeExtensions(t *testing.T) {
 		if !DeepEqual(info["resources"], []interface{}{"https://api.example.com/data"}) {
 			t.Fatalf("expected server resources to be preserved, got %v", info["resources"])
 		}
+	})
+}
+
+func TestSpendControls(t *testing.T) {
+	network := Network("eip155:8453")
+	usdc := DefaultAsset{
+		Asset:    "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+		Decimals: 6,
+		Symbol:   "USDC",
+	}
+	usdt := DefaultAsset{
+		Asset:    "0xUsdTSecondaryAsset0000000000000000000001",
+		Decimals: 6,
+		Symbol:   "USDT",
+	}
+	mUsd := DefaultAsset{
+		Asset:    "0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503",
+		Decimals: 18,
+		Symbol:   "mUSD",
+	}
+
+	clientWithDefaultAsset := func(entry DefaultAsset, controls *SpendControls, disabled bool) *x402Client {
+		mockClient := &mockSchemeNetworkClientV2{scheme: "exact"}
+		mockClient.findDefaultAsset = func(asset string, _ Network) *DefaultAsset {
+			if strings.EqualFold(asset, entry.Asset) {
+				copied := entry
+				return &copied
+			}
+			return nil
+		}
+		client := Newx402Client()
+		client.Register(network, mockClient)
+		if disabled {
+			client.DisableSpendControls()
+		} else if controls != nil {
+			client.SetSpendControls(*controls)
+		}
+		return client
+	}
+
+	req := func(asset, amount string, net Network) types.PaymentRequirements {
+		if net == "" {
+			net = network
+		}
+		return types.PaymentRequirements{
+			Scheme:  "exact",
+			Network: string(net),
+			Asset:   asset,
+			Amount:  amount,
+			PayTo:   "0xpay",
+		}
+	}
+
+	t.Run("allows a payment at or below the default $1 USD cap", func(t *testing.T) {
+		client := clientWithDefaultAsset(usdc, nil, false)
+		selected, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "1000000", "")})
+		require.NoError(t, err)
+		require.Equal(t, "1000000", selected.Amount)
+	})
+
+	t.Run("rejects a payment above the default $1 USD cap", func(t *testing.T) {
+		client := clientWithDefaultAsset(usdc, nil, false)
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "1000001", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maxAmountPerPayment")
+	})
+
+	t.Run("picks the affordable accept when both under and over the cap are offered", func(t *testing.T) {
+		client := clientWithDefaultAsset(usdc, nil, false)
+		selected, err := client.SelectPaymentRequirements([]types.PaymentRequirements{
+			req(usdc.Asset, "50000000", ""),
+			req(usdc.Asset, "500000", ""),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "500000", selected.Amount)
+	})
+
+	t.Run("caps a second USD asset on the same network identically to the default", func(t *testing.T) {
+		mockClient := &mockSchemeNetworkClientV2{scheme: "exact"}
+		mockClient.findDefaultAsset = func(asset string, _ Network) *DefaultAsset {
+			switch strings.ToLower(asset) {
+			case strings.ToLower(usdc.Asset):
+				copied := usdc
+				return &copied
+			case strings.ToLower(usdt.Asset):
+				copied := usdt
+				return &copied
+			}
+			return nil
+		}
+		client := Newx402Client()
+		client.Register(network, mockClient)
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdt.Asset, "2000000", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maxAmountPerPayment")
+	})
+
+	t.Run("rejects unrecognized assets by default and schemes without findDefaultAsset", func(t *testing.T) {
+		client := clientWithDefaultAsset(usdc, nil, false)
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req("0xCustomUnknownToken", "1", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "spendControls.allowedAssets")
+
+		bare := &mockSchemeNetworkClientV2{scheme: "exact", noFindDefaultAsset: true}
+		bareClient := Newx402Client()
+		bareClient.Register(network, bare)
+		_, err = bareClient.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "1", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "spendControls.allowedAssets")
+	})
+
+	t.Run("DisableSpendControls disables allowlist and USD cap", func(t *testing.T) {
+		client := clientWithDefaultAsset(usdc, nil, true)
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req("0xCustomUnknownToken", "999999999999", "")})
+		require.NoError(t, err)
+		_, err = client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "5000000", "")})
+		require.NoError(t, err)
+	})
+
+	t.Run("AllowAnyAsset allows any asset while still applying the USD cap to defaults", func(t *testing.T) {
+		client := clientWithDefaultAsset(usdc, &SpendControls{AllowAnyAsset: true}, false)
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req("0xCustomUnknownToken", "999999999999", "")})
+		require.NoError(t, err)
+		_, err = client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "1000001", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maxAmountPerPayment")
+	})
+
+	t.Run("scales the USD cap for an 18-decimal default asset", func(t *testing.T) {
+		mockClient := &mockSchemeNetworkClientV2{scheme: "exact"}
+		mockClient.findDefaultAsset = func(asset string, _ Network) *DefaultAsset {
+			if strings.EqualFold(asset, mUsd.Asset) {
+				copied := mUsd
+				return &copied
+			}
+			return nil
+		}
+		mezo := Network("eip155:31611")
+		client := Newx402Client()
+		client.Register(mezo, mockClient)
+
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(mUsd.Asset, "1000000000000000001", mezo)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maxAmountPerPayment")
+
+		selected, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(mUsd.Asset, "1000000000000000000", mezo)})
+		require.NoError(t, err)
+		require.Equal(t, "1000000000000000000", selected.Amount)
+	})
+
+	t.Run("honours DisableMaxAmountPerPayment, custom Money, and SetSpendControls", func(t *testing.T) {
+		client := clientWithDefaultAsset(usdc, &SpendControls{DisableMaxAmountPerPayment: true}, false)
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "5000000", "")})
+		require.NoError(t, err)
+
+		mock5 := &mockSchemeNetworkClientV2{scheme: "exact"}
+		mock5.findDefaultAsset = func(asset string, _ Network) *DefaultAsset {
+			if strings.EqualFold(asset, usdc.Asset) {
+				copied := usdc
+				return &copied
+			}
+			return nil
+		}
+		client5 := Newx402Client(WithSpendControls(SpendControls{MaxAmountPerPayment: "$5"}))
+		client5.Register(network, mock5)
+		_, err = client5.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "5000000", "")})
+		require.NoError(t, err)
+	})
+
+	t.Run("allows opt-in assets uncapped or with an atomic maxAmountPerPayment", func(t *testing.T) {
+		customAsset := "0xCustomToken"
+		cappedClient := clientWithDefaultAsset(usdc, &SpendControls{
+			AllowedAssets: []SpendControlAsset{{Asset: customAsset, Network: network, MaxAmountPerPayment: "10000"}},
+		}, false)
+		_, err := cappedClient.SelectPaymentRequirements([]types.PaymentRequirements{req(customAsset, "10001", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "allowedAssets maxAmountPerPayment")
+
+		uncappedClient := clientWithDefaultAsset(usdc, &SpendControls{
+			AllowedAssets: []SpendControlAsset{{Asset: strings.ToLower(customAsset), Network: "eip155:*"}},
+		}, false)
+		_, err = uncappedClient.SelectPaymentRequirements([]types.PaymentRequirements{req(customAsset, "999999999999", "")})
+		require.NoError(t, err)
+	})
+
+	t.Run("overrides the USD cap for default assets by id or symbol", func(t *testing.T) {
+		byID := clientWithDefaultAsset(usdc, &SpendControls{
+			AllowedAssets: []SpendControlAsset{{Asset: usdc.Asset, Network: network, MaxAmountPerPayment: "500000"}},
+		}, false)
+		_, err := byID.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "600000", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "allowedAssets maxAmountPerPayment")
+		_, err = byID.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "400000", "")})
+		require.NoError(t, err)
+
+		pyusd := DefaultAsset{Asset: "0xPayPalUsdAsset000000000000000000000001", Decimals: 6, Symbol: "PYUSD"}
+		mockPyusd := &mockSchemeNetworkClientV2{scheme: "exact"}
+		mockPyusd.findDefaultAsset = func(asset string, _ Network) *DefaultAsset {
+			if strings.EqualFold(asset, pyusd.Asset) {
+				copied := pyusd
+				return &copied
+			}
+			return nil
+		}
+		clientBySymbol := Newx402Client()
+		clientBySymbol.Register(network, mockPyusd)
+		clientBySymbol.SetSpendControls(SpendControls{
+			AllowedAssets: []SpendControlAsset{{Asset: "pyusd", Network: network, MaxAmountPerPayment: "500000"}},
+		})
+		_, err = clientBySymbol.SelectPaymentRequirements([]types.PaymentRequirements{req(pyusd.Asset, "600000", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "allowedAssets maxAmountPerPayment")
+		_, err = clientBySymbol.SelectPaymentRequirements([]types.PaymentRequirements{req(pyusd.Asset, "400000", "")})
+		require.NoError(t, err)
+	})
+
+	t.Run("keeps the USD cap when a default asset is listed without a per-entry cap", func(t *testing.T) {
+		client := clientWithDefaultAsset(usdc, &SpendControls{
+			AllowedAssets: []SpendControlAsset{{Asset: usdc.Symbol, Network: network}},
+		}, false)
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "1000001", "")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maxAmountPerPayment")
+	})
+
+	t.Run("allows defaults plus listed custom assets", func(t *testing.T) {
+		custom := "0xCustomToken"
+		client := clientWithDefaultAsset(usdc, &SpendControls{
+			DisableMaxAmountPerPayment: true,
+			AllowedAssets:              []SpendControlAsset{{Asset: custom, Network: network}},
+		}, false)
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc.Asset, "1", "")})
+		require.NoError(t, err)
+		_, err = client.SelectPaymentRequirements([]types.PaymentRequirements{req(custom, "1", "")})
+		require.NoError(t, err)
+	})
+
+	t.Run("caps v1 accepts via maxAmountRequired", func(t *testing.T) {
+		mockClient := &mockSchemeNetworkClientV1{scheme: "exact"}
+		mockClient.findDefaultAsset = func(asset string, _ Network) *DefaultAsset {
+			if strings.EqualFold(asset, usdc.Asset) {
+				copied := usdc
+				return &copied
+			}
+			return nil
+		}
+		client := Newx402Client()
+		client.RegisterV1("base", mockClient)
+		_, err := client.SelectPaymentRequirementsV1([]types.PaymentRequirementsV1{{
+			Scheme:            "exact",
+			Network:           "base",
+			Asset:             usdc.Asset,
+			MaxAmountRequired: "2000000",
+			PayTo:             "0xpay",
+			MaxTimeoutSeconds: 60,
+		}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maxAmountPerPayment")
+	})
+
+	t.Run("only exposes requirements that passed spend controls to user policies", func(t *testing.T) {
+		var seen []string
+		client := clientWithDefaultAsset(usdc, nil, false)
+		client.RegisterPolicy(func(reqs []PaymentRequirementsView) []PaymentRequirementsView {
+			for _, r := range reqs {
+				seen = append(seen, r.GetAmount())
+			}
+			return reqs
+		})
+		selected, err := client.SelectPaymentRequirements([]types.PaymentRequirements{
+			req(usdc.Asset, "50000000", ""),
+			req(usdc.Asset, "250000", ""),
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{"250000"}, seen)
+		require.Equal(t, "250000", selected.Amount)
+	})
+
+	t.Run("compares non-integer decimal amounts to the USD cap directly", func(t *testing.T) {
+		rlusd := DefaultAsset{
+			Asset:    "524C555344000000000000000000000000000000",
+			Decimals: 15,
+			Symbol:   "RLUSD",
+		}
+		mockClient := &mockSchemeNetworkClientV2{scheme: "exact"}
+		mockClient.findDefaultAsset = func(asset string, _ Network) *DefaultAsset {
+			if asset == rlusd.Asset {
+				copied := rlusd
+				return &copied
+			}
+			return nil
+		}
+		xrpl := Network("xrpl:1")
+		client := Newx402Client()
+		client.Register(xrpl, mockClient)
+
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(rlusd.Asset, "1.0", xrpl)})
+		require.NoError(t, err)
+		_, err = client.SelectPaymentRequirements([]types.PaymentRequirements{req(rlusd.Asset, "1.01", xrpl)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "maxAmountPerPayment")
 	})
 }

--- a/go/http/client_test.go
+++ b/go/http/client_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestNewx402HTTPClient(t *testing.T) {
-	x402Client := x402.Newx402Client()
+	x402Client := x402.Newx402Client().DisableSpendControls()
 	client := Newx402HTTPClient(x402Client)
 	if client == nil {
 		t.Fatal("Expected client to be created")
@@ -52,7 +52,7 @@ func TestPaymentRoundTripper_OnPaymentRequiredHeaderRetry(t *testing.T) {
 		}
 		return stringResponse(http.StatusOK, nil, "ok")
 	})
-	client := Newx402HTTPClient(x402.Newx402Client()).
+	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls()).
 		OnPaymentRequired(func(_ context.Context, paymentRequired types.PaymentRequired) (*PaymentRequiredHookResult, error) {
 			if paymentRequired.Extensions["sign-in-with-x"] == nil {
 				t.Fatal("paymentRequired missing SIWX extension")
@@ -97,7 +97,7 @@ func TestPaymentRoundTripper_OnPaymentRequiredHookSkippedWithoutHeaders(t *testi
 	}
 
 	calls := 0
-	client := Newx402HTTPClient(x402.Newx402Client()).
+	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls()).
 		OnPaymentRequired(func(context.Context, types.PaymentRequired) (*PaymentRequiredHookResult, error) {
 			calls++
 			return nil, nil
@@ -153,7 +153,7 @@ func TestPaymentRoundTripper_RegisteredExtensionHookRetry(t *testing.T) {
 		}
 		return stringResponse(http.StatusOK, nil, "ok")
 	})
-	x402Client := x402.Newx402Client().
+	x402Client := x402.Newx402Client().DisableSpendControls().
 		RegisterExtension(testHTTPClientExtension{
 			key: "test-extension",
 			hook: func(_ context.Context, paymentRequired types.PaymentRequired) (*PaymentRequiredHookResult, error) {
@@ -204,7 +204,7 @@ func TestPaymentRoundTripper_RegisteredExtensionHookSkippedWithoutDeclaration(t 
 	}
 
 	calls := 0
-	x402Client := x402.Newx402Client().
+	x402Client := x402.Newx402Client().DisableSpendControls().
 		RegisterExtension(testHTTPClientExtension{
 			key: "test-extension",
 			hook: func(context.Context, types.PaymentRequired) (*PaymentRequiredHookResult, error) {
@@ -239,7 +239,7 @@ func TestPaymentRoundTripper_RegisteredExtensionHookSkippedWithoutDeclaration(t 
 }
 
 func TestEncodePaymentSignatureHeader(t *testing.T) {
-	client := Newx402HTTPClient(x402.Newx402Client())
+	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls())
 
 	tests := []struct {
 		name     string
@@ -396,7 +396,7 @@ func stringResponse(status int, headers map[string]string, body string) (*http.R
 }
 
 func TestGetPaymentRequiredResponse(t *testing.T) {
-	client := Newx402HTTPClient(x402.Newx402Client())
+	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls())
 
 	// Test v2 header format
 	requirements := x402.PaymentRequired{
@@ -466,7 +466,7 @@ func TestGetPaymentRequiredResponse(t *testing.T) {
 }
 
 func TestGetPaymentSettleResponse(t *testing.T) {
-	client := Newx402HTTPClient(x402.Newx402Client())
+	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls())
 
 	settleResponse := x402.SettleResponse{
 		Success:     true,
@@ -610,7 +610,7 @@ func TestPaymentRoundTripper(t *testing.T) {
 	}
 
 	// Create x402 client
-	x402Client := x402.Newx402Client()
+	x402Client := x402.Newx402Client().DisableSpendControls()
 	x402Client.Register("test:1", mockClient)
 
 	// Create HTTP client wrapper
@@ -682,7 +682,7 @@ func TestPaymentRoundTripper_ReplaysOneShotBody(t *testing.T) {
 			}))
 			defer server.Close()
 
-			x402Client := x402.Newx402Client()
+			x402Client := x402.Newx402Client().DisableSpendControls()
 			x402Client.Register("test:1", &mockSchemeClient{scheme: "mock"})
 			client := Newx402HTTPClient(x402Client)
 			if tt.authRetry {
@@ -872,7 +872,7 @@ func TestPaymentRoundTripperNoRetryOn200(t *testing.T) {
 	}))
 	defer server.Close()
 
-	x402Client := Newx402HTTPClient(x402.Newx402Client())
+	x402Client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls())
 	httpClient := WrapHTTPClientWithPayment(http.DefaultClient, x402Client)
 
 	ctx := context.Background()
@@ -895,7 +895,7 @@ func TestDoWithPayment(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := Newx402HTTPClient(x402.Newx402Client())
+	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls())
 	ctx := context.Background()
 	req, _ := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
 
@@ -919,7 +919,7 @@ func TestGetWithPayment(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := Newx402HTTPClient(x402.Newx402Client())
+	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls())
 	ctx := context.Background()
 
 	resp, err := client.GetWithPayment(ctx, server.URL)
@@ -942,7 +942,7 @@ func TestPostWithPayment(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := Newx402HTTPClient(x402.Newx402Client())
+	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls())
 	ctx := context.Background()
 
 	resp, err := client.PostWithPayment(ctx, server.URL, strings.NewReader("test body"))
@@ -1028,7 +1028,7 @@ func paymentResponseHeader(t *testing.T, settle x402.SettleResponse) string {
 // code should not need to call ProcessSettleResponse manually.
 func TestPaymentRoundTripper_DispatchesOnPaymentResponseOnSuccess(t *testing.T) {
 	scheme := &hookSchemeClient{scheme: "test-scheme"}
-	x402Client := x402.Newx402Client()
+	x402Client := x402.Newx402Client().DisableSpendControls()
 	x402Client.Register("eip155:1", scheme)
 
 	accepts := []types.PaymentRequirements{{
@@ -1097,7 +1097,7 @@ func TestPaymentRoundTripper_PropagatesPaymentResponseHookErrors(t *testing.T) {
 				signalRecover: tt.corrective,
 				settleErr:     hookErr,
 			}
-			x402Client := x402.Newx402Client()
+			x402Client := x402.Newx402Client().DisableSpendControls()
 			x402Client.Register("eip155:1", scheme)
 
 			responseBody := &oneShotBody{reader: strings.NewReader("response")}
@@ -1158,7 +1158,7 @@ func TestPaymentRoundTripper_PropagatesPaymentResponseHookErrors(t *testing.T) {
 // transport rebuilds the payload and retries one more time.
 func TestPaymentRoundTripper_RetriesOnceWhenHookSignalsRecovered(t *testing.T) {
 	scheme := &hookSchemeClient{scheme: "test-scheme", signalRecover: true}
-	x402Client := x402.Newx402Client()
+	x402Client := x402.Newx402Client().DisableSpendControls()
 	x402Client.Register("eip155:1", scheme)
 
 	accepts := []types.PaymentRequirements{{
@@ -1239,7 +1239,7 @@ func TestPaymentRoundTripper_RetriesOnceWhenHookSignalsRecovered(t *testing.T) {
 // without recovery propagates as-is — no extra retries, no infinite loops.
 func TestPaymentRoundTripper_NoRecoveryWhenHookDeclines(t *testing.T) {
 	scheme := &hookSchemeClient{scheme: "test-scheme", signalRecover: false}
-	x402Client := x402.Newx402Client()
+	x402Client := x402.Newx402Client().DisableSpendControls()
 	x402Client.Register("eip155:1", scheme)
 
 	accepts := []types.PaymentRequirements{{
@@ -1288,7 +1288,7 @@ func TestWrapHTTPClientWithPayment_DoesNotMutateInput(t *testing.T) {
 	originalDefault := http.DefaultClient.Transport
 	defer func() { http.DefaultClient.Transport = originalDefault }()
 
-	x402Client := Newx402HTTPClient(x402.Newx402Client())
+	x402Client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls())
 
 	wrapped := WrapHTTPClientWithPayment(http.DefaultClient, x402Client)
 

--- a/go/http/server_test.go
+++ b/go/http/server_test.go
@@ -1561,6 +1561,10 @@ func (m *mockSchemeServer) ParsePrice(price x402.Price, network x402.Network) (x
 	}, nil
 }
 
+func (m *mockSchemeServer) GetAssetDecimals(asset string, network x402.Network) (int, bool) {
+	return 6, true
+}
+
 func (m *mockSchemeServer) EnhancePaymentRequirements(ctx context.Context, base types.PaymentRequirements, supported types.SupportedKind, extensions []string) (types.PaymentRequirements, error) {
 	return base, nil
 }

--- a/go/interfaces.go
+++ b/go/interfaces.go
@@ -13,13 +13,13 @@ import (
 //
 // Args:
 //
-//	amount: Decimal amount (e.g., 1.50 for $1.50)
+//	amount: Decimal string (e.g., "1.50" for $1.50)
 //	network: Network identifier
 //
 // Returns:
 //
 //	AssetAmount or nil if this parser cannot handle the conversion
-type MoneyParser func(amount float64, network Network) (*AssetAmount, error)
+type MoneyParser func(amount string, network Network) (*AssetAmount, error)
 
 // ============================================================================
 // V1 Interfaces (Legacy - explicitly versioned)

--- a/go/interfaces.go
+++ b/go/interfaces.go
@@ -98,6 +98,12 @@ type ExtensionAwareClient interface {
 	CreatePaymentPayloadWithExtensions(ctx context.Context, requirements types.PaymentRequirements, extensions map[string]interface{}) (types.PaymentPayload, error)
 }
 
+// DefaultAssetFinder is an optional reverse lookup for USD spend caps.
+// Not the same as AssetDecimalsProvider.
+type DefaultAssetFinder interface {
+	FindDefaultAsset(asset string, network Network) *DefaultAsset
+}
+
 // PaymentResponseContext is passed to PaymentResponseHandler implementations after
 // the transport receives the response to a paid request. Exactly one of SettleResponse
 // or PaymentRequired is populated:
@@ -238,9 +244,9 @@ type SchemeNetworkServer interface {
 // AssetDecimalsProvider is an optional interface that SchemeNetworkServer implementations
 // can satisfy to report the decimal precision of the asset for a given network.
 // SettlePayment uses this to convert dollar-format settlement overrides to atomic units.
-// Falls back to 6 decimals when the scheme does not implement this interface.
+// ok is false when the asset is not a known default (TS undefined).
 type AssetDecimalsProvider interface {
-	GetAssetDecimals(asset string, network Network) int
+	GetAssetDecimals(asset string, network Network) (decimals int, ok bool)
 }
 
 // SettleOnCancelProvider is an optional interface for schemes that settle once when a

--- a/go/mcp/README.md
+++ b/go/mcp/README.md
@@ -98,11 +98,10 @@ Creates an x402 MCP client from an MCP session (MCPCaller) and payment client.
 ```go
 paymentClient := x402.Newx402Client()
 paymentClient.Register("eip155:84532", evmClientScheme)
+// paymentClient.SetSpendControls(x402.SpendControls{MaxAmountPerPayment: "$5"})
+// paymentClient.DisableSpendControls()
 
-x402Mcp := mcp.NewX402MCPClient(session, paymentClient, mcp.Options{
-    // SpendControls: &x402.SpendControls{MaxAmountPerPayment: "$5"},
-    // DisableSpendControls: true,
-})
+x402Mcp := mcp.NewX402MCPClient(session, paymentClient, mcp.Options{})
 ```
 
 #### `NewX402MCPClientFromConfig`
@@ -113,12 +112,10 @@ Pass `*mcp.ClientSession` from the official MCP SDK.
 ```go
 x402Mcp := mcp.NewX402MCPClientFromConfig(session, []mcp.SchemeRegistration{
     {Network: "eip155:84532", Client: evmClientScheme},
-}, mcp.Options{
-    // Spend controls (default: recognized pegged assets only, $1 USD cap)
-    SpendControls: &x402.SpendControls{MaxAmountPerPayment: "$5"},
-    // DisableSpendControls: true, // disable all spend controls (any asset, no caps)
-})
+}, mcp.Options{})
 ```
+
+FromConfig uses the payment client's default `$1` USD cap and default-asset allowlist. For custom spend controls, configure `*x402.X402Client` then wrap with `NewX402MCPClient`.
 
 ### Server
 
@@ -184,7 +181,7 @@ if mcp.IsObject(value) {
 ### Client Types
 
 - `X402MCPClient` - x402-enabled MCP client
-- `Options` - Options for x402 MCP client behavior (AutoPayment defaults to true; `SpendControls` and `DisableSpendControls` are applied by both constructors)
+- `Options` - Options for x402 MCP client behavior (AutoPayment defaults to true)
 - `SchemeRegistration` - Payment scheme registration for factory functions
 - `MCPToolCallResult` - Result of a tool call with payment metadata
 - `PaymentRequiredContext` - Context provided to payment required hooks

--- a/go/mcp/README.md
+++ b/go/mcp/README.md
@@ -99,7 +99,10 @@ Creates an x402 MCP client from an MCP session (MCPCaller) and payment client.
 paymentClient := x402.Newx402Client()
 paymentClient.Register("eip155:84532", evmClientScheme)
 
-x402Mcp := mcp.NewX402MCPClient(session, paymentClient, mcp.Options{})
+x402Mcp := mcp.NewX402MCPClient(session, paymentClient, mcp.Options{
+    // SpendControls: &x402.SpendControls{MaxAmountPerPayment: "$5"},
+    // DisableSpendControls: true,
+})
 ```
 
 #### `NewX402MCPClientFromConfig`
@@ -181,7 +184,7 @@ if mcp.IsObject(value) {
 ### Client Types
 
 - `X402MCPClient` - x402-enabled MCP client
-- `Options` - Options for x402 MCP client behavior (AutoPayment defaults to true; `SpendControls` and `DisableSpendControls` are consumed by `NewX402MCPClientFromConfig` only)
+- `Options` - Options for x402 MCP client behavior (AutoPayment defaults to true; `SpendControls` and `DisableSpendControls` are applied by both constructors)
 - `SchemeRegistration` - Payment scheme registration for factory functions
 - `MCPToolCallResult` - Result of a tool call with payment metadata
 - `PaymentRequiredContext` - Context provided to payment required hooks

--- a/go/mcp/README.md
+++ b/go/mcp/README.md
@@ -110,7 +110,11 @@ Pass `*mcp.ClientSession` from the official MCP SDK.
 ```go
 x402Mcp := mcp.NewX402MCPClientFromConfig(session, []mcp.SchemeRegistration{
     {Network: "eip155:84532", Client: evmClientScheme},
-}, mcp.Options{}) // AutoPayment defaults to true
+}, mcp.Options{
+    // Spend controls (default: recognized pegged assets only, $1 USD cap)
+    SpendControls: &x402.SpendControls{MaxAmountPerPayment: "$5"},
+    // DisableSpendControls: true, // disable all spend controls (any asset, no caps)
+})
 ```
 
 ### Server
@@ -177,7 +181,7 @@ if mcp.IsObject(value) {
 ### Client Types
 
 - `X402MCPClient` - x402-enabled MCP client
-- `Options` - Options for x402 MCP client behavior (AutoPayment defaults to true)
+- `Options` - Options for x402 MCP client behavior (AutoPayment defaults to true; `SpendControls` and `DisableSpendControls` are consumed by `NewX402MCPClientFromConfig` only)
 - `SchemeRegistration` - Payment scheme registration for factory functions
 - `MCPToolCallResult` - Result of a tool call with payment metadata
 - `PaymentRequiredContext` - Context provided to payment required hooks

--- a/go/mcp/client.go
+++ b/go/mcp/client.go
@@ -28,14 +28,9 @@ type X402MCPClient struct {
 }
 
 // NewX402MCPClient creates an x402-aware MCP client wrapping an existing payment client.
-// DisableSpendControls or a non-nil SpendControls on options is applied to paymentClient.
-// When both are unset, the wrapped client's existing spend controls are left as-is.
+// Configure spend controls on paymentClient (SetSpendControls / DisableSpendControls)
+// before wrapping; this constructor does not change them.
 func NewX402MCPClient(caller MCPCaller, paymentClient *x402.X402Client, options Options) *X402MCPClient {
-	if options.DisableSpendControls {
-		paymentClient.DisableSpendControls()
-	} else if options.SpendControls != nil {
-		paymentClient.SetSpendControls(*options.SpendControls)
-	}
 	return &X402MCPClient{
 		caller:        caller,
 		paymentClient: paymentClient,
@@ -44,8 +39,8 @@ func NewX402MCPClient(caller MCPCaller, paymentClient *x402.X402Client, options 
 }
 
 // NewX402MCPClientFromConfig creates an x402-aware MCP client from scheme registrations.
-// Spend controls are applied via Options the same way as NewX402MCPClient.
-// nil SpendControls means the constructed client's default $1 cap and default-asset allowlist.
+// The constructed payment client uses the default $1 cap and default-asset allowlist.
+// For custom spend controls, configure an *x402.X402Client and pass it to NewX402MCPClient.
 func NewX402MCPClientFromConfig(caller MCPCaller, schemes []SchemeRegistration, options Options) *X402MCPClient {
 	paymentClient := x402.Newx402Client()
 	for _, reg := range schemes {

--- a/go/mcp/client.go
+++ b/go/mcp/client.go
@@ -47,6 +47,11 @@ func NewX402MCPClientFromConfig(caller MCPCaller, schemes []SchemeRegistration, 
 			paymentClient.RegisterV1(reg.Network, reg.ClientV1)
 		}
 	}
+	if options.DisableSpendControls {
+		paymentClient.DisableSpendControls()
+	} else if options.SpendControls != nil {
+		paymentClient.SetSpendControls(*options.SpendControls)
+	}
 	return NewX402MCPClient(caller, paymentClient, options)
 }
 
@@ -274,7 +279,12 @@ func (c *X402MCPClient) callToolWithV1Payment(
 		}
 	}
 
-	payload, err := c.paymentClient.CreatePaymentPayloadV1(ctx, paymentRequired.Accepts[0])
+	selected, err := c.paymentClient.SelectPaymentRequirementsV1(paymentRequired.Accepts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select v1 payment requirements: %w", err)
+	}
+
+	payload, err := c.paymentClient.CreatePaymentPayloadV1(ctx, selected)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create v1 payment: %w", err)
 	}
@@ -462,7 +472,11 @@ func CallPaidTool(
 			return buildResult(result, false), nil
 		}
 
-		payloadV1, err := x402Client.CreatePaymentPayloadV1(ctx, prV1.Accepts[0])
+		selected, err := x402Client.SelectPaymentRequirementsV1(prV1.Accepts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to select v1 payment requirements: %w", err)
+		}
+		payloadV1, err := x402Client.CreatePaymentPayloadV1(ctx, selected)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create v1 payment: %w", err)
 		}

--- a/go/mcp/client.go
+++ b/go/mcp/client.go
@@ -27,7 +27,9 @@ type X402MCPClient struct {
 	onAfterPay    AfterPaymentHook
 }
 
-// NewX402MCPClient creates an x402-aware MCP client.
+// NewX402MCPClient creates an x402-aware MCP client wrapping an existing payment client.
+// Options.SpendControls and Options.DisableSpendControls are ignored; configure
+// spend controls on paymentClient before wrapping.
 func NewX402MCPClient(caller MCPCaller, paymentClient *x402.X402Client, options Options) *X402MCPClient {
 	return &X402MCPClient{
 		caller:        caller,
@@ -37,6 +39,8 @@ func NewX402MCPClient(caller MCPCaller, paymentClient *x402.X402Client, options 
 }
 
 // NewX402MCPClientFromConfig creates an x402-aware MCP client from scheme registrations.
+// Options.SpendControls and Options.DisableSpendControls are applied to the constructed
+// payment client. nil SpendControls means the default $1 cap and default-asset allowlist.
 func NewX402MCPClientFromConfig(caller MCPCaller, schemes []SchemeRegistration, options Options) *X402MCPClient {
 	paymentClient := x402.Newx402Client()
 	for _, reg := range schemes {

--- a/go/mcp/client.go
+++ b/go/mcp/client.go
@@ -28,9 +28,14 @@ type X402MCPClient struct {
 }
 
 // NewX402MCPClient creates an x402-aware MCP client wrapping an existing payment client.
-// Options.SpendControls and Options.DisableSpendControls are ignored; configure
-// spend controls on paymentClient before wrapping.
+// DisableSpendControls or a non-nil SpendControls on options is applied to paymentClient.
+// When both are unset, the wrapped client's existing spend controls are left as-is.
 func NewX402MCPClient(caller MCPCaller, paymentClient *x402.X402Client, options Options) *X402MCPClient {
+	if options.DisableSpendControls {
+		paymentClient.DisableSpendControls()
+	} else if options.SpendControls != nil {
+		paymentClient.SetSpendControls(*options.SpendControls)
+	}
 	return &X402MCPClient{
 		caller:        caller,
 		paymentClient: paymentClient,
@@ -39,8 +44,8 @@ func NewX402MCPClient(caller MCPCaller, paymentClient *x402.X402Client, options 
 }
 
 // NewX402MCPClientFromConfig creates an x402-aware MCP client from scheme registrations.
-// Options.SpendControls and Options.DisableSpendControls are applied to the constructed
-// payment client. nil SpendControls means the default $1 cap and default-asset allowlist.
+// Spend controls are applied via Options the same way as NewX402MCPClient.
+// nil SpendControls means the constructed client's default $1 cap and default-asset allowlist.
 func NewX402MCPClientFromConfig(caller MCPCaller, schemes []SchemeRegistration, options Options) *X402MCPClient {
 	paymentClient := x402.Newx402Client()
 	for _, reg := range schemes {
@@ -50,11 +55,6 @@ func NewX402MCPClientFromConfig(caller MCPCaller, schemes []SchemeRegistration, 
 		if reg.ClientV1 != nil {
 			paymentClient.RegisterV1(reg.Network, reg.ClientV1)
 		}
-	}
-	if options.DisableSpendControls {
-		paymentClient.DisableSpendControls()
-	} else if options.SpendControls != nil {
-		paymentClient.SetSpendControls(*options.SpendControls)
 	}
 	return NewX402MCPClient(caller, paymentClient, options)
 }

--- a/go/mcp/client_test.go
+++ b/go/mcp/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -175,11 +176,23 @@ func TestNewX402MCPClientFromConfig(t *testing.T) {
 
 // Mock scheme network client for testing
 type mockSchemeNetworkClient struct {
-	scheme string
+	scheme             string
+	findDefaultAsset   func(asset string, network x402.Network) *x402.DefaultAsset
+	noFindDefaultAsset bool
 }
 
 func (m *mockSchemeNetworkClient) Scheme() string {
 	return m.scheme
+}
+
+func (m *mockSchemeNetworkClient) FindDefaultAsset(asset string, network x402.Network) *x402.DefaultAsset {
+	if m.noFindDefaultAsset {
+		return nil
+	}
+	if m.findDefaultAsset != nil {
+		return m.findDefaultAsset(asset, network)
+	}
+	return &x402.DefaultAsset{Asset: asset, Decimals: 6, Symbol: "MOCK"}
 }
 
 func (m *mockSchemeNetworkClient) CreatePaymentPayload(ctx context.Context, requirements types.PaymentRequirements) (types.PaymentPayload, error) {
@@ -914,4 +927,177 @@ func TestX402MCPClient_CallTool_UnderlyingError(t *testing.T) {
 	if !errors.Is(err, mockMCPCaller.callToolError) {
 		t.Errorf("Expected wrapped connection error, got: %v", err)
 	}
+}
+
+func mcp402Result(t *testing.T, required any) MCPToolResult {
+	t.Helper()
+	structuredBytes, err := json.Marshal(required)
+	if err != nil {
+		t.Fatalf("marshal payment required: %v", err)
+	}
+	var structuredContent map[string]interface{}
+	if err := json.Unmarshal(structuredBytes, &structuredContent); err != nil {
+		t.Fatalf("unmarshal structured content: %v", err)
+	}
+	return MCPToolResult{
+		IsError:           true,
+		StructuredContent: structuredContent,
+		Content:           []MCPContentItem{{Type: "text", Text: string(structuredBytes)}},
+	}
+}
+
+func mcpPaidResult() MCPToolResult {
+	return MCPToolResult{
+		Content: []MCPContentItem{{Type: "text", Text: "ok"}},
+		Meta: map[string]interface{}{
+			MCP_PAYMENT_RESPONSE_META_KEY: map[string]interface{}{"success": true, "transaction": "0xtx"},
+		},
+	}
+}
+
+func TestX402MCPClientFromConfig_SpendControlsDefaultRejectsOverCap(t *testing.T) {
+	mockMCP := &mockMCPCaller{
+		callToolResults: []MCPToolResult{
+			mcp402Result(t, types.PaymentRequired{
+				X402Version: 2,
+				Accepts: []types.PaymentRequirements{{
+					Scheme: "exact", Network: "eip155:84532",
+					Asset: "0xCustomUnknownToken", Amount: "2000000",
+					PayTo: "0xrecipient", MaxTimeoutSeconds: 300,
+				}},
+			}),
+		},
+	}
+	client := NewX402MCPClientFromConfig(mockMCP, []SchemeRegistration{
+		{Network: "eip155:84532", Client: &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true}},
+	}, Options{AutoPayment: BoolPtr(true)})
+
+	_, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
+	if err == nil || !strings.Contains(err.Error(), "spendControls") {
+		t.Fatalf("expected spendControls rejection, got %v", err)
+	}
+}
+
+func TestX402MCPClientFromConfig_DisableSpendControlsAllowsOverCap(t *testing.T) {
+	mockMCP := &mockMCPCaller{
+		callToolResults: []MCPToolResult{
+			mcp402Result(t, types.PaymentRequired{
+				X402Version: 2,
+				Accepts: []types.PaymentRequirements{{
+					Scheme: "exact", Network: "eip155:84532",
+					Asset: "0xCustomUnknownToken", Amount: "2000000",
+					PayTo: "0xrecipient", MaxTimeoutSeconds: 300,
+				}},
+			}),
+			mcpPaidResult(),
+		},
+	}
+	client := NewX402MCPClientFromConfig(mockMCP, []SchemeRegistration{
+		{Network: "eip155:84532", Client: &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true}},
+	}, Options{AutoPayment: BoolPtr(true), DisableSpendControls: true})
+
+	result, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.PaymentMade {
+		t.Fatal("expected payment to be made")
+	}
+}
+
+func TestX402MCPClientFromConfig_AllowAnyAssetSucceeds(t *testing.T) {
+	mockMCP := &mockMCPCaller{
+		callToolResults: []MCPToolResult{
+			mcp402Result(t, types.PaymentRequired{
+				X402Version: 2,
+				Accepts: []types.PaymentRequirements{{
+					Scheme: "exact", Network: "eip155:84532",
+					Asset: "0xCustomUnknownToken", Amount: "1",
+					PayTo: "0xrecipient", MaxTimeoutSeconds: 300,
+				}},
+			}),
+			mcpPaidResult(),
+		},
+	}
+	client := NewX402MCPClientFromConfig(mockMCP, []SchemeRegistration{
+		{Network: "eip155:84532", Client: &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true}},
+	}, Options{
+		AutoPayment:   BoolPtr(true),
+		SpendControls: &x402.SpendControls{AllowAnyAsset: true},
+	})
+
+	result, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.PaymentMade {
+		t.Fatal("expected payment to be made")
+	}
+}
+
+func TestX402MCPClient_WrapExistingClientHonoursSpendControls(t *testing.T) {
+	mockMCP := &mockMCPCaller{
+		callToolResults: []MCPToolResult{
+			mcp402Result(t, types.PaymentRequired{
+				X402Version: 2,
+				Accepts: []types.PaymentRequirements{{
+					Scheme: "exact", Network: "eip155:84532",
+					Asset: "0xCustomUnknownToken", Amount: "1",
+					PayTo: "0xrecipient", MaxTimeoutSeconds: 300,
+				}},
+			}),
+		},
+	}
+	paymentClient := x402.Newx402Client()
+	paymentClient.Register("eip155:84532", &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true})
+	paymentClient.SetSpendControls(x402.SpendControls{})
+	client := NewX402MCPClient(mockMCP, paymentClient, Options{
+		AutoPayment:          BoolPtr(true),
+		DisableSpendControls: true, // must not overwrite the wrapped client
+	})
+
+	_, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
+	if err == nil || !strings.Contains(err.Error(), "spendControls") {
+		t.Fatalf("expected wrapped client controls to reject, got %v", err)
+	}
+}
+
+func TestX402MCPClient_V1CallToolRejectsOverCap(t *testing.T) {
+	mockMCP := &mockMCPCaller{
+		callToolResults: []MCPToolResult{
+			mcp402Result(t, types.PaymentRequiredV1{
+				X402Version: 1,
+				Accepts: []types.PaymentRequirementsV1{{
+					Scheme:            "exact",
+					Network:           "base",
+					Asset:             "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+					MaxAmountRequired: "2000000",
+					PayTo:             "0xrecipient",
+					MaxTimeoutSeconds: 120,
+				}},
+			}),
+		},
+	}
+	paymentClient := x402.Newx402Client()
+	paymentClient.RegisterV1("base", &mockSchemeNetworkClientV1{scheme: "exact"})
+	client := NewX402MCPClient(mockMCP, paymentClient, Options{AutoPayment: BoolPtr(true)})
+
+	_, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
+	if err == nil || !strings.Contains(err.Error(), "maxAmountPerPayment") {
+		t.Fatalf("expected v1 cap rejection, got %v", err)
+	}
+}
+
+type mockSchemeNetworkClientV1 struct {
+	scheme string
+}
+
+func (m *mockSchemeNetworkClientV1) Scheme() string { return m.scheme }
+
+func (m *mockSchemeNetworkClientV1) FindDefaultAsset(asset string, network x402.Network) *x402.DefaultAsset {
+	return &x402.DefaultAsset{Asset: asset, Decimals: 6, Symbol: "USDC"}
+}
+
+func (m *mockSchemeNetworkClientV1) CreatePaymentPayload(ctx context.Context, requirements types.PaymentRequirementsV1) (types.PaymentPayloadV1, error) {
+	return types.PaymentPayloadV1{X402Version: 1, Scheme: m.scheme, Network: requirements.Network, Payload: map[string]interface{}{"signature": "0xmock"}}, nil
 }

--- a/go/mcp/client_test.go
+++ b/go/mcp/client_test.go
@@ -978,63 +978,6 @@ func TestX402MCPClientFromConfig_SpendControlsDefaultRejectsOverCap(t *testing.T
 	}
 }
 
-func TestX402MCPClientFromConfig_DisableSpendControlsAllowsOverCap(t *testing.T) {
-	mockMCP := &mockMCPCaller{
-		callToolResults: []MCPToolResult{
-			mcp402Result(t, types.PaymentRequired{
-				X402Version: 2,
-				Accepts: []types.PaymentRequirements{{
-					Scheme: "exact", Network: "eip155:84532",
-					Asset: "0xCustomUnknownToken", Amount: "2000000",
-					PayTo: "0xrecipient", MaxTimeoutSeconds: 300,
-				}},
-			}),
-			mcpPaidResult(),
-		},
-	}
-	client := NewX402MCPClientFromConfig(mockMCP, []SchemeRegistration{
-		{Network: "eip155:84532", Client: &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true}},
-	}, Options{AutoPayment: BoolPtr(true), DisableSpendControls: true})
-
-	result, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !result.PaymentMade {
-		t.Fatal("expected payment to be made")
-	}
-}
-
-func TestX402MCPClientFromConfig_AllowAnyAssetSucceeds(t *testing.T) {
-	mockMCP := &mockMCPCaller{
-		callToolResults: []MCPToolResult{
-			mcp402Result(t, types.PaymentRequired{
-				X402Version: 2,
-				Accepts: []types.PaymentRequirements{{
-					Scheme: "exact", Network: "eip155:84532",
-					Asset: "0xCustomUnknownToken", Amount: "1",
-					PayTo: "0xrecipient", MaxTimeoutSeconds: 300,
-				}},
-			}),
-			mcpPaidResult(),
-		},
-	}
-	client := NewX402MCPClientFromConfig(mockMCP, []SchemeRegistration{
-		{Network: "eip155:84532", Client: &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true}},
-	}, Options{
-		AutoPayment:   BoolPtr(true),
-		SpendControls: &x402.SpendControls{AllowAnyAsset: true},
-	})
-
-	result, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !result.PaymentMade {
-		t.Fatal("expected payment to be made")
-	}
-}
-
 func TestX402MCPClient_WrapExistingClientHonoursSpendControlsWhenUnset(t *testing.T) {
 	mockMCP := &mockMCPCaller{
 		callToolResults: []MCPToolResult{
@@ -1059,7 +1002,7 @@ func TestX402MCPClient_WrapExistingClientHonoursSpendControlsWhenUnset(t *testin
 	}
 }
 
-func TestX402MCPClient_WrapAppliesDisableSpendControls(t *testing.T) {
+func TestX402MCPClient_WrapUsesPaymentClientDisableSpendControls(t *testing.T) {
 	mockMCP := &mockMCPCaller{
 		callToolResults: []MCPToolResult{
 			mcp402Result(t, types.PaymentRequired{
@@ -1075,10 +1018,8 @@ func TestX402MCPClient_WrapAppliesDisableSpendControls(t *testing.T) {
 	}
 	paymentClient := x402.Newx402Client()
 	paymentClient.Register("eip155:84532", &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true})
-	client := NewX402MCPClient(mockMCP, paymentClient, Options{
-		AutoPayment:          BoolPtr(true),
-		DisableSpendControls: true,
-	})
+	paymentClient.DisableSpendControls()
+	client := NewX402MCPClient(mockMCP, paymentClient, Options{AutoPayment: BoolPtr(true)})
 
 	result, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
 	if err != nil {
@@ -1089,7 +1030,7 @@ func TestX402MCPClient_WrapAppliesDisableSpendControls(t *testing.T) {
 	}
 }
 
-func TestX402MCPClient_WrapAppliesSpendControls(t *testing.T) {
+func TestX402MCPClient_WrapUsesPaymentClientSpendControls(t *testing.T) {
 	mockMCP := &mockMCPCaller{
 		callToolResults: []MCPToolResult{
 			mcp402Result(t, types.PaymentRequired{
@@ -1105,10 +1046,8 @@ func TestX402MCPClient_WrapAppliesSpendControls(t *testing.T) {
 	}
 	paymentClient := x402.Newx402Client()
 	paymentClient.Register("eip155:84532", &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true})
-	client := NewX402MCPClient(mockMCP, paymentClient, Options{
-		AutoPayment:   BoolPtr(true),
-		SpendControls: &x402.SpendControls{AllowAnyAsset: true},
-	})
+	paymentClient.SetSpendControls(x402.SpendControls{AllowAnyAsset: true})
+	client := NewX402MCPClient(mockMCP, paymentClient, Options{AutoPayment: BoolPtr(true)})
 
 	result, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
 	if err != nil {

--- a/go/mcp/client_test.go
+++ b/go/mcp/client_test.go
@@ -1035,7 +1035,7 @@ func TestX402MCPClientFromConfig_AllowAnyAssetSucceeds(t *testing.T) {
 	}
 }
 
-func TestX402MCPClient_WrapExistingClientHonoursSpendControls(t *testing.T) {
+func TestX402MCPClient_WrapExistingClientHonoursSpendControlsWhenUnset(t *testing.T) {
 	mockMCP := &mockMCPCaller{
 		callToolResults: []MCPToolResult{
 			mcp402Result(t, types.PaymentRequired{
@@ -1051,14 +1051,71 @@ func TestX402MCPClient_WrapExistingClientHonoursSpendControls(t *testing.T) {
 	paymentClient := x402.Newx402Client()
 	paymentClient.Register("eip155:84532", &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true})
 	paymentClient.SetSpendControls(x402.SpendControls{})
-	client := NewX402MCPClient(mockMCP, paymentClient, Options{
-		AutoPayment:          BoolPtr(true),
-		DisableSpendControls: true, // must not overwrite the wrapped client
-	})
+	client := NewX402MCPClient(mockMCP, paymentClient, Options{AutoPayment: BoolPtr(true)})
 
 	_, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
 	if err == nil || !strings.Contains(err.Error(), "spendControls") {
 		t.Fatalf("expected wrapped client controls to reject, got %v", err)
+	}
+}
+
+func TestX402MCPClient_WrapAppliesDisableSpendControls(t *testing.T) {
+	mockMCP := &mockMCPCaller{
+		callToolResults: []MCPToolResult{
+			mcp402Result(t, types.PaymentRequired{
+				X402Version: 2,
+				Accepts: []types.PaymentRequirements{{
+					Scheme: "exact", Network: "eip155:84532",
+					Asset: "0xCustomUnknownToken", Amount: "2000000",
+					PayTo: "0xrecipient", MaxTimeoutSeconds: 300,
+				}},
+			}),
+			mcpPaidResult(),
+		},
+	}
+	paymentClient := x402.Newx402Client()
+	paymentClient.Register("eip155:84532", &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true})
+	client := NewX402MCPClient(mockMCP, paymentClient, Options{
+		AutoPayment:          BoolPtr(true),
+		DisableSpendControls: true,
+	})
+
+	result, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.PaymentMade {
+		t.Fatal("expected payment to be made")
+	}
+}
+
+func TestX402MCPClient_WrapAppliesSpendControls(t *testing.T) {
+	mockMCP := &mockMCPCaller{
+		callToolResults: []MCPToolResult{
+			mcp402Result(t, types.PaymentRequired{
+				X402Version: 2,
+				Accepts: []types.PaymentRequirements{{
+					Scheme: "exact", Network: "eip155:84532",
+					Asset: "0xCustomUnknownToken", Amount: "1",
+					PayTo: "0xrecipient", MaxTimeoutSeconds: 300,
+				}},
+			}),
+			mcpPaidResult(),
+		},
+	}
+	paymentClient := x402.Newx402Client()
+	paymentClient.Register("eip155:84532", &mockSchemeNetworkClient{scheme: "exact", noFindDefaultAsset: true})
+	client := NewX402MCPClient(mockMCP, paymentClient, Options{
+		AutoPayment:   BoolPtr(true),
+		SpendControls: &x402.SpendControls{AllowAnyAsset: true},
+	})
+
+	result, err := client.CallTool(context.Background(), "paid_tool", map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.PaymentMade {
+		t.Fatal("expected payment to be made")
 	}
 }
 

--- a/go/mcp/types.go
+++ b/go/mcp/types.go
@@ -63,6 +63,12 @@ type Options struct {
 	// OnPaymentRequested is called before creating a payment, allowing the caller
 	// to approve or deny. Return (true, nil) to approve, (false, nil) to deny.
 	OnPaymentRequested func(context PaymentRequiredContext) (bool, error)
+
+	// SpendControls is consumed by NewX402MCPClientFromConfig only.
+	// nil means default $1 + default-asset allowlist.
+	SpendControls *x402.SpendControls
+	// DisableSpendControls disables all spend controls (TS spendControls: false).
+	DisableSpendControls bool
 }
 
 // BoolPtr returns a pointer to the given bool value.

--- a/go/mcp/types.go
+++ b/go/mcp/types.go
@@ -55,10 +55,6 @@ type AfterPaymentContext struct {
 }
 
 // Options configures x402MCPClient behavior.
-//
-// SpendControls and DisableSpendControls are applied by both NewX402MCPClient and
-// NewX402MCPClientFromConfig. When both are unset, NewX402MCPClient leaves the
-// wrapped payment client's existing spend controls unchanged.
 type Options struct {
 	// AutoPayment enables automatic payment handling when a tool requires payment.
 	// Defaults to true. When nil, defaults to true. Set to BoolPtr(false) to disable.
@@ -67,13 +63,6 @@ type Options struct {
 	// OnPaymentRequested is called before creating a payment, allowing the caller
 	// to approve or deny. Return (true, nil) to approve, (false, nil) to deny.
 	OnPaymentRequested func(context PaymentRequiredContext) (bool, error)
-
-	// SpendControls, when non-nil, is applied to the payment client.
-	// nil means leave existing controls (wrap) or use the default $1 + default-asset
-	// allowlist (FromConfig / Newx402Client).
-	SpendControls *x402.SpendControls
-	// DisableSpendControls disables all spend controls (TS spendControls: false).
-	DisableSpendControls bool
 }
 
 // BoolPtr returns a pointer to the given bool value.

--- a/go/mcp/types.go
+++ b/go/mcp/types.go
@@ -56,9 +56,9 @@ type AfterPaymentContext struct {
 
 // Options configures x402MCPClient behavior.
 //
-// SpendControls and DisableSpendControls are applied by NewX402MCPClientFromConfig
-// only. NewX402MCPClient ignores them; configure the wrapped payment client instead
-// (SetSpendControls / DisableSpendControls).
+// SpendControls and DisableSpendControls are applied by both NewX402MCPClient and
+// NewX402MCPClientFromConfig. When both are unset, NewX402MCPClient leaves the
+// wrapped payment client's existing spend controls unchanged.
 type Options struct {
 	// AutoPayment enables automatic payment handling when a tool requires payment.
 	// Defaults to true. When nil, defaults to true. Set to BoolPtr(false) to disable.
@@ -68,8 +68,9 @@ type Options struct {
 	// to approve or deny. Return (true, nil) to approve, (false, nil) to deny.
 	OnPaymentRequested func(context PaymentRequiredContext) (bool, error)
 
-	// SpendControls is consumed by NewX402MCPClientFromConfig only.
-	// nil means default $1 + default-asset allowlist.
+	// SpendControls, when non-nil, is applied to the payment client.
+	// nil means leave existing controls (wrap) or use the default $1 + default-asset
+	// allowlist (FromConfig / Newx402Client).
 	SpendControls *x402.SpendControls
 	// DisableSpendControls disables all spend controls (TS spendControls: false).
 	DisableSpendControls bool

--- a/go/mcp/types.go
+++ b/go/mcp/types.go
@@ -54,7 +54,11 @@ type AfterPaymentContext struct {
 	SettleResponse *x402.SettleResponse
 }
 
-// Options configures x402MCPClient behavior
+// Options configures x402MCPClient behavior.
+//
+// SpendControls and DisableSpendControls are applied by NewX402MCPClientFromConfig
+// only. NewX402MCPClient ignores them; configure the wrapped payment client instead
+// (SetSpendControls / DisableSpendControls).
 type Options struct {
 	// AutoPayment enables automatic payment handling when a tool requires payment.
 	// Defaults to true. When nil, defaults to true. Set to BoolPtr(false) to disable.

--- a/go/mechanisms/evm/batch-settlement/client/scheme.go
+++ b/go/mechanisms/evm/batch-settlement/client/scheme.go
@@ -123,6 +123,14 @@ func (c *BatchSettlementEvmScheme) Scheme() string {
 	return batchsettlement.SchemeBatched
 }
 
+func (c *BatchSettlementEvmScheme) FindDefaultAsset(asset string, network x402.Network) *x402.DefaultAsset {
+	info := evm.FindDefaultAsset(asset, string(network))
+	if info == nil {
+		return nil
+	}
+	return &x402.DefaultAsset{Asset: info.Asset, Decimals: info.Decimals, Symbol: info.Symbol}
+}
+
 // CreatePaymentPayload creates a batched payment payload.
 //
 // The client loads local session state, falls back to onchain recovery when

--- a/go/mechanisms/evm/batch-settlement/server/scheme.go
+++ b/go/mechanisms/evm/batch-settlement/server/scheme.go
@@ -412,12 +412,12 @@ func (s *BatchSettlementEvmScheme) PaymentFlows() map[string]x402.PaymentFlowCon
 }
 
 // GetAssetDecimals implements AssetDecimalsProvider.
-func (s *BatchSettlementEvmScheme) GetAssetDecimals(asset string, network x402.Network) int {
-	info, err := evm.GetAssetInfo(string(network), asset)
-	if err != nil || info == nil {
-		return 6
+func (s *BatchSettlementEvmScheme) GetAssetDecimals(asset string, network x402.Network) (int, bool) {
+	found := evm.FindDefaultAsset(asset, string(network))
+	if found == nil {
+		return 0, false
 	}
-	return info.Decimals
+	return found.Decimals, true
 }
 
 // RegisterMoneyParser registers a custom money parser.
@@ -506,7 +506,7 @@ func (s *BatchSettlementEvmScheme) ParsePrice(price x402.Price, network x402.Net
 		}
 	}
 
-	decimalAmount, err := parseMoneyToDecimal(price)
+	decimalAmount, symbol, err := x402.ParseMoney(price)
 	if err != nil {
 		return x402.AssetAmount{}, err
 	}
@@ -521,7 +521,7 @@ func (s *BatchSettlementEvmScheme) ParsePrice(price x402.Price, network x402.Net
 		}
 	}
 
-	return defaultMoneyConversion(decimalAmount, network)
+	return defaultMoneyConversion(decimalAmount, network, symbol)
 }
 
 // EnhancePaymentRequirements adds batched-specific fields to payment requirements.
@@ -747,70 +747,28 @@ func (s *BatchSettlementEvmScheme) DeleteSession(channelId string) error {
 
 // Helper functions
 
-func parseMoneyToDecimal(price x402.Price) (float64, error) {
-	switch v := price.(type) {
-	case string:
-		cleanPrice := strings.TrimSpace(v)
-		cleanPrice = strings.TrimPrefix(cleanPrice, "$")
-		cleanPrice = strings.TrimSpace(cleanPrice)
-		amount, err := strconv.ParseFloat(cleanPrice, 64)
-		if err != nil {
-			return 0, fmt.Errorf(ErrFailedToParsePrice+": '%s': %w", v, err)
-		}
-		return amount, nil
-	case float64:
-		return v, nil
-	case int:
-		return float64(v), nil
-	case int64:
-		return float64(v), nil
-	default:
-		return 0, fmt.Errorf(ErrUnsupportedPriceType+": %T", price)
-	}
-}
-
-func defaultMoneyConversion(amount float64, network x402.Network) (x402.AssetAmount, error) {
-	networkStr := string(network)
-	config, err := evm.GetNetworkConfig(networkStr)
+func defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
+	assetInfo, err := evm.GetDefaultAsset(string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err
 	}
-	if config.DefaultAsset.Address == "" {
-		return x402.AssetAmount{}, fmt.Errorf("no default stablecoin for network %s", networkStr)
-	}
 
-	extra := map[string]interface{}{
-		// Token EIP-712 domain — see comment in GetExtra above for why both
-		// ERC-3009 and Permit2(+EIP-2612) paths need name/version.
-		"name":    config.DefaultAsset.Name,
-		"version": config.DefaultAsset.Version,
-	}
-	if config.DefaultAsset.AssetTransferMethod != "" {
-		extra["assetTransferMethod"] = string(config.DefaultAsset.AssetTransferMethod)
-	}
-
-	oneUnit := float64(1)
-	for i := 0; i < config.DefaultAsset.Decimals; i++ {
-		oneUnit *= 10
-	}
-
-	if amount >= oneUnit && amount == float64(int64(amount)) {
-		return x402.AssetAmount{
-			Asset:  config.DefaultAsset.Address,
-			Amount: fmt.Sprintf("%.0f", amount),
-			Extra:  extra,
-		}, nil
-	}
-
-	amountStr := fmt.Sprintf("%.6f", amount)
-	parsedAmount, err := evm.ParseAmount(amountStr, config.DefaultAsset.Decimals)
+	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
 	if err != nil {
 		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmt+": %w", err)
 	}
 
+	extra := map[string]interface{}{
+		"name":    assetInfo.Name,
+		"version": assetInfo.Version,
+	}
+	if assetInfo.AssetTransferMethod != "" {
+		extra["assetTransferMethod"] = string(assetInfo.AssetTransferMethod)
+	}
+
 	return x402.AssetAmount{
-		Asset:  config.DefaultAsset.Address,
-		Amount: parsedAmount.String(),
+		Asset:  assetInfo.Asset,
+		Amount: tokenAmount,
 		Extra:  extra,
 	}, nil
 }

--- a/go/mechanisms/evm/batch-settlement/server/scheme.go
+++ b/go/mechanisms/evm/batch-settlement/server/scheme.go
@@ -747,7 +747,7 @@ func (s *BatchSettlementEvmScheme) DeleteSession(channelId string) error {
 
 // Helper functions
 
-func defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
+func defaultMoneyConversion(amount string, network x402.Network, symbol string) (x402.AssetAmount, error) {
 	assetInfo, tokenAmount, err := evm.ConvertDefaultMoney(amount, string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err

--- a/go/mechanisms/evm/batch-settlement/server/scheme.go
+++ b/go/mechanisms/evm/batch-settlement/server/scheme.go
@@ -748,14 +748,9 @@ func (s *BatchSettlementEvmScheme) DeleteSession(channelId string) error {
 // Helper functions
 
 func defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
-	assetInfo, err := evm.GetDefaultAsset(string(network), symbol)
+	assetInfo, tokenAmount, err := evm.ConvertDefaultMoney(amount, string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err
-	}
-
-	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
-	if err != nil {
-		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmt+": %w", err)
 	}
 
 	extra := map[string]interface{}{

--- a/go/mechanisms/evm/batch-settlement/server/scheme_test.go
+++ b/go/mechanisms/evm/batch-settlement/server/scheme_test.go
@@ -400,10 +400,10 @@ func TestSession_RoundTrip_CaseInsensitive(t *testing.T) {
 	}
 }
 
-func TestGetAssetDecimals_DefaultsTo6(t *testing.T) {
+func TestGetAssetDecimals_UnknownAsset(t *testing.T) {
 	s := NewBatchSettlementEvmScheme("0xreceiver", nil)
-	if got := s.GetAssetDecimals("0xunknown", x402.Network("nope")); got != 6 {
-		t.Fatalf("got %d", got)
+	if _, ok := s.GetAssetDecimals("0xunknown", x402.Network("nope")); ok {
+		t.Fatal("expected ok=false for unknown asset")
 	}
 }
 
@@ -415,7 +415,7 @@ func TestCreateChannelManager_NotNil(t *testing.T) {
 	}
 }
 
-func TestParseMoneyToDecimal_AllNumericTypes(t *testing.T) {
+func TestParseMoney_AllNumericTypes(t *testing.T) {
 	cases := []struct {
 		in   x402.Price
 		want float64
@@ -427,7 +427,7 @@ func TestParseMoneyToDecimal_AllNumericTypes(t *testing.T) {
 		{int64(5), 5.0},
 	}
 	for _, c := range cases {
-		got, err := parseMoneyToDecimal(c.in)
+		got, _, err := x402.ParseMoney(c.in)
 		if err != nil {
 			t.Fatalf("err on %v: %v", c.in, err)
 		}
@@ -437,14 +437,14 @@ func TestParseMoneyToDecimal_AllNumericTypes(t *testing.T) {
 	}
 }
 
-func TestParseMoneyToDecimal_BadString(t *testing.T) {
-	if _, err := parseMoneyToDecimal("nope"); err == nil {
+func TestParseMoney_BadString(t *testing.T) {
+	if _, _, err := x402.ParseMoney("nope"); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestParseMoneyToDecimal_UnsupportedType(t *testing.T) {
-	if _, err := parseMoneyToDecimal(big.NewInt(1)); err == nil {
+func TestParseMoney_UnsupportedType(t *testing.T) {
+	if _, _, err := x402.ParseMoney(big.NewInt(1)); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/go/mechanisms/evm/batch-settlement/server/scheme_test.go
+++ b/go/mechanisms/evm/batch-settlement/server/scheme_test.go
@@ -131,7 +131,7 @@ func TestParsePrice_UnsupportedType(t *testing.T) {
 func TestRegisterMoneyParser_OverridesDefault(t *testing.T) {
 	s := NewBatchSettlementEvmScheme("0xreceiver", nil)
 	called := false
-	s.RegisterMoneyParser(func(_ float64, _ x402.Network) (*x402.AssetAmount, error) {
+	s.RegisterMoneyParser(func(_ string, _ x402.Network) (*x402.AssetAmount, error) {
 		called = true
 		return &x402.AssetAmount{Amount: "777", Asset: "0xcustom"}, nil
 	})
@@ -418,13 +418,13 @@ func TestCreateChannelManager_NotNil(t *testing.T) {
 func TestParseMoney_AllNumericTypes(t *testing.T) {
 	cases := []struct {
 		in   x402.Price
-		want float64
+		want string
 	}{
-		{"1.5", 1.5},
-		{"$2.25", 2.25},
-		{float64(3.5), 3.5},
-		{int(4), 4.0},
-		{int64(5), 5.0},
+		{"1.5", "1.5"},
+		{"$2.25", "2.25"},
+		{float64(3.5), "3.5"},
+		{int(4), "4"},
+		{int64(5), "5"},
 	}
 	for _, c := range cases {
 		got, _, err := x402.ParseMoney(c.in)

--- a/go/mechanisms/evm/default_assets.go
+++ b/go/mechanisms/evm/default_assets.go
@@ -3,6 +3,8 @@ package evm
 import (
 	"fmt"
 	"strings"
+
+	x402 "github.com/x402-foundation/x402/go/v2"
 )
 
 // DefaultAssetInfo is a USD-pegged EVM asset used for money strings and spend caps.
@@ -121,6 +123,20 @@ func resolveNetworkKey(network string) string {
 		return fmt.Sprintf("eip155:%d", chainID)
 	}
 	return network
+}
+
+// ConvertDefaultMoney looks up the network's default (or ticker-matched) asset
+// and converts a decimal amount to token smallest units.
+func ConvertDefaultMoney(amount float64, network string, symbol string) (*DefaultAssetInfo, string, error) {
+	assetInfo, err := GetDefaultAsset(network, symbol)
+	if err != nil {
+		return nil, "", err
+	}
+	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to convert amount: %w", err)
+	}
+	return assetInfo, tokenAmount, nil
 }
 
 // GetDefaultAsset looks up a default asset by network and optional ticker.

--- a/go/mechanisms/evm/default_assets.go
+++ b/go/mechanisms/evm/default_assets.go
@@ -127,12 +127,12 @@ func resolveNetworkKey(network string) string {
 
 // ConvertDefaultMoney looks up the network's default (or ticker-matched) asset
 // and converts a decimal amount to token smallest units.
-func ConvertDefaultMoney(amount float64, network string, symbol string) (*DefaultAssetInfo, string, error) {
+func ConvertDefaultMoney(amount string, network string, symbol string) (*DefaultAssetInfo, string, error) {
 	assetInfo, err := GetDefaultAsset(network, symbol)
 	if err != nil {
 		return nil, "", err
 	}
-	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
+	tokenAmount, err := x402.ConvertToTokenAmount(amount, assetInfo.Decimals)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to convert amount: %w", err)
 	}

--- a/go/mechanisms/evm/default_assets.go
+++ b/go/mechanisms/evm/default_assets.go
@@ -1,0 +1,174 @@
+package evm
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DefaultAssetInfo is a USD-pegged EVM asset used for money strings and spend caps.
+type DefaultAssetInfo struct {
+	Asset               string
+	Name                string
+	Version             string
+	Decimals            int
+	Symbol              string
+	AssetTransferMethod AssetTransferMethod
+	SupportsEip2612     bool
+}
+
+// DefaultAssets maps CAIP-2 network to USD-pegged assets; index 0 is the "$0.10" default.
+var DefaultAssets = map[string][]DefaultAssetInfo{
+	"eip155:8453": {
+		{Asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", Name: "USD Coin", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:84532": {
+		{Asset: "0x036CbD53842c5426634e7929541eC2318f3dCF7e", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:4326": {
+		{Asset: "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7", Name: "MegaUSD", Version: "1", Decimals: 18, Symbol: "MegaUSD", AssetTransferMethod: AssetTransferMethodPermit2, SupportsEip2612: true},
+	},
+	"eip155:143": {
+		{Asset: "0x754704Bc059F8C67012fEd69BC8A327a5aafb603", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:988": {
+		{Asset: "0x779Ded0c9e1022225f8E0630b35a9b54bE713736", Name: "USDT0", Version: "1", Decimals: 6, Symbol: "USDT0"},
+	},
+	"eip155:2201": {
+		{Asset: "0x78Cf24370174180738C5B8E352B6D14c83a6c9A9", Name: "USDT0", Version: "1", Decimals: 6, Symbol: "USDT0"},
+	},
+	"eip155:137": {
+		{Asset: "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359", Name: "USD Coin", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:42161": {
+		{Asset: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831", Name: "USD Coin", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:421614": {
+		{Asset: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d", Name: "USD Coin", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:31612": {
+		{Asset: "0xdD468A1DDc392dcdbEf6db6e34E89AA338F9F186", Name: "Mezo USD", Version: "1", Decimals: 18, Symbol: "mUSD", AssetTransferMethod: AssetTransferMethodPermit2, SupportsEip2612: true},
+	},
+	"eip155:31611": {
+		{Asset: "0x118917a40FAF1CD7a13dB0Ef56C86De7973Ac503", Name: "Mezo USD", Version: "1", Decimals: 18, Symbol: "mUSD", AssetTransferMethod: AssetTransferMethodPermit2, SupportsEip2612: true},
+	},
+	"eip155:723487": {
+		{Asset: "0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb", Name: "Stable Coin", Version: "1", Decimals: 6, Symbol: "SBC", AssetTransferMethod: AssetTransferMethodPermit2, SupportsEip2612: true},
+	},
+	"eip155:72344": {
+		{Asset: "0x33ad9e4BD16B69B5BFdED37D8B5D9fF9aba014Fb", Name: "Stable Coin", Version: "1", Decimals: 6, Symbol: "SBC", AssetTransferMethod: AssetTransferMethodPermit2, SupportsEip2612: true},
+	},
+	"eip155:36900": {
+		{Asset: "0x9cb8142aEBBcdc60AF7c97Af897A67A8f3CA71C2", Name: "USDC.e", Version: "2", Decimals: 6, Symbol: "USDC.e"},
+	},
+	"eip155:190415": {
+		{Asset: "0x401eCb1D350407f13ba348573E5630B83638E30D", Name: "Bridged USDC", Version: "2", Decimals: 6, Symbol: "USDC.e"},
+	},
+	"eip155:181228": {
+		{Asset: "0x401eCb1D350407f13ba348573E5630B83638E30D", Name: "Bridged USDC", Version: "2", Decimals: 6, Symbol: "USDC.e"},
+	},
+	"eip155:50": {
+		{Asset: "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:51": {
+		{Asset: "0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:38833": {
+		{Asset: "0xA5b8BF902b2844dA17d4506cc827F7F1681735E7", Name: "USDC", Version: "1", Decimals: 6, Symbol: "USDC", AssetTransferMethod: AssetTransferMethodPermit2},
+	},
+	"eip155:14": {
+		{Asset: "0xe7cd86e13AC4309349F30B3435a9d337750fC82D", Name: "USD₮0", Version: "1", Decimals: 6, Symbol: "USDT0"},
+	},
+	"eip155:42220": {
+		{Asset: "0xcebA9300f2b948710d2653dD7B07f33A8B32118C", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+	"eip155:11142220": {
+		{Asset: "0x01C5C0122039549AD1493B8220cABEdD739BC44E", Name: "USDC", Version: "2", Decimals: 6, Symbol: "USDC"},
+	},
+}
+
+// legacyNetworkChainIDs maps v1 network names to chain IDs (mirrors v1.NetworkChainIDs).
+var legacyNetworkChainIDs = map[string]int64{
+	"ethereum":           1,
+	"sepolia":            11155111,
+	"abstract":           2741,
+	"abstract-testnet":   11124,
+	"base-sepolia":       84532,
+	"base":               8453,
+	"avalanche-fuji":     43113,
+	"avalanche":          43114,
+	"iotex":              4689,
+	"sei":                1329,
+	"sei-testnet":        1328,
+	"polygon":            137,
+	"polygon-amoy":       80002,
+	"peaq":               3338,
+	"story":              1514,
+	"educhain":           41923,
+	"skale-base-sepolia": 324705682,
+	"megaeth":            4326,
+	"monad":              143,
+	"stable":             988,
+	"stable-testnet":     2201,
+	"celo":               42220,
+	"flare":              14,
+}
+
+func resolveNetworkKey(network string) string {
+	if _, ok := DefaultAssets[network]; ok {
+		return network
+	}
+	if chainID, ok := legacyNetworkChainIDs[network]; ok {
+		return fmt.Sprintf("eip155:%d", chainID)
+	}
+	return network
+}
+
+// GetDefaultAsset looks up a default asset by network and optional ticker.
+// Empty symbol returns the network default (index 0).
+func GetDefaultAsset(network string, symbol string) (*DefaultAssetInfo, error) {
+	key := resolveNetworkKey(network)
+	assets := DefaultAssets[key]
+	if len(assets) == 0 {
+		return nil, fmt.Errorf("no default asset configured for network %s", network)
+	}
+	if symbol == "" {
+		entry := assets[0]
+		return &entry, nil
+	}
+	normalized := strings.ToUpper(symbol)
+	for i := range assets {
+		if strings.ToUpper(assets[i].Symbol) == normalized {
+			entry := assets[i]
+			return &entry, nil
+		}
+	}
+	return nil, fmt.Errorf("no %s default asset configured for network %s", symbol, network)
+}
+
+// FindDefaultAsset reverse-looks up by asset id (case-insensitive) and network.
+func FindDefaultAsset(asset string, network string) *DefaultAssetInfo {
+	key := resolveNetworkKey(network)
+	assets := DefaultAssets[key]
+	if len(assets) == 0 {
+		return nil
+	}
+	normalized := strings.ToLower(asset)
+	for i := range assets {
+		if strings.ToLower(assets[i].Asset) == normalized {
+			entry := assets[i]
+			return &entry
+		}
+	}
+	return nil
+}
+
+func defaultAssetToAssetInfo(info *DefaultAssetInfo) *AssetInfo {
+	return &AssetInfo{
+		Address:             info.Asset,
+		Name:                info.Name,
+		Version:             info.Version,
+		Decimals:            info.Decimals,
+		AssetTransferMethod: info.AssetTransferMethod,
+		SupportsEip2612:     info.SupportsEip2612,
+	}
+}

--- a/go/mechanisms/evm/exact/client/scheme.go
+++ b/go/mechanisms/evm/exact/client/scheme.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/extensions/eip2612gassponsor"
 	"github.com/x402-foundation/x402/go/v2/extensions/erc20approvalgassponsor"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
@@ -33,6 +34,14 @@ func NewExactEvmScheme(signer evm.ClientEvmSigner, config *ExactEvmSchemeConfig)
 // Scheme returns the scheme identifier
 func (c *ExactEvmScheme) Scheme() string {
 	return evm.SchemeExact
+}
+
+func (c *ExactEvmScheme) FindDefaultAsset(asset string, network x402.Network) *x402.DefaultAsset {
+	info := evm.FindDefaultAsset(asset, string(network))
+	if info == nil {
+		return nil
+	}
+	return &x402.DefaultAsset{Asset: info.Asset, Decimals: info.Decimals, Symbol: info.Symbol}
 }
 
 // CreatePaymentPayload creates a V2 payment payload for the exact scheme.

--- a/go/mechanisms/evm/exact/server/errors.go
+++ b/go/mechanisms/evm/exact/server/errors.go
@@ -2,16 +2,8 @@ package server
 
 // Server error constants for the exact EVM scheme (V2)
 const (
-	ErrAmountMustBeString    = "invalid_exact_evm_server_amount_must_be_string"
-	ErrAssetAddressRequired  = "invalid_exact_evm_server_asset_address_required"
-	ErrFailedToParsePrice    = "invalid_exact_evm_server_failed_to_parse_price"
-	ErrUnsupportedPriceType  = "invalid_exact_evm_server_unsupported_price_type"
-	ErrFailedToConvertAmount = "invalid_exact_evm_server_failed_to_convert_amount"
-	ErrNoAssetSpecified      = "invalid_exact_evm_server_no_asset_specified"
-	ErrFailedToParseAmount   = "invalid_exact_evm_server_failed_to_parse_amount"
-	ErrInvalidPayToAddress   = "invalid_exact_evm_server_invalid_payto_address"
-	ErrAmountRequired        = "invalid_exact_evm_server_amount_required"
-	ErrInvalidAmount         = "invalid_exact_evm_server_invalid_amount"
-	ErrInvalidAsset          = "invalid_exact_evm_server_invalid_asset"
-	ErrInvalidTokenAmount    = "invalid_exact_evm_server_invalid_token_amount"
+	ErrAmountMustBeString   = "invalid_exact_evm_server_amount_must_be_string"
+	ErrAssetAddressRequired = "invalid_exact_evm_server_asset_address_required"
+	ErrNoAssetSpecified     = "invalid_exact_evm_server_no_asset_specified"
+	ErrFailedToParseAmount  = "invalid_exact_evm_server_failed_to_parse_amount"
 )

--- a/go/mechanisms/evm/exact/server/scheme.go
+++ b/go/mechanisms/evm/exact/server/scheme.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
@@ -47,14 +46,14 @@ func (s *ExactEvmScheme) PaymentFlows() map[string]x402.PaymentFlowConfig {
 	}
 }
 
-// GetAssetDecimals implements AssetDecimalsProvider. Returns the decimal precision for the
-// given asset on the given network, falling back to 6 if the asset is not recognized.
-func (s *ExactEvmScheme) GetAssetDecimals(asset string, network x402.Network) int {
-	info, err := evm.GetAssetInfo(string(network), asset)
-	if err != nil || info == nil {
-		return 6
+// GetAssetDecimals implements AssetDecimalsProvider. Returns the decimal precision for a
+// known default asset. ok is false when the asset is unrecognized.
+func (s *ExactEvmScheme) GetAssetDecimals(asset string, network x402.Network) (int, bool) {
+	found := evm.FindDefaultAsset(asset, string(network))
+	if found == nil {
+		return 0, false
 	}
-	return info.Decimals
+	return found.Decimals, true
 }
 
 // RegisterMoneyParser registers a custom money parser in the parser chain.
@@ -138,7 +137,7 @@ func (s *ExactEvmScheme) ParsePrice(price x402.Price, network x402.Network) (x40
 	}
 
 	// Parse Money to decimal number
-	decimalAmount, err := s.parseMoneyToDecimal(price)
+	decimalAmount, symbol, err := x402.ParseMoney(price)
 	if err != nil {
 		return x402.AssetAmount{}, err
 	}
@@ -158,91 +157,34 @@ func (s *ExactEvmScheme) ParsePrice(price x402.Price, network x402.Network) (x40
 	}
 
 	// All custom parsers returned nil, use default conversion
-	return s.defaultMoneyConversion(decimalAmount, network)
+	return s.defaultMoneyConversion(decimalAmount, network, symbol)
 }
 
-// parseMoneyToDecimal converts Money (string | number) to decimal amount
-func (s *ExactEvmScheme) parseMoneyToDecimal(price x402.Price) (float64, error) {
-	switch v := price.(type) {
-	case string:
-		cleanPrice := strings.TrimSpace(v)
-		cleanPrice = strings.TrimPrefix(cleanPrice, "$")
-		cleanPrice = strings.TrimSpace(cleanPrice)
-
-		// Parse as float
-		amount, err := strconv.ParseFloat(cleanPrice, 64)
-		if err != nil {
-			return 0, fmt.Errorf(ErrFailedToParsePrice+": '%s': %w", v, err)
-		}
-		return amount, nil
-
-	case float64:
-		return v, nil
-
-	case int:
-		return float64(v), nil
-
-	case int64:
-		return float64(v), nil
-
-	default:
-		return 0, fmt.Errorf(ErrUnsupportedPriceType+": %T", price)
-	}
-}
-
-// defaultMoneyConversion converts decimal amount to USDC AssetAmount
-func (s *ExactEvmScheme) defaultMoneyConversion(amount float64, network x402.Network) (x402.AssetAmount, error) {
-	networkStr := string(network)
-
-	// Get network config to determine the asset
-	config, err := evm.GetNetworkConfig(networkStr)
+// defaultMoneyConversion converts a decimal amount to an AssetAmount using the default token.
+func (s *ExactEvmScheme) defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
+	assetInfo, err := evm.GetDefaultAsset(string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err
 	}
 
-	if config.DefaultAsset.Address == "" {
-		return x402.AssetAmount{}, fmt.Errorf("no default stablecoin configured for network %s; use RegisterMoneyParser or specify an explicit AssetAmount", networkStr)
-	}
-
-	// EIP-3009 tokens always need name/version for their transferWithAuthorization domain.
-	// Permit2 tokens only need them if the token supports EIP-2612 (for gasless permit signing).
-	// Omitting name/version for permit2 tokens signals the client to skip EIP-2612 and use ERC-20 approval gas sponsoring instead.
-	extra := map[string]interface{}{}
-	includeEip712Domain := config.DefaultAsset.AssetTransferMethod == "" || config.DefaultAsset.SupportsEip2612
-	if includeEip712Domain {
-		extra["name"] = config.DefaultAsset.Name
-		extra["version"] = config.DefaultAsset.Version
-	}
-	if config.DefaultAsset.AssetTransferMethod != "" {
-		extra["assetTransferMethod"] = string(config.DefaultAsset.AssetTransferMethod)
-	}
-
-	// Check if amount appears to already be in smallest unit
-	// (e.g., 1500000 for $1.50 USDC is likely already in smallest unit, not $1.5M)
-	oneUnit := float64(1)
-	for i := 0; i < config.DefaultAsset.Decimals; i++ {
-		oneUnit *= 10
-	}
-
-	// If amount is >= 1 unit AND is a whole number, it's likely already in smallest unit
-	if amount >= oneUnit && amount == float64(int64(amount)) {
-		return x402.AssetAmount{
-			Asset:  config.DefaultAsset.Address,
-			Amount: fmt.Sprintf("%.0f", amount),
-			Extra:  extra,
-		}, nil
-	}
-
-	// Convert decimal to smallest unit (e.g., $1.50 -> 1500000 for USDC with 6 decimals)
-	amountStr := fmt.Sprintf("%.6f", amount)
-	parsedAmount, err := evm.ParseAmount(amountStr, config.DefaultAsset.Decimals)
+	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
 	if err != nil {
 		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
 	}
 
+	extra := map[string]interface{}{}
+	includeEip712Domain := assetInfo.AssetTransferMethod == "" || assetInfo.SupportsEip2612
+	if includeEip712Domain {
+		extra["name"] = assetInfo.Name
+		extra["version"] = assetInfo.Version
+	}
+	if assetInfo.AssetTransferMethod != "" {
+		extra["assetTransferMethod"] = string(assetInfo.AssetTransferMethod)
+	}
+
 	return x402.AssetAmount{
-		Asset:  config.DefaultAsset.Address,
-		Amount: parsedAmount.String(),
+		Asset:  assetInfo.Asset,
+		Amount: tokenAmount,
 		Extra:  extra,
 	}, nil
 }

--- a/go/mechanisms/evm/exact/server/scheme.go
+++ b/go/mechanisms/evm/exact/server/scheme.go
@@ -162,14 +162,9 @@ func (s *ExactEvmScheme) ParsePrice(price x402.Price, network x402.Network) (x40
 
 // defaultMoneyConversion converts a decimal amount to an AssetAmount using the default token.
 func (s *ExactEvmScheme) defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
-	assetInfo, err := evm.GetDefaultAsset(string(network), symbol)
+	assetInfo, tokenAmount, err := evm.ConvertDefaultMoney(amount, string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err
-	}
-
-	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
-	if err != nil {
-		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
 	}
 
 	extra := map[string]interface{}{}

--- a/go/mechanisms/evm/exact/server/scheme.go
+++ b/go/mechanisms/evm/exact/server/scheme.go
@@ -57,7 +57,7 @@ func (s *ExactEvmScheme) GetAssetDecimals(asset string, network x402.Network) (i
 
 // RegisterMoneyParser registers a custom money parser in the parser chain.
 // Multiple parsers can be registered - they will be tried in registration order.
-// Each parser receives a decimal amount (e.g., 1.50 for $1.50).
+// Each parser receives a decimal string (e.g., "1.50" for $1.50).
 // If a parser returns nil, the next parser in the chain will be tried.
 // The default parser is always the final fallback.
 //
@@ -71,16 +71,16 @@ func (s *ExactEvmScheme) GetAssetDecimals(asset string, network x402.Network) (i
 //
 // Example:
 //
-//	evmServer.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-//	    // Use DAI for large amounts
-//	    if amount > 100 {
-//	        return &x402.AssetAmount{
-//	            Amount: fmt.Sprintf("%.0f", amount * 1e18),
-//	            Asset:  "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI
-//	            Extra:  map[string]interface{}{"token": "DAI"},
-//	        }, nil
+//	evmServer.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+//	    tokenAmount, err := x402.ConvertToTokenAmount(amount, 18)
+//	    if err != nil {
+//	        return nil, err
 //	    }
-//	    return nil, nil // Use next parser
+//	    return &x402.AssetAmount{
+//	        Amount: tokenAmount,
+//	        Asset:  "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI
+//	        Extra:  map[string]interface{}{"token": "DAI"},
+//	    }, nil
 //	})
 func (s *ExactEvmScheme) RegisterMoneyParser(parser x402.MoneyParser) *ExactEvmScheme {
 	s.moneyParsers = append(s.moneyParsers, parser)
@@ -135,7 +135,7 @@ func (s *ExactEvmScheme) ParsePrice(price x402.Price, network x402.Network) (x40
 		}
 	}
 
-	// Parse Money to decimal number
+	// Parse Money to a decimal string
 	decimalAmount, symbol, err := x402.ParseMoney(price)
 	if err != nil {
 		return x402.AssetAmount{}, err
@@ -160,7 +160,7 @@ func (s *ExactEvmScheme) ParsePrice(price x402.Price, network x402.Network) (x40
 }
 
 // defaultMoneyConversion converts a decimal amount to an AssetAmount using the default token.
-func (s *ExactEvmScheme) defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
+func (s *ExactEvmScheme) defaultMoneyConversion(amount string, network x402.Network, symbol string) (x402.AssetAmount, error) {
 	assetInfo, tokenAmount, err := evm.ConvertDefaultMoney(amount, string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err

--- a/go/mechanisms/evm/exact/server/scheme.go
+++ b/go/mechanisms/evm/exact/server/scheme.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"strings"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
@@ -246,81 +245,4 @@ func (s *ExactEvmScheme) EnhancePaymentRequirements(
 	}
 
 	return requirements, nil
-}
-
-// GetDisplayAmount formats an amount for display
-func (s *ExactEvmScheme) GetDisplayAmount(amount string, network string, asset string) (string, error) {
-	// Get asset info
-	assetInfo, err := evm.GetAssetInfo(network, asset)
-	if err != nil {
-		return "", err
-	}
-
-	// Parse amount
-	amountBig, ok := new(big.Int).SetString(amount, 10)
-	if !ok {
-		return "", fmt.Errorf("invalid amount: %s", amount)
-	}
-
-	// Format with decimals
-	formatted := evm.FormatAmount(amountBig, assetInfo.Decimals)
-
-	// Add currency symbol
-	return "$" + formatted + " USDC", nil
-}
-
-// ValidatePaymentRequirements validates that requirements are valid for this scheme.
-// All EVM networks are supported - this validates required fields only.
-func (s *ExactEvmScheme) ValidatePaymentRequirements(requirements x402.PaymentRequirements) error {
-	networkStr := string(requirements.Network)
-
-	// Check PayTo is a valid address
-	if !evm.IsValidAddress(requirements.PayTo) {
-		return fmt.Errorf(ErrInvalidPayToAddress+": %s", requirements.PayTo)
-	}
-
-	// Check amount is valid
-	if requirements.Amount == "" {
-		return errors.New(ErrAmountRequired)
-	}
-
-	amount, ok := new(big.Int).SetString(requirements.Amount, 10)
-	if !ok || amount.Sign() <= 0 {
-		return fmt.Errorf(ErrInvalidAmount+": %s", requirements.Amount)
-	}
-
-	// Check asset is valid if specified
-	if requirements.Asset != "" && !evm.IsValidAddress(requirements.Asset) {
-		// Try to look it up (only works for networks with default assets)
-		_, err := evm.GetAssetInfo(networkStr, requirements.Asset)
-		if err != nil {
-			return fmt.Errorf(ErrInvalidAsset+": %s", requirements.Asset)
-		}
-	}
-
-	return nil
-}
-
-// ConvertFromTokenAmount converts from token smallest unit to decimal
-func (s *ExactEvmScheme) ConvertFromTokenAmount(tokenAmount string, network string) (string, error) {
-	config, err := evm.GetNetworkConfig(network)
-	if err != nil {
-		return "", err
-	}
-
-	amount, ok := new(big.Int).SetString(tokenAmount, 10)
-	if !ok {
-		return "", fmt.Errorf(ErrInvalidTokenAmount+": %s", tokenAmount)
-	}
-
-	return evm.FormatAmount(amount, config.DefaultAsset.Decimals), nil
-}
-
-// GetSupportedNetworks returns the list of supported networks
-func (s *ExactEvmScheme) GetSupportedNetworks() []string {
-	networks := make([]string, 0, len(evm.NetworkConfigs))
-	for network := range evm.NetworkConfigs {
-		networks = append(networks, network)
-	}
-	return networks
 }

--- a/go/mechanisms/evm/exact/server/scheme.go
+++ b/go/mechanisms/evm/exact/server/scheme.go
@@ -301,21 +301,6 @@ func (s *ExactEvmScheme) ValidatePaymentRequirements(requirements x402.PaymentRe
 	return nil
 }
 
-// ConvertToTokenAmount converts a decimal amount to token smallest unit
-func (s *ExactEvmScheme) ConvertToTokenAmount(decimalAmount string, network string) (string, error) {
-	config, err := evm.GetNetworkConfig(network)
-	if err != nil {
-		return "", err
-	}
-
-	amount, err := evm.ParseAmount(decimalAmount, config.DefaultAsset.Decimals)
-	if err != nil {
-		return "", err
-	}
-
-	return amount.String(), nil
-}
-
 // ConvertFromTokenAmount converts from token smallest unit to decimal
 func (s *ExactEvmScheme) ConvertFromTokenAmount(tokenAmount string, network string) (string, error) {
 	config, err := evm.GetNetworkConfig(network)

--- a/go/mechanisms/evm/exact/server/server_money_parser_test.go
+++ b/go/mechanisms/evm/exact/server/server_money_parser_test.go
@@ -2,10 +2,16 @@ package server
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
 )
+
+func decimalGreaterThan(amount string, n int64) bool {
+	rat, ok := new(big.Rat).SetString(amount)
+	return ok && rat.Cmp(big.NewRat(n, 1)) > 0
+}
 
 // Base mainnet USDC address
 const baseMainnetUSDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
@@ -15,10 +21,14 @@ func TestRegisterMoneyParser_SingleCustomParser(t *testing.T) {
 	server := NewExactEvmScheme()
 
 	// Register custom parser: large amounts use DAI
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 100 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 100) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 18)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e18),             // DAI has 18 decimals
+				Amount: tokenAmount,                                  // DAI has 18 decimals
 				Asset:  "0x6B175474E89094C44Da98b954EedeAC495271d0F", // DAI
 				Extra: map[string]interface{}{
 					"token": "DAI",
@@ -35,7 +45,7 @@ func TestRegisterMoneyParser_SingleCustomParser(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	expectedAmount1 := fmt.Sprintf("%.0f", 150*1e18)
+	expectedAmount1 := "150000000000000000000"
 	if result1.Amount != expectedAmount1 {
 		t.Errorf("Expected amount %s, got %s", expectedAmount1, result1.Amount)
 	}
@@ -70,10 +80,14 @@ func TestRegisterMoneyParser_MultipleInChain(t *testing.T) {
 	server := NewExactEvmScheme()
 
 	// Parser 1: Premium tier (> 1000)
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 1000 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 1000) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 18)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e18),
+				Amount: tokenAmount,
 				Asset:  "0xPremiumToken",
 				Extra:  map[string]interface{}{"tier": "premium"},
 			}, nil
@@ -82,10 +96,14 @@ func TestRegisterMoneyParser_MultipleInChain(t *testing.T) {
 	})
 
 	// Parser 2: Large tier (> 100)
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 100 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 100) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 18)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e18),
+				Amount: tokenAmount,
 				Asset:  "0xLargeToken",
 				Extra:  map[string]interface{}{"tier": "large"},
 			}, nil
@@ -94,10 +112,14 @@ func TestRegisterMoneyParser_MultipleInChain(t *testing.T) {
 	})
 
 	// Parser 3: Medium tier (> 10)
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 10 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 10) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 6)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e6),
+				Amount: tokenAmount,
 				Asset:  "0xMediumToken",
 				Extra:  map[string]interface{}{"tier": "medium"},
 			}, nil
@@ -148,11 +170,15 @@ func TestRegisterMoneyParser_NetworkSpecific(t *testing.T) {
 	server := NewExactEvmScheme()
 
 	// Network-specific parser
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
 		// Only handle Base Sepolia
 		if string(network) == "eip155:84532" {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 6)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e6),
+				Amount: tokenAmount,
 				Asset:  "0xBaseSepoliaCustomToken",
 				Extra:  map[string]interface{}{"network": "base-sepolia"},
 			}, nil
@@ -183,10 +209,14 @@ func TestRegisterMoneyParser_NetworkSpecific(t *testing.T) {
 func TestRegisterMoneyParser_StringPrices(t *testing.T) {
 	server := NewExactEvmScheme()
 
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 50 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 50) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 18)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e18),
+				Amount: tokenAmount,
 				Asset:  "0xDAI",
 			}, nil
 		}
@@ -220,16 +250,16 @@ func TestRegisterMoneyParser_ErrorHandling(t *testing.T) {
 	server := NewExactEvmScheme()
 
 	// Parser that returns an error
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount == 99 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if amount == "99" {
 			return nil, fmt.Errorf("amount 99 is not allowed")
 		}
 		return nil, nil
 	})
 
 	// Parser that handles successfully
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 50 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 50) {
 			return &x402.AssetAmount{
 				Amount: "100000000",
 				Asset:  "0xCustom",
@@ -253,10 +283,10 @@ func TestRegisterMoneyParser_Chainability(t *testing.T) {
 	server := NewExactEvmScheme()
 
 	result := server.
-		RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+		RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
 			return nil, nil
 		}).
-		RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+		RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
 			return nil, nil
 		})
 
@@ -283,5 +313,37 @@ func TestRegisterMoneyParser_NoCustomParsers(t *testing.T) {
 	expectedAmount := "10000000" // 10 * 1e6
 	if result.Amount != expectedAmount {
 		t.Errorf("Expected amount %s, got %s", expectedAmount, result.Amount)
+	}
+}
+
+func TestParsePrice_MegaUSDExactness(t *testing.T) {
+	server := NewExactEvmScheme()
+	const price = "8975.978289462729"
+
+	mega, err := server.ParsePrice(price, "eip155:4326")
+	if err != nil {
+		t.Fatalf("ParsePrice MegaUSD: %v", err)
+	}
+	if mega.Amount != "8975978289462729000000" {
+		t.Errorf("MegaUSD amount = %s, want 8975978289462729000000", mega.Amount)
+	}
+
+	usdc, err := server.ParsePrice(price, "eip155:8453")
+	if err != nil {
+		t.Fatalf("ParsePrice USDC: %v", err)
+	}
+	if usdc.Amount != "8975978289" {
+		t.Errorf("USDC truncated amount = %s, want 8975978289", usdc.Amount)
+	}
+}
+
+func TestParsePrice_DustTruncatesToZero(t *testing.T) {
+	server := NewExactEvmScheme()
+	result, err := server.ParsePrice("0.0000005", "eip155:8453")
+	if err != nil {
+		t.Fatalf("ParsePrice dust: %v", err)
+	}
+	if result.Amount != "0" {
+		t.Errorf("dust amount = %s, want 0", result.Amount)
 	}
 }

--- a/go/mechanisms/evm/exact/v1/client/scheme.go
+++ b/go/mechanisms/evm/exact/v1/client/scheme.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"time"
 
+	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
 	evmv1 "github.com/x402-foundation/x402/go/v2/mechanisms/evm/v1"
 	"github.com/x402-foundation/x402/go/v2/types"
@@ -27,6 +28,14 @@ func NewExactEvmSchemeV1(signer evm.ClientEvmSigner) *ExactEvmSchemeV1 {
 // Scheme returns the scheme identifier
 func (c *ExactEvmSchemeV1) Scheme() string {
 	return evm.SchemeExact
+}
+
+func (c *ExactEvmSchemeV1) FindDefaultAsset(asset string, network x402.Network) *x402.DefaultAsset {
+	info := evm.FindDefaultAsset(asset, string(network))
+	if info == nil {
+		return nil
+	}
+	return &x402.DefaultAsset{Asset: info.Asset, Decimals: info.Decimals, Symbol: info.Symbol}
 }
 
 // CreatePaymentPayload creates a V1 payment payload for the exact scheme

--- a/go/mechanisms/evm/upto/client/scheme.go
+++ b/go/mechanisms/evm/upto/client/scheme.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 
+	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/extensions/eip2612gassponsor"
 	"github.com/x402-foundation/x402/go/v2/extensions/erc20approvalgassponsor"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
@@ -31,6 +32,14 @@ func NewUptoEvmScheme(signer evm.ClientEvmSigner, config *UptoEvmSchemeConfig) *
 
 func (c *UptoEvmScheme) Scheme() string {
 	return evm.SchemeUpto
+}
+
+func (c *UptoEvmScheme) FindDefaultAsset(asset string, network x402.Network) *x402.DefaultAsset {
+	info := evm.FindDefaultAsset(asset, string(network))
+	if info == nil {
+		return nil
+	}
+	return &x402.DefaultAsset{Asset: info.Asset, Decimals: info.Decimals, Symbol: info.Symbol}
 }
 
 // CreatePaymentPayload creates a V2 payment payload for the upto scheme (always Permit2).

--- a/go/mechanisms/evm/upto/server/errors.go
+++ b/go/mechanisms/evm/upto/server/errors.go
@@ -1,16 +1,8 @@
 package server
 
 const (
-	ErrAmountMustBeString    = "invalid_upto_evm_server_amount_must_be_string"
-	ErrAssetAddressRequired  = "invalid_upto_evm_server_asset_address_required"
-	ErrFailedToParsePrice    = "invalid_upto_evm_server_failed_to_parse_price"
-	ErrUnsupportedPriceType  = "invalid_upto_evm_server_unsupported_price_type"
-	ErrFailedToConvertAmount = "invalid_upto_evm_server_failed_to_convert_amount"
-	ErrNoAssetSpecified      = "invalid_upto_evm_server_no_asset_specified"
-	ErrFailedToParseAmount   = "invalid_upto_evm_server_failed_to_parse_amount"
-	ErrInvalidPayToAddress   = "invalid_upto_evm_server_invalid_payto_address"
-	ErrAmountRequired        = "invalid_upto_evm_server_amount_required"
-	ErrInvalidAmount         = "invalid_upto_evm_server_invalid_amount"
-	ErrInvalidAsset          = "invalid_upto_evm_server_invalid_asset"
-	ErrInvalidTokenAmount    = "invalid_upto_evm_server_invalid_token_amount"
+	ErrAmountMustBeString   = "invalid_upto_evm_server_amount_must_be_string"
+	ErrAssetAddressRequired = "invalid_upto_evm_server_asset_address_required"
+	ErrNoAssetSpecified     = "invalid_upto_evm_server_no_asset_specified"
+	ErrFailedToParseAmount  = "invalid_upto_evm_server_failed_to_parse_amount"
 )

--- a/go/mechanisms/evm/upto/server/scheme.go
+++ b/go/mechanisms/evm/upto/server/scheme.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
@@ -44,14 +43,14 @@ func (s *UptoEvmScheme) PaymentFlows() map[string]x402.PaymentFlowConfig {
 	}
 }
 
-// GetAssetDecimals implements AssetDecimalsProvider. Returns the decimal precision for the
-// given asset on the given network, falling back to 6 if the asset is not recognized.
-func (s *UptoEvmScheme) GetAssetDecimals(asset string, network x402.Network) int {
-	info, err := evm.GetAssetInfo(string(network), asset)
-	if err != nil || info == nil {
-		return 6
+// GetAssetDecimals implements AssetDecimalsProvider. Returns the decimal precision for a
+// known default asset. ok is false when the asset is unrecognized.
+func (s *UptoEvmScheme) GetAssetDecimals(asset string, network x402.Network) (int, bool) {
+	found := evm.FindDefaultAsset(asset, string(network))
+	if found == nil {
+		return 0, false
 	}
-	return info.Decimals
+	return found.Decimals, true
 }
 
 func (s *UptoEvmScheme) RegisterMoneyParser(parser x402.MoneyParser) *UptoEvmScheme {
@@ -93,7 +92,7 @@ func (s *UptoEvmScheme) ParsePrice(price x402.Price, network x402.Network) (x402
 		}
 	}
 
-	decimalAmount, err := s.parseMoneyToDecimal(price)
+	decimalAmount, symbol, err := x402.ParseMoney(price)
 	if err != nil {
 		return x402.AssetAmount{}, err
 	}
@@ -108,76 +107,29 @@ func (s *UptoEvmScheme) ParsePrice(price x402.Price, network x402.Network) (x402
 		}
 	}
 
-	return s.defaultMoneyConversion(decimalAmount, network)
+	return s.defaultMoneyConversion(decimalAmount, network, symbol)
 }
 
-func (s *UptoEvmScheme) parseMoneyToDecimal(price x402.Price) (float64, error) {
-	switch v := price.(type) {
-	case string:
-		cleanPrice := strings.TrimSpace(v)
-		cleanPrice = strings.TrimPrefix(cleanPrice, "$")
-		cleanPrice = strings.TrimSpace(cleanPrice)
-
-		amount, err := strconv.ParseFloat(cleanPrice, 64)
-		if err != nil {
-			return 0, fmt.Errorf(ErrFailedToParsePrice+": '%s': %w", v, err)
-		}
-		return amount, nil
-
-	case float64:
-		return v, nil
-
-	case int:
-		return float64(v), nil
-
-	case int64:
-		return float64(v), nil
-
-	default:
-		return 0, fmt.Errorf(ErrUnsupportedPriceType+": %T", price)
-	}
-}
-
-func (s *UptoEvmScheme) defaultMoneyConversion(amount float64, network x402.Network) (x402.AssetAmount, error) {
-	networkStr := string(network)
-
-	config, err := evm.GetNetworkConfig(networkStr)
+func (s *UptoEvmScheme) defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
+	assetInfo, err := evm.GetDefaultAsset(string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err
 	}
 
-	if config.DefaultAsset.Address == "" {
-		return x402.AssetAmount{}, fmt.Errorf("no default stablecoin configured for network %s; use RegisterMoneyParser or specify an explicit AssetAmount", networkStr)
-	}
-
-	extra := map[string]interface{}{
-		"name":                config.DefaultAsset.Name,
-		"version":             config.DefaultAsset.Version,
-		"assetTransferMethod": "permit2",
-	}
-
-	oneUnit := float64(1)
-	for i := 0; i < config.DefaultAsset.Decimals; i++ {
-		oneUnit *= 10
-	}
-
-	if amount >= oneUnit && amount == float64(int64(amount)) {
-		return x402.AssetAmount{
-			Asset:  config.DefaultAsset.Address,
-			Amount: fmt.Sprintf("%.0f", amount),
-			Extra:  extra,
-		}, nil
-	}
-
-	amountStr := fmt.Sprintf("%.6f", amount)
-	parsedAmount, err := evm.ParseAmount(amountStr, config.DefaultAsset.Decimals)
+	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
 	if err != nil {
 		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
 	}
 
+	extra := map[string]interface{}{
+		"name":                assetInfo.Name,
+		"version":             assetInfo.Version,
+		"assetTransferMethod": "permit2",
+	}
+
 	return x402.AssetAmount{
-		Asset:  config.DefaultAsset.Address,
-		Amount: parsedAmount.String(),
+		Asset:  assetInfo.Asset,
+		Amount: tokenAmount,
 		Extra:  extra,
 	}, nil
 }

--- a/go/mechanisms/evm/upto/server/scheme.go
+++ b/go/mechanisms/evm/upto/server/scheme.go
@@ -111,14 +111,9 @@ func (s *UptoEvmScheme) ParsePrice(price x402.Price, network x402.Network) (x402
 }
 
 func (s *UptoEvmScheme) defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
-	assetInfo, err := evm.GetDefaultAsset(string(network), symbol)
+	assetInfo, tokenAmount, err := evm.ConvertDefaultMoney(amount, string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err
-	}
-
-	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
-	if err != nil {
-		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
 	}
 
 	extra := map[string]interface{}{

--- a/go/mechanisms/evm/upto/server/scheme.go
+++ b/go/mechanisms/evm/upto/server/scheme.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 	"strings"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
@@ -191,30 +190,4 @@ func (s *UptoEvmScheme) EnhancePaymentRequirements(
 	}
 
 	return requirements, nil
-}
-
-// ValidatePaymentRequirements validates that requirements are valid for this scheme.
-func (s *UptoEvmScheme) ValidatePaymentRequirements(requirements x402.PaymentRequirements) error {
-	if !evm.IsValidAddress(requirements.PayTo) {
-		return fmt.Errorf(ErrInvalidPayToAddress+": %s", requirements.PayTo)
-	}
-
-	if requirements.Amount == "" {
-		return errors.New(ErrAmountRequired)
-	}
-
-	amount, ok := new(big.Int).SetString(requirements.Amount, 10)
-	if !ok || amount.Sign() <= 0 {
-		return fmt.Errorf(ErrInvalidAmount+": %s", requirements.Amount)
-	}
-
-	if requirements.Asset != "" && !evm.IsValidAddress(requirements.Asset) {
-		networkStr := string(requirements.Network)
-		_, err := evm.GetAssetInfo(networkStr, requirements.Asset)
-		if err != nil {
-			return fmt.Errorf(ErrInvalidAsset+": %s", requirements.Asset)
-		}
-	}
-
-	return nil
 }

--- a/go/mechanisms/evm/upto/server/scheme.go
+++ b/go/mechanisms/evm/upto/server/scheme.go
@@ -109,7 +109,7 @@ func (s *UptoEvmScheme) ParsePrice(price x402.Price, network x402.Network) (x402
 	return s.defaultMoneyConversion(decimalAmount, network, symbol)
 }
 
-func (s *UptoEvmScheme) defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
+func (s *UptoEvmScheme) defaultMoneyConversion(amount string, network x402.Network, symbol string) (x402.AssetAmount, error) {
 	assetInfo, tokenAmount, err := evm.ConvertDefaultMoney(amount, string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err

--- a/go/mechanisms/evm/upto/server/server_money_parser_test.go
+++ b/go/mechanisms/evm/upto/server/server_money_parser_test.go
@@ -2,11 +2,16 @@ package server
 
 import (
 	"context"
-	"fmt"
+	"math/big"
 	"testing"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
 )
+
+func decimalGreaterThan(amount string, n int64) bool {
+	rat, ok := new(big.Rat).SetString(amount)
+	return ok && rat.Cmp(big.NewRat(n, 1)) > 0
+}
 
 const baseMainnetUSDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
 
@@ -44,10 +49,14 @@ func TestParsePrice_DefaultNoCustomParsers(t *testing.T) {
 func TestParsePrice_CustomParser(t *testing.T) {
 	server := NewUptoEvmScheme()
 
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 100 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 100) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 18)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e18),
+				Amount: tokenAmount,
 				Asset:  "0x6B175474E89094C44Da98b954EedeAC495271d0F",
 				Extra:  map[string]interface{}{"token": "DAI"},
 			}, nil
@@ -125,10 +134,10 @@ func TestRegisterMoneyParser_Chainability(t *testing.T) {
 	server := NewUptoEvmScheme()
 
 	result := server.
-		RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+		RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
 			return nil, nil
 		}).
-		RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+		RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
 			return nil, nil
 		})
 

--- a/go/mechanisms/evm/utils.go
+++ b/go/mechanisms/evm/utils.go
@@ -262,17 +262,13 @@ func GetNetworkConfig(network string) (*NetworkConfig, error) {
 //   - AssetInfo for the requested asset
 //   - Error if default asset is requested but not configured for this network
 func GetAssetInfo(network string, assetSymbolOrAddress string) (*AssetInfo, error) {
+	if found := FindDefaultAsset(assetSymbolOrAddress, network); found != nil {
+		return defaultAssetToAssetInfo(found), nil
+	}
+
 	// Check if it's an explicit address - works for ANY network
 	if IsValidAddress(assetSymbolOrAddress) {
 		normalizedAddr := NormalizeAddress(assetSymbolOrAddress)
-
-		// Check if this matches a known default asset for richer metadata
-		config, err := GetNetworkConfig(network)
-		if err == nil && config.DefaultAsset.Address != "" {
-			if normalizedAddr == NormalizeAddress(config.DefaultAsset.Address) {
-				return &config.DefaultAsset, nil
-			}
-		}
 
 		// Unknown token - return basic info (works for any EVM network)
 		return &AssetInfo{
@@ -284,17 +280,11 @@ func GetAssetInfo(network string, assetSymbolOrAddress string) (*AssetInfo, erro
 	}
 
 	// Not an explicit address - need the network's default asset
-	config, err := GetNetworkConfig(network)
+	info, err := GetDefaultAsset(network, "")
 	if err != nil {
-		return nil, err
-	}
-
-	// Check if default asset is configured
-	if config.DefaultAsset.Address == "" {
 		return nil, fmt.Errorf("no default asset configured for network %s; specify an explicit asset address or register a money parser", network)
 	}
-
-	return &config.DefaultAsset, nil
+	return defaultAssetToAssetInfo(info), nil
 }
 
 // CreateValidityWindow creates valid after/before timestamps

--- a/go/mechanisms/evm/v1/utils.go
+++ b/go/mechanisms/evm/v1/utils.go
@@ -27,15 +27,19 @@ func GetNetworkConfig(network string) (*evm.NetworkConfig, error) {
 // If assetSymbolOrAddress is a valid address, returns info for that specific token.
 // If assetSymbolOrAddress is empty or a symbol, attempts to use the network's default asset.
 func GetAssetInfo(network string, assetSymbolOrAddress string) (*evm.AssetInfo, error) {
+	if found := evm.FindDefaultAsset(assetSymbolOrAddress, network); found != nil {
+		return &evm.AssetInfo{
+			Address:             found.Asset,
+			Name:                found.Name,
+			Version:             found.Version,
+			Decimals:            found.Decimals,
+			AssetTransferMethod: found.AssetTransferMethod,
+			SupportsEip2612:     found.SupportsEip2612,
+		}, nil
+	}
+
 	if evm.IsValidAddress(assetSymbolOrAddress) {
 		normalizedAddr := evm.NormalizeAddress(assetSymbolOrAddress)
-
-		config, err := GetNetworkConfig(network)
-		if err == nil && config.DefaultAsset.Address != "" {
-			if normalizedAddr == evm.NormalizeAddress(config.DefaultAsset.Address) {
-				return &config.DefaultAsset, nil
-			}
-		}
 
 		return &evm.AssetInfo{
 			Address:  normalizedAddr,
@@ -45,14 +49,16 @@ func GetAssetInfo(network string, assetSymbolOrAddress string) (*evm.AssetInfo, 
 		}, nil
 	}
 
-	config, err := GetNetworkConfig(network)
+	info, err := evm.GetDefaultAsset(network, "")
 	if err != nil {
-		return nil, err
-	}
-
-	if config.DefaultAsset.Address == "" {
 		return nil, fmt.Errorf("no default asset configured for v1 network %s; specify an explicit asset address", network)
 	}
-
-	return &config.DefaultAsset, nil
+	return &evm.AssetInfo{
+		Address:             info.Asset,
+		Name:                info.Name,
+		Version:             info.Version,
+		Decimals:            info.Decimals,
+		AssetTransferMethod: info.AssetTransferMethod,
+		SupportsEip2612:     info.SupportsEip2612,
+	}, nil
 }

--- a/go/mechanisms/svm/default_assets.go
+++ b/go/mechanisms/svm/default_assets.go
@@ -1,0 +1,96 @@
+package svm
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	TokenProgramAddress     = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+	Token2022ProgramAddress = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+)
+
+// SvmDefaultAsset is a USD-pegged SVM asset used for money strings and spend caps.
+type SvmDefaultAsset struct {
+	Asset        string
+	Decimals     int
+	Symbol       string
+	TokenProgram string
+}
+
+// DefaultAssets maps CAIP-2 network to USD-pegged assets; index 0 is the "$0.10" default.
+var DefaultAssets = map[string][]SvmDefaultAsset{
+	SolanaMainnetCAIP2: {
+		{Asset: USDCMainnetAddress, Decimals: 6, Symbol: "USDC", TokenProgram: TokenProgramAddress},
+		{Asset: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", Decimals: 6, Symbol: "USDT", TokenProgram: TokenProgramAddress},
+		{Asset: "2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH", Decimals: 6, Symbol: "USDG", TokenProgram: Token2022ProgramAddress},
+		{Asset: "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo", Decimals: 6, Symbol: "PYUSD", TokenProgram: Token2022ProgramAddress},
+		{Asset: "CASHx9KJUStyftLFWGvEVf59SGeG9sh5FfcnZMVPCASH", Decimals: 6, Symbol: "CASH", TokenProgram: Token2022ProgramAddress},
+	},
+	SolanaDevnetCAIP2: {
+		{Asset: USDCDevnetAddress, Decimals: 6, Symbol: "USDC", TokenProgram: TokenProgramAddress},
+		{Asset: "4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7", Decimals: 6, Symbol: "USDG", TokenProgram: Token2022ProgramAddress},
+		{Asset: "CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM", Decimals: 6, Symbol: "PYUSD", TokenProgram: Token2022ProgramAddress},
+	},
+	SolanaTestnetCAIP2: {
+		{Asset: USDCTestnetAddress, Decimals: 6, Symbol: "USDC", TokenProgram: TokenProgramAddress},
+		{Asset: "4F6PM96JJxngmHnZLBh9n58RH4aTVNWvDs2nuwrT5BP7", Decimals: 6, Symbol: "USDG", TokenProgram: Token2022ProgramAddress},
+		{Asset: "CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM", Decimals: 6, Symbol: "PYUSD", TokenProgram: Token2022ProgramAddress},
+	},
+}
+
+func resolveNetworkKey(network string) (string, error) {
+	return NormalizeNetwork(network)
+}
+
+// GetDefaultAsset looks up a default asset by network and optional ticker.
+// Empty symbol returns the network default (index 0).
+func GetDefaultAsset(network string, symbol string) (*SvmDefaultAsset, error) {
+	key, err := resolveNetworkKey(network)
+	if err != nil {
+		return nil, fmt.Errorf("no default asset configured for network %s", network)
+	}
+	assets := DefaultAssets[key]
+	if len(assets) == 0 {
+		return nil, fmt.Errorf("no default asset configured for network %s", network)
+	}
+	if symbol == "" {
+		entry := assets[0]
+		return &entry, nil
+	}
+	normalized := strings.ToUpper(symbol)
+	for i := range assets {
+		if strings.ToUpper(assets[i].Symbol) == normalized {
+			entry := assets[i]
+			return &entry, nil
+		}
+	}
+	return nil, fmt.Errorf("no %s default asset configured for network %s", symbol, network)
+}
+
+// FindDefaultAsset reverse-looks up by mint address and network.
+func FindDefaultAsset(asset string, network string) *SvmDefaultAsset {
+	key, err := resolveNetworkKey(network)
+	if err != nil {
+		return nil
+	}
+	assets := DefaultAssets[key]
+	if len(assets) == 0 {
+		return nil
+	}
+	for i := range assets {
+		if assets[i].Asset == asset {
+			entry := assets[i]
+			return &entry
+		}
+	}
+	return nil
+}
+
+func defaultAssetToAssetInfo(info *SvmDefaultAsset) *AssetInfo {
+	return &AssetInfo{
+		Address:  info.Asset,
+		Symbol:   info.Symbol,
+		Decimals: info.Decimals,
+	}
+}

--- a/go/mechanisms/svm/default_assets.go
+++ b/go/mechanisms/svm/default_assets.go
@@ -5,11 +5,6 @@ import (
 	"strings"
 )
 
-const (
-	TokenProgramAddress     = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-	Token2022ProgramAddress = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-)
-
 // SvmDefaultAsset is a USD-pegged SVM asset used for money strings and spend caps.
 type SvmDefaultAsset struct {
 	Asset        string

--- a/go/mechanisms/svm/exact/client/scheme.go
+++ b/go/mechanisms/svm/exact/client/scheme.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gagliardetto/solana-go/programs/token"
 	"github.com/gagliardetto/solana-go/rpc"
 
+	x402 "github.com/x402-foundation/x402/go/v2"
 	"github.com/x402-foundation/x402/go/v2/mechanisms/svm"
 	"github.com/x402-foundation/x402/go/v2/types"
 )
@@ -41,6 +42,14 @@ func NewExactSvmScheme(signer svm.ClientSvmSigner, config ...*svm.ClientConfig) 
 // Scheme returns the scheme identifier
 func (c *ExactSvmScheme) Scheme() string {
 	return svm.SchemeExact
+}
+
+func (c *ExactSvmScheme) FindDefaultAsset(asset string, network x402.Network) *x402.DefaultAsset {
+	info := svm.FindDefaultAsset(asset, string(network))
+	if info == nil {
+		return nil
+	}
+	return &x402.DefaultAsset{Asset: info.Asset, Decimals: info.Decimals, Symbol: info.Symbol}
 }
 
 // CreatePaymentPayload creates a V2 payment payload for the Exact scheme

--- a/go/mechanisms/svm/exact/server/scheme.go
+++ b/go/mechanisms/svm/exact/server/scheme.go
@@ -68,7 +68,7 @@ func (s *ExactSvmScheme) PaymentFlows() map[string]x402.PaymentFlowConfig {
 
 // RegisterMoneyParser registers a custom money parser in the parser chain.
 // Multiple parsers can be registered - they will be tried in registration order.
-// Each parser receives a decimal amount (e.g., 1.50 for $1.50).
+// Each parser receives a decimal string (e.g., "1.50" for $1.50).
 // If a parser returns nil, the next parser in the chain will be tried.
 // The default parser is always the final fallback.
 //
@@ -82,16 +82,16 @@ func (s *ExactSvmScheme) PaymentFlows() map[string]x402.PaymentFlowConfig {
 //
 // Example:
 //
-//	svmServer.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-//	    // Use custom token for large amounts
-//	    if amount > 100 {
-//	        return &x402.AssetAmount{
-//	            Amount: fmt.Sprintf("%.0f", amount * 1e9),
-//	            Asset:  "CustomTokenMint111111111111111111111",
-//	            Extra:  map[string]interface{}{"token": "CUSTOM", "tier": "large"},
-//	        }, nil
+//	svmServer.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+//	    tokenAmount, err := x402.ConvertToTokenAmount(amount, 9)
+//	    if err != nil {
+//	        return nil, err
 //	    }
-//	    return nil, nil // Use next parser
+//	    return &x402.AssetAmount{
+//	        Amount: tokenAmount,
+//	        Asset:  "CustomTokenMint111111111111111111111",
+//	        Extra:  map[string]interface{}{"token": "CUSTOM", "tier": "large"},
+//	    }, nil
 //	})
 func (s *ExactSvmScheme) RegisterMoneyParser(parser x402.MoneyParser) *ExactSvmScheme {
 	s.moneyParsers = append(s.moneyParsers, parser)
@@ -150,7 +150,7 @@ func (s *ExactSvmScheme) ParsePrice(price x402.Price, network x402.Network) (x40
 		}
 	}
 
-	// Parse Money to decimal number
+	// Parse Money to a decimal string
 	decimalAmount, symbol, err := x402.ParseMoney(price)
 	if err != nil {
 		return x402.AssetAmount{}, err
@@ -175,13 +175,13 @@ func (s *ExactSvmScheme) ParsePrice(price x402.Price, network x402.Network) (x40
 }
 
 // defaultMoneyConversion converts decimal amount to a default-asset AssetAmount
-func (s *ExactSvmScheme) defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
+func (s *ExactSvmScheme) defaultMoneyConversion(amount string, network x402.Network, symbol string) (x402.AssetAmount, error) {
 	assetInfo, err := svm.GetDefaultAsset(string(network), symbol)
 	if err != nil {
 		return x402.AssetAmount{}, err
 	}
 
-	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
+	tokenAmount, err := x402.ConvertToTokenAmount(amount, assetInfo.Decimals)
 	if err != nil {
 		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
 	}

--- a/go/mechanisms/svm/exact/server/scheme.go
+++ b/go/mechanisms/svm/exact/server/scheme.go
@@ -41,6 +41,16 @@ func (s *ExactSvmScheme) DefaultAssetTransferMethod() string {
 	return x402.SDKDefaultAssetTransferMethod
 }
 
+// GetAssetDecimals implements AssetDecimalsProvider. Returns the decimal precision for a
+// known default asset. ok is false when the asset is unrecognized.
+func (s *ExactSvmScheme) GetAssetDecimals(asset string, network x402.Network) (int, bool) {
+	found := svm.FindDefaultAsset(asset, string(network))
+	if found == nil {
+		return 0, false
+	}
+	return found.Decimals, true
+}
+
 // DynamicExtraFields returns extra keys regenerated on each PaymentRequired response.
 func (s *ExactSvmScheme) DynamicExtraFields() []string {
 	return []string{"recentBlockhash", "lastValidBlockHeight"}
@@ -141,7 +151,7 @@ func (s *ExactSvmScheme) ParsePrice(price x402.Price, network x402.Network) (x40
 	}
 
 	// Parse Money to decimal number
-	decimalAmount, err := s.parseMoneyToDecimal(price)
+	decimalAmount, symbol, err := x402.ParseMoney(price)
 	if err != nil {
 		return x402.AssetAmount{}, err
 	}
@@ -161,55 +171,24 @@ func (s *ExactSvmScheme) ParsePrice(price x402.Price, network x402.Network) (x40
 	}
 
 	// All custom parsers returned nil, use default conversion
-	return s.defaultMoneyConversion(decimalAmount, config)
+	return s.defaultMoneyConversion(decimalAmount, network, symbol)
 }
 
-// parseMoneyToDecimal converts Money (string | number) to decimal amount
-func (s *ExactSvmScheme) parseMoneyToDecimal(price x402.Price) (float64, error) {
-	// Handle string prices
-	if priceStr, ok := price.(string); ok {
-		// Remove $ sign and currency identifiers
-		cleanPrice := strings.TrimSpace(priceStr)
-		cleanPrice = strings.TrimPrefix(cleanPrice, "$")
-		cleanPrice = strings.TrimSpace(cleanPrice)
-
-		// Check if it contains a currency/asset identifier
-		parts := strings.Fields(cleanPrice)
-		if len(parts) >= 1 {
-			// Use the first part as the amount
-			amount, err := strconv.ParseFloat(parts[0], 64)
-			if err != nil {
-				return 0, fmt.Errorf(ErrFailedToParsePrice+": '%s': %w", priceStr, err)
-			}
-			return amount, nil
-		}
+// defaultMoneyConversion converts decimal amount to a default-asset AssetAmount
+func (s *ExactSvmScheme) defaultMoneyConversion(amount float64, network x402.Network, symbol string) (x402.AssetAmount, error) {
+	assetInfo, err := svm.GetDefaultAsset(string(network), symbol)
+	if err != nil {
+		return x402.AssetAmount{}, err
 	}
 
-	// Handle number input
-	switch v := price.(type) {
-	case float64:
-		return v, nil
-	case int:
-		return float64(v), nil
-	case int64:
-		return float64(v), nil
-	}
-
-	return 0, fmt.Errorf(ErrInvalidPriceFormat+": %v", price)
-}
-
-// defaultMoneyConversion converts decimal amount to USDC AssetAmount
-func (s *ExactSvmScheme) defaultMoneyConversion(amount float64, config *svm.NetworkConfig) (x402.AssetAmount, error) {
-	// Convert decimal to smallest unit (e.g., $1.50 -> 1500000 for USDC with 6 decimals)
-	amountStr := fmt.Sprintf("%.6f", amount)
-	parsedAmount, err := svm.ParseAmount(amountStr, config.DefaultAsset.Decimals)
+	tokenAmount, err := x402.ConvertToTokenAmount(x402.NumberToDecimalString(amount), assetInfo.Decimals)
 	if err != nil {
 		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
 	}
 
 	return x402.AssetAmount{
-		Amount: strconv.FormatUint(parsedAmount, 10),
-		Asset:  config.DefaultAsset.Address,
+		Amount: tokenAmount,
+		Asset:  assetInfo.Asset,
 		Extra:  make(map[string]interface{}),
 	}, nil
 }

--- a/go/mechanisms/svm/exact/server/server_money_parser_test.go
+++ b/go/mechanisms/svm/exact/server/server_money_parser_test.go
@@ -1,21 +1,30 @@
 package server
 
 import (
-	"fmt"
+	"math/big"
 	"testing"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
 )
+
+func decimalGreaterThan(amount string, n int64) bool {
+	rat, ok := new(big.Rat).SetString(amount)
+	return ok && rat.Cmp(big.NewRat(n, 1)) > 0
+}
 
 // TestRegisterMoneyParser_SingleCustomParser tests a single custom money parser
 func TestRegisterMoneyParser_SingleCustomParser(t *testing.T) {
 	server := NewExactSvmScheme()
 
 	// Register custom parser: large amounts use custom token
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 100 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 100) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 9)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e9), // Custom token with 9 decimals
+				Amount: tokenAmount, // Custom token with 9 decimals
 				Asset:  "CustomLargeTokenMint111111111111111",
 				Extra: map[string]interface{}{
 					"token": "CUSTOM",
@@ -32,7 +41,7 @@ func TestRegisterMoneyParser_SingleCustomParser(t *testing.T) {
 		t.Fatalf("Expected no error, got %v", err)
 	}
 
-	expectedAmount1 := fmt.Sprintf("%.0f", 150*1e9)
+	expectedAmount1 := "150000000000"
 	if result1.Amount != expectedAmount1 {
 		t.Errorf("Expected amount %s, got %s", expectedAmount1, result1.Amount)
 	}
@@ -67,10 +76,14 @@ func TestRegisterMoneyParser_MultipleInChain(t *testing.T) {
 	server := NewExactSvmScheme()
 
 	// Parser 1: Premium tier (> 1000)
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 1000 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 1000) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 9)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e9),
+				Amount: tokenAmount,
 				Asset:  "PremiumMint1111111111111111111111111",
 				Extra:  map[string]interface{}{"tier": "premium"},
 			}, nil
@@ -79,10 +92,14 @@ func TestRegisterMoneyParser_MultipleInChain(t *testing.T) {
 	})
 
 	// Parser 2: Large tier (> 100)
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 100 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 100) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 9)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e9),
+				Amount: tokenAmount,
 				Asset:  "LargeMint11111111111111111111111111",
 				Extra:  map[string]interface{}{"tier": "large"},
 			}, nil
@@ -123,10 +140,14 @@ func TestRegisterMoneyParser_MultipleInChain(t *testing.T) {
 func TestRegisterMoneyParser_StringPrices(t *testing.T) {
 	server := NewExactSvmScheme()
 
-	server.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
-		if amount > 50 {
+	server.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
+		if decimalGreaterThan(amount, 50) {
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 9)
+			if err != nil {
+				return nil, err
+			}
 			return &x402.AssetAmount{
-				Amount: fmt.Sprintf("%.0f", amount*1e9),
+				Amount: tokenAmount,
 				Asset:  "CustomMint111111111111111111111111",
 			}, nil
 		}
@@ -162,10 +183,10 @@ func TestRegisterMoneyParser_Chainability(t *testing.T) {
 	server := NewExactSvmScheme()
 
 	result := server.
-		RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+		RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
 			return nil, nil
 		}).
-		RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+		RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
 			return nil, nil
 		})
 

--- a/go/mechanisms/svm/exact/v1/client/scheme.go
+++ b/go/mechanisms/svm/exact/v1/client/scheme.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gagliardetto/solana-go/programs/token"
 	"github.com/gagliardetto/solana-go/rpc"
 
+	x402 "github.com/x402-foundation/x402/go/v2"
 	svm "github.com/x402-foundation/x402/go/v2/mechanisms/svm"
 	"github.com/x402-foundation/x402/go/v2/types"
 )
@@ -42,6 +43,14 @@ func NewExactSvmSchemeV1(signer svm.ClientSvmSigner, config ...*svm.ClientConfig
 // Scheme returns the scheme identifier
 func (c *ExactSvmSchemeV1) Scheme() string {
 	return svm.SchemeExact
+}
+
+func (c *ExactSvmSchemeV1) FindDefaultAsset(asset string, network x402.Network) *x402.DefaultAsset {
+	info := svm.FindDefaultAsset(asset, string(network))
+	if info == nil {
+		return nil
+	}
+	return &x402.DefaultAsset{Asset: info.Asset, Decimals: info.Decimals, Symbol: info.Symbol}
 }
 
 // CreatePaymentPayload creates a V1 payment payload for the Exact scheme

--- a/go/mechanisms/svm/upto/server/scheme.go
+++ b/go/mechanisms/svm/upto/server/scheme.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -24,9 +23,6 @@ import (
 // AssetTransferMethodChannel is the asset transfer method advertised for
 // SVM `upto`: funds move through an onchain payment channel.
 const AssetTransferMethodChannel = "channel"
-
-// priceSuffixPattern matches a trailing asset symbol in a price string.
-var priceSuffixPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9]*\s*$`)
 
 // Config configures the server-side SVM `upto` scheme.
 type Config struct {
@@ -187,7 +183,7 @@ func (s *UptoSvmScheme) EnrichSettlementPayload(ctx x402.SettleContext) (map[str
 
 // RegisterMoneyParser registers a custom money parser in the parser chain.
 // Multiple parsers can be registered - they will be tried in registration order.
-// Each parser receives a decimal amount (e.g., 1.50 for $1.50).
+// Each parser receives a decimal string (e.g., "1.50" for $1.50).
 // If a parser returns nil, the next parser in the chain will be tried.
 // The default parser is always the final fallback.
 func (s *UptoSvmScheme) RegisterMoneyParser(parser x402.MoneyParser) *UptoSvmScheme {
@@ -227,7 +223,7 @@ func (s *UptoSvmScheme) ParsePrice(price x402.Price, network x402.Network) (x402
 		}
 	}
 
-	decimalAmount, stablecoin, err := s.parseMoney(price)
+	decimalAmount, symbol, err := x402.ParseMoney(price)
 	if err != nil {
 		return x402.AssetAmount{}, err
 	}
@@ -242,7 +238,7 @@ func (s *UptoSvmScheme) ParsePrice(price x402.Price, network x402.Network) (x402
 		}
 	}
 
-	return s.defaultMoneyConversion(decimalAmount, networkStr, stablecoin)
+	return s.defaultMoneyConversion(decimalAmount, networkStr, symbol)
 }
 
 // EnhancePaymentRequirements folds the facilitator's feePayer into the
@@ -334,75 +330,44 @@ func (s *UptoSvmScheme) enrichBlockhashHints(ctx context.Context, extra map[stri
 	extra[upto.ExtraRecentSlot] = strconv.FormatUint(latest.Context.Slot, 10)
 }
 
-// parseMoney converts Money (string | number) to a decimal amount, recognizing a
-// trailing stablecoin symbol ("$1.50", "1.50 PYUSD"). An empty symbol selects the
-// network default.
-func (s *UptoSvmScheme) parseMoney(price x402.Price) (float64, string, error) {
-	switch typed := price.(type) {
-	case string:
-		cleanPrice := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(typed), "$"))
-		parts := strings.Fields(cleanPrice)
-		if len(parts) == 0 {
-			return 0, "", fmt.Errorf(ErrInvalidPriceFormat+": %v", price)
-		}
-		amount, err := strconv.ParseFloat(parts[0], 64)
-		if err != nil {
-			return 0, "", fmt.Errorf(ErrFailedToParsePrice+": '%s': %w", typed, err)
-		}
-		return amount, priceStablecoinSuffix(cleanPrice), nil
-	case float64:
-		return typed, "", nil
-	case int:
-		return float64(typed), "", nil
-	case int64:
-		return float64(typed), "", nil
-	}
-	return 0, "", fmt.Errorf(ErrInvalidPriceFormat+": %v", price)
-}
-
-// priceStablecoinSuffix reads a trailing stablecoin symbol from a price. "USD" is
-// USDC; anything unsupported is ignored so the network default applies.
-func priceStablecoinSuffix(cleanPrice string) string {
-	suffix := strings.ToUpper(priceSuffixPattern.FindString(cleanPrice))
-	if suffix == "USD" {
-		return "USDC"
-	}
-	if _, ok := svm.StablecoinTokenPrograms[suffix]; ok {
-		return suffix
-	}
-	return ""
-}
-
 // defaultMoneyConversion converts a decimal amount to atomic units of the
 // requested stablecoin, defaulting to the network's default asset.
 func (s *UptoSvmScheme) defaultMoneyConversion(
-	amount float64,
+	amount string,
 	network string,
-	stablecoin string,
+	symbol string,
 ) (x402.AssetAmount, error) {
-	asset, err := svm.GetStablecoinAddress(defaultStablecoin(stablecoin), network)
+	assetInfo, err := svm.GetDefaultAsset(network, symbol)
 	if err != nil {
-		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
+		if symbol != "" {
+			if address, stablecoinErr := svm.GetStablecoinAddress(strings.ToUpper(symbol), network); stablecoinErr == nil {
+				tokenAmount, convertErr := x402.ConvertToTokenAmount(amount, svm.StablecoinDecimals)
+				if convertErr != nil {
+					return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", convertErr)
+				}
+				return x402.AssetAmount{
+					Amount: tokenAmount,
+					Asset:  address,
+					Extra:  make(map[string]interface{}),
+				}, nil
+			}
+		}
+		assetInfo, err = svm.GetDefaultAsset(network, "")
+		if err != nil {
+			return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
+		}
 	}
 
-	amountStr := strconv.FormatFloat(amount, 'f', svm.StablecoinDecimals, 64)
-	parsedAmount, err := svm.ParseAmount(amountStr, svm.StablecoinDecimals)
+	tokenAmount, err := x402.ConvertToTokenAmount(amount, assetInfo.Decimals)
 	if err != nil {
 		return x402.AssetAmount{}, fmt.Errorf(ErrFailedToConvertAmount+": %w", err)
 	}
 
 	return x402.AssetAmount{
-		Amount: strconv.FormatUint(parsedAmount, 10),
-		Asset:  asset,
+		Amount: tokenAmount,
+		Asset:  assetInfo.Asset,
 		Extra:  make(map[string]interface{}),
 	}, nil
-}
-
-func defaultStablecoin(stablecoin string) string {
-	if stablecoin == "" {
-		return "USDC"
-	}
-	return stablecoin
 }
 
 // requirementsFromView rebuilds concrete requirements from the version-agnostic

--- a/go/mechanisms/svm/utils.go
+++ b/go/mechanisms/svm/utils.go
@@ -56,6 +56,10 @@ func GetNetworkConfig(network string) (*NetworkConfig, error) {
 
 // GetAssetInfo returns information about an asset on a network
 func GetAssetInfo(network string, assetSymbolOrAddress string) (*AssetInfo, error) {
+	if found := FindDefaultAsset(assetSymbolOrAddress, network); found != nil {
+		return defaultAssetToAssetInfo(found), nil
+	}
+
 	config, err := GetNetworkConfig(network)
 	if err != nil {
 		return nil, err
@@ -63,11 +67,6 @@ func GetAssetInfo(network string, assetSymbolOrAddress string) (*AssetInfo, erro
 
 	// Check if it's a valid Solana address (mint address)
 	if ValidateSolanaAddress(assetSymbolOrAddress) {
-		// Check if it matches the default asset
-		if assetSymbolOrAddress == config.DefaultAsset.Address {
-			return &config.DefaultAsset, nil
-		}
-
 		// Unknown token - return basic info with default decimals
 		return &AssetInfo{
 			Address:  assetSymbolOrAddress,

--- a/go/server.go
+++ b/go/server.go
@@ -1337,15 +1337,28 @@ func (s *x402ResourceServer) SettlePaymentWithExtensions(
 		// Only `$…` overrides need asset decimals. Atomic and percent formats must
 		// not force a decimals lookup (unknown custom mints would otherwise fail).
 		decimals := 6
+		decimalsKnown := false
 		if dollarRegex.MatchString(overrides.Amount) {
 			s.mu.RLock()
 			network := Network(requirements.Network)
 			if scheme := findByNetworkAndScheme(s.schemes, requirements.Scheme, network); scheme != nil {
 				if dp, ok := scheme.(AssetDecimalsProvider); ok {
-					decimals = dp.GetAssetDecimals(requirements.Asset, network)
+					if d, found := dp.GetAssetDecimals(requirements.Asset, network); found {
+						decimals = d
+						decimalsKnown = true
+					}
 				}
 			}
 			s.mu.RUnlock()
+			if !decimalsKnown {
+				return nil, NewSettleError(
+					"invalid_settlement_override",
+					"",
+					Network(requirements.Network),
+					"",
+					fmt.Sprintf("cannot convert dollar settlement override %q to atomic units: asset decimals are unknown. Pass an atomic amount or register the asset", overrides.Amount),
+				)
+			}
 		}
 		resolved, err := ResolveSettlementOverrideAmount(overrides.Amount, requirements, decimals)
 		if err != nil {

--- a/go/server.go
+++ b/go/server.go
@@ -46,16 +46,7 @@ func ResolveSettlementOverrideAmount(rawAmount string, requirements types.Paymen
 	}
 
 	if m := dollarRegex.FindStringSubmatch(rawAmount); m != nil {
-		dollarFloat, ok := new(big.Float).SetPrec(256).SetString(m[1])
-		if !ok {
-			return "", fmt.Errorf("invalid dollar amount: %s", rawAmount)
-		}
-		multiplier := new(big.Float).SetPrec(256).SetInt(
-			new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil),
-		)
-		atomicFloat := new(big.Float).SetPrec(256).Mul(dollarFloat, multiplier)
-		atomicInt, _ := atomicFloat.Int(nil) // truncates toward zero (floor for positive values)
-		return atomicInt.String(), nil
+		return ConvertToTokenAmount(m[1], decimals)
 	}
 
 	return rawAmount, nil

--- a/go/server_test.go
+++ b/go/server_test.go
@@ -1233,6 +1233,10 @@ func TestResolveSettlementOverrideAmount(t *testing.T) {
 			{"$0.05", "50000"},
 			{"$0.001", "1000"},
 			{"$0", "0"},
+			{"$1.0000005", "1000000"},
+			{"$0.0000005", "0"},
+			{"$0.0000009", "0"},
+			{"$0.00", "0"},
 		}
 		for _, tt := range tests {
 			result, err := ResolveSettlementOverrideAmount(tt.input, baseReqs, 6)

--- a/go/test/integration/core_test.go
+++ b/go/test/integration/core_test.go
@@ -16,6 +16,7 @@ func TestCoreIntegration(t *testing.T) {
 
 		// Setup client with cash scheme
 		client := x402.Newx402Client()
+		client.DisableSpendControls()
 		client.Register("x402:cash", cash.NewSchemeNetworkClient("John"))
 
 		// Setup facilitator with cash scheme

--- a/go/test/integration/evm_test.go
+++ b/go/test/integration/evm_test.go
@@ -626,14 +626,19 @@ func TestEVMIntegrationV2Permit2(t *testing.T) {
 
 		// Setup resource server with EVM v2
 		evmServer := exactevmserver.NewExactEvmScheme()
-		evmServer.RegisterMoneyParser(func(amount float64, network x402.Network) (*x402.AssetAmount, error) {
+		evmServer.RegisterMoneyParser(func(amount string, network x402.Network) (*x402.AssetAmount, error) {
 			if string(network) != "eip155:84532" {
 				return nil, nil
 			}
 
+			tokenAmount, err := x402.ConvertToTokenAmount(amount, 6)
+			if err != nil {
+				return nil, err
+			}
+
 			return &x402.AssetAmount{
 				Asset:  "0x036CbD53842c5426634e7929541eC2318f3dCF7e", // USDC on Base Sepolia
-				Amount: fmt.Sprintf("%.0f", amount*1e6),
+				Amount: tokenAmount,
 				Extra: map[string]interface{}{
 					"assetTransferMethod": "permit2",
 					"name":                "USDC",

--- a/go/test/integration/http_test.go
+++ b/go/test/integration/http_test.go
@@ -92,6 +92,7 @@ func TestHTTPIntegration(t *testing.T) {
 
 		// Setup x402 client with cash scheme
 		x402Client := x402.Newx402Client()
+		x402Client.DisableSpendControls()
 		x402Client.Register("x402:cash", cash.NewSchemeNetworkClient("John"))
 
 		// Setup HTTP client wrapper
@@ -344,6 +345,7 @@ func TestHTTPIntegration_FacilitatorReturnsIsValidFalse(t *testing.T) {
 			// Build a structurally valid payment payload using the cash client so
 			// the server accepts the header encoding and reaches the facilitator call.
 			x402Client := x402.Newx402Client()
+			x402Client.DisableSpendControls()
 			x402Client.Register("x402:cash", cash.NewSchemeNetworkClient("Alice"))
 			httpClient := x402http.Newx402HTTPClient(x402Client)
 

--- a/go/test/unit/evm_default_assets_test.go
+++ b/go/test/unit/evm_default_assets_test.go
@@ -66,6 +66,26 @@ func TestEVMDefaultAssets(t *testing.T) {
 		}
 	})
 
+	t.Run("ConvertDefaultMoney converts decimal amount using default asset decimals", func(t *testing.T) {
+		info, amount, err := evm.ConvertDefaultMoney(1.5, "eip155:8453", "")
+		if err != nil {
+			t.Fatalf("ConvertDefaultMoney: %v", err)
+		}
+		if info.Asset != baseUSDC.Asset {
+			t.Fatalf("asset = %s, want %s", info.Asset, baseUSDC.Asset)
+		}
+		if amount != "1500000" {
+			t.Fatalf("amount = %s, want 1500000", amount)
+		}
+	})
+
+	t.Run("ConvertDefaultMoney returns lookup errors as-is", func(t *testing.T) {
+		_, _, err := evm.ConvertDefaultMoney(1, "eip155:8453", "USDT")
+		if err == nil || !strings.Contains(err.Error(), "no USDT default asset configured for network eip155:8453") {
+			t.Fatalf("expected USDT error, got %v", err)
+		}
+	})
+
 	t.Run("GetAssetDecimals returns false for unrecognized asset on 18-decimal network", func(t *testing.T) {
 		server := evmserver.NewExactEvmScheme()
 		otherAsset := "0x0000000000000000000000000000000000000001"

--- a/go/test/unit/evm_default_assets_test.go
+++ b/go/test/unit/evm_default_assets_test.go
@@ -67,7 +67,7 @@ func TestEVMDefaultAssets(t *testing.T) {
 	})
 
 	t.Run("ConvertDefaultMoney converts decimal amount using default asset decimals", func(t *testing.T) {
-		info, amount, err := evm.ConvertDefaultMoney(1.5, "eip155:8453", "")
+		info, amount, err := evm.ConvertDefaultMoney("1.5", "eip155:8453", "")
 		if err != nil {
 			t.Fatalf("ConvertDefaultMoney: %v", err)
 		}
@@ -80,7 +80,7 @@ func TestEVMDefaultAssets(t *testing.T) {
 	})
 
 	t.Run("ConvertDefaultMoney returns lookup errors as-is", func(t *testing.T) {
-		_, _, err := evm.ConvertDefaultMoney(1, "eip155:8453", "USDT")
+		_, _, err := evm.ConvertDefaultMoney("1", "eip155:8453", "USDT")
 		if err == nil || !strings.Contains(err.Error(), "no USDT default asset configured for network eip155:8453") {
 			t.Fatalf("expected USDT error, got %v", err)
 		}

--- a/go/test/unit/evm_default_assets_test.go
+++ b/go/test/unit/evm_default_assets_test.go
@@ -1,0 +1,80 @@
+package unit_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	evmserver "github.com/x402-foundation/x402/go/v2/mechanisms/evm/exact/server"
+)
+
+func TestEVMDefaultAssets(t *testing.T) {
+	baseUSDC := evm.DefaultAssets["eip155:8453"][0]
+	mezoTestnetMUSD := evm.DefaultAssets["eip155:31611"][0]
+
+	t.Run("findDefaultAsset matches checksummed and lowercase addresses", func(t *testing.T) {
+		checksummed := common.HexToAddress(baseUSDC.Asset).Hex()
+		lowercase := strings.ToLower(baseUSDC.Asset)
+
+		got := evm.FindDefaultAsset(checksummed, "eip155:8453")
+		if got == nil || got.Asset != baseUSDC.Asset {
+			t.Fatalf("checksummed lookup = %+v, want %+v", got, baseUSDC)
+		}
+		got = evm.FindDefaultAsset(lowercase, "eip155:8453")
+		if got == nil || got.Asset != baseUSDC.Asset {
+			t.Fatalf("lowercase lookup = %+v, want %+v", got, baseUSDC)
+		}
+	})
+
+	t.Run("resolves v1 legacy network name base to eip155:8453", func(t *testing.T) {
+		got := evm.FindDefaultAsset(baseUSDC.Asset, "base")
+		if got == nil || got.Asset != baseUSDC.Asset {
+			t.Fatalf("base lookup = %+v, want %+v", got, baseUSDC)
+		}
+	})
+
+	t.Run("finds 18-decimal mUSD on Mezo testnet", func(t *testing.T) {
+		got := evm.FindDefaultAsset(mezoTestnetMUSD.Asset, "eip155:31611")
+		if got == nil || got.Decimals != 18 {
+			t.Fatalf("mezo lookup = %+v, want decimals 18", got)
+		}
+	})
+
+	t.Run("returns nil for an unknown asset", func(t *testing.T) {
+		got := evm.FindDefaultAsset("0x0000000000000000000000000000000000000001", "eip155:8453")
+		if got != nil {
+			t.Fatalf("unknown asset = %+v, want nil", got)
+		}
+	})
+
+	t.Run("getDefaultAsset returns the first list entry", func(t *testing.T) {
+		got, err := evm.GetDefaultAsset("eip155:8453", "")
+		if err != nil || got.Asset != baseUSDC.Asset {
+			t.Fatalf("GetDefaultAsset(eip155:8453) = %+v, %v", got, err)
+		}
+		got, err = evm.GetDefaultAsset("base", "")
+		if err != nil || got.Asset != baseUSDC.Asset {
+			t.Fatalf("GetDefaultAsset(base) = %+v, %v", got, err)
+		}
+	})
+
+	t.Run("throws when requesting a symbol that is not configured", func(t *testing.T) {
+		_, err := evm.GetDefaultAsset("eip155:8453", "USDT")
+		if err == nil || !strings.Contains(err.Error(), "no USDT default asset configured for network eip155:8453") {
+			t.Fatalf("expected USDT error, got %v", err)
+		}
+	})
+
+	t.Run("GetAssetDecimals returns false for unrecognized asset on 18-decimal network", func(t *testing.T) {
+		server := evmserver.NewExactEvmScheme()
+		otherAsset := "0x0000000000000000000000000000000000000001"
+		if _, ok := server.GetAssetDecimals(otherAsset, "eip155:31611"); ok {
+			t.Fatal("expected unrecognized asset to return ok=false")
+		}
+		decimals, ok := server.GetAssetDecimals(mezoTestnetMUSD.Asset, "eip155:31611")
+		if !ok || decimals != 18 {
+			t.Fatalf("mUSD decimals = %d, %v, want 18, true", decimals, ok)
+		}
+	})
+}

--- a/go/test/unit/evm_test.go
+++ b/go/test/unit/evm_test.go
@@ -3,6 +3,7 @@ package unit_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
@@ -220,6 +221,57 @@ func TestEVMDualVersionSupport(t *testing.T) {
 		// Verify V2 structure (has scheme/network in Accepted)
 		if payloadV2.Accepted.Scheme == "" {
 			t.Error("Expected V2 payload to have Accepted.Scheme")
+		}
+	})
+}
+
+func TestEVMSpendControls(t *testing.T) {
+	usdc := "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+	network := x402.Network("eip155:8453")
+	client := x402.Newx402Client()
+	client.Register(network, evmclient.NewExactEvmScheme(&mockClientEvmSigner{}, nil))
+
+	req := func(asset, amount string) types.PaymentRequirements {
+		return types.PaymentRequirements{
+			Scheme:  evm.SchemeExact,
+			Network: string(network),
+			Asset:   asset,
+			Amount:  amount,
+			PayTo:   "0x9876543210987654321098765432109876543210",
+		}
+	}
+
+	t.Run("documented USDC at or below $1 is allowed", func(t *testing.T) {
+		selected, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc, "1000000")})
+		if err != nil {
+			t.Fatalf("expected allow: %v", err)
+		}
+		if selected.Amount != "1000000" {
+			t.Fatalf("amount = %s", selected.Amount)
+		}
+	})
+
+	t.Run("above $1 is rejected", func(t *testing.T) {
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(usdc, "1000001")})
+		if err == nil || !strings.Contains(err.Error(), "maxAmountPerPayment") {
+			t.Fatalf("expected cap error, got %v", err)
+		}
+	})
+
+	t.Run("unknown asset is rejected unless allowedAssets", func(t *testing.T) {
+		custom := "0x0000000000000000000000000000000000000001"
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(custom, "1")})
+		if err == nil || !strings.Contains(err.Error(), "spendControls.allowedAssets") {
+			t.Fatalf("expected allowlist error, got %v", err)
+		}
+
+		optIn := x402.Newx402Client()
+		optIn.Register(network, evmclient.NewExactEvmScheme(&mockClientEvmSigner{}, nil))
+		optIn.SetSpendControls(x402.SpendControls{
+			AllowedAssets: []x402.SpendControlAsset{{Network: network, Asset: custom}},
+		})
+		if _, err := optIn.SelectPaymentRequirements([]types.PaymentRequirements{req(custom, "1")}); err != nil {
+			t.Fatalf("opt-in custom asset: %v", err)
 		}
 	})
 }

--- a/go/test/unit/svm_default_assets_test.go
+++ b/go/test/unit/svm_default_assets_test.go
@@ -1,0 +1,51 @@
+package unit_test
+
+import (
+	"strings"
+	"testing"
+
+	svm "github.com/x402-foundation/x402/go/v2/mechanisms/svm"
+)
+
+func TestSVMDefaultAssets(t *testing.T) {
+	mainnetUSDC := svm.DefaultAssets[svm.SolanaMainnetCAIP2][0]
+
+	t.Run("resolves v1 legacy network name solana", func(t *testing.T) {
+		got := svm.FindDefaultAsset(svm.USDCMainnetAddress, "solana")
+		if got == nil || got.Asset != mainnetUSDC.Asset {
+			t.Fatalf("solana lookup = %+v, want %+v", got, mainnetUSDC)
+		}
+	})
+
+	t.Run("returns nil for an unknown asset", func(t *testing.T) {
+		got := svm.FindDefaultAsset("UnknownMint1111111111111111111111111111111", "solana")
+		if got != nil {
+			t.Fatalf("unknown mint = %+v, want nil", got)
+		}
+	})
+
+	t.Run("getDefaultAsset returns the first list entry", func(t *testing.T) {
+		got, err := svm.GetDefaultAsset(svm.SolanaMainnetCAIP2, "")
+		if err != nil || got.Asset != mainnetUSDC.Asset {
+			t.Fatalf("GetDefaultAsset(mainnet) = %+v, %v", got, err)
+		}
+		got, err = svm.GetDefaultAsset("solana", "")
+		if err != nil || got.Asset != mainnetUSDC.Asset {
+			t.Fatalf("GetDefaultAsset(solana) = %+v, %v", got, err)
+		}
+	})
+
+	t.Run("resolves a suffixed ticker to a non-default entry", func(t *testing.T) {
+		got, err := svm.GetDefaultAsset(svm.SolanaMainnetCAIP2, "USDT")
+		if err != nil || got.Symbol != "USDT" {
+			t.Fatalf("USDT lookup = %+v, %v", got, err)
+		}
+	})
+
+	t.Run("throws when requesting a symbol that is not configured", func(t *testing.T) {
+		_, err := svm.GetDefaultAsset(svm.SolanaDevnetCAIP2, "USDT")
+		if err == nil || !strings.Contains(err.Error(), "no USDT default asset configured for network") {
+			t.Fatalf("expected USDT error, got %v", err)
+		}
+	})
+}

--- a/go/test/unit/svm_test.go
+++ b/go/test/unit/svm_test.go
@@ -2,13 +2,16 @@
 package unit_test
 
 import (
+	"strings"
 	"testing"
 
 	solana "github.com/gagliardetto/solana-go"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
 	svm "github.com/x402-foundation/x402/go/v2/mechanisms/svm"
+	svmclient "github.com/x402-foundation/x402/go/v2/mechanisms/svm/exact/client"
 	svmserver "github.com/x402-foundation/x402/go/v2/mechanisms/svm/exact/server"
+	"github.com/x402-foundation/x402/go/v2/types"
 )
 
 // TestSolanaServerPriceParsing tests V2 server price parsing
@@ -325,6 +328,56 @@ func TestSolanaGetAssetInfo(t *testing.T) {
 		// Should return default asset
 		if info.Address != svm.USDCDevnetAddress {
 			t.Errorf("Expected default asset address %s, got %s", svm.USDCDevnetAddress, info.Address)
+		}
+	})
+}
+
+func TestSVMSpendControls(t *testing.T) {
+	network := x402.Network(svm.SolanaMainnetCAIP2)
+	client := x402.Newx402Client()
+	client.Register(network, svmclient.NewExactSvmScheme(nil))
+
+	req := func(asset, amount string) types.PaymentRequirements {
+		return types.PaymentRequirements{
+			Scheme:  svm.SchemeExact,
+			Network: string(network),
+			Asset:   asset,
+			Amount:  amount,
+			PayTo:   "PayTo1111111111111111111111111111111111111",
+		}
+	}
+
+	t.Run("documented USDC mint at or below $1 is allowed", func(t *testing.T) {
+		selected, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(svm.USDCMainnetAddress, "1000000")})
+		if err != nil {
+			t.Fatalf("expected allow: %v", err)
+		}
+		if selected.Amount != "1000000" {
+			t.Fatalf("amount = %s", selected.Amount)
+		}
+	})
+
+	t.Run("above $1 is rejected", func(t *testing.T) {
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(svm.USDCMainnetAddress, "1000001")})
+		if err == nil || !strings.Contains(err.Error(), "maxAmountPerPayment") {
+			t.Fatalf("expected cap error, got %v", err)
+		}
+	})
+
+	t.Run("unknown mint is rejected unless allowedAssets", func(t *testing.T) {
+		custom := "CustomMint1111111111111111111111111111111"
+		_, err := client.SelectPaymentRequirements([]types.PaymentRequirements{req(custom, "1")})
+		if err == nil || !strings.Contains(err.Error(), "spendControls.allowedAssets") {
+			t.Fatalf("expected allowlist error, got %v", err)
+		}
+
+		optIn := x402.Newx402Client()
+		optIn.Register(network, svmclient.NewExactSvmScheme(nil))
+		optIn.SetSpendControls(x402.SpendControls{
+			AllowedAssets: []x402.SpendControlAsset{{Network: network, Asset: custom}},
+		})
+		if _, err := optIn.SelectPaymentRequirements([]types.PaymentRequirements{req(custom, "1")}); err != nil {
+			t.Fatalf("opt-in custom mint: %v", err)
 		}
 	})
 }

--- a/go/types.go
+++ b/go/types.go
@@ -49,6 +49,41 @@ func (n Network) Match(pattern Network) bool {
 // Price represents a price that can be specified in various formats
 type Price interface{}
 
+// DefaultMaxAmountPerPayment is the default USD cap for recognized default assets.
+const DefaultMaxAmountPerPayment = "$1"
+
+// DefaultAsset is a USD-pegged asset used for money strings and client spend caps.
+type DefaultAsset struct {
+	Asset    string
+	Decimals int
+	Symbol   string
+}
+
+// SpendControlAsset is an opt-in asset for SpendControls.AllowedAssets.
+// Default assets are always allowed; list non-default tokens here (and optional atomic caps).
+type SpendControlAsset struct {
+	Network Network
+	// Asset is an onchain asset id, or a default-asset symbol (e.g. "PYUSD").
+	Asset string
+	// MaxAmountPerPayment is an optional atomic per-payment cap. Empty means unset.
+	MaxAmountPerPayment string
+}
+
+// SpendControls are client spend controls enforced before policies.
+// By default only assets FindDefaultAsset recognizes are allowed, capped at
+// DefaultMaxAmountPerPayment. Disable with DisableSpendControls.
+type SpendControls struct {
+	// MaxAmountPerPayment is the per-payment USD cap on assets FindDefaultAsset recognizes.
+	// Empty means DefaultMaxAmountPerPayment. Disable with DisableMaxAmountPerPayment.
+	MaxAmountPerPayment string
+	// DisableMaxAmountPerPayment disables the USD cap (TS maxAmountPerPayment: false).
+	DisableMaxAmountPerPayment bool
+	// AllowAnyAsset allows any asset (USD cap still applies to defaults).
+	AllowAnyAsset bool
+	// AllowedAssets lists opt-in non-default assets (ignored when AllowAnyAsset is set).
+	AllowedAssets []SpendControlAsset
+}
+
 // AssetAmount represents an amount of a specific asset
 type AssetAmount struct {
 	Asset  string                 `json:"asset"`

--- a/go/utils.go
+++ b/go/utils.go
@@ -2,14 +2,15 @@ package x402
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
 )
 
 var (
-	moneyStringPattern = regexp.MustCompile(`^-?\d+(?:\.\d+)?$`)
-	moneyParsePattern  = regexp.MustCompile(`^\$?\s*(-?\d+(?:\.\d+)?)(?:\s+([A-Za-z][A-Za-z0-9.]*))?$`)
+	moneyStringPattern = regexp.MustCompile(`^\d+(?:\.\d+)?$`)
+	moneyParsePattern  = regexp.MustCompile(`^\$?\s*(\d+(?:\.\d+)?)(?:\s+([A-Za-z][A-Za-z0-9.]*))?$`)
 	tokenAmountPattern = regexp.MustCompile(`^-?\d+\.?\d*$`)
 	scientificPattern  = regexp.MustCompile(`[eE]`)
 )
@@ -106,63 +107,55 @@ func NumberToDecimalString(n float64) string {
 	return strconv.FormatFloat(n, 'f', -1, 64)
 }
 
-// ParseMoneyString parses a money string into a finite, non-negative decimal number.
+// ParseMoneyString extracts a non-negative decimal substring from a money string.
 // Accepts plain decimal strings with an optional leading dollar sign.
 // Rejects ticker suffixes — use ParseMoney when a symbol may be present.
-func ParseMoneyString(money string) (float64, error) {
+func ParseMoneyString(money string) (string, error) {
 	cleaned := strings.TrimSpace(strings.TrimPrefix(money, "$"))
 	if !moneyStringPattern.MatchString(cleaned) || scientificPattern.MatchString(cleaned) {
-		return 0, fmt.Errorf("invalid money format: %s", money)
+		return "", fmt.Errorf("invalid money format: %s", money)
 	}
-	amount, err := strconv.ParseFloat(cleaned, 64)
-	if err != nil || amount < 0 {
-		return 0, fmt.Errorf("invalid money format: %s", money)
-	}
-	return amount, nil
+	return cleaned, nil
 }
 
-// ParseMoney parses money into amount and optional uppercase ticker.
+// ParseMoney parses money into a decimal string and optional uppercase ticker.
 // "1.50 USDT" → symbol; "1.50 USD" and bare amounts have none.
 // Glued tickers ("1.50USDT") are rejected.
-func ParseMoney(money Price) (amount float64, symbol string, err error) {
+func ParseMoney(money Price) (amount string, symbol string, err error) {
 	switch v := money.(type) {
 	case float64:
-		if v < 0 {
-			return 0, "", fmt.Errorf("invalid money format: %v", v)
+		if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 {
+			return "", "", fmt.Errorf("invalid money format: %v", v)
 		}
-		return v, "", nil
+		return NumberToDecimalString(v), "", nil
 	case float32:
-		if v < 0 {
-			return 0, "", fmt.Errorf("invalid money format: %v", v)
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) || v < 0 {
+			return "", "", fmt.Errorf("invalid money format: %v", v)
 		}
-		return float64(v), "", nil
+		return NumberToDecimalString(float64(v)), "", nil
 	case int:
 		if v < 0 {
-			return 0, "", fmt.Errorf("invalid money format: %v", v)
+			return "", "", fmt.Errorf("invalid money format: %v", v)
 		}
-		return float64(v), "", nil
+		return strconv.Itoa(v), "", nil
 	case int64:
 		if v < 0 {
-			return 0, "", fmt.Errorf("invalid money format: %v", v)
+			return "", "", fmt.Errorf("invalid money format: %v", v)
 		}
-		return float64(v), "", nil
+		return strconv.FormatInt(v, 10), "", nil
 	case string:
 		trimmed := strings.TrimSpace(v)
 		match := moneyParsePattern.FindStringSubmatch(trimmed)
 		if match == nil {
-			return 0, "", fmt.Errorf("invalid money format: %s", v)
-		}
-		parsed, parseErr := ParseMoneyString(match[1])
-		if parseErr != nil {
-			return 0, "", parseErr
+			return "", "", fmt.Errorf("invalid money format: %s", v)
 		}
 		rawSymbol := match[2]
 		if rawSymbol == "" || strings.ToUpper(rawSymbol) == "USD" {
-			return parsed, "", nil
+			return match[1], "", nil
 		}
-		return parsed, strings.ToUpper(rawSymbol), nil
+		return match[1], strings.ToUpper(rawSymbol), nil
 	default:
-		return 0, "", fmt.Errorf("invalid money format: %v", money)
+		return "", "", fmt.Errorf("invalid money format: %v", money)
 	}
 }
 
@@ -186,9 +179,6 @@ func ConvertToTokenAmount(decimalAmount string, decimals int) (string, error) {
 	tokenAmount := strings.TrimLeft(intPart+paddedDec, "0")
 	if tokenAmount == "" {
 		tokenAmount = "0"
-	}
-	if tokenAmount == "0" && strings.ContainsAny(decimalAmount, "123456789") {
-		return "", fmt.Errorf("amount %s is too small to represent with %d decimal places", decimalAmount, decimals)
 	}
 	return tokenAmount, nil
 }

--- a/go/utils.go
+++ b/go/utils.go
@@ -1,6 +1,18 @@
 package x402
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	moneyStringPattern = regexp.MustCompile(`^-?\d+(?:\.\d+)?$`)
+	moneyParsePattern  = regexp.MustCompile(`^\$?\s*(-?\d+(?:\.\d+)?)(?:\s+([A-Za-z][A-Za-z0-9.]*))?$`)
+	tokenAmountPattern = regexp.MustCompile(`^-?\d+\.?\d*$`)
+	scientificPattern  = regexp.MustCompile(`[eE]`)
+)
 
 // ValidatePaymentPayload performs basic validation on a payment payload
 // Version-aware: handles both v1 and v2 payload structures
@@ -87,4 +99,96 @@ func findSchemesByNetwork[T any](networkMap map[Network]map[string]T, network Ne
 	}
 
 	return nil
+}
+
+// NumberToDecimalString converts a float64 to a plain decimal string without scientific notation.
+func NumberToDecimalString(n float64) string {
+	return strconv.FormatFloat(n, 'f', -1, 64)
+}
+
+// ParseMoneyString parses a money string into a finite, non-negative decimal number.
+// Accepts plain decimal strings with an optional leading dollar sign.
+// Rejects ticker suffixes — use ParseMoney when a symbol may be present.
+func ParseMoneyString(money string) (float64, error) {
+	cleaned := strings.TrimSpace(strings.TrimPrefix(money, "$"))
+	if !moneyStringPattern.MatchString(cleaned) || scientificPattern.MatchString(cleaned) {
+		return 0, fmt.Errorf("invalid money format: %s", money)
+	}
+	amount, err := strconv.ParseFloat(cleaned, 64)
+	if err != nil || amount < 0 {
+		return 0, fmt.Errorf("invalid money format: %s", money)
+	}
+	return amount, nil
+}
+
+// ParseMoney parses money into amount and optional uppercase ticker.
+// "1.50 USDT" → symbol; "1.50 USD" and bare amounts have none.
+// Glued tickers ("1.50USDT") are rejected.
+func ParseMoney(money Price) (amount float64, symbol string, err error) {
+	switch v := money.(type) {
+	case float64:
+		if v < 0 {
+			return 0, "", fmt.Errorf("invalid money format: %v", v)
+		}
+		return v, "", nil
+	case float32:
+		if v < 0 {
+			return 0, "", fmt.Errorf("invalid money format: %v", v)
+		}
+		return float64(v), "", nil
+	case int:
+		if v < 0 {
+			return 0, "", fmt.Errorf("invalid money format: %v", v)
+		}
+		return float64(v), "", nil
+	case int64:
+		if v < 0 {
+			return 0, "", fmt.Errorf("invalid money format: %v", v)
+		}
+		return float64(v), "", nil
+	case string:
+		trimmed := strings.TrimSpace(v)
+		match := moneyParsePattern.FindStringSubmatch(trimmed)
+		if match == nil {
+			return 0, "", fmt.Errorf("invalid money format: %s", v)
+		}
+		parsed, parseErr := ParseMoneyString(match[1])
+		if parseErr != nil {
+			return 0, "", parseErr
+		}
+		rawSymbol := match[2]
+		if rawSymbol == "" || strings.ToUpper(rawSymbol) == "USD" {
+			return parsed, "", nil
+		}
+		return parsed, strings.ToUpper(rawSymbol), nil
+	default:
+		return 0, "", fmt.Errorf("invalid money format: %v", money)
+	}
+}
+
+// ConvertToTokenAmount converts a decimal amount to token smallest units.
+// Accepts only plain decimal strings — scientific notation is not allowed.
+func ConvertToTokenAmount(decimalAmount string, decimals int) (string, error) {
+	if scientificPattern.MatchString(decimalAmount) {
+		return "", fmt.Errorf("invalid amount: %s — use decimal notation, not scientific notation", decimalAmount)
+	}
+	if !tokenAmountPattern.MatchString(decimalAmount) {
+		return "", fmt.Errorf("invalid amount: %s", decimalAmount)
+	}
+	intPart, decPart, found := strings.Cut(decimalAmount, ".")
+	if !found {
+		decPart = ""
+	}
+	paddedDec := decPart + strings.Repeat("0", decimals)
+	if len(paddedDec) > decimals {
+		paddedDec = paddedDec[:decimals]
+	}
+	tokenAmount := strings.TrimLeft(intPart+paddedDec, "0")
+	if tokenAmount == "" {
+		tokenAmount = "0"
+	}
+	if tokenAmount == "0" && strings.ContainsAny(decimalAmount, "123456789") {
+		return "", fmt.Errorf("amount %s is too small to represent with %d decimal places", decimalAmount, decimals)
+	}
+	return tokenAmount, nil
 }

--- a/go/utils_test.go
+++ b/go/utils_test.go
@@ -1,6 +1,7 @@
 package x402
 
 import (
+	"math"
 	"testing"
 )
 
@@ -407,4 +408,149 @@ func findSubstring(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestParseMoneyString(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"1.0000005", "1.0000005", false},
+		{"0.0000005", "0.0000005", false},
+		{"0.0000009", "0.0000009", false},
+		{"0", "0", false},
+		{"0.00", "0.00", false},
+		{"$1.50", "1.50", false},
+		{"$0", "0", false},
+		{"-1", "", true},
+		{"1e6", "", true},
+		{"1.50 USDT", "", true},
+		{"1.50USDT", "", true},
+	}
+	for _, tt := range tests {
+		got, err := ParseMoneyString(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("ParseMoneyString(%q) expected error", tt.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseMoneyString(%q) unexpected error: %v", tt.in, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseMoneyString(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParseMoney(t *testing.T) {
+	t.Run("string amounts keep exact digits", func(t *testing.T) {
+		got, symbol, err := ParseMoney("8975.978289462729")
+		if err != nil {
+			t.Fatalf("ParseMoney: %v", err)
+		}
+		if got != "8975.978289462729" {
+			t.Errorf("amount = %q, want 8975.978289462729", got)
+		}
+		if symbol != "" {
+			t.Errorf("symbol = %q, want empty", symbol)
+		}
+	})
+
+	t.Run("ticker and dollar prefix", func(t *testing.T) {
+		got, symbol, err := ParseMoney("1.50 USDT")
+		if err != nil {
+			t.Fatalf("ParseMoney: %v", err)
+		}
+		if got != "1.50" || symbol != "USDT" {
+			t.Errorf("got (%q, %q), want (\"1.50\", \"USDT\")", got, symbol)
+		}
+
+		got, symbol, err = ParseMoney("1.50 USD")
+		if err != nil {
+			t.Fatalf("ParseMoney: %v", err)
+		}
+		if got != "1.50" || symbol != "" {
+			t.Errorf("got (%q, %q), want (\"1.50\", \"\")", got, symbol)
+		}
+
+		got, symbol, err = ParseMoney("$1.50")
+		if err != nil {
+			t.Fatalf("ParseMoney: %v", err)
+		}
+		if got != "1.50" || symbol != "" {
+			t.Errorf("got (%q, %q), want (\"1.50\", \"\")", got, symbol)
+		}
+	})
+
+	t.Run("numeric types stringify without float for integers", func(t *testing.T) {
+		got, _, err := ParseMoney(4)
+		if err != nil || got != "4" {
+			t.Errorf("ParseMoney(4) = %q, %v, want \"4\"", got, err)
+		}
+		got, _, err = ParseMoney(int64(5))
+		if err != nil || got != "5" {
+			t.Errorf("ParseMoney(int64(5)) = %q, %v, want \"5\"", got, err)
+		}
+		got, _, err = ParseMoney(3.5)
+		if err != nil || got != "3.5" {
+			t.Errorf("ParseMoney(3.5) = %q, %v, want \"3.5\"", got, err)
+		}
+	})
+
+	t.Run("rejects invalid values", func(t *testing.T) {
+		invalid := []Price{-1, -1.5, math.NaN(), math.Inf(1), math.Inf(-1), "nope", "1.50USDT", "1e6"}
+		for _, in := range invalid {
+			if _, _, err := ParseMoney(in); err == nil {
+				t.Errorf("ParseMoney(%v) expected error", in)
+			}
+		}
+	})
+}
+
+func TestConvertToTokenAmount(t *testing.T) {
+	tests := []struct {
+		amount   string
+		decimals int
+		want     string
+		wantErr  bool
+	}{
+		{"1.0000005", 6, "1000000", false},
+		{"0.0000005", 6, "0", false},
+		{"0.0000009", 6, "0", false},
+		{"0", 6, "0", false},
+		{"0.00", 6, "0", false},
+		{"8975.978289462729", 18, "8975978289462729000000", false},
+		{"8975.978289462729", 6, "8975978289", false},
+		{"1e6", 6, "", true},
+		{"not-a-number", 6, "", true},
+	}
+	for _, tt := range tests {
+		got, err := ConvertToTokenAmount(tt.amount, tt.decimals)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("ConvertToTokenAmount(%q, %d) expected error", tt.amount, tt.decimals)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ConvertToTokenAmount(%q, %d) unexpected error: %v", tt.amount, tt.decimals, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ConvertToTokenAmount(%q, %d) = %q, want %q", tt.amount, tt.decimals, got, tt.want)
+		}
+	}
+}
+
+func TestNumberToDecimalString(t *testing.T) {
+	if got := NumberToDecimalString(4.02); got != "4.02" {
+		t.Errorf("NumberToDecimalString(4.02) = %q, want \"4.02\"", got)
+	}
+	if got := NumberToDecimalString(0); got != "0" {
+		t.Errorf("NumberToDecimalString(0) = %q, want \"0\"", got)
+	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Go sdk port of spend controls introduced in https://github.com/x402-foundation/x402/pull/3124

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 