### PR TITLE
fix(stellar): surface real RPC failure detail in settle response (#3125)

### DIFF
--- a/typescript/.changeset/stellar-settle-error-detail.md
+++ b/typescript/.changeset/stellar-settle-error-detail.md
@@ -1,0 +1,10 @@
+---
+'@x402/stellar': patch
+---
+
+Fixed `ExactStellarScheme.settle` collapsing every non-`PENDING` `sendTransaction`
+result into the same constant `errorReason`. The RPC's `status`, `errorResult` code,
+and `latestLedger` are now surfaced via `errorMessage`/`extra`, and a `TRY_AGAIN_LATER`
+response is reported with a distinct, retryable `errorReason`
+(`settle_exact_stellar_transaction_submission_retryable`) instead of being treated as
+a terminal failure identical to `ERROR`.

--- a/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/stellar/src/exact/facilitator/scheme.ts
@@ -326,12 +326,28 @@ export class ExactStellarScheme implements SchemeNetworkFacilitator {
       const sendResult = await server.sendTransaction(txToSubmit);
 
       if (sendResult.status !== "PENDING") {
+        // TRY_AGAIN_LATER means nothing reached a ledger and nothing was spent, so
+        // the caller can safely retry. Every other non-PENDING status (e.g. ERROR)
+        // is terminal for this payload and must not be retried as-is.
+        const isRetryable = sendResult.status === "TRY_AGAIN_LATER";
+        const errorResultCode = sendResult.errorResult?.result().switch().name;
         return {
           success: false,
           network: payload.accepted.network,
           transaction: "",
-          errorReason: "settle_exact_stellar_transaction_submission_failed",
+          errorReason: isRetryable
+            ? "settle_exact_stellar_transaction_submission_retryable"
+            : "settle_exact_stellar_transaction_submission_failed",
+          errorMessage: `Soroban RPC sendTransaction returned status ${sendResult.status}${
+            errorResultCode ? ` (${errorResultCode})` : ""
+          }`,
           payer,
+          extra: {
+            rpcStatus: sendResult.status,
+            retryable: isRetryable,
+            latestLedger: sendResult.latestLedger,
+            ...(errorResultCode ? { errorResultCode } : {}),
+          },
         };
       }
 

--- a/typescript/packages/mechanisms/stellar/test/unit/facilitator-settle.test.ts
+++ b/typescript/packages/mechanisms/stellar/test/unit/facilitator-settle.test.ts
@@ -8,6 +8,7 @@ import {
   FeeBumpTransaction,
   Transaction,
   BASE_FEE,
+  xdr,
 } from "@stellar/stellar-sdk";
 import { Api } from "@stellar/stellar-sdk/rpc";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -200,10 +201,41 @@ describe("ExactStellarScheme - Settle (randomly using 1-2 facilitator signers)",
       });
     });
 
