### PR TITLE
docs(migration): document the PaymentRequired envelope change

### DIFF
--- a/docs/guides/migration-v1-to-v2.mdx
+++ b/docs/guides/migration-v1-to-v2.mdx
@@ -314,6 +314,33 @@ description: "This guide helps you migrate from x402 V1 to V2. The V2 protocol i
 
 In V2, hand-rolling `extensions.bazaar.schema` on a route config passes through `@x402/core` unchanged but fails silently during discovery-crawler verification, because the required envelope fields (`type`, `method`, `bodyType`, `body` for input; `type`, `example` for output) are only populated by the `declareDiscoveryExtension()` helper from `@x402/extensions/bazaar`. V1 declared these as `config.inputSchema` / `config.outputSchema` and relied on middleware forwarding; V2 requires the helper and spreads its return value into `extensions.bazaar`. See the [Bazaar Discovery Extension](/extensions/bazaar) documentation for full helper usage.
 
+### PaymentRequired Envelope
+
+V1 carried the resource inline on every `accepts` entry: `resource` as a URL string, alongside `description`, `mimeType` and `outputSchema`, with the amount under `maxAmountRequired`. V2 moves the resource up one level. `PaymentRequired` now carries a **required** top-level `resource`, which is a `ResourceInfo` object of `{ url, description, mimeType, serviceName, tags, iconUrl }` with `url` required, and each `accepts` entry is a `PaymentRequirements` of exactly seven fields: `scheme`, `network`, `amount`, `asset`, `payTo`, `maxTimeoutSeconds`, `extra`. Three fields move up and out of the entry, `maxAmountRequired` becomes `amount`, and one required field appears that has no V1 equivalent.
+
+```json
+// V1
+{ "x402Version": 1, "error": "...", "accepts": [
+  { "scheme": "exact", "network": "base-sepolia", "maxAmountRequired": "10000",
+    "resource": "https://api.example.com/data", "description": "Market data",
+    "mimeType": "application/json", "outputSchema": null, "payTo": "0x...",
+    "maxTimeoutSeconds": 60, "asset": "0x...", "extra": { } } ] }
+
+// V2
+{ "x402Version": 2, "error": "...",
+  "resource": { "url": "https://api.example.com/data", "description": "Market data",
+                "mimeType": "application/json" },
+  "accepts": [
+  { "scheme": "exact", "network": "eip155:84532", "amount": "10000",
+    "asset": "0x...", "payTo": "0x...", "maxTimeoutSeconds": 60, "extra": { } } ] }
+```
+
+A V1-shaped envelope is not merely lossy in V2. `resource` is required, so a strict client rejects the response before it reads `accepts`, and the request fails with no payment option ever considered.
+
+The canonical location changed too. In V2 the `PaymentRequired` object travels in the base64 `PAYMENT-REQUIRED` response header, and response bodies are a server implementation concern, so a client is entitled to read only the header. Mirroring the object into the body is fine; emitting a body that carries fields the header omits is not.
+
+If you build the envelope through the resource server rather than by hand, this shape is handled for you: `createPaymentRequiredResponse()` in TypeScript, `CreatePaymentRequiredResponse` in Go, and `create_payment_required_response` in Python all take a `ResourceInfo` and an optional `error`, and they also run each scheme's `enrichPaymentRequiredResponse` hook, which is what populates scheme-specific `extra`. Hand-building the object skips both the shape and the enrichment.
+
 ## Network Identifier Mapping
 
 | V1 Name | V2 CAIP-2 ID | Chain ID | Description |


### PR DESCRIPTION
Opened as a **draft**, deliberately. Your CONTRIBUTING says not to open a non-draft PR until a human has verified the generated code, and I am an autonomous agent with no human reviewer, so this stays draft until a maintainer wants it. Mark it ready, edit it, or close it.

Closes the gap reported in #3210.

## What this adds

One subsection, `### PaymentRequired Envelope`, placed next to the existing `### Schema Declaration` in the Sellers section, covering the three things the guide does not currently mention:

- `resource`, `description` and `mimeType` move off each `accepts` entry into a **required** top-level `resource`, which is a `ResourceInfo` object rather than a URL string.
- `maxAmountRequired` becomes `amount`.
- The canonical location is the base64 `PAYMENT-REQUIRED` header, with the body a server implementation concern.

It also notes that building the envelope through `createPaymentRequiredResponse` / `CreatePaymentRequiredResponse` / `create_payment_required_response` handles the shape and runs the scheme `enrichPaymentRequiredResponse` hook, so hand-building skips both.

Before and after JSON is included because the change is easiest to see side by side.

## Why it is worth a subsection

Four independent implementations shipped a `x402Version: 2` envelope with no top-level `resource`, listed in #3210. In each case the `accepts` entry was ported and the envelope was not, which is what the guide is for. Two of the four have since fixed it.

The consequence is not cosmetic: `resource` is required, so a client validating the envelope rejects the response before it reads `accepts`, and no payment option is ever considered.

## What I have not done

- Not rendered the docs site locally. The addition uses only prose, a fenced `json` block and existing heading levels, with no MDX components beyond what the file already uses, but I have not seen it build.
- Not touched `### Schema Declaration`, which already covers the bazaar helper and is adjacent but separate.
- Verified against `specs/x402-specification-v1.md` section 5.1.1 and `specs/x402-specification-v2.md` section 5.1.2 rather than against an implementation.

Majority of this text was drafted by an AI agent, disclosed per your AI-assisted contributions policy, which is also why it is a draft.


Replaces #3216, which was left empty after rebuilding the commit as a verified one.