### PR TITLE
fix(core): derive one wildcard pattern per namespace, not one for the whole registration

### DIFF
--- a/typescript/.changeset/wild-plums-drive.md
+++ b/typescript/.changeset/wild-plums-drive.md
@@ -1,0 +1,5 @@
+---
+"@x402/core": patch
+---
+
+Fixed `x402Facilitator.derivePattern()` silently dropping wildcard network matching when a single `register()`/`registerV1()` call spans more than one CAIP-2 namespace (e.g. `["stellar:testnet", "stellar:futurenet", "eip155:8453"]`). Previously any mixed-namespace registration collapsed to a single literal exact-match pattern derived from `networks[0]`, discarding the wildcard a same-namespace group would otherwise have earned on its own — even for a namespace with multiple explicitly registered networks. Each namespace present in a registration now derives its own wildcard pattern independently.

--- a/typescript/packages/core/src/facilitator/x402Facilitator.ts
+++ b/typescript/packages/core/src/facilitator/x402Facilitator.ts
@@ -521,12 +521,38 @@ export class x402Facilitator {
     }
     const schemeDataArray = this.registeredFacilitatorSchemes.get(x402Version)!;
 
-    // Add new scheme data (supports multiple facilitators with same scheme name)
-    schemeDataArray.push({
-      facilitator,
-      networks: new Set(networks),
-      pattern: this.derivePattern(networks),
-    });
+    // One SchemeData entry per CAIP-2 namespace present in `networks`, not
+    // one entry for the whole (possibly mixed-namespace) list: a single
+    // `pattern` can only ever be a wildcard for ONE namespace at a time
+    // (derivePattern's own contract), so a mixed-namespace registration
+    // (e.g. ["stellar:testnet", "eip155:8453"]) needs one wildcard per
+    // namespace it actually covers, not a single pattern collapsed onto
+    // the first network's namespace, which previously provided no
+    // wildcard coverage in ANY namespace involved: it just duplicated the
+    // exact-match Set's own coverage of that one network. `networks`
+    // stays the SAME full set on every entry, so exact matching (checked
+    // first in verify()/settle()'s dispatch loop, before pattern
+    // matching) is unaffected either way; only the wildcard fallback
+    // needed to become namespace-scoped.
+    const networksByNamespace = new Map<string, Network[]>();
+    for (const network of networks) {
+      const namespace = network.split(":")[0];
+      const existing = networksByNamespace.get(namespace);
+      if (existing) {
+        existing.push(network);
+      } else {
+        networksByNamespace.set(namespace, [network]);
+      }
+    }
+
+    const fullNetworkSet = new Set(networks);
+    for (const namespaceNetworks of networksByNamespace.values()) {
+      schemeDataArray.push({
+        facilitator,
+        networks: fullNetworkSet,
+        pattern: this.derivePattern(namespaceNetworks),
+      });
+    }
 
     return this;
   }

--- a/typescript/packages/core/test/unit/facilitator/x402Facilitator.test.ts
+++ b/typescript/packages/core/test/unit/facilitator/x402Facilitator.test.ts
@@ -263,6 +263,97 @@ describe("x402Facilitator", () => {
       expect(testFacilitator.verifyCalls.length).toBe(1);
     });
 
