### PR TITLE
fix(ts): handle missing accepted requirements

### DIFF
--- a/typescript/.changeset/safe-payments-match.md
+++ b/typescript/.changeset/safe-payments-match.md
@@ -1,0 +1,5 @@
+---
+'@x402/core': patch
+---
+
+Handled missing accepted payment requirements without leaking a runtime error.

--- a/typescript/packages/core/src/server/x402ResourceServer.ts
+++ b/typescript/packages/core/src/server/x402ResourceServer.ts
@@ -1462,6 +1462,10 @@ export class x402ResourceServer {
   ): PaymentRequirements | undefined {
     switch (paymentPayload.x402Version) {
       case 2:
+        if (!paymentPayload.accepted) {
+          return undefined;
+        }
+
         // For v2, all server-declared requirements must match.
         // The client may include additive scheme-specific metadata under `accepted.extra`.
         // Scheme-declared dynamicExtraFields are omitted from the extra comparison
@@ -1478,6 +1482,10 @@ export class x402ResourceServer {
           );
         });
       case 1:
+        if (!paymentPayload.accepted) {
+          return undefined;
+        }
+
         // For v1, match by scheme and network
         return availableRequirements.find(
           req =>

--- a/typescript/packages/core/test/unit/http/x402HTTPResourceServer.errors.test.ts
+++ b/typescript/packages/core/test/unit/http/x402HTTPResourceServer.errors.test.ts
@@ -9,7 +9,7 @@ import {
   buildPaymentRequirements,
   buildSupportedResponse,
 } from "../../mocks";
-import { encodePaymentSignatureHeader } from "../../../src/http";
+import { decodePaymentRequiredHeader, encodePaymentSignatureHeader } from "../../../src/http";
 
 class MockHTTPAdapter implements HTTPAdapter {
   constructor(private readonly headers: Record<string, string> = {}) {}
@@ -113,6 +113,35 @@ describe("x402HTTPResourceServer facilitator response errors", () => {
       httpServer.processSettlement(buildPaymentPayload({ x402Version: 2, accepted }), accepted),
     ).rejects.toThrow(FacilitatorResponseError);
   });
+
+  it.each([
+    { x402Version: 1 as const, accepted: undefined },
+    { x402Version: 1 as const, accepted: null },
+    { x402Version: 2 as const, accepted: undefined },
+    { x402Version: 2 as const, accepted: null },
+  ])(
+    "returns a stable payment error when v$x402Version accepted is $accepted",
+    async ({ x402Version, accepted }) => {
+      const payload = Object.assign(buildPaymentPayload({ x402Version }), { accepted });
+      const paymentHeader = encodePaymentSignatureHeader(payload);
+
+      const result = await httpServer.processHTTPRequest({
+        adapter: new MockHTTPAdapter({ "payment-signature": paymentHeader }),
+        path: "/api/test",
+        method: "GET",
+        paymentHeader,
+      });
+
+      expect(result.type).toBe("payment-error");
+      if (result.type !== "payment-error") {
+        throw new Error("Expected payment-error");
+      }
+
+      const response = decodePaymentRequiredHeader(result.response.headers["PAYMENT-REQUIRED"]);
+      expect(response.error).toBe("No matching payment requirements");
+      expect(facilitator.verifyCalls).toHaveLength(0);
+    },
+  );
 
   it("returns payment-error when client extension echo mismatches before facilitator verify", async () => {
     const httpServerWithExtensions = new x402HTTPResourceServer(resourceServer, {


### PR DESCRIPTION
## Description

- Treat missing or null `accepted` requirements as no match for both supported protocol versions.
- Return the existing stable protocol error instead of leaking a runtime `TypeError` from client-controlled input.
- Add end-to-end HTTP regression coverage for v1/v2 × omitted/null `accepted` values.

Fixes #3171

AI assistance: significant. The behavior was reproduced first, the patch was reviewed on separate standards and spec axes, and the repository-wide suite was run before submission.

## Tests

- `corepack pnpm test` from `typescript/` — 55/55 tasks passed
- `corepack pnpm --filter @x402/core lint:check`
- `corepack pnpm --filter @x402/core format:check`
- `corepack pnpm --filter @x402/core build`

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] I added a changelog fragment for the user-facing change