### PR TITLE
fix(go): bind SIWX client challenge to the request origin

### DIFF
--- a/go/extensions/signinwithx/README.md
+++ b/go/extensions/signinwithx/README.md
@@ -85,4 +85,6 @@ x402Client := x402.Newx402Client().
 ```
 
 The HTTP client first tries to satisfy a `sign-in-with-x` challenge by sending a
-`SIGN-IN-WITH-X` header. If auth fails, the normal x402 payment flow continues.
+`SIGN-IN-WITH-X` header. It verifies the challenge is bound to the 402 response
+origin before signing. If auth fails or the challenge is not origin-bound, the
+normal x402 payment flow continues.

--- a/go/extensions/signinwithx/client.go
+++ b/go/extensions/signinwithx/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	x402 "github.com/x402-foundation/x402/go/v2"
@@ -61,13 +62,50 @@ func (e *ClientExtension) PaymentRequiredHook() x402http.PaymentRequiredHook {
 
 var _ x402.ClientExtension = (*ClientExtension)(nil)
 
+// AssertChallengeBoundToOrigin verifies that a SIWX challenge is bound to the origin of the
+// resource that issued the 402.
+//
+// Checks domain and uri only. EIP-4361 resources may be cross-origin URIs and are not
+// validated here (matching server-side ValidateMessage).
+func AssertChallengeBoundToOrigin(info Info, responseURL string) error {
+	origin, err := url.Parse(responseURL)
+	if err != nil || origin.Scheme == "" || origin.Host == "" {
+		return fmt.Errorf("SIWX challenge response URL %q is not a valid URL", responseURL)
+	}
+
+	if info.Domain != origin.Host {
+		return fmt.Errorf(
+			"SIWX challenge domain %q does not match response origin host %q",
+			info.Domain,
+			origin.Host,
+		)
+	}
+
+	uri, err := url.Parse(info.URI)
+	if err != nil || uri.Scheme == "" || uri.Host == "" {
+		return fmt.Errorf("SIWX challenge uri %q is not a valid URL", info.URI)
+	}
+
+	if urlOrigin(uri) != urlOrigin(origin) {
+		return fmt.Errorf(
+			"SIWX challenge uri origin %q does not match response origin %q",
+			urlOrigin(uri),
+			urlOrigin(origin),
+		)
+	}
+	return nil
+}
+
 // CreatePayload creates and signs a SIWX payload from a server declaration.
-func CreatePayload(ctx context.Context, declaration interface{}, signer EVMSigner) (Payload, error) {
-	return CreatePayloadWithSigners(ctx, declaration, NewEVMSIWXSigner(signer))
+// requestURL is the final URL of the 402 response (after redirects).
+func CreatePayload(ctx context.Context, declaration interface{}, signer EVMSigner, requestURL string) (Payload, error) {
+	return CreatePayloadWithSigners(ctx, declaration, requestURL, NewEVMSIWXSigner(signer))
 }
 
 // CreatePayloadWithSigners creates and signs a SIWX payload using the first compatible signer.
-func CreatePayloadWithSigners(ctx context.Context, declaration interface{}, signers ...Signer) (Payload, error) {
+// requestURL is the final URL of the 402 response (after redirects). Signing is refused when
+// challenge domain or uri origin does not match that URL's origin.
+func CreatePayloadWithSigners(ctx context.Context, declaration interface{}, requestURL string, signers ...Signer) (Payload, error) {
 	signers = compactSigners(signers)
 	if len(signers) == 0 {
 		return Payload{}, fmt.Errorf("SIWX signer is required")
@@ -75,6 +113,9 @@ func CreatePayloadWithSigners(ctx context.Context, declaration interface{}, sign
 
 	ext, err := extensionFromInterface(declaration)
 	if err != nil {
+		return Payload{}, err
+	}
+	if err := AssertChallengeBoundToOrigin(ext.Info, requestURL); err != nil {
 		return Payload{}, err
 	}
 
@@ -107,8 +148,9 @@ func CreatePayloadWithSigners(ctx context.Context, declaration interface{}, sign
 }
 
 // CreateHeader creates a SIGN-IN-WITH-X header value from a server declaration.
-func CreateHeader(ctx context.Context, declaration interface{}, signer EVMSigner) (string, error) {
-	payload, err := CreatePayload(ctx, declaration, signer)
+// requestURL is the final URL of the 402 response (after redirects).
+func CreateHeader(ctx context.Context, declaration interface{}, signer EVMSigner, requestURL string) (string, error) {
+	payload, err := CreatePayload(ctx, declaration, signer, requestURL)
 	if err != nil {
 		return "", err
 	}
@@ -116,8 +158,9 @@ func CreateHeader(ctx context.Context, declaration interface{}, signer EVMSigner
 }
 
 // CreateHeaderWithSigners creates a SIGN-IN-WITH-X header value with ordered signers.
-func CreateHeaderWithSigners(ctx context.Context, declaration interface{}, signers ...Signer) (string, error) {
-	payload, err := CreatePayloadWithSigners(ctx, declaration, signers...)
+// requestURL is the final URL of the 402 response (after redirects).
+func CreateHeaderWithSigners(ctx context.Context, declaration interface{}, requestURL string, signers ...Signer) (string, error) {
+	payload, err := CreatePayloadWithSigners(ctx, declaration, requestURL, signers...)
 	if err != nil {
 		return "", err
 	}
@@ -132,7 +175,7 @@ func CreateClientHook(signer EVMSigner) x402http.PaymentRequiredHook {
 // CreateClientHookWithSigners creates an HTTP on-payment-required hook using ordered SIWX signers.
 func CreateClientHookWithSigners(signers ...Signer) x402http.PaymentRequiredHook {
 	signers = compactSigners(signers)
-	return func(ctx context.Context, paymentRequired types.PaymentRequired) (*x402http.PaymentRequiredHookResult, error) {
+	return func(ctx context.Context, paymentRequired types.PaymentRequired, requestURL string) (*x402http.PaymentRequiredHookResult, error) {
 		if paymentRequired.Extensions == nil {
 			return nil, nil
 		}
@@ -140,7 +183,7 @@ func CreateClientHookWithSigners(signers ...Signer) x402http.PaymentRequiredHook
 		if !ok {
 			return nil, nil
 		}
-		header, createErr := CreateHeaderWithSigners(ctx, declaration, signers...)
+		header, createErr := CreateHeaderWithSigners(ctx, declaration, requestURL, signers...)
 		if createErr != nil {
 			return noPaymentRequiredHookResult()
 		}

--- a/go/extensions/signinwithx/client_test.go
+++ b/go/extensions/signinwithx/client_test.go
@@ -69,7 +69,7 @@ func TestCreatePayloadSignsEVMDeclaration(t *testing.T) {
 		Schema: Schema(),
 	}
 
-	payload, err := CreatePayload(context.Background(), declaration, signer)
+	payload, err := CreatePayload(context.Background(), declaration, signer, "https://api.example.com/profile")
 	if err != nil {
 		t.Fatalf("CreatePayload() error = %v", err)
 	}
@@ -118,7 +118,7 @@ func TestCreatePayloadWithSignersSignsSolanaDeclaration(t *testing.T) {
 		Schema: Schema(),
 	}
 
-	payload, err := CreatePayloadWithSigners(context.Background(), declaration, NewSolanaSIWXSigner(signer))
+	payload, err := CreatePayloadWithSigners(context.Background(), declaration, "https://api.example.com/profile", NewSolanaSIWXSigner(signer))
 	if err != nil {
 		t.Fatalf("CreatePayloadWithSigners() error = %v", err)
 	}
@@ -168,7 +168,7 @@ func TestCreatePayloadWithSignersUsesFirstCompatibleSigner(t *testing.T) {
 		SupportedChains: []SupportedChain{
 			{ChainID: SolanaMainnet, Type: SignatureTypeEd25519},
 		},
-	}, NewEVMSIWXSigner(evmSigner), NewSolanaSIWXSigner(solanaSigner))
+	}, "https://api.example.com/profile", NewEVMSIWXSigner(evmSigner), NewSolanaSIWXSigner(solanaSigner))
 	if err != nil {
 		t.Fatalf("CreatePayloadWithSigners() error = %v", err)
 	}
@@ -209,7 +209,7 @@ func TestCreateHeaderAcceptsJSONDecodedDeclaration(t *testing.T) {
 		"schema": Schema(),
 	}
 
-	header, err := CreateHeader(context.Background(), declaration, signer)
+	header, err := CreateHeader(context.Background(), declaration, signer, "https://api.example.com/profile")
 	if err != nil {
 		t.Fatalf("CreateHeader() error = %v", err)
 	}
@@ -236,18 +236,22 @@ func TestCreatePayloadRejectsUnsupportedDeclaration(t *testing.T) {
 	}
 
 	_, err := CreatePayload(context.Background(), Extension{
-		Info: Info{Version: Version},
+		Info: Info{
+			Domain:  "api.example.com",
+			URI:     "https://api.example.com/profile",
+			Version: Version,
+		},
 		SupportedChains: []SupportedChain{
 			{ChainID: "solana:mainnet", Type: SignatureTypeEd25519},
 		},
-	}, signer)
+	}, signer, "https://api.example.com/profile")
 	if err == nil || !strings.Contains(err.Error(), "does not support any configured signer") {
 		t.Fatalf("error = %v, want unsupported signer", err)
 	}
 }
 
 func TestCreatePayloadRequiresSigner(t *testing.T) {
-	_, err := CreatePayload(context.Background(), Extension{}, nil)
+	_, err := CreatePayload(context.Background(), Extension{}, nil, "https://api.example.com/profile")
 	if err == nil || !strings.Contains(err.Error(), "signer is required") {
 		t.Fatalf("error = %v, want signer required", err)
 	}
@@ -286,7 +290,7 @@ func TestCreateClientHookReturnsSIWXHeader(t *testing.T) {
 				SupportedChains: []SupportedChain{{ChainID: "eip155:8453", Type: SignatureTypeEIP191}},
 			},
 		},
-	})
+	}, "https://api.example.com/profile")
 	if err != nil {
 		t.Fatalf("hook error = %v", err)
 	}
@@ -329,7 +333,7 @@ func TestCreateClientHookWithSignersReturnsSolanaHeader(t *testing.T) {
 				SupportedChains: []SupportedChain{{ChainID: SolanaMainnet, Type: SignatureTypeEd25519}},
 			},
 		},
-	})
+	}, "https://api.example.com/profile")
 	if err != nil {
 		t.Fatalf("hook error = %v", err)
 	}
@@ -347,7 +351,7 @@ func TestCreateClientHookWithSignersReturnsSolanaHeader(t *testing.T) {
 
 func TestCreateClientHookReturnsNilWithoutDeclaration(t *testing.T) {
 	hook := CreateClientHook(&testEVMSigner{})
-	result, err := hook(context.Background(), types.PaymentRequired{X402Version: 2})
+	result, err := hook(context.Background(), types.PaymentRequired{X402Version: 2}, "http://example.com/resource")
 	if err != nil {
 		t.Fatalf("hook error = %v", err)
 	}
@@ -373,5 +377,187 @@ func TestCreateClientExtension(t *testing.T) {
 	}
 	if !reflect.DeepEqual(enriched, payload) {
 		t.Fatalf("EnrichPaymentPayload() = %#v, want %#v", enriched, payload)
+	}
+}
+
+func TestCreatePayloadRejectsMismatchedDomain(t *testing.T) {
+	signer := &testEVMSigner{
+		address: "0x0000000000000000000000000000000000000001",
+		sign: func(context.Context, string) (string, error) {
+			t.Fatal("sign should not be called")
+			return "", nil
+		},
+	}
+	declaration := Extension{
+		Info: Info{
+			Domain:   "evil.example.com",
+			URI:      "https://api.example.com/resource",
+			Version:  Version,
+			Nonce:    "nonceabc1",
+			IssuedAt: "2026-06-05T00:00:00Z",
+		},
+		SupportedChains: []SupportedChain{
+			{ChainID: "eip155:8453", Type: SignatureTypeEIP191},
+		},
+	}
+
+	_, err := CreatePayload(context.Background(), declaration, signer, "https://api.example.com/resource")
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "domain") || !strings.Contains(strings.ToLower(err.Error()), "does not match") {
+		t.Fatalf("error = %v, want domain mismatch", err)
+	}
+}
+
+func TestCreatePayloadRejectsMismatchedURIOrigin(t *testing.T) {
+	signer := &testEVMSigner{
+		address: "0x0000000000000000000000000000000000000001",
+		sign: func(context.Context, string) (string, error) {
+			t.Fatal("sign should not be called")
+			return "", nil
+		},
+	}
+	declaration := Extension{
+		Info: Info{
+			Domain:   "api.example.com",
+			URI:      "https://evil.example.com/resource",
+			Version:  Version,
+			Nonce:    "nonceabc1",
+			IssuedAt: "2026-06-05T00:00:00Z",
+		},
+		SupportedChains: []SupportedChain{
+			{ChainID: "eip155:8453", Type: SignatureTypeEIP191},
+		},
+	}
+
+	_, err := CreatePayload(context.Background(), declaration, signer, "https://api.example.com/resource")
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "uri origin") || !strings.Contains(strings.ToLower(err.Error()), "does not match") {
+		t.Fatalf("error = %v, want uri origin mismatch", err)
+	}
+}
+
+func TestCreatePayloadSignsWhenBoundToResponseOrigin(t *testing.T) {
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	address := crypto.PubkeyToAddress(privateKey.PublicKey)
+	signer := &testEVMSigner{
+		address: address.Hex(),
+		sign: func(_ context.Context, message string) (string, error) {
+			signature, err := crypto.Sign(accounts.TextHash([]byte(message)), privateKey)
+			if err != nil {
+				return "", err
+			}
+			signature[64] += 27
+			return "0x" + common.Bytes2Hex(signature), nil
+		},
+	}
+	declaration := Extension{
+		Info: Info{
+			Domain:   "api.example.com",
+			URI:      "https://api.example.com/resource",
+			Version:  Version,
+			Nonce:    "nonceabc1",
+			IssuedAt: "2026-06-05T00:00:00Z",
+		},
+		SupportedChains: []SupportedChain{
+			{ChainID: "eip155:8453", Type: SignatureTypeEIP191},
+		},
+	}
+
+	payload, err := CreatePayload(context.Background(), declaration, signer, "https://api.example.com/resource")
+	if err != nil {
+		t.Fatalf("CreatePayload() error = %v", err)
+	}
+	if payload.Signature == "" {
+		t.Fatal("signature is empty")
+	}
+}
+
+func TestCreatePayloadAllowsCrossOriginResources(t *testing.T) {
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	address := crypto.PubkeyToAddress(privateKey.PublicKey)
+	signer := &testEVMSigner{
+		address: address.Hex(),
+		sign: func(_ context.Context, message string) (string, error) {
+			signature, err := crypto.Sign(accounts.TextHash([]byte(message)), privateKey)
+			if err != nil {
+				return "", err
+			}
+			signature[64] += 27
+			return "0x" + common.Bytes2Hex(signature), nil
+		},
+	}
+	declaration := Extension{
+		Info: Info{
+			Domain:    "api.example.com",
+			URI:       "https://api.example.com/resource",
+			Version:   Version,
+			Nonce:     "nonceabc1",
+			IssuedAt:  "2026-06-05T00:00:00Z",
+			Resources: []string{"https://cdn.other-example.com/asset"},
+		},
+		SupportedChains: []SupportedChain{
+			{ChainID: "eip155:8453", Type: SignatureTypeEIP191},
+		},
+	}
+
+	payload, err := CreatePayload(context.Background(), declaration, signer, "https://api.example.com/resource")
+	if err != nil {
+		t.Fatalf("CreatePayload() error = %v", err)
+	}
+	if payload.Signature == "" {
+		t.Fatal("signature is empty")
+	}
+	if !reflect.DeepEqual(payload.Resources, []string{"https://cdn.other-example.com/asset"}) {
+		t.Fatalf("resources = %#v", payload.Resources)
+	}
+}
+
+func TestAssertChallengeBoundToOriginRejectsInvalidURI(t *testing.T) {
+	err := AssertChallengeBoundToOrigin(Info{
+		Domain:   "api.example.com",
+		URI:      "not-a-url",
+		Version:  Version,
+		Nonce:    "abc",
+		IssuedAt: "2026-06-05T00:00:00Z",
+	}, "https://api.example.com/resource")
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "uri") || !strings.Contains(strings.ToLower(err.Error()), "not a valid url") {
+		t.Fatalf("error = %v, want invalid uri", err)
+	}
+}
+
+func TestCreateClientHookDoesNotSignWhenOriginMismatched(t *testing.T) {
+	signer := &testEVMSigner{
+		address: "0x0000000000000000000000000000000000000001",
+		sign: func(context.Context, string) (string, error) {
+			t.Fatal("sign should not be called")
+			return "", nil
+		},
+	}
+	hook := CreateClientHook(signer)
+	result, err := hook(context.Background(), types.PaymentRequired{
+		X402Version: 2,
+		Accepts:     []types.PaymentRequirements{{Network: "eip155:1"}},
+		Extensions: map[string]interface{}{
+			ExtensionKey: Extension{
+				Info: Info{
+					Domain:   "evil.example.com",
+					URI:      "https://evil.example.com/resource",
+					Version:  Version,
+					Nonce:    "noncehook",
+					IssuedAt: "2026-06-05T00:00:00Z",
+				},
+				SupportedChains: []SupportedChain{{ChainID: "eip155:1", Type: SignatureTypeEIP191}},
+			},
+		},
+	}, "http://example.com/resource")
+	if err != nil {
+		t.Fatalf("hook error = %v", err)
+	}
+	if result != nil {
+		t.Fatalf("result = %#v, want nil", result)
 	}
 }

--- a/go/http/client.go
+++ b/go/http/client.go
@@ -39,7 +39,9 @@ type PaymentRequiredHookResult struct {
 }
 
 // PaymentRequiredHook can respond to a 402 PaymentRequired before payment payload creation.
-type PaymentRequiredHook func(ctx context.Context, paymentRequired types.PaymentRequired) (*PaymentRequiredHookResult, error)
+// requestURL is the URL of the request that received the payment required response
+// (the final URL after redirects).
+type PaymentRequiredHook func(ctx context.Context, paymentRequired types.PaymentRequired, requestURL string) (*PaymentRequiredHookResult, error)
 
 // ClientExtensionPaymentRequiredHookProvider lets registered client extensions
 // expose HTTP auth-style retry hooks.
@@ -250,7 +252,7 @@ func (t *PaymentRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		return t.sendPaymentRetry(req, ctx, payloadBytes)
 	}
 
-	if authResp, authHeaders, authBody, ok, err := t.tryPaymentRequiredHooks(req, ctx, headers, body); err != nil {
+	if authResp, authHeaders, authBody, ok, err := t.tryPaymentRequiredHooks(req, resp, ctx, headers, body); err != nil {
 		return nil, err
 	} else if ok {
 		if authResp.StatusCode != http.StatusPaymentRequired {
@@ -350,6 +352,7 @@ func prepareRequestBody(req *http.Request) (*http.Request, error) {
 
 func (t *PaymentRoundTripper) tryPaymentRequiredHooks(
 	req *http.Request,
+	resp *http.Response,
 	ctx context.Context,
 	headers map[string]string,
 	body []byte,
@@ -363,8 +366,13 @@ func (t *PaymentRoundTripper) tryPaymentRequiredHooks(
 		return nil, headers, body, false, err
 	}
 
+	requestURL := req.URL.String()
+	if resp != nil && resp.Request != nil && resp.Request.URL != nil {
+		requestURL = resp.Request.URL.String()
+	}
+
 	for _, hook := range t.x402Client.getPaymentRequiredHooks(paymentRequired) {
-		result, err := hook(ctx, paymentRequired)
+		result, err := hook(ctx, paymentRequired, requestURL)
 		if err != nil {
 			return nil, headers, body, false, err
 		}

--- a/go/http/client_test.go
+++ b/go/http/client_test.go
@@ -53,7 +53,7 @@ func TestPaymentRoundTripper_OnPaymentRequiredHeaderRetry(t *testing.T) {
 		return stringResponse(http.StatusOK, nil, "ok")
 	})
 	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls()).
-		OnPaymentRequired(func(_ context.Context, paymentRequired types.PaymentRequired) (*PaymentRequiredHookResult, error) {
+		OnPaymentRequired(func(_ context.Context, paymentRequired types.PaymentRequired, _ string) (*PaymentRequiredHookResult, error) {
 			if paymentRequired.Extensions["sign-in-with-x"] == nil {
 				t.Fatal("paymentRequired missing SIWX extension")
 			}
@@ -98,7 +98,7 @@ func TestPaymentRoundTripper_OnPaymentRequiredHookSkippedWithoutHeaders(t *testi
 
 	calls := 0
 	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls()).
-		OnPaymentRequired(func(context.Context, types.PaymentRequired) (*PaymentRequiredHookResult, error) {
+		OnPaymentRequired(func(context.Context, types.PaymentRequired, string) (*PaymentRequiredHookResult, error) {
 			calls++
 			return nil, nil
 		})
@@ -125,6 +125,55 @@ func TestPaymentRoundTripper_OnPaymentRequiredHookSkippedWithoutHeaders(t *testi
 	}
 	if calls != 1 {
 		t.Fatalf("hook calls = %d, want 1", calls)
+	}
+}
+
+func TestPaymentRoundTripper_OnPaymentRequiredPassesRequestURL(t *testing.T) {
+	required := types.PaymentRequired{
+		X402Version: 2,
+		Accepts: []types.PaymentRequirements{
+			{Scheme: "unsupported", Network: "eip155:1"},
+		},
+	}
+	encodedRequired, err := encodePaymentRequiredHeader(required)
+	if err != nil {
+		t.Fatalf("encodePaymentRequiredHeader() error = %v", err)
+	}
+
+	var receivedURL string
+	client := Newx402HTTPClient(x402.Newx402Client().DisableSpendControls()).
+		OnPaymentRequired(func(_ context.Context, _ types.PaymentRequired, requestURL string) (*PaymentRequiredHookResult, error) {
+			receivedURL = requestURL
+			return nil, nil
+		})
+	rt := &PaymentRoundTripper{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			resp, err := stringResponse(http.StatusPaymentRequired, map[string]string{
+				"PAYMENT-REQUIRED": encodedRequired,
+			}, "")
+			if err != nil {
+				return nil, err
+			}
+			resp.Request = req
+			return resp, nil
+		}),
+		x402Client: client,
+		retryCount: &sync.Map{},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://test.com/resource", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "cannot fulfill V2 payment requirements") {
+		t.Fatalf("RoundTrip() error = %v, want payment fallback error", err)
+	}
+	if receivedURL != "https://test.com/resource" {
+		t.Fatalf("requestURL = %q, want %q", receivedURL, "https://test.com/resource")
 	}
 }
 
@@ -156,7 +205,7 @@ func TestPaymentRoundTripper_RegisteredExtensionHookRetry(t *testing.T) {
 	x402Client := x402.Newx402Client().DisableSpendControls().
 		RegisterExtension(testHTTPClientExtension{
 			key: "test-extension",
-			hook: func(_ context.Context, paymentRequired types.PaymentRequired) (*PaymentRequiredHookResult, error) {
+			hook: func(_ context.Context, paymentRequired types.PaymentRequired, _ string) (*PaymentRequiredHookResult, error) {
 				if paymentRequired.Extensions["test-extension"] == nil {
 					t.Fatal("paymentRequired missing test extension")
 				}
@@ -207,7 +256,7 @@ func TestPaymentRoundTripper_RegisteredExtensionHookSkippedWithoutDeclaration(t 
 	x402Client := x402.Newx402Client().DisableSpendControls().
 		RegisterExtension(testHTTPClientExtension{
 			key: "test-extension",
-			hook: func(context.Context, types.PaymentRequired) (*PaymentRequiredHookResult, error) {
+			hook: func(context.Context, types.PaymentRequired, string) (*PaymentRequiredHookResult, error) {
 				calls++
 				return &PaymentRequiredHookResult{Headers: map[string]string{"X-EXTENSION-AUTH": "signed"}}, nil
 			},
@@ -686,7 +735,7 @@ func TestPaymentRoundTripper_ReplaysOneShotBody(t *testing.T) {
 			x402Client.Register("test:1", &mockSchemeClient{scheme: "mock"})
 			client := Newx402HTTPClient(x402Client)
 			if tt.authRetry {
-				client.OnPaymentRequired(func(context.Context, types.PaymentRequired) (*PaymentRequiredHookResult, error) {
+				client.OnPaymentRequired(func(context.Context, types.PaymentRequired, string) (*PaymentRequiredHookResult, error) {
 					return &PaymentRequiredHookResult{Headers: map[string]string{"SIGN-IN-WITH-X": "signed"}}, nil
 				})
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to x402!
Please fill out the information below to help reviewers understand your changes.

Note: We require commit signing.
See here for instructions: https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification
-->

## Description

Go sdk port of https://github.com/x402-foundation/x402/pull/3133

## Tests

<!--
Please describe the tests you've performed to verify your changes.
Include relevant code samples, unit test cases, or screenshots if applicable.

For TypeScript: Run `pnpm test` from the `/typescript` directory
For Python: Run `uv run pytest` from the `python/x402/` directory
For Go: Run `go test ./...` from the `/go` directory
-->

## Checklist

- [ ] I have formatted and linted my code
- [ ] All new and existing tests pass
- [ ] My commits are signed (required for merge) -- you may need to rebase if you initially pushed unsigned commits
- [ ] I added a changelog fragment for user-facing changes (docs-only changes can skip)

<!--
Changelog fragments (required for user-facing changes):

- TypeScript: add a Changesets file under `typescript/.changeset/*.md`
  - Create: `pnpm -C typescript changeset`
  - Select only publishable `@x402/*` packages
- Go: add a Changie fragment under `go/.changes/unreleased/*`
  - Create: `make -C go changelog-new`
- Python (python/x402 v2): add a Towncrier fragment under `python/x402/changelog.d/<PR>.<type>.md`
  - Create: `cd python/x402 && uv run towncrier create --content "Fixed ..." 123.bugfix.md`
-->

<!--
For TypeScript: Run `pnpm format && pnpm lint` from `/typescript` and/or `/examples/typescript`
For Python: Run `uvx ruff format && uvx ruff check` from the `python/x402/` directory
For Go: Run `go fmt ./...` and `go vet ./...` from the `/go` directory
--> 