+    // Regression coverage for https://github.com/x402-foundation/x402/issues/3172:
+    // a single register() call spanning more than one CAIP-2 namespace used
+    // to derive a single pattern from networks[0]'s namespace only, so
+    // every OTHER namespace involved got no wildcard coverage at all, not
+    // even the one networks[0] belonged to (that namespace's "pattern"
+    // was just a duplicate of the exact-match Set's own coverage of that
+    // one network).
+    it("keeps a namespace's own wildcard when it has multiple networks but is mixed with another namespace", async () => {
+      const facilitator = new x402Facilitator();
+      const testFacilitator = new TestFacilitator("exact");
+
+      // Two stellar networks (enough for derivePattern to justify a
+      // "stellar:*" wildcard on its own, same as the single-namespace
+      // "should use pattern matching for network" test above) PLUS one
+      // eip155 network, all in a single register() call. Previously,
+      // mixing in even one other-namespace network collapsed wildcard
+      // derivation entirely: uniqueNamespaces.size !== 1, so the whole
+      // call fell back to "use networks[0] for exact matching",
+      // discarding the wildcard "stellar:*" would otherwise have
+      // earned on its own.
+      facilitator.register(
+        ["stellar:testnet" as Network, "stellar:futurenet" as Network, "eip155:8453" as Network],
+        testFacilitator,
+      );
+
+      // Unlisted stellar network: matched via the "stellar:*" wildcard,
+      // previously lost the moment eip155:8453 joined the same call.
+      const stellarResult = await facilitator.verify(
+        buildPaymentPayload({ x402Version: 2 }),
+        buildPaymentRequirements({ scheme: "exact", network: "stellar:pubnet" as Network }),
+      );
+      expect(stellarResult.isValid).toBe(true);
+
+      // The explicitly-listed eip155 network still matches via the exact
+      // Set, unaffected either way.
+      const evmResult = await facilitator.verify(
+        buildPaymentPayload({ x402Version: 2 }),
+        buildPaymentRequirements({ scheme: "exact", network: "eip155:8453" as Network }),
+      );
+      expect(evmResult.isValid).toBe(true);
+
+      // eip155 only ever had ONE network registered here, so (same rule
+      // as any single-network namespace, mixed registration or not)
+      // it earns no wildcard of its own: an unlisted eip155 network must
+      // still fail closed, not be swept in by stellar's wildcard.
+      await expect(
+        facilitator.verify(
+          buildPaymentPayload({ x402Version: 2 }),
+          buildPaymentRequirements({ scheme: "exact", network: "eip155:11155111" as Network }),
+        ),
+      ).rejects.toThrow("No facilitator registered for scheme: exact and network: eip155:11155111");
+
+      // A namespace never registered at all must still fail closed too.
+      await expect(
+        facilitator.verify(
+          buildPaymentPayload({ x402Version: 2 }),
+          buildPaymentRequirements({ scheme: "exact", network: "solana:mainnet" as Network }),
+        ),
+      ).rejects.toThrow("No facilitator registered for scheme: exact and network: solana:mainnet");
+    });
+
+    it("derives independent wildcards for two namespaces registered together, each with multiple networks", async () => {
+      const facilitator = new x402Facilitator();
+      const testFacilitator = new TestFacilitator("exact");
+
+      facilitator.register(
+        [
+          "stellar:testnet" as Network,
+          "stellar:futurenet" as Network,
+          "eip155:8453" as Network,
+          "eip155:1" as Network,
+        ],
+        testFacilitator,
+      );
+
+      // Both namespaces have enough representatives to derive their own
+      // wildcard; both must work independently in the same registration.
+      const stellarResult = await facilitator.verify(
+        buildPaymentPayload({ x402Version: 2 }),
+        buildPaymentRequirements({ scheme: "exact", network: "stellar:pubnet" as Network }),
+      );
+      expect(stellarResult.isValid).toBe(true);
+
+      const evmResult = await facilitator.verify(
+        buildPaymentPayload({ x402Version: 2 }),
+        buildPaymentRequirements({ scheme: "exact", network: "eip155:11155111" as Network }),
+      );
+      expect(evmResult.isValid).toBe(true);
+      expect(testFacilitator.verifyCalls.length).toBe(2);
+    });
+
     it("should not treat regex metacharacters in network namespaces as wildcards", async () => {
       const facilitator = new x402Facilitator();
       const testFacilitator = new TestFacilitator("exact");


### PR DESCRIPTION
## What

`x402Facilitator.derivePattern()` collapsed a single `register()`/`registerV1()` call spanning more than one CAIP-2 namespace to a literal exact-match pattern (`networks[0]`), discarding wildcard coverage entirely — not just for the second namespace onward, for **every** namespace involved, including one with enough same-namespace networks to have earned a wildcard on its own if registered alone.

## Fix

`_registerScheme` now groups the registered networks by namespace and pushes one `SchemeData` entry per namespace, each with its own `derivePattern()` result computed over just that namespace's networks. `networks` stays the same full `Set` on every entry (exact matching, checked first in `verify()`/`settle()`'s dispatch loop, is unaffected either way); only the wildcard fallback needed to become namespace-scoped. No change to `SchemeData`'s shape, `networkMatchesPattern`, or anything client-side — the whole fix lives inside `_registerScheme`'s own bookkeeping, which is the only place that knew about the whole (possibly mixed) list at once.

## A self-correction on my own original report

Filing this made me re-verify the original issue's own reproduction more carefully, and it doesn't hold up exactly as written. It registered exactly **one** network per namespace (`stellar:testnet` + `eip155:8453`) and claimed the unlisted `stellar:pubnet` should match after a fix. That doesn't actually follow from a *correct* namespace-scoped fix: `derivePattern`'s own pre-existing single-network rule (`if (networks.length === 1) return networks[0]`) means a namespace with only one registered network never derives a wildcard — mixed registration or not, same as a single-namespace registration of one network never did either.

The real, still-fully-valid bug is narrower and different from how I originally framed it: a namespace with **multiple** registered networks (enough to justify a wildcard on its own) loses that wildcard entirely the moment even one other-namespace network joins the same registration call. E.g. `register(["stellar:testnet", "stellar:futurenet", "eip155:8453"], ...)` should derive `stellar:*`, exactly as `register(["stellar:testnet", "stellar:futurenet"], ...)` alone already correctly does — but before this fix, adding the single `eip155:8453` silently threw that wildcard away.

## Testing

Added to `test/unit/facilitator/x402Facilitator.test.ts`, reflecting the corrected behavior above, not the original repro's overclaim:
- a namespace with multiple networks keeps its own wildcard when mixed with a single-network second namespace (the real bug)
- a namespace with only one registered network still fails closed for an unlisted sibling network, mixed registration or not (this is the case my original report got wrong — included so the corrected behavior is pinned down, not just fixed silently)
- two namespaces registered together, each with multiple networks, both derive independent wildcards

```
pnpm exec vitest run   # full @x402/core suite: 657 tests, 0 failures
eslint . / prettier    # clean
```

Changeset added (`@x402/core`, patch).

Fixes #3172
