### PR TITLE
docs(migration): use real Solana genesis-hash CAIP-2 ids

### DIFF
--- a/docs/guides/migration-v1-to-v2.mdx
+++ b/docs/guides/migration-v1-to-v2.mdx
@@ -322,8 +322,8 @@ In V2, hand-rolling `extensions.bazaar.schema` on a route config passes through 
 | `base` | `eip155:8453` | 8453 | Base Mainnet |
 | `ethereum` | `eip155:1` | 1 | Ethereum Mainnet |
 | `sepolia` | `eip155:11155111` | 11155111 | Ethereum Sepolia Testnet |
-| `solana-devnet` | `solana:devnet` | - | Solana Devnet |
-| `solana` | `solana:mainnet` | - | Solana Mainnet |
+| `solana-devnet` | `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1` | - | Solana Devnet |
+| `solana` | `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` | - | Solana Mainnet |
 
 ## Package Migration Reference
 


### PR DESCRIPTION
## Description

The v1→v2 network table listed `solana:devnet` and `solana:mainnet`. Both are invalid — `normalizeNetwork()` throws `Unsupported SVM network` for them (`typescript/packages/mechanisms/svm/src/constants.ts:73`).

The table documents `V1_TO_V2_NETWORK_MAP` (`constants.ts:61`), so this replaces the two rows with the values that map holds (`constants.ts:53-54`). Same ids are used by the Go and Python SDKs, `e2e/config/mechanisms_svm.json`, and every other docs page.

## Tests

Docs-only, no code paths touched.

CAIP-2 `solana` uses the first 32 chars of the base58 genesis hash. Checked against live RPC (`getGenesisHash`):

- mainnet-beta → `5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`
- devnet → `EtWTRABZaYq6iMfeYKouRu166VU2xqa1`

## Checklist

- [x] I have formatted and linted my code — n/a: docs-only
- [x] All new and existing tests pass — n/a: no test suite run
- [x] My commits are signed (required for merge)
- [x] I added a changelog fragment for user-facing changes (docs-only changes can skip)
