### PR TITLE
fix(extensions): decode routeTemplate to a fixed point before traversal checks

### DIFF
--- a/typescript/.changeset/route-template-fixed-point-decode.md
+++ b/typescript/.changeset/route-template-fixed-point-decode.md
@@ -1,0 +1,5 @@
+---
+"@x402/extensions": patch
+---
+
+`isValidRouteTemplate` now decodes a routeTemplate to a fixed point (up to a bounded pass budget) before running its traversal/scheme-injection checks, instead of a single decode pass. A double- or deeper-encoded payload (`%252e%252e`, `%253a%252f%252f`, ...) previously survived one decode still percent-encoded and slipped past the `..`/`://` checks, letting a malicious routeTemplate cause the facilitator to catalog a payment under an arbitrary URL.

--- a/typescript/packages/extensions/src/bazaar/facilitator.ts
+++ b/typescript/packages/extensions/src/bazaar/facilitator.ts
@@ -31,6 +31,52 @@ import { buildV1CatalogExtensions, extractDiscoveryInfoV1 } from "./v1/facilitat
 const ROUTE_TEMPLATE_REGEX = /^\/[a-zA-Z0-9_/:.\-~%]+$/;
 
 /**
+ * Maximum number of successive `decodeURIComponent` passes applied while
+ * canonicalizing a routeTemplate before giving up and rejecting it.
+ *
+ * A legitimate single-encoded value reaches a fixed point (further decoding
+ * changes nothing) after one pass. This allows a few extra passes so
+ * multiply-encoded traversal/injection payloads (not just doubly-encoded
+ * ones) are still caught, while bounding the work done on adversarial input.
+ */
+const MAX_ROUTE_TEMPLATE_DECODE_PASSES = 5;
+
+/**
+ * Repeatedly percent-decodes `value` until a fixed point is reached (further
+ * decoding produces no change) or {@link MAX_ROUTE_TEMPLATE_DECODE_PASSES} is
+ * exhausted, returning the fully-canonicalized string.
+ *
+ * A single decode pass only catches a payload encoded exactly once (e.g.
+ * `%2e%2e`); a double- or triple-encoded payload (`%252e%252e`,
+ * `%25252e%25252e`, ...) would still contain literal `%` sequences after one
+ * pass and slip past a traversal/injection substring check performed on that
+ * partially-decoded result. Decoding to a fixed point closes that gap for any
+ * encoding depth, not just the double-encoded case.
+ *
+ * @param value - The string to canonicalize.
+ * @returns The fully-decoded string, or `undefined` if any pass fails to
+ *   parse (malformed percent-encoding) or the pass budget is exhausted
+ *   without reaching a fixed point.
+ */
+function fullyDecodeRouteTemplate(value: string): string | undefined {
+  let decoded = value;
+  for (let i = 0; i < MAX_ROUTE_TEMPLATE_DECODE_PASSES; i++) {
+    let next: string;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      return undefined;
+    }
+    if (next === decoded) return decoded;
+    decoded = next;
+  }
+  // Still changing after the pass budget: either pathologically deep
+  // encoding or a `%` that never resolves to a fixed point. Either way,
+  // there's no safe canonical form to validate against — reject.
+  return undefined;
+}
+
+/**
  * Checks whether a routeTemplate value is structurally valid.
  *
  * Expected format: "/:param" segments using colon-prefixed identifiers
@@ -42,8 +88,8 @@ const ROUTE_TEMPLATE_REGEX = /^\/[a-zA-Z0-9_/:.\-~%]+$/;
  * This function enforces minimal structural requirements:
  * - Must be a non-empty string starting with "/"
  * - Must match the safe URL path character set (alphanumeric, _, :, /, ., -, ~, %)
- * - Must not contain ".." (path traversal)
- * - Must not contain "://" (URL injection)
+ * - Must not contain ".." (path traversal), at any percent-encoding depth
+ * - Must not contain "://" (URL injection), at any percent-encoding depth
  *
  * @param value - The raw routeTemplate string from the client payload
  * @returns true if the value is a valid routeTemplate, false otherwise
@@ -53,13 +99,11 @@ const ROUTE_TEMPLATE_REGEX = /^\/[a-zA-Z0-9_/:.\-~%]+$/;
 export function isValidRouteTemplate(value: string | undefined): value is string {
   if (!value) return false;
   if (!ROUTE_TEMPLATE_REGEX.test(value)) return false;
-  // Decode percent-encoding before traversal checks so that %2e%2e is caught.
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(value);
-  } catch {
-    return false;
-  }
+  // Decode to a fixed point before traversal checks, so that %2e%2e,
+  // %252e%252e, and deeper encodings are all caught rather than just the
+  // single-encoded case.
+  const decoded = fullyDecodeRouteTemplate(value);
+  if (decoded === undefined) return false;
   if (decoded.includes("..")) return false;
   if (decoded.includes("://")) return false;
   return true;

--- a/typescript/packages/extensions/test/bazaar.test.ts
+++ b/typescript/packages/extensions/test/bazaar.test.ts
@@ -2117,6 +2117,42 @@ describe("Bazaar Discovery Extension", () => {
       expect(isValidRouteTemplate("/users/%2e%2e/admin")).toBe(false);
       expect(isValidRouteTemplate("/users/%2E%2E/admin")).toBe(false);
     });
+
+    it("rejects double-encoded traversal sequences (regression for double-decode bypass)", () => {
+      // %25 decodes to "%", so %252e%252e decodes-once to "%2e%2e" (still
+      // encoded) and only decodes-twice to "..". A single-pass decode
+      // wouldn't see the traversal here.
+      expect(isValidRouteTemplate("/users/%252e%252e/admin")).toBe(false);
+      expect(isValidRouteTemplate("/users/%252E%252E/admin")).toBe(false);
+    });
+
+    it("rejects triple-encoded traversal sequences", () => {
+      expect(isValidRouteTemplate("/users/%25252e%25252e/admin")).toBe(false);
+    });
+
+    it("rejects double-encoded scheme injection", () => {
+      // %3a decodes to ":", %2f decodes to "/" — %253a%252f%252f decodes-once
+      // to "%3a%2f%2f" (still encoded) and decodes-twice to "://".
+      expect(isValidRouteTemplate("/users/javascript%253a%252f%252fevil")).toBe(false);
+    });
+
+    it("still accepts a legitimate single percent-encoded segment", () => {
+      // One decode pass resolves this to plain text with no further
+      // encoding, reaching a fixed point immediately — must not be rejected
+      // just for containing a "%".
+      expect(isValidRouteTemplate("/search/caf%C3%A9")).toBe(true);
+    });
+
+    it("rejects a value whose percent-encoding never resolves to a fixed point", () => {
+      // Pathologically deep encoding (more than the decode-pass budget) has
+      // no safe canonical form to validate — reject rather than decode
+      // indefinitely. ":" is re-encoded ("%3A" → "%253A" → ...) on every
+      // encodeURIComponent pass, so this compounds correctly (unlike "..",
+      // whose dots encodeURIComponent leaves untouched).
+      let value: string = ":";
+      for (let i = 0; i < 8; i++) value = encodeURIComponent(value);
+      expect(isValidRouteTemplate(`/users/x${value}/admin`)).toBe(false);
+    });
   });
 
   describe("isValidServiceName", () => {


### PR DESCRIPTION
## What

`isValidRouteTemplate` decoded a `routeTemplate` with a single `decodeURIComponent` pass before checking for `".."` (traversal) and `"://"` (scheme injection). `ROUTE_TEMPLATE_REGEX` explicitly allows `%`, so a double percent-encoded payload (`%252e%252e`, `%253a%252f%252f`, ...) survives one decode still percent-encoded — the substring checks never see the traversal/injection content, and the function incorrectly returns `true`. Per its own doc comment, a malicious `routeTemplate` lets a client cause the facilitator to catalog a payment under an arbitrary URL (catalog poisoning).

## Fix

A single extra decode pass would only close the *double*-encoded case specifically; triple-encoding (or deeper) would still bypass a fixed-count decode. Added `fullyDecodeRouteTemplate`, which decodes repeatedly until a fixed point is reached (further decoding produces no change) or a bounded pass budget (5) is exhausted, then runs the existing traversal/injection checks against that canonical form. This closes the gap for any encoding depth, not just double, while bounding the work done on adversarial input rather than decoding indefinitely. Malformed percent-encoding (fails to parse) or encoding that never reaches a fixed point within the budget both reject, matching the existing "malformed input → false" behavior.

## Testing

Added regression tests in `typescript/packages/extensions/test/bazaar.test.ts`:
- double- and triple-encoded traversal sequences rejected
- double-encoded scheme injection rejected
- a legitimate single percent-encoded segment (café) still accepted — must not become overly strict
- pathologically deep encoding (more passes than the budget) rejected

```
pnpm --filter @x402/extensions test
```
9 test files, 532 tests pass (including the 6 new ones) — no regressions.

Fixes #3169