### PR TITLE
feat(legacy): add deprecation warning to unscoped v1 packages (#3091)

### DIFF
--- a/typescript/packages/legacy/x402-axios/src/deprecation.test.ts
+++ b/typescript/packages/legacy/x402-axios/src/deprecation.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("x402/client", () => ({
+  createPaymentHeader: vi.fn(),
+  selectPaymentRequirements: vi.fn(),
+}));
+
+describe("x402-axios legacy deprecation warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns once on withPaymentInterceptor construction pointing to @x402/axios", async () => {
+    const { withPaymentInterceptor } = await import("./index");
+    const mockAxiosClient = { interceptors: { response: { use: vi.fn() } } } as never;
+    const mockWalletClient = { signMessage: vi.fn() } as never;
+
+    withPaymentInterceptor(mockAxiosClient, mockWalletClient);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("x402-axios");
+    expect(warnSpy.mock.calls[0][0]).toContain("@x402/axios");
+
+    withPaymentInterceptor(mockAxiosClient, mockWalletClient);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  }, 20000);
+});

--- a/typescript/packages/legacy/x402-axios/src/deprecation.test.ts
+++ b/typescript/packages/legacy/x402-axios/src/deprecation.test.ts
@@ -17,7 +17,7 @@ describe("x402-axios legacy deprecation warning", () => {
     warnSpy.mockRestore();
   });
 
-  it("warns once on withPaymentInterceptor construction pointing to @x402/axios", async () => {
+  it("tags withPaymentInterceptor construction as the x402-axios client, pointing to @x402/axios", async () => {
     const { withPaymentInterceptor } = await import("./index");
     const mockAxiosClient = { interceptors: { response: { use: vi.fn() } } } as never;
     const mockWalletClient = { signMessage: vi.fn() } as never;
@@ -27,9 +27,5 @@ describe("x402-axios legacy deprecation warning", () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0][0]).toContain("x402-axios");
     expect(warnSpy.mock.calls[0][0]).toContain("@x402/axios");
-
-    withPaymentInterceptor(mockAxiosClient, mockWalletClient);
-
-    expect(warnSpy).toHaveBeenCalledTimes(1);
   }, 20000);
 });

--- a/typescript/packages/legacy/x402-axios/src/index.ts
+++ b/typescript/packages/legacy/x402-axios/src/index.ts
@@ -16,23 +16,7 @@ import {
   PaymentRequirementsSelector,
   selectPaymentRequirements,
 } from "x402/client";
