### PR TITLE
fix(evm): sign/verify/settle EIP-3009 payments against extra.verifyingContract (Go)

### DIFF
--- a/go/.changes/unreleased/fixed-20260815-200311.yaml
+++ b/go/.changes/unreleased/fixed-20260815-200311.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Client EIP-3009 signing and facilitator verify/settle (V1 and V2) always resolved the EIP-712 domain and settlement contract from requirements.Asset, ignoring a seller-supplied extra.verifyingContract (e.g. Circle Gateway's batch-settlement contract). Trusting extra.verifyingContract is opt-in via a VerifyingContractValidator (client: WithVerifyingContractValidator option; facilitator: ExactEvmSchemeConfig/ExactEvmSchemeV1Config field); by default (none configured) signing, verification, and settlement still always use the asset address, matching prior behavior
+time: 2026-08-15T20:03:11.000000+00:00

--- a/go/mechanisms/evm/exact/client/eip3009_test.go
+++ b/go/mechanisms/evm/exact/client/eip3009_test.go
@@ -1,0 +1,116 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+const (
+	gatewayContract = "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE"
+	usdcAsset       = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+)
+
+type recordingSigner struct {
+	address string
+	domain  evm.TypedDataDomain
+}
+
+func (s *recordingSigner) Address() string {
+	return s.address
+}
+
+func (s *recordingSigner) SignTypedData(
+	ctx context.Context,
+	domain evm.TypedDataDomain,
+	fields map[string][]evm.TypedDataField,
+	primaryType string,
+	message map[string]interface{},
+) ([]byte, error) {
+	s.domain = domain
+	return make([]byte, 65), nil
+}
+
+func gatewayRequirements() types.PaymentRequirements {
+	return types.PaymentRequirements{
+		Scheme:            "exact",
+		Network:           "eip155:8453",
+		Asset:             usdcAsset,
+		Amount:            "8000",
+		PayTo:             "0x0987654321098765432109876543210987654321",
+		MaxTimeoutSeconds: 3600,
+		Extra: map[string]interface{}{
+			"name":              "GatewayWalletBatched",
+			"version":           "1",
+			"verifyingContract": gatewayContract,
+		},
+	}
+}
+
+func TestCreateEIP3009PayloadSignsAgainstVerifyingContractWhenValidatorApproves(t *testing.T) {
+	signer := &recordingSigner{address: "0x1234567890123456789012345678901234567890"}
+	scheme := NewExactEvmScheme(signer, nil, WithVerifyingContractValidator(
+		func(candidate string, requirements types.PaymentRequirements) bool {
+			return candidate == gatewayContract
+		},
+	))
+
+	if _, err := scheme.CreatePaymentPayload(context.Background(), gatewayRequirements()); err != nil {
+		t.Fatalf("CreatePaymentPayload failed: %v", err)
+	}
+
+	if got := evm.NormalizeAddress(signer.domain.VerifyingContract); got != evm.NormalizeAddress(gatewayContract) {
+		t.Fatalf("expected domain.VerifyingContract = %s, got %s", gatewayContract, got)
+	}
+}
+
+func TestCreateEIP3009PayloadFallsBackToAssetWhenNoValidatorConfigured(t *testing.T) {
+	signer := &recordingSigner{address: "0x1234567890123456789012345678901234567890"}
+	scheme := NewExactEvmScheme(signer, nil)
+
+	if _, err := scheme.CreatePaymentPayload(context.Background(), gatewayRequirements()); err != nil {
+		t.Fatalf("CreatePaymentPayload failed: %v", err)
+	}
+
+	if got := evm.NormalizeAddress(signer.domain.VerifyingContract); got != evm.NormalizeAddress(usdcAsset) {
+		t.Fatalf("expected domain.VerifyingContract = %s, got %s", usdcAsset, got)
+	}
+}
+
+func TestCreateEIP3009PayloadFallsBackToAssetWhenValidatorRejects(t *testing.T) {
+	signer := &recordingSigner{address: "0x1234567890123456789012345678901234567890"}
+	scheme := NewExactEvmScheme(signer, nil, WithVerifyingContractValidator(
+		func(candidate string, requirements types.PaymentRequirements) bool {
+			return false
+		},
+	))
+
+	if _, err := scheme.CreatePaymentPayload(context.Background(), gatewayRequirements()); err != nil {
+		t.Fatalf("CreatePaymentPayload failed: %v", err)
+	}
+
+	if got := evm.NormalizeAddress(signer.domain.VerifyingContract); got != evm.NormalizeAddress(usdcAsset) {
+		t.Fatalf("expected domain.VerifyingContract = %s, got %s", usdcAsset, got)
+	}
+}
+
+func TestCreateEIP3009PayloadFallsBackToAssetWhenNoVerifyingContractInExtra(t *testing.T) {
+	signer := &recordingSigner{address: "0x1234567890123456789012345678901234567890"}
+	scheme := NewExactEvmScheme(signer, nil, WithVerifyingContractValidator(
+		func(candidate string, requirements types.PaymentRequirements) bool {
+			return true
+		},
+	))
+	requirements := gatewayRequirements()
+	requirements.Extra = map[string]interface{}{"name": "USD Coin", "version": "2"}
+
+	if _, err := scheme.CreatePaymentPayload(context.Background(), requirements); err != nil {
+		t.Fatalf("CreatePaymentPayload failed: %v", err)
+	}
+
+	if got := evm.NormalizeAddress(signer.domain.VerifyingContract); got != evm.NormalizeAddress(usdcAsset) {
+		t.Fatalf("expected domain.VerifyingContract = %s, got %s", usdcAsset, got)
+	}
+}

--- a/go/mechanisms/evm/exact/client/scheme.go
+++ b/go/mechanisms/evm/exact/client/scheme.go
@@ -14,20 +14,43 @@ import (
 	"github.com/x402-foundation/x402/go/v2/types"
 )
 
+// VerifyingContractValidator validates a seller-supplied extra.verifyingContract before it is
+// trusted for EIP-712 signing. Returns true to sign against candidate; false falls back to
+// requirements.Asset, same as if no verifyingContract were supplied.
+type VerifyingContractValidator func(candidate string, requirements types.PaymentRequirements) bool
+
+// ExactEvmSchemeOption configures optional ExactEvmScheme behavior.
+type ExactEvmSchemeOption func(*ExactEvmScheme)
+
+// WithVerifyingContractValidator sets an opt-in callback that lets the client trust a
+// seller-supplied extra.verifyingContract (e.g. Circle Gateway's batch-settlement contract)
+// instead of requirements.Asset for EIP-712 signing. If not set, extra.verifyingContract is
+// never trusted and signing always uses requirements.Asset.
+func WithVerifyingContractValidator(v VerifyingContractValidator) ExactEvmSchemeOption {
+	return func(s *ExactEvmScheme) {
+		s.verifyingContractValidator = v
+	}
+}
+
 // ExactEvmScheme implements the SchemeNetworkClient interface for EVM exact payments (V2)
 type ExactEvmScheme struct {
-	signer evm.ClientEvmSigner
-	config *ExactEvmSchemeConfig
+	signer                     evm.ClientEvmSigner
+	config                     *ExactEvmSchemeConfig
+	verifyingContractValidator VerifyingContractValidator
 }
 
 // NewExactEvmScheme creates a new ExactEvmScheme.
 // Base flows only require a signer that can sign typed data.
 // Extension enrichment paths use optional runtime capabilities.
-func NewExactEvmScheme(signer evm.ClientEvmSigner, config *ExactEvmSchemeConfig) *ExactEvmScheme {
-	return &ExactEvmScheme{
+func NewExactEvmScheme(signer evm.ClientEvmSigner, config *ExactEvmSchemeConfig, opts ...ExactEvmSchemeOption) *ExactEvmScheme {
+	s := &ExactEvmScheme{
 		signer: signer,
 		config: config,
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Scheme returns the scheme identifier
@@ -272,12 +295,18 @@ func (c *ExactEvmScheme) createEIP3009Payload(
 	// Extract extra fields for EIP-3009
 	tokenName := assetInfo.Name
 	tokenVersion := assetInfo.Version
+	verifyingContract := assetInfo.Address
 	if requirements.Extra != nil {
 		if name, ok := requirements.Extra["name"].(string); ok {
 			tokenName = name
 		}
 		if ver, ok := requirements.Extra["version"].(string); ok {
 			tokenVersion = ver
+		}
+		if candidate, ok := requirements.Extra["verifyingContract"].(string); ok && candidate != "" {
+			if c.verifyingContractValidator != nil && c.verifyingContractValidator(candidate, requirements) {
+				verifyingContract = candidate
+			}
 		}
 	}
 
@@ -292,7 +321,7 @@ func (c *ExactEvmScheme) createEIP3009Payload(
 	}
 
 	// Sign the authorization
-	signature, err := c.signAuthorization(ctx, authorization, chainID, assetInfo.Address, tokenName, tokenVersion)
+	signature, err := c.signAuthorization(ctx, authorization, chainID, verifyingContract, tokenName, tokenVersion)
 	if err != nil {
 		return types.PaymentPayload{}, fmt.Errorf(ErrFailedToSignAuthorization+": %w", err)
 	}

--- a/go/mechanisms/evm/exact/facilitator/eip3009.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009.go
@@ -15,6 +15,20 @@ import (
 	"github.com/x402-foundation/x402/go/v2/types"
 )
 
+// resolveVerifyingContract resolves the contract to verify and settle against. Defaults to
+// requirements.Asset. Only trusts a seller-supplied extra.verifyingContract if a validator was
+// configured and it approves this specific candidate.
+func (f *ExactEvmScheme) resolveVerifyingContract(requirements types.PaymentRequirements) string {
+	candidate, ok := requirements.Extra["verifyingContract"].(string)
+	if !ok || candidate == "" || f.config.VerifyingContractValidator == nil {
+		return evm.NormalizeAddress(requirements.Asset)
+	}
+	if f.config.VerifyingContractValidator(candidate, requirements) {
+		return evm.NormalizeAddress(candidate)
+	}
+	return evm.NormalizeAddress(requirements.Asset)
+}
+
 // verifyEIP3009 verifies an EIP-3009 payment payload.
 func (f *ExactEvmScheme) verifyEIP3009(
 	ctx context.Context,
@@ -44,7 +58,7 @@ func (f *ExactEvmScheme) verifyEIP3009(
 		return nil, x402.NewVerifyError(ErrFailedToGetNetworkConfig, "", err.Error())
 	}
 
-	tokenAddress := evm.NormalizeAddress(requirements.Asset)
+	tokenAddress := f.resolveVerifyingContract(requirements)
 
 	if !strings.EqualFold(evmPayload.Authorization.To, requirements.PayTo) {
 		return nil, x402.NewVerifyError(ErrRecipientMismatch, "", fmt.Sprintf("recipient mismatch: %s != %s", evmPayload.Authorization.To, requirements.PayTo))
@@ -115,10 +129,10 @@ func (f *ExactEvmScheme) verifyEIP3009(
 		}
 	}
 
-	if errReason, err := evm.ValidateAssetIsContract(ctx, f.signer, requirements.Asset); err != nil {
+	if errReason, err := evm.ValidateAssetIsContract(ctx, f.signer, tokenAddress); err != nil {
 		return nil, fmt.Errorf("asset contract check failed: %w", err)
 	} else if errReason != "" {
-		return nil, x402.NewVerifyError(errReason, evmPayload.Authorization.From, fmt.Sprintf("asset %s is not a deployed contract", requirements.Asset))
+		return nil, x402.NewVerifyError(errReason, evmPayload.Authorization.From, fmt.Sprintf("asset %s is not a deployed contract", tokenAddress))
 	}
 
 	if simulate {
@@ -175,7 +189,7 @@ func (f *ExactEvmScheme) settleEIP3009(
 		return nil, x402.NewSettleError(ErrInvalidPayload, verifyResp.Payer, network, "", err.Error())
 	}
 
-	tokenAddress := evm.NormalizeAddress(requirements.Asset)
+	tokenAddress := f.resolveVerifyingContract(requirements)
 
 	signatureBytes, err := evm.HexToBytes(evmPayload.Signature)
 	if err != nil {

--- a/go/mechanisms/evm/exact/facilitator/eip3009_verifying_contract_test.go
+++ b/go/mechanisms/evm/exact/facilitator/eip3009_verifying_contract_test.go
@@ -1,0 +1,194 @@
+package facilitator
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+const (
+	vcGatewayContract = "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE"
+	vcUsdcAsset       = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+)
+
+// verifyingContractMockSigner is a minimal FacilitatorEvmSigner that reports every address in
+// codeByAddress as a deployed contract (empty/absent = EOA), always succeeds ReadContract (so
+// transfer simulation passes), and records the WriteContract target address for settle
+// assertions. Signature verification for EOA payers goes through the real ecrecover path in
+// evm.VerifyUniversalSignature, so tests use a real ECDSA key rather than mocking it out.
+type verifyingContractMockSigner struct {
+	codeByAddress map[string][]byte
+	writeAddress  string
+}
+
+func (m *verifyingContractMockSigner) GetAddresses() []string { return []string{"0xFac11"} }
+
+func (m *verifyingContractMockSigner) ReadContract(ctx context.Context, address string, abi []byte, functionName string, args ...interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *verifyingContractMockSigner) VerifyTypedData(ctx context.Context, address string, domain evm.TypedDataDomain, types map[string][]evm.TypedDataField, primaryType string, message map[string]interface{}, signature []byte) (bool, error) {
+	return false, nil
+}
+
+func (m *verifyingContractMockSigner) WriteContract(ctx context.Context, address string, abi []byte, functionName string, dataSuffix []byte, args ...interface{}) (string, error) {
+	m.writeAddress = address
+	return "0x" + strings.Repeat("ab", 32), nil
+}
+
+func (m *verifyingContractMockSigner) SendTransaction(ctx context.Context, to string, data []byte) (string, error) {
+	return "0x" + strings.Repeat("cd", 32), nil
+}
+
+func (m *verifyingContractMockSigner) WaitForTransactionReceipt(ctx context.Context, txHash string) (*evm.TransactionReceipt, error) {
+	return &evm.TransactionReceipt{Status: evm.TxStatusSuccess, TxHash: txHash}, nil
+}
+
+func (m *verifyingContractMockSigner) GetBalance(ctx context.Context, address string, tokenAddress string) (*big.Int, error) {
+	return big.NewInt(1_000_000_000), nil
+}
+
+func (m *verifyingContractMockSigner) GetChainID(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(8453), nil
+}
+
+func (m *verifyingContractMockSigner) GetCode(ctx context.Context, address string) ([]byte, error) {
+	return m.codeByAddress[strings.ToLower(address)], nil
+}
+
+// signedGatewayPayload builds a real ECDSA-signed EIP-3009 payload + matching requirements,
+// signed against the given verifyingContract (not necessarily requirements.Asset).
+func signedGatewayPayload(t *testing.T, verifyingContract string) (types.PaymentPayload, types.PaymentRequirements) {
+	t.Helper()
+
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	payer := crypto.PubkeyToAddress(privateKey.PublicKey).Hex()
+
+	now := time.Now().Unix()
+	authorization := evm.ExactEIP3009Authorization{
+		From:        payer,
+		To:          "0x0987654321098765432109876543210987654321",
+		Value:       "8000",
+		ValidAfter:  fmt.Sprintf("%d", now-60),
+		ValidBefore: fmt.Sprintf("%d", now+600),
+		Nonce:       "0x" + strings.Repeat("11", 32),
+	}
+
+	hash, err := evm.HashEIP3009Authorization(authorization, big.NewInt(8453), verifyingContract, "GatewayWalletBatched", "1")
+	if err != nil {
+		t.Fatalf("failed to hash authorization: %v", err)
+	}
+	sig, err := crypto.Sign(hash, privateKey)
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+	if sig[64] < 27 {
+		sig[64] += 27
+	}
+
+	evmPayload := &evm.ExactEIP3009Payload{
+		Signature:     evm.BytesToHex(sig),
+		Authorization: authorization,
+	}
+
+	requirements := types.PaymentRequirements{
+		Scheme:            "exact",
+		Network:           "eip155:8453",
+		Asset:             vcUsdcAsset,
+		Amount:            "8000",
+		PayTo:             authorization.To,
+		MaxTimeoutSeconds: 3600,
+		Extra: map[string]interface{}{
+			"name":              "GatewayWalletBatched",
+			"version":           "1",
+			"verifyingContract": vcGatewayContract,
+		},
+	}
+
+	payload := types.PaymentPayload{
+		X402Version: 2,
+		Accepted:    requirements,
+		Payload:     evmPayload.ToMap(),
+	}
+
+	return payload, requirements
+}
+
+func TestVerifyEIP3009_TrustsVerifyingContractWhenValidatorApproves(t *testing.T) {
+	payload, requirements := signedGatewayPayload(t, vcGatewayContract)
+
+	signer := &verifyingContractMockSigner{
+		codeByAddress: map[string][]byte{
+			strings.ToLower(vcGatewayContract): {0x60},
+		},
+	}
+	scheme := NewExactEvmScheme(signer, &ExactEvmSchemeConfig{
+		VerifyingContractValidator: func(candidate string, r types.PaymentRequirements) bool {
+			return candidate == vcGatewayContract
+		},
+	})
+
+	resp, err := scheme.Verify(context.Background(), payload, requirements, nil)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if !resp.IsValid {
+		t.Fatalf("expected valid, got invalid: %+v", resp)
+	}
+}
+
+func TestVerifyEIP3009_RejectsVerifyingContractSignatureWhenNoValidatorConfigured(t *testing.T) {
+	// Signed against the gateway domain, but the facilitator has no validator configured,
+	// so it checks against requirements.Asset -- the digest won't match, ecrecover won't
+	// recover to the payer, and the signature is rejected.
+	payload, requirements := signedGatewayPayload(t, vcGatewayContract)
+
+	signer := &verifyingContractMockSigner{
+		codeByAddress: map[string][]byte{
+			strings.ToLower(vcUsdcAsset): {0x60},
+		},
+	}
+	scheme := NewExactEvmScheme(signer, nil)
+
+	resp, err := scheme.Verify(context.Background(), payload, requirements, nil)
+	if err == nil {
+		t.Fatalf("expected verify error, got success: %+v", resp)
+	}
+}
+
+func TestSettleEIP3009_SettlesAgainstVerifyingContractNotAsset(t *testing.T) {
+	payload, requirements := signedGatewayPayload(t, vcGatewayContract)
+
+	signer := &verifyingContractMockSigner{
+		codeByAddress: map[string][]byte{
+			strings.ToLower(vcGatewayContract): {0x60},
+		},
+	}
+	scheme := NewExactEvmScheme(signer, &ExactEvmSchemeConfig{
+		VerifyingContractValidator: func(candidate string, r types.PaymentRequirements) bool {
+			return candidate == vcGatewayContract
+		},
+	})
+
+	resp, err := scheme.Settle(context.Background(), payload, requirements, nil)
+	if err != nil {
+		t.Fatalf("Settle returned error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success, got failure: %+v", resp)
+	}
+	if got := evm.NormalizeAddress(signer.writeAddress); got != evm.NormalizeAddress(vcGatewayContract) {
+		t.Fatalf("expected WriteContract address = %s, got %s", vcGatewayContract, got)
+	}
+}

--- a/go/mechanisms/evm/exact/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/facilitator/scheme.go
@@ -9,6 +9,12 @@ import (
 	"github.com/x402-foundation/x402/go/v2/types"
 )
 
+// VerifyingContractValidator validates a seller-supplied extra.verifyingContract before the
+// facilitator trusts it as the contract to verify against and settle through. Returns true to
+// verify and settle against candidate; false falls back to requirements.Asset, same as if no
+// verifyingContract were supplied.
+type VerifyingContractValidator func(candidate string, requirements types.PaymentRequirements) bool
+
 // ExactEvmSchemeConfig holds configuration for the ExactEvmScheme facilitator
 type ExactEvmSchemeConfig struct {
 	// EIP6492AllowedFactories is the allowlist of factory contract addresses (hex strings,
@@ -20,6 +26,17 @@ type ExactEvmSchemeConfig struct {
 	EIP6492AllowedFactories []string
 	// SimulateInSettle reruns transfer simulation during settle. Verify always simulates.
 	SimulateInSettle bool
+	// VerifyingContractValidator is an optional callback invoked when a payment requirement's
+	// extra.verifyingContract differs from requirements.Asset (e.g. Circle Gateway's
+	// batch-settlement contract). Receives the candidate address and the requirements, and must
+	// return true to trust it.
+	//
+	// When trusted, the candidate replaces requirements.Asset everywhere this facilitator
+	// resolves the payment's contract: the EIP-712 domain checked during verify, the
+	// deployed-code check, the transfer simulation, and the on-chain transferWithAuthorization
+	// call during settle. If nil (default), extra.verifyingContract is never trusted and
+	// requirements.Asset is always used, matching pre-existing behavior.
+	VerifyingContractValidator VerifyingContractValidator
 }
 
 // ExactEvmScheme implements the SchemeNetworkFacilitator interface for EVM exact payments (V2)

--- a/go/mechanisms/evm/exact/v1/client/eip3009_test.go
+++ b/go/mechanisms/evm/exact/v1/client/eip3009_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+const (
+	gatewayContract = "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE"
+	usdcAsset       = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+)
+
+type recordingSigner struct {
+	address string
+	domain  evm.TypedDataDomain
+}
+
+func (s *recordingSigner) Address() string {
+	return s.address
+}
+
+func (s *recordingSigner) SignTypedData(
+	ctx context.Context,
+	domain evm.TypedDataDomain,
+	fields map[string][]evm.TypedDataField,
+	primaryType string,
+	message map[string]interface{},
+) ([]byte, error) {
+	s.domain = domain
+	return make([]byte, 65), nil
+}
+
+func gatewayRequirementsV1() types.PaymentRequirementsV1 {
+	extra := json.RawMessage(`{"name":"GatewayWalletBatched","version":"1","verifyingContract":"` + gatewayContract + `"}`)
+	return types.PaymentRequirementsV1{
+		Scheme:            "exact",
+		Network:           "base",
+		Asset:             usdcAsset,
+		MaxAmountRequired: "8000",
+		PayTo:             "0x0987654321098765432109876543210987654321",
+		MaxTimeoutSeconds: 3600,
+		Extra:             &extra,
+	}
+}
+
+func TestCreatePaymentPayloadV1SignsAgainstVerifyingContractWhenValidatorApproves(t *testing.T) {
+	signer := &recordingSigner{address: "0x1234567890123456789012345678901234567890"}
+	scheme := NewExactEvmSchemeV1(signer, WithVerifyingContractValidator(
+		func(candidate string, requirements types.PaymentRequirementsV1) bool {
+			return candidate == gatewayContract
+		},
+	))
+
+	if _, err := scheme.CreatePaymentPayload(context.Background(), gatewayRequirementsV1()); err != nil {
+		t.Fatalf("CreatePaymentPayload failed: %v", err)
+	}
+
+	if got := evm.NormalizeAddress(signer.domain.VerifyingContract); got != evm.NormalizeAddress(gatewayContract) {
+		t.Fatalf("expected domain.VerifyingContract = %s, got %s", gatewayContract, got)
+	}
+}
+
+func TestCreatePaymentPayloadV1FallsBackToAssetWhenNoValidatorConfigured(t *testing.T) {
+	signer := &recordingSigner{address: "0x1234567890123456789012345678901234567890"}
+	scheme := NewExactEvmSchemeV1(signer)
+
+	if _, err := scheme.CreatePaymentPayload(context.Background(), gatewayRequirementsV1()); err != nil {
+		t.Fatalf("CreatePaymentPayload failed: %v", err)
+	}
+
+	if got := evm.NormalizeAddress(signer.domain.VerifyingContract); got != evm.NormalizeAddress(usdcAsset) {
+		t.Fatalf("expected domain.VerifyingContract = %s, got %s", usdcAsset, got)
+	}
+}
+
+func TestCreatePaymentPayloadV1FallsBackToAssetWhenValidatorRejects(t *testing.T) {
+	signer := &recordingSigner{address: "0x1234567890123456789012345678901234567890"}
+	scheme := NewExactEvmSchemeV1(signer, WithVerifyingContractValidator(
+		func(candidate string, requirements types.PaymentRequirementsV1) bool {
+			return false
+		},
+	))
+
+	if _, err := scheme.CreatePaymentPayload(context.Background(), gatewayRequirementsV1()); err != nil {
+		t.Fatalf("CreatePaymentPayload failed: %v", err)
+	}
+
+	if got := evm.NormalizeAddress(signer.domain.VerifyingContract); got != evm.NormalizeAddress(usdcAsset) {
+		t.Fatalf("expected domain.VerifyingContract = %s, got %s", usdcAsset, got)
+	}
+}

--- a/go/mechanisms/evm/exact/v1/client/scheme.go
+++ b/go/mechanisms/evm/exact/v1/client/scheme.go
@@ -12,16 +12,39 @@ import (
 	"github.com/x402-foundation/x402/go/v2/types"
 )
 
+// VerifyingContractValidator validates a seller-supplied extra.verifyingContract before it is
+// trusted for EIP-712 signing. Returns true to sign against candidate; false falls back to
+// requirements.Asset, same as if no verifyingContract were supplied.
+type VerifyingContractValidator func(candidate string, requirements types.PaymentRequirementsV1) bool
+
+// ExactEvmSchemeV1Option configures optional ExactEvmSchemeV1 behavior.
+type ExactEvmSchemeV1Option func(*ExactEvmSchemeV1)
+
+// WithVerifyingContractValidator sets an opt-in callback that lets the client trust a
+// seller-supplied extra.verifyingContract instead of requirements.Asset for EIP-712 signing.
+// If not set, extra.verifyingContract is never trusted and signing always uses
+// requirements.Asset.
+func WithVerifyingContractValidator(v VerifyingContractValidator) ExactEvmSchemeV1Option {
+	return func(s *ExactEvmSchemeV1) {
+		s.verifyingContractValidator = v
+	}
+}
+
 // ExactEvmSchemeV1 implements the SchemeNetworkClientV1 interface for EVM exact payments (V1)
 type ExactEvmSchemeV1 struct {
-	signer evm.ClientEvmSigner
+	signer                     evm.ClientEvmSigner
+	verifyingContractValidator VerifyingContractValidator
 }
 
 // NewExactEvmSchemeV1 creates a new ExactEvmSchemeV1
-func NewExactEvmSchemeV1(signer evm.ClientEvmSigner) *ExactEvmSchemeV1 {
-	return &ExactEvmSchemeV1{
+func NewExactEvmSchemeV1(signer evm.ClientEvmSigner, opts ...ExactEvmSchemeV1Option) *ExactEvmSchemeV1 {
+	s := &ExactEvmSchemeV1{
 		signer: signer,
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Scheme returns the scheme identifier
@@ -74,6 +97,7 @@ func (c *ExactEvmSchemeV1) CreatePaymentPayload(
 	// Extract extra fields for EIP-3009
 	tokenName := assetInfo.Name
 	tokenVersion := assetInfo.Version
+	verifyingContract := assetInfo.Address
 	if requirements.Extra != nil {
 		var extraMap map[string]interface{}
 		if err := json.Unmarshal(*requirements.Extra, &extraMap); err == nil {
@@ -82,6 +106,11 @@ func (c *ExactEvmSchemeV1) CreatePaymentPayload(
 			}
 			if ver, ok := extraMap["version"].(string); ok {
 				tokenVersion = ver
+			}
+			if candidate, ok := extraMap["verifyingContract"].(string); ok && candidate != "" {
+				if c.verifyingContractValidator != nil && c.verifyingContractValidator(candidate, requirements) {
+					verifyingContract = candidate
+				}
 			}
 		}
 	}
@@ -97,7 +126,7 @@ func (c *ExactEvmSchemeV1) CreatePaymentPayload(
 	}
 
 	// Sign the authorization
-	signature, err := c.signAuthorization(ctx, authorization, chainID, assetInfo.Address, tokenName, tokenVersion)
+	signature, err := c.signAuthorization(ctx, authorization, chainID, verifyingContract, tokenName, tokenVersion)
 	if err != nil {
 		return types.PaymentPayloadV1{}, fmt.Errorf(ErrFailedToSignAuthorization+": %w", err)
 	}

--- a/go/mechanisms/evm/exact/v1/facilitator/eip3009_verifying_contract_test.go
+++ b/go/mechanisms/evm/exact/v1/facilitator/eip3009_verifying_contract_test.go
@@ -1,0 +1,195 @@
+package facilitator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/x402-foundation/x402/go/v2/mechanisms/evm"
+	evmv1 "github.com/x402-foundation/x402/go/v2/mechanisms/evm/v1"
+	"github.com/x402-foundation/x402/go/v2/types"
+)
+
+const (
+	vcGatewayContract = "0x77777777Dcc4d5A8B6E418Fd04D8997ef11000eE"
+	vcUsdcAsset       = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+)
+
+// verifyingContractMockSignerV1 mirrors the V2 facilitator's test mock (see
+// exact/facilitator/eip3009_verifying_contract_test.go): every address in codeByAddress reports
+// as a deployed contract, ReadContract always succeeds, and WriteContract records its target
+// address for settle assertions.
+type verifyingContractMockSignerV1 struct {
+	codeByAddress map[string][]byte
+	writeAddress  string
+}
+
+func (m *verifyingContractMockSignerV1) GetAddresses() []string { return []string{"0xFac11"} }
+
+func (m *verifyingContractMockSignerV1) ReadContract(ctx context.Context, address string, abi []byte, functionName string, args ...interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *verifyingContractMockSignerV1) VerifyTypedData(ctx context.Context, address string, domain evm.TypedDataDomain, types map[string][]evm.TypedDataField, primaryType string, message map[string]interface{}, signature []byte) (bool, error) {
+	return false, nil
+}
+
+func (m *verifyingContractMockSignerV1) WriteContract(ctx context.Context, address string, abi []byte, functionName string, dataSuffix []byte, args ...interface{}) (string, error) {
+	m.writeAddress = address
+	return "0x" + strings.Repeat("ab", 32), nil
+}
+
+func (m *verifyingContractMockSignerV1) SendTransaction(ctx context.Context, to string, data []byte) (string, error) {
+	return "0x" + strings.Repeat("cd", 32), nil
+}
+
+func (m *verifyingContractMockSignerV1) WaitForTransactionReceipt(ctx context.Context, txHash string) (*evm.TransactionReceipt, error) {
+	return &evm.TransactionReceipt{Status: evm.TxStatusSuccess, TxHash: txHash}, nil
+}
+
+func (m *verifyingContractMockSignerV1) GetBalance(ctx context.Context, address string, tokenAddress string) (*big.Int, error) {
+	return big.NewInt(1_000_000_000), nil
+}
+
+func (m *verifyingContractMockSignerV1) GetChainID(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(8453), nil
+}
+
+func (m *verifyingContractMockSignerV1) GetCode(ctx context.Context, address string) ([]byte, error) {
+	return m.codeByAddress[strings.ToLower(address)], nil
+}
+
+// signedGatewayPayloadV1 builds a real ECDSA-signed EIP-3009 V1 payload + matching V1
+// requirements, signed against the given verifyingContract (not necessarily requirements.Asset).
+func signedGatewayPayloadV1(t *testing.T, verifyingContract string) (types.PaymentPayloadV1, types.PaymentRequirementsV1) {
+	t.Helper()
+
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	payer := crypto.PubkeyToAddress(privateKey.PublicKey).Hex()
+
+	chainID, err := evmv1.GetEvmChainId("base")
+	if err != nil {
+		t.Fatalf("failed to get chain id: %v", err)
+	}
+
+	now := time.Now().Unix()
+	authorization := evm.ExactEIP3009Authorization{
+		From:        payer,
+		To:          "0x0987654321098765432109876543210987654321",
+		Value:       "8000",
+		ValidAfter:  fmt.Sprintf("%d", now-60),
+		ValidBefore: fmt.Sprintf("%d", now+600),
+		Nonce:       "0x" + strings.Repeat("11", 32),
+	}
+
+	hash, err := evm.HashEIP3009Authorization(authorization, chainID, verifyingContract, "GatewayWalletBatched", "1")
+	if err != nil {
+		t.Fatalf("failed to hash authorization: %v", err)
+	}
+	sig, err := crypto.Sign(hash, privateKey)
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+	if sig[64] < 27 {
+		sig[64] += 27
+	}
+
+	evmPayload := &evm.ExactEIP3009Payload{
+		Signature:     evm.BytesToHex(sig),
+		Authorization: authorization,
+	}
+
+	extra := json.RawMessage(`{"name":"GatewayWalletBatched","version":"1","verifyingContract":"` + vcGatewayContract + `"}`)
+	requirements := types.PaymentRequirementsV1{
+		Scheme:            "exact",
+		Network:           "base",
+		Asset:             vcUsdcAsset,
+		MaxAmountRequired: "8000",
+		PayTo:             authorization.To,
+		MaxTimeoutSeconds: 3600,
+		Extra:             &extra,
+	}
+
+	payload := types.PaymentPayloadV1{
+		X402Version: 1,
+		Scheme:      "exact",
+		Network:     "base",
+		Payload:     evmPayload.ToMap(),
+	}
+
+	return payload, requirements
+}
+
+func TestVerifyV1_TrustsVerifyingContractWhenValidatorApproves(t *testing.T) {
+	payload, requirements := signedGatewayPayloadV1(t, vcGatewayContract)
+
+	signer := &verifyingContractMockSignerV1{
+		codeByAddress: map[string][]byte{
+			strings.ToLower(vcGatewayContract): {0x60},
+		},
+	}
+	scheme := NewExactEvmSchemeV1(signer, &ExactEvmSchemeV1Config{
+		VerifyingContractValidator: func(candidate string, r types.PaymentRequirementsV1) bool {
+			return candidate == vcGatewayContract
+		},
+	})
+
+	resp, err := scheme.Verify(context.Background(), payload, requirements, nil)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if !resp.IsValid {
+		t.Fatalf("expected valid, got invalid: %+v", resp)
+	}
+}
+
+func TestVerifyV1_RejectsVerifyingContractSignatureWhenNoValidatorConfigured(t *testing.T) {
+	payload, requirements := signedGatewayPayloadV1(t, vcGatewayContract)
+
+	signer := &verifyingContractMockSignerV1{
+		codeByAddress: map[string][]byte{
+			strings.ToLower(vcUsdcAsset): {0x60},
+		},
+	}
+	scheme := NewExactEvmSchemeV1(signer, nil)
+
+	resp, err := scheme.Verify(context.Background(), payload, requirements, nil)
+	if err == nil {
+		t.Fatalf("expected verify error, got success: %+v", resp)
+	}
+}
+
+func TestSettleV1_SettlesAgainstVerifyingContractNotAsset(t *testing.T) {
+	payload, requirements := signedGatewayPayloadV1(t, vcGatewayContract)
+
+	signer := &verifyingContractMockSignerV1{
+		codeByAddress: map[string][]byte{
+			strings.ToLower(vcGatewayContract): {0x60},
+		},
+	}
+	scheme := NewExactEvmSchemeV1(signer, &ExactEvmSchemeV1Config{
+		VerifyingContractValidator: func(candidate string, r types.PaymentRequirementsV1) bool {
+			return candidate == vcGatewayContract
+		},
+	})
+
+	resp, err := scheme.Settle(context.Background(), payload, requirements, nil)
+	if err != nil {
+		t.Fatalf("Settle returned error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("expected success, got failure: %+v", resp)
+	}
+	if got := evm.NormalizeAddress(signer.writeAddress); got != evm.NormalizeAddress(vcGatewayContract) {
+		t.Fatalf("expected WriteContract address = %s, got %s", vcGatewayContract, got)
+	}
+}

--- a/go/mechanisms/evm/exact/v1/facilitator/scheme.go
+++ b/go/mechanisms/evm/exact/v1/facilitator/scheme.go
@@ -18,6 +18,12 @@ import (
 	"github.com/x402-foundation/x402/go/v2/types"
 )
 
+// VerifyingContractValidator validates a seller-supplied extra.verifyingContract before the
+// facilitator trusts it as the contract to verify against and settle through. Returns true to
+// verify and settle against candidate; false falls back to requirements.Asset, same as if no
+// verifyingContract were supplied.
+type VerifyingContractValidator func(candidate string, requirements types.PaymentRequirementsV1) bool
+
 // ExactEvmSchemeV1Config holds configuration for the ExactEvmSchemeV1 facilitator
 type ExactEvmSchemeV1Config struct {
 	// EIP6492AllowedFactories is the allowlist of factory contract addresses (hex strings,
@@ -29,6 +35,10 @@ type ExactEvmSchemeV1Config struct {
 	EIP6492AllowedFactories []string
 	// SimulateInSettle reruns transfer simulation during settle. Verify always simulates.
 	SimulateInSettle bool
+	// VerifyingContractValidator is an optional callback to trust a seller-supplied
+	// extra.verifyingContract instead of requirements.Asset, for both verification and
+	// settlement. Not trusted by default (nil).
+	VerifyingContractValidator VerifyingContractValidator
 }
 
 // ExactEvmSchemeV1 implements the SchemeNetworkFacilitatorV1 interface for EVM exact payments (V1)
@@ -89,6 +99,24 @@ func (f *ExactEvmSchemeV1) Verify(
 	return f.verify(ctx, payload, requirements, fctx, true)
 }
 
+// resolveVerifyingContract resolves the contract to verify and settle against. Defaults to
+// requirements.Asset. Only trusts a seller-supplied extra.verifyingContract if a validator was
+// configured and it approves this specific candidate.
+func (f *ExactEvmSchemeV1) resolveVerifyingContract(requirements types.PaymentRequirementsV1) string {
+	var extraMap map[string]interface{}
+	if requirements.Extra != nil {
+		_ = json.Unmarshal(*requirements.Extra, &extraMap)
+	}
+	candidate, ok := extraMap["verifyingContract"].(string)
+	if !ok || candidate == "" || f.config.VerifyingContractValidator == nil {
+		return evm.NormalizeAddress(requirements.Asset)
+	}
+	if f.config.VerifyingContractValidator(candidate, requirements) {
+		return evm.NormalizeAddress(candidate)
+	}
+	return evm.NormalizeAddress(requirements.Asset)
+}
+
 func (f *ExactEvmSchemeV1) verify(
 	ctx context.Context,
 	payload types.PaymentPayloadV1,
@@ -131,7 +159,7 @@ func (f *ExactEvmSchemeV1) verify(
 		return nil, x402.NewVerifyError(ErrFailedToGetNetworkConfig, "", err.Error())
 	}
 
-	tokenAddress := evm.NormalizeAddress(requirements.Asset)
+	tokenAddress := f.resolveVerifyingContract(requirements)
 
 	// Check EIP-712 domain parameters
 	var extraMap map[string]interface{}
@@ -275,7 +303,7 @@ func (f *ExactEvmSchemeV1) Settle(
 		return nil, x402.NewSettleError(ErrInvalidPayload, verifyResp.Payer, network, "", err.Error())
 	}
 
-	tokenAddress := evm.NormalizeAddress(requirements.Asset)
+	tokenAddress := f.resolveVerifyingContract(requirements)
 
 	// Parse signature
 	signatureBytes, err := evm.HexToBytes(evmPayload.Signature)


### PR DESCRIPTION
## Problem

Go EIP-3009 client signing (`createEIP3009Payload`/`signAuthorization` for V2, `ExactEvmSchemeV1.signAuthorization` for V1) and facilitator verify/settle (`verifyEIP3009`/`settleEIP3009` for V2, `ExactEvmSchemeV1` for V1) all resolve the EIP-712 domain and the on-chain settlement contract from `requirements.Asset` unconditionally, ignoring `extra["verifyingContract"]` entirely — the Go counterpart of:
- Client: x402-foundation/x402#2885 (Python), x402-foundation/x402#3175 (TS)
- Facilitator: x402-foundation/x402#3174 (Python), x402-foundation/x402#3175 (TS)

Same root cause each time: correct only when the token contract itself is the EIP-3009 verifier — wrong whenever a seller settles through a distinct contract (e.g. Circle Gateway's `GatewayWalletBatched`). Flagged as a cross-SDK gap by `@0rkz` on #2885 ([comment](https://github.com/x402-foundation/x402/pull/2885#issuecomment-5112127349)): "...and Go (`exact/facilitator/eip3009.go`)... all rebuild the domain from `requirements.asset`."

## Fix

Same opt-in `VerifyingContractValidator` design as Python/TS, adapted to two different Go idioms depending on what each config type already was:

- **Client** (`NewExactEvmScheme`/`NewExactEvmSchemeV1`): a new **functional option**, `WithVerifyingContractValidator(...)`, appended as a variadic trailing parameter. The client's existing `ExactEvmSchemeConfig` is a type alias to the shared `evm.RPCConfig` also used by the `upto` scheme — adding a validator field there would leak an EIP-3009-specific concern into unrelated schemes, so a functional option was the only option that didn't touch that shared type. This also kept the change backward-compatible: `NewExactEvmScheme`/`NewExactEvmSchemeV1` are called at ~40 sites across this repo (integration tests, unit tests) with the old 2-arg (or 1-arg, for V1) signature — a variadic option means every one of those keeps compiling unchanged.
- **Facilitator** (`ExactEvmSchemeConfig`/`ExactEvmSchemeV1Config`): both are already dedicated per-scheme structs (not shared aliases), so `VerifyingContractValidator` goes directly on them as a new field — same precedent as `EIP6492AllowedFactories`. Once trusted, the candidate is used consistently for **both** verification and settlement (the deployed-code check via `ValidateAssetIsContract`, transfer simulation, the on-chain `transferWithAuthorization` call, and the settled Transfer-event check) — not just the signature check.

Nil/absent by default in both cases — no behavior change for existing callers.

## Spec

Not touching `specs/schemes/exact/scheme_exact_evm.md` in this PR, same reasoning as #3175 — that documentation is being introduced by #2885 and #3174, both still open; duplicating here would conflict.

## Testing

Added test files/cases for all four surfaces:
- `mechanisms/evm/exact/client/eip3009_test.go` (new file — only `rpc_test.go` existed here before)
- `mechanisms/evm/exact/v1/client/eip3009_test.go` (new file — no tests existed for this package before)
- `mechanisms/evm/exact/facilitator/eip3009_verifying_contract_test.go` (new file)
- `mechanisms/evm/exact/v1/facilitator/eip3009_verifying_contract_test.go` (new file — no tests existed for this package before)

Client tests assert the signed domain via a recording mock signer. Facilitator tests use **real ECDSA signing and `ecrecover`** (`crypto.GenerateKey`/`crypto.Sign`, same pattern already used for Permit2 in `test/unit/evm_client_facilitator_test.go`), not mocked signature checks — Go's `FacilitatorEvmSigner`/`VerifyUniversalSignature` has no "always valid" bypass for EOA payers the way the TS mock's `isValidSignature` magic value does, so this is the genuine signature-domain check.

Verified all 4 new test files fail to *compile* without the production fix (temporarily reverted — `undefined: WithVerifyingContractValidator` / `unknown field VerifyingContractValidator`) and pass with it. Full module: `go build ./...`, `go vet ./...`, and `go test -race -cover ./...` all clean, including every pre-existing call site using the old constructor signatures.

## Disclosure

Most of this change (diagnosis, fix, and tests) was written with AI assistance (Claude Code), reviewed and verified by me — including confirming the failure/fix behavior by running the test suite before and after the change — before opening this PR, per this repo's AI-assisted contribution guidelines. Marked Draft pending my own review pass.