### PR TITLE
feat(evm): add Upto-only deployment entrypoint

### DIFF
--- a/contracts/evm/README.md
+++ b/contracts/evm/README.md
@@ -115,12 +115,12 @@ and `keccak256(initCode)`—not on who sends the transaction.
 
 4. **Deploy**
    ```bash
-   cast wallet import x402-deployer --interactive
+   cast wallet import x402-deployment-signer --interactive
 
    forge script script/Deploy.s.sol \
      --rpc-url <RPC_URL> \
-     --account x402-deployer \
-     --sender <DEPLOYER_ADDRESS> \
+     --account x402-deployment-signer \
+     --sender <DEPLOYMENT_SIGNER_ADDRESS> \
      --broadcast \
      --verify
    ```
@@ -131,8 +131,8 @@ and `keccak256(initCode)`—not on who sends the transaction.
    forge script script/Deploy.s.sol \
      --sig "runUpto()" \
      --rpc-url <RPC_URL> \
-     --account x402-deployer \
-     --sender <DEPLOYER_ADDRESS> \
+     --account x402-deployment-signer \
+     --sender <DEPLOYMENT_SIGNER_ADDRESS> \
      --broadcast \
      --verify
    ```

--- a/contracts/evm/README.md
+++ b/contracts/evm/README.md
@@ -115,15 +115,29 @@ and `keccak256(initCode)`—not on who sends the transaction.
 
 4. **Deploy**
    ```bash
-   export PRIVATE_KEY="your_private_key"
+   cast wallet import x402-deployer --interactive
 
    forge script script/Deploy.s.sol \
      --rpc-url <RPC_URL> \
+     --account x402-deployer \
+     --sender <DEPLOYER_ADDRESS> \
      --broadcast \
      --verify
    ```
 
-   The script automatically:
+   To deploy only the Upto proxy, select its deployment entry point:
+
+   ```bash
+   forge script script/Deploy.s.sol \
+     --sig "runUpto()" \
+     --rpc-url <RPC_URL> \
+     --account x402-deployer \
+     --sender <DEPLOYER_ADDRESS> \
+     --broadcast \
+     --verify
+   ```
+
+   The default `run()` entry point automatically:
    - Loads the pre-built initCode for Exact and compiler-derived initCode for Upto
    - Skips any contract already deployed at the expected address
    - Verifies `PERMIT2()` returns the correct address after deployment

--- a/contracts/evm/script/Deploy.s.sol
+++ b/contracts/evm/script/Deploy.s.sol
@@ -81,6 +81,21 @@ contract DeployX402Proxies is Script {
         console2.log("");
     }
 
+    /// @notice Deploys only x402UptoPermit2Proxy.
+    function runUpto() public {
+        address permit2 = vm.envOr("PERMIT2_ADDRESS", CANONICAL_PERMIT2);
+
+        if (block.chainid != 31_337 && block.chainid != 1337) {
+            require(permit2.code.length > 0, "Permit2 not found on this network");
+            console2.log("Permit2 verified");
+
+            require(CREATE2_DEPLOYER.code.length > 0, "CREATE2 deployer not found on this network");
+            console2.log("CREATE2 deployer verified");
+        }
+
+        _deployUpto(permit2);
+    }
+
     function _deployExact(
         address permit2
     ) internal {

--- a/contracts/evm/test/Deploy.t.sol
+++ b/contracts/evm/test/Deploy.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {DeployX402Proxies} from "../script/Deploy.s.sol";
+import {x402UptoPermit2Proxy} from "../src/x402UptoPermit2Proxy.sol";
+
+contract DeployX402ProxiesTest is Test {
+    address constant CANONICAL_PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
+    function test_runUptoDeploysOnlyUpto() public {
+        DeployX402Proxies deployer = new DeployX402Proxies();
+        uint64 nonceBefore = vm.getNonce(DEFAULT_SENDER);
+        address expectedAddress = vm.computeCreateAddress(DEFAULT_SENDER, nonceBefore);
+
+        deployer.runUpto();
+
+        assertEq(vm.getNonce(DEFAULT_SENDER), nonceBefore + 1);
+        assertGt(expectedAddress.code.length, 0);
+        x402UptoPermit2Proxy referenceProxy = new x402UptoPermit2Proxy(CANONICAL_PERMIT2);
+        assertEq(expectedAddress.codehash, address(referenceProxy).codehash);
+        assertEq(address(x402UptoPermit2Proxy(expectedAddress).PERMIT2()), CANONICAL_PERMIT2);
+    }
+}


### PR DESCRIPTION
## Description

Adds a chain-agnostic `runUpto()` entrypoint that deploys only `x402UptoPermit2Proxy` while preserving the existing deterministic deployment path and canonical address. The existing `run()` entrypoint deploys both proxies, but Arc testnet currently requires only the Upto proxy.

Updates the deployment guide to use an encrypted Foundry keystore and documents selecting `runUpto()`. Adds a deployment test that verifies exactly one contract is created, its runtime is the Upto proxy, and it uses canonical Permit2.

AI assistance was used in preparing this PR.

No contract has been deployed by this PR.

## Tests

- `forge fmt --check`
- `forge build`
- `forge test`: 190 passed, 0 failed
- Fixed-block Arc testnet simulation of `runUpto()`: exactly one zero-value CREATE2 transaction to the canonical factory and Upto address

## Checklist

- [x] I have formatted and linted my code
- [x] All new and existing tests pass
- [x] My commits are signed
- [x] No SDK changelog fragment is needed for EVM deployment tooling and documentation
