### PR TITLE
fix(py): bind SIWX client challenge to the request origin

### DIFF
--- a/examples/python/clients/httpx/README.md
+++ b/examples/python/clients/httpx/README.md
@@ -13,7 +13,7 @@ cp .env-local .env
 2. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 ## Usage

--- a/examples/python/clients/requests/README.md
+++ b/examples/python/clients/requests/README.md
@@ -13,7 +13,7 @@ cp .env-local .env
 2. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 ## Usage

--- a/examples/python/clients/sign-in-with-x/README.md
+++ b/examples/python/clients/sign-in-with-x/README.md
@@ -75,7 +75,7 @@ and provide at least one private key:
 2. Install dependencies:
 
 ```bash
-uv sync
+uv sync --reinstall-package x402
 ```
 
 3. Start the SIWX server:

--- a/examples/python/clients/sign-in-with-x/uv.lock
+++ b/examples/python/clients/sign-in-with-x/uv.lock
@@ -2076,7 +2076,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.15.0"
+version = "2.19.0"
 source = { editable = "../../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/examples/python/servers/sign-in-with-x/uv.lock
+++ b/examples/python/servers/sign-in-with-x/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "x402"
-version = "2.15.0"
+version = "2.19.0"
 source = { editable = "../../../../python/x402" }
 dependencies = [
     { name = "nest-asyncio" },

--- a/python/x402/extensions/README.md
+++ b/python/x402/extensions/README.md
@@ -232,5 +232,12 @@ from x402.extensions.sign_in_with_x import create_siwx_client_extension
 client.register_extension(create_siwx_client_extension(signers=[evm_signer]))
 ```
 
+The client extension automatically:
+- Detects SIWX support in 402 responses
+- Matches your wallet's chain with the server's `supportedChains`
+- Verifies the challenge is bound to the 402 response origin before signing
+- Signs and sends the authentication proof
+- Falls back to payment if SIWX auth fails or the challenge is not origin-bound
+
 Requires `x402[extensions]` (signinwithethereum, PyNaCl). EVM signing uses `x402[evm]`; Solana signing uses `x402[svm]`.
 

--- a/python/x402/extensions/__init__.py
+++ b/python/x402/extensions/__init__.py
@@ -110,6 +110,7 @@ from .sign_in_with_x import (  # noqa: E402
     SIWxVerifyOptions,
     SIWxVerifyResult,
     SupportedChain,
+    assert_siwx_challenge_bound_to_origin,
     build_siwx_schema,
     create_siwx_client_extension,
     create_siwx_client_hook,
@@ -269,6 +270,7 @@ __all__ = [
     "verify_siwx_signature",
     "build_siwx_schema",
     # Sign-In-With-X client
+    "assert_siwx_challenge_bound_to_origin",
     "create_siwx_message",
     "create_siwx_payload",
     "encode_siwx_header",

--- a/python/x402/extensions/sign_in_with_x/__init__.py
+++ b/python/x402/extensions/sign_in_with_x/__init__.py
@@ -1,6 +1,6 @@
 """Sign-In-With-X extension for x402 v2."""
 
-from .client import CompleteSIWxInfo, create_siwx_payload
+from .client import CompleteSIWxInfo, assert_siwx_challenge_bound_to_origin, create_siwx_payload
 from .declare import declare_siwx_extension, get_signature_type
 from .encode import encode_siwx_header
 from .evm import (
@@ -103,6 +103,7 @@ __all__ = [
     "verify_siwx_signature",
     "build_siwx_schema",
     "create_siwx_message",
+    "assert_siwx_challenge_bound_to_origin",
     "create_siwx_payload",
     "encode_siwx_header",
     "create_siwx_client_extension",

--- a/python/x402/extensions/sign_in_with_x/client.py
+++ b/python/x402/extensions/sign_in_with_x/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 from .message import create_siwx_message
 from .sign import get_evm_address, get_solana_address, sign_evm_message, sign_solana_message
@@ -11,8 +12,49 @@ from .types import SignatureType, SIWxExtensionInfo, SIWxPayload
 CompleteSIWxInfo = SIWxExtensionInfo | dict[str, Any]
 
 
-async def create_siwx_payload(server_extension: Any, signer: Any) -> SIWxPayload:
-    """Create a complete SIWX payload from server extension info with selected chain."""
+def assert_siwx_challenge_bound_to_origin(info: Any, response_url: str) -> None:
+    """Verify that a SIWX challenge is bound to the origin of the resource that issued the 402.
+
+    Checks `domain` and `uri` only. EIP-4361 `resources` may be cross-origin URIs and are not
+    validated here (matching server-side validate_siwx_message).
+
+    Args:
+        info: Server extension info from the 402 response.
+        response_url: Final URL of the 402 response (after redirects).
+
+    Raises:
+        ValueError: When domain or uri origin does not match.
+    """
+    origin = urlparse(response_url)
+    domain = info.domain if hasattr(info, "domain") else info["domain"]
+    uri = info.uri if hasattr(info, "uri") else info["uri"]
+
+    if domain != origin.netloc:
+        raise ValueError(
+            f'SIWX challenge domain "{domain}" does not match response origin host "{origin.netloc}"'
+        )
+
+    uri_parsed = urlparse(uri)
+    if not uri_parsed.scheme or not uri_parsed.netloc:
+        raise ValueError(f'SIWX challenge uri "{uri}" is not a valid URL')
+
+    uri_origin = f"{uri_parsed.scheme}://{uri_parsed.netloc}"
+    origin_value = f"{origin.scheme}://{origin.netloc}"
+    if uri_origin != origin_value:
+        raise ValueError(
+            f'SIWX challenge uri origin "{uri_origin}" does not match response origin "{origin_value}"'
+        )
+
+
+async def create_siwx_payload(server_extension: Any, signer: Any, request_url: str) -> SIWxPayload:
+    """Create a complete SIWX payload from server extension info with selected chain.
+
+    Args:
+        server_extension: Server extension info with chain selected (includes chainId, type).
+        signer: Wallet that can sign messages.
+        request_url: Final URL of the 402 response (after redirects).
+    """
+    assert_siwx_challenge_bound_to_origin(server_extension, request_url)
     chain_id = (
         server_extension.chain_id
         if hasattr(server_extension, "chain_id")

--- a/python/x402/extensions/sign_in_with_x/hooks.py
+++ b/python/x402/extensions/sign_in_with_x/hooks.py
@@ -10,7 +10,11 @@ from urllib.parse import urlparse
 
 from x402.http.types import HTTPRequestContext, PaymentOption, RouteConfig
 from x402.schemas.extensions import ClientExtension
-from x402.schemas.hooks import GrantAccessResult, PaymentRequiredHeadersResult
+from x402.schemas.hooks import (
+    GrantAccessResult,
+    PaymentRequiredContext,
+    PaymentRequiredHeadersResult,
+)
 
 from .client import create_siwx_payload
 from .encode import encode_siwx_header
@@ -199,7 +203,7 @@ def create_siwx_client_hook(signer: Any):
     signer_is_solana = is_solana_signer(signer)
     expected_signature_type: SignatureType = "ed25519" if signer_is_solana else "eip191"
 
-    async def hook(context: Any) -> PaymentRequiredHeadersResult | None:
+    async def hook(context: PaymentRequiredContext) -> PaymentRequiredHeadersResult | None:
         extensions = context.payment_required.extensions or {}
         siwx_extension = extensions.get(SIGN_IN_WITH_X)
         if not siwx_extension:
@@ -229,7 +233,7 @@ def create_siwx_client_hook(signer: Any):
             chain_id = matching["chainId"] if isinstance(matching, dict) else matching.chain_id
             sig_type = matching["type"] if isinstance(matching, dict) else matching.type
             complete_info = {**info, "chainId": chain_id, "type": sig_type}
-            payload = await create_siwx_payload(complete_info, signer)
+            payload = await create_siwx_payload(complete_info, signer, context.request_url)
             header = encode_siwx_header(payload)
             return PaymentRequiredHeadersResult(headers={SIGN_IN_WITH_X: header})
         except Exception:

--- a/python/x402/http/clients/httpx.py
+++ b/python/x402/http/clients/httpx.py
@@ -144,7 +144,14 @@ class x402AsyncTransport(AsyncBaseTransport):
 
             payment_required = self._http_client.get_payment_required_response(get_header, body)
 
-            hook_headers = await self._http_client.handle_payment_required(payment_required)
+            try:
+                request_url = str(response.url)
+            except RuntimeError:
+                request_url = ""
+            request_url = request_url or str(request.url)
+            hook_headers = await self._http_client.handle_payment_required(
+                payment_required, request_url
+            )
             if hook_headers:
                 hook_response = await self._send_retry(request, hook_headers)
                 if hook_response.status_code != 402:

--- a/python/x402/http/clients/requests.py
+++ b/python/x402/http/clients/requests.py
@@ -136,7 +136,9 @@ class x402HTTPAdapter(HTTPAdapter):
 
             payment_required = self._http_client.get_payment_required_response(get_header, body)
 
-            hook_headers = self._http_client.handle_payment_required(payment_required)
+            hook_headers = self._http_client.handle_payment_required(
+                payment_required, response.url or request.url
+            )
             if hook_headers:
                 hook_request = request.copy()
                 hook_request.headers.update(hook_headers)

--- a/python/x402/http/x402_http_client.py
+++ b/python/x402/http/x402_http_client.py
@@ -63,9 +63,15 @@ class x402HTTPClient(x402HTTPClientBase):
     async def handle_payment_required(
         self,
         payment_required: PaymentRequired | PaymentRequiredV1,
+        request_url: str,
     ) -> dict[str, str] | None:
-        """Run hooks; return headers for a pre-payment retry, or None to pay."""
-        ctx = PaymentRequiredContext(payment_required=payment_required)
+        """Run hooks; return headers for a pre-payment retry, or None to pay.
+
+        Args:
+            payment_required: The payment required response from the server.
+            request_url: The URL of the request that received the payment required response.
+        """
+        ctx = PaymentRequiredContext(payment_required=payment_required, request_url=request_url)
         for hook in self._collect_payment_required_hooks(payment_required):
             result = await self._execute_hook(hook, ctx)
             if isinstance(result, PaymentRequiredHeadersResult):
@@ -124,6 +130,7 @@ class x402HTTPClient(x402HTTPClientBase):
         self,
         headers: dict[str, str],
         body: bytes | None,
+        request_url: str,
     ) -> tuple[dict[str, str], PaymentPayload | PaymentPayloadV1]:
         """Handle a 402 response and create payment headers.
 
@@ -136,6 +143,7 @@ class x402HTTPClient(x402HTTPClientBase):
         Args:
             headers: Response headers.
             body: Response body bytes.
+            request_url: The URL of the request that received the 402 response.
 
         Returns:
             Tuple of (headers_to_add, payment_payload).
@@ -143,7 +151,7 @@ class x402HTTPClient(x402HTTPClientBase):
         # Get payment required
         get_header, body_data = self._handle_402_common(headers, body)
         payment_required = self.get_payment_required_response(get_header, body_data)
-        hook_headers = await self.handle_payment_required(payment_required)
+        hook_headers = await self.handle_payment_required(payment_required, request_url)
         if hook_headers:
             return hook_headers, None
         # Create payment
@@ -198,9 +206,15 @@ class x402HTTPClientSync(x402HTTPClientBase):
     def handle_payment_required(
         self,
         payment_required: PaymentRequired | PaymentRequiredV1,
+        request_url: str,
     ) -> dict[str, str] | None:
-        """Run hooks; return headers for a pre-payment retry, or None to pay."""
-        ctx = PaymentRequiredContext(payment_required=payment_required)
+        """Run hooks; return headers for a pre-payment retry, or None to pay.
+
+        Args:
+            payment_required: The payment required response from the server.
+            request_url: The URL of the request that received the payment required response.
+        """
+        ctx = PaymentRequiredContext(payment_required=payment_required, request_url=request_url)
         for hook in self._collect_payment_required_hooks(payment_required):
             result = hook(ctx)
             if asyncio.iscoroutine(result):
@@ -251,6 +265,7 @@ class x402HTTPClientSync(x402HTTPClientBase):
         self,
         headers: dict[str, str],
         body: bytes | None,
+        request_url: str,
     ) -> tuple[dict[str, str], PaymentPayload | PaymentPayloadV1]:
         """Handle a 402 response and create payment headers.
 
@@ -263,6 +278,7 @@ class x402HTTPClientSync(x402HTTPClientBase):
         Args:
             headers: Response headers.
             body: Response body bytes.
+            request_url: The URL of the request that received the 402 response.
 
         Returns:
             Tuple of (headers_to_add, payment_payload).
@@ -270,7 +286,7 @@ class x402HTTPClientSync(x402HTTPClientBase):
         # Get payment required
         get_header, body_data = self._handle_402_common(headers, body)
         payment_required = self.get_payment_required_response(get_header, body_data)
-        hook_headers = self.handle_payment_required(payment_required)
+        hook_headers = self.handle_payment_required(payment_required, request_url)
         if hook_headers:
             return hook_headers, None
         # Create payment
@@ -313,6 +329,7 @@ class PaymentRoundTripper:
         headers: dict[str, str],
         body: bytes | None,
         retry_func: Callable[[dict[str, str]], Any],
+        request_url: str,
     ) -> Any:
         """Handle HTTP response, automatically paying on 402.
 
@@ -322,6 +339,7 @@ class PaymentRoundTripper:
             headers: Response headers.
             body: Response body.
             retry_func: Function to retry request with additional headers.
+            request_url: The URL of the request that received the response.
 
         Returns:
             Original response if not 402, or retried response with payment.
@@ -342,7 +360,7 @@ class PaymentRoundTripper:
         get_header, body_data = self._x402_client._handle_402_common(headers, body)
         payment_required = self._x402_client.get_payment_required_response(get_header, body_data)
 
-        hook_headers = self._x402_client.handle_payment_required(payment_required)
+        hook_headers = self._x402_client.handle_payment_required(payment_required, request_url)
         if hook_headers:
             hook_result = retry_func(hook_headers)
             if getattr(hook_result, "status_code", 402) != 402:

--- a/python/x402/schemas/hooks.py
+++ b/python/x402/schemas/hooks.py
@@ -432,6 +432,7 @@ class PaymentRequiredContext:
     """Context for HTTP on_payment_required hooks."""
 
     payment_required: "PaymentRequired | PaymentRequiredV1"
+    request_url: str
 
 
 @dataclass

--- a/python/x402/tests/unit/extensions/sign_in_with_x/test_sign_in_with_x.py
+++ b/python/x402/tests/unit/extensions/sign_in_with_x/test_sign_in_with_x.py
@@ -22,6 +22,7 @@ from x402.extensions.sign_in_with_x import (
     SIWxValidationCode,
     SIWxValidationOptions,
     SIWxVerifyOptions,
+    assert_siwx_challenge_bound_to_origin,
     create_siwx_client_hook,
     create_siwx_payload,
     create_siwx_request_hook,
@@ -59,6 +60,11 @@ pytest.importorskip("nacl")
 
 API_ORIGIN = "https://api.example.com"
 EXAMPLE_ORIGIN = "http://example.com"
+
+
+def _bound_request_url(info: dict) -> str:
+    """Return a 402 response URL bound to the challenge's declared uri origin."""
+    return info["uri"]
 
 
 def _valid_payload(**overrides) -> SIWxPayload:
@@ -329,7 +335,7 @@ class TestEvmIntegration:
             "chainId": ext["supportedChains"][0]["chainId"],
             "type": "eip191",
         }
-        payload = await create_siwx_payload(complete, account)
+        payload = await create_siwx_payload(complete, account, _bound_request_url(complete))
         parsed = parse_siwx_header(encode_siwx_header(payload))
         assert (await validate_siwx_message(parsed, API_ORIGIN)).is_valid
         verification = await verify_siwx_signature(parsed)
@@ -390,7 +396,7 @@ class TestSolana:
             "chainId": ext["supportedChains"][0]["chainId"],
             "type": "ed25519",
         }
-        payload = await create_siwx_payload(complete, _Signer())
+        payload = await create_siwx_payload(complete, _Signer(), _bound_request_url(complete))
         result = await verify_siwx_signature(payload)
         assert result.is_valid
         assert result.payer == address
@@ -438,7 +444,7 @@ class TestSolana:
             "chainId": ext["supportedChains"][0]["chainId"],
             "type": "ed25519",
         }
-        payload = await create_siwx_payload(complete, signer)
+        payload = await create_siwx_payload(complete, signer, _bound_request_url(complete))
         result = await verify_siwx_signature(payload)
         assert result.is_valid
         assert result.payer == signer.address
@@ -488,7 +494,7 @@ class TestVerifyStructuredErrors:
             "chainId": ext["supportedChains"][0]["chainId"],
             "type": "eip191",
         }
-        payload = await create_siwx_payload(complete, account)
+        payload = await create_siwx_payload(complete, account, _bound_request_url(complete))
 
         async def _verifier(**_kwargs) -> bool:
             return False
@@ -512,7 +518,7 @@ class TestVerifyStructuredErrors:
             "chainId": ext["supportedChains"][0]["chainId"],
             "type": "eip191",
         }
-        payload = await create_siwx_payload(complete, account)
+        payload = await create_siwx_payload(complete, account, _bound_request_url(complete))
 
         async def _verifier(**_kwargs) -> bool:
             raise RuntimeError("RPC error")
@@ -588,7 +594,9 @@ class TestRequestHook:
             "chainId": ext["supportedChains"][0]["chainId"],
             "type": "eip191",
         }
-        header = encode_siwx_header(await create_siwx_payload(complete, account))
+        header = encode_siwx_header(
+            await create_siwx_payload(complete, account, _bound_request_url(complete))
+        )
         hook = create_siwx_request_hook(
             CreateSIWxRequestHookOptions(storage=storage, origin=EXAMPLE_ORIGIN)
         )
@@ -626,7 +634,9 @@ class TestRequestHookOriginBinding:
             "chainId": ext["supportedChains"][0]["chainId"],
             "type": "eip191",
         }
-        header = encode_siwx_header(await create_siwx_payload(complete, account))
+        header = encode_siwx_header(
+            await create_siwx_payload(complete, account, _bound_request_url(complete))
+        )
         hook = create_siwx_request_hook(
             CreateSIWxRequestHookOptions(storage=storage, origin=API_ORIGIN)
         )
@@ -693,7 +703,8 @@ class TestClientHook:
                     )
                 ],
                 extensions=challenge,
-            )
+            ),
+            request_url="http://example.com/resource",
         )
         result = await hook(ctx)
         assert isinstance(result, PaymentRequiredHeadersResult)
@@ -718,11 +729,133 @@ class TestClientHook:
                 x402_version=2,
                 accepts=[],
                 extensions=challenge,
-            )
+            ),
+            request_url="http://example.com/profile",
         )
         result = await hook(ctx)
         assert isinstance(result, PaymentRequiredHeadersResult)
         assert SIGN_IN_WITH_X in result.headers
+
+
+class TestOriginBinding:
+    @pytest.mark.asyncio
+    async def test_throws_when_challenge_domain_does_not_match_response_origin(self):
+        account = Account.create()
+        challenge = _test_challenge(
+            domain="evil.example.com",
+            resource_uri="https://api.example.com/resource",
+            network="eip155:8453",
+        )
+        ext = challenge[SIGN_IN_WITH_X]
+        complete = {
+            **ext["info"],
+            "chainId": ext["supportedChains"][0]["chainId"],
+            "type": ext["supportedChains"][0]["type"],
+        }
+
+        with pytest.raises(ValueError, match="domain.*does not match"):
+            await create_siwx_payload(complete, account, "https://api.example.com/resource")
+
+    @pytest.mark.asyncio
+    async def test_throws_when_challenge_uri_origin_does_not_match_response_origin(self):
+        account = Account.create()
+        challenge = _test_challenge(
+            domain="api.example.com",
+            resource_uri="https://evil.example.com/resource",
+            network="eip155:8453",
+        )
+        ext = challenge[SIGN_IN_WITH_X]
+        complete = {
+            **ext["info"],
+            "chainId": ext["supportedChains"][0]["chainId"],
+            "type": ext["supportedChains"][0]["type"],
+        }
+
+        with pytest.raises(ValueError, match="uri origin.*does not match"):
+            await create_siwx_payload(complete, account, "https://api.example.com/resource")
+
+    @pytest.mark.asyncio
+    async def test_signs_when_challenge_is_bound_to_response_origin(self):
+        account = Account.create()
+        challenge = _test_challenge(
+            domain="api.example.com",
+            resource_uri="https://api.example.com/resource",
+            network="eip155:8453",
+        )
+        ext = challenge[SIGN_IN_WITH_X]
+        complete = {
+            **ext["info"],
+            "chainId": ext["supportedChains"][0]["chainId"],
+            "type": ext["supportedChains"][0]["type"],
+        }
+
+        payload = await create_siwx_payload(complete, account, "https://api.example.com/resource")
+        assert payload.signature
+
+    @pytest.mark.asyncio
+    async def test_allows_cross_origin_resources_when_domain_and_uri_match(self):
+        account = Account.create()
+        challenge = _test_challenge(
+            domain="api.example.com",
+            resource_uri="https://api.example.com/resource",
+            network="eip155:8453",
+        )
+        ext = challenge[SIGN_IN_WITH_X]
+        complete = {
+            **ext["info"],
+            "resources": ["https://cdn.other-example.com/asset"],
+            "chainId": ext["supportedChains"][0]["chainId"],
+            "type": ext["supportedChains"][0]["type"],
+        }
+
+        payload = await create_siwx_payload(complete, account, "https://api.example.com/resource")
+        assert payload.signature
+        assert payload.resources == ["https://cdn.other-example.com/asset"]
+
+    def test_assert_siwx_challenge_bound_to_origin_throws_on_invalid_uri(self):
+        with pytest.raises(ValueError, match="uri.*not a valid URL"):
+            assert_siwx_challenge_bound_to_origin(
+                {
+                    "domain": "api.example.com",
+                    "uri": "not-a-url",
+                    "version": "1",
+                    "nonce": "abc",
+                    "issuedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                },
+                "https://api.example.com/resource",
+            )
+
+    @pytest.mark.asyncio
+    async def test_client_hook_does_not_sign_when_origin_is_mismatched(self):
+        account = Account.create()
+        hook = create_siwx_client_hook(account)
+        challenge = _test_challenge(
+            domain="evil.example.com",
+            resource_uri="https://evil.example.com/resource",
+            network="eip155:1",
+        )
+
+        result = await hook(
+            PaymentRequiredContext(
+                payment_required=PaymentRequired(
+                    x402_version=2,
+                    accepts=[
+                        PaymentRequirements(
+                            scheme="exact",
+                            network="eip155:1",
+                            asset="0xusdc",
+                            amount="1000",
+                            pay_to="0xpay",
+                            max_timeout_seconds=300,
+                        )
+                    ],
+                    extensions=challenge,
+                ),
+                request_url="http://example.com/resource",
+            )
+        )
+
+        assert result is None
 
 
 class TestServerExtension:

--- a/python/x402/tests/unit/http/clients/test_httpx.py
+++ b/python/x402/tests/unit/http/clients/test_httpx.py
@@ -330,6 +330,43 @@ class TestX402AsyncTransport:
         assert mock_transport.handle_async_request.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_hook_uses_request_url_when_response_has_no_request(self):
+        """Transport-level 402 responses often lack request; fall back to request.url."""
+        mock_client = MockX402Client()
+        http_client = x402HTTPClient(mock_client)
+        received: list[str] = []
+
+        def capture_url(ctx):
+            received.append(ctx.request_url)
+            return PaymentRequiredHeadersResult(headers={"Authorization": "Bearer x"})
+
+        http_client.on_payment_required(capture_url)
+
+        payment_required = PaymentRequired(
+            x402_version=2,
+            accepts=[make_payment_requirements()],
+        )
+        encoded = encode_payment_required_header(payment_required)
+        response_402 = httpx.Response(
+            402,
+            headers={"PAYMENT-REQUIRED": encoded},
+            content=b"{}",
+        )
+        response_200 = httpx.Response(200, content=b"{}")
+
+        mock_transport = AsyncMock()
+        mock_transport.handle_async_request = AsyncMock(side_effect=[response_402, response_200])
+
+        transport = x402AsyncTransport(http_client, mock_transport)
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "https://example.com/api")
+        )
+
+        assert response is response_200
+        assert received == ["https://example.com/api"]
+        assert len(mock_client.create_calls) == 0
+
+    @pytest.mark.asyncio
     async def test_recovery_calls_create_payment_payload_twice(self):
         """Recovery retry creates a fresh payload after hook signals recovered."""
         mock_client = MockRecoveringClient()

--- a/python/x402/tests/unit/http/clients/test_requests.py
+++ b/python/x402/tests/unit/http/clients/test_requests.py
@@ -146,12 +146,14 @@ class TestX402HTTPAdapter:
         # Create mock request
         mock_request = MagicMock(spec=requests.PreparedRequest)
         mock_request.headers = {}
+        mock_request.url = "https://api.example.com/"
 
         # Create 402 and 200 responses
         mock_402_response = MagicMock(spec=requests.Response)
         mock_402_response.status_code = 402
         mock_402_response.headers = {"PAYMENT-REQUIRED": encoded}
         mock_402_response.content = b"{}"
+        mock_402_response.url = "https://api.example.com/"
 
         mock_200_response = MagicMock(spec=requests.Response)
         mock_200_response.status_code = 200
@@ -187,6 +189,7 @@ class TestX402HTTPAdapter:
 
         mock_request = MagicMock(spec=requests.PreparedRequest)
         mock_request.headers = {}
+        mock_request.url = "https://api.example.com/"
 
         # Configure copy() to return a mock with a real dict for headers
         retry_headers: dict = {}
@@ -198,6 +201,7 @@ class TestX402HTTPAdapter:
         mock_402_response.status_code = 402
         mock_402_response.headers = {"PAYMENT-REQUIRED": encoded}
         mock_402_response.content = b"{}"
+        mock_402_response.url = "https://api.example.com/"
 
         mock_200_response = MagicMock(spec=requests.Response)
         mock_200_response.status_code = 200
@@ -246,11 +250,13 @@ class TestX402HTTPAdapter:
 
         mock_request = MagicMock(spec=requests.PreparedRequest)
         mock_request.headers = {}
+        mock_request.url = "https://example.com"
 
         mock_402_response = MagicMock(spec=requests.Response)
         mock_402_response.status_code = 402
         mock_402_response.headers = {}  # No header
         mock_402_response.content = json.dumps(v1_body).encode("utf-8")
+        mock_402_response.url = "https://example.com"
 
         mock_200_response = MagicMock(spec=requests.Response)
         mock_200_response.status_code = 200
@@ -304,11 +310,13 @@ class TestX402HTTPAdapter:
 
         mock_request = MagicMock(spec=requests.PreparedRequest)
         mock_request.headers = {}
+        mock_request.url = "https://example.com/api"
 
         mock_402 = MagicMock(spec=requests.Response)
         mock_402.status_code = 402
         mock_402.headers = {"PAYMENT-REQUIRED": encoded}
         mock_402.content = b"{}"
+        mock_402.url = "https://example.com/api"
 
         mock_200 = MagicMock(spec=requests.Response)
         mock_200.status_code = 200
@@ -350,6 +358,7 @@ class TestX402HTTPAdapter:
 
         mock_request = MagicMock(spec=requests.PreparedRequest)
         mock_request.headers = {}
+        mock_request.url = "https://example.com/api"
         mock_retry_request = MagicMock(spec=requests.PreparedRequest)
         mock_retry_request.headers = {}
         mock_request.copy.return_value = mock_retry_request
@@ -358,6 +367,7 @@ class TestX402HTTPAdapter:
         mock_initial_402.status_code = 402
         mock_initial_402.headers = {"PAYMENT-REQUIRED": encoded_required}
         mock_initial_402.content = b"{}"
+        mock_initial_402.url = "https://example.com/api"
 
         mock_paid_402 = MagicMock(spec=requests.Response)
         mock_paid_402.status_code = 402
@@ -481,7 +491,7 @@ class MockX402HTTPClient:
     def encode_payment_signature_header(self, _payload):
         return {"X-Payment": "mock_payment_header"}
 
-    def handle_payment_required(self, _payment_required):
+    def handle_payment_required(self, _payment_required, _request_url):
         return None
 
     def process_payment_result(self, _payment_payload, _get_header, _status):

--- a/python/x402/tests/unit/http/test_extension_transport_hooks.py
+++ b/python/x402/tests/unit/http/test_extension_transport_hooks.py
@@ -172,6 +172,8 @@ async def test_client_extension_on_payment_required_runs_after_manual():
         accepts=[requirements],
         extensions={"cli-ext": {}},
     )
-    headers = await http_client.handle_payment_required(payment_required)
+    headers = await http_client.handle_payment_required(
+        payment_required, "https://api.example.com/"
+    )
     assert order == ["manual"]
     assert headers == {"X-Test": "1"}

--- a/python/x402/tests/unit/http/test_x402_http_client.py
+++ b/python/x402/tests/unit/http/test_x402_http_client.py
@@ -310,7 +310,9 @@ class TestX402HTTPClient:
         encoded = encode_payment_required_header(payment_required)
         headers = {PAYMENT_REQUIRED_HEADER: encoded}
 
-        payment_headers, payload = await http_client.handle_402_response(headers, None)
+        payment_headers, payload = await http_client.handle_402_response(
+            headers, None, "https://api.example.com/"
+        )
 
         assert PAYMENT_SIGNATURE_HEADER in payment_headers
         assert payload.x402_version == 2
@@ -351,7 +353,9 @@ class TestX402HTTPClientSync:
         encoded = encode_payment_required_header(payment_required)
         headers = {PAYMENT_REQUIRED_HEADER: encoded}
 
-        payment_headers, payload = http_client.handle_402_response(headers, None)
+        payment_headers, payload = http_client.handle_402_response(
+            headers, None, "https://api.example.com/"
+        )
 
         assert PAYMENT_SIGNATURE_HEADER in payment_headers
         assert payload.x402_version == 2
@@ -486,6 +490,7 @@ class TestPaymentRoundTripper:
             headers={},
             body=None,
             retry_func=lambda h: "should not be called",
+            request_url="https://api.example.com/",
         )
 
         assert result is None
@@ -515,6 +520,7 @@ class TestPaymentRoundTripper:
             headers=headers,
             body=None,
             retry_func=retry_func,
+            request_url="https://api.example.com/",
         )
 
         assert result == "retry_response"
@@ -541,6 +547,7 @@ class TestPaymentRoundTripper:
             headers=headers,
             body=None,
             retry_func=lambda h: "first",
+            request_url="https://api.example.com/",
         )
 
         # Manually set retry count to simulate already retried
@@ -554,4 +561,5 @@ class TestPaymentRoundTripper:
                 headers=headers,
                 body=None,
                 retry_func=lambda h: "should not happen",
+                request_url="https://api.example.com/",
             )

--- a/python/x402/tests/unit/http/test_x402_http_client_hooks.py
+++ b/python/x402/tests/unit/http/test_x402_http_client_hooks.py
@@ -46,7 +46,12 @@ class TestHandlePaymentRequired:
     @pytest.mark.asyncio
     async def test_returns_none_without_hooks(self):
         http_client = x402HTTPClient(x402Client())
-        assert await http_client.handle_payment_required(make_payment_required()) is None
+        assert (
+            await http_client.handle_payment_required(
+                make_payment_required(), "https://api.example.com/"
+            )
+            is None
+        )
 
     @pytest.mark.asyncio
     async def test_returns_headers_from_hook(self):
@@ -54,7 +59,9 @@ class TestHandlePaymentRequired:
         http_client.on_payment_required(
             lambda ctx: PaymentRequiredHeadersResult(headers={"Authorization": "Bearer t"})
         )
-        result = await http_client.handle_payment_required(make_payment_required())
+        result = await http_client.handle_payment_required(
+            make_payment_required(), "https://api.example.com/"
+        )
         assert result == {"Authorization": "Bearer t"}
 
     @pytest.mark.asyncio
@@ -71,7 +78,9 @@ class TestHandlePaymentRequired:
             )
         )
 
-        result = await http_client.handle_payment_required(make_payment_required())
+        result = await http_client.handle_payment_required(
+            make_payment_required(), "https://api.example.com/"
+        )
 
         assert result == {"X-Hook": "first"}
         assert order == [1]
@@ -88,7 +97,9 @@ class TestHandlePaymentRequired:
             )
         )
 
-        result = await http_client.handle_payment_required(make_payment_required())
+        result = await http_client.handle_payment_required(
+            make_payment_required(), "https://api.example.com/"
+        )
 
         assert result == {"X-Hook": "second"}
         assert order == [1, 2]
@@ -101,10 +112,11 @@ class TestHandlePaymentRequired:
 
         http_client.on_payment_required(lambda ctx: received.append(ctx))
 
-        await http_client.handle_payment_required(payment_required)
+        await http_client.handle_payment_required(payment_required, "https://test.com/resource")
 
         assert len(received) == 1
         assert received[0].payment_required == payment_required
+        assert received[0].request_url == "https://test.com/resource"
 
     def test_sync_first_headers_win(self):
         http_client = x402HTTPClientSync(x402ClientSync())
@@ -114,5 +126,7 @@ class TestHandlePaymentRequired:
         http_client.on_payment_required(
             lambda ctx: PaymentRequiredHeadersResult(headers={"X-Hook": "second"})
         )
-        result = http_client.handle_payment_required(make_payment_required())
+        result = http_client.handle_payment_required(
+            make_payment_required(), "https://api.example.com/"
+        )
         assert result == {"X-Hook": "first"}


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Python sdk port of https://github.com/x402-foundation/x402/pull/3133

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 