-    it("should return error when transaction submission returns non-PENDING status", async () => {
+    it("should surface a retryable errorReason and RPC status when submission returns TRY_AGAIN_LATER", async () => {
       vi.mocked(mockServer.sendTransaction).mockResolvedValue({
         status: "TRY_AGAIN_LATER",
         hash: "",
+        latestLedger: 4085901,
+      } as Api.SendTransactionResponse);
+
+      const result = await facilitator.settle(validPayload, validRequirements);
+
+      expect(result).toEqual({
+        success: false,
+        errorReason: "settle_exact_stellar_transaction_submission_retryable",
+        errorMessage: "Soroban RPC sendTransaction returned status TRY_AGAIN_LATER",
+        payer: CLIENT_PUBLIC,
+        network: STELLAR_TESTNET_CAIP2,
+        transaction: "",
+        extra: {
+          rpcStatus: "TRY_AGAIN_LATER",
+          retryable: true,
+          latestLedger: 4085901,
+        },
+      });
+    });
+
+    it("should surface a terminal errorReason and the RPC error result when submission returns ERROR", async () => {
+      const errorResult = new xdr.TransactionResult({
+        feeCharged: new xdr.Int64(32755),
+        result: xdr.TransactionResultResult.txBadSeq(),
+        ext: new xdr.TransactionResultExt(0),
+      });
+      vi.mocked(mockServer.sendTransaction).mockResolvedValue({
+        status: "ERROR",
+        hash: "",
+        latestLedger: 4085902,
+        errorResult,
       } as Api.SendTransactionResponse);
 
       const result = await facilitator.settle(validPayload, validRequirements);
@@ -211,9 +243,16 @@ describe("ExactStellarScheme - Settle (randomly using 1-2 facilitator signers)",
       expect(result).toEqual({
         success: false,
         errorReason: "settle_exact_stellar_transaction_submission_failed",
+        errorMessage: "Soroban RPC sendTransaction returned status ERROR (txBadSeq)",
         payer: CLIENT_PUBLIC,
         network: STELLAR_TESTNET_CAIP2,
         transaction: "",
+        extra: {
+          rpcStatus: "ERROR",
+          retryable: false,
+          latestLedger: 4085902,
+          errorResultCode: "txBadSeq",
+        },
       });
     });
 


### PR DESCRIPTION
Closes #3125

## Description

`ExactStellarScheme.settle` collapsed every non-`PENDING` `sendTransaction` result into a single constant `errorReason` (`settle_exact_stellar_transaction_submission_failed`), discarding the RPC's `status`, `errorResult`, and `latestLedger`. That erased the distinction between:

- `TRY_AGAIN_LATER` — nothing reached a ledger, nothing was spent, safe to retry
- `ERROR` (e.g. `txBadSeq`) — terminal, the payload must not be resubmitted

Both surfaced identically to callers, so a facilitator operator (or anything downstream) couldn't tell a transient RPC refusal from a dead payload.

This PR passes the real RPC detail through the **existing** `errorMessage`/`extra` fields already defined on `SettleResponse` (no schema change):

- `extra.rpcStatus` — the raw Soroban RPC `SendTransactionStatus`
- `extra.retryable` — `true` only for `TRY_AGAIN_LATER`
- `extra.latestLedger` — the ledger reported alongside the result
- `extra.errorResultCode` — the `TransactionResult` result-code name (e.g. `txBadSeq`), when present
- `errorMessage` — a human-readable summary of the above

`TRY_AGAIN_LATER` now gets its own `errorReason` (`settle_exact_stellar_transaction_submission_retryable`) instead of reusing the terminal-failure string, so existing consumers matching on `settle_exact_stellar_transaction_submission_failed` for genuine terminal errors are unaffected — only the previously-collapsed `TRY_AGAIN_LATER` case changes its `errorReason`.

Includes a Changesets fragment (`typescript/.changeset/stellar-settle-error-detail.md`).

## Tests

Added two unit tests in `typescript/packages/mechanisms/stellar/test/unit/facilitator-settle.test.ts` mocking `sendTransaction`:

- `TRY_AGAIN_LATER` → asserts `errorReason: settle_exact_stellar_transaction_submission_retryable` and `extra.retryable: true`
- `ERROR` with a `txBadSeq` `errorResult` → asserts `errorReason: settle_exact_stellar_transaction_submission_failed`, `extra.errorResultCode: "txBadSeq"`, and the `errorMessage` text

Updated the pre-existing "non-PENDING status" test to match the new, more specific behavior.

Ran, from `typescript/`:

```
pnpm --filter @x402/core build
pnpm --filter @x402/stellar test        # 10 files, 162 tests passed
pnpm --filter @x402/stellar lint        # clean
pnpm --filter @x402/stellar format      # clean
pnpm --filter @x402/stellar build       # tsup + type-check clean
```

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] I added a changelog fragment (`typescript/.changeset/stellar-settle-error-detail.md`)