-
-let hasWarnedLegacyDeprecation = false;
-
-/**
- * Warns once per process that this package is the frozen x402 protocol v1
- * implementation.
- */
-function warnLegacyDeprecation(): void {
-  if (hasWarnedLegacyDeprecation) return;
-  hasWarnedLegacyDeprecation = true;
-  console.warn(
-    '[x402-axios] DEPRECATED: "x402-axios" is the x402 protocol v1 client implementation and ' +
-      "is frozen. It will not interoperate with servers that only advertise payment terms via " +
-      'the v2 "PAYMENT-REQUIRED" header. Please migrate to "@x402/axios": ' +
-      "https://www.npmjs.com/package/@x402/axios",
-  );
-}
+import { warnLegacyDeprecation } from "x402/shared";
 
 /**
  * Enables the payment of APIs using the x402 payment protocol.
@@ -80,7 +64,7 @@ export function withPaymentInterceptor(
   paymentRequirementsSelector: PaymentRequirementsSelector = selectPaymentRequirements,
   config?: X402Config,
 ) {
-  warnLegacyDeprecation();
+  warnLegacyDeprecation("x402-axios", "@x402/axios", "client");
 
   axiosClient.interceptors.response.use(
     response => response,

--- a/typescript/packages/legacy/x402-axios/src/index.ts
+++ b/typescript/packages/legacy/x402-axios/src/index.ts
@@ -17,6 +17,23 @@ import {
   selectPaymentRequirements,
 } from "x402/client";
 
+let hasWarnedLegacyDeprecation = false;
+
+/**
+ * Warns once per process that this package is the frozen x402 protocol v1
+ * implementation.
+ */
+function warnLegacyDeprecation(): void {
+  if (hasWarnedLegacyDeprecation) return;
+  hasWarnedLegacyDeprecation = true;
+  console.warn(
+    '[x402-axios] DEPRECATED: "x402-axios" is the x402 protocol v1 client implementation and ' +
+      "is frozen. It will not interoperate with servers that only advertise payment terms via " +
+      'the v2 "PAYMENT-REQUIRED" header. Please migrate to "@x402/axios": ' +
+      "https://www.npmjs.com/package/@x402/axios",
+  );
+}
+
 /**
  * Enables the payment of APIs using the x402 payment protocol.
  *
@@ -63,6 +80,8 @@ export function withPaymentInterceptor(
   paymentRequirementsSelector: PaymentRequirementsSelector = selectPaymentRequirements,
   config?: X402Config,
 ) {
+  warnLegacyDeprecation();
+
   axiosClient.interceptors.response.use(
     response => response,
     async (error: AxiosError) => {

--- a/typescript/packages/legacy/x402-express/src/deprecation.test.ts
+++ b/typescript/packages/legacy/x402-express/src/deprecation.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("x402-express legacy deprecation warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns once on middleware construction pointing to @x402/express", async () => {
+    const { paymentMiddleware } = await import("./index");
+
+    paymentMiddleware("0x1234567890123456789012345678901234567890", {
+      "/test": { price: "$0.01", network: "base-sepolia" },
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("x402-express");
+    expect(warnSpy.mock.calls[0][0]).toContain("@x402/express");
+
+    paymentMiddleware("0x1234567890123456789012345678901234567890", {
+      "/other": { price: "$0.01", network: "base-sepolia" },
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  }, 20000);
+});

--- a/typescript/packages/legacy/x402-express/src/index.ts
+++ b/typescript/packages/legacy/x402-express/src/index.ts
@@ -8,6 +8,7 @@ import {
   findMatchingRoute,
   processPriceToAtomicAmount,
   toJsonSafe,
+  warnLegacyDeprecation,
 } from "x402/shared";
 import { getPaywallHtml } from "x402/paywall";
 import {
@@ -24,23 +25,6 @@ import {
   SupportedSVMNetworks,
 } from "x402/types";
 import { useFacilitator } from "x402/verify";
-
-let hasWarnedLegacyDeprecation = false;
-
-/**
- * Warns once per process that this package is the frozen x402 protocol v1
- * implementation and does not speak the v2 "PAYMENT-REQUIRED" header dialect.
- */
-function warnLegacyDeprecation(): void {
-  if (hasWarnedLegacyDeprecation) return;
-  hasWarnedLegacyDeprecation = true;
-  console.warn(
-    '[x402-express] DEPRECATED: "x402-express" implements x402 protocol v1 and only emits ' +
-      'payment terms in the JSON response body. v2 clients read the "PAYMENT-REQUIRED" header ' +
-      'instead and will not be able to pay you. Please migrate to "@x402/express": ' +
-      "https://www.npmjs.com/package/@x402/express",
-  );
-}
 
 /**
  * Creates a payment middleware factory for Express
@@ -95,7 +79,7 @@ export function paymentMiddleware(
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
 ) {
-  warnLegacyDeprecation();
+  warnLegacyDeprecation("x402-express", "@x402/express", "server");
 
   const { verify, settle, supported } = useFacilitator(facilitator);
   const x402Version = 1;

--- a/typescript/packages/legacy/x402-express/src/index.ts
+++ b/typescript/packages/legacy/x402-express/src/index.ts
@@ -25,6 +25,23 @@ import {
 } from "x402/types";
 import { useFacilitator } from "x402/verify";
 
+let hasWarnedLegacyDeprecation = false;
+
+/**
+ * Warns once per process that this package is the frozen x402 protocol v1
+ * implementation and does not speak the v2 "PAYMENT-REQUIRED" header dialect.
+ */
+function warnLegacyDeprecation(): void {
+  if (hasWarnedLegacyDeprecation) return;
+  hasWarnedLegacyDeprecation = true;
+  console.warn(
+    '[x402-express] DEPRECATED: "x402-express" implements x402 protocol v1 and only emits ' +
+      'payment terms in the JSON response body. v2 clients read the "PAYMENT-REQUIRED" header ' +
+      'instead and will not be able to pay you. Please migrate to "@x402/express": ' +
+      "https://www.npmjs.com/package/@x402/express",
+  );
+}
+
 /**
  * Creates a payment middleware factory for Express
  *
@@ -78,6 +95,8 @@ export function paymentMiddleware(
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
 ) {
+  warnLegacyDeprecation();
+
   const { verify, settle, supported } = useFacilitator(facilitator);
   const x402Version = 1;
 

--- a/typescript/packages/legacy/x402-fetch/src/deprecation.test.ts
+++ b/typescript/packages/legacy/x402-fetch/src/deprecation.test.ts
@@ -17,7 +17,7 @@ describe("x402-fetch legacy deprecation warning", () => {
     warnSpy.mockRestore();
   });
 
-  it("warns once on wrapFetchWithPayment construction pointing to @x402/fetch", async () => {
+  it("tags wrapFetchWithPayment construction as the x402-fetch client, pointing to @x402/fetch", async () => {
     const { wrapFetchWithPayment } = await import("./index");
     const mockWalletClient = { signMessage: vi.fn() } as never;
 
@@ -26,9 +26,5 @@ describe("x402-fetch legacy deprecation warning", () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0][0]).toContain("x402-fetch");
     expect(warnSpy.mock.calls[0][0]).toContain("@x402/fetch");
-
-    wrapFetchWithPayment(vi.fn() as never, mockWalletClient);
-
-    expect(warnSpy).toHaveBeenCalledTimes(1);
   }, 20000);
 });

--- a/typescript/packages/legacy/x402-fetch/src/deprecation.test.ts
+++ b/typescript/packages/legacy/x402-fetch/src/deprecation.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("x402/client", () => ({
+  createPaymentHeader: vi.fn(),
+  selectPaymentRequirements: vi.fn(),
+}));
+
+describe("x402-fetch legacy deprecation warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns once on wrapFetchWithPayment construction pointing to @x402/fetch", async () => {
+    const { wrapFetchWithPayment } = await import("./index");
+    const mockWalletClient = { signMessage: vi.fn() } as never;
+
+    wrapFetchWithPayment(vi.fn() as never, mockWalletClient);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("x402-fetch");
+    expect(warnSpy.mock.calls[0][0]).toContain("@x402/fetch");
+
+    wrapFetchWithPayment(vi.fn() as never, mockWalletClient);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  }, 20000);
+});

--- a/typescript/packages/legacy/x402-fetch/src/index.ts
+++ b/typescript/packages/legacy/x402-fetch/src/index.ts
@@ -14,23 +14,7 @@ import {
   PaymentRequirementsSelector,
   selectPaymentRequirements,
 } from "x402/client";
-
-let hasWarnedLegacyDeprecation = false;
-
-/**
- * Warns once per process that this package is the frozen x402 protocol v1
- * implementation.
- */
-function warnLegacyDeprecation(): void {
-  if (hasWarnedLegacyDeprecation) return;
-  hasWarnedLegacyDeprecation = true;
-  console.warn(
-    '[x402-fetch] DEPRECATED: "x402-fetch" is the x402 protocol v1 client implementation and ' +
-      "is frozen. It will not interoperate with servers that only advertise payment terms via " +
-      'the v2 "PAYMENT-REQUIRED" header. Please migrate to "@x402/fetch": ' +
-      "https://www.npmjs.com/package/@x402/fetch",
-  );
-}
+import { warnLegacyDeprecation } from "x402/shared";
 
 /**
  * Enables the payment of APIs using the x402 payment protocol.
@@ -76,7 +60,7 @@ export function wrapFetchWithPayment(
   paymentRequirementsSelector: PaymentRequirementsSelector = selectPaymentRequirements,
   config?: X402Config,
 ) {
-  warnLegacyDeprecation();
+  warnLegacyDeprecation("x402-fetch", "@x402/fetch", "client");
 
   return async (input: RequestInfo, init?: RequestInit) => {
     const response = await fetch(input, init);

--- a/typescript/packages/legacy/x402-fetch/src/index.ts
+++ b/typescript/packages/legacy/x402-fetch/src/index.ts
@@ -15,6 +15,23 @@ import {
   selectPaymentRequirements,
 } from "x402/client";
 
+let hasWarnedLegacyDeprecation = false;
+
+/**
+ * Warns once per process that this package is the frozen x402 protocol v1
+ * implementation.
+ */
+function warnLegacyDeprecation(): void {
+  if (hasWarnedLegacyDeprecation) return;
+  hasWarnedLegacyDeprecation = true;
+  console.warn(
+    '[x402-fetch] DEPRECATED: "x402-fetch" is the x402 protocol v1 client implementation and ' +
+      "is frozen. It will not interoperate with servers that only advertise payment terms via " +
+      'the v2 "PAYMENT-REQUIRED" header. Please migrate to "@x402/fetch": ' +
+      "https://www.npmjs.com/package/@x402/fetch",
+  );
+}
+
 /**
  * Enables the payment of APIs using the x402 payment protocol.
  *
@@ -59,6 +76,8 @@ export function wrapFetchWithPayment(
   paymentRequirementsSelector: PaymentRequirementsSelector = selectPaymentRequirements,
   config?: X402Config,
 ) {
+  warnLegacyDeprecation();
+
   return async (input: RequestInfo, init?: RequestInit) => {
     const response = await fetch(input, init);
 

--- a/typescript/packages/legacy/x402-hono/src/deprecation.test.ts
+++ b/typescript/packages/legacy/x402-hono/src/deprecation.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("x402-hono legacy deprecation warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns once on middleware construction pointing to @x402/hono", async () => {
+    const { paymentMiddleware } = await import("./index");
+
+    paymentMiddleware("0x1234567890123456789012345678901234567890", {
+      "/test": { price: "$0.01", network: "base-sepolia" },
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("x402-hono");
+    expect(warnSpy.mock.calls[0][0]).toContain("@x402/hono");
+
+    paymentMiddleware("0x1234567890123456789012345678901234567890", {
+      "/other": { price: "$0.01", network: "base-sepolia" },
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  }, 20000);
+});

--- a/typescript/packages/legacy/x402-hono/src/deprecation.test.ts
+++ b/typescript/packages/legacy/x402-hono/src/deprecation.test.ts
@@ -1,3 +1,4 @@
+import { Context } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("x402-hono legacy deprecation warning", () => {
@@ -28,5 +29,19 @@ describe("x402-hono legacy deprecation warning", () => {
     });
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
+  }, 20000);
+
+  it("warns once on session-token POST invocation pointing to @x402/hono", async () => {
+    const { POST } = await import("./session-token");
+    const mockContext = {
+      req: { json: vi.fn().mockResolvedValue({}) },
+      json: vi.fn(),
+    } as unknown as Context;
+
+    await POST(mockContext);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("x402-hono");
+    expect(warnSpy.mock.calls[0][0]).toContain("@x402/hono");
   }, 20000);
 });

--- a/typescript/packages/legacy/x402-hono/src/index.ts
+++ b/typescript/packages/legacy/x402-hono/src/index.ts
@@ -25,6 +25,23 @@ import {
 } from "x402/types";
 import { useFacilitator } from "x402/verify";
 
+let hasWarnedLegacyDeprecation = false;
+
+/**
+ * Warns once per process that this package is the frozen x402 protocol v1
+ * implementation and does not speak the v2 "PAYMENT-REQUIRED" header dialect.
+ */
+function warnLegacyDeprecation(): void {
+  if (hasWarnedLegacyDeprecation) return;
+  hasWarnedLegacyDeprecation = true;
+  console.warn(
+    '[x402-hono] DEPRECATED: "x402-hono" implements x402 protocol v1 and only emits ' +
+      'payment terms in the JSON response body. v2 clients read the "PAYMENT-REQUIRED" header ' +
+      'instead and will not be able to pay you. Please migrate to "@x402/hono": ' +
+      "https://www.npmjs.com/package/@x402/hono",
+  );
+}
+
 /**
  * Creates a payment middleware factory for Hono
  *
@@ -78,6 +95,8 @@ export function paymentMiddleware(
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
 ) {
+  warnLegacyDeprecation();
+
   const { verify, settle, supported } = useFacilitator(facilitator);
   const x402Version = 1;
 

--- a/typescript/packages/legacy/x402-hono/src/index.ts
+++ b/typescript/packages/legacy/x402-hono/src/index.ts
@@ -8,6 +8,7 @@ import {
   findMatchingRoute,
   processPriceToAtomicAmount,
   toJsonSafe,
+  warnLegacyDeprecation,
 } from "x402/shared";
 import { getPaywallHtml } from "x402/paywall";
 import {
@@ -24,23 +25,6 @@ import {
   SupportedSVMNetworks,
 } from "x402/types";
 import { useFacilitator } from "x402/verify";
-
-let hasWarnedLegacyDeprecation = false;
-
-/**
- * Warns once per process that this package is the frozen x402 protocol v1
- * implementation and does not speak the v2 "PAYMENT-REQUIRED" header dialect.
- */
-function warnLegacyDeprecation(): void {
-  if (hasWarnedLegacyDeprecation) return;
-  hasWarnedLegacyDeprecation = true;
-  console.warn(
-    '[x402-hono] DEPRECATED: "x402-hono" implements x402 protocol v1 and only emits ' +
-      'payment terms in the JSON response body. v2 clients read the "PAYMENT-REQUIRED" header ' +
-      'instead and will not be able to pay you. Please migrate to "@x402/hono": ' +
-      "https://www.npmjs.com/package/@x402/hono",
-  );
-}
 
 /**
  * Creates a payment middleware factory for Hono
@@ -95,7 +79,7 @@ export function paymentMiddleware(
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
 ) {
-  warnLegacyDeprecation();
+  warnLegacyDeprecation("x402-hono", "@x402/hono", "server");
 
   const { verify, settle, supported } = useFacilitator(facilitator);
   const x402Version = 1;

--- a/typescript/packages/legacy/x402-hono/src/session-token.ts
+++ b/typescript/packages/legacy/x402-hono/src/session-token.ts
@@ -1,5 +1,6 @@
 import { generateJwt } from "@coinbase/cdp-sdk/auth";
 import type { Context } from "hono";
+import { warnLegacyDeprecation } from "x402/shared";
 
 /**
  * Generate a session token for Coinbase Onramp and Offramp using Secure Init
@@ -15,6 +16,8 @@ import type { Context } from "hono";
  * @returns Promise<Response> - The response containing the session token or error
  */
 export async function POST(c: Context) {
+  warnLegacyDeprecation("x402-hono", "@x402/hono", "server");
+
   try {
     // Get CDP API credentials from environment variables
     const apiKeyId = process.env.CDP_API_KEY_ID;

--- a/typescript/packages/legacy/x402-next/src/deprecation.test.ts
+++ b/typescript/packages/legacy/x402-next/src/deprecation.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("x402-next legacy deprecation warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns once across paymentMiddleware and withX402, pointing to @x402/next", async () => {
+    const { paymentMiddleware, withX402 } = await import("./index");
+
+    paymentMiddleware("0x1234567890123456789012345678901234567890", {
+      "/test": { price: "$0.01", network: "base-sepolia" },
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("x402-next");
+    expect(warnSpy.mock.calls[0][0]).toContain("@x402/next");
+
+    withX402(
+      async () => new Response(null) as never,
+      "0x1234567890123456789012345678901234567890",
+      {
+        price: "$0.01",
+        network: "base-sepolia",
+      },
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  }, 20000);
+});

--- a/typescript/packages/legacy/x402-next/src/index.ts
+++ b/typescript/packages/legacy/x402-next/src/index.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { Address } from "viem";
 import type { Address as SolanaAddress } from "@solana/kit";
-import { computeRoutePatterns, findMatchingRoute } from "x402/shared";
+import { computeRoutePatterns, findMatchingRoute, warnLegacyDeprecation } from "x402/shared";
 import { FacilitatorConfig, Resource, RoutesConfig, RouteConfig, PaywallConfig } from "x402/types";
 import { useFacilitator } from "x402/verify";
 
@@ -13,23 +13,6 @@ import {
   verifyPayment,
   settlePayment,
 } from "./utils";
-
-let hasWarnedLegacyDeprecation = false;
-
-/**
- * Warns once per process that this package is the frozen x402 protocol v1
- * implementation and does not speak the v2 "PAYMENT-REQUIRED" header dialect.
- */
-function warnLegacyDeprecation(): void {
-  if (hasWarnedLegacyDeprecation) return;
-  hasWarnedLegacyDeprecation = true;
-  console.warn(
-    '[x402-next] DEPRECATED: "x402-next" implements x402 protocol v1 and only emits ' +
-      'payment terms in the JSON response body. v2 clients read the "PAYMENT-REQUIRED" header ' +
-      'instead and will not be able to pay you. Please migrate to "@x402/next": ' +
-      "https://www.npmjs.com/package/@x402/next",
-  );
-}
 
 /**
  * Creates a payment middleware factory for Next.js
@@ -99,7 +82,7 @@ export function paymentMiddleware(
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
 ) {
-  warnLegacyDeprecation();
+  warnLegacyDeprecation("x402-next", "@x402/next", "server");
 
   const { verify, settle, supported } = useFacilitator(facilitator);
   const x402Version = 1;
@@ -264,7 +247,7 @@ export function withX402<T = unknown>(
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
 ): (request: NextRequest) => Promise<NextResponse<T | unknown>> {
-  warnLegacyDeprecation();
+  warnLegacyDeprecation("x402-next", "@x402/next", "server");
 
   const { verify, settle, supported } = useFacilitator(facilitator);
   const x402Version = 1;

--- a/typescript/packages/legacy/x402-next/src/index.ts
+++ b/typescript/packages/legacy/x402-next/src/index.ts
@@ -14,6 +14,23 @@ import {
   settlePayment,
 } from "./utils";
 
+let hasWarnedLegacyDeprecation = false;
+
+/**
+ * Warns once per process that this package is the frozen x402 protocol v1
+ * implementation and does not speak the v2 "PAYMENT-REQUIRED" header dialect.
+ */
+function warnLegacyDeprecation(): void {
+  if (hasWarnedLegacyDeprecation) return;
+  hasWarnedLegacyDeprecation = true;
+  console.warn(
+    '[x402-next] DEPRECATED: "x402-next" implements x402 protocol v1 and only emits ' +
+      'payment terms in the JSON response body. v2 clients read the "PAYMENT-REQUIRED" header ' +
+      'instead and will not be able to pay you. Please migrate to "@x402/next": ' +
+      "https://www.npmjs.com/package/@x402/next",
+  );
+}
+
 /**
  * Creates a payment middleware factory for Next.js
  *
@@ -82,6 +99,8 @@ export function paymentMiddleware(
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
 ) {
+  warnLegacyDeprecation();
+
   const { verify, settle, supported } = useFacilitator(facilitator);
   const x402Version = 1;
 
@@ -245,6 +264,8 @@ export function withX402<T = unknown>(
   facilitator?: FacilitatorConfig,
   paywall?: PaywallConfig,
 ): (request: NextRequest) => Promise<NextResponse<T | unknown>> {
+  warnLegacyDeprecation();
+
   const { verify, settle, supported } = useFacilitator(facilitator);
   const x402Version = 1;
 

--- a/typescript/packages/legacy/x402/package.json
+++ b/typescript/packages/legacy/x402/package.json
@@ -65,6 +65,16 @@
     "zod": "^3.24.2"
   },
   "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.mts",
+        "default": "./dist/esm/index.mjs"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    },
     "./shared": {
       "import": {
         "types": "./dist/esm/shared/index.d.mts",

--- a/typescript/packages/legacy/x402/src/deprecation.test.ts
+++ b/typescript/packages/legacy/x402/src/deprecation.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("x402 legacy deprecation warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns once on module load pointing to @x402/core", async () => {
+    await import("./index");
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("x402");
+    expect(warnSpy.mock.calls[0][0]).toContain("@x402/core");
+  }, 20000);
+});

--- a/typescript/packages/legacy/x402/src/index.ts
+++ b/typescript/packages/legacy/x402/src/index.ts
@@ -2,3 +2,8 @@ export * from "./client";
 export * from "./facilitator";
 
 export const x402Version = 1;
+
+console.warn(
+  '[x402] DEPRECATED: "x402" is the x402 protocol v1 implementation and is frozen. ' +
+    'Please migrate to "@x402/core" for x402 protocol v2 support: https://www.npmjs.com/package/@x402/core',
+);

--- a/typescript/packages/legacy/x402/src/index.ts
+++ b/typescript/packages/legacy/x402/src/index.ts
@@ -1,9 +1,8 @@
+import { warnLegacyDeprecation } from "./shared/deprecation";
+
 export * from "./client";
 export * from "./facilitator";
 
 export const x402Version = 1;
 
-console.warn(
-  '[x402] DEPRECATED: "x402" is the x402 protocol v1 implementation and is frozen. ' +
-    'Please migrate to "@x402/core" for x402 protocol v2 support: https://www.npmjs.com/package/@x402/core',
-);
+warnLegacyDeprecation("x402", "@x402/core", "core");

--- a/typescript/packages/legacy/x402/src/shared/deprecation.test.ts
+++ b/typescript/packages/legacy/x402/src/shared/deprecation.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { warnLegacyDeprecation } from "./deprecation";
+
+describe("warnLegacyDeprecation", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    delete process.env.X402_SUPPRESS_LEGACY_WARNING;
+  });
+
+  const cases = [
+    {
+      pkg: "x402-shared-test-core",
+      replacement: "@x402/core",
+      kind: "core" as const,
+      contains: ["v1 implementation and is frozen", "@x402/core"],
+    },
+    {
+      pkg: "x402-shared-test-axios",
+      replacement: "@x402/axios",
+      kind: "client" as const,
+      contains: ["v1 client implementation", "PAYMENT-REQUIRED", "@x402/axios"],
+    },
+    {
+      pkg: "x402-shared-test-express",
+      replacement: "@x402/express",
+      kind: "server" as const,
+      contains: ["JSON response body", "PAYMENT-REQUIRED", "@x402/express"],
+    },
+  ];
+
+  it.each(cases)(
+    "builds the $kind message and warns once for $pkg",
+    ({ pkg, replacement, kind, contains }) => {
+      warnLegacyDeprecation(pkg, replacement, kind);
+      warnLegacyDeprecation(pkg, replacement, kind);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = warnSpy.mock.calls[0][0] as string;
+      expect(message).toContain(`[${pkg}]`);
+      for (const substr of contains) {
+        expect(message).toContain(substr);
+      }
+    },
+  );
+
+  it("suppresses the warning when X402_SUPPRESS_LEGACY_WARNING is set", () => {
+    process.env.X402_SUPPRESS_LEGACY_WARNING = "1";
+    warnLegacyDeprecation("x402-shared-test-suppressed", "@x402/fetch", "client");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/typescript/packages/legacy/x402/src/shared/deprecation.ts
+++ b/typescript/packages/legacy/x402/src/shared/deprecation.ts
@@ -1,0 +1,34 @@
+const warnedPackages = new Set<string>();
+
+export type LegacyDeprecationKind = "core" | "client" | "server";
+
+/**
+ * Warns once per process that a legacy x402 v1 package is frozen and should migrate to its
+ * v2 replacement. Set X402_SUPPRESS_LEGACY_WARNING=1 to suppress this warning.
+ *
+ * @param pkg - The legacy package name, e.g. "x402-axios"
+ * @param replacement - The v2 replacement package name, e.g. "@x402/axios"
+ * @param kind - The shape of the package: "core" (the base x402 package), "client" (outbound payment wrappers), or "server" (inbound payment middleware)
+ */
+export function warnLegacyDeprecation(
+  pkg: string,
+  replacement: string,
+  kind: LegacyDeprecationKind,
+): void {
+  if (process.env.X402_SUPPRESS_LEGACY_WARNING) return;
+  if (warnedPackages.has(pkg)) return;
+  warnedPackages.add(pkg);
+
+  const detail =
+    kind === "core"
+      ? `is the x402 protocol v1 implementation and is frozen. Please migrate to "${replacement}" for x402 protocol v2 support`
+      : kind === "client"
+        ? "is the x402 protocol v1 client implementation and is frozen. It will not interoperate with " +
+          `servers that only advertise payment terms via the v2 "PAYMENT-REQUIRED" header. Please migrate to "${replacement}"`
+        : "implements x402 protocol v1 and only emits payment terms in the JSON response body. v2 " +
+          `clients read the "PAYMENT-REQUIRED" header instead and will not be able to pay you. Please migrate to "${replacement}"`;
+
+  console.warn(
+    `[${pkg}] DEPRECATED: "${pkg}" ${detail}: https://www.npmjs.com/package/${replacement}`,
+  );
+}

--- a/typescript/packages/legacy/x402/src/shared/index.ts
+++ b/typescript/packages/legacy/x402/src/shared/index.ts
@@ -2,4 +2,5 @@ export * from "./json";
 export * from "./base64";
 export * from "./network";
 export * from "./middleware";
+export * from "./deprecation";
 export * as svm from "./svm";


### PR DESCRIPTION
Addresses #3091

## Description

The unscoped v1 packages (`x402`, `x402-express`, `x402-hono`, `x402-next`, `x402-fetch`, `x402-axios`) still install cleanly with no indication that they are frozen on the x402 protocol v1 line, while `@x402/*` carries v2 forward. As the issue notes, this causes silent interop failures: v1 servers put payment terms only in the JSON response body, while v2 clients read the `PAYMENT-REQUIRED` header, so neither side errors and the buyer just leaves.

This PR adds a one-time `console.warn` fired at middleware/client construction time (module load for `x402` core, since it has no single construction entry point):

- `x402-express` → `@x402/express`
- `x402-hono` (main entry and `session-token` entry) → `@x402/hono`
- `x402-next` (`paymentMiddleware` and `withX402`) → `@x402/next`
- `x402-fetch` → `@x402/fetch`
- `x402-axios` → `@x402/axios`
- `x402` (core) → `@x402/core`, warns on import

`x402`'s `package.json` had no `"."` export entry, so with `exports` present, `require("x402")`/`import "x402"` never resolved to the module that logs the warning — the fix now includes a `"."` export pointing at the built entry, so the warning is actually reachable from real consumers, not just internal subpath imports.

The five wrapper packages' near-identical warning logic is now a single `warnLegacyDeprecation(pkg, replacement, kind)` helper in `x402/shared`, called with each package's own name/replacement/kind instead of reimplementing the block per package. The warning is once-per-process per package name, and can be suppressed with `X402_SUPPRESS_LEGACY_WARNING=1` for hot-start environments (e.g. serverless) where a console warning per cold start is disruptive.

**Note on `npm deprecate`:** the issue's suggested fix (`npm deprecate <pkg>@"<2" "..."`) surfaces on `npm install`/`npm outdated`, which is more visible than a runtime warning, but requires npm registry publish rights I don't have as an outside contributor. This PR is the code-level alternative I can ship. If a maintainer with registry access can also run the `npm deprecate` commands, that closes the remaining gap.

This does not touch the "already-deployed endpoint" gap from the issue's second comment (adding the `PAYMENT-REQUIRED` header to existing v1 servers) — that's a separate, larger change to the legacy middleware response-building logic.

## Tests

- `x402/src/shared/deprecation.test.ts`: table-driven coverage of the shared helper's three message kinds (core/client/server), once-per-package dedup, and the `X402_SUPPRESS_LEGACY_WARNING` opt-out.
- `x402/src/deprecation.test.ts`: end-to-end check that importing `x402` still warns.
- Each wrapper package keeps a slim `deprecation.test.ts` asserting its own construction entry points call the warning with the right package/replacement/kind.
- `x402-hono/src/deprecation.test.ts` also covers the `session-token` entry point, which is a real standalone import.

Ran from `/typescript`:
```
pnpm install --filter "./packages/legacy/*" --filter x402
cd packages/legacy/x402 && npx tsup   # build core so other legacy packages resolve x402/* subpaths
cd packages/legacy/<pkg> && npx vitest run
```

All pre-existing tests plus the new/updated deprecation tests pass:
- `x402`: 20 test files, 275 tests
- `x402-express`: 3 test files, 31 tests
- `x402-hono`: 3 test files, 44 tests
- `x402-next`: 4 test files, 58 tests
- `x402-fetch`: 2 test files, 7 tests
- `x402-axios`: 2 test files, 11 tests

Also confirmed directly that `require("x402")` and `import("x402")` now trigger the warning, which they did not before this PR.

Ran `eslint --fix` (prettier + jsdoc rules) on all touched files — clean.

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [ ] My commits are signed — not currently signing commits in this environment; happy to re-sign/rebase if required for merge
- [x] No changelog fragment: these six legacy packages are unscoped and outside the Changesets `fixed` group in `typescript/.changeset/config.json`, so a changeset isn't applicable here
