### PR TITLE
feat(svm): allow injecting an RPC client into the upto facilitator

### DIFF
--- a/typescript/.changeset/upto-facilitator-rpc-injection.md
+++ b/typescript/.changeset/upto-facilitator-rpc-injection.md
@@ -1,0 +1,5 @@
+---
+"@x402/svm": minor
+---
+
+Allow injecting a pre-built RPC client into the SVM `upto` facilitator (`UptoSvmFacilitatorConfig.rpc`, and the rent cleanup manager's config). When provided it is preferred over constructing a client from `rpcUrl`, letting facilitators route channel claim/cleanup sends through their own paced or instrumented transport (e.g. to respect a provider's sendTransaction rate limit).

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/rentCleanupManager.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/rentCleanupManager.ts
@@ -103,6 +103,8 @@ export interface UptoSvmRentCleanupManagerConfig {
    * (`reclaimComputeUnitLimit`) and are mint-independent.
    */
   settleComputeUnitLimit?: number;
+  /** Injected RPC client used instead of building one from `rpcUrl`. */
+  rpc?: ChannelRpc;
 }
 
 /**
@@ -119,6 +121,7 @@ export class UptoSvmRentCleanupManager {
   private readonly rpcUrl: string | undefined;
   private readonly computeUnitPriceMicroLamports: number | undefined;
   private readonly settleComputeUnitLimit: number | undefined;
+  private readonly rpc: ChannelRpc | undefined;
 
   private timer: ReturnType<typeof setInterval> | undefined;
   private running = false;
@@ -144,6 +147,7 @@ export class UptoSvmRentCleanupManager {
     this.rpcUrl = config.rpcUrl;
     this.computeUnitPriceMicroLamports = config.computeUnitPriceMicroLamports;
     this.settleComputeUnitLimit = config.settleComputeUnitLimit;
+    this.rpc = config.rpc;
   }
 
   /**
@@ -159,7 +163,7 @@ export class UptoSvmRentCleanupManager {
     const maxTxsPerRun = opts.maxTxsPerRun ?? DEFAULT_MAX_TXS_PER_RUN;
     const maxClosesPerRun = opts.maxClosesPerRun ?? DEFAULT_MAX_CLOSES_PER_RUN;
 
-    const rpc = createRpcClient(this.network, this.rpcUrl);
+    const rpc = this.rpc ?? createRpcClient(this.network, this.rpcUrl);
     const records = await this.storage.list();
     const nowSecs = Math.floor(Date.now() / 1_000);
     let currentSlot: bigint | undefined;

--- a/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
+++ b/typescript/packages/mechanisms/svm/src/upto/facilitator/scheme.ts
@@ -26,6 +26,7 @@ import {
   fetchAndVerifyOpenChannel,
   simulateOpenSettleDistribute,
   submitSettle,
+  type ChannelRpc,
   type UptoSvmSigner,
 } from "./channel";
 import {
@@ -80,6 +81,11 @@ function assertLimit(name: string, value: number | undefined, min: number): void
 export interface UptoSvmFacilitatorConfig {
   /** Custom RPC URL (per-network defaults are used when omitted). */
   rpcUrl?: string;
+  /**
+   * Injected RPC client used instead of building one from `rpcUrl`. Lets the
+   * host route channel sends through its own paced/instrumented transport.
+   */
+  rpc?: ChannelRpc;
   /**
    * Channel storage for rent cleanup. Defaults to in-memory storage.
    * Inject a durable implementation for multi-process facilitators.
@@ -241,6 +247,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       network,
       rpcUrl: this.config.rpcUrl,
       settleComputeUnitLimit: this.config.settleComputeUnitLimit,
+      rpc: this.config.rpc,
       signer: this.signer,
       storage: this.channelStorage,
     });
@@ -375,7 +382,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
 
     const { p, channelConfig, feePayerSigner, maxAmount, tokenProgram } = auth.ctx;
     const feePayer = channelConfig.feePayer;
-    const rpc = createRpcClient(requirements.network, this.config.rpcUrl);
+    const rpc = this.config.rpc ?? createRpcClient(requirements.network, this.config.rpcUrl);
 
     // One authorization → one deposit open. A confirmed channel is replay or a
     // stranded prior open, not a supported re-bind path; handler failure after
@@ -558,7 +565,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       (requirements.extra?.tokenProgram as string | undefined) ??
       getStablecoinTokenProgram(requirements.asset, requirements.network);
     const network = requirements.network;
-    const rpc = createRpcClient(network, this.config.rpcUrl);
+    const rpc = this.config.rpc ?? createRpcClient(network, this.config.rpcUrl);
 
     let channel: Awaited<ReturnType<typeof fetchAndVerifyOpenChannel>>;
     try {
@@ -746,7 +753,7 @@ export class UptoSvmScheme implements SchemeNetworkFacilitator {
       };
     }
 
-    const rpc = createRpcClient(requirements.network, this.config.rpcUrl);
+    const rpc = this.config.rpc ?? createRpcClient(requirements.network, this.config.rpcUrl);
     let openSlot: bigint;
     let recentSlot: bigint;
     let nonce: bigint;


### PR DESCRIPTION
## Motivation

The SVM `upto` facilitator builds its own RPC clients internally from `rpcUrl` (`createRpcClient` in `scheme.ts` and `rentCleanupManager.ts`). A facilitator operator has no way to route the scheme's channel claim/cleanup `sendTransaction` calls through their own transport — which matters when the operator paces sends to respect an RPC provider's `sendTransaction`-per-second cap, adds rate-limit retry, or instruments RPC usage. Today those sends bypass any operator-side client entirely.

## Change

- `UptoSvmFacilitatorConfig.rpc?` — an optional pre-built client, preferred over constructing one from `rpcUrl` at the scheme's three build sites.
- `UptoSvmRentCleanupManagerConfig.rpc?` — same for the rent cleanup manager; the scheme threads its configured client through.
- No behavior change when the field is omitted; `rpcUrl` continues to work as before.

~15 lines, additive-only. Changeset included (`@x402/svm`: minor).

## Testing

- `pnpm turbo run build --filter=@x402/svm...` clean
- `@x402/svm` test suite: 365/365 passing

Downstream we run this in production as a vendored build, injecting a client that paces and retries `sendTransaction` against a provider rate limit while leaving simulation/confirmation behavior untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)