### PR TITLE
docs(extensions): optional pricing metadata for bazaar listings

### DIFF
--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -419,6 +419,82 @@ responsibility (e.g. via Cloudinary at serve time).
 
 ---
 
+## Pricing Metadata (`pricing`)
+
+For the `exact` scheme, `accepts[].amount` is the price. For metered schemes such
+as `upto`, it is the **authorization ceiling**, which is not the price and is
+usually much larger. A catalog that surfaces the ceiling in the field agents read
+as "cost" makes every metered service look expensive next to a fixed-price one,
+and a budget filter keyed on it silently excludes metered services whose settled
+cost lands under budget.
+
+Resource servers MAY therefore publish an optional `pricing` object on the
+`bazaar` extension, as a sibling of `info` and `schema`. Like the service
+metadata above, it is purely additive: servers that omit it produce byte-identical
+402 bodies, and clients that don't recognize it ignore it. `accepts[].amount`
+remains unambiguously the authorization ceiling; `pricing` never participates in
+payment authorization or settlement.
+
+### Example
+
+```json
+{
+  "extensions": {
+    "bazaar": {
+      "info": { ... },
+      "schema": { ... },
+      "pricing": {
+        "model": "per-token",
+        "unit": { "amount": "12", "per": "1000 tokens" },
+        "typical": "350",
+        "note": "long prompts settle above typical"
+      }
+    }
+  }
+}
+```
+
+### Fields
+
+| Field     | Type   | Required | Description                                                                                                                                          |
+|-----------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `model`   | string | Yes      | One of `"per-call"`, `"per-token"`, `"per-second"`, `"per-byte"`, `"tiered"`, `"custom"`. The pricing model the resource meters by.                  |
+| `unit`    | object | No       | `{ "amount": string, "per": string }` — cost per stated quantity, e.g. `{ "amount": "12", "per": "1000 tokens" }`. Omitted when no single unit is meaningful. |
+| `typical` | string | No       | What a median call settles, in the asset's smallest unit, encoded as a decimal string like every other amount on the wire.                            |
+| `note`    | string | No       | Free-form clarification for models that fit none of the above.                                                                                       |
+
+`unit` and `typical` are optional precisely because metered products do not share
+a unit (per-token, per-second, per-byte, per-GB-month, multi-dimensional). A
+catalog that receives none of them SHOULD fall back to the ceiling and say so,
+rather than presenting the ceiling as a price.
+
+### Validation Rules
+
+`pricing` crosses the same trust boundary as the service metadata above: clients
+echo it from `PaymentRequired` into `PaymentPayload`, so facilitators MUST apply
+soft-drop rules during extraction. A field that fails its rule is discarded; the
+listing survives.
+
+| Field     | Rule                                                                                                                                     | On violation             |
+|-----------|------------------------------------------------------------------------------------------------------------------------------------------|--------------------------|
+| `pricing` | Object containing a valid `model`.                                                                                                       | Drop the whole `pricing`. |
+| `model`   | One of the six enumerated strings.                                                                                                       | Drop the whole `pricing`. |
+| `unit`    | Object; `amount` a non-empty string of ASCII digits (optionally one `.`); `per` a non-empty printable-ASCII string, length ≤ 64.          | Drop `unit`.             |
+| `typical` | Non-empty string of ASCII digits (an integer amount in the asset's smallest unit).                                                       | Drop `typical`.          |
+| `note`    | Printable ASCII (U+0020–U+007E), length ≤ 256, no Unicode control characters.                                                            | Drop `note`.             |
+
+### Catalogs and settled amounts (non-normative)
+
+A seller-declared `typical` is a claim, and the catalog is the only party
+positioned to check it. Where a settlement response exposes the actual settled
+amount in a stable location, a catalog holding a resource's settlement history
+can compare declared-`typical` against the observed median and flag or down-rank
+the gap, which keeps the field self-correcting rather than another number sellers
+optimise. How (and whether) a catalog uses `pricing` for filtering or ranking is
+an implementation detail, exactly as with the rest of discovery.
+
+---
+
 ## Facilitator Behavior
 
 When a facilitator receives a `PaymentPayload` containing the `bazaar` extension, it should:

--- a/specs/extensions/bazaar.md
+++ b/specs/extensions/bazaar.md
@@ -429,9 +429,15 @@ and a budget filter keyed on it silently excludes metered services whose settled
 cost lands under budget.
 
 Resource servers MAY therefore publish an optional `pricing` object on the
-`bazaar` extension, as a sibling of `info` and `schema`. Like the service
-metadata above, it is purely additive: servers that omit it produce byte-identical
-402 bodies, and clients that don't recognize it ignore it. `accepts[].amount`
+`bazaar` extension, as a sibling of `info` and `schema`. It is purely additive in
+the same sense as the service metadata above: servers that omit it produce
+byte-identical 402 bodies, and clients that don't recognize it ignore it.
+
+The placement differs from that section, deliberately. `serviceName`, `tags` and
+`iconUrl` sit on the top-level `resource` object because they describe the service
+itself, which the payment path already carries. `pricing` sits on the extension
+object because it is consumed only by catalogs and never by the payment path, and
+keeping it inside the extension keeps that boundary legible. `accepts[].amount`
 remains unambiguously the authorization ceiling; `pricing` never participates in
 payment authorization or settlement.
 
@@ -454,6 +460,27 @@ payment authorization or settlement.
 }
 ```
 
+A `per-call` listing that omits both `unit` and `typical` is the fallback case,
+and the one a catalog implementer meets first:
+
+```json
+{
+  "extensions": {
+    "bazaar": {
+      "pricing": {
+        "model": "per-call",
+        "note": "Flat rate; the ceiling in accepts[].amount is the price."
+      }
+    }
+  }
+}
+```
+
+Here the catalog has nothing better than the ceiling, and per the fallback rule
+below it should say so rather than presenting the ceiling as a price. Everything
+except `model` is optional precisely so this case is expressible, instead of
+forcing a server to invent a unit it does not meter by.
+
 ### Fields
 
 | Field     | Type   | Required | Description                                                                                                                                          |
@@ -471,9 +498,15 @@ rather than presenting the ceiling as a price.
 ### Validation Rules
 
 `pricing` crosses the same trust boundary as the service metadata above: clients
-echo it from `PaymentRequired` into `PaymentPayload`, so facilitators MUST apply
-soft-drop rules during extraction. A field that fails its rule is discarded; the
-listing survives.
+echo it from `PaymentRequired` into `PaymentPayload`. Facilitators SHOULD apply the
+soft-drop rules below during extraction — a field that fails its rule is discarded
+and the listing survives.
+
+These are stated as SHOULD rather than MUST because the reference implementations
+do not carry them yet. The `resource` metadata rules above are MUST, and they
+arrived together with their TypeScript, Go and Python extraction paths in the same
+change; raising `pricing` to MUST belongs with the follow-up PR that implements it
+in all three, not with this one.
 
 | Field     | Rule                                                                                                                                     | On violation             |
 |-----------|------------------------------------------------------------------------------------------------------------------------------------------|--------------------------|


### PR DESCRIPTION
## Motivation

Closes #3264

For the `exact` scheme, `accepts[].amount` is the price. For metered schemes (`upto`), it is the authorization ceiling, which is not the price and is usually much larger. Catalogs that surface the ceiling in the field agents read as "cost" bias discovery against exactly the services upto exists to enable. Three concrete failures observed across current Stellar implementations:

1. Budget filters silently exclude metered services whose settled cost lands under budget (only the ceiling is visible pre-call).
2. A catalog advertised a lower price than an upto route could legitimately charge, because the settlement layer rewrites the amount field before the catalog reads it.
3. Settlement-count ranking stops being comparable once amounts vary, and gaming it gets cheaper the smaller the settlements are.

The author of the `upto` binding draft (#3134) stated the placement directly — *"richer pricing metadata belongs at the discovery layer rather than in the core upto scheme"* ([comment](https://github.com/stellar/x402-stellar/issues/72#issuecomment-5304064452)). The author of #3098 responded to the same proposal from the settlement-catalog side, opening with *"this is additive to your three points rather than a counter to any of them"* and noting it would give his catalog's `accepts` dedupe key somewhere to pick up a profile discriminator ([comment](https://github.com/stellar/x402-stellar/issues/72#issuecomment-5309876697)); I read that as an endorsement of usefulness rather than a position on where the field belongs, and it is worth reading in his own words rather than through my summary.

Keeping this at the discovery layer leaves `PaymentRequirements.amount` unambiguously the authorization ceiling, and lets discovery decide how a settled amount is presented. This PR proposes the shape.

*Edited 2026-08-25: an earlier version of this paragraph said both `scheme_upto_stellar` authors had agreed the metadata belongs at the discovery layer. Only #3134's author said that. Corrected above, and apologies to both for the mischaracterisation.*

## Design

An optional `pricing` object on the bazaar extension, sibling of `info`/`schema`:

- `model` (required if `pricing` is present): `"per-call" | "per-token" | "per-second" | "per-byte" | "tiered" | "custom"`. Always expressible.
- `unit` (optional): amount per stated quantity, omitted when meaningless.
- `typical` (optional): what a median call settles, in the asset's smallest unit, as a string like every other amount on the wire.
- `note` (optional): free-form, for models that fit none of the above.

`unit` and `typical` are optional precisely because metered products do not share a unit. A catalog that receives none of them falls back to the ceiling and says so. Malformed `pricing` is a soft-drop (the field is discarded, the listing survives), consistent with the extension's existing validation posture.

## The self-correcting property

A seller-declared `typical` is a claim, and the catalog is the only party positioned to check it: once the settled actual amount is exposed in a stable place, a catalog holding a resource's settlement history can compare declared-typical against observed-median and flag or down-rank the gap. That keeps the field honest without the settlement scheme enforcing anything, which is further evidence the metadata belongs here.

## Non-goals

- No change to any payment scheme: `amount` remains the authorization ceiling.
- No mandated ranking: catalogs decide how (and whether) to use `pricing`.

## AI disclosure

Drafted with AI assistance, then reviewed and verified by hand. Flagging per CONTRIBUTING.md so reviewers can calibrate.


