### PR TITLE
feat(evm): harden Arc testnet Upto deployment

### DIFF
--- a/contracts/evm/README.md
+++ b/contracts/evm/README.md
@@ -66,6 +66,7 @@ Both contracts:
 ## Prerequisites
 
 - [Foundry](https://book.getfoundry.sh/getting-started/installation)
+- `curl` and `jq` for the Arc testnet receipt and verification checks
 
 ## Installation
 
@@ -78,6 +79,14 @@ forge build
 
 Anyone can deploy both contracts to their canonical addresses on any EVM chain.
 No special build environment, private key, or permission is required—only gas on the target chain.
+
+Foundry eagerly reads the explorer configuration in `foundry.toml`. Set non-secret placeholders when
+an explorer key is not needed so that local build, simulation, and test commands work in a clean shell:
+
+```bash
+export ETHERSCAN_API_KEY="${ETHERSCAN_API_KEY:-unused}"
+export POLYGONSCAN_API_KEY="${POLYGONSCAN_API_KEY:-unused}"
+```
 
 ### How it works
 
@@ -111,29 +120,211 @@ and `keccak256(initCode)`—not on who sends the transaction.
 3. **Check prerequisites on the target chain**
    - [Permit2](https://github.com/Uniswap/permit2) must be deployed at `0x000000000022D473030F116dDEE9F6B43aC78BA3`
    - The CREATE2 deployer must exist at `0x4e59b44847b379578588920cA78FbF26c0B4956C`
-   - Your wallet needs enough native gas to pay for deployment (~300k gas per contract)
+   - Your wallet needs enough native gas for the dry-run gas estimate and configured fee cap
 
 4. **Deploy**
    ```bash
-   export PRIVATE_KEY="your_private_key"
+   cast wallet import x402-deployer --interactive
 
    forge script script/Deploy.s.sol \
      --rpc-url <RPC_URL> \
+     --account x402-deployer \
+     --sender <DEPLOYER_ADDRESS> \
      --broadcast \
      --verify
    ```
 
-   The script automatically:
+   Replace the placeholder explorer key with a real key before using `--verify` on a chain whose
+   explorer requires one.
+
+   To deploy only the canonical Upto proxy to Arc testnet, use its fail-closed entry point:
+
+   ```bash
+   set -euo pipefail
+
+   export X402_DEPLOYMENT_EVIDENCE_DIR="$HOME/x402-deployment-evidence/arc-testnet"
+   export INDEPENDENT_ARC_RPC_URL="<INDEPENDENT_ARC_RPC_URL>"
+
+   REPO_ROOT=$(git rev-parse --show-toplevel)
+   EVIDENCE_DIR="${X402_DEPLOYMENT_EVIDENCE_DIR:?set this to a directory outside the Git checkout}"
+   mkdir -p "$EVIDENCE_DIR"
+   EVIDENCE_DIR=$(cd "$EVIDENCE_DIR" && pwd -P)
+   case "$EVIDENCE_DIR/" in "$REPO_ROOT/"*) echo "evidence directory must be outside $REPO_ROOT" >&2; exit 1;; esac
+   ```
+
+   Generate and persist the checksum for the exact Standard JSON before deployment:
+
+   ```bash
+   STANDARD_JSON="$EVIDENCE_DIR/x402UptoPermit2Proxy.standard.json"
+   STANDARD_JSON_CHECKSUM="$EVIDENCE_DIR/x402UptoPermit2Proxy.standard.json.sha256"
+
+   forge verify-contract 0x402015c795ecb48A360bDC6e35a2EaEb313a0002 \
+     src/x402UptoPermit2Proxy.sol:x402UptoPermit2Proxy \
+     --constructor-args $(cast abi-encode "constructor(address)" 0x000000000022D473030F116dDEE9F6B43aC78BA3) \
+     --show-standard-json-input > "$STANDARD_JSON"
+
+   shasum -a 256 "$STANDARD_JSON" > "$STANDARD_JSON_CHECKSUM"
+   shasum -a 256 -c "$STANDARD_JSON_CHECKSUM"
+   ```
+
+   ```bash
+   forge script script/Deploy.s.sol \
+     --sig "runUptoArcTestnet()" \
+     --rpc-url https://rpc.testnet.arc.network \
+     --sender <DEPLOYER_ADDRESS>
+   ```
+
+   This is a simulation-only command. It requires Arc testnet chain ID `5042002` and validates the
+   canonical factory, Permit2, init code, target address, and target vacancy.
+
+   For a reviewed deployment, construct and sign the exact factory transaction without publishing it:
+
+   ```bash
+   UPTO_SALT=0x0000000000000000000000000000000000000000000000000800000007e2e4de
+   FACTORY=0x4e59b44847b379578588920cA78FbF26c0B4956C
+   PERMIT2=0x000000000022D473030F116dDEE9F6B43aC78BA3
+   CREATION_CODE=$(forge inspect src/x402UptoPermit2Proxy.sol:x402UptoPermit2Proxy bytecode)
+   CONSTRUCTOR_ARGS=$(cast abi-encode "constructor(address)" "$PERMIT2")
+   INIT_CODE=$(cast concat-hex "$CREATION_CODE" "$CONSTRUCTOR_ARGS")
+   CALLDATA=$(cast concat-hex "$UPTO_SALT" "$INIT_CODE")
+
+   test "$(cast keccak "$INIT_CODE")" = \
+     "0x01575bfc9cacbf6463db62ee8867594b1657139c8493a712ef6bcefa848a20b7"
+
+   RAW=$(cast mktx "$FACTORY" "$CALLDATA" \
+     --rpc-url https://rpc.testnet.arc.network \
+     --chain 5042002 \
+     --from <DEPLOYER_ADDRESS> \
+     --account x402-deployer \
+     --nonce <NONCE> \
+     --gas-limit <GAS_LIMIT> \
+     --gas-price <MAX_FEE_PER_GAS> \
+     --priority-gas-price <MAX_PRIORITY_FEE_PER_GAS> \
+     --value 0)
+
+   cast decode-transaction --json "$RAW"
+   ```
+
+   Review the decoded signed transaction and record its hash. Immediately before publishing, require
+   both RPC providers to agree on a shared committed block and rerun the fail-closed preparation against
+   that block:
+
+   ```bash
+   SIGNED_TX_HASH=$(cast keccak "$RAW")
+   printf '%s\n' "$SIGNED_TX_HASH" > "$EVIDENCE_DIR/signed-deployment-transaction.hash"
+
+   REFERENCE_BLOCK=$(cast block-number --rpc-url https://rpc.testnet.arc.network)
+   PRIMARY_BLOCK_HASH=$(cast block "$REFERENCE_BLOCK" --rpc-url https://rpc.testnet.arc.network --json | jq -r '.hash')
+   INDEPENDENT_BLOCK_HASH=$(cast block "$REFERENCE_BLOCK" --rpc-url "$INDEPENDENT_ARC_RPC_URL" --json | jq -r '.hash')
+   test "$PRIMARY_BLOCK_HASH" = "$INDEPENDENT_BLOCK_HASH"
+
+   forge script script/Deploy.s.sol \
+     --sig "prepareUptoArcTestnet()" \
+     --rpc-url https://rpc.testnet.arc.network \
+     --fork-block-number "$REFERENCE_BLOCK"
+   forge script script/Deploy.s.sol \
+     --sig "prepareUptoArcTestnet()" \
+     --rpc-url "$INDEPENDENT_ARC_RPC_URL" \
+     --fork-block-number "$REFERENCE_BLOCK"
+
+   cast publish --rpc-url https://rpc.testnet.arc.network "$RAW"
+   ```
+
+   Fetch the final receipt from both providers, require status `1` and the same committed block hash,
+   then validate the actual deployed state at that receipt block:
+
+   ```bash
+   PRIMARY_RECEIPT="$EVIDENCE_DIR/deployment-receipt-primary.json"
+   INDEPENDENT_RECEIPT="$EVIDENCE_DIR/deployment-receipt-independent.json"
+   cast receipt "$SIGNED_TX_HASH" --confirmations 1 --rpc-url https://rpc.testnet.arc.network --json > "$PRIMARY_RECEIPT"
+   cast receipt "$SIGNED_TX_HASH" --confirmations 1 --rpc-url "$INDEPENDENT_ARC_RPC_URL" --json > "$INDEPENDENT_RECEIPT"
+
+   test "$(jq -r '.status' "$PRIMARY_RECEIPT")" = "0x1"
+   test "$(jq -r '.status' "$INDEPENDENT_RECEIPT")" = "0x1"
+   test "$(jq -r '.blockHash' "$PRIMARY_RECEIPT")" = "$(jq -r '.blockHash' "$INDEPENDENT_RECEIPT")"
+   RECEIPT_BLOCK=$(cast to-dec "$(jq -r '.blockNumber' "$PRIMARY_RECEIPT")")
+
+   forge script script/Deploy.s.sol \
+     --sig "validateUptoArcTestnet()" \
+     --rpc-url https://rpc.testnet.arc.network \
+     --fork-block-number "$RECEIPT_BLOCK"
+   forge script script/Deploy.s.sol \
+     --sig "validateUptoArcTestnet()" \
+     --rpc-url "$INDEPENDENT_ARC_RPC_URL" \
+     --fork-block-number "$RECEIPT_BLOCK"
+   ```
+
+   The generic `run()` entry point automatically:
    - Loads the pre-built initCode for Exact and compiler-derived initCode for Upto
    - Skips any contract already deployed at the expected address
    - Verifies `PERMIT2()` returns the correct address after deployment
 
-5. **Verify on Etherscan** (if `--verify` didn't work automatically)
+   The Arc-specific entry point is stricter: it rejects an occupied canonical Upto address before
+   deployment and validates the pinned runtime bytecode after deployment.
+
+5. **Verify separately after deployment**
+
+   For a generic deployment, verify the contract with the explorer selected for that chain:
+
    ```bash
-   forge verify-contract <DEPLOYED_ADDRESS> x402UptoPermit2Proxy \
+   forge verify-contract <DEPLOYED_ADDRESS> src/x402UptoPermit2Proxy.sol:x402UptoPermit2Proxy \
      --rpc-url <RPC_URL> \
-     --constructor-args $(cast abi-encode "constructor(address)" 0x000000000022D473030F116dDEE9F6B43aC78BA3)
+     --constructor-args $(cast abi-encode "constructor(address)" 0x000000000022D473030F116dDEE9F6B43aC78BA3) \
+     --watch
    ```
+
+   For Arc testnet, submit the exact Standard JSON and checksum generated before deployment. This binds
+   the compiler version, fully qualified contract name, and constructor arguments explicitly:
+
+   ```bash
+   set -euo pipefail
+
+   EVIDENCE_DIR="${X402_DEPLOYMENT_EVIDENCE_DIR:?set the evidence directory used before deployment}"
+   STANDARD_JSON="$EVIDENCE_DIR/x402UptoPermit2Proxy.standard.json"
+   STANDARD_JSON_CHECKSUM="$EVIDENCE_DIR/x402UptoPermit2Proxy.standard.json.sha256"
+   VERIFICATION_SUBMISSION="$EVIDENCE_DIR/arcscan-verification-submit.json"
+   VERIFICATION_STATUS="$EVIDENCE_DIR/arcscan-verification-status.json"
+
+   shasum -a 256 -c "$STANDARD_JSON_CHECKSUM"
+   CONSTRUCTOR_ARGS=$(cast abi-encode \
+     "constructor(address)" 0x000000000022D473030F116dDEE9F6B43aC78BA3)
+
+   curl --fail-with-body --request POST 'https://testnet.arcscan.app/api/' \
+     --form 'module=contract' \
+     --form 'action=verifysourcecode' \
+     --form 'codeformat=solidity-standard-json-input' \
+     --form 'contractaddress=0x402015c795ecb48A360bDC6e35a2EaEb313a0002' \
+     --form 'contractname=src/x402UptoPermit2Proxy.sol:x402UptoPermit2Proxy' \
+     --form 'compilerversion=v0.8.28+commit.7893614a' \
+     --form "sourceCode=<$STANDARD_JSON" \
+     --form "constructorArguments=${CONSTRUCTOR_ARGS#0x}" \
+     --output "$VERIFICATION_SUBMISSION"
+
+   test "$(jq -r '.status' "$VERIFICATION_SUBMISSION")" = "1"
+   VERIFICATION_GUID=$(jq -er '.result | select(type == "string" and length > 0)' "$VERIFICATION_SUBMISSION")
+
+   attempt=0
+   VERIFICATION_RESULT=""
+   while [ "$attempt" -lt 60 ]; do
+     curl --fail-with-body --get 'https://testnet.arcscan.app/api/' \
+       --data-urlencode 'module=contract' \
+       --data-urlencode 'action=checkverifystatus' \
+       --data-urlencode "guid=$VERIFICATION_GUID" \
+       --output "$VERIFICATION_STATUS"
+
+     test "$(jq -r '.status' "$VERIFICATION_STATUS")" = "1"
+     VERIFICATION_RESULT=$(jq -er '.result | select(type == "string")' "$VERIFICATION_STATUS")
+     case "$VERIFICATION_RESULT" in
+       "Pass - Verified") break ;;
+       "Pending in queue") attempt=$((attempt + 1)); sleep 2 ;;
+       *) cat "$VERIFICATION_STATUS" >&2; exit 1 ;;
+     esac
+   done
+   test "$VERIFICATION_RESULT" = "Pass - Verified"
+   ```
+
+   Preserve the submission response, terminal status response, Standard JSON, and persisted checksum
+   together in the evidence directory.
 
    For the Exact proxy, verification may require matching the original compiler metadata.
    The verified source on Base Sepolia / Base Mainnet can be used as a reference.

--- a/contracts/evm/script/Deploy.s.sol
+++ b/contracts/evm/script/Deploy.s.sol
@@ -9,7 +9,7 @@ import {ISignatureTransfer} from "../src/interfaces/ISignatureTransfer.sol";
 /**
  * @title DeployX402Proxies
  * @notice Deployment script for x402 Permit2 Proxy contracts using CREATE2
- * @dev Run with: forge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast --verify
+ * @dev Run with: forge script script/Deploy.s.sol --rpc-url $RPC_URL --broadcast
  *
  *      ## Deployment Strategy
  *
@@ -33,6 +33,8 @@ import {ISignatureTransfer} from "../src/interfaces/ISignatureTransfer.sol";
  *      deploy it first.
  */
 contract DeployX402Proxies is Script {
+    uint256 constant ARC_TESTNET_CHAIN_ID = 5_042_002;
+
     /// @notice Canonical Permit2 address (Uniswap's official deployment)
     /// @dev Override via environment variable PERMIT2_ADDRESS for chains with different Permit2
     address constant CANONICAL_PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
@@ -50,6 +52,18 @@ contract DeployX402Proxies is Script {
 
     /// @notice Expected initCodeHash for x402ExactPermit2Proxy (pre-built, includes CBOR metadata)
     bytes32 constant EXACT_INIT_CODE_HASH = 0xe774d1d5a07218946ab54efe010b300481478b86861bb17d69c98a57f68a604c;
+
+    address constant ARC_TESTNET_UPTO_ADDRESS = 0x402015c795ecb48A360bDC6e35a2EaEb313a0002;
+    bytes32 constant ARC_TESTNET_UPTO_INIT_CODE_HASH =
+        0x01575bfc9cacbf6463db62ee8867594b1657139c8493a712ef6bcefa848a20b7;
+    bytes32 constant ARC_TESTNET_UPTO_RUNTIME_CODE_HASH =
+        0xc858e50b1c4c2207d032578532415db2db50ed0ad509b67b8ac7200d771c70f3;
+    bytes32 constant ARC_TESTNET_PERMIT2_RUNTIME_CODE_HASH =
+        0x53681d3cf8f702f849c1504b491049c3d0a282e4595d9b297c410dcf36f0908e;
+    bytes32 constant ARC_TESTNET_PERMIT2_DOMAIN_SEPARATOR =
+        0xe59c8d3fa907f1186bfa334839eb895f53f88b07e4cf5aafaef4af163d83ce93;
+    bytes32 constant CREATE2_DEPLOYER_RUNTIME_CODE_HASH =
+        0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989;
 
     function run() public {
         address permit2 = vm.envOr("PERMIT2_ADDRESS", CANONICAL_PERMIT2);
@@ -79,6 +93,77 @@ contract DeployX402Proxies is Script {
         console2.log("");
         console2.log("All deployments complete!");
         console2.log("");
+    }
+
+    /// @notice Deploys only x402UptoPermit2Proxy using Arc testnet's canonical dependencies.
+    function runUptoArcTestnet() public {
+        bytes memory deploymentData = prepareUptoArcTestnet();
+
+        vm.startBroadcast();
+        (bool success, bytes memory returnData) = CREATE2_DEPLOYER.call(deploymentData);
+        vm.stopBroadcast();
+
+        require(success, "CREATE2 deployment failed for Upto");
+        require(returnData.length == 20, "Unexpected CREATE2 deployer response");
+
+        address returnedAddress;
+        assembly {
+            returnedAddress := shr(96, mload(add(returnData, 32)))
+        }
+        require(returnedAddress == ARC_TESTNET_UPTO_ADDRESS, "CREATE2 deployer returned wrong address");
+
+        validateUptoArcTestnet();
+        console2.log("Deployed x402UptoPermit2Proxy to:", ARC_TESTNET_UPTO_ADDRESS);
+    }
+
+    /// @notice Validates Arc testnet dependencies and returns the exact factory calldata.
+    function prepareUptoArcTestnet() public view returns (bytes memory deploymentData) {
+        require(block.chainid == ARC_TESTNET_CHAIN_ID, "Arc testnet chain ID mismatch");
+        _validateArcTestnetDependencies();
+        deploymentData = uptoArcTestnetDeploymentData();
+        require(ARC_TESTNET_UPTO_ADDRESS.code.length == 0, "Upto target already occupied");
+    }
+
+    /// @notice Validates the deployed Arc testnet proxy against the approved artifact.
+    function validateUptoArcTestnet() public view {
+        require(block.chainid == ARC_TESTNET_CHAIN_ID, "Arc testnet chain ID mismatch");
+        _validateArcTestnetDependencies();
+        uptoArcTestnetDeploymentData();
+
+        require(
+            ARC_TESTNET_UPTO_ADDRESS.codehash == ARC_TESTNET_UPTO_RUNTIME_CODE_HASH, "Upto runtime code hash mismatch"
+        );
+        require(
+            address(x402UptoPermit2Proxy(ARC_TESTNET_UPTO_ADDRESS).PERMIT2()) == CANONICAL_PERMIT2,
+            "Upto PERMIT2 mismatch"
+        );
+    }
+
+    /// @notice Returns factory calldata only when the locally compiled Upto artifact is canonical.
+    function uptoArcTestnetDeploymentData() public pure returns (bytes memory deploymentData) {
+        bytes memory initCode = abi.encodePacked(type(x402UptoPermit2Proxy).creationCode, abi.encode(CANONICAL_PERMIT2));
+        bytes32 initCodeHash = keccak256(initCode);
+        require(initCodeHash == ARC_TESTNET_UPTO_INIT_CODE_HASH, "Upto init code hash mismatch");
+
+        address expectedAddress = _computeCreate2Addr(UPTO_SALT, initCodeHash, CREATE2_DEPLOYER);
+        require(expectedAddress == ARC_TESTNET_UPTO_ADDRESS, "Upto CREATE2 address mismatch");
+
+        deploymentData = abi.encodePacked(UPTO_SALT, initCode);
+    }
+
+    function _validateArcTestnetDependencies() internal view {
+        require(CREATE2_DEPLOYER.codehash == CREATE2_DEPLOYER_RUNTIME_CODE_HASH, "CREATE2 deployer code hash mismatch");
+        require(
+            CANONICAL_PERMIT2.codehash == ARC_TESTNET_PERMIT2_RUNTIME_CODE_HASH, "Permit2 runtime code hash mismatch"
+        );
+
+        (bool success, bytes memory returnData) =
+            CANONICAL_PERMIT2.staticcall(abi.encodeWithSignature("DOMAIN_SEPARATOR()"));
+        require(success && returnData.length == 32, "Permit2 DOMAIN_SEPARATOR call failed");
+        require(
+            abi.decode(returnData, (bytes32)) == ARC_TESTNET_PERMIT2_DOMAIN_SEPARATOR,
+            "Permit2 DOMAIN_SEPARATOR mismatch"
+        );
     }
 
     function _deployExact(

--- a/contracts/evm/test/Deploy.t.sol
+++ b/contracts/evm/test/Deploy.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {DeployX402Proxies} from "../script/Deploy.s.sol";
+import {x402UptoPermit2Proxy} from "../src/x402UptoPermit2Proxy.sol";
+
+contract DeployX402ProxiesTest is Test {
+    uint256 constant ARC_TESTNET_CHAIN_ID = 5_042_002;
+    address constant CANONICAL_PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+    address constant CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+    address constant ARC_TESTNET_UPTO_ADDRESS = 0x402015c795ecb48A360bDC6e35a2EaEb313a0002;
+    bytes32 constant UPTO_SALT = 0x0000000000000000000000000000000000000000000000000800000007e2e4de;
+    bytes32 constant UPTO_INIT_CODE_HASH = 0x01575bfc9cacbf6463db62ee8867594b1657139c8493a712ef6bcefa848a20b7;
+    bytes32 constant UPTO_RUNTIME_CODE_HASH = 0xc858e50b1c4c2207d032578532415db2db50ed0ad509b67b8ac7200d771c70f3;
+
+    DeployX402Proxies internal deployer;
+
+    function setUp() public {
+        deployer = new DeployX402Proxies();
+    }
+
+    function test_uptoArcTestnetDeploymentDataMatchesPinnedArtifact() public view {
+        bytes memory initCode = abi.encodePacked(type(x402UptoPermit2Proxy).creationCode, abi.encode(CANONICAL_PERMIT2));
+        bytes memory expectedDeploymentData = abi.encodePacked(UPTO_SALT, initCode);
+        bytes memory deploymentData = deployer.uptoArcTestnetDeploymentData();
+
+        assertEq(keccak256(initCode), UPTO_INIT_CODE_HASH);
+        assertEq(keccak256(deploymentData), keccak256(expectedDeploymentData));
+
+        address expectedAddress = address(
+            uint160(
+                uint256(keccak256(abi.encodePacked(bytes1(0xff), CREATE2_DEPLOYER, UPTO_SALT, UPTO_INIT_CODE_HASH)))
+            )
+        );
+        assertEq(expectedAddress, ARC_TESTNET_UPTO_ADDRESS);
+    }
+
+    function test_uptoRuntimeMatchesPinnedArtifact() public {
+        x402UptoPermit2Proxy proxy = new x402UptoPermit2Proxy(CANONICAL_PERMIT2);
+        assertEq(address(proxy).codehash, UPTO_RUNTIME_CODE_HASH);
+        assertEq(address(proxy.PERMIT2()), CANONICAL_PERMIT2);
+    }
+
+    function test_prepareUptoArcTestnetRejectsWrongChain() public {
+        vm.chainId(1);
+        vm.expectRevert("Arc testnet chain ID mismatch");
+        deployer.prepareUptoArcTestnet();
+    }
+
+    function test_prepareUptoArcTestnetRejectsWrongFactoryCode() public {
+        vm.chainId(ARC_TESTNET_CHAIN_ID);
+        vm.etch(CREATE2_DEPLOYER, hex"00");
+        vm.expectRevert("CREATE2 deployer code hash mismatch");
+        deployer.prepareUptoArcTestnet();
+    }
+
+    function test_prepareUptoArcTestnetRejectsWrongPermit2Code() public {
+        vm.chainId(ARC_TESTNET_CHAIN_ID);
+        vm.expectRevert("Permit2 runtime code hash mismatch");
+        deployer.prepareUptoArcTestnet();
+    }
+}

--- a/contracts/evm/test/DeployArcFork.t.sol
+++ b/contracts/evm/test/DeployArcFork.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {DeployX402Proxies} from "../script/Deploy.s.sol";
+
+contract DeployX402ProxiesArcForkTest is Test {
+    uint256 constant ARC_TESTNET_CHAIN_ID = 5_042_002;
+    address constant CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+    address constant ARC_TESTNET_UPTO_ADDRESS = 0x402015c795ecb48A360bDC6e35a2EaEb313a0002;
+    bytes32 constant UPTO_RUNTIME_CODE_HASH = 0xc858e50b1c4c2207d032578532415db2db50ed0ad509b67b8ac7200d771c70f3;
+
+    modifier onlyArcFork() {
+        if (block.chainid == 31_337) {
+            vm.skip(true, "Run this test with --fork-url https://rpc.testnet.arc.network");
+        }
+        require(block.chainid == ARC_TESTNET_CHAIN_ID, "Run this test against Arc testnet");
+        _;
+    }
+
+    function test_fork_arcUptoDeploymentAndValidation() public onlyArcFork {
+        DeployX402Proxies deployer = new DeployX402Proxies();
+
+        if (ARC_TESTNET_UPTO_ADDRESS.code.length == 0) {
+            bytes memory deploymentData = deployer.prepareUptoArcTestnet();
+            (bool success, bytes memory returnData) = CREATE2_DEPLOYER.call(deploymentData);
+
+            assertTrue(success);
+            assertEq(returnData.length, 20);
+
+            address returnedAddress;
+            assembly {
+                returnedAddress := shr(96, mload(add(returnData, 32)))
+            }
+            assertEq(returnedAddress, ARC_TESTNET_UPTO_ADDRESS);
+        }
+
+        deployer.validateUptoArcTestnet();
+        assertEq(ARC_TESTNET_UPTO_ADDRESS.codehash, UPTO_RUNTIME_CODE_HASH);
+
+        vm.expectRevert("Upto target already occupied");
+        deployer.prepareUptoArcTestnet();
+    }
+}

--- a/contracts/evm/test/ValidateArcDeploymentFork.t.sol
+++ b/contracts/evm/test/ValidateArcDeploymentFork.t.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {x402UptoPermit2Proxy} from "../src/x402UptoPermit2Proxy.sol";
+import {ISignatureTransfer} from "../src/interfaces/ISignatureTransfer.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+
+contract ValidateArcDeploymentForkTest is Test {
+    uint256 constant ARC_TESTNET_CHAIN_ID = 5_042_002;
+    address constant PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+    address constant ARC_TESTNET_UPTO_ADDRESS = 0x402015c795ecb48A360bDC6e35a2EaEb313a0002;
+    bytes32 constant UPTO_RUNTIME_CODE_HASH = 0xc858e50b1c4c2207d032578532415db2db50ed0ad509b67b8ac7200d771c70f3;
+
+    bytes32 constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+    bytes32 constant PERMIT_TYPEHASH = keccak256(
+        "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,Witness witness)TokenPermissions(address token,uint256 amount)Witness(address to,address facilitator,uint256 validAfter)"
+    );
+    bytes32 constant TOKEN_PERMISSIONS_TYPEHASH = keccak256("TokenPermissions(address token,uint256 amount)");
+    uint256 constant PAYER_KEY = uint256(keccak256("arc-deployment-validator-payer"));
+
+    modifier onlyArcFork() {
+        if (block.chainid == 31_337) {
+            vm.skip(true, "Run this test with --fork-url https://rpc.testnet.arc.network");
+        }
+        require(block.chainid == ARC_TESTNET_CHAIN_ID, "Run this test against Arc testnet");
+        _;
+    }
+
+    function _sign(
+        address token,
+        uint256 amount,
+        uint256 nonce,
+        uint256 deadline,
+        x402UptoPermit2Proxy.Witness memory witness
+    ) internal view returns (bytes memory) {
+        x402UptoPermit2Proxy proxy = x402UptoPermit2Proxy(ARC_TESTNET_UPTO_ADDRESS);
+        bytes32 domainSeparator = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256("Permit2"), block.chainid, PERMIT2));
+        bytes32 witnessHash =
+            keccak256(abi.encode(proxy.WITNESS_TYPEHASH(), witness.to, witness.facilitator, witness.validAfter));
+        bytes32 tokenHash = keccak256(abi.encode(TOKEN_PERMISSIONS_TYPEHASH, token, amount));
+        bytes32 structHash =
+            keccak256(abi.encode(PERMIT_TYPEHASH, tokenHash, address(proxy), nonce, deadline, witnessHash));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PAYER_KEY, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function test_fork_deployedArcUptoPartialSettlement() public onlyArcFork {
+        require(ARC_TESTNET_UPTO_ADDRESS.codehash == UPTO_RUNTIME_CODE_HASH, "Canonical Upto proxy not deployed");
+
+        x402UptoPermit2Proxy proxy = x402UptoPermit2Proxy(ARC_TESTNET_UPTO_ADDRESS);
+        require(address(proxy.PERMIT2()) == PERMIT2, "Upto PERMIT2 mismatch");
+
+        MockERC20 token = new MockERC20("USDC", "USDC", 6);
+        address payer = vm.addr(PAYER_KEY);
+        address recipient = makeAddr("arc-deployment-validator-recipient");
+        uint256 permittedAmount = 100e6;
+        uint256 settlementAmount = 40e6;
+
+        token.mint(payer, permittedAmount);
+        vm.prank(payer);
+        token.approve(PERMIT2, permittedAmount);
+
+        uint256 nonce = uint256(keccak256(abi.encodePacked(block.number, address(this))));
+        uint256 deadline = block.timestamp + 1 hours;
+        x402UptoPermit2Proxy.Witness memory witness =
+            x402UptoPermit2Proxy.Witness({to: recipient, facilitator: address(this), validAfter: block.timestamp - 1});
+
+        bytes memory signature = _sign(address(token), permittedAmount, nonce, deadline, witness);
+
+        ISignatureTransfer.PermitTransferFrom memory permit = ISignatureTransfer.PermitTransferFrom({
+            permitted: ISignatureTransfer.TokenPermissions({token: address(token), amount: permittedAmount}),
+            nonce: nonce,
+            deadline: deadline
+        });
+
+        proxy.settle(permit, settlementAmount, payer, witness, signature);
+
+        assertEq(token.balanceOf(recipient), settlementAmount);
+        assertEq(token.balanceOf(payer), permittedAmount - settlementAmount);
+        assertEq(token.balanceOf(ARC_TESTNET_UPTO_ADDRESS), 0);
+    }
+}


### PR DESCRIPTION
## Description

Adds a fail-closed Arc testnet deployment path for the canonical `x402UptoPermit2Proxy` without changing proxy business logic. The generic deployment entry point can deploy both proxies and only checks that dependencies have code; using it unchanged for Arc would not bind the deployment to the reviewed chain, dependency bytecode, init code, runtime code, or target address.

The Arc-specific path deploys only Upto and pins the Arc testnet chain ID, CREATE2 deployer, Permit2 runtime and domain separator, init-code hash, runtime hash, salt, and expected address. It rejects an occupied target, validates the factory return value, and exposes preparation and postdeployment validation functions.

The deployment guide now documents encrypted-keystore use, exact raw-transaction review and publication, dual-RPC receipt validation, and exact Standard JSON submission to Arcscan. Generic deployment and verification instructions remain available for other chains.

Significant AI assistance was used in preparing this PR.

No contract has been deployed by this PR.

## Tests

- `forge fmt --check`
- `forge build`
- `forge test`: 194 passed, 2 explicit Arc fork skips
- `forge test --match-contract DeployX402ProxiesTest`: 5 passed
- Default Arc fork-test execution: 2 explicit skips
- Fixed-block Arc preparation simulation against `https://rpc.testnet.arc.network`
- Fixed-block Arc fork deployment and validation against chain ID `5042002`
- Live checks of the pinned CREATE2 deployer, Permit2 runtime/domain, target vacancy, init-code hash, runtime hash, and deterministic target address
- Standard JSON generation and persisted checksum verification

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] No SDK changelog fragment is needed for EVM deployment tooling and documentation
