### PR TITLE
fix(evm/batch-settlement): guard against missing channelId in settle response

### DIFF
--- a/typescript/packages/mechanisms/evm/src/batch-settlement/client/channel.ts
+++ b/typescript/packages/mechanisms/evm/src/batch-settlement/client/channel.ts
@@ -17,14 +17,26 @@ type ResponseChannelState = NonNullable<BatchSettlementPaymentResponseExtra["cha
 /**
  * Reads the nested channel state from a settlement response extra object.
  *
+ * Validates `channelId` is present as a non-empty string, since it's read
+ * unconditionally by every caller (`processSettleResponse`,
+ * `updateChannelAfterRefund`) immediately after this returns — a response
+ * whose `extra.channelState` is an object but omits or malforms `channelId`
+ * would otherwise throw deep in a caller instead of being treated as "no
+ * channel state present," which is how every other malformed-response shape
+ * here is already handled.
+ *
  * @param extra - Settlement response extra fields.
- * @returns Channel state fields, or undefined when absent.
+ * @returns Channel state fields, or undefined when absent or malformed.
  */
 function readResponseChannelState(
   extra: Record<string, unknown>,
 ): ResponseChannelState | undefined {
   const channelState = extra.channelState;
   if (typeof channelState !== "object" || channelState === null) {
+    return undefined;
+  }
+  const { channelId } = channelState as Record<string, unknown>;
+  if (typeof channelId !== "string" || channelId.length === 0) {
     return undefined;
   }
   return channelState as ResponseChannelState;

--- a/typescript/packages/mechanisms/evm/test/unit/batch-settlement/channel.test.ts
+++ b/typescript/packages/mechanisms/evm/test/unit/batch-settlement/channel.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import type { SettleResponse } from "@x402/core/types";
+import { processSettleResponse, updateChannelAfterRefund } from "../../../src/batch-settlement/client/channel";
+import { InMemoryClientChannelStorage } from "../../../src/batch-settlement/client/storage";
+
+const VALID_CHANNEL_ID = "0x" + "ab".repeat(32);
+
+function settleResponse(extra: Record<string, unknown> | undefined): SettleResponse {
+  return {
+    success: true,
+    transaction: "0x" + "11".repeat(32),
+    network: "eip155:8453" as SettleResponse["network"],
+    extra,
+  };
+}
+
+describe("processSettleResponse", () => {
+  it("updates storage when channelState has a valid channelId", async () => {
+    const storage = new InMemoryClientChannelStorage();
+    const settle = settleResponse({
+      channelState: { channelId: VALID_CHANNEL_ID, balance: "100" },
+    });
+
+    await processSettleResponse(storage, settle);
+
+    const stored = await storage.get(VALID_CHANNEL_ID);
+    expect(stored?.balance).toBe("100");
+  });
+
+  it("is a no-op instead of throwing when channelState has no channelId", async () => {
+    // Regression test for #3188: a settle response whose extra.channelState is a
+    // well-formed object but omits channelId used to throw
+    // "Cannot read properties of undefined (reading 'toLowerCase')" here.
+    const storage = new InMemoryClientChannelStorage();
+    const settle = settleResponse({ channelState: { balance: "100" } });
+
+    await expect(processSettleResponse(storage, settle)).resolves.toBeUndefined();
+  });
+
+  it("is a no-op when channelState.channelId is not a string", async () => {
+    const storage = new InMemoryClientChannelStorage();
+    const settle = settleResponse({ channelState: { channelId: 12345, balance: "100" } });
+
+    await expect(processSettleResponse(storage, settle)).resolves.toBeUndefined();
+  });
+
+  it("is a no-op when channelState.channelId is an empty string", async () => {
+    const storage = new InMemoryClientChannelStorage();
+    const settle = settleResponse({ channelState: { channelId: "", balance: "100" } });
+
+    await expect(processSettleResponse(storage, settle)).resolves.toBeUndefined();
+  });
+
+  it("is a no-op when extra.channelState itself is absent", async () => {
+    const storage = new InMemoryClientChannelStorage();
+    const settle = settleResponse({});
+
+    await expect(processSettleResponse(storage, settle)).resolves.toBeUndefined();
+  });
+});
+
+describe("updateChannelAfterRefund", () => {
+  it("deletes the channel record instead of throwing when channelState has no channelId", async () => {
+    // Same root cause as above (both call readResponseChannelState), covered here too
+    // since this function's own signature takes an already-lowercased channelKey rather
+    // than reading channelId itself — confirms the shared helper's guard protects both callers.
+    const storage = new InMemoryClientChannelStorage();
+    await storage.set(VALID_CHANNEL_ID, { balance: "50" });
+
+    await expect(
+      updateChannelAfterRefund(storage, VALID_CHANNEL_ID, { channelState: { balance: "0" } }),
+    ).resolves.toBeUndefined();
+
+    // Malformed channelState is treated as "absent", same as updateChannelAfterRefund's
+    // own explicit "no channelState at all" branch: delete the local record.
+    expect(await storage.get(VALID_CHANNEL_ID)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

`processSettleResponse` dereferenced `channelState.channelId` immediately after `readResponseChannelState` confirmed only that `extra.channelState` was a non-null object — a settle response whose `channelState` omits `channelId` (or has a malformed one) threw `Cannot read properties of undefined (reading 'toLowerCase')` mid-purchase instead of being treated as absent, the same way every other malformed-response shape in this module already is.

`hooks.ts` already reads this same field defensively (`typeof channelId === "string" && channelId`), confirming the partial shape is a known possibility — just not guarded at the source.

## Fix

Strengthened `readResponseChannelState` itself to validate `channelId` is a non-empty string, rather than patching the one call site — both callers (`processSettleResponse`, `updateChannelAfterRefund`) go through this function, so the fix protects both without duplicating `hooks.ts`'s inline check. `hooks.ts` is untouched; its existing guard is now redundant but harmless.

## Testing

Added `typescript/packages/mechanisms/evm/test/unit/batch-settlement/channel.test.ts` (no prior test coverage existed for this client module):
- `processSettleResponse` updates storage on a valid `channelId` (baseline)
- no-op instead of throwing when `channelId` is absent / non-string / empty
- no-op when `extra.channelState` itself is absent
- `updateChannelAfterRefund` deletes the local record when `channelState` is malformed, same as its existing "no `channelState`" branch

```
pnpm --filter @x402/evm test
```
36 test files, 884 tests pass (including the 6 new ones) — no regressions.

Fixes #3188