### PR TITLE
fix(evm): sign/verify/settle EIP-3009 payments against extra.verifyingContract (TS)

### DIFF
--- a/typescript/.changeset/verifying-contract-eip3009.md
+++ b/typescript/.changeset/verifying-contract-eip3009.md
@@ -1,0 +1,5 @@
+---
+'@x402/evm': patch
+---
+
+Fixed EIP-3009 client signing and facilitator verify/settle against `requirements.asset` unconditionally, ignoring a seller-supplied `extra.verifyingContract` (e.g. Circle Gateway's batch-settlement contract). Trusting `extra.verifyingContract` is opt-in via a `verifyingContractValidator` callback on `ExactEvmScheme`/`ExactEvmSchemeV1` (client and facilitator); by default (no validator supplied) signing, verification, and settlement still always use the asset address, matching prior behavior.

--- a/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/eip3009.ts
@@ -6,17 +6,54 @@ import { ExactEIP3009Payload } from "../../types";
 import { createNonce, getEvmChainId } from "../../utils";
 
 /**
+ * Validates a seller-supplied extra.verifyingContract before it is trusted for EIP-712 signing.
+ *
+ * @param candidate - The address from requirements.extra.verifyingContract
+ * @param requirements - The full payment requirements, for context (e.g. network)
+ * @returns True to sign against `candidate`. False to fall back to requirements.asset, same as
+ *   if no verifyingContract were supplied.
+ */
+export type VerifyingContractValidator = (
+  candidate: string,
+  requirements: PaymentRequirements,
+) => boolean;
+
+/**
+ * Resolve the EIP-712 verifyingContract for signing. Defaults to requirements.asset. Only trusts
+ * a seller-supplied extra.verifyingContract if a validator was supplied and it approves this
+ * specific candidate.
+ *
+ * @param requirements - The payment requirements
+ * @param validator - Optional validator to trust extra.verifyingContract
+ * @returns The address to use as the EIP-712 domain's verifyingContract
+ */
+function resolveVerifyingContract(
+  requirements: PaymentRequirements,
+  validator?: VerifyingContractValidator,
+): `0x${string}` {
+  const candidate = requirements.extra?.verifyingContract as string | undefined;
+  if (!candidate || !validator || !validator(candidate, requirements)) {
+    return getAddress(requirements.asset);
+  }
+  return getAddress(candidate);
+}
+
+/**
  * Creates an EIP-3009 (transferWithAuthorization) payload.
  *
  * @param signer - The EVM signer for client operations
  * @param x402Version - The x402 protocol version
  * @param paymentRequirements - The payment requirements
+ * @param verifyingContractValidator - Optional callback to trust a seller-supplied
+ *   extra.verifyingContract (e.g. Circle Gateway's batch-settlement contract) instead of
+ *   requirements.asset. If not provided, extra.verifyingContract is never trusted.
  * @returns Promise resolving to a payment payload result
  */
 export async function createEIP3009Payload(
   signer: ClientEvmSigner,
   x402Version: number,
   paymentRequirements: PaymentRequirements,
+  verifyingContractValidator?: VerifyingContractValidator,
 ): Promise<PaymentPayloadResult> {
   const nonce = createNonce();
   const now = Math.floor(Date.now() / 1000);
@@ -30,7 +67,12 @@ export async function createEIP3009Payload(
     nonce,
   };
 
-  const signature = await signEIP3009Authorization(signer, authorization, paymentRequirements);
+  const signature = await signEIP3009Authorization(
+    signer,
+    authorization,
+    paymentRequirements,
+    verifyingContractValidator,
+  );
 
   const payload: ExactEIP3009Payload = {
     authorization,
@@ -49,12 +91,14 @@ export async function createEIP3009Payload(
  * @param signer - The EVM signer
  * @param authorization - The authorization to sign
  * @param requirements - The payment requirements
+ * @param verifyingContractValidator - Optional callback to trust extra.verifyingContract
  * @returns Promise resolving to the signature
  */
 async function signEIP3009Authorization(
   signer: ClientEvmSigner,
   authorization: ExactEIP3009Payload["authorization"],
   requirements: PaymentRequirements,
+  verifyingContractValidator?: VerifyingContractValidator,
 ): Promise<`0x${string}`> {
   const chainId = getEvmChainId(requirements.network);
 
@@ -70,7 +114,7 @@ async function signEIP3009Authorization(
     name,
     version,
     chainId,
-    verifyingContract: getAddress(requirements.asset),
+    verifyingContract: resolveVerifyingContract(requirements, verifyingContractValidator),
   };
 
   const message = {

--- a/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/client/scheme.ts
@@ -6,7 +6,7 @@ import {
 } from "@x402/core/types";
 import { ClientEvmSigner } from "../../signer";
 import { AssetTransferMethod } from "../../types";
-import { createEIP3009Payload } from "./eip3009";
+import { createEIP3009Payload, VerifyingContractValidator } from "./eip3009";
 import { createPermit2Payload } from "./permit2";
 import {
   trySignEip2612PermitExtension,
@@ -39,10 +39,16 @@ export class ExactEvmScheme implements SchemeNetworkClient {
    *   Extension enrichment (EIP-2612 / ERC-20 approval sponsoring) additionally
    *   requires optional capabilities like `readContract` and tx signing helpers.
    * @param options - Optional RPC configuration used to backfill extension capabilities.
+   * @param verifyingContractValidator - Optional callback invoked when a payment requirement's
+   *   extra.verifyingContract differs from requirements.asset (e.g. Circle Gateway's
+   *   batch-settlement contract). Receives the candidate address and the requirements, and must
+   *   return true to trust it for EIP-712 signing (EIP-3009 flow only). If not provided (default),
+   *   extra.verifyingContract is never trusted and signing always uses requirements.asset.
    */
   constructor(
     private readonly signer: ClientEvmSigner,
     private readonly options?: EvmSchemeOptions,
+    private readonly verifyingContractValidator?: VerifyingContractValidator,
   ) {}
 
   /**
@@ -100,6 +106,11 @@ export class ExactEvmScheme implements SchemeNetworkClient {
       return result;
     }
 
-    return createEIP3009Payload(this.signer, x402Version, paymentRequirements);
+    return createEIP3009Payload(
+      this.signer,
+      x402Version,
+      paymentRequirements,
+      this.verifyingContractValidator,
+    );
   }
 }

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/eip3009.ts
@@ -26,6 +26,20 @@ export interface VerifyEIP3009Options {
   simulate?: boolean;
 }
 
+/**
+ * Validates a seller-supplied extra.verifyingContract before the facilitator trusts it as the
+ * contract to verify against and settle through.
+ *
+ * @param candidate - The address from requirements.extra.verifyingContract
+ * @param requirements - The full payment requirements, for context (e.g. network)
+ * @returns True to verify and settle against `candidate`. False to fall back to
+ *   requirements.asset, same as if no verifyingContract were supplied.
+ */
+export type VerifyingContractValidator = (
+  candidate: string,
+  requirements: PaymentRequirements,
+) => boolean;
+
 export interface EIP3009FacilitatorConfig {
   /**
    * Allowlist of factory contract addresses (hex strings, case-insensitive) that the facilitator
@@ -45,6 +59,38 @@ export interface EIP3009FacilitatorConfig {
    * @default false
    */
   simulateInSettle?: boolean;
+  /**
+   * Optional callback invoked when a payment requirement's extra.verifyingContract differs from
+   * requirements.asset (e.g. Circle Gateway's batch-settlement contract). Receives the candidate
+   * address and the requirements, and must return true to trust it.
+   *
+   * When trusted, the candidate replaces requirements.asset everywhere this facilitator resolves
+   * the payment's contract: the EIP-712 domain checked during verify, the deployed-code check,
+   * the transfer simulation, and the on-chain transferWithAuthorization call during settle. If
+   * not provided (default), extra.verifyingContract is never trusted and requirements.asset is
+   * always used, matching pre-existing behavior.
+   */
+  verifyingContractValidator?: VerifyingContractValidator;
+}
+
+/**
+ * Resolve the contract to verify and settle against. Defaults to requirements.asset. Only trusts
+ * a seller-supplied extra.verifyingContract if a validator was configured and it approves this
+ * specific candidate.
+ *
+ * @param requirements - The payment requirements
+ * @param validator - Optional validator to trust extra.verifyingContract
+ * @returns The address to verify and settle against
+ */
+function resolveVerifyingContract(
+  requirements: PaymentRequirements,
+  validator?: VerifyingContractValidator,
+): `0x${string}` {
+  const candidate = requirements.extra?.verifyingContract as string | undefined;
+  if (!candidate || !validator || !validator(candidate, requirements)) {
+    return getAddress(requirements.asset);
+  }
+  return getAddress(candidate);
 }
 
 /**
@@ -57,6 +103,8 @@ export interface EIP3009FacilitatorConfig {
  * @param options - Optional verification options
  * @param allowedFactories - Allowlisted ERC-6492 factory addresses; a counterfactual payment whose
  *   factory is not in this list is rejected here so verify mirrors settle's policy gate.
+ * @param verifyingContractValidator - Optional callback to trust extra.verifyingContract instead
+ *   of requirements.asset for both signature verification and settlement.
  * @returns Promise resolving to verification response
  */
 export async function verifyEIP3009(
@@ -66,6 +114,7 @@ export async function verifyEIP3009(
   eip3009Payload: ExactEIP3009Payload,
   options?: VerifyEIP3009Options,
   allowedFactories: string[] = [],
+  verifyingContractValidator?: VerifyingContractValidator,
 ): Promise<VerifyResponse> {
   const payer = eip3009Payload.authorization.from;
   let eip6492Deployment:
@@ -91,7 +140,7 @@ export async function verifyEIP3009(
   }
 
   const { name, version } = requirements.extra as { name: string; version: string };
-  const erc20Address = getAddress(requirements.asset);
+  const erc20Address = resolveVerifyingContract(requirements, verifyingContractValidator);
 
   // Verify network matches
   if (payload.accepted.network !== requirements.network) {
@@ -269,6 +318,7 @@ export async function settleEIP3009(
   context?: FacilitatorContext,
 ): Promise<SettleResponse> {
   const payer = eip3009Payload.authorization.from;
+  const erc20Address = resolveVerifyingContract(requirements, config.verifyingContractValidator);
 
   // Re-verify before settling
   const valid = await verifyEIP3009(
@@ -278,6 +328,7 @@ export async function settleEIP3009(
     eip3009Payload,
     { simulate: config.simulateInSettle ?? false },
     config.eip6492AllowedFactories ?? [],
+    config.verifyingContractValidator,
   );
   if (!valid.isValid) {
     return {
@@ -371,7 +422,7 @@ export async function settleEIP3009(
 
     const tx = await executeTransferWithAuthorization(
       signer,
-      getAddress(requirements.asset),
+      erc20Address,
       settlePayload,
       dataSuffix,
     );
@@ -394,7 +445,7 @@ export async function settleEIP3009(
     const auth = eip3009Payload.authorization;
     if (
       receipt.logs != null &&
-      !verifyEip3009TransferEvent(receipt.logs, getAddress(requirements.asset), {
+      !verifyEip3009TransferEvent(receipt.logs, erc20Address, {
         from: getAddress(auth.from),
         to: getAddress(auth.to),
         value: BigInt(auth.value),

--- a/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/facilitator/scheme.ts
@@ -8,7 +8,7 @@ import {
 } from "@x402/core/types";
 import { FacilitatorEvmSigner } from "../../signer";
 import { ExactEvmPayloadV2, ExactEIP3009Payload, isPermit2Payload } from "../../types";
-import { verifyEIP3009, settleEIP3009 } from "./eip3009";
+import { verifyEIP3009, settleEIP3009, VerifyingContractValidator } from "./eip3009";
 import { verifyPermit2, settlePermit2 } from "./permit2";
 
 export interface ExactEvmSchemeConfig {
@@ -28,6 +28,12 @@ export interface ExactEvmSchemeConfig {
    * @default false
    */
   simulateInSettle?: boolean;
+  /**
+   * Optional callback to trust a seller-supplied extra.verifyingContract (EIP-3009 flow only)
+   * instead of requirements.asset, for both verification and settlement. See
+   * `VerifyingContractValidator` in `./eip3009` for the full contract. Not trusted by default.
+   */
+  verifyingContractValidator?: VerifyingContractValidator;
 }
 
 /**
@@ -39,7 +45,8 @@ export interface ExactEvmSchemeConfig {
 export class ExactEvmScheme implements SchemeNetworkFacilitator {
   readonly scheme = "exact";
   readonly caipFamily = "eip155:*";
-  private readonly config: Required<ExactEvmSchemeConfig>;
+  private readonly config: Required<Omit<ExactEvmSchemeConfig, "verifyingContractValidator">> &
+    Pick<ExactEvmSchemeConfig, "verifyingContractValidator">;
 
   /**
    * Creates a new ExactEvmScheme facilitator instance.
@@ -54,6 +61,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
     this.config = {
       eip6492AllowedFactories: config?.eip6492AllowedFactories ?? [],
       simulateInSettle: config?.simulateInSettle ?? false,
+      verifyingContractValidator: config?.verifyingContractValidator,
     };
   }
 
@@ -107,6 +115,7 @@ export class ExactEvmScheme implements SchemeNetworkFacilitator {
       eip3009Payload,
       undefined,
       this.config.eip6492AllowedFactories,
+      this.config.verifyingContractValidator,
     );
   }
 

--- a/typescript/packages/mechanisms/evm/src/exact/v1/client/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/client/scheme.ts
@@ -14,6 +14,19 @@ import { findDefaultAsset } from "../../../defaultAssets";
 import { EvmNetworkV1, getEvmChainIdV1 } from "../../../v1";
 
 /**
+ * Validates a seller-supplied extra.verifyingContract before it is trusted for EIP-712 signing.
+ *
+ * @param candidate - The address from requirements.extra.verifyingContract
+ * @param requirements - The full V1 payment requirements, for context (e.g. network)
+ * @returns True to sign against `candidate`. False to fall back to requirements.asset, same as
+ *   if no verifyingContract were supplied.
+ */
+export type VerifyingContractValidator = (
+  candidate: string,
+  requirements: PaymentRequirementsV1,
+) => boolean;
+
+/**
  * EVM client implementation for the Exact payment scheme (V1).
  */
 export class ExactEvmSchemeV1 implements SchemeNetworkClient {
@@ -24,8 +37,16 @@ export class ExactEvmSchemeV1 implements SchemeNetworkClient {
    * Creates a new ExactEvmClientV1 instance.
    *
    * @param signer - The EVM signer for client operations
+   * @param verifyingContractValidator - Optional callback invoked when a payment requirement's
+   *   extra.verifyingContract differs from requirements.asset. Receives the candidate address and
+   *   the requirements, and must return true to trust it for EIP-712 signing. If not provided
+   *   (default), extra.verifyingContract is never trusted and signing always uses
+   *   requirements.asset.
    */
-  constructor(private readonly signer: ClientEvmSigner) {}
+  constructor(
+    private readonly signer: ClientEvmSigner,
+    private readonly verifyingContractValidator?: VerifyingContractValidator,
+  ) {}
 
   /**
    * Creates a payment payload for the Exact scheme (V1).
@@ -90,11 +111,17 @@ export class ExactEvmSchemeV1 implements SchemeNetworkClient {
 
     const { name, version } = requirements.extra;
 
+    const candidate = requirements.extra?.verifyingContract as string | undefined;
+    const trusted =
+      candidate && this.verifyingContractValidator?.(candidate, requirements)
+        ? candidate
+        : requirements.asset;
+
     const domain = {
       name,
       version,
       chainId,
-      verifyingContract: getAddress(requirements.asset),
+      verifyingContract: getAddress(trusted),
     };
 
     const message = {

--- a/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/evm/src/exact/v1/facilitator/scheme.ts
@@ -28,6 +28,20 @@ export interface VerifyV1Options {
   simulate?: boolean;
 }
 
+/**
+ * Validates a seller-supplied extra.verifyingContract before the facilitator trusts it as the
+ * contract to verify against and settle through.
+ *
+ * @param candidate - The address from requirements.extra.verifyingContract
+ * @param requirements - The full V1 payment requirements, for context (e.g. network)
+ * @returns True to verify and settle against `candidate`. False to fall back to
+ *   requirements.asset, same as if no verifyingContract were supplied.
+ */
+export type VerifyingContractValidator = (
+  candidate: string,
+  requirements: PaymentRequirementsV1,
+) => boolean;
+
 export interface ExactEvmSchemeV1Config {
   /**
    * Allowlist of factory contract addresses (hex strings, case-insensitive) that the facilitator
@@ -47,6 +61,31 @@ export interface ExactEvmSchemeV1Config {
    * @default false
    */
   simulateInSettle?: boolean;
+  /**
+   * Optional callback to trust a seller-supplied extra.verifyingContract instead of
+   * requirements.asset, for both verification and settlement. Not trusted by default.
+   */
+  verifyingContractValidator?: VerifyingContractValidator;
+}
+
+/**
+ * Resolve the contract to verify and settle against. Defaults to requirements.asset. Only trusts
+ * a seller-supplied extra.verifyingContract if a validator was configured and it approves this
+ * specific candidate.
+ *
+ * @param requirements - The V1 payment requirements
+ * @param validator - Optional validator to trust extra.verifyingContract
+ * @returns The address to verify and settle against
+ */
+function resolveVerifyingContract(
+  requirements: PaymentRequirementsV1,
+  validator?: VerifyingContractValidator,
+): `0x${string}` {
+  const candidate = requirements.extra?.verifyingContract as string | undefined;
+  if (!candidate || !validator || !validator(candidate, requirements)) {
+    return getAddress(requirements.asset);
+  }
+  return getAddress(candidate);
 }
 
 /**
@@ -55,7 +94,8 @@ export interface ExactEvmSchemeV1Config {
 export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
   readonly scheme = "exact";
   readonly caipFamily = "eip155:*";
-  private readonly config: Required<ExactEvmSchemeV1Config>;
+  private readonly config: Required<Omit<ExactEvmSchemeV1Config, "verifyingContractValidator">> &
+    Pick<ExactEvmSchemeV1Config, "verifyingContractValidator">;
 
   /**
    * Creates a new ExactEvmFacilitatorV1 instance.
@@ -70,6 +110,7 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
     this.config = {
       eip6492AllowedFactories: config?.eip6492AllowedFactories ?? [],
       simulateInSettle: config?.simulateInSettle ?? false,
+      verifyingContractValidator: config?.verifyingContractValidator,
     };
   }
 
@@ -123,7 +164,12 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
     context?: FacilitatorContext,
   ): Promise<SettleResponse> {
     const payloadV1 = payload as unknown as PaymentPayloadV1;
+    const requirementsV1 = requirements as unknown as PaymentRequirementsV1;
     const exactEvmPayload = payload.payload as ExactEvmPayloadV1;
+    const erc20Address = resolveVerifyingContract(
+      requirementsV1,
+      this.config.verifyingContractValidator,
+    );
 
     // Re-verify before settling
     const valid = await this._verify(payload, requirements, {
@@ -208,7 +254,7 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
 
       const tx = await executeTransferWithAuthorization(
         this.signer,
-        getAddress(requirements.asset),
+        erc20Address,
         exactEvmPayload,
         dataSuffix,
       );
@@ -231,7 +277,7 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
       const auth = exactEvmPayload.authorization;
       if (
         receipt.logs != null &&
-        !verifyEip3009TransferEvent(receipt.logs, getAddress(requirements.asset), {
+        !verifyEip3009TransferEvent(receipt.logs, erc20Address, {
           from: getAddress(auth.from),
           to: getAddress(auth.to),
           value: BigInt(auth.value),
@@ -314,7 +360,10 @@ export class ExactEvmSchemeV1 implements SchemeNetworkFacilitator {
     }
 
     const { name, version } = requirements.extra as { name: string; version: string };
-    const erc20Address = getAddress(requirements.asset);
+    const erc20Address = resolveVerifyingContract(
+      requirementsV1,
+      this.config.verifyingContractValidator,
+    );
 
     // Verify network matches
     if (payloadV1.network !== requirements.network) {

--- a/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/client.test.ts
@@ -930,3 +930,78 @@ describe("registerExactEvmScheme", () => {
     expect(getRegisteredNetworks(client, 1).sort()).toEqual([...NETWORKS].sort());
   });
 });
+
+describe("ExactEvmScheme verifyingContractValidator", () => {
+  const GATEWAY_CONTRACT = "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE";
+  const USDC_ASSET = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+  let mockSigner: ClientEvmSigner;
+  let requirements: PaymentRequirements;
+
+  beforeEach(() => {
+    mockSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature123456789"),
+      readContract: vi.fn().mockResolvedValue(BigInt(0)),
+    };
+    requirements = {
+      scheme: "exact",
+      network: "eip155:8453",
+      amount: "8000",
+      asset: USDC_ASSET,
+      payTo: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+      maxTimeoutSeconds: 300,
+      extra: {
+        name: "GatewayWalletBatched",
+        version: "1",
+        verifyingContract: GATEWAY_CONTRACT,
+      },
+    };
+  });
+
+  it("signs against extra.verifyingContract when the validator approves it", async () => {
+    const client = new ExactEvmScheme(mockSigner, undefined, addr => addr === GATEWAY_CONTRACT);
+
+    await client.createPaymentPayload(2, requirements);
+
+    const callArgs = (mockSigner.signTypedData as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.domain.verifyingContract.toLowerCase()).toBe(GATEWAY_CONTRACT.toLowerCase());
+  });
+
+  it("falls back to requirements.asset when no validator is supplied", async () => {
+    const client = new ExactEvmScheme(mockSigner);
+
+    await client.createPaymentPayload(2, requirements);
+
+    const callArgs = (mockSigner.signTypedData as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.domain.verifyingContract.toLowerCase()).toBe(USDC_ASSET.toLowerCase());
+  });
+
+  it("falls back to requirements.asset when the validator rejects the candidate", async () => {
+    const client = new ExactEvmScheme(mockSigner, undefined, () => false);
+
+    await client.createPaymentPayload(2, requirements);
+
+    const callArgs = (mockSigner.signTypedData as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.domain.verifyingContract.toLowerCase()).toBe(USDC_ASSET.toLowerCase());
+  });
+
+  it("falls back to requirements.asset when extra.verifyingContract is absent", async () => {
+    const client = new ExactEvmScheme(mockSigner, undefined, () => true);
+    requirements.extra = { name: "USD Coin", version: "2" };
+
+    await client.createPaymentPayload(2, requirements);
+
+    const callArgs = (mockSigner.signTypedData as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.domain.verifyingContract.toLowerCase()).toBe(USDC_ASSET.toLowerCase());
+  });
+
+  it("passes the candidate and requirements to the validator", async () => {
+    const validator = vi.fn().mockReturnValue(true);
+    const client = new ExactEvmScheme(mockSigner, undefined, validator);
+
+    await client.createPaymentPayload(2, requirements);
+
+    expect(validator).toHaveBeenCalledWith(GATEWAY_CONTRACT, requirements);
+  });
+});

--- a/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/exact/facilitator.test.ts
@@ -2116,3 +2116,103 @@ describe("ExactEvmScheme (Facilitator)", () => {
     });
   });
 });
+
+describe("ExactEvmScheme (Facilitator) verifyingContractValidator", () => {
+  const GATEWAY_CONTRACT = "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE";
+  const USDC_ASSET = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+  let mockFacilitatorSigner: FacilitatorEvmSigner;
+  let client: ClientExactEvmScheme;
+  let mockClientSigner: ClientEvmSigner;
+  let requirements: PaymentRequirements;
+
+  beforeEach(() => {
+    mockClientSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+      readContract: vi.fn().mockResolvedValue(BigInt(0)),
+    };
+
+    // Default mock: every address (payer, asset, gateway) reports as a deployed contract with
+    // an always-valid isValidSignature, so these tests isolate the resolved-address wiring from
+    // signature cryptography (already covered by the client-side tests).
+    mockFacilitatorSigner = {
+      getAddresses: vi.fn().mockReturnValue(["0x742D35CC6634c0532925A3b844BC9E7595F0BEb0"]),
+      readContract: vi.fn().mockImplementation(async (args: { functionName: string }) => {
+        if (args?.functionName === "isValidSignature") return "0x1626ba7e";
+        return 0n;
+      }),
+      verifyTypedData: vi.fn().mockResolvedValue(true),
+      writeContract: vi.fn().mockResolvedValue("0xtxhash"),
+      sendTransaction: vi.fn().mockResolvedValue("0xtxhash"),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success" }),
+      getCode: vi.fn().mockResolvedValue("0x6080604052"),
+    };
+
+    requirements = {
+      scheme: "exact",
+      network: "eip155:8453",
+      amount: "8000",
+      asset: USDC_ASSET,
+      payTo: "0x742D35CC6634c0532925A3b844BC9E7595F0BEb0",
+      maxTimeoutSeconds: 300,
+      extra: {
+        name: "GatewayWalletBatched",
+        version: "1",
+        verifyingContract: GATEWAY_CONTRACT,
+      },
+    };
+  });
+
+  async function buildPayload(): Promise<PaymentPayload> {
+    client = new ClientExactEvmScheme(mockClientSigner);
+    const paymentPayload = await client.createPaymentPayload(2, requirements);
+    return {
+      ...paymentPayload,
+      accepted: requirements,
+      resource: { url: "test", description: "", mimeType: "" },
+    };
+  }
+
+  it("verifies against the resolved contract when the validator approves it", async () => {
+    const facilitator = new ExactEvmScheme(mockFacilitatorSigner, {
+      verifyingContractValidator: addr => addr === GATEWAY_CONTRACT,
+    });
+    const fullPayload = await buildPayload();
+
+    const result = await facilitator.verify(fullPayload, requirements);
+
+    expect(result.isValid).toBe(true);
+    expect(mockFacilitatorSigner.getCode).toHaveBeenCalledWith(
+      expect.objectContaining({ address: GATEWAY_CONTRACT }),
+    );
+  });
+
+  it("checks against requirements.asset when no validator is configured", async () => {
+    const facilitator = new ExactEvmScheme(mockFacilitatorSigner);
+    const fullPayload = await buildPayload();
+
+    await facilitator.verify(fullPayload, requirements);
+
+    expect(mockFacilitatorSigner.getCode).toHaveBeenCalledWith(
+      expect.objectContaining({ address: USDC_ASSET }),
+    );
+    expect(mockFacilitatorSigner.getCode).not.toHaveBeenCalledWith(
+      expect.objectContaining({ address: GATEWAY_CONTRACT }),
+    );
+  });
+
+  it("settles transferWithAuthorization against the resolved contract, not requirements.asset", async () => {
+    const facilitator = new ExactEvmScheme(mockFacilitatorSigner, {
+      verifyingContractValidator: addr => addr === GATEWAY_CONTRACT,
+    });
+    const fullPayload = await buildPayload();
+
+    const result = await facilitator.settle(fullPayload, requirements);
+
+    expect(result.success).toBe(true);
+    expect(mockFacilitatorSigner.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ address: GATEWAY_CONTRACT }),
+    );
+  });
+});

--- a/typescript/packages/mechanisms/evm/test/unit/v1/client.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/v1/client.test.ts
@@ -207,3 +207,58 @@ describe("ExactEvmSchemeV1", () => {
     });
   });
 });
+
+describe("ExactEvmSchemeV1 verifyingContractValidator", () => {
+  const GATEWAY_CONTRACT = "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE";
+  const USDC_ASSET = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+  let mockSigner: ClientEvmSigner;
+  let requirements: PaymentRequirementsV1;
+
+  beforeEach(() => {
+    mockSigner = {
+      address: "0x1234567890123456789012345678901234567890",
+      signTypedData: vi.fn().mockResolvedValue("0xmocksignature"),
+    };
+    requirements = {
+      scheme: "exact",
+      network: "base",
+      asset: USDC_ASSET,
+      maxAmountRequired: "8000",
+      payTo: "0x9876543210987654321098765432109876543210",
+      maxTimeoutSeconds: 3600,
+      extra: {
+        name: "GatewayWalletBatched",
+        version: "1",
+        verifyingContract: GATEWAY_CONTRACT,
+      },
+    };
+  });
+
+  it("signs against extra.verifyingContract when the validator approves it", async () => {
+    const client = new ExactEvmSchemeV1(mockSigner, addr => addr === GATEWAY_CONTRACT);
+
+    await client.createPaymentPayload(1, requirements as never);
+
+    const callArgs = (mockSigner.signTypedData as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.domain.verifyingContract.toLowerCase()).toBe(GATEWAY_CONTRACT.toLowerCase());
+  });
+
+  it("falls back to requirements.asset when no validator is supplied", async () => {
+    const client = new ExactEvmSchemeV1(mockSigner);
+
+    await client.createPaymentPayload(1, requirements as never);
+
+    const callArgs = (mockSigner.signTypedData as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.domain.verifyingContract.toLowerCase()).toBe(USDC_ASSET.toLowerCase());
+  });
+
+  it("falls back to requirements.asset when the validator rejects the candidate", async () => {
+    const client = new ExactEvmSchemeV1(mockSigner, () => false);
+
+    await client.createPaymentPayload(1, requirements as never);
+
+    const callArgs = (mockSigner.signTypedData as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArgs.domain.verifyingContract.toLowerCase()).toBe(USDC_ASSET.toLowerCase());
+  });
+});

--- a/typescript/packages/mechanisms/evm/test/unit/v1/facilitator.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/v1/facilitator.test.ts
@@ -391,3 +391,91 @@ describe("ExactEvmSchemeV1", () => {
     });
   });
 });
+
+describe("ExactEvmSchemeV1 verifyingContractValidator", () => {
+  const GATEWAY_CONTRACT = "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE";
+  const USDC_ASSET = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+  let mockSigner: FacilitatorEvmSigner;
+  let payload: PaymentPayloadV1;
+  let requirements: PaymentRequirementsV1;
+
+  beforeEach(() => {
+    mockSigner = {
+      address: "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0",
+      readContract: rcWithSig(BigInt("10000000")),
+      verifyTypedData: vi.fn().mockResolvedValue(true),
+      writeContract: vi.fn().mockResolvedValue("0xtxhash"),
+      waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success" }),
+      getCode: vi.fn().mockResolvedValue("0x6080604052"),
+    };
+
+    payload = {
+      x402Version: 1,
+      scheme: "exact",
+      network: "base",
+      payload: {
+        signature: "0xvalidsignature",
+        authorization: {
+          from: "0x1234567890123456789012345678901234567890",
+          to: "0x9876543210987654321098765432109876543210",
+          value: "8000",
+          validAfter: (Math.floor(Date.now() / 1000) - 300).toString(),
+          validBefore: (Math.floor(Date.now() / 1000) + 3600).toString(),
+          nonce: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+    };
+
+    requirements = {
+      scheme: "exact",
+      network: "base",
+      asset: USDC_ASSET,
+      maxAmountRequired: "8000",
+      payTo: "0x9876543210987654321098765432109876543210",
+      maxTimeoutSeconds: 3600,
+      extra: {
+        name: "GatewayWalletBatched",
+        version: "1",
+        verifyingContract: GATEWAY_CONTRACT,
+      },
+    };
+  });
+
+  it("verifies against the resolved contract when the validator approves it", async () => {
+    const facilitator = new ExactEvmSchemeV1(mockSigner, {
+      verifyingContractValidator: addr => addr === GATEWAY_CONTRACT,
+    });
+
+    const result = await facilitator.verify(payload as never, requirements as never);
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it("settles transferWithAuthorization against the resolved contract, not requirements.asset", async () => {
+    const facilitator = new ExactEvmSchemeV1(mockSigner, {
+      verifyingContractValidator: addr => addr === GATEWAY_CONTRACT,
+    });
+
+    const result = await facilitator.settle(payload as never, requirements as never);
+
+    expect(result.success).toBe(true);
+    expect(mockSigner.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ address: GATEWAY_CONTRACT }),
+    );
+  });
+
+  it("settles against requirements.asset when no validator is configured", async () => {
+    const facilitator = new ExactEvmSchemeV1(mockSigner);
+
+    const result = await facilitator.settle(payload as never, requirements as never);
+
+    expect(result.success).toBe(true);
+    expect(mockSigner.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ address: USDC_ASSET }),
+    );
+    expect(mockSigner.writeContract).not.toHaveBeenCalledWith(
+      expect.objectContaining({ address: GATEWAY_CONTRACT }),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

TS EIP-3009 client signing (`createEIP3009Payload`/`signEIP3009Authorization` for V2, `ExactEvmSchemeV1.signAuthorization` for V1) and facilitator verify/settle (`verifyEIP3009`/`settleEIP3009` for V2, `ExactEvmSchemeV1` for V1) all resolve the EIP-712 domain and the on-chain settlement contract from `requirements.asset` unconditionally, ignoring `extra["verifyingContract"]` entirely:

```ts
const domain = {
  name,
  version,
  chainId,
  verifyingContract: getAddress(requirements.asset), // always the token, even when
};                                                     // extra specifies a different verifier
```

This is the TypeScript counterpart of the already-reviewed Python fixes:
- Client: x402-foundation/x402#2885
- Facilitator: x402-foundation/x402#3174

Same root cause as both: correct only when the token contract itself is the EIP-3009 verifier — wrong whenever a seller settles through a distinct contract (e.g. Circle Gateway's `GatewayWalletBatched`). Flagged as a cross-SDK gap by `@0rkz` in review on #2885 ([comment](https://github.com/x402-foundation/x402/pull/2885#issuecomment-5112127349)): "TS v2 (`mechanisms/evm/src/exact/facilitator/eip3009.ts`)... TS v1... all rebuild the domain from `requirements.asset`."

## Fix

Mirrors the reviewed Python design exactly: an opt-in `verifyingContractValidator` callback.

- **Client** (`ExactEvmScheme`/`ExactEvmSchemeV1`, both takes a new optional constructor param — TS's client had no config object at all before this, unlike the facilitator side): absent by default, so signing always uses `requirements.asset` unless a validator is supplied and approves the specific candidate.
- **Facilitator** (`EIP3009FacilitatorConfig`/`ExactEvmSchemeConfig`/`ExactEvmSchemeV1Config`): same opt-in shape. Once trusted, the candidate is used consistently for **both** verification and settlement — the deployed-code check, transfer simulation, the on-chain `transferWithAuthorization` call, and the settled Transfer-event check — not just the signature check. A facilitator that verifies a signature against one contract can't settle against a different one.

No behavior change for existing callers in either direction (strict opt-in, matches the pre-existing default in both languages).

## Spec

Not touching `specs/schemes/exact/scheme_exact_evm.md` in this PR — that documentation is being introduced by #2885 (client-side) and #3174 (facilitator-side), both still open. Duplicating the edit here would conflict with those. This PR's behavior matches what's specified there once merged.

## Testing

Added `verifyingContractValidator` test suites to all four existing test files (`test/unit/exact/client.test.ts`, `test/unit/v1/client.test.ts`, `test/unit/exact/facilitator.test.ts`, `test/unit/v1/facilitator.test.ts`) — 14 new tests total. Client tests assert the signed EIP-712 domain via the mocked `signTypedData` call args (existing pattern in this suite, e.g. the Permit2 domain test). Facilitator tests assert `getCode`/`writeContract` are called against the resolved contract, using the suite's existing "everything is a deployed contract with an always-valid signature" mock convention to isolate the address-resolution wiring from signature cryptography.

Verified all 6 "trusts the verifying contract" tests fail without the production fix (temporarily reverted, re-ran — 6 failures, mix of `TypeError`-shaped and wrong-address assertion failures) and pass with it. Full `@x402/evm` suite: 851 tests pass (up from 837 pre-PR).

## Disclosure

Most of this change (diagnosis, fix, and tests) was written with AI assistance (Claude Code), reviewed and verified by me — including confirming the failure/fix behavior by running the test suite before and after the change — before opening this PR, per this repo's AI-assisted contribution guidelines. Marked Draft pending my own review